### PR TITLE
Use spreadsheet icon for CSV files

### DIFF
--- a/indico/MaKaC/webinterface/tpls/Abstracts.tpl
+++ b/indico/MaKaC/webinterface/tpls/Abstracts.tpl
@@ -155,7 +155,7 @@
                                         </a>
                                         <ul class="dropdown">
                                           <li><a href="#" class="icon-file-pdf" id="export_pdf">${_("PDF")}</a></li>
-                                          <li><a href="#" class="icon-file-excel" id="export_csv">${_("CSV")}</a></li>
+                                          <li><a href="#" class="icon-file-spreadsheet" id="export_csv">${_("CSV")}</a></li>
                                           <li><a href="#" class="icon-file-xml" id="export_xml">${_("XML")}</a></li>
                                         </ul>
 

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -72,7 +72,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="#" class="icon-file-excel js-requires-selected-row disabled js-submit-reglist-form"
+                        <a href="#" class="icon-file-spreadsheet js-requires-selected-row disabled js-submit-reglist-form"
                            data-href="{{ url_for('.registrations_csv_export', regform) }}">CSV</a>
                     </li>
                     <li>

--- a/indico/modules/events/surveys/templates/management/survey.html
+++ b/indico/modules/events/surveys/templates/management/survey.html
@@ -75,7 +75,7 @@
                     <ul class="dropdown">
                         <li>
                             <a href="#" data-href="{{ url_for('.export_submissions_csv', survey) }}"
-                               class="icon-file-excel js-submission-action js-export-submissions">
+                               class="icon-file-spreadsheet js-submission-action js-export-submissions">
                                 {% trans %}CSV{% endtrans %}
                             </a>
                         </li>


### PR DESCRIPTION
This is consistent with what's in ./indico/util/mimetypes.py and allow
to differentiate CSV and Excel.

I didn't find a better icon for CSV files in IcoMoon.

Fixes #2218.