### PR TITLE
Apply permissions to specific occurrences

### DIFF
--- a/indico/modules/rb/models/reservation_occurrences.py
+++ b/indico/modules/rb/models/reservation_occurrences.py
@@ -243,6 +243,16 @@ class ReservationOccurrence(db.Model, Serializer):
 
         return q.order_by(Room.id)
 
+    def can_reject(self, user, allow_admin=True):
+        if not self.is_valid:
+            return False
+        return self.reservation.can_reject(user, allow_admin=allow_admin)
+
+    def can_cancel(self, user, allow_admin=True):
+        if not self.is_valid or self.end_dt < datetime.now():
+            return False
+        return self.reservation.can_cancel(user, allow_admin=allow_admin)
+
     @proxy_to_reservation_if_last_valid_occurrence
     @unify_user_args
     def cancel(self, user, reason=None, silent=False):

--- a/indico/modules/rb_new/client/js/common/bookings/OccurrenceActionsDropdown.jsx
+++ b/indico/modules/rb_new/client/js/common/bookings/OccurrenceActionsDropdown.jsx
@@ -126,13 +126,14 @@ class OccurrenceActionsDropdown extends React.Component {
 
     render() {
         const {activeConfirmation, actionInProgress, dropdownOpen, top, left} = this.state;
-        const {booking: {canCancel, canReject}, date} = this.props;
+        const {booking: {occurrences}, date} = this.props;
         const serializedDate = serializeDate(date, 'L');
         const rejectionForm = (
             <FinalForm onSubmit={(data) => this.changeOccurrenceState('reject', data)}
                        render={this.renderRejectionForm} />
         );
 
+        const {canCancel, canReject} = occurrences.bookings[serializeDate(date)][0];
         if (!canCancel && !canReject) {
             return null;
         }


### PR DESCRIPTION
This prevents e.g. cancelling past occurrences, just like we disallow cancelling past bookings.