### PR TITLE
Fix missing import in registration API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Bugfixes
 - Fix error when exporting abstracts with review questions to JSON
 - Point the timetable to correct day in the session details
 - Fix massive performance issue on the material package page in big events
+- Fix error when using the checkin app to mark someone as checked in
+  (:issue:`3473`, thanks :user:`femtobit`)
 
 Version 2.1.2
 -------------

--- a/indico/modules/events/registration/api.py
+++ b/indico/modules/events/registration/api.py
@@ -20,6 +20,7 @@ from flask import jsonify, request
 from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import BadRequest, Forbidden
 
+from indico.core import signals
 from indico.modules.events.models.events import Event
 from indico.modules.events.registration.util import build_registration_api_data, build_registrations_api_data
 from indico.modules.oauth import oauth


### PR DESCRIPTION
While using a local Indico installation (version 2.1.2), I noticed that check-in did not work with the Indico Check-In Android app from Google Play Store. This was due to a `NameError` being thrown in line 61 here:
https://github.com/indico/indico/blob/9fa826ebb672021b59ecc2744e98ad1eaaabb4b8/indico/modules/events/registration/api.py#L59-L61

Importing the `signals` model from `indico.core` fixes this.