### PR TITLE
Event page: Add keywords to metadata in header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,7 @@ Improvements
 - Show a nicer error message when entering an excessively high base
   registration fee (:issue:`3260`)
 - Use proper British English for person titles (:issue:`3279`)
+- Add event keywords in meta tags (:issue:`3262`, thanks :user:`bpedersen2`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/templates/meta.html
+++ b/indico/modules/events/templates/meta.html
@@ -2,3 +2,6 @@
 <meta property="og:image" content="{{ event.logo_url if event.has_logo else
                                       (indico_config.IMAGES_BASE_URL + '/logo_indico.png') }}">
 <meta property="og:description" content="{{ event.description|striptags|truncate(500) }}">
+{% if event.keywords -%}
+    <meta name="keywords" content="{{ event.keywords|join(',') }}">
+{%- endif %}


### PR DESCRIPTION
Currently the  assigned keywords are only use in some calendar views,
but for search engines they should also be provided in the keywords
meta header.