### PR TITLE
[WIP] Improve registration im/export

### DIFF
--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -87,6 +87,8 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/book.pdf'
                  reglists.RHRegistrationsExportPDFBook, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/registrations.csv', 'registrations_csv_export',
                  reglists.RHRegistrationsExportCSV, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/registrations_i.csv',
+                 'registrations_csv_export_2', reglists.RHRegistrationsExportCSVForImport, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/registrations.xlsx',
                  'registrations_excel_export', reglists.RHRegistrationsExportExcel, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/modify-status', 'registrations_modify_status',

--- a/indico/modules/events/registration/templates/management/import_registrations.html
+++ b/indico/modules/events/registration/templates/management/import_registrations.html
@@ -7,29 +7,16 @@
         following order:
     {% endtrans %}
     <ul>
+    {% for regform.active_fields as form_item %}
         <li>
-            {%- trans %}First Name{% endtrans -%}
+            {form_item.html_field_name}{% if form_item.is_required %}*{% endif %}
         </li>
-        <li>
-            {%- trans %}Last Name{% endtrans -%}
-        </li>
-        <li>
-            {%- trans %}Affiliation{% endtrans -%}
-        </li>
-        <li>
-            {%- trans %}Position{% endtrans -%}
-        </li>
-        <li>
-            {%- trans %}Phone Number{% endtrans -%}
-        </li>
-        <li>
-            {%- trans %}E-mail{% endtrans -%}
-        </li>
+    {% endfor %}
     </ul>
-    {% trans -%}
-        The fields "First Name", "Last Name" and "E-mail" are mandatory.
-    {%- endtrans %}
     <br>
+    {% trans -%}
+        The first  line should name the fields like shown above.
+    {%- endtrans %}
     {% trans -%}
         Users will be matched with existing Indico identities through their e-mail.
     {%- endtrans %}

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -86,6 +86,10 @@
                                data-href="{{ url_for('.registrations_csv_export', regform) }}">CSV</a>
                         </li>
                         <li>
+                            <a href="#" class="icon-file-spreadsheet js-requires-selected-row disabled js-submit-list-form"
+                               data-href="{{ url_for('.registrations_csv_export_2', regform) }}">CSV(re-importable)</a>
+                        </li>
+                        <li>
                             <a href="#" class="icon-file-excel js-requires-selected-row disabled js-submit-list-form"
                                data-href="{{ url_for('.registrations_excel_export', regform) }}">XLSX (Excel)</a>
                         </li>


### PR DESCRIPTION
Add an export that exports all fields and handle more fields in the import.

Currently the re-import is limited to the same regform, as way do not
have a generic field mapping system (see #3164 where a similar matching would
be needed).

TODO: verify and fix the different input types(may need  id's instead of text
at some places).

While not yet fully ready, I would like to get some comments if this is a useful approach.