### PR TITLE
Timetable improvements

### DIFF
--- a/indico/htdocs/js/indico/modules/timetable/timetable/Base.js
+++ b/indico/htdocs/js/indico/modules/timetable/timetable/Base.js
@@ -551,8 +551,17 @@ type("TopLevelTimeTableMixin", ["JLookupTabWidget"], {
              if (exists(data[todayStr])) {
                  initialTab = todayStr;
              } else {
-                 // otherwise use the default
-                 initialTab = this.sortedKeys[0];
+                 // look for the first non-empty day
+                 for (var day in this.data) {
+                     if (Object.getOwnPropertyNames(this.data[day]).length > 0) {
+                         initialTab = day;
+                         break;
+                     }
+                 }
+                 if (initialTab === null) {
+                     // otherwise show the first day
+                     initialTab = this.sortedKeys[0];
+                 }
              }
          }
 

--- a/indico/htdocs/js/indico/modules/timetable/timetable/Base.js
+++ b/indico/htdocs/js/indico/modules/timetable/timetable/Base.js
@@ -1400,7 +1400,15 @@ type("TopLevelManagementTimeTable", ["ManagementTimeTable", "TopLevelTimeTableMi
     },
 
     getTTMenu: function() {
-        return null;
+        if (this.isSessionTimetable) {
+            var goBackLink = $('<a>', {
+                'class': 'icon-arrow-up i-button',
+                'href': build_url(Indico.Urls.Timetable.management, {'confId': this.eventInfo.id})
+            }).text($T('Go to event timetable'));
+            return $('<div>', {'class': 'group right'}).append(goBackLink);
+        } else {
+            return null;
+        }
     },
 
     _retrieveHistoryState: function(hash) {

--- a/indico/modules/events/timetable/controllers/display.py
+++ b/indico/modules/events/timetable/controllers/display.py
@@ -43,7 +43,7 @@ class RHTimetable(RHConferenceBaseDisplay):
     def _process(self):
         if self.event_new.theme == 'static':
             event_info = serialize_event_info(self.event_new)
-            timetable_data = TimetableSerializer().serialize_timetable(self.event_new)
+            timetable_data = TimetableSerializer().serialize_timetable(self.event_new, hide_empty_days=True)
             return self.view_class.render_template('display.html', self._conf, event_info=event_info,
                                                    timetable_data=timetable_data, timetable_layout=self.layout)
         else:

--- a/indico/modules/events/timetable/templates/_timetable.html
+++ b/indico/modules/events/timetable/templates/_timetable.html
@@ -44,9 +44,13 @@
                 new BrowserHistoryBroker()
             ].concat(extraArgs);
 
-            var timetable = new (Function.prototype.bind.apply(timetableClass, timetableArgs));
-            $('#timetable').html(timetable.draw());
-            timetable.postDraw();
+            if (Object.getOwnPropertyNames(timetableArgs[1]).length > 0) {
+                var timetable = new (Function.prototype.bind.apply(timetableClass, timetableArgs));
+                $('#timetable').html(timetable.draw());
+                timetable.postDraw();
+            } else {
+                $('#timetable').html($T("The timetable has not been filled yet."));
+            }
         });
     </script>
 {% endmacro %}

--- a/indico/modules/events/timetable/util.py
+++ b/indico/modules/events/timetable/util.py
@@ -266,7 +266,8 @@ def render_session_timetable(session, timetable_layout=None, management=False):
     if not session.start_dt:
         # no scheduled sessions present
         return ''
-    timetable_data = TimetableSerializer().serialize_session_timetable(session, without_blocks=True)
+    timetable_data = TimetableSerializer().serialize_session_timetable(session, without_blocks=True,
+                                                                       hide_empty_days=True)
     event_info = serialize_event_info(session.event_new)
     tpl = get_template_module('events/timetable/_timetable.html')
     return tpl.render_timetable(timetable_data, event_info, timetable_layout=timetable_layout, management=management)

--- a/indico/web/assets/vars_js.py
+++ b/indico/web/assets/vars_js.py
@@ -93,6 +93,7 @@ def generate_global_file(config):
             },
 
             'Timetable': {
+                'management': url_rule_to_js('timetable.management'),
                 'default_pdf': url_rule_to_js('timetable.export_default_pdf'),
                 'pdf': url_rule_to_js('timetable.export_pdf'),
                 'reschedule': url_rule_to_js('timetable.reschedule'),


### PR DESCRIPTION
- Hide empty days on the timetable of display pages
- Show a message when the event timetable is empty instead of loading forever
- If no day is specified by a hash in the URL, default to today if it is part of the event otherwise the first non-empty day or the first day if all are empty.
- Add a link to go from a session timetable `/manage/timetable/session/...` to the event timetable