### PR TITLE
Keep the ellipsis inside the box

### DIFF
--- a/indico/htdocs/css/Default.css
+++ b/indico/htdocs/css/Default.css
@@ -3941,6 +3941,8 @@ div.timetableBlockTitle {
     font-weight: bold;
     font-size: 11px;
     padding: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 div.timetableBlockPresenters {


### PR DESCRIPTION
 - adds style to hide overflowing text with an ellipsis
 - fixes #1536
 - this is more of a temporary fix to prevent overflowing text. The code to
   generate the timetable is chaotic and should be properly rewritten