### PR TITLE
Fix breaking of urls in confirmation email

### DIFF
--- a/indico/MaKaC/webinterface/rh/CFADisplay.py
+++ b/indico/MaKaC/webinterface/rh/CFADisplay.py
@@ -150,6 +150,7 @@ class _AbstractSubmissionNotification:
         msg.append(tw.fill(_("The submission of your abstract has been successfully processed.")))
         msg.append("")
         tw.break_long_words = False
+        tw.break_on_hyphens = False
         msg.append(tw.fill(i18nformat("""_("Abstract submitted"):\n<%s>.""") % urlHandlers.UHUserAbstracts.getURL(self._conf)))
         msg.append("")
         msg.append(tw.fill(i18nformat("""_("Status of your abstract"):\n<%s>.""") % urlHandlers.UHAbstractDisplay.getURL(self._abstract)))


### PR DESCRIPTION
Closes #2649. Only applies to 1.2 branch.

Since I fixed this locally I thought I could just as well submit it as a PR. If you don't accept PRs on the 1.2 branch anymore, feel free to just dismiss this.
