### PR TITLE
Fix event overview when events expand through days

### DIFF
--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -16,7 +16,7 @@
 
 from __future__ import unicode_literals
 
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta, date, time
 from functools import partial
 from io import BytesIO
 from itertools import chain, groupby, imap
@@ -537,9 +537,13 @@ class RHCategoryOverview(RHDisplayCategoryBase):
     def _get_days(start_dt, end_dt):
         # Return all days in the open-ended interval
         current_dt = start_dt
+        tz = current_dt.tzinfo
+        next_day = current_dt.date() + timedelta(1)
+        beginning_of_next_day = tz.localize(datetime.combine(next_day, time()))
         while current_dt < end_dt:
             yield current_dt
-            current_dt = current_dt + relativedelta(days=1)
+            current_dt = beginning_of_next_day
+            beginning_of_next_day = current_dt + relativedelta(days=1)
 
     @staticmethod
     def _pop_head_while(predicate, list_):


### PR DESCRIPTION
The issue was in the calculation of days between the start and end
datetime of the event. When the time of the event end datetime was
prior to the time of the start datetime, the last day was not
included in the calculation (ex: 1/1/16 14:00, 3/1/16 10:00)