### PR TITLE
Fix persons display in edit contribution dialog and cleanup i-box style

### DIFF
--- a/indico/htdocs/sass/modules/contributions/_widgets.scss
+++ b/indico/htdocs/sass/modules/contributions/_widgets.scss
@@ -28,15 +28,8 @@
         border-top: none;
     }
 
-    .people-lists .titled-rule {
-        margin-top: 5px;
-        margin-bottom: 5px;
-
-        &:first-child {
-            margin-top: -18px;
-            margin-left: -10px;
-            margin-right: -10px;
-        }
+    .person-list {
+        @include i-box-cancel-horizontal-padding;
     }
 
     .person-row,
@@ -51,12 +44,24 @@
     }
 
     .person-row {
+        @include i-box-horizontal-padding;
         @include single-transition(background-color);
-        padding: 0 10px;
-        margin: 0 -10px;
+        display: flex;
+
+        .name {
+            flex-grow: 1;
+            flex-shrink: 1;
+            flex-basis: 0;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
 
         .person-status {
-            float: right;
+            flex-grow: 0;
+        }
+
+        .person-status {
             height: 2em;
             white-space: nowrap;
             overflow: hidden;

--- a/indico/htdocs/sass/modules/contributions/_widgets.scss
+++ b/indico/htdocs/sass/modules/contributions/_widgets.scss
@@ -29,7 +29,7 @@
     }
 
     .person-list {
-        @include i-box-cancel-horizontal-padding;
+        @extend %i-box-cancel-horizontal-padding;
     }
 
     .person-row,
@@ -44,7 +44,7 @@
     }
 
     .person-row {
-        @include i-box-horizontal-padding;
+        @extend %i-box-horizontal-padding;
         @include single-transition(background-color);
         display: flex;
 

--- a/indico/htdocs/sass/partials/_boxes.scss
+++ b/indico/htdocs/sass/partials/_boxes.scss
@@ -107,13 +107,13 @@ $i-box-padding: 10px;
 }
 
 %i-box-padding {
-    @include i-box-horizontal-padding;
-    @include i-box-vertical-padding;
+    @extend %i-box-horizontal-padding;
+    @extend %i-box-vertical-padding;
 }
 
 %i-box-cancel-padding {
-    @include i-box-cancel-horizontal-padding;
-    @include i-box-cancel-vertical-padding;
+    @extend %i-box-cancel-horizontal-padding;
+    @extend %i-box-cancel-vertical-padding;
 }
 
 .i-box {
@@ -121,10 +121,10 @@ $i-box-padding: 10px;
     @include box-sizing(border-box);
     @include border-all();
     @include single-box-shadow();
+    @extend %i-box-padding;
 
     background: white;
     color: $black;
-    @include i-box-padding;
 
     hr {
         @extend %box-hr;
@@ -171,12 +171,12 @@ $i-box-padding: 10px;
     }
 
     > .titled-rule:first-child {
-        @include i-box-cancel-horizontal-padding;
+        @extend %i-box-cancel-horizontal-padding;
         margin-top: -18px; // Pure magic number to align the rule with the i-box border
     }
 
     .i-box-footer {
-        @include i-box-cancel-padding;
+        @extend %i-box-cancel-padding;
         background-color: $light-gray;
         box-shadow: inset 0px 15px 20px -20px $gray;
         overflow: auto;
@@ -186,8 +186,8 @@ $i-box-padding: 10px;
 
     .i-box-header {
         @include border-bottom();
-        @include i-box-cancel-padding;
-        @include i-box-padding;
+        @extend %i-box-cancel-padding;
+        @extend %i-box-padding;
         background-color: $light-gray;
         overflow: hidden;
         margin-bottom: $i-box-padding;
@@ -235,14 +235,14 @@ $i-box-padding: 10px;
     }
 
     .i-box-table-widget {
-        @include i-box-cancel-padding;
+        @extend %i-box-cancel-padding;
 
         > table.i-table-widget {
             border: 0;
         }
 
         > *:not(table) {
-            @include i-box-padding;
+            @extend %i-box-padding;
         }
     }
 }

--- a/indico/htdocs/sass/partials/_boxes.scss
+++ b/indico/htdocs/sass/partials/_boxes.scss
@@ -84,6 +84,38 @@
 // Boxes
 // ============================================================================
 
+$i-box-padding: 10px;
+
+%i-box-horizontal-padding {
+    padding-left: $i-box-padding;
+    padding-right: $i-box-padding;
+}
+
+%i-box-cancel-horizontal-padding {
+    margin-left: -$i-box-padding;
+    margin-right: -$i-box-padding;
+}
+
+%i-box-vertical-padding {
+    padding-top: $i-box-padding;
+    padding-bottom: $i-box-padding;
+}
+
+%i-box-cancel-vertical-padding {
+    margin-top: -$i-box-padding;
+    margin-bottom: -$i-box-padding;
+}
+
+%i-box-padding {
+    @include i-box-horizontal-padding;
+    @include i-box-vertical-padding;
+}
+
+%i-box-cancel-padding {
+    @include i-box-cancel-horizontal-padding;
+    @include i-box-cancel-vertical-padding;
+}
+
 .i-box {
     @include border-radius();
     @include box-sizing(border-box);
@@ -92,7 +124,7 @@
 
     background: white;
     color: $black;
-    padding: 10px;
+    @include i-box-padding;
 
     hr {
         @extend %box-hr;
@@ -133,21 +165,32 @@
         }
     }
 
+    .titled-rule {
+        margin-top: 5px;
+        margin-bottom: 5px;
+    }
+
+    > .titled-rule:first-child {
+        @include i-box-cancel-horizontal-padding;
+        margin-top: -18px; // Pure magic number to align the rule with the i-box border
+    }
+
     .i-box-footer {
+        @include i-box-cancel-padding;
         background-color: $light-gray;
         box-shadow: inset 0px 15px 20px -20px $gray;
         overflow: auto;
-        padding: 10px;
-        margin: 10px -10px -10px;
+        padding: $i-box-padding;
+        margin-top: $i-box-padding;
     }
 }
 
 .i-box.titled {
     .i-box-header {
         @include border-bottom();
+        @include i-box-cancel-padding;
+        @include i-box-padding;
         background-color: $light-gray;
-        margin: -10px -10px;
-        padding: 10px 10px;
         overflow: hidden;
 
         .i-box-header-text {
@@ -212,13 +255,13 @@
     }
 
     > .i-box-header {
+        @include i-box-padding;
         margin: 0;
-        padding: 10px;
     }
 
     > .i-box-content {
         > .empty {
-            padding: 10px;
+            @include i-box-padding;
         }
 
         > ul.group-list {

--- a/indico/htdocs/sass/partials/_boxes.scss
+++ b/indico/htdocs/sass/partials/_boxes.scss
@@ -247,36 +247,6 @@ $i-box-padding: 10px;
     }
 }
 
-.i-box.no-padding {
-    padding: 0;
-
-    &.titled > .i-box-content {
-        margin-top: 0;
-    }
-
-    > .i-box-header {
-        @include i-box-padding;
-        margin: 0;
-    }
-
-    > .i-box-content {
-        > .empty {
-            @include i-box-padding;
-        }
-
-        > ul.group-list {
-            margin: 0;
-
-            > li {
-                margin: 0;
-                margin-right: 0;
-                margin-left: 0;
-                padding: 10px;
-            }
-        }
-    }
-}
-
 .i-box.no-shadow {
     @include single-box-shadow(none);
 }

--- a/indico/htdocs/sass/partials/_boxes.scss
+++ b/indico/htdocs/sass/partials/_boxes.scss
@@ -183,15 +183,14 @@ $i-box-padding: 10px;
         padding: $i-box-padding;
         margin-top: $i-box-padding;
     }
-}
 
-.i-box.titled {
     .i-box-header {
         @include border-bottom();
         @include i-box-cancel-padding;
         @include i-box-padding;
         background-color: $light-gray;
         overflow: hidden;
+        margin-bottom: $i-box-padding;
 
         .i-box-header-text {
             float: left;

--- a/indico/htdocs/sass/partials/_boxes.scss
+++ b/indico/htdocs/sass/partials/_boxes.scss
@@ -234,14 +234,15 @@ $i-box-padding: 10px;
         }
     }
 
-    .i-box-content {
-        margin-top: 20px;
-        > .empty {
-            @extend %i-box-empty;
-        }
+    .i-box-table-widget {
+        @include i-box-cancel-padding;
 
         > table.i-table-widget {
             border: 0;
+        }
+
+        > *:not(table) {
+            @include i-box-padding;
         }
     }
 }

--- a/indico/modules/attachments/templates/generate_package.html
+++ b/indico/modules/attachments/templates/generate_package.html
@@ -10,7 +10,7 @@
 
 {% block content %}
     <div class="i-box-group vert fixed-width attachments-package">
-        <div class="i-box titled no-padding">
+        <div class="i-box titled">
             <div class="i-box-header">
                 <div class="i-box-title">{%- trans %}Material Package{% endtrans -%}</div>
                 {% if management %}

--- a/indico/modules/events/contributions/templates/forms/contribution_person_widget.html
+++ b/indico/modules/events/contributions/templates/forms/contribution_person_widget.html
@@ -2,36 +2,34 @@
 
 {% block html %}
     <input type="hidden" id="{{ field.id }}" name="{{ field.name }}" value="{{ field._value()|tojson|forceescape }}">
-    <div class="contribution-people {% if field.allow_authors %}no-border-top{% endif %}" data-tooltip-anchor>
-        <div id="people-list-{{ field.id }}" class="people-lists">
-            {% if field.allow_authors %}
-                <div id="author-list-title-{{ field.id }}" class="titled-rule">
-                    {% trans %}Authors{% endtrans %}
-                </div>
-                <div id="no-author-placeholder-{{ field.id }}" class="nobody-placeholder">
-                    {% trans %}There are no authors{% endtrans %}
-                </div>
-                <div id="author-list-{{ field.id }}"></div>
-                <div id="coauthor-list-title-{{ field.id }}" class="titled-rule">
-                    {% trans %}Co-authors{% endtrans %}
-                </div>
-                {% if field.show_empty_coauthors %}
-                    <div id="no-coauthor-placeholder-{{ field.id }}" class="nobody-placeholder">
-                        {% trans %}There are no co-authors{% endtrans %}
-                    </div>
-                {% endif %}
-                <div id="coauthor-list-{{ field.id }}"></div>
-                <div id="other-list-title-{{ field.id }}" class="titled-rule">
-                    {% trans %}Others{% endtrans %}
-                </div>
-                <div id="other-list-{{ field.id }}"></div>
-            {% else %}
-                <div id="other-list-{{ field.id }}"></div>
-                <div id="nobody-placeholder-{{ field.id }}" class="nobody-placeholder">
-                    {% trans %}There are no speakers{% endtrans %}
+    <div id="people-list-{{ field.id }}" class="contribution-people {% if field.allow_authors %}no-border-top{% endif %}" data-tooltip-anchor>
+        {% if field.allow_authors %}
+            <div id="author-list-title-{{ field.id }}" class="titled-rule">
+                {% trans %}Authors{% endtrans %}
+            </div>
+            <div id="no-author-placeholder-{{ field.id }}" class="nobody-placeholder">
+                {% trans %}There are no authors{% endtrans %}
+            </div>
+            <div id="author-list-{{ field.id }}" class="person-list"></div>
+            <div id="coauthor-list-title-{{ field.id }}" class="titled-rule">
+                {% trans %}Co-authors{% endtrans %}
+            </div>
+            {% if field.show_empty_coauthors %}
+                <div id="no-coauthor-placeholder-{{ field.id }}" class="nobody-placeholder">
+                    {% trans %}There are no co-authors{% endtrans %}
                 </div>
             {% endif %}
-        </div>
+            <div id="coauthor-list-{{ field.id }}" class="person-list"></div>
+            <div id="other-list-title-{{ field.id }}" class="titled-rule">
+                {% trans %}Others{% endtrans %}
+            </div>
+            <div id="other-list-{{ field.id }}" class="person-list"></div>
+        {% else %}
+            <div id="other-list-{{ field.id }}" class="person-list"></div>
+            <div id="nobody-placeholder-{{ field.id }}" class="nobody-placeholder">
+                {% trans %}There are no speakers{% endtrans %}
+            </div>
+        {% endif %}
         <div class="i-box-footer" style="text-align: right;">
             <i class="info-helper"
                title="{% trans %}Added people can be modified by moving the cursor over them.{% endtrans %}"></i>
@@ -82,8 +80,8 @@
 
             function renderPerson(person) {
                 var $personRow = $('<div>').addClass('person-row');
-                var $personName = $('<span>').text(person.name);
-                var $personStatus = $('<span>').addClass('person-status');
+                var $personName = $('<div>').addClass('name').text(person.name);
+                var $personStatus = $('<div>').addClass('person-status');
                 var $personRoles = $('<span>').addClass('person-roles');
                 var $personButtons = $('<span>').addClass('person-buttons');
                 var $buttonRemove = $('<a>').addClass('i-button-icon danger icon-close').attr('title', $T.gettext("Remove person"));

--- a/indico/modules/events/reminders/templates/reminders.html
+++ b/indico/modules/events/reminders/templates/reminders.html
@@ -39,7 +39,7 @@
 
 {% block content %}
     <div class="i-box-group vert fixed-width reminders">
-        <div class="i-box titled no-padding">
+        <div class="i-box titled">
             <div class="i-box-header">
                 <div class="i-box-title">{%- trans %}Pending Reminders{% endtrans -%}</div>
                 <div class="i-box-buttons">
@@ -57,7 +57,7 @@
             </div>
         </div>
         {% if sent_reminders %}
-            <div class="i-box titled no-padding">
+            <div class="i-box titled">
                 <div class="i-box-header">
                     <div class="i-box-title">{%- trans %}Sent Reminders{% endtrans -%}</div>
                 </div>

--- a/indico/modules/events/static/templates/static_sites.html
+++ b/indico/modules/events/static/templates/static_sites.html
@@ -19,7 +19,7 @@
                 {% trans %}This will build an offline copy of the event. This is useful if you want to make it available where no Internet connection is available.{% endtrans %}
             </div>
         </div>
-        <div class="i-box titled no-padding">
+        <div class="i-box titled">
             <div class="i-box-header">
                 <div class="i-box-title">{%- trans %}Existing Offline Copies{% endtrans -%}</div>
             </div>

--- a/indico/modules/events/static/templates/static_sites.html
+++ b/indico/modules/events/static/templates/static_sites.html
@@ -23,7 +23,7 @@
             <div class="i-box-header">
                 <div class="i-box-title">{%- trans %}Existing Offline Copies{% endtrans -%}</div>
             </div>
-            <div class="i-box-content">
+            <div class="i-box-table-widget">
                 {% if static_sites %}
                     {% set label_mapping = {
                         'success': 'accept',

--- a/indico/modules/events/templates/references/reference_types.html
+++ b/indico/modules/events/templates/references/reference_types.html
@@ -18,7 +18,7 @@
                 </a>
             </div>
         </div>
-        <div id="external-id-types" class="i-box-content">
+        <div id="external-id-types" class="i-box-table-widget">
             {{ render_reference_type_list(reference_types) }}
         </div>
     </div>

--- a/indico/modules/events/templates/references/reference_types.html
+++ b/indico/modules/events/templates/references/reference_types.html
@@ -5,7 +5,7 @@
 {% block title %}{% trans %}External ID types{% endtrans %}{% endblock %}
 
 {%- block content %}
-    <div class="i-box titled no-padding">
+    <div class="i-box titled">
         <div class="i-box-header">
             <div class="i-box-title">{%- trans %}Existing external ID types{% endtrans -%}</div>
             <div class="i-box-buttons toolbar right">

--- a/indico/modules/groups/templates/groups.html
+++ b/indico/modules/groups/templates/groups.html
@@ -48,7 +48,7 @@
                     </div>
                 </div>
             </div>
-            <div class="i-box-content">
+            <div class="i-box-table-widget">
                 {{ group_table(groups, show_members=true) }}
             </div>
         </div>


### PR DESCRIPTION
* The persons in the "edit contribution" dialog are now displayed properly with the background of the highlighted row extending to the edge of the `.i-box` 
* Removed two unnecessary classes (`.no-padding` and `.titled`) that were used on `.i-boxes`
* The tables that need to be displayed without padding inside in `.i-box` are now wrapped inside a div with `.i-box-table-widget` class

![](http://i.imgur.com/Td781v1.png)
