### PR TITLE
Fix flower login if used behind a proxy via socket

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,8 @@ Improvements
 - Keep page titles in sync with conference menu item titles (:issue:`3236`)
 - Add option to hide an attachment folder in the display areas of an event
   (:issue:`3181`, thanks :user:`bpedersen2`)
+- Improve flower redirect URI generation (:issue:`3187`, thanks
+  :user:`bpedersen2`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/core/celery/cli.py
+++ b/indico/core/celery/cli.py
@@ -59,6 +59,8 @@ def celery_cmd(args):
                     'INDICO_FLOWER_AUTHORIZE_URL': url_for('oauth.oauth_authorize', _external=True),
                     'INDICO_FLOWER_TOKEN_URL': url_for('oauth.oauth_token', _external=True),
                     'INDICO_FLOWER_USER_URL': url_for('users.authenticated_user', _external=True)}
+        if config.FLOWER_URL:
+            auth_env['INDICO_FLOWER_URL'] = config.FLOWER_URL
         args = ['celery', '-b', config.CELERY_BROKER] + args + auth_args
         env = dict(os.environ, **auth_env)
         os.execvpe('celery', args, env)


### PR DESCRIPTION
The login redirect uri was always using the port, even if flower is served
via a proxy server, e.g. nginx.


Run flower as:

    indico celery flower --address=<yourhost>  --url-prefix=flower --unix-socket=/var/run/flower/flower.socket 

example nginx snippet:

```
server { ....
  location /flower {
    rewrite ^/flower/(.*)$ /$1 break;
    proxy_pass http://unix:/var/run/flower/flower.socket;
    proxy_set_header Host $host;
    proxy_redirect off;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "upgrade";
    allow 127.0.0.1;
    deny all;
  }
}
```