### PR TITLE
Manage reviewed_for_tracks list

### DIFF
--- a/indico/htdocs/js/indico/modules/abstracts.js
+++ b/indico/htdocs/js/indico/modules/abstracts.js
@@ -63,9 +63,9 @@
                     showFormErrors($box);
                 }
             });
-        }).on('indico:confirmed', '.review-button', function(evt) {
+        }).on('indico:confirmed', '.review-button, #save-reviewing-tracks-list', function(evt) {
             var $this = $(this);
-            var $box = $this.closest('.abstract-review-box');
+            var $box = $this.closest('.i-timeline-item');
             var $form = $box.find('form');
 
             evt.preventDefault();
@@ -98,6 +98,9 @@
         }).on('indico:htmlUpdated', function() {
             initForms($(this));
             showFormErrors($(this));
+        }).on('click', '#edit-reviewed-for-track-list', function(evt) {
+            evt.preventDefault();
+            $(this).closest('.i-timeline-item').find('.i-box-footer').toggleClass('hidden');
         });
     };
 

--- a/indico/modules/events/abstracts/blueprint.py
+++ b/indico/modules/events/abstracts/blueprint.py
@@ -48,7 +48,8 @@ from indico.modules.events.abstracts.controllers.reviewing import (RHAbstractsDo
                                                                    RHDisplayAbstractsExportPDF,
                                                                    RHDisplayAbstractsExportCSV,
                                                                    RHDisplayAbstractsExportExcel,
-                                                                   RHDisplayAbstractsDownloadAttachments)
+                                                                   RHDisplayAbstractsDownloadAttachments,
+                                                                   RHEditReviewedForTrackList)
 from indico.web.flask.util import make_compat_redirect_func
 from indico.web.flask.wrappers import IndicoBlueprint
 
@@ -131,7 +132,6 @@ _bp.add_url_rule('/manage/abstracts/email-templates/<email_tpl_id>', 'email_tpl_
 _bp.add_url_rule('/manage/abstracts/<int:abstract_id>/', 'manage_abstract', RHManageAbstract, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/abstracts/<int:abstract_id>/abstract.pdf', 'manage_abstract_pdf_export', RHAbstractExportPDF)
 
-# Abstract reviewing actions
 for prefix in ('/manage/abstracts', '/abstracts'):
     defaults = {'management': prefix != '/abstracts'}
     _bp.add_url_rule(prefix + '/<int:abstract_id>/withdraw', 'withdraw_abstract',
@@ -144,6 +144,8 @@ for prefix in ('/manage/abstracts', '/abstracts'):
                      RHReviewAbstractForTrack, methods=('POST',), defaults=defaults)
     _bp.add_url_rule(prefix + '/<int:abstract_id>/judge', 'judge_abstract',
                      RHJudgeAbstract, methods=('POST',), defaults=defaults)
+    _bp.add_url_rule(prefix + '/<int:abstract_id>/reviewing-tracks', 'edit_review_tracks',
+                     RHEditReviewedForTrackList, methods=('POST',), defaults=defaults)
 
 # Legacy URLs
 _compat_bp = IndicoBlueprint('compat_abstracts', __name__, url_prefix='/event/<event_id>')

--- a/indico/modules/events/abstracts/controllers/base.py
+++ b/indico/modules/events/abstracts/controllers/base.py
@@ -22,10 +22,9 @@ from operator import attrgetter
 from flask import render_template, redirect, request, session
 from werkzeug.exceptions import Forbidden
 
-from indico.modules.events.abstracts.forms import AbstractJudgmentForm, make_review_form
+from indico.modules.events.abstracts.forms import AbstractJudgmentForm, make_review_form, AbstractReviewedForTracksForm
 from indico.modules.events.abstracts.models.abstracts import Abstract
 from indico.modules.events.abstracts.util import generate_spreadsheet_from_abstracts
-from indico.modules.events.abstracts.views import WPDisplayAbstractsReviewing
 from indico.modules.events.util import ZipGeneratorMixin
 from indico.util.fs import secure_filename
 from indico.util.spreadsheets import send_csv, send_xlsx
@@ -54,10 +53,11 @@ def render_abstract_page(abstract, management=False):
     review_forms = {track.id: build_review_form(abstract, track)
                     for track in abstract.reviewed_for_tracks
                     if track.can_review_abstracts(session.user)}
-    judgment_form = AbstractJudgmentForm(abstract=abstract)
-
+    judgment_form = AbstractJudgmentForm(abstract=abstract, formdata=None)
+    review_track_list_form = AbstractReviewedForTracksForm(event=abstract.event_new, obj=abstract, formdata=None)
     return render_template('events/abstracts/abstract.html', abstract=abstract, judgment_form=judgment_form,
-                           review_forms=review_forms, management=management, no_javascript=True)
+                           review_forms=review_forms, review_track_list_form=review_track_list_form,
+                           management=management, no_javascript=True)
 
 
 class AbstractMixin:
@@ -83,9 +83,11 @@ class AbstractPageMixin(AbstractMixin):
                         for track in self.abstract.reviewed_for_tracks
                         if track.can_review_abstracts(session.user)}
         judgment_form = AbstractJudgmentForm(abstract=self.abstract)
+        review_track_list_form = AbstractReviewedForTracksForm(event=self.event_new, obj=self.abstract)
 
         return self.page_class.render_template('abstract.html', self._conf, abstract=self.abstract,
                                                judgment_form=judgment_form, review_forms=review_forms,
+                                               review_track_list_form=review_track_list_form,
                                                management=self.management)
 
 

--- a/indico/modules/events/abstracts/controllers/reviewing.py
+++ b/indico/modules/events/abstracts/controllers/reviewing.py
@@ -26,12 +26,13 @@ from indico.modules.events.abstracts.controllers.base import (AbstractMixin, Dis
                                                               AbstractsExportExcel,
                                                               CustomizeAbstractListMixin, build_review_form,
                                                               render_abstract_page)
-from indico.modules.events.abstracts.forms import AbstractJudgmentForm
+from indico.modules.events.abstracts.forms import AbstractJudgmentForm, AbstractReviewedForTracksForm
 from indico.modules.events.abstracts.models.abstracts import Abstract, AbstractState
 from indico.modules.events.abstracts.models.files import AbstractFile
 from indico.modules.events.abstracts.models.review_ratings import AbstractReviewRating
 from indico.modules.events.abstracts.models.reviews import AbstractReview
-from indico.modules.events.abstracts.operations import judge_abstract, reset_abstract_state, withdraw_abstract
+from indico.modules.events.abstracts.operations import (judge_abstract, reset_abstract_state, withdraw_abstract,
+                                                        update_reviewed_for_tracks)
 from indico.modules.events.abstracts.util import (AbstractListGeneratorDisplay, get_track_reviewer_abstract_counts,
                                                   get_user_tracks)
 from indico.modules.events.abstracts.views import WPDisplayAbstractsReviewing
@@ -265,3 +266,14 @@ class RHDisplayAbstractsExportCSV(AbstractsExportCSV, RHDisplayAbstractsActionsB
 
 class RHDisplayAbstractsExportExcel(AbstractsExportExcel, RHDisplayAbstractsActionsBase):
     pass
+
+
+class RHEditReviewedForTrackList(RHAbstractReviewBase):
+    def _process(self):
+        form = AbstractReviewedForTracksForm(event=self.event_new, obj=self.abstract)
+        if form.validate_on_submit:
+            update_reviewed_for_tracks(self.abstract, form.reviewed_for_tracks.data)
+            return jsonify_data(page_html=render_abstract_page(self.abstract, management=self.management))
+        tpl = get_template_module('events/abstracts/abstract/review.html')
+        return jsonify_data(box_html=tpl.render_reviewed_for_tracks_box(self.abstract, form=form,
+                                                                        management=self.management))

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -378,7 +378,7 @@ class AbstractForm(IndicoForm):
 
 
 class SingleTrackMixin(object):
-    submitted_for_tracks = QuerySelectField(_("Track"), get_label=lambda x: x.title, allow_blank=True)
+    submitted_for_tracks = QuerySelectField(_("Track"), get_label='title', allow_blank=True)
 
     def __init__(self, *args, **kwargs):
         event = kwargs['event']
@@ -391,8 +391,7 @@ class SingleTrackMixin(object):
 
 
 class MultiTrackMixin(object):
-    submitted_for_tracks = IndicoQuerySelectMultipleCheckboxField(_("Tracks"), get_label=lambda x: x.title,
-                                                                  collection_class=set)
+    submitted_for_tracks = IndicoQuerySelectMultipleCheckboxField(_("Tracks"), get_label='title', collection_class=set)
 
     def __init__(self, *args, **kwargs):
         event = kwargs['event']
@@ -415,3 +414,12 @@ class AbstractsScheduleForm(IndicoForm):
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')
         super(AbstractsScheduleForm, self).__init__(*args, **kwargs)
+
+
+class AbstractReviewedForTracksForm(IndicoForm):
+    reviewed_for_tracks = IndicoQuerySelectMultipleCheckboxField(_("Tracks"), get_label='title', collection_class=set)
+
+    def __init__(self, *args, **kwargs):
+        event = kwargs.pop('event')
+        super(AbstractReviewedForTracksForm, self).__init__(*args, **kwargs)
+        self.reviewed_for_tracks.query = Track.query.with_parent(event).order_by(Track.title)

--- a/indico/modules/events/abstracts/operations.py
+++ b/indico/modules/events/abstracts/operations.py
@@ -143,3 +143,12 @@ def close_cfa(event):
     event.cfa.close()
     logger.info("Call for abstracts for %s closed by %s", event, session.user)
     event.log(EventLogRealm.management, EventLogKind.negative, 'Abstracts', 'Call for abstracts closed', session.user)
+
+
+def update_reviewed_for_tracks(abstract, tracks):
+    abstract.reviewed_for_tracks = tracks
+    db.session.flush()
+    logger.info('The list of tracks the abstract %s is reviewed for has been updated by %s', abstract, session.user)
+    abstract.event_new.log(EventLogRealm.management, EventLogKind.change, 'Abstracts',
+                           'The list of tracks the abstract "{}" is reviewed for has been updated'
+                           .format(abstract.title), session.user)

--- a/indico/modules/events/abstracts/templates/abstract.html
+++ b/indico/modules/events/abstracts/templates/abstract.html
@@ -2,7 +2,7 @@
 
 {% from 'events/abstracts/abstract/public.html' import render_abstract_public %}
 {% from 'events/abstracts/abstract/judge.html' import render_decision_box %}
-{% from 'events/abstracts/abstract/review.html' import render_abstract_reviews, render_abstract_comments, render_review_boxes %}
+{% from 'events/abstracts/abstract/review.html' import render_abstract_reviews, render_abstract_comments, render_review_boxes, render_reviewed_for_tracks_box %}
 
 {% block content %}
     {{ render_abstract_public(abstract, management=management) }}
@@ -29,6 +29,7 @@
         {% endif %}
 
         {% if can_judge %}
+            {{ render_reviewed_for_tracks_box(abstract, review_track_list_form, management=management) }}
             <div id="abstract-decision-box" class="i-timeline-item">
                 {{ render_decision_box(abstract, judgment_form, management=management) }}
             </div>

--- a/indico/modules/events/abstracts/templates/abstract/_common.html
+++ b/indico/modules/events/abstracts/templates/abstract/_common.html
@@ -10,3 +10,10 @@
         </span>
     {% endif %}
 {% endmacro %}
+
+{% macro render_tracks(tracks) %}
+    {% for track in tracks %}
+        <span class="abstract-track">{{ track.title }}</span>
+        {%- if not loop.last -%},{% endif %}
+    {% endfor %}
+{% endmacro %}

--- a/indico/modules/events/abstracts/templates/abstract/public.html
+++ b/indico/modules/events/abstracts/templates/abstract/public.html
@@ -1,11 +1,4 @@
-{% from 'events/abstracts/abstract/_common.html' import render_edited_hint %}
-
-{% macro _render_tracks(tracks) %}
-    {% for track in tracks %}
-        <span class="abstract-track">{{ track.title }}</span>
-        {%- if not loop.last -%},{% endif %}
-    {% endfor %}
-{% endmacro %}
+{% from 'events/abstracts/abstract/_common.html' import render_edited_hint, render_tracks %}
 
 {% macro _render_submission_info(abstract) %}
     {% if abstract.submitted_contrib_type %}
@@ -25,7 +18,7 @@
                     Tracks:
                 {%- endtrans -%}
             </label>
-            {{ _render_tracks(abstract.submitted_for_tracks) }}
+            {{ render_tracks(abstract.submitted_for_tracks) }}
         </div>
     {% endif %}
     {% if abstract.primary_authors %}
@@ -154,7 +147,7 @@
                         {%- pluralize -%}
                             For tracks:
                         {%- endtrans %}
-                        {{ _render_tracks(abstract.submitted_for_tracks) }}
+                        {{ render_tracks(abstract.submitted_for_tracks) }}
                     </div>
                 {% endif %}
             {% elif abstract.state.name == 'accepted' %}

--- a/indico/modules/events/abstracts/templates/abstract/review.html
+++ b/indico/modules/events/abstracts/templates/abstract/review.html
@@ -1,5 +1,5 @@
 {% from 'forms/_form.html' import form_header, form_rows, form_footer %}
-{% from 'events/abstracts/abstract/_common.html' import render_edited_hint %}
+{% from 'events/abstracts/abstract/_common.html' import render_edited_hint, render_tracks %}
 
 {% macro render_abstract_reviews(abstract, review_forms, management=false) %}
     <div id="abstract-reviews" class="i-timeline">
@@ -228,4 +228,46 @@
     {% if can_change_review %}
         {{ render_review_box(form, review.abstract, review.track, edit=true, management=management) }}
     {% endif %}
+{% endmacro %}
+
+{% macro render_reviewed_for_tracks_box(abstract, form, management=false) %}
+    <div id="abstract-reviewed-for-tracks-box" class="i-timeline-item">
+        <div class="i-timeline-item-label action icon-list"></div>
+        <div class="i-timeline-item-box content-indicator">
+            <div class="i-box-content">
+                <div class="flex">
+                    <div class="stretch">
+                        <div class="info-line">
+                            <label>
+                                {% trans count=abstract.reviewed_for_tracks|length -%}
+                                    Reviewing for track:
+                                {%- pluralize -%}
+                                    Reviewing for tracks:
+                                {%- endtrans -%}
+                            </label>
+                            {{ render_tracks(abstract.reviewed_for_tracks) }}
+                        </div>
+                    </div>
+                    <div>
+                        <a href="#" id="edit-reviewed-for-track-list">
+                            {%- trans %}Edit track list{% endtrans -%}
+                        </a>
+                    </div>
+                </div>
+            </div>
+            <div class="i-box-footer hidden">
+                <span>{% trans %}The abstract is being reviewed for the following tracks:{% endtrans %}</span>
+                {{ form_header(form) }}
+                {{ form_rows(form, skip_labels=true) }}
+                {% call form_footer(form, skip_label=true) %}
+                    <button class="i-button big highlight"
+                            id="save-reviewing-tracks-list"
+                            data-method="POST"
+                            data-href="{{ url_for('.edit_review_tracks', abstract, management=management) }}">
+                        {%- trans %}Save{% endtrans -%}
+                    </button>
+                {% endcall %}
+            </div>
+        </div>
+    </div>
 {% endmacro %}


### PR DESCRIPTION
* [x] Figure out why after a review submission the list of tracks loses its defaults
* [x] Clean up macros and extract common bits to `_common.html`