### PR TITLE
add Sender header to mails if custom From address is used

### DIFF
--- a/indico/core/emails.py
+++ b/indico/core/emails.py
@@ -98,6 +98,8 @@ def do_send_email(email, log_entry=None, _from_task=False):
             msg.extra_headers['To'] = 'Undisclosed-recipients:;'
         if email['html']:
             msg.content_subtype = 'html'
+        if email['from'] != config.NO_REPLY_EMAIL:
+            msg.extra_headers['Sender'] = config.NO_REPLY_EMAIL
         msg.send()
     if not _from_task:
         logger.info('Sent email "%s"', truncate(email['subject'], 100))


### PR DESCRIPTION
Programs that send mail on behalf of other user's mailboxes should alwas add a `Sender` header with their own mail address, according to RFC 822: https://tools.ietf.org/html/rfc822#section-4.4.2

Indico does not do this currently and simply sends out mail with the mail adress specified in the registration form settings. This leads to an increased probability of the (registration) mails being classified as spam mails, since many spam filters check if the sending mail server is related to the domain name in the From header (e.g., by DNS lookup or SPF rules). Therefore, Indico should use its own mail adress as Sender, which is most likely the no-reply address from the config file.