### PR TITLE
fix user search

### DIFF
--- a/indico/MaKaC/user.py
+++ b/indico/MaKaC/user.py
@@ -1150,7 +1150,7 @@ class AvatarHolder(ObjectHolder):
             for userid in match:
                 if self.getById(userid) not in result:
                     av = self.getById(userid)
-                    if not onlyActivated or av.isActivated():
+                    if av and (not onlyActivated or av.isActivated()):
                         result[av.getEmail()] = av
         if searchInAuthenticators:
             for authenticator in AuthenticatorMgr().getList():
@@ -1184,7 +1184,7 @@ class AvatarHolder(ObjectHolder):
                         iset = iset & set(match)
         for userid in iset:
             av=self.getById(userid)
-            if not onlyActivated or av.isActivated():
+            if av and (not onlyActivated or av.isActivated()):
                 result[av.getEmail()]=av
         if searchInAuthenticators:
             for authenticator in AuthenticatorMgr().getList():


### PR DESCRIPTION
 - prevent user search from failing because of invalid avatar ids
 - check for bad (`None`) avatars returned from invalid ids
 - fix #1643