### PR TITLE
Richcards

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ Improvements
 - Allow div/span/pre with classes when writing raw HTML in CKEditor
   (:issue:`3332`, thanks :user:`bpedersen2`)
 - Sort abstract authors/speakers by last name (:issue:`3340`)
+- Improve machine-readable metadata for events and categories
+  (:issue:`3287`, thanks :user:`bpedersen2`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -243,8 +243,9 @@ class RHDisplayCategoryEventsBase(RHDisplayCategoryBase):
     _category_query_options = (joinedload('children').load_only('id', 'title', 'protection_mode'),
                                undefer('attachment_count'), undefer('has_events'))
     _event_query_options = (joinedload('person_links'), joinedload('series'), undefer_group('series'),
-                            load_only('id', 'category_id', 'created_dt', 'end_dt', 'protection_mode', 'start_dt',
-                                      'title', 'type_', 'series_pos', 'series_count'))
+                            load_only('id', 'category_id', 'created_dt', 'start_dt', 'end_dt', 'timezone',
+                                      'protection_mode', 'title', 'type_', 'series_pos', 'series_count',
+                                      'own_address', 'own_venue_id', 'own_venue_name'))
 
     def _process_args(self):
         RHDisplayCategoryBase._process_args(self)

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -345,7 +345,6 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
         params.update(get_base_ical_parameters(session.user, 'category',
                                                '/export/categ/{0}.ics'.format(self.category.id), {'from': '-31d'}))
 
-
         if not self.category.is_root:
             return WPCategory.render_template('display/category.html', self.category, **params)
 

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -38,7 +38,7 @@ from indico.modules.categories.legacy import XMLCategorySerializer
 from indico.modules.categories.models.categories import Category
 from indico.modules.categories.serialize import (serialize_categories_ical, serialize_category, serialize_category_atom,
                                                  serialize_category_chain)
-from indico.modules.categories.util import get_category_stats, get_upcoming_events, serialize_events_for_json_ld
+from indico.modules.categories.util import get_category_stats, get_upcoming_events, serialize_event_for_json_ld
 from indico.modules.categories.views import WPCategory, WPCategoryStatistics
 from indico.modules.events.models.events import Event
 from indico.modules.events.timetable.util import get_category_timetable
@@ -339,7 +339,7 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
                   'past_event_count': past_event_count,
                   'show_past_events': show_past_events,
                   'past_threshold': past_threshold.strftime(threshold_format),
-                  'json_ld': serialize_events_for_json_ld(events + future_events),
+                  'json_ld': map(serialize_event_for_json_ld, (events + future_events)),
                   'atom_feed_url': url_for('.export_atom', self.category),
                   'atom_feed_title': _('Events of "{}"').format(self.category.title)}
         params.update(get_base_ical_parameters(session.user, 'category',

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -87,3 +87,6 @@
     });
     setupCategoryDisplay();
 </script>
+<script type="application/ld+json">
+{{ json_ld|tojson }}
+</script>

--- a/indico/modules/categories/templates/display/event_list.html
+++ b/indico/modules/categories/templates/display/event_list.html
@@ -85,19 +85,16 @@
         <ul>
             {% for event in month.events %}
                 {% set is_lecture = (event.type == 'lecture') %}
-                <li itemscope itemtype="http://data-vocabulary.org/Event">
+                <li>
                     <span class="ical">
                         <a class="icon-calendar" href="{{ url_for('events.export_event_ical', event) }}"></a>
                     </span>
                     <span class="list-name">
                         <span class="date {% if happening_now(event) %}today{% endif %}">
                             {{ format_event_date(event) }}
-                            <time itemprop="startDate" datetime="{{ event.start_dt.isoformat() }}">
                         </span>
-                        <a href="{{ event.url }}" itemprop="url">
-                            <span itemprop="summary">
-                                {{ event.get_verbose_title(show_speakers=is_lecture, show_series_pos=is_lecture) | striptags }}
-                            </span>
+                        <a href="{{ event.url }}">
+                            {{ event.get_verbose_title(show_speakers=is_lecture, show_series_pos=is_lecture) | striptags }}
                         </a>
                         <span class="protected">
                             {% if event.is_self_protected %}

--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -204,7 +204,3 @@ def get_image_data(image_type, category):
         'size': metadata['size'],
         'content_type': metadata['content_type']
     }
-
-
-def serialize_events_for_json_ld(events):
-    return [serialize_event_for_json_ld(event) for event in events]

--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -35,6 +35,7 @@ from indico.modules.events.contributions import Contribution
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.sessions import Session
 from indico.modules.events.timetable.models.entries import TimetableEntry, TimetableEntryType
+from indico.modules.events.util import serialize_event_for_json_ld
 from indico.util.caching import memoize_redis
 from indico.util.date_time import now_utc
 from indico.util.i18n import _, ngettext
@@ -203,3 +204,7 @@ def get_image_data(image_type, category):
         'size': metadata['size'],
         'content_type': metadata['content_type']
     }
+
+
+def serialize_events_for_json_ld(events):
+    return [serialize_event_for_json_ld(event) for event in events]

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -480,6 +480,10 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         return url_for('event_images.logo_display', self, slug=self.logo_metadata['hash'])
 
     @property
+    def external_logo_url(self):
+        return url_for('event_images.logo_display', self, slug=self.logo_metadata['hash'], _external=True)
+
+    @property
     def participation_regform(self):
         return next((form for form in self.registration_forms if form.is_participation), None)
 

--- a/indico/modules/events/templates/display/conference/base.html
+++ b/indico/modules/events/templates/display/conference/base.html
@@ -19,7 +19,7 @@
 
 
 {% block page %}
-    <div class="conf clearfix" itemscope itemtype="http://schema.org/Event">
+    <div class="conf clearfix">
         <div class="confheader clearfix" style="{{ conf_layout_params.bg_color_css }}">
             <div class="confTitleBox clearfix" style="{{ conf_layout_params.bg_color_css }}">
                 <div class="confTitle">

--- a/indico/modules/events/templates/display/indico/_common.html
+++ b/indico/modules/events/templates/display/indico/_common.html
@@ -76,7 +76,7 @@
         {%- if caller -%}
             {{- caller(link) -}}
         {%- else -%}
-            <span itemprop="performers" itemscope itemtype="http://schema.org/Person" class="{{ span_class }}">
+            <span class="{{ span_class }}">
                 {{- render_user_data(link, show_title=title, italic_affiliation=italic_affiliation) -}}
             </span>
         {%- endif -%}

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -10,7 +10,7 @@
                        or event.contact_emails or event.contact_phones
                        or (event.references and event.type == 'meeting') or hook_event_header %}
 
-<div class="event-wrapper" itemscope itemtype="http://schema.org/Event">
+<div class="event-wrapper">
     {% block header %}
         <div class="event-header event-header-lecture {%- if not has_subheader %} round-bottom-corners{% endif %}">
             {% if not g.static_site %}
@@ -25,7 +25,7 @@
                 {{ render_manage_button(event, 'EVENT', show_button=show_button, toggle_notes=false) }}
             </div>
 
-            <h1 itemprop="name">{{ event.get_verbose_title(show_series_pos=true) }}</h1>
+            <h1>{{ event.get_verbose_title(show_series_pos=true) }}</h1>
             {% set chairpersons = event.person_links %}
             {% if chairpersons %}
                 <h2>

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -10,7 +10,7 @@
                        or event.contact_emails or event.contact_phones
                        or (event.references and event.type == 'meeting') or hook_event_header %}
 
-<div class="event-wrapper" itemscope itemtype="http://schema.org/Event">
+<div class="event-wrapper">
     {% block header %}
         <div class="event-header {%- if not has_subheader %} round-bottom-corners{% endif %}">
             {% set show_button = not event.is_locked and event.can_manage_attachments(session.user) %}

--- a/indico/modules/events/templates/meta.html
+++ b/indico/modules/events/templates/meta.html
@@ -5,3 +5,7 @@
 {% if event.keywords -%}
     <meta name="keywords" content="{{ event.keywords|join(',') }}">
 {%- endif %}
+
+<script type="application/ld+json">
+{{ json_ld|tojson }}
+</script>

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -569,7 +569,7 @@ def serialize_event_for_json_ld(event):
         'description': strip_tags(event.description),
     }
     if event.person_links:
-        data['performer'] = map(_get_json_ld_performer, event.person_links)
+        data['performer'] = map(serialize_person_for_json_ld, event.person_links)
     if event.has_logo:
         data['image'] = event.external_logo_url
     return data

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -565,12 +565,13 @@ def serialize_event_for_json_ld(event, full=False):
             '@type': 'Place',
             'name': event.venue_name or 'No location set',
             'address': event.address or 'No address set'
-        },
-        'description': strip_tags(event.description),
+        }
     }
+    if full and event.description:
+        data['description'] = strip_tags(event.description)
     if full and event.person_links:
         data['performer'] = map(serialize_person_for_json_ld, event.person_links)
-    if event.has_logo:
+    if full and event.has_logo:
         data['image'] = event.external_logo_url
     return data
 

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -578,7 +578,7 @@ def serialize_event_for_json_ld(event, full=False):
 def serialize_person_for_json_ld(person):
     return {
         '@type': 'Person',
-        'name': person.display_full_name,
+        'name': person.full_name,
         'affiliation': {
             '@type': 'Organization',
             'name': person.affiliation

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -553,7 +553,7 @@ def serialize_event_for_ical(event, detail_level):
     return data
 
 
-def serialize_event_for_json_ld(event):
+def serialize_event_for_json_ld(event, full=False):
     data = {
         '@context': 'http://schema.org',
         '@type': 'Event',
@@ -568,7 +568,7 @@ def serialize_event_for_json_ld(event):
         },
         'description': strip_tags(event.description),
     }
-    if event.person_links:
+    if full and event.person_links:
         data['performer'] = map(serialize_person_for_json_ld, event.person_links)
     if event.has_logo:
         data['image'] = event.external_logo_url

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -124,7 +124,7 @@ class WPEventBase(WPDecorated):
     def _getHeadContent(self):
         site_name = core_settings.get('site_title')
         meta = render_template('events/meta.html', event=self.event, site_name=site_name,
-                               json_ld=serialize_event_for_json_ld(self.event))
+                               json_ld=serialize_event_for_json_ld(self.event, full=True))
         return WPDecorated._getHeadContent(self) + meta
 
 

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -120,9 +120,41 @@ class WPEventBase(WPDecorated):
     def getJSFiles(self):
         return WPDecorated.getJSFiles(self) + self._asset_env['modules_event_display_js'].urls()
 
+    def _get_json_ld_data(self):
+        data = {
+            '@context': 'http://schema.org',
+            '@type': 'Event',
+            'url': self.event.external_url,
+            'name': self.event.title,
+            'startDate': self.event.start_dt_local.isoformat(),
+            'endDate': self.event.end_dt_local.isoformat(),
+            'location': {
+                '@type': 'Place',
+                'name': self.event.venue_name or 'No location set',
+                'address': self.event.address or 'No address set'
+            },
+            'description': strip_tags(self.event.description),
+        }
+        if self.event.person_links:
+            data['performer'] = map(self._get_json_ld_performer, self.event.person_links)
+        if self.event.has_logo:
+            data['image'] = self.event.external_logo_url
+        return data
+
+    def _get_json_ld_performer(self, chair):
+        return {
+            '@type': 'Person',
+            'name': chair.display_full_name,
+            'affiliation': {
+                '@type': 'Organization',
+                'name': chair.affiliation
+            }
+        }
+
     def _getHeadContent(self):
         site_name = core_settings.get('site_title')
-        meta = render_template('events/meta.html', event=self.event, site_name=site_name)
+        meta = render_template('events/meta.html', event=self.event, site_name=site_name,
+                               json_ld=self._get_json_ld_data())
         return WPDecorated._getHeadContent(self) + meta
 
 


### PR DESCRIPTION
Instead of using inline microdata, render the metadata as json-ld in the header.

The resulting data validates in the [Google data testing tool](https://search.google.com/structured-data/testing-tool/) with just warnings about missing option entries (mainly: "offers")

Fixes: #3269 