### PR TITLE
Fix palette-picker preventing the display of tooltips

### DIFF
--- a/indico/htdocs/js/indico/jquery/palettepicker.js
+++ b/indico/htdocs/js/indico/jquery/palettepicker.js
@@ -87,6 +87,7 @@
             var qtipOptions = {
                 prerender: false,
                 overwrite: false,
+                suppress: false,
                 style: {
                     classes: 'palette-picker-qtip'
                 },


### PR DESCRIPTION
The tooltip of the palette-picker icon was not displayed on the session list due to this.