### PR TITLE
Fix rules layout and improve UX

### DIFF
--- a/indico/htdocs/js/indico/jquery/rulelistwidget.js
+++ b/indico/htdocs/js/indico/jquery/rulelistwidget.js
@@ -63,6 +63,10 @@
                     self.element.trigger('change');
                 });
 
+            if (condition.value === 'track') {
+                $select.css('width', '100%');
+            }
+
             if (condition.required) {
                 $select.prepend($('<option disabled selected>', {
                     value: ''

--- a/indico/htdocs/sass/modules/abstracts/_email_templates.scss
+++ b/indico/htdocs/sass/modules/abstracts/_email_templates.scss
@@ -68,3 +68,11 @@
        the last element works properly. */
     padding-bottom: 15px;
 }
+
+#form-group-rules {
+    margin-top: 0;
+
+    .form-field {
+        width: 100%;
+    }
+}

--- a/indico/modules/events/abstracts/fields.py
+++ b/indico/modules/events/abstracts/fields.py
@@ -16,12 +16,10 @@
 
 from __future__ import unicode_literals
 
-from flask import jsonify, request, session
+from flask import jsonify, session
 from sqlalchemy.orm import joinedload
-from werkzeug.exceptions import BadRequest
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
 
-from indico.core.db.sqlalchemy.util.queries import escape_like
 from indico.core.db.sqlalchemy.util.session import no_autoflush
 from indico.modules.events.abstracts.models.abstracts import Abstract
 from indico.modules.events.abstracts.models.persons import AbstractPersonLink

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -130,7 +130,8 @@ class EditEmailTemplateRuleForm(IndicoForm):
     title = StringField(_("Title"), [DataRequired()])
     rules = EmailRuleListField(_("Rules"), [DataRequired()])
     stop_on_match = BooleanField(_("Stop on match"), [DataRequired()], widget=SwitchWidget(), default=True,
-                                 description=_("Do not evaluate any other rules once this one matches."))
+                                 description=_("If any of the rules from this email template matches, do not "
+                                               "send emails from any following email template."))
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -21,7 +21,7 @@ from wtforms.fields import BooleanField, IntegerField, SelectField, TextAreaFiel
 from wtforms.validators import NumberRange, Optional, DataRequired, ValidationError, InputRequired
 
 from indico.modules.events.abstracts.fields import (EmailRuleListField, AbstractReviewQuestionsField,
-                                                    AbstractPersonLinkListField, AbstractField)
+                                                    AbstractPersonLinkListField)
 from indico.modules.events.abstracts.settings import BOASortField, BOACorrespondingAuthorType, abstracts_settings
 from indico.modules.events.tracks.models.tracks import Track
 from indico.util.i18n import _

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -149,7 +149,7 @@ class EditEmailTemplateTextForm(IndicoForm):
 
     reply_to_address = SelectField(_('"Reply to" address'), [DataRequired()])
     include_submitter = BooleanField(_('Send to submitter'), widget=SwitchWidget())
-    include_authors = BooleanField(_('Send to primary authorized_submittershors'), widget=SwitchWidget())
+    include_authors = BooleanField(_('Send to primary authors'), widget=SwitchWidget())
     include_coauthors = BooleanField(_('Send to co-authors'), widget=SwitchWidget())
     cc_addresses = EmailListField(_("CC"), description=_("Additional CC e-mail addresses (one per line)"))
     subject = StringField(_("Subject"), [DataRequired()])

--- a/indico/modules/events/abstracts/templates/forms/rule_list_widget.html
+++ b/indico/modules/events/abstracts/templates/forms/rule_list_widget.html
@@ -2,6 +2,11 @@
 {% from 'message_box.html' import message_box %}
 
 {% block html %}
+    <div>
+        {%- trans -%}
+            The emails generated from this notification template will be sent once <strong>any</strong> of the following rules is matched.
+        {%- endtrans -%}
+    </div>
     <input type="hidden" id="{{ field.id }}" name="{{ field.name }}" value="{{ field._value() }}">
     <div id="rule-widget-{{ field.id }}"class="js-rule-list-widget">
         <ul class="rule-list"></ul>

--- a/indico/modules/events/abstracts/templates/management/notification_tpl_form.html
+++ b/indico/modules/events/abstracts/templates/management/notification_tpl_form.html
@@ -2,9 +2,9 @@
 
 {{ form_header(form) }}
     {{ form_row(form.title) }}
+    {{ form_row(form.stop_on_match) }}
     {% call form_fieldset(_('Rules')) %}
         {{ form_row(form.rules, skip_label=true) }}
-        {{ form_row(form.stop_on_match) }}
     {% endcall %}
 
     {% if not is_edit %}


### PR DESCRIPTION
### Fix layout

The layout was broken when any of the `<select>` fiends inside a rule had a very long `<option>`.
![](http://i.imgur.com/6vVZFhy.png)
### Improve UX

The **description** and the **position** of the _Stop on match_ field is very misleading. The text _"Do not evaluate any other rules once this one matches"_ feels wrong because what the user will think is that it refers to the rules of this email template (since it is positioned inside the **Rules** fieldset) and not to the rules of the following email templates.

I had to check the code to understand the logic behind _Stop on match_ and a user won't be able to do that :wink: 

This is my (easy-fix) solution:
![](http://i.imgur.com/4aSWWYH.png)
### Future improvements

The best solution imo would be to add a button in the list of email templates which will trigger an AJAX request. Here's a quick mockup:
![](http://i.imgur.com/gfU8zEE.png)
