### PR TITLE
Add support for hidden attachment folders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ Improvements
   category. Also keep the per-category status in the session (:issue:`3233`,
   thanks :user:`bpedersen2`)
 - Keep page titles in sync with conference menu item titles (:issue:`3236`)
+- Add option to hide an attachment folder in the display areas of an event
+  (:issue:`3181`, thanks :user:`bpedersen2`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/migrations/versions/20180129_0842_813ea74ce8dc_add_attachment_folder_is_hidden.py
+++ b/indico/migrations/versions/20180129_0842_813ea74ce8dc_add_attachment_folder_is_hidden.py
@@ -1,0 +1,29 @@
+"""Add AttachmentFolder.is_hidden
+
+Revision ID: 813ea74ce8dc
+Revises: c820455976ba
+Create Date: 2018-01-29 08:42:10.760814
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '813ea74ce8dc'
+down_revision = 'c820455976ba'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('folders', sa.Column('is_hidden', sa.Boolean(), nullable=False, server_default='false'),
+                  schema='attachments')
+    op.alter_column('folders', 'is_hidden', server_default=None, schema='attachments')
+    op.create_check_constraint('is_hidden_not_is_always_visible', 'folders', 'NOT (is_hidden AND is_always_visible)',
+                               schema='attachments')
+
+
+def downgrade():
+    op.drop_constraint('ck_folders_is_hidden_not_is_always_visible', 'folders', schema='attachments')
+    op.drop_column('folders', 'is_hidden', schema='attachments')

--- a/indico/modules/attachments/forms.py
+++ b/indico/modules/attachments/forms.py
@@ -107,12 +107,12 @@ class AttachmentFolderForm(IndicoForm):
                                      description=_("By default, folders are always visible, even if a user cannot "
                                                    "access them. You can disable this behavior here, hiding the folder "
                                                    "for anyone who does not have permission to access it."))
-    is_hidden = BooleanField(_("Always Hidden in Event page"),
-                             [HiddenUnless('is_always_visible', value=False), ],
+    is_hidden = BooleanField(_("Always hidden"),
+                             [HiddenUnless('is_always_visible', value=False)],
                              widget=SwitchWidget(),
-                             description=_("Always hide the folder in the event page materials listing. "
-                                           "You can use this for folders to store non-image files used "
-                                           "in e.g. in download links. The access permissions still apply."))
+                             description=_("Always hide the folder and its contents from public display areas of "
+                                           "the event. You can use this for folders to store non-image files used "
+                                           "e.g. in download links. The access permissions still apply."))
 
     def __init__(self, *args, **kwargs):
         self.linked_object = kwargs.pop('linked_object')

--- a/indico/modules/attachments/templates/_attachments.html
+++ b/indico/modules/attachments/templates/_attachments.html
@@ -64,6 +64,14 @@
                    title="{% trans %}The access to this folder is restricted, regardless of the protection scheme of
                           the parent.{% endtrans %}"></i>
             {% endif %}
+            {% if folder.is_hidden and management %}
+                <i class="icon-eye-blocked"
+                   title="{% trans %}This folder is always hidden in the frontend.{% endtrans %}"></i>
+            {% endif %}
+            {% if folder.is_always_visible and management %}
+                <i class="icon-eye"
+                   title="{% trans %}This folder is always visible in the frontend.{% endtrans %}"></i>
+            {% endif %}
         </td>
         {% if management -%}
             <td class="actions hide-if-locked">


### PR DESCRIPTION
Not all uploaded files need to be shown in the materials listing
on the event front page, sometimes it should only be used for links
at some place in the event. Allow to always hide folders in the
frontend indepently from the access rights.

Fixes: #3180