### PR TITLE
Force attachment download from the previewer

### DIFF
--- a/indico/core/storage.py
+++ b/indico/core/storage.py
@@ -171,7 +171,7 @@ class Storage(object):
         """
         raise NotImplementedError
 
-    def send_file(self, file_id, content_type, filename):  # pragma: no cover
+    def send_file(self, file_id, content_type, filename, inline=True):  # pragma: no cover
         """Sends the file to the client.
 
         This returns a flask response that will eventually result in
@@ -185,6 +185,10 @@ class Storage(object):
         :param filename: The file name to use when sending the file to
                          the client (may or may not be used depending
                          on the backend).
+        :param inline: Whether the file should be displayed inline or
+                       downloaded. Typically this will set the
+                       Content-Disposition header. Depending on the
+                       backend, this argument could be ignored.
         """
         raise NotImplementedError
 
@@ -252,9 +256,9 @@ class FileSystemStorage(Storage):
         except Exception as e:
             raise StorageError('Could not get size of "{}": {}'.format(file_id, e)), None, sys.exc_info()[2]
 
-    def send_file(self, file_id, content_type, filename):
+    def send_file(self, file_id, content_type, filename, inline=True):
         try:
-            return send_file(filename, self._resolve_path(file_id).encode('utf-8'), content_type)
+            return send_file(filename, self._resolve_path(file_id).encode('utf-8'), content_type, inline=inline)
         except Exception as e:
             raise StorageError('Could not send "{}": {}'.format(file_id, e)), None, sys.exc_info()[2]
 

--- a/indico/modules/attachments/controllers/display/base.py
+++ b/indico/modules/attachments/controllers/display/base.py
@@ -49,4 +49,4 @@ class DownloadAttachmentMixin(SpecificAttachmentMixin):
             if self.attachment.type == AttachmentType.link:
                 return redirect(self.attachment.link_url)
             else:
-                return self.attachment.file.send()
+                return self.attachment.file.send(inline=not from_preview)

--- a/indico/modules/attachments/models/attachments.py
+++ b/indico/modules/attachments/models/attachments.py
@@ -340,9 +340,9 @@ class AttachmentFile(db.Model):
         """Returns the stored file as a file-like object"""
         return self.storage.open(self.storage_file_id)
 
-    def send(self):
+    def send(self, inline=True):
         """Sends the file to the user"""
-        return self.storage.send_file(self.storage_file_id, self.content_type, self.filename)
+        return self.storage.send_file(self.storage_file_id, self.content_type, self.filename, inline=inline)
 
     @return_ascii
     def __repr__(self):


### PR DESCRIPTION
 - expose the inline kwarg (to set the Content-Disposition header to
   inline or download) to the attachment's send function
 - set Content-Disposition: download to force download when accessing
   attachments via the download button of the previewer
 - fix #1995