### PR TITLE
"Convener" view of abstracts inside track

### DIFF
--- a/indico/htdocs/sass/base/_pages.scss
+++ b/indico/htdocs/sass/base/_pages.scss
@@ -203,6 +203,10 @@
         font-size: 2em;
         font-weight: normal;
         padding-right: 5px;
+
+        .track-name {
+            font-style: italic;
+        }
     }
 }
 

--- a/indico/htdocs/sass/modules/_abstracts.scss
+++ b/indico/htdocs/sass/modules/_abstracts.scss
@@ -19,4 +19,4 @@
 @import 'abstracts/abstract_list';
 @import 'abstracts/email_templates';
 @import 'abstracts/notification_logs';
-@import 'abstracts/roles'
+@import 'abstracts/roles';

--- a/indico/htdocs/sass/modules/_tracks.scss
+++ b/indico/htdocs/sass/modules/_tracks.scss
@@ -54,3 +54,31 @@
 #no-tracks-box {
     margin-top: 20px;
 }
+
+.track-review-list {
+    ul {
+        padding-left: 10px;
+    }
+}
+
+.track-review-row {
+    list-style-type: none;
+
+    .title {
+        font-size: 14pt;
+    }
+
+    .label {
+        display: inline-block;
+        background-color: $gray;
+        border: 0;
+        padding: 3px;
+        margin: 10px 5px 10px 0;
+    }
+
+    .badge {
+        font-weight: bold;
+        font-size: 0.6em;
+        cursor: default;
+    }
+}

--- a/indico/htdocs/sass/modules/event_display/_conferences.scss
+++ b/indico/htdocs/sass/modules/event_display/_conferences.scss
@@ -120,10 +120,10 @@
     }
 }
 
-.contribution-list {
+.contribution-list, .track-review-list {
     @extend %font-family-modern-body;
 
-    .contribution-row {
+    .contribution-row, .track-review-row {
         padding: 0 10px;
         border-left: 3px solid $pastel-gray;
         margin-bottom: 1em;

--- a/indico/modules/events/abstracts/__init__.py
+++ b/indico/modules/events/abstracts/__init__.py
@@ -112,7 +112,7 @@ def _extend_event_menu(sender, **kwargs):
     yield MenuEntryData(title=_("Call for Abstracts"), name='call_for_abstracts', endpoint='event.conferenceCFA',
                         position=2, visible=lambda event: event.has_feature('abstracts'))
 
-    yield MenuEntryData(title=_("View my Tracks"), name='user_tracks', endpoint='abstracts.display_reviewable_tracks',
+    yield MenuEntryData(title=_("Reviewing Area"), name='user_tracks', endpoint='abstracts.display_reviewable_tracks',
                         position=2, parent='call_for_abstracts',
                         visible=lambda event: session.user and event.has_feature('abstracts'))
     yield MenuEntryData(title=_("Book of Abstracts"), name='abstracts_book', endpoint='abstracts.export_boa',

--- a/indico/modules/events/abstracts/__init__.py
+++ b/indico/modules/events/abstracts/__init__.py
@@ -109,14 +109,11 @@ def _get_notification_placeholders(sender, **kwargs):
 def _extend_event_menu(sender, **kwargs):
     from indico.modules.events.layout.util import MenuEntryData
 
-    return MenuEntryData(title=_("Book of Abstracts"), name='abstracts_book', endpoint='abstracts.export_boa',
-                         position=9, visible=lambda event: event.has_feature('abstracts'), static_site=True)
+    yield MenuEntryData(title=_("Call for Abstracts"), name='call_for_abstracts', endpoint='event.conferenceCFA',
+                        position=2, visible=lambda event: event.has_feature('abstracts'))
 
-
-@signals.event.sidemenu.connect
-def _extend_event_menu(sender, **kwargs):
-    from indico.modules.events.layout.util import MenuEntryData
-
-    return MenuEntryData(title=_("View my Tracks"), name='user_tracks', endpoint='abstracts.display_reviewable_tracks',
-                         position=2, parent='call_for_abstracts',
-                         visible=lambda event: session.user and event.has_feature('abstracts'))
+    yield MenuEntryData(title=_("View my Tracks"), name='user_tracks', endpoint='abstracts.display_reviewable_tracks',
+                        position=2, parent='call_for_abstracts',
+                        visible=lambda event: session.user and event.has_feature('abstracts'))
+    yield MenuEntryData(title=_("Book of Abstracts"), name='abstracts_book', endpoint='abstracts.export_boa',
+                        position=9, visible=lambda event: event.has_feature('abstracts'), static_site=True)

--- a/indico/modules/events/abstracts/__init__.py
+++ b/indico/modules/events/abstracts/__init__.py
@@ -118,5 +118,5 @@ def _extend_event_menu(sender, **kwargs):
     from indico.modules.events.layout.util import MenuEntryData
 
     return MenuEntryData(title=_("View my Tracks"), name='user_tracks', endpoint='abstracts.display_reviewable_tracks',
-                         position=2, parent='call_for_abstracts', visible=lambda event: event.has_feature('abstracts'),
-                         static_site=True)
+                         position=2, parent='call_for_abstracts',
+                         visible=lambda event: session.user and event.has_feature('abstracts'))

--- a/indico/modules/events/abstracts/__init__.py
+++ b/indico/modules/events/abstracts/__init__.py
@@ -111,3 +111,12 @@ def _extend_event_menu(sender, **kwargs):
 
     return MenuEntryData(title=_("Book of Abstracts"), name='abstracts_book', endpoint='abstracts.export_boa',
                          position=9, visible=lambda event: event.has_feature('abstracts'), static_site=True)
+
+
+@signals.event.sidemenu.connect
+def _extend_event_menu(sender, **kwargs):
+    from indico.modules.events.layout.util import MenuEntryData
+
+    return MenuEntryData(title=_("View my Tracks"), name='user_tracks', endpoint='abstracts.display_reviewable_tracks',
+                         position=2, parent='call_for_abstracts', visible=lambda event: event.has_feature('abstracts'),
+                         static_site=True)

--- a/indico/modules/events/abstracts/blueprint.py
+++ b/indico/modules/events/abstracts/blueprint.py
@@ -17,15 +17,13 @@
 from __future__ import unicode_literals
 
 from indico.modules.events.abstracts.controllers.boa import RHManageBOA, RHExportBOA
-from indico.modules.events.abstracts.controllers.display import (RHDisplayAbstract, RHDisplayAbstractExportPDF,
-                                                                 RHDisplayReviewableTracks,
-                                                                 RHDisplayReviewableTrackAbstracts)
+from indico.modules.events.abstracts.controllers.display import RHDisplayAbstract, RHDisplayAbstractExportPDF
 from indico.modules.events.abstracts.controllers.email_templates import (RHAddEmailTemplate, RHEditEmailTemplateRules,
                                                                          RHEditEmailTemplateText, RHEmailTemplateList,
                                                                          RHDeleteEmailTemplate, RHPreviewEmailTemplate,
                                                                          RHSortEmailTemplates)
-from indico.modules.events.abstracts.controllers.management import (RHAbstracts, RHAbstractList,
-                                                                    RHAbstractListCustomize, RHAbstractListStaticURL,
+from indico.modules.events.abstracts.controllers.management import (RHAbstracts, RHAbstractListCustomize,
+                                                                    RHAbstractListStaticURL,
                                                                     RHManageAbstractSubmission, RHManageAbstract,
                                                                     RHManageAbstractReviewing, RHCreateAbstract,
                                                                     RHDeleteAbstracts, RHAbstractPersonList,
@@ -35,8 +33,12 @@ from indico.modules.events.abstracts.controllers.management import (RHAbstracts,
                                                                     RHAbstractsExportJSON,
                                                                     RHScheduleCFA, RHOpenCFA, RHCloseCFA,
                                                                     RHManageReviewingRoles, RHResetAbstractJudgment,
-                                                                    RHBulkAbstractJudgment, RHAbstractNotificationLog)
-from indico.modules.events.abstracts.controllers.reviewing import RHAbstractsDownloadAttachment
+                                                                    RHBulkAbstractJudgment, RHAbstractNotificationLog,
+                                                                    RHAbstractList)
+from indico.modules.events.abstracts.controllers.reviewing import (RHAbstractsDownloadAttachment,
+                                                                   RHDisplayReviewableTracks,
+                                                                   RHDisplayReviewableTrackAbstracts,
+                                                                   RHDisplayAbstractListCustomize)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 _bp = IndicoBlueprint('abstracts', __name__, url_prefix='/event/<confId>', template_folder='templates',
@@ -48,9 +50,13 @@ _bp.add_url_rule('/abstracts/<int:abstract_id>/notifications', 'notification_log
 _bp.add_url_rule('/abstracts/<int:abstract_id>/abstract.pdf', 'display_abstract_pdf_export', RHDisplayAbstractExportPDF)
 _bp.add_url_rule('/abstracts/<int:abstract_id>/attachments/<file_id>/<filename>', 'download_attachment',
                  RHAbstractsDownloadAttachment)
+
+# Reviewing pages (display area)
 _bp.add_url_rule('/call-for-abstracts/reviewing/', 'display_reviewable_tracks', RHDisplayReviewableTracks)
-_bp.add_url_rule('/call-for-abstracts/reviewing/<int:track_id>', 'display_reviewable_track_abstracts',
+_bp.add_url_rule('/call-for-abstracts/reviewing/<int:track_id>/', 'display_reviewable_track_abstracts',
                  RHDisplayReviewableTrackAbstracts)
+_bp.add_url_rule('/call-for-abstracts/reviewing/<int:track_id>/customize', 'display_customize_abstract_list',
+                 RHDisplayAbstractListCustomize, methods=('GET', 'POST'))
 
 # Book of Abstracts
 _bp.add_url_rule('/manage/abstracts/boa', 'manage_boa', RHManageBOA, methods=('GET', 'POST'))

--- a/indico/modules/events/abstracts/blueprint.py
+++ b/indico/modules/events/abstracts/blueprint.py
@@ -17,7 +17,8 @@
 from __future__ import unicode_literals
 
 from indico.modules.events.abstracts.controllers.boa import RHManageBOA, RHExportBOA
-from indico.modules.events.abstracts.controllers.display import RHDisplayAbstract, RHDisplayAbstractExportPDF
+from indico.modules.events.abstracts.controllers.display import (RHDisplayAbstract, RHDisplayAbstractExportPDF,
+                                                                 RHDisplayReviewableTracks)
 from indico.modules.events.abstracts.controllers.email_templates import (RHAddEmailTemplate, RHEditEmailTemplateRules,
                                                                          RHEditEmailTemplateText, RHEmailTemplateList,
                                                                          RHDeleteEmailTemplate, RHPreviewEmailTemplate,
@@ -46,6 +47,7 @@ _bp.add_url_rule('/abstracts/<int:abstract_id>/notifications', 'notification_log
 _bp.add_url_rule('/abstracts/<int:abstract_id>/abstract.pdf', 'display_abstract_pdf_export', RHDisplayAbstractExportPDF)
 _bp.add_url_rule('/abstracts/<int:abstract_id>/attachments/<file_id>/<filename>', 'download_attachment',
                  RHAbstractsDownloadAttachment)
+_bp.add_url_rule('/call-for-abstracts/reviewing', 'display_reviewable_tracks', RHDisplayReviewableTracks)
 
 # Book of Abstracts
 _bp.add_url_rule('/manage/abstracts/boa', 'manage_boa', RHManageBOA, methods=('GET', 'POST'))

--- a/indico/modules/events/abstracts/blueprint.py
+++ b/indico/modules/events/abstracts/blueprint.py
@@ -18,7 +18,8 @@ from __future__ import unicode_literals
 
 from indico.modules.events.abstracts.controllers.boa import RHManageBOA, RHExportBOA
 from indico.modules.events.abstracts.controllers.display import (RHDisplayAbstract, RHDisplayAbstractExportPDF,
-                                                                 RHDisplayReviewableTracks)
+                                                                 RHDisplayReviewableTracks,
+                                                                 RHDisplayReviewableTrackAbstracts)
 from indico.modules.events.abstracts.controllers.email_templates import (RHAddEmailTemplate, RHEditEmailTemplateRules,
                                                                          RHEditEmailTemplateText, RHEmailTemplateList,
                                                                          RHDeleteEmailTemplate, RHPreviewEmailTemplate,
@@ -47,7 +48,9 @@ _bp.add_url_rule('/abstracts/<int:abstract_id>/notifications', 'notification_log
 _bp.add_url_rule('/abstracts/<int:abstract_id>/abstract.pdf', 'display_abstract_pdf_export', RHDisplayAbstractExportPDF)
 _bp.add_url_rule('/abstracts/<int:abstract_id>/attachments/<file_id>/<filename>', 'download_attachment',
                  RHAbstractsDownloadAttachment)
-_bp.add_url_rule('/call-for-abstracts/reviewing', 'display_reviewable_tracks', RHDisplayReviewableTracks)
+_bp.add_url_rule('/call-for-abstracts/reviewing/', 'display_reviewable_tracks', RHDisplayReviewableTracks)
+_bp.add_url_rule('/call-for-abstracts/reviewing/<int:track_id>', 'display_reviewable_track_abstracts',
+                 RHDisplayReviewableTrackAbstracts)
 
 # Book of Abstracts
 _bp.add_url_rule('/manage/abstracts/boa', 'manage_boa', RHManageBOA, methods=('GET', 'POST'))

--- a/indico/modules/events/abstracts/controllers/base.py
+++ b/indico/modules/events/abstracts/controllers/base.py
@@ -16,10 +16,11 @@
 
 from __future__ import unicode_literals
 
-from flask import request, session
+from flask import redirect, request, session
 from werkzeug.exceptions import Forbidden
 
 from indico.modules.events.abstracts.models.abstracts import Abstract
+from indico.web.util import jsonify_data
 
 
 class AbstractMixin:
@@ -35,3 +36,36 @@ class AbstractMixin:
     def _checkProtection(self):
         if not self.abstract.can_access(session.user):
             raise Forbidden
+
+
+class DisplayAbstractListMixin:
+    """Display the list of abstracts"""
+
+    view_class = None
+    template = None
+
+    def _process(self):
+        if self.list_generator.static_link_used:
+            return redirect(self.list_generator.get_list_url())
+        return self._render_template(**self.list_generator.get_list_kwargs())
+
+    def _render_template(self, **kwargs):
+        return self.view_class.render_template(self.template, self._conf, event=self.event_new, **kwargs)
+
+
+class CustomizeAbstractListMixin:
+    """Filter options and columns to display for the abstract list of an event"""
+
+    view_class = None
+
+    def _process_GET(self):
+        list_config = self.list_generator._get_config()
+        return self.view_class.render_template('management/abstract_list_filter.html', self._conf,
+                                               event=self.event_new, visible_items=list_config['items'],
+                                               static_items=self.list_generator.static_items,
+                                               extra_filters=self.list_generator.extra_filters,
+                                               filters=list_config['filters'])
+
+    def _process_POST(self):
+        self.list_generator.store_configuration()
+        return jsonify_data(flash=False, **self.list_generator.render_list())

--- a/indico/modules/events/abstracts/controllers/display.py
+++ b/indico/modules/events/abstracts/controllers/display.py
@@ -16,8 +16,12 @@
 
 from __future__ import unicode_literals
 
+from flask import request
+from flask import session
 from indico.modules.events.abstracts.controllers.base import AbstractMixin
 from indico.modules.events.abstracts.views import WPDisplayAbstracts
+from indico.modules.events.tracks.models.tracks import Track
+from indico.modules.users import User
 from indico.util.fs import secure_filename
 from indico.web.flask.util import send_file
 from MaKaC.PDFinterface.conference import AbstractToPDF
@@ -44,3 +48,29 @@ class RHDisplayAbstractExportPDF(RHDisplayAbstract):
         pdf = AbstractToPDF(self.abstract)
         file_name = secure_filename('abstract-{}.pdf'.format(self.abstract.friendly_id), 'abstract.pdf')
         return send_file(file_name, pdf.generate(), 'application/pdf')
+
+
+class RHDisplayReviewableTracks(RHConferenceBaseDisplay):
+    def _process(self):
+        user = session.user
+        tracks_set, events_set = set(), set()
+        tracks_set.update(user.convener_for_tracks, user.abstract_reviewer_for_tracks)
+        events_set.update(user.global_convener_for_events, user.global_abstract_reviewer_for_events)
+        for e in events_set:
+            tracks_set.update(e.tracks)
+        tracks = {t for t in tracks_set if t.event_id == self.event_new.id}
+        return WPDisplayAbstracts.render_template('display/tracks.html', self._conf, event=self.event_new,
+                                                  tracks=tracks)
+
+
+class RHDisplayReviewableTrackAbstracts(RHConferenceBaseDisplay):
+    def _checkParams(self, params):
+        RHConferenceBaseDisplay._checkParams(self, params)
+        self.track = Track.get_one(request.view_args['track_id'])
+
+    def _process(self):
+        abstracts_set = set()
+        abstracts_set.update(self.track.abstracts_accepted, self.track.abstracts_reviewed,
+                             self.track.abstracts_submitted)
+        return WPDisplayAbstracts.render_template('display/abstracts.html', self._conf, track_title=self.track.title,
+                                                  abstracts=abstracts_set)

--- a/indico/modules/events/abstracts/controllers/management.py
+++ b/indico/modules/events/abstracts/controllers/management.py
@@ -25,7 +25,8 @@ from sqlalchemy.orm import joinedload, subqueryload
 from werkzeug.exceptions import Forbidden
 
 from indico.modules.events.abstracts import logger
-from indico.modules.events.abstracts.controllers.base import AbstractMixin
+from indico.modules.events.abstracts.controllers.base import (AbstractMixin, DisplayAbstractListMixin,
+                                                              CustomizeAbstractListMixin)
 from indico.modules.events.abstracts.forms import (AbstractSubmissionSettingsForm,
                                                    AbstractReviewingRolesForm, AbstractReviewingSettingsForm,
                                                    AbstractsScheduleForm, AbstractJudgmentForm,
@@ -38,8 +39,8 @@ from indico.modules.events.abstracts.operations import (create_abstract, delete_
                                                         close_cfa, judge_abstract, reset_abstract_judgment)
 from indico.modules.events.abstracts.schemas import abstracts_schema
 from indico.modules.events.abstracts.settings import abstracts_settings, abstracts_reviewing_settings
-from indico.modules.events.abstracts.util import (AbstractListGenerator, make_abstract_form, get_roles_for_event,
-                                                  generate_spreadsheet_from_abstracts)
+from indico.modules.events.abstracts.util import (make_abstract_form, get_roles_for_event,
+                                                  generate_spreadsheet_from_abstracts, AbstractListGeneratorManagement)
 from indico.modules.events.abstracts.views import WPManageAbstracts
 from indico.modules.events.contributions.models.persons import AuthorType
 from indico.modules.events.tracks.models.tracks import Track
@@ -82,7 +83,7 @@ class RHAbstractListBase(RHManageAbstractsBase):
 
     def _checkParams(self, params):
         RHManageAbstractsBase._checkParams(self, params)
-        self.list_generator = AbstractListGenerator(event=self.event_new)
+        self.list_generator = AbstractListGeneratorManagement(event=self.event_new)
 
 
 class RHManageAbstractsActionsBase(RHAbstractListBase):
@@ -260,31 +261,13 @@ class RHManageAbstractReviewing(RHManageAbstractsBase):
         return jsonify_form(form, disabled_fields=disabled_fields)
 
 
-class RHAbstractList(RHAbstractListBase):
-    """Display the list of abstracts"""
-
-    def _process(self):
-        if self.list_generator.static_link_used:
-            return redirect(self.list_generator.get_list_url())
-        list_kwargs = self.list_generator.get_list_kwargs()
-        return WPManageAbstracts.render_template('management/abstract_list.html', self._conf, event=self.event_new,
-                                                 **list_kwargs)
+class RHAbstractList(DisplayAbstractListMixin, RHAbstractListBase):
+    template = 'management/abstract_list.html'
+    view_class = WPManageAbstracts
 
 
-class RHAbstractListCustomize(RHAbstractListBase):
-    """Filter options and columns to display for the abstract list of an event"""
-
-    def _process_GET(self):
-        list_config = self.list_generator._get_config()
-        return WPManageAbstracts.render_template('management/abstract_list_filter.html', self._conf,
-                                                 event=self.event_new, visible_items=list_config['items'],
-                                                 static_items=self.list_generator.static_items,
-                                                 extra_filters=self.list_generator.extra_filters,
-                                                 filters=list_config['filters'])
-
-    def _process_POST(self):
-        self.list_generator.store_configuration()
-        return jsonify_data(flash=False, **self.list_generator.render_list())
+class RHAbstractListCustomize(CustomizeAbstractListMixin, RHAbstractListBase):
+    view_class = WPManageAbstracts
 
 
 class RHAbstractListStaticURL(RHAbstractListBase):

--- a/indico/modules/events/abstracts/controllers/reviewing.py
+++ b/indico/modules/events/abstracts/controllers/reviewing.py
@@ -16,14 +16,15 @@
 
 
 from __future__ import unicode_literals
-
 from flask import request, session
 from werkzeug.exceptions import Forbidden
 
+from indico.core.db import db
+from indico.modules.users import User
 from indico.modules.events.abstracts.controllers.base import (AbstractMixin, DisplayAbstractListMixin,
                                                               CustomizeAbstractListMixin)
 from indico.modules.events.abstracts.models.files import AbstractFile
-from indico.modules.events.abstracts.util import AbstractListGeneratorDisplay
+from indico.modules.events.abstracts.util import AbstractListGeneratorDisplay, get_track_reviewer_abstract_counts
 from indico.modules.events.abstracts.views import WPDisplayAbstractsReviewing
 from indico.modules.events.tracks.models.tracks import Track
 from MaKaC.webinterface.rh.conferenceDisplay import RHConferenceBaseDisplay
@@ -68,13 +69,24 @@ class RHAbstractsDownloadAttachment(RHAbstractsReviewBase):
 
 
 class RHDisplayReviewableTracks(RHAbstractsBase):
+    def _checkProtection(self):
+        RHAbstractsBase._checkProtection(self)
+        if not session.user:
+            raise Forbidden
+
     def _process(self):
-        user = session.user
-        tracks_set = (user.convener_for_tracks | user.abstract_reviewer_for_tracks) & set(self.event_new.tracks)
-        if user in self.event_new.global_abstract_reviewers or user in self.event_new.global_conveners:
-            tracks_set.update(self.event_new.tracks)
+        query = Track.query.with_parent(self.event_new)
+        track_reviewer_abstract_count = get_track_reviewer_abstract_counts(self.event_new, session.user)
+
+        # if the user is not a global convener only show their tracks
+        if (session.user not in self.event_new.global_abstract_reviewers and
+                session.user not in self.event_new.global_conveners):
+            query = query.filter(db.or_(Track.conveners.any(User.id == session.user.id),
+                                        Track.abstract_reviewers.any(User.id == session.user.id)))
+
         return WPDisplayAbstractsReviewing.render_template('display/tracks.html', self._conf, event=self.event_new,
-                                                           tracks=tracks_set)
+                                                           abstract_count=track_reviewer_abstract_count,
+                                                           tracks=query.all())
 
 
 class RHDisplayAbstractListBase(RHAbstractsBase):

--- a/indico/modules/events/abstracts/templates/display/abstracts.html
+++ b/indico/modules/events/abstracts/templates/display/abstracts.html
@@ -1,7 +1,11 @@
 {% extends 'layout/conference_page_base.html' %}
+{% from 'events/abstracts/management/_abstract_list.html' import render_abstract_list %}
+{% from 'events/management/_lists.html' import render_displayed_entries_fragment %}
 
 {% block title %}
-    {% trans %}Abstracts from <span class="track-name">{{ track_title }}</span>{% endtrans %}
+    {% trans track_title=track.title -%}
+        Abstracts from <span class="track-name">{{ track_title }}</span>
+    {%- endtrans %}
 {% endblock %}
 
 {% block content %}
@@ -12,14 +16,62 @@
             {%- endtrans -%}
         </p>
     {% else %}
-        <ul class="programme">
-            {% for abstract in abstracts %}
-                <li>
-                    <span class="title">
-                        <a href="{{ url_for('abstracts.display_abstract', abstract) }}">{{ abstract.title }}</a>
-                    </span>
-                </li>
-            {%  endfor %}
-        </ul>
+        <div class="toolbar left">
+            <div class="group">
+                <button class="i-button icon-settings js-dialog-action js-customize-list highlight"
+                    data-href="{{ url_for('.display_customize_abstract_list', event, track) }}"
+                    data-title="{% trans %}Abstract list configuration{% endtrans %}"
+                    data-dialog-classes="list-filter-dialog"
+                    data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
+                    data-ajax-dialog>
+                    {% trans %}Customize list{% endtrans %}
+                </button>
+            </div>
+            <div class="group">
+                <a href="#" class="i-button icon-attachment js-requires-selected-row js-submit-list-form disabled"
+                   data-href="{{ url_for('.download_attachments', event) }}">
+                    {%- trans %}Download attachments{%- endtrans %}
+                </a>
+            </div>
+            <div class="group">
+                <a class="i-button arrow button js-requires-selected-row disabled" data-toggle="dropdown">
+                    {%- trans %}Export{% endtrans -%}
+                </a>
+                <ul class="dropdown">
+                    <li>
+                        <a href="#"
+                           class="icon-file-pdf js-requires-selected-row disabled js-submit-list-form"
+                           data-href="{{ url_for('.abstracts_pdf_export', event) }}">PDF</a>
+                    </li>
+                    <li>
+                        <a href="#"
+                           class="icon-file-spreadsheet js-requires-selected-row disabled js-submit-list-form"
+                           data-href="{{ url_for('.abstracts_csv_export', event) }}">CSV</a>
+                    </li>
+                    <li>
+                        <a href="#"
+                           class="icon-file-excel js-requires-selected-row disabled js-submit-list-form"
+                           data-href="{{ url_for('.abstracts_xlsx_export', event) }}">XLSX (Excel)</a>
+                    </li>
+                    <li>
+                        <a href="#"
+                           class="icon-file-css js-requires-selected-row disabled js-submit-list-form"
+                           {# TODO: data-href="{{ url_for('.abstracts_json_export', event) }}" #}>JSON</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+        <div class="toolbar right">
+            <div class="group">
+                <div id="filter-statistics">
+                    {{ render_displayed_entries_fragment(abstracts|length, total_abstracts) }}
+                </div>
+            </div>
+        </div>
+
+        <div id="abstract-list">
+            {{ render_abstract_list(abstracts, dynamic_columns, static_columns, total_abstracts) }}
+        </div>
     {% endif %}
 {% endblock %}

--- a/indico/modules/events/abstracts/templates/display/abstracts.html
+++ b/indico/modules/events/abstracts/templates/display/abstracts.html
@@ -1,0 +1,25 @@
+{% extends 'layout/conference_page_base.html' %}
+
+{% block title %}
+    {% trans %}Abstracts from <span class="track-name">{{ track_title }}</span>{% endtrans %}
+{% endblock %}
+
+{% block content %}
+    {% if not abstracts %}
+        <p>
+            {%- trans -%}
+                There are currently no abstracts within this track which you are reviewer or convener of.
+            {%- endtrans -%}
+        </p>
+    {% else %}
+        <ul class="programme">
+            {% for abstract in abstracts %}
+                <li>
+                    <span class="title">
+                        <a href="{{ url_for('abstracts.display_abstract', abstract) }}">{{ abstract.title }}</a>
+                    </span>
+                </li>
+            {%  endfor %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/indico/modules/events/abstracts/templates/display/abstracts.html
+++ b/indico/modules/events/abstracts/templates/display/abstracts.html
@@ -12,7 +12,7 @@
     {% if not abstracts %}
         <p>
             {%- trans -%}
-                There are currently no abstracts within this track which you are reviewer or convener of.
+                There are currently no abstracts within this track for which you are a reviewer or convener.
             {%- endtrans -%}
         </p>
     {% else %}

--- a/indico/modules/events/abstracts/templates/display/tracks.html
+++ b/indico/modules/events/abstracts/templates/display/tracks.html
@@ -1,0 +1,28 @@
+{% extends 'layout/conference_page_base.html' %}
+
+{% block title %}
+    {% trans %}Tracks I can review or convene{% endtrans %}
+{% endblock %}
+
+{% block content %}
+    {% if not tracks %}
+        <p>
+            {%- trans -%}
+                There are currently no tracks which you are reviewer or convener of.
+            {%- endtrans -%}
+        </p>
+    {% else %}
+        <ul class="programme">
+            {% for track in tracks %}
+                <li>
+                    <span class="title">
+                        <a href="{{ url_for('abstracts.display_reviewable_track_abstracts', track) }}">{{ track.title }}</a>
+                    </span>
+                    <div class="description">
+                        {{ track.description }}
+                    </div>
+                </li>
+            {%  endfor %}
+        </ul>
+    {% endif %}
+{% endblock %}

--- a/indico/modules/events/abstracts/templates/display/tracks.html
+++ b/indico/modules/events/abstracts/templates/display/tracks.html
@@ -1,28 +1,46 @@
 {% extends 'layout/conference_page_base.html' %}
 
 {% block title %}
-    {% trans %}Tracks I can review or convene{% endtrans %}
+    {% trans %}Reviewing Area{% endtrans %}
 {% endblock %}
 
 {% block content %}
-    {% if not tracks %}
-        <p>
-            {%- trans -%}
-                There are currently no tracks which you are reviewer or convener of.
-            {%- endtrans -%}
-        </p>
-    {% else %}
-        <ul class="programme">
-            {% for track in tracks %}
-                <li>
-                    <span class="title">
-                        <a href="{{ url_for('abstracts.display_reviewable_track_abstracts', track) }}">{{ track.title }}</a>
-                    </span>
-                    <div class="description">
-                        {{ track.description }}
+    <div class="track-review-list">
+        {% if not tracks %}
+            <p>
+                {%- trans -%}
+                    There are currently no tracks for which you are a reviewer or convener.
+                {%- endtrans -%}
+            </p>
+        {% else %}
+            <ul>
+                {% for track in tracks %}
+                    <div class="track-review-row">
+                        <li>
+                            <div class="title">
+                                <a href="{{ url_for('abstracts.display_reviewable_track_abstracts', track) }}">
+                                    {{- track.title -}}
+                                </a>
+                                <span class="badge"
+                                      title="{{ abstract_count[track]['total'] }} {% trans %}total{% endtrans %}">
+                                    {{- abstract_count[track]['total'] - abstract_count[track]['reviewed'] }}
+                                    {% trans %}left to review{% endtrans -%}
+                                </span>
+                            </div>
+                            {% if track.can_review_abstracts(session.user) %}
+                                <div class="label i-tag">
+                                    {%- trans %}Reviewer{% endtrans -%}
+                                </div>
+                            {% endif %}
+                            {% if track.can_convene(session.user) %}
+                                <div class="label i-tag">
+                                    {%- trans %}Convener{% endtrans -%}
+                                </div>
+                            {% endif %}
+                        </li>
                     </div>
-                </li>
-            {%  endfor %}
-        </ul>
-    {% endif %}
+                {%  endfor %}
+            </ul>
+        {% endif %}
+    </div>
 {% endblock %}

--- a/indico/modules/events/abstracts/templates/management/abstract_list_filter.html
+++ b/indico/modules/events/abstracts/templates/management/abstract_list_filter.html
@@ -97,15 +97,17 @@
         {% endfor %}
     </div>
 
-    <div class="clearfix i-form horizontal">
-        <h3>{% trans %}Extra filters{% endtrans %}</h3>
-        {% for item_id, item in extra_filters.iteritems() %}
-            {% set name = 'field_{}'.format(item_id) %}
-            {% if item.type == 'bool' %}
-                {{ _render_boolean_filter(id=item_id, name=name, label=item.title) }}
-            {% endif %}
-        {% endfor %}
-    </div>
+    {% if extra_filters %}
+        <div class="clearfix i-form horizontal">
+            <h3>{% trans %}Extra filters{% endtrans %}</h3>
+            {% for item_id, item in extra_filters.iteritems() %}
+                {% set name = 'field_{}'.format(item_id) %}
+                {% if item.type == 'bool' %}
+                    {{ _render_boolean_filter(id=item_id, name=name, label=item.title) }}
+                {% endif %}
+            {% endfor %}
+        </div>
+    {% endif %}
 
     <div class="bottom-buttons">
         <input class="i-button big highlight" type="submit" data-disabled-until-change

--- a/indico/modules/events/abstracts/util.py
+++ b/indico/modules/events/abstracts/util.py
@@ -26,6 +26,7 @@ from indico.core.db.sqlalchemy.util.session import no_autoflush
 from indico.modules.events.abstracts.models.abstracts import Abstract, AbstractState
 from indico.modules.events.abstracts.models.email_templates import AbstractEmailTemplate
 from indico.modules.events.abstracts.models.fields import AbstractFieldValue
+from indico.modules.events.abstracts.models.reviews import AbstractReview
 from indico.modules.events.abstracts.settings import abstracts_settings
 from indico.modules.events.contributions.models.fields import ContributionField
 from indico.modules.events.tracks.models.tracks import Track
@@ -405,3 +406,29 @@ def get_roles_for_event(event):
     roles['*']['reviewer'] = [reviewer.id for reviewer in event.global_abstract_reviewers]
     roles['*']['convener'] = [reviewer.id for reviewer in event.global_conveners]
     return roles
+
+
+def get_track_reviewer_abstract_counts(event, user):
+    """
+    Get the number of unreviewed/reviewed abstracts per track for a
+    specific user.
+
+    Note that this does not take into account if the user is a
+    reviewer for a track; it just checks whether the user has
+    reviewed an abstract in a track or not.
+
+    :return: A ``{track: (unreviewed_count, reviewed_count)}`` dict.
+    """
+    # COUNT() does not count NULL values so we pass NULL in case an
+    # abstract is not in the submitted state. That way we still get
+    # the track - filtering using WHERE would only include tracks
+    # that have some abstract in the submitted state.
+    count_total = db.func.count(db.case({AbstractState.submitted.value: Abstract.id}, value=Abstract.state))
+    count_reviewed = db.func.count(db.case({AbstractState.submitted.value: AbstractReview.id}, value=Abstract.state))
+    query = (Track.query.with_parent(event)
+             .with_entities(Track, count_total - count_reviewed, count_reviewed)
+             .outerjoin(Track.abstracts_reviewed)
+             .outerjoin(AbstractReview, db.and_(AbstractReview.abstract_id == Abstract.id,
+                                                AbstractReview.user_id == user.id))
+             .group_by(Track.id))
+    return {track: (unreviewed, reviewed) for track, unreviewed, reviewed in query}

--- a/indico/modules/events/abstracts/util.py
+++ b/indico/modules/events/abstracts/util.py
@@ -410,14 +410,14 @@ def get_roles_for_event(event):
 
 def get_track_reviewer_abstract_counts(event, user):
     """
-    Get the number of unreviewed/reviewed abstracts per track for a
+    Get the number of total/reviewed abstracts per track for a
     specific user.
 
     Note that this does not take into account if the user is a
     reviewer for a track; it just checks whether the user has
     reviewed an abstract in a track or not.
 
-    :return: A ``{track: (unreviewed_count, reviewed_count)}`` dict.
+    :return: A ``{track: (total_count, reviewed_count)}`` dict.
     """
     # COUNT() does not count NULL values so we pass NULL in case an
     # abstract is not in the submitted state. That way we still get
@@ -426,9 +426,9 @@ def get_track_reviewer_abstract_counts(event, user):
     count_total = db.func.count(db.case({AbstractState.submitted.value: Abstract.id}, value=Abstract.state))
     count_reviewed = db.func.count(db.case({AbstractState.submitted.value: AbstractReview.id}, value=Abstract.state))
     query = (Track.query.with_parent(event)
-             .with_entities(Track, count_total - count_reviewed, count_reviewed)
+             .with_entities(Track, count_total, count_reviewed)
              .outerjoin(Track.abstracts_reviewed)
              .outerjoin(AbstractReview, db.and_(AbstractReview.abstract_id == Abstract.id,
                                                 AbstractReview.user_id == user.id))
              .group_by(Track.id))
-    return {track: (unreviewed, reviewed) for track, unreviewed, reviewed in query}
+    return {track: {'total': total, 'reviewed': reviewed} for track, total, reviewed in query}

--- a/indico/modules/events/abstracts/views.py
+++ b/indico/modules/events/abstracts/views.py
@@ -64,3 +64,11 @@ class WPDisplayAbstracts(WPJinjaMixin, WPConferenceDefaultDisplayBase):
         return (WPConferenceDefaultDisplayBase._getHeadContent(self) + render('js/mathjax.config.js.tpl') +
                 '\n'.join('<script src="{0}" type="text/javascript"></script>'.format(url)
                           for url in self._asset_env['mathjax_js'].urls()))
+
+
+class WPDisplayAbstractsReviewing(WPDisplayAbstracts):
+    menu_entry_name = 'user_tracks'
+
+    def getJSFiles(self):
+        return (WPDisplayAbstracts.getJSFiles(self) +
+                self._asset_env['modules_event_management_js'].urls())

--- a/indico/modules/events/abstracts/views.py
+++ b/indico/modules/events/abstracts/views.py
@@ -72,3 +72,8 @@ class WPDisplayAbstractsReviewing(WPDisplayAbstracts):
     def getJSFiles(self):
         return (WPDisplayAbstracts.getJSFiles(self) +
                 self._asset_env['modules_event_management_js'].urls())
+
+    def getCSSFiles(self):
+        return (WPDisplayAbstracts.getCSSFiles(self) +
+                self._asset_env['event_display_sass'].urls() +
+                self._asset_env['tracks_sass'].urls())

--- a/indico/modules/events/layout/default.py
+++ b/indico/modules/events/layout/default.py
@@ -24,10 +24,6 @@ from indico.util.i18n import _
 from MaKaC.paperReviewing import ConferencePaperReview
 
 
-def _visibility_call_for_abstracts(event):
-    return event.getAbstractMgr().isActive() and event.hasEnabledSection('cfa')
-
-
 def _visibility_my_conference(event):
     return session.user is not None
 
@@ -84,13 +80,6 @@ def get_default_menu_entries():
             endpoint='event.conferenceDisplay-overview',
             position=0,
             static_site=True
-        ),
-        MenuEntryData(
-            title=_("Call for Abstracts"),
-            name='call_for_abstracts',
-            endpoint='event.conferenceCFA',
-            position=2,
-            visible=_visibility_call_for_abstracts,
         ),
         MenuEntryData(
             title=_("View my Abstracts"),

--- a/indico/modules/events/tracks/models/tracks.py
+++ b/indico/modules/events/tracks/models/tracks.py
@@ -108,3 +108,27 @@ class Track(DescriptionMixin, db.Model):
 
     def can_delete(self, user):
         return self.event_new.can_manage(user) and not self.abstracts_accepted
+
+    def can_review_abstracts(self, user):
+        if not user:
+            return False
+        elif not self.event_new.can_manage(user, role='abstract_reviewer'):
+            return False
+        elif user in self.event_new.global_abstract_reviewers:
+            return True
+        elif user in self.abstract_reviewers:
+            return True
+        else:
+            return False
+
+    def can_convene(self, user):
+        if not user:
+            return False
+        elif not self.event_new.can_manage(user, role='track_convener'):
+            return False
+        elif user in self.event_new.global_conveners:
+            return True
+        elif user in self.conveners:
+            return True
+        else:
+            return False


### PR DESCRIPTION
- I agree that the names/strings/sentences are not the most suitable, but I couldn't find better ones. 
- The link to an abstract display page is not working.
- I reused the styles from the Scientific Programme because I considered them appropriate.

List of tracks the user is a reviewer or convener of:
![image](https://cloud.githubusercontent.com/assets/8863238/19725962/dbcf0e62-9b88-11e6-8556-7580c87d523a.png)
![image](https://cloud.githubusercontent.com/assets/8863238/19726010/0d57c76c-9b89-11e6-9f85-ac91d0247e05.png)

List of abstracts within a track the user is a reviewer or convener of:
![image](https://cloud.githubusercontent.com/assets/8863238/19726040/3b747532-9b89-11e6-9f8b-eb72225553d7.png)
![image](https://cloud.githubusercontent.com/assets/8863238/19726072/59b163b6-9b89-11e6-854c-b7a7fdea67c3.png)
