### PR TITLE
Contribution fields fixes

### DIFF
--- a/indico/htdocs/sass/modules/event_display/_conferences.scss
+++ b/indico/htdocs/sass/modules/event_display/_conferences.scss
@@ -67,23 +67,17 @@
     }
 
     #other-fields {
-        overflow: auto;
+        margin-left: 2em;
 
-        dd, dt {
-            float: left;
-            vertical-align: top;
-        }
-        dt {
-            margin-bottom: 1em;
-            text-align: right;
-            width: 25%;
+        th {
             color: $orange;
+            text-align: right;
+            vertical-align: top;
+            max-width: 220px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
-        dd {
-            margin: 0 0 1em 1em;
-            width: 70%;
-        }
-        clear: both;
     }
 
     .description, .infogrid {

--- a/indico/modules/events/abstracts/legacy.py
+++ b/indico/modules/events/abstracts/legacy.py
@@ -400,11 +400,7 @@ class AbstractLegacyMixin(object):
                 field = self.event.contribution_fields.filter_by(legacy_id=field_id).one()
             except NoResultFound:
                 field = self.event.contribution_fields.filter_by(id=field_id).one()
-            fval = AbstractFieldValue.find_first(contribution_field=field, abstract=self.as_new)
-            if fval:
-                return fval
-            else:
-                return AbstractFieldValue(contribution_field=field, abstract=self.as_new, data={})
+            return AbstractFieldValue.find_first(contribution_field=field, abstract=self.as_new)
 
     @property
     @memoize_request
@@ -467,11 +463,13 @@ class AbstractFieldContentWrapper(object):
 
     @property
     def field(self):
-        return self.field_val.contribution_field
+        if self.field_val is not None:
+            return self.field_val.contribution_field
 
     @property
     def value(self):
-        return self.field_val.data
+        if self.field_val is not None:
+            return self.field_val.data
 
     def __eq__(self, other):
         if isinstance(other, AbstractFieldContentWrapper) and self.field.id == other.field.id:
@@ -481,14 +479,14 @@ class AbstractFieldContentWrapper(object):
         return False
 
     def __len__(self):
-        return len(self.field_val.data)
+        return 0 if self.field_val is None else len(self.field_val.data)
 
     def __ne__(self, other):
         return not (self == other)
 
     @encode_utf8
     def __str__(self):
-        if self.field.field_type == 'single_choice':
+        if self.field is not None and self.field.field_type == 'single_choice':
             return unicode(AbstractSelectionFieldWrapper(self.field).getOption(self.value))
         return unicode(self.value or '')
 

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -8,14 +8,16 @@
 
 {% macro _render_field_value(field_value) -%}
     {% set field = field_value.contribution_field %}
-    <dt>{{ field.title }}</dt>
-    <dd>
-        {% if field.field_type == 'text' %}
-            {{ field_value.data }}
-        {% elif field.field_type == 'single_choice' %}
-            {{ field_value.friendly_data }}
-        {% endif %}
-    </dd>
+    <tr>
+        <th>{{ field.title }}</th>
+        <td>
+            {% if field.field_type == 'text' %}
+                {{ field_value.data }}
+            {% elif field.field_type == 'single_choice' %}
+                {{ field_value.friendly_data }}
+            {% endif %}
+        </td>
+    </tr>
 {%- endmacro %}
 
 {% macro render_author_list(authors) %}
@@ -146,14 +148,14 @@
             {% endif %}
         {% endfor %}
 
-        <dl id="other-fields">
+        <table id="other-fields">
             {% for field_value in contribution.field_values %}
                 {% set field = field_value.contribution_field %}
                 {% if field.field_type == 'single_choice' or not field.field_data.multiline %}
                     {{ _render_field_value(field_value) }}
                 {% endif %}
             {% endfor %}
-        </dl>
+        </table>
 
         <div class="infogrid condensed">
             {% if contribution.primary_authors %}


### PR DESCRIPTION
- Fix the cause of the apparition of empty dict in contribution field values

IMHO it is better to handle the fact that a contribution field can have no answers (when it was added after the abstract) rather than creating an empty answer when it is displayed.

- Use a table instead of floats to display the contribution fields on the display page. The previous layout with `float: left` was rendered as shown below.

![2016-05-31-154530_756x334_scrot](https://cloud.githubusercontent.com/assets/2007047/15678621/568a8eb4-274f-11e6-9ef8-84b7794e8a32.png)
