### PR TITLE
Prevent goto next page when pressing enter in RB

### DIFF
--- a/indico/htdocs/js/indico/RoomBooking/roomselector.js
+++ b/indico/htdocs/js/indico/RoomBooking/roomselector.js
@@ -301,6 +301,11 @@
                         }
                     })))
                 .append(filter.capacity)
+                .on('keydown', 'input', function(e){
+                    if (e.which == K.ENTER) {
+                        e.preventDefault();
+                    }
+                })
                 .appendTo(header);
             filter.capacity.realtimefilter({
                 clearable: false,


### PR DESCRIPTION
- prevent the default behavior of submitting the form when pressing enter in
  the room booking capacity filter which leads to going to the next page
- the capcity filter now behaves like the rooms filter and auto-updates live
- fix #1687
