### PR TITLE
Add abstract picker field

### DIFF
--- a/indico/htdocs/js/indico/widgets/selectize_widget.js
+++ b/indico/htdocs/js/indico/widgets/selectize_widget.js
@@ -56,8 +56,9 @@
             score: function(query) {
                 var data = getSearchData(query);
                 if (data && data.id !== undefined) {
+                    // when searching by ID ensure we don't get other results from selectize's internal cache
                     return function(item) {
-                        return item.friendly_id === +data.id;
+                        return +(item.friendly_id === +data.id);
                     };
                 } else {
                     var scoreFunc = this.getScoreFunction(query);

--- a/indico/htdocs/sass/partials/_forms.scss
+++ b/indico/htdocs/sass/partials/_forms.scss
@@ -195,6 +195,9 @@ $i-form-button-line-height: 1.8;
     }
 
     @include apply-to-text-inputs('%form-field-input');
+    .selectize-control input[type=text] {
+        height: auto;
+    }
     textarea {
         @extend %form-field-input;
         height: auto;

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -21,7 +21,7 @@ from wtforms.fields import BooleanField, IntegerField, SelectField, TextAreaFiel
 from wtforms.validators import NumberRange, Optional, DataRequired, ValidationError, InputRequired
 
 from indico.modules.events.abstracts.fields import (EmailRuleListField, AbstractReviewQuestionsField,
-                                                    AbstractPersonLinkListField)
+                                                    AbstractPersonLinkListField, AbstractField)
 from indico.modules.events.abstracts.settings import BOASortField, BOACorrespondingAuthorType, abstracts_settings
 from indico.modules.events.tracks.models.tracks import Track
 from indico.util.i18n import _

--- a/indico/modules/events/abstracts/views.py
+++ b/indico/modules/events/abstracts/views.py
@@ -28,11 +28,13 @@ class WPManageAbstracts(WPJinjaMixin, WPConferenceModifBase):
     def getJSFiles(self):
         return (WPConferenceModifBase.getJSFiles(self) +
                 self._asset_env['markdown_js'].urls() +
+                self._asset_env['selectize_js'].urls() +
                 self._asset_env['modules_abstracts_js'].urls())
 
     def getCSSFiles(self):
         return (WPConferenceModifBase.getCSSFiles(self) +
                 self._asset_env['markdown_sass'].urls() +
+                self._asset_env['selectize_css'].urls() +
                 self._asset_env['abstracts_sass'].urls())
 
     def _getHeadContent(self):

--- a/indico/web/forms/jinja_helpers.py
+++ b/indico/web/forms/jinja_helpers.py
@@ -25,9 +25,12 @@ from wtforms.validators import Length, Regexp, NumberRange
 from indico.util.struct.enum import TitledEnum
 from indico.web.forms.fields import IndicoSelectMultipleCheckboxField, IndicoEnumRadioField
 from indico.web.forms.validators import ConfirmPassword, HiddenUnless
+from indico.web.forms.widgets import SelectizeWidget
 
 
 def is_single_line_field(field):
+    if isinstance(field.widget, SelectizeWidget):
+        return True
     if isinstance(field.widget, Select):
         return not field.widget.multiple
     if isinstance(field.widget, Input):

--- a/indico/web/forms/widgets.py
+++ b/indico/web/forms/widgets.py
@@ -165,19 +165,33 @@ class SelectizeWidget(JinjaWidget):
     :param search_url: The URL used to retrieve items.
     :param min_trigger_length: Number of characters needed to start
                                searching for suggestions.
+    :param allow_by_id: Whether to allow `#123` searches regardless of
+                        the trigger length.  Such searches will be sent
+                        as 'id' instead of 'q' in the AJAX request.
+    :param value_field: The attribute of the response used as the
+                        field value.
+    :param label_field: The attribute of the response used as the
+                        item label.
+    :param search_field: The attribute of the response used to search
+                         in locally available data.
     """
 
-    def __init__(self, search_url=None, min_trigger_length=3):
+    def __init__(self, search_url=None, min_trigger_length=3, allow_by_id=False,
+                 value_field='id', label_field='name', search_field='name'):
         self.min_trigger_length = min_trigger_length
+        self.allow_by_id = allow_by_id
         self.search_url = search_url
+        self.value_field = value_field
+        self.label_field = label_field
+        self.search_field = search_field
         super(SelectizeWidget, self).__init__('forms/selectize_widget.html')
 
     def __call__(self, field, **kwargs):
         choices = [{'name': field.data.name, 'id': field.data.id}] if field.data is not None else []
         options = {
-            'valueField': 'id',
-            'labelField': 'name',
-            'searchField': 'name',
+            'valueField': self.value_field,
+            'labelField': self.label_field,
+            'searchField': self.search_field,
             'persist': False,
             'options': choices,
             'create': False,
@@ -186,8 +200,10 @@ class SelectizeWidget(JinjaWidget):
         }
 
         options.update(kwargs.pop('options', {}))
-        return super(SelectizeWidget, self).__call__(field, options=options, search_url=self.search_url,
-                                                     min_trigger_length=self.min_trigger_length)
+        return super(SelectizeWidget, self).__call__(field, options=options,
+                                                     search_url=getattr(field, 'search_url', self.search_url),
+                                                     min_trigger_length=self.min_trigger_length,
+                                                     allow_by_id=self.allow_by_id, input_args=kwargs)
 
 
 class TypeaheadWidget(JinjaWidget):

--- a/indico/web/templates/forms/selectize_widget.html
+++ b/indico/web/templates/forms/selectize_widget.html
@@ -4,7 +4,8 @@
 {% block html %}
     <div class="i-form-field-fixed-width" data-tooltip-anchor>
         <input id="{{ field.id }}" class="typeahead" type="text" name="{{ field.name }}"
-               {%- if field.data is not none -%}value="{{ field._value() | tojson }}"{%- endif -%}>
+               {%- if field.data is not none -%}value="{{ field._value() | tojson }}"{%- endif -%}
+               {{ input_args | html_params }}>
         <span></span>
     </div>
 {% endblock %}
@@ -16,7 +17,8 @@
             fieldId: {{ field.id | tojson }},
             minTriggerLength: {{ min_trigger_length | tojson }},
             searchUrl: {{ search_url | tojson }},
-            selectizeOptions: {{ options | tojson }}
+            selectizeOptions: {{ options | tojson }},
+            allowById: {{ allow_by_id | tojson }}
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Here's a patch that adds the field to the reviewing settings form just for testing it:

```patch
diff --git a/indico/modules/events/abstracts/controllers/management.py b/indico/modules/events/abstracts/controllers/management.py
index b318f93..860f5aa 100644
--- a/indico/modules/events/abstracts/controllers/management.py
+++ b/indico/modules/events/abstracts/controllers/management.py
@@ -127,8 +127,11 @@ class RHManageAbstractReviewing(RHManageAbstractsBase):
         defaults = FormDefaults(abstract_review_questions=self.event_new.abstract_review_questions,
                                 **abstracts_reviewing_settings.get_all(self.event_new))
         form = AbstractReviewingSettingsForm(event=self.event_new, obj=defaults, has_ratings=has_ratings)
-        if form.validate_on_submit():
+        if form.process_ajax():
+            return form.ajax_response
+        elif form.validate_on_submit():
             data = form.data
+            flash('Selected abstract: {}'.format(data.pop('test')))
             # XXX: we need to do this assignment for new questions,
             # but editing or deleting existing questions changes an
             # object that is already in the session so it's updated
diff --git a/indico/modules/events/abstracts/forms.py b/indico/modules/events/abstracts/forms.py
index c5bfc22..ee14f6a 100644
--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -96,6 +96,7 @@ class AbstractReviewingSettingsForm(IndicoForm):
                                            description=_('Enabling this allows track conveners to make a judgment '
                                                          'such as accepting or rejecting an abstract.'))
     abstract_review_questions = AbstractReviewQuestionsField(_('Review questions'))
+    test = AbstractField('XXX')

     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')
```