### PR TITLE
Legacy LaTeX pdfs: Use colored links

### DIFF
--- a/indico/legacy/webinterface/tpls/latex/inc/document.tpl
+++ b/indico/legacy/webinterface/tpls/latex/inc/document.tpl
@@ -16,6 +16,7 @@
 </%block>
 
 \usepackage{hyperref}
+\usepackage[ocgcolorlinks]{ocgx2}[2017/03/30]
 \usepackage{amssymb}
 \usepackage{amsmath}
 \usepackage{fontspec}


### PR DESCRIPTION
Add the hyperref option colorlinks to generate colored links
in pdf files instead of the default red boxes.

User-visible change: The links will be colored both onscreen and
in the printed pdf.