### PR TITLE
Fix badge background handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,12 @@ Improvements
 - Improve flower redirect URI generation (:issue:`3187`, thanks
   :user:`bpedersen2`)
 
+Bugfixes
+^^^^^^^^
+
+- Take 'center' background orientation of badge/poster backgrounds into
+  account (:issue:`3238`, thanks :user:`bpedersen2`)
+
 Internal Changes
 ^^^^^^^^^^^^^^^^
 

--- a/indico/modules/designer/pdf.py
+++ b/indico/modules/designer/pdf.py
@@ -142,10 +142,10 @@ class DesignerPDFBase(object):
                 p.drawOn(canvas, margin_x + item_x, self.height - margin_y - item_y - h)
                 item_y += h
 
-    def _draw_background(self, canvas, img_reader, tpl_data, pos_x, pos_y, width, height, stretch=True):
+    def _draw_background(self, canvas, img_reader, tpl_data, pos_x, pos_y, width, height):
         img_width, img_height = img_reader.getSize()
 
-        if stretch:
+        if tpl_data.background_position == 'stretch':
             bg_x = pos_x
             bg_y = pos_y
             bg_width = width

--- a/indico/modules/designer/pdf.py
+++ b/indico/modules/designer/pdf.py
@@ -151,23 +151,23 @@ class DesignerPDFBase(object):
             bg_width = width
             bg_height = height
         else:
-            bg_width = img_width / tpl_data.pixels_cm * cm
-            bg_height = img_height / tpl_data.pixels_cm * cm
+            bg_width = img_width
+            bg_height = img_height
             page_width = width
             page_height = height
 
             bg_x = pos_x + (page_width - bg_width) / 2.0
             bg_y = pos_y + (page_height - bg_height) / 2.0
 
-            if width > page_width:
-                ratio = float(page_width) / width
+            if bg_width > page_width:
+                ratio = float(page_width) / bg_width
                 bg_width = page_width
                 bg_height *= ratio
                 bg_x = pos_x
                 bg_y = pos_y + (page_height - bg_height) / 2.0
 
-            if height > page_height:
-                ratio = float(page_height) / height
+            if bg_height > page_height:
+                ratio = float(page_height) / bg_height
                 bg_height = page_height
                 bg_width *= ratio
                 bg_x = pos_x + (page_width - bg_width) / 2.0


### PR DESCRIPTION
The background  position setting in a template was never honored in pdf-generation. 
Additionally the calculation did the wrong scaling