### PR TITLE
Hide border of last element in badge designer toolbar

### DIFF
--- a/indico/web/client/styles/modules/_designer.scss
+++ b/indico/web/client/styles/modules/_designer.scss
@@ -229,17 +229,17 @@
         margin: 1em 0;
         min-height: 37px;
 
-        &:not(:last-child) {
-            padding-right: 1em;
-            border-right: 1px solid $gray;
+        &:not(:first-child) {
+            padding-left: 1em;
+            border-left: 1px solid $gray;
         }
 
         &:first-child {
             margin-left: 1em;
         }
 
-        &:not(:first-child) {
-            padding-left: 1em;
+        &:not(:last-child) {
+            padding-right: 1em;
         }
 
         &:last-child {


### PR DESCRIPTION
The last element of the toolbar has a right border, even though it is the last one (in fact, it is the last **visible** one). This fix switches the border from the right to the left side, and so there is no border on the last visible item.

## Before
<img width="1792" alt="screen shot 2018-10-18 at 18 07 04" src="https://user-images.githubusercontent.com/1579899/47168421-24c33100-d301-11e8-81f5-8d5fcf20f090.png">

## After
<img width="1792" alt="screen shot 2018-10-18 at 18 06 42" src="https://user-images.githubusercontent.com/1579899/47168414-1c6af600-d301-11e8-81bc-1af3680ee36f.png">