### PR TITLE
Fix the rendering of the advanced search box

### DIFF
--- a/indico/ext/search/tpls/SearchBoxBase.tpl
+++ b/indico/ext/search/tpls/SearchBoxBase.tpl
@@ -58,7 +58,7 @@ function expandMenu(domElem)
 
     if(!exists(elem.dom.extraShown))
     {
-        $('#extraOptions').width($('#searchControls').width()).slideDown('fast');
+        $('#extraOptions').css('display', 'table').slideDown('fast');
         $('#extraOptions').position({
             of: $('#searchControls'),
             my: 'right top',

--- a/indico/htdocs/css/Default.css
+++ b/indico/htdocs/css/Default.css
@@ -2022,6 +2022,8 @@ div#UISearchBox #extraOptions
     border: 1px solid #888888;
     border-radius: 6px;
     min-width: 250px;
+    white-space: nowrap;
+    width: 100%;
     display: none;
     position: absolute;
     top: 23px;


### PR DESCRIPTION
 - fix the rendering of the advanced options box (search) to make sure the
   labels stay on one line (by increasing the width of the box)
 - fix #1702