### PR TITLE
Add site name in <title>

### DIFF
--- a/indico/web/templates/indico_base.html
+++ b/indico/web/templates/indico_base.html
@@ -4,7 +4,9 @@
 <html prefix="og: http://ogp.me/ns#"
       data-static-site="{{ g.get('static_site', false)|tojson|forceescape }}">
 <head>
-    <title>{{ page_title }}</title>
+    <title>
+      {{- page_title }} &middot; {% if site_name != 'Indico' %}Indico - {% endif %}{{ site_name -}}
+    </title>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="csrf-token" id="csrf-token" content="{{ session.csrf_token }}">


### PR DESCRIPTION
Closes #3018

Example when site name is the default ("Indico")
> Indico [Home] - Management area &middot; Indico

Example when site name is not "Indico":
> Indico [Home] - Management area &middot; Indico - My Awesome Organization

Current behaviour:

> Indico [Home] - Management area