### PR TITLE
Optionally display check-in status

### DIFF
--- a/indico/htdocs/sass/modules/_event_display.scss
+++ b/indico/htdocs/sass/modules/_event_display.scss
@@ -175,6 +175,10 @@ li > table + .note-area-wrapper {
             &:not(first-child) {
                 margin-left: 0.1em;
             }
+
+            &.checked-in {
+                background: lighten($pastel-green, 30%);
+            }
         }
     }
 }

--- a/indico/modules/events/registration/__init__.py
+++ b/indico/modules/events/registration/__init__.py
@@ -69,7 +69,6 @@ def _inject_regform_announcement(event, **kwargs):
 def _inject_event_header(event, **kwargs):
     from indico.modules.events.registration.models.forms import RegistrationForm
     from indico.modules.events.registration.models.registrations import Registration
-    from indico.modules.events.registration.util import get_unique_published_registrations
 
     event = event.as_event
     regforms = (event.registration_forms
@@ -77,9 +76,21 @@ def _inject_event_header(event, **kwargs):
                 .order_by(db.func.lower(RegistrationForm.title))
                 .all())
 
-    participants = get_unique_published_registrations(event)
+    registrations = (Registration
+                     .find(Registration.is_active,
+                           ~RegistrationForm.is_deleted,
+                           RegistrationForm.event_id == event.id,
+                           RegistrationForm.publish_registrations_enabled,
+                           _join=Registration.registration_form,
+                           _eager=Registration.registration_form)
+                     .order_by(db.func.lower(Registration.first_name),
+                               db.func.lower(Registration.last_name),
+                               Registration.friendly_id))
+
+    # A participant could appear more than once in the list in case he register to multiple registration form.
+    # This is deemed very unlikely in the case of meetings and lectures and thus not worth the extra complexity.
     return render_template('events/registration/display/event_header.html', event=event, regforms=regforms,
-                           participants=participants)
+                           participants=registrations)
 
 
 @signals.event.sidemenu.connect

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -109,21 +109,29 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
                        RegistrationForm.publish_registrations_enabled,
                        ~RegistrationForm.is_deleted,
                        ~Registration.is_deleted,
-                       _join=Registration.registration_form)
-                 .order_by(db.func.lower(Registration.last_name), db.func.lower(Registration.first_name)))
-        registrations = [(reg.get_full_name(), reg.get_personal_data()) for reg in query]
+                       _join=Registration.registration_form,
+                       _eager=Registration.registration_form)
+                 .order_by(*Registration.order_by_name))
+
+        def _is_checkin_visible(reg):
+            return reg.registration_form.publish_checkin_enabled and reg.checked_in
+
+        registrations = [(reg.get_full_name(), reg.get_personal_data(), _is_checkin_visible(reg)) for reg in query]
         enabled_pd_fields = {field.personal_data_type for reg in regforms for field in reg.active_fields}
         affiliation_enabled = PersonalDataType.affiliation in enabled_pd_fields
         position_enabled = PersonalDataType.position in enabled_pd_fields
+        checkin_enabled = any(checked_in for __, __, checked_in in registrations)
         published = bool(RegistrationForm.find(RegistrationForm.publish_registrations_enabled,
                          RegistrationForm.event_id == int(self.event.id)).count())
+
         return self.view_class.render_template(
             'display/participant_list.html',
             self.event,
             event=self.event,
             regforms=regforms,
-            show_affiliation=affiliation_enabled and any(pd.get('affiliation') for reg, pd in registrations),
-            show_position=position_enabled and any(pd.get('position') for reg, pd in registrations),
+            show_affiliation=affiliation_enabled and any(pd.get('affiliation') for __, pd, __ in registrations),
+            show_position=position_enabled and any(pd.get('position') for __, pd, __ in registrations),
+            show_checkin=checkin_enabled,
             registrations=registrations,
             published=published
         )

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -74,8 +74,7 @@ class RegistrationFormForm(IndicoForm):
                                                  description=_("Registrations from this form will be displayed in the "
                                                                "event page"))
     publish_checkin_enabled = BooleanField(_('Publish check-in status'), widget=SwitchWidget(),
-                                                 description=_("Check-in status will be shown publicly on the event page "
-                                                               "event page"))
+                                           description=_("Check-in status will be shown publicly on the event page"))
     base_price = DecimalField(_('Registration fee'), [NumberRange(min=0), Optional(), _check_if_payment_required],
                               filters=[lambda x: x if x is not None else 0],
                               widget=NumberInput(step='0.01'),

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -73,6 +73,9 @@ class RegistrationFormForm(IndicoForm):
     publish_registrations_enabled = BooleanField(_('Publish registrations'), widget=SwitchWidget(),
                                                  description=_("Registrations from this form will be displayed in the "
                                                                "event page"))
+    publish_checkin_enabled = BooleanField(_('Publish check-in status'), widget=SwitchWidget(),
+                                                 description=_("Check-in status will be shown publicly on the event page "
+                                                               "event page"))
     base_price = DecimalField(_('Registration fee'), [NumberRange(min=0), Optional(), _check_if_payment_required],
                               filters=[lambda x: x if x is not None else 0],
                               widget=NumberInput(step='0.01'),

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -131,6 +131,12 @@ class RegistrationForm(db.Model):
         nullable=False,
         default=False
     )
+    #: Whether checked-in status should be displayed in the event pages and participant list
+    publish_checkin_enabled = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
     #: Whether registrations must be approved by a manager
     moderation_enabled = db.Column(
         db.Boolean,

--- a/indico/modules/events/registration/templates/display/event_header.html
+++ b/indico/modules/events/registration/templates/display/event_header.html
@@ -55,7 +55,9 @@
             <div class="participant-list-wrapper">
                 <ul class="participant-list">
                     {%- for participant in participants -%}
-                        <li>{{ participant.full_name }}</li>
+                    <li {% if participant.checked_in and participant.registration_form.publish_checkin_enabled %}class="checked-in"{% endif %}>
+                      {{ participant.full_name }}
+                    </li>
                     {%- endfor -%}
                 </ul>
                 <div class="gradient-layer"></div>

--- a/indico/modules/events/registration/templates/display/participant_list.html
+++ b/indico/modules/events/registration/templates/display/participant_list.html
@@ -29,10 +29,13 @@
                     {% if show_affiliation %}
                         <th class="i-table">{% trans %}Affiliation{% endtrans %}</th>
                     {% endif %}
+                    {% if show_checkin %}
+                        <th class="i-table">{% trans %}Checked-in{% endtrans %}</th>
+                    {% endif %}
                 </tr>
             </thead>
             <tbody>
-                {% for name, personal_data in registrations %}
+                {% for name, personal_data, checked_in in registrations %}
                     <tr class="i-table">
                         <td class="i-table" data-text="{{ name }}">
                             {{ title }} {{ name }}
@@ -42,6 +45,11 @@
                         {% endif %}
                         {% if show_affiliation %}
                             <td class="i-table">{{ personal_data.affiliation or '' }}</td>
+                        {% endif %}
+                        {% if show_checkin %}
+                            <td class="i-table">
+                                {% if checked_in %}✓{% endif %}
+                            </td>
                         {% endif %}
                     </tr>
                 {% endfor %}

--- a/indico/modules/events/registration/templates/display/participant_list.html
+++ b/indico/modules/events/registration/templates/display/participant_list.html
@@ -22,6 +22,9 @@
         <table class="i-table tablesorter">
             <thead>
                 <tr class="i-table">
+                    {% if show_checkin %}
+                        <th class="i-table checkbox-column" data-sorter="false"></th>
+                    {% endif %}
                     <th class="i-table">{% trans %}Full name{% endtrans %}</th>
                     {% if show_position %}
                         <th class="i-table">{% trans %}Position{% endtrans %}</th>
@@ -29,14 +32,16 @@
                     {% if show_affiliation %}
                         <th class="i-table">{% trans %}Affiliation{% endtrans %}</th>
                     {% endif %}
-                    {% if show_checkin %}
-                        <th class="i-table">{% trans %}Checked-in{% endtrans %}</th>
-                    {% endif %}
                 </tr>
             </thead>
             <tbody>
                 {% for name, personal_data, checked_in in registrations %}
                     <tr class="i-table">
+                        {% if show_checkin %}
+                            <td class="i-table center" {% if checked_in %}title="{% trans %}Checked in{% endtrans %}"{% endif %}>
+                                {% if checked_in %}<i class="icon-checkmark"></i>{% endif %}
+                            </td>
+                        {% endif %}
                         <td class="i-table" data-text="{{ name }}">
                             {{ title }} {{ name }}
                         </td>
@@ -45,11 +50,6 @@
                         {% endif %}
                         {% if show_affiliation %}
                             <td class="i-table">{{ personal_data.affiliation or '' }}</td>
-                        {% endif %}
-                        {% if show_checkin %}
-                            <td class="i-table">
-                                {% if checked_in %}✓{% endif %}
-                            </td>
                         {% endif %}
                     </tr>
                 {% endfor %}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -335,27 +335,6 @@ def get_registrations_with_tickets(user, event):
                              _join=Registration.registration_form).all()
 
 
-def get_unique_published_registrations(event):
-    """Get a list of unique published registrations for an event.
-
-    Uniqueness is determined by associated user, so if someone has
-    registered in more than one registration form in the event, they
-    will be included only once.
-
-    :param event: The Event to get registrations for
-    """
-    registrations = Registration.find_all(Registration.is_active,
-                                          ~RegistrationForm.is_deleted,
-                                          RegistrationForm.event_id == event.id,
-                                          RegistrationForm.publish_registrations_enabled,
-                                          _join=Registration.registration_form)
-
-    linked_participants = {reg.user_id: reg for reg in registrations if reg.user_id is not None}
-    non_linked_participants = {reg for reg in registrations if reg.user_id is None}
-    return sorted(set(linked_participants.viewvalues()) | non_linked_participants,
-                  key=lambda x: (x.first_name.lower(), x.last_name.lower(), x.id))
-
-
 def get_events_registered(user, from_dt=None, to_dt=None):
     """Gets the IDs of events where the user is registered.
 

--- a/migrations/versions/201602021203_27299745573_add_publish_checkin_column_to_reg_form.py
+++ b/migrations/versions/201602021203_27299745573_add_publish_checkin_column_to_reg_form.py
@@ -1,0 +1,24 @@
+"""Add publish_checkin column to reg form
+
+Revision ID: 27299745573
+Revises: 47a8b5324cd6
+Create Date: 2016-02-02 12:03:15.973817
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '27299745573'
+down_revision = '47a8b5324cd6'
+
+
+def upgrade():
+    op.add_column('forms', sa.Column('publish_checkin_enabled', sa.Boolean(), nullable=False, server_default='false'),
+                  schema='event_registration')
+    op.alter_column('forms', 'publish_checkin_enabled', server_default=None, schema='event_registration')
+
+
+def downgrade():
+    op.drop_column('forms', 'publish_checkin_enabled', schema='event_registration')


### PR DESCRIPTION
Check-in status can optionally be shown on the event page (for lectures and meetings) and the participant list (for conferences). The settings is per-registration. This PR fixes #2202.

Commit first commit will also make a person with multiple registrations appear multiple times on the event page (previously this was the case only for persons without account). This case is unlikely and thus not worth handling in a special way.