### PR TITLE
Improve event list

### DIFF
--- a/indico/modules/categories/templates/display/event_list.html
+++ b/indico/modules/categories/templates/display/event_list.html
@@ -93,18 +93,20 @@
                         <span class="date {% if happening_now(event) %}today{% endif %}">
                             {{ format_event_date(event) }}
                         </span>
-                        <a href="{{ event.url }}">
-                            {{ event.get_verbose_title(show_speakers=is_lecture, show_series_pos=is_lecture) | striptags }}
-                        </a>
-                        <span class="protected">
-                            {% if event.is_self_protected %}
-                                <span data-type="restricted">({% trans %}protected{% endtrans %})</span>
-                            {% endif %}
+                        <div class="event-title">
+                            <a href="{{ event.url }}">
+                                {{ event.get_verbose_title(show_speakers=is_lecture, show_series_pos=is_lecture) | striptags }}
+                            </a>
+                            <span class="protected">
+                                {% if event.is_self_protected %}
+                                    <span data-type="restricted">({% trans %}protected{% endtrans %})</span>
+                                {% endif %}
 
-                            {% if is_recent(event.created_dt) %}
-                                <i class="icon-new new-label" title="{% trans %}This event is new.{% endtrans %}"></i>
-                            {% endif %}
-                        </span>
+                                {% if is_recent(event.created_dt) %}
+                                    <i class="icon-new new-label" title="{% trans %}This event is new.{% endtrans %}"></i>
+                                {% endif %}
+                            </span>
+                        </div>
                     </span>
                 </li>
             {% endfor %}

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -388,7 +388,8 @@ ul.category-resource-qtip {
         display: block;
 
         .date {
-            padding: 0 10px 0 0;
+            padding: 5px;
+            margin-right: 10px;
             font-size: 13px;
             color: #444;
         }
@@ -407,8 +408,6 @@ ul.category-resource-qtip {
         }
 
         .today {
-            margin: 0 10px 0 0;
-            padding: 5px;
             font-size: 13px;
             color: #444;
             background-color: #F6E8BD;

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -385,13 +385,20 @@ ul.category-resource-qtip {
     li {
         margin: 0 0 10px 60px;
         padding: 0;
-        display: block;
+        display: flex;
+        align-items: baseline;
+
+        .list-name {
+            display: flex;
+            align-items: baseline;
+        }
 
         .date {
             padding: 5px;
             margin-right: 10px;
             font-size: 13px;
             color: #444;
+            flex-shrink: 0;
         }
 
         .ical {


### PR DESCRIPTION
This MR fixes the alignment of labeled dates compared to the not labeled ones as well as the text arrangement of long titled events. See demonstration:

## Before
<img width="1792" alt="screen shot 2018-10-18 at 20 42 00" src="https://user-images.githubusercontent.com/1579899/47176963-47604480-d317-11e8-9801-59d52b67609a.png">


## After
<img width="1792" alt="screen shot 2018-10-18 at 20 45 52" src="https://user-images.githubusercontent.com/1579899/47176969-4d562580-d317-11e8-840f-f5ed564e24fe.png">
