### PR TITLE
Hide reviews from abstract PDF export depending on role

### DIFF
--- a/indico/modules/events/abstracts/templates/abstract/public.html
+++ b/indico/modules/events/abstracts/templates/abstract/public.html
@@ -298,12 +298,32 @@
                         </a>
                     {% endif %}
                 </div>
+            {% endif %}
+            {% if abstract.can_see_reviews(session.user) %}
                 <div class="group">
-                    {% set endpoint = '.manage_abstract_pdf_export' if management else '.display_abstract_pdf_export' %}
-                    <a class="i-button icon-file-download"
-                       href="{{ url_for(endpoint, abstract) }}"
+                    <a class="i-button arrow icon-file-pdf js-dropdown-abstract-pdf" data-toggle="dropdown"></a>
+                    <ul class="dropdown">
+                        <li>
+                            <a href="{{ url_for('.display_abstract_pdf_export', abstract) }}">PDF</a>
+                        </li>
+                        <li>
+                            <a href="{{ url_for('.manage_abstract_pdf_export', abstract) }}">
+                                {%- trans %}PDF with reviews{% endtrans -%}
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <script>
+                    $('.js-dropdown-abstract-pdf').parent().dropdown();
+                </script>
+            {% else %}
+                <div class="group">
+                    <a class="i-button icon-file-pdf"
+                       href="{{ url_for('.display_abstract_pdf_export', abstract) }}"
                        title="{% trans %}Download abstract submission in PDF{% endtrans %}"></a>
                 </div>
+            {% endif %}
+            {% if can_manage or abstract.user_owns(session.user) %}
                 <div class="group">
                     {% if abstract.can_edit(session.user) %}
                         <a href="#" class="i-button icon-edit"

--- a/indico/modules/events/abstracts/templates/abstract/review.html
+++ b/indico/modules/events/abstracts/templates/abstract/review.html
@@ -97,7 +97,7 @@
                                        data-ajax></a>
                                     <a class="i-button-icon icon-cross js-delete-comment"
                                        title="{% trans %}Remove comment{% endtrans %}"
-                                       data-method="POST"
+                                       data-method="DELETE"
                                        data-href="{{ url_for('.delete_abstract_comment', comment) }}"
                                        data-title="{% trans %}Remove comment{% endtrans %}"
                                        data-confirm="{% trans %}Are you sure you want to remove this comment?{% endtrans %}"


### PR DESCRIPTION
Adds a dropdown menu for users that can see the reviews to choose whether they want to export the PDF with or without reviews.

- [x] Fix bug when deleting comments in abstract review