### PR TITLE
Add header-only class when needed

### DIFF
--- a/indico/htdocs/js/indico/modules/reviews.js
+++ b/indico/htdocs/js/indico/modules/reviews.js
@@ -53,7 +53,10 @@
                 $item.addClass('header-indicator-left');
             }
             if ($item.data('no-comment') !== undefined) {
-                $item.addClass('header-only');
+                var $ratingsDetails = $item.find('.ratings-details');
+                if (!$ratingsDetails.length || !$ratingsDetails.is(':visible')) {
+                    $item.addClass('header-only');
+                }
             }
         }).on('focus', '.new-comment textarea', function() {
             var $box = $('#review-timeline-input');


### PR DESCRIPTION
Sometime the ratings-details box may look broken, e.g. when

1) User clicks `show ratings`
2) User clicks icon `Edit review`
3) User clicks `Cancel`

<img width="732" alt="untitled" src="https://user-images.githubusercontent.com/3616940/33708695-6aa19798-db3b-11e7-971e-cc302f274fa1.png">
