### PR TITLE
Untrusted/pending event persons

### DIFF
--- a/indico/htdocs/js/indico/modules/events/management.js
+++ b/indico/htdocs/js/indico/modules/events/management.js
@@ -15,6 +15,8 @@
  * along with Indico; if not, see <http://www.gnu.org/licenses/>.
  */
 
+/* global strnatcmp:false */
+
 (function(global) {
     'use strict';
 
@@ -75,8 +77,10 @@
             },
             content: {
                 text: function() {
-                    var items = $(this).data('items');
                     var html = $('<ul class="qbubble-item-list">');
+                    var items = _.values($(this).data('items')).sort(function(a, b) {
+                        return strnatcmp(a.title.toLowerCase(), b.title.toLowerCase());
+                    });
 
                     $.each(items, function() {
                         var item = $('<li>');

--- a/indico/htdocs/sass/modules/_event_management.scss
+++ b/indico/htdocs/sass/modules/_event_management.scss
@@ -503,9 +503,7 @@ th.i-table {
         max-width: 20em;
         min-width: 20em;
     }
-}
 
-.event-person-list {
     .no-role {
         opacity: 0.25;
         .badge {
@@ -520,7 +518,9 @@ th.i-table {
             color: $dark-gray;
         }
     }
+}
 
+.event-person-list {
     thead {
         @include border-bottom();
         display: block;

--- a/indico/htdocs/sass/modules/_event_management.scss
+++ b/indico/htdocs/sass/modules/_event_management.scss
@@ -513,6 +513,14 @@ th.i-table {
         }
     }
 
+    .pending {
+        background-color: $light-gray;
+
+        td {
+            color: $dark-gray;
+        }
+    }
+
     thead {
         @include border-bottom();
         display: block;

--- a/indico/htdocs/sass/modules/_event_management.scss
+++ b/indico/htdocs/sass/modules/_event_management.scss
@@ -511,7 +511,7 @@ th.i-table {
         }
     }
 
-    .pending {
+    .untrusted {
         background-color: $light-gray;
 
         td {

--- a/indico/modules/events/abstracts/fields.py
+++ b/indico/modules/events/abstracts/fields.py
@@ -135,7 +135,7 @@ class AbstractPersonLinkListField(PersonLinkListFieldBase):
     person_link_cls = AbstractPersonLink
     linked_object_attr = 'abstract'
     default_sort_alpha = False
-    create_pending_persons = True
+    create_untrusted_persons = True
     widget = JinjaWidget('events/contributions/forms/contribution_person_link_widget.html', allow_empty_email=True)
 
     def __init__(self, *args, **kwargs):

--- a/indico/modules/events/abstracts/fields.py
+++ b/indico/modules/events/abstracts/fields.py
@@ -135,6 +135,7 @@ class AbstractPersonLinkListField(PersonLinkListFieldBase):
     person_link_cls = AbstractPersonLink
     linked_object_attr = 'abstract'
     default_sort_alpha = False
+    create_pending_persons = True
     widget = JinjaWidget('events/contributions/forms/contribution_person_link_widget.html', allow_empty_email=True)
 
     def __init__(self, *args, **kwargs):

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -84,6 +84,10 @@ class EventPersonListField(PrincipalListField):
     Requires its form to have an event set.
     """
 
+    #: Whether new event persons created by the field should be
+    #: marked as pending
+    create_pending_persons = False
+
     def __init__(self, *args, **kwargs):
         self.event_person_conversions = {}
         super(EventPersonListField, self).__init__(*args, groups=False, allow_external=True, **kwargs)
@@ -100,13 +104,13 @@ class EventPersonListField(PrincipalListField):
         person = EventPerson(event_new=self.event, email=data.get('email', '').lower(), _title=title,
                              first_name=data.get('firstName'), last_name=data['familyName'],
                              affiliation=data.get('affiliation'), address=data.get('address'),
-                             phone=data.get('phone'))
+                             phone=data.get('phone'), is_pending=self.create_pending_persons)
         # Keep the original data to cancel the conversion if the person is not persisted to the db
         self.event_person_conversions[person] = data
         return person
 
     def _get_event_person_for_user(self, user):
-        person = EventPerson.for_user(user, self.event)
+        person = EventPerson.for_user(user, self.event, is_pending=self.create_pending_persons)
         # Keep a reference to the user to cancel the conversion if the person is not persisted to the db
         self.event_person_conversions[person] = user
         return person

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -85,8 +85,8 @@ class EventPersonListField(PrincipalListField):
     """
 
     #: Whether new event persons created by the field should be
-    #: marked as pending
-    create_pending_persons = False
+    #: marked as untrusted
+    create_untrusted_persons = False
 
     def __init__(self, *args, **kwargs):
         self.event_person_conversions = {}
@@ -104,13 +104,13 @@ class EventPersonListField(PrincipalListField):
         person = EventPerson(event_new=self.event, email=data.get('email', '').lower(), _title=title,
                              first_name=data.get('firstName'), last_name=data['familyName'],
                              affiliation=data.get('affiliation'), address=data.get('address'),
-                             phone=data.get('phone'), is_pending=self.create_pending_persons)
+                             phone=data.get('phone'), is_untrusted=self.create_untrusted_persons)
         # Keep the original data to cancel the conversion if the person is not persisted to the db
         self.event_person_conversions[person] = data
         return person
 
     def _get_event_person_for_user(self, user):
-        person = EventPerson.for_user(user, self.event, is_pending=self.create_pending_persons)
+        person = EventPerson.for_user(user, self.event, is_untrusted=self.create_untrusted_persons)
         # Keep a reference to the user to cancel the conversion if the person is not persisted to the db
         self.event_person_conversions[person] = user
         return person

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -145,6 +145,12 @@ class EventPerson(PersonMixin, db.Model):
         UTCDateTime,
         nullable=True
     )
+    is_pending = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
+
     event_new = db.relationship(
         'Event',
         lazy=True,
@@ -178,7 +184,7 @@ class EventPerson(PersonMixin, db.Model):
 
     @return_ascii
     def __repr__(self):
-        return format_repr(self, 'id', _text=self.full_name)
+        return format_repr(self, 'id', is_pending=False, _text=self.full_name)
 
     @property
     def principal(self):

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -473,3 +473,10 @@ def _mapper_configured():
             target.person.event_new = value
         else:
             assert target.person.event_new == value
+
+    @listens_for(EventPerson.event_links, 'append')
+    @listens_for(EventPerson.session_block_links, 'append')
+    @listens_for(EventPerson.contribution_links, 'append')
+    @listens_for(EventPerson.subcontribution_links, 'append')
+    def _mark_not_pending(target, value, *unused):
+        target.is_pending = False

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -145,7 +145,7 @@ class EventPerson(PersonMixin, db.Model):
         UTCDateTime,
         nullable=True
     )
-    is_pending = db.Column(
+    is_untrusted = db.Column(
         db.Boolean,
         nullable=False,
         default=False
@@ -184,7 +184,7 @@ class EventPerson(PersonMixin, db.Model):
 
     @return_ascii
     def __repr__(self):
-        return format_repr(self, 'id', is_pending=False, _text=self.full_name)
+        return format_repr(self, 'id', is_untrusted=False, _text=self.full_name)
 
     @property
     def principal(self):
@@ -195,16 +195,16 @@ class EventPerson(PersonMixin, db.Model):
         return None
 
     @classmethod
-    def create_from_user(cls, user, event=None, is_pending=False):
+    def create_from_user(cls, user, event=None, is_untrusted=False):
         return EventPerson(user=user, event_new=event, first_name=user.first_name, last_name=user.last_name,
                            email=user.email, affiliation=user.affiliation, address=user.address, phone=user.phone,
-                           is_pending=is_pending)
+                           is_untrusted=is_untrusted)
 
     @classmethod
-    def for_user(cls, user, event=None, is_pending=False):
+    def for_user(cls, user, event=None, is_untrusted=False):
         """Return EventPerson for a matching User in Event creating if needed"""
         person = event.persons.filter_by(user=user).first() if event else None
-        return person or cls.create_from_user(user, event, is_pending=is_pending)
+        return person or cls.create_from_user(user, event, is_untrusted=is_untrusted)
 
     @classmethod
     def link_user_by_email(cls, user):
@@ -478,5 +478,5 @@ def _mapper_configured():
     @listens_for(EventPerson.session_block_links, 'append')
     @listens_for(EventPerson.contribution_links, 'append')
     @listens_for(EventPerson.subcontribution_links, 'append')
-    def _mark_not_pending(target, value, *unused):
-        target.is_pending = False
+    def _mark_not_untrusted(target, value, *unused):
+        target.is_untrusted = False

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -195,15 +195,16 @@ class EventPerson(PersonMixin, db.Model):
         return None
 
     @classmethod
-    def create_from_user(cls, user, event=None):
+    def create_from_user(cls, user, event=None, is_pending=False):
         return EventPerson(user=user, event_new=event, first_name=user.first_name, last_name=user.last_name,
-                           email=user.email, affiliation=user.affiliation, address=user.address, phone=user.phone)
+                           email=user.email, affiliation=user.affiliation, address=user.address, phone=user.phone,
+                           is_pending=is_pending)
 
     @classmethod
-    def for_user(cls, user, event=None):
+    def for_user(cls, user, event=None, is_pending=False):
         """Return EventPerson for a matching User in Event creating if needed"""
         person = event.persons.filter_by(user=user).first() if event else None
-        return person or cls.create_from_user(user, event)
+        return person or cls.create_from_user(user, event, is_pending=is_pending)
 
     @classmethod
     def link_user_by_email(cls, user):

--- a/indico/modules/events/persons/templates/management/_person_list_row.html
+++ b/indico/modules/events/persons/templates/management/_person_list_row.html
@@ -5,13 +5,14 @@
     </td>
     <td class="i-table name-column">
         {{ person.display_full_name }}
-        {% if person.is_pending %}
-            {% set pending_tooltip -%}
+        {% if person.is_untrusted %}
+            {% set untrusted_tooltip -%}
                 {%- trans -%}
                     This person is currently just an author of an abstract with no other ties to the event.
+                    Their data may have been provided by the submitter of the abstract.
                 {%- endtrans -%}
             {%- endset %}
-            <span class="icon-question" title="{{ pending_tooltip }}"></span>
+            <span class="icon-question" title="{{ untrusted_tooltip }}"></span>
         {% endif %}
     </td>
     <td class="i-table email-column">

--- a/indico/modules/events/persons/templates/management/_person_list_row.html
+++ b/indico/modules/events/persons/templates/management/_person_list_row.html
@@ -49,6 +49,17 @@
                 </span>
             </span>
         </td>
+        {% if person.event_new.has_feature('abstracts') %}
+            <td class="i-table">
+                <span class="i-label js-count-label {{ 'no-role' if not person_data.abstracts }}"
+                      data-items="{{ person_data.abstracts | tojson | forceescape }}">
+                    {% trans %}Abstract author{% endtrans %}
+                    <span class="badge">
+                        {{ person_data.abstracts | length }}
+                    </span>
+                </span>
+            </td>
+        {% endif %}
     {% endif %}
     <td class="i-table">
         {% if person_data.roles.no_account %}

--- a/indico/modules/events/persons/templates/management/_person_list_row.html
+++ b/indico/modules/events/persons/templates/management/_person_list_row.html
@@ -5,6 +5,14 @@
     </td>
     <td class="i-table name-column">
         {{ person.display_full_name }}
+        {% if person.is_pending %}
+            {% set pending_tooltip -%}
+                {%- trans -%}
+                    This person is currently just an author of an abstract with no other ties to the event.
+                {%- endtrans -%}
+            {%- endset %}
+            <span class="icon-question" title="{{ pending_tooltip }}"></span>
+        {% endif %}
     </td>
     <td class="i-table email-column">
         {{ person.email }}

--- a/indico/modules/events/persons/templates/management/person_list.html
+++ b/indico/modules/events/persons/templates/management/person_list.html
@@ -137,6 +137,12 @@
                         <label for="filter-speakers" class="i-button">{% trans %}Speakers{% endtrans %}</label>
                         <input type="checkbox" id="filter-conveners" data-filter="convener" checked>
                         <label for="filter-conveners" class="i-button">{% trans %}Conveners{% endtrans %}</label>
+                        {% if event.has_feature('abstracts') %}
+                            <input type="checkbox" id="filter-abstract-author" data-filter="author" checked>
+                            <label for="filter-abstract-author" class="i-button">
+                                {%- trans %}Abstract authors{% endtrans -%}
+                            </label>
+                        {% endif %}
                     {% endif %}
                     <span class="i-button label">{% trans %}or{% endtrans %}</span>
                     <input type="checkbox" id="filter-no-account" data-filter="no_account">
@@ -168,6 +174,9 @@
                             <th class="i-table" data-sorter="false"></th>
                             <th class="i-table" data-sorter="false"></th>
                             <th class="i-table" data-sorter="false"></th>
+                            {% if event.has_feature('abstracts') %}
+                                <th class="i-table" data-sorter="false"></th>
+                            {% endif %}
                         {% endif %}
                         <th class="i-table" data-sorter="false"></th>
                         <th class="i-table" data-sorter="false"></th>
@@ -183,7 +192,7 @@
                         </tr>
                     {%- else -%}
                         <tr class="i-table">
-                            <td colspan="{{ 8 if event.type == 'lecture' else 11 }}">
+                            <td colspan="{{ 8 if event.type == 'lecture' else (11 + event.has_feature('abstracts')) }}">
                                 {%- trans %}No persons{% endtrans -%}
                             </td>
                         </tr>

--- a/indico/modules/events/persons/templates/management/person_list.html
+++ b/indico/modules/events/persons/templates/management/person_list.html
@@ -186,7 +186,7 @@
                 <tbody>
                     {% for person_data in persons -%}
                         <tr id="person-{{ person_data.person.id }}"
-                            class="i-table {{ 'pending' if person_data.person.is_pending }}"
+                            class="i-table {{ 'untrusted' if person_data.person.is_untrusted }}"
                             data-person-roles="{{ person_data.roles | tojson | forceescape }}"
                             {{ 'data-no-account' if person_data.roles.no_account }}>
                             {{ render_person_row(person_data) }}

--- a/indico/modules/events/persons/templates/management/person_list.html
+++ b/indico/modules/events/persons/templates/management/person_list.html
@@ -185,7 +185,8 @@
                 </thead>
                 <tbody>
                     {% for person_data in persons -%}
-                        <tr id="person-{{ person_data.person.id }}" class="i-table"
+                        <tr id="person-{{ person_data.person.id }}"
+                            class="i-table {{ 'pending' if person_data.person.is_pending }}"
                             data-person-roles="{{ person_data.roles | tojson | forceescape }}"
                             {{ 'data-no-account' if person_data.roles.no_account }}>
                             {{ render_person_row(person_data) }}

--- a/migrations/versions/201608200000_4f426059ddd1_add_eventperson_is_pending.py
+++ b/migrations/versions/201608200000_4f426059ddd1_add_eventperson_is_pending.py
@@ -1,0 +1,24 @@
+"""Add EventPerson.is_pending
+
+Revision ID: 4f426059ddd1
+Revises: ccd9d0858ff
+Create Date: 2016-11-23 16:45:37.646802
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '4f426059ddd1'
+down_revision = 'ccd9d0858ff'
+
+
+def upgrade():
+    op.add_column('persons', sa.Column('is_pending', sa.Boolean(), nullable=False, server_default='false'),
+                  schema='events')
+    op.alter_column('persons', 'is_pending', server_default=None, schema='events')
+
+
+def downgrade():
+    op.drop_column('persons', 'is_pending', schema='events')

--- a/migrations/versions/201608200000_4f426059ddd1_add_eventperson_is_untrusted.py
+++ b/migrations/versions/201608200000_4f426059ddd1_add_eventperson_is_untrusted.py
@@ -1,4 +1,4 @@
-"""Add EventPerson.is_pending
+"""Add EventPerson.is_untrusted
 
 Revision ID: 4f426059ddd1
 Revises: ccd9d0858ff
@@ -15,10 +15,10 @@ down_revision = 'ccd9d0858ff'
 
 
 def upgrade():
-    op.add_column('persons', sa.Column('is_pending', sa.Boolean(), nullable=False, server_default='false'),
+    op.add_column('persons', sa.Column('is_untrusted', sa.Boolean(), nullable=False, server_default='false'),
                   schema='events')
-    op.alter_column('persons', 'is_pending', server_default=None, schema='events')
+    op.alter_column('persons', 'is_untrusted', server_default=None, schema='events')
 
 
 def downgrade():
-    op.drop_column('persons', 'is_pending', schema='events')
+    op.drop_column('persons', 'is_untrusted', schema='events')

--- a/migrations/versions/201608241100_2ce1756a2f12_add_abstract_tables.py
+++ b/migrations/versions/201608241100_2ce1756a2f12_add_abstract_tables.py
@@ -1,7 +1,7 @@
 """Add abstracts tables
 
 Revision ID: 2ce1756a2f12
-Revises: ccd9d0858ff
+Revises: 4f426059ddd1
 Create Date: 2016-08-22 14:57:28.005919
 """
 
@@ -17,7 +17,7 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision = '2ce1756a2f12'
-down_revision = 'ccd9d0858ff'
+down_revision = '4f426059ddd1'
 
 
 def upgrade():


### PR DESCRIPTION
- [x] Handle pending event persons in the backend
- [x] Create pending event persons when creating abstracts
- [x] Mark them as not pending as soon as they are associated with anything else
- [x] Show persons linked only to abstracts on "roles" page (currently not shown at all)
- [x] Indicate pending event persons on that page (with a tooltip explaining it)
- [x] Make pending person indicator pretty

SQL to run:

```sql
ALTER TABLE events.persons ADD COLUMN is_untrusted boolean NOT NULL DEFAULT false;
ALTER TABLE events.persons ALTER COLUMN is_untrusted DROP DEFAULT;
```