### PR TITLE
Add signal for checkin state changed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ Internal Changes
 - Rename *Roles* in ACL entries to *Permissions*.  This especially affects
   the ``can_manage`` method whose ``role`` argument has been renamed to
   ``permission`` (:issue:`3057`)
+- Add new ``registration_checkin_updated`` signal that can be used by
+  plugins to perform an action when the checkin state of a registration
+  changes (:issue:`3161`, thanks :user:`bpedersen2`)
 
 
 ----

--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -27,9 +27,14 @@ Called when the registration personal data is modified. The `sender` is the
 """)
 
 registration_state_updated = _signals.signal('registration-state-updated', """
-Called when the state of registration changes. The `sender` is the
+Called when the state of a registration changes. The `sender` is the
 `Registration` object; the previous state is passed in the `previous_state`
 kwarg.
+""")
+
+registration_checkin_updated = _signals.signal('registration-checkin-updated', """
+Called when the checkin state of a registration changes. The `sender` is the
+`Registration` object.
 """)
 
 registration_deleted = _signals.signal('registration-deleted', """

--- a/indico/modules/events/registration/api.py
+++ b/indico/modules/events/registration/api.py
@@ -57,6 +57,7 @@ class RHAPIRegistrant(RH):
 
         if 'checked_in' in request.json:
             self._registration.checked_in = bool(request.json['checked_in'])
+            signals.event.registration_checkin_updated.send(self._registration)
 
         return jsonify(build_registration_api_data(self._registration))
 

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -573,10 +573,12 @@ class RHRegistrationCheckIn(RHManageRegistrationBase):
 
     def _process_PUT(self):
         self.registration.checked_in = True
+        signals.event.registration_checkin_updated.send(self.registration)
         return jsonify_data(html=_render_registration_details(self.registration))
 
     def _process_DELETE(self):
         self.registration.checked_in = False
+        signals.event.registration_checkin_updated.send(self.registration)
         return jsonify_data(html=_render_registration_details(self.registration))
 
 
@@ -588,6 +590,7 @@ class RHRegistrationBulkCheckIn(RHRegistrationsActionBase):
         msg = 'checked-in' if check_in else 'not checked-in'
         for registration in self.registrations:
             registration.checked_in = check_in
+            signals.event.registration_checkin_updated.send(registration)
             logger.info('Registration %s marked as %s by %s', registration, msg, session.user)
         flash(_("Selected registrations marked as {} successfully.").format(msg), 'success')
         return jsonify_data(**self.list_generator.render_list())


### PR DESCRIPTION
This signal can be used e.g. in a plugin to print badges or further
material on demand at a check-in desk.
See https://talk.getindico.io/t/print-on-registration-plugin/99 for
the discussion.