### PR TITLE
Sync conference page titles with menu item titles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,7 @@ Improvements
 - Add user setting whether to show future events or not by default in a
   category. Also keep the per-category status in the session (:issue:`3233`,
   thanks :user:`bpedersen2`)
+- Keep page titles in sync with conference menu item titles (:issue:`3236`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/abstracts/templates/display/call_for_abstracts.html
+++ b/indico/modules/events/abstracts/templates/display/call_for_abstracts.html
@@ -6,7 +6,7 @@
 {% from 'events/reviews/_common.html' import render_timeline_section %}
 
 {% block title %}
-    {%- trans %}Call for Abstracts{% endtrans -%}
+    {{- page_title -}}
 {% endblock %}
 
 {% macro render_user_abstract_list(event, abstracts) %}

--- a/indico/modules/events/abstracts/templates/display/tracks.html
+++ b/indico/modules/events/abstracts/templates/display/tracks.html
@@ -1,7 +1,7 @@
 {% extends 'events/display/conference/base.html' %}
 
 {% block title %}
-    {%- trans %}Reviewing Area{% endtrans -%}
+    {{- page_title -}}
 {% endblock %}
 
 {% block description %}

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -25,7 +25,6 @@ from indico.legacy.pdfinterface.conference import ContribsToPDF, ContribToPDF
 from indico.modules.events.abstracts.util import filter_field_values
 from indico.modules.events.contributions.lists import ContributionDisplayListGenerator
 from indico.modules.events.contributions.models.contributions import Contribution
-from indico.modules.events.contributions.models.fields import ContributionFieldVisibility
 from indico.modules.events.contributions.models.persons import AuthorType, ContributionPersonLink
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.contributions.util import (get_contribution_ical_file,

--- a/indico/modules/events/contributions/templates/display/author_list.html
+++ b/indico/modules/events/contributions/templates/display/author_list.html
@@ -1,7 +1,7 @@
 {% extends 'events/contributions/display/contribution_person_list_base.html' %}
 
 {% block title -%}
-    {% trans %}List of Authors{% endtrans %}
+    {{- page_title -}}
 {%- endblock %}
 
 {% block list %}

--- a/indico/modules/events/contributions/templates/display/contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/contribution_list.html
@@ -4,7 +4,7 @@
 {% from 'events/management/_lists.html' import render_displayed_entries_fragment %}
 
 {% block title %}
-    {% trans %}Contribution List{% endtrans %}
+    {{- page_title -}}
 {% endblock %}
 
 {% block content -%}

--- a/indico/modules/events/contributions/templates/display/speaker_list.html
+++ b/indico/modules/events/contributions/templates/display/speaker_list.html
@@ -1,7 +1,7 @@
 {% extends 'events/contributions/display/contribution_person_list_base.html' %}
 
 {% block title -%}
-    {% trans %}List of Speakers{% endtrans %}
+    {{- page_title -}}
 {%- endblock %}
 
 {% block list %}

--- a/indico/modules/events/contributions/templates/display/user_contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/user_contribution_list.html
@@ -1,7 +1,7 @@
 {% extends 'events/display/conference/base.html' %}
 
 {% block title -%}
-    {% trans %}My Contributions{% endtrans %}
+    {{- page_title -}}
 {%- endblock %}
 
 {% block content -%}

--- a/indico/modules/events/papers/templates/_base.html
+++ b/indico/modules/events/papers/templates/_base.html
@@ -1,5 +1,5 @@
 {% extends 'events/reviews/_base.html' %}
 
 {% block title %}
-    {% trans %}Call for Papers{% endtrans %}
+    {{- page_title -}}
 {% endblock %}

--- a/indico/modules/events/papers/templates/display/call_for_papers.html
+++ b/indico/modules/events/papers/templates/display/call_for_papers.html
@@ -6,10 +6,6 @@
 {% from 'events/reviews/_common.html' import render_timeline_section %}
 {% from 'message_box.html' import message_box %}
 
-{% block title %}
-    {%- trans %}Call for Papers{% endtrans -%}
-{% endblock %}
-
 {% block content %}
     <div class="call-for-papers">
         {% set cfp = event.cfp %}

--- a/indico/modules/events/papers/templates/display/judging_area.html
+++ b/indico/modules/events/papers/templates/display/judging_area.html
@@ -4,7 +4,7 @@
 {% from 'message_box.html' import message_box %}
 
 {% block title %}
-    {%- trans %}Judging Area{% endtrans -%}
+    {{- page_title -}}
 {% endblock %}
 
 {% block description %}

--- a/indico/modules/events/papers/templates/display/reviewing_area.html
+++ b/indico/modules/events/papers/templates/display/reviewing_area.html
@@ -5,7 +5,7 @@
 {% from 'message_box.html' import message_box %}
 
 {% block title %}
-    {%- trans %}Reviewing Area{% endtrans -%}
+    {{- page_title -}}
 {% endblock %}
 
 {% block description %}

--- a/indico/modules/events/registration/templates/display/_event_registration_base.html
+++ b/indico/modules/events/registration/templates/display/_event_registration_base.html
@@ -1,5 +1,5 @@
 {% extends 'events/display/conference/base.html' %}
 
 {% block title %}
-    {%- trans %}Registration{% endtrans -%}
+    {{- page_title -}}
 {% endblock %}

--- a/indico/modules/events/registration/templates/display/participant_list.html
+++ b/indico/modules/events/registration/templates/display/participant_list.html
@@ -7,7 +7,7 @@
 {% from 'message_box.html' import message_box %}
 
 {% block title %}
-    {% trans %}Participant List{% endtrans %}
+    {{- page_title -}}
 {% endblock %}
 
 {% block subtitle %}

--- a/indico/modules/events/sessions/templates/display/session_list.html
+++ b/indico/modules/events/sessions/templates/display/session_list.html
@@ -1,7 +1,7 @@
 {% extends 'events/display/conference/base.html' %}
 
 {% block title %}
-    {% trans %}My Sessions{% endtrans %}
+    {{- page_title -}}
 {% endblock %}
 
 {% block content %}

--- a/indico/modules/events/surveys/templates/display/survey_list.html
+++ b/indico/modules/events/surveys/templates/display/survey_list.html
@@ -1,7 +1,7 @@
 {% extends 'events/display/conference/base.html' if event.type == 'conference' else 'layout/meeting_page_base.html' %}
 
 {% block title %}
-    {%- trans %}Surveys{% endtrans -%}
+    {{- page_title -}}
 {% endblock %}
 
 {% block content %}

--- a/indico/modules/events/timetable/templates/display.html
+++ b/indico/modules/events/timetable/templates/display.html
@@ -2,7 +2,7 @@
 {% from 'events/timetable/_timetable.html' import render_timetable %}
 
 {% block title %}
-    {%- trans %}Timetable{% endtrans -%}
+    {{- page_title -}}
 {% endblock %}
 
 {% block content %}

--- a/indico/modules/events/tracks/controllers.py
+++ b/indico/modules/events/tracks/controllers.py
@@ -25,7 +25,6 @@ from sqlalchemy.orm import subqueryload
 from indico.core.db.sqlalchemy.descriptions import RENDER_MODE_WRAPPER_MAP
 from indico.legacy.pdfinterface.conference import ProgrammeToPDF
 from indico.modules.events.controllers.base import RHDisplayEventBase
-from indico.modules.events.layout.util import get_menu_entry_by_name
 from indico.modules.events.management.controllers import RHManageEventBase
 from indico.modules.events.tracks.forms import ProgramForm, TrackForm
 from indico.modules.events.tracks.models.tracks import Track
@@ -122,7 +121,6 @@ class RHDeleteTrack(RHManageTrackBase):
 
 class RHDisplayTracks(RHDisplayEventBase):
     def _process(self):
-        page_title = get_menu_entry_by_name('program', self.event).localized_title
         program = track_settings.get(self.event, 'program')
         render_mode = track_settings.get(self.event, 'program_render_mode')
         program = RENDER_MODE_WRAPPER_MAP[render_mode](program)
@@ -131,8 +129,7 @@ class RHDisplayTracks(RHDisplayEventBase):
                            subqueryload('abstract_reviewers'))
                   .order_by(Track.position)
                   .all())
-        return WPDisplayTracks.render_template('display.html', self.event,
-                                               page_title=page_title, program=program, tracks=tracks)
+        return WPDisplayTracks.render_template('display.html', self.event, program=program, tracks=tracks)
 
 
 class RHTracksPDF(RHDisplayEventBase):

--- a/indico/modules/vc/templates/event_vc.html
+++ b/indico/modules/vc/templates/event_vc.html
@@ -3,7 +3,7 @@
 {% from 'vc/list_vc_rooms.html' import render_vc_rooms_list  %}
 
 {% block title %}
-    {% trans %}Videoconference Rooms{% endtrans %}
+    {{- page_title -}}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Similar to #3169 but moved the logic to get the menu name into a property instead of repeating it. Also added it to all other pages that are associated with menu entries.

closes #3165 