### PR TITLE
Export timetable as JSON

### DIFF
--- a/indico/modules/events/timetable/legacy.py
+++ b/indico/modules/events/timetable/legacy.py
@@ -125,6 +125,8 @@ class TimetableSerializer(object):
             data.update(self._get_color_data(contribution.session))
         data.update(self._get_location_data(contribution))
         data.update({'entryType': 'Contribution',
+                     '_type': 'ContribSchEntry',
+                     '_fossil': 'contribSchEntryDisplay',
                      'contributionId': contribution.id,
                      'attachments': self._get_attachment_data(contribution),
                      'description': contribution.description,
@@ -151,6 +153,8 @@ class TimetableSerializer(object):
         data.update(self._get_color_data(break_))
         data.update(self._get_location_data(break_))
         data.update({'entryType': 'Break',
+                     '_type': 'BreakTimeSchEntry',
+                     '_fossil': 'breakTimeSchEntry',
                      'description': break_.description,
                      'duration': break_.duration.seconds / 60,
                      'sessionId': block.session_id if block else None,
@@ -162,10 +166,17 @@ class TimetableSerializer(object):
 
     def _get_attachment_data(self, obj):
         def serialize_attachment(attachment):
-            return {'title': attachment.title, 'download_url': attachment.download_url}
+            return {'id': attachment.id,
+                    '_type': 'Attachment',
+                    '_fossil': 'attachment',
+                    'title': attachment.title,
+                    'download_url': attachment.download_url}
 
         def serialize_folder(folder):
-            return {'title': folder.title,
+            return {'id': folder.id,
+                    '_type': 'AttachmentFolder',
+                    '_fossil': 'folder',
+                    'title': folder.title,
                     'attachments': map(serialize_attachment, folder.attachments)}
 
         data = {'files': [], 'folders': []}

--- a/indico/modules/events/timetable/legacy.py
+++ b/indico/modules/events/timetable/legacy.py
@@ -190,7 +190,7 @@ class TimetableSerializer(object):
         data.update(self._get_date_data(entry))
         data['id'] = self._get_entry_key(entry)
         data['uniqueId'] = data['id']
-        data['conferenceId'] = entry.event_id,
+        data['conferenceId'] = entry.event_id
         if self.management:
             data['scheduleEntryId'] = entry.id
         return data
@@ -227,7 +227,7 @@ class TimetableSerializer(object):
         data['affiliation'] = person_link.affiliation
         data['email'] = person_link.person.email
         data['name'] = person_link.get_full_name(last_name_first=False, last_name_upper=False,
-                                                 abbrev_first_name=False, show_title=True),
+                                                 abbrev_first_name=False, show_title=True)
         if self.management:
             data['id'] = person_link.person_id
             data['address'] = person_link.person.address

--- a/indico/modules/events/timetable/legacy.py
+++ b/indico/modules/events/timetable/legacy.py
@@ -131,7 +131,7 @@ class TimetableSerializer(object):
                      'attachments': self._get_attachment_data(contribution),
                      'description': contribution.description,
                      'duration': contribution.duration.seconds / 60,
-                     'pdf': None,
+                     'pdf': url_for('contributions.export_pdf', entry.contribution),
                      'presenters': map(self._get_person_data,
                                        sorted(contribution.person_links,
                                               key=lambda x: (x.author_type != AuthorType.primary,


### PR DESCRIPTION
Adapt TimetableSerializer to export the Timetable as JSON.

The output format is very close to the previous one.