### PR TITLE
Fix margins of event description

### DIFF
--- a/indico/htdocs/sass/themes/indico.scss
+++ b/indico/htdocs/sass/themes/indico.scss
@@ -577,6 +577,7 @@ div.event-details {
 
     .event-details-content {
         flex: 1;
+        padding-right: calc(120px + 1em);
     }
 }
 


### PR DESCRIPTION
This fix adds margin to the right of the description, equal to the space on the left:

![image](https://user-images.githubusercontent.com/1579899/32024447-e02a0304-b9dc-11e7-92a5-55556264d95b.png)

In order to address the problem with the positioning of the "Description" label, how about reusing the labelling system of the agenda?

![image](https://user-images.githubusercontent.com/1579899/32024495-11e5bd98-b9dd-11e7-89b7-86039ffcd486.png)

imo, the "Description" label is unnecessary (although the idea @pferreir mentioned in #3035 for a better styling of the description is interesting):

![image](https://user-images.githubusercontent.com/1579899/32024631-8045b90a-b9dd-11e7-8e08-2450115bbb81.png)
