### PR TITLE
Fix timezone display in time pickers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Bugfixes
   moving/disabling some items
 - Fix error after updating from 2.0rc1 if there are cached Mako
   templates
+- Fix rendering of time pickers in recent Firefox versions (:issue:`3194`)
 
 
 Version 2.0rc2

--- a/indico/htdocs/js/indico/widgets/occurrences_widget.js
+++ b/indico/htdocs/js/indico/widgets/occurrences_widget.js
@@ -22,15 +22,12 @@
         options = $.extend(true, {
             fieldId: null,
             defaultTime: null,
-            defaultDuration: null,
-            timezone: null,
-            timezoneFieldId: null
+            defaultDuration: null
         }, options);
 
         var rowTemplate = $($.parseHTML($('#' + options.fieldId + '-template').html())).filter('.occurrence');
         var container = $('#' + options.fieldId + '-container');
         var dataField = $('#' + options.fieldId + '');
-        var timezone = options.timezone;
 
         function createRow(data) {
             var row = rowTemplate.clone().insertBefore(container.find('.add-occurrence'));
@@ -45,14 +42,6 @@
 
             row.find('.remove-occurrence').on('click', function() {
                 removeRow(row);
-            });
-
-            row.find('.timezone').qtip({
-                content: {
-                    text: function() {
-                        return timezone;
-                    }
-                }
             });
 
             dateField.datepicker({
@@ -141,12 +130,6 @@
                 return rv;
             }).get();
             dataField.val(JSON.stringify(data)).trigger('change');
-        }
-
-        if (options.timezoneFieldId) {
-            $('#' + options.timezoneFieldId).on('change', function() {
-                timezone = $(this).val();
-            });
         }
 
         container.find('.add-occurrence').on('click', function(evt) {

--- a/indico/htdocs/sass/partials/_inputs.scss
+++ b/indico/htdocs/sass/partials/_inputs.scss
@@ -272,15 +272,11 @@ $dropdown-transition: $dropdown-transition-step ease-out;
         width: 40% !important;
     }
 
-    .timepicker {
-        width: 30% !important;
-    }
-
     .timezone {
         @include icon-before('icon-earth');
         color: $light-black;
         position: relative;
-        right: 24px;
+        left: 15px;
         top: 2px;
     }
 

--- a/indico/htdocs/sass/widgets/_occurrences.scss
+++ b/indico/htdocs/sass/widgets/_occurrences.scss
@@ -30,6 +30,19 @@
 
     .durationpicker {
         width: 20% !important;
+
+        &::-webkit-inner-spin-button,
+        &::-webkit-outer-spin-button {
+            display: none;
+        }
+    }
+
+    .ui-datepicker-trigger {
+        width: 0;
+    }
+
+    input ~ input {
+        margin-left: 1em;
     }
 
     .timezone {

--- a/indico/web/templates/forms/occurrences_widget.html
+++ b/indico/web/templates/forms/occurrences_widget.html
@@ -11,7 +11,6 @@
         <div class="occurrence">
             <input type="text" class="datepicker" readonly>{#--#}
             <input type="time" class="timepicker" placeholder="HH:MM" pattern="{{ time_regex_hhmm }}">{#--#}
-            <i class="timezone"></i>{#--#}
             <input type="number" class="durationpicker" step="1" min="1">{#--#}
             <i class="duration-info" title="{% trans %}Duration in minutes{% endtrans %}"></i>{#--#}
             <span class="icon-remove remove-occurrence" title="{% trans %}Remove occurrence{% endtrans %}"></span>
@@ -24,9 +23,7 @@
         setupOccurrencesWidget({
             fieldId: {{ field.id | tojson }},
             defaultTime: {{ field.default_time | format_time('code', timezone=field.timezone) | tojson }},
-            defaultDuration: {{ (field.default_duration.total_seconds() // 60) | int | tojson }},
-            timezone: {{ field.timezone | tojson }},
-            timezoneFieldId: {{ (field.timezone_field.id if field.timezone_field else none) | tojson }}
+            defaultDuration: {{ (field.default_duration.total_seconds() // 60) | int | tojson }}
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Firefox always shows a clear button (even on required fields) that cannot be removed, so we now show the timezone indicator outside (and completely hide it in case of the lecture occurrence widget).

![image](https://user-images.githubusercontent.com/179599/34670984-d51fcef4-f478-11e7-9511-cba54822d50a.png)

  