### PR TITLE
Show parent event and clones under the "event actions" toolbar

### DIFF
--- a/indico/MaKaC/webinterface/rh/conferenceModif.py
+++ b/indico/MaKaC/webinterface/rh/conferenceModif.py
@@ -660,7 +660,7 @@ class RHConfPerformCloning(RHConferenceModifBase, object):
             self._redirect( urlHandlers.UHConfClone.getURL( self._conf ) )
         elif self._confirm:
             if self._cloneType == "once" :
-                newConf = self._conf.clone( self._date, options, userPerformingClone = self._aw._currentUser )
+                newConf = self._conf.clone(self._date, options, userPerformingClone=self._aw._currentUser)
                 self._redirect( urlHandlers.UHConferenceModification.getURL( newConf ) )
             elif self._cloneType == "intervals" :
                 self._withIntervals(options)
@@ -690,7 +690,7 @@ class RHConfPerformCloning(RHConferenceModifBase, object):
             endDate = datetime(int(params["stdyi"]),int(params["stdmi"]),int(params["stddi"]), self._conf.getEndDate().hour,self._conf.getEndDate().minute)
             while date <= endDate:
                 if confirmed:
-                    self._conf.clone(date,options, userPerformingClone = self._aw._currentUser)
+                    self._conf.clone(date, options, userPerformingClone=self._aw._currentUser)
                 nbClones += 1
                 if params["freq"] == "day" or params["freq"] == "week":
                     date = date + inter
@@ -711,7 +711,7 @@ class RHConfPerformCloning(RHConferenceModifBase, object):
             while i < stop:
                 i = i + 1
                 if confirmed:
-                    self._conf.clone(date,options, userPerformingClone = self._aw._currentUser)
+                    self._conf.clone(date, options, userPerformingClone=self._aw._currentUser)
                 nbClones += 1
                 if params["freq"] == "day" or params["freq"] == "week":
                     date = date + inter
@@ -804,18 +804,21 @@ class RHConfPerformCloning(RHConferenceModifBase, object):
                     od=self._getOpenDay(date,params["order"])
                     if od <= endDate:
                         if confirmed:
-                            self._conf.clone(od, options, userPerformingClone = self._aw._currentUser)
+                            self._conf.clone(od, options, userPerformingClone=self._aw._currentUser)
                         nbClones += 1
                 else:
                     if params["order"] == "last":
                         if self._getLastDay(date,int(params["day"])) <= endDate:
                             if confirmed:
-                                self._conf.clone(self._getLastDay(date,int(params["day"])), options, userPerformingClone = self._aw._currentUser)
+                                self._conf.clone(self._getLastDay(date, int(params["day"])), options,
+                                                 userPerformingClone=self._aw._currentUser)
                             nbClones += 1
                     else:
-                        if self._getFirstDay(date, int(params["day"])) + timedelta((int(params["order"])-1)*7) <= endDate:
+                        new_date = (self._getFirstDay(date, int(params["day"])) +
+                                    timedelta((int(params["order"]) - 1) * 7))
+                        if new_date <= endDate:
                             if confirmed:
-                                self._conf.clone(self._getFirstDay(date, int(params["day"]))+ timedelta((int(params["order"])-1)*7), options, userPerformingClone = self._aw._currentUser)
+                                self._conf.clone(new_date, options, userPerformingClone=self._aw._currentUser)
                             nbClones += 1
                 month = int(date.month) + int(params["monthPeriod"])
                 year = int(date.year)
@@ -845,16 +848,20 @@ class RHConfPerformCloning(RHConferenceModifBase, object):
                 i = i + 1
                 if params["day"] == "OpenDay":
                     if confirmed:
-                        self._conf.clone(self._getOpenDay(date, params["order"]), options, userPerformingClone = self._aw._currentUser)
+                        self._conf.clone(self._getOpenDay(date, params["order"]), options,
+                                         userPerformingClone=self._aw._currentUser)
                     nbClones += 1
                 else:
                     if params["order"] == "last":
                         if confirmed:
-                            self._conf.clone(self._getLastDay(date,int(params["day"])), options, userPerformingClone = self._aw._currentUser)
+                            self._conf.clone(self._getLastDay(date, int(params["day"])), options,
+                                             userPerformingClone=self._aw._currentUser)
                         nbClones += 1
                     else:
                         if confirmed:
-                            self._conf.clone(self._getFirstDay(date, int(params["day"]))+ timedelta((int(params["order"])-1)*7), options, userPerformingClone = self._aw._currentUser)
+                            new_date = (self._getFirstDay(date, int(params["day"])) +
+                                        timedelta((int(params["order"]) - 1) * 7))
+                            self._conf.clone(new_date, options, userPerformingClone=self._aw._currentUser)
                         nbClones += 1
                 month = int(date.month) + int(params["monthPeriod"])
                 year = int(date.year)

--- a/indico/MaKaC/webinterface/tpls/AdminFrame.tpl
+++ b/indico/MaKaC/webinterface/tpls/AdminFrame.tpl
@@ -1,4 +1,8 @@
-<div class="banner"><span class="bannerTitle bannerTitle_0">${ _("Server Administration") }</span></div>
+<div class="banner">
+    <div class="title">
+        ${ _("Server Administration") }
+    </div>
+</div>
 
 ${ sideMenu }
 

--- a/indico/MaKaC/webinterface/tpls/CategoryModifFrame.tpl
+++ b/indico/MaKaC/webinterface/tpls/CategoryModifFrame.tpl
@@ -1,6 +1,8 @@
-<div class="banner"><span class="bannerTitle bannerTitle_0">
-<span style="font-style: italic;">${ _("Category") }</span>: ${ category.getTitle()}
-</span></div>
+<div class="banner">
+    <div class="title">
+        ${ category.getTitle() }
+    </div>
+</div>
 
 ${ sideMenu }
 

--- a/indico/MaKaC/webinterface/tpls/ConferenceModifFrame.tpl
+++ b/indico/MaKaC/webinterface/tpls/ConferenceModifFrame.tpl
@@ -4,22 +4,23 @@ from MaKaC.webinterface.urlHandlers import UHConferenceModification
 
 <div class="banner">
 
-    ${ template_hook('event-manage-header', event=conf) }
-
-    <a href="${ UHConferenceModification.getURL(conf) }">
-        <span class="bannerTitle bannerTitle_0">
-            ${ conf.getTitle() | remove_tags } &nbsp;<span style="font-size: 0.8em; font-style: italic;">
-            % if startDate == endDate:
-                ${ startDate }
-            % else:
-                ${ startDate } - ${ endDate }
-            % endif
+    <div class="title">
+        <a href="${ UHConferenceModification.getURL(conf) }">
+            ${ conf.getTitle() | remove_tags } &nbsp;
+            <span class="date">
+                % if startDate == endDate:
+                    ${ startDate }
+                % else:
+                    ${ startDate } - ${ endDate }
+                % endif
             </span>
-        </span>
-    </a>
-    <div class="banner_creator">
-        ${ _(u"Created by {name} ({email})").format(name=conf.as_event.creator.full_name, email=conf.as_event.creator.email)}
+        </a>
+        <div class="subtitle">
+            ${ _(u"Created by {name} ({email})").format(name=conf.as_event.creator.full_name, email=conf.as_event.creator.email)}
+        </div>
     </div>
+
+    ${ template_hook('event-manage-header', event=conf) }
 
 </div>
 

--- a/indico/MaKaC/webinterface/tpls/ConferenceModifFrame.tpl
+++ b/indico/MaKaC/webinterface/tpls/ConferenceModifFrame.tpl
@@ -1,5 +1,8 @@
 <%
 from MaKaC.webinterface.urlHandlers import UHConferenceModification
+
+event = conf.as_event
+cloned_from = event.cloned_from if event.cloned_from_id is not None and not event.cloned_from.is_deleted else None
 %>
 
 <div class="banner">
@@ -16,7 +19,19 @@ from MaKaC.webinterface.urlHandlers import UHConferenceModification
             </span>
         </a>
         <div class="subtitle">
-            ${ _(u"Created by {name} ({email})").format(name=conf.as_event.creator.full_name, email=conf.as_event.creator.email)}
+            % if cloned_from:
+
+                ${ _(u'Created by {name} ({email}) from event on <a href="{link}" title="{title}">{date}</a>').format(
+                    date=formatDate(cloned_from.start_dt, format="medium"),
+                    title=event.title,
+                    link=url_for('event_mgmt.conferenceModification', cloned_from),
+                    name=event.creator.full_name,
+                    email=event.creator.email)}
+            % else:
+                ${ _(u"Created by {name} ({email})").format(
+                    name=event.creator.full_name,
+                    email=event.creator.email)}
+            % endif
         </div>
     </div>
 

--- a/indico/htdocs/css/Default.css
+++ b/indico/htdocs/css/Default.css
@@ -2276,15 +2276,6 @@ ul.listCompact {
 
 /* General Titles */
 
-.banner
-{
-    background-color: #ECECEC;
-    color: #888;
-    vertical-align: middle;
-    padding: 20px 30px;
-    line-height: 30px;
-}
-
 .selectedCategoryName{
     padding:20px;
     font-size: 16px;
@@ -2398,59 +2389,6 @@ div.ACModifButtonEntry {
 
 div.ACUserListDiv {
     margin-bottom: 20px;
-}
-
-.bannerTitle
-{
-    font-family: "Helvetica Neue", Helvetica, Verdana, Arial, Sans-serif;
-    color: #777777;
-}
-
-.bannerTitle:hover
-{
-    color: #E25300
-}
-
-.bannerTitle_0
-{
-    font-size: 21px;
-}
-
-.bannerTitle_1
-{
-    font-size: 14px;
-}
-
-.bannerTitle_2
-{
-    font-size: 13px;
-}
-
-.bannerTitle_3
-{
-    font-size: 13px;
-}
-
-.bannerTitle_4
-{
-    font-size: 13px;
-}
-
-.bannerTitle_5
-{
-    font-size: 13px;
-}
-
-.bannerTitle_noIcon
-{
-    margin-left: 37px;
-}
-
-.banner_creator
-{
-    font-size: 11px;
-    font-weight: normal;
-    line-height: 10px;
 }
 
 .areaTitle_orange {

--- a/indico/htdocs/js/indico/jquery/global.js
+++ b/indico/htdocs/js/indico/jquery/global.js
@@ -53,6 +53,12 @@ $(document).ready(function() {
 
     $('.contextHelp[title]').qtip();
 
+    /* Add qTips to elements with a title attribute. The position of the qTip
+     * can be specified in the data-qtip-position attribute and is one of
+     * "top", "left", "bottom" or "right". It defaults to "bottom".
+     *
+     * It is also possible to have HTML inside the qTip by using the
+     * data-qtip-html attribute instead of the title attribute. */
     $(document).on("mouseenter",
                    '[title]:not([title=""]):not(iframe), [data-qtip-html], [data-qtip-oldtitle]:not(iframe)',
                    function(event) {
@@ -63,6 +69,8 @@ $(document).ready(function() {
             qtipHTMLContainer = $(this).data('qtip-html'),
             qtipHTML = (qtipHTMLContainer && qtipHTMLContainer.length) ? $(this).next(qtipHTMLContainer) : null;
 
+        var title = ($target.attr('title') || $target.data('qtip-oldtitle') || '').trim();
+
         if (!qtipHTML && !title) {
             return;
         }
@@ -70,12 +78,31 @@ $(document).ready(function() {
         $target.attr('data-qtip-oldtitle', title);
         $target.removeAttr('title');
 
+        var position = $(this).data('qtip-position');
+        var positionOptions;
+        if (position == "left") {
+            positionOptions = {
+                my: 'right center',
+                at: 'left center'
+            };
+        } else if (position == "right") {
+            positionOptions = {
+                my: 'left center',
+                at: 'right center'
+            };
+        } else if (position == "top") {
+            positionOptions = {
+                my: 'bottom center',
+                at: 'top center'
+            };
+        }
+
         /* Attach the qTip to a new element to avoid side-effects on all elements with "title" attributes. */
         var container = $('<span>').qtip($.extend(true, {}, {
             overwrite: false,
-            position: {
+            position: $.extend({
                 target: $target
-            },
+            }, positionOptions),
 
             show: {
                 event: event.type,

--- a/indico/htdocs/sass/base/_pages.scss
+++ b/indico/htdocs/sass/base/_pages.scss
@@ -57,25 +57,27 @@
     $banner-title-color: #777777;
 
     display: flex;
-    align-items: center;
     background-color: #ECECEC;
     color: $banner-color;
     padding: 20px 30px 0px 20px;
 
     .title {
         flex-grow: 1;
-        align-self: flex-start;
         margin-bottom: 20px;
         font-size: 1.6em;
         color: $banner-title-color;
 
-        & > a:not(:hover) {
+        a:not(:hover) {
             color: inherit;
         }
 
         .subtitle {
             color: $banner-color;
             font-size: 0.6em;
+
+            a {
+                border-bottom: 1px dashed;
+            }
         }
 
         .date {

--- a/indico/htdocs/sass/base/_pages.scss
+++ b/indico/htdocs/sass/base/_pages.scss
@@ -51,6 +51,42 @@
     }
 }
 
+.banner
+{
+    $banner-color: #888;
+    $banner-title-color: #777777;
+
+    display: flex;
+    align-items: center;
+    background-color: #ECECEC;
+    color: $banner-color;
+    padding: 20px 30px 0px 20px;
+
+    .title {
+        flex-grow: 1;
+        align-self: flex-start;
+        margin-bottom: 20px;
+        font-size: 1.6em;
+        color: $banner-title-color;
+
+        & > a:not(:hover) {
+            color: inherit;
+        }
+
+        .subtitle {
+            color: $banner-color;
+            font-size: 0.6em;
+        }
+
+        .date {
+            color: $banner-color;
+            font-size: 0.75em;
+            font-style: italic;
+
+        }
+    }
+}
+
 .management-page {
     @extend %indico-page;
 

--- a/indico/htdocs/sass/modules/_event_management.scss
+++ b/indico/htdocs/sass/modules/_event_management.scss
@@ -19,6 +19,34 @@
 @import "compass";
 @import "partials/icons";
 
+.action-menu {
+    .toolbar {
+        margin-bottom: 0px;
+        padding-bottom: 0px;
+
+        .group {
+            margin-bottom: 0px;
+        }
+    }
+
+    .clones a {
+        @include icon-after('icon-arrow-down');
+        &:after {
+            vertical-align: -10%;
+        }
+    }
+
+    #action-menu-clones,
+    #action-menu-actions {
+        display: none;
+    }
+}
+
+#action-menu-clones ul {
+    list-style-type: disc;
+    padding-left: 1.5em;
+}
+
 .static-sites {
     width: 650px;
     .i-table-widget {

--- a/indico/htdocs/sass/partials/_buttons.scss
+++ b/indico/htdocs/sass/partials/_buttons.scss
@@ -193,6 +193,11 @@
         }
     }
 
+    &.clickable-label {
+        @extend .i-button.label;
+        cursor: pointer !important;
+    }
+
     &.arrow {
         @include icon-after('icon-arrow-down');
 

--- a/indico/htdocs/sass/partials/_qtips.scss
+++ b/indico/htdocs/sass/partials/_qtips.scss
@@ -18,11 +18,14 @@
 .qtip-default {
     @include border-radius();
     @include border-all($black);
+    font-size: 1em;
+}
+
+.qtip-default:not(.qbubble) {
     box-shadow: 1px 0px 0px 1px rgba(0, 0, 0, 0.2);
 
     color: $light-gray;
     background-color: $black;
-    font-size: 1em;
 
     .qtip-titlebar {
         background-color: #F0F0F0;
@@ -40,12 +43,12 @@
 
 .qtip-danger {
     border-color: $red;
-    background-color: $red;
+    background-color: $red !important;
 }
 
 .qtip-warning {
     border-color: $yellow;
-    background-color: $yellow;
+    background-color: $yellow !important;
 }
 
 .qtip-popup {

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -248,6 +248,11 @@ def _get_cloners(sender, **kwargs):
     yield clone.EventPersonLinkCloner
 
 
+@signals.event.cloned.connect
+def _event_cloned(old_event, new_event, **kwargs):
+    new_event.cloned_from = old_event
+
+
 @template_hook('event-references-list')
 def _inject_event_references(event, **kwargs):
     return render_template('events/management/reference_list.html', event=event, references=event.references, **kwargs)

--- a/indico/modules/events/management/__init__.py
+++ b/indico/modules/events/management/__init__.py
@@ -21,6 +21,7 @@ from flask import session, render_template
 from indico.core import signals
 from indico.core.config import Config
 from indico.modules.events.management.util import can_lock
+from indico.util.event import unify_event_args
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.flask.templating import template_hook
@@ -28,9 +29,10 @@ from indico.web.menu import SideMenuItem, SideMenuSection
 
 
 @template_hook('event-manage-header')
+@unify_event_args
 def _add_action_menu(event, **kwargs):
     return render_template('events/management/action_menu.html', event=event, can_lock=can_lock(event, session.user),
-                           can_manage=event.as_event.can_manage(session.user))
+                           can_manage=event.can_manage(session.user))
 
 
 @signals.menu.sections.connect_via('event-management-sidemenu')

--- a/indico/modules/events/management/templates/action_menu.html
+++ b/indico/modules/events/management/templates/action_menu.html
@@ -1,39 +1,91 @@
-<div class="toolbar action-menu-toolbar">
-    {% if can_manage %}
+{% set clones = event.clones|rejectattr('is_deleted')|list %}
+
+<div class="action-menu">
+    <div class="toolbar">
+        {% if can_manage %}
+            <div class="group left">
+                <a class="i-button icon-copy" href="{{ url_for('event_mgmt.confModifTools-clone', event) }}"
+                   title="{% trans %}Clone event{% endtrans %}">Clone</a>
+                {% if clones %}
+                <a id="action-menu-clones-target" class="i-button clickable-label arrow" >{{ clones|length }}</a>
+                {% endif %}
+            </div>
+
+
+            <a id="action-menu-actions-target" class="i-button icon-settings i-button arrow"
+               title="{% trans %}Event actions{% endtrans %}"></a>
+
+            <div id="action-menu-actions">
+                {% if event.as_legacy.isClosed() %}
+                    <button class="i-button icon-lock-center disabled"
+                            title="{% trans %}This event is already locked.{% endtrans %}"></button>
+                {% elif not can_lock %}
+                    <button class="i-button icon-lock-center disabled"
+                            title="{% trans %}Only the event creator and category managers may lock an event.{% endtrans %}"></button>
+                {% else %}
+                    <button class="i-button icon-lock-center js-ajax-dialog-lock"
+                            data-href="{{ url_for('event_management.lock', event) }}"
+                            title="{% trans %}Lock event{% endtrans %}"
+                            {{ 'disabled' if event.as_legacy.isClosed() }}>
+                        {% trans %}Lock{% endtrans %}</button>
+                {% endif %}
+
+                <button class="i-button icon-remove js-ajax-dialog-delete danger light"
+                        data-href="{{ url_for('event_management.delete', event) }}"
+                        title="{% trans %}Delete event{% endtrans %}"
+                        data-qtip-style="danger">
+                    {% trans %}Delete{% endtrans %}</button>
+            </div>
+
+            <div id="action-menu-clones">
+                {% trans %}Events cloned from the current event:{% endtrans %}
+                <ul>
+                    {% for clone in clones %}
+                        <li>
+                            <a href="{{ url_for('event_mgmt.conferenceModification', clone) }}"
+                               title="{{ clone.title }}" data-qtip-position="left">
+                                {{ clone.start_dt | format_date }}
+                            </a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endif %}
+
         <div class="group">
-            <span class="icon-wrench i-button label">{% trans %}Event actions{% endtrans %}</span>
-            <a class="i-button icon-copy" href="{{ url_for('event_mgmt.confModifTools-clone', event) }}"
-               title="{% trans %}Clone event{% endtrans %}"></a>
-            {% if event.isClosed() %}
-                <button class="i-button icon-lock-center disabled"
-                        title="{% trans %}This event is already locked.{% endtrans %}"></button>
-            {% elif not can_lock %}
-                <button class="i-button icon-lock-center disabled"
-                        title="{% trans %}Only the event creator and category managers may lock an event.{% endtrans %}"></button>
-            {% else %}
-                <button class="i-button icon-lock-center js-ajax-dialog-lock" data-href="{{ url_for('event_management.lock', event) }}"
-                        title="{% trans %}Lock event{% endtrans %}" {{ 'disabled' if event.isClosed() }}></button>
-            {% endif %}
-            <button class="i-button icon-remove js-ajax-dialog-delete danger light"
-                    data-href="{{ url_for('event_management.delete', event) }}"
-                    title="{% trans %}Delete event{% endtrans %}"
-                    data-qtip-style="danger"></button>
+            <a class="icon-switchon highlight i-button"
+               title="{% trans %}See the display page of the event{% endtrans %}"
+               href="{{ url_for('event.conferenceDisplay', event) }}">{% trans %}Switch to display view{% endtrans %}</a>
         </div>
-    {% endif %}
-    <div class="group">
-        <a class="icon-switchon highlight i-button"
-           title="{% trans %}See the display page of the event{% endtrans %}"
-           href="{{ url_for('event.conferenceDisplay', event) }}">{% trans %}Switch to display view{% endtrans %}</a>
     </div>
 </div>
 
 <script>
-    $('.js-ajax-dialog-delete, .js-ajax-dialog-lock').ajaxDialog({
-        onClose: function(data) {
-            if (data && data.url) {
-                location.href = data.url;
+    (function() {
+        'use strict';
+        $('.js-ajax-dialog-delete, .js-ajax-dialog-lock').ajaxDialog({
+            onClose: function(data) {
+                if (data && data.url) {
+                    location.href = data.url;
+                }
+                return true;
             }
-            return true;
-        }
-    });
+        });
+
+        $('#action-menu-clones-target').qbubble({
+            content: {
+                text: $('#action-menu-clones')
+            }
+        });
+
+        $('#action-menu-actions-target').qbubble({
+            content: {
+                text: $('#action-menu-actions')
+            }
+        });
+
+        $('#action-menu-actions button').on('click', function() {
+            $('#action-menu-actions-target').qbubble('hide');
+        });
+    })();
 </script>

--- a/indico/modules/events/management/templates/action_menu.html
+++ b/indico/modules/events/management/templates/action_menu.html
@@ -1,4 +1,4 @@
-<div class="toolbar right action-menu-toolbar">
+<div class="toolbar action-menu-toolbar">
     {% if can_manage %}
         <div class="group">
             <span class="icon-wrench i-button label">{% trans %}Event actions{% endtrans %}</span>

--- a/migrations/versions/201603081617_38ed666dda98_add_event_cloned_from_id.py
+++ b/migrations/versions/201603081617_38ed666dda98_add_event_cloned_from_id.py
@@ -1,0 +1,29 @@
+"""Add event cloned_from_id
+
+Revision ID: 38ed666dda98
+Revises: 29232c09e58a
+Create Date: 2016-03-08 16:17:39.294809
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '38ed666dda98'
+down_revision = '29232c09e58a'
+
+
+def upgrade():
+    op.add_column('events', sa.Column('cloned_from_id', sa.Integer(), nullable=True), schema='events')
+    op.create_index(None, 'events', ['cloned_from_id'], schema='events')
+    op.create_check_constraint('not_cloned_from_self', 'events', 'cloned_from_id != id', schema='events')
+    op.create_foreign_key(None, 'events', 'events',
+                          ['cloned_from_id'], ['id'],
+                          source_schema='events',
+                          referent_schema='events')
+
+
+def downgrade():
+    op.drop_constraint('ck_events_not_cloned_from_self', 'events', schema='events')
+    op.drop_column('events', 'cloned_from_id', schema='events')


### PR DESCRIPTION
Add a cloned_from_id column in the event table which allow to show the parent and children of an event.

Fixes #1708