### PR TITLE
Fix html/locale issues in rb emails

### DIFF
--- a/indico/modules/rb/templates/emails/blockings/awaiting_confirmation_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/blockings/awaiting_confirmation_email_to_manager.txt
@@ -13,7 +13,7 @@ Rooms:
     {% endfor %}
 {%- endif %}
 Reason: {{ blocking.reason }}
-Dates: {{ blocking.start_date | format_date }} - {{ blocking.end_date | format_date }}
+Dates: {{ blocking.start_date | format_date(locale='en_GB') }} - {{ blocking.end_date | format_date(locale='en_GB') }}
 
 You can approve or reject this blocking request here:
 {{ url_for('rooms.blocking_my_rooms', state='pending', _external=true) }}

--- a/indico/modules/rb/templates/emails/reservations/creation_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/creation_email_to_user.txt
@@ -5,9 +5,9 @@
 The conference room {{ reservation.room.full_name }}
 has been {% block prebooked_prefix %}{% endblock %}booked for {{ reservation.booked_for_name }}
 {% if reservation.repeat_frequency == RepeatFrequency.NEVER -%}
-    on {{ reservation.start_dt | format_date }} from {{ reservation.start_dt | format_time }} to {{ reservation.end_dt | format_time }}.
+    on {{ reservation.start_dt | format_date(locale='en_GB') }} from {{ reservation.start_dt | format_time(locale='en_GB') }} to {{ reservation.end_dt | format_time(locale='en_GB') }}.
 {%- else -%}
-    {{ RepeatMapping.get_short_name(reservation.repeat_frequency, reservation.repeat_interval) }} from {{ reservation.start_dt | format_date }} to {{ reservation.end_dt | format_date }} between {{ reservation.start_dt | format_time }} and {{ reservation.end_dt | format_time }}.
+    {{ RepeatMapping.get_short_name(reservation.repeat_frequency, reservation.repeat_interval) }} from {{ reservation.start_dt | format_date(locale='en_GB') }} to {{ reservation.end_dt | format_date(locale='en_GB') }} between {{ reservation.start_dt | format_time(locale='en_GB') }} and {{ reservation.end_dt | format_time(locale='en_GB') }}.
 {%- endif %}
 Reason: {{ reservation.booking_reason }}
 {%- block confirmed_booking -%}

--- a/indico/modules/rb/templates/emails/reservations/occurrence_cancellation_email_to_assistance.txt
+++ b/indico/modules/rb/templates/emails/reservations/occurrence_cancellation_email_to_assistance.txt
@@ -1,5 +1,5 @@
 {% extends 'rb/emails/reservations/base_email_to_assistance.txt' %}
 
 {% block body -%}
-{{ session.user.full_name }} has cancelled the occurrence on {{ occurrence.start_dt | format_date }} of the following meeting. Support is NOT needed anymore.
+{{ session.user.full_name }} has cancelled the occurrence on {{ occurrence.start_dt | format_date(locale='en_GB') }} of the following meeting. Support is NOT needed anymore.
 {%- endblock %}

--- a/indico/modules/rb/templates/emails/reservations/occurrence_cancellation_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/occurrence_cancellation_email_to_manager.txt
@@ -1,5 +1,5 @@
 {% extends 'rb/emails/reservations/base_email_to_manager.txt' %}
 
 {% block body -%}
-The date {{ reservation.start_dt | format_date }} from a booking that concerns one of your rooms has been CANCELLED by the user.
+The date {{ reservation.start_dt | format_date(locale='en_GB') }} from a booking that concerns one of your rooms has been CANCELLED by the user.
 {%- endblock %}

--- a/indico/modules/rb/templates/emails/reservations/occurrence_cancellation_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/occurrence_cancellation_email_to_user.txt
@@ -1,7 +1,7 @@
 {% extends 'rb/emails/reservations/base_email_to_user.txt' %}
 
 {% block body -%}
-You have CANCELLED an occurrence of your booking on {{ occurrence.start_dt | format_date }}.
+You have CANCELLED an occurrence of your booking on {{ occurrence.start_dt | format_date(locale='en_GB') }}.
 
 {% include 'rb/emails/reservations/reservation_info.txt' %}
 {%- endblock %}

--- a/indico/modules/rb/templates/emails/reservations/occurrence_cancellation_email_to_vc_support.txt
+++ b/indico/modules/rb/templates/emails/reservations/occurrence_cancellation_email_to_vc_support.txt
@@ -1,5 +1,5 @@
 {% extends 'rb/emails/reservations/base_email_to_vc_support.txt' %}
 
 {% block body -%}
-An occurrence of a booking has been CANCELLED for the {{ occurrence.start_dt | format_date }}.
+An occurrence of a booking has been CANCELLED for the {{ occurrence.start_dt | format_date(locale='en_GB') }}.
 {%- endblock %}

--- a/indico/modules/rb/templates/emails/reservations/occurrence_rejection_email_to_assistance.txt
+++ b/indico/modules/rb/templates/emails/reservations/occurrence_rejection_email_to_assistance.txt
@@ -1,7 +1,7 @@
 {% extends 'rb/emails/reservations/base_email_to_assistance.txt' %}
 
 {% block body -%}
-A booking has been REJECTED by the manager of the room '{{ reservation.room.full_name }}' for the {{ occurrence.start_dt | format_date }}.
+A booking has been REJECTED by the manager of the room '{{ reservation.room.full_name }}' for the {{ occurrence.start_dt | format_date(locale='en_GB') }}.
 Assistance for the meeting startup in NOT needed anymore.
 
 Rejection reason:

--- a/indico/modules/rb/templates/emails/reservations/occurrence_rejection_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/occurrence_rejection_email_to_manager.txt
@@ -1,7 +1,7 @@
 {% extends 'rb/emails/reservations/base_email_to_manager.txt' %}
 
 {% block body -%}
-A booking has been REJECTED by the manager of the room '{{ reservation.room.full_name }}' for the {{ occurrence.start_dt | format_date }}.
+A booking has been REJECTED by the manager of the room '{{ reservation.room.full_name }}' for the {{ occurrence.start_dt | format_date(locale='en_GB') }}.
 
 Rejection reason:
 {{ occurrence.rejection_reason }}

--- a/indico/modules/rb/templates/emails/reservations/occurrence_rejection_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/occurrence_rejection_email_to_user.txt
@@ -1,7 +1,7 @@
 {% extends 'rb/emails/reservations/base_email_to_user.txt' %}
 
 {% block body -%}
-Your booking has been REJECTED by the manager of the room for the {{ occurrence.start_dt | format_date }}.
+Your booking has been REJECTED by the manager of the room for the {{ occurrence.start_dt | format_date(locale='en_GB') }}.
 
 Rejection reason:
 {{ occurrence.rejection_reason }}

--- a/indico/modules/rb/templates/emails/reservations/reminders/reservation_digest.txt
+++ b/indico/modules/rb/templates/emails/reservations/reminders/reservation_digest.txt
@@ -5,12 +5,12 @@
 This is a reminder digest about a weekly booking under your name:
 
 Room: {{ reservation.room.name }}
-Time: {{ reservation.start_dt | format_time }} - {{ reservation.end_dt | format_time }}
+Time: {{ reservation.start_dt | format_time(locale='en_GB') }} - {{ reservation.end_dt | format_time(locale='en_GB') }}
 Reason: {{ reservation.booking_reason }}
 
 Days:
 {%- for occ in occurrences %}
-  * {{ occ.start_dt | format_date }}
+  * {{ occ.start_dt | format_date(locale='en_GB') }}
 {%- endfor %}
 
 If you don't need to use the room some of these days, please cancel them on this page:

--- a/indico/modules/rb/templates/emails/reservations/reminders/upcoming_occurrence.txt
+++ b/indico/modules/rb/templates/emails/reservations/reminders/upcoming_occurrence.txt
@@ -6,11 +6,11 @@ This is a reminder about a booking under your name:
 
 Room: {{ occurrence.reservation.room.name }}
 {% if occurrence.reservation.repeat_frequency == RepeatFrequency.DAY -%}
-Daily: {{ occurrence.reservation.start_dt | format_date }} - {{ occurrence.reservation.end_dt | format_date }}
+Daily: {{ occurrence.reservation.start_dt | format_date(locale='en_GB') }} - {{ occurrence.reservation.end_dt | format_date(locale='en_GB') }}
 {%- else -%}
-Date: {{ occurrence.start_dt | format_date }}
+Date: {{ occurrence.start_dt | format_date(locale='en_GB') }}
 {%- endif %}
-Time: {{ occurrence.start_dt | format_time }} - {{ occurrence.end_dt | format_time }}
+Time: {{ occurrence.start_dt | format_time(locale='en_GB') }} - {{ occurrence.end_dt | format_time(locale='en_GB') }}
 
 
 If you don't need to use the room, please cancel your occurrence on this page:

--- a/indico/modules/rb/templates/emails/reservations/reservation_info.txt
+++ b/indico/modules/rb/templates/emails/reservations/reservation_info.txt
@@ -1,5 +1,5 @@
 Room:  {{ reservation.room.full_name }}
 For:  {{ reservation.booked_for_name }}
 Reason: {{ reservation.booking_reason }}
-Dates: {{ reservation.start_dt | format_date }} - {{ reservation.end_dt | format_date }}
-Hours: {{ reservation.start_dt | format_time }} - {{ reservation.end_dt | format_time }}
+Dates: {{ reservation.start_dt | format_date(locale='en_GB') }} - {{ reservation.end_dt | format_date(locale='en_GB') }}
+Hours: {{ reservation.start_dt | format_time(locale='en_GB') }} - {{ reservation.end_dt | format_time(locale='en_GB') }}

--- a/indico/modules/rb/templates/emails/reservations/reservation_key_info.txt
+++ b/indico/modules/rb/templates/emails/reservations/reservation_key_info.txt
@@ -1,5 +1,5 @@
 {% if reservation.room.key_location %}
 
 How to find a key:
-{{ reservation.room.key_location }}
+{{ reservation.room.key_location | strip_tags }}
 {%- endif %}

--- a/indico/web/flask/app.py
+++ b/indico/web/flask/app.py
@@ -56,7 +56,7 @@ from indico.util.mimetypes import icon_from_mimetype
 from indico.util.signals import values_from_signal
 from indico.web.assets import core_env, register_all_css, register_all_js, include_js_assets, include_css_assets
 from indico.web.flask.templating import (EnsureUnicodeExtension, underline, markdown, dedent, natsort, instanceof,
-                                         equalto, call_template_hook, groupby)
+                                         equalto, call_template_hook, groupby, strip_tags)
 from indico.web.flask.util import (XAccelMiddleware, make_compat_blueprint, ListConverter, url_for, url_rule_to_js,
                                    IndicoConfigWrapper, discover_blueprints)
 from indico.web.flask.wrappers import IndicoFlask
@@ -190,6 +190,7 @@ def setup_jinja(app):
     app.add_template_filter(natsort)
     app.add_template_filter(groupby)
     app.add_template_filter(any)
+    app.add_template_filter(strip_tags)
     # Tests
     app.add_template_test(instanceof)  # only use this test if you really have to!
     app.add_template_test(equalto)

--- a/indico/web/flask/templating.py
+++ b/indico/web/flask/templating.py
@@ -19,6 +19,7 @@ import itertools
 import re
 from heapq import heappush
 
+import bleach
 from flask import current_app as app
 from jinja2 import environmentfilter
 from jinja2.ext import Extension
@@ -80,6 +81,11 @@ def groupby(environment, value, attribute, reverse=False):
     """Like Jinja's builtin `groupby` filter, but allows reversed order."""
     expr = make_attrgetter(environment, attribute)
     return sorted(map(_GroupTuple, itertools.groupby(sorted(value, key=expr), expr)), reverse=reverse)
+
+
+def strip_tags(value):
+    """Strips provided text of html tags"""
+    return bleach.clean(value, tags=[], strip=True).strip()
 
 
 def instanceof(value, type_):


### PR DESCRIPTION
* New filter for striping html tags.
* Set locale to en_GB for reservations-related emails