### PR TITLE
Fix bug in rendering of TZ-aware timetable

### DIFF
--- a/indico/modules/events/timetable/legacy.py
+++ b/indico/modules/events/timetable/legacy.py
@@ -34,6 +34,7 @@ class TimetableSerializer(object):
         self.management = management
 
     def serialize_timetable(self, event, days=None, hide_weekends=False, strip_empty_days=False):
+        tzinfo = event.tzinfo if self.management else event.display_tzinfo
         event.preload_all_acl_entries()
         timetable = {}
         for day in iterdays(event.start_dt_local, event.end_dt_local, skip_weekends=hide_weekends, day_whitelist=days):
@@ -48,7 +49,7 @@ class TimetableSerializer(object):
                  .options(*query_options)
                  .order_by(TimetableEntry.type != TimetableEntryType.SESSION_BLOCK))
         for entry in query:
-            day = entry.start_dt.astimezone(event.tzinfo).date()
+            day = entry.start_dt.astimezone(tzinfo).date()
             date_str = day.strftime('%Y%m%d')
             if date_str not in timetable:
                 continue

--- a/indico/modules/events/timetable/templates/balloons/_balloon_utils.html
+++ b/indico/modules/events/timetable/templates/balloons/_balloon_utils.html
@@ -1,5 +1,7 @@
-{% macro render_time_and_location(obj, editable) %}
+{% macro render_time_and_location(obj, editable, use_event_tz) %}
     {% set tt_entry = obj.timetable_entry %}
+    {% set event = tt_entry.event_new %}
+    {% set tz = event.tzinfo if use_event_tz else event.display_tzinfo %}
     <dl class="i-data-list">
         {% if editable %}
             <dt>
@@ -10,16 +12,16 @@
                 <div class="duration">
                     <a class="js-edit-time"
                        title="{% trans %}Change time{% endtrans %}">
-                        {{- tt_entry.start_dt | format_time(timezone=tt_entry.event_new.timezone) }} -
-                        {{ tt_entry.end_dt | format_time(timezone=tt_entry.event_new.timezone) -}}
+                        {{- tt_entry.start_dt | format_time(timezone=tz) }} -
+                        {{ tt_entry.end_dt | format_time(timezone=tz) -}}
                     </a>
                 </div>
             </dd>
         {% else %}
             <dt class="icon-time"></dt>
             <dd>
-                {{- tt_entry.start_dt | format_time(timezone=tt_entry.event_new.timezone) }} -
-                {{ tt_entry.end_dt | format_time(timezone=tt_entry.event_new.timezone) -}}
+                {{- tt_entry.start_dt | format_time(timezone=tz) }} -
+                {{ tt_entry.end_dt | format_time(timezone=tz) -}}
             </dd>
         {% endif %}
         {% if obj.venue_name %}

--- a/indico/modules/events/timetable/templates/balloons/block.html
+++ b/indico/modules/events/timetable/templates/balloons/block.html
@@ -32,7 +32,7 @@
         </div>
         <div class="title">{{ block.title }}</div>
     </div>
-    {{ render_time_and_location(block, editable=(editable and can_manage_blocks)) }}
+    {{ render_time_and_location(block, editable=(editable and can_manage_blocks), use_event_tz=editable) }}
     <span class="hr"></span>
     <div class="section-title-container">
         <div class="title-header">

--- a/indico/modules/events/timetable/templates/balloons/break.html
+++ b/indico/modules/events/timetable/templates/balloons/break.html
@@ -22,5 +22,5 @@
         {% endif %}
     </div>
     <div class="description">{{ break_.description }}</div>
-    {{ render_time_and_location(break_, editable) }}
+    {{ render_time_and_location(break_, editable=editable, use_event_tz=editable) }}
 </div>

--- a/indico/modules/events/timetable/templates/balloons/contribution.html
+++ b/indico/modules/events/timetable/templates/balloons/contribution.html
@@ -41,7 +41,7 @@
     <div class="description" data-display-href="{{ url_for('contributions.display_contribution', contrib) }}">
          {{ contrib.description }}
      </div>
-    {{ render_time_and_location(contrib, editable=(editable and can_manage_contributions)) }}
+    {{ render_time_and_location(contrib, editable=(editable and can_manage_contributions), use_event_tz=editable) }}
     {% if contrib.speakers or (editable and can_manage_contributions) %}
         <span class="hr"></span>
         <dl class="i-data-list thirty-seventy">


### PR DESCRIPTION
The balloons are still displaying the times in the event's timezone. I've opened #2729 for that.