### PR TITLE
Use Jinja instead of AdminFrame.tpl and build top menu using signals

### DIFF
--- a/indico/__init__.py
+++ b/indico/__init__.py
@@ -16,6 +16,6 @@
 
 from indico.util.mimetypes import register_custom_mimetypes
 
-__version__ = '1.9.11.dev0'
+__version__ = '1.9.11.dev1'
 
 register_custom_mimetypes()

--- a/indico/core/__init__.py
+++ b/indico/core/__init__.py
@@ -1,0 +1,39 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2017 European Organization for Nuclear Research (CERN).
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# Indico is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
+from indico.core import signals
+from indico.core.config import Config
+from indico.util.i18n import _
+from indico.web.flask.util import url_for
+from indico.web.menu import TopMenuSection, TopMenuItem
+from indico.web.util import url_for_index
+
+
+@signals.menu.sections.connect_via('top-menu')
+def _topmenu_sections(sender, **kwargs):
+    yield TopMenuSection('services', _('Services'), 60)
+    yield TopMenuSection('help', _('Help'), -10)  # put the help section always last
+
+
+@signals.menu.items.connect_via('top-menu')
+def _topmenu_items(sender, **kwargs):
+    yield TopMenuItem('home', _('Home'), url_for_index(), 100)
+    yield TopMenuItem('help', _('Indico help'), None, 30, section='help')
+    if Config.getInstance().getPublicSupportEmail():
+        yield TopMenuItem('contact', _('Contact'), url_for('misc.contact'), 20, section='help')
+    yield TopMenuItem('about', _('More about Indico'), 'http://indico-software.org', 10, section='help')

--- a/indico/core/celery/__init__.py
+++ b/indico/core/celery/__init__.py
@@ -17,6 +17,7 @@
 from __future__ import unicode_literals
 
 from celery.signals import import_modules
+from flask import session
 
 from indico.core import signals
 from indico.core.celery.core import IndicoCelery
@@ -44,4 +45,5 @@ def _import_modules(*args, **kwargs):
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _extend_admin_menu(sender, **kwargs):
-    return SideMenuItem('celery', _("Tasks"), url_for('celery.index'), 20, icon='time')
+    if session.user.is_admin:
+        return SideMenuItem('celery', _("Tasks"), url_for('celery.index'), 20, icon='time')

--- a/indico/core/celery/controllers.py
+++ b/indico/core/celery/controllers.py
@@ -52,4 +52,5 @@ class RHCeleryTasks(RHAdminBase):
                           'disabled': disabled})
         tasks.sort(key=itemgetter('disabled', 'name'))
 
-        return WPCelery.render_template('celery_tasks.html', flower_url=flower_url, tasks=tasks, timedelta=timedelta)
+        return WPCelery.render_template('celery_tasks.html', 'celery',
+                                        flower_url=flower_url, tasks=tasks, timedelta=timedelta)

--- a/indico/core/celery/templates/celery_tasks.html
+++ b/indico/core/celery/templates/celery_tasks.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'message_box.html' import message_box %}
 
 {% block title %}

--- a/indico/core/celery/views.py
+++ b/indico/core/celery/views.py
@@ -16,10 +16,8 @@
 
 from __future__ import unicode_literals
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
-from indico.legacy.webinterface.pages.base import WPJinjaMixin
+from indico.modules.admin.views import WPAdmin
 
 
-class WPCelery(WPJinjaMixin, WPAdminsBase):
+class WPCelery(WPAdmin):
     template_prefix = 'celery/'
-    sidemenu_option = 'celery'

--- a/indico/core/plugins/__init__.py
+++ b/indico/core/plugins/__init__.py
@@ -19,6 +19,7 @@ import os
 import re
 from urlparse import urlparse
 
+from flask import session
 from flask_babelex import Domain
 from flask_pluginengine import (PluginEngine, Plugin, PluginBlueprintMixin, PluginBlueprintSetupStateMixin,
                                 current_plugin, render_plugin_template, wrap_in_plugin_context)
@@ -363,7 +364,8 @@ class WPJinjaMixinPlugin(WPJinjaMixin):
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _extend_admin_menu(sender, **kwargs):
-    return SideMenuItem(u'plugins', _(u"Plugins"), url_for(u'plugins.index'), 80, icon=u'puzzle')
+    if session.user.is_admin:
+        return SideMenuItem(u'plugins', _(u"Plugins"), url_for(u'plugins.index'), 80, icon=u'puzzle')
 
 
 plugin_engine = IndicoPluginEngine()

--- a/indico/core/plugins/controllers.py
+++ b/indico/core/plugins/controllers.py
@@ -52,7 +52,7 @@ class RHPlugins(RHPluginsBase):
         ordered_categories = OrderedDict(sorted(categories.items()))
         if other:
             ordered_categories[PluginCategory.other] = other
-        return WPPlugins.render_template('index.html', categorized_plugins=ordered_categories)
+        return WPPlugins.render_template('index.html', 'plugins', categorized_plugins=ordered_categories)
 
 
 class RHPluginDetails(RHPluginsBase):
@@ -74,5 +74,5 @@ class RHPluginDetails(RHPluginsBase):
                     plugin.settings.set_multi(form.data)
                     flash(_('Settings saved ({0})').format(plugin.title), 'success')
                     return redirect_or_jsonify(request.url)
-            return WPPlugins.render_template('details.html', plugin=plugin, form=form,
+            return WPPlugins.render_template('details.html', 'plugins', plugin=plugin, form=form,
                                              back_url=url_for(self.back_button_endpoint))

--- a/indico/core/plugins/templates/details.html
+++ b/indico/core/plugins/templates/details.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import form_header, form_rows, form_footer, form_fieldset %}
 
 {% block title %}{{ plugin.title }}{% endblock %}

--- a/indico/core/plugins/templates/index.html
+++ b/indico/core/plugins/templates/index.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 
 {% block title %}
     {% trans %}Plugins{% endtrans %}

--- a/indico/core/plugins/views.py
+++ b/indico/core/plugins/views.py
@@ -16,10 +16,8 @@
 
 from __future__ import unicode_literals
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
-from indico.legacy.webinterface.pages.base import WPJinjaMixin
+from indico.modules.admin.views import WPAdmin
 
 
-class WPPlugins(WPJinjaMixin, WPAdminsBase):
+class WPPlugins(WPAdmin):
     template_prefix = 'plugins/'
-    sidemenu_option = 'plugins'

--- a/indico/core/signals/core.py
+++ b/indico/core/signals/core.py
@@ -34,11 +34,6 @@ after_process = _signals.signal('after-process', """
 Called after an Indico request has been processed.
 """)
 
-indico_menu = _signals.signal('indico-menu', """
-Expected to return `HeaderMenuEntry` objects which are then added to the
-Indico head menu.
-""")
-
 get_storage_backends = _signals.signal('get-storage-backends', """
 Expected to return one or more Storage subclasses.
 """)

--- a/indico/htdocs/css/Default.css
+++ b/indico/htdocs/css/Default.css
@@ -458,16 +458,9 @@ div.pageOverHeader
 
 /* Breadcrumb styles */
 
-.path {
-}
-
 .path img {
     padding-right: 5px;
     padding-left: 7px;
-}
-
-.path a {
-   font-size: 12px;
 }
 
 /* Root Page */

--- a/indico/htdocs/sass/partials/_main.scss
+++ b/indico/htdocs/sass/partials/_main.scss
@@ -110,12 +110,13 @@ div.main-breadcrumb {
             color: $dark-gray;
             padding: 0 0.5em;
         }
-    }
 
-    .path a {
-        color: $light-black;
+        .item {
+            color: $light-black;
+            font-size: 12px;
+        }
 
-        &:hover {
+        a.item:hover {
             color: $dark-blue;
         }
     }

--- a/indico/legacy/webinterface/pages/admins.py
+++ b/indico/legacy/webinterface/pages/admins.py
@@ -40,7 +40,7 @@ class WPAdminsBase(WPMainBase):
         })
 
     def _getNavigationDrawer(self):
-        return wcomponents.WSimpleNavigationDrawer(_("Server Admin"), bgColor="white")
+        return wcomponents.WSimpleNavigationDrawer(_("Administration"), bgColor="white")
 
     def _createTabCtrl(self):
         pass

--- a/indico/legacy/webinterface/pages/admins.py
+++ b/indico/legacy/webinterface/pages/admins.py
@@ -14,59 +14,23 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
+
+from flask import render_template_string
+
 from indico.legacy.webinterface import wcomponents
 from indico.legacy.webinterface.pages.main import WPMainBase
-from indico.legacy.webinterface.wcomponents import render_header
 from indico.util.i18n import _
-from indico.web.menu import render_sidemenu
 
 
 class WPAdminsBase(WPMainBase):
-    def getJSFiles(self):
-        return WPMainBase.getJSFiles(self) + self._includeJSPackage('Management')
-
-    def _getHeader(self):
-        return render_header()
-
     def _getBody(self, params):
-        self._createTabCtrl()
-        self._setActiveTab()
-
-        frame = WAdminFrame()
-
-        return frame.getHTML({
-            "body": self._getPageContent(params),
-            "sideMenu": render_sidemenu('admin-sidemenu', active_item=self.sidemenu_option)
-        })
+        body = self._getPageContent(params)
+        tpl = "{% extends 'layout/admin_page.html' %}{% block content %}{{ body | safe }}{% endblock %}"
+        return render_template_string(tpl, active_menu_item=self.sidemenu_option, body=body)
 
     def _getNavigationDrawer(self):
-        return wcomponents.WSimpleNavigationDrawer(_("Administration"), bgColor="white")
-
-    def _createTabCtrl(self):
-        pass
-
-    def _getTabContent(self):
-        raise NotImplementedError
-
-    def _setActiveTab(self):
-        pass
+        return wcomponents.WSimpleNavigationDrawer(_('Administration'), bgColor='white')
 
     def _getPageContent(self, params):
         raise NotImplementedError
-
-
-class WAdminFrame(wcomponents.WTemplated):
-    def __init__( self ):
-        pass
-
-    def getVars( self ):
-        vars = wcomponents.WTemplated.getVars( self )
-        vars["titleTabPixels"] = self.getTitleTabPixels()
-        vars["intermediateVTabPixels"] = self.getIntermediateVTabPixels()
-        return vars
-
-    def getIntermediateVTabPixels( self ):
-        return 0
-
-    def getTitleTabPixels( self ):
-        return 260

--- a/indico/legacy/webinterface/pages/base.py
+++ b/indico/legacy/webinterface/pages/base.py
@@ -29,7 +29,6 @@ from indico.util.signals import values_from_signal
 from indico.util.string import to_unicode
 from indico.web import assets
 from indico.web.util import jsonify_template
-from indico.legacy.webinterface import wcomponents
 
 
 class WPJinjaMixin:

--- a/indico/legacy/webinterface/pages/contact.py
+++ b/indico/legacy/webinterface/pages/contact.py
@@ -15,22 +15,22 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from indico.core.config import Config
-from indico.web.flask.util import url_for
-from indico.legacy.webinterface import wcomponents
 from indico.legacy.webinterface.pages.main import WPMainBase
+from indico.legacy.webinterface.wcomponents import WSimpleNavigationDrawer, WTemplated
+from indico.util.i18n import _
 
 
 class WPContact(WPMainBase):
     def _getNavigationDrawer(self):
-        return wcomponents.WSimpleNavigationDrawer("Contact", lambda: url_for('misc.contact'))
+        return WSimpleNavigationDrawer(_('Contact'))
 
     def _getBody(self, params):
         wc = WContact()
         return wc.getHTML()
 
 
-class WContact(wcomponents.WTemplated):
+class WContact(WTemplated):
     def getVars(self):
-        vars = wcomponents.WTemplated.getVars(self)
+        vars = WTemplated.getVars(self)
         vars["supportEmail"] = Config.getInstance().getPublicSupportEmail()
         return vars

--- a/indico/legacy/webinterface/tpls/AdminFrame.tpl
+++ b/indico/legacy/webinterface/tpls/AdminFrame.tpl
@@ -1,9 +1,0 @@
-<div class="layout-side-menu">
-    <div class="menu-column">
-        ${ sideMenu }
-    </div>
-    <div class="content-column">
-        ${ render_template('flashed_messages.html') }
-        ${ body }
-    </div>
-</div>

--- a/indico/legacy/webinterface/tpls/NavigationDrawer.tpl
+++ b/indico/legacy/webinterface/tpls/NavigationDrawer.tpl
@@ -35,7 +35,7 @@ arrowImage = systemIcon( "breadcrumb_arrow.png" )
                 <span class="sep">»</span>
             % endif
             <% name, url = l[i] %>
-            <a href="${ url }" itemscope itemtype="http://data-vocabulary.org/Breadcrumb" itemprop="url">
+            <a href="${ url }" itemscope itemtype="http://data-vocabulary.org/Breadcrumb" itemprop="url" class="item">
                 <span itemprop="title">${ escape(truncateTitle(name, 40)) }</span>
             </a>
         % endfor

--- a/indico/legacy/webinterface/tpls/RoomBookingAdmin.tpl
+++ b/indico/legacy/webinterface/tpls/RoomBookingAdmin.tpl
@@ -11,19 +11,11 @@
 
 <table align="center" width="95%">
 
-<tr>
-  <td class="formTitle">${ _("Room Booking Administration") }</td>
-</tr>
-
 <!-- ==================== Manage Locations  ==================== -->
 <!-- =========================================================== -->
 <tr>
   <td>
-    <br />
     <table>
-    <tr>
-      <td colspan="2" class="groupTitle">${ _("Manage Locations")}</td>
-    </tr>
     <tr>
       <td class="titleUpCellTD" style="width: 160px;">
         <span class="titleCellFormat">${ _('Available locations')}</span>

--- a/indico/legacy/webinterface/tpls/SimpleNavigationDrawer.tpl
+++ b/indico/legacy/webinterface/tpls/SimpleNavigationDrawer.tpl
@@ -1,13 +1,11 @@
-<div class="main-breadcrumb" ${'style="background-color: '+ bgColor +';" ' if bgColor else ""}>
+<div class="main-breadcrumb">
     <span class="path">
-        <a href="${ url_for_index() }">
-            ${ _("Home") }
-        </a>
-       <span class="sep">»</span>
+        <a href="${ url_for_index() }" class="item">${ _("Home") }</a>
 
-        <a href="${ urlHandler(**pars) if urlHandler else "#"}">
-            ${ title }
-        </a>
+        % for item in items:
+            <span class="sep">»</span>
+            <span class="item">${ item }</span>
+        % endfor
     </span>
 </span>
 </div>

--- a/indico/legacy/webinterface/wcomponents.py
+++ b/indico/legacy/webinterface/wcomponents.py
@@ -154,24 +154,15 @@ class WNavigationDrawer(WTemplated):
     def getHTML(self, params=None):
         return WTemplated.getHTML(self, params)
 
+
 class WSimpleNavigationDrawer(WTemplated):
+    def __init__(self, *items):
+        self._items = items
 
-    def __init__( self, title, handler = None, bgColor = None, **pars  ):
-        self._urlHandler = handler
-        self._pars = pars
-        self._title = title
-        self._bgColor = bgColor
-
-    def getVars( self ):
-        vars = WTemplated.getVars( self )
-        vars["urlHandler"] = self._urlHandler
-        vars["title"] = self._title
-        vars["pars"] = self._pars
-        vars["bgColor"] = self._bgColor
-        return vars
-
-    def getHTML(self, params=None):
-        return WTemplated.getHTML(self, params)
+    def getVars(self):
+        params = WTemplated.getVars(self)
+        params['items'] = self._items
+        return params
 
 
 class TabControl:

--- a/indico/legacy/webinterface/wcomponents.py
+++ b/indico/legacy/webinterface/wcomponents.py
@@ -20,18 +20,16 @@ import pkg_resources
 from flask import g, render_template
 from speaklater import _LazyString
 
-from indico.legacy.common.TemplateExec import render as render_mako
-from indico.core import signals
 from indico.core.config import Config
-from indico.util.signals import values_from_signal
-from indico.web.menu import HeaderMenuEntry
+from indico.legacy.common.TemplateExec import render as render_mako
+from indico.web.menu import build_menu_structure
 
 
 def render_header(category=None, protected_object=None, local_tz=None, force_local_tz=False):
-    extra_menu_items = HeaderMenuEntry.group(values_from_signal(signals.indico_menu.send()))
+    top_menu_items = build_menu_structure('top-menu')
     rv = render_template('header.html',
                          category=category,
-                         extra_menu_items=extra_menu_items,
+                         top_menu_items=top_menu_items,
                          protected_object=protected_object,
                          local_tz=local_tz,
                          force_local_tz=force_local_tz)

--- a/indico/modules/admin/__init__.py
+++ b/indico/modules/admin/__init__.py
@@ -16,11 +16,13 @@
 
 from __future__ import unicode_literals
 
+from flask import session
+
 from indico.core import signals
 from indico.modules.admin.controllers.base import RHAdminBase
 from indico.util.i18n import _
-from indico.web.menu import SideMenuSection
-
+from indico.web.flask.util import url_for
+from indico.web.menu import SideMenuSection, TopMenuItem
 
 __all__ = ('RHAdminBase',)
 
@@ -32,3 +34,9 @@ def _sidemenu_sections(sender, **kwargs):
     yield SideMenuSection('customization', _("Customization"), 50, icon='wrench')
     yield SideMenuSection('integration', _("Integration"), 30, icon='earth')
     yield SideMenuSection('homepage', _("Homepage"), 40, icon='home')
+
+
+@signals.menu.items.connect_via('top-menu')
+def _topmenu_items(sender, **kwargs):
+    if session.user and session.user.is_admin:
+        yield TopMenuItem('admin', _('Administration'), url_for('core.admin_dashboard'), 70)

--- a/indico/modules/admin/views.py
+++ b/indico/modules/admin/views.py
@@ -32,7 +32,9 @@ class WPAdmin(WPJinjaMixin, WPMainBase):
 
     def _getNavigationDrawer(self):
         menu_item = get_menu_item('admin-sidemenu', self._kwargs['active_menu_item'])
-        items = [_('Administration'), menu_item.title]
+        items = [_('Administration')]
+        if menu_item:
+            items.append(menu_item.title)
         return WSimpleNavigationDrawer(*items)
 
     def _getBody(self, params):

--- a/indico/modules/admin/views.py
+++ b/indico/modules/admin/views.py
@@ -20,6 +20,7 @@ from indico.legacy.webinterface.pages.base import WPJinjaMixin
 from indico.legacy.webinterface.pages.main import WPMainBase
 from indico.legacy.webinterface.wcomponents import WSimpleNavigationDrawer
 from indico.util.i18n import _
+from indico.web.menu import get_menu_item
 
 
 class WPAdmin(WPJinjaMixin, WPMainBase):
@@ -30,7 +31,9 @@ class WPAdmin(WPJinjaMixin, WPMainBase):
         WPMainBase.__init__(self, rh, **kwargs)
 
     def _getNavigationDrawer(self):
-        return WSimpleNavigationDrawer(_('Administration'), bgColor='white')
+        menu_item = get_menu_item('admin-sidemenu', self._kwargs['active_menu_item'])
+        items = [_('Administration'), menu_item.title]
+        return WSimpleNavigationDrawer(*items)
 
     def _getBody(self, params):
         return self._getPageContent(params)

--- a/indico/modules/admin/views.py
+++ b/indico/modules/admin/views.py
@@ -16,21 +16,21 @@
 
 from __future__ import unicode_literals
 
-from flask import render_template_string
-
-from indico.legacy.webinterface import wcomponents
+from indico.legacy.webinterface.pages.base import WPJinjaMixin
 from indico.legacy.webinterface.pages.main import WPMainBase
+from indico.legacy.webinterface.wcomponents import WSimpleNavigationDrawer
 from indico.util.i18n import _
 
 
-class WPAdminsBase(WPMainBase):
-    def _getBody(self, params):
-        body = self._getPageContent(params)
-        tpl = "{% extends 'layout/admin_page.html' %}{% block content %}{{ body | safe }}{% endblock %}"
-        return render_template_string(tpl, active_menu_item=self.sidemenu_option, body=body)
+class WPAdmin(WPJinjaMixin, WPMainBase):
+    """Base class for admin pages."""
+
+    def __init__(self, rh, active_menu_item, **kwargs):
+        kwargs['active_menu_item'] = active_menu_item
+        WPMainBase.__init__(self, rh, **kwargs)
 
     def _getNavigationDrawer(self):
-        return wcomponents.WSimpleNavigationDrawer(_('Administration'), bgColor='white')
+        return WSimpleNavigationDrawer(_('Administration'), bgColor='white')
 
-    def _getPageContent(self, params):
-        raise NotImplementedError
+    def _getBody(self, params):
+        return self._getPageContent(params)

--- a/indico/modules/announcement/__init__.py
+++ b/indico/modules/announcement/__init__.py
@@ -16,7 +16,7 @@
 
 from __future__ import unicode_literals
 
-from flask import render_template
+from flask import render_template, session
 
 from indico.core import signals
 from indico.core.settings import SettingsProxy
@@ -42,4 +42,5 @@ def _inject_announcement_header(**kwargs):
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _sidemenu_items(sender, **kwargs):
-    yield SideMenuItem('announcement', _('Announcement'), url_for('announcement.manage'), section='homepage')
+    if session.user.is_admin:
+        yield SideMenuItem('announcement', _('Announcement'), url_for('announcement.manage'), section='homepage')

--- a/indico/modules/announcement/controllers.py
+++ b/indico/modules/announcement/controllers.py
@@ -34,4 +34,4 @@ class RHAnnouncement(RHAdminBase):
             announcement_settings.set_multi(form.data)
             flash(_('Settings have been saved'), 'success')
             return redirect(url_for('announcement.manage'))
-        return WPAnnouncement.render_template('settings.html', form=form)
+        return WPAnnouncement.render_template('settings.html', 'announcement', form=form)

--- a/indico/modules/announcement/templates/settings.html
+++ b/indico/modules/announcement/templates/settings.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import simple_form %}
 
 {% block title %}

--- a/indico/modules/announcement/views.py
+++ b/indico/modules/announcement/views.py
@@ -16,10 +16,8 @@
 
 from __future__ import unicode_literals
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
-from indico.legacy.webinterface.pages.base import WPJinjaMixin
+from indico.modules.admin.views import WPAdmin
 
 
-class WPAnnouncement(WPJinjaMixin, WPAdminsBase):
-    sidemenu_option = 'announcement'
+class WPAnnouncement(WPAdmin):
     template_prefix = 'announcement/'

--- a/indico/modules/api/__init__.py
+++ b/indico/modules/api/__init__.py
@@ -16,6 +16,8 @@
 
 from __future__ import unicode_literals
 
+from flask import session
+
 from indico.core import signals
 from indico.core.db import db
 from indico.core.settings import SettingsProxy
@@ -67,7 +69,8 @@ def _merge_users(target, source, **kwargs):
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _extend_admin_menu(sender, **kwargs):
-    return SideMenuItem('api', _("API"), url_for('api.admin_settings'), section='integration')
+    if session.user.is_admin:
+        return SideMenuItem('api', _("API"), url_for('api.admin_settings'), section='integration')
 
 
 @signals.menu.items.connect_via('user-profile-sidemenu')

--- a/indico/modules/api/controllers.py
+++ b/indico/modules/api/controllers.py
@@ -49,7 +49,7 @@ class RHAPIAdminSettings(RHAdminBase):
             flash(_('Settings saved'), 'success')
             return redirect(url_for('.admin_settings'))
         count = APIKey.find(is_active=True).count()
-        return WPAPIAdmin.render_template('admin_settings.html', form=form, count=count)
+        return WPAPIAdmin.render_template('admin_settings.html', 'api', form=form, count=count)
 
 
 class RHAPIAdminKeys(RHAdminBase):
@@ -57,7 +57,7 @@ class RHAPIAdminKeys(RHAdminBase):
 
     def _process(self):
         keys = sorted(APIKey.find_all(is_active=True), key=lambda ak: (ak.use_count == 0, ak.user.full_name))
-        return WPAPIAdmin.render_template('admin_keys.html', keys=keys)
+        return WPAPIAdmin.render_template('admin_keys.html', 'api', keys=keys)
 
 
 class RHUserAPIBase(RHUserBase):

--- a/indico/modules/api/templates/admin_keys.html
+++ b/indico/modules/api/templates/admin_keys.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 
 {% block title %}{% trans %}API Keys{% endtrans %}{% endblock %}
 

--- a/indico/modules/api/templates/admin_settings.html
+++ b/indico/modules/api/templates/admin_settings.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import form_header, form_rows, form_footer  %}
 
 {% block title %}{% trans %}API Settings{% endtrans %}{% endblock %}

--- a/indico/modules/api/views.py
+++ b/indico/modules/api/views.py
@@ -16,14 +16,12 @@
 
 from __future__ import unicode_literals
 
+from indico.modules.admin.views import WPAdmin
 from indico.modules.users.views import WPUser
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
-from indico.legacy.webinterface.pages.base import WPJinjaMixin
 
 
-class WPAPIAdmin(WPJinjaMixin, WPAdminsBase):
+class WPAPIAdmin(WPAdmin):
     template_prefix = 'api/'
-    sidemenu_option = 'api'
 
 
 class WPAPIUserProfile(WPUser):

--- a/indico/modules/categories/__init__.py
+++ b/indico/modules/categories/__init__.py
@@ -16,6 +16,8 @@
 
 from __future__ import unicode_literals
 
+from flask import session
+
 from indico.core import signals
 from indico.core.logger import Logger
 from indico.core.roles import check_roles, ManagementRole
@@ -58,8 +60,9 @@ def _sidemenu_items(sender, category, **kwargs):
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _sidemenu_items(sender, **kwargs):
-    yield SideMenuItem('upcoming_events', _('Upcoming events'), url_for('categories.manage_upcoming'),
-                       section='homepage')
+    if session.user.is_admin:
+        yield SideMenuItem('upcoming_events', _('Upcoming events'), url_for('categories.manage_upcoming'),
+                           section='homepage')
 
 
 @signals.app_created.connect

--- a/indico/modules/categories/controllers/admin.py
+++ b/indico/modules/categories/controllers/admin.py
@@ -36,4 +36,4 @@ class RHManageUpcomingEvents(RHAdminBase):
             get_upcoming_events.clear_cached()
             flash(_('Settings saved!'), 'success')
             return redirect(url_for('categories.manage_upcoming'))
-        return WPManageUpcomingEvents.render_template('admin/upcoming_events.html', form=form)
+        return WPManageUpcomingEvents.render_template('admin/upcoming_events.html', 'upcoming_events', form=form)

--- a/indico/modules/categories/templates/admin/upcoming_events.html
+++ b/indico/modules/categories/templates/admin/upcoming_events.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import simple_form %}
 
 {% block title %}

--- a/indico/modules/categories/views.py
+++ b/indico/modules/categories/views.py
@@ -18,16 +18,15 @@ from __future__ import unicode_literals
 
 from markupsafe import escape
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
 from indico.legacy.webinterface.pages.base import WPJinjaMixin
 from indico.legacy.webinterface.pages.main import WPMainBase
 from indico.legacy.webinterface.wcomponents import WNavigationDrawer, render_header
+from indico.modules.admin.views import WPAdmin
 from indico.util.i18n import _
 from indico.util.mathjax import MathjaxMixin
 
 
-class WPManageUpcomingEvents(WPJinjaMixin, WPAdminsBase):
-    sidemenu_option = 'upcoming_events'
+class WPManageUpcomingEvents(WPAdmin):
     template_prefix = 'categories/'
 
 

--- a/indico/modules/cephalopod/__init__.py
+++ b/indico/modules/cephalopod/__init__.py
@@ -16,6 +16,8 @@
 
 from __future__ import unicode_literals
 
+from flask import session
+
 from indico.core import signals
 from indico.core.logger import Logger
 from indico.core.settings import SettingsProxy
@@ -38,4 +40,5 @@ cephalopod_settings = SettingsProxy('cephalopod', {
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _extend_admin_menu(sender, **kwargs):
-    return SideMenuItem('cephalopod', _("Community Hub"), url_for('cephalopod.index'), section='integration')
+    if session.user.is_admin:
+        return SideMenuItem('cephalopod', _("Community Hub"), url_for('cephalopod.index'), section='integration')

--- a/indico/modules/cephalopod/controllers.py
+++ b/indico/modules/cephalopod/controllers.py
@@ -66,7 +66,7 @@ class RHCephalopod(RHCephalopodBase):
         instance_url = config.getBaseURL()
         language = config.getDefaultLocale()
         tracker_url = urljoin(config.getTrackerURL(), 'api/instance/{}'.format(cephalopod_settings.get('uuid')))
-        return WPCephalopod.render_template('cephalopod.html',
+        return WPCephalopod.render_template('cephalopod.html', 'cephalopod',
                                             affiliation=core_settings.get('site_organization'),
                                             enabled=enabled,
                                             form=form,

--- a/indico/modules/cephalopod/templates/cephalopod.html
+++ b/indico/modules/cephalopod/templates/cephalopod.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 
 {% from 'forms/_form.html' import form_footer, form_header, form_row_static, form_rows %}
 {% from 'message_box.html' import message_box %}

--- a/indico/modules/cephalopod/views.py
+++ b/indico/modules/cephalopod/views.py
@@ -16,13 +16,11 @@
 
 from __future__ import unicode_literals
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
-from indico.legacy.webinterface.pages.base import WPJinjaMixin
+from indico.modules.admin.views import WPAdmin
 
 
-class WPCephalopod(WPJinjaMixin, WPAdminsBase):
+class WPCephalopod(WPAdmin):
     template_prefix = 'cephalopod/'
-    sidemenu_option = 'cephalopod'
 
     def getJSFiles(self):
-        return WPAdminsBase.getJSFiles(self) + self._asset_env['modules_cephalopod_js'].urls()
+        return WPAdmin.getJSFiles(self) + self._asset_env['modules_cephalopod_js'].urls()

--- a/indico/modules/core/__init__.py
+++ b/indico/modules/core/__init__.py
@@ -16,6 +16,8 @@
 
 from __future__ import unicode_literals
 
+from flask import session
+
 from indico.core import signals
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
@@ -24,4 +26,5 @@ from indico.web.menu import SideMenuItem
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _sidemenu_items(sender, **kwargs):
-    yield SideMenuItem('settings', _('General Settings'), url_for('core.settings'), 100, icon='settings')
+    if session.user.is_admin:
+        yield SideMenuItem('settings', _('General Settings'), url_for('core.settings'), 100, icon='settings')

--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -55,7 +55,7 @@ class RHSettings(RHAdminBase):
             return redirect(url_for('.settings'))
 
         cephalopod_url, cephalopod_data = self._get_cephalopod_data()
-        return WPSettings.render_template('settings.html',
+        return WPSettings.render_template('settings.html', 'settings',
                                           form=form,
                                           core_settings=core_settings.get_all(),
                                           social_settings=social_settings.get_all(),

--- a/indico/modules/core/templates/settings.html
+++ b/indico/modules/core/templates/settings.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'message_box.html' import message_box %}
 {% from 'forms/_form.html' import simple_form, form_rows, form_fieldset %}
 

--- a/indico/modules/core/views.py
+++ b/indico/modules/core/views.py
@@ -16,13 +16,11 @@
 
 from __future__ import unicode_literals
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
-from indico.legacy.webinterface.pages.base import WPJinjaMixin
+from indico.modules.admin.views import WPAdmin
 
 
-class WPSettings(WPJinjaMixin, WPAdminsBase):
-    sidemenu_option = 'settings'
+class WPSettings(WPAdmin):
     template_prefix = 'core/'
 
     def getJSFiles(self):
-        return WPAdminsBase.getJSFiles(self) + self._asset_env['modules_cephalopod_js'].urls()
+        return WPAdmin.getJSFiles(self) + self._asset_env['modules_cephalopod_js'].urls()

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -193,8 +193,9 @@ class SubmitterRole(ManagementRole):
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _sidemenu_items(sender, **kwargs):
-    yield SideMenuItem('reference_types', _('External ID Types'), url_for('events.reference_types'),
-                       section='customization')
+    if session.user.is_admin:
+        yield SideMenuItem('reference_types', _('External ID Types'), url_for('events.reference_types'),
+                           section='customization')
 
 
 @signals.app_created.connect

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -31,8 +31,7 @@ from indico.util.i18n import _, ngettext, orig_string
 from indico.util.string import is_legacy_id
 from indico.web.flask.templating import template_hook
 from indico.web.flask.util import url_for
-from indico.web.menu import SideMenuItem
-
+from indico.web.menu import SideMenuItem, TopMenuSection, TopMenuItem
 
 __all__ = ('Event', 'logger', 'event_management_object_url_prefixes', 'event_object_url_prefixes')
 logger = Logger.get('events')
@@ -196,6 +195,18 @@ def _sidemenu_items(sender, **kwargs):
     if session.user.is_admin:
         yield SideMenuItem('reference_types', _('External ID Types'), url_for('events.reference_types'),
                            section='customization')
+
+
+@signals.menu.sections.connect_via('top-menu')
+def _topmenu_sections(sender, **kwargs):
+    yield TopMenuSection('create-event', _('Create event'), 90)
+
+
+@signals.menu.items.connect_via('top-menu')
+def _topmenu_items(sender, **kwargs):
+    yield TopMenuItem('create-lecture', _('Create lecture'), 'lecture', 30, section='create-event')
+    yield TopMenuItem('create-meeting', _('Create meeting'), 'meeting', 20, section='create-event')
+    yield TopMenuItem('create-conference', _('Create conference'), 'conference', 10, section='create-event')
 
 
 @signals.app_created.connect

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -52,7 +52,7 @@ class RHReferenceTypes(RHAdminBase):
 
     def _process(self):
         types = _get_all_reference_types()
-        return WPReferenceTypes.render_template('admin/reference_types.html', reference_types=types)
+        return WPReferenceTypes.render_template('admin/reference_types.html', 'reference_types', reference_types=types)
 
 
 class RHCreateReferenceType(RHAdminBase):

--- a/indico/modules/events/payment/__init__.py
+++ b/indico/modules/events/payment/__init__.py
@@ -52,7 +52,8 @@ event_settings = EventSettingsProxy('payment', {
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _extend_admin_menu(sender, **kwargs):
-    return SideMenuItem('payment', _("Payment"), url_for('payment.admin_settings'), section='customization')
+    if session.user.is_admin:
+        return SideMenuItem('payment', _("Payment"), url_for('payment.admin_settings'), section='customization')
 
 
 @signals.menu.items.connect_via('event-management-sidemenu')

--- a/indico/modules/events/payment/controllers.py
+++ b/indico/modules/events/payment/controllers.py
@@ -44,7 +44,8 @@ class RHPaymentAdminSettings(RHAdminBase):
             settings.set_multi(form.data)
             flash(_('Settings saved'), 'success')
             return redirect(url_for('.admin_settings'))
-        return WPPaymentAdmin.render_template('admin_settings.html', form=form, plugins=get_payment_plugins().values())
+        return WPPaymentAdmin.render_template('admin_settings.html', 'payment',
+                                              form=form, plugins=get_payment_plugins().values())
 
 
 class RHPaymentAdminPluginSettings(RHPluginDetails):

--- a/indico/modules/events/payment/templates/admin_settings.html
+++ b/indico/modules/events/payment/templates/admin_settings.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import form_header, form_rows, form_footer  %}
 
 {% block title %}{% trans %}Payment{% endtrans %}{% endblock %}

--- a/indico/modules/events/payment/views.py
+++ b/indico/modules/events/payment/views.py
@@ -16,17 +16,17 @@
 
 from __future__ import unicode_literals
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
 from indico.legacy.webinterface.pages.base import WPJinjaMixin
 from indico.legacy.webinterface.pages.conferences import WPConferenceDefaultDisplayBase, WPConferenceModifBase
+from indico.modules.admin.views import WPAdmin
 
 
 class WPPaymentJinjaMixin(WPJinjaMixin):
     template_prefix = 'events/payment/'
 
 
-class WPPaymentAdmin(WPPaymentJinjaMixin, WPAdminsBase):
-    sidemenu_option = 'payment'
+class WPPaymentAdmin(WPPaymentJinjaMixin, WPAdmin):
+    pass
 
 
 class WPPaymentEventManagement(WPConferenceModifBase, WPPaymentJinjaMixin):

--- a/indico/modules/events/templates/admin/reference_types.html
+++ b/indico/modules/events/templates/admin/reference_types.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'events/admin/_reference_type_list.html' import render_reference_type_list %}
 
 {%- block content %}

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -21,10 +21,9 @@ import posixpath
 from flask import render_template, request
 from sqlalchemy.orm import load_only
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
-from indico.legacy.webinterface.pages.base import WPJinjaMixin
 from indico.legacy.webinterface.pages.conferences import (render_event_header, render_event_footer,
                                                           WPConferenceBase, WConfMetadata, WPrintPageFrame)
+from indico.modules.admin.views import WPAdmin
 from indico.modules.events import Event
 from indico.modules.events.layout import theme_settings
 from indico.modules.events.layout.util import get_css_url
@@ -32,9 +31,8 @@ from indico.util.mathjax import MathjaxMixin
 from indico.util.string import to_unicode
 
 
-class WPReferenceTypes(WPJinjaMixin, WPAdminsBase):
+class WPReferenceTypes(WPAdmin):
     template_prefix = 'events/'
-    sidemenu_option = 'reference_types'
 
 
 class WPSimpleEventDisplayBase(MathjaxMixin, WPConferenceBase):

--- a/indico/modules/groups/__init__.py
+++ b/indico/modules/groups/__init__.py
@@ -16,6 +16,8 @@
 
 from __future__ import unicode_literals
 
+from flask import session
+
 from indico.core import signals
 from indico.modules.groups.core import GroupProxy
 from indico.util.i18n import _
@@ -28,7 +30,8 @@ __all__ = ('GroupProxy',)
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _extend_admin_menu(sender, **kwargs):
-    return SideMenuItem('groups', _("Groups"), url_for('groups.groups'), section='user_management')
+    if session.user.is_admin:
+        return SideMenuItem('groups', _("Groups"), url_for('groups.groups'), section='user_management')
 
 
 @signals.users.merged.connect

--- a/indico/modules/groups/controllers.py
+++ b/indico/modules/groups/controllers.py
@@ -56,7 +56,7 @@ class RHGroups(RHAdminBase):
             search_results.sort(key=attrgetter('provider', 'name'))
         provider_titles = {p.name: p.title for p in multipass.identity_providers.itervalues()}
         provider_titles[None] = _('Local')
-        return WPGroupsAdmin.render_template('groups.html', groups=groups, providers=providers, form=form,
+        return WPGroupsAdmin.render_template('groups.html', 'groups', groups=groups, providers=providers, form=form,
                                              search_results=search_results, provider_titles=provider_titles)
 
 
@@ -77,7 +77,7 @@ class RHGroupDetails(RHGroupBase):
     def _process(self):
         group = self.group
         provider_title = multipass.identity_providers[group.provider].title if not group.is_local else _('Local')
-        return WPGroupsAdmin.render_template('group_details.html', group=group, provider_title=provider_title)
+        return WPGroupsAdmin.render_template('group_details.html', 'groups', group=group, provider_title=provider_title)
 
 
 class RHGroupMembers(RHGroupBase):
@@ -115,7 +115,7 @@ class RHGroupEdit(RHAdminBase):
             db.session.flush()
             flash(msg.format(name=self.group.name), 'success')
             return redirect(url_for('.groups'))
-        return WPGroupsAdmin.render_template('group_edit.html', group=existing_group, form=form)
+        return WPGroupsAdmin.render_template('group_edit.html', 'groups', group=existing_group, form=form)
 
 
 class RHLocalGroupBase(RHAdminBase):

--- a/indico/modules/groups/templates/group_details.html
+++ b/indico/modules/groups/templates/group_details.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'groups/_group_members.html' import group_members %}
 
 {% block title %}{% trans %}Group Details{% endtrans %}{% endblock %}

--- a/indico/modules/groups/templates/group_edit.html
+++ b/indico/modules/groups/templates/group_edit.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import form_header, form_rows, form_footer  %}
 
 {% block title %}

--- a/indico/modules/groups/templates/groups.html
+++ b/indico/modules/groups/templates/groups.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import form_header, form_rows, form_footer %}
 
 {% macro group_table(groups, show_members=false, show_provider=false) %}

--- a/indico/modules/groups/views.py
+++ b/indico/modules/groups/views.py
@@ -16,10 +16,8 @@
 
 from __future__ import unicode_literals
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
-from indico.legacy.webinterface.pages.base import WPJinjaMixin
+from indico.modules.admin.views import WPAdmin
 
 
-class WPGroupsAdmin(WPJinjaMixin, WPAdminsBase):
+class WPGroupsAdmin(WPAdmin):
     template_prefix = 'groups/'
-    sidemenu_option = 'groups'

--- a/indico/modules/legal/__init__.py
+++ b/indico/modules/legal/__init__.py
@@ -16,7 +16,7 @@
 
 from __future__ import unicode_literals
 
-from flask import render_template
+from flask import render_template, session
 
 from indico.core import signals
 from indico.util.i18n import _
@@ -42,7 +42,8 @@ legal_settings = SettingsProxy('legal', {
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _sidemenu_items(sender, **kwargs):
-    yield SideMenuItem('legal_messages', _('Legal/Disclaimers'), url_for('legal.manage'), section='security')
+    if session.user.is_admin:
+        yield SideMenuItem('legal_messages', _('Legal/Disclaimers'), url_for('legal.manage'), section='security')
 
 
 @template_hook('page-footer')

--- a/indico/modules/legal/controllers.py
+++ b/indico/modules/legal/controllers.py
@@ -32,7 +32,7 @@ class RHManageLegalMessages(RHAdminBase):
         if form.validate_on_submit():
             legal_settings.set_multi(form.data)
             return redirect(url_for('legal.manage'))
-        return WPManageLegalMessages.render_template('manage_messages.html', form=form)
+        return WPManageLegalMessages.render_template('manage_messages.html', 'legal_messages', form=form)
 
 
 class RHDisplayLegalMessages(RH):

--- a/indico/modules/legal/templates/manage_messages.html
+++ b/indico/modules/legal/templates/manage_messages.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import simple_form %}
 
 {% block title %}

--- a/indico/modules/legal/views.py
+++ b/indico/modules/legal/views.py
@@ -16,16 +16,16 @@
 
 from __future__ import unicode_literals
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
 from indico.legacy.webinterface.pages.base import WPDecorated, WPJinjaMixin
+from indico.modules.admin.views import WPAdmin
 
 
 class WPLegalMixin:
     template_prefix = 'legal/'
 
 
-class WPManageLegalMessages(WPLegalMixin, WPJinjaMixin, WPAdminsBase):
-    sidemenu_option = 'legal_messages'
+class WPManageLegalMessages(WPLegalMixin, WPAdmin):
+    pass
 
 
 class WPDisplayLegalMessages(WPLegalMixin, WPJinjaMixin, WPDecorated):

--- a/indico/modules/networks/__init__.py
+++ b/indico/modules/networks/__init__.py
@@ -16,7 +16,7 @@
 
 from __future__ import unicode_literals
 
-from flask import has_request_context, request
+from flask import has_request_context, request, session
 
 from indico.core import signals
 from indico.core.logger import Logger
@@ -32,7 +32,8 @@ logger = Logger.get('networks')
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _sidemenu_items(sender, **kwargs):
-    yield SideMenuItem('ip_networks', _('IP Networks'), url_for('networks.manage'), section='security')
+    if session.user.is_admin:
+        yield SideMenuItem('ip_networks', _('IP Networks'), url_for('networks.manage'), section='security')
 
 
 @signals.acl.can_access.connect_via(Attachment)

--- a/indico/modules/networks/controllers.py
+++ b/indico/modules/networks/controllers.py
@@ -39,7 +39,7 @@ class RHManageNetworks(RHNetworkBase):
 
     def _process(self):
         network_groups = IPNetworkGroup.find().order_by(IPNetworkGroup.name).all()
-        return WPNetworksAdmin.render_template('networks.html', network_groups=network_groups)
+        return WPNetworksAdmin.render_template('networks.html', 'ip_networks', network_groups=network_groups)
 
 
 class RHCreateNetworkGroup(RHNetworkBase):

--- a/indico/modules/networks/templates/networks.html
+++ b/indico/modules/networks/templates/networks.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 
 {% from 'message_box.html' import message_box %}
 

--- a/indico/modules/networks/views.py
+++ b/indico/modules/networks/views.py
@@ -16,10 +16,8 @@
 
 from __future__ import unicode_literals
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
-from indico.legacy.webinterface.pages.base import WPJinjaMixin
+from indico.modules.admin.views import WPAdmin
 
 
-class WPNetworksAdmin(WPJinjaMixin, WPAdminsBase):
+class WPNetworksAdmin(WPAdmin):
     template_prefix = 'networks/'
-    sidemenu_option = 'ip_networks'

--- a/indico/modules/news/__init__.py
+++ b/indico/modules/news/__init__.py
@@ -16,6 +16,8 @@
 
 from __future__ import unicode_literals
 
+from flask import session
+
 from indico.core import signals
 from indico.core.logger import Logger
 from indico.core.settings import SettingsProxy
@@ -40,4 +42,5 @@ news_settings = SettingsProxy('news', {
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _sidemenu_items(sender, **kwargs):
-    yield SideMenuItem('news', _('News'), url_for('news.manage'), section='homepage')
+    if session.user.is_admin:
+        yield SideMenuItem('news', _('News'), url_for('news.manage'), section='homepage')

--- a/indico/modules/news/controllers.py
+++ b/indico/modules/news/controllers.py
@@ -57,7 +57,7 @@ class RHManageNewsBase(RHAdminBase):
 class RHManageNews(RHManageNewsBase):
     def _process(self):
         news = NewsItem.query.order_by(NewsItem.created_dt.desc()).all()
-        return WPManageNews.render_template('admin/news.html', news=news)
+        return WPManageNews.render_template('admin/news.html', 'news', news=news)
 
 
 class RHNewsSettings(RHManageNewsBase):

--- a/indico/modules/news/templates/admin/news.html
+++ b/indico/modules/news/templates/admin/news.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import simple_form %}
 
 {%- block content %}

--- a/indico/modules/news/views.py
+++ b/indico/modules/news/views.py
@@ -16,9 +16,9 @@
 
 from __future__ import unicode_literals
 
-from indico.util.i18n import _
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
 from indico.legacy.webinterface.pages.base import WPJinjaMixin, WPDecorated
+from indico.modules.admin.views import WPAdmin
+from indico.util.i18n import _
 
 
 class WPNews(WPJinjaMixin, WPDecorated):
@@ -31,6 +31,5 @@ class WPNews(WPJinjaMixin, WPDecorated):
         return WPDecorated._getTitle(self) + ' - ' + _("News")
 
 
-class WPManageNews(WPJinjaMixin, WPAdminsBase):
-    sidemenu_option = 'news'
+class WPManageNews(WPAdmin):
     template_prefix = 'news/'

--- a/indico/modules/oauth/__init__.py
+++ b/indico/modules/oauth/__init__.py
@@ -20,6 +20,7 @@ import os
 from datetime import timedelta
 from uuid import uuid4
 
+from flask import session
 from flask_oauthlib.provider import OAuth2Provider
 
 from indico.core import signals
@@ -43,7 +44,8 @@ logger = Logger.get('oauth')
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _extend_admin_menu(sender, **kwargs):
-    return SideMenuItem('applications', 'Applications', url_for('oauth.apps'), section='integration')
+    if session.user.is_admin:
+        return SideMenuItem('applications', 'Applications', url_for('oauth.apps'), section='integration')
 
 
 @signals.menu.items.connect_via('user-profile-sidemenu')

--- a/indico/modules/oauth/controllers.py
+++ b/indico/modules/oauth/controllers.py
@@ -82,7 +82,7 @@ class RHOAuthAdmin(RHAdminBase):
 
     def _process(self):
         applications = OAuthApplication.find().order_by(db.func.lower(OAuthApplication.name)).all()
-        return WPOAuthAdmin.render_template('apps.html', applications=applications)
+        return WPOAuthAdmin.render_template('apps.html', 'applications', applications=applications)
 
 
 class RHOAuthAdminApplicationBase(RHAdminBase):
@@ -101,7 +101,7 @@ class RHOAuthAdminApplication(RHOAuthAdminApplicationBase):
             logger.info("Application %s updated by %s", self.application, session.user)
             flash(_("Application {} was modified").format(self.application.name), 'success')
             return redirect(url_for('.apps'))
-        return WPOAuthAdmin.render_template('app_details.html', application=self.application, form=form)
+        return WPOAuthAdmin.render_template('app_details.html', 'applications', application=self.application, form=form)
 
 
 class RHOAuthAdminApplicationDelete(RHOAuthAdminApplicationBase):
@@ -127,7 +127,7 @@ class RHOAuthAdminApplicationNew(RHAdminBase):
             logger.info("Application %s created by %s", application, session.user)
             flash(_("Application {} registered successfully").format(application.name), 'success')
             return redirect(url_for('.app_details', application))
-        return WPOAuthAdmin.render_template('app_new.html', form=form)
+        return WPOAuthAdmin.render_template('app_new.html', 'applications', form=form)
 
 
 class RHOAuthAdminApplicationReset(RHOAuthAdminApplicationBase):

--- a/indico/modules/oauth/templates/apps_base.html
+++ b/indico/modules/oauth/templates/apps_base.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 
 {% block title %}
     {%- trans %}Applications{% endtrans -%}

--- a/indico/modules/oauth/views.py
+++ b/indico/modules/oauth/views.py
@@ -16,17 +16,17 @@
 
 from __future__ import unicode_literals
 
-from indico.modules.users.views import WPUser
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
 from indico.legacy.webinterface.pages.base import WPJinjaMixin
+from indico.modules.admin.views import WPAdmin
+from indico.modules.users.views import WPUser
 
 
 class WPOAuthJinjaMixin(WPJinjaMixin):
     template_prefix = 'oauth/'
 
 
-class WPOAuthAdmin(WPOAuthJinjaMixin, WPAdminsBase):
-    sidemenu_option = 'applications'
+class WPOAuthAdmin(WPOAuthJinjaMixin, WPAdmin):
+    pass
 
 
 class WPOAuthUserProfile(WPOAuthJinjaMixin, WPUser):

--- a/indico/modules/rb/__init__.py
+++ b/indico/modules/rb/__init__.py
@@ -18,7 +18,7 @@ from __future__ import unicode_literals
 
 from flask import session
 
-from indico.core import signals
+from indico.core import signals, Config
 from indico.core.logger import Logger
 from indico.core.settings import SettingsProxy
 from indico.modules.rb.models.blocking_principals import BlockingPrincipal
@@ -52,6 +52,8 @@ def _import_tasks(sender, **kwargs):
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _extend_admin_menu(sender, **kwargs):
+    if not Config.getInstance().getIsRoomBookingActive():
+        return
     if session.user.is_admin:
         yield SideMenuItem('rb-settings', _("Settings"), url_for('rooms_admin.settings'),
                            section='roombooking', icon='location')

--- a/indico/modules/rb/__init__.py
+++ b/indico/modules/rb/__init__.py
@@ -63,8 +63,7 @@ def _extend_admin_menu(sender, **kwargs):
 
 @signals.menu.sections.connect_via('admin-sidemenu')
 def _sidemenu_sections(sender, **kwargs):
-    if session.user.is_admin:
-        yield SideMenuSection('roombooking', _("Room Booking"), 70, icon='location')
+    yield SideMenuSection('roombooking', _("Room Booking"), 70, icon='location')
 
 
 @signals.users.merged.connect

--- a/indico/modules/rb/__init__.py
+++ b/indico/modules/rb/__init__.py
@@ -52,7 +52,19 @@ def _import_tasks(sender, **kwargs):
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _extend_admin_menu(sender, **kwargs):
-    return SideMenuItem('rb', _("Rooms"), url_for('rooms_admin.settings'), 70, icon='location')
+    if session.user.is_admin:
+        yield SideMenuItem('rb-settings', _("Settings"), url_for('rooms_admin.settings'),
+                           section='roombooking', icon='location')
+        yield SideMenuItem('rb-rooms', _("Rooms"), url_for('rooms_admin.roomBooking-admin'),
+                           section='roombooking', icon='location')
+    else:
+        yield SideMenuItem('rb-rooms', _("Rooms"), url_for('rooms_admin.roomBooking-admin'), 70, icon='location')
+
+
+@signals.menu.sections.connect_via('admin-sidemenu')
+def _sidemenu_sections(sender, **kwargs):
+    if session.user.is_admin:
+        yield SideMenuSection('roombooking', _("Room Booking"), 70, icon='location')
 
 
 @signals.users.merged.connect

--- a/indico/modules/rb/__init__.py
+++ b/indico/modules/rb/__init__.py
@@ -29,8 +29,7 @@ from indico.modules.rb.models.rooms import Room
 from indico.modules.rb.util import rb_is_admin
 from indico.web.flask.util import url_for
 from indico.util.i18n import _
-from indico.web.menu import SideMenuSection, SideMenuItem
-
+from indico.web.menu import SideMenuSection, SideMenuItem, TopMenuItem
 
 logger = Logger.get('rb')
 
@@ -61,6 +60,12 @@ def _extend_admin_menu(sender, **kwargs):
                            section='roombooking', icon='location')
     else:
         yield SideMenuItem('rb-rooms', _("Rooms"), url_for('rooms_admin.roomBooking-admin'), 70, icon='location')
+
+
+@signals.menu.items.connect_via('top-menu')
+def _topmenu_items(sender, **kwargs):
+    if Config.getInstance().getIsRoomBookingActive():
+        yield TopMenuItem('rb', _('Room booking'), url_for('rooms.roomBooking'), 80)
 
 
 @signals.menu.sections.connect_via('admin-sidemenu')

--- a/indico/modules/rb/controllers/admin/index.py
+++ b/indico/modules/rb/controllers/admin/index.py
@@ -38,4 +38,4 @@ class RHRoomBookingSettings(RHAdminBase):
             return redirect(url_for('.settings'))
 
         rb_active = Config.getInstance().getIsRoomBookingActive()
-        return WPRoomBookingSettings(self, rb_active=rb_active, form=form).display()
+        return WPRoomBookingSettings(self, 'rb-settings', rb_active=rb_active, form=form).display()

--- a/indico/modules/rb/controllers/admin/index.py
+++ b/indico/modules/rb/controllers/admin/index.py
@@ -22,7 +22,7 @@ from indico.core.config import Config
 from indico.modules.admin import RHAdminBase
 from indico.modules.rb import settings as rb_settings
 from indico.modules.rb.forms.settings import SettingsForm
-from indico.modules.rb.views.admin.index import WPRoomBookingSettings
+from indico.modules.rb.views.admin.settings import WPRoomBookingSettings
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults

--- a/indico/modules/rb/controllers/admin/locations.py
+++ b/indico/modules/rb/controllers/admin/locations.py
@@ -33,7 +33,7 @@ from indico.web.flask.util import url_for
 
 class RHRoomBookingAdmin(RHRoomBookingAdminBase):
     def _process(self):
-        return WPRoomBookingAdmin(self, locations=Location.find_all()).display()
+        return WPRoomBookingAdmin(self, 'rb-rooms', locations=Location.find_all()).display()
 
 
 class RHRoomBookingLocationMixin:
@@ -103,7 +103,7 @@ class RHRoomBookingAdminLocation(RHRoomBookingAdminBase):
                                             if room.is_reservable)
             kpi['booking_stats'] = compose_rooms_stats(self._location.rooms)
             kpi['booking_count'] = Reservation.find(Reservation.room.has(Room.location == self._location)).count()
-        return WPRoomBookingAdminLocation(self,
+        return WPRoomBookingAdminLocation(self, 'rb-rooms',
                                           location=self._location,
                                           rooms=rooms,
                                           action_succeeded=self._actionSucceeded,

--- a/indico/modules/rb/controllers/admin/rooms.py
+++ b/indico/modules/rb/controllers/admin/rooms.py
@@ -136,8 +136,8 @@ class RHRoomBookingCreateModifyRoomBase(RHRoomBookingAdminBase):
             self._save()
             return redirect(url_for('rooms.roomBooking-roomDetails', self._room))
         else:
-            return room_views.WPRoomBookingRoomForm(self, form=self._form, room=self._room, location=self._location,
-                                                    errors=self._form.error_list).display()
+            return room_views.WPRoomBookingRoomForm(self, 'rb-rooms', form=self._form, room=self._room,
+                                                    location=self._location, errors=self._form.error_list).display()
 
 
 class RHRoomBookingModifyRoom(RHRoomBookingCreateModifyRoomBase):

--- a/indico/modules/rb/templates/admin.html
+++ b/indico/modules/rb/templates/admin.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 
 {% block title -%}
     {% trans %}Room Booking{% endtrans %}

--- a/indico/modules/rb/templates/admin.html
+++ b/indico/modules/rb/templates/admin.html
@@ -1,0 +1,13 @@
+{% extends 'layout/base.html' %}
+
+{% block title -%}
+    {% trans %}Room Booking{% endtrans %}
+{%- endblock %}
+
+{% block subtitle -%}
+    {{ subtitle }}
+{%- endblock %}
+
+{% block content -%}
+    {{ body | safe }}
+{%- endblock %}

--- a/indico/modules/rb/views/admin/__init__.py
+++ b/indico/modules/rb/views/admin/__init__.py
@@ -13,53 +13,16 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
-
-from flask import session
+from flask import render_template
 
 from indico.legacy.webinterface.pages.admins import WPAdminsBase
-from indico.legacy.webinterface.wcomponents import TabControl, WTabControl
-
-from indico.util.i18n import _
-from indico.web.flask.util import url_for
 
 
-class WPRoomsBase(WPAdminsBase):
-    sidemenu_option = 'rb'
+class WPRoomBookingAdminBase(WPAdminsBase):
+    subtitle = u''
 
-    def _createTabCtrl(self):
-        self._tabCtrl = TabControl()
-        if session.user.is_admin:
-            self._subTabRoomBooking = self._tabCtrl.newTab(
-                'booking',
-                _('Room Booking'),
-                url_for('rooms_admin.settings')
-            )
-
-            self._subTabMain = self._subTabRoomBooking.newSubTab(
-                'settings',
-                _('Settings'),
-                url_for('rooms_admin.settings')
-            )
-        else:
-            self._subTabRoomBooking = self._tabCtrl.newTab(
-                'booking',
-                _('Room Booking'),
-                url_for('rooms_admin.roomBooking-admin')
-            )
-
-        self._subTabConfig = self._subTabRoomBooking.newSubTab(
-            'management',
-            _('Management'),
-            url_for('rooms_admin.roomBooking-admin')
-        )
+    def getJSFiles(self):
+        return WPAdminsBase.getJSFiles(self) + self._includeJSPackage('Management')
 
     def _getPageContent(self, params):
-        return WTabControl(self._tabCtrl).getHTML(self._getTabContent(params))
-
-
-class WPRoomBookingAdminBase(WPRoomsBase):
-    def getJSFiles(self):
-        return WPRoomsBase.getJSFiles(self) + self._includeJSPackage('Management')
-
-    def _setActiveTab(self):
-        self._subTabRoomBooking.setActive()
+        return render_template('rb/admin.html', body=self._getTabContent(params), subtitle=self.subtitle)

--- a/indico/modules/rb/views/admin/__init__.py
+++ b/indico/modules/rb/views/admin/__init__.py
@@ -13,16 +13,23 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import unicode_literals
+
 from flask import render_template
 
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
+from indico.modules.admin.views import WPAdmin
 
 
-class WPRoomBookingAdminBase(WPAdminsBase):
+class WPRoomBookingAdminBase(WPAdmin):
     subtitle = u''
 
     def getJSFiles(self):
-        return WPAdminsBase.getJSFiles(self) + self._includeJSPackage('Management')
+        return WPAdmin.getJSFiles(self) + self._includeJSPackage('Management')
 
     def _getPageContent(self, params):
-        return render_template('rb/admin.html', body=self._getTabContent(params), subtitle=self.subtitle)
+        return render_template('rb/admin.html', body=self._get_legacy_content(params), subtitle=self.subtitle,
+                               active_menu_item=self._kwargs['active_menu_item'])
+
+    def _get_legacy_content(self, params):
+        raise NotImplementedError

--- a/indico/modules/rb/views/admin/locations.py
+++ b/indico/modules/rb/views/admin/locations.py
@@ -16,19 +16,23 @@
 
 from indico.legacy.webinterface.wcomponents import WTemplated
 from indico.modules.rb.views.admin import WPRoomBookingAdminBase
+from indico.util.i18n import _
 
 
 class WPRoomBookingAdmin(WPRoomBookingAdminBase):
-    def _setActiveTab(self):
-        self._subTabConfig.setActive()
+    sidemenu_option = 'rb-rooms'
+    subtitle = _(u'Locations')
 
     def _getTabContent(self, params):
         return WTemplated('RoomBookingAdmin').getHTML(params)
 
 
 class WPRoomBookingAdminLocation(WPRoomBookingAdminBase):
-    def _setActiveTab(self):
-        self._subTabConfig.setActive()
+    sidemenu_option = 'rb-rooms'
+
+    @property
+    def subtitle(self):
+        return self._kwargs['location'].name
 
     def _getTabContent(self, params):
         return WTemplated('RoomBookingAdminLocation').getHTML(params)

--- a/indico/modules/rb/views/admin/locations.py
+++ b/indico/modules/rb/views/admin/locations.py
@@ -20,10 +20,9 @@ from indico.util.i18n import _
 
 
 class WPRoomBookingAdmin(WPRoomBookingAdminBase):
-    sidemenu_option = 'rb-rooms'
     subtitle = _(u'Locations')
 
-    def _getTabContent(self, params):
+    def _get_legacy_content(self, params):
         return WTemplated('RoomBookingAdmin').getHTML(params)
 
 
@@ -34,5 +33,5 @@ class WPRoomBookingAdminLocation(WPRoomBookingAdminBase):
     def subtitle(self):
         return self._kwargs['location'].name
 
-    def _getTabContent(self, params):
+    def _get_legacy_content(self, params):
         return WTemplated('RoomBookingAdminLocation').getHTML(params)

--- a/indico/modules/rb/views/admin/rooms.py
+++ b/indico/modules/rb/views/admin/rooms.py
@@ -14,14 +14,22 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from indico.modules.rb.views.admin import WPRoomBookingAdminBase
 from indico.legacy.webinterface.wcomponents import WTemplated
+from indico.modules.rb.views.admin import WPRoomBookingAdminBase
+from indico.util.i18n import _
 
 
 class WPRoomBookingRoomForm(WPRoomBookingAdminBase):
-    def _setActiveTab(self):
-        WPRoomBookingAdminBase._setActiveTab(self)
-        self._subTabConfig.setActive()
+    sidemenu_option = 'rb-rooms'
+
+    @property
+    def subtitle(self):
+        room = self._kwargs['room']
+        location = self._kwargs['location']
+        if room.id is not None:
+            return _(u'{location}: Edit room: {room}').format(room=room.full_name, location=location.name)
+        else:
+            return _(u'{location}: Create room').format(location=location.name)
 
     def _getTabContent(self, params):
         return WTemplated('RoomBookingRoomForm').getHTML(params)

--- a/indico/modules/rb/views/admin/rooms.py
+++ b/indico/modules/rb/views/admin/rooms.py
@@ -31,5 +31,5 @@ class WPRoomBookingRoomForm(WPRoomBookingAdminBase):
         else:
             return _(u'{location}: Create room').format(location=location.name)
 
-    def _getTabContent(self, params):
+    def _get_legacy_content(self, params):
         return WTemplated('RoomBookingRoomForm').getHTML(params)

--- a/indico/modules/rb/views/admin/settings.py
+++ b/indico/modules/rb/views/admin/settings.py
@@ -20,10 +20,9 @@ from indico.util.i18n import _
 
 
 class WPRoomBookingSettings(WPRoomBookingAdminBase):
-    sidemenu_option = 'rb-settings'
     subtitle = _(u'Settings')
 
-    def _getTabContent(self, params):
+    def _get_legacy_content(self, params):
         params['field_opts'] = {
             'assistance_emails': {'rows': 3, 'cols': 40},
             'notification_hour': {'size': 2},

--- a/indico/modules/rb/views/admin/settings.py
+++ b/indico/modules/rb/views/admin/settings.py
@@ -14,14 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from indico.modules.rb.views.admin import WPRoomBookingAdminBase
 from indico.legacy.webinterface.wcomponents import WTemplated
+from indico.modules.rb.views.admin import WPRoomBookingAdminBase
+from indico.util.i18n import _
 
 
 class WPRoomBookingSettings(WPRoomBookingAdminBase):
-    def _setActiveTab(self):
-        WPRoomBookingAdminBase._setActiveTab(self)
-        self._subTabMain.setActive()
+    sidemenu_option = 'rb-settings'
+    subtitle = _(u'Settings')
 
     def _getTabContent(self, params):
         params['field_opts'] = {

--- a/indico/modules/users/__init__.py
+++ b/indico/modules/users/__init__.py
@@ -57,8 +57,9 @@ user_management_settings = SettingsProxy('user_management', {
 
 @signals.menu.items.connect_via('admin-sidemenu')
 def _extend_admin_menu(sender, **kwargs):
-    yield SideMenuItem('admins', _("Admins"), url_for('users.admins'), section='user_management')
-    yield SideMenuItem('users', _("Users"), url_for('users.users_admin'), section='user_management')
+    if session.user.is_admin:
+        yield SideMenuItem('admins', _("Admins"), url_for('users.admins'), section='user_management')
+        yield SideMenuItem('users', _("Users"), url_for('users.users_admin'), section='user_management')
 
 
 @signals.category.deleted.connect

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -42,7 +42,7 @@ from indico.modules.users.models.emails import UserEmail
 from indico.modules.users.operations import create_user
 from indico.modules.users.util import (get_related_categories, get_suggested_categories,
                                        serialize_user, search_users, merge_users, get_linked_events)
-from indico.modules.users.views import WPUser, WPUsersAdmin, WPAdmins
+from indico.modules.users.views import WPUser, WPUsersAdmin
 from indico.modules.users.forms import (UserDetailsForm, UserPreferencesForm, UserEmailsForm, SearchForm, MergeForm,
                                         AdminUserSettingsForm, AdminAccountRegistrationForm, AdminsForm)
 from indico.util.date_time import timedelta_split, now_utc
@@ -354,7 +354,7 @@ class RHAdmins(RHAdminBase):
                 flash(_('Admin removed: {name} ({email})').format(name=user.name, email=user.email), 'success')
             return redirect(url_for('.admins'))
 
-        return WPAdmins.render_template('admins.html', form=form)
+        return WPUsersAdmin.render_template('admins.html', 'admins', form=form)
 
 
 class RHUsersAdmin(RHAdminBase):
@@ -393,7 +393,7 @@ class RHUsersAdmin(RHAdminBase):
             search_results.sort(key=attrgetter('first_name', 'last_name'))
 
         num_reg_requests = RegistrationRequest.query.count()
-        return WPUsersAdmin.render_template('users_admin.html', form=form, search_results=search_results,
+        return WPUsersAdmin.render_template('users_admin.html', 'users', form=form, search_results=search_results,
                                             num_of_users=num_of_users, num_deleted_users=num_deleted_users,
                                             num_reg_requests=num_reg_requests)
 
@@ -473,7 +473,7 @@ class RHUsersAdminMerge(RHAdminBase):
             flash(_('The users have been successfully merged.'), 'success')
             return redirect(url_for('.user_profile', user_id=target.id))
 
-        return WPUsersAdmin.render_template('users_merge.html', form=form)
+        return WPUsersAdmin.render_template('users_merge.html', 'users', form=form)
 
 
 class RHUsersAdminMergeCheck(RHAdminBase):
@@ -489,7 +489,7 @@ class RHRegistrationRequestList(RHAdminBase):
 
     def _process(self):
         requests = RegistrationRequest.query.order_by(RegistrationRequest.email).all()
-        return WPUsersAdmin.render_template('registration_requests.html', pending_requests=requests)
+        return WPUsersAdmin.render_template('registration_requests.html', 'users', pending_requests=requests)
 
 
 class RHRegistrationRequestBase(RHAdminBase):

--- a/indico/modules/users/templates/admins.html
+++ b/indico/modules/users/templates/admins.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import simple_form %}
 
 {% block title %}

--- a/indico/modules/users/templates/registration_requests.html
+++ b/indico/modules/users/templates/registration_requests.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 
 {% block title %}
     {% trans %}Registration requests{% endtrans %}

--- a/indico/modules/users/templates/users_admin.html
+++ b/indico/modules/users/templates/users_admin.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import form_header, form_rows, form_footer, simple_form %}
 
 {% block title %}{% trans %}Users{% endtrans %}{% endblock %}

--- a/indico/modules/users/templates/users_merge.html
+++ b/indico/modules/users/templates/users_merge.html
@@ -1,4 +1,4 @@
-{% extends 'layout/base.html' %}
+{% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import form_header, form_rows, form_footer %}
 
 {% block title %}{% trans %}Merge users{% endtrans %}{% endblock %}

--- a/indico/modules/users/views.py
+++ b/indico/modules/users/views.py
@@ -18,13 +18,12 @@ from __future__ import unicode_literals
 
 from flask import request
 
-from indico.modules.users import User
-from indico.util.i18n import _
-
-from indico.legacy.webinterface.pages.admins import WPAdminsBase
 from indico.legacy.webinterface.pages.base import WPJinjaMixin
 from indico.legacy.webinterface.pages.main import WPMainBase
 from indico.legacy.webinterface.wcomponents import WSimpleNavigationDrawer
+from indico.modules.admin.views import WPAdmin
+from indico.modules.users import User
+from indico.util.i18n import _
 
 
 class WPUser(WPJinjaMixin, WPMainBase):
@@ -54,13 +53,8 @@ class WPUser(WPJinjaMixin, WPMainBase):
         return self._getPageContent(params)
 
 
-class WPUsersAdmin(WPJinjaMixin, WPAdminsBase):
-    sidemenu_option = 'users'
+class WPUsersAdmin(WPAdmin):
     template_prefix = 'users/'
 
     def getJSFiles(self):
-        return WPAdminsBase.getJSFiles(self) + self._asset_env['modules_users_js'].urls()
-
-
-class WPAdmins(WPUsersAdmin):
-    sidemenu_option = 'admins'
+        return WPAdmin.getJSFiles(self) + self._asset_env['modules_users_js'].urls()

--- a/indico/modules/vc/__init__.py
+++ b/indico/modules/vc/__init__.py
@@ -28,7 +28,7 @@ from indico.modules.vc.plugins import VCPluginMixin
 from indico.modules.vc.util import get_vc_plugins, get_managed_vc_plugins
 from indico.web.flask.templating import get_overridable_template_name, template_hook
 from indico.web.flask.util import url_for
-from indico.web.menu import HeaderMenuEntry, SideMenuItem
+from indico.web.menu import SideMenuItem, TopMenuItem
 from indico.util.i18n import _
 
 
@@ -90,11 +90,11 @@ def _event_deleted(event, **kwargs):
         event_vc_room.delete(user)
 
 
-@signals.indico_menu.connect
-def extend_header_menu(sender, **kwargs):
+@signals.menu.items.connect_via('top-menu')
+def _topmenu_items(sender, **kwargs):
     if not session.user or not get_managed_vc_plugins(session.user):
         return
-    return HeaderMenuEntry(url_for('vc.vc_room_list'), _('Videoconference'), _('Services'))
+    return TopMenuItem('services-vc', _('Videoconference'), url_for('vc.vc_room_list'), section='services')
 
 
 @signals.event_management.get_cloners.connect

--- a/indico/modules/vc/views.py
+++ b/indico/modules/vc/views.py
@@ -16,7 +16,6 @@
 
 from __future__ import unicode_literals
 
-from indico.web.flask.util import url_for
 from indico.legacy.webinterface.pages.base import WPJinjaMixin
 from indico.legacy.webinterface.pages.conferences import WPConferenceDefaultDisplayBase, WPConferenceModifBase
 from indico.legacy.webinterface.pages.main import WPMainBase
@@ -59,7 +58,7 @@ class WPVCEventPage(WPVCJinjaMixin, WPConferenceDefaultDisplayBase):
 
 class WPVCService(WPVCJinjaMixin, WPMainBase):
     def _getNavigationDrawer(self):
-        return WSimpleNavigationDrawer('Videoconference', lambda: url_for('.vc_room_list'))
+        return WSimpleNavigationDrawer('Videoconference')
 
     def _getBody(self, params):
         return self._getPageContent(params)

--- a/indico/web/menu.py
+++ b/indico/web/menu.py
@@ -123,8 +123,7 @@ class SideMenuItem(object):
 
 
 def build_menu_structure(menu_id, active_item=None, **kwargs):
-    """
-    Build a menu (list of entries) with sections/items.
+    """Build a menu (list of entries) with sections/items.
 
     Information is provided by specific signals and filtered
     by menu id.
@@ -134,7 +133,7 @@ def build_menu_structure(menu_id, active_item=None, **kwargs):
     :param menu_id: menu_id used to filter out signal calls
     :param active_item: ID of currently active menu item
     :param kwargs: extra arguments passed to the signals
-    :returns: properly sorted list (taking weights into account)
+    :return: properly sorted list (taking weights into account)
     """
     top_level = set()
     sections = {}
@@ -152,6 +151,17 @@ def build_menu_structure(menu_id, active_item=None, **kwargs):
             sections[item.section].add_item(item)
 
     return sorted(top_level, key=lambda x: (-x.weight, x.title))
+
+
+def get_menu_item(menu_id, item, **kwargs):
+    """Get a specific menu item.
+
+    :param menu_id: menu_id used to filter out signal calls
+    :param item: ID of the item to retrieve
+    :param kwargs: extra arguments passed to the signals
+    :return: the specified menu item or ``None``
+    """
+    return named_objects_from_signal(signals.menu.items.send(menu_id, **kwargs)).get(item)
 
 
 def render_sidemenu(menu_id, active_item=None, **kwargs):

--- a/indico/web/templates/header.html
+++ b/indico/web/templates/header.html
@@ -15,64 +15,31 @@
     </div>
 
     <div class="global-menu toolbar">
-        <a href="{{ url_for_index() }}">{% trans %}Home{% endtrans %}</a>
-        <a class="arrow js-dropdown" href="#" data-toggle="dropdown">{% trans %}Create event{% endtrans %}</a>
-        <ul class="dropdown">
-            <li>
-                {{ create_event_link(category, 'lecture', _('Create lecture'), id='create-lecture') }}
-            </li>
-            <li>
-                {{ create_event_link(category, 'meeting', _('Create meeting'), id='create-meeting') }}
-            </li>
-            <li>
-                {{ create_event_link(category, 'conference', _('Create conference'), id='create-conference') }}
-            </li>
-        </ul>
-
-        {% if indico_config.IsRoomBookingActive %}
-            <a href="{{ url_for('rooms.roomBooking') }}">{% trans %}Room booking{% endtrans %}</a>
-        {% endif %}
-
-        {% if session.user and session.user.is_admin %}
-            <a href="{{ url_for('core.admin_dashboard') }}">{% trans %}Administration{% endtrans %}</a>
-        {% endif %}
-
-        {% for dropdown_title, items in extra_menu_items %}
-            {% if not dropdown_title %}
-                {% for item in items %}
-                    <a href="{{ item.url }}">{{ item.caption }}</a>
-                {% endfor %}
-            {% else %}
-                <a class="arrow js-dropdown" href="#" data-toggle="dropdown">
-                    {{- dropdown_title -}}
-                </a>
+        {% for item in top_menu_items recursive %}
+            {% if loop.depth0 %}
+                {# we're inside a section #}
+                <li>
+                    {% if item.section == 'create-event' and item.url in ('lecture', 'meeting', 'conference') %}
+                        {# special handling for event creation links #}
+                        {{ create_event_link(category, item.url, item.title, id=item.name) }}
+                    {% elif item.section == 'help' and item.name == 'help' and item.url is none %}
+                        <a style="color: #777; cursor: initial;"
+                           title="{% trans %}We are working on updating the documentation. Stay tuned!{% endtrans %}">
+                            {{ item.title }}
+                        </a>
+                    {% else %}
+                        <a href="{{ item.url }}">{{ item.title }}</a>
+                    {% endif %}
+                </li>
+            {% elif not item.is_section %}
+                <a href="{{ item.url }}">{{ item.title }}</a>
+            {% elif item.items %}
+                <a class="arrow js-dropdown" href="#" data-toggle="dropdown">{{ item.title }}</a>
                 <ul class="dropdown">
-                    {% for item in items %}
-                        <li><a href="{{ item.url }}">{{ item.caption }}</a></li>
-                    {% endfor %}
+                    {{ loop(item.items) }}
                 </ul>
             {% endif %}
         {% endfor %}
-
-        {% if session.user %}
-            <a href="{{ url_for('users.user_dashboard', user_id=none) }}">
-                {%- trans %}My profile{% endtrans -%}
-            </a>
-        {% endif %}
-
-        <a class="arrow js-dropdown" href="#" data-toggle="dropdown">{% trans %}Help{% endtrans %}</a>
-        <ul class="dropdown">
-            <li>
-                <a style="color: #777; cursor: initial;"
-                   title="{% trans %}We are working on updating the documentation. Stay tuned!{% endtrans %}">
-                    {% trans %}Indico help{% endtrans %}
-                </a>
-            </li>
-            {% if indico_config.PublicSupportEmail %}
-                <li><a href="{{ url_for('misc.contact') }}">{% trans %}Contact{% endtrans %}</a></li>
-            {% endif %}
-            <li><a href="http://indico-software.org">{% trans %}More about Indico{% endtrans %}</a></li>
-        </ul>
     </div>
 </div>
 

--- a/indico/web/templates/layout/admin_page.html
+++ b/indico/web/templates/layout/admin_page.html
@@ -1,0 +1,5 @@
+{% extends 'layout/management_page.html' %}
+
+{% block side_menu %}
+    {{ render_sidemenu('admin-sidemenu', active_item=active_menu_item) }}
+{% endblock %}

--- a/indico/web/templates/layout/management_page.html
+++ b/indico/web/templates/layout/management_page.html
@@ -1,25 +1,28 @@
 {% extends 'layout/base.html' %}
 
 {% set show_side_menu = self.side_menu() or self.display_view_button() %}
+{% set show_banner_area = self.display_view_button() or self.banner_title() or self.banner_actions() %}
 
 {% block page %}
-    <div class="layout-side-menu">
-        {% if show_side_menu %}
-            <div class="menu-column">
-                {% block display_view_button %}{% endblock %}
-            </div>
-        {% endif %}
-        <div class="content-column">
-            <div class="banner {% block banner_class %}{% endblock %}">
-                <div class="title">
-                    {% block banner_title %}{% endblock %}
+    {% if show_banner_area %}
+        <div class="layout-side-menu">
+            {% if show_side_menu %}
+                <div class="menu-column">
+                    {% block display_view_button %}{% endblock %}
                 </div>
-                <div class="action-menu">
-                    {% block banner_actions %}{% endblock %}
+            {% endif %}
+            <div class="content-column">
+                <div class="banner {% block banner_class %}{% endblock %}">
+                    <div class="title">
+                        {% block banner_title %}{% endblock %}
+                    </div>
+                    <div class="action-menu">
+                        {% block banner_actions %}{% endblock %}
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    {% endif %}
     <div class="layout-side-menu">
         {% if show_side_menu %}
             <div class="menu-column">


### PR DESCRIPTION
- Cleanup the menu/tab mess in room booking (the legacy pages still look like 💩 though)
- Use new WPAdmin class and jinja inheritance for admin pages/templates
- Hide admin menu items from non-admins (i.e. RB admins who cannot access anything else)
- Improve the breadcrumbs in the admin area
- Build the top menu using the standard menu signals