### PR TITLE
Add a dialog to manage contribution types

### DIFF
--- a/indico/htdocs/js/indico/jquery/ajaxdialog.js
+++ b/indico/htdocs/js/indico/jquery/ajaxdialog.js
@@ -203,13 +203,14 @@
 
         function ajaxifyForms() {
             var killProgress = null;
+            popup.contentContainer.on('click', options.backSelector, function(e) {
+                e.preventDefault();
+                closeDialog();
+            });
             var forms = popup.contentContainer.find('form');
             showFormErrors(popup.resultContainer);
             initForms(forms);
-            forms.on('click', options.backSelector, function(e) {
-                e.preventDefault();
-                closeDialog();
-            }).each(function() {
+            forms.each(function() {
                 var $this = $(this);
                 $this.on('ajaxDialog:beforeSubmit', function() {
                     killProgress = IndicoUI.Dialogs.Util.progress();

--- a/indico/htdocs/js/indico/jquery/declarative.js
+++ b/indico/htdocs/js/indico/jquery/declarative.js
@@ -67,7 +67,7 @@
             var paramsSelector = $this.data('params-selector');
             var update = $this.data('update');
             var dialog = $this.data('ajax-dialog') !== undefined;
-            var reload = $this.data('reload-after') !== undefined;
+            var reload = $this.data('reload-after');
             if (!$.isPlainObject(params)) {
                 throw new Error('Invalid params. Must be valid JSON if set.');
             }
@@ -120,14 +120,16 @@
                         data: params,
                         title: $this.data('title'),
                         dialogClasses: $this.data('dialog-classes'),
-                        onClose: function(data) {
+                        onClose: function(data, customData) {
                             if (data) {
                                 handleFlashes(data, true, $this);
                                 if (update) {
                                     handleHtmlUpdate(data, update, $this);
-                                } else if (reload) {
+                                } else if (reload !== undefined && reload !== 'customData') {
                                     location.reload();
                                 }
+                            } else if (reload === 'customData' && customData) {
+                                location.reload();
                             }
                         }
                     });

--- a/indico/htdocs/js/indico/jquery/qbubble.js
+++ b/indico/htdocs/js/indico/jquery/qbubble.js
@@ -19,6 +19,7 @@
     $.widget('indico.qbubble', {
         defaultQtipOptions: {
             overwrite: true,
+            suppress: false,
             position: {
                 my: 'top center',
                 at: 'bottom center',

--- a/indico/htdocs/sass/base/_pages.scss
+++ b/indico/htdocs/sass/base/_pages.scss
@@ -15,6 +15,10 @@
  * along with Indico; if not, see <http://www.gnu.org/licenses/>.
  */
 
+%title-border {
+    border-bottom: 1px solid $separator-color;
+}
+
 %indico-page {
     header {
         $separator-margin: 0.4rem;
@@ -22,17 +26,18 @@
 
         h2, h3 {
             display: inline-block;
-            margin-bottom: $separator-margin;
             margin-top: 0;
+            margin-bottom: 0;
         }
 
         h3 {
             color: $light-black;
+            margin-top: $separator-margin;
             margin-left: 1em;
         }
 
-        div.title {
-            border-bottom: 1px solid $separator-color;
+        > div.title {
+            @extend %title-border;
         }
 
         div.description {
@@ -40,6 +45,16 @@
             color: $dark-gray;
             font-size: 1.2em;
             margin-top: $separator-margin;
+        }
+
+        .title-with-actions {
+            @extend %title-border;
+            display: flex;
+            padding-bottom: $separator-margin;
+
+            > .actions .i-button{
+                margin-top: 3px;
+            }
         }
     }
 }

--- a/indico/htdocs/sass/modules/_contributions.scss
+++ b/indico/htdocs/sass/modules/_contributions.scss
@@ -114,3 +114,18 @@
 .qbubble-contrib-duration {
     max-width: 420px !important;
 }
+
+.manage-contribution-types {
+    table.i-table {
+        table-layout: auto;
+
+        th, td {
+            white-space: normal;
+        }
+
+        .action-column {
+            white-space: nowrap;
+            width: 1px;
+        }
+    }
+}

--- a/indico/htdocs/sass/modules/_contributions.scss
+++ b/indico/htdocs/sass/modules/_contributions.scss
@@ -116,11 +116,17 @@
 }
 
 .manage-contribution-types {
+    max-width: 600px;
+
     table.i-table {
         table-layout: auto;
 
         th, td {
             white-space: normal;
+
+            &.name-column {
+                white-space: nowrap;
+            }
         }
 
         .action-column {

--- a/indico/htdocs/sass/partials/_buttons.scss
+++ b/indico/htdocs/sass/partials/_buttons.scss
@@ -205,6 +205,12 @@
             vertical-align: -10%;
         }
     }
+
+    &.inconspicuous {
+        box-shadow: none !important;
+        background: transparent !important;
+        border: none;
+    }
 }
 
 a.i-big-button {

--- a/indico/htdocs/sass/partials/_dropdowns.scss
+++ b/indico/htdocs/sass/partials/_dropdowns.scss
@@ -24,6 +24,7 @@
     padding: 0px;
     position: absolute;
     z-index: 0;
+    display: none;
 
     > li {
         cursor: pointer;

--- a/indico/htdocs/sass/partials/_tables.scss
+++ b/indico/htdocs/sass/partials/_tables.scss
@@ -204,6 +204,13 @@ tr.i-table.content {
     }
 }
 
+td, th {
+    &.small-column, &.action-column {
+        white-space: nowrap;
+        width: 1px;
+    }
+}
+
 
 // ============================================================================
 // Widget table
@@ -232,11 +239,6 @@ tr.i-table.content {
     tr > td {
         border-top: 1px solid $gray;
         vertical-align: middle;
-    }
-
-    th.small-column, th.action-column {
-        white-space: nowrap;
-        width: 1px;
     }
 
     .col-50 {

--- a/indico/htdocs/sass/partials/_toolbars.scss
+++ b/indico/htdocs/sass/partials/_toolbars.scss
@@ -106,7 +106,6 @@ $toolbar-thin-height: 1.9em;
     }
 
     .dropdown {
-        display: none;
         z-index: 1;
 
         & > li {

--- a/indico/modules/events/contributions/blueprint.py
+++ b/indico/modules/events/contributions/blueprint.py
@@ -28,7 +28,9 @@ from indico.modules.events.contributions.controllers import (RHContributions, RH
                                                              RHContributionsMaterialPackage, RHContributionsExportCSV,
                                                              RHContributionsExportExcel, RHContributionsExportPDF,
                                                              RHContributionsExportPDFBook,
-                                                             RHContributionsExportPDFBookSorted)
+                                                             RHContributionsExportPDFBookSorted,
+                                                             RHManageContributionTypes, RHEditContributionType,
+                                                             RHCreateContributionType, RHDeleteContributionType)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
@@ -79,3 +81,12 @@ _bp.add_url_rule('/manage/contributions/<int:contrib_id>/subcontributions/<int:s
                  'manage_subcontrib_rest', RHSubContributionREST, methods=('DELETE',))
 _bp.add_url_rule('/manage/contributions/<int:contrib_id>/subcontributions/<int:subcontrib_id>/edit',
                  'manage_edit_subcontrib', RHEditSubContribution, methods=('GET', 'POST'))
+
+# Contribution types
+_bp.add_url_rule('/manage/contributions/types/', 'manage_types', RHManageContributionTypes)
+_bp.add_url_rule('/manage/contributions/types/create', 'create_type', RHCreateContributionType,
+                 methods=('GET', 'POST'))
+_bp.add_url_rule('/manage/contributions/types/<int:contrib_type_id>', 'manage_type', RHEditContributionType,
+                 methods=('GET', 'POST'))
+_bp.add_url_rule('/manage/contributions/types/<int:contrib_type_id>/delete', 'delete_type',
+                 RHDeleteContributionType, methods=('POST',))

--- a/indico/modules/events/contributions/models/types.py
+++ b/indico/modules/events/contributions/models/types.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.declarative import declared_attr
 
 from indico.core.db import db
 from indico.util.string import format_repr, return_ascii
+from indico.util.locators import locator_property
 
 
 class ContributionType(db.Model):
@@ -67,3 +68,7 @@ class ContributionType(db.Model):
     @return_ascii
     def __repr__(self):
         return format_repr(self, 'id', _text=self.name)
+
+    @locator_property
+    def locator(self):
+        return dict(self.event_new.locator, contrib_type_id=self.id)

--- a/indico/modules/events/contributions/templates/management/_types_table.html
+++ b/indico/modules/events/contributions/templates/management/_types_table.html
@@ -1,0 +1,18 @@
+{% macro types_table_row(contrib_type) %}
+    <tr class="i-table">
+        <td class="i-table">{{ contrib_type.name }}</td>
+        <td class="i-table">{{ contrib_type.description }}</td>
+        <td class="i-table action-column">
+            <a class="js-edit-contribution-type icon-edit"
+               data-ajax-dialog
+               data-href="{{ url_for('.manage_type', contrib_type) }}"
+               data-title="{% trans %}Edit contribution type{% endtrans %}"></a>
+            <a class="js-delete-contribution-type icon-remove"
+               data-method="POST"
+               data-href="{{ url_for('.delete_type', contrib_type) }}"
+               data-confirm="{% trans %}Do you really want to delete this contribution type?{% endtrans %}"
+               data-title="{% trans %}Confirm deletion{% endtrans %}"></a>
+      </td>
+    </tr>
+{% endmacro %}
+

--- a/indico/modules/events/contributions/templates/management/_types_table.html
+++ b/indico/modules/events/contributions/templates/management/_types_table.html
@@ -1,6 +1,6 @@
 {% macro types_table_row(contrib_type) %}
     <tr class="i-table">
-        <td class="i-table">{{ contrib_type.name }}</td>
+        <td class="i-table name-column">{{ contrib_type.name }}</td>
         <td class="i-table">{{ contrib_type.description }}</td>
         <td class="i-table action-column">
             <a class="js-edit-contribution-type icon-edit"

--- a/indico/modules/events/contributions/templates/management/contributions.html
+++ b/indico/modules/events/contributions/templates/management/contributions.html
@@ -8,15 +8,21 @@
 
 {% block page_actions %}
     {%- if event.type == 'conference' -%}
-        <div class="group">
-            <div class="i-button label icon-settings"></div>
-            <button class="i-button" data-ajax-dialog data-reload-after="customData"
-                    title="{% trans %}Manage contribution types{% endtrans %}"
-                    data-title="{% trans %}Manage contribution types{% endtrans %}"
-                    data-href="{{ url_for('.manage_types', event) }}">
-                {% trans %}Types{% endtrans %}
-            </button>
-        </div>
+        <a id="contributions-settings-dropdown"
+           class="i-button inconspicuous icon-settings arrow js-dropdown"
+           data-toggle="dropdown"></a>
+        <ul class="dropdown">
+            <li>
+                <a href="#"
+                   title="{% trans %}Manage contribution types{% endtrans %}"
+                   data-ajax-dialog
+                   data-reload-after="customData"
+                   data-title="{% trans %}Manage contribution types{% endtrans %}"
+                   data-href="{{ url_for('.manage_types', event) }}"
+                   data-qtip-position="right">
+                    {% trans %}Contribution types{% endtrans %}</a>
+            </li>
+        </ul>
     {%- endif -%}
 {% endblock %}
 

--- a/indico/modules/events/contributions/templates/management/contributions.html
+++ b/indico/modules/events/contributions/templates/management/contributions.html
@@ -6,6 +6,20 @@
     {% trans %}Contributions{% endtrans %}
 {% endblock %}
 
+{% block page_actions %}
+    {%- if event.type == 'conference' -%}
+        <div class="group">
+            <div class="i-button label icon-settings"></div>
+            <button class="i-button" data-ajax-dialog data-reload-after="customData"
+                    title="{% trans %}Manage contribution types{% endtrans %}"
+                    data-title="{% trans %}Manage contribution types{% endtrans %}"
+                    data-href="{{ url_for('.manage_types', event) }}">
+                {% trans %}Types{% endtrans %}
+            </button>
+        </div>
+    {%- endif -%}
+{% endblock %}
+
 {% block content %}
     <div class="report-section">
         <div class="toolbar">

--- a/indico/modules/events/contributions/templates/management/types_dialog.html
+++ b/indico/modules/events/contributions/templates/management/types_dialog.html
@@ -13,7 +13,7 @@
     {% if contrib_types %}
         <table class="i-table">
             <thead>
-                <th class="i-table">
+                <th class="i-table name-column">
                     {% trans %}Name{% endtrans %}
                 </th>
                 <th class="i-table">

--- a/indico/modules/events/contributions/templates/management/types_dialog.html
+++ b/indico/modules/events/contributions/templates/management/types_dialog.html
@@ -1,0 +1,101 @@
+{% from 'message_box.html' import message_box %}
+{% from 'events/contributions/management/_types_table.html' import types_table_row %}
+
+<div class="manage-contribution-types">
+    <div class="toolbar">
+        <button id="js-new-contribution-type" class="i-button icon-plus highlight" data-ajax-dialog
+                data-href="{{ url_for('.create_type', event) }}"
+                data-title="{% trans %}Add new contribution type{% endtrans %}">
+            {% trans %}New contribution type{% endtrans %}
+        </button>
+    </div>
+
+    {% if contrib_types %}
+        <table class="i-table">
+            <thead>
+                <th class="i-table">
+                    {% trans %}Name{% endtrans %}
+                </th>
+                <th class="i-table">
+                    {% trans %}Description{% endtrans %}
+                </th>
+                <th class="i-table action-column"></th>
+            </thead>
+            <tbody>
+                {% for contrib_type in contrib_types %}
+                    {{ types_table_row(contrib_type) }}
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        {%- call message_box('info') %}
+            {%- trans %}There are no contribution types yet.{% endtrans %}
+        {%- endcall %}
+    {% endif %}
+
+    <div class="toolbar">
+        <div class="group right">
+            <button class="i-button big" data-button-back>{% trans %}Close{% endtrans %}</button>
+        </div>
+    </div>
+</div>
+
+<script>
+    (function() {
+        'use strict';
+
+        /* Set the customData to true indicating that the contribution list needs to be refreshed */
+        function dialogModified() {
+            $('.manage-contribution-types').trigger('ajaxDialog:setData', [true]);
+        }
+
+        $('.manage-contribution-types table').tablesorter({
+            sortList: [[0, 0]],
+            headers: {
+                2: {
+                    sorter: false
+                }
+            }
+        });
+
+        $('#js-new-contribution-type').on('ajaxDialog:closed', function(evt, data) {
+            evt.preventDefault();
+            if (data) {
+                var $lastRow = $('.manage-contribution-types table tr:last');
+                if ($lastRow.length) {
+                    $lastRow.after(data.html_row);
+                } else {
+                    $('.manage-contribution-types').trigger('ajaxDialog:reload');
+                }
+            }
+        });
+
+        $('.manage-contribution-types').on('ajaxDialog:closed', '.js-edit-contribution-type', function(evt, data) {
+            evt.preventDefault();
+            var $row = $(this).closest('tr');
+            if (data) {
+                $row.replaceWith(data.html_row);
+                dialogModified();
+            }
+        });
+
+        $('.manage-contribution-types').on('indico:confirmed', '.js-delete-contribution-type', function(evt) {
+            evt.preventDefault();
+            var $this = $(this);
+            var $row = $this.closest('tr');
+            $.ajax({
+                url: $this.data('href'),
+                method: $this.data('method'),
+                complete: IndicoUI.Dialogs.Util.progress(),
+                error: handleAjaxError,
+                success: function() {
+                    $row.remove();
+                    dialogModified();
+                    if ($('.manage-contribution-types table tbody tr').length == 0) {
+                        $('.manage-contribution-types').trigger('ajaxDialog:reload');
+                    }
+                }
+            });
+        });
+    })();
+</script>

--- a/indico/modules/events/contributions/util.py
+++ b/indico/modules/events/contributions/util.py
@@ -32,6 +32,7 @@ from indico.util.date_time import format_human_timedelta, format_date
 from indico.util.i18n import _
 from indico.util.string import to_unicode
 from indico.web.flask.templating import get_template_module
+from indico.web.util import jsonify_data
 
 
 def get_events_with_linked_contributions(user, from_dt=None, to_dt=None):
@@ -214,3 +215,9 @@ def make_contribution_form(event):
         name = 'custom_{}'.format(custom_field.id)
         setattr(form_class, name, field_impl.create_wtf_field())
     return form_class
+
+
+def contribution_type_row(contrib_type):
+    template = get_template_module('events/contributions/management/_types_table.html')
+    html = template.types_table_row(contrib_type=contrib_type)
+    return jsonify_data(html_row=html, flash=False)

--- a/indico/web/templates/layout/base.html
+++ b/indico/web/templates/layout/base.html
@@ -6,6 +6,11 @@
                 {% if self.subtitle() -%}
                     <h3>{% block subtitle %}{% endblock %}</h3>
                 {% endif %}
+                {% if self.page_actions() %}
+                    <div class="toolbar right">
+                        {% block page_actions %}{% endblock %}
+                    </div>
+                {% endif %}
             </div>
             {% if self.description() -%}
                 <div class="description">

--- a/indico/web/templates/layout/base.html
+++ b/indico/web/templates/layout/base.html
@@ -1,16 +1,18 @@
 {% block page %}
     <div class="{% block page_class %}management-page{% endblock %}">
         <header>
-            <div class="title">
-                <h2>{% block title %}{% endblock %}</h2>
-                {% if self.subtitle() -%}
-                    <h3>{% block subtitle %}{% endblock %}</h3>
-                {% endif %}
-                {% if self.page_actions() %}
-                    <div class="toolbar right">
+            <div class="title-with-actions">
+                <div class="title">
+                    <h2>{% block title %}{% endblock %}</h2>
+                    {% if self.subtitle() -%}
+                        <h3>{% block subtitle %}{% endblock %}</h3>
+                    {% endif %}
+                </div>
+                <div class="actions">
+                    {% if self.page_actions() %}
                         {% block page_actions %}{% endblock %}
-                    </div>
-                {% endif %}
+                    {% endif %}
+                </div>
             </div>
             {% if self.description() -%}
                 <div class="description">


### PR DESCRIPTION
The dialog allows to create/update/delete contribution types. (The cog icon is in a label next to the "Types" button because there will soon be an additional "Fields" button.)

Also contains two small fixes:

- qTips for `title` attributes on the target element of a qBubble were not shown
- Allow the close button of an ajaxDialog to be outside of a form