### PR TITLE
Add (friendly) registration id to designer fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Improvements
 - Add a privacy policy page linked from the footer (:issue:`1415`)
 - *Terms & Conditions* can now link to an external URL
 - Show a warning to all admins if Celery is not running or outdated
+- Add registration ID placeholder for badges (:issue:`3370`, thanks
+  :user:`bpedersen2`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/designer/placeholders.py
+++ b/indico/modules/designer/placeholders.py
@@ -32,7 +32,7 @@ __all__ = ('EventDatesPlaceholder', 'EventDescriptionPlaceholder', 'Registration
            'RegistrationFullNameNoTitlePlaceholderD', 'RegistrationTitlePlaceholder',
            'RegistrationFirstNamePlaceholder', 'RegistrationLastNamePlaceholder', 'RegistrationTicketQRPlaceholder',
            'RegistrationEmailPlaceholder', 'RegistrationAmountPlaceholder', 'RegistrationPricePlaceholder',
-           'RegistrationAffiliationPlaceholder',
+           'RegistrationFriendlyIDPlaceholder', 'RegistrationAffiliationPlaceholder',
            'RegistrationPositionPlaceholder', 'RegistrationAddressPlaceholder', 'RegistrationCountryPlaceholder',
            'RegistrationPhonePlaceholder', 'EventTitlePlaceholder', 'CategoryTitlePlaceholder', 'EventRoomPlaceholder',
            'EventVenuePlaceholder', 'EventSpeakersPlaceholder')
@@ -266,6 +266,12 @@ class RegistrationPricePlaceholder(RegistrationPlaceholder):
     def render(cls, registration):
         # XXX: Use event locale once we have such a setting
         return format_currency(registration.price, registration.currency, locale='en_GB')
+
+
+class RegistrationFriendlyIDPlaceholder(RegistrationPlaceholder):
+    name = 'registration_friendly_id'
+    description = _('Registration ID')
+    field = 'friendly_id'
 
 
 class RegistrationAffiliationPlaceholder(RegistrationPDPlaceholder):


### PR DESCRIPTION
This sometimes to allow to easily identify users during (manual) check-in.