### PR TITLE
Update default columns for abstract list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,8 @@ Improvements
 - When blocking a user account, the user will be forcefully logged out in
   addition to being prevented from logging in
 - Warn when editing a speaker/author would result in duplicate emails
+- Show track-related columns in abstract list only if there are tracks
+  defined for the event (:issue:`2813`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/lists.py
+++ b/indico/modules/events/abstracts/lists.py
@@ -225,8 +225,9 @@ class AbstractListGeneratorManagement(AbstractListGeneratorBase):
 
     def __init__(self, event):
         super(AbstractListGeneratorManagement, self).__init__(event)
-        self.default_list_config['items'] = ('submitted_contrib_type', 'accepted_contrib_type', 'submitted_for_tracks',
-                                             'reviewed_for_tracks', 'accepted_track', 'state')
+        self.default_list_config['items'] = ('submitted_contrib_type', 'accepted_contrib_type', 'state')
+        if event.tracks:
+            self.default_list_config['items'] += ('submitted_for_tracks', 'reviewed_for_tracks', 'accepted_track')
         self.extra_filters = OrderedDict([
             ('multiple_tracks', {'title': _('Proposed for multiple tracks'), 'type': 'bool'}),
             ('comments', {'title': _('Must have comments'), 'type': 'bool'})


### PR DESCRIPTION
Show track related columns in abstract list only if there are tracks
available for the event

closes #2813 