### PR TITLE
LaTeX pdfs: Allow link format customisation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Improvements
   :user:`bpedersen2`)
 - Improve message when the call for abstracts is scheduled to open but
   hasn't started yet
+- Make link color handling for LaTeX pdfs configurable (:issue:`3283`,
+  thanks :user:`bpedersen2`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/legacy/pdfinterface/latex.py
+++ b/indico/legacy/pdfinterface/latex.py
@@ -230,6 +230,7 @@ class AbstractToPDF(PDFLaTeXBase):
             'tz': timezone(tz),
             'track_class': self._get_track_classification(abstract),
             'contrib_type': self._get_contrib_type(abstract),
+            'link_format': boa_settings.get(event, 'link_format'),
         })
         self._args['logo_img'] = create_event_logo_tmp_file(event, self.source_dir) if event.logo else None
 
@@ -265,6 +266,7 @@ class AbstractsToPDF(PDFLaTeXBase):
             'get_contrib_type': AbstractToPDF._get_contrib_type,
             'items': abstracts,
             'url': event.short_external_url,
+            'link_format': boa_settings.get(event, 'link_format'),
         })
 
         self._args['logo_img'] = create_event_logo_tmp_file(event, self.source_dir) if event.logo else None
@@ -363,6 +365,7 @@ class ContribToPDF(PDFLaTeXBase):
             'contrib': contrib,
             'event': event,
             'tz': timezone(tz or event.timezone),
+            'link_format': boa_settings.get(event, 'link_format'),
         })
 
         self._args['logo_img'] = create_event_logo_tmp_file(event, self.source_dir) if event.logo else None
@@ -381,7 +384,8 @@ class ContribsToPDF(PDFLaTeXBase):
             'event': event,
             'items': contribs,
             'url': event.short_external_url,
-            'tz': timezone(tz or event.timezone)
+            'tz': timezone(tz or event.timezone),
+            'link_format': boa_settings.get(event, 'link_format'),
         })
 
         self._args['logo_img'] = create_event_logo_tmp_file(event, self.source_dir) if event.logo else None
@@ -450,6 +454,7 @@ class ContributionBook(PDFLaTeXBase):
             'boa_text': boa_settings.get(event, 'extra_text'),
             'boa_text_end': boa_settings.get(event, 'extra_text_end'),
             'min_lines_per_abstract': boa_settings.get(event, 'min_lines_per_abstract'),
+            'link_format': boa_settings.get(event, 'link_format'),
         })
 
         self._args['logo_img'] = create_event_logo_tmp_file(event, self.source_dir) if event.logo else None

--- a/indico/legacy/pdfinterface/latex_templates/inc/document.tex
+++ b/indico/legacy/pdfinterface/latex_templates/inc/document.tex
@@ -6,7 +6,8 @@
     \usepackage[a4paper, top=1em, bottom=10em]{geometry}
 \JINJA{endblock}
 
-\usepackage{hyperref}
+\usepackage\VAR{link_format.value[0] | rawlatex}{hyperref}
+\VAR{link_format.value[1] | rawlatex}
 \usepackage{amssymb}
 \usepackage{amsmath}
 \usepackage{fontspec}

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -21,7 +21,8 @@ from indico.modules.events.abstracts.fields import (AbstractField, AbstractPerso
                                                     TrackRoleField)
 from indico.modules.events.abstracts.models.abstracts import EditTrackMode
 from indico.modules.events.abstracts.models.reviews import AbstractAction, AbstractCommentVisibility
-from indico.modules.events.abstracts.settings import BOACorrespondingAuthorType, BOASortField, abstracts_settings
+from indico.modules.events.abstracts.settings import (BOACorrespondingAuthorType, BOALinkFormat, BOASortField,
+                                                      abstracts_settings)
 from indico.modules.events.contributions.models.persons import AuthorType
 from indico.modules.events.contributions.models.types import ContributionType
 from indico.modules.events.sessions.models.sessions import Session
@@ -96,6 +97,7 @@ class BOASettingsForm(IndicoForm):
                                      description=_("Show abstract IDs in the table of contents."))
     min_lines_per_abstract = IntegerField(_("Minimum lines per abstract"),
                                           description=_("Minimum lines to reserve per abstract."))
+    link_format = IndicoEnumSelectField(_('Link formatting'), [DataRequired()], enum=BOALinkFormat, sorted=True)
 
 
 class AbstractSubmissionSettingsForm(IndicoForm):

--- a/indico/modules/events/abstracts/settings.py
+++ b/indico/modules/events/abstracts/settings.py
@@ -42,7 +42,6 @@ class BOALinkFormat(RichEnum):
 
     frame = ('', '')
     colorlinks = ('[colorlinks]', '')
-    ocgx2colorlinks = ('', '\\usepackage[ocgcolorlinks]{ocgx2}[2017/03/30]')
     unstyled = ('[hidelinks]', '')
 
 
@@ -69,7 +68,6 @@ BOACorrespondingAuthorType.__titles__ = {
 BOALinkFormat.__titles__ = {
     BOALinkFormat.frame: _('Border around links (screen only)'),
     BOALinkFormat.colorlinks: _('Color links'),
-    BOALinkFormat.ocgx2colorlinks: _('Color links (screen only)'),
     BOALinkFormat.unstyled: _('Do not highlight links')
 }
 

--- a/indico/modules/events/abstracts/settings.py
+++ b/indico/modules/events/abstracts/settings.py
@@ -32,6 +32,20 @@ class BOACorrespondingAuthorType(RichEnum):
     speakers = 'speakers'
 
 
+class BOALinkFormat(RichEnum):
+    """LaTeX book of abstracts link format setting
+
+    value is a 2-tuple of strings:
+    first is the hyperref option to use
+    second sets additional tex commands
+    """
+
+    frame = ('', '')
+    colorlinks = ('[colorlinks]', '')
+    ocgx2colorlinks = ('', '\\usepackage[ocgcolorlinks]{ocgx2}[2017/03/30]')
+    unstyled = ('[hidelinks]', '')
+
+
 BOASortField.__titles__ = {
     BOASortField.id: _('ID'),
     BOASortField.abstract_title: _('Abstract title'),
@@ -51,6 +65,13 @@ BOACorrespondingAuthorType.__titles__ = {
     BOACorrespondingAuthorType.speakers: _('Speakers')
 }
 
+
+BOALinkFormat.__titles__ = {
+    BOALinkFormat.frame: _('Border around links (screen only)'),
+    BOALinkFormat.colorlinks: _('Color links'),
+    BOALinkFormat.ocgx2colorlinks: _('Color links (screen only)'),
+    BOALinkFormat.unstyled: _('Do not highlight links')
+}
 
 abstracts_settings = EventSettingsProxy('abstracts', {
     'description_settings': {
@@ -100,8 +121,10 @@ boa_settings = EventSettingsProxy('abstracts_book', {
     'show_abstract_ids': False,
     'cache_path': None,
     'min_lines_per_abstract': 0,
+    'link_format': BOALinkFormat.frame,
 }, converters={
     'sort_by': EnumConverter(BOASortField),
     'corresponding_author': EnumConverter(BOACorrespondingAuthorType),
-    'announcement_render_mode': EnumConverter(RenderMode)
+    'announcement_render_mode': EnumConverter(RenderMode),
+    'link_format': EnumConverter(BOALinkFormat),
 })


### PR DESCRIPTION
Make the hyperref link color options configurabable.

This is a more complete alternative to #3277