### PR TITLE
Attach automatically created qTips on new elements

### DIFF
--- a/indico/htdocs/js/indico/jquery/global.js
+++ b/indico/htdocs/js/indico/jquery/global.js
@@ -106,6 +106,10 @@ $(document).ready(function() {
                 classes: qtipClass ? 'qtip-' + qtipClass : null
             }
         }, extraOpts), event);
+
+        $target.one('remove', function(evt) {
+            container.qtip('hide');
+        });
     });
 
     // Enable colorbox for links with .js-lightbox

--- a/indico/htdocs/js/indico/jquery/qbubble.js
+++ b/indico/htdocs/js/indico/jquery/qbubble.js
@@ -28,7 +28,7 @@
                 }
             },
             show: {
-                event: '',
+                event: 'click',
                 solo: true
             },
             hide: {
@@ -40,34 +40,29 @@
             var self = this;
             var classes = self.options.style ? self.options.style.classes : '';
 
-            self.container = $('<span>').qtip($.extend(true, {}, self.defaultQtipOptions, self.options, {
-                position: {target: self.element},
+            self.element.qtip($.extend(true, {}, self.defaultQtipOptions, self.options, {
                 style: {classes: 'qbubble ' + classes}
             }));
-
-            self.element.on('click', function() {
-                self.container.qtip('api').show();
-            });
         },
 
         api: function() {
             var self = this;
-            return self.container.qtip('api');
+            return self.element.qtip('api');
         },
 
         destroy: function() {
             var self = this;
-            self.container.qtip('destroy');
+            self.element.qtip('destroy');
         },
 
         hide: function() {
             var self = this;
-            self.container.qtip('hide');
+            self.element.qtip('hide');
         },
 
         option: function(entry, value) {
             var self = this;
-            self.container.qtip('option', entry, value);
+            self.element.qtip('option', entry, value);
         }
     });
 })(jQuery);

--- a/indico/htdocs/js/indico/modules/contributions/common.js
+++ b/indico/htdocs/js/indico/modules/contributions/common.js
@@ -34,15 +34,9 @@
     }
 
     function setState(visible, total) {
-        var $state = $('#filtering-state'),
-            title = '{0} out of {1} contributions displayed'.format(visible.length, total.length);
+        var $state = $('#filtering-state');
         $state.html(formatState(visible, total));
-
-        // oldtitle needs to be updated too, because of qTip
-        $state.attr({
-            oldtitle: title,
-            title: title
-        });
+        $state.attr('title', $T.gettext("{0} out of {1} contributions displayed").format(visible.length, total.length));
     }
 
     function applyFilters() {

--- a/indico/web/templates/forms/multiple_items_widget.html
+++ b/indico/web/templates/forms/multiple_items_widget.html
@@ -131,7 +131,7 @@
                         row.data('hasItem', true);
                     }
                     updateField();
-                    updateRow(row, false);
+                    updateRow(row, false, false);
                 }
             }).on('click', '.js-add-row', function(e) {
                 e.preventDefault();
@@ -142,12 +142,12 @@
                 if (!row.data('hasItem')) {
                     removeRow(row);
                 } else {
-                    updateRow(row, false);
+                    updateRow(row, false, false);
                 }
             }).on('click', '.js-edit-row', function(e) {
                 e.preventDefault();
                 var row = $(this).closest('tr');
-                updateRow(row, true);
+                updateRow(row, true, false);
             }).on('keypress', 'input', function(e) {
                 if (e.keyCode == 13) {
                     e.preventDefault();
@@ -172,13 +172,15 @@
                 });
             }
 
-            function rowsChanged() {
+            function rowsChanged(moveTooltips) {
                 if (sortable) {
                     widget.find('tbody.ui-sortable').sortable('refresh');
                 }
                 fixWidths();
                 addButton.prop('disabled', !!widget.find('.js-table-input').length);
-                repositionTooltips();
+                if (moveTooltips === undefined || moveTooltips) {
+                    repositionTooltips();
+                }
             }
 
             function makeColData(item, col, forceEditable) {
@@ -294,7 +296,7 @@
                 rowsChanged();
             }
 
-            function updateRow(row, editMode) {
+            function updateRow(row, editMode, moveTooltips) {
                 row.children('td:not(.sort-handle):not(.js-action-col)').each(function(i) {
                     $(this).replaceWith($('<td>', makeColData(data[row.index()], columns[i], editMode)));
                 });
@@ -303,7 +305,7 @@
                 } else {
                     row.children('.js-action-col').html(deleteButton.clone().add(editButton.clone()));
                 }
-                rowsChanged();
+                rowsChanged(moveTooltips);
             }
 
             function removeRow(row) {
@@ -312,7 +314,7 @@
                     updateField();
                 }
                 row.remove();
-                rowsChanged();
+                rowsChanged(false);
             }
 
             function updateField() {


### PR DESCRIPTION
When adding qTips to an element with a `title` attribute, attach the qTip to a an element created just for this purpose. This way we avoid side-effects on all elements with a `title` attribute.

This allow to attach the qBubble widget on the element used to open it.

Hide the tooltips when their target is removed from the DOM and avoid to reposition them when deleting elements. (Even by calling `destroy`on the qTip before repositioning it, it would still fly a split second. Thus not repositioning them on deletion is the only solution.) 