### PR TITLE
Hide `password` and `passwordBis` HTTP parameters from logfile

### DIFF
--- a/indico/MaKaC/webinterface/rh/base.py
+++ b/indico/MaKaC/webinterface/rh/base.py
@@ -155,8 +155,8 @@ class RequestHandlerBase(OldObservable):
         """Truncates params"""
         params = {}
         for key, value in self._reqParams.iteritems():
-            if key == 'password':
-                params[key] = '[password hidden, len=%d]' % len(value)
+            if key == 'password' or key == 'passwordBis':
+                params[key] = '[hidden, len=%d]' % len(value)
             elif isinstance(value, basestring):
                 params[key] = truncate(value, 1024)
             else:


### PR DESCRIPTION
Fixes #1740