### PR TITLE
Display times in correct timezone

### DIFF
--- a/indico/modules/events/agreements/templates/agreement_form.html
+++ b/indico/modules/events/agreements/templates/agreement_form.html
@@ -1,19 +1,21 @@
 {% from 'message_box.html' import message_box %}
 {% from 'forms/_form.html' import form_header, form_footer %}
 
+{% set tzinfo = agreement.event_new.display_tzinfo %}
+
 <h2 class="page-title">
     {{ agreement.definition.title }}
 </h2>
 
 {% if agreement.accepted %}
     {% call message_box('success') %}
-        {% trans dt=agreement.signed_dt|format_datetime -%}
+        {% trans dt=agreement.signed_dt|format_datetime(timezone=tzinfo) -%}
             Accepted on {{ dt }}
         {%- endtrans %}
     {% endcall %}
 {% elif agreement.rejected %}
     {% call message_box('error') %}
-        {% trans dt=agreement.signed_dt|format_datetime -%}
+        {% trans dt=agreement.signed_dt|format_datetime(timezone=tzinfo) -%}
             Rejected on {{ dt }}
         {%- endtrans %}
     {% endcall %}
@@ -45,7 +47,7 @@
                 </div>
                 <div class="info-event-details">
                     <i class="icon-time"></i>
-                    {{ agreement.event_new.start_dt | format_datetime }}
+                    {{ agreement.event_new.start_dt | format_datetime(timezone=tzinfo) }}
                 </div>
                 {% if agreement.event_new.venue_name %}
                     <div class="info-event-details">

--- a/indico/modules/events/agreements/templates/agreement_type_details.html
+++ b/indico/modules/events/agreements/templates/agreement_type_details.html
@@ -116,7 +116,7 @@
             </div>
         {% endif %}
 
-        <div class="agreement-list i-box">
+        <div class="agreement-list i-box{% if not (not_sent or pending) %} titled{% endif %}">
             {% if not_sent %}
                 <div class="toolbar">
                     <div class="group">

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -68,7 +68,7 @@
         <div class="time-data">
             <span class="time-info icon-time">
                 {% if contribution.timetable_entry -%}
-                    {{ contribution.timetable_entry.start_dt|format_datetime }}
+                    {{ contribution.timetable_entry.start_dt|format_datetime(timezone=contribution.event_new.display_tzinfo) }}
                 {%- else -%}
                     {% trans %}Not scheduled{% endtrans %}
                 {%- endif %}

--- a/indico/modules/events/contributions/templates/display/subcontribution_display.html
+++ b/indico/modules/events/contributions/templates/display/subcontribution_display.html
@@ -19,7 +19,7 @@
     <div class="time-data">
         <span class="time-info icon-time">
             {% if subcontrib.timetable_entry -%}
-                {{ subcontrib.timetable_entry.start_dt|format_datetime }}
+                {{ subcontrib.timetable_entry.start_dt|format_datetime(timezone=subcontrib.event_new.display_tzinfo) }}
             {%- else -%}
                 {% trans %}Not scheduled{% endtrans %}
             {%- endif %}

--- a/indico/modules/events/management/templates/action_menu.html
+++ b/indico/modules/events/management/templates/action_menu.html
@@ -44,7 +44,7 @@
                         <li>
                             <a href="{{ url_for('event_mgmt.conferenceModification', clone) }}"
                                title="{{ clone.title }}" data-qtip-position="left">
-                                {{ clone.start_dt | format_date }}
+                                {{ clone.start_dt | format_date(timezone=clone.tzinfo) }}
                             </a>
                         </li>
                     {% endfor %}

--- a/indico/modules/events/payment/templates/transaction_details.html
+++ b/indico/modules/events/payment/templates/transaction_details.html
@@ -3,7 +3,7 @@
     <dt>{% trans %}Amount{% endtrans %}</dt>
     <dd>{{ transaction.amount }} {{ transaction.currency }}</dd>
     <dt>{% trans %}Payment date{% endtrans %}</dt>
-    <dd>{{ transaction.timestamp | format_datetime }}</dd>
+    <dd>{{ transaction.timestamp | format_datetime(timezone=transaction.registration.event_new.tzinfo) }}</dd>
     {% if plugin %}
         <dt>{% trans %}Paid with{% endtrans %}</dt>
         <dd>{{ plugin.title }}</dd>

--- a/indico/modules/events/registration/templates/display/_regform_info.html
+++ b/indico/modules/events/registration/templates/display/_regform_info.html
@@ -11,7 +11,7 @@
                             {% trans %}From{% endtrans %}
                         </span>
                         <span class="datetime">
-                            {{ regform.start_dt|format_date }}
+                            {{ regform.start_dt|format_date(timezone=regform.event_new.tzinfo) }}
                         </span>
                     </div>
                     <div>
@@ -20,7 +20,7 @@
                         </span>
                         <span class="datetime">
                             {% if regform.end_dt %}
-                                {{ regform.end_dt|format_date }}
+                                {{ regform.end_dt|format_date(timezone=regform.event_new.tzinfo) }}
                             {% else %}
                                 <em>{% trans %}Not specified{% endtrans %}</em>
                             {% endif %}

--- a/indico/modules/events/registration/templates/display/regform_list.html
+++ b/indico/modules/events/registration/templates/display/regform_list.html
@@ -28,8 +28,8 @@
                             {{ regform.title }}
                         {% endif %}
                     </td>
-                    <td>{{ regform.start_dt | format_datetime if regform.start_dt else _('Not started') }}</td>
-                    <td>{{ regform.end_dt | format_datetime if regform.end_dt else _('No deadline') }}</td>
+                    <td>{{ regform.start_dt | format_datetime(timezone=event.as_event.display_tzinfo) if regform.start_dt else _('Not started') }}</td>
+                    <td>{{ regform.end_dt | format_datetime(timezone=event.as_event.display_tzinfo) if regform.end_dt else _('No deadline') }}</td>
                     <td class="regform-actions">
                         {% if session.user and regform.get_registration(user=session.user) %}
                             <a href="{{ url_for('.display_regform', regform) }}"

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -30,7 +30,7 @@
                             <div class="checkbox-with-text">
                                 <div class="payment-conditions-agreement">
                                     {%- trans updated_by=registration.transaction.data.changed_by_name,
-                                             timestamp=registration.transaction.timestamp | format_date -%}
+                                             timestamp=registration.transaction.timestamp | format_date(timezone=registration.event_new.tzinfo) -%}
                                         Last updated by {{ updated_by }} on {{ timestamp }}.
                                     {% endtrans -%}
                                 </div>
@@ -141,7 +141,7 @@
         <div class="label">
             {% trans %}This registration is complete{% endtrans %}
         </div>
-        {% trans submitted=registration.submitted_dt|format_date %}
+        {% trans submitted=registration.submitted_dt|format_date(timezone=registration.event_new.tzinfo) %}
             Submitted: {{ submitted }}
         {% endtrans %}
     </div>
@@ -174,7 +174,7 @@
                 <div class="label">
                     {% trans %}Checked in{% endtrans %}
                 </div>
-                {% trans checked_in_dt=registration.checked_in_dt|format_date -%}
+                {% trans checked_in_dt=registration.checked_in_dt|format_date(timezone=registration.event_new.tzinfo) -%}
                     Checked in: {{ checked_in_dt }}
                 {%- endtrans %}
                 (<a href="#"

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -49,7 +49,7 @@
                                 {% for item in basic_columns %}
                                     {% if item.id == 'reg_date' %}
                                         <td class="i-table" data-text="{{ registration.submitted_dt }}">
-                                            {{- registration.submitted_dt | format_datetime -}}
+                                            {{- registration.submitted_dt | format_datetime(timezone=registration.event_new.tzinfo) -}}
                                         </td>
                                     {% elif item.id == 'state' %}
                                         <td class="i-table">{{ registration.state.title }}</td>
@@ -65,7 +65,7 @@
                                     {% elif item.id == 'checked_in_date' %}
                                         <td class="i-table" data-text="{{ registration.checked_in_dt }}">
                                             {%- if registration.checked_in_dt %}
-                                                {{- registration.checked_in_dt | format_datetime -}}
+                                                {{- registration.checked_in_dt | format_datetime(timezone=registration.event_new.tzinfo) -}}
                                             {%- endif %}
                                         </td>
                                     {% else %}

--- a/indico/modules/events/requests/templates/emails/base_to_request_managers.txt
+++ b/indico/modules/events/requests/templates/emails/base_to_request_managers.txt
@@ -12,9 +12,9 @@
 {% macro event_details(event) -%}
     Name:     {{ event.title }}
     {% if event.start_dt.date() == event.end_dt.date() -%}
-    Date:     {{ event.start_dt | format_date }}, {{ event.start_dt | format_time }}
+    Date:     {{ event.start_dt | format_date(timezone=event.tzinfo) }}, {{ event.start_dt | format_time(timezone=event.tzinfo) }}
     {%- else -%}
-    Dates:    {{ event.start_dt | format_date }}, {{ event.start_dt | format_time }} - {{ event.end_dt | format_date }}, {{ event.end_dt | format_time }}
+    Dates:    {{ event.start_dt | format_date(timezone=event.tzinfo) }}, {{ event.start_dt | format_time(timezone=event.tzinfo) }} - {{ event.end_dt | format_date(timezone=event.tzinfo) }}, {{ event.end_dt | format_time(timezone=event.tzinfo) }}
     {%- endif %}
     Location: {% if event.venue_name %}{{ event.venue_name }}: {% endif %}{{ event.room_name }}
     Details:  {{ url_for('event.conferenceDisplay', event, _external=True) }}

--- a/indico/modules/events/requests/templates/event_request_details.html
+++ b/indico/modules/events/requests/templates/event_request_details.html
@@ -65,7 +65,7 @@
                             (Phone: {{ req.created_by_user.phone }})
                         {% endif %}
                     {% endcall %}
-                    {{ form_row_static(_('Created at'), req.created_dt | format_datetime) }}
+                    {{ form_row_static(_('Created at'), req.created_dt | format_datetime(timezone=req.event_new.tzinfo)) }}
                 {% endif %}
                 {{ form_rows(form) }}
             {% endblock %}
@@ -102,7 +102,7 @@
                 {{ form_row_static(_('Processed by'), req.processed_by_user.full_name) }}
             {% endif %}
             {% if req.processed_dt %}
-                {{ form_row_static(_('Processed at'), req.processed_dt | format_datetime) }}
+                {{ form_row_static(_('Processed at'), req.processed_dt | format_datetime(timezone=req.event_new.tzinfo)) }}
             {% endif %}
             {% block manager_form %}
                 {{ form_rows(manager_form, skip=manager_form.action_buttons) }}

--- a/indico/modules/events/sessions/templates/display/session_display.html
+++ b/indico/modules/events/sessions/templates/display/session_display.html
@@ -19,7 +19,7 @@
     <div class="time-data">
         <span class="time-info icon-time">
             {% if sess.start_dt -%}
-                {{ sess.start_dt|format_datetime }}
+                {{ sess.start_dt|format_datetime(timezone=sess.event_new.display_tzinfo) }}
             {%- else -%}
                 {% trans %}Not scheduled{% endtrans %}
             {%- endif %}

--- a/indico/modules/events/static/templates/static_sites.html
+++ b/indico/modules/events/static/templates/static_sites.html
@@ -47,7 +47,7 @@
                             {% for site in static_sites %}
                                 <tr>
                                     <td>{{ site.creator.full_name }}</td>
-                                    <td>{{ site.requested_dt|format_datetime }}</td>
+                                    <td>{{ site.requested_dt|format_datetime(timezone=site.event_new.tzinfo) }}</td>
                                     <td>
                                         <span class="i-label {{ label_mapping.get(site.state.name, 'disabled') }}">
                                             {{ site.state.title }}

--- a/indico/modules/events/surveys/templates/display/survey_list.html
+++ b/indico/modules/events/surveys/templates/display/survey_list.html
@@ -24,8 +24,8 @@
                             {{ survey.title }}
                         {% endif %}
                     </td>
-                    <td>{{ survey.start_dt | format_datetime if survey.start_dt else _('Not started') }}</td>
-                    <td>{{ survey.end_dt | format_datetime if survey.end_dt else _('No deadline') }}</td>
+                    <td>{{ survey.start_dt | format_datetime(timezone=event.as_event.display_tzinfo) if survey.start_dt else _('Not started') }}</td>
+                    <td>{{ survey.end_dt | format_datetime(timezone=event.as_event.display_tzinfo) if survey.end_dt else _('No deadline') }}</td>
                     <td class="survey-actions">
                         {% if was_survey_submitted(survey) %}
                             <a class="i-button highlight disabled"

--- a/indico/modules/events/surveys/templates/management/survey.html
+++ b/indico/modules/events/surveys/templates/management/survey.html
@@ -131,7 +131,7 @@
         <td>
             <a href="{{ url_for('.display_submission', submission) }}">{{ submission.id }}</a>
         </td>
-        <td>{{ submission.submitted_dt|format_datetime }}</td>
+        <td>{{ submission.submitted_dt|format_datetime(timezone=submission.survey.event_new.tzinfo) }}</td>
         <td>
             {% if submission.user %}
                 {{ submission.user.full_name }}

--- a/indico/modules/events/surveys/templates/management/survey_submission.html
+++ b/indico/modules/events/surveys/templates/management/survey_submission.html
@@ -15,7 +15,7 @@
         {%- endtrans %}
     {% endif %}
     <br>
-    {% trans submission_dt=submission.submitted_dt | format_datetime -%}
+    {% trans submission_dt=submission.submitted_dt | format_datetime(timezone=survey.event_new.tzinfo) -%}
         Date of submission: {{ submission_dt }}
     {%- endtrans %}
 {% endblock %}


### PR DESCRIPTION
Management pages always use the event timezone while display pages use the user settings.

Also include a display fix for the i-box listing recording/broadcasting agreements.