### PR TITLE
Fix conference logo and title alignment

### DIFF
--- a/indico/MaKaC/webinterface/tpls/ConfDisplayFrame.tpl
+++ b/indico/MaKaC/webinterface/tpls/ConfDisplayFrame.tpl
@@ -13,7 +13,7 @@ else:
 
 <div class="conf clearfix" itemscope itemtype="http://schema.org/Event">
     <div class="confheader clearfix" ${ bgColorStyle }>
-        <div class="confTitleBox" ${ bgColorStyle }>
+        <div class="confTitleBox clearfix" ${ bgColorStyle }>
             <div class="confTitle">
                 <h1>
                     <a href="${ displayURL }">


### PR DESCRIPTION
When the logo became higher than the title of the conference, the subtitle row of the conference would wrap next to it:

![image](https://cloud.githubusercontent.com/assets/1579899/21232140/ede6fd10-c2ea-11e6-93f8-1c4caf01c5eb.png)

Making the logo align with the title only, fixes the problem:

![image](https://cloud.githubusercontent.com/assets/1579899/21232158/09c817e4-c2eb-11e6-8377-ab318242c1dc.png)
