### PR TITLE
Add libz-devel to installation.rst

### DIFF
--- a/doc/dev/source/installation.rst
+++ b/doc/dev/source/installation.rst
@@ -17,6 +17,7 @@ You will need some system libraries:
 * *libxslt-devel*
 * *libxml2-devel*
 * *libffi-devel*
+* *libz-devel*
 * *openldap-devel* (if you wish to use LDAP authentication)
 
 You will also need to ``easy_install python-ldap`` if you want LDAP to work.


### PR DESCRIPTION
Just tried to install indico on a fresh Debian Jessie, and I found out that one also needs libz-dev, otherwise easy-install fails.