### PR TITLE
Fix export of abstract as PDF

### DIFF
--- a/indico/MaKaC/review.py
+++ b/indico/MaKaC/review.py
@@ -249,6 +249,10 @@ class AbstractParticipation(Persistent):
     def getAffiliation(self):
         return self._affilliation
 
+    @property
+    def affiliation(self):
+        return self._affilliation
+
     def setAddress(self, address):
         self._address = address.strip()
         self._notifyModification()
@@ -291,6 +295,10 @@ class AbstractParticipation(Persistent):
         if self.getTitle():
             res = "%s %s" % (self.getTitle(), res)
         return res
+
+    @property
+    def full_name(self):
+        return self.getFullName()
 
     def getStraightFullName(self):
         name = ""

--- a/indico/modules/events/abstracts/legacy.py
+++ b/indico/modules/events/abstracts/legacy.py
@@ -159,6 +159,10 @@ class AbstractFieldWrapper(object):
             return [_("The field '{}' is mandatory").format(self.field.title)]
         return []
 
+    @property
+    def _type(self):
+        return self.getType()
+
 
 class AbstractTextFieldWrapper(AbstractFieldWrapper):
     """Wraps legacy ``AbstractTextAreaField`` and ``AbstractInputField``."""


### PR DESCRIPTION
This fix is ugly but touches only legacy classes that will eventually be removed. Moreover the new code that relies on the changes that introduced the issue can be left unmodified.