### PR TITLE
Fix disabled "Save" button after copy&paste to min

### DIFF
--- a/indico/htdocs/js/indico/Core/Widgets/RichText.js
+++ b/indico/htdocs/js/indico/Core/Widgets/RichText.js
@@ -87,6 +87,10 @@ type("RichTextEditor", ["IWidget", "Accessor"],
 
          onChange: function(callback) {
              this.getEditor().on('change', callback);
+         },
+
+         afterPaste: function(callback) {
+            this.getEditor().on('afterPaste', callback);
          }
 
      },

--- a/indico/htdocs/js/indico/Legacy/Dialogs.js
+++ b/indico/htdocs/js/indico/Legacy/Dialogs.js
@@ -658,6 +658,10 @@ extend(IndicoUI.Dialogs,
                   }
                 });
 
+                rtWidget.afterPaste(function afterPaste() {
+                  changedText.set(true);
+                });
+
                 // the editor is ready, so let's ask for data from the server
                 killProgress = IndicoUI.Dialogs.Util.progress();
                 req.refresh();


### PR DESCRIPTION
- enable the save button correctly after pasting in the minutes editor
- fix #1653
