### PR TITLE
Increment SQLAlchemy version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ Flask-SQLAlchemy==2.0
 Flask-Testing==0.4
 Flask-WTF==0.10.3
 Flask-BabelEx==0.9.2
-SQLAlchemy==0.9.8
+SQLAlchemy==0.9.9
 WTForms==2.0.2
 WTForms-Components==0.9.7
 psycopg2==2.5.2


### PR DESCRIPTION
Old version number for SQLAlchemy breaks build process, changing this to the required 0.9.9 from the old 0.9.8 resolves this issue.