### PR TITLE
Fix overlap in menu customization page when not enough width

### DIFF
--- a/indico/htdocs/sass/modules/_event_management.scss
+++ b/indico/htdocs/sass/modules/_event_management.scss
@@ -161,8 +161,7 @@
 }
 
 .menu-entries {
-    width: 370px;
-    padding: 5px 10px 5px 5px;
+    padding: 5px 10px;
     margin-top: 0;
 
     list-style: none;
@@ -176,6 +175,7 @@
                 @include border-bottom-radius(0);
             }
             > .i-label {
+                margin: 0;
                 width: 100%;
                 text-align: left;
                 font-weight: bold;
@@ -321,8 +321,7 @@
         @include border-all(darken($pastel-gray, $light-color-variation));
         @include border-bottom-radius();
 
-        width: 333px;
-        margin: 0 20px;
+        margin-left: 20px;
         padding-right: 10px;
         padding-left: 10px;
 


### PR DESCRIPTION
Before:
![screenshot from 2016-11-11 11-35-17](https://cloud.githubusercontent.com/assets/8863238/20212500/d06cb5f6-a803-11e6-9885-1abdc8bd8a86.png)

After:
![screenshot from 2016-11-11 12-11-08](https://cloud.githubusercontent.com/assets/8863238/20213254/ff316540-a807-11e6-9b8f-a98abc3dd29f.png)
