### PR TITLE
Update TeXLive installation instructions

### DIFF
--- a/docs/source/installation/latex.rst
+++ b/docs/source/installation/latex.rst
@@ -88,4 +88,4 @@ a good idea to periodically update the TeXLive packages by running:
 
 .. code-block:: shell
 
-    /opt/texlive/bin/x86_64-linux/tlmgr update --all
+    /opt/texlive/bin/x86_64-linux/tlmgr update --self --all

--- a/docs/source/installation/latex.rst
+++ b/docs/source/installation/latex.rst
@@ -33,69 +33,27 @@ Create the setup config file to install all the packages you need:
     selected_scheme scheme-full
     TEXDIR /opt/texlive
     TEXMFCONFIG ~/.texlive/texmf-config
-    TEXMFLOCAL /opt/texlive/texmf-local
     TEXMFHOME ~/texmf
+    TEXMFLOCAL /opt/texlive/texmf-local
     TEXMFSYSCONFIG /opt/texlive/texmf-config
     TEXMFSYSVAR /opt/texlive/texmf-var
     TEXMFVAR ~/.texlive/texmf-var
     binary_x86_64-linux 1
-    collection-basic 1
-    collection-bibtexextra 1
-    collection-binextra 1
-    collection-context 1
-    collection-fontsextra 1
-    collection-fontsrecommended 1
-    collection-fontutils 1
-    collection-formatsextra 1
-    collection-games 1
-    collection-humanities 1
-    collection-langarabic 1
-    collection-langchinese 1
-    collection-langcjk 1
-    collection-langcyrillic 1
-    collection-langczechslovak 1
-    collection-langenglish 1
-    collection-langeuropean 1
-    collection-langfrench 1
-    collection-langgerman 1
-    collection-langgreek 1
-    collection-langitalian 1
-    collection-langjapanese 1
-    collection-langkorean 1
-    collection-langother 1
-    collection-langpolish 1
-    collection-langportuguese 1
-    collection-langspanish 1
-    collection-latex 1
-    collection-latexextra 1
-    collection-latexrecommended 1
-    collection-luatex 1
-    collection-mathscience 1
-    collection-metapost 1
-    collection-music 1
-    collection-pictures 1
-    collection-plaingeneric 1
-    collection-pstricks 1
-    collection-publishers 1
-    collection-texworks 1
-    collection-xetex 1
-    option_adjustrepo 0
-    option_autobackup 1
-    option_backupdir tlpkg/backups
-    option_desktop_integration 1
-    option_doc 1
-    option_file_assocs 1
-    option_fmt 1
-    option_letter 1
-    option_path 0
-    option_post_code 1
-    option_src 1
-    option_sys_bin /usr/local/bin
-    option_sys_info /usr/local/share/info
-    option_sys_man /usr/local/share/man
-    option_w32_multi_user 0
-    option_write18_restricted 1
-    portable 0
+    instopt_adjustpath 0
+    instopt_adjustrepo 0
+    instopt_letter 0
+    instopt_portable 0
+    instopt_write18_restricted 1
+    tlpdbopt_autobackup 1
+    tlpdbopt_backupdir tlpkg/backups
+    tlpdbopt_create_formats 1
+    tlpdbopt_generate_updmap 0
+    tlpdbopt_install_docfiles 0
+    tlpdbopt_install_srcfiles 0
+    tlpdbopt_post_code 1
+    tlpdbopt_sys_bin /usr/local/bin
+    tlpdbopt_sys_info /usr/local/share/info
+    tlpdbopt_sys_man /usr/local/share/man
     EOF
 
 Start the installer and wait for it to complete. This may take between
@@ -115,3 +73,10 @@ your new TeXLive installation:
 
 If you are in a production setup, reload uWSGI using
 ``touch /opt/indico/web/indico.wsgi`` to reload the config file.
+
+As security-related updates are released frequently, it is also
+a good idea to periodically update the TeXLive packages by running:
+
+.. code-block:: shell
+
+    /opt/texlive/bin/x86_64-linux/tlmgr update --all

--- a/docs/source/installation/latex.rst
+++ b/docs/source/installation/latex.rst
@@ -10,7 +10,16 @@ Since Indico requires quite a few LaTeX packages which are not always]
 installed by default when using the texlive packages of the various
 linux distrubtions, we recommend installing it manually.
 
-The following commands should work fine to install everything you need.
+First of all, you will need to install some dependencies so that all TeX
+formats are generated successfully upon TeXLive installation.
+
+.. code-block:: shell
+
+    yum install fontconfig ghostscript     # CentOS / CC7
+    apt install libfontconfig1 ghostscript # Debian / Ubuntu
+
+You are now ready to install TeXLive. The following commands should work
+fine to install everything you need.
 You need to run the installation as root or create ``/opt/texlive`` as
 root and grant your user write access to it.
 


### PR DESCRIPTION
- Remove irrelevant/redundant entries from installation profile
- Add hint to periodically update TeXLive packages
- This resolves #3460 and resolves #3461

No need to have all collections listed, as `selected_scheme scheme-full` covers them anyway.

Also, regarding #3461, `option_desktop_integration 1` is only relevant for Win32 systems, so we can just remove that option. Documentation and source packages are also removed.