### PR TITLE
My Abstracts display page

### DIFF
--- a/indico/htdocs/sass/modules/event_display/_conferences.scss
+++ b/indico/htdocs/sass/modules/event_display/_conferences.scss
@@ -154,7 +154,7 @@
     }
 }
 
-.contrib-session, .contrib-track, .contrib-type {
+.contrib-session, .contrib-track, .contrib-type, .contrib-state {
     @include border-radius();
     @include ellipsis;
 

--- a/indico/modules/events/abstracts/__init__.py
+++ b/indico/modules/events/abstracts/__init__.py
@@ -107,7 +107,14 @@ def _get_notification_placeholders(sender, **kwargs):
 
 @signals.event.sidemenu.connect
 def _extend_event_menu(sender, **kwargs):
+    from indico.modules.events.abstracts.util import get_user_abstracts
     from indico.modules.events.layout.util import MenuEntryData
 
-    return MenuEntryData(title=_("Book of Abstracts"), name='abstracts_book', endpoint='abstracts.export_boa',
-                         position=9, visible=lambda event: event.has_feature('abstracts'), static_site=True)
+    def _is_visible(conf):
+        return (session.user and conf.has_feature('abstracts') and
+                bool(get_user_abstracts(conf.as_event, session.user)))
+
+    yield MenuEntryData(title=_("Book of Abstracts"), name='abstracts_book', endpoint='abstracts.export_boa',
+                        position=9, visible=lambda event: event.has_feature('abstracts'), static_site=True)
+    yield MenuEntryData(title=_("My Abstracts"), name='user_abstracts', visible=_is_visible,
+                        endpoint='abstracts.my_abstracts', position=0, parent='call_for_abstracts')

--- a/indico/modules/events/abstracts/blueprint.py
+++ b/indico/modules/events/abstracts/blueprint.py
@@ -17,7 +17,8 @@
 from __future__ import unicode_literals
 
 from indico.modules.events.abstracts.controllers.boa import RHManageBOA, RHExportBOA
-from indico.modules.events.abstracts.controllers.display import RHDisplayAbstract, RHDisplayAbstractExportPDF
+from indico.modules.events.abstracts.controllers.display import (RHDisplayAbstract, RHDisplayAbstractExportPDF,
+                                                                 RHMyAbstracts)
 from indico.modules.events.abstracts.controllers.email_templates import (RHAddEmailTemplate, RHEditEmailTemplateRules,
                                                                          RHEditEmailTemplateText, RHEmailTemplateList,
                                                                          RHDeleteEmailTemplate, RHPreviewEmailTemplate,
@@ -35,6 +36,7 @@ from indico.modules.events.abstracts.controllers.management import (RHAbstracts,
                                                                     RHManageReviewingRoles, RHResetAbstractJudgment,
                                                                     RHBulkAbstractJudgment, RHAbstractNotificationLog)
 from indico.modules.events.abstracts.controllers.reviewing import RHAbstractsDownloadAttachment
+from indico.web.flask.util import make_compat_redirect_func
 from indico.web.flask.wrappers import IndicoBlueprint
 
 _bp = IndicoBlueprint('abstracts', __name__, url_prefix='/event/<confId>', template_folder='templates',
@@ -46,6 +48,7 @@ _bp.add_url_rule('/abstracts/<int:abstract_id>/notifications', 'notification_log
 _bp.add_url_rule('/abstracts/<int:abstract_id>/abstract.pdf', 'display_abstract_pdf_export', RHDisplayAbstractExportPDF)
 _bp.add_url_rule('/abstracts/<int:abstract_id>/attachments/<file_id>/<filename>', 'download_attachment',
                  RHAbstractsDownloadAttachment)
+_bp.add_url_rule('/abstracts/mine', 'my_abstracts', RHMyAbstracts)
 
 # Book of Abstracts
 _bp.add_url_rule('/manage/abstracts/boa', 'manage_boa', RHManageBOA, methods=('GET', 'POST'))
@@ -98,3 +101,10 @@ _bp.add_url_rule('/manage/abstracts/<int:abstract_id>/', 'manage_abstract', RHMa
 _bp.add_url_rule('/manage/abstracts/<int:abstract_id>/reset',
                  'reset_abstract_judgment', RHResetAbstractJudgment, methods=('POST',))
 _bp.add_url_rule('/manage/abstracts/<int:abstract_id>/abstract.pdf', 'manage_abstract_pdf_export', RHAbstractExportPDF)
+
+
+# Legacy URLs
+_compat_bp = IndicoBlueprint('compat_abstracts', __name__, url_prefix='/event/<event_id>')
+
+_compat_bp.add_url_rule('/call-for-abstracts/my-abstracts', 'my_abstracts',
+                        make_compat_redirect_func(_bp, 'my_abstracts', view_args_conv={'event_id': 'confId'}))

--- a/indico/modules/events/abstracts/blueprint.py
+++ b/indico/modules/events/abstracts/blueprint.py
@@ -18,7 +18,7 @@ from __future__ import unicode_literals
 
 from indico.modules.events.abstracts.controllers.boa import RHManageBOA, RHExportBOA
 from indico.modules.events.abstracts.controllers.display import (RHDisplayAbstract, RHDisplayAbstractExportPDF,
-                                                                 RHMyAbstracts)
+                                                                 RHMyAbstracts, RHMyAbstractsExportPDF)
 from indico.modules.events.abstracts.controllers.email_templates import (RHAddEmailTemplate, RHEditEmailTemplateRules,
                                                                          RHEditEmailTemplateText, RHEmailTemplateList,
                                                                          RHDeleteEmailTemplate, RHPreviewEmailTemplate,
@@ -49,6 +49,7 @@ _bp.add_url_rule('/abstracts/<int:abstract_id>/abstract.pdf', 'display_abstract_
 _bp.add_url_rule('/abstracts/<int:abstract_id>/attachments/<file_id>/<filename>', 'download_attachment',
                  RHAbstractsDownloadAttachment)
 _bp.add_url_rule('/abstracts/mine', 'my_abstracts', RHMyAbstracts)
+_bp.add_url_rule('/abstracts/mine.pdf', 'my_abstracts_pdf', RHMyAbstractsExportPDF)
 
 # Book of Abstracts
 _bp.add_url_rule('/manage/abstracts/boa', 'manage_boa', RHManageBOA, methods=('GET', 'POST'))

--- a/indico/modules/events/abstracts/controllers/display.py
+++ b/indico/modules/events/abstracts/controllers/display.py
@@ -26,7 +26,7 @@ from indico.modules.events.abstracts.util import get_user_abstracts
 from indico.modules.events.abstracts.views import WPDisplayAbstracts, WPMyAbstracts
 from indico.util.fs import secure_filename
 from indico.web.flask.util import send_file
-from MaKaC.PDFinterface.conference import AbstractToPDF
+from MaKaC.PDFinterface.conference import AbstractToPDF, AbstractsToPDF
 from MaKaC.webinterface.rh.conferenceDisplay import RHConferenceBaseDisplay
 
 
@@ -71,3 +71,10 @@ class RHMyAbstracts(RHMyAbstractsBase):
     def _process(self):
         return WPMyAbstracts.render_template('display/user_abstract_list.html', self._conf, event=self.event_new,
                                              abstracts=self.abstracts)
+
+
+class RHMyAbstractsExportPDF(RHMyAbstractsBase):
+    def _process(self):
+        sorted_abstracts = sorted(self.abstracts, key=attrgetter('friendly_id'))
+        pdf = AbstractsToPDF(self.event_new, sorted_abstracts)
+        return send_file('my-abstracts.pdf', pdf.generate(), 'application/pdf')

--- a/indico/modules/events/abstracts/templates/display/user_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/display/user_abstract_list.html
@@ -59,6 +59,13 @@
 {%- endblock %}
 
 {% block content -%}
+    <div class="toolbar">
+        <div class="group right">
+            <a class="i-button icon-file-pdf"
+               href="{{ url_for('abstracts.my_abstracts_pdf', event) }}"
+               title="{% trans %}Export to PDF{% endtrans %}"></a>
+        </div>
+    </div>
     <div id="display-contribution-list" class="contribution-list">
         {{ render_abstract_list(event, abstracts) }}
     </div>

--- a/indico/modules/events/abstracts/templates/display/user_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/display/user_abstract_list.html
@@ -1,0 +1,65 @@
+{% from 'events/display/indico/_common.html' import render_users %}
+
+{% extends 'layout/conference_page_base.html' %}
+
+{% macro render_abstract_list(event, abstracts) %}
+    {% set mapping = {'under_review': 'highlight',
+                      'withdrawn': 'outline dashed',
+                      'accepted': 'success',
+                      'rejected': 'error',
+                      'merged': 'visited',
+                      'duplicate': 'strong'} %}
+    {% for abstract in abstracts -%}
+        <div class="contribution-row" data-friendly-id="{{ abstract.friendly_id }}">
+            <div class="contrib-title info">
+                <span class="value">
+                    <a class="js-mathjax" href="{{ url_for('abstracts.display_abstract', abstract) }}">
+                        <span class="contrib-id">{{ abstract.friendly_id }}.</span>
+                        {{- abstract.title -}}
+                    </a>
+                </span>
+            </div>
+            <div class="speaker-list icon-user">
+                {{ render_users(abstract.speakers|sort(attribute='display_order_key'),
+                                span_class='speaker-item-inline') }}
+            </div>
+            <div class="contrib-time icon-time">
+                {% set dt = abstract.modified_dt or abstract.submitted_dt %}
+                <span>{% trans %}Last modified:{% endtrans %}</span>
+                <time datetime="{{ dt.isoformat() }}">{{ dt | format_human_date }}</time>
+            </div>
+            <div>
+                <div class="contrib-state small i-tag {{ mapping[abstract.public_state.name] }}">
+                    {{- abstract.state.title -}}
+                </div>
+                {% if abstract.accepted_track -%}
+                    <div class="contrib-track small">
+                        {{- abstract.accepted_track.title -}}
+                    </div>
+                {%- endif %}
+                {% if abstract.accepted_contrib_type -%}
+                    <div class="contrib-type small">
+                        {{- abstract.accepted_contrib_type.name -}}
+                    </div>
+                {%- endif %}
+            </div>
+            {% if abstract.description -%}
+                <a href="{{ url_for('abstracts.display_abstract', abstract) }}">
+                    <div class="description js-mathjax">
+                        {{- abstract.description|truncate(400) -}}
+                    </div>
+                </a>
+            {%- endif %}
+        </div>
+    {%- endfor %}
+{% endmacro %}
+
+{% block title -%}
+    {% trans %}My Abstracts{% endtrans %}
+{%- endblock %}
+
+{% block content -%}
+    <div id="display-contribution-list" class="contribution-list">
+        {{ render_abstract_list(event, abstracts) }}
+    </div>
+{%- endblock %}

--- a/indico/modules/events/abstracts/views.py
+++ b/indico/modules/events/abstracts/views.py
@@ -43,9 +43,8 @@ class WPManageAbstracts(WPJinjaMixin, WPConferenceModifBase):
                           for url in self._asset_env['mathjax_js'].urls()))
 
 
-class WPDisplayAbstracts(WPJinjaMixin, WPConferenceDefaultDisplayBase):
+class WPDisplayAbstractsBase(WPJinjaMixin, WPConferenceDefaultDisplayBase):
     template_prefix = 'events/abstracts/'
-    menu_entry_name = 'call_for_abstracts'
 
     def getJSFiles(self):
         return (WPConferenceDefaultDisplayBase.getJSFiles(self) +
@@ -55,7 +54,9 @@ class WPDisplayAbstracts(WPJinjaMixin, WPConferenceDefaultDisplayBase):
     def getCSSFiles(self):
         return (WPConferenceDefaultDisplayBase.getCSSFiles(self) +
                 self._asset_env['markdown_sass'].urls() +
-                self._asset_env['abstracts_sass'].urls())
+                self._asset_env['abstracts_sass'].urls() +
+                self._asset_env['event_display_sass'].urls() +
+                self._asset_env['contributions_sass'].urls())
 
     def _getBody(self, params):
         return WPJinjaMixin._getPageContent(self, params).encode('utf-8')
@@ -64,3 +65,11 @@ class WPDisplayAbstracts(WPJinjaMixin, WPConferenceDefaultDisplayBase):
         return (WPConferenceDefaultDisplayBase._getHeadContent(self) + render('js/mathjax.config.js.tpl') +
                 '\n'.join('<script src="{0}" type="text/javascript"></script>'.format(url)
                           for url in self._asset_env['mathjax_js'].urls()))
+
+
+class WPDisplayAbstracts(WPDisplayAbstractsBase):
+    menu_entry_name = 'call_for_abstracts'
+
+
+class WPMyAbstracts(WPDisplayAbstractsBase):
+    menu_entry_name = 'user_abstracts'

--- a/indico/modules/events/layout/default.py
+++ b/indico/modules/events/layout/default.py
@@ -93,13 +93,6 @@ def get_default_menu_entries():
             visible=_visibility_call_for_abstracts,
         ),
         MenuEntryData(
-            title=_("View my Abstracts"),
-            name='user_abstracts',
-            endpoint='event.userAbstracts',
-            position=0,
-            parent='call_for_abstracts'
-        ),
-        MenuEntryData(
             title=_("Submit Abstract"),
             name='abstract_submission',
             endpoint='event.abstractSubmission',


### PR DESCRIPTION
- [x] List abstracts
- [x] PDF export

Before you judge the CSS classes I used: The display of the "my abstracts" list is the same as the "contribution list". To avoid creating new classes (renaming `contribution-` to `abstract-`) and abstracting the term of contribution and abstract, I reused the contribution CSS classes and imported the contributions scss file.
Preview:
![image](https://cloud.githubusercontent.com/assets/1579899/19646172/83b43ad6-99f8-11e6-8219-dac3fd57d087.png)
