### PR TITLE
Use text sort in reg.-lists for dynamic fields

### DIFF
--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -27,7 +27,7 @@
                                 <th class="i-table" data-sorter="text">{{ item.caption }}</th>
                             {% endfor %}
                             {% for item in dynamic_columns %}
-                                <th class="i-table">{{ item.title }}</th>
+                                <th class="i-table" data-sorter="text">{{ item.title }}</th>
                             {% endfor %}
                         </tr>
                     </thead>


### PR DESCRIPTION
As these fields also are text fields, this should not have bad
side effects.

Fixes: #3265