### PR TITLE
Add terms and conditions page

### DIFF
--- a/indico/MaKaC/webinterface/tpls/Footer.CERN.tpl
+++ b/indico/MaKaC/webinterface/tpls/Footer.CERN.tpl
@@ -13,5 +13,9 @@
     <a id="cern_link" href="http://cern.ch">
         <img src="${ systemIcon("cern_small_light" if is_meeting else "cern_small") }" alt="${ _("Indico")}" class="cern_logo" style="vertical-align: middle; margin: 15px;">
     </a>
-    <div class="text" style="width: 200px">${ _("Powered by ")} <a href="http://indico-software.org">Indico</a></div>
+    <div class="text" style="width: 200px">
+        ${ _("Powered by ")} <a href="http://indico-software.org">Indico</a>
+        <br/>
+        <a href="${ url_for('legal.display') }">${ _("Terms and conditions") }</a>
+    </div>
 </%block>

--- a/indico/MaKaC/webinterface/tpls/Footer.tpl
+++ b/indico/MaKaC/webinterface/tpls/Footer.tpl
@@ -22,10 +22,12 @@ else:
          }
      </script>
 % endif
-  <%block name="footer">
-          <img src="${ systemIcon("indico_small") }" alt="${ _("Indico")}" style="vertical-align: middle; margin-right: 2px;"/>
-            <span style="vertical-align: middle;">${ _("Powered by ")} <a href="http://indico-software.org">Indico</a></span>
-  </%block>
+    <%block name="footer">
+        <img src="${ systemIcon("indico_small") }" alt="${ _("Indico")}" style="vertical-align: middle; margin-right: 2px;"/>
+        <span>${ _("Powered by ")} <a href="http://indico-software.org">Indico</a></span>
+        <br/>
+        <a href="${ url_for('legal.display') }">${ _("Terms and conditions") }</a>
+    </%block>
 
     ${ template_hook('page-footer') }
 </div>

--- a/indico/MaKaC/webinterface/wcomponents.py
+++ b/indico/MaKaC/webinterface/wcomponents.py
@@ -51,6 +51,7 @@ from indico.modules.api import APIMode
 from indico.modules.api import settings as api_settings
 from indico.modules.events.layout import layout_settings, theme_settings
 from indico.modules.events.util import preload_events
+from indico.modules.legal import settings as legal_settings
 from indico.util.i18n import i18nformat, get_current_locale, get_all_locales
 from indico.util.date_time import utc_timestamp, is_same_month, format_date
 from indico.util.signals import values_from_signal
@@ -296,8 +297,8 @@ class WHeader(WTemplated):
 
         minfo = info.HelperMaKaCInfo.getMaKaCInfoInstance()
         vars['roomBooking'] = Config.getInstance().getIsRoomBookingActive()
-        vars['protectionDisclaimerProtected'] = minfo.getProtectionDisclaimerProtected()
-        vars['protectionDisclaimerRestricted'] = minfo.getProtectionDisclaimerRestricted()
+        vars['protectionDisclaimerProtected'] = legal_settings.get('protected_disclaimer')
+        vars['protectionDisclaimerRestricted'] = legal_settings.get('restricted_disclaimer')
         #Build a list of items for the administration menu
         adminItemList = []
         if session.user and session.user.is_admin:

--- a/indico/htdocs/sass/base/_layout.scss
+++ b/indico/htdocs/sass/base/_layout.scss
@@ -24,6 +24,10 @@ body {
 
 body > .main {
     flex-grow: 1;
+
+    .terms-and-conditions {
+        margin: 2em auto;
+    }
 }
 
 /* Work around issues in WebKit (used by Safari) which shrinks the contained

--- a/indico/htdocs/sass/base/_layout.scss
+++ b/indico/htdocs/sass/base/_layout.scss
@@ -26,7 +26,7 @@ body > .main {
     flex-grow: 1;
 
     .terms-and-conditions {
-        margin: 2em auto;
+        margin: 3em;
     }
 }
 

--- a/indico/modules/admin/__init__.py
+++ b/indico/modules/admin/__init__.py
@@ -21,7 +21,6 @@ from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.menu import SideMenuSection, SideMenuItem
 
-
 @signals.menu.sections.connect_via('admin-sidemenu')
 def _sidemenu_sections(sender, **kwargs):
     yield SideMenuSection('security', _("Security"), 90, icon='shield')

--- a/indico/modules/legal/__init__.py
+++ b/indico/modules/legal/__init__.py
@@ -1,0 +1,34 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2016 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+from indico.core import signals
+from indico.util.i18n import _
+from indico.core.settings.core import SettingsProxy
+from indico.web.flask.util import url_for
+from indico.web.menu import SideMenuItem
+
+settings = SettingsProxy('legal', {
+    'protected_disclaimer': "",
+    'restricted_disclaimer': "",
+    'terms_and_conditions': ""
+}, preload=True)
+
+
+@signals.menu.items.connect_via('admin-sidemenu')
+def _sidemenu_items(sender, **kwargs):
+    yield SideMenuItem('legal_messages', _('Legal/Disclaimers'), url_for('legal.manage'), section='security')

--- a/indico/modules/legal/blueprint.py
+++ b/indico/modules/legal/blueprint.py
@@ -16,9 +16,10 @@
 
 from __future__ import unicode_literals
 
-from indico.modules.legal.controllers import RHManageLegalMessages
+from indico.modules.legal.controllers import RHDisplayLegalMessages, RHManageLegalMessages
 from indico.web.flask.wrappers import IndicoBlueprint
 
 _bp = IndicoBlueprint('legal', __name__, template_folder='templates', virtual_template_folder='legal')
 
 _bp.add_url_rule('/admin/legal', 'manage', RHManageLegalMessages, methods=('GET', 'POST'))
+_bp.add_url_rule('/tos', 'display', RHDisplayLegalMessages)

--- a/indico/modules/legal/blueprint.py
+++ b/indico/modules/legal/blueprint.py
@@ -1,0 +1,24 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2016 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+from indico.modules.legal.controllers import RHManageLegalMessages
+from indico.web.flask.wrappers import IndicoBlueprint
+
+_bp = IndicoBlueprint('legal', __name__, template_folder='templates', virtual_template_folder='legal')
+
+_bp.add_url_rule('/admin/legal', 'manage', RHManageLegalMessages, methods=('GET', 'POST'))

--- a/indico/modules/legal/controllers.py
+++ b/indico/modules/legal/controllers.py
@@ -1,0 +1,32 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2016 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+from indico.modules.legal import settings
+from indico.modules.legal.forms import LegalMessagesForm
+from indico.modules.legal.views import WPManageLegalMessages
+from MaKaC.webinterface.rh.admins import RHAdminBase
+
+
+class RHManageLegalMessages(RHAdminBase):
+
+    def _process(self):
+        form = LegalMessagesForm(**settings.get_all())
+        if form.validate_on_submit():
+            for field in form.visible_fields:
+                settings.set(field.name, getattr(form, field.name).data)
+        return WPManageLegalMessages.render_template('manage_messages.html', form=form)

--- a/indico/modules/legal/controllers.py
+++ b/indico/modules/legal/controllers.py
@@ -16,17 +16,29 @@
 
 from __future__ import unicode_literals
 
+from flask import request
+
 from indico.modules.legal import settings
 from indico.modules.legal.forms import LegalMessagesForm
-from indico.modules.legal.views import WPManageLegalMessages
+from indico.modules.legal.views import WPDisplayLegalMessages, WPManageLegalMessages
+from indico.web.util import jsonify_template
 from MaKaC.webinterface.rh.admins import RHAdminBase
+from MaKaC.webinterface.rh.base import RH
 
 
 class RHManageLegalMessages(RHAdminBase):
-
     def _process(self):
         form = LegalMessagesForm(**settings.get_all())
         if form.validate_on_submit():
             for field in form.visible_fields:
                 settings.set(field.name, getattr(form, field.name).data)
         return WPManageLegalMessages.render_template('manage_messages.html', form=form)
+
+
+class RHDisplayLegalMessages(RH):
+    def _process(self):
+        tos = settings.get('terms_and_conditions')
+        if request.is_xhr:
+            return jsonify_template('legal/tos.html', tos=tos)
+        else:
+            return WPDisplayLegalMessages.render_template('tos.html', tos=tos)

--- a/indico/modules/legal/forms.py
+++ b/indico/modules/legal/forms.py
@@ -1,0 +1,29 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2016 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+from wtforms.fields import TextAreaField
+
+from indico.util.i18n import _
+from indico.web.forms.base import IndicoForm
+from indico.web.forms.widgets import CKEditorWidget
+
+
+class LegalMessagesForm(IndicoForm):
+    protected_disclaimer = TextAreaField(_("Protected information disclaimer"), widget=CKEditorWidget())
+    restricted_disclaimer = TextAreaField(_("Restricted information disclaimer"), widget=CKEditorWidget())
+    terms_and_conditions = TextAreaField(_("Terms and conditions"), widget=CKEditorWidget())

--- a/indico/modules/legal/templates/manage_messages.html
+++ b/indico/modules/legal/templates/manage_messages.html
@@ -1,0 +1,14 @@
+{% from 'forms/_form.html' import form_header, form_rows, form_footer  %}
+{% extends 'layout/base.html' %}
+
+{% block title %}
+    {% trans %}Legal and disclaimer messages{% endtrans %}
+{% endblock %}
+
+{% block content %}
+    {{ form_header(form) }}
+    {{ form_rows(form) }}
+    {% call form_footer(form) %}
+        <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}">
+    {% endcall %}
+{% endblock %}

--- a/indico/modules/legal/templates/tos.html
+++ b/indico/modules/legal/templates/tos.html
@@ -1,0 +1,3 @@
+<div class="terms-and-conditions">
+    {{ tos|safe }}
+</div>

--- a/indico/modules/legal/views.py
+++ b/indico/modules/legal/views.py
@@ -17,9 +17,17 @@
 from __future__ import unicode_literals
 
 from MaKaC.webinterface.pages.admins import WPAdminsBase
-from MaKaC.webinterface.pages.base import WPJinjaMixin
+from MaKaC.webinterface.pages.base import WPDecorated, WPJinjaMixin
 
 
-class WPManageLegalMessages(WPJinjaMixin, WPAdminsBase):
+class WPLegalMixin:
     template_prefix = 'legal/'
+
+
+class WPManageLegalMessages(WPLegalMixin, WPJinjaMixin, WPAdminsBase):
     sidemenu_option = 'legal_messages'
+
+
+class WPDisplayLegalMessages(WPLegalMixin, WPJinjaMixin, WPDecorated):
+    def _getBody(self, params):
+        return self._getPageContent(params)

--- a/indico/modules/legal/views.py
+++ b/indico/modules/legal/views.py
@@ -1,0 +1,25 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2016 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+from MaKaC.webinterface.pages.admins import WPAdminsBase
+from MaKaC.webinterface.pages.base import WPJinjaMixin
+
+
+class WPManageLegalMessages(WPJinjaMixin, WPAdminsBase):
+    template_prefix = 'legal/'
+    sidemenu_option = 'legal_messages'

--- a/indico_zodbimport/modules/legal.py
+++ b/indico_zodbimport/modules/legal.py
@@ -1,0 +1,38 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2016 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+from indico.core.db import db
+from indico.modules.legal import settings
+from indico.util.console import cformat
+
+from indico_zodbimport import Importer
+
+
+class LegalImporter(Importer):
+    def migrate(self):
+        self.migrate_settings()
+
+    def migrate_settings(self):
+        print cformat('%{white!}migrating settings')
+        settings_map = {
+            '_protectionDisclaimerProtected': 'protected_disclaimer',
+            '_protectionDisclaimerRestricted': 'restricted_disclaimer'
+        }
+        for old, new in settings_map.iteritems():
+            settings.set(new, getattr(self.zodb_root['MaKaCInfo']['main'], old))
+        db.session.commit()

--- a/setup.py
+++ b/setup.py
@@ -362,6 +362,7 @@ if __name__ == '__main__':
             event_dates_titles = indico_zodbimport.modules.event_dates_titles:EventDatesTitlesImporter
             event_abstracts_zodb = indico_zodbimport.modules.event_abstracts_zodb:EventAbstractZODBPatcher
             event_paper_reviewing = indico_zodbimport.modules.event_paper_reviewing:EventPaperReviewingImporter
+            legal = indico_zodbimport.modules.legal:LegalImporter
             """,
           zip_safe=False,
           packages=foundPackages,


### PR DESCRIPTION
- Add "legal" module
- Store the two existing disclaimers and the new terms and conditions in a SettingsProxy for the "legal" module
- Importer for the disclaimer messages
- Add a link to the terms and conditions in the footer

The `/tos` page could be displayed in a dialog but the current styling is suboptimal if the text is long.