### PR TITLE
Align footer-links in the center of the page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,7 @@ Bugfixes
 - Fix incorrect order of session blocks inside timetable (:issue:`2999`)
 - Add missing email validation to contribution CSV import (:issue:`3568`,
   thanks :user:`Kush22`)
+- Correctly align centered footer links (:issue:`3599`, thanks :user:`nop33`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/partials/_footer.scss
+++ b/indico/web/client/styles/partials/_footer.scss
@@ -48,6 +48,10 @@
             content: '|';
         }
     }
+
+    .footer-extra {
+        text-align: right;
+    }
 }
 
 .social-share {

--- a/indico/web/templates/footer.html
+++ b/indico/web/templates/footer.html
@@ -4,7 +4,7 @@
             <a href="https://getindico.io">Indico</a>
         {%- endset -%}
         <div class="flexrow f-j-space-between">
-            <div class="flexrow f-a-center">
+            <div class="flexrow f-a-center f-self-stretch">
                 {% block footer_logo %}
                     {% set filename = 'indico_small_white.png' if dark else 'indico_small.png' %}
                     <img src="{{ url_for('assets.image', filename=filename) }}" class="footer-logo" alt="Indico">
@@ -32,7 +32,7 @@
                     </li>
                 {% endfor %}
             </ul>
-            <div class="footer-extra">
+            <div class="footer-extra f-self-stretch">
                 {% block footer_extra %}
                 {% endblock %}
             </div>


### PR DESCRIPTION
I noticed that the footer links are clearly not in the center of the page and it seems like it was intended to be. This PR fixes this issue. To demonstrate:

## Before
<img width="1792" alt="screen shot 2018-10-17 at 23 21 36" src="https://user-images.githubusercontent.com/1579899/47117102-c005c900-d263-11e8-9d88-c1b2cc2f112c.png">

## After
<img width="1792" alt="screen shot 2018-10-17 at 23 22 34" src="https://user-images.githubusercontent.com/1579899/47117107-c6944080-d263-11e8-8708-13067369c748.png">

Also, is there a reason why the right padding of the footer is `5px` but the left is `10px` in `indico/web/client/styles/partials/_footer.scss`?
