### PR TITLE
Render paper state nicely

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ Bugfixes
 - Use friendly IDs in abstract attachment package folder names
 - Fix typo in material package subcontribution folder names
 
+Improvements
+^^^^^^^^^^^^
+
+- Render the reviewing state of papers in the same way as abstracts
+  (:issue:`3665`);
+
 Version 2.1.4
 -------------
 

--- a/indico/htdocs/sass/modules/_papers.scss
+++ b/indico/htdocs/sass/modules/_papers.scss
@@ -62,6 +62,10 @@
     .revision-column {
         width: 4rem;
     }
+
+    table > tbody > tr > td {
+        vertical-align: baseline;
+    }
 }
 
 .paper-contribution-list {

--- a/indico/modules/events/papers/templates/_paper_list.html
+++ b/indico/modules/events/papers/templates/_paper_list.html
@@ -1,6 +1,21 @@
 {% from 'message_box.html' import message_box %}
 {% from 'events/management/_lists.html' import render_displayed_entries_fragment %}
 
+{% macro _render_paper_state(paper) %}
+    {% set paper_css_class = paper.state.css_class %}
+    <div class="i-tag outline semantic-text state-badge {{ paper_css_class }}">
+        {% if paper.state.name == 'submitted' and paper.can_judge(session.user) %}
+            {% trans count=paper.last_revision.reviews|length -%}
+                {{- count }} review
+            {%- pluralize -%}
+                {{- count }} reviews
+            {%- endtrans %}
+        {% else %}
+            {{- paper.state.title -}}
+        {% endif %}
+    </div>
+{% endmacro %}
+
 {% macro render_paper_assignment_list(event, total_entries, contribs, static_columns, management=false) %}
     {% if not contribs %}
         {%- call message_box('info') %}
@@ -87,7 +102,15 @@
                                 {% if item.id == 'state' %}
                                     <td class="i-table"
                                         data-searchable="{{ last_revision_state | lower }}">
-                                        <span class="vertical-aligner">{{ last_revision_state }}</span>
+                                        {% if contrib.paper %}
+                                            <span class="vertical-aligner">
+                                                {{ _render_paper_state(contrib.paper) }}
+                                            </span>
+                                        {% else %}
+                                            <span class="i-tag outline semantic-text state-badge">
+                                                {% trans %}No submission{% endtrans %}
+                                            </span>
+                                        {% endif %}
                                     </td>
                                 {% elif item.id == 'track' %}
                                     <td class="i-table"


### PR DESCRIPTION
Contrarily to what happens in the abstracts module, we currently render paper state quite plainly:

![screenshot 2018-11-20 at 16 35 21](https://user-images.githubusercontent.com/2699/48784616-5144e100-ece3-11e8-8556-2dd5cf3e39c7.png)

This commit makes it look a bit nicer:

![screenshot 2018-11-20 at 16 33 41](https://user-images.githubusercontent.com/2699/48784731-8cdfab00-ece3-11e8-836f-4ebadec6e20c.png)

![screenshot 2018-11-20 at 16 31 38](https://user-images.githubusercontent.com/2699/48784783-a84ab600-ece3-11e8-8a16-fa7e9063b8a6.png)

and shows the number of reviews in the current paper revision as well:

![screenshot 2018-11-20 at 16 33 37](https://user-images.githubusercontent.com/2699/48784750-9bc65d80-ece3-11e8-83c9-2b1970d0b060.png)
