### PR TITLE
Remove authors sections from the widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,7 @@ Bugfixes
 - Make number inputs big enough to show 5 digits in chrome
 - Sort chairperson list on lecture pages
 - Remove whitespace before commas in speaker lists
+- Hide author UI for subcontribution speakers (:issue:`3222`)
 
 
 Version 2.0

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -119,7 +119,7 @@ class SubContributionForm(IndicoForm):
     description = TextAreaField(_('Description'))
     duration = TimeDeltaField(_('Duration'), [DataRequired(), MaxDuration(timedelta(hours=24))],
                               default=timedelta(minutes=20), units=('minutes', 'hours'))
-    speakers = SubContributionPersonLinkListField(_('Speakers'), allow_submitters=False,
+    speakers = SubContributionPersonLinkListField(_('Speakers'), allow_submitters=False, allow_authors=False,
                                                   description=_('The speakers of the subcontribution'))
     references = ReferencesField(_("External IDs"), reference_class=SubContributionReference,
                                  description=_("Manage external resources for this sub-contribution"))


### PR DESCRIPTION
We don't need the authors sections for the
SubContributionPersonLinkList widget because
subcontribution persons are always speakers.