### PR TITLE
Show the room's fullname in the events ical export

### DIFF
--- a/indico/web/http_api/metadata/ical.py
+++ b/indico/web/http_api/metadata/ical.py
@@ -58,7 +58,7 @@ def serialize_event(cal, fossil, now, id_prefix="indico-event"):
     if loc:
         loc = loc.decode('utf-8')
     if fossil['room']:
-        loc += ' ' + fossil['room'].decode('utf-8')
+        loc += ' ' + fossil['roomFullname'].decode('utf-8')
     event.set('location', loc)
     description = ""
     if fossil.get('speakers'):


### PR DESCRIPTION
 - show the fullname of a room in the ical exported file for an event
 - fix #1652