### PR TITLE
Don't put div inside table

### DIFF
--- a/indico/MaKaC/webinterface/tpls/ConfModifMainData.tpl
+++ b/indico/MaKaC/webinterface/tpls/ConfModifMainData.tpl
@@ -1,6 +1,11 @@
-<table class="groupTable">
-    <div class="management-page">
-        <%include file="EventModifMainData.tpl" args="evtType='conference', confObj=self_._conf"/>
+<div class="management-page">
+    <header>
+        <div class="title">
+            <h2>${ _("General Settings")}</h2>
+        </div>
+    </header>
+    <table class="groupTable">
+            <%include file="EventModifMainData.tpl" args="evtType='conference', confObj=self_._conf"/>
         <tr>
             <td class="dataCaptionTD"><span class="dataCaptionFormat"> ${ _("Screen dates")}</span></td>
             <td class="blacktext">${screenDates}</td>
@@ -37,8 +42,8 @@
         <tr>
             <td colspan="3" class="horizontalLine">&nbsp;</td>
         </tr>
-    </div>
-</table>
+    </table>
+</div>
 
 <script type="text/javascript">
 function removeItem(number, form)

--- a/indico/MaKaC/webinterface/tpls/EventModifMainData.tpl
+++ b/indico/MaKaC/webinterface/tpls/EventModifMainData.tpl
@@ -38,11 +38,6 @@ favoriteRooms = confObj.getFavoriteRooms()
 additionalInfo = confObj.getContactInfo()
 
 %>
-<header>
-    <div class="title">
-        <h2>${ _("General Settings")}</h2>
-    </div>
-</header>
 
 <tr>
     <td class="dataCaptionTD">

--- a/indico/MaKaC/webinterface/tpls/MConfModifMainData.tpl
+++ b/indico/MaKaC/webinterface/tpls/MConfModifMainData.tpl
@@ -1,5 +1,10 @@
-<table width="100%">
-    <div class="management-page">
+<div class="management-page">
+    <header>
+        <div class="title">
+            <h2>${ _("General Settings")}</h2>
+        </div>
+    </header>
+    <table width="100%">
         <%include file="EventModifMainData.tpl" args="evtType='meeting', confObj=self_._conf"/>
         % if Config.getInstance().getReportNumberSystems():
         <tr>
@@ -13,5 +18,5 @@
             <td colspan="3" class="horizontalLine">&nbsp;</td>
         </tr>
         % endif
-    </div>
-</table>
+    </table>
+</div>

--- a/indico/MaKaC/webinterface/tpls/SEConfModifMainData.tpl
+++ b/indico/MaKaC/webinterface/tpls/SEConfModifMainData.tpl
@@ -1,5 +1,11 @@
-<table width="100%">
-    <div class="management-page">
+<div class="management-page">
+    <header>
+        <div class="title">
+            <h2>${ _("General Settings")}</h2>
+        </div>
+    </header>
+
+    <table width="100%">
         <%include file="EventModifMainData.tpl" args="evtType='lecture', confObj=self_._conf"/>
-    </div>
-</table>
+    </table>
+</div>


### PR DESCRIPTION
The header for page title is moved outside of the table because when
inside a table row it is off by one or two pixels.