### PR TITLE
Reset the paper review stats when removing it

### DIFF
--- a/indico/MaKaC/conference.py
+++ b/indico/MaKaC/conference.py
@@ -10909,6 +10909,8 @@ class Material(CommonObjectBase):
         self.__ac.unlinkAvatars('access')
         for res in self.getResourceList():
             self.removeResource( res )
+        if self.getReviewingState():
+            self.owner._reviewManager = ReviewManager(self.owner)
         self.notify_protection_to_owner(self, delete=True)
         TrashCanManager().add(self)
 

--- a/indico/MaKaC/webinterface/wcomponents.py
+++ b/indico/MaKaC/webinterface/wcomponents.py
@@ -3721,7 +3721,7 @@ class WShowExistingReviewingMaterial(WTemplated):
         vars = WTemplated.getVars(self)
         reviewManager = self._target.getReviewManager()
         vars["Contribution"] = self._target
-        vars["CanModify"] = (self._target.getReviewing().getReviewingState() in [2, 3] if self._target.getReviewing() else False) and \
+        vars["CanModify"] = (self._target.getReviewing().getReviewingState() in [2, 3] if self._target.getReviewing() else True) and \
                             (self._target.canModify(self._rh._aw) or RCPaperReviewManager.hasRights(self._rh) \
                             or reviewManager.isReferee(self._rh._getUser()) or reviewManager.isEditor(self._rh._getUser()))
         vars["ShowWarning"] = (self._target.getReviewing().getReviewingState() == 2 if self._target.getReviewing() else False) and \


### PR DESCRIPTION
 - reset the review state of a paper within a contribution if the paper is
   deleted
 - allows to reupload a paper if the contrib's paper is removed while awaiting
   review
 - enable the `Upload paper` link in the "Material to Review" tab of the
   contrib's management area if there is no paper submitted
 - fix #1599