### PR TITLE
Display improvements when modifying a registration

### DIFF
--- a/indico/htdocs/js/indico/modules/registration/form/field.js
+++ b/indico/htdocs/js/indico/modules/registration/form/field.js
@@ -334,8 +334,8 @@ ndRegForm.directive('ndField', function($rootScope, url, regFormFactory) {
 
                 // After the field is loaded, we can check whether it's billable, etc
                 // and disable it if needed
-                scope.field.billableDisabled = !scope.regMetadata.manager && (scope.regMetadata.paid &&
-                    (scope.field.isBillable && scope.field.price > 0)) ||
+                scope.field.billableDisabled =
+                    (scope.regMetadata.paid && (scope.field.isBillable && scope.field.price > 0)) ||
                     (scope.selectedItemIsBillable && scope.selectedItemIsBillable(scope.userdata, scope.regMetadata));
             });
         }

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/field.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/field.tpl.html
@@ -2,7 +2,7 @@
     <table border="0" cellpadding="0" cellspacing="0"
         class="regform-field"
         ng-class="{disabled: !field.isEnabled, 'billable-disabled': field.billableDisabled, editable: editMode}">
-        <tr ng-attr-title="{{ field.billableDisabled ? ('This option could trigger a price change and has been locked.' | i18n) : undefined }}">
+        <tr>
             <td ng-if="editMode" class="field-sortable-handle"/>
             <td ng-if="!settings.singleColumn" class="field-caption">
                 <div>
@@ -38,7 +38,8 @@
                     title="{{ 'Configure field' | i18n }}"/>
             </td>
 
-            <td ng-if="field.billableDisabled" class="icon-lock billable-disabled-warning">
+            <td ng-if="field.billableDisabled" class="icon-lock billable-disabled-warning"
+                title="{{ 'This option is locked since changing it could trigger a price change.' | i18n }}{{ regMetadata.manager ? (' ' + ('But as a manager you can still modify it.' | i18n)) : '' }}">
             </td>
         </tr>
     </table>

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/accommodation.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/accommodation.tpl.html
@@ -61,19 +61,19 @@
                 <td>
                     <span ng-if="!regMetadata.manager && (paymentBlocked(item, userdata, regMetadata) || billableOptionPayed(userdata, regMetadata))"
                           class="icon-warning billable-items-warning"
-                          data-qtip-style="danger"
+                          data-qtip-style="warning"
                           title="{{ 'This option could trigger a price change and has been blocked.' | i18n }}">
                     </span>
                 </td>
                 <td>
                     <span ng-if="field.deletedChoice && field.deletedChoice.indexOf(item.id) != -1"
                           class="icon-warning deleted-option-warning right"
-                          data-qtip-style="danger"
+                          data-qtip-style="warning"
                           title="{{ 'The currently chosen option is not available anymore. If you unselect it you won\'t be able to choose it back' | i18n }}">
                     </span>
                     <span ng-if="field.modifiedChoice && field.modifiedChoice.indexOf(item.id) != -1"
                           class="icon-warning deleted-option-warning right"
-                          data-qtip-style="danger"
+                          data-qtip-style="warning"
                           title="{{ 'The currently chosen option has been modified. If you unselect it you may not be able to select it again for the same price' | i18n }}">
                     </span>
                 </td>

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/accommodation.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/accommodation.tpl.html
@@ -60,24 +60,24 @@
                 </td>
                 <td>
                     <span ng-if="!regMetadata.manager && (paymentBlocked(item, userdata, regMetadata) || billableOptionPayed(userdata, regMetadata))"
-                          class="icon-warning billable-items-warning"
+                          class="icon-warning item-warning"
                           data-qtip-style="warning"
                           title="{{ 'This option could trigger a price change and has been blocked.' | i18n }}">
                     </span>
                     <span ng-if="regMetadata.manager && (paymentBlocked(item, userdata, regMetadata) || billableOptionPayed(userdata, regMetadata))"
-                          class="icon-warning billable-items-warning"
+                          class="icon-warning item-warning"
                           data-qtip-style="warning"
                           title="{{ 'Choosing this option will result in a price change.' | i18n }}">
                     </span>
                 </td>
                 <td>
                     <span ng-if="field.deletedChoice && field.deletedChoice.indexOf(item.id) != -1"
-                          class="icon-warning deleted-option-warning right"
+                          class="icon-warning item-warning"
                           data-qtip-style="warning"
                           title="{{ 'The currently chosen option is not available anymore. If you unselect it you won\'t be able to choose it back' | i18n }}">
                     </span>
                     <span ng-if="field.modifiedChoice && field.modifiedChoice.indexOf(item.id) != -1"
-                          class="icon-warning deleted-option-warning right"
+                          class="icon-warning item-warning"
                           data-qtip-style="warning"
                           title="{{ 'The currently chosen option has been modified. If you unselect it you may not be able to select it again for the same price' | i18n }}">
                     </span>

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/accommodation.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/accommodation.tpl.html
@@ -64,6 +64,11 @@
                           data-qtip-style="warning"
                           title="{{ 'This option could trigger a price change and has been blocked.' | i18n }}">
                     </span>
+                    <span ng-if="regMetadata.manager && (paymentBlocked(item, userdata, regMetadata) || billableOptionPayed(userdata, regMetadata))"
+                          class="icon-warning billable-items-warning"
+                          data-qtip-style="warning"
+                          title="{{ 'Choosing this option will result in a price change.' | i18n }}">
+                    </span>
                 </td>
                 <td>
                     <span ng-if="field.deletedChoice && field.deletedChoice.indexOf(item.id) != -1"

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/checkbox.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/checkbox.tpl.html
@@ -4,7 +4,7 @@
             <input type="checkbox"
                 id="field-{{ section.id }}-{{ field.id }}"
                 name="{{ field.htmlName }}"
-                ng-disabled="field.billableDisabled || !hasPlacesLeft(field, userdata[field.htmlName])"
+                ng-disabled="(!regMetadata.manager && field.billableDisabled) || !hasPlacesLeft(field, userdata[field.htmlName])"
                 ng-model="checkboxValue"
                 ng-required="field.isRequired">
             <div>

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/dropdown.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/dropdown.tpl.html
@@ -27,12 +27,12 @@
         </option>
     </select>
     <span ng-if="!regMetadata.manager && regMetadata.paid && !field.billableDisabled && hasBillableOptions(field)"
-          class="icon-warning billable-items-warning"
+          class="icon-warning item-warning"
           data-qtip-style="warning"
           title="{{ 'Options that could trigger a price change have been blocked.' | i18n }}">
     </span>
     <span ng-if="regMetadata.manager && regMetadata.paid && !field.billableDisabled && hasBillableOptions(field)"
-          class="icon-warning billable-items-warning"
+          class="icon-warning item-warning"
           data-qtip-style="warning"
           title="{{ 'Changing this option might trigger a price change.' | i18n }}">
     </span>

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/dropdown.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/dropdown.tpl.html
@@ -31,6 +31,11 @@
           data-qtip-style="warning"
           title="{{ 'Options that could trigger a price change have been blocked.' | i18n }}">
     </span>
+    <span ng-if="regMetadata.manager && regMetadata.paid && !field.billableDisabled && hasBillableOptions(field)"
+          class="icon-warning billable-items-warning"
+          data-qtip-style="warning"
+          title="{{ 'Changing this option might trigger a price change.' | i18n }}">
+    </span>
     <div ng-repeat="item in field.choices | filter:isVisible" style="margin-top: 10px;">
         <span ng-if="showExtraSlotsInput(item, userdata[fieldName], input==item.id, getPlacesLeft(item))">
             <select id="extraSlotsSelect-{{ item.id }}"

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/dropdown.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/dropdown.tpl.html
@@ -1,5 +1,15 @@
 <ng-form name="nestedForm" ng-init="input = getId(fieldName)">
-   <select
+    <div ng-if="field.deletedChoice" class="warning-message-box">
+        <div class="message-text normal-size">
+            {{ "The currently chosen option is not available anymore. If you unselect it you won't be able to choose it back." | i18n }}
+        </div>
+    </div>
+    <div ng-if="field.modifiedChoice" class="warning-message-box">
+        <div class="message-text normal-size">
+            {{ "The currently chosen option has been modified since you registered. If you unselect it you may not be able to select it again for the same price." | i18n }}
+        </div>
+    </div>
+    <select
         id="{{ field.id }}"
         ng-model="input"
         ng-required="field.isRequired"
@@ -16,18 +26,10 @@
             {{ getBillableStr(item, getUserdataValue()) }}
         </option>
     </select>
-    <span ng-if="field.deletedChoice" class="icon-warning deleted-option-warning"
-          data-qtip-style="danger"
-          title="{{ 'The currently chosen option is not available anymore. If you unselect it you won\'t be able to choose it back' | i18n }}">
-    </span>
-    <span ng-if="field.modifiedChoice" class="icon-warning deleted-option-warning"
-          data-qtip-style="danger"
-          title="{{ 'The currently chosen option has been modified. If you unselect it you may not be able to select it again for the same price' | i18n }}">
-    </span>
     <span ng-if="!regMetadata.manager && regMetadata.paid && !field.billableDisabled && hasBillableOptions(field)"
-          class="icon-warning billable-items-warning right"
-          data-qtip-style="danger"
-          title="{{ 'There are options that could trigger a price change and have been blocked.' | i18n }}">
+          class="icon-warning billable-items-warning"
+          data-qtip-style="warning"
+          title="{{ 'Options that could trigger a price change have been blocked.' | i18n }}">
     </span>
     <div ng-repeat="item in field.choices | filter:isVisible" style="margin-top: 10px;">
         <span ng-if="showExtraSlotsInput(item, userdata[fieldName], input==item.id, getPlacesLeft(item))">

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/multi_choice.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/multi_choice.tpl.html
@@ -34,22 +34,22 @@
                     </span>
                 </span>
                 <span ng-if="!regMetadata.manager && regMetadata.paid && changesPrice(item)"
-                      class="icon-warning billable-items-warning"
+                      class="icon-warning item-warning"
                       data-qtip-style="warning"
                       title="{{ 'This option would result in a price change and has been blocked.' | i18n }}">
                 </span>
                 <span ng-if="regMetadata.manager && regMetadata.paid && changesPrice(item)"
-                      class="icon-warning billable-items-warning"
+                      class="icon-warning item-warning"
                       data-qtip-style="warning"
                       title="{{ 'Changing this option will result in a price change.' | i18n }}">
                 </span>
                 <span ng-if="field.deletedChoice && field.deletedChoice.indexOf(item.id) != -1"
-                      class="icon-warning deleted-option-warning"
+                      class="icon-warning item-warning"
                       data-qtip-style="warning"
                       title="{{ 'The currently chosen option is not available anymore. If you unselect it you won\'t be able to choose it back' | i18n }}">
                 </span>
                 <span ng-if="field.modifiedChoice && field.modifiedChoice.indexOf(item.id) != -1"
-                      class="icon-warning deleted-option-warning"
+                      class="icon-warning item-warning"
                       data-qtip-style="warning"
                       title="{{ 'The currently chosen option has been modified. If you unselect it you may not be able to select it again for the same price' | i18n }}">
                 </span>

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/multi_choice.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/multi_choice.tpl.html
@@ -38,6 +38,11 @@
                       data-qtip-style="danger"
                       title="{{ 'This option would result in a price change and has been blocked.' | i18n }}">
                 </span>
+                <span ng-if="regMetadata.manager && regMetadata.paid && changesPrice(item)"
+                      class="icon-warning billable-items-warning"
+                      data-qtip-style="warning"
+                      title="{{ 'Changing this option will result in a price change.' | i18n }}">
+                </span>
                 <span ng-if="field.deletedChoice && field.deletedChoice.indexOf(item.id) != -1"
                       class="icon-warning deleted-option-warning"
                       data-qtip-style="danger"

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/multi_choice.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/multi_choice.tpl.html
@@ -35,7 +35,7 @@
                 </span>
                 <span ng-if="!regMetadata.manager && regMetadata.paid && changesPrice(item)"
                       class="icon-warning billable-items-warning"
-                      data-qtip-style="danger"
+                      data-qtip-style="warning"
                       title="{{ 'This option would result in a price change and has been blocked.' | i18n }}">
                 </span>
                 <span ng-if="regMetadata.manager && regMetadata.paid && changesPrice(item)"
@@ -45,12 +45,12 @@
                 </span>
                 <span ng-if="field.deletedChoice && field.deletedChoice.indexOf(item.id) != -1"
                       class="icon-warning deleted-option-warning"
-                      data-qtip-style="danger"
+                      data-qtip-style="warning"
                       title="{{ 'The currently chosen option is not available anymore. If you unselect it you won\'t be able to choose it back' | i18n }}">
                 </span>
                 <span ng-if="field.modifiedChoice && field.modifiedChoice.indexOf(item.id) != -1"
                       class="icon-warning deleted-option-warning"
-                      data-qtip-style="danger"
+                      data-qtip-style="warning"
                       title="{{ 'The currently chosen option has been modified. If you unselect it you may not be able to select it again for the same price' | i18n }}">
                 </span>
             </li>

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/multi_choice.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/multi_choice.tpl.html
@@ -39,12 +39,12 @@
                       title="{{ 'This option would result in a price change and has been blocked.' | i18n }}">
                 </span>
                 <span ng-if="field.deletedChoice && field.deletedChoice.indexOf(item.id) != -1"
-                      class="icon-warning deleted-option-warning right"
+                      class="icon-warning deleted-option-warning"
                       data-qtip-style="danger"
                       title="{{ 'The currently chosen option is not available anymore. If you unselect it you won\'t be able to choose it back' | i18n }}">
                 </span>
                 <span ng-if="field.modifiedChoice && field.modifiedChoice.indexOf(item.id) != -1"
-                      class="icon-warning deleted-option-warning right"
+                      class="icon-warning deleted-option-warning"
                       data-qtip-style="danger"
                       title="{{ 'The currently chosen option has been modified. If you unselect it you may not be able to select it again for the same price' | i18n }}">
                 </span>

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/radiogroup.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/radiogroup.tpl.html
@@ -34,17 +34,17 @@
             </span>
             <span ng-if="!regMetadata.manager && !field.billableDisabled &&(paymentBlocked(item, userdata, regMetadata) || selectedItemIsBillable(userdata, regMetadata))"
                   class="icon-warning billable-items-warning"
-                  data-qtip-style="danger"
+                  data-qtip-style="warning"
                   title="{{ 'This option could trigger a price change and has been blocked.' | i18n }}">
             </span>
             <span ng-if="field.deletedChoice && field.deletedChoice.indexOf(item.id) != -1"
                   class="icon-warning deleted-option-warning"
-                  data-qtip-style="danger"
+                  data-qtip-style="warning"
                   title="{{ 'The currently chosen option is not available anymore. If you unselect it you won\'t be able to choose it back' | i18n }}">
             </span>
             <span ng-if="field.modifiedChoice && field.modifiedChoice.indexOf(item.id) != -1"
                   class="icon-warning deleted-option-warning"
-                  data-qtip-style="danger"
+                  data-qtip-style="warning"
                   title="{{ 'The currently chosen option has been modified. If you unselect it you may not be able to select it again for the same price' | i18n }}">
             </span>
         </li>

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/radiogroup.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/radiogroup.tpl.html
@@ -38,12 +38,12 @@
                   title="{{ 'This option could trigger a price change and has been blocked.' | i18n }}">
             </span>
             <span ng-if="field.deletedChoice && field.deletedChoice.indexOf(item.id) != -1"
-                  class="icon-warning deleted-option-warning right"
+                  class="icon-warning deleted-option-warning"
                   data-qtip-style="danger"
                   title="{{ 'The currently chosen option is not available anymore. If you unselect it you won\'t be able to choose it back' | i18n }}">
             </span>
             <span ng-if="field.modifiedChoice && field.modifiedChoice.indexOf(item.id) != -1"
-                  class="icon-warning deleted-option-warning right"
+                  class="icon-warning deleted-option-warning"
                   data-qtip-style="danger"
                   title="{{ 'The currently chosen option has been modified. If you unselect it you may not be able to select it again for the same price' | i18n }}">
             </span>

--- a/indico/htdocs/js/indico/modules/registration/form/tpls/fields/radiogroup.tpl.html
+++ b/indico/htdocs/js/indico/modules/registration/form/tpls/fields/radiogroup.tpl.html
@@ -33,17 +33,17 @@
                 </span>
             </span>
             <span ng-if="!regMetadata.manager && !field.billableDisabled &&(paymentBlocked(item, userdata, regMetadata) || selectedItemIsBillable(userdata, regMetadata))"
-                  class="icon-warning billable-items-warning"
+                  class="icon-warning item-warning"
                   data-qtip-style="warning"
                   title="{{ 'This option could trigger a price change and has been blocked.' | i18n }}">
             </span>
             <span ng-if="field.deletedChoice && field.deletedChoice.indexOf(item.id) != -1"
-                  class="icon-warning deleted-option-warning"
+                  class="icon-warning item-warning"
                   data-qtip-style="warning"
                   title="{{ 'The currently chosen option is not available anymore. If you unselect it you won\'t be able to choose it back' | i18n }}">
             </span>
             <span ng-if="field.modifiedChoice && field.modifiedChoice.indexOf(item.id) != -1"
-                  class="icon-warning deleted-option-warning"
+                  class="icon-warning item-warning"
                   data-qtip-style="warning"
                   title="{{ 'The currently chosen option has been modified. If you unselect it you may not be able to select it again for the same price' | i18n }}">
             </span>

--- a/indico/htdocs/sass/modules/_registrationform.scss
+++ b/indico/htdocs/sass/modules/_registrationform.scss
@@ -520,16 +520,9 @@
         }
     }
 
-    .deleted-option-warning {
-        margin-left: 1em;
-        color: $yellow;
-        vertical-align: middle;
-    }
-
-    .billable-items-warning {
+    .item-warning {
         margin-left: 0.5em;
         color: $yellow;
-        font-size: 1.1em;
     }
 }
 

--- a/indico/htdocs/sass/partials/_inputs.scss
+++ b/indico/htdocs/sass/partials/_inputs.scss
@@ -111,6 +111,11 @@ select {
         color: transparent !important;
         text-shadow: 0 0 0 $black !important;
     }
+
+    option[disabled] {
+        color: #888;
+        background-color: #eee;
+    }
 }
 
 select, ul {

--- a/indico/htdocs/sass/partials/_messageboxes.scss
+++ b/indico/htdocs/sass/partials/_messageboxes.scss
@@ -43,6 +43,10 @@
         p:last-child {
             margin-bottom: 0;
         }
+
+        &.normal-size {
+            font-size: 1em;
+        }
     }
 
     .message-box-footer {


### PR DESCRIPTION
- Show the important messages in a message box instead of a qTip
- Show the qTip related to the lock icon only when the lock icon is hovered. This works around an issue in Firefox where the the comboboxes are closed when a qTip is opened.