### PR TITLE
Show validation message for radio_buttons_widget

### DIFF
--- a/indico/web/templates/forms/radio_buttons_widget.html
+++ b/indico/web/templates/forms/radio_buttons_widget.html
@@ -3,7 +3,7 @@
 {% set vertical_alignment = field.option_orientation == 'vertical' %}
 
 {% block html %}
-    <div class="{{ 'i-group' if vertical_alignment else 'group i-selection' }}">
+    <div id="{{ field.id }}" class="{{ 'i-group' if vertical_alignment else 'group i-selection' }}">
         {% for subfield in field %}
             <div class="{{ 'i-radio' if vertical_alignment else 'inline-vcentered'}} radio-item-{{ loop.index0 }}">
                 {{ subfield(**input_args) }}
@@ -11,4 +11,18 @@
             </div>
         {% endfor %}
     </div>
+{% endblock %}
+
+{% block javascript %}
+    <script>
+        (function() {
+            'use strict';
+
+            $('#{{ field.id }} input').on('invalid', function(evt) {
+                evt.preventDefault();
+
+                $('#{{ field.id }} div:last-child').stickyTooltip('warning', this.validationMessage);
+            });
+        })();
+    </script>
 {% endblock %}


### PR DESCRIPTION
Validation message can't be shown because the `input[type=radio]` is not visible, thus not focusable.