### PR TITLE
Adapt export API for events (including all detail levels)

### DIFF
--- a/indico/modules/attachments/api/util.py
+++ b/indico/modules/attachments/api/util.py
@@ -27,9 +27,15 @@ from indico.modules.attachments.models.folders import AttachmentFolder
 from MaKaC.common.contextManager import ContextManager
 
 
+def get_event(linked_object):
+    from MaKaC.conference import Category
+
+    return linked_object.event_new if not isinstance(linked_object, Category) else None
+
+
 def build_material_legacy_api_data(linked_object):
     # Skipping root folder and files in legacy API
-    event = linked_object.event_new
+    event = get_event(linked_object)
     try:
         cache = g.legacy_api_event_attachments[event]
     except (AttributeError, KeyError):

--- a/indico/modules/attachments/models/folders.py
+++ b/indico/modules/attachments/models/folders.py
@@ -177,9 +177,9 @@ class AttachmentFolder(LinkMixin, ProtectionMixin, db.Model):
                               This must not be used when ``linked_object``
                               is a category.
         """
-        from MaKaC.conference import Category
+        from indico.modules.attachments.api.util import get_event
 
-        event = linked_object.event_new if not isinstance(linked_object, Category) else None
+        event = get_event(linked_object)
 
         if event and event in g.get('event_attachments', {}):
             return g.event_attachments[event].get(linked_object, [])
@@ -192,7 +192,7 @@ class AttachmentFolder(LinkMixin, ProtectionMixin, db.Model):
             if 'event_attachments' not in g:
                 g.event_attachments = {}
             g.event_attachments[event] = defaultdict(list)
-            query = (linked_object.event_new.all_attachment_folders
+            query = (event.all_attachment_folders
                      .filter_by(is_deleted=False)
                      .order_by(AttachmentFolder.is_default.desc(), db.func.lower(AttachmentFolder.title))
                      .options(joinedload(AttachmentFolder.attachments),

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -347,7 +347,7 @@ class CategoryEventFetcher(IteratedDataFetcher):
             'address': session_.address,
             '_fossil': 'sessionMinimal',
             'numSlots': len(session_.blocks),
-            'id': session_.friendly_id,
+            'id': session_.legacy_mapping.legacy_session_id if session_.legacy_mapping else session_.id,
             'room': session_.get_room_name(full=False)
         }
 
@@ -474,7 +474,7 @@ class CategoryEventFetcher(IteratedDataFetcher):
         data = {
             '_type': 'Contribution',
             '_fossil': self.fossils_mapping['contribution'].get(self._detail_level, None),
-            'id': contrib.id,
+            'id': contrib.legacy_mapping.legacy_contribution_id if contrib.legacy_mapping else contrib.id,
             'title': contrib.title,
             'startDate': self._serialize_date(contrib.start_dt) if contrib.start_dt else None,
             'endDate': self._serialize_date(contrib.start_dt + contrib.duration) if contrib.start_dt else None,
@@ -507,7 +507,7 @@ class CategoryEventFetcher(IteratedDataFetcher):
         data = {
             '_type': 'SubContribution',
             '_fossil': 'subContributionMetadata',
-            'id': subcontrib.id,
+            'id': subcontrib.legacy_mapping.legacy_subcontribution_id if subcontrib.legacy_mapping else subcontrib.id,
             'title': subcontrib.title,
             'duration': subcontrib.duration.seconds // 60,
             'note': build_note_api_data(subcontrib.note),

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -352,6 +352,11 @@ class Event(DescriptionMixin, LocationMixin, ProtectionManagersMixin, AttachedIt
         return pytz.timezone(self.timezone)
 
     @property
+    def category(self):
+        from MaKaC.conference import CategoryManager
+        return CategoryManager().getById(str(self.category_id), True)
+
+    @property
     @contextmanager
     def logging_disabled(self):
         """Temporarily disables event logging

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -239,6 +239,10 @@ class PersonLinkBase(PersonMixin, db.Model):
             )
         )
 
+    @property
+    def email(self):
+        return self.person.email
+
     first_name = override_attr('first_name', 'person')
     last_name = override_attr('last_name', 'person')
     title = override_attr('title', 'person', fget=lambda self, __: self._get_title())

--- a/indico/modules/events/sessions/models/sessions.py
+++ b/indico/modules/events/sessions/models/sessions.py
@@ -152,6 +152,17 @@ class Session(DescriptionMixin, ColorMixin, ProtectionManagersMixin, LocationMix
         """Convenience property so all event entities have it"""
         return self
 
+    @property
+    def conveners(self):
+        from indico.modules.events.sessions.models.blocks import SessionBlock
+        from indico.modules.events.sessions.models.persons import SessionBlockPersonLink
+
+        return (SessionBlockPersonLink.query
+                .join(SessionBlock)
+                .filter(SessionBlock.session_id == self.id)
+                .distinct(SessionBlockPersonLink.person_id)
+                .all())
+
     @locator_property
     def locator(self):
         return dict(self.event_new.locator, session_id=self.id)

--- a/indico/modules/events/sessions/models/sessions.py
+++ b/indico/modules/events/sessions/models/sessions.py
@@ -30,6 +30,7 @@ from indico.core.db.sqlalchemy.protection import ProtectionManagersMixin
 from indico.core.db.sqlalchemy.util.models import auto_table_args
 from indico.core.db.sqlalchemy.util.queries import increment_and_get
 from indico.modules.events.management.util import get_non_inheriting_objects
+from indico.util.caching import memoize_request
 from indico.util.locators import locator_property
 from indico.util.string import format_repr, return_ascii
 
@@ -153,6 +154,7 @@ class Session(DescriptionMixin, ColorMixin, ProtectionManagersMixin, LocationMix
         return self
 
     @property
+    @memoize_request
     def conveners(self):
         from indico.modules.events.sessions.models.blocks import SessionBlock
         from indico.modules.events.sessions.models.persons import SessionBlockPersonLink

--- a/indico/modules/events/sessions/models/sessions.py
+++ b/indico/modules/events/sessions/models/sessions.py
@@ -19,6 +19,7 @@ from __future__ import unicode_literals
 from datetime import timedelta
 
 from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import noload, contains_eager, load_only
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy.attachments import AttachedItemsMixin
@@ -30,6 +31,7 @@ from indico.core.db.sqlalchemy.protection import ProtectionManagersMixin
 from indico.core.db.sqlalchemy.util.models import auto_table_args
 from indico.core.db.sqlalchemy.util.queries import increment_and_get
 from indico.modules.events.management.util import get_non_inheriting_objects
+from indico.modules.events.timetable.models.entries import TimetableEntryType, TimetableEntry
 from indico.util.caching import memoize_request
 from indico.util.locators import locator_property
 from indico.util.string import format_repr, return_ascii
@@ -164,6 +166,30 @@ class Session(DescriptionMixin, ColorMixin, ProtectionManagersMixin, LocationMix
                 .filter(SessionBlock.session_id == self.id)
                 .distinct(SessionBlockPersonLink.person_id)
                 .all())
+
+    @property
+    def start_dt(self):
+        from indico.modules.events.sessions.models.blocks import SessionBlock
+        start_dt = (self.event_new.timetable_entries
+                    .with_entities(TimetableEntry.start_dt)
+                    .join('session_block')
+                    .filter(TimetableEntry.type == TimetableEntryType.SESSION_BLOCK, SessionBlock.session == self)
+                    .first())
+        if start_dt:
+            return start_dt[0]
+
+    @property
+    def end_dt(self):
+        from indico.modules.events.sessions.models.blocks import SessionBlock
+        block = (SessionBlock.query.with_parent(self)
+                 .join(TimetableEntry)
+                 .options(noload('*'))
+                 .options(load_only('id'))
+                 .options(contains_eager('timetable_entry').load_only('start_dt'))
+                 .order_by((TimetableEntry.start_dt + SessionBlock.duration).desc())
+                 .first())
+        if block:
+            return block.timetable_entry.end_dt
 
     @locator_property
     def locator(self):


### PR DESCRIPTION
### Changes from legacy:
* `id` of chairpersons, speakers, authors, coauthors, conveners:
    * was a friendly id. After this PR it will change to the `EventPerson.id`.
    * was a `str`, now it's an `int`.
* `id` of the event was a `str` now it's an `int`
* session block id was in the format `<session friendly id>-<block friendly id>`, now it's the postgres `SessionBlock.id`.
* There is no `description` in `SessionBlock` anymore.

### Dependencies
- [x] Un-comment session `startDate` and `endDate` when https://github.com/indico/indico/pull/2272 gets merged