### PR TITLE
add sphinx-rtd-theme to dev requirements

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,6 +3,7 @@ pojson>=0.4
 termcolor
 sphinx
 sphinx-autobuild
+sphinx-rtd-theme
 sphinx-issues
 repoze.sphinx.autointerface
 pygments


### PR DESCRIPTION
To build docs on fresh install, need sphinx-rtd-theme.  Might need (to do) other stuff too, but that is a separate topic.

(When I tried to build the docs after installing sphinx-rtd-theme, it complained because indico module was not available.  But I will try reading more install instructions before making another issue for this other problem ... maybe I'm just doing things in the wrong order.  So unfortunately I can't say that installing sphinx-rtd-theme made everything work ... but it did get further than before.)