### PR TITLE
Small corrections to apache.rst and upgrade.rst

### DIFF
--- a/docs/source/installation/production/debian/apache.rst
+++ b/docs/source/installation/production/debian/apache.rst
@@ -13,7 +13,7 @@ PostgreSQL is installed from its upstream repos to get a much more recent versio
     echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     apt update
-    apt install -y postgresql-9.6 postgresql-contrib-9.6 libpq-dev apache2 libapache2-mod-proxy-uwsgi libapache2-mod-xsendfile python-dev python-virtualenv virtualenv libxslt1-dev libxml2-dev libffi-dev libpcre3-dev libyaml-dev build-essential redis-server uwsgi uwsgi-plugin-python
+    apt install -y --install-recommends postgresql-9.6 libpq-dev apache2 libapache2-mod-proxy-uwsgi libapache2-mod-xsendfile python-dev python-virtualenv libxslt1-dev libxml2-dev libffi-dev libpcre3-dev libyaml-dev build-essential redis-server uwsgi uwsgi-plugin-python
 
 
 If you use Debian, run this command:

--- a/docs/source/installation/production/debian/apache.rst
+++ b/docs/source/installation/production/debian/apache.rst
@@ -13,7 +13,7 @@ PostgreSQL is installed from its upstream repos to get a much more recent versio
     echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     apt update
-    apt install -y postgresql-9.6 libpq-dev apache2 libapache2-mod-proxy-uwsgi libapache2-mod-xsendfile python-dev python-virtualenv libxslt1-dev libxml2-dev libffi-dev libpcre3-dev libyaml-dev build-essential redis-server uwsgi uwsgi-plugin-python
+    apt install -y postgresql-9.6 postgresql-contrib-9.6 libpq-dev apache2 libapache2-mod-proxy-uwsgi libapache2-mod-xsendfile python-dev python-virtualenv virtualenv libxslt1-dev libxml2-dev libffi-dev libpcre3-dev libyaml-dev build-essential redis-server uwsgi uwsgi-plugin-python
 
 
 If you use Debian, run this command:

--- a/docs/source/installation/production/debian/nginx.rst
+++ b/docs/source/installation/production/debian/nginx.rst
@@ -18,7 +18,7 @@ much more recent versions.
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     wget --quiet -O - https://nginx.org/keys/nginx_signing.key | apt-key add -
     apt update
-    apt install -y postgresql-9.6 libpq-dev nginx python-dev python-virtualenv libxslt1-dev libxml2-dev libffi-dev libpcre3-dev libyaml-dev build-essential redis-server uwsgi uwsgi-plugin-python
+    apt install -y --install-recommends postgresql-9.6 libpq-dev nginx python-dev python-virtualenv libxslt1-dev libxml2-dev libffi-dev libpcre3-dev libyaml-dev build-essential redis-server uwsgi uwsgi-plugin-python
 
 
 If you use Debian, run this command:

--- a/docs/source/installation/upgrade.rst
+++ b/docs/source/installation/upgrade.rst
@@ -168,7 +168,7 @@ An example:
 
 .. code-block:: shell
 
-    indico-migrate postgresql:///indico file:///opt/indico-legacy/db/Data.fs --archive-dir /opt/indico/archive --storage-backend legacy --default-email default@acme.example.com --default-currency EUR --symlink-target ~/archive/legacy_symlinks/ --symlink-backend legacy-symlinks
+    indico-migrate postgresql:///indico file:///opt/indico-legacy/db/Data.fs --archive-dir /opt/indico-legacy/archive --storage-backend legacy --default-email default@acme.example.com --default-currency EUR --symlink-target ~/archive/legacy_symlinks/ --symlink-backend legacy-symlinks
 
 
 .. note::


### PR DESCRIPTION
Debian apache.rst: Add two more dependencies: postgresql-contrib-9.6 and virtualenv

upgrade.rst: Changed `--archive-dir /opt/indico/archive` to `--archive-dir /opt/indico-legacy/archive` in Copy & Paste example for "Running indico-migrate"