### PR TITLE
Persist "show future events" in categories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,9 @@ Improvements
 - Add option to include the event description in reminder emails
   (:issue:`3157`, thanks :user:`bpedersen2`)
 - Pin default themes to the top for event managers (:issue:`3166`)
+- Add user setting whether to show future events or not by default in a
+  category. Also keep the per-category status in the session (:issue:`3233`,
+  thanks :user:`bpedersen2`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/htdocs/js/indico/modules/categories/display.js
+++ b/indico/htdocs/js/indico/modules/categories/display.js
@@ -38,16 +38,28 @@
         });
     };
 
-    global.setupCategoryDisplayEventList = function setupCategoryDisplayEventList(showPastEvents) {
+    global.setupCategoryDisplayEventList = function setupCategoryDisplayEventList(showFutureEvents, showPastEvents) {
         var $eventList = $('.event-list');
         var $futureEvents = $eventList.find('.future-events');
         var $pastEvents = $eventList.find('.past-events');
 
-        setupToggleEventListButton($futureEvents);
+        setupToggleEventListButton($futureEvents, onToggleFutureEvents);
         setupToggleEventListButton($pastEvents, onTogglePastEvents);
+
+        if (showFutureEvents) {
+            $futureEvents.find('.js-toggle-list').first().trigger('click', true);
+        }
 
         if (showPastEvents) {
             $pastEvents.find('.js-toggle-list').first().trigger('click', true);
+        }
+
+        function onToggleFutureEvents(shown) {
+            $.ajax({
+                url: $eventList.data('show-future-events-url'),
+                method: shown ? 'PUT' : 'DELETE',
+                error: handleAjaxError
+            });
         }
 
         function onTogglePastEvents(shown) {

--- a/indico/modules/categories/blueprint.py
+++ b/indico/modules/categories/blueprint.py
@@ -24,8 +24,9 @@ from indico.modules.categories.controllers.display import (RHCategoryCalendarVie
                                                            RHCategoryLogo, RHCategoryOverview, RHCategorySearch,
                                                            RHCategoryStatistics, RHDisplayCategory, RHEventList,
                                                            RHExportCategoryAtom, RHExportCategoryICAL,
-                                                           RHReachableCategoriesInfo, RHShowPastEventsInCategory,
-                                                           RHSubcatInfo, RHXMLExportCategoryInfo)
+                                                           RHReachableCategoriesInfo, RHShowFutureEventsInCategory,
+                                                           RHShowPastEventsInCategory, RHSubcatInfo,
+                                                           RHXMLExportCategoryInfo)
 from indico.modules.categories.controllers.management import (RHCreateCategory, RHDeleteCategory, RHDeleteEvents,
                                                               RHDeleteSubcategories, RHManageCategoryContent,
                                                               RHManageCategoryIcon, RHManageCategoryLogo,
@@ -77,6 +78,7 @@ _bp.add_url_rule('/info', 'info', RHCategoryInfo)
 _bp.add_url_rule('/info-from', 'info_from', RHReachableCategoriesInfo, methods=('GET', 'POST'))
 _bp.add_url_rule('/logo-<slug>.png', 'display_logo', RHCategoryLogo)
 _bp.add_url_rule('/overview', 'overview', RHCategoryOverview)
+_bp.add_url_rule('/show-future-events', 'show_future_events', RHShowFutureEventsInCategory, methods=('DELETE', 'PUT'))
 _bp.add_url_rule('/show-past-events', 'show_past_events', RHShowPastEventsInCategory, methods=('DELETE', 'PUT'))
 _bp.add_url_rule('/statistics', 'statistics', RHCategoryStatistics)
 _bp.add_url_rule('/subcat-info', 'subcat_info', RHSubcatInfo)

--- a/indico/modules/categories/templates/display/category.html
+++ b/indico/modules/categories/templates/display/category.html
@@ -27,7 +27,7 @@
         {{ event_list(events_by_month=events_by_month, format_event_date=format_event_date, is_recent=is_recent,
                       happening_now=happening_now, category=category, future_event_count=future_event_count,
                       past_event_count=past_event_count, future_threshold=future_threshold, past_threshold=past_threshold,
-                      show_past_events=show_past_events) }}
+                      show_future_events=show_future_events, show_past_events=show_past_events) }}
     {% endif %}
 {% endblock %}
 

--- a/indico/modules/categories/templates/display/event_list.html
+++ b/indico/modules/categories/templates/display/event_list.html
@@ -43,8 +43,9 @@
 
 {% macro event_list(events_by_month, format_event_date, is_recent, happening_now, category, future_event_count,
                     past_event_count, future_threshold, past_threshold, future_events_by_month=[],
-                    past_events_by_month=[], show_past_events=false) %}
+                    past_events_by_month=[], show_future_events=false, show_past_events=false) %}
     <div class="event-list"
+         data-show-future-events-url="{{ url_for('.show_future_events', category) }}"
          data-show-past-events-url="{{ url_for('.show_past_events', category) }}">
         {% if future_event_count %}
             {% call _hidden_events_block('future-events', category, future_events_by_month, format_event_date,
@@ -71,7 +72,8 @@
         {% endif %}
     </div>
     <script>
-        setupCategoryDisplayEventList({{ (show_past_events and not past_events_by_month) | tojson }});
+        setupCategoryDisplayEventList({{ (show_future_events and not future_events_by_month) | tojson }},
+                                      {{ (show_past_events and not past_events_by_month) | tojson }});
     </script>
 {% endmacro %}
 

--- a/indico/modules/users/__init__.py
+++ b/indico/modules/users/__init__.py
@@ -40,6 +40,7 @@ user_settings = UserSettingsProxy('users', {
     'lang': None,
     'timezone': None,
     'force_timezone': False,  # always use the user's timezone instead of an event's timezone
+    'show_future_events': False,
     'show_past_events': False,
     'name_format': NameFormat.first_last,
     'use_previewer_pdf': True,

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -55,6 +55,11 @@ class UserPreferencesForm(IndicoForm):
         widget=SwitchWidget(),
         description=_("Always use my current timezone instead of an event's timezone."))
 
+    show_future_events = BooleanField(
+        _('Show future events'),
+        widget=SwitchWidget(),
+        description=_('Show future events by default.'))
+
     show_past_events = BooleanField(
         _('Show past events'),
         widget=SwitchWidget(),


### PR DESCRIPTION
Use the same logic as for past events to enable
(session-)persistent storage of the "show future
events" state.