### PR TITLE
Show colour preview as soon as a color is selected

### DIFF
--- a/indico/htdocs/js/indico/jquery/clearableinput.js
+++ b/indico/htdocs/js/indico/jquery/clearableinput.js
@@ -34,8 +34,9 @@
             self.buttonBox = $('<span>').addClass('button-box');
             self.clearIcon = $('<a>').addClass('i-button-icon danger icon-close')
                 .css('line-height', self.element.outerHeight() + 'px')
-                .click(function() {
+                .click(function(evt) {
                     self._clear();
+                    evt.stopPropagation();
                 });
 
             var display = self.element.css('display');

--- a/indico/htdocs/js/indico/jquery/colorpicker.js
+++ b/indico/htdocs/js/indico/jquery/colorpicker.js
@@ -31,7 +31,7 @@
             var colorInput = element.find('input');
 
             var updateColorPreview = function(color){
-                preview.css('background', color);
+                preview.css('background', color).removeClass('no-value');;
             };
 
             colorInput.on('keyup', function() {

--- a/indico/htdocs/js/indico/jquery/colorpicker.js
+++ b/indico/htdocs/js/indico/jquery/colorpicker.js
@@ -30,12 +30,12 @@
             var preview = element.find('.color-preview');
             var colorInput = element.find('input');
 
-            var updateColorPreview = function(color){
-                preview.css('background', color).removeClass('no-value');;
-            };
+            function updateColorPreview(color) {
+                preview.css('background', color).removeClass('no-value');
+            }
 
-            var updateWidget = function() {
-                preview.toggleClass('no-value', !colorInput.val().length)
+            function updateWidget() {
+                preview.toggleClass('no-value', !colorInput.val().length);
                 if (colorInput.val()) {
                     updateColorPreview(colorInput.val());
                     clickableWrapper.ColorPickerSetColor(colorInput.val());
@@ -43,21 +43,21 @@
                 else {
                     preview.attr('style', null);
                 }
-            };
+            }
 
             colorInput.on('input change', updateWidget);
 
             clickableWrapper.ColorPicker({
                 color: opt.defaultColor,
                 onSubmit: function(hsb, hex, rgb, el) {
-                        $(el).val(hex);
-                        updateColorPreview('#' + hex);
-                        $(el).ColorPickerHide();
+                    $(el).val(hex);
+                    updateColorPreview('#' + hex);
+                    $(el).ColorPickerHide();
                 },
                 onChange: function (hsb, hex, rgb) {
-                        colorInput.val('#' + hex);
-                        updateColorPreview('#' + hex);
-                        colorInput.trigger('input');
+                    colorInput.val('#' + hex);
+                    updateColorPreview('#' + hex);
+                    colorInput.trigger('input');
                 },
                 onShow: function (colorpicker) {
                     $(colorpicker).fadeIn(500);

--- a/indico/htdocs/js/indico/jquery/colorpicker.js
+++ b/indico/htdocs/js/indico/jquery/colorpicker.js
@@ -34,7 +34,7 @@
                 preview.css('background', color).removeClass('no-value');;
             };
 
-            colorInput.on('keyup', function() {
+            var updateWidget = function() {
                 preview.toggleClass('no-value', !colorInput.val().length)
                 if (colorInput.val()) {
                     updateColorPreview(colorInput.val());
@@ -43,9 +43,9 @@
                 else {
                     preview.attr('style', null);
                 }
-            });
+            };
 
-            colorInput.trigger('keyup');
+            colorInput.on('input change', updateWidget);
 
             clickableWrapper.ColorPicker({
                 color: opt.defaultColor,
@@ -68,6 +68,8 @@
                     return false;
                 }
             });
+
+            updateWidget();
         }
     });
 })(jQuery);


### PR DESCRIPTION
Previously the preview was kept disabled until a page reload.

Also improve the behavior of the widget:

* Update the selected color when text is pasted in the input field
* Disable the color preview when the input field is empty
* Stop click event propagation when clearing input with clearableinput widget
