### PR TITLE
Disable qTip animation of timetable balloons

### DIFF
--- a/indico/htdocs/js/indico/modules/timetable/timetable/Draw.js
+++ b/indico/htdocs/js/indico/modules/timetable/timetable/Draw.js
@@ -759,7 +759,8 @@ function drawBalloon(self, evt, editable) {
                 target: [ evt.pageX, evt.pageY ],
                 adjust: {
                     mouse: false
-                }
+                },
+                effect: false
             },
             style: {
                 classes: 'balloon-qtip'


### PR DESCRIPTION
Since elements in HTML have a non-configurable north-west gravity, they
always extend/shrink to/from the right and bottom. In our case since the
qTips are displayed on top of the timetable entries they thus need to be
moved every time the content changes size. This cause the animation of
the qTip to kick in and produce the weird up movement.