### PR TITLE
Fix calculation of conflicting occurrences

### DIFF
--- a/indico/modules/rb/controllers/user/reservations.py
+++ b/indico/modules/rb/controllers/user/reservations.py
@@ -281,7 +281,7 @@ class RHRoomBookingNewBookingBase(RHRoomBookingBase):
         pre_conflicts = defaultdict(list)
 
         candidates = ReservationOccurrence.create_series(form.start_dt.data, form.end_dt.data,
-                                                         (form.repeat_interval.data, form.repeat_interval.data))
+                                                         (form.repeat_frequency.data, form.repeat_interval.data))
         occurrences = ReservationOccurrence.find_overlapping_with(room, candidates, reservation_id).all()
 
         for cand in candidates:


### PR DESCRIPTION
Since the `repeat_interval` is always 1 for now in the interface and we were passing it as `repeat_frequency`, we were actually calculating conflicting occurrences as if the reservation was always **daily**. This probably caused some false positives when creating/modifying long lasting reservations.
