### PR TITLE
[RFC] Make image upload better configurable

### DIFF
--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -40,6 +40,8 @@ from indico.util.string import crc32, snakify
 DEFAULTS = {
     'ASSETS_DIR': '/opt/indico/assets',
     'ATTACHMENT_STORAGE': 'default',
+    'ALLOWED_IMAGE_MIME_TYPES': ['image/jpeg', 'image/jpg', 'image/gif', 'image/png'],
+    'ALLOWED_IMAGE_TYPES': ['jpeg', 'gif', 'png'],
     'AUTH_PROVIDERS': {},
     'BASE_URL': None,
     'CACHE_BACKEND': 'files',

--- a/indico/htdocs/sass/modules/_event_management.scss
+++ b/indico/htdocs/sass/modules/_event_management.scss
@@ -383,6 +383,15 @@
             height: 200px;
         }
 
+        span {
+            .nonimage {
+                margin: 2px;
+                height: 200px;
+                display: inline-block;
+                vertical-align: bottom;
+            }
+        }
+
         .menu {
             color: white;
             text-align: right;

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -24,6 +24,7 @@ from PIL import Image
 from sqlalchemy.orm import joinedload, load_only, undefer_group
 from werkzeug.exceptions import BadRequest, Forbidden
 
+from indico.core.config import config
 from indico.core.db import db
 from indico.modules.categories import logger
 from indico.modules.categories.controllers.base import RHManageCategoryBase
@@ -121,7 +122,7 @@ class RHCategoryImageUploadBase(RHManageCategoryBase):
         except IOError:
             flash(_('You cannot upload this file as an icon/logo.'), 'error')
             return jsonify_data(content=None)
-        if img.format.lower() not in {'jpeg', 'png', 'gif'}:
+        if img.format.lower() not in config.ALLOWED_IMAGE_TYPES:
             flash(_('The file has an invalid format ({format})').format(format=img.format), 'error')
             return jsonify_data(content=None)
         if img.mode == 'CMYK':

--- a/indico/modules/events/layout/controllers/layout.py
+++ b/indico/modules/events/layout/controllers/layout.py
@@ -25,6 +25,7 @@ from werkzeug.exceptions import NotFound
 from wtforms import fields as wtforms_fields
 from wtforms.validators import DataRequired
 
+from indico.core.config import config
 from indico.core.db import db
 from indico.modules.events.controllers.base import RHDisplayEventBase
 from indico.modules.events.layout import layout_settings, logger, theme_settings

--- a/indico/modules/events/layout/forms.py
+++ b/indico/modules/events/layout/forms.py
@@ -152,7 +152,7 @@ class MenuPageForm(MenuUserEntryFormBase):
 
 
 class AddImagesForm(IndicoForm):
-    image = FileField("Image", multiple_files=True, accepted_file_types='image/jpeg,image/jpg,image/png,image/gif')
+    image = FileField("Image", multiple_files=True, accepted_file_types=','.join(config.ALLOWED_IMAGE_MIME_TYPES))
 
 
 class CSSSelectionForm(IndicoForm):

--- a/indico/modules/events/layout/templates/image_list.html
+++ b/indico/modules/events/layout/templates/image_list.html
@@ -2,9 +2,13 @@
     <ul class="image-list">
     {% for image in images %}
         <li>
+            {%- if image.content_type.startswith('image/') -%}
             <a href="{{ url_for('event_images.image_display', image) }}" class="js-lightbox">
                 <img src="{{ url_for('event_images.image_display', image) }}" alt="{% trans %}Image{% endtrans %}">
             </a>
+            {%- else -%}
+            <a href="{{ url_for('event_images.image_display', image) }}"><span class="nonimage">{{ image.filename }}</span></a>
+            {%- endif -%}
             <span class="menu">
                 <a class="icon-link js-copy-to-clipboard" title="{% trans %}Get link to image{% endtrans %}"
                    href="{{ url_for('event_images.image_display', image, _external=true) }}"


### PR DESCRIPTION
Add configs for image types and try to handle pdf as well.

This allows to upload 'hidden' files (e.g. pdf files) and link them
from pages or the menu, without having these files show up in the
materials listing on the event front page.