### PR TITLE
CKEditor: Allows some custom formatting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,8 @@ Improvements
 - Allow definition lists in places where Markdown or HTML is accepted
   (:issue:`3325`)
 - Include event date/time in registration emails (:issue:`3337`)
+- Allow div/span/pre with classes when writing raw HTML in CKEditor
+  (:issue:`3332`, thanks :user:`bpedersen2`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/htdocs/js/indico/Core/Widgets/RichText.js
+++ b/indico/htdocs/js/indico/Core/Widgets/RichText.js
@@ -279,7 +279,8 @@ function initializeEditor( wrapper, editorId, text, callbacks, width, height, si
             ],
             format_tags: 'p;h1;h2;h3;pre',
             removeDialogTabs: 'image:advanced;link:advanced',
-            extraAllowedContent: 'dl dt dd'
+            // Note: *(*) => allow additional classes on any allowed element
+            extraAllowedContent: 'dl dt dd div span pre; *(*)'
         };
 
         if (simple) {


### PR DESCRIPTION
Add some more allowed formats that can be used in source edit
mode as discussed on "talk.getindico.org".

Specifically add div, span and pre to the allowed types and allow
classes on all allowed elements.