### PR TITLE
keep the input after an HTML security error in PR

### DIFF
--- a/indico/MaKaC/services/implementation/conference.py
+++ b/indico/MaKaC/services/implementation/conference.py
@@ -51,10 +51,11 @@ from MaKaC.webinterface.common import contribFilters
 from MaKaC.webinterface.mail import GenericMailer, GenericNotification
 import MaKaC.webinterface.pages.conferences as conferences
 
-from MaKaC.services.implementation.base import ProtectedModificationService, ListModificationBase, ParameterManager, \
-    ProtectedDisplayService, ServiceBase, TextModificationBase, HTMLModificationBase, DateTimeModificationBase, ExportToICalBase
-from MaKaC.services.interface.rpc.common import ServiceError, ServiceAccessError, Warning, \
-        ResultWithWarning, TimingNoReportError, NoReportError
+from MaKaC.services.implementation.base import (ProtectedModificationService, ListModificationBase, ParameterManager,
+                                                ProtectedDisplayService, ServiceBase, TextModificationBase,
+                                                HTMLModificationBase, DateTimeModificationBase, ExportToICalBase)
+from MaKaC.services.interface.rpc.common import (HTMLSecurityError, NoReportError, ResultWithWarning,
+                                                 ServiceAccessError, ServiceError, TimingNoReportError, Warning)
 
 
 # indico imports
@@ -326,6 +327,12 @@ class ConferenceKeywordsModification(ConferenceTextModificationBase):
 
     def _handleGet(self):
         return self._target.getKeywords()
+
+    def process(self):
+        try:
+            return ConferenceTextModificationBase.process(self)
+        except HTMLSecurityError as e:
+            raise NoReportError(e.message)
 
 
 class ConferenceSpeakerTextModification(ConferenceTextModificationBase):

--- a/indico/MaKaC/services/implementation/reviewing.py
+++ b/indico/MaKaC/services/implementation/reviewing.py
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # This file is part of Indico.
 # Copyright (C) 2002 - 2015 European Organization for Nuclear Research (CERN).
 #
@@ -14,99 +13,22 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
-from MaKaC.paperReviewing import ConferencePaperReview
-from MaKaC.services.implementation.base import ProtectedModificationService, ParameterManager
-from MaKaC.services.implementation.contribution import ContributionBase
-from MaKaC.services.implementation.base import TextModificationBase
-from MaKaC.services.implementation.base import HTMLModificationBase
-from MaKaC.webinterface.rh.reviewingModif import RCPaperReviewManager,\
-    RCReferee
-from MaKaC.services.implementation.conference import ConferenceModifBase
-from MaKaC.services.implementation.base import DateTimeModificationBase
-from MaKaC.webinterface.rh.contribMod import RCContributionReferee
-from MaKaC.webinterface.rh.contribMod import RCContributionEditor
-from MaKaC.webinterface.rh.contribMod import RCContributionReviewer
-from MaKaC.webinterface.user import UserModificationBase, UserListModificationBase
-from MaKaC.services.implementation.base import ListModificationBase
-from MaKaC import user
-from MaKaC.services.interface.rpc.common import ServiceError, NoReportError
-from MaKaC.i18n import _
-from MaKaC.errors import MaKaCError
-||||||| merged common ancestors
-# -*- coding: utf-8 -*-
-##
-##
-## This file is part of Indico.
-## Copyright (C) 2002 - 2014 European Organization for Nuclear Research (CERN).
-##
-## Indico is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 3 of the
-## License, or (at your option) any later version.
-##
-## Indico is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Indico;if not, see <http://www.gnu.org/licenses/>.
-from MaKaC.paperReviewing import ConferencePaperReview
-from MaKaC.services.implementation.base import ProtectedModificationService, ParameterManager
-from MaKaC.services.implementation.contribution import ContributionBase
-from MaKaC.services.implementation.base import TextModificationBase
-from MaKaC.services.implementation.base import HTMLModificationBase
-from MaKaC.webinterface.rh.reviewingModif import RCPaperReviewManager,\
-    RCReferee
-from MaKaC.services.implementation.conference import ConferenceModifBase
-from MaKaC.services.implementation.base import DateTimeModificationBase
-from MaKaC.webinterface.rh.contribMod import RCContributionReferee
-from MaKaC.webinterface.rh.contribMod import RCContributionEditor
-from MaKaC.webinterface.rh.contribMod import RCContributionReviewer
-from MaKaC.webinterface.user import UserModificationBase, UserListModificationBase
-from MaKaC.services.implementation.base import ListModificationBase
-from MaKaC import user
-from MaKaC.services.interface.rpc.common import ServiceError, NoReportError
-from MaKaC.i18n import _
-from MaKaC.errors import MaKaCError
-=======
-# -*- coding: utf-8 -*-
-##
-##
-## This file is part of Indico.
-## Copyright (C) 2002 - 2014 European Organization for Nuclear Research (CERN).
-##
-## Indico is free software; you can redistribute it and/or
-## modify it under the terms of the GNU General Public License as
-## published by the Free Software Foundation; either version 3 of the
-## License, or (at your option) any later version.
-##
-## Indico is distributed in the hope that it will be useful, but
-## WITHOUT ANY WARRANTY; without even the implied warranty of
-## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-## General Public License for more details.
-##
-## You should have received a copy of the GNU General Public License
-## along with Indico;if not, see <http://www.gnu.org/licenses/>.
->>>>>>> keep the input after an HTML security error in PR
+
 import datetime
 
 from MaKaC import user
 from MaKaC.common.fossilize import fossilize
-from MaKaC.common.mail import GenericMailer
-from MaKaC.contributionReviewing import ReviewManager
 from MaKaC.errors import MaKaCError
-from MaKaC.fossils.reviewing import IReviewingQuestionFossil
 from MaKaC.i18n import _
 from MaKaC.paperReviewing import ConferencePaperReview
 from MaKaC.services.implementation.base import (DateTimeModificationBase, HTMLModificationBase, ListModificationBase,
                                                 ParameterManager, ProtectedModificationService, TextModificationBase)
 from MaKaC.services.implementation.conference import ConferenceModifBase
 from MaKaC.services.implementation.contribution import ContributionBase
-from MaKaC.services.interface.rpc.common import (HTMLSecurityError, NoReportError, ServiceError)
-from MaKaC.webinterface.rh.contribMod import (RCContributionEditor, RCContributionReferee, RCContributionReviewer)
+from MaKaC.services.interface.rpc.common import HTMLSecurityError, NoReportError, ServiceError
+from MaKaC.webinterface.rh.contribMod import RCContributionEditor, RCContributionReferee, RCContributionReviewer
 from MaKaC.webinterface.rh.reviewingModif import RCPaperReviewManager, RCReferee
-from MaKaC.webinterface.user import (UserListModificationBase, UserModificationBase)
+from MaKaC.webinterface.user import UserListModificationBase, UserModificationBase
 
 """
 Asynchronous request handlers for conference and contribution reviewing related data

--- a/indico/MaKaC/services/implementation/reviewing.py
+++ b/indico/MaKaC/services/implementation/reviewing.py
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # This file is part of Indico.
 # Copyright (C) 2002 - 2015 European Organization for Nuclear Research (CERN).
 #
@@ -31,11 +32,81 @@ from MaKaC import user
 from MaKaC.services.interface.rpc.common import ServiceError, NoReportError
 from MaKaC.i18n import _
 from MaKaC.errors import MaKaCError
+||||||| merged common ancestors
+# -*- coding: utf-8 -*-
+##
+##
+## This file is part of Indico.
+## Copyright (C) 2002 - 2014 European Organization for Nuclear Research (CERN).
+##
+## Indico is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 3 of the
+## License, or (at your option) any later version.
+##
+## Indico is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Indico;if not, see <http://www.gnu.org/licenses/>.
+from MaKaC.paperReviewing import ConferencePaperReview
+from MaKaC.services.implementation.base import ProtectedModificationService, ParameterManager
+from MaKaC.services.implementation.contribution import ContributionBase
+from MaKaC.services.implementation.base import TextModificationBase
+from MaKaC.services.implementation.base import HTMLModificationBase
+from MaKaC.webinterface.rh.reviewingModif import RCPaperReviewManager,\
+    RCReferee
+from MaKaC.services.implementation.conference import ConferenceModifBase
+from MaKaC.services.implementation.base import DateTimeModificationBase
+from MaKaC.webinterface.rh.contribMod import RCContributionReferee
+from MaKaC.webinterface.rh.contribMod import RCContributionEditor
+from MaKaC.webinterface.rh.contribMod import RCContributionReviewer
+from MaKaC.webinterface.user import UserModificationBase, UserListModificationBase
+from MaKaC.services.implementation.base import ListModificationBase
+from MaKaC import user
+from MaKaC.services.interface.rpc.common import ServiceError, NoReportError
+from MaKaC.i18n import _
+from MaKaC.errors import MaKaCError
+=======
+# -*- coding: utf-8 -*-
+##
+##
+## This file is part of Indico.
+## Copyright (C) 2002 - 2014 European Organization for Nuclear Research (CERN).
+##
+## Indico is free software; you can redistribute it and/or
+## modify it under the terms of the GNU General Public License as
+## published by the Free Software Foundation; either version 3 of the
+## License, or (at your option) any later version.
+##
+## Indico is distributed in the hope that it will be useful, but
+## WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+## General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with Indico;if not, see <http://www.gnu.org/licenses/>.
+>>>>>>> keep the input after an HTML security error in PR
 import datetime
+
+from MaKaC import user
+from MaKaC.common.fossilize import fossilize
 from MaKaC.common.mail import GenericMailer
 from MaKaC.contributionReviewing import ReviewManager
-from MaKaC.common.fossilize import fossilize
+from MaKaC.errors import MaKaCError
 from MaKaC.fossils.reviewing import IReviewingQuestionFossil
+from MaKaC.i18n import _
+from MaKaC.paperReviewing import ConferencePaperReview
+from MaKaC.services.implementation.base import (DateTimeModificationBase, HTMLModificationBase, ListModificationBase,
+                                                ParameterManager, ProtectedModificationService, TextModificationBase)
+from MaKaC.services.implementation.conference import ConferenceModifBase
+from MaKaC.services.implementation.contribution import ContributionBase
+from MaKaC.services.interface.rpc.common import (HTMLSecurityError, NoReportError, ServiceError)
+from MaKaC.webinterface.rh.contribMod import (RCContributionEditor, RCContributionReferee, RCContributionReviewer)
+from MaKaC.webinterface.rh.reviewingModif import RCPaperReviewManager, RCReferee
+from MaKaC.webinterface.user import (UserListModificationBase, UserModificationBase)
 
 """
 Asynchronous request handlers for conference and contribution reviewing related data
@@ -832,6 +903,12 @@ class ContributionReviewingCommentsModification(ContributionReviewingHTMLModific
 
     def _handleGet(self):
         return self.getJudgementObject().getComments()
+
+    def process(self):
+        try:
+            return super(ContributionReviewingCommentsModification, self).process()
+        except HTMLSecurityError as e:
+            raise NoReportError(e.message)
 
 class ContributionReviewingCriteriaModification(ContributionReviewingTextModificationBase):
 

--- a/indico/MaKaC/services/implementation/user.py
+++ b/indico/MaKaC/services/implementation/user.py
@@ -22,7 +22,11 @@ from MaKaC.services.implementation.base import LoggedOnlyService, AdminService
 from MaKaC.services.implementation.base import ServiceBase
 
 import MaKaC.user as user
-from MaKaC.services.interface.rpc.common import ServiceError, ServiceAccessError, NoReportError, Warning, ResultWithWarning
+from MaKaC.services.interface.rpc.common import (HTMLSecurityError,
+                                                 NoReportError,
+                                                 ResultWithWarning,
+                                                 ServiceAccessError,
+                                                 ServiceError, Warning)
 
 from MaKaC.common import info
 from MaKaC.fossils.user import IAvatarAllDetailsFossil, IAvatarFossil
@@ -365,6 +369,12 @@ class UserSetPersonalData(UserPersonalDataBase):
                 raise ServiceAccessError(_("The email address is not valid. Please, review it."))
         else:
             self._value = self._pm.extract("value", pType=str, allowEmpty=True)
+
+    def process(self):
+        try:
+            return UserPersonalDataBase.process(self)
+        except HTMLSecurityError as e:
+            raise NoReportError(e.message)
 
     def _buildEmailList(self):
         emailList = []

--- a/indico/MaKaC/webinterface/tpls/UserDetails.tpl
+++ b/indico/MaKaC/webinterface/tpls/UserDetails.tpl
@@ -176,14 +176,24 @@ var requestTitle = function() {
 };
 
 var beforeEdit = function(field, widget) {
-    if(!canSynchronize) {
-        return;
-    }
-    new ConfirmPopup($T("Change field"), $T('This field is currently synchronized with the {0} database. If you change it, synchronization will be disabled.').format(authenticatorName), function(confirmed){
-        if(confirmed || _.contains(unlockedFields, field)){
-            widget.modeChooser.set("edit");
+    if(!canSynchronize) { return; }
+
+    syncPopup = new ConfirmPopup(
+        $T("Change field"),
+        $T('This field is currently synchronized with the {0} database. If you change it, synchronization will be disabled.')
+            .format(authenticatorName),
+        function(confirmed){
+            if(confirmed || _.contains(unlockedFields, field)){
+                widget.modeChooser.set("edit");
         }
-    }).open();
+    });
+
+    if (!_.contains(unlockedFields, field)) {
+        syncPopup.open();
+    } else {
+        widget.modeChooser.set("edit");
+    }
+
     return false;
 }
 

--- a/indico/htdocs/js/indico/Core/Widgets/Inline.js
+++ b/indico/htdocs/js/indico/Core/Widgets/Inline.js
@@ -1600,6 +1600,10 @@ type("TextAreaEditWidget", ["InlineEditWidget"],
                 }
             },
 
+            _handleBackToEditMode: function() {
+                this.textarea.set(this._savedValue);
+            },
+
             _handleSuccess: function() {
                 if (this.successHandler) {
                     return this.successHandler();


### PR DESCRIPTION
 - keep the input area active with its content when encountering an HTML
   security error in the paper review assessment comments
 - fix #1674