### PR TITLE
Add backlink to conference in title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,8 @@ Improvements
 - Add event keywords in meta tags (:issue:`3262`, thanks :user:`bpedersen2`)
 - Improve sorting by date fields in the registrant list
 - Use the user's preferred name format in more places
+- Add "back to conference" link when viewing a conference timetable using
+  a meeting theme (:issue:`3297`, thanks :user:`bpedersen2`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -54,12 +54,6 @@
             {% endfor %}
         {% endfor %}
     </ul>
-    {% if event.type == 'conference' and theme %}
-        <span class="separator"></span>
-        <a href="{{ event.url }}" class="i-button text-color subtle">
-            {%- trans %}Conference View{% endtrans -%}
-        </a>
-    {% endif %}
 {%- endmacro -%}
 
 
@@ -221,6 +215,12 @@
                href="{{ url_for('event_management.settings', event) }}"
                title="{% trans %}Switch to the management area of this event{% endtrans %}"></a>
 
+            {% if event.type == 'conference' and theme %}
+                <span class="separator"></span>
+                <a href="{{ event.url }}" class="i-button text-color subtle">
+                    {%- trans %}Back to Conference View{% endtrans -%}
+                </a>
+            {% endif %}
         </div>
 
         {{ render_session_bar(protected_object=event, local_tz=event.display_tzinfo.zone) }}

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -54,6 +54,12 @@
             {% endfor %}
         {% endfor %}
     </ul>
+    {% if event.type == 'conference' and theme %}
+        <span class="separator"></span>
+        <a href="{{ event.url }}" class="i-button text-color subtle">
+            {%- trans %}Conference View{% endtrans -%}
+        </a>
+    {% endif %}
 {%- endmacro -%}
 
 


### PR DESCRIPTION
For conference, if a theme is selected, add a backlink
to the main conference page.

Just using a home icon is not useful here, as the icon already
is used for the link to the indico home.

Fixes: #3297