### PR TITLE
Remove the possibility for service managers to withdraw someone's request

### DIFF
--- a/indico/modules/events/requests/controllers.py
+++ b/indico/modules/events/requests/controllers.py
@@ -102,7 +102,8 @@ class RHRequestsEventRequestDetailsBase(EventOrRequestManagerMixin, RHRequestsEv
 
         form_html = self.definition.render_form(event=self.event_new, definition=self.definition, req=self.request,
                                                 form=self.form, manager_form=self.manager_form,
-                                                is_manager=self.is_manager)
+                                                is_manager=self.is_manager,
+                                                protection_overridden=self.protection_overridden)
         return WPRequestsEventManagement.render_string(form_html, self._conf)
 
     def process_form(self):
@@ -177,6 +178,11 @@ class RHRequestsEventRequestProcess(RHRequestsEventRequestDetailsBase):
 
 class RHRequestsEventRequestWithdraw(EventOrRequestManagerMixin, RHRequestsEventRequestBase):
     """Withdraw a request"""
+
+    def _checkProtection(self):
+        EventOrRequestManagerMixin._checkProtection(self)
+        if self.protection_overridden:
+            raise Forbidden
 
     def _process(self):
         if self.request.state not in {RequestState.pending, RequestState.accepted}:

--- a/indico/modules/events/requests/templates/event_request_details.html
+++ b/indico/modules/events/requests/templates/event_request_details.html
@@ -84,7 +84,7 @@
                 {%- trans -%}Send new request{%- endtrans -%}
             {%- endif -%}
         ">
-        {% if req and req.state.name in ('pending', 'accepted') %}
+        {% if not protection_overridden and req and req.state.name in ('pending', 'accepted') %}
             <input type="button" class="i-button big warning" id="withdraw-request"
                data-href="{{ url_for('.event_requests_withdraw', req) }}"
                data-method="POST"


### PR DESCRIPTION
Fixes #1812

It could still be improved by duplicating all the messages and changing the wording slightly for the service manager but is not really worth it.