### PR TITLE
Elastic timeline & more

### DIFF
--- a/indico/modules/rb_new/client/js/common/roomSearch/serializers.js
+++ b/indico/modules/rb_new/client/js/common/roomSearch/serializers.js
@@ -42,7 +42,7 @@ export const ajax = {
         serializer: filterDTHandler('start')
     },
     end_dt: {
-        onlyIf: (data) => data.dates && data.dates.endDate,
+        onlyIf: (data) => data.dates,
         serializer: filterDTHandler('end')
     },
     sw_lat: {

--- a/indico/modules/rb_new/client/js/common/roomSearch/serializers.js
+++ b/indico/modules/rb_new/client/js/common/roomSearch/serializers.js
@@ -38,11 +38,11 @@ export const ajax = {
     text: ({text}) => text,
     division: ({division}) => division,
     start_dt: {
-        onlyIf: (data) => data.dates && data.dates.startDate && data.timeSlot.startTime,
+        onlyIf: (data) => data.dates && data.dates.startDate,
         serializer: filterDTHandler('start')
     },
     end_dt: {
-        onlyIf: (data) => data.dates && data.timeSlot.endTime,
+        onlyIf: (data) => data.dates && data.dates.endDate,
         serializer: filterDTHandler('end')
     },
     sw_lat: {

--- a/indico/modules/rb_new/client/js/common/rooms/RoomRenderer.jsx
+++ b/indico/modules/rb_new/client/js/common/rooms/RoomRenderer.jsx
@@ -1,0 +1,86 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Button, Card} from 'semantic-ui-react';
+import {Slot} from 'indico/react/util';
+import Room from '../../components/Room';
+
+import './RoomRenderer.module.scss';
+
+
+/**
+ * `RoomRenderer` encapsulates the rendering of rooms in both
+ * the List of Rooms and the "Book a Room" page.
+ */
+export default class RoomRenderer extends React.Component {
+    static propTypes = {
+        rooms: PropTypes.array.isRequired,
+        onSelectRoom: PropTypes.func,
+        selectedRooms: PropTypes.object,
+        inSelectionMode: PropTypes.bool,
+        children: PropTypes.func
+    };
+
+    static defaultProps = {
+        onSelectRoom: null,
+        selectedRooms: {},
+        inSelectionMode: false,
+        children: null
+    };
+
+    renderRoom = (room) => {
+        const {onSelectRoom, selectedRooms, inSelectionMode, children} = this.props;
+
+        if (inSelectionMode) {
+            const isRoomSelected = room.id in selectedRooms;
+            const buttonProps = {compact: true, size: 'tiny'};
+
+            if (!isRoomSelected) {
+                buttonProps.icon = 'check';
+            } else {
+                buttonProps.icon = 'check';
+                buttonProps.primary = true;
+            }
+
+            return (
+                <Room key={room.id} room={room}>
+                    <Slot>
+                        <Button styleName="selection-add-btn"
+                                onClick={() => !!onSelectRoom && onSelectRoom(room)}
+                                {...buttonProps} />
+                    </Slot>
+                </Room>
+            );
+        } else {
+            return (
+                <Room key={room.id} room={room} showFavoriteButton>
+                    {children ? children(room) : null}
+                </Room>
+            );
+        }
+    };
+
+    render() {
+        const {rooms} = this.props;
+        return (
+            <Card.Group stackable>
+                {rooms.map(this.renderRoom)}
+            </Card.Group>);
+    }
+}

--- a/indico/modules/rb_new/client/js/common/rooms/RoomRenderer.module.scss
+++ b/indico/modules/rb_new/client/js/common/rooms/RoomRenderer.module.scss
@@ -15,28 +15,7 @@
  * along with Indico; if not, see <http://www.gnu.org/licenses/>.
  */
 
-.room-list {
-    .results-count {
-        margin-bottom: 10px;
-        font-weight: bold;
-        font-size: 1.5em;
-    }
-
-    :global(.redux-lazy-scroll) {
-        overflow: visible !important;
-        margin: 0.15em;
-    }
-
-    .actions {
-        margin-left: auto;
-
-        :global(.ui.button.dropdown) {
-            display: flex;
-            align-items: baseline;
-        }
-    }
-}
-
-:global(.ui.inline.loader).rooms-loader {
-    margin-top: 2em;
+.selection-add-btn {
+    pointer-events: all;
+    margin: 10px;
 }

--- a/indico/modules/rb_new/client/js/common/rooms/actions.js
+++ b/indico/modules/rb_new/client/js/common/rooms/actions.js
@@ -21,6 +21,7 @@ import fetchRoomAvailabilityURL from 'indico-url:rooms_new.room_availability';
 import fetchRoomAttributesURL from 'indico-url:rooms_new.room_attributes';
 
 import {indicoAxios} from 'indico/utils/axios';
+import camelizeKeys from 'indico/utils/camelize';
 import {ajaxAction} from 'indico/utils/redux';
 import {actions as modalActions} from '../../modals';
 
@@ -82,7 +83,7 @@ export function fetchAvailability(id) {
             FETCH_AVAILABILITY_REQUEST,
             [AVAILABILITY_RECEIVED, FETCH_AVAILABILITY_SUCCESS],
             FETCH_AVAILABILITY_ERROR,
-            data => ({id, availability: data}),
+            data => ({id, availability: camelizeKeys(data)}),
         )(dispatch);
     };
 }

--- a/indico/modules/rb_new/client/js/common/rooms/index.js
+++ b/indico/modules/rb_new/client/js/common/rooms/index.js
@@ -21,5 +21,6 @@ import * as selectors from './selectors';
 
 export {default as reducer} from './reducers';
 export {default as RoomDetailsPreloader} from './RoomDetailsPreloader';
+export {default as RoomRenderer} from './RoomRenderer';
 export {default as modalHandlers} from './modals';
 export {actions, selectors};

--- a/indico/modules/rb_new/client/js/common/timeline/DailyTimelineContent.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/DailyTimelineContent.jsx
@@ -165,7 +165,9 @@ export default class DailyTimelineContent extends React.Component {
                             {this.renderDividers(hourSpan, hourStep)}
                         </div>
                     </div>
-                    <Loader active={wrapperProps.isFetching || isLoading} inline="centered" styleName="timeline-loader" />
+                    {(wrapperProps.isFetching || isLoading) && (
+                        <Loader active inline="centered" styleName="timeline-loader" />
+                    )}
                 </WrapperComponent>
             </>
         );

--- a/indico/modules/rb_new/client/js/common/timeline/DailyTimelineContent.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/DailyTimelineContent.jsx
@@ -33,7 +33,6 @@ export default class DailyTimelineContent extends React.Component {
     static propTypes = {
         step: PropTypes.number,
         rows: PropTypes.array.isRequired,
-        recurrenceType: PropTypes.string,
         onClickCandidate: PropTypes.func,
         onClickReservation: PropTypes.func,
         longLabel: PropTypes.bool,
@@ -50,7 +49,6 @@ export default class DailyTimelineContent extends React.Component {
 
     static defaultProps = {
         step: 2,
-        recurrenceType: null,
         onClickCandidate: null,
         onClickReservation: null,
         longLabel: false,
@@ -81,12 +79,10 @@ export default class DailyTimelineContent extends React.Component {
 
     renderTimelineRow = ({availability, label, conflictIndicator, key, room}) => {
         const {
-            minHour, maxHour, hourStep, itemClass: ItemClass, itemProps, recurrenceType, onClickCandidate,
+            minHour, maxHour, hourStep, itemClass: ItemClass, itemProps, onClickCandidate,
             onClickReservation, longLabel, showUnused
         } = this.props;
         const columns = ((maxHour - minHour) / hourStep) + 1;
-
-        // TODO: Consider plan B (availability='alternatives') option when implemented
         const hasConflicts = !(_.isEmpty(availability.conflicts) && _.isEmpty(availability.preConflicts));
         if (!showUnused && !this.hasUsage(availability)) {
             return null;
@@ -102,7 +98,7 @@ export default class DailyTimelineContent extends React.Component {
                     <ItemClass startHour={minHour} endHour={maxHour} data={availability} room={room}
                                onClickReservation={onClickReservation}
                                onClickCandidate={() => {
-                                   if (onClickCandidate && (!hasConflicts || recurrenceType !== 'single')) {
+                                   if (onClickCandidate && !hasConflicts) {
                                        onClickCandidate(room.id);
                                    }
                                }}

--- a/indico/modules/rb_new/client/js/common/timeline/DailyTimelineContent.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/DailyTimelineContent.jsx
@@ -41,6 +41,7 @@ export default class DailyTimelineContent extends React.Component {
         itemClass: PropTypes.func,
         itemProps: PropTypes.object,
         isLoading: PropTypes.bool,
+        inlineLoader: PropTypes.bool,
         lazyScroll: PropTypes.object,
         minHour: PropTypes.number,
         maxHour: PropTypes.number,
@@ -57,6 +58,7 @@ export default class DailyTimelineContent extends React.Component {
         itemClass: TimelineItem,
         itemProps: {},
         isLoading: false,
+        inlineLoader: false,
         lazyScroll: null,
         minHour: 6,
         maxHour: 22,
@@ -138,7 +140,9 @@ export default class DailyTimelineContent extends React.Component {
     }
 
     render() {
-        const {rows, minHour, maxHour, hourStep, longLabel, lazyScroll, isLoading} = this.props;
+        const {
+            rows, minHour, maxHour, hourStep, longLabel, lazyScroll, isLoading, inlineLoader
+        } = this.props;
         const {selectable} = this.state;
         const labelWidth = longLabel ? 200 : 150;
         const WrapperComponent = lazyScroll ? LazyScroll : React.Fragment;
@@ -157,11 +161,7 @@ export default class DailyTimelineContent extends React.Component {
                                     <div styleName="timeline-content"
                                          className={!selectable && 'timeline-non-selectable'}
                                          style={{width}}>
-                                        {(wrapperProps.isFetching || isLoading) && (
-                                            <Dimmer active inverted>
-                                                <Loader active styleName="timeline-loader" />
-                                            </Dimmer>
-                                        )}
+
                                         <div style={{
                                             left: labelWidth,
                                             width: `calc(100% - ${labelWidth}px)`,
@@ -169,19 +169,27 @@ export default class DailyTimelineContent extends React.Component {
                                              styleName="timeline-lines">
                                             {this.renderDividers(hourSpan, hourStep)}
                                         </div>
-                                        <List width={width}
-                                              height={height}
-                                              autoHeight
-                                              rowCount={rows.length}
-                                              overscanRowCount={15}
-                                              rowHeight={50}
-                                              rowRenderer={({index, style, key}) => (
-                                                  this.renderTimelineRow(rows[index], key, style)
-                                              )}
-                                              isScrolling={isScrolling}
-                                              onScroll={onChildScroll}
-                                              scrollTop={scrollTop}
-                                              tabIndex={null} />
+                                        <div>
+                                            {isLoading && !inlineLoader && (
+                                                <Dimmer active inverted style={{zIndex: 1}}>
+                                                    <Loader active />
+                                                </Dimmer>
+                                            )}
+                                            <List width={width}
+                                                  height={height}
+                                                  autoHeight
+                                                  rowCount={rows.length}
+                                                  overscanRowCount={15}
+                                                  rowHeight={50}
+                                                  rowRenderer={({index, style, key}) => (
+                                                      this.renderTimelineRow(rows[index], key, style)
+                                                  )}
+                                                  isScrolling={isScrolling}
+                                                  onScroll={onChildScroll}
+                                                  scrollTop={scrollTop}
+                                                  tabIndex={null} />
+                                            {isLoading && inlineLoader && <Loader active styleName="timeline-loader" />}
+                                        </div>
                                     </div>
                                 )}
                             </AutoSizer>

--- a/indico/modules/rb_new/client/js/common/timeline/DateNavigator.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/DateNavigator.jsx
@@ -1,0 +1,221 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Button} from 'semantic-ui-react';
+import RCCalendar from 'rc-calendar';
+import DatePicker from 'rc-calendar/lib/Picker';
+import {Translate} from 'indico/react/i18n';
+import {toMoment} from 'indico/utils/date';
+import {isDateWithinRange} from '../../util';
+
+
+/**
+ * Component that renders a 'mode selector' (day/week/month) and a date picker.
+ * This is used in timeline-style views (e.g. 'Book a Room' or 'Calendar').
+ */
+export default class DateNavigator extends React.Component {
+    static propTypes = {
+        selectedDate: PropTypes.string.isRequired,
+        mode: PropTypes.string.isRequired,
+        dateRange: PropTypes.array.isRequired,
+        onDateChange: PropTypes.func.isRequired,
+        onModeChange: PropTypes.func.isRequired,
+        isLoading: PropTypes.bool,
+        disabled: PropTypes.bool
+    };
+
+    static defaultProps = {
+        isLoading: false,
+        disabled: false
+    };
+
+    constructor(props) {
+        super(props);
+        const {mode} = this.props;
+        this.setDateWithMode(this.selectedDate, mode);
+    }
+
+    componentDidUpdate(prevProps) {
+        const {mode, selectedDate} = this.props;
+        const {mode: prevMode, selectedDate: prevSelectedDate} = prevProps;
+        if (prevMode !== mode || prevSelectedDate !== selectedDate) {
+            this.setDateWithMode(this.selectedDate, mode);
+        }
+    }
+
+    /**
+     * Get moment representation of prop with the same name
+     */
+    get selectedDate() {
+        const {selectedDate} = this.props;
+        return toMoment(selectedDate, 'YYYY-MM-DD');
+    }
+
+    /**
+     * Get moment representation of the minimum/maximum date values with the
+     * current mode. That is beginning/end of week/month the booking starts/ends
+     * in.
+     */
+    get dateBounds() {
+        const {dateRange, mode} = this.props;
+        if (!dateRange.length) {
+            return null;
+        }
+        return [
+            toMoment(dateRange[0], 'YYYY-MM-DD').startOf(mode),
+            toMoment(dateRange[dateRange.length - 1], 'YYYY-MM-DD').startOf(mode)
+        ];
+    }
+
+    /**
+     * Set the currently selected date, taking into account the currently
+     * selected 'interval mode'. That means rounding down to the first day of
+     * the month/week.
+     *
+     * @param {Moment} date - selected date
+     * @param {String} mode - current interval mode (days/weeks/months)
+     * @param {Boolean} force - update even if the date didn't really change
+     */
+    setDateWithMode(date, mode, force = false) {
+        const {onDateChange} = this.props;
+        let expectedDate;
+        if (mode === 'weeks') {
+            expectedDate = date.clone().startOf('week');
+        } else if (mode === 'months') {
+            expectedDate = date.clone().startOf('month');
+        } else {
+            expectedDate = date.clone();
+        }
+
+        if (force || !expectedDate.isSame(date)) {
+            onDateChange(expectedDate);
+        }
+    }
+
+    calendarDisabledDate = (date) => {
+        const {dateRange} = this.props;
+        if (!date) {
+            return false;
+        }
+        return dateRange.length !== 0 && !isDateWithinRange(date, dateRange, toMoment);
+    };
+
+    onSelect = (date) => {
+        const {mode, dateRange} = this.props;
+        const freeRange = dateRange.length === 0;
+        if (freeRange || isDateWithinRange(date, dateRange, toMoment)) {
+            if (mode === 'weeks') {
+                date = date.clone().startOf('week');
+            } else if (mode === 'months') {
+                date = date.clone().startOf('month');
+            } else {
+                date = date.clone();
+            }
+            this.setDateWithMode(date, mode, true);
+        }
+    };
+
+    changeSelectedDate = (direction) => {
+        const {selectedDate, dateRange, onDateChange, mode} = this.props;
+        const step = direction === 'next' ? 1 : -1;
+
+        // dateRange is not set (unlimited)
+        if (dateRange.length === 0 || mode !== 'days') {
+            onDateChange(this.selectedDate.clone().add(step, mode));
+        } else {
+            const index = dateRange.findIndex((dt) => dt === selectedDate) + step;
+            onDateChange(toMoment(dateRange[index]));
+        }
+    };
+
+    handleModeChange = (mode) => {
+        const {onModeChange} = this.props;
+        onModeChange(mode);
+        this.setDateWithMode(this.selectedDate, mode);
+    };
+
+    renderModeSwitcher(disabled) {
+        const {mode} = this.props;
+        return !!mode && (
+            <Button.Group size="small" style={{marginRight: 10}}>
+                <Button content={Translate.string('Day')}
+                        onClick={() => this.handleModeChange('days')}
+                        primary={mode === 'days'}
+                        disabled={disabled} />
+                <Button content={Translate.string('Week')}
+                        onClick={() => this.handleModeChange('weeks')}
+                        primary={mode === 'weeks'}
+                        disabled={disabled} />
+                <Button content={Translate.string('Month')}
+                        onClick={() => this.handleModeChange('months')}
+                        primary={mode === 'months'}
+                        disabled={disabled} />
+            </Button.Group>
+        );
+    }
+
+    /**
+     * Render the DateNavigator, with its prev/next arrows.
+     *
+     * @param {Boolean} disabled - whether to render the navigator as disabled
+     */
+    renderNavigator(disabled) {
+        const {dateRange, mode} = this.props;
+        const startDate = toMoment(dateRange[0]);
+        const endDate = toMoment(dateRange[dateRange.length - 1]);
+
+        const calendar = (
+            <RCCalendar disabledDate={this.calendarDisabledDate}
+                        onChange={this.onSelect}
+                        value={this.selectedDate} />
+        );
+        const prevDisabled = disabled || this.selectedDate.clone().subtract(1, mode).isBefore(startDate);
+        const nextDisabled = disabled || this.selectedDate.clone().add(1, mode).isAfter(endDate);
+
+        return (
+            <Button.Group size="small">
+                <Button icon="left arrow"
+                        onClick={() => this.changeSelectedDate('prev')}
+                        disabled={prevDisabled} />
+                <DatePicker calendar={calendar} disabled={disabled}>
+                    {
+                        () => (
+                            <Button primary>
+                                {this.selectedDate.format('L')}
+                            </Button>
+                        )
+                    }
+                </DatePicker>
+                <Button icon="right arrow"
+                        onClick={() => this.changeSelectedDate('next')}
+                        disabled={nextDisabled} />
+            </Button.Group>
+        );
+    }
+
+    render = () => {
+        const {disabled, isLoading} = this.props;
+        return (
+            <div>
+                {this.renderModeSwitcher(disabled || isLoading)}
+                {this.renderNavigator(disabled || isLoading)}
+            </div>
+        );
+    };
+}

--- a/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
@@ -49,7 +49,8 @@ export default class ElasticTimeline extends React.Component {
         emptyMessage: PropTypes.node,
         lazyScroll: PropTypes.object,
         extraContent: PropTypes.node,
-        showUnused: PropTypes.bool
+        showUnused: PropTypes.bool,
+        fixedHeight: PropTypes.string
     };
 
     static defaultProps = {
@@ -71,7 +72,8 @@ export default class ElasticTimeline extends React.Component {
         longLabel: false,
         onClickLabel: null,
         lazyScroll: null,
-        showUnused: true
+        showUnused: true,
+        fixedHeight: null
     };
 
     _getDayRowSerializer(dt) {
@@ -182,7 +184,7 @@ export default class ElasticTimeline extends React.Component {
         const {
             extraContent, onClickCandidate, onClickReservation, availability, isLoading, itemClass,
             itemProps, longLabel, onClickLabel, lazyScroll, datePicker: {minHour, maxHour, hourStep, mode},
-            showUnused, inlineLoader
+            showUnused, inlineLoader, fixedHeight
         } = this.props;
         let Component = DailyTimelineContent;
         let rows = this.calcDailyRows(availability);
@@ -216,7 +218,8 @@ export default class ElasticTimeline extends React.Component {
                                isLoading={isLoading}
                                inlineLoader={inlineLoader}
                                lazyScroll={lazyScroll}
-                               showUnused={showUnused} />
+                               showUnused={showUnused}
+                               fixedHeight={fixedHeight} />
                 </div>
             </>
         );

--- a/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
@@ -38,8 +38,8 @@ export default class ElasticTimeline extends React.Component {
         availability: PropTypes.array.isRequired,
         datePicker: PropTypes.object.isRequired,
         bookingAllowed: PropTypes.bool,
-
         isLoading: PropTypes.bool,
+        inlineLoader: PropTypes.bool,
         itemClass: PropTypes.func,
         itemProps: PropTypes.object,
         onClickLabel: PropTypes.func,
@@ -65,6 +65,7 @@ export default class ElasticTimeline extends React.Component {
         bookingAllowed: false,
         extraContent: null,
         isLoading: false,
+        inlineLoader: false,
         itemClass: TimelineItem,
         itemProps: {},
         longLabel: false,
@@ -181,7 +182,7 @@ export default class ElasticTimeline extends React.Component {
         const {
             extraContent, onClickCandidate, onClickReservation, availability, isLoading, itemClass,
             itemProps, longLabel, onClickLabel, lazyScroll, datePicker: {minHour, maxHour, hourStep, mode},
-            showUnused
+            showUnused, inlineLoader
         } = this.props;
         let Component = DailyTimelineContent;
         let rows = this.calcDailyRows(availability);
@@ -213,6 +214,7 @@ export default class ElasticTimeline extends React.Component {
                                longLabel={longLabel}
                                onClickLabel={onClickLabel}
                                isLoading={isLoading}
+                               inlineLoader={inlineLoader}
                                lazyScroll={lazyScroll}
                                showUnused={showUnused} />
                 </div>

--- a/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
@@ -26,20 +26,20 @@ import TimelineItem from './TimelineItem';
 import './Timeline.module.scss';
 
 
+/**
+ * An *elastic* implementation of a Timeline, which can provide
+ * an overview by day, week or month.
+ */
 export default class ElasticTimeline extends React.Component {
     static propTypes = {
         rows: PropTypes.arrayOf(PropTypes.object).isRequired,
-        minHour: PropTypes.number,
-        maxHour: PropTypes.number,
-        hourStep: PropTypes.number,
-        onClickCandidate: PropTypes.func,
-        onClickReservation: PropTypes.func,
+        datePicker: PropTypes.object.isRequired,
         isLoading: PropTypes.bool,
-        recurrenceType: PropTypes.string,
-
         itemClass: PropTypes.func,
         itemProps: PropTypes.object,
         onClickLabel: PropTypes.func,
+        onClickCandidate: PropTypes.func,
+        onClickReservation: PropTypes.func,
         longLabel: PropTypes.bool,
         emptyMessage: PropTypes.node,
         lazyScroll: PropTypes.object,
@@ -55,15 +55,10 @@ export default class ElasticTimeline extends React.Component {
                 </Translate>
             </Message>
         ),
-
-        hourStep: 2,
-        minHour: 6,
-        maxHour: 22,
         onClickCandidate: null,
         onClickReservation: null,
         extraContent: null,
         isLoading: false,
-        recurrenceType: 'single',
         itemClass: TimelineItem,
         itemProps: {},
         longLabel: false,
@@ -74,28 +69,29 @@ export default class ElasticTimeline extends React.Component {
 
     renderTimeline = () => {
         const {
-            extraContent, onClickCandidate, onClickReservation, recurrenceType, rows, isLoading, itemClass, itemProps,
-            longLabel, onClickLabel, lazyScroll, minHour, maxHour, hourStep, showUnused
+            extraContent, onClickCandidate, onClickReservation, rows, isLoading, itemClass, itemProps,
+            longLabel, onClickLabel, lazyScroll, datePicker: {minHour, maxHour, hourStep, mode},
+            showUnused
         } = this.props;
         return (
             <>
                 <div styleName="timeline">
                     {extraContent}
-                    <DailyTimelineContent rows={rows}
-                                          minHour={minHour}
-                                          maxHour={maxHour}
-                                          hourStep={hourStep}
-                                          recurrenceType={recurrenceType}
-                                          onClickCandidate={onClickCandidate}
-                                          onClickReservation={onClickReservation}
-                                          itemClass={itemClass}
-                                          itemProps={itemProps}
-                                          longLabel={longLabel}
-                                          onClickLabel={onClickLabel}
-                                          isLoading={isLoading}
-                                          lazyScroll={lazyScroll}
-                                          showUnused={showUnused} />
-
+                    {mode === 'day' && (
+                        <DailyTimelineContent rows={rows}
+                                              minHour={minHour}
+                                              maxHour={maxHour}
+                                              hourStep={hourStep}
+                                              onClickCandidate={onClickCandidate}
+                                              onClickReservation={onClickReservation}
+                                              itemClass={itemClass}
+                                              itemProps={itemProps}
+                                              longLabel={longLabel}
+                                              onClickLabel={onClickLabel}
+                                              isLoading={isLoading}
+                                              lazyScroll={lazyScroll}
+                                              showUnused={showUnused} />
+                    )}
                 </div>
             </>
         );

--- a/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
@@ -26,11 +26,9 @@ import TimelineItem from './TimelineItem';
 import './Timeline.module.scss';
 
 
-export default class TimelineBase extends React.Component {
+export default class ElasticTimeline extends React.Component {
     static propTypes = {
         rows: PropTypes.arrayOf(PropTypes.object).isRequired,
-        emptyMessage: PropTypes.node,
-        extraContent: PropTypes.node,
         minHour: PropTypes.number,
         maxHour: PropTypes.number,
         hourStep: PropTypes.number,
@@ -38,11 +36,14 @@ export default class TimelineBase extends React.Component {
         onClickReservation: PropTypes.func,
         isLoading: PropTypes.bool,
         recurrenceType: PropTypes.string,
+
         itemClass: PropTypes.func,
         itemProps: PropTypes.object,
-        longLabel: PropTypes.bool,
         onClickLabel: PropTypes.func,
+        longLabel: PropTypes.bool,
+        emptyMessage: PropTypes.node,
         lazyScroll: PropTypes.object,
+        extraContent: PropTypes.node,
         showUnused: PropTypes.bool
     };
 

--- a/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
@@ -97,16 +97,8 @@ export default class ElasticTimeline extends React.Component {
     }
 
     calcDailyRows() {
-        const {availability, datePicker: {selectedDate, dateRange}} = this.props;
+        const {availability, datePicker: {selectedDate}} = this.props;
 
-        if (this.singleRoom) {
-            const roomAvailability = this.singleRoom;
-            return dateRange.map(dt => ({
-                ...this._getRowSerializer(dt)(roomAvailability),
-                label: toMoment(dt).format('L'),
-                key: dt
-            }));
-        }
         return availability.map(([, data]) => data).map((data) => ({
             availability: this._getDayRowSerializer(selectedDate)(data),
             label: data.room.full_name,

--- a/indico/modules/rb_new/client/js/common/timeline/MonthlyTimelineContent.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/MonthlyTimelineContent.jsx
@@ -34,7 +34,7 @@ export default class MonthlyTimelineContent extends WeeklyTimelineContent {
         return [];
     }
 
-    renderTimelineRow({availability, room, label, conflictIndicator}) {
+    renderTimelineRow({availability, room, label, conflictIndicator}, key, rowStyle = null) {
         const {
             minHour, maxHour, itemClass: ItemClass, itemProps, longLabel,
             onClickCandidate, onClickReservation
@@ -43,7 +43,7 @@ export default class MonthlyTimelineContent extends WeeklyTimelineContent {
             !!conflicts.length
         ));
         return (
-            <div styleName="baseStyle.timeline-row" key={`element-${room.id}`}>
+            <div styleName="baseStyle.timeline-row" key={key} style={rowStyle}>
                 <TimelineRowLabel label={label}
                                   availability={conflictIndicator ? (hasConflicts ? 'conflict' : 'available') : null}
                                   longLabel={longLabel}

--- a/indico/modules/rb_new/client/js/common/timeline/MonthlyTimelineContent.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/MonthlyTimelineContent.jsx
@@ -18,18 +18,26 @@
 import _ from 'lodash';
 import React from 'react';
 import {toMoment} from 'indico/utils/date';
-import DailyTimelineContent, {TimelineRowLabel} from './DailyTimelineContent';
+import WeeklyTimelineContent, {TimelineRowLabel} from './DailyTimelineContent';
 
 /* eslint-disable no-unused-vars */
 import baseStyle from './TimelineContent.module.scss';
 import style from './WeeklyTimelineContent.module.scss';
 /* eslint-enable no-unused-vars */
 
-export default class WeeklyTimelineContent extends DailyTimelineContent {
+export default class MonthlyTimelineContent extends WeeklyTimelineContent {
+    get dates() {
+        const {rows} = this.props;
+        if (rows.length) {
+            return rows[0].availability.map(([dt]) => dt);
+        }
+        return [];
+    }
+
     renderTimelineRow({availability, room, label, conflictIndicator}) {
         const {
             minHour, maxHour, itemClass: ItemClass, itemProps, longLabel,
-            onClickReservation, onClickCandidate
+            onClickCandidate, onClickReservation
         } = this.props;
         const hasConflicts = availability.some(([, {conflicts}]) => (
             !!conflicts.length
@@ -63,34 +71,32 @@ export default class WeeklyTimelineContent extends DailyTimelineContent {
         );
     }
 
-    renderDividers(hourSpan, hourStep) {
-        const daySize = (100 / 7);
+    renderDividers() {
+        const nDays = this.dates.length;
+        const daySize = (100 / nDays);
 
         return (
-            _.times(7, n => (
+            _.times(nDays, n => (
                 <div styleName="style.timeline-day-divider"
                      style={{left: `${n * daySize}%`, width: `${daySize}%`}}
-                     key={`day-divider-${n}`}>
-                    {super.renderDividers(hourSpan, hourStep)}
-                </div>
+                     key={`day-divider-${n}`} />
             ))
         );
     }
 
     renderHeader() {
-        const {longLabel, selectable, rows} = this.props;
+        const {longLabel, selectable} = this.props;
         const labelWidth = longLabel ? 200 : 150;
-        const dates = rows[0].availability.map(([dt]) => dt);
         return (
             <>
                 <div styleName="baseStyle.timeline-header" className={!selectable && 'timeline-non-selectable'}>
                     <div style={{minWidth: labelWidth}} />
                     <div styleName="style.timeline-header-labels">
-                        {_.map(dates, (dt, n) => (
+                        {_.map(this.dates, (dt, n) => (
                             <div styleName="style.timeline-header-label"
                                  key={`timeline-header-${n}`}>
                                 <span styleName="style.timeline-label-text">
-                                    {toMoment(dt, 'YYYY-MM-DD').format('ddd D MMM')}
+                                    {toMoment(dt, 'YYYY-MM-DD').format('D')}
                                 </span>
                             </div>
                         ))}

--- a/indico/modules/rb_new/client/js/common/timeline/TimelineContent.module.scss
+++ b/indico/modules/rb_new/client/js/common/timeline/TimelineContent.module.scss
@@ -98,17 +98,20 @@ $row-height: 50px;
     &:global(.timeline-non-selectable) {
         user-select: none;
     }
+}
 
-    & + .timeline-loader {
-        margin-top: 2em !important;
-        color: rgba(0, 0, 0, 0.87) !important;
+.timeline-loader:global(.ui.loader) {
+    margin-top: 2em !important;
+    color: rgba(0, 0, 0, 0.87) !important;
+    position: fixed;
+    bottom: 10px;
+    top: auto;
 
-        &::before {
-            border-color: rgba(0, 0, 0, 0.1) !important;
-        }
+    &::before {
+        border-color: rgba(0, 0, 0, 0.1) !important;
+    }
 
-        &::after {
-            border-color: $sui-grey transparent transparent !important;
-        }
+    &::after {
+        border-color: $sui-grey transparent transparent !important;
     }
 }

--- a/indico/modules/rb_new/client/js/common/timeline/TimelineContent.module.scss
+++ b/indico/modules/rb_new/client/js/common/timeline/TimelineContent.module.scss
@@ -24,8 +24,12 @@ $row-height: 50px;
     display: flex;
     height: $row-height;
 
-    .timeline-header-label {
+    .timeline-header-labels {
         flex: 1;
+        position: relative;
+    }
+
+    .timeline-header-label {
         height: 100%;
         line-height: $row-height;
         text-align: left;
@@ -53,7 +57,7 @@ $row-height: 50px;
         position: absolute;
         top: 0;
         height: 100%;
-        border-left: 1px solid #ededee;
+        border-left: 1px solid $light-gray;
     }
 }
 

--- a/indico/modules/rb_new/client/js/common/timeline/TimelineContent.module.scss
+++ b/indico/modules/rb_new/client/js/common/timeline/TimelineContent.module.scss
@@ -103,10 +103,6 @@ $row-height: 50px;
         margin-top: 2em !important;
         color: rgba(0, 0, 0, 0.87) !important;
 
-        &:not(.active) {
-            display: none;
-        }
-
         &::before {
             border-color: rgba(0, 0, 0, 0.1) !important;
         }

--- a/indico/modules/rb_new/client/js/common/timeline/TimelineItem.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/TimelineItem.jsx
@@ -43,6 +43,14 @@ const types = {
     unbookableHours: 'unbookable-hours',
 };
 
+function getKeyForOccurrence({reservation, startDt, endDt}) {
+    let key = '';
+    if (reservation) {
+        key += `${reservation.id}-`;
+    }
+    return `${name}-${key}${startDt}-${endDt}`;
+}
+
 export default class TimelineItem extends React.Component {
     static propTypes = {
         startHour: PropTypes.number.isRequired,
@@ -168,16 +176,12 @@ export default class TimelineItem extends React.Component {
 
     renderOccurrences = () => {
         const {data} = this.props;
-        return (
-            Object.entries(data).map(([name, occurrences]) => (
-                occurrences.map((occurrence, i) => (
-                    // eslint-disable-next-line react/no-array-index-key
-                    <React.Fragment key={i}>
-                        {this.renderOccurrence(occurrence, classes[name] || 'default', types[name])}
-                    </React.Fragment>
-                ))
-            ))
-        );
+        return Object.entries(data).map(([name, occurrences]) => (
+            occurrences.map(occurrence => (
+                <React.Fragment key={getKeyForOccurrence(occurrence)}>
+                    {this.renderOccurrence(occurrence, classes[name] || 'default', types[name])}
+                </React.Fragment>
+            ))));
     };
 
     render() {

--- a/indico/modules/rb_new/client/js/common/timeline/TimelineItem.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/TimelineItem.jsx
@@ -141,7 +141,7 @@ export default class TimelineItem extends React.Component {
         } else {
             let popupMessage;
             if (reservation) {
-                popupMessage = reservation.booking_reason;
+                popupMessage = reservation.bookingReason;
             } else if (bookable) {
                 popupMessage = Translate.string('Click to book it');
             }
@@ -169,7 +169,7 @@ export default class TimelineItem extends React.Component {
 
         return (
             <Popup trigger={segment} content={popupContent} position="bottom center"
-                   header={reservation && reservation.booked_for_name}
+                   header={reservation && reservation.bookedForName}
                    hideOnScroll />
         );
     };

--- a/indico/modules/rb_new/client/js/common/timeline/TimelineLegend.module.scss
+++ b/indico/modules/rb_new/client/js/common/timeline/TimelineLegend.module.scss
@@ -18,44 +18,49 @@
 @import 'rb_new:styles/palette';
 @import 'rb_new:styles/util';
 
-.legend .labels {
-    &.compact {
-        display: flex;
-        align-items: center;
-    }
+.legend {
+    display: flex;
+    justify-content: space-between;
 
-    :global(.label) {
-        color: white;
-
+    .labels {
         &.compact {
-            padding: 0.5em;
+            display: flex;
+            align-items: center;
+        }
 
-            &+ .text {
-                padding-left: 0.25em;
+        :global(.label) {
+            color: white;
+
+            &.compact {
+                padding: 0.5em;
+
+                & + .text {
+                    padding-left: 0.25em;
+                }
             }
-        }
 
-        &.pre-booking {
-            @include stripes($pre-booking-stripe-colors...);
-            background-size: 35px 35px;
-        }
+            &.pre-booking {
+                @include stripes($pre-booking-stripe-colors...);
+                background-size: 35px 35px;
+            }
 
-        &.pre-booking-conflict {
-            @include stripes($pre-booking-conflict-stripe-colors...);
-            background-size: 35px 35px;
-        }
+            &.pre-booking-conflict {
+                @include stripes($pre-booking-conflict-stripe-colors...);
+                background-size: 35px 35px;
+            }
 
-        &.unbookable {
-            background-color: lighten($sui-grey, 40%);
-            border: 1px solid lighten($sui-grey, 20%);
-            color: $sui-grey;
-        }
+            &.unbookable {
+                background-color: lighten($sui-grey, 40%);
+                border: 1px solid lighten($sui-grey, 20%);
+                color: $sui-grey;
+            }
 
-        &.blocking {
-            @include thin-stripes($blocking-stripe-colors...);
-            background-size: 35px 35px;
-            border: 1px solid darken($light-red, 10%);
-            color: darken($light-red, 40%);
+            &.blocking {
+                @include thin-stripes($blocking-stripe-colors...);
+                background-size: 35px 35px;
+                border: 1px solid darken($light-red, 10%);
+                color: darken($light-red, 40%);
+            }
         }
     }
 }

--- a/indico/modules/rb_new/client/js/common/timeline/WeeklyTimelineContent.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/WeeklyTimelineContent.jsx
@@ -1,0 +1,103 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+import _ from 'lodash';
+import React from 'react';
+import {toMoment} from 'indico/utils/date';
+import DailyTimelineContent, {TimelineRowLabel} from './DailyTimelineContent';
+
+/* eslint-disable no-unused-vars */
+import baseStyle from './TimelineContent.module.scss';
+import style from './WeeklyTimelineContent.module.scss';
+/* eslint-enable no-unused-vars */
+
+export default class WeeklyTimelineContent extends DailyTimelineContent {
+    renderTimelineRow({availability, room, label, conflictIndicator}) {
+        const {
+            minHour, maxHour, itemClass: ItemClass, itemProps, longLabel,
+            onClickReservation, onClickCandidate
+        } = this.props;
+        const hasConflicts = availability.some(([, {conflicts}]) => (
+            !!conflicts.length
+        ));
+        return (
+            <div styleName="baseStyle.timeline-row" key={`element-${room.id}`}>
+                <TimelineRowLabel label={label}
+                                  availability={conflictIndicator ? (hasConflicts ? 'conflict' : 'available') : null}
+                                  longLabel={longLabel}
+                                  onClickLabel={this.onClickLabel(room.id)} />
+                <div styleName="style.timeline-row-content">
+                    {availability.map(([dt, data]) => (
+                        <ItemClass key={dt}
+                                   startHour={minHour}
+                                   endHour={maxHour}
+                                   data={data}
+                                   room={room}
+                                   onClickReservation={onClickReservation}
+                                   onClickCandidate={() => {
+                                       if (onClickCandidate && !hasConflicts) {
+                                           onClickCandidate(room.id);
+                                       }
+                                   }}
+                                   setSelectable={selectable => {
+                                       this.setState({selectable});
+                                   }}
+                                   {...itemProps} />
+                    ))}
+                </div>
+            </div>
+        );
+    }
+
+    renderDividers(hourSpan, hourStep) {
+        const daySize = (100 / 7);
+
+        return (
+            _.times(7, n => (
+                <div styleName="style.timeline-day-divider"
+                     style={{left: `${n * daySize}%`, width: `${daySize}%`}}
+                     key={`day-divider-${n}`}>
+                    {super.renderDividers(hourSpan, hourStep)}
+                </div>
+            ))
+        );
+    }
+
+    renderHeader() {
+        const {longLabel, selectable, rows} = this.props;
+        const labelWidth = longLabel ? 200 : 150;
+        const dates = rows[0].availability.map(([dt]) => dt);
+        return (
+            <>
+                <div styleName="baseStyle.timeline-header" className={!selectable && 'timeline-non-selectable'}>
+                    <div style={{minWidth: labelWidth}} />
+                    <div styleName="style.timeline-header-labels">
+                        {_.map(dates, (dt, n) => (
+                            <div styleName="style.timeline-header-label"
+                                 key={`timeline-header-${n}`}
+                                 width={{width: `${100 / n}%`}}>
+                                <span styleName="style.timeline-label-text">
+                                    {toMoment(dt, 'YYYY-MM-DD').format('ddd D MMM')}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </>
+        );
+    }
+}

--- a/indico/modules/rb_new/client/js/common/timeline/WeeklyTimelineContent.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/WeeklyTimelineContent.jsx
@@ -26,7 +26,7 @@ import style from './WeeklyTimelineContent.module.scss';
 /* eslint-enable no-unused-vars */
 
 export default class WeeklyTimelineContent extends DailyTimelineContent {
-    renderTimelineRow({availability, room, label, conflictIndicator}) {
+    renderTimelineRow({availability, room, label, conflictIndicator}, key, rowStyle = null) {
         const {
             minHour, maxHour, itemClass: ItemClass, itemProps, longLabel,
             onClickReservation, onClickCandidate
@@ -35,7 +35,7 @@ export default class WeeklyTimelineContent extends DailyTimelineContent {
             !!conflicts.length
         ));
         return (
-            <div styleName="baseStyle.timeline-row" key={`element-${room.id}`}>
+            <div styleName="baseStyle.timeline-row" key={key} style={rowStyle}>
                 <TimelineRowLabel label={label}
                                   availability={conflictIndicator ? (hasConflicts ? 'conflict' : 'available') : null}
                                   longLabel={longLabel}

--- a/indico/modules/rb_new/client/js/common/timeline/WeeklyTimelineContent.module.scss
+++ b/indico/modules/rb_new/client/js/common/timeline/WeeklyTimelineContent.module.scss
@@ -15,11 +15,35 @@
  * along with Indico; if not, see <http://www.gnu.org/licenses/>.
  */
 
-export const initialDatePickerState = {
-    selectedDate: null,
-    dateRange: [],
-    minHour: 6,
-    maxHour: 23,
-    hourStep: 2,
-    mode: 'days'
-};
+@import 'rb_new:styles/palette';
+@import './TimelineContent.module.scss';
+
+.timeline-day-divider {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    border-left: 1px solid $pastel-gray;
+}
+
+.timeline-row-content {
+    display: flex;
+    width: 100%;
+}
+
+.timeline-header-labels {
+    flex: 1;
+    display: flex;
+    position: relative;
+}
+
+.timeline-header-label {
+    flex: 1;
+    height: 100%;
+    line-height: $row-height;
+    text-align: center;
+
+    .timeline-label-text {
+        display: inline-block;
+        color: $gray;
+    }
+}

--- a/indico/modules/rb_new/client/js/common/timeline/index.js
+++ b/indico/modules/rb_new/client/js/common/timeline/index.js
@@ -16,7 +16,7 @@
  */
 
 export {default as EditableTimelineItem} from './EditableTimelineItem';
-export {default as TimelineBase} from './TimelineBase';
+export {default as ElasticTimeline} from './ElasticTimeline';
 export {default as DailyTimelineContent} from './DailyTimelineContent';
 export {default as TimelineHeader} from './TimelineHeader';
 export {default as TimelineLegend} from './TimelineLegend';

--- a/indico/modules/rb_new/client/js/common/timeline/index.js
+++ b/indico/modules/rb_new/client/js/common/timeline/index.js
@@ -19,4 +19,5 @@ export {default as EditableTimelineItem} from './EditableTimelineItem';
 export {default as ElasticTimeline} from './ElasticTimeline';
 export {default as DailyTimelineContent} from './DailyTimelineContent';
 export {default as TimelineHeader} from './TimelineHeader';
+export {default as TimelineItem} from './TimelineItem';
 export {default as TimelineLegend} from './TimelineLegend';

--- a/indico/modules/rb_new/client/js/common/timeline/reducers.js
+++ b/indico/modules/rb_new/client/js/common/timeline/reducers.js
@@ -15,19 +15,11 @@
  * along with Indico; if not, see <http://www.gnu.org/licenses/>.
  */
 
-import {createSelector} from 'reselect';
-import {RequestState} from 'indico/utils/redux';
-import {selectors as roomsSelectors} from '../../common/rooms';
-
-
-export const isFetching = ({calendar}) => calendar.request.state === RequestState.STARTED;
-export const getDatePickerInfo = ({calendar}) => calendar.datePicker;
-export const getCalendarData = createSelector(
-    ({calendar: {data}}) => data,
-    roomsSelectors.getAllRooms,
-    ({roomIds, rows}, allRooms) => ({
-        roomIds,
-        rows: rows.map(entry => ({...entry, room: allRooms[entry.roomId]}))
-    })
-);
-export const getFilters = ({calendar}) => calendar.filters;
+export const initialDatePickerState = {
+    selectedDate: null,
+    dateRange: [],
+    minHour: 6,
+    maxHour: 23,
+    hourStep: 2,
+    mode: 'day'
+};

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookFromListModal.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookFromListModal.jsx
@@ -36,8 +36,8 @@ import '../../common/rooms/RoomDetailsModal.module.scss';
 function ConflictIndicator(
     {
         availability: {
-            num_days_available: numDaysAvailable,
-            all_days_available: allDaysAvailable
+            numDaysAvailable,
+            allDaysAvailable
         }
     }
 ) {
@@ -104,7 +104,7 @@ class BookFromListModal extends React.Component {
 
     render() {
         const {room, refreshCollisions, availability, availabilityLoading, defaults} = this.props;
-        const buttonDisabled = availabilityLoading || !availability || availability.num_days_available === 0;
+        const buttonDisabled = availabilityLoading || !availability || availability.numDaysAvailable === 0;
         return (
             <Modal open onClose={this.handleCloseModal} size="large" closeIcon>
                 <Modal.Header styleName="room-details-header">

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookRoom.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookRoom.jsx
@@ -27,7 +27,7 @@ import LazyScroll from 'redux-lazy-scroll';
 
 import {Overridable, Slot, toClasses} from 'indico/react/util';
 import {PluralTranslate, Translate, Singular, Param, Plural} from 'indico/react/i18n';
-import {serializeTime, serializeDate, toMoment} from 'indico/utils/date';
+import {serializeTime, serializeDate} from 'indico/utils/date';
 import searchBarFactory from '../../components/SearchBar';
 import Room from '../../components/Room';
 import BookingFilterBar from './BookingFilterBar';
@@ -75,8 +75,7 @@ class BookRoom extends React.Component {
             setTimelineMode: PropTypes.func.isRequired
         }).isRequired,
         datePicker: PropTypes.object.isRequired,
-        showSuggestions: PropTypes.bool,
-        dateRange: PropTypes.array.isRequired
+        showSuggestions: PropTypes.bool
     };
 
     static defaultProps = {
@@ -168,10 +167,10 @@ class BookRoom extends React.Component {
             results,
             isTimelineVisible,
             actions,
-            dateRange,
-            datePicker: {selectedDate, mode}
+            datePicker
         } = this.props;
 
+        const {selectedDate} = datePicker;
         const legendLabels = [
             {label: Translate.string('Available'), color: 'green'},
             {label: Translate.string('Booked'), color: 'orange'},
@@ -197,12 +196,12 @@ class BookRoom extends React.Component {
                                    total={totalResultCount}
                                    isFetching={isSearching} />
                 {isTimelineVisible && selectedDate && (
-                    <TimelineHeader activeDate={toMoment(selectedDate)}
-                                    mode={mode}
+                    <TimelineHeader datePicker={datePicker}
+                                    disableDatePicker={isSearching}
                                     onDateChange={actions.setDate}
-                                    setMode={actions.setTimelineMode}
+                                    onModeChange={actions.setTimelineMode}
                                     legendLabels={legendLabels}
-                                    dateRange={dateRange} />
+                                    isLoading={isSearching} />
                 )}
             </Sticky>
         );

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookRoom.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookRoom.jsx
@@ -39,7 +39,7 @@ import {queryStringRules as qsFilterRules} from '../../common/roomSearch';
 import {rules as qsBookRoomRules} from './queryString';
 import * as bookRoomActions from './actions';
 import {actions as filtersActions} from '../../common/filters';
-import {actions as roomsActions} from '../../common/rooms';
+import {actions as roomsActions, RoomRenderer} from '../../common/rooms';
 import * as bookRoomSelectors from './selectors';
 import {mapControllerFactory, selectors as mapSelectors} from '../../common/map';
 
@@ -245,6 +245,14 @@ class BookRoom extends React.Component {
             isTimelineVisible,
             showSuggestions
         } = this.props;
+        const {actions: {openRoomDetails}} = this.props;
+
+        const bookingModalBtn = room => (
+            <Button positive icon="check" circular onClick={() => this.openBookingForm(room)} />
+        );
+        const showDetailsBtn = ({id}) => (
+            <Button primary icon="search" circular onClick={() => openRoomDetails(id)} />
+        );
 
         if (!isTimelineVisible) {
             return (
@@ -254,9 +262,23 @@ class BookRoom extends React.Component {
                         {!isSearching && (
                             <>
                                 <LazyScroll hasMore={this.hasMoreRooms()} loadMore={this.loadMoreRooms}>
-                                    <Card.Group stackable>
-                                        {this.visibleRooms.map(this.renderRoom)}
-                                    </Card.Group>
+                                    <Overridable id="RoomRenderer">
+                                        <RoomRenderer rooms={this.visibleRooms}>
+                                            {room => (
+                                                <Slot name="actions">
+                                                    <Popup trigger={bookingModalBtn(room)}
+                                                           content={Translate.string('Book room')}
+                                                           position="top center"
+                                                           hideOnScroll />
+                                                    <Popup trigger={showDetailsBtn(room)}
+                                                           content={Translate.string('Room details')}
+                                                           position="top center"
+                                                           hideOnScroll />
+                                                </Slot>
+
+                                            )}
+                                        </RoomRenderer>
+                                    </Overridable>
                                     <Loader active={isSearching} inline="centered" styleName="rooms-loader" />
                                 </LazyScroll>
                                 {this.renderSuggestions()}

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookRoom.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookRoom.jsx
@@ -71,7 +71,8 @@ class BookRoom extends React.Component {
             toggleTimelineView: PropTypes.func.isRequired,
             openRoomDetails: PropTypes.func.isRequired,
             openBookingForm: PropTypes.func.isRequired,
-            setDate: PropTypes.func.isRequired
+            setDate: PropTypes.func.isRequired,
+            setTimelineMode: PropTypes.func.isRequired
         }).isRequired,
         datePicker: PropTypes.object.isRequired,
         showSuggestions: PropTypes.bool,
@@ -168,7 +169,7 @@ class BookRoom extends React.Component {
             isTimelineVisible,
             actions,
             dateRange,
-            datePicker: {selectedDate}
+            datePicker: {selectedDate, mode}
         } = this.props;
 
         const legendLabels = [
@@ -197,7 +198,9 @@ class BookRoom extends React.Component {
                                    isFetching={isSearching} />
                 {isTimelineVisible && selectedDate && (
                     <TimelineHeader activeDate={toMoment(selectedDate)}
+                                    mode={mode}
                                     onDateChange={actions.setDate}
+                                    setMode={actions.setTimelineMode}
                                     legendLabels={legendLabels}
                                     dateRange={dateRange} />
                 )}
@@ -456,7 +459,8 @@ const mapDispatchToProps = dispatch => ({
         toggleTimelineView: bookRoomActions.toggleTimelineView,
         openRoomDetails: roomsActions.openRoomDetailsBook,
         openBookingForm: bookRoomActions.openBookingForm,
-        setDate: date => bookRoomActions.setDate(serializeDate(date))
+        setDate: date => bookRoomActions.setDate(serializeDate(date)),
+        setTimelineMode: bookRoomActions.setTimelineMode
     }, dispatch),
 });
 

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookingTimeline.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookingTimeline.jsx
@@ -62,14 +62,6 @@ class _BookingTimelineComponent extends React.Component {
 
     state = {};
 
-    get singleRoom() {
-        const {availability, allowSingleRoom} = this.props;
-        if (!allowSingleRoom || availability.length !== 1) {
-            return null;
-        }
-        return availability[0][1];
-    }
-
     renderRoomSummary({room: {full_name: fullName}}) {
         return (
             <Segment>
@@ -100,7 +92,6 @@ class _BookingTimelineComponent extends React.Component {
                                  emptyMessage={emptyMessage}
                                  onClickCandidate={clickable ? openBookingForm : null}
                                  onClickLabel={clickable ? openRoomDetails : null}
-                                 extraContent={this.singleRoom && this.renderRoomSummary(this.singleRoom)}
                                  isLoading={isLoading}
                                  inlineLoader
                                  fixedHeight={fixedHeight} />

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookingTimeline.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookingTimeline.jsx
@@ -48,6 +48,7 @@ class _BookingTimelineComponent extends React.Component {
             openRoomDetails: PropTypes.func.isRequired,
             openBookingForm: PropTypes.func.isRequired,
         }).isRequired,
+        fixedHeight: PropTypes.string
     };
 
     static defaultProps = {
@@ -56,6 +57,7 @@ class _BookingTimelineComponent extends React.Component {
         allowSingleRoom: true,
         showEmptyMessage: true,
         bookingAllowed: false,
+        fixedHeight: null
     };
 
     state = {};
@@ -78,7 +80,7 @@ class _BookingTimelineComponent extends React.Component {
 
     render() {
         const {
-            isLoading, lazyScroll, showEmptyMessage, clickable, datePicker,
+            isLoading, lazyScroll, showEmptyMessage, clickable, datePicker, fixedHeight,
             actions: {openBookingForm, openRoomDetails}, availability, bookingAllowed
         } = this.props;
         const emptyMessage = showEmptyMessage ? (
@@ -100,7 +102,8 @@ class _BookingTimelineComponent extends React.Component {
                                  onClickLabel={clickable ? openRoomDetails : null}
                                  extraContent={this.singleRoom && this.renderRoomSummary(this.singleRoom)}
                                  isLoading={isLoading}
-                                 inlineLoader />
+                                 inlineLoader
+                                 fixedHeight={fixedHeight} />
             )
         );
     }

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookingTimeline.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookingTimeline.jsx
@@ -99,8 +99,7 @@ class _BookingTimelineComponent extends React.Component {
                                  onClickCandidate={clickable ? openBookingForm : null}
                                  onClickLabel={clickable ? openRoomDetails : null}
                                  extraContent={this.singleRoom && this.renderRoomSummary(this.singleRoom)}
-                                 isLoading={isFetching}
-                                 disableDatePicker={!!this.singleRoom} />
+                                 isLoading={isFetching} />
             )
         );
     }

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookingTimeline.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookingTimeline.jsx
@@ -40,7 +40,7 @@ class _BookingTimelineComponent extends React.Component {
         ...timelinePropTypes,
         clickable: PropTypes.bool,
         lazyScroll: PropTypes.object,
-        isFetching: PropTypes.bool.isRequired,
+        isLoading: PropTypes.bool.isRequired,
         showEmptyMessage: PropTypes.bool,
         allowSingleRoom: PropTypes.bool,
         bookingAllowed: PropTypes.bool,
@@ -78,7 +78,7 @@ class _BookingTimelineComponent extends React.Component {
 
     render() {
         const {
-            isFetching, lazyScroll, showEmptyMessage, clickable, datePicker,
+            isLoading, lazyScroll, showEmptyMessage, clickable, datePicker,
             actions: {openBookingForm, openRoomDetails}, availability, bookingAllowed
         } = this.props;
         const emptyMessage = showEmptyMessage ? (
@@ -99,7 +99,8 @@ class _BookingTimelineComponent extends React.Component {
                                  onClickCandidate={clickable ? openBookingForm : null}
                                  onClickLabel={clickable ? openRoomDetails : null}
                                  extraContent={this.singleRoom && this.renderRoomSummary(this.singleRoom)}
-                                 isLoading={isFetching} />
+                                 isLoading={isLoading}
+                                 inlineLoader />
             )
         );
     }
@@ -119,7 +120,7 @@ export const BookingTimelineComponent = connect(
 class BookingTimeline extends React.Component {
     static propTypes = {
         ...timelinePropTypes,
-        fetchingTimeline: PropTypes.bool.isRequired,
+        isLoading: PropTypes.bool.isRequired,
         searchFinished: PropTypes.bool.isRequired,
         hasMoreTimelineData: PropTypes.bool.isRequired,
         filters: PropTypes.shape({
@@ -208,7 +209,7 @@ class BookingTimeline extends React.Component {
 
     render() {
         const {
-            fetchingTimeline,
+            isLoading,
             hasMoreTimelineData,
             availability,
             datePicker,
@@ -219,12 +220,12 @@ class BookingTimeline extends React.Component {
         const lazyScroll = {
             hasMore: hasMoreTimelineData,
             loadMore: fetchTimeline,
-            isFetching: fetchingTimeline,
+            isFetching: isLoading,
         };
 
         return (
             <BookingTimelineComponent lazyScroll={lazyScroll}
-                                      isFetching={fetchingTimeline}
+                                      isLoading={isLoading}
                                       availability={availability}
                                       datePicker={datePicker}
                                       defaultDate={startDate}
@@ -240,7 +241,7 @@ export default connect(
     state => ({
         availability: bookRoomSelectors.getTimelineAvailability(state),
         datePicker: bookRoomSelectors.getTimelineDatePicker(state),
-        fetchingTimeline: bookRoomSelectors.isFetchingTimeline(state),
+        isLoading: bookRoomSelectors.isFetchingTimeline(state),
         searchFinished: bookRoomSelectors.isSearchFinished(state),
         roomIds: bookRoomSelectors.getSearchResultIds(state),
         suggestedRoomIds: bookRoomSelectors.getSuggestedRoomIds(state),

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookingTimeline.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookingTimeline.jsx
@@ -24,7 +24,7 @@ import {connect} from 'react-redux';
 import {Message, Segment} from 'semantic-ui-react';
 import {Translate, Param} from 'indico/react/i18n';
 import {serializeDate, toMoment} from 'indico/utils/date';
-import {TimelineBase} from '../../common/timeline';
+import {ElasticTimeline} from '../../common/timeline';
 import {isDateWithinRange} from '../../util';
 import {actions as roomsActions} from '../../common/rooms';
 import * as bookRoomActions from './actions';
@@ -144,16 +144,16 @@ class _BookingTimelineComponent extends React.Component {
         ) : null;
 
         return (
-            <TimelineBase lazyScroll={lazyScroll}
-                          rows={this.calcRows()}
-                          emptyMessage={emptyMessage}
-                          onClickCandidate={clickable ? openBookingForm : null}
-                          onClickLabel={clickable ? openRoomDetails : null}
-                          dateRange={dateRange}
-                          extraContent={this.singleRoom && this.renderRoomSummary(this.singleRoom)}
-                          isLoading={isFetching}
-                          recurrenceType={recurrenceType}
-                          disableDatePicker={!!this.singleRoom} />
+            <ElasticTimeline lazyScroll={lazyScroll}
+                             rows={this.calcRows()}
+                             emptyMessage={emptyMessage}
+                             onClickCandidate={clickable ? openBookingForm : null}
+                             onClickLabel={clickable ? openRoomDetails : null}
+                             dateRange={dateRange}
+                             extraContent={this.singleRoom && this.renderRoomSummary(this.singleRoom)}
+                             isLoading={isFetching}
+                             recurrenceType={recurrenceType}
+                             disableDatePicker={!!this.singleRoom} />
         );
     }
 }

--- a/indico/modules/rb_new/client/js/modules/bookRoom/UnavailableRoomsModal.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/UnavailableRoomsModal.jsx
@@ -48,7 +48,7 @@ class UnavailableRoomsModal extends React.Component {
     }
 
     render() {
-        const {availability, dateRange, filters, isFetching, onClose} = this.props;
+        const {availability, dateRange, isFetching, onClose} = this.props;
         if (!dateRange || availability.length === 0) {
             return <Dimmer active page><Loader /></Dimmer>;
         }
@@ -61,7 +61,6 @@ class UnavailableRoomsModal extends React.Component {
                 <Modal.Content scrolling>
                     <BookingTimelineComponent isFetching={isFetching}
                                               isFetchingRooms={false}
-                                              recurrenceType={filters.recurrence.type}
                                               availability={availability}
                                               dateRange={dateRange} />
                 </Modal.Content>

--- a/indico/modules/rb_new/client/js/modules/bookRoom/UnavailableRoomsModal.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/UnavailableRoomsModal.jsx
@@ -28,18 +28,17 @@ import {BookingTimelineComponent} from './BookingTimeline';
 
 class UnavailableRoomsModal extends React.Component {
     static propTypes = {
+        datePicker: PropTypes.object.isRequired,
         actions: PropTypes.object.isRequired,
         availability: PropTypes.array,
         filters: PropTypes.object.isRequired,
         isFetching: PropTypes.bool.isRequired,
-        dateRange: PropTypes.array,
         onClose: PropTypes.func
     };
 
     static defaultProps = {
         availability: [],
         onClose: null,
-        dateRange: null,
     };
 
     componentDidMount() {
@@ -48,8 +47,11 @@ class UnavailableRoomsModal extends React.Component {
     }
 
     render() {
-        const {availability, dateRange, isFetching, onClose} = this.props;
-        if (!dateRange || availability.length === 0) {
+        const {availability, isFetching, onClose, datePicker, filters: {dates: {startDate}}} = this.props;
+        // If we're in "timeline" mode, use the datepicker, otherwise the current starting day
+        const picker = datePicker.selectedDate ? datePicker : {...datePicker, selectedDate: startDate};
+
+        if (availability.length === 0) {
             return <Dimmer active page><Loader /></Dimmer>;
         }
 
@@ -58,11 +60,11 @@ class UnavailableRoomsModal extends React.Component {
                 <Modal.Header>
                     <Translate>Unavailable Rooms</Translate>
                 </Modal.Header>
-                <Modal.Content scrolling>
-                    <BookingTimelineComponent isFetching={isFetching}
-                                              isFetchingRooms={false}
+                <Modal.Content>
+                    <BookingTimelineComponent isLoading={isFetching}
                                               availability={availability}
-                                              dateRange={dateRange} />
+                                              datePicker={picker}
+                                              fixedHeight="70vh" />
                 </Modal.Content>
             </Modal>
         );
@@ -74,7 +76,7 @@ export default connect(
         availability: selectors.getUnavailableRoomInfo(state),
         filters: selectors.getFilters(state),
         isFetching: selectors.isFetchingUnavailableRooms(state),
-        dateRange: selectors.getAvailabilityDateRange(state),
+        datePicker: selectors.getTimelineDatePicker(state)
     }),
     dispatch => ({
         actions: bindActionCreators({

--- a/indico/modules/rb_new/client/js/modules/bookRoom/actions.js
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/actions.js
@@ -195,3 +195,7 @@ export const openBookingForm = (roomId, data) => modalActions.openModal('booking
 export function setDate(date) {
     return {type: SET_TIMELINE_DATE, date};
 }
+
+export function setTimelineMode(mode) {
+    return {type: SET_TIMELINE_MODE, mode};
+}

--- a/indico/modules/rb_new/client/js/modules/bookRoom/actions.js
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/actions.js
@@ -49,6 +49,8 @@ export const GET_TIMELINE_REQUEST = 'bookRoom/GET_TIMELINE_REQUEST';
 export const GET_TIMELINE_SUCCESS = 'bookRoom/GET_TIMELINE_SUCCESS';
 export const GET_TIMELINE_ERROR = 'bookRoom/GET_TIMELINE_ERROR';
 export const TIMELINE_RECEIVED = 'bookRoom/TIMELINE_RECEIVED';
+export const SET_TIMELINE_MODE = 'bookRoom/SET_TIMELINE_MODE';
+export const SET_TIMELINE_DATE = 'bookRoom/SET_TIMELINE_DATE';
 
 // Unavailable room list
 export const GET_UNAVAILABLE_TIMELINE_REQUEST = 'bookRoom/GET_UNAVAILABLE_TIMELINE_REQUEST';
@@ -190,3 +192,6 @@ export const {searchRooms} = roomSearchActionsFactory('bookRoom');
 export const openBookRoom = (roomId, data = null) => modalActions.openModal('book-room', roomId, data);
 export const openUnavailableRooms = () => modalActions.openModal('unavailable-rooms');
 export const openBookingForm = (roomId, data) => modalActions.openModal('booking-form', roomId, data);
+export function setDate(date) {
+    return {type: SET_TIMELINE_DATE, date};
+}

--- a/indico/modules/rb_new/client/js/modules/bookRoom/reducers.js
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/reducers.js
@@ -22,14 +22,44 @@ import {requestReducer} from 'indico/utils/redux';
 import * as actions from './actions';
 import * as globalActions from '../../actions';
 import {roomSearchReducerFactory} from '../../common/roomSearch';
+import {initialDatePickerState} from '../../common/timeline/reducers';
 
 
 export const initialTimelineState = {
     availability: [],
-    dateRange: [],
     isVisible: false,
+    /** Rooms currently visible */
     roomIds: [],
+    /** Here, parameters are saved for future requests (other rooms) */
     params: null,
+};
+
+const datePickerReducer = (state = initialDatePickerState, action) => {
+    switch (action.type) {
+        case actions.SET_TIMELINE_MODE:
+            return {
+                ...state,
+                mode: action.mode
+            };
+        case actions.SET_TIMELINE_DATE:
+            return {
+                ...state,
+                selectedDate: action.date
+            };
+        case actions.INIT_TIMELINE:
+            return {
+                ...state,
+                dateRange: [],
+                selectedDate: action.params.dates.startDate
+            };
+        case actions.TIMELINE_RECEIVED:
+            return {
+                ...state,
+                dateRange: action.data.date_range
+            };
+        default:
+            return state;
+    }
 };
 
 const timelineReducer = combineReducers({
@@ -38,6 +68,7 @@ const timelineReducer = combineReducers({
         actions.GET_TIMELINE_SUCCESS,
         actions.GET_TIMELINE_ERROR
     ),
+    datePicker: datePickerReducer,
     data: (state = initialTimelineState, action) => {
         switch (action.type) {
             case actions.TOGGLE_TIMELINE_VIEW:
@@ -47,7 +78,6 @@ const timelineReducer = combineReducers({
             case actions.INIT_TIMELINE:
                 return {
                     ...state,
-                    dateRange: [],
                     availability: [],
                     params: action.params,
                     roomIds: action.roomIds
@@ -60,7 +90,6 @@ const timelineReducer = combineReducers({
             case actions.TIMELINE_RECEIVED:
                 return {
                     ...state,
-                    dateRange: action.data.date_range,
                     availability: state.availability.concat(camelizeKeys(action.data.availability)),
                 };
             case actions.CREATE_BOOKING_SUCCESS: {

--- a/indico/modules/rb_new/client/js/modules/bookRoom/selectors.js
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/selectors.js
@@ -49,7 +49,8 @@ export const getUnavailableRoomInfo = createSelector(
 );
 export const isFetchingTimeline = ({bookRoom}) => bookRoom.timeline.request.state === RequestState.STARTED;
 export const isTimelineVisible = ({bookRoom}) => bookRoom.timeline.data.isVisible;
-export const getTimelineDateRange = ({bookRoom}) => bookRoom.timeline.data.dateRange;
+export const getTimelineDateRange = ({bookRoom}) => bookRoom.timeline.datePicker.dateRange;
+export const getTimelineDatePicker = ({bookRoom}) => bookRoom.timeline.datePicker;
 export const getTimelineAvailability = createSelector(
     ({bookRoom}) => bookRoom.timeline.data.availability,
     roomsSelectors.getAllRooms,

--- a/indico/modules/rb_new/client/js/modules/calendar/Calendar.jsx
+++ b/indico/modules/rb_new/client/js/modules/calendar/Calendar.jsx
@@ -16,7 +16,6 @@
  */
 
 import _ from 'lodash';
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {bindActionCreators} from 'redux';
@@ -132,7 +131,6 @@ class Calendar extends React.Component {
                 onlyFavorites
             }
         } = this.props;
-        const {selectedDate} = datePicker;
         const {showUnused} = this.state;
         const legendLabels = [
             {label: Translate.string('Booked'), color: 'orange'},
@@ -167,9 +165,9 @@ class Calendar extends React.Component {
                                         <SearchBar />
                                     </div>
                                 </Grid.Row>
-                                <TimelineHeader activeDate={selectedDate ? moment(selectedDate) : moment()}
-                                                setMode={setMode}
-                                                mode={datePicker.mode}
+                                <TimelineHeader datePicker={datePicker}
+                                                disableDatePicker={isFetching}
+                                                onModeChange={setMode}
                                                 onDateChange={setDate}
                                                 legendLabels={legendLabels} />
                             </Sticky>

--- a/indico/modules/rb_new/client/js/modules/calendar/Calendar.jsx
+++ b/indico/modules/rb_new/client/js/modules/calendar/Calendar.jsx
@@ -23,6 +23,7 @@ import {bindActionCreators} from 'redux';
 import {Button, ButtonGroup, Container, Grid, Popup, Sticky} from 'semantic-ui-react';
 import {connect} from 'react-redux';
 import {Translate} from 'indico/react/i18n';
+import {serializeDate} from 'indico/utils/date';
 import searchBarFactory from '../../components/SearchBar';
 import * as calendarActions from './actions';
 import * as calendarSelectors from './selectors';
@@ -45,6 +46,8 @@ class Calendar extends React.Component {
         isFetching: PropTypes.bool.isRequired,
         actions: PropTypes.exact({
             fetchCalendar: PropTypes.func.isRequired,
+            setDate: PropTypes.func.isRequired,
+            setMode: PropTypes.func.isRequired,
             openRoomDetails: PropTypes.func.isRequired,
             openBookRoom: PropTypes.func.isRequired,
             setFilterParameter: PropTypes.func.isRequired,
@@ -69,10 +72,10 @@ class Calendar extends React.Component {
         fetchCalendar();
     }
 
-    componentDidUpdate({datePicker: {selectedDate: prevDate}, filters: prevFilters}) {
-        const {datePicker: {selectedDate}, actions: {fetchCalendar}, filters} = this.props;
+    componentDidUpdate({datePicker: {selectedDate: prevDate, mode: prevMode}, filters: prevFilters}) {
+        const {datePicker: {selectedDate, mode}, actions: {fetchCalendar}, filters} = this.props;
         const filtersChanged = !_.isEqual(prevFilters, filters);
-        if (prevDate !== selectedDate || filtersChanged) {
+        if (prevDate !== selectedDate || mode !== prevMode || filtersChanged) {
             fetchCalendar(filtersChanged);
         }
     }
@@ -116,8 +119,18 @@ class Calendar extends React.Component {
 
     render() {
         const {
-            isFetching, calendarData: {rows}, actions: {openRoomDetails, setDate, setFilterParameter, openBookingDetails},
-            datePicker, hasFavoriteRooms, filters: {onlyFavorites}
+            isFetching,
+            calendarData: {
+                rows
+            },
+            actions: {
+                openRoomDetails, setDate, setFilterParameter, openBookingDetails, setMode
+            },
+            datePicker,
+            hasFavoriteRooms,
+            filters: {
+                onlyFavorites
+            }
         } = this.props;
         const {selectedDate} = datePicker;
         const {showUnused} = this.state;
@@ -155,6 +168,8 @@ class Calendar extends React.Component {
                                     </div>
                                 </Grid.Row>
                                 <TimelineHeader activeDate={selectedDate ? moment(selectedDate) : moment()}
+                                                setMode={setMode}
+                                                mode={datePicker.mode}
                                                 onDateChange={setDate}
                                                 legendLabels={legendLabels} />
                             </Sticky>
@@ -188,6 +203,8 @@ export default connect(
     dispatch => ({
         actions: bindActionCreators({
             fetchCalendar: calendarActions.fetchCalendar,
+            setDate: (date) => calendarActions.setDate(serializeDate(date)),
+            setMode: calendarActions.setMode,
             openRoomDetails: roomsActions.openRoomDetails,
             openBookRoom: bookRoomActions.openBookRoom,
             setFilterParameter: (param, value) => filtersActions.setFilterParameter('calendar', param, value),

--- a/indico/modules/rb_new/client/js/modules/calendar/Calendar.jsx
+++ b/indico/modules/rb_new/client/js/modules/calendar/Calendar.jsx
@@ -28,11 +28,11 @@ import searchBarFactory from '../../components/SearchBar';
 import * as calendarActions from './actions';
 import * as calendarSelectors from './selectors';
 import {actions as bookingsActions} from '../../common/bookings';
-import {EditableTimelineItem, TimelineBase, TimelineHeader} from '../../common/timeline';
+import {selectors as roomsSelectors, actions as roomsActions} from '../../common/rooms';
+import {EditableTimelineItem, ElasticTimeline, TimelineHeader} from '../../common/timeline';
 import {actions as bookRoomActions} from '../../modules/bookRoom';
 import {actions as filtersActions} from '../../common/filters';
 import {selectors as userSelectors} from '../../common/user';
-import {selectors as roomsSelectors, actions as roomsActions} from '../../common/rooms';
 
 import './Calendar.module.scss';
 
@@ -168,14 +168,14 @@ class Calendar extends React.Component {
                                                 onDateChange={(newDate) => setFilterParameter('date', serializeDate(newDate))}
                                                 legendLabels={legendLabels} />
                             </Sticky>
-                            <TimelineBase rows={rows.map(this._getRowSerializer(date || serializeDate(moment())))}
-                                          onClickLabel={openRoomDetails}
-                                          isLoading={isFetching}
-                                          onClickReservation={openBookingDetails}
-                                          itemClass={EditableTimelineItem}
-                                          itemProps={{onAddSlot: this.onAddSlot}}
-                                          showUnused={showUnused}
-                                          longLabel />
+                            <ElasticTimeline rows={rows.map(this._getRowSerializer(date || serializeDate(moment())))}
+                                             onClickLabel={openRoomDetails}
+                                             isLoading={isFetching}
+                                             onClickReservation={openBookingDetails}
+                                             itemClass={EditableTimelineItem}
+                                             itemProps={{onAddSlot: this.onAddSlot}}
+                                             showUnused={showUnused}
+                                             longLabel />
                         </div>
                     </Container>
                 </Grid.Row>

--- a/indico/modules/rb_new/client/js/modules/calendar/Calendar.jsx
+++ b/indico/modules/rb_new/client/js/modules/calendar/Calendar.jsx
@@ -99,7 +99,7 @@ class Calendar extends React.Component {
         const {datePicker: {selectedDate}, actions: {openBookRoom}} = this.props;
         openBookRoom(id, {
             dates: {
-                startDate: moment(selectedDate, 'YYYY-MM-DD'),
+                startDate: selectedDate,
                 endDate: null,
             },
             timeSlot: {
@@ -178,8 +178,8 @@ class Calendar extends React.Component {
                                              onClickLabel={openRoomDetails}
                                              isLoading={isFetching}
                                              onClickReservation={openBookingDetails}
-                                             itemClass={datePicker.mode === 'day' ? EditableTimelineItem : TimelineItem}
-                                             itemProps={{onAddSlot: this.onAddSlot}}
+                                             itemClass={datePicker.mode === 'days' ? EditableTimelineItem : TimelineItem}
+                                             itemProps={datePicker.mode === 'days' ? {onAddSlot: this.onAddSlot} : {}}
                                              showUnused={showUnused}
                                              longLabel />
                         </div>

--- a/indico/modules/rb_new/client/js/modules/calendar/Calendar.jsx
+++ b/indico/modules/rb_new/client/js/modules/calendar/Calendar.jsx
@@ -29,7 +29,7 @@ import * as calendarActions from './actions';
 import * as calendarSelectors from './selectors';
 import {actions as bookingsActions} from '../../common/bookings';
 import {selectors as roomsSelectors, actions as roomsActions} from '../../common/rooms';
-import {EditableTimelineItem, ElasticTimeline, TimelineHeader} from '../../common/timeline';
+import {EditableTimelineItem, ElasticTimeline, TimelineHeader, TimelineItem} from '../../common/timeline';
 import {actions as bookRoomActions} from '../../modules/bookRoom';
 import {actions as filtersActions} from '../../common/filters';
 import {selectors as userSelectors} from '../../common/user';
@@ -178,7 +178,7 @@ class Calendar extends React.Component {
                                              onClickLabel={openRoomDetails}
                                              isLoading={isFetching}
                                              onClickReservation={openBookingDetails}
-                                             itemClass={EditableTimelineItem}
+                                             itemClass={datePicker.mode === 'day' ? EditableTimelineItem : TimelineItem}
                                              itemProps={{onAddSlot: this.onAddSlot}}
                                              showUnused={showUnused}
                                              longLabel />

--- a/indico/modules/rb_new/client/js/modules/calendar/actions.js
+++ b/indico/modules/rb_new/client/js/modules/calendar/actions.js
@@ -35,6 +35,14 @@ export const FETCH_ERROR = 'calendar/FETCH_ERROR';
 export const ROOM_IDS_RECEIVED = 'calendar/ROOM_IDS_RECEIVED';
 
 
+export function setDate(date) {
+    return {type: SET_DATE, date};
+}
+
+export function setMode(mode) {
+    return {type: SET_MODE, mode};
+}
+
 export function fetchCalendar(fetchRooms = true) {
     return async (dispatch, getState) => {
         dispatch({type: FETCH_REQUEST});

--- a/indico/modules/rb_new/client/js/modules/calendar/actions.js
+++ b/indico/modules/rb_new/client/js/modules/calendar/actions.js
@@ -23,8 +23,11 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {ajaxAction} from 'indico/utils/redux';
 import {preProcessParameters} from '../../util';
 import {ajaxRules as roomSearchAjaxRules} from '../../common/roomSearch';
+import {ajax as ajaxRules} from './serializers';
 
 
+export const SET_DATE = 'calendar/SET_DATE';
+export const SET_MODE = 'calendar/SET_MODE';
 export const ROWS_RECEIVED = 'calendar/ROWS_RECEIVED';
 export const FETCH_REQUEST = 'calendar/FETCH_REQUEST';
 export const FETCH_SUCCESS = 'calendar/FETCH_SUCCESS';
@@ -32,13 +35,13 @@ export const FETCH_ERROR = 'calendar/FETCH_ERROR';
 export const ROOM_IDS_RECEIVED = 'calendar/ROOM_IDS_RECEIVED';
 
 
-export function fetchCalendar(onlyDateChanged = false) {
+export function fetchCalendar(fetchRooms = true) {
     return async (dispatch, getState) => {
         dispatch({type: FETCH_REQUEST});
-        const {calendar: {filters}, calendar: {data: {roomIds}}} = getState();
+        const {calendar: {filters, data: {roomIds}, datePicker}} = getState();
         let newRoomIds = roomIds;
 
-        if (!onlyDateChanged) {
+        if (fetchRooms) {
             newRoomIds = null;
             if (!_.isEmpty(filters)) {
                 const searchParams = preProcessParameters({...filters}, roomSearchAjaxRules);
@@ -60,8 +63,9 @@ export function fetchCalendar(onlyDateChanged = false) {
             }
         }
 
+        const params = preProcessParameters(datePicker, ajaxRules);
         return await ajaxAction(
-            () => indicoAxios.post(fetchCalendarURL(), {room_ids: newRoomIds}, {params: {day: filters.date}}),
+            () => indicoAxios.post(fetchCalendarURL(), {room_ids: newRoomIds}, {params}),
             null,
             [ROWS_RECEIVED, FETCH_SUCCESS],
             [FETCH_ERROR]

--- a/indico/modules/rb_new/client/js/modules/calendar/queryString.js
+++ b/indico/modules/rb_new/client/js/modules/calendar/queryString.js
@@ -42,13 +42,22 @@ const rules = {
     },
     text: {
         stateField: 'filters.text'
+    },
+    mode: {
+        validator: v.isIn(['days', 'weeks', 'months']),
+        stateField: 'mode'
     }
 };
 
 
 export const routeConfig = {
     '/calendar': {
-        listen: [filtersActions.SET_FILTER_PARAMETER, filtersActions.SET_FILTERS, calendarActions.SET_DATE],
+        listen: [
+            filtersActions.SET_FILTER_PARAMETER,
+            filtersActions.SET_FILTERS,
+            calendarActions.SET_DATE,
+            calendarActions.SET_MODE
+        ],
         select: ({calendar}) => calendar,
         serialize: rules
     }

--- a/indico/modules/rb_new/client/js/modules/calendar/queryString.js
+++ b/indico/modules/rb_new/client/js/modules/calendar/queryString.js
@@ -21,34 +21,35 @@ import {createQueryStringReducer, validator as v} from 'redux-router-querystring
 
 import * as actions from '../../actions';
 import {history} from '../../store';
-import {initialFilterState} from './reducers';
+import {initialState} from './reducers';
 import {actions as filtersActions} from '../../common/filters';
 import {boolStateField} from '../../util';
+import * as calendarActions from './actions';
 
 
 const rules = {
     date: {
         validator: (date) => v.isDate(date) && moment(date).isBetween('1970-01-01', '2999-12-31'),
-        stateField: 'date'
+        stateField: 'datePicker.selectedDate'
     },
     favorite: {
         validator: v.isBoolean(),
         sanitizer: v.toBoolean(),
-        stateField: boolStateField('onlyFavorites')
+        stateField: boolStateField('filters.onlyFavorites')
     },
     building: {
-        stateField: 'building'
+        stateField: 'filters.building'
     },
     text: {
-        stateField: 'text'
-    },
+        stateField: 'filters.text'
+    }
 };
 
 
 export const routeConfig = {
     '/calendar': {
-        listen: [filtersActions.SET_FILTER_PARAMETER, filtersActions.SET_FILTERS],
-        select: ({calendar: {filters}}) => filters,
+        listen: [filtersActions.SET_FILTER_PARAMETER, filtersActions.SET_FILTERS, calendarActions.SET_DATE],
+        select: ({calendar}) => calendar,
         serialize: rules
     }
 };
@@ -59,13 +60,13 @@ export const queryStringReducer = createQueryStringReducer(
     (state, action) => {
         if (action.type === actions.INIT) {
             return {
-                namespace: 'calendar.filters',
+                namespace: 'calendar',
                 queryString: history.location.search.slice(1)
             };
         }
         return null;
     },
     (state, namespace) => (namespace
-        ? _.merge({}, state, _.set({}, namespace, initialFilterState()))
+        ? _.merge({}, state, _.set({}, namespace, initialState()))
         : state)
 );

--- a/indico/modules/rb_new/client/js/modules/calendar/reducers.js
+++ b/indico/modules/rb_new/client/js/modules/calendar/reducers.js
@@ -22,6 +22,7 @@ import camelizeKeys from 'indico/utils/camelize';
 import {serializeDate} from 'indico/utils/date';
 import {requestReducer} from 'indico/utils/redux';
 import {actions as bookRoomActions} from '../../modules/bookRoom';
+import * as actions from '../../actions';
 import * as calendarActions from './actions';
 import {filterReducerFactory} from '../../common/filters';
 import {processRoomFilters} from '../../common/roomSearch/reducers';
@@ -31,12 +32,20 @@ import {initialDatePickerState} from '../../common/timeline/reducers';
 const datePickerState = () => ({...initialDatePickerState, selectedDate: serializeDate(moment())});
 
 const datePickerReducer = (state = datePickerState(), action) => {
-    if (action.type === calendarActions.SET_DATE) {
-        return {
-            ...state,
-            dateRange: [],
-            selectedDate: action.date
-        };
+    switch (action.type) {
+        case calendarActions.SET_DATE:
+            return {
+                ...state,
+                dateRange: [],
+                selectedDate: action.date
+            };
+        case calendarActions.SET_MODE:
+            return {
+                ...state,
+                mode: action.mode
+            };
+        case actions.RESET_PAGE_STATE:
+            return datePickerState();
     }
     return state;
 };

--- a/indico/modules/rb_new/client/js/modules/calendar/reducers.js
+++ b/indico/modules/rb_new/client/js/modules/calendar/reducers.js
@@ -74,8 +74,6 @@ export default combineReducers({
         switch (action.type) {
             case calendarActions.ROWS_RECEIVED:
                 return {...state, rows: camelizeKeys(action.data)};
-            case calendarActions.SET_DATE:
-                return {...state, rows: []};
             case calendarActions.ROOM_IDS_RECEIVED:
                 return {...state, roomIds: action.data.slice()};
             case bookRoomActions.CREATE_BOOKING_SUCCESS: {

--- a/indico/modules/rb_new/client/js/modules/calendar/selectors.js
+++ b/indico/modules/rb_new/client/js/modules/calendar/selectors.js
@@ -27,7 +27,13 @@ export const getCalendarData = createSelector(
     roomsSelectors.getAllRooms,
     ({roomIds, rows}, allRooms) => ({
         roomIds,
-        rows: rows.map(entry => ({...entry, room: allRooms[entry.roomId]}))
+        rows: rows.map(entry => {
+            const room = allRooms[entry.roomId];
+            return [
+                room.id,
+                {...entry, room}
+            ];
+        })
     })
 );
 export const getFilters = ({calendar}) => calendar.filters;

--- a/indico/modules/rb_new/client/js/modules/calendar/serializers.js
+++ b/indico/modules/rb_new/client/js/modules/calendar/serializers.js
@@ -15,19 +15,14 @@
  * along with Indico; if not, see <http://www.gnu.org/licenses/>.
  */
 
-import {createSelector} from 'reselect';
-import {RequestState} from 'indico/utils/redux';
-import {selectors as roomsSelectors} from '../../common/rooms';
+import {serializeDate, toMoment} from 'indico/utils/date';
 
 
-export const isFetching = ({calendar}) => calendar.request.state === RequestState.STARTED;
-export const getDatePickerInfo = ({calendar}) => calendar.datePicker;
-export const getCalendarData = createSelector(
-    ({calendar: {data}}) => data,
-    roomsSelectors.getAllRooms,
-    ({roomIds, rows}, allRooms) => ({
-        roomIds,
-        rows: rows.map(entry => ({...entry, room: allRooms[entry.roomId]}))
-    })
-);
-export const getFilters = ({calendar}) => calendar.filters;
+export const ajax = {
+    start_date: ({selectedDate, mode}) => (
+        serializeDate(toMoment(selectedDate).startOf(mode))
+    ),
+    end_date: ({selectedDate, mode}) => (
+        serializeDate(toMoment(selectedDate).endOf(mode))
+    )
+};

--- a/indico/modules/rb_new/client/js/modules/roomList/RoomList.jsx
+++ b/indico/modules/rb_new/client/js/modules/roomList/RoomList.jsx
@@ -182,10 +182,10 @@ class RoomList extends React.Component {
                             {results.length !== 0 && (
                                 <PluralTranslate count={results.length}>
                                     <Singular>
-                                        There is <Param name="count" value={results.length} /> room matching the criteria
+                                        There is <Param name="count" value={results.length} /> match
                                     </Singular>
                                     <Plural>
-                                        There are <Param name="count" value={results.length} /> rooms matching the criteria
+                                        There are <Param name="count" value={results.length} /> matches
                                     </Plural>
                                 </PluralTranslate>
                             )}

--- a/indico/modules/rb_new/client/js/store.js
+++ b/indico/modules/rb_new/client/js/store.js
@@ -44,8 +44,14 @@ export const history = createHistory({
     basename: `${Indico.Urls.BasePath}/rooms-new`
 });
 
-
-export default function createRBStore(overrides = {}) {
+/**
+ * Create the redux store of the RB module.
+ *
+ * @param {Object} overrides - overrides provided by e.g. a plugin
+ * @param {Array} additionalReducers - additional reducers provided by
+ * e.g. a plugin
+ */
+export default function createRBStore(overrides = {}, additionalReducers = []) {
     return createReduxStore(
         'rb-new',
         getReducers(),
@@ -59,6 +65,7 @@ export default function createRBStore(overrides = {}) {
             qsBookRoomReducer,
             qsCalendarReducer,
             qsBlockingsReducer,
+            ...additionalReducers
         ],
         rootReducer => connectRouter(history)(rootReducer));
 }

--- a/indico/modules/rb_new/controllers/backend/bookings.py
+++ b/indico/modules/rb_new/controllers/backend/bookings.py
@@ -92,11 +92,12 @@ class RHTimeline(RHRoomBookingBase):
 
 class RHCalendar(RHRoomBookingBase):
     @use_kwargs({
-        'day': fields.Date(),
+        'start_date': fields.Date(),
+        'end_date': fields.Date(),
         'room_ids': fields.List(fields.Int(), missing=None)
     })
-    def _process(self, room_ids, day):
-        calendar = get_room_calendar(day or date.today(), room_ids)
+    def _process(self, start_date, end_date, room_ids):
+        calendar = get_room_calendar(start_date or date.today(), end_date or date.today(), room_ids)
         return jsonify(_serialize_availability(calendar).values())
 
 

--- a/indico/modules/rb_new/operations/bookings.py
+++ b/indico/modules/rb_new/operations/bookings.py
@@ -132,9 +132,9 @@ def get_rooms_availability(rooms, start_dt, end_dt, repeat_frequency, repeat_int
     return date_range, availability
 
 
-def get_room_calendar(day, room_ids):
-    start_dt = datetime.combine(day, time(hour=0, minute=0))
-    end_dt = datetime.combine(day, time(hour=23, minute=59))
+def get_room_calendar(start_date, end_date, room_ids):
+    start_dt = datetime.combine(start_date, time(hour=0, minute=0))
+    end_dt = datetime.combine(end_date, time(hour=23, minute=59))
     reservation_strategy = contains_eager('reservation')
     reservation_strategy.noload('room')
     reservation_strategy.noload('booked_for_user')

--- a/indico/web/client/js/react/util/Overridable.jsx
+++ b/indico/web/client/js/react/util/Overridable.jsx
@@ -27,10 +27,10 @@ Overridable.defaultProps = {
     children: null
 };
 
-const ConnectedOverriable = connect(({_overrides}) => ({
+const ConnectedOverridable = connect(({_overrides}) => ({
     overrides: _overrides
 }))(Overridable);
 
 
-export default ConnectedOverriable;
-export const RouteAwareOverridable = withRouter(ConnectedOverriable);
+export default ConnectedOverridable;
+export const RouteAwareOverridable = withRouter(ConnectedOverridable);

--- a/indico/web/client/js/utils/date.js
+++ b/indico/web/client/js/utils/date.js
@@ -45,3 +45,13 @@ export async function setMomentLocale(locale) {
     }
     moment.locale(momentLocale);
 }
+
+export function dayRange(start, end, step = 1) {
+    const next = start.clone();
+    const result = [];
+    while (next.isSameOrBefore(end)) {
+        result.push(next.clone());
+        next.add(step, 'd');
+    }
+    return result;
+}

--- a/indico/web/client/js/utils/redux.js
+++ b/indico/web/client/js/utils/redux.js
@@ -35,6 +35,19 @@ export function combineRootReducers(...reducers) {
 }
 
 
+/**
+ * Create a redux store that is connected to all necessary development
+ * middleware.
+ *
+ * @param {String} name - the name of this store
+ * @param {Object} reducers - a mapping of keys / reducers
+ * @param {Object} initialData - initial state
+ * @param {Array} additionalMiddleware - additional redux middleware
+ * @param {Array} postReducers - list of reducers that will be run after
+ * everything else
+ * @param {(reducer: Function) => Function} enhancer - function that will be
+ * applied on the final reducer function (incl. post reducers)
+ */
 export default function createReduxStore(
     name, reducers, initialData = {}, additionalMiddleware = [], postReducers = [], enhancer = r => r
 ) {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-redux": "^5.0.7",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
+    "react-virtualized": "^9.20.1",
     "redux": "^4.0.1",
     "redux-devtools-extension": "^2.13.5",
     "redux-lazy-scroll": "^0.1.1",


### PR DESCRIPTION
Still WIP.

Added:
 * Handling currently selected date and browsing "mode" with `datePicker` object;
 * ElasticTimeline which can switch between daily/weekly/monthly views;
 * Support for [react-virtualized](https://bvaughn.github.io/react-virtualized/) in large listings of rooms (calendar + timeline);
 * A few improvements to allow plugins to extend/tune behaviour;

TO FIX:
 * [x] Date picker goes bananas when moving from month -> day;
 * [x] Empty days in recurring bookings (should load other days too);