### PR TITLE
Refresh data after leaving RB administration

### DIFF
--- a/indico/modules/rb_new/client/js/setup.jsx
+++ b/indico/modules/rb_new/client/js/setup.jsx
@@ -10,6 +10,7 @@ import createRBStore, {history} from './store';
 import {init} from './actions';
 import {selectors as configSelectors} from './common/config';
 import {selectors as userSelectors} from './common/user';
+import {actions as roomsActions} from './common/rooms';
 
 import 'semantic-ui-css/semantic.css';
 import '../styles/main.scss';
@@ -19,6 +20,17 @@ export default function setup(overrides = {}, postReducers = []) {
     document.addEventListener('DOMContentLoaded', () => {
         const appContainer = document.getElementById('rb-app-container');
         const store = createRBStore(overrides, postReducers);
+
+        let oldPath = history.location.pathname;
+        history.listen(({pathname: newPath}) => {
+            if (oldPath.startsWith('/admin') && !newPath.startsWith('/admin')) {
+                // user left the admin area so we need to reload some data that might have been changed
+                // TODO: add more things here once admins can change them (e.g. map areas)
+                store.dispatch(roomsActions.fetchEquipmentTypes());
+                store.dispatch(roomsActions.fetchRooms());
+            }
+            oldPath = newPath;
+        });
 
         store.dispatch(init());
         setupUserMenu(


### PR DESCRIPTION
Feels a bit hacky to me but otherwise we'd need to add extra logic to every single admin action that changes data (and it'd also result in reloading data more often than needed).