### PR TITLE
Markdown rendering of room comments

### DIFF
--- a/indico/modules/rb_new/client/js/common/rooms/RoomDetailsModal.jsx
+++ b/indico/modules/rb_new/client/js/common/rooms/RoomDetailsModal.jsx
@@ -22,7 +22,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {Button, Grid, Icon, Modal, Header, Message, List, Segment, Popup} from 'semantic-ui-react';
 import {Translate, Param} from 'indico/react/i18n';
-import {Overridable, IndicoPropTypes} from 'indico/react/util';
+import {Overridable, IndicoPropTypes, Markdown} from 'indico/react/util';
 import RoomBasicDetails from '../../components/RoomBasicDetails';
 import RoomKeyLocation from '../../components/RoomKeyLocation';
 import RoomStats from './RoomStats';
@@ -236,7 +236,14 @@ RoomAvailabilityBox.propTypes = {
 };
 
 function RoomCommentsBox({room}) {
-    return room.comments && (<Message styleName="message-icon" icon="info" content={room.comments} info />);
+    return room.comments && (
+        <Message styleName="message-icon" icon info>
+            <Icon name="info" />
+            <Message.Content>
+                <Markdown source={room.comments} targetBlank />
+            </Message.Content>
+        </Message>
+    );
 }
 
 RoomCommentsBox.propTypes = {

--- a/indico/modules/rb_new/client/js/components/RoomKeyLocation.jsx
+++ b/indico/modules/rb_new/client/js/components/RoomKeyLocation.jsx
@@ -17,15 +17,20 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Message} from 'semantic-ui-react';
+import {Icon, Message} from 'semantic-ui-react';
+import {Markdown} from 'indico/react/util';
 
 import './RoomKeyLocation.module.scss';
 
 
 export default function RoomKeyLocation({room}) {
     return room.keyLocation && (
-        <Message styleName="message-icon" icon="key"
-                 content={room.keyLocation} />
+        <Message styleName="message-icon" icon>
+            <Icon name="key" />
+            <Message.Content>
+                <Markdown source={room.keyLocation} targetBlank />
+            </Message.Content>
+        </Message>
     );
 }
 

--- a/indico/web/client/js/react/util/Markdown.jsx
+++ b/indico/web/client/js/react/util/Markdown.jsx
@@ -1,0 +1,52 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2019 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactMarkdown from 'react-markdown';
+
+// eslint-disable-next-line react/prop-types
+const ExternalLink = ({href, children}) => (
+    <a href={href} target="_blank" rel="noopener noreferrer">{children}</a>
+);
+
+
+/**
+ * This component wraps ReactMarkdown and provides some convenience props.
+ */
+const Markdown = ({targetBlank, ...props}) => {
+    if (targetBlank) {
+        // XXX: not using linkTarget since that doesn't set noopener
+        props.renderers = {link: ExternalLink, linkReference: ExternalLink, ...props.renderers};
+    }
+    return <ReactMarkdown {...props} />;
+};
+
+Markdown.propTypes = {
+    source: PropTypes.string.isRequired,
+    renderers: PropTypes.object,
+    targetBlank: PropTypes.bool,
+    // see https://github.com/rexxars/react-markdown#options for more props
+};
+
+Markdown.defaultProps = {
+    targetBlank: false,
+    renderers: {},
+};
+
+
+export default Markdown;

--- a/indico/web/client/js/react/util/index.js
+++ b/indico/web/client/js/react/util/index.js
@@ -20,3 +20,4 @@ export {default as Slot} from './Slot';
 export {default as Overridable, RouteAwareOverridable, parametrize} from './Overridable';
 export {toClasses} from './html';
 export {default as IndicoPropTypes} from './propTypes';
+export {default as Markdown} from './Markdown';

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-jsx-i18n": ">=0.1.2",
     "react-leaflet": "^2.1.4",
     "react-leaflet-markercluster": "^2.0.0-rc3",
+    "react-markdown": "^4.0.6",
     "react-modal": "^3.8.1",
     "react-redux": "^6.0.0",
     "react-router": "^4.3.1",


### PR DESCRIPTION
Script to fix existing comments & key locations:

```python
import re
from html2text import HTML2Text

def _fix(s):
    s = re.sub(r'<font color=[^> ]+>(.+?)</font>', r'<strong>\1</strong>', s)
    return HTML2Text(bodywidth=0).handle(s).strip()

for r in Room.query:
    for attr in ('comments', 'key_location'):
        if not getattr(r, attr):
            continue
        old = getattr(r, attr).strip()
        new = _fix(old)
        if old != new:
            print 'fixing {} in {}'.format(attr, r.name), '\n', old, '\n', new, '\n\n'
            setattr(r, attr, new)
```