### PR TITLE
Improve handling of system OAuth apps

### DIFF
--- a/indico/core/celery/cli.py
+++ b/indico/core/celery/cli.py
@@ -21,9 +21,9 @@ import sys
 
 from celery.bin.celery import CeleryCommand, command_classes
 
-from indico.core.config import Config
 from indico.core.celery import celery
-from indico.modules.oauth.models.applications import OAuthApplication
+from indico.core.config import Config
+from indico.modules.oauth.models.applications import OAuthApplication, SystemAppType
 from indico.util.console import cformat
 from indico.web.flask.util import url_for
 
@@ -43,30 +43,20 @@ def celery_cmd(args):
             print cformat('%{red!}Flower is not installed')
             sys.exit(1)
 
-        client_id = Config.getInstance().getFlowerClientId()
-        if client_id:
-            app = OAuthApplication.find_first(client_id=client_id)
-            if app is None:
-                print cformat('%{red!}There is no OAuth application with the client id {}.').format(client_id)
-                sys.exit(1)
-            elif 'read:user' not in app.default_scopes:
-                print cformat('%{red!}The {} application needs the read:user scope.').format(app.name)
-                sys.exit(1)
-            print cformat('%{green!}Only Indico admins will have access to flower.')
-            print cformat('%{yellow}Note that revoking admin privileges will not revoke Flower access.')
-            print cformat('%{yellow}To force re-authentication, restart Flower.')
-            auth_args = ['--auth=^Indico Admin$', '--auth_provider=indico.core.celery.flower.FlowerAuthHandler']
-            auth_env = {'INDICO_FLOWER_CLIENT_ID': app.client_id,
-                        'INDICO_FLOWER_CLIENT_SECRET': app.client_secret,
-                        'INDICO_FLOWER_AUTHORIZE_URL': url_for('oauth.oauth_authorize', _external=True),
-                        'INDICO_FLOWER_TOKEN_URL': url_for('oauth.oauth_token', _external=True),
-                        'INDICO_FLOWER_USER_URL': url_for('users.authenticated_user', _external=True)}
-        else:
-            print cformat('%{red!}WARNING: %{yellow!}Flower authentication is disabled.')
-            print cformat('%{yellow!}Having access to Flower allows one to shutdown Celery workers.')
-            print
-            auth_args = []
-            auth_env = {}
+        app = OAuthApplication.find_one(system_app_type=SystemAppType.flower)
+        if not app.redirect_uris:
+            print cformat('%{yellow!}Authentication will fail unless you configure the redirect url for the {} OAuth '
+                          'application in the administration area.').format(app.name)
+
+        print cformat('%{green!}Only Indico admins will have access to flower.')
+        print cformat('%{yellow}Note that revoking admin privileges will not revoke Flower access.')
+        print cformat('%{yellow}To force re-authentication, restart Flower.')
+        auth_args = ['--auth=^Indico Admin$', '--auth_provider=indico.core.celery.flower.FlowerAuthHandler']
+        auth_env = {'INDICO_FLOWER_CLIENT_ID': app.client_id,
+                    'INDICO_FLOWER_CLIENT_SECRET': app.client_secret,
+                    'INDICO_FLOWER_AUTHORIZE_URL': url_for('oauth.oauth_authorize', _external=True),
+                    'INDICO_FLOWER_TOKEN_URL': url_for('oauth.oauth_token', _external=True),
+                    'INDICO_FLOWER_USER_URL': url_for('users.authenticated_user', _external=True)}
         args = ['celery', '-b', Config.getInstance().getCeleryBroker()] + args + auth_args
         env = dict(os.environ, **auth_env)
         os.execvpe('celery', args, env)

--- a/indico/core/celery/templates/celery_tasks.html
+++ b/indico/core/celery/templates/celery_tasks.html
@@ -7,18 +7,14 @@
 
 {% block content %}
     <div class="tasks">
-        {%- call message_box('info', fixed_width=True) -%}
-            {%- if flower_url -%}
+        {%- if flower_url -%}
+            {%- call message_box('info', fixed_width=True) -%}
                 {%- trans -%}
-                    Monitor Indico's Celery tasks with Flower <a class="bold" href="{{ flower_url }}" target="_blank">here</a>.
+                    Monitor Indico's Celery tasks with Flower
+                    <a class="bold" href="{{ flower_url }}" target="_blank">here</a>.
                 {%- endtrans -%}
-            {%- else -%}
-                {%- trans -%}
-                    Indico uses Celery to manage tasks, which can be monitored using Flower.<br>
-                    Configure the Flower URL in <span class="mono">indico.conf</span> to have a link displayed here.
-                {%- endtrans %}
-            {%- endif -%}
-        {%- endcall %}
+            {%- endcall %}
+        {%- endif -%}
         <h2>{% trans %}Periodic Tasks{% endtrans %}</h2>
         <table class="i-table-widget fixed-width">
             <thead>

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -269,8 +269,6 @@ class Config:
         'CeleryResultBackend'       : None,
         'CeleryConfig'              : {},
         'ScheduledTaskOverride'     : {},
-        'CheckinAppClientId'        : None,
-        'FlowerClientId'            : None,
         'FlowerURL'                 : None,
         'StorageBackends'           : {'default': 'fs:/opt/indico/archive'},
         'AttachmentStorage'         : 'default',

--- a/indico/core/db/sqlalchemy/util/management.py
+++ b/indico/core/db/sqlalchemy/util/management.py
@@ -97,6 +97,7 @@ def create_all_tables(db, verbose=False, add_initial_data=True):
     from indico.modules.categories import Category
     from indico.modules.designer import TemplateType
     from indico.modules.designer.models.templates import DesignerTemplate
+    from indico.modules.oauth.models.applications import OAuthApplication, SystemAppType
     from indico.modules.users import User
     if verbose:
         print cformat('%{green}Creating tables')
@@ -116,4 +117,9 @@ def create_all_tables(db, verbose=False, add_initial_data=True):
                               data=DEFAULT_TEMPLATE_DATA, is_system_template=True)
         cat.default_ticket_template = dt
         db.session.add(dt)
+        if verbose:
+            print cformat('%{green}Creating system oauth apps')
+        for sat in SystemAppType:
+            if sat != SystemAppType.none:
+                db.session.add(OAuthApplication(system_app_type=sat, **sat.default_data))
         db.session.commit()

--- a/indico/indico.conf.sample
+++ b/indico/indico.conf.sample
@@ -360,27 +360,13 @@ MaxUploadFileSize = 0
 #
 # Your Celery workers can be monitored using Flower.  To use it, simply start it
 # using `indico celery flower`; by default it will listen on the same host as
-# specified in BaseURL (non-SSL) on port 5555.  However, having an open Flower
-# instance is a security issue as it will allow anyone to shut down your celery
-# workers.  To avoid this, you can use Indico's OAuth2 provider to restrict the
-# access to flower to Indico administrators.  To do so, register a new OAuth
-# application in the administration interface (`Server admin > Applications`)
-# and set the `FlowerClientId` option to its Client ID.
-#FlowerClientId = None
-#
+# specified in BaseURL (non-SSL) on port 5555.  Authentication is done using
+# OAuth so only indico administrators can access flower.  You need to configure
+# the allowed auth callback URLs in the Indico administration area; otherwise
+# authentication will fail with an OAuth error.
 # To get a link to Flower in the administration menu, set `FlowerURL` to the URL
 # under which your Flower instance is accessible:
 #FlowerURL = None
-
-
-# ------------------------------------------------------------------------------
-# Indico Checkin
-# ------------------------------------------------------------------------------
-
-# In order to use Indico check-in app, first register the application manually
-# within `Server admin > Applications` and then fill in here the client_id
-# assigned to it.
-#CheckinAppClientId = ''
 
 
 # ------------------------------------------------------------------------------

--- a/indico/migrations/versions/201708301158_09fd62e56097_add_oauth_system_app_type.py
+++ b/indico/migrations/versions/201708301158_09fd62e56097_add_oauth_system_app_type.py
@@ -1,0 +1,57 @@
+"""Add oauth system_app_type
+
+Revision ID: 09fd62e56097
+Revises: dc2c2fa6f5be
+Create Date: 2017-08-30 11:58:34.857558
+"""
+
+import sqlalchemy as sa
+from alembic import context, op
+
+from indico.core.db.sqlalchemy import PyIntEnum
+from indico.modules.oauth.models.applications import OAuthApplication, SystemAppType
+
+
+# revision identifiers, used by Alembic.
+revision = '09fd62e56097'
+down_revision = 'dc2c2fa6f5be'
+branch_labels = None
+depends_on = None
+
+
+def _create_app(system_app_type):
+    insert = OAuthApplication.__table__.insert()
+    op.execute(insert.values(system_app_type=system_app_type, **system_app_type.default_data))
+
+
+def _update_app(app_id, system_app_type):
+    update = OAuthApplication.__table__.update()
+    if app_id.isdigit():
+        update = update.where(OAuthApplication.__table__.c.id == int(app_id))
+    else:
+        update = update.where(OAuthApplication.__table__.c.client_id == app_id)
+    op.execute(update.values(system_app_type=system_app_type, **system_app_type.enforced_data))
+
+
+def upgrade():
+    xargs = context.get_x_argument(as_dictionary=True)
+    checkin_app_id = xargs.get('checkin_app_id')
+    flower_app_id = xargs.get('flower_app_id')
+    op.add_column('applications',
+                  sa.Column('system_app_type', PyIntEnum(SystemAppType), nullable=False, server_default='0'),
+                  schema='oauth')
+    op.alter_column('applications', 'system_app_type', server_default=None, schema='oauth')
+    op.create_index(None, 'applications', ['system_app_type'], unique=True, schema='oauth',
+                    postgresql_where=sa.text('system_app_type != 0'))
+    if checkin_app_id is None:
+        _create_app(SystemAppType.checkin)
+    else:
+        _update_app(checkin_app_id, SystemAppType.checkin)
+    if flower_app_id is None:
+        _create_app(SystemAppType.flower)
+    else:
+        _update_app(flower_app_id, SystemAppType.flower)
+
+
+def downgrade():
+    op.drop_column('applications', 'system_app_type', schema='oauth')

--- a/indico/modules/events/registration/controllers/management/tickets.py
+++ b/indico/modules/events/registration/controllers/management/tickets.py
@@ -32,8 +32,7 @@ from indico.modules.events.registration.controllers.display import RHRegistratio
 from indico.modules.events.registration.controllers.management import RHManageRegFormBase
 from indico.modules.events.registration.forms import TicketsForm
 from indico.modules.events.registration.models.registrations import RegistrationState
-from indico.modules.oauth.models.applications import OAuthApplication
-from indico.util.i18n import _
+from indico.modules.oauth.models.applications import OAuthApplication, SystemAppType
 from indico.web.flask.util import secure_filename, send_file, url_for
 from indico.web.util import jsonify_data, jsonify_template
 
@@ -55,19 +54,6 @@ DEFAULT_TICKET_PRINTING_SETTINGS = {
 class RHRegistrationFormTickets(RHManageRegFormBase):
     """Display and modify ticket settings."""
 
-    def _check_ticket_app_enabled(self):
-        checkin_app_client_id = Config.getInstance().getCheckinAppClientId()
-
-        if checkin_app_client_id is None:
-            return False, _("indico-checkin client_id is not defined in the Indico configuration")
-
-        checkin_app = OAuthApplication.find_first(client_id=checkin_app_client_id)
-        if checkin_app is None:
-            msg = (_("indico-checkin is not registered as an OAuth application with client_id {}")
-                   .format(checkin_app_client_id))
-            return False, msg
-        return True, None
-
     def _process(self):
         form = TicketsForm(obj=self.regform, event=self.event_new)
         if form.validate_on_submit():
@@ -75,10 +61,7 @@ class RHRegistrationFormTickets(RHManageRegFormBase):
             db.session.flush()
             return jsonify_data(flash=False, tickets_enabled=self.regform.tickets_enabled)
 
-        can_enable_tickets, ticket_warning = self._check_ticket_app_enabled()
-        return jsonify_template('events/registration/management/regform_tickets.html',
-                                regform=self.regform, form=form, can_enable_tickets=can_enable_tickets,
-                                ticket_warning=ticket_warning)
+        return jsonify_template('events/registration/management/regform_tickets.html', regform=self.regform, form=form)
 
 
 def generate_ticket(registration):
@@ -126,9 +109,7 @@ class RHTicketConfigQRCodeImage(RHManageRegFormBase):
             border=1
         )
 
-        checkin_app_client_id = config.getCheckinAppClientId()
-        checkin_app = OAuthApplication.find_first(client_id=checkin_app_client_id)
-
+        checkin_app = OAuthApplication.find_one(system_app_type=SystemAppType.checkin)
         qr_data = {
             "event_id": self.event_new.id,
             "title": self.event_new.title,

--- a/indico/modules/events/registration/templates/management/regform_tickets.html
+++ b/indico/modules/events/registration/templates/management/regform_tickets.html
@@ -1,15 +1,11 @@
 {% from 'forms/_form.html' import form_header, form_footer, form_rows, form_row %}
 {% from 'message_box.html' import message_box %}
 
-{% if ticket_warning %}
-    {{ message_box('warning', ticket_warning) }}
-{% endif %}
-
 {{ form_header(form)}}
-{{ form_row(form.tickets_enabled, disabled=not can_enable_tickets) }}
+{{ form_row(form.tickets_enabled) }}
 {{ form_rows(form, skip=('tickets_enabled',)) }}
 {% call form_footer(form) %}
-    <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}" data-disabled-until-change >
+    <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}" data-disabled-until-change>
     <a class="i-button big" data-button-back>
         {% trans %}Back{% endtrans %}
     </a>

--- a/indico/modules/oauth/forms.py
+++ b/indico/modules/oauth/forms.py
@@ -20,14 +20,14 @@ import re
 from operator import itemgetter
 
 from markupsafe import escape
-from wtforms.fields import StringField, TextAreaField, BooleanField
+from wtforms.fields import BooleanField, StringField, TextAreaField
 from wtforms.validators import DataRequired, ValidationError
 
 from indico.core.db import db
-from indico.modules.oauth.models.applications import OAuthApplication, SCOPES
+from indico.modules.oauth.models.applications import SCOPES, OAuthApplication
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm
-from indico.web.forms.fields import TextListField, IndicoSelectMultipleCheckboxField
+from indico.web.forms.fields import IndicoSelectMultipleCheckboxField, TextListField
 from indico.web.forms.widgets import SwitchWidget
 
 
@@ -60,6 +60,9 @@ class ApplicationForm(IndicoForm):
     def __init__(self, *args, **kwargs):
         self.application = kwargs.pop('application', None)
         super(ApplicationForm, self).__init__(*args, **kwargs)
+        for field in self.application.system_app_type.enforced_data:
+            # preserve existing value for disabled fields
+            self[field].data = self[field].object_data
 
     def validate_name(self, field):
         query = OAuthApplication.find(name=field.data)

--- a/indico/modules/oauth/templates/app_details.html
+++ b/indico/modules/oauth/templates/app_details.html
@@ -1,10 +1,15 @@
 {% extends 'oauth/apps_base.html' %}
+
 {% from 'forms/_form.html' import form_header, form_rows, form_footer %}
+{% from 'message_box.html' import message_box %}
+
 {% set num_tokens = application.tokens.count() %}
+
 
 {% block subtitle %}
     {{ application.name }}
 {% endblock %}
+
 
 {% block content %}
     <div class="i-box">
@@ -26,13 +31,15 @@
                         {%- trans %}Reset client secret{% endtrans -%}
                     </button>
                 </div>
-                <div class="group">
-                    <button class="i-button icon-remove danger"
-                        data-href="{{ url_for('.app_delete', application) }}" data-method="POST"
-                        data-confirm="{% trans %}Are you sure you want to remove this application?{% endtrans %}">
-                        {%- trans -%}Delete{%- endtrans -%}
-                    </button>
-                </div>
+                {% if not application.system_app_type %}
+                    <div class="group">
+                        <button class="i-button icon-remove danger"
+                                data-href="{{ url_for('.app_delete', application) }}" data-method="POST"
+                                data-confirm="{% trans %}Are you sure you want to remove this application?{% endtrans %}">
+                            {%- trans -%}Delete{%- endtrans -%}
+                        </button>
+                    </div>
+                {% endif %}
             </div>
             <div class="i-box-metadata">
                 <span class="label">
@@ -45,6 +52,15 @@
             </div>
         </div>
         <div class="i-box-content">
+            {% if application.system_app_type %}
+                {% call message_box('highlight') -%}
+                    {%- trans -%}
+                        This is a system application.
+                        It cannot be deleted and certain attributes cannot be changed.
+                    {%- endtrans -%}
+                {%- endcall %}
+            {% endif %}
+
             <dl class="i-data-list dt-select-disabled">
                 {# Do not translate <dt> since they are the official terms in OAuth2 RFC #}
                 <dt>Client ID</dt>{#--#}
@@ -58,7 +74,7 @@
             </dl>
             <hr>
             {{ form_header(form) }}
-            {{ form_rows(form) }}
+            {{ form_rows(form, disable=disabled_fields) }}
             {% call form_footer(form) %}
                 <input class="i-button big highlight" type="submit" data-disabled-until-change
                        value="{% trans %}Update application{% endtrans %}">


### PR DESCRIPTION
- created automatically
- not deletable
- certain fields locked to the right values
- no need to set their id in the config file

if the apps already exist, their ids (either db id or client id) can be set via x-args, e.g.:

    indico db upgrade -x checkin_app_id=00000000-dead-c0de-beef-000000001111 -x flower_app_id=1