### PR TITLE
Fix bug in cloning - missing last occurrence

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Bugfixes
 - Fix rendering of time pickers in recent Firefox versions (:issue:`3194`)
 - Fix error when trying to use the html serializer with the timetable API
 - Fix error when receiving invalid payment events that should be ignored
+- Fix last occurrence not being created when cloning events (:issue:`3192`)
 
 
 Version 2.0rc2

--- a/indico/modules/events/management/controllers/cloning.py
+++ b/indico/modules/events/management/controllers/cloning.py
@@ -21,7 +21,6 @@ from datetime import datetime
 
 from dateutil import rrule
 from flask import flash, jsonify, request, session
-from pytz import utc
 from werkzeug.exceptions import BadRequest
 
 from indico.modules.events.cloning import EventCloner
@@ -82,7 +81,7 @@ class CloneCalculator(object):
     def _calc_stop_criteria(self, form):
         args = {}
         if form.stop_criterion.data == 'day':
-            args['until'] = datetime.combine(form.until_dt.data, form.start_dt.data.time())
+            args['until'] = datetime.combine(form.until_dt.data, self._naivify(form.start_dt.data).time())
         else:
             args['count'] = form.num_times.data
         return args


### PR DESCRIPTION
We were taking the UTC time into account, which made the interval shorter.
  