### PR TITLE
Improve the user selection dialog

### DIFF
--- a/indico/MaKaC/services/implementation/search.py
+++ b/indico/MaKaC/services/implementation/search.py
@@ -59,7 +59,8 @@ class SearchUsers(SearchBase):
             event_persons = self._event.persons.filter(*criteria).all()
         fossilized_users = fossilize(sorted(users, key=lambda av: (av.getStraightFullName(), av.getEmail())))
         fossilized_event_persons = map(serialize_event_person, event_persons)
-        return fossilized_users + fossilized_event_persons
+        unique_users = {user['email']: user for user in fossilized_users + fossilized_event_persons}
+        return sorted(unique_users.values(), key=lambda x: (x['name'].lower(), x['email']))
 
 
 class SearchGroups(SearchBase):

--- a/indico/htdocs/js/indico/Core/Dialogs/Users.js
+++ b/indico/htdocs/js/indico/Core/Dialogs/Users.js
@@ -117,16 +117,23 @@ type ("FoundPeopleList", ["SelectableListWidget"], {
             var affiliation = Html.$($('<span class="affiliation">').text(peopleData.get('affiliation')));
             var html = Html.div("info", userName, userEmail, affiliation);
 
+            var $actionButtons = $('<div>', {'class': 'actions'});
             if (this.showToggleFavouriteButtons && IndicoGlobalVars.isUserAuthenticated && peopleData.get('_type') == "Avatar") {
-                var favouritizeButtonDiv = Html.div("actions", new Html(create_favorite_button(peopleData.get('id')).get(0)));
-                return [html, favouritizeButtonDiv];
-            } else if (peopleData.get('_type') == 'EventPerson') {
-                var eventPersonIcon = $('<span>', {'class': 'event-person', 'title': $T("This person exists in the event")});
-                var wrapper = $('<div>', {'class': 'actions', 'html': eventPersonIcon});
-                return [html, Html.$(wrapper)];
-            } else {
-                return html;
+                var favouritizeButtonDiv = create_favorite_button(peopleData.get('id')).get(0);
+                $actionButtons.append(favouritizeButtonDiv);
             }
+            if (peopleData.get('_type') == 'EventPerson') {
+                var userId = peopleData.get('user_id');
+                if (userId) {
+                    $actionButtons.append(create_favorite_button(userId));
+                }
+                $('<span>', {
+                    'class': 'event-person',
+                    'title': $T("This person exists in the event")
+                }).appendTo($actionButtons);
+            }
+
+            return [html, new Html.$($actionButtons)];
         }
     }
 },

--- a/indico/htdocs/js/indico/jquery/principalfield.js
+++ b/indico/htdocs/js/indico/jquery/principalfield.js
@@ -54,7 +54,7 @@
                 if (first.id !== undefined && second.id !== undefined) {
                     return first.id == second.id;
                 } else {
-                    return first.email && second.email && first.email == second.email;
+                    return first.email && second.email && first.email.toLowerCase() == second.email.toLowerCase();
                 }
             }
 

--- a/indico/htdocs/js/indico/jquery/principalfield.js
+++ b/indico/htdocs/js/indico/jquery/principalfield.js
@@ -50,15 +50,19 @@
         _add: function _add(people) {
             var self = this;
 
+            function comparePersons(first, second) {
+                if (first.id !== undefined && second.id !== undefined) {
+                    return first.id == second.id;
+                } else {
+                    return first.email && second.email && first.email == second.email;
+                }
+            }
+
             function cleanDuplicates(people) {
                 _.each(self.people, function(person) {
-                    var criteria;
-                    if (person.id) {
-                        criteria = {id: person.id, _type: person._type};
-                    } else {
-                        criteria = {email: person.email};
-                    }
-                    people = _.without(people, _.findWhere(people, criteria));
+                    people = _.without(people, _.find(people, function(p) {
+                        return comparePersons(person, p);
+                    }));
                 });
                 return people;
             }

--- a/indico/modules/events/contributions/fields.py
+++ b/indico/modules/events/contributions/fields.py
@@ -57,16 +57,12 @@ class ContributionPersonLinkListField(PersonLinkListFieldBase):
 
     def pre_validate(self, form):
         super(ContributionPersonLinkListField, self).pre_validate(form)
-        persons = set()
         for person_link in self.data:
-            if person_link.person in persons:
-                raise ValueError(_("Person with email '{}' is duplicated").format(person_link.person.email))
             if not self.allow_authors and person_link.author_type != AuthorType.none:
                 if not self.object_data or person_link not in self.object_data:
                     person_link.author_type = AuthorType.none
             if person_link.author_type == AuthorType.none and not person_link.is_speaker:
                 raise ValueError(_("{} has no role").format(person_link.full_name))
-            persons.add(person_link.person)
 
 
 class SubContributionPersonLinkListField(ContributionPersonLinkListField):

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -194,7 +194,8 @@ def serialize_event_person(person):
             'title': person.title,
             'affiliation': person.affiliation,
             'phone': person.phone,
-            'address': person.address}
+            'address': person.address,
+            'user_id': person.user_id}
 
 
 def serialize_person_link(person_link):


### PR DESCRIPTION
- When including event persons in the search results, hide the related users to avoid duplicates.
- Also show the favourite icon for event persons.
- Compare EventPerson with PersonLink properly.