### PR TITLE
Hide late warning in rb for events

### DIFF
--- a/indico/modules/rb/controllers/user/event.py
+++ b/indico/modules/rb/controllers/user/event.py
@@ -316,6 +316,7 @@ class RHRoomBookingEventNewBooking(RHRoomBookingEventBase, RHRoomBookingNewBooki
         defaults = RHRoomBookingNewBooking._get_select_room_form_defaults(self)
         for key, value in _get_defaults_from_object(self._assign_to or self.event).iteritems():
             defaults[key] = value
+        self.date_changed = False  # date is not changed but retrieved from defaults
         return defaults
 
     def _make_confirm_form(self, *args, **kwargs):

--- a/indico/modules/rb/controllers/user/event.py
+++ b/indico/modules/rb/controllers/user/event.py
@@ -313,11 +313,10 @@ class RHRoomBookingEventNewBooking(RHRoomBookingEventBase, RHRoomBookingNewBooki
         return views[view](self, self.event, **kwargs)
 
     def _get_select_room_form_defaults(self):
-        defaults = RHRoomBookingNewBooking._get_select_room_form_defaults(self)
+        defaults, _ = RHRoomBookingNewBooking._get_select_room_form_defaults(self)
         for key, value in _get_defaults_from_object(self._assign_to or self.event).iteritems():
             defaults[key] = value
-        self.date_changed = False  # date is not changed but retrieved from defaults
-        return defaults
+        return defaults, False
 
     def _make_confirm_form(self, *args, **kwargs):
         if 'defaults' in kwargs:

--- a/indico/modules/rb/controllers/user/reservations.py
+++ b/indico/modules/rb/controllers/user/reservations.py
@@ -486,15 +486,16 @@ class RHRoomBookingNewBooking(RHRoomBookingNewBookingBase):
         return views[view](self, **kwargs)
 
     def _get_select_room_form_defaults(self):
-        start_dt, end_dt, self.date_changed = get_default_booking_interval(duration=self.DEFAULT_BOOKING_DURATION,
-                                                                           precision=self.DEFAULT_START_TIME_PRECISION,
-                                                                           force_today=False)
-        return FormDefaults(start_dt=start_dt, end_dt=end_dt)
+        start_dt, end_dt, date_changed = get_default_booking_interval(duration=self.DEFAULT_BOOKING_DURATION,
+                                                                      precision=self.DEFAULT_START_TIME_PRECISION,
+                                                                      force_today=False)
+        return FormDefaults(start_dt=start_dt, end_dt=end_dt), date_changed
 
     def _make_select_room_form(self):
         # Step 1
         self._rooms = sorted(Room.find_all(is_active=True), key=lambda r: natural_sort_key(r.full_name))
-        form = NewBookingCriteriaForm(obj=self._get_select_room_form_defaults())
+        form_obj, self.date_changed = self._get_select_room_form_defaults()
+        form = NewBookingCriteriaForm(obj=form_obj)
         form.room_ids.choices = [(r.id, None) for r in self._rooms]
         return form
 


### PR DESCRIPTION
 - Hide the late warning message when booking a room in an event with fixed
   date and time
 - fix #1630