### PR TITLE
Remove only leading and trailing empty days from display timetables

### DIFF
--- a/indico/modules/events/timetable/controllers/display.py
+++ b/indico/modules/events/timetable/controllers/display.py
@@ -43,7 +43,7 @@ class RHTimetable(RHConferenceBaseDisplay):
     def _process(self):
         if self.event_new.theme == 'static':
             event_info = serialize_event_info(self.event_new)
-            timetable_data = TimetableSerializer().serialize_timetable(self.event_new, hide_empty_days=True)
+            timetable_data = TimetableSerializer().serialize_timetable(self.event_new, strip_empty_days=True)
             return self.view_class.render_template('display.html', self._conf, event_info=event_info,
                                                    timetable_data=timetable_data, timetable_layout=self.layout)
         else:

--- a/indico/modules/events/timetable/util.py
+++ b/indico/modules/events/timetable/util.py
@@ -267,7 +267,7 @@ def render_session_timetable(session, timetable_layout=None, management=False):
         # no scheduled sessions present
         return ''
     timetable_data = TimetableSerializer().serialize_session_timetable(session, without_blocks=True,
-                                                                       hide_empty_days=True)
+                                                                       strip_empty_days=True)
     event_info = serialize_event_info(session.event_new)
     tpl = get_template_module('events/timetable/_timetable.html')
     return tpl.render_timetable(timetable_data, event_info, timetable_layout=timetable_layout, management=management)


### PR DESCRIPTION
Having the timetable tabs showing non-consecutive days (although in
order) can confuse the user as the next tab might not be the next day.