### PR TITLE
Fix participant roles table

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bugfixes
   designer page
 - Hide "Save answers" in surveys while not logged in
 - Fix importing event archives containing registrations with attachments
+- Fix display issue in participants table after editing data (:issue:`3511`)
 
 Version 2.1.3
 -------------

--- a/indico/htdocs/js/indico/modules/events/management.js
+++ b/indico/htdocs/js/indico/modules/events/management.js
@@ -110,6 +110,20 @@
         $('.js-reset-role-filter').toggleClass('disabled', isInitialState);
     }
 
+    function initTooltip() {
+        $('.js-show-regforms').qtip({
+            content: {
+                text: function() {
+                    return $(this).data('title');
+                }
+            },
+            hide: {
+                delay: 100,
+                fixed: true
+            }
+        });
+    }
+
     global.setupEventPersonsList = function setupEventPersonsList(options) {
         options = $.extend({
             hasNoAccountFilter: false
@@ -208,17 +222,7 @@
             });
         }
 
-        $('.js-show-regforms').qtip({
-            content: {
-                text: function() {
-                    return $(this).data('title');
-                }
-            },
-            hide: {
-                delay: 100,
-                fixed: true
-            }
-        });
+        initTooltip();
 
         var $personFilters = $('#person-filters');
         // Sets background color of role filter items based on their colored squared color
@@ -248,6 +252,8 @@
             $checkbox.prop('checked', !$checkbox.prop('checked')).trigger('change');
             toggleResetBtn();
         });
+
+        $('#event-participants-list').on('indico:htmlUpdated', initTooltip);
     };
 
 

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -360,5 +360,5 @@ class RHEditEventPerson(RHPersonsBase):
             update_person(self.person, form.data)
             person_data = self.get_persons()[self.person.email or self.person.id]
             tpl = get_template_module('events/persons/management/_person_list_row.html')
-            return jsonify_data(html=tpl.render_person_row(person_data))
+            return jsonify_data(html=tpl.render_person_row(person_data, bool(self.event.registration_forms)))
         return jsonify_form(form)

--- a/indico/modules/events/persons/templates/management/person_list.html
+++ b/indico/modules/events/persons/templates/management/person_list.html
@@ -199,7 +199,7 @@
                 {% endcall %}
             {% endif %}
             <table class="i-table-widget tablesorter">
-                {% set event_has_registration_forms = event.registration_forms != [] %}
+                {% set event_has_registration_forms = event.registration_forms|bool %}
                 <thead>
                     <tr class="i-table">
                         <th class="i-table thin-column hide-if-locked" data-sorter="false"></th>


### PR DESCRIPTION
Table layout does not break after editing a person and there is at least one
registration icon showing

closes #3511