### PR TITLE
Fix adjust event end time on contrib shifting

### DIFF
--- a/indico/MaKaC/conference.py
+++ b/indico/MaKaC/conference.py
@@ -2807,7 +2807,7 @@ class Conference(CommonObjectBase, Locatable):
             #else:
             #    entries = self.getSchedule().getEntriesOnDay(sDate.astimezone(timezone(self.getTimezone())))[:]
             entries = self.getSchedule().getEntries()[:]
-            self.getSchedule().moveEntriesBelow(diff, entries)
+            self.getSchedule().moveEntriesBelow(diff, entries, check=check)
         #datetime object is non-mutable so we must "force" the modification
         #   otherwise ZODB won't be able to notice the change
         self.notifyModification()

--- a/indico/MaKaC/schedule.py
+++ b/indico/MaKaC/schedule.py
@@ -491,7 +491,7 @@ class TimeSchedule(Schedule, Persistent):
                 return d
         return None
 
-    def moveEntriesBelow(self, diff, entriesList):
+    def moveEntriesBelow(self, diff, entriesList, check=2):
         """diff: the difference we have to increase/decrease each entry of the list.
            entriesList: list of entries for applying the diff"""
 
@@ -507,7 +507,7 @@ class TimeSchedule(Schedule, Persistent):
                         if session.getSchedule().getEntries()[0].getOwner() == entry.getOwner():
                             session.setStartDate(session.getStartDate() + diff, check=0, moveEntries=0)
                         sessionsAlreadyModif.append(session)
-                entry.setStartDate(entry.getStartDate()+diff, check=0, moveEntries=1)
+                entry.setStartDate(entry.getStartDate() + diff, check=check, moveEntries=1)
 
 
 class SchEntry(Persistent, Fossilizable):


### PR DESCRIPTION
This patch avoids the regression introduced by commit 68863de