### PR TITLE
Add .editorconfig and .isort.cfg

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root=true
+
+[*]
+indent_style=space
+indent_size=4
+end_of_line=lf
+charset=utf-8
+trim_trailing_whitespace=true
+insert_final_newline=true
+
+[{*.yml,*.yaml}]
+indent_size=2
+
+[Makefile]
+indent_style=tab

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,7 @@
+[isort]
+line_length=120
+multi_line_output=0
+lines_after_imports=2
+add_imports=from __future__ import unicode_literals
+sections=FUTURE,STDLIB,THIRDPARTY,INDICO,FIRSTPARTY,LOCALFOLDER
+known_indico=indico


### PR DESCRIPTION
I didn't add the isort config to .editorconfig since it feels very dirty to me that isort settings in there don't have any kind of prefix.