### PR TITLE
Fix incorrect behavior when editing start time

### DIFF
--- a/indico/MaKaC/services/implementation/schedule.py
+++ b/indico/MaKaC/services/implementation/schedule.py
@@ -723,8 +723,8 @@ class ModifyStartEndDate(ScheduleOperation):
         # The order to set the start date and duration is important, please keep it like this.
         # Otherwise, by modifying the startDate we might find entries inside a slot that are
         # temporarly outside and an exception will be raised.
-        self._schEntry.setDuration(dur=duration,check=checkFlag)
         self._schEntry.setStartDate(self._startDate, moveEntries=1, check=checkFlag)
+        self._schEntry.setDuration(dur=duration,check=checkFlag)
 
         # In case of 'reschedule', calculate the time difference
         if self._reschedule:


### PR DESCRIPTION
 - set the start date before the duration which relies on the start date to
   assert its validity.
 - removes inconsistent error message about an incorrect end time which
   corresponds to the old start time plus the new duration.
 - fixes #1583 