### PR TITLE
Prevent repeated positions when disabling regform sections

### DIFF
--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -24,10 +24,8 @@ from indico.modules.events.registration import logger
 from indico.modules.events.registration.controllers.management.sections import RHManageRegFormSectionBase
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.items import RegistrationFormItemType, RegistrationFormText
+from indico.modules.events.registration.util import update_regform_item_positions
 from indico.util.string import snakify_keys
-
-
-FIRST_DISABLED_POSITION = 1000
 
 
 def _fill_form_field_with_data(field, field_data, set_data=True):
@@ -42,13 +40,6 @@ def _fill_form_field_with_data(field, field_data, set_data=True):
         else:
             field.data, field.versioned_data = field.field_impl.process_field_data(field_data, field.data,
                                                                                    field.versioned_data)
-
-
-def _remove_regform_item_gaps(form_items, from_position):
-    """Update positions when deleting/disabling an item in order to prevent gaps"""
-    for item in form_items:
-        if item.position > from_position and item.is_enabled:
-            item.position -= 1
 
 
 class RHManageRegFormFieldBase(RHManageRegFormSectionBase):
@@ -74,11 +65,8 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
         if (not enabled and self.field.type == RegistrationFormItemType.field_pd and
                 self.field.personal_data_type.is_required):
             raise BadRequest
-        if not enabled:
-            _remove_regform_item_gaps(self.field.parent.fields, self.field.position)
-        positions = [x.position for x in self.field.parent.fields if x.is_enabled == enabled]
-        self.field.position = max(positions) + 1 if positions else FIRST_DISABLED_POSITION
         self.field.is_enabled = enabled
+        update_regform_item_positions(self.regform)
         db.session.flush()
         logger.info('Field %s modified by %s', self.field, session.user)
         return jsonify(view_data=self.field.view_data)
@@ -91,7 +79,7 @@ class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
         if self.field.type == RegistrationFormItemType.field_pd:
             raise BadRequest
         self.field.is_deleted = True
-        _remove_regform_item_gaps(self.field.parent.fields, self.field.position)
+        update_regform_item_positions(self.regform)
         db.session.flush()
         logger.info('Field %s deleted by %s', self.field, session.user)
         return jsonify()

--- a/indico/modules/events/registration/controllers/management/sections.py
+++ b/indico/modules/events/registration/controllers/management/sections.py
@@ -23,6 +23,7 @@ from indico.core.db import db
 from indico.modules.events.registration import logger
 from indico.modules.events.registration.controllers.management import RHManageRegFormBase
 from indico.modules.events.registration.models.items import RegistrationFormItemType, RegistrationFormSection
+from indico.modules.events.registration.util import update_regform_item_positions
 from indico.web.util import jsonify_data
 
 
@@ -84,6 +85,7 @@ class RHRegistrationFormToggleSection(RHManageRegFormSectionBase):
         if not enabled and self.section.type == RegistrationFormItemType.section_pd:
             raise BadRequest
         self.section.is_enabled = enabled
+        update_regform_item_positions(self.regform)
         db.session.flush()
         if self.section.is_enabled:
             logger.info('Section %s enabled by %s', self.section, session.user)
@@ -102,12 +104,13 @@ class RHRegistrationFormMoveSection(RHManageRegFormSectionBase):
             return jsonify(success=True)
         elif new_position < old_position:
             def fn(section):
-                return section.position >= new_position and section.id != self.section.id
+                return (section.position >= new_position and section.id != self.section.id and not section.is_deleted
+                        and section.is_enabled)
             start_enum = new_position + 1
         else:
             def fn(section):
-                return (section.position > old_position and section.position <= new_position
-                        and section.id != self.section.id)
+                return (old_position < section.position <= new_position and section.id != self.section.id
+                        and not section.is_deleted and section.is_enabled)
             start_enum = self.section.position
         to_update = filter(fn, RegistrationFormSection.find(registration_form=self.regform, is_deleted=False)
                                                       .order_by(RegistrationFormSection.position).all())

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -16,7 +16,9 @@
 
 from __future__ import unicode_literals
 
+import itertools
 from collections import OrderedDict
+from operator import attrgetter
 
 from flask import current_app, json, session
 from qrcode import QRCode, constants
@@ -493,3 +495,18 @@ def generate_ticket(registration):
 
 def get_ticket_attachments(registration):
     return [('Ticket.pdf', generate_ticket(registration).getvalue())]
+
+
+def update_regform_item_positions(regform):
+    """Update positions when deleting/disabling an item in order to prevent gaps"""
+    section_positions = itertools.count(1)
+    disabled_section_positions = itertools.count(1000)
+    for section in sorted(regform.sections, key=attrgetter('position')):
+        section_active = section.is_enabled and not section.is_deleted
+        section.position = next(section_positions if section_active else disabled_section_positions)
+        # ensure consistent field ordering
+        positions = itertools.count(1)
+        disabled_positions = itertools.count(1000)
+        for child in section.children:
+            child_active = child.is_enabled and not child.is_deleted
+            child.position = next(positions if child_active else disabled_positions)


### PR DESCRIPTION
Use the same position system that it's being used with fields. Disabled sections have positions >= 1000