### PR TITLE
Add vidyo option to append text to booking emails

### DIFF
--- a/indico/MaKaC/plugins/Collaboration/Vidyo/mail.py
+++ b/indico/MaKaC/plugins/Collaboration/Vidyo/mail.py
@@ -205,24 +205,23 @@ class NewVidyoPublicRoomNotificationAdmin(VidyoAdminNotificationBase):
         self.setSubject("""[Vidyo] New Vidyo public room: %s (event id: %s)"""
                         % (self._conference.getTitle(), str(self._conference.getId())))
 
-        self.setBody("""Dear Vidyo Manager,<br />
-<br />
-There is a <strong>new Vidyo public room</strong> in <a href="%s">%s</a><br />
-Click <a href="%s">here</a> to see it in Indico.<br />
-<br />
-%s
-<br />
-%s
-<br />
-<br />
-%s
-""" % (MailTools.getServerName(),
-       MailTools.getServerName(),
-       self._modifLink,
-       MailTools.eventDetails(self._conference),
-       MailTools.organizerDetails(self._conference),
-       self._getBookingDetails('new')
-       ))
+        body = (
+            "Dear Vidyo Manager<br>"
+            "There is a <strong>new Vidyo public room</strong> in <a href=\"{0}\">{0}</a><br>"
+            "Click <a href=\"{1}\">here</a> to see it in Indico."
+            "<br><br>{2}<br>{3}<br><br>{4}"
+        ).format(MailTools.getServerName(),
+                 self._modifLink,
+                 MailTools.eventDetails(self._conference),
+                 MailTools.organizerDetails(self._conference),
+                 self._getBookingDetails('new'))
+
+        extra_message = getVidyoOptionValue('booking_admin_message')
+
+        if extra_message:
+            body += '<br>' + extra_message
+
+        self.setBody(body)
 
 
 class VidyoPublicRoomModifiedNotificationAdmin(VidyoAdminNotificationBase):

--- a/indico/MaKaC/plugins/Collaboration/Vidyo/options.py
+++ b/indico/MaKaC/plugins/Collaboration/Vidyo/options.py
@@ -145,5 +145,11 @@ globalOptions = [
     ('phoneNumbers', {"description": "VidyoVoice Phone Numbers",
                        "type": "list_multiline",
                        "editable": True,
-                       "defaultValue": [] })
+                       "defaultValue": [] }),
+    ('booking_admin_message', {
+        "description": "Message to append to Vidyo booking emails",
+        "type": "ckEditor",
+        "editable": True,
+        "defaultValue": ""
+    })
 ]

--- a/indico/MaKaC/webinterface/tpls/AdminPlugins.tpl
+++ b/indico/MaKaC/webinterface/tpls/AdminPlugins.tpl
@@ -80,7 +80,7 @@
     </tr>
     % endif
     % if PluginType.getOptions() is not None and len(PluginType.getOptions()) > 0:
-         <%include file="AdminPluginsOptionList.tpl" args="Object = PluginType, ObjectType = 'PluginType', Favorites = Favorites, Index = 0, rbActive = rbActive, baseURL = baseURL"/>
+         <%include file="AdminPluginsOptionList.tpl" args="Object = PluginType, ObjectType = 'PluginType', Favorites = Favorites, Index = 0, rbActive = rbActive, baseURL = baseURL, Id = PluginType.getId()"/>
     % endif
     % if not PluginType.getOptions() and True not in self_._notify('hasPluginSettings', PluginType.getId(), None):
     <tr>
@@ -100,9 +100,12 @@
 
     <div>
         % for i, plugin in enumerate(pluginList):
-        <div id="${plugin.getName()}OptionsDiv" style="display:none;">
+        <%
+            PluginOptionsListId = plugin.getName() + "OptionsDiv"
+        %>
+        <div id="${ PluginOptionsListId }" style="display:none;">
             % if plugin.hasAnyOptions():
-                <%include file="AdminPluginsOptionList.tpl" args="Object = plugin, ObjectType = 'Plugin', Favorites = Favorites, Index = i, rbActive = rbActive, baseURL = baseURL"/>
+                <%include file="AdminPluginsOptionList.tpl" args="Object = plugin, ObjectType = 'Plugin', Favorites = Favorites, Index = i, rbActive = rbActive, baseURL = baseURL, Id = PluginOptionsListId"/>
             % elif True in self_._notify('hasPluginSettings', PluginType.getId(), plugin.getId()):
                 ${ ''.join(list(elem for elem in self_._notify('getPluginSettingsHTML', PluginType.getId(), plugin.getId()) if elem != None)) }
             % else:

--- a/indico/MaKaC/webinterface/tpls/AdminPluginsOptionList.tpl
+++ b/indico/MaKaC/webinterface/tpls/AdminPluginsOptionList.tpl
@@ -1,4 +1,4 @@
-<%page args="Object=None, ObjectType=None, Favorites=None, Index=None, rbActive=None, baseURL=None"/>
+<%page args="Object=None, ObjectType=None, Favorites=None, Index=None, rbActive=None, baseURL=None, Id=None"/>
 <% from MaKaC.fossils.user import IAvatarFossil %>
     % if ObjectType == "PluginType" :
     <form method="post" action="${ urlHandlers.UHAdminPluginsTypeSaveOptions.getURL(Object, subtab = Index) }" >
@@ -372,8 +372,8 @@
                     $(function setCkEditorInput() {
                         var editor = new RichTextEditor(600, 300);
                         $E('${ name }-ckEditor').set(editor.draw());
-                        editor.set('${ escapeHTMLForJS(option.getValue()) }');
-                        $('input[type="submit"][name="Save"]').on('hover', function setTextInput() {
+                        editor.set(${ option.getValue() | n, j });
+                        $('#${ Id }-save-btn').on('click', function setTextInput() {
                             $E("${ name }").dom.value = editor.get();
                         });
                     });
@@ -570,7 +570,7 @@
         % if len(Object.getOptionList(includeOnlyEditable=True, includeOnlyVisible=True)) > 0:
         <tr>
             <td colspan="2" style="text-align: right;">
-                <input type="submit" name="Save" value="${ _("Save settings") }" />
+                <input id="${ Id }-save-btn" type="submit" name="Save" value="${ _("Save settings") }" />
             </td>
         </tr>
         % endif

--- a/indico/MaKaC/webinterface/tpls/AdminPluginsOptionList.tpl
+++ b/indico/MaKaC/webinterface/tpls/AdminPluginsOptionList.tpl
@@ -1,12 +1,5 @@
 <%page args="Object=None, ObjectType=None, Favorites=None, Index=None, rbActive=None, baseURL=None"/>
 <% from MaKaC.fossils.user import IAvatarFossil %>
-
-    <script type="text/javascript">
-    // dummies which will be redefined if ckEditor is used
-    var fillText = function() {};
-    var editor = { get: function(){} };
-    </script>
-
     % if ObjectType == "PluginType" :
     <form method="post" action="${ urlHandlers.UHAdminPluginsTypeSaveOptions.getURL(Object, subtab = Index) }" >
     % else:
@@ -374,14 +367,16 @@
                 % elif option.getType() =="ckEditor":
                     <input type="hidden" name="${ name }" id="${ name }" />
 
-                    <div id="editor" style="margin-bottom: 10px"></div>
+                    <div id="${ name }-ckEditor" style="margin-bottom: 10px"></div>
                     <script type="text/javascript">
+                    $(function setCkEditorInput() {
                         var editor = new RichTextEditor(600, 300);
-                            $E('editor').set(editor.draw());
-                            editor.set('${ escapeHTMLForJS(option.getValue()) }');
-                            var fillText = function(text){
-                                $E("${ name }").dom.value = text;
-                            };
+                        $E('${ name }-ckEditor').set(editor.draw());
+                        editor.set('${ escapeHTMLForJS(option.getValue()) }');
+                        $('input[type="submit"][name="Save"]').on('hover', function setTextInput() {
+                            $E("${ name }").dom.value = editor.get();
+                        });
+                    });
                     </script>
                 % elif option.getType() =="rooms":
                     <div id="roomList${name}"></div>
@@ -430,7 +425,7 @@
 
                         $E('roomList${name}').set(rlf.draw());
                     </script>
-               % elif option.getType() == "usersGroups":
+                % elif option.getType() == "usersGroups":
                     <div id="userGroupList${name}" style="margin-bottom: 10px">
                     </div>
 
@@ -575,7 +570,7 @@
         % if len(Object.getOptionList(includeOnlyEditable=True, includeOnlyVisible=True)) > 0:
         <tr>
             <td colspan="2" style="text-align: right;">
-                <input type="submit" name="Save" value="${ _("Save settings") }" onclick="fillText(editor.get());"/>
+                <input type="submit" name="Save" value="${ _("Save settings") }" />
             </td>
         </tr>
         % endif


### PR DESCRIPTION
 - Add an option to the vidyo plugin to allow admins to add HTML content at
   the bottom of vidyo room booking confirmation emails
 - fix broken ckEditor in plugin options
 - fix #1650