### PR TITLE
Upcoming events with subcategories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Improvements
   thanks :user:`nop33`)
 - Include event page title in the page's ``<title>`` (:issue:`3285`,
   thanks :user:`bpedersen2`)
+- Add option to include subcategories in upcoming events (:issue:`3449`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -644,12 +644,12 @@ class RHCategoryCalendarView(RHDisplayCategoryBase):
         end = tz.localize(dateutil.parser.parse(request.args['end'])).astimezone(utc)
         query = (Event.query
                  .filter(Event.starts_between(start, end),
-                         Event.is_visible_in(self.category),
+                         Event.is_visible_in(self.category.id),
                          ~Event.is_deleted)
                  .options(load_only('id', 'title', 'start_dt', 'end_dt', 'category_id')))
         events = self._get_event_data(query)
         ongoing_events = (Event.query
-                          .filter(Event.is_visible_in(self.category),
+                          .filter(Event.is_visible_in(self.category.id),
                                   Event.start_dt < start,
                                   Event.end_dt > end)
                           .options(load_only('id', 'title', 'start_dt', 'end_dt', 'timezone'))

--- a/indico/modules/categories/forms.py
+++ b/indico/modules/categories/forms.py
@@ -162,7 +162,9 @@ class UpcomingEventsForm(IndicoForm):
                                           'step': 1, 'coerce': int},
                                          {'id': 'weight', 'caption': _("Weight"), 'required': True, 'type': 'number',
                                           'coerce': float}],
-                                 choices={'type': {'category': _('Category'), 'event': _('Event')}},
+                                 choices={'type': {'category': _('Category'),
+                                                   'category_tree': _('Category & Subcategories'),
+                                                   'event': _('Event')}},
                                  description=_("Specify categories/events shown in the 'upcoming events' list on the "
                                                "home page."))
 
@@ -172,9 +174,9 @@ class UpcomingEventsForm(IndicoForm):
         for entry in field.data:
             if entry['days'] < 0:
                 raise ValidationError(_("'Days' must be a positive integer"))
-            if entry['type'] not in {'category', 'event'}:
+            if entry['type'] not in {'category', 'category_tree', 'event'}:
                 raise ValidationError(_('Invalid type'))
-            if entry['type'] == 'category' and not Category.get(entry['id'], is_deleted=False):
+            if entry['type'] in {'category', 'category_tree'} and not Category.get(entry['id'], is_deleted=False):
                 raise ValidationError(_('Invalid category: {}').format(entry['id']))
             if entry['type'] == 'event' and not Event.get(entry['id'], is_deleted=False):
                 raise ValidationError(_('Invalid event: {}').format(entry['id']))

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -470,15 +470,15 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
             return None  # Category is invisible
         return Category.get(horizon_id)
 
-    @property
-    def visible_categories_cte(self):
+    @staticmethod
+    def get_visible_categories_cte(category_id):
         """
         Get a sqlalchemy select for the visible categories within
-        this category, including the category itself.
+        the given category, including the category itself.
         """
         cte_query = (select([Category.id, literal(0).label('level')])
-                     .where((Category.id == self.id) & (Category.visibility.is_(None) | (Category.visibility > 0)))
-                     .cte('visibility_chain', recursive=True))
+                     .where((Category.id == category_id) & (Category.visibility.is_(None) | (Category.visibility > 0)))
+                     .cte(recursive=True))
         parent_query = (select([Category.id, cte_query.c.level + 1])
                         .where(db.and_(Category.parent_id == cte_query.c.id,
                                        db.or_(Category.visibility.is_(None),
@@ -491,7 +491,7 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
         Get a query object for the visible categories within
         this category, including the category itself.
         """
-        cte_query = self.visible_categories_cte
+        cte_query = Category.get_visible_categories_cte(self.id)
         return Category.query.join(cte_query, Category.id == cte_query.c.id)
 
     @property

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -440,12 +440,12 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         return (cte.c.id == Event.category_id) & cte.c.path.overlap(category_ids)
 
     @classmethod
-    def is_visible_in(cls, category):
+    def is_visible_in(cls, category_id):
         """
         Create a filter that checks whether the event is visible in
         the specified category.
         """
-        cte = category.visible_categories_cte
+        cte = Category.get_visible_categories_cte(category_id)
         return (db.exists(db.select([1]))
                 .where(db.and_(cte.c.id == Event.category_id,
                                db.or_(Event.visibility.is_(None), Event.visibility > cte.c.level))))

--- a/indico/modules/events/timetable/util.py
+++ b/indico/modules/events/timetable/util.py
@@ -167,7 +167,7 @@ def get_category_timetable(categ_ids, start_dt, end_dt, detail_level='event', tz
     # specified range of dates (and category set)
     events = _query_events(categ_ids, day_start, day_end)
     if from_categ:
-        events = events.filter(Event.is_visible_in(from_categ))
+        events = events.filter(Event.is_visible_in(from_categ.id))
     for eid, tt_start_dt in events:
         if tt_start_dt:
             items[eid][tt_start_dt.astimezone(tz).date()].append(tt_start_dt)


### PR DESCRIPTION
- Fix issue with Category CTEs not being usable to union queries.
- Add a new entry to the upcoming events administration section that allows to display the upcoming events of the hierarchy.
- This resolves #3449.