### PR TITLE
Show hidden text in a badge's title

### DIFF
--- a/indico/htdocs/sass/partials/_badges.scss
+++ b/indico/htdocs/sass/partials/_badges.scss
@@ -156,6 +156,7 @@
             font-size: 1.1em;
             font-weight: bold;
             text-overflow: ellipsis;
+            overflow: visible;
         }
     }
 


### PR DESCRIPTION
 - fixes #1780
 - note: This was due to different fonts in each OS which take slightly
   different amounts of vertical and horizontal space and tend to overflow as
   a result.