### PR TITLE
Clear calendar timeline when loading new data

### DIFF
--- a/indico/modules/rb_new/client/js/common/timeline/DailyTimelineContent.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/DailyTimelineContent.jsx
@@ -182,7 +182,7 @@ export default class DailyTimelineContent extends React.Component {
 
     render() {
         const {
-            maxHour, minHour, rows, lazyScroll, hourStep, fixedHeight
+            maxHour, minHour, rows, lazyScroll, hourStep, fixedHeight, isLoading
         } = this.props;
         const WrapperComponent = lazyScroll ? LazyScroll : React.Fragment;
         const wrapperProps = lazyScroll || {};
@@ -218,7 +218,7 @@ export default class DailyTimelineContent extends React.Component {
 
         return (
             <>
-                {!!rows.length && this.renderHeader(hourSpan, hourSeries)}
+                {(isLoading || !!rows.length) && this.renderHeader(hourSpan, hourSeries)}
                 <WrapperComponent {...wrapperProps}>
                     {(fixedHeight ? (
                         autoSizerWrapper(fixedHeight)

--- a/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/ElasticTimeline.jsx
@@ -136,7 +136,7 @@ export default class ElasticTimeline extends React.Component {
             return [];
         }
 
-        const d = availability.map(([, data]) => {
+        return availability.map(([, data]) => {
             const {room} = data;
             return {
                 availability: monthRange.map(dt => [dt, this._getDayRowSerializer(dt)(data)]),
@@ -146,7 +146,6 @@ export default class ElasticTimeline extends React.Component {
                 room
             };
         });
-        return d;
     }
 
     hasUsage = (availability) => {

--- a/indico/modules/rb_new/client/js/common/timeline/WeeklyTimelineContent.jsx
+++ b/indico/modules/rb_new/client/js/common/timeline/WeeklyTimelineContent.jsx
@@ -64,7 +64,12 @@ export default class WeeklyTimelineContent extends DailyTimelineContent {
     }
 
     renderDividers(hourSpan, hourStep) {
+        const {rows} = this.props;
         const daySize = (100 / 7);
+
+        if (!rows.length) {
+            return null;
+        }
 
         return (
             _.times(7, n => (
@@ -80,7 +85,7 @@ export default class WeeklyTimelineContent extends DailyTimelineContent {
     renderHeader() {
         const {longLabel, selectable, rows} = this.props;
         const labelWidth = longLabel ? 200 : 150;
-        const dates = rows[0].availability.map(([dt]) => dt);
+        const dates = rows.length ? rows[0].availability.map(([dt]) => dt) : [];
         return (
             <>
                 <div styleName="baseStyle.timeline-header" className={!selectable && 'timeline-non-selectable'}>

--- a/indico/modules/rb_new/client/js/modules/calendar/queryString.js
+++ b/indico/modules/rb_new/client/js/modules/calendar/queryString.js
@@ -22,6 +22,7 @@ import {createQueryStringReducer, validator as v} from 'redux-router-querystring
 import * as actions from '../../actions';
 import {history} from '../../store';
 import {initialState} from './reducers';
+import {defaultStateField} from '../../util';
 import {actions as filtersActions} from '../../common/filters';
 import {queryStringRules as roomSearchQueryStringRules} from '../../common/roomSearch';
 import * as calendarActions from './actions';
@@ -35,7 +36,7 @@ const rules = {
     },
     mode: {
         validator: v.isIn(['days', 'weeks', 'months']),
-        stateField: 'mode'
+        stateField: defaultStateField('datePicker.mode', 'days'),
     }
 };
 

--- a/indico/modules/rb_new/client/js/modules/calendar/reducers.js
+++ b/indico/modules/rb_new/client/js/modules/calendar/reducers.js
@@ -116,6 +116,8 @@ export default combineReducers({
     filters: filterReducerFactory('calendar', initialRoomFilterStateFactory, processRoomFilters),
     data: (state = initialDataState, action) => {
         switch (action.type) {
+            case calendarActions.FETCH_REQUEST:
+                return {...state, rows: []};
             case calendarActions.ROWS_RECEIVED:
                 return {...state, rows: camelizeKeys(action.data)};
             case calendarActions.ROOM_IDS_RECEIVED:

--- a/indico/modules/rb_new/client/js/util.jsx
+++ b/indico/modules/rb_new/client/js/util.jsx
@@ -103,9 +103,32 @@ export const pushStateMergeProps = (stateProps, dispatchProps, ownProps) => {
     };
 };
 
+/**
+ * Defines a query string state field for a boolean that is only added
+ * to the query string if it's true.
+ * @param {string} name - Name of the state field.
+ */
 export function boolStateField(name) {
     return {
         serialize: state => _.get(state, name) || null,
+        parse: (value, state) => {
+            _.set(state, name, value);
+        }
+    };
+}
+
+/**
+ * Defines a query string state field that is only added to the query
+ * string if the value doesn't match the default.
+ * @param {string} name - Name of the state field.
+ * @param defaultValue - The default value that will not go to the query string.
+ */
+export function defaultStateField(name, defaultValue) {
+    return {
+        serialize: state => {
+            const value = _.get(state, name, null);
+            return value === defaultValue ? null : value;
+        },
         parse: (value, state) => {
             _.set(state, name, value);
         }


### PR DESCRIPTION
That way we always see the loading indicator which was previously pushed out of the visible are if there were more than a few rooms.

Also fixed the query string mapping for the calendar view mode.

---

![image](https://user-images.githubusercontent.com/179599/47847200-c602ba80-ddca-11e8-8c63-5e5ae5791d61.png)

In case of weekly/monthly we don't have data to show in the header, so we keep it empty. IMHO it's not worth adding the extra complexity of calculating the days for the currently-loading month/week in JS just for this.

![image](https://user-images.githubusercontent.com/179599/47847248-e6327980-ddca-11e8-8498-d31e4755a9ea.png)
