### PR TITLE
Resolve Issues: #1679. Problem with admin user id=0

### DIFF
--- a/indico/MaKaC/common/ObjectHolders.py
+++ b/indico/MaKaC/common/ObjectHolders.py
@@ -72,7 +72,7 @@ class ObjectHolder:
 
     def _getIdx( self ):
         """Returns the holder/catalog where all the objects are stored"""
-        if self._idx == None:
+        if self._idx is None:
             self._setIdx()
         return self._idx
 

--- a/indico/MaKaC/user.py
+++ b/indico/MaKaC/user.py
@@ -485,14 +485,16 @@ class Avatar(Persistent, Fossilizable):
         favorites = self.getLinkTo('category', 'favorite')
         managed = self.getLinkTo('category', 'manager')
         res = {}
-        for categ in union(favorites, managed):
-            res[(categ.getTitle(), categ.getId())] = {
-                'categ': categ,
-                'favorite': categ in favorites,
-                'managed': categ in managed,
-                'path': truncate_path(categ.getCategoryPathTitles(), 30, False)
-            }
-        return OrderedDict(sorted(res.items(), key=operator.itemgetter(0)))
+        if favorites or managed:
+            for categ in union(favorites, managed):
+                res[(categ.getTitle(), categ.getId())] = {
+                    'categ': categ,
+                    'favorite': categ in favorites,
+                    'managed': categ in managed,
+                    'path': truncate_path(categ.getCategoryPathTitles(), 30, False)
+                }
+            return OrderedDict(sorted(res.items(), key=operator.itemgetter(0)))
+        return None
 
     def getSuggestedCategories(self):
         if not redis_write_client:


### PR DESCRIPTION
Fixed the problem with the admin user having id=0
after the upgrade to the release 1.2.

Additionally, a fix for the personal setting of the admin solved.
Since there were not favorites and managed categories and exception
raised and the personal admin page was not working
