### PR TITLE
Travis CI: Start testing on Python 3 in allow_failures mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
-sudo: false
 language: python
 python:
   - 2.7
+  - 3.6
+matrix:
+  allow_failures:
+    - python: 3.6
 git:
   submodules: false
   depth: 500

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - 2.7
-  - 3.6
+  # - 3.6  # TODO: Enable Python 3
 matrix:
   allow_failures:
     - python: 3.6


### PR DESCRIPTION
https://docs.travis-ci.com/user/customizing-the-build/#rows-that-are-allowed-to-fail

Also, [Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"