### PR TITLE
Disable Delete Event button when no access allowed

### DIFF
--- a/indico/modules/events/management/__init__.py
+++ b/indico/modules/events/management/__init__.py
@@ -29,7 +29,8 @@ from indico.web.menu import SideMenuItem, SideMenuSection
 
 @template_hook('event-manage-header')
 def _add_action_menu(event, **kwargs):
-    return render_template('events/management/action_menu.html', event=event, can_lock=can_lock(event, session.user))
+    return render_template('events/management/action_menu.html', event=event, can_lock=can_lock(event, session.user),
+                           can_manage=event.as_event.can_manage(session.user))
 
 
 @signals.menu.sections.connect_via('event-management-sidemenu')

--- a/indico/modules/events/management/templates/action_menu.html
+++ b/indico/modules/events/management/templates/action_menu.html
@@ -1,22 +1,25 @@
 <div class="toolbar right action-menu-toolbar">
-    <div class="group">
-        <span class="icon-wrench i-button label">{% trans %}Event actions{% endtrans %}</span>
-        <a class="i-button icon-copy" href="{{ url_for('event_mgmt.confModifTools-clone', event) }}"
-           title="{% trans %}Clone event{% endtrans %}"></a>
-        {% if event.isClosed() %}
-            <button class="i-button icon-lock-center disabled"
-                    title="{% trans %}This event is already locked.{% endtrans %}"></button>
-        {% elif not can_lock %}
-            <button class="i-button icon-lock-center disabled"
-                    title="{% trans %}Only the event creator and category managers may lock an event.{% endtrans %}"></button>
-        {% else %}
-            <button class="i-button icon-lock-center js-ajax-dialog-lock" data-href="{{ url_for('event_management.lock', event) }}"
-                    title="{% trans %}Lock event{% endtrans %}" {{ 'disabled' if event.isClosed() }}></button>
-        {% endif %}
-        <button class="i-button icon-remove js-ajax-dialog-delete danger light" data-qtip-style="error"
-                data-href="{{ url_for('event_management.delete', event) }}"
-                title="{% trans %}Delete event{% endtrans %}"></button>
-    </div>
+    {% if can_manage %}
+        <div class="group">
+            <span class="icon-wrench i-button label">{% trans %}Event actions{% endtrans %}</span>
+            <a class="i-button icon-copy" href="{{ url_for('event_mgmt.confModifTools-clone', event) }}"
+               title="{% trans %}Clone event{% endtrans %}"></a>
+            {% if event.isClosed() %}
+                <button class="i-button icon-lock-center disabled"
+                        title="{% trans %}This event is already locked.{% endtrans %}"></button>
+            {% elif not can_lock %}
+                <button class="i-button icon-lock-center disabled"
+                        title="{% trans %}Only the event creator and category managers may lock an event.{% endtrans %}"></button>
+            {% else %}
+                <button class="i-button icon-lock-center js-ajax-dialog-lock" data-href="{{ url_for('event_management.lock', event) }}"
+                        title="{% trans %}Lock event{% endtrans %}" {{ 'disabled' if event.isClosed() }}></button>
+            {% endif %}
+            <button class="i-button icon-remove js-ajax-dialog-delete danger light"
+                    data-href="{{ url_for('event_management.delete', event) }}"
+                    title="{% trans %}Delete event{% endtrans %}"
+                    data-qtip-style="error"></button>
+        </div>
+    {% endif %}
     <div class="group">
         <a class="icon-switchon highlight i-button"
            title="{% trans %}See the display page of the event{% endtrans %}"


### PR DESCRIPTION
Reported by a user through the error reports. When a user with contribution modification access clicks on the event deletion button, a `ModificationError` is raised. This PR makes sure that the user has event management access before enabling the delete button.