### PR TITLE
Use new contribution display page

### DIFF
--- a/indico/MaKaC/webinterface/tpls/AuthorDisplay.tpl
+++ b/indico/MaKaC/webinterface/tpls/AuthorDisplay.tpl
@@ -28,7 +28,7 @@
 <div>
     % for i, contrib in enumerate(contributions):
         <div class="contribItem" style="clear: both; padding-bottom: 7px; padding-left: 20px;">
-            <a href="${url_for('event.contributionDisplay', contrib)}">${contrib.getTitle()}</a>
+            <a href="${url_for('contributions.display_contribution', contrib)}">${contrib.getTitle()}</a>
         </div>
     % endfor
 </div>

--- a/indico/modules/events/timetable/templates/display/_weeks.html
+++ b/indico/modules/events/timetable/templates/display/_weeks.html
@@ -2,7 +2,7 @@
 
 {% macro _render_contribution(item, count) %}
     <a class="week-anchor"
-       href="{{ url_for('event.contributionDisplay', confId=item.event_id, contribId=item.id) }}">
+       href="{{ url_for('contributions.display_contribution', item) }}">
         <span class="main">
             <span class="title">{{ item.title }}</span>
             {% set speakers = item.person_links|selectattr("is_speaker")|list %}


### PR DESCRIPTION
event.contributionDisplay -> contributions.display_contribution

Solves `Could_ not build url for endpoint 'event.contributionDisplay'` when showing an event with the "Indico Weeks View" layout.

I also changed the same URL in AuthorDisplay.tpl although I'm not sure where it is used.