### PR TITLE
RB Admin: General settings

### DIFF
--- a/indico/modules/events/controllers/creation.py
+++ b/indico/modules/events/controllers/creation.py
@@ -127,7 +127,7 @@ class RHCreateEvent(RHProtected):
                 notify_event_creation(event)
             return jsonify_data(flash=False, redirect=url_for('event_management.settings', event))
         check_room_availability = rb_check_user_access(session.user) and config.ENABLE_ROOMBOOKING
-        rb_excluded_categories = rb_settings.get('excluded_categories')
+        rb_excluded_categories = [c.id for c in rb_settings.get('excluded_categories')]
         return jsonify_template('events/forms/event_creation_form.html', form=form, fields=form._field_order,
                                 event_type=self.event_type.name, single_category=self.single_category,
                                 check_room_availability=check_room_availability,

--- a/indico/modules/rb/__init__.py
+++ b/indico/modules/rb/__init__.py
@@ -22,6 +22,8 @@ from indico.core import signals
 from indico.core.config import config
 from indico.core.logger import Logger
 from indico.core.settings import SettingsProxy
+from indico.core.settings.converters import ModelListConverter
+from indico.modules.categories.models.categories import Category
 from indico.modules.rb.models.locations import Location
 from indico.modules.rb.models.rooms import Room
 from indico.modules.rb.util import rb_is_admin
@@ -44,7 +46,12 @@ rb_settings = SettingsProxy('roombooking', {
     'notifications_enabled': True,
     'booking_limit': 365,
     'tileserver_url': ''
-}, acls={'admin_principals', 'authorized_principals'})
+}, acls={
+    'admin_principals',
+    'authorized_principals'
+}, converters={
+    'excluded_categories': ModelListConverter(Category)
+})
 
 
 @signals.import_tasks.connect

--- a/indico/modules/rb_new/blueprint.py
+++ b/indico/modules/rb_new/blueprint.py
@@ -93,6 +93,7 @@ _bp.add_url_rule('/api/blockings/<int:blocking_id>', 'delete_blocking', blocking
 
 
 # Administration
+_bp.add_url_rule('/api/admin/settings', 'admin_settings', admin.RHSettings, methods=('GET', 'PATCH'))
 _bp.add_url_rule('/api/admin/locations', 'admin_locations', admin.RHLocations)
 _bp.add_url_rule('/api/admin/equipment-types', 'admin_equipment_types', admin.RHEquipmentTypes, methods=('GET', 'POST'))
 _bp.add_url_rule('/api/admin/equipment-types/<int:equipment_type_id>', 'admin_equipment_types', admin.RHEquipmentTypes,

--- a/indico/modules/rb_new/client/js/modules/admin/AdminArea.jsx
+++ b/indico/modules/rb_new/client/js/modules/admin/AdminArea.jsx
@@ -21,12 +21,12 @@ import {Route} from 'react-router-dom';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import {Container, Grid} from 'semantic-ui-react';
-import {Translate} from 'indico/react/i18n';
 import {selectors as userSelectors} from '../../common/user';
 import AdminMenu from './AdminMenu';
 import AdminLocationRooms from './AdminLocationRooms';
 import EquipmentPage from './EquipmentPage';
 import AttributesPage from './AttributesPage';
+import SettingsPage from './SettingsPage';
 import * as adminActions from './actions';
 
 import './AdminArea.module.scss';
@@ -59,8 +59,7 @@ class AdminArea extends React.Component {
                         <AdminMenu />
                     </Grid.Column>
                     <Grid.Column width={12}>
-                        <Route exact path="/admin"
-                               render={() => <Translate>General settings</Translate>} />
+                        <Route exact path="/admin" component={SettingsPage} />
                         <Route exact path="/admin/equipment" component={EquipmentPage} />
                         <Route exact path="/admin/attributes" component={AttributesPage} />
                         <Route exact path="/admin/location/:locationId"

--- a/indico/modules/rb_new/client/js/modules/admin/CategoryList.jsx
+++ b/indico/modules/rb_new/client/js/modules/admin/CategoryList.jsx
@@ -1,0 +1,74 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2019 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+import _ from 'lodash';
+import React, {useState} from 'react';
+import PropTypes from 'prop-types';
+import {Dropdown} from 'semantic-ui-react';
+import {Translate} from 'indico/react/i18n';
+
+
+const isValid = value => (+value >= 0);
+
+
+// TODO: make this nicer (searching by title/id, showing titles instead of IDs)
+
+/**
+ * A field that lets the user enter category IDs.
+ */
+const CategoryList = (props) => {
+    const {value, disabled, onChange, onFocus, onBlur} = props;
+    const [options, setOptions] = useState(value.map(x => ({text: x, value: x})));
+
+    const handleAddItem = (e, {value: newValue}) => {
+        if (isValid(newValue)) {
+            setOptions([...options, {text: newValue, value: +newValue}]);
+        }
+    };
+
+    const handleChange = (e, {value: newValue}) => {
+        newValue = _.uniq(newValue.filter(isValid).map(x => +x));
+        setOptions(newValue.map(x => ({text: x, value: x})));
+        onChange(newValue);
+        onFocus();
+        onBlur();
+    };
+
+    return (
+        <Dropdown options={options}
+                  value={value}
+                  disabled={disabled}
+                  searchInput={{onFocus, onBlur, pattern: '^\\d+$'}}
+                  search selection multiple allowAdditions fluid closeOnChange
+                  noResultsMessage={Translate.string('Please enter a category ID')}
+                  placeholder={Translate.string('Please enter a category ID')}
+                  additionLabel={Translate.string('Add category') + ' #'} // eslint-disable-line prefer-template
+                  onAddItem={handleAddItem}
+                  onChange={handleChange} />
+    );
+};
+
+CategoryList.propTypes = {
+    value: PropTypes.arrayOf(PropTypes.number).isRequired,
+    disabled: PropTypes.bool.isRequired,
+    onChange: PropTypes.func.isRequired,
+    onFocus: PropTypes.func.isRequired,
+    onBlur: PropTypes.func.isRequired,
+};
+
+
+export default React.memo(CategoryList);

--- a/indico/modules/rb_new/client/js/modules/admin/actions.js
+++ b/indico/modules/rb_new/client/js/modules/admin/actions.js
@@ -15,6 +15,7 @@
  * along with Indico; if not, see <http://www.gnu.org/licenses/>.
  */
 
+import settingsURL from 'indico-url:rooms_new.admin_settings';
 import fetchLocationsURL from 'indico-url:rooms_new.admin_locations';
 import equipmentTypesURL from 'indico-url:rooms_new.admin_equipment_types';
 import featuresURL from 'indico-url:rooms_new.admin_features';
@@ -24,6 +25,11 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {ajaxAction, submitFormAction} from 'indico/utils/redux';
 import {actions as filtersActions} from '../../common/filters';
 
+
+export const FETCH_SETTINGS_REQUEST = 'admin/FETCH_SETTINGS_REQUEST';
+export const FETCH_SETTINGS_SUCCESS = 'admin/FETCH_SETTINGS_SUCCESS';
+export const FETCH_SETTINGS_ERROR = 'admin/FETCH_SETTINGS_ERROR';
+export const SETTINGS_RECEIVED = 'admin/SETTINGS_RECEIVED';
 
 export const FETCH_LOCATIONS_REQUEST = 'admin/FETCH_LOCATIONS_REQUEST';
 export const FETCH_LOCATIONS_SUCCESS = 'admin/FETCH_LOCATIONS_SUCCESS';
@@ -52,6 +58,23 @@ export const ATTRIBUTE_RECEIVED = 'admin/ATTRIBUTE_RECEIVED';
 export const ATTRIBUTE_DELETED = 'admin/ATTRIBUTE_DELETED';
 
 export const FILTER_NAMESPACE = 'admin';
+
+
+export function fetchSettings() {
+    return ajaxAction(
+        () => indicoAxios.get(settingsURL()),
+        FETCH_SETTINGS_REQUEST,
+        [SETTINGS_RECEIVED, FETCH_SETTINGS_SUCCESS],
+        FETCH_SETTINGS_ERROR
+    );
+}
+
+export function updateSettings(data) {
+    return submitFormAction(
+        () => indicoAxios.patch(settingsURL(), data),
+        null, SETTINGS_RECEIVED
+    );
+}
 
 
 export function fetchLocations() {

--- a/indico/modules/rb_new/client/js/modules/admin/reducers.js
+++ b/indico/modules/rb_new/client/js/modules/admin/reducers.js
@@ -28,6 +28,11 @@ export const initialFilterStateFactory = () => ({
 
 export default combineReducers({
     requests: combineReducers({
+        settings: requestReducer(
+            adminActions.FETCH_SETTINGS_REQUEST,
+            adminActions.FETCH_SETTINGS_SUCCESS,
+            adminActions.FETCH_SETTINGS_ERROR
+        ),
         locations: requestReducer(
             adminActions.FETCH_LOCATIONS_REQUEST,
             adminActions.FETCH_LOCATIONS_SUCCESS,
@@ -53,6 +58,14 @@ export default combineReducers({
         switch (action.type) {
             case adminActions.LOCATIONS_RECEIVED:
                 return camelizeKeys(action.data);
+            default:
+                return state;
+        }
+    },
+    settings: (state = {}, action) => {
+        switch (action.type) {
+            case adminActions.SETTINGS_RECEIVED:
+                return action.data;
             default:
                 return state;
         }

--- a/indico/modules/rb_new/client/js/modules/admin/selectors.js
+++ b/indico/modules/rb_new/client/js/modules/admin/selectors.js
@@ -74,3 +74,7 @@ export const getAttributes = createSelector(
     _getAttributes,
     attributes => attributes.slice().sort(makeSorter('title'))
 );
+
+
+export const hasSettingsLoaded = ({admin}) => admin.requests.settings.state === RequestState.SUCCESS;
+export const getSettings = ({admin}) => admin.settings;

--- a/indico/modules/rb_new/client/styles/forms.scss
+++ b/indico/modules/rb_new/client/styles/forms.scss
@@ -1,0 +1,25 @@
+/* This file is part of Indico.
+ * Copyright (C) 2002 - 2019 European Organization for Nuclear Research (CERN).
+ *
+ * Indico is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * Indico is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Indico; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+@import 'base/palette';
+
+
+.field-description {
+    font-style: italic;
+    font-size: 0.9em;
+    color: $dark-gray;
+}

--- a/indico/modules/rb_new/client/styles/main.scss
+++ b/indico/modules/rb_new/client/styles/main.scss
@@ -17,6 +17,7 @@
 
 @import 'base/palette';
 @import 'rb_new:styles/palette';
+@import 'rb_new:styles/forms';
 
 $indico-top-bar-height: 50px;
 

--- a/indico/modules/rb_new/operations/bookings.py
+++ b/indico/modules/rb_new/operations/bookings.py
@@ -377,7 +377,7 @@ def get_matching_events(start_dt, end_dt, repeat_frequency, repeat_interval):
                     ~Event.room_reservation_links.any(ReservationLink.reservation.has(Reservation.is_accepted)),
                     db.or_(Event.happens_between(as_utc(occ.start_dt), as_utc(occ.end_dt)) for occ in occurrences),
                     Event.timezone == config.DEFAULT_TIMEZONE,
-                    db.and_(Event.category_id != cat['id'] for cat in excluded_categories),
+                    db.and_(Event.category_id != cat.id for cat in excluded_categories),
                     Event.acl_entries.any(db.and_(EventPrincipal.type == PrincipalType.user,
                                                   EventPrincipal.user_id == session.user.id,
                                                   EventPrincipal.full_access)))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/179599/53750130-4d5f5800-3ea9-11e9-8248-120a2186020b.png)


`admin_principals` and `authorized_principals` are still missing ad those are more complex. I'll do that in a separate PR - they need a modified `PrincipalSearchField` component that can work with simple data and doesn't need a dict with details for each users.