### PR TITLE
BOA latex pdf: Use single fancyhdr invocation

### DIFF
--- a/indico/legacy/pdfinterface/latex_templates/book_of_abstracts.tex
+++ b/indico/legacy/pdfinterface/latex_templates/book_of_abstracts.tex
@@ -58,10 +58,10 @@
 
 
 \JINJA{block book_body}
+   \fancyhead[L]{\small \rmfamily \color{gray} \truncateellipses{\VAR{event.title}}{300pt} / \VAR{_('Book of Abstracts')}}
+   \fancyhead[R]{}
+   \fancyfoot[C]{\small \rmfamily \color{gray} \VAR{(_('Page {}')|latex(true)).format('\\thepage')|rawlatex }}
     \JINJA{for contrib in contribs if contrib.can_access(session.user)}
-        \fancyhead[L]{\small \rmfamily \color{gray} \truncateellipses{\VAR{event.title}}{300pt} / \VAR{_('Book of Abstracts')}}
-        \fancyhead[R]{}
-
         \JINJA{if min_lines_per_abstract and not loop.first}
             \needspace{\VAR{min_lines_per_abstract}\baselineskip}
         \JINJA{endif}
@@ -71,7 +71,5 @@
 
         \VAR{render_contribution_condensed(contrib, affiliation_contribs, corresp_authors)|rawlatex}
         \vspace{3em}
-
-        \fancyfoot[C]{\small \rmfamily \color{gray} \VAR{(_('Page {}')|latex(true)).format('\\thepage')|rawlatex }}
     \JINJA{endfor}
 \JINJA{endblock}

--- a/indico/legacy/pdfinterface/latex_templates/contribution_list_book.tex
+++ b/indico/legacy/pdfinterface/latex_templates/contribution_list_book.tex
@@ -61,15 +61,15 @@
     %% body
     \mainmatter
     \JINJA{block book_body}
+        \fancyhead[L]{\small \rmfamily \color{gray} \truncateellipses{\VAR{event.title}}{300pt} / \VAR{_('Report of Abstracts')}}
+        \fancyfoot[C]{\small \rmfamily \color{gray} \VAR{(_('Page {}')|latex(true)).format('\\thepage')|rawlatex }}
         \JINJA{for contrib in contribs if contrib.can_access(user)}
-            \fancyhead[L]{\small \rmfamily \color{gray} \truncateellipses{\VAR{event.title}}{300pt} / \VAR{_('Report of Abstracts')}}
             \phantomsection
             \addcontentsline{toc}{chapter}{\VAR{contrib.title}}
 
             \vspace{3em}
             \VAR{render_contribution_condensed(contrib, affiliation_contribs, corresp_authors)|rawlatex}
 
-            \fancyfoot[C]{\small \rmfamily \color{gray} \VAR{(_('Page {}')|latex(true)).format('\\thepage')|rawlatex }}
         \JINJA{endfor}
     \JINJA{endblock}
 


### PR DESCRIPTION
As the default template does not render contribution
specific content in the header/footer part, just invoke
the fancyhdr setup macros once before the list of abstracts.