### PR TITLE
Display fixes

### DIFF
--- a/indico/htdocs/js/indico/modules/eventdisplay.js
+++ b/indico/htdocs/js/indico/modules/eventdisplay.js
@@ -40,7 +40,15 @@
         $('.js-go-to-day').dropdown({
             always_listen: true
         }).find('li a').on('menu_select', function() {
-            window.location = $(this).attr('href');
+            var anchor = $(this).attr('href');
+            $('body, html').animate({
+                'scrollTop': $(anchor).offset().top
+            }, {
+                duration: 700,
+                complete: function() {
+                    location.href = anchor;
+                }
+            });
             return false;
         });
 

--- a/indico/htdocs/sass/custom/_jquery-ui.scss
+++ b/indico/htdocs/sass/custom/_jquery-ui.scss
@@ -19,6 +19,10 @@
     @include border-radius();
 }
 
+.ui-dialog {
+    box-shadow: 0px 0px 24px rgba(0, 0, 0, 0.3);
+}
+
 .ui-widget {
     @extend %font-family-body;
 

--- a/indico/htdocs/sass/custom/_jquery-ui.scss
+++ b/indico/htdocs/sass/custom/_jquery-ui.scss
@@ -17,6 +17,11 @@
 
 .ui-corner-all {
     @include border-radius();
+
+    .ui-dialog-content {
+        /* For some reason the dialogs don't get their bottom corners rounded without this. */
+        @include border-bottom-radius();
+    }
 }
 
 .ui-dialog {

--- a/indico/htdocs/sass/modules/_contributions.scss
+++ b/indico/htdocs/sass/modules/_contributions.scss
@@ -140,6 +140,8 @@
 
     table.i-table {
         table-layout: auto;
+        min-width: 360px;
+        margin-bottom: 1.5em;
 
         th, td {
             white-space: normal;

--- a/indico/htdocs/sass/partials/_tables.scss
+++ b/indico/htdocs/sass/partials/_tables.scss
@@ -79,7 +79,6 @@ tr.i-table {
 
 td.i-table, th.i-table {
     @include box-sizing(border-box);
-    border-left: 2px solid transparent;
     overflow: hidden;
     padding: 5px 3px 5px 3px;
     text-overflow: ellipsis;
@@ -89,10 +88,6 @@ td.i-table, th.i-table {
     &.empty {
         color: $dark-gray;
         font-style: italic;
-    }
-
-    & ~ td.i-table {
-        border-left: none !important;
     }
 
     &.checkbox-column {

--- a/indico/htdocs/sass/partials/reports.scss
+++ b/indico/htdocs/sass/partials/reports.scss
@@ -23,8 +23,6 @@
         }
 
         th {
-            border-left: 0;
-
             &:not(.sorter-false){
                 cursor: pointer;
             }


### PR DESCRIPTION
- Add a shadow beneath the dialogs
- Fix the rounding of the bottom corners of dialogs
- Improve the contribution types dialog appearance
- Correctly display `<th>` in i-tables (fix was previously applied to `.report`only)
- Scroll to the date instead of jumping to it when selecting a date on the event display page