### PR TITLE
Timetable: Pre-cache ACL information for contribs

### DIFF
--- a/indico/MaKaC/webinterface/tpls/latex/book_of_abstracts.tpl
+++ b/indico/MaKaC/webinterface/tpls/latex/book_of_abstracts.tpl
@@ -25,7 +25,7 @@
             \fancyhead[R]{}
 
             \phantomsection
-            \addcontentsline{toc}{chapter}{${contrib.title | latex_escape} ${('{0}').format(contrib.id) if conf.getBOAConfig().getShowIds() else ''}
+            \addcontentsline{toc}{chapter}{${contrib.title | latex_escape} ${('{0}').format(contrib.friendly_id) if conf.getBOAConfig().getShowIds() else ''}
             }
 
             <%include file="inc/contribution_condensed.tpl" args="contrib=contrib"/>

--- a/indico/core/db/sqlalchemy/core.py
+++ b/indico/core/db/sqlalchemy/core.py
@@ -184,6 +184,8 @@ def _transaction_ended(session, transaction):
             del g.event_notes
         if 'event_attachments' in g:
             del g.event_attachments
+        if 'contribution_acl_cache' in g:
+            del g.contribution_acl_cache
     if has_request_context() and hasattr(flask_session, '_user'):
         delattr(flask_session, '_user')
 

--- a/indico/modules/events/timetable/legacy.py
+++ b/indico/modules/events/timetable/legacy.py
@@ -19,9 +19,12 @@ from __future__ import unicode_literals
 from collections import defaultdict
 from pytz import timezone
 
-from flask import session
-from sqlalchemy.orm import defaultload
+from flask import g, session
+from sqlalchemy.orm import defaultload, joinedload
 
+from indico.core.db import db
+from indico.modules.events.contributions.models.contributions import Contribution
+from indico.modules.events.contributions.models.principals import ContributionPrincipal
 from indico.modules.events.contributions.models.persons import AuthorType
 from indico.modules.events.timetable.models.entries import TimetableEntry, TimetableEntryType
 from indico.util.date_time import iterdays
@@ -36,6 +39,10 @@ class TimetableSerializer(object):
         self.management = management
 
     def serialize_timetable(self, event, days=None, hide_weekends=False, strip_empty_days=False):
+        # pre-fetch ContributionPrincipals (to save time)
+        query = Contribution.find(Contribution.event_new == event).options(joinedload('acl_entries'))
+        g.contribution_acl_cache = {contrib.id: contrib.acl_entries for contrib in query}
+
         timetable = {}
         for day in iterdays(event.start_dt_local, event.end_dt_local, skip_weekends=hide_weekends, day_whitelist=days):
             date_str = day.strftime('%Y%m%d')


### PR DESCRIPTION
This saves us hundreds of render-time queries trying to figure out who
can access what.