### PR TITLE
Display long text correctly in i-checkbox and i-radio

### DIFF
--- a/indico/htdocs/sass/partials/_inputs.scss
+++ b/indico/htdocs/sass/partials/_inputs.scss
@@ -286,12 +286,18 @@ $dropdown-transition: $dropdown-transition-step ease-out;
 }
 
 .i-radio, .i-checkbox {
-    white-space: nowrap;
+    display: flex;
+
+    input {
+        flex-shrink: 0;
+        flex-grow: 0;
+        margin-top: 2px;
+    }
+
     label {
         display: inline-block;
+        flex-grow: 1;
         margin-left: 0.5em;
-        position: relative;
-        bottom: 1px;
     }
 }
 


### PR DESCRIPTION
Fixes  #2051 — Text overflow issue in Material Package
The labels of `i-checkbox`es and `i-radio`s is now wrapped correctly instead of overflowing.

![](http://i.imgur.com/xIsdT1F.png)
