### PR TITLE
Link contribution list item overlay to contribution page

### DIFF
--- a/indico/modules/events/contributions/templates/display/_contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/_contribution_list.html
@@ -2,52 +2,51 @@
 
 {% macro render_contribution_list(event, timezone, contributions, with_session_info=true) %}
     {% for contrib in contributions -%}
-        <div class="contribution-row" data-friendly-id="{{ contrib.friendly_id }}">
-            <div class="contrib-title info" data-searchable="{{ contrib.title|lower }}">
-                <span class="value">
-                    <a class="js-mathjax" href="{{ url_for('contributions.display_contribution', contrib) }}">
+        <a href="{{ url_for('contributions.display_contribution', contrib) }}">
+            <div class="contribution-row" data-friendly-id="{{ contrib.friendly_id }}">
+                <div class="contrib-title info js-mathjax" data-searchable="{{ contrib.title|lower }}">
+                    <span class="value">
                         <span class="contrib-id">{{ contrib.friendly_id }}.</span>
                         {{ contrib.title }}
-                    </a>
-                </span>
+                    </span>
+                </div>
+                {% if contrib.speakers -%}
+                    <div class="speaker-list icon-user">
+                        {{ render_users(contrib.speakers|sort(attribute='full_name'),
+                                        span_class='speaker-item-inline') }}
+                    </div>
+                {%- endif %}
+                {% if contrib.timetable_entry -%}
+                    <div class="contrib-time icon-time">
+                        {{ contrib.timetable_entry.start_dt|format_datetime(format='short', timezone=timezone) }}
+                    </div>
+                {%- endif %}
+                <div class="">
+                    {% if contrib.track -%}
+                        <div class="contrib-track small" data-searchable="{{ contrib.track.title|lower }}">
+                            {{ contrib.track.title }}
+                        </div>
+                    {%- endif %}
+                    {% if contrib.type -%}
+                        <div class="contrib-type small" data-searchable="{{ contrib.type.name|lower }}">
+                            {{ contrib.type.name }}
+                        </div>
+                    {%- endif %}
+                    {% if contrib.session and with_session_info -%}
+                        <div class="contrib-session small" data-searchable="{{ contrib.session.title|lower }}"
+                             style="{{ contrib.session.colors.css }}">
+                            <a href="{{ url_for('sessions.display_session', contrib.session) }}"
+                               style="color: #{{ contrib.session.colors.text }}">{{ contrib.session.title }}</a>
+                            <span class="session-bg-color" style="background: #{{ contrib.session.colors.background }};"></span>
+                        </div>
+                    {%- endif %}
+                </div>
+                {% if contrib.description -%}
+                    <div class="description js-mathjax">
+                        {{ contrib.description|truncate(400) }}
+                    </div>
+                {%- endif %}
             </div>
-            {% if contrib.speakers -%}
-                <div class="speaker-list icon-user">
-                    {{ render_users(contrib.speakers|sort(attribute='full_name'),
-                                    span_class='speaker-item-inline') }}
-                </div>
-            {%- endif %}
-            {% if contrib.timetable_entry -%}
-                <div class="contrib-time icon-time">
-                    {{ contrib.timetable_entry.start_dt|format_datetime(format='short', timezone=timezone) }}
-                </div>
-            {%- endif %}
-            <div class="">
-                {% if contrib.track -%}
-                    <div class="contrib-track small" data-searchable="{{ contrib.track.title|lower }}">
-                        {{ contrib.track.title }}
-                    </div>
-                {%- endif %}
-                {% if contrib.type -%}
-                    <div class="contrib-type small" data-searchable="{{ contrib.type.name|lower }}">
-                        {{ contrib.type.name }}
-                    </div>
-                {%- endif %}
-                {% if contrib.session and with_session_info -%}
-                    <div class="contrib-session small" data-searchable="{{ contrib.session.title|lower }}"
-                         style="{{ contrib.session.colors.css }}">
-                        <a href="{{ url_for('sessions.display_session', contrib.session) }}"
-                           style="color: #{{ contrib.session.colors.text }}">{{ contrib.session.title }}</a>
-                        <span class="session-bg-color" style="background: #{{ contrib.session.colors.background }};"></span>
-                    </div>
-                {%- endif %}
-            </div>
-            {% if contrib.description -%}
-                <div class="description js-mathjax">
-                    {{ contrib.description|truncate(400) }}
-                </div>
-            {%- endif %}
-
-        </div>
+        </a>
     {%- endfor %}
 {% endmacro %}


### PR DESCRIPTION
closes #2451 

The diff isn't particularly easy to read, I've moved the anchor from around the contribution title and placed it around the contribution row item.

I'm not to sure what the anchor class js-mathjax is doing, it looks like the filter by id is broken without this change but that could be something else entirely.