### PR TITLE
Support for vagrant added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ node_modules
 coverage.xml
 htmlcov/
 /.cache/
+.vagrant
 
 # sphinx
 /docs/build/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -2,6 +2,23 @@ Tips for developers
 -------------------
 It's dangerous to go alone. Take these tips in case you need to fit Indico to your particular needs.
 
+## Running a virtual machine
+Install [vagrant](https://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/), install
+[vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin with `vagrant plugin install vagrant-vbguest`.
+Simply call `vagrant up` to get your virtual machine running and `vagrant ssh` to jump into the virtual machine.
+
+Next steps:
+```
+indico user create -a
+indico-run
+```
+
+Type `exit` to get back to your host system, use `vagrant rsync` or `vagrant rsync-auto` to synchronize all indico
+files from your host system with your virtual machine.
+
+You can access Indico by poiting your browser to http://localhost:8080/ and a virtual mailbox collecting all outgoing
+mails under http://localhost:8081/.
+
 ## Initializing the database
 Use `indico db prepare` to create your tables based on the SQLAlchemy models and set the migration status to the most
 recent alembic revision.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,81 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANT_COMMAND = ARGV[0]
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "debian/stretch64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+  config.vm.network "forwarded_port", guest: 8081, host: 8081
+  config.vm.network "forwarded_port", guest: 5432, host: 5435
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder "./", "/home/vagrant/indico", create: true, type: "rsync",
+    rsync__exclude: ["*.egg-info", "*.pyc", "ext_modules/", "node_modules/",
+                     "indico/indico.conf", "indico/logging.yaml", "celeryd.pid",
+                     "indico/htdocs/css/lib/", "indico/htdocs/js/lib/", "indico/htdocs/sass/lib/"],
+    rsync__verbose: true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+  config.vm.provision "shell", path: "./bin/vagrant/vagrant-provision.sh", name: "initial setup", run: "once"
+  config.vm.provision "shell", path: "./bin/vagrant/vagrant-bootstrap.sh", name: "boostrap", run: "always"
+
+end

--- a/bin/vagrant/vagrant-bootstrap.sh
+++ b/bin/vagrant/vagrant-bootstrap.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# run celery worker in background
+sudo -i -u vagrant indico celery worker -D -B
+
+# start maildump server
+sudo -i -u vagrant maildump --smtp-port 8025 --http-ip 0.0.0.0 --http-port 8081 \
+    --db /home/vagrant/data/mails/db.sqlite --pidfile /home/vagrant/data/mails/maildump.pid

--- a/bin/vagrant/vagrant-provision.sh
+++ b/bin/vagrant/vagrant-provision.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+
+# prepare Debian system
+apt-get update && apt-get dist-upgrade -y
+apt-get install python-pip python-dev build-essential default-jre libxslt-dev libxml2-dev libffi-dev libssl-dev git net-tools curl -y
+
+# get nodejs from external sources (Debian is outdated)
+curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
+apt-get install nodejs -y
+
+# Install PostgreSQL
+apt-get install postgresql-9.6 postgresql-server-dev-9.6 libpq-dev -y
+su -l postgres -c "createuser indico"
+su -l postgres -c "createdb -O indico indico"
+su -l postgres -c "psql -d indico -c \"CREATE EXTENSION pg_trgm;\""
+su -l postgres -c "psql -d indico -c \"CREATE EXTENSION unaccent;\""
+mv /etc/postgresql/9.6/main/pg_hba.conf /etc/postgresql/9.6/main/pg_hba.conf.default
+sed -i "s:#listen_addresses = 'localhost':listen_addresses = '*':g" /etc/postgresql/9.6/main/postgresql.conf
+echo "
+# TYPE   DATABASE   USER   ADDRESS        METHOD
+local    all        all                   trust
+host     all        all    127.0.0.1/32   trust
+host     all        all    ::1/128        trust
+host     all        all    10.0.0.1/8     trust
+host     all        all    192.186.0.1/16 trust
+" > /etc/postgresql/9.6/main/pg_hba.conf
+service postgresql restart
+
+# Install Redis
+apt-get install redis-server -y
+
+# install some general Python packages
+pip install -U setuptools
+pip install -U virtualenv
+pip install -U maildump
+
+# create virtualenv
+sudo -i -u vagrant virtualenv indicoenv
+
+# set some defaults for SSH login
+echo "
+# Automatically activate Python virtualenv for Indico
+source ~/indicoenv/bin/activate
+cd ~/indico/
+" >> /home/vagrant/.profile
+echo "
+# Define shortcut to run Indico development server
+alias indico-run='indico run -h 0.0.0.0 -p 8080 -u http://localhost:8080/'
+" >> /home/vagrant/.bashrc
+
+# install Python dependencies and Indico
+sudo -i -u vagrant pip install -r requirements.txt
+sudo -i -u vagrant pip install -r requirements.dev.txt
+sudo -i -u vagrant pip install -e .
+
+# create configuration for logging
+sudo -i -u vagrant indico setup create_logging_config /home/vagrant/indico/indico/
+
+# create configuration for Indico itself
+echo "# General settings
+SQLALCHEMY_DATABASE_URI = 'postgresql://indico@127.0.0.1/indico'
+SECRET_KEY = '$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)'
+BASE_URL = 'http://localhost:8080'
+CELERY_BROKER = 'redis://127.0.0.1:6379/0'
+REDIS_CACHE_URL = 'redis://127.0.0.1:6379/1'
+CACHE_BACKEND = 'redis'
+DEFAULT_TIMEZONE = 'Europe/Berlin'
+DEFAULT_LOCALE = 'en_GB'
+ENABLE_ROOMBOOKING = True
+CACHE_DIR = '/home/vagrant/data/cache'
+TEMP_DIR = '/home/vagrant/data/tmp'
+LOG_DIR = '/home/vagrant/data/log'
+ASSETS_DIR = '/home/vagrant/data/assets'
+STORAGE_BACKENDS = {'default': 'fs:/home/vagrant/data/archive'}
+ATTACHMENT_STORAGE = 'default'
+PLUGINS = {}
+
+# Email settings
+SMTP_SERVER = ('localhost', 8025)
+SMTP_USE_TLS = False
+SMTP_LOGIN = ''
+SMTP_PASSWORD = ''
+SUPPORT_EMAIL = 'indico@localhost'
+PUBLIC_SUPPORT_EMAIL = 'indico@localhost'
+NO_REPLY_EMAIL = 'noreply@localhost'
+
+# Development options
+DB_LOG = True
+DEBUG = True
+SMTP_USE_CELERY = False
+" > /home/vagrant/indico/indico/indico.conf
+chown vagrant:vagrant /home/vagrant/indico/indico/indico.conf
+
+# create all folders
+mkdir /home/vagrant/data
+mkdir /home/vagrant/data/log
+mkdir /home/vagrant/data/assets
+mkdir /home/vagrant/data/tmp
+mkdir /home/vagrant/data/cache
+mkdir /home/vagrant/data/custom
+mkdir /home/vagrant/data/archive
+mkdir /home/vagrant/data/mails
+chown -R vagrant:vagrant /home/vagrant/data
+
+# do some initial setup for Indico
+sudo -i -u vagrant fab setup_deps
+sudo -i -u vagrant indico db prepare


### PR DESCRIPTION
This PR adds a `Vagrantfile` and two bash scripts. [Vagrant](https://www.vagrantup.com/) builds a virtual machine with a complete development environment, simply by calling `vagrant up` from the root directory of the project.