### PR TITLE
Add url-shortener template hooks

### DIFF
--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -115,6 +115,8 @@
                data-ajax-dialog
                data-reload-after></a>
         {%- endif %}
+        {{ template_hook('url-shortener', target=url_for('contributions.display_contribution', contribution),
+                         classes='i-button icon-link') }}
         <a href="{{ url_for('contributions.export_pdf', contribution) }}" class="i-button icon-file-pdf"></a>
         {% if contribution.timetable_entry -%}
             {% if g.static_site %}

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -216,6 +216,8 @@
 
             <span class="separator"></span>
 
+            {{ template_hook('url-shortener', event=event, classes='i-button text-color subtle icon-link') }}
+
             <a class="i-button text-color subtle icon-edit"
                href="{{ url_for('event_management.settings', event) }}"
                title="{% trans %}Switch to the management area of this event{% endtrans %}"></a>

--- a/indico/web/client/js/jquery/widgets/misc.js
+++ b/indico/web/client/js/jquery/widgets/misc.js
@@ -67,7 +67,7 @@
         }).end();
     };
 
-    $.fn.copyURLTooltip = function(url) {
+    $.fn.copyURLTooltip = function(url, hideEvent = 'mouseleave') {
         /*
          * Creates a tooltip with a URL in a text input with indication on how
          * to copy it.
@@ -96,7 +96,7 @@
                 at: 'bottom center'
             },
             hide: {
-                event: 'mouseleave',
+                event: hideEvent,
                 fixed: true,
                 delay: 700
             },


### PR DESCRIPTION
- Parametrised hide event for copy URL tooltip (required from ursh plugin)
- URL shortener template hooks for events and contributions

Should also add hooks to attachments and sessions, but those proved more tricky and possibly require additional changes to the respective templates.