### PR TITLE
Make conference program editable

### DIFF
--- a/indico/htdocs/sass/base/_pages.scss
+++ b/indico/htdocs/sass/base/_pages.scss
@@ -79,6 +79,7 @@
 
         .page-description {
             @extend %font-family-title-light;
+            @extend .fixed-width;
             color: $dark-gray;
             font-size: 1.2em;
             margin-top: $separator-margin;

--- a/indico/modules/events/tracks/__init__.py
+++ b/indico/modules/events/tracks/__init__.py
@@ -41,8 +41,14 @@ def _sidemenu_items(sender, event, **kwargs):
 @signals.event.sidemenu.connect
 def _extend_event_menu(sender, **kwargs):
     from indico.modules.events.layout.util import MenuEntryData
+    from indico.modules.events.tracks.settings import track_settings
+
+    def _program_visible(conf):
+        event = conf.as_event
+        return bool(track_settings.get(event, 'program').strip() or event.tracks)
+
     return MenuEntryData(title=_("Scientific Programme"), name='program', endpoint='tracks.program', position=1,
-                         static_site=True)
+                         visible=_program_visible, static_site=True)
 
 
 @signals.users.merged.connect

--- a/indico/modules/events/tracks/blueprint.py
+++ b/indico/modules/events/tracks/blueprint.py
@@ -16,7 +16,7 @@
 
 from __future__ import unicode_literals
 
-from indico.modules.events.tracks.controllers import (RHManageTracks, RHCreateTrack, RHEditTrack,
+from indico.modules.events.tracks.controllers import (RHManageTracks, RHEditProgram, RHCreateTrack, RHEditTrack,
                                                       RHSortTracks, RHDeleteTrack, RHDisplayTracks, RHTracksPDF)
 from indico.web.flask.util import make_compat_redirect_func
 from indico.web.flask.wrappers import IndicoBlueprint
@@ -25,6 +25,7 @@ _bp = IndicoBlueprint('tracks', __name__, template_folder='templates', virtual_t
                       url_prefix='/event/<confId>')
 
 _bp.add_url_rule('/manage/tracks/', 'manage', RHManageTracks)
+_bp.add_url_rule('/manage/tracks/program', 'edit_program', RHEditProgram, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/tracks/create', 'create_track', RHCreateTrack, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/tracks/sort', 'sort_tracks', RHSortTracks, methods=('POST',))
 _bp.add_url_rule('/manage/tracks/<int:track_id>', 'edit_track', RHEditTrack, methods=('GET', 'POST'))

--- a/indico/modules/events/tracks/forms.py
+++ b/indico/modules/events/tracks/forms.py
@@ -19,11 +19,21 @@ from __future__ import unicode_literals
 from wtforms.fields import StringField, TextAreaField
 from wtforms.validators import DataRequired
 
+from indico.core.db.sqlalchemy.descriptions import RenderMode
 from indico.util.i18n import _
-from indico.web.forms.base import IndicoForm
+from indico.web.forms.base import IndicoForm, generated_data
+from indico.web.forms.fields import IndicoMarkdownField
 
 
 class TrackForm(IndicoForm):
     title = StringField(_('Title'), [DataRequired()])
     code = StringField(_('Code'))
     description = TextAreaField(_('Description'), render_kw={'rows': 10})
+
+
+class ProgramForm(IndicoForm):
+    program = IndicoMarkdownField(_('Programme'), editor=True, mathjax=True)
+
+    @generated_data
+    def program_render_mode(self):
+        return RenderMode.markdown

--- a/indico/modules/events/tracks/operations.py
+++ b/indico/modules/events/tracks/operations.py
@@ -22,6 +22,7 @@ from indico.core.db import db
 from indico.modules.events.logs import EventLogKind, EventLogRealm
 from indico.modules.events.tracks import logger
 from indico.modules.events.tracks.models.tracks import Track
+from indico.modules.events.tracks.settings import track_settings
 
 
 def create_track(event, data):
@@ -45,3 +46,9 @@ def update_track(track, data):
 def delete_track(track):
     db.session.delete(track)
     logger.info('Track deleted by %r: %r', session.user, track)
+
+
+def update_program(event, data):
+    track_settings.set_multi(event, data)
+    logger.info('Program of %r updated by %r', event, session.user)
+    event.log(EventLogRealm.management, EventLogKind.change, 'Tracks', 'The program has been updated', session.user)

--- a/indico/modules/events/tracks/settings.py
+++ b/indico/modules/events/tracks/settings.py
@@ -16,9 +16,14 @@
 
 from __future__ import unicode_literals
 
+from indico.core.db.sqlalchemy.descriptions import RenderMode
+from indico.core.settings.converters import EnumConverter
 from indico.modules.events.settings import EventSettingsProxy
 
 
 track_settings = EventSettingsProxy('tracks', {
-    'program': ''
+    'program': '',
+    'program_render_mode': RenderMode.markdown
+}, converters={
+    'program_render_mode': EnumConverter(RenderMode)
 })

--- a/indico/modules/events/tracks/templates/display.html
+++ b/indico/modules/events/tracks/templates/display.html
@@ -16,7 +16,7 @@
 
 {% block content %}
     {% if program %}
-        <div class="quotation tracks">
+        <div class="quotation tracks js-mathjax">
             {{- program -}}
         </div>
     {% endif %}

--- a/indico/modules/events/tracks/templates/management.html
+++ b/indico/modules/events/tracks/templates/management.html
@@ -5,23 +5,6 @@
     {%- trans %}Programme{% endtrans -%}
 {% endblock %}
 
-{% block title_actions %}
-    <a class="i-button borderless icon-settings arrow js-dropdown" data-toggle="dropdown"></a>
-    <ul class="dropdown">
-        <li>
-            <a href="#"
-               title="{% trans %}Edit programme{% endtrans %}"
-               data-href="{{ url_for('.edit_program', event) }}"
-               data-title="{% trans %}Edit programme{% endtrans %}"
-               data-qtip-position="right"
-               data-reload-after
-               data-ajax-dialog>
-                {% trans %}Edit programme{% endtrans %}
-            </a>
-        </li>
-    </ul>
-{% endblock %}
-
 {% block description %}
     {%- trans -%}
         Tracks represent the subject matter of the conference.
@@ -31,13 +14,44 @@
 {% endblock %}
 
 {% block content %}
-    <a class="i-button highlight icon-plus"
-       data-href="{{ url_for('.create_track', event) }}"
-       data-title="{% trans %}Add new track{% endtrans %}"
-       data-update="#track-list-container"
-       data-ajax-dialog>
-        {% trans %}Add track{% endtrans %}
-    </a>
+    <div class="action-box">
+        <div class="section">
+            <div class="icon icon-file-text"></div>
+            <div class="text">
+                <div class="label">
+                    {% trans %}Programme{% endtrans %}
+                </div>
+                {% trans -%}Configure the conference page displaying the scientific programme.{%- endtrans %}
+            </div>
+            <div class="toolbar">
+                <div class="group">
+                    <a href="#" class="i-button icon-settings"
+                       data-href="{{ url_for('.edit_program', event) }}"
+                       data-title="{% trans %}Configure programme{% endtrans %}"
+                       data-qtip-position="right"
+                       data-reload-after
+                       data-ajax-dialog>
+                        {% trans %}Configure{% endtrans %}
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {# TODO: Use new flex classes instead of the inline CSS once they are available #}
+    <div class="flex" style="flex-direction: row;">
+        <h3 style="flex-grow: 1; margin-bottom: 0;">{% trans %}List of tracks{% endtrans %}</h3>
+        <div style="margin: 1em 0 0 0;">
+            <a class="i-button highlight icon-plus"
+               data-href="{{ url_for('.create_track', event) }}"
+               data-title="{% trans %}Add new track{% endtrans %}"
+               data-update="#track-list-container"
+               data-ajax-dialog>
+                {% trans %}Add track{% endtrans %}
+            </a>
+        </div>
+    </div>
+
     <div id="track-list-container">
         {{ render_track_list(event) }}
     </div>

--- a/indico/modules/events/tracks/templates/management.html
+++ b/indico/modules/events/tracks/templates/management.html
@@ -5,6 +5,23 @@
     {%- trans %}Programme{% endtrans -%}
 {% endblock %}
 
+{% block title_actions %}
+    <a class="i-button borderless icon-settings arrow js-dropdown" data-toggle="dropdown"></a>
+    <ul class="dropdown">
+        <li>
+            <a href="#"
+               title="{% trans %}Edit programme{% endtrans %}"
+               data-href="{{ url_for('.edit_program', event) }}"
+               data-title="{% trans %}Edit programme{% endtrans %}"
+               data-qtip-position="right"
+               data-reload-after
+               data-ajax-dialog>
+                {% trans %}Edit programme{% endtrans %}
+            </a>
+        </li>
+    </ul>
+{% endblock %}
+
 {% block description %}
     {%- trans -%}
         Tracks represent the subject matter of the conference.

--- a/indico/modules/events/tracks/views.py
+++ b/indico/modules/events/tracks/views.py
@@ -16,27 +16,45 @@
 
 from __future__ import unicode_literals
 
+from indico.modules.events.abstracts.views import _MathjaxMixin
 from MaKaC.webinterface.pages.base import WPJinjaMixin
 from MaKaC.webinterface.pages.conferences import WPConferenceModifBase, WPConferenceDefaultDisplayBase
 
 
-class WPManageTracks(WPJinjaMixin, WPConferenceModifBase):
+class WPManageTracks(_MathjaxMixin, WPJinjaMixin, WPConferenceModifBase):
     template_prefix = 'events/tracks/'
     sidemenu_option = 'program'
 
     def getJSFiles(self):
-        return WPConferenceModifBase.getJSFiles(self) + self._asset_env['modules_tracks_js'].urls()
+        return (WPConferenceModifBase.getJSFiles(self) +
+                self._asset_env['markdown_js'].urls() +
+                self._asset_env['modules_tracks_js'].urls())
 
     def getCSSFiles(self):
-        return WPConferenceModifBase.getCSSFiles(self) + self._asset_env['tracks_sass'].urls()
+        return (WPConferenceModifBase.getCSSFiles(self) +
+                self._asset_env['markdown_sass'].urls() +
+                self._asset_env['tracks_sass'].urls())
+
+    def _getHeadContent(self):
+        return WPConferenceModifBase._getHeadContent(self) + _MathjaxMixin._getHeadContent(self)
 
 
-class WPDisplayTracks(WPJinjaMixin, WPConferenceDefaultDisplayBase):
+class WPDisplayTracks(_MathjaxMixin, WPJinjaMixin, WPConferenceDefaultDisplayBase):
     template_prefix = 'events/tracks/'
     menu_entry_name = 'program'
 
     def _getBody(self, params):
         return WPJinjaMixin._getPageContent(self, params)
 
+    def getJSFiles(self):
+        return (WPConferenceDefaultDisplayBase.getJSFiles(self) +
+                self._asset_env['markdown_js'].urls() +
+                self._asset_env['modules_tracks_js'].urls())
+
     def getCSSFiles(self):
-        return WPConferenceDefaultDisplayBase.getCSSFiles(self) + self._asset_env['tracks_sass'].urls()
+        return (WPConferenceDefaultDisplayBase.getCSSFiles(self) +
+                self._asset_env['markdown_sass'].urls() +
+                self._asset_env['tracks_sass'].urls())
+
+    def _getHeadContent(self):
+        return WPConferenceDefaultDisplayBase._getHeadContent(self) + _MathjaxMixin._getHeadContent(self)

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -22,6 +22,8 @@ from __future__ import absolute_import
 
 import binascii
 import functools
+from operator import attrgetter
+
 import re
 import string
 import unicodedata
@@ -618,7 +620,8 @@ class PlainText(Markup):
         return u'<div class="preformatted">{}</div>'.format(escape(unicode(self)))
 
 
-def handle_legacy_description(field, obj):
+def handle_legacy_description(field, obj, get_render_mode=attrgetter('render_mode'),
+                              get_value=attrgetter('_description')):
     """Check if the object in question is using an HTML description and convert it.
 
        The description will be automatically converted to Markdown and a warning will
@@ -629,11 +632,11 @@ def handle_legacy_description(field, obj):
     """
     from indico.core.db.sqlalchemy.descriptions import RenderMode
     from indico.util.i18n import _
-    if obj.render_mode == RenderMode.html:
-        field.warning = _(u"This description has been automatically converted from HTML to Markdown. "
+    if get_render_mode(obj) == RenderMode.html:
+        field.warning = _(u"This text has been automatically converted from HTML to Markdown. "
                           u"Please double-check that it's properly displayed.")
         ht = HTML2Text(bodywidth=0)
-        desc = obj._description
+        desc = get_value(obj)
         if RichMarkup(desc)._preformatted:
             desc = desc.replace(u'\n', u'<br>\n')
         field.data = ht.handle(desc)

--- a/indico_zodbimport/modules/event_abstracts.py
+++ b/indico_zodbimport/modules/event_abstracts.py
@@ -30,6 +30,7 @@ from werkzeug.utils import cached_property
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy import UTCDateTime
+from indico.core.db.sqlalchemy.descriptions import RenderMode
 from indico.modules.events import Event
 from indico.modules.events.abstracts.models.abstracts import Abstract, AbstractState
 from indico.modules.events.abstracts.models.comments import AbstractComment
@@ -215,7 +216,7 @@ class AbstractMigration(object):
     def _migrate_tracks(self):
         program = convert_to_unicode(getattr(self.conf, 'programDescription', ''))
         if program:
-            track_settings.set(self.event, 'program', program)
+            track_settings.set_multi(self.event, {'program_render_mode': RenderMode.html, 'program': program})
         for pos, old_track in enumerate(self.conf.program, 1):
             track = Track(title=convert_to_unicode(old_track.title),
                           description=convert_to_unicode(old_track.description),


### PR DESCRIPTION
...and convert it from html to markdown when editing an old one, with the usual warning etc

Run this in the shell so all old ones are rendered as HTML by default:

```python
from indico.core.db.sqlalchemy.descriptions import RenderMode
from indico.modules.events.tracks.settings import track_settings
for setting in EventSetting.query.filter_by(module='tracks', name='program'):
    track_settings.set(setting.event_id, 'program_render_mode', RenderMode.html)
transaction.commit()
```