### PR TITLE
Fix person link widget

### DIFF
--- a/indico/htdocs/js/indico/widgets/person_link_widget.js
+++ b/indico/htdocs/js/indico/widgets/person_link_widget.js
@@ -60,6 +60,12 @@
         var $buttonAlphaOrder = $fieldDisplay.find('.alpha-order-switch');
         var $form = $field.closest('form');
         var customOrder = !$buttonAlphaOrder.hasClass('active');
+        var maxNewPersonID = 0;
+
+        function setNewPersonID(person) {
+            person.id = 'new-' + maxNewPersonID;
+            maxNewPersonID++;
+        }
 
         function updatePersonOrder() {
             var people = _.map($fieldDisplay.find('.person-row'), function(e) {
@@ -205,6 +211,9 @@
             }
             if (person.isSubmitter === undefined) {
                 person.isSubmitter = options.defaults.isSubmitter;
+            }
+            if (person.id === undefined) {
+                setNewPersonID(person);
             }
         }
 

--- a/indico/modules/events/abstracts/fields.py
+++ b/indico/modules/events/abstracts/fields.py
@@ -27,10 +27,10 @@ from indico.modules.events.abstracts.models.abstracts import Abstract
 from indico.modules.events.abstracts.models.persons import AbstractPersonLink
 from indico.modules.events.abstracts.models.review_questions import AbstractReviewQuestion
 from indico.modules.events.abstracts.notifications import StateCondition, TrackCondition, ContributionTypeCondition
-from indico.modules.events.abstracts.util import serialize_abstract_person_link
 from indico.modules.events.contributions.models.persons import AuthorType
 from indico.modules.events.fields import PersonLinkListFieldBase
 from indico.modules.events.tracks.models.tracks import Track
+from indico.modules.events.util import serialize_person_link
 from indico.modules.users.models.users import User
 from indico.util.decorators import classproperty
 from indico.util.i18n import _
@@ -157,7 +157,11 @@ class AbstractPersonLinkListField(PersonLinkListFieldBase):
         return super(AbstractPersonLinkListField, self)._get_person_link(data, extra_data)
 
     def _serialize_person_link(self, principal, extra_data=None):
-        return serialize_abstract_person_link(principal)
+        extra_data = extra_data or {}
+        data = dict(extra_data, **serialize_person_link(principal))
+        data['isSpeaker'] = principal.is_speaker
+        data['authorType'] = principal.author_type.value
+        return data
 
     def pre_validate(self, form):
         super(AbstractPersonLinkListField, self).pre_validate(form)

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -31,6 +31,7 @@ from indico.modules.events.abstracts.models.reviews import AbstractAction
 from indico.modules.events.abstracts.models.comments import AbstractCommentVisibility
 from indico.modules.events.abstracts.settings import BOASortField, BOACorrespondingAuthorType, abstracts_settings
 from indico.modules.events.contributions.models.types import ContributionType
+from indico.modules.events.contributions.models.persons import AuthorType
 from indico.modules.events.sessions.models.sessions import Session
 from indico.modules.events.tracks.models.tracks import Track
 from indico.util.i18n import _
@@ -388,7 +389,7 @@ class AbstractForm(IndicoForm):
     description = IndicoMarkdownField(_('Content'), [DataRequired()], editor=True, mathjax=True)
     submitted_contrib_type = QuerySelectField(_("Type"), get_label='name', allow_blank=True,
                                               blank_text=_("No type selected"))
-    person_links = AbstractPersonLinkListField(_("People"), [DataRequired()])
+    person_links = AbstractPersonLinkListField(_("People"), [DataRequired()], default_author_type=AuthorType.primary)
     submission_comment = TextAreaField(_("Comments"))
     attachments = FileField(_('Attachments'), param_name='attachments', multiple_files=True, lightweight=True)
 

--- a/indico/modules/events/abstracts/util.py
+++ b/indico/modules/events/abstracts/util.py
@@ -31,7 +31,6 @@ from indico.modules.events.abstracts.models.persons import AbstractPersonLink
 from indico.modules.events.abstracts.models.reviews import AbstractReview
 from indico.modules.events.abstracts.settings import abstracts_settings, boa_settings
 from indico.modules.events.tracks.models.tracks import Track
-from indico.modules.events.util import serialize_person_link
 from indico.modules.users import User
 from indico.util.caching import memoize_request
 from indico.util.date_time import format_datetime
@@ -144,14 +143,6 @@ def create_mock_abstract(event):
                         judgment_comment='Vague but interesting!')
 
     return abstract
-
-
-def serialize_abstract_person_link(person_link):
-    """Serialize AbstractPersonLink to JSON-like object"""
-    data = serialize_person_link(person_link)
-    data['isSpeaker'] = person_link.is_speaker
-    data['authorType'] = person_link.author_type.value
-    return data
 
 
 def make_abstract_form(event):

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -206,6 +206,9 @@ class PersonLinkListFieldBase(EventPersonListField):
     def _serialize_person_link(self, principal, extra_data=None):
         raise NotImplementedError
 
+    def _value(self):
+        return [self._serialize_person_link(person_link) for person_link in self.data] if self.data else []
+
 
 class EventPersonLinkListField(PersonLinkListFieldBase):
     """A field to manage event's chairpersons"""


### PR DESCRIPTION
### Notes

I deleted the `serialize_abstract_person_link` method and moved the code into `_serialize_person_link`, since it's the approach we use in other classes as well. I don't see any point having a class method calling a util function which is only used once.