### PR TITLE
Avoid guest sessions

### DIFF
--- a/indico/modules/auth/util.py
+++ b/indico/modules/auth/util.py
@@ -61,7 +61,7 @@ def redirect_to_login(next_url=None, reason=None):
     if not next_url:
         next_url = request.relative_url
     if reason:
-        session['login_reason'] = reason
+        session['login_reason'] = unicode(reason)
     return redirect(url_for_login(next_url))
 
 

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -25,7 +25,7 @@ from babel import negotiate_locale
 from babel.core import Locale, LOCALE_ALIASES
 from babel.messages.pofile import read_po
 from babel.support import Translations, NullTranslations
-from flask import session, request, has_request_context, current_app, has_app_context
+from flask import session, request, has_request_context, current_app, has_app_context, g
 from flask_babelex import Babel, get_domain, Domain
 from flask_pluginengine import current_plugin
 from speaklater import is_lazy_string, make_lazy_string
@@ -219,7 +219,11 @@ def set_best_lang():
             minfo = HelperMaKaCInfo.getMaKaCInfoInstance()
             resolved_lang = minfo.getLang()
 
-    session.lang = resolved_lang
+    # As soon as we looked up a language, cache it during the request.
+    # This will be returned when accessing `session.lang` since there's code
+    # which reads the language from there and might fail (e.g. by returning
+    # lazy strings) if it's not set.
+    g.lang = resolved_lang
     return resolved_lang
 
 

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -105,6 +105,9 @@ class IndicoSession(BaseSession):
     @cached_property
     def csrf_token(self):
         if '_csrf_token' not in self:
+            if not self.csrf_protected:
+                # don't store a token in the session if we don't really need CSRF protection
+                return '00000000-0000-0000-0000-000000000000'
             self['_csrf_token'] = str(uuid.uuid4())
         return self['_csrf_token']
 

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -20,7 +20,7 @@ import cPickle
 import uuid
 from datetime import datetime, timedelta
 
-from flask import request, flash
+from flask import request, flash, g
 from flask.sessions import SessionInterface, SessionMixin
 from markupsafe import Markup
 from werkzeug.datastructures import CallbackDict
@@ -91,6 +91,8 @@ class IndicoSession(BaseSession):
     def lang(self):
         if '_lang' in self:
             return self['_lang']
+        elif 'lang' in g:
+            return g.lang
         elif self.user:
             return self.user.settings.get('lang')
         else:

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -159,7 +159,7 @@ class IndicoSessionInterface(SessionInterface):
         return session['_expires'] - datetime.now() < threshold
 
     def should_refresh_sid(self, app, session):
-        if self.get_cookie_secure(app) and not session.get('_secure'):
+        if not session.new and self.get_cookie_secure(app) and not session.get('_secure'):
             return True
         if getattr(session, '_refresh_sid', False):
             return True


### PR DESCRIPTION
Creating a session on every single page load even if you are not logged in and do not change the language just adds lots of extra load to the cache backend storing sessions.