### PR TITLE
Event reminder: Allow to send description for lectures

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Improvements
 - Add support for custom session types (:issue:`3189`)
 - Move poster session flag from session settings to session type settings
 - Add contribution cloning within an event (:issue:`3207`)
+- Add option to include the event description in reminder emails
+  (:issue:`3157`, thanks :user:`bpedersen2`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/migrations/versions/20180129_0706_c820455976ba_add_include_description_to_reminders.py
+++ b/indico/migrations/versions/20180129_0706_c820455976ba_add_include_description_to_reminders.py
@@ -1,0 +1,26 @@
+"""Add include_description to reminders
+
+Revision ID: c820455976ba
+Revises: 093533d27a96
+Create Date: 2018-01-29 07:06:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'c820455976ba'
+down_revision = '093533d27a96'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('reminders', sa.Column('include_description', sa.Boolean(), nullable=False,
+                                         server_default='false'), schema='events')
+    op.alter_column('reminders', 'include_description', server_default=None, schema='events')
+
+
+def downgrade():
+    op.drop_column('reminders', 'include_description', schema='events')

--- a/indico/modules/events/reminders/controllers.py
+++ b/indico/modules/events/reminders/controllers.py
@@ -143,6 +143,7 @@ class RHPreviewReminder(RHRemindersBase):
 
     def _process(self):
         include_summary = request.form.get('include_summary') == '1'
-        tpl = make_reminder_email(self.event, include_summary, request.form.get('message'))
+        include_description = request.form.get('include_description') == '1'
+        tpl = make_reminder_email(self.event, include_summary, include_description, request.form.get('message'))
         html = render_template('events/reminders/preview.html', subject=tpl.get_subject(), body=tpl.get_body())
         return jsonify(html=html)

--- a/indico/modules/events/reminders/forms.py
+++ b/indico/modules/events/reminders/forms.py
@@ -56,6 +56,8 @@ class ReminderForm(IndicoForm):
     message = TextAreaField(_('Note'), description=_('A custom message to include in the email.'))
     include_summary = BooleanField(_('Include agenda'),
                                    description=_("Includes a simple text version of the event's agenda in the email."))
+    include_description = BooleanField(_('Include description'),
+                                       description=_("Includes the event's description in the email."))
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')

--- a/indico/modules/events/reminders/models/reminders.py
+++ b/indico/modules/events/reminders/models/reminders.py
@@ -96,6 +96,12 @@ class EventReminder(db.Model):
         nullable=False,
         default=False
     )
+    #: If the notification should include the event's description.
+    include_description = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
     #: The address to use as Reply-To in the notification email.
     reply_to_address = db.Column(
         db.String,
@@ -164,7 +170,7 @@ class EventReminder(db.Model):
         if not recipients:
             logger.info('Notification %s has no recipients; not sending anything', self)
             return
-        email_tpl = make_reminder_email(self.event, self.include_summary, self.message)
+        email_tpl = make_reminder_email(self.event, self.include_summary, self.include_description, self.message)
         email = make_email(bcc_list=recipients, from_address=self.reply_to_address, template=email_tpl)
         send_email(email, self.event, 'Reminder', self.creator)
 

--- a/indico/modules/events/reminders/templates/edit_reminder.html
+++ b/indico/modules/events/reminders/templates/edit_reminder.html
@@ -44,6 +44,7 @@
                     data: function() {
                         return {
                             include_summary: $('#include_summary').prop('checked') ? '1' : '0',
+                            include_description: $('#include_description').prop('checked') ? '1' : '0',
                             message: $('#message').val()
                         };
                     }

--- a/indico/modules/events/reminders/templates/emails/event_reminder.txt
+++ b/indico/modules/events/reminders/templates/emails/event_reminder.txt
@@ -23,6 +23,14 @@ It will take place at {{ render_location() }}
 You can access the full event here:
 {{ url }}
 
+{%- if with_description and event.description %}
+
+{% filter underline %}Description{% endfilter %}
+
+{{ event.description | html_to_plaintext | trim }}
+
+{%- endif -%}
+
 {#- Blank lines are intended #}
 {%- if note %}
 

--- a/indico/modules/events/reminders/util.py
+++ b/indico/modules/events/reminders/util.py
@@ -20,7 +20,7 @@ from indico.modules.events.models.events import EventType
 from indico.web.flask.templating import get_template_module
 
 
-def make_reminder_email(event, with_agenda, note):
+def make_reminder_email(event, with_agenda, with_description, note):
     """Returns the template module for the reminder email.
 
     :param event: The event
@@ -31,4 +31,5 @@ def make_reminder_email(event, with_agenda, note):
         with_agenda = False
     agenda = event.timetable_entries.filter_by(parent_id=None).all() if with_agenda else None
     return get_template_module('events/reminders/emails/event_reminder.txt', event=event,
-                               url=event.short_external_url, note=note, with_agenda=with_agenda, agenda=agenda)
+                               url=event.short_external_url, note=note, with_agenda=with_agenda,
+                               with_description=with_description, agenda=agenda)

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -558,6 +558,10 @@ def sanitize_html(string):
                         styles=BLEACH_ALLOWED_STYLES_HTML)
 
 
+def html_to_plaintext(string):
+    return html.html5parser.fromstring(string).xpath('string()')
+
+
 def inject_unicode_debug(s, level=1):
     """
     Wrap a string in invisible unicode characters to trigger a unicode

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -19,9 +19,9 @@ from itertools import count
 
 import pytest
 
-from indico.util.string import (camelize, camelize_keys, crc32, format_repr, make_unique_token, normalize_phone_number,
-                                render_markdown, sanitize_email, seems_html, slugify, snakify, snakify_keys, strip_tags,
-                                text_to_repr, to_unicode)
+from indico.util.string import (camelize, camelize_keys, crc32, format_repr, html_to_plaintext, make_unique_token,
+                                normalize_phone_number, render_markdown, sanitize_email, seems_html, slugify, snakify,
+                                snakify_keys, strip_tags, text_to_repr, to_unicode)
 
 
 def test_seems_html():
@@ -205,6 +205,16 @@ def test_normalize_phone_number(input, output):
 ))
 def test_sanitize_email(input, output):
     assert sanitize_email(input) == output
+
+
+@pytest.mark.parametrize(('input', 'output'), (
+    ('Simple text', 'Simple text'),
+    ('<h1>Some html</h1>', 'Some html'),
+    ('foo &amp; bar <a href="test">xxx</a> 1<2 <test>', 'foo & bar xxx 1<2 '),
+    (u'<strong>m\xf6p</strong> test', u'm\xf6p test')
+))
+def test_html_to_plaintext(input, output):
+    assert html_to_plaintext(input) == output
 
 
 @pytest.mark.parametrize(('input', 'output'), (

--- a/indico/web/flask/app.py
+++ b/indico/web/flask/app.py
@@ -51,7 +51,7 @@ from indico.util import date_time as date_time_util
 from indico.util.i18n import _, babel, get_current_locale, gettext_context, ngettext_context
 from indico.util.mimetypes import icon_from_mimetype
 from indico.util.signals import values_from_signal
-from indico.util.string import RichMarkup, alpha_enum, crc32, sanitize_html, slugify
+from indico.util.string import RichMarkup, alpha_enum, crc32, html_to_plaintext, sanitize_html, slugify
 from indico.web.assets import (core_env, include_css_assets, include_js_assets, register_all_css, register_all_js,
                                register_theme_sass)
 from indico.web.flask.errors import errors_bp
@@ -208,6 +208,7 @@ def setup_jinja(app):
     app.add_template_filter(underline)
     app.add_template_filter(markdown)
     app.add_template_filter(dedent)
+    app.add_template_filter(html_to_plaintext)
     app.add_template_filter(natsort)
     app.add_template_filter(groupby)
     app.add_template_filter(any)


### PR DESCRIPTION
Redid the pull request on branch 2.1-dev

As for the plain text problem: Currently the apporaoch is to use striptags in the template.