### PR TITLE
Support for managing registrations with pending payments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,8 @@ Bugfixes
 - Fix sorting book of abstracts by board number (:issue:`3429`, thanks
   :user:`bpedersen2`)
 - Enforce survey submission limit (:issue:`3256`)
+- Do not show "Mark as paid" button and checkout link while a transaction
+  is pending (:issue:`3361`, thanks :user:`driehle`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/templates/display/registration_summary.html
+++ b/indico/modules/events/registration/templates/display/registration_summary.html
@@ -62,7 +62,7 @@
 
 {{ render_registration_summary(registration) }}
 {% call render_invoice(registration, payment_enabled, payment_conditions) %}
-    {% if payment_enabled and registration.state.name == 'unpaid' %}
+    {% if payment_enabled and registration.state.name == 'unpaid' and not registration.is_paid %}
         <table class="regform-done-footer" width="100%" cellpadding="0" cellspacing="0">
             <tr>
                 <td>

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -61,7 +61,7 @@
         {% endcall %}
 
         {% if registration.transaction %}
-            <div id="registration-summary" class="regform-done">
+            <div id="transaction-summary" class="regform-done">
                 <div class="i-box-header">
                     <div class="i-box-title">
                         {% trans %}Payment transaction{% endtrans %}
@@ -113,26 +113,30 @@
         <div class="label">
            {% trans %}Registration not paid yet{% endtrans %}
         </div>
-        {% trans -%}
-            You can mark the registration as paid manually.
-        {%- endtrans %}
+        {% if registration.is_paid %}
+            {% trans %}The current transaction is still pending.{% endtrans %}
+        {% else %}
+            {% trans %}You can mark the registration as paid manually.{% endtrans %}
+        {% endif %}
     </div>
-    <div class="toolbar">
-        <div class="group">
-            <span class="i-button label icon-coins">
-                {{ registration.render_price() }}
-            </span>
+    {% if not registration.is_paid %}
+        <div class="toolbar">
+            <div class="group">
+                <span class="i-button label icon-coins">
+                    {{ registration.render_price() }}
+                </span>
+            </div>
+            <div class="group">
+                <a class="i-button"
+                   data-update="#registration-details"
+                   data-method="POST"
+                   data-params="{{ dict(pay=1) | tojson | forceescape }}"
+                   data-href="{{ url_for('.toggle_registration_payment', registration) }}">
+                    {% trans %}Mark as paid{% endtrans %}
+                </a>
+            </div>
         </div>
-        <div class="group">
-            <a class="i-button"
-               data-update="#registration-details"
-               data-method="POST"
-               data-params="{{ dict(pay=1) | tojson | forceescape }}"
-               data-href="{{ url_for('.toggle_registration_payment', registration) }}">
-                {% trans %}Mark as paid{% endtrans %}
-            </a>
-        </div>
-    </div>
+    {% endif %}
 {% endmacro %}
 
 


### PR DESCRIPTION
In Indico, payments can have a `pending` state, which is useful for several situations. Registrations having a pending transaction still have the registration state `unpaid`, but are still considered as being payed in the `is_paid` method of the registration object. This might be a bit confusing, but it works.

Currently, for registrations which have a pending transaction, the "Mark as paid" button in the management area does not work. This is o.k., since managers should most likely not interfer with pending transactions. Therefore, this pull requests removes the "Mark as paid" button from the backend under the described circumstances. Additionally, if there still is a pending transactions, users are not allowed to check out a second time.

Managers can always use the "Mark as unpaid" button to reset the transactions. This also allows the user to do another check out, if needed.