### PR TITLE
Fix person filters in author list

### DIFF
--- a/indico/htdocs/js/indico/jquery/dropdown.js
+++ b/indico/htdocs/js/indico/jquery/dropdown.js
@@ -20,7 +20,7 @@
 
     $.widget('indico.dropdown', {
         options: {
-            selector: '.i-button',
+            selector: '.i-button[data-toggle]',
             effect_on: 'slideDown',
             effect_off: 'fadeOut',
             time_on: 200,


### PR DESCRIPTION
This is a tricky commit that needs an explanation. You might notice that the filters in the author list (in abstract and in contribution lists) aren't working. After not being able to find the solution to this problem I went through our old commits to see where the change that made this fail was. I found the commit! (https://github.com/indico/indico/commit/2afd5f0a04145500829e760c0dc86c9094373c48). Apparently it's a very simple commit that seems unrelated with the problem but it's not, because before this commit the filters were working fine. I noticed that the `dropdown()` function was applying at the whole toolbar (including the filter buttons) and someway disabling them. I went through the dropdown documentation of Bootstrap and I saw that in all cases they are wrapping the dropdown button and the dropdown options in an HTML element as we have before the commit. So, my suspicion is that the `dropdown()` function is affecting the `<label>` and `<input type="checkbox">`'s don't really know how.

I might be wrong, if anybody has an idea of what might be causing this problem is more than welcome to share it.