### PR TITLE
Keep page header and page title in sync

### DIFF
--- a/indico/modules/events/abstracts/controllers/display.py
+++ b/indico/modules/events/abstracts/controllers/display.py
@@ -25,6 +25,7 @@ from indico.modules.events.abstracts.controllers.base import RHAbstractsBase
 from indico.modules.events.abstracts.operations import create_abstract
 from indico.modules.events.abstracts.util import get_user_abstracts, make_abstract_form
 from indico.modules.events.abstracts.views import WPDisplayCallForAbstracts
+from indico.modules.events.layout.util import get_menu_entry_by_name
 from indico.modules.events.util import get_field_values
 from indico.util.i18n import _
 from indico.web.flask.util import send_file, url_for
@@ -35,9 +36,10 @@ class RHCallForAbstracts(RHAbstractsBase):
     """Show the main CFA page"""
 
     def _process(self):
+        page_title = get_menu_entry_by_name('call_for_abstracts', self.event).localized_title
         abstracts = get_user_abstracts(self.event, session.user) if session.user else []
         return WPDisplayCallForAbstracts.render_template('display/call_for_abstracts.html', self.event,
-                                                         abstracts=abstracts)
+                                                         abstracts=abstracts, page_title=page_title)
 
 
 class RHMyAbstractsExportPDF(RHAbstractsBase):

--- a/indico/modules/events/abstracts/templates/display/call_for_abstracts.html
+++ b/indico/modules/events/abstracts/templates/display/call_for_abstracts.html
@@ -6,7 +6,7 @@
 {% from 'events/reviews/_common.html' import render_timeline_section %}
 
 {% block title %}
-    {%- trans %}Call for Abstracts{% endtrans -%}
+    {% if page_title %}{{ page_title }}{% else %}{%- trans %}Call for Abstracts{% endtrans -%}{% endif %}
 {% endblock %}
 
 {% macro render_user_abstract_list(event, abstracts) %}

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -105,8 +105,10 @@ class RHContributionList(RHDisplayProtectionBase):
         self.list_generator = ContributionDisplayListGenerator(event=self.event)
 
     def _process(self):
+        page_title = get_menu_entry_by_name(self.MENU_ENTRY_NAME, self.event).localized_title
+
         return self.view_class.render_template('display/contribution_list.html', self.event,
-                                               timezone=self.event.display_tzinfo,
+                                               timezone=self.event.display_tzinfo, page_title=page_title,
                                                **self.list_generator.get_list_kwargs())
 
 

--- a/indico/modules/events/contributions/templates/display/contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/contribution_list.html
@@ -4,7 +4,7 @@
 {% from 'events/management/_lists.html' import render_displayed_entries_fragment %}
 
 {% block title %}
-    {% trans %}Contribution List{% endtrans %}
+    {% if page_title %}{{ page_title }}{% else %}{% trans %}Contribution List{% endtrans %}{% endif %}
 {% endblock %}
 
 {% block content -%}

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -25,6 +25,7 @@ from werkzeug.exceptions import Forbidden, NotFound
 
 from indico.modules.auth.util import redirect_to_login
 from indico.modules.events.controllers.base import RHDisplayEventBase
+from indico.modules.events.layout.util import get_menu_entry_by_name
 from indico.modules.events.models.events import EventType
 from indico.modules.events.payment import payment_event_settings
 from indico.modules.events.registration import registration_settings
@@ -164,6 +165,7 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
                 'show_checkin': any(registration['checked_in'] for registration in registrations)}
 
     def _process(self):
+        page_title = get_menu_entry_by_name('participants', self.event).localized_title
         regforms = (RegistrationForm.query.with_parent(self.event)
                     .filter(RegistrationForm.publish_registrations_enabled,
                             ~RegistrationForm.is_deleted)
@@ -196,7 +198,8 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
             regforms=regforms,
             tables=tables,
             published=published,
-            num_participants=num_participants
+            num_participants=num_participants,
+            page_title=page_title
         )
 
 

--- a/indico/modules/events/registration/templates/display/participant_list.html
+++ b/indico/modules/events/registration/templates/display/participant_list.html
@@ -7,7 +7,7 @@
 {% from 'message_box.html' import message_box %}
 
 {% block title %}
-    {% trans %}Participant List{% endtrans %}
+    {% if page_title %}{{ page_title }}{% else %}{% trans %}Participant List{% endtrans %}{% endif %}
 {% endblock %}
 
 {% block subtitle %}


### PR DESCRIPTION
Use the same logic that is used for tracks/program display

Fixes: #3165