### PR TITLE
Load celery tasks after plugins

### DIFF
--- a/indico/core/celery/__init__.py
+++ b/indico/core/celery/__init__.py
@@ -30,6 +30,11 @@ __all__ = ('celery',)
 celery = IndicoCelery('indico')
 
 
+@signals.app_created.connect
+def _load_default_modules(app, **kwargs):
+    celery.loader.import_default_modules()  # load all tasks
+
+
 @import_modules.connect
 def _import_modules(*args, **kwargs):
     signals.import_tasks.send()

--- a/indico/core/celery/controllers.py
+++ b/indico/core/celery/controllers.py
@@ -17,6 +17,7 @@
 from __future__ import unicode_literals
 
 from datetime import timedelta
+from operator import itemgetter
 
 from indico.core.celery.views import WPCelery
 from MaKaC.webinterface.rh.admins import RHAdminBase
@@ -49,5 +50,6 @@ class RHCeleryTasks(RHAdminBase):
                           'schedule': entry['schedule'],
                           'custom_schedule': custom_schedule,
                           'disabled': disabled})
+        tasks.sort(key=itemgetter('disabled', 'name'))
 
         return WPCelery.render_template('celery_tasks.html', flower_url=flower_url, tasks=tasks, timedelta=timedelta)

--- a/indico/core/celery/core.py
+++ b/indico/core/celery/core.py
@@ -88,7 +88,6 @@ class IndicoCelery(Celery):
         self.conf.update(cfg.getCeleryConfig())
         assert self.flask_app is None or self.flask_app is app
         self.flask_app = app
-        self.loader.import_default_modules()  # load all tasks
 
     def periodic_task(self, *args, **kwargs):
         """Decorator to register a periodic task.


### PR DESCRIPTION
Celery tasks should be loaded after plugins in order to make plugins
tasks available first.

> Not sure if delaying tasks loading until after the plugins are loaded might have any negative side effects?