### PR TITLE
Add (sub-)page title to title tag

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Improvements
 - Support markdown in survey questions (:issue:`3366`)
 - Improve event list in case of long event titles (:issue:`3607`,
   thanks :user:`nop33`)
+- Include event page title in the page's ``<title>`` (:issue:`3285`,
+  thanks :user:`bpedersen2`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -130,6 +130,7 @@ class RHContributionDisplay(RHContributionDisplayBase):
                                                contribution=contrib,
                                                show_author_link=_author_page_active(self.event),
                                                field_values=field_values,
+                                               page_title=contrib.title,
                                                **ical_params)
 
 

--- a/indico/modules/events/layout/views.py
+++ b/indico/modules/events/layout/views.py
@@ -44,5 +44,5 @@ class WPPage(WPConferenceDisplayBase):
         WPConferenceDisplayBase.__init__(self, rh, conference, **kwargs)
 
     @property
-    def sidemenu_option(self):
-        return self.page.menu_entry.id
+    def sidemenu_entry(self):
+        return self.page.menu_entry

--- a/indico/modules/events/sessions/controllers/display.py
+++ b/indico/modules/events/sessions/controllers/display.py
@@ -79,7 +79,8 @@ class RHDisplaySession(RHDisplaySessionBase):
                 .filter_by(id=self.session.id)
                 .options(contributions_strategy, blocks_strategy)
                 .one())
-        return self.view_class.render_template('display/session_display.html', self.event, sess=sess, **ical_params)
+        return self.view_class.render_template('display/session_display.html', self.event,
+                                               sess=sess, page_title=sess.title, **ical_params)
 
 
 class RHExportSessionToICAL(RHDisplaySessionBase):

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -226,7 +226,7 @@ class WPConferenceDisplayBase(WPJinjaMixin, MathjaxMixin, WPEventBase):
         assert event_ == kwargs.setdefault('event', event_)
         self.event = event_
         kwargs['conf_layout_params'] = self._get_layout_params()
-        kwargs['page_title'] = self.sidemenu_title
+        kwargs.setdefault('page_title', self.sidemenu_title)
         WPEventBase.__init__(self, rh, event_, **kwargs)
 
     def _get_layout_params(self):

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -115,6 +115,9 @@ class WPEventBase(WPDecorated):
                 dates = ' ({} - {})'.format(to_unicode(format_date(start_dt_local, format='long')),
                                             to_unicode(format_date(end_dt_local, format='long')))
         self.title = '{} {}'.format(strip_tags(self.event.title), dates)
+        page_title = kwargs.get('page_title')
+        if page_title:
+            self.title += ': {}'.format(strip_tags(page_title))
 
     def _getHeader(self):
         raise NotImplementedError  # must be overridden by meeting/lecture and conference WPs


### PR DESCRIPTION
E.g. google will otherwise complain about multiple identical title
tags on different pages.