### PR TITLE
1586 fix booking days limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ node_modules
 # IDE files
 .idea
 *.sublime-*
+*.komodoproject
 
 # testing
 .noseids

--- a/indico/htdocs/js/indico/RoomBooking/RoomBookingCalendar.js
+++ b/indico/htdocs/js/indico/RoomBooking/RoomBookingCalendar.js
@@ -23,7 +23,7 @@ var START_H = 6;
 // Width of the calendar
 var DAY_WIDTH_PX = 35 * 12 * 2;
 // Room types, used for selecting proper CSS classes
-var barClasses = ['barBlocked', 'barPreB', 'barPreConc', 'barUnaval', 'barCand', 'barPreC', 'barConf', 'barDisable'];
+var barClasses = ['barBlocked', 'barPreB', 'barPreConc', 'barUnaval', 'barCand', 'barPreC', 'barConf', 'barOutOfRange'];
 
 var calendarLegend = Html.div({style:{clear: 'both', padding: pixels(5), marginBottom: pixels(10), border: "1px solid #eaeaea", borderRadius: pixels(2)}},
         Html.div( {className:'barLegend', style:{color: 'black'}}, $T('Legend:')),
@@ -34,7 +34,7 @@ var calendarLegend = Html.div({style:{clear: 'both', padding: pixels(5), marginB
         Html.div( {className:'barLegend barPreC', style:{color: 'white'}}, $T('Conflict with PRE-Booking')),
         Html.div( {className:'barLegend barPreConc', style:{color: 'white'}}, $T('Concurrent PRE-Bookings')),
         Html.div( {className:'barLegend barBlocked'}, $T('Blocked')),
-        Html.div( {className:'barLegend barDisable'}, $T('Booking not allowed')));
+        Html.div( {className:'barLegend barOutOfRange'}, $T('Too early to book')));
 
 
 function compare_alphanum(elem1, elem2) {
@@ -261,7 +261,7 @@ type ("RoomBookingCalendarDrawer", [],
                     resvInfo = $T("Room blocked by") + ":<br/>" +
                                   bar.blocking.creator + "<br/>" +
                                   $T('Reason') + ': ' + bar.blocking.reason;
-                } else if (bar.type == 'barDisable') {
+                } else if (bar.type == 'barOutOfRange') {
                     resvInfo = $T('Booking not allowed for this period.<br>This room can only be booked {0} days in advance.').format(bar.room.max_advance_days)
                 } else {
                     resvInfo = bar.startDT.print("%H:%M") + "  -  " +
@@ -332,11 +332,11 @@ type ("RoomBookingCalendarDrawer", [],
                     return $(this).find('.barBlocked').length;
                 }).get());
 
-                var disabled = _.any($('.barDefaultHover').closest('.dayCalendarDiv').map(function() {
-                    return $(this).find('.barDisable').length;
+                var outOfRange = _.any($('.barDefaultHover').closest('.dayCalendarDiv').map(function() {
+                    return $(this).find('.barOutOfRange').length;
                 }).get());
 
-                if (disabled) {
+                if (outOfRange) {
                     this._setDialog("search-again");
                     $('#booking-dialog-content').html($T("This room cannot booked more than {0} days in advance.").format(bar.room.max_advance_days));
                     $('#booking-dialog').dialog("open");

--- a/indico/htdocs/sass/modules/roombooking/_bars.scss
+++ b/indico/htdocs/sass/modules/roombooking/_bars.scss
@@ -104,6 +104,19 @@
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
+.barDisable { /* Bar representing a period where booking is disabled */
+    background-color: #708090;
+    border-color: #4E5964 #4E5964 #434C56;
+    border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+
+    &:hover {
+        border-color: #4E5964 #4E5964 #434C56 !important;
+        border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25) !important;
+        opacity: 1;
+        filter:alpha(opacity=70);
+    }
+}
+
 .barProt.barCand {
     background-image: none;
     background-color: #DA4F49;

--- a/indico/htdocs/sass/modules/roombooking/_bars.scss
+++ b/indico/htdocs/sass/modules/roombooking/_bars.scss
@@ -59,67 +59,50 @@
 .barDefaultHover {
     border-color: #06F !important;
     opacity:0.7;
-    filter:alpha(opacity=70);
 }
 
 .barCand {  /* Bar representing candidate reservation */
     background-color: #5BB75B;
-    border-color: #51A351 #51A351 #387038;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barBlocked {
     background-color: $light-black;
-    border-color: #51A351 #51A351 #387038;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barUnaval { /* Bar representing unavailable period */
     background-color: #FAA732;
-    border-color: #F89406 #F89406 #AD6704;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barConf { /* Bar representing conflict */
     background-color: #DA4F49;
-    border-color: #BD362F #BD362F #802420;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barPreB { /* Bar representing PRE-booking */
     background-color: #F5E916;
-    border-color: #bcbc00;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barPreC { /* Bar representing conflict with PRE-booking */
     background-color: #0074CC;
-    border-color: #05C #05C #003580;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barPreConc { /* Bar representing concurrent PRE-bookings */
     background-color: #49AFCD;
-    border-color: #2F96B4 #2F96B4 #1F6377;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
-.barDisable { /* Bar representing a period where booking is disabled */
+.barOutOfRange { /* Bar representing a period outside the booking range */
     background-color: #708090;
-    border-color: #4E5964 #4E5964 #434C56;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-
-    &:hover {
-        border-color: #4E5964 #4E5964 #434C56 !important;
-        border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25) !important;
-        opacity: 1;
-        filter:alpha(opacity=70);
-    }
 }
 
 .barProt.barCand {
     background-image: none;
     background-color: #DA4F49;
-    border-color: #BD362F #BD362F #802420;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }

--- a/indico/modules/rb/controllers/user/reservations.py
+++ b/indico/modules/rb/controllers/user/reservations.py
@@ -370,6 +370,10 @@ class RHRoomBookingNewBookingSimple(RHRoomBookingNewBookingBase):
                 start_date = datetime.strptime(request.args['start_date'], '%Y-%m-%d').date()
             except ValueError:
                 pass
+            else:
+                if not self._room.check_advance_days(start_date, user=session.user, quiet=True):
+                    start_date = date.today()
+                    flash(_(u"This room cannot be booked at the desired date, using today's date instead."), 'warning')
 
         self.past_date = start_date is not None and start_date < date.today()
         if start_date is None or start_date <= date.today():

--- a/indico/modules/rb/models/rooms.py
+++ b/indico/modules/rb/models/rooms.py
@@ -71,7 +71,8 @@ class Room(versioned_cache(_cache, 'id'), db.Model, Serializer):
     ]
 
     __calendar_public__ = [
-        'id', 'building', 'name', 'floor', 'number', 'kind', 'booking_url', 'details_url', 'location_name'
+        'id', 'building', 'name', 'floor', 'number', 'kind', 'booking_url', 'details_url', 'location_name',
+        'max_advance_days'
     ]
 
     __api_public__ = (

--- a/indico/modules/rb/models/rooms.py
+++ b/indico/modules/rb/models/rooms.py
@@ -707,9 +707,9 @@ class Room(versioned_cache(_cache, 'id'), db.Model, Serializer):
 
     def check_advance_days(self, end_date, user=None, quiet=False):
         if not self.max_advance_days:
-            return
+            return True
         if user and (user.isRBAdmin() or self.is_owned_by(user)):
-            return
+            return True
         advance_days = (end_date - date.today()).days
         ok = advance_days < self.max_advance_days
         if quiet:

--- a/indico/modules/rb/views/calendar.py
+++ b/indico/modules/rb/views/calendar.py
@@ -205,6 +205,8 @@ class RoomBookingCalendarWidget(object):
                     bar = Bar.from_candidate(cand, room.id, start_dt, end_dt, blocking)
                     self.bars.append(bar)
 
+        self._produce_disabled_bars()  # If we have candidate bars we also want to show when the room cannot be booked.
+
     def _produce_prereservation_overlap_bars(self):
         for _, occurrences in groupby((o for o in self.occurrences if not o.reservation.is_accepted),
                                       key=lambda o: o.reservation.room_id):
@@ -232,6 +234,16 @@ class RoomBookingCalendarWidget(object):
                              for day in self.iter_days()
                              if blocking.start_date <= day <= blocking.end_date)
 
+    def _produce_disabled_bars(self):
+        # Produces bars for days when bookings cannot be made.
+        for room in self.rooms:
+            self.bars.extend(
+                Bar(datetime.combine(day, time()), datetime.combine(day, time(23, 59)), kind=Bar.DISABLED,
+                    room_id=room.id)
+                for day in self.iter_days()
+                if not room.check_advance_days(day, user=session.user, quiet=True)
+            )
+
 
 class Bar(Serializer):
     __public__ = [
@@ -239,7 +251,7 @@ class Bar(Serializer):
         ('reservation_end', 'resvEndDT')
     ]
 
-    BLOCKED, PREBOOKED, PRECONCURRENT, UNAVAILABLE, CANDIDATE, PRECONFLICT, CONFLICT = range(7)
+    BLOCKED, PREBOOKED, PRECONCURRENT, UNAVAILABLE, CANDIDATE, PRECONFLICT, CONFLICT, DISABLED = range(8)
     _mapping = {
         BLOCKED: 'blocked',                 # A blocked-room period
         CANDIDATE: 'candidate',             # A reservation candidate
@@ -247,16 +259,17 @@ class Bar(Serializer):
         PREBOOKED: 'pre-booked',            # A unconfirmed reservation
         PRECONCURRENT: 'pre-concurrent',    # A conflict between unconfirmed reservations
         PRECONFLICT: 'pre-conflict',        # A conflicting unconfirmed reservation
-        UNAVAILABLE: 'unavailable'          # A confirmed reservation
+        UNAVAILABLE: 'unavailable',         # A confirmed reservation
+        DISABLED: 'disabled'                # A period during which bookings are disabled
     }
 
-    def __init__(self, start, end, kind=None, reservation=None, overlapping=False, blocking=None):
+    def __init__(self, start, end, kind=None, reservation=None, overlapping=False, blocking=None, room_id=None):
         self.start = start
         self.end = end
         self.reservation = reservation
         self.reservation_start = None
         self.reservation_end = None
-        self.room_id = None
+        self.room_id = room_id
         self.blocking = None
 
         if reservation is not None:
@@ -288,8 +301,7 @@ class Bar(Serializer):
 
     @classmethod
     def from_candidate(cls, candidate, room_id, resv_start, resv_end, blocking=None):
-        self = cls(candidate.start_dt, candidate.end_dt, cls.CANDIDATE, blocking=blocking)
-        self.room_id = room_id
+        self = cls(candidate.start_dt, candidate.end_dt, cls.CANDIDATE, blocking=blocking, room_id=room_id)
         self.reservation_start = resv_start
         self.reservation_end = resv_end
         return self
@@ -300,10 +312,8 @@ class Bar(Serializer):
 
     @classmethod
     def from_blocked_room(cls, blocked_room, day):
-        bar = cls(datetime.combine(day, time()), datetime.combine(day, time(23, 59)), Bar.BLOCKED,
-                  blocking=blocked_room.blocking)
-        bar.room_id = blocked_room.room_id
-        return bar
+        return cls(datetime.combine(day, time()), datetime.combine(day, time(23, 59)), Bar.BLOCKED,
+                   blocking=blocked_room.blocking, room_id=blocked_room.room_id)
 
     @property
     def date(self):

--- a/indico/modules/rb/views/calendar.py
+++ b/indico/modules/rb/views/calendar.py
@@ -29,7 +29,7 @@ from indico.modules.rb.models.utils import Serializer
 from indico.modules.rb.models.blocked_rooms import BlockedRoom
 from indico.modules.rb.models.reservation_occurrences import ReservationOccurrence
 from indico.modules.rb.models.rooms import Room
-from indico.util.date_time import iterdays, format_time, overlaps
+from indico.util.date_time import iterdays, overlaps
 from indico.util.i18n import _
 from indico.util.string import natural_sort_key
 from indico.util.struct.iterables import group_list
@@ -180,6 +180,7 @@ class RoomBookingCalendarWidget(object):
         if self.candidates is not None:
             self._produce_candidate_bars()
             self._produce_conflict_bars()
+            self._produce_out_of_range_bars()
         if self.show_blockings:
             self._produce_blocking_bars()
 
@@ -204,8 +205,6 @@ class RoomBookingCalendarWidget(object):
                 for cand in candidates:
                     bar = Bar.from_candidate(cand, room.id, start_dt, end_dt, blocking)
                     self.bars.append(bar)
-
-        self._produce_disabled_bars()  # If we have candidate bars we also want to show when the room cannot be booked.
 
     def _produce_prereservation_overlap_bars(self):
         for _, occurrences in groupby((o for o in self.occurrences if not o.reservation.is_accepted),
@@ -234,11 +233,10 @@ class RoomBookingCalendarWidget(object):
                              for day in self.iter_days()
                              if blocking.start_date <= day <= blocking.end_date)
 
-    def _produce_disabled_bars(self):
-        # Produces bars for days when bookings cannot be made.
+    def _produce_out_of_range_bars(self):
         for room in self.rooms:
             self.bars.extend(
-                Bar(datetime.combine(day, time()), datetime.combine(day, time(23, 59)), kind=Bar.DISABLED,
+                Bar(datetime.combine(day, time()), datetime.combine(day, time(23, 59)), kind=Bar.OUT_OF_RANGE,
                     room_id=room.id)
                 for day in self.iter_days()
                 if not room.check_advance_days(day, user=session.user, quiet=True)
@@ -251,7 +249,7 @@ class Bar(Serializer):
         ('reservation_end', 'resvEndDT')
     ]
 
-    BLOCKED, PREBOOKED, PRECONCURRENT, UNAVAILABLE, CANDIDATE, PRECONFLICT, CONFLICT, DISABLED = range(8)
+    BLOCKED, PREBOOKED, PRECONCURRENT, UNAVAILABLE, CANDIDATE, PRECONFLICT, CONFLICT, OUT_OF_RANGE = range(8)
     _mapping = {
         BLOCKED: 'blocked',                 # A blocked-room period
         CANDIDATE: 'candidate',             # A reservation candidate
@@ -260,7 +258,7 @@ class Bar(Serializer):
         PRECONCURRENT: 'pre-concurrent',    # A conflict between unconfirmed reservations
         PRECONFLICT: 'pre-conflict',        # A conflicting unconfirmed reservation
         UNAVAILABLE: 'unavailable',         # A confirmed reservation
-        DISABLED: 'disabled'                # A period during which bookings are disabled
+        OUT_OF_RANGE: 'out_of_range'        # A period out of the booking range
     }
 
     def __init__(self, start, end, kind=None, reservation=None, overlapping=False, blocking=None, room_id=None):


### PR DESCRIPTION
Limit choice of days in 3-step booking
 - Add new bar to the calendar to show days where booking is not possible.
 - Replace error report with nicer message.
 - Extend the Bar class to accept a room id directly upon instantiation
   (as a keyword argument)
 - fixes #1586
 - remove unused sass rule for bar borders
 - remove rule for IE version prior to IE9
 - remove unused import