### PR TITLE
1586 fix booking days limit—1722 display nonbookable periods

### DIFF
--- a/indico/MaKaC/webinterface/tpls/RoomBookingNewBookingConflictsWidget.tpl
+++ b/indico/MaKaC/webinterface/tpls/RoomBookingNewBookingConflictsWidget.tpl
@@ -12,7 +12,7 @@
         <div class="message-text">
             ${ _('Some of your days will not be booked as they overlap with other existing bookings.') }
             <ul>
-                % for occurrence, overlap in conflicts.iteritems():
+                % for occurrence, overlap in sorted(conflicts.iteritems(), key=lambda k: k[0].start_dt):
                 <li>
                     ${ format_date(occurrence.start_dt, format='full') }:
                     <ul>
@@ -61,7 +61,7 @@
                 </div>
             % endif
             <ul>
-                % for occurrence, overlap in pre_conflicts.iteritems():
+                % for occurrence, overlap in sorted(pre_conflicts.iteritems(), key=lambda k: k[0].start_dt):
                 <li>
                     ${ format_date(occurrence.start_dt, format='full') }:
                     <ul>

--- a/indico/htdocs/js/indico/RoomBooking/RoomBookingCalendar.js
+++ b/indico/htdocs/js/indico/RoomBooking/RoomBookingCalendar.js
@@ -23,7 +23,7 @@ var START_H = 6;
 // Width of the calendar
 var DAY_WIDTH_PX = 35 * 12 * 2;
 // Room types, used for selecting proper CSS classes
-var barClasses = ['barBlocked', 'barPreB', 'barPreConc', 'barUnaval', 'barCand', 'barPreC', 'barConf', 'barDisable'];
+var barClasses = ['barBlocked', 'barPreB', 'barPreConc', 'barUnaval', 'barCand', 'barPreC', 'barConf', 'barOutOfRange'];
 
 var calendarLegend = Html.div({style:{clear: 'both', padding: pixels(5), marginBottom: pixels(10), border: "1px solid #eaeaea", borderRadius: pixels(2)}},
         Html.div( {className:'barLegend', style:{color: 'black'}}, $T('Legend:')),
@@ -34,7 +34,7 @@ var calendarLegend = Html.div({style:{clear: 'both', padding: pixels(5), marginB
         Html.div( {className:'barLegend barPreC', style:{color: 'white'}}, $T('Conflict with PRE-Booking')),
         Html.div( {className:'barLegend barPreConc', style:{color: 'white'}}, $T('Concurrent PRE-Bookings')),
         Html.div( {className:'barLegend barBlocked'}, $T('Blocked')),
-        Html.div( {className:'barLegend barDisable'}, $T('Booking not allowed')));
+        Html.div( {className:'barLegend barOutOfRange'}, $T('Too early to book')));
 
 
 function compare_alphanum(elem1, elem2) {
@@ -261,7 +261,7 @@ type ("RoomBookingCalendarDrawer", [],
                     resvInfo = $T("Room blocked by") + ":<br/>" +
                                   bar.blocking.creator + "<br/>" +
                                   $T('Reason') + ': ' + bar.blocking.reason;
-                } else if (bar.type == 'barDisable') {
+                } else if (bar.type == 'barOutOfRange') {
                     resvInfo = $T('Booking not allowed for this period.<br>This room can only be booked {0} days in advance.').format(bar.room.max_advance_days)
                 } else {
                     resvInfo = bar.startDT.print("%H:%M") + "  -  " +
@@ -332,11 +332,11 @@ type ("RoomBookingCalendarDrawer", [],
                     return $(this).find('.barBlocked').length;
                 }).get());
 
-                var disabled = _.any($('.barDefaultHover').closest('.dayCalendarDiv').map(function() {
-                    return $(this).find('.barDisable').length;
+                var outOfRange = _.any($('.barDefaultHover').closest('.dayCalendarDiv').map(function() {
+                    return $(this).find('.barOutOfRange').length;
                 }).get());
 
-                if (disabled) {
+                if (outOfRange) {
                     this._setDialog("search-again");
                     $('#booking-dialog-content').html($T("This room cannot booked more than {0} days in advance.").format(bar.room.max_advance_days));
                     $('#booking-dialog').dialog("open");

--- a/indico/htdocs/sass/modules/roombooking/_bars.scss
+++ b/indico/htdocs/sass/modules/roombooking/_bars.scss
@@ -55,67 +55,50 @@
 .barDefaultHover {
     border-color: #06F !important;
     opacity:0.7;
-    filter:alpha(opacity=70);
 }
 
 .barCand {  /* Bar representing candidate reservation */
     background-color: #5BB75B;
-    border-color: #51A351 #51A351 #387038;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barBlocked {
     background-color: $light-black;
-    border-color: #51A351 #51A351 #387038;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barUnaval { /* Bar representing unavailable period */
     background-color: #FAA732;
-    border-color: #F89406 #F89406 #AD6704;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barConf { /* Bar representing conflict */
     background-color: #DA4F49;
-    border-color: #BD362F #BD362F #802420;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barPreB { /* Bar representing PRE-booking */
     background-color: #F5E916;
-    border-color: #bcbc00;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barPreC { /* Bar representing conflict with PRE-booking */
     background-color: #0074CC;
-    border-color: #05C #05C #003580;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
 .barPreConc { /* Bar representing concurrent PRE-bookings */
     background-color: #49AFCD;
-    border-color: #2F96B4 #2F96B4 #1F6377;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
-.barDisable { /* Bar representing a period where booking is disabled */
+.barOutOfRange { /* Bar representing a period outside the booking range */
     background-color: #708090;
-    border-color: #4E5964 #4E5964 #434C56;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
-
-    &:hover {
-        border-color: #4E5964 #4E5964 #434C56 !important;
-        border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25) !important;
-        opacity: 1;
-        filter:alpha(opacity=70);
-    }
 }
 
 .barProt.barCand {
     background-image: none;
     background-color: #DA4F49;
-    border-color: #BD362F #BD362F #802420;
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }

--- a/indico/htdocs/sass/modules/roombooking/_bars.scss
+++ b/indico/htdocs/sass/modules/roombooking/_bars.scss
@@ -100,6 +100,19 @@
     border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
 }
 
+.barDisable { /* Bar representing a period where booking is disabled */
+    background-color: #708090;
+    border-color: #4E5964 #4E5964 #434C56;
+    border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+
+    &:hover {
+        border-color: #4E5964 #4E5964 #434C56 !important;
+        border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25) !important;
+        opacity: 1;
+        filter:alpha(opacity=70);
+    }
+}
+
 .barProt.barCand {
     background-image: none;
     background-color: #DA4F49;

--- a/indico/modules/rb/controllers/user/reservations.py
+++ b/indico/modules/rb/controllers/user/reservations.py
@@ -377,6 +377,10 @@ class RHRoomBookingNewBookingSimple(RHRoomBookingNewBookingBase):
                 start_date = datetime.strptime(request.args['start_date'], '%Y-%m-%d').date()
             except ValueError:
                 pass
+            else:
+                if not self._room.check_advance_days(start_date, user=session.user, quiet=True):
+                    start_date = date.today()
+                    flash(_(u"This room cannot be booked at the desired date, using today's date instead."), 'warning')
 
         self.past_date = start_date is not None and start_date < date.today()
         if start_date is None or start_date <= date.today():

--- a/indico/modules/rb/models/room_nonbookable_periods.py
+++ b/indico/modules/rb/models/room_nonbookable_periods.py
@@ -14,6 +14,8 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
+from sqlalchemy.ext.hybrid import hybrid_method
+
 from indico.core.db import db
 from indico.util.string import return_ascii
 
@@ -47,5 +49,6 @@ class NonBookablePeriod(db.Model):
             self.end_dt
         )
 
+    @hybrid_method
     def overlaps(self, st, et):
-        return self.start_dt < et and self.end_dt > st
+        return (self.start_dt < et) & (self.end_dt > st)

--- a/indico/modules/rb/models/rooms.py
+++ b/indico/modules/rb/models/rooms.py
@@ -68,7 +68,8 @@ class Room(versioned_cache(_cache, 'id'), db.Model, Serializer):
     ]
 
     __calendar_public__ = [
-        'id', 'building', 'name', 'floor', 'number', 'kind', 'booking_url', 'details_url', 'location_name'
+        'id', 'building', 'name', 'floor', 'number', 'kind', 'booking_url', 'details_url', 'location_name',
+        'max_advance_days'
     ]
 
     __api_public__ = (

--- a/indico/modules/rb/services/rooms.py
+++ b/indico/modules/rb/services/rooms.py
@@ -99,10 +99,13 @@ class BookingPermission(LoggedOnlyService):
         blocking_id = self._params.get('blocking_id')
         self._room = Room.get(self._params['room_id'])
         self._blocking = Blocking.get(blocking_id) if blocking_id else None
-        self._start_dt = datetime.strptime(self._params.get('start_dt'), '%H:%M %Y-%m-%d')
-        self._end_dt = datetime.strptime(self._params.get('end_dt'), '%H:%M %Y-%m-%d')
-        self._nonbookable = bool(NonBookablePeriod.find_first(NonBookablePeriod.room_id == self._room.id,
-                                                              NonBookablePeriod.overlaps(self._start_dt, self._end_dt)))
+        if 'start_dt' in self._params and 'end_dt' in self._params:
+            start_dt = datetime.strptime(self._params['start_dt'], '%H:%M %Y-%m-%d')
+            end_dt = datetime.strptime(self._params['end_dt'], '%H:%M %Y-%m-%d')
+            self._nonbookable = bool(NonBookablePeriod.find_first(NonBookablePeriod.room_id == self._room.id,
+                                                                  NonBookablePeriod.overlaps(start_dt, end_dt)))
+        else:
+            self._nonbookable = False
 
     def _getAnswer(self):
         user = session.user

--- a/indico/modules/rb/services/rooms.py
+++ b/indico/modules/rb/services/rooms.py
@@ -14,12 +14,15 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
+from datetime import datetime
+
 from flask import session
 from sqlalchemy.orm.exc import NoResultFound
 
 from indico.core.config import Config
 from indico.modules.rb.models.blockings import Blocking
 from indico.modules.rb.models.locations import Location
+from indico.modules.rb.models.room_nonbookable_periods import NonBookablePeriod
 from indico.modules.rb.models.reservations import RepeatFrequency
 from indico.modules.rb.models.rooms import Room
 from indico.util.date_time import get_datetime_from_request
@@ -96,11 +99,16 @@ class BookingPermission(LoggedOnlyService):
         blocking_id = self._params.get('blocking_id')
         self._room = Room.get(self._params['room_id'])
         self._blocking = Blocking.get(blocking_id) if blocking_id else None
+        self._start_dt = datetime.strptime(self._params.get('start_dt'), '%H:%M %Y-%m-%d')
+        self._end_dt = datetime.strptime(self._params.get('end_dt'), '%H:%M %Y-%m-%d')
+        self._nonbookable = bool(NonBookablePeriod.find_first(NonBookablePeriod.room_id == self._room.id,
+                                                              NonBookablePeriod.overlaps(self._start_dt, self._end_dt)))
 
     def _getAnswer(self):
         user = session.user
         return {
-            'blocked': not self._blocking.can_be_overridden(user, self._room) if self._blocking else False,
+            'blocked': not self._blocking.can_be_overridden(user, self._room) if self._blocking else self._nonbookable,
+            'blocking_type': 'blocking' if self._blocking else 'nonbookable' if self._nonbookable else None,
             'is_reservable': self._room.is_reservable,
             'can_book': self._room.can_be_booked(user) or self._room.can_be_prebooked(user),
             'group': self._room.get_attribute_value('allowed-booking-group')

--- a/indico/modules/rb/views/calendar.py
+++ b/indico/modules/rb/views/calendar.py
@@ -24,9 +24,10 @@ from sqlalchemy.orm import joinedload
 from werkzeug.datastructures import MultiDict
 
 from indico.modules.rb.models.blocked_rooms import BlockedRoom
+from indico.modules.rb.models.room_nonbookable_periods import NonBookablePeriod
 from indico.modules.rb.models.reservation_occurrences import ReservationOccurrence
 from indico.modules.rb.models.rooms import Room
-from indico.util.date_time import iterdays, overlaps
+from indico.util.date_time import iterdays, overlaps, format_date
 from indico.util.i18n import _
 from indico.util.serializer import Serializer
 from indico.util.string import natural_sort_key
@@ -66,11 +67,18 @@ class RoomBookingCalendarWidget(object):
             user_strategy = joinedload('blocking').defaultload('created_by_user')
             user_strategy.noload('*')
             user_strategy.load_only('first_name', 'last_name')
-            self.blocked_rooms = (BlockedRoom.find_with_filters({'room_ids': [r.id for r in self.rooms],
-                                                                 'state': BlockedRoom.State.accepted,
-                                                                 'start_date': self.start_dt.date(),
-                                                                 'end_date': self.end_dt.date()})
-                                  .options(user_strategy))
+            room_ids = [r.id for r in self.rooms]
+            filters = {
+                'room_ids': room_ids,
+                'state': BlockedRoom.State.accepted,
+                'start_date': self.start_dt.date(),
+                'end_date': self.end_dt.date()
+            }
+            self.blocked_rooms = BlockedRoom.find_with_filters(filters).options(user_strategy)
+            self.nonbookable_periods = NonBookablePeriod.find(
+                NonBookablePeriod.room_id.in_(room_ids),
+                NonBookablePeriod.overlaps(self.start_dt, self.end_dt)
+            ).all()
         else:
             self.blocked_rooms = []
 
@@ -236,6 +244,11 @@ class RoomBookingCalendarWidget(object):
                              for day in self.iter_days()
                              if blocking.start_date <= day <= blocking.end_date)
 
+        self.bars.extend(Bar.from_nonbookable_period(nbp, day)
+                         for nbp in self.nonbookable_periods
+                         for day in self.iter_days()
+                         if nbp.start_dt.date() <= day <= nbp.end_dt.date())
+
     def _produce_out_of_range_bars(self):
         for room in self.rooms:
             self.bars.extend(
@@ -264,14 +277,16 @@ class Bar(Serializer):
         OUT_OF_RANGE: 'out_of_range'        # A period out of the booking range
     }
 
-    def __init__(self, start, end, kind=None, reservation=None, overlapping=False, blocking=None, room_id=None):
+    def __init__(self, start, end, kind=None, reservation=None, overlapping=False, blocking=None, room_id=None,
+                 nb_period=None):
         self.start = start
         self.end = end
         self.reservation = reservation
         self.reservation_start = None
         self.reservation_end = None
         self.room_id = room_id
-        self.blocking = None
+        self.blocking = blocking
+        self.nb_period = nb_period
 
         if reservation is not None:
             self.reservation_start = reservation.start_dt
@@ -282,10 +297,6 @@ class Bar(Serializer):
                     kind = Bar.UNAVAILABLE if reservation.is_accepted else Bar.PREBOOKED
                 else:
                     kind = Bar.CONFLICT if reservation.is_accepted else Bar.PRECONFLICT
-
-        if blocking is not None:
-            self.blocking = blocking
-
         self.kind = kind
 
     def __cmp__(self, other):
@@ -316,6 +327,11 @@ class Bar(Serializer):
         return cls(datetime.combine(day, time()), datetime.combine(day, time(23, 59)), Bar.BLOCKED,
                    blocking=blocked_room.blocking, room_id=blocked_room.room_id)
 
+    @classmethod
+    def from_nonbookable_period(cls, nb_period, day):
+        return cls(datetime.combine(day, time()), datetime.combine(day, time(23, 59)), Bar.BLOCKED,
+                   nb_period=nb_period, room_id=nb_period.room_id)
+
     @property
     def date(self):
         return self.start.date()
@@ -335,12 +351,25 @@ class Bar(Serializer):
     def blocking_data(self):
         if not self.blocking:
             return None
-        return {
-            'id': self.blocking.id,
-            'creator': self.blocking.created_by_user.full_name,
-            'reason': self.blocking.reason,
-            'blocking_url': url_for('rooms.blocking_details', blocking_id=self.blocking.id)
-        }
+        elif self.blocking:
+            return {
+                'id': self.blocking.id,
+                'creator': self.blocking.created_by_user.full_name,
+                'reason': self.blocking.reason,
+                'blocking_url': url_for('rooms.blocking_details', blocking_id=self.blocking.id),
+                'type': 'blocking'
+            }
+        elif self.nb_period:
+            print self.nb_period.__dict__
+            return {
+                'id': None,
+                'creator': None,
+                'reason': 'Unavailable from {0} until {1}.'.format(format_date(self.nb_period.start_dt),
+                                                                   format_date(self.nb_period.end_dt)),
+                'blocking_url': None,
+                'type': 'nonbookable'
+            }
+        return None
 
     @property
     def importance(self):


### PR DESCRIPTION
- check start date in query string of single page booking
- add new bar to the calendar to show days where booking is not possible.
- limit choice of days in 3-step booking 
- fixes #1586  
- display and check nonbookable periods in the view
- fixes #1722 
- sort days with (pre-)conflicts in the warning msg

> **Note:** This PR will close both the issue #1586 and the issue #1722.
> As a result, the PR #1609 for the issue #1586 has been closed preemptively.
