### PR TITLE
Fix right spacing of session bar in event page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Bugfixes
 - Do not show border after last item in badge designer toolbar
   (:issue:`3607`, thanks :user:`nop33`)
 - Correctly align centered footer links (:issue:`3599`, thanks :user:`nop33`)
+- Fix top/right alignment of session bar in event display view (:issue:`3599`,
+  thanks :user:`nop33`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -64,6 +64,7 @@
 .event-page-header {
     .session-bar {
         margin-top: 0;
+        margin-right: 0.8em;
     }
 
     .main-action-bar {


### PR DESCRIPTION
The navigation bar in the event page has different left and right spacing. This fix unifies the spacings by updating the right spacing to be the same as the left. Demonstration:

## Before
![image](https://user-images.githubusercontent.com/1579899/47118003-47ecd280-d266-11e8-9e48-105a2e6459f6.png)


## After
![image](https://user-images.githubusercontent.com/1579899/47117960-268be680-d266-11e8-8308-5ec2d43ed5e9.png)
