### PR TITLE
Fix meeting header bar on IE 11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Bugfixes
 - Properly align the label of the attachment folder title field
 - Fix some rare unicode errors during exception handling/logging
 - Clarify messages in session block rescheduling dialogs (:issue:`3080`)
+- Fix event header bar in IE11 (:issue:`3135`)
 
 
 Version 2.0a1

--- a/indico/htdocs/sass/modules/event_display/_common.scss
+++ b/indico/htdocs/sass/modules/event_display/_common.scss
@@ -67,6 +67,7 @@
     }
 
     .main-action-bar {
+        height: 50px;
         min-height: 50px;
     }
 


### PR DESCRIPTION
https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items