### PR TITLE
Fix contribution pdf sorting

### DIFF
--- a/indico/legacy/pdfinterface/conference.py
+++ b/indico/legacy/pdfinterface/conference.py
@@ -365,6 +365,15 @@ class ContributionBook(PDFLaTeXBase):
                 if not c.speakers:
                     return True, None
                 return False, speakers[0].get_full_name(last_name_upper=False, abbrev_first_name=False).lower()
+        elif sort_by == BOASortField.board_number:
+            key_func = attrgetter('board_number')
+        elif sort_by == BOASortField.session_board_number:
+            key_func = lambda c: (c.session is None, c.session.title.lower() if c.session else '', c.board_number)
+        elif sort_by == BOASortField.schedule_board_number:
+            key_func = lambda c: (c.start_dt is None, c.start_dt, c.board_number if c.board_number else '')
+        elif sort_by == BOASortField.session_schedule_board:
+            key_func = lambda c: (c.session is None, c.session.title.lower() if c.session else '',
+                                  c.start_dt is None, c.start_dt, c.board_number if c.board_number else '')
         else:
             key_func = attrgetter(mapping.get(sort_by) or 'title')
         return sorted(contribs, key=key_func)

--- a/indico/modules/events/abstracts/settings.py
+++ b/indico/modules/events/abstracts/settings.py
@@ -26,9 +26,13 @@ from indico.util.struct.enum import RichEnum
 class BOASortField(RichEnum):
     id = 'id'
     abstract_title = 'title'
+    board_number = 'board_number'
+    session_board_number = 'session_board_number'
     session_title = 'session_title'
     speaker = 'speaker'
     schedule = 'schedule'
+    schedule_board_number = 'schedule_board_number'
+    session_schedule_board = 'session_schedule_board'
 
 
 class BOACorrespondingAuthorType(RichEnum):
@@ -40,9 +44,13 @@ class BOACorrespondingAuthorType(RichEnum):
 BOASortField.__titles__ = {
     BOASortField.id: _('ID'),
     BOASortField.abstract_title: _('Abstract title'),
+    BOASortField.board_number: _('Board Number'),
+    BOASortField.session_board_number: _('Session title, then Board Number'),
     BOASortField.session_title: _('Session title'),
     BOASortField.speaker: _('Presenter'),
-    BOASortField.schedule: _('Schedule')
+    BOASortField.schedule: _('Schedule'),
+    BOASortField.schedule_board_number: _('Schedule, then board number'),
+    BOASortField.session_schedule_board: _('Session, Schedule, Board number')
 }
 
 

--- a/indico/modules/events/contributions/blueprint.py
+++ b/indico/modules/events/contributions/blueprint.py
@@ -50,6 +50,12 @@ _bp.add_url_rule('/manage/contributions/book.pdf', 'contributions_pdf_export_boo
                  management.RHContributionsExportPDFBook, methods=('POST',))
 _bp.add_url_rule('/manage/contributions/book-sorted.pdf', 'contributions_pdf_export_book_sorted',
                  management.RHContributionsExportPDFBookSorted, methods=('POST',))
+_bp.add_url_rule('/manage/contributions/book-sorted-schedule.pdf', 'contributions_pdf_export_book_sorted_schedule',
+                 management.RHContributionsExportPDFBookSortedSchedule, methods=('POST',))
+_bp.add_url_rule('/manage/contributions/book-sorted-session.pdf', 'contributions_pdf_export_book_sorted_session',
+                 management.RHContributionsExportPDFBookSortedSession, methods=('POST',))
+_bp.add_url_rule('/manage/contributions/book-sorted-all.pdf', 'contributions_pdf_export_book_sorted_all',
+                 management.RHContributionsExportPDFBookSortedAll, methods=('POST',))
 _bp.add_url_rule('/manage/contributions/import', 'contributions_import',
                  management.RHContributionsImportCSV, methods=('GET', 'POST'))
 

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -28,7 +28,7 @@ from indico.core.permissions import get_principal_permissions
 from indico.legacy.pdfinterface.conference import ContribsToPDF, ContributionBook
 from indico.modules.attachments.controllers.event_package import AttachmentPackageGeneratorMixin
 from indico.modules.events.abstracts.forms import AbstractContentSettingsForm
-from indico.modules.events.abstracts.settings import abstracts_settings
+from indico.modules.events.abstracts.settings import BOASortField, abstracts_settings
 from indico.modules.events.contributions import get_contrib_field_types
 from indico.modules.events.contributions.clone import ContributionCloner
 from indico.modules.events.contributions.controllers.common import ContributionListMixin
@@ -465,7 +465,28 @@ class RHContributionsExportPDFBook(RHManageContributionsExportActionsBase):
 class RHContributionsExportPDFBookSorted(RHManageContributionsExportActionsBase):
     def _process(self):
         pdf = ContributionBook(self.event, session.user, self.contribs, tz=self.event.timezone,
-                               sort_by='board_number')
+                               sort_by=BOASortField.board_number)
+        return send_file('book-of-abstracts.pdf', pdf.generate(), 'application/pdf')
+
+
+class RHContributionsExportPDFBookSortedSession(RHManageContributionsExportActionsBase):
+    def _process(self):
+        pdf = ContributionBook(self.event, session.user, self.contribs, tz=self.event.timezone,
+                               sort_by=BOASortField.session_board_number)
+        return send_file('book-of-abstracts.pdf', pdf.generate(), 'application/pdf')
+
+
+class RHContributionsExportPDFBookSortedSchedule(RHManageContributionsExportActionsBase):
+    def _process(self):
+        pdf = ContributionBook(self.event, session.user, self.contribs, tz=self.event.timezone,
+                               sort_by=BOASortField.schedule_board_number)
+        return send_file('book-of-abstracts.pdf', pdf.generate(), 'application/pdf')
+
+
+class RHContributionsExportPDFBookSortedAll(RHManageContributionsExportActionsBase):
+    def _process(self):
+        pdf = ContributionBook(self.event, session.user, self.contribs, tz=self.event.timezone,
+                               sort_by=BOASortField.session_schedule_board)
         return send_file('book-of-abstracts.pdf', pdf.generate(), 'application/pdf')
 
 

--- a/indico/modules/events/contributions/templates/management/contributions.html
+++ b/indico/modules/events/contributions/templates/management/contributions.html
@@ -112,6 +112,25 @@
                             </a>
                         </li>
                         <li>
+                            <a href="#" class="icon-file-pdf js-submit-form js-enable-if-checked disabled"
+                               data-href="{{ url_for('.contributions_pdf_export_book_sorted_schedule', event) }}">
+                                {%- trans %}PDF (book of abstracts - sorted by schedule and board number){% endtrans -%}
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#" class="icon-file-pdf js-submit-form js-enable-if-checked disabled"
+                               data-href="{{ url_for('.contributions_pdf_export_book_sorted_session', event) }}">
+                                {%- trans %}PDF (book of abstracts - sorted by session and board number){% endtrans -%}
+                            </a>
+                        </li>
+                        <li>
+                            <a href="#" class="icon-file-pdf js-submit-form js-enable-if-checked disabled"
+                               data-href="{{ url_for('.contributions_pdf_export_book_sorted_all', event) }}">
+                                {%- trans %}PDF (book of abstracts - sorted by session, schedule and board number)
+                                {% endtrans -%}
+                            </a>
+                        </li>
+                        <li>
                             <a href="#" class="icon-file-spreadsheet js-submit-form js-enable-if-checked disabled"
                                data-href="{{ url_for('.contributions_csv_export', event) }}">
                                 {%- trans %}CSV{% endtrans -%}


### PR DESCRIPTION
Only fall back to title if sort_by is empty after mapping.
Otherwise e.g. Contribution PDF export sorted by boardnumber
does not sort by board_number.