### PR TITLE
Adding requests library to requirements.txt

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -7,3 +7,4 @@ sphinx
 repoze.sphinx.autointerface
 pygments
 sqlparse
+requests


### PR DESCRIPTION
It is required by fab and isn't always installed on every LAMP box.