### PR TITLE
Refactored the behavior of enter in realtimefilter

### DIFF
--- a/indico/htdocs/js/indico/RoomBooking/roomselector.js
+++ b/indico/htdocs/js/indico/RoomBooking/roomselector.js
@@ -202,11 +202,6 @@
                 .append(filter.search)
                 .on('click', 'a', function(e) {
                     e.stopPropagation();
-                })
-                .on('keydown', 'input', function(e){
-                    if (e.which == K.ENTER) {
-                        e.preventDefault();
-                    }
                 });
             filter.search.realtimefilter({
                 callback: function() {
@@ -301,11 +296,6 @@
                         }
                     })))
                 .append(filter.capacity)
-                .on('keydown', 'input', function(e){
-                    if (e.which == K.ENTER) {
-                        e.preventDefault();
-                    }
-                })
                 .appendTo(header);
             filter.capacity.realtimefilter({
                 clearable: false,

--- a/indico/htdocs/js/indico/jquery/realtimefilter.js
+++ b/indico/htdocs/js/indico/jquery/realtimefilter.js
@@ -22,6 +22,7 @@
             callback: function() {},
             validation: function(e) { return true; },
             clearable: true,
+            disableenter: true,
             emptyvalue: "",
             invalidclass: "invalid",
             wait: 250
@@ -59,6 +60,14 @@
                     $(this).val(opt.emptyvalue);
                 }
             });
+
+            if (opt.disableenter) {
+                element.on('keydown', function(e) {
+                    if (e.which == K.ENTER) {
+                        e.preventDefault();
+                    }
+                });
+            }
         },
 
         setValue: function(value) {


### PR DESCRIPTION
 - disable the behavior of the 'enter' key in realtimefilter by default
 - provide an option to enable the behavior if needed
 - remove the logic to disable the behavior of the enter key from the roomselector