### PR TITLE
Display full name of room in reservation details

### DIFF
--- a/indico/MaKaC/webinterface/tpls/RoomBookingDetails.tpl
+++ b/indico/MaKaC/webinterface/tpls/RoomBookingDetails.tpl
@@ -185,7 +185,7 @@
                       </td>
                       <td align="left" class="blacktext">
                         <a href="${ url_for(endpoints['room_details'], event, reservation.room) }">
-                          ${ reservation.room.name }
+                          ${ reservation.room.full_name }
                         </a>
                       </td>
                     </tr>


### PR DESCRIPTION
As indicated from a group of users (`INC1216902`), the name of the room is misleading since it doesn't contain the code of the room. An example is the following case, where the reserved room is the `112-4-019 - EN ACE Meeting Room` but the room key is `112-4-020`:
![image](https://cloud.githubusercontent.com/assets/1579899/21229067/97cb5520-c2e0-11e6-805e-496a16cb9f04.png)


Using the full name of the room eliminates any ambiguity:
![image](https://cloud.githubusercontent.com/assets/1579899/21229100/b1d64d80-c2e0-11e6-9460-404b77540c04.png)

Besides, we follow the exact same principle in the reservation confirmation page:
![image](https://cloud.githubusercontent.com/assets/1579899/21229123/c51303de-c2e0-11e6-8090-e9a63b89d67c.png)

