### PR TITLE
Bug fix about latex_escape

### DIFF
--- a/indico/MaKaC/webinterface/tpls/latex/single_doc.tpl
+++ b/indico/MaKaC/webinterface/tpls/latex/single_doc.tpl
@@ -25,7 +25,7 @@
 
     % if logo_img:
         \begin{figure}[h!]
-            \includegraphics[max width=0.85\linewidth, min width=0.5\linewidth, max height=10em]{${logo_img | latex_escape}}
+            \includegraphics[max width=0.85\linewidth, min width=0.5\linewidth, max height=10em]{${logo_img}}
             \centering
         \end{figure}
     % endif


### PR DESCRIPTION
  For latex it's not recommended (and for some tex-distrib it's simply
not working) to escape a "_" inside a file name.

  This fix just drop the latex_escape inside the filename