### PR TITLE
Add more persistent way of linking stuff to bookings

### DIFF
--- a/indico/modules/rb_new/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb_new/client/js/common/bookings/BookingDetails.jsx
@@ -35,7 +35,7 @@ import RoomBasicDetails from '../../components/RoomBasicDetails';
 import RoomKeyLocation from '../../components/RoomKeyLocation';
 import TimeInformation from '../../components/TimeInformation';
 import {actions as modalActions} from '../../modals';
-import BookingObjectLink from './BookingObjectLink';
+import LazyBookingObjectLink from './LazyBookingObjectLink';
 import * as bookingsSelectors from './selectors';
 import * as bookRoomActions from './actions';
 
@@ -426,7 +426,7 @@ class BookingDetails extends React.Component {
                                     {bookedForUser && this.renderBookedFor(bookedForUser)}
                                     {this.renderReason(bookingReason)}
                                     {isLinkedToObject && (
-                                        <BookingObjectLink type={_.camelCase(link.type)} id={link.id} />
+                                        <LazyBookingObjectLink type={_.camelCase(link.type)} id={link.id} />
                                     )}
                                     {this.renderBookingHistory(editLogs, createdDt, createdByUser)}
                                     {this.renderMessageAfterSplitting(newBookingId)}

--- a/indico/modules/rb_new/client/js/common/bookings/LazyBookingObjectLink.jsx
+++ b/indico/modules/rb_new/client/js/common/bookings/LazyBookingObjectLink.jsx
@@ -1,0 +1,91 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+import getLinkedObjectDataURL from 'indico-url:rooms_new.linked_object_data';
+
+import _ from 'lodash';
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Placeholder, Segment} from 'semantic-ui-react';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+import camelizeKeys from 'indico/utils/camelize';
+import BookingObjectLink from './BookingObjectLink';
+
+/**
+ * `LazyBookingObjectLink` wraps `BookingObjectLink` and loads the data
+ * of the object on demand.
+ */
+export default class LazyBookingObjectLink extends React.PureComponent {
+    static propTypes = {
+        type: PropTypes.oneOf(['event', 'contribution', 'sessionBlock']).isRequired,
+        id: PropTypes.number.isRequired,
+        /** Whether it is a pending link or the booking is already linked */
+        pending: PropTypes.bool,
+    };
+
+    static defaultProps = {
+        pending: false,
+    };
+
+    state = {
+        loaded: false,
+        link: {},
+        canAccess: false,
+    };
+
+    componentDidMount() {
+        const {type, id} = this.props;
+        this.fetchLinkedObjectData(type, id);
+    }
+
+    async fetchLinkedObjectData(type, id) {
+        let response;
+        try {
+            response = await indicoAxios.get(getLinkedObjectDataURL({type: _.snakeCase(type), id}));
+        } catch (error) {
+            handleAxiosError(error);
+            return;
+        }
+        const {canAccess, ...data} = camelizeKeys(response.data);
+        this.setState({
+            loaded: true,
+            link: canAccess ? {type, ...data} : null,
+            canAccess,
+        });
+    }
+
+    render() {
+        const {pending} = this.props;
+        const {loaded, link, canAccess} = this.state;
+        if (loaded && !canAccess) {
+            return null;
+        } else if (loaded) {
+            return <BookingObjectLink pending={pending} link={link} />;
+        } else {
+            return (
+                <Segment>
+                    <Placeholder fluid>
+                        <Placeholder.Header image>
+                            <Placeholder.Line length="full" />
+                            <Placeholder.Line length="full" />
+                        </Placeholder.Header>
+                    </Placeholder>
+                </Segment>
+            );
+        }
+    }
+}

--- a/indico/modules/rb_new/client/js/common/bookings/index.js
+++ b/indico/modules/rb_new/client/js/common/bookings/index.js
@@ -21,5 +21,6 @@ import * as selectors from './selectors';
 
 export {default as reducer} from './reducers';
 export {default as BookingDetailsPreloader} from './BookingDetailsPreloader';
+export {default as BookingObjectLink} from './BookingObjectLink';
 export {default as modalHandlers} from './modals';
 export {actions, selectors};

--- a/indico/modules/rb_new/client/js/common/config/reducers.js
+++ b/indico/modules/rb_new/client/js/common/config/reducers.js
@@ -33,7 +33,7 @@ export default combineReducers({
     data: (state = initialState, action) => {
         switch (action.type) {
             case configActions.CONFIG_RECEIVED: {
-                const {roomsSpriteToken, tileserverUrl: tileServerURL} = camelizeKeys(action.data);
+                const {roomsSpriteToken, tileserverURL: tileServerURL} = camelizeKeys(action.data);
                 const {languages} = action.data;
                 return {
                     roomsSpriteToken,

--- a/indico/modules/rb_new/client/js/common/linking/LinkBar.jsx
+++ b/indico/modules/rb_new/client/js/common/linking/LinkBar.jsx
@@ -23,6 +23,7 @@ import {Icon, Popup} from 'semantic-ui-react';
 import {Translate} from 'indico/react/i18n';
 import * as linkingActions from './actions';
 import * as linkingSelectors from './selectors';
+import {linkDataShape} from './props';
 
 import './LinkBar.module.scss';
 
@@ -33,11 +34,16 @@ const messages = {
     sessionBlock: Translate.string('Your booking will be linked to a session block:'),
 };
 
-const LinkBar = ({visible, clear, data: {type, title, eventURL, eventTitle}}) => {
+/**
+ * `LinkBar` shows an indicator in case the user's booking will be linked to
+ * an event, contribution or session block.
+ */
+const LinkBar = ({visible, clear, data}) => {
     if (!visible) {
         return null;
     }
 
+    const {type, title, eventURL, eventTitle} = data;
     return (
         <header styleName="link-bar">
             <Icon name="info circle" />
@@ -63,13 +69,11 @@ const LinkBar = ({visible, clear, data: {type, title, eventURL, eventTitle}}) =>
 LinkBar.propTypes = {
     visible: PropTypes.bool.isRequired,
     clear: PropTypes.func.isRequired,
-    data: PropTypes.shape({
-        type: PropTypes.string,
-        id: PropTypes.number,
-        title: PropTypes.string,
-        eventURL: PropTypes.string,
-        eventTitle: PropTypes.string,
-    }).isRequired,
+    data: linkDataShape,
+};
+
+LinkBar.defaultProps = {
+    data: null,
 };
 
 export default connect(

--- a/indico/modules/rb_new/client/js/common/linking/LinkBar.jsx
+++ b/indico/modules/rb_new/client/js/common/linking/LinkBar.jsx
@@ -1,0 +1,83 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2019 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+import {Icon, Popup} from 'semantic-ui-react';
+import {Translate} from 'indico/react/i18n';
+import * as linkingActions from './actions';
+import * as linkingSelectors from './selectors';
+
+import './LinkBar.module.scss';
+
+
+const messages = {
+    event: Translate.string('Your booking will be linked to an event:'),
+    contribution: Translate.string('Your booking will be linked to a contribution:'),
+    sessionBlock: Translate.string('Your booking will be linked to a session block:'),
+};
+
+const LinkBar = ({visible, clear, data: {type, title, eventURL, eventTitle}}) => {
+    if (!visible) {
+        return null;
+    }
+
+    return (
+        <header styleName="link-bar">
+            <Icon name="info circle" />
+            <span>
+                {messages[type]}{' '}
+                {type === 'event'
+                    /* eslint-disable react/jsx-no-target-blank */
+                    ? <a href={eventURL} target="_blank"><em>{title}</em></a>
+                    : <span><em>{title}</em> (<a href={eventURL} target="_blank">{eventTitle}</a>)</span>
+                }
+            </span>
+            <span styleName="clear" onClick={clear}>
+                <Popup trigger={<Icon name="close" />}>
+                    <Translate>
+                        Exit linking mode
+                    </Translate>
+                </Popup>
+            </span>
+        </header>
+    );
+};
+
+LinkBar.propTypes = {
+    visible: PropTypes.bool.isRequired,
+    clear: PropTypes.func.isRequired,
+    data: PropTypes.shape({
+        type: PropTypes.string,
+        id: PropTypes.number,
+        title: PropTypes.string,
+        eventURL: PropTypes.string,
+        eventTitle: PropTypes.string,
+    }).isRequired,
+};
+
+export default connect(
+    state => ({
+        visible: linkingSelectors.hasLinkObject(state),
+        data: linkingSelectors.getLinkObject(state),
+    }),
+    dispatch => ({
+        clear: bindActionCreators(linkingActions.clearObject, dispatch),
+    })
+)(LinkBar);

--- a/indico/modules/rb_new/client/js/common/linking/LinkBar.module.scss
+++ b/indico/modules/rb_new/client/js/common/linking/LinkBar.module.scss
@@ -1,0 +1,37 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2019 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+@import 'rb_new:styles/palette';
+
+.link-bar {
+    display: flex;
+    padding: 0 20px 0 10px;
+    margin: 0;
+    height: 30px;
+    line-height: 30px;
+    background-color: $primary-color;
+    color: $white;
+
+    a, a:hover {
+        color: $light-yellow;
+    }
+
+    .clear {
+        margin-left: auto;
+        cursor: pointer;
+    }
+}

--- a/indico/modules/rb_new/client/js/common/linking/actions.js
+++ b/indico/modules/rb_new/client/js/common/linking/actions.js
@@ -29,7 +29,7 @@ export const CLEAR_OBJECT = 'linking/CLEAR_OBJECT';
 
 export function setObjectFromURL(queryString) {
     return async (dispatch) => {
-        const {linkType, linkId} = qs.parse(queryString);
+        const {linkType, linkId} = camelizeKeys(qs.parse(queryString));
         if (linkType === undefined || linkId === undefined) {
             return;
         }
@@ -47,7 +47,7 @@ export function setObjectFromURL(queryString) {
         }
         dispatch({
             type: SET_OBJECT,
-            objectType: linkType,
+            objectType: _.camelCase(linkType),
             objectId: +linkId,
             objectTitle: data.title,
             eventURL: data.eventURL,

--- a/indico/modules/rb_new/client/js/common/linking/actions.js
+++ b/indico/modules/rb_new/client/js/common/linking/actions.js
@@ -50,7 +50,7 @@ export function setObjectFromURL(queryString) {
             objectType: linkType,
             objectId: +linkId,
             objectTitle: data.title,
-            eventURL: data.eventUrl,
+            eventURL: data.eventURL,
             eventTitle: data.eventTitle,
         });
     };

--- a/indico/modules/rb_new/client/js/common/linking/actions.js
+++ b/indico/modules/rb_new/client/js/common/linking/actions.js
@@ -1,0 +1,62 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2019 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+import getLinkedObjectDataURL from 'indico-url:rooms_new.linked_object_data';
+
+import _ from 'lodash';
+import qs from 'qs';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+import camelizeKeys from 'indico/utils/camelize';
+
+
+export const SET_OBJECT = 'linking/SET_OBJECT';
+export const CLEAR_OBJECT = 'linking/CLEAR_OBJECT';
+
+
+export function setObjectFromURL(queryString) {
+    return async (dispatch) => {
+        const {linkType, linkId} = qs.parse(queryString);
+        if (linkType === undefined || linkId === undefined) {
+            return;
+        }
+
+        let response;
+        try {
+            response = await indicoAxios.get(getLinkedObjectDataURL({type: _.snakeCase(linkType), id: linkId}));
+        } catch (error) {
+            handleAxiosError(error);
+            return;
+        }
+        const data = camelizeKeys(response.data);
+        if (!data.canAccess) {
+            return;
+        }
+        dispatch({
+            type: SET_OBJECT,
+            objectType: linkType,
+            objectId: +linkId,
+            objectTitle: data.title,
+            eventURL: data.eventUrl,
+            eventTitle: data.eventTitle,
+        });
+    };
+}
+
+
+export function clearObject() {
+    return {type: CLEAR_OBJECT};
+}

--- a/indico/modules/rb_new/client/js/common/linking/index.js
+++ b/indico/modules/rb_new/client/js/common/linking/index.js
@@ -1,0 +1,24 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2019 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as actions from './actions';
+import * as selectors from './selectors';
+
+
+export {default as reducer} from './reducers';
+export {default as LinkBar} from './LinkBar';
+export {actions, selectors};

--- a/indico/modules/rb_new/client/js/common/linking/index.js
+++ b/indico/modules/rb_new/client/js/common/linking/index.js
@@ -19,6 +19,7 @@ import * as actions from './actions';
 import * as selectors from './selectors';
 
 
+export {linkDataShape} from './props';
 export {default as reducer} from './reducers';
 export {default as LinkBar} from './LinkBar';
 export {actions, selectors};

--- a/indico/modules/rb_new/client/js/common/linking/props.js
+++ b/indico/modules/rb_new/client/js/common/linking/props.js
@@ -15,5 +15,13 @@
  * along with Indico; if not, see <http://www.gnu.org/licenses/>.
  */
 
-export const hasLinkObject = ({linking}) => linking.type !== null;
-export const getLinkObject = ({linking}) => (linking.type !== null ? linking : null);
+import PropTypes from 'prop-types';
+
+
+export const linkDataShape = PropTypes.shape({
+    type: PropTypes.oneOf(['event', 'contribution', 'sessionBlock']).isRequired,
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    eventURL: PropTypes.string.isRequired,
+    eventTitle: PropTypes.string.isRequired,
+});

--- a/indico/modules/rb_new/client/js/common/linking/reducers.js
+++ b/indico/modules/rb_new/client/js/common/linking/reducers.js
@@ -16,6 +16,7 @@
  */
 
 import * as linkingActions from './actions';
+import {actions as bookRoomActions} from '../../modules/bookRoom';
 
 
 const initialState = {
@@ -37,6 +38,7 @@ export default (state = initialState, action) => {
                 eventTitle: action.eventTitle,
             };
         case linkingActions.CLEAR_OBJECT:
+        case bookRoomActions.CREATE_BOOKING_SUCCESS:
             return initialState;
         default:
             return state;

--- a/indico/modules/rb_new/client/js/common/linking/reducers.js
+++ b/indico/modules/rb_new/client/js/common/linking/reducers.js
@@ -1,0 +1,44 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2019 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as linkingActions from './actions';
+
+
+const initialState = {
+    type: null,
+    id: null,
+    title: null,
+    eventURL: null,
+    eventTitle: null,
+};
+
+export default (state = initialState, action) => {
+    switch (action.type) {
+        case linkingActions.SET_OBJECT:
+            return {
+                type: action.objectType,
+                id: action.objectId,
+                title: action.objectTitle,
+                eventURL: action.eventURL,
+                eventTitle: action.eventTitle,
+            };
+        case linkingActions.CLEAR_OBJECT:
+            return initialState;
+        default:
+            return state;
+    }
+};

--- a/indico/modules/rb_new/client/js/common/linking/selectors.js
+++ b/indico/modules/rb_new/client/js/common/linking/selectors.js
@@ -1,0 +1,19 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2019 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const hasLinkObject = ({linking}) => linking.type !== null;
+export const getLinkObject = ({linking}) => linking;

--- a/indico/modules/rb_new/client/js/components/App.jsx
+++ b/indico/modules/rb_new/client/js/components/App.jsx
@@ -34,13 +34,14 @@ import BlockingList from '../modules/blockings';
 import ModalController from '../modals';
 import Menu from './Menu';
 import AdminOverrideBar from './AdminOverrideBar';
+import {LinkBar} from '../common/linking';
 import {actions as configActions} from '../common/config';
 import {actions as mapActions} from '../common/map';
 import {actions as roomsActions} from '../common/rooms';
 import {actions as userActions} from '../common/user';
 import * as globalActions from '../actions';
-import * as globalSelectors from '../selectors';
 
+import * as globalSelectors from '../selectors';
 import './App.module.scss';
 
 
@@ -161,6 +162,7 @@ class App extends React.Component {
                         </div>
                     </header>
                     <AdminOverrideBar />
+                    <LinkBar />
                     {this.renderContent()}
                     <Dimmer.Dimmable>
                         <Dimmer active={isInitializing} page>

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookRoomModal.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookRoomModal.jsx
@@ -30,14 +30,14 @@ import PrincipalSearchField from 'indico/react/components/PrincipalSearchField';
 import {Overridable, IndicoPropTypes} from 'indico/react/util';
 import TimeInformation from '../../components/TimeInformation';
 import {selectors as roomsSelectors} from '../../common/rooms';
+import {selectors as linkingSelectors, linkDataShape} from '../../common/linking';
 import RoomBasicDetails from '../../components/RoomBasicDetails';
 import {DailyTimelineContent, TimelineLegend} from '../../common/timeline';
 import * as actions from './actions';
 import {actions as modalActions} from '../../modals';
 import {selectors as userSelectors} from '../../common/user';
 import * as bookRoomSelectors from './selectors';
-import BookingObjectLink from '../../common/bookings/BookingObjectLink';
-
+import {BookingObjectLink} from '../../common/bookings';
 
 import './BookRoomModal.module.scss';
 
@@ -76,6 +76,7 @@ class BookRoomModal extends React.Component {
         favoriteUsers: PropTypes.array.isRequired,
         timeInformationComponent: PropTypes.func,
         relatedEvents: PropTypes.array.isRequired,
+        link: linkDataShape,
         actions: PropTypes.exact({
             createBooking: PropTypes.func.isRequired,
             fetchAvailability: PropTypes.func.isRequired,
@@ -94,6 +95,7 @@ class BookRoomModal extends React.Component {
         room: null,
         availability: null,
         timeInformationComponent: TimeInformation,
+        link: null,
         defaultTitles: {
             booking: <Translate>Create Booking</Translate>,
             preBooking: <Translate>Create Pre-booking</Translate>
@@ -256,7 +258,7 @@ class BookRoomModal extends React.Component {
     }
 
     submitBooking = async (data) => {
-        const {actions: {createBooking}, bookingData: {link}} = this.props;
+        const {actions: {createBooking}, link} = this.props;
         if (link) {
             data.linkType = _.snakeCase(link.type);
             data.linkId = link.id;
@@ -410,10 +412,11 @@ class BookRoomModal extends React.Component {
 
     render() {
         const {
-            bookingData: {recurrence, dates, timeSlot, isPrebooking, link},
+            bookingData: {recurrence, dates, timeSlot, isPrebooking},
             room, availability,
             timeInformationComponent: TimeInformationComponent,
-            defaultTitles
+            defaultTitles,
+            link,
         } = this.props;
         const {skipConflicts, bookingConflictsVisible} = this.state;
         if (!room) {
@@ -449,7 +452,7 @@ class BookRoomModal extends React.Component {
                         </Grid.Column>
                         <Grid.Column width={8}>
                             {isPrebooking && this.renderPrebookingMessage()}
-                            {link && <BookingObjectLink type={link.type} id={link.id} pending />}
+                            {link && <BookingObjectLink link={link} pending />}
                             <Form id="book-room-form" onSubmit={fprops.handleSubmit}>
                                 <Segment inverted color="blue">
                                     <h3>
@@ -533,6 +536,7 @@ export default connect(
         availability: bookRoomSelectors.getBookingFormAvailability(state),
         relatedEvents: bookRoomSelectors.getBookingFormRelatedEvents(state),
         room: roomsSelectors.getRoom(state, {roomId}),
+        link: linkingSelectors.getLinkObject(state),
     }),
     dispatch => ({
         actions: bindActionCreators({

--- a/indico/modules/rb_new/client/js/modules/bookRoom/actions.js
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/actions.js
@@ -74,7 +74,7 @@ export const FETCH_RELATED_EVENTS_REQUEST = 'bookRoom/FETCH_RELATED_EVENTS_REQUE
 export const FETCH_RELATED_EVENTS_SUCCESS = 'bookRoom/FETCH_RELATED_EVENTS_SUCCESS';
 export const FETCH_RELATED_EVENTS_ERROR = 'bookRoom/FETCH_RELATED_EVENTS_ERROR';
 export const RELATED_EVENTS_RECEIVED = 'bookRoom/RELATED_EVENTS_RECEIVED';
-export const RESET_RELATED_EVENTS = 'bookRoom/REST_RELATED_EVENTS';
+export const RESET_RELATED_EVENTS = 'bookRoom/RESET_RELATED_EVENTS';
 
 export function createBooking(args) {
     const params = preProcessParameters(args, ajaxRules);

--- a/indico/modules/rb_new/client/js/modules/bookRoom/modals.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/modals.jsx
@@ -33,8 +33,8 @@ const BookingDataProvider = connect(
         bookRoomFilters: bookRoomSelectors.getFilters(state),
     })
 )(
-    ({bookRoomFilters: {dates, timeSlot, recurrence}, bookingData: {isPrebooking, link}, ...restProps}) => (
-        <BookRoomModal {...restProps} bookingData={{dates, timeSlot, recurrence, isPrebooking, link}} />
+    ({bookRoomFilters: {dates, timeSlot, recurrence}, bookingData: {isPrebooking}, ...restProps}) => (
+        <BookRoomModal {...restProps} bookingData={{dates, timeSlot, recurrence, isPrebooking}} />
     )
 );
 
@@ -54,7 +54,7 @@ const momentizeBookRoomDefaults = (defaults) => (!_.isEmpty(defaults) ? {
 export default {
     /* eslint-disable react/display-name */
     'booking-form': (onClose, roomId, data) => {
-        const {isPrebooking, link, ...bookingData} = data;
+        const {isPrebooking, ...bookingData} = data;
         return (
             <RoomDetailsPreloader roomId={roomId}>
                 {() => (!_.isEmpty(bookingData)

--- a/indico/modules/rb_new/client/js/reducers.js
+++ b/indico/modules/rb_new/client/js/reducers.js
@@ -28,6 +28,7 @@ import {reducer as landingReducer} from './modules/landing';
 import {reducer as roomListReducer} from './modules/roomList';
 import {reducer as bookingReducer} from './common/bookings';
 import {reducer as adminReducer} from './modules/admin';
+import {reducer as linkingReducer} from './common/linking';
 
 
 export default (history) => ({
@@ -43,4 +44,5 @@ export default (history) => ({
     landing: landingReducer,
     bookings: bookingReducer,
     admin: adminReducer,
+    linking: linkingReducer,
 });

--- a/indico/modules/rb_new/client/js/setup.jsx
+++ b/indico/modules/rb_new/client/js/setup.jsx
@@ -27,6 +27,7 @@ import {init} from './actions';
 import {selectors as configSelectors} from './common/config';
 import {selectors as userSelectors, actions as userActions} from './common/user';
 import {actions as roomsActions} from './common/rooms';
+import {actions as linkingActions} from './common/linking';
 
 import 'indico-sui-theme/semantic.css';
 import '../styles/main.scss';
@@ -50,6 +51,7 @@ export default function setup(overrides = {}, postReducers = []) {
         });
 
         store.dispatch(init());
+        store.dispatch(linkingActions.setObjectFromURL(history.location.search.slice(1)));
         setupUserMenu(
             document.getElementById('indico-user-menu-container'), store,
             userSelectors.getUserInfo, configSelectors.getLanguages

--- a/indico/modules/rb_new/controllers/backend/bookings.py
+++ b/indico/modules/rb_new/controllers/backend/bookings.py
@@ -279,11 +279,9 @@ class RHLinkedObjectData(RHRoomBookingBase):
         type_ = LinkType[request.view_args['type']]
         id_ = request.view_args['id']
         self.linked_object = get_linked_object(type_, id_)
-        if self.linked_object is None:
-            raise NotFound
 
     def _process(self):
-        if not self.linked_object.can_access(session.user):
+        if not self.linked_object or not self.linked_object.can_access(session.user):
             return jsonify(can_access=False)
         return jsonify(can_access=True, **reservation_linked_object_data_schema.dump(self.linked_object).data)
 

--- a/indico/modules/rb_new/controllers/backend/bookings.py
+++ b/indico/modules/rb_new/controllers/backend/bookings.py
@@ -279,11 +279,10 @@ class RHLinkedObjectData(RHRoomBookingBase):
         type_ = LinkType[request.view_args['type']]
         id_ = request.view_args['id']
         self.linked_object = get_linked_object(type_, id_)
-
-    def _process(self):
         if self.linked_object is None:
             raise NotFound
 
+    def _process(self):
         if not self.linked_object.can_access(session.user):
             return jsonify(can_access=False)
         return jsonify(can_access=True, **reservation_linked_object_data_schema.dump(self.linked_object).data)

--- a/indico/modules/rb_new/schemas.py
+++ b/indico/modules/rb_new/schemas.py
@@ -82,7 +82,6 @@ class ReservationSchema(mm.ModelSchema):
 class ReservationLinkedObjectDataSchema(Schema):
     id = Number()
     title = Method('_get_title')
-    url = String()
     event_title = Function(lambda obj: obj.event.title)
     event_url = Function(lambda obj: obj.event.url)
 

--- a/indico/modules/rb_new/util.py
+++ b/indico/modules/rb_new/util.py
@@ -91,16 +91,16 @@ def serialize_unbookable_hours(data):
 
 def get_linked_object(type_, id_):
     if type_ == LinkType.event:
-        return Event.get_one(id_, is_deleted=False)
+        return Event.get(id_, is_deleted=False)
     elif type_ == LinkType.contribution:
         return (Contribution.query
                 .filter(Contribution.id == id_,
                         ~Contribution.is_deleted,
                         Contribution.event.has(is_deleted=False))
-                .one())
+                .first())
     elif type_ == LinkType.session_block:
         return (SessionBlock.query
                 .filter(SessionBlock.id == id_,
                         SessionBlock.session.has(db.and_(~Session.is_deleted,
                                                          Session.event.has(is_deleted=False))))
-                .one())
+                .first())

--- a/indico/web/client/js/utils/camelize.js
+++ b/indico/web/client/js/utils/camelize.js
@@ -18,6 +18,11 @@
 import _ from 'lodash';
 
 
+function smartCamelCase(string) {
+    return _.camelCase(string).replace(/Url/g, 'URL');
+}
+
+
 export default function camelizeKeys(obj) {
     if (!_.isPlainObject(obj) && !_.isArray(obj)) {
         return obj;
@@ -29,7 +34,7 @@ export default function camelizeKeys(obj) {
 
     return Object.entries(obj).reduce((accum, [key, value]) => {
         if (key.match(/^[A-Za-z_]+$/)) {
-            return {...accum, [_.camelCase(key)]: camelizeKeys(value)};
+            return {...accum, [smartCamelCase(key)]: camelizeKeys(value)};
         } else {
             return {...accum, [key]: camelizeKeys(value)};
         }


### PR DESCRIPTION
Opening RB with `linkType=...&linkId=...` sets it in the state and keeps it there until the user leaves linking mode or creates a booking.