### PR TITLE
RegForm: allow modification end date to be set

### DIFF
--- a/indico/modules/events/registration/controllers/management/regforms.py
+++ b/indico/modules/events/registration/controllers/management/regforms.py
@@ -255,6 +255,7 @@ class RHRegistrationFormSchedule(RHManageRegFormBase):
         if form.validate_on_submit():
             self.regform.start_dt = form.start_dt.data
             self.regform.end_dt = form.end_dt.data
+            self.regform.modification_end_dt = form.modification_end_dt.data
             flash(_("Registrations for {} have been scheduled").format(self.regform.title), 'success')
             logger.info("Registrations for %s scheduled by %s", self.regform, session.user)
             return jsonify_data(flash=False)

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -124,6 +124,10 @@ class RegistrationFormScheduleForm(IndicoForm):
                                    description=_("Moment when registrations will be open"))
     end_dt = IndicoDateTimeField(_("End"), [Optional(), LinkedDateTime('start_dt')], default_time=time(23, 59),
                                  description=_("Moment when registrations will be closed"))
+    modification_end_dt = IndicoDateTimeField(_("Modification deadline"), [Optional(), LinkedDateTime('end_dt')],
+                                              default_time=time(23, 59),
+                                              description=_("Deadline until which registration information can be "
+                                                            "modified (defaults to the end date if empty)"))
 
     def __init__(self, *args, **kwargs):
         regform = kwargs.pop('regform')

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -40,7 +40,7 @@ from indico.util.struct.enum import RichIntEnum
 
 
 class ModificationMode(RichIntEnum):
-    __titles__ = [None, L_('Always'), L_('Until payment'), L_('Never')]
+    __titles__ = [None, L_('Until modification deadline'), L_('Until payment'), L_('Never')]
     allowed_always = 1
     allowed_until_payment = 2
     not_allowed = 3


### PR DESCRIPTION
There's currently no way to set it, even though it's included in the models (and has been migrated).