### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/bin/maintenance/update_backrefs.py
+++ b/bin/maintenance/update_backrefs.py
@@ -15,6 +15,7 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import sys
 from collections import defaultdict
@@ -90,10 +91,10 @@ def main(ci):
         if in_backrefs and not backrefs_written:
             _write_backrefs(rels, new_source)
         if not backrefs_written:
-            print cformat('%{yellow}Class {} has no comment for backref information').format(cls.__name__)
+            print(cformat('%{yellow}Class {} has no comment for backref information').format(cls.__name__))
             has_missing = True
         if source != new_source:
-            print cformat('%{green!}Updating backref info for {} in {}').format(cls.__name__, path)
+            print(cformat('%{green!}Updating backref info for {} in {}').format(cls.__name__, path))
             has_updates = True
             with open(path, 'w') as f:
                 f.writelines(line + '\n' for line in new_source)

--- a/bin/maintenance/update_backrefs.py
+++ b/bin/maintenance/update_backrefs.py
@@ -14,19 +14,20 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import sys
 from collections import defaultdict
 from operator import itemgetter
 
 import click
-from sqlalchemy import inspect
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy.util.models import import_all_models
 from indico.util.console import cformat
+
+from sqlalchemy import inspect
+
 
 click.disable_unicode_literals_warning = True
 

--- a/bin/maintenance/update_backrefs.py
+++ b/bin/maintenance/update_backrefs.py
@@ -21,12 +21,11 @@ from collections import defaultdict
 from operator import itemgetter
 
 import click
+from sqlalchemy import inspect
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy.util.models import import_all_models
 from indico.util.console import cformat
-
-from sqlalchemy import inspect
 
 
 click.disable_unicode_literals_warning = True

--- a/bin/utils/apiProxy.py
+++ b/bin/utils/apiProxy.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # This file is part of Indico.
 # Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
 #
@@ -15,16 +14,19 @@ from __future__ import print_function
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import hashlib
 import hmac
 import optparse
-import requests
 import sys
 import time
 import urllib
 from contextlib import closing
 
-from flask import Flask, request, Response, abort
+import requests
+
+from flask import Flask, Response, abort, request
 from werkzeug.datastructures import MultiDict
 
 app = Flask(__name__)

--- a/bin/utils/apiProxy.py
+++ b/bin/utils/apiProxy.py
@@ -25,9 +25,9 @@ import urllib
 from contextlib import closing
 
 import requests
-
 from flask import Flask, Response, abort, request
 from werkzeug.datastructures import MultiDict
+
 
 app = Flask(__name__)
 

--- a/bin/utils/apiProxy.py
+++ b/bin/utils/apiProxy.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This file is part of Indico.
 # Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
 #
@@ -72,7 +73,7 @@ def indicoproxy(path):
         abort(403)
     content_type, resp = indico_request('/' + path)
     if not content_type:
-        print 'WARNING: Did not receive a content type, falling back to text/plain'
+        print('WARNING: Did not receive a content type, falling back to text/plain')
         content_type = 'text/plain'
     return Response(resp, mimetype=content_type)
 
@@ -98,15 +99,15 @@ def main():
     use_evalex = options.debug
     if options.host not in ('::1', '127.0.0.1'):
         if not options.allowed_ips:
-            print 'Listening on a non-loopback interface is not permitted without IP restriction!'
+            print('Listening on a non-loopback interface is not permitted without IP restriction!')
             sys.exit(1)
         if use_evalex:
             if options.evalex:
-                print 'Binding to non-loopback host with evalex enabled.'
-                print 'This means anyone with access to this app is able to execute arbitrary' \
-                      ' python code!'
+                print('Binding to non-loopback host with evalex enabled.')
+                print('This means anyone with access to this app is able to execute arbitrary' \
+                      ' python code!')
             else:
-                print 'Binding to non-loopback host; disabling evalex (aka remote code execution).'
+                print('Binding to non-loopback host; disabling evalex (aka remote code execution).')
                 use_evalex = False
 
     app.config['ALLOWED_IPS'] = options.allowed_ips
@@ -114,9 +115,9 @@ def main():
     app.config['INDICO_API_KEY'] = options.api_key
     app.config['INDICO_SECRET_KEY'] = options.secret_key
 
-    print ' * Using indico at {}'.format(app.config['INDICO_URL'])
-    print ' * To use this script, simply append a valid Indico HTTP API request to the URL shown' \
-          ' below. It MUST NOT contain an API key, secret key or timestamp!'
+    print(' * Using indico at {}'.format(app.config['INDICO_URL']))
+    print(' * To use this script, simply append a valid Indico HTTP API request to the URL shown' \
+          ' below. It MUST NOT contain an API key, secret key or timestamp!')
     app.debug = options.debug
     app.run(host=options.host, port=options.port, use_evalex=use_evalex)
 

--- a/bin/utils/createDatabaseGraphs.py
+++ b/bin/utils/createDatabaseGraphs.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # This file is part of Indico.
 # Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
 #
@@ -15,15 +14,18 @@ from __future__ import print_function
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import argparse
 import importlib
 import os
+
+from indico.core.db import db
 
 from flask import Flask
 from sqlalchemy import MetaData
 from sqlalchemy.orm import class_mapper
 
-from indico.core.db import db
 
 try:
     from sqlalchemy_schemadisplay import create_schema_graph, create_uml_graph

--- a/bin/utils/createDatabaseGraphs.py
+++ b/bin/utils/createDatabaseGraphs.py
@@ -20,11 +20,11 @@ import argparse
 import importlib
 import os
 
-from indico.core.db import db
-
 from flask import Flask
 from sqlalchemy import MetaData
 from sqlalchemy.orm import class_mapper
+
+from indico.core.db import db
 
 
 try:

--- a/bin/utils/createDatabaseGraphs.py
+++ b/bin/utils/createDatabaseGraphs.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This file is part of Indico.
 # Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
 #
@@ -27,7 +28,7 @@ from indico.core.db import db
 try:
     from sqlalchemy_schemadisplay import create_schema_graph, create_uml_graph
 except ImportError:
-    print 'You need to install sqlalchemy-schemadisplay to create graphs'
+    print('You need to install sqlalchemy-schemadisplay to create graphs')
     import sys
     sys.exit(1)
 
@@ -67,8 +68,8 @@ def generate_uml_graph(package, output):
             if not attr.startswith('_'):
                 try:
                     mappers.append(class_mapper(getattr(module, attr)))
-                except Exception, e:
-                    print str(e)
+                except Exception as e:
+                    print(str(e))
 
     graph = create_uml_graph(mappers, show_operations=False, show_multiplicity_one=False)
     graph.write_png(output)
@@ -91,14 +92,14 @@ if __name__ == '__main__':
     if args.create and args.database:
         create_schema(args.database, args.create)
     elif args.create and not args.database:
-        print '-c and -d must be supplied together'
+        print('-c and -d must be supplied together')
 
     if args.database and args.schema_output:
         generate_schema_graph(args.database, args.schema_output)
     elif not (not args.database and not args.schema_output):
-        print '-d and -s must be supplied together'
+        print('-d and -s must be supplied together')
 
     if args.package and args.uml_output:
         generate_uml_graph(args.package, args.uml_output)
     elif not(not args.package and not args.uml_output):
-        print '-p and -u must be supplied together'
+        print('-p and -u must be supplied together')

--- a/bin/utils/db_log.py
+++ b/bin/utils/db_log.py
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import cPickle
 import fcntl
@@ -31,11 +30,12 @@ import textwrap
 from threading import Lock
 
 import click
-import sqlparse
 from pygments import highlight
 from pygments.formatters.terminal256 import Terminal256Formatter
 from pygments.lexers.agile import PythonLexer, PythonTracebackLexer
 from pygments.lexers.sql import SqlLexer
+
+import sqlparse
 
 
 click.disable_unicode_literals_warning = True

--- a/bin/utils/db_log.py
+++ b/bin/utils/db_log.py
@@ -30,12 +30,11 @@ import textwrap
 from threading import Lock
 
 import click
+import sqlparse
 from pygments import highlight
 from pygments.formatters.terminal256 import Terminal256Formatter
 from pygments.lexers.agile import PythonLexer, PythonTracebackLexer
 from pygments.lexers.sql import SqlLexer
-
-import sqlparse
 
 
 click.disable_unicode_literals_warning = True

--- a/bin/utils/db_log.py
+++ b/bin/utils/db_log.py
@@ -15,6 +15,7 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import cPickle
 import fcntl
@@ -81,18 +82,18 @@ class LogRecordStreamHandler(SocketServer.StreamRequestHandler):
         sql_log_type = obj.get('sql_log_type')
         if sql_log_type == 'start_request':
             with output_lock:
-                print '\n' * 5
+                print('\n' * 5)
                 print_linesep(True, 10)
-                print '\x1b[38;5;70mBegin request\x1b[0m  {}'.format(self._format_request(obj))
+                print('\x1b[38;5;70mBegin request\x1b[0m  {}'.format(self._format_request(obj)))
                 print_linesep()
             return
         elif sql_log_type == 'end_request':
             with output_lock:
                 fmt = '\x1b[38;5;202mEnd request\x1b[0m    {} [{} queries ({}) | {}]'
-                print fmt.format(self._format_request(obj),
+                print(fmt.format(self._format_request(obj),
                                  prettify_count(obj['sql_query_count']),
                                  prettify_duration(obj['req_query_duration'], True),
-                                 prettify_duration(obj['req_duration'], True))
+                                 prettify_duration(obj['req_duration'], True)))
                 print_linesep(True, 196)
             return
         # XXX: `WITH` queries could be something different from SELECT but so far
@@ -103,8 +104,8 @@ class LogRecordStreamHandler(SocketServer.StreamRequestHandler):
         if ignored:
             if sql_log_type == 'end':
                 with output_lock:
-                    print '\x1b[38;5;216mIgnored query\x1b[0m   {} [{:.06f}s]'.format(ignored['file'],
-                                                                                      obj['sql_duration'])
+                    print('\x1b[38;5;216mIgnored query\x1b[0m   {} [{:.06f}s]'.format(ignored['file'],
+                                                                                      obj['sql_duration']))
                     print_linesep()
             return
         if sql_log_type == 'start':
@@ -113,20 +114,20 @@ class LogRecordStreamHandler(SocketServer.StreamRequestHandler):
             params = prettify_params(obj['sql_params']) if obj['sql_params'] else None
             with output_lock:
                 if source:
-                    print prettify_caption('Source')
-                    print source
-                    print
-                print prettify_caption('Statement')
-                print statement
+                    print(prettify_caption('Source'))
+                    print(source)
+                    print()
+                print(prettify_caption('Statement'))
+                print(statement)
                 if params:
-                    print
-                    print prettify_caption('Params')
-                    print params
+                    print()
+                    print(prettify_caption('Params'))
+                    print(params)
         elif sql_log_type == 'end':
             with output_lock:
-                print
-                print prettify_caption('Duration')
-                print '    {}'.format(prettify_duration(obj['sql_duration']))
+                print()
+                print(prettify_caption('Duration'))
+                print('    {}'.format(prettify_duration(obj['sql_duration'])))
                 print_linesep()
 
 
@@ -155,9 +156,9 @@ def print_linesep(double=False, color=None):
     char = u'\N{BOX DRAWINGS DOUBLE HORIZONTAL}' if double else u'\N{BOX DRAWINGS LIGHT HORIZONTAL}'
     sep = terminal_size()[0] * char
     if color is None:
-        print sep
+        print(sep)
     else:
-        print u'\x1b[38;5;{}m{}\x1b[0m'.format(color, sep)
+        print(u'\x1b[38;5;{}m{}\x1b[0m'.format(color, sep))
 
 
 def indent(msg, level=4):
@@ -209,7 +210,7 @@ def prettify_params(args):
 
 
 def sigint(*unused):
-    print '\rTerminating'
+    print('\rTerminating')
     os._exit(1)
 
 
@@ -227,14 +228,14 @@ def sigint(*unused):
                    '/assets/js-vars/user.js). Prefix with ~ to use a regex match instead of an exact string match.')
 def main(port, traceback_frames, ignore_selects, ignored_sources, ignored_request_paths):
     signal.signal(signal.SIGINT, sigint)
-    print 'Listening on 127.0.0.1:{}'.format(port)
+    print('Listening on 127.0.0.1:{}'.format(port))
     server = LogRecordSocketReceiver('localhost', port, traceback_frames=traceback_frames,
                                      ignore_selects=ignore_selects, ignored_sources=ignored_sources,
                                      ignored_request_paths=ignored_request_paths)
     try:
         server.serve_forever()
     except KeyboardInterrupt:
-        print
+        print()
 
 
 if __name__ == '__main__':

--- a/bin/utils/descriptions/generate_processing_page.py
+++ b/bin/utils/descriptions/generate_processing_page.py
@@ -18,14 +18,14 @@ from __future__ import print_function
 
 import os
 
+from flask.json import htmlsafe_dumps
+from jinja2 import Environment, FileSystemLoader
+from sqlalchemy.orm import load_only
+
 from indico.modules.categories.models.categories import Category
 from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.web.flask.app import make_app
-
-from flask.json import htmlsafe_dumps
-from jinja2 import Environment, FileSystemLoader
-from sqlalchemy.orm import load_only
 
 
 def main():

--- a/bin/utils/descriptions/generate_processing_page.py
+++ b/bin/utils/descriptions/generate_processing_page.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This file is part of Indico.
 # Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
 #
@@ -56,7 +57,7 @@ def main():
     env = Environment(loader=FileSystemLoader(os.path.dirname(__file__)))
 
     template = env.get_template('fix_descriptions_template.html')
-    print template.render(object_descriptions=htmlsafe_dumps(object_descriptions))
+    print(template.render(object_descriptions=htmlsafe_dumps(object_descriptions)))
 
 
 if __name__ == '__main__':

--- a/bin/utils/descriptions/generate_processing_page.py
+++ b/bin/utils/descriptions/generate_processing_page.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # This file is part of Indico.
 # Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
 #
@@ -15,16 +14,18 @@ from __future__ import print_function
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-import os
+from __future__ import print_function
 
-from flask.json import htmlsafe_dumps
-from jinja2 import Environment, FileSystemLoader
-from sqlalchemy.orm import load_only
+import os
 
 from indico.modules.categories.models.categories import Category
 from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.web.flask.app import make_app
+
+from flask.json import htmlsafe_dumps
+from jinja2 import Environment, FileSystemLoader
+from sqlalchemy.orm import load_only
 
 
 def main():

--- a/bin/utils/migrate_html_descriptions.py
+++ b/bin/utils/migrate_html_descriptions.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # This file is part of Indico.
 # Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
 #
@@ -15,6 +14,8 @@ from __future__ import print_function
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 import re
 import subprocess
 import sys
@@ -24,8 +25,6 @@ from itertools import chain, ifilter
 from xml.dom import minidom
 
 import click
-import html5lib
-from html2text import HTML2Text
 from pygments import highlight
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import HtmlLexer
@@ -33,6 +32,9 @@ from pygments.lexers import HtmlLexer
 from indico.core.db import db
 from indico.util.string import render_markdown
 from indico.web.flask.app import make_app
+
+import html5lib
+from html2text import HTML2Text
 
 
 EMPTY_OR_TRALING_WS_ONLY_REGEX = re.compile(r'()(\s*(?!.))', re.MULTILINE | re.DOTALL)

--- a/bin/utils/migrate_html_descriptions.py
+++ b/bin/utils/migrate_html_descriptions.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This file is part of Indico.
 # Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
 #
@@ -189,7 +190,7 @@ def purify_html(input_html, obj):
 
             container = document.createElement('ul')
             li.parentNode.replaceChild(container, li)
-            print "!! Adding missing ul", obj
+            print("!! Adding missing ul", obj)
             container.appendChild(li)
             for child in sibling_items:
                 if child != li:
@@ -200,7 +201,7 @@ def purify_html(input_html, obj):
     for ul in document.getElementsByTagName('ul'):
         for child in ul.childNodes:
             if isinstance(child, minidom.Comment) or isinstance(child, minidom.Text) and not child.data.isspace():
-                print "!! Adding missing li", obj
+                print("!! Adding missing li", obj)
                 li = document.createElement('li')
                 ul.insertBefore(li, child)
                 ul.removeChild(child)
@@ -212,7 +213,7 @@ def purify_html(input_html, obj):
         for li in ul.childNodes:
             if not isinstance(li, (minidom.Text, minidom.Comment)):
                 if li.getElementsByTagName('p'):
-                    print "!! Cannot convert to markdown because a list contains a paragraph:", obj
+                    print("!! Cannot convert to markdown because a list contains a paragraph:", obj)
                     convert_to_markdown = False
 
     # Markdown doesn't like a bold or italic section to start or end with a whitespace
@@ -222,7 +223,7 @@ def purify_html(input_html, obj):
         if first_text_node is not None:
             whitespace, text = _split_leading_whitespace(first_text_node.data)
             if whitespace:
-                print "!! Moving leading whitespace outside of the element:", obj
+                print("!! Moving leading whitespace outside of the element:", obj)
                 first_text_node.data = text
                 element.parentNode.insertBefore(document.createTextNode(whitespace), element)
                 dom_modified = True
@@ -230,7 +231,7 @@ def purify_html(input_html, obj):
         if last_text_node is not None:
             text, whitespace = _split_trailing_whitespace(last_text_node.data)
             if whitespace:
-                print "!! Moving trailing whitespace outside of the element:", obj, whitespace.__repr__()
+                print("!! Moving trailing whitespace outside of the element:", obj, whitespace.__repr__())
                 last_text_node.data = text
                 _insertAfter(document.createTextNode(whitespace), element)
                 dom_modified = True
@@ -246,9 +247,9 @@ def purify_html(input_html, obj):
     # * c
     if _contains_problematic_space_near_delimiter("".join([x.toxml() for x
                                                            in document.getElementsByTagName('body')[0].childNodes])):
-        print "!! Cannot convert to markdown because the description contains '_ ' or '* ' " \
+        print("!! Cannot convert to markdown because the description contains '_ ' or '* ' " \
               "at a position which is very likely to trigger bugs in our markdown renderer." \
-              "(It is likely that this description is not being rendered properly in its current form.)", obj
+              "(It is likely that this description is not being rendered properly in its current form.)", obj)
         # I'm pretty sure that converting such descriptions now yields CommonMark-compliant Markdown but proper
         # testing with a compliant python parser has not been performed. I'm leaving those description as
         # HTML for now which should make it easier to find them when switching to a compliant Markdown renderer.

--- a/bin/utils/migrate_html_descriptions.py
+++ b/bin/utils/migrate_html_descriptions.py
@@ -25,6 +25,8 @@ from itertools import chain, ifilter
 from xml.dom import minidom
 
 import click
+import html5lib
+from html2text import HTML2Text
 from pygments import highlight
 from pygments.formatters import Terminal256Formatter
 from pygments.lexers import HtmlLexer
@@ -32,9 +34,6 @@ from pygments.lexers import HtmlLexer
 from indico.core.db import db
 from indico.util.string import render_markdown
 from indico.web.flask.app import make_app
-
-import html5lib
-from html2text import HTML2Text
 
 
 EMPTY_OR_TRALING_WS_ONLY_REGEX = re.compile(r'()(\s*(?!.))', re.MULTILINE | re.DOTALL)

--- a/bin/utils/room_occupancy.py
+++ b/bin/utils/room_occupancy.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # This file is part of Indico.
 # Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
 #
@@ -15,15 +14,18 @@ from __future__ import print_function
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
+
 from datetime import date
 
 import click
-from dateutil.relativedelta import relativedelta
 
-from indico.modules.rb.models.rooms import Room
 from indico.modules.rb.models.locations import Location
+from indico.modules.rb.models.rooms import Room
 from indico.modules.rb.statistics import calculate_rooms_occupancy
 from indico.web.flask.app import make_app
+
+from dateutil.relativedelta import relativedelta
 
 
 def _main(location):

--- a/bin/utils/room_occupancy.py
+++ b/bin/utils/room_occupancy.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # This file is part of Indico.
 # Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
 #
@@ -35,12 +36,12 @@ def _main(location):
     else:
         rooms = Room.find_all(Location.name.in_(location), _join=Location)
 
-    print 'Month\tYear\tPublic?\tRoom'
+    print('Month\tYear\tPublic?\tRoom')
     for room in rooms:
-        print '{2:.2f}%\t{3:.2f}%\t{1}\t{0}'.format(room.full_name,
+        print('{2:.2f}%\t{3:.2f}%\t{1}\t{0}'.format(room.full_name,
                                                     "Y" if room.is_public else "N",
                                                     calculate_rooms_occupancy([room], past_month, yesterday) * 100,
-                                                    calculate_rooms_occupancy([room], past_year, yesterday) * 100)
+                                                    calculate_rooms_occupancy([room], past_year, yesterday) * 100))
 
 
 @click.command()

--- a/bin/utils/room_occupancy.py
+++ b/bin/utils/room_occupancy.py
@@ -19,13 +19,12 @@ from __future__ import print_function
 from datetime import date
 
 import click
+from dateutil.relativedelta import relativedelta
 
 from indico.modules.rb.models.locations import Location
 from indico.modules.rb.models.rooms import Room
 from indico.modules.rb.statistics import calculate_rooms_occupancy
 from indico.web.flask.app import make_app
-
-from dateutil.relativedelta import relativedelta
 
 
 def _main(location):

--- a/docs/source/exec_directive.py
+++ b/docs/source/exec_directive.py
@@ -19,7 +19,7 @@ class ExecDirective(Directive):
         old_stdout, sys.stdout = sys.stdout, StringIO()
 
         try:
-            exec '\n'.join(self.content)
+            exec('\n'.join(self.content))
             text = sys.stdout.getvalue()
             lines = string2lines(text, tab_width, convert_whitespace=True)
             self.state_machine.insert_input(lines, source)

--- a/indico/cli/database.py
+++ b/indico/cli/database.py
@@ -15,6 +15,7 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import os
 import sys
@@ -75,29 +76,29 @@ def reset_alembic():
     """
     tables = get_all_tables(db)['public']
     if 'alembic_version' not in tables:
-        print 'No alembic_version table found'
+        print('No alembic_version table found')
         sys.exit(1)
     current_revs = [rev for rev, in db.session.execute('SELECT version_num FROM alembic_version').fetchall()]
     if current_revs != ['65c079b091bf']:
         print ('Your database is not at the latest 1.9.11 revision (got [{}], expected [65c079b091bf]).'
                .format(', '.join(current_revs)))
-        print 'This can have multiple reasons:'
-        print '1) You did not upgrade from 1.9.x, so you do not need this command'
-        print '2) You have already executed the script'
-        print '3) You did not fully upgrade to the latest 1.9.11 revision before upgrading to 2.x'
+        print('This can have multiple reasons:')
+        print('1) You did not upgrade from 1.9.x, so you do not need this command')
+        print('2) You have already executed the script')
+        print('3) You did not fully upgrade to the latest 1.9.11 revision before upgrading to 2.x')
         print ('In case of (3), you need to install v1.9.11 and then upgrade the database before updating Indico back '
                'to {}'.format(indico.__version__))
         sys.exit(1)
     plugins = sorted(x[23:] for x in tables if x.startswith('alembic_version_plugin_'))
-    print 'Resetting core alembic state...'
+    print('Resetting core alembic state...')
     _stamp()
-    print 'Plugins found: {}'.format(', '.join(plugins))
+    print('Plugins found: {}'.format(', '.join(plugins)))
     no_revision_plugins = {'audiovisual', 'payment_cern'}
     for plugin in no_revision_plugins:
         # All revisions were just data migrations -> get rid of them
         if plugin not in plugins:
             continue
-        print '[{}] Deleting revision table'.format(plugin)
+        print('[{}] Deleting revision table'.format(plugin))
         db.session.execute('DROP TABLE alembic_version_plugin_{}'.format(plugin))
     plugin_revisions = {'chat': '3888761f35f7',
                         'livesync': 'aa0dbc6c14aa',
@@ -106,27 +107,27 @@ def reset_alembic():
     for plugin, revision in plugin_revisions.iteritems():
         if plugin not in plugins:
             continue
-        print '[{}] Stamping to new revision'.format(plugin)
+        print('[{}] Stamping to new revision'.format(plugin))
         _stamp(plugin, revision)
     db.session.commit()
 
 
 def _safe_downgrade(*args, **kwargs):
     func = kwargs.pop('_func')
-    print cformat('%{yellow!}*** DANGER')
-    print cformat('%{yellow!}***%{reset} '
-                  '%{red!}This operation may %{yellow!}PERMANENTLY ERASE %{red!}some data!%{reset}')
+    print(cformat('%{yellow!}*** DANGER'))
+    print(cformat('%{yellow!}***%{reset} '
+                  '%{red!}This operation may %{yellow!}PERMANENTLY ERASE %{red!}some data!%{reset}'))
     if current_app.debug:
         skip_confirm = os.environ.get('INDICO_ALWAYS_DOWNGRADE', '').lower() in ('1', 'yes')
-        print cformat('%{yellow!}***%{reset} '
-                      "%{green!}Debug mode is active, so you probably won't destroy valuable data")
+        print(cformat('%{yellow!}***%{reset} '
+                      "%{green!}Debug mode is active, so you probably won't destroy valuable data"))
     else:
         skip_confirm = False
-        print cformat('%{yellow!}***%{reset} '
-                      "%{red!}Debug mode is NOT ACTIVE, so make sure you are on the right machine!")
+        print(cformat('%{yellow!}***%{reset} '
+                      "%{red!}Debug mode is NOT ACTIVE, so make sure you are on the right machine!"))
     if not skip_confirm and raw_input(cformat('%{yellow!}***%{reset} '
                                               'To confirm this, enter %{yellow!}YES%{reset}: ')) != 'YES':
-        print cformat('%{green}Aborted%{reset}')
+        print(cformat('%{green}Aborted%{reset}'))
         sys.exit(1)
     else:
         return func(*args, **kwargs)
@@ -151,9 +152,9 @@ def _call_with_plugins(*args, **kwargs):
         alembic.command.ScriptDirectory = PluginScriptDirectory
         for plugin in plugins:
             if not os.path.exists(plugin.alembic_versions_path):
-                print cformat("%{cyan}skipping plugin '{}' (no migrations folder)").format(plugin.name)
+                print(cformat("%{cyan}skipping plugin '{}' (no migrations folder)").format(plugin.name))
                 continue
-            print cformat("%{cyan!}executing command for plugin '{}'").format(plugin.name)
+            print(cformat("%{cyan!}executing command for plugin '{}'").format(plugin.name))
             with plugin.plugin_context():
                 func(*args, **kwargs)
 

--- a/indico/cli/database.py
+++ b/indico/cli/database.py
@@ -79,14 +79,14 @@ def reset_alembic():
         sys.exit(1)
     current_revs = [rev for rev, in db.session.execute('SELECT version_num FROM alembic_version').fetchall()]
     if current_revs != ['65c079b091bf']:
-        print ('Your database is not at the latest 1.9.11 revision (got [{}], expected [65c079b091bf]).'
-               .format(', '.join(current_revs)))
+        print('Your database is not at the latest 1.9.11 revision (got [{}], expected [65c079b091bf]).'
+              .format(', '.join(current_revs)))
         print('This can have multiple reasons:')
         print('1) You did not upgrade from 1.9.x, so you do not need this command')
         print('2) You have already executed the script')
         print('3) You did not fully upgrade to the latest 1.9.11 revision before upgrading to 2.x')
-        print ('In case of (3), you need to install v1.9.11 and then upgrade the database before updating Indico back '
-               'to {}'.format(indico.__version__))
+        print('In case of (3), you need to install v1.9.11 and then upgrade the database before updating Indico back '
+              'to {}'.format(indico.__version__))
         sys.exit(1)
     plugins = sorted(x[23:] for x in tables if x.startswith('alembic_version_plugin_'))
     print('Resetting core alembic state...')

--- a/indico/cli/database.py
+++ b/indico/cli/database.py
@@ -20,7 +20,11 @@ import os
 import sys
 from functools import partial
 
+import alembic.command
 import click
+from flask import current_app
+from flask.cli import with_appcontext
+from flask_migrate.cli import db as flask_migrate_cli
 
 import indico
 from indico.cli.core import cli_group
@@ -29,11 +33,6 @@ from indico.core.db.sqlalchemy.migration import PluginScriptDirectory, migrate, 
 from indico.core.db.sqlalchemy.util.management import get_all_tables
 from indico.core.plugins import plugin_engine
 from indico.util.console import cformat
-
-import alembic.command
-from flask import current_app
-from flask.cli import with_appcontext
-from flask_migrate.cli import db as flask_migrate_cli
 
 
 @cli_group()

--- a/indico/cli/database.py
+++ b/indico/cli/database.py
@@ -14,18 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import os
 import sys
 from functools import partial
 
-import alembic.command
 import click
-from flask import current_app
-from flask.cli import with_appcontext
-from flask_migrate.cli import db as flask_migrate_cli
 
 import indico
 from indico.cli.core import cli_group
@@ -34,6 +29,11 @@ from indico.core.db.sqlalchemy.migration import PluginScriptDirectory, migrate, 
 from indico.core.db.sqlalchemy.util.management import get_all_tables
 from indico.core.plugins import plugin_engine
 from indico.util.console import cformat
+
+import alembic.command
+from flask import current_app
+from flask.cli import with_appcontext
+from flask_migrate.cli import db as flask_migrate_cli
 
 
 @cli_group()

--- a/indico/cli/devserver.py
+++ b/indico/cli/devserver.py
@@ -15,6 +15,7 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import os
 
@@ -59,11 +60,11 @@ def run_cmd(info, host, port, url, ssl, ssl_key, ssl_cert, quiet, proxy, enable_
     })
 
     if os.environ.get('WERKZEUG_RUN_MAIN') != 'true':
-        print ' * Serving Indico on {}'.format(url)
+        print(' * Serving Indico on {}'.format(url))
         if evalex_whitelist:
-            print ' * Werkzeug debugger console on {}/console'.format(url)
+            print(' * Werkzeug debugger console on {}/console'.format(url))
             if evalex_whitelist is True:  # noqa
-                print ' * Werkzeug debugger console is available to all clients!'
+                print(' * Werkzeug debugger console is available to all clients!')
 
     try:
         from indico.core.config import get_config_path

--- a/indico/cli/devserver.py
+++ b/indico/cli/devserver.py
@@ -14,8 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import os
 

--- a/indico/core/celery/cli.py
+++ b/indico/core/celery/cli.py
@@ -19,15 +19,15 @@ from __future__ import print_function, unicode_literals
 import os
 import sys
 
+from celery.bin.base import Command
+from celery.bin.celery import CeleryCommand, command_classes
+
 from indico.core.celery import celery
 from indico.core.celery.util import unlock_task
 from indico.core.config import config
 from indico.modules.oauth.models.applications import OAuthApplication, SystemAppType
 from indico.util.console import cformat
 from indico.web.flask.util import url_for
-
-from celery.bin.base import Command
-from celery.bin.celery import CeleryCommand, command_classes
 
 
 def celery_cmd(args):

--- a/indico/core/celery/cli.py
+++ b/indico/core/celery/cli.py
@@ -14,14 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import os
 import sys
-
-from celery.bin.base import Command
-from celery.bin.celery import CeleryCommand, command_classes
 
 from indico.core.celery import celery
 from indico.core.celery.util import unlock_task
@@ -29,6 +25,9 @@ from indico.core.config import config
 from indico.modules.oauth.models.applications import OAuthApplication, SystemAppType
 from indico.util.console import cformat
 from indico.web.flask.util import url_for
+
+from celery.bin.base import Command
+from celery.bin.celery import CeleryCommand, command_classes
 
 
 def celery_cmd(args):

--- a/indico/core/celery/cli.py
+++ b/indico/core/celery/cli.py
@@ -15,6 +15,7 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import os
 import sys
@@ -42,17 +43,17 @@ def celery_cmd(args):
         try:
             import flower
         except ImportError:
-            print cformat('%{red!}Flower is not installed')
+            print(cformat('%{red!}Flower is not installed'))
             sys.exit(1)
 
         app = OAuthApplication.find_one(system_app_type=SystemAppType.flower)
         if not app.redirect_uris:
-            print cformat('%{yellow!}Authentication will fail unless you configure the redirect url for the {} OAuth '
-                          'application in the administration area.').format(app.name)
+            print(cformat('%{yellow!}Authentication will fail unless you configure the redirect url for the {} OAuth '
+                          'application in the administration area.').format(app.name))
 
-        print cformat('%{green!}Only Indico admins will have access to flower.')
-        print cformat('%{yellow}Note that revoking admin privileges will not revoke Flower access.')
-        print cformat('%{yellow}To force re-authentication, restart Flower.')
+        print(cformat('%{green!}Only Indico admins will have access to flower.'))
+        print(cformat('%{yellow}Note that revoking admin privileges will not revoke Flower access.'))
+        print(cformat('%{yellow}To force re-authentication, restart Flower.'))
         auth_args = ['--auth=^Indico Admin$', '--auth_provider=indico.core.celery.flower.FlowerAuthHandler']
         auth_env = {'INDICO_FLOWER_CLIENT_ID': app.client_id,
                     'INDICO_FLOWER_CLIENT_SECRET': app.client_secret,
@@ -65,7 +66,7 @@ def celery_cmd(args):
         env = dict(os.environ, **auth_env)
         os.execvpe('celery', args, env)
     elif args and args[0] == 'shell':
-        print cformat('%{red!}Please use `indico shell`.')
+        print(cformat('%{red!}Please use `indico shell`.'))
         sys.exit(1)
     else:
         CeleryCommand(celery).execute_from_commandline(['indico celery'] + args)
@@ -84,6 +85,6 @@ class UnlockCommand(Command):
 
     def run(self, name, **kwargs):
         if unlock_task(name):
-            print cformat('%{green!}Task {} unlocked').format(name)
+            print(cformat('%{green!}Task {} unlocked').format(name))
         else:
-            print cformat('%{yellow}Task {} is not locked').format(name)
+            print(cformat('%{yellow}Task {} is not locked').format(name))

--- a/indico/core/celery/core.py
+++ b/indico/core/celery/core.py
@@ -14,20 +14,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import logging
 import os
 from operator import itemgetter
 
-from celery import Celery
-from celery.app.log import Logging
-from celery.beat import PersistentScheduler
-from contextlib2 import ExitStack
 from flask_pluginengine import current_plugin, plugin_context
-from sqlalchemy import inspect
-from terminaltables import AsciiTable
 
 from indico.core.celery.util import locked_task
 from indico.core.config import config
@@ -38,6 +31,13 @@ from indico.util.console import cformat
 from indico.util.fossilize import clearCache
 from indico.util.string import return_ascii
 from indico.web.flask.stats import request_stats_request_started
+
+from celery import Celery
+from celery.app.log import Logging
+from celery.beat import PersistentScheduler
+from contextlib2 import ExitStack
+from sqlalchemy import inspect
+from terminaltables import AsciiTable
 
 
 class IndicoCelery(Celery):

--- a/indico/core/celery/core.py
+++ b/indico/core/celery/core.py
@@ -15,6 +15,7 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import logging
 import os
@@ -191,7 +192,7 @@ class IndicoPersistentScheduler(PersistentScheduler):
         for task_name in sorted(deleted):
             table_data.append([cformat('%{yellow}{}%{reset}').format(task_name),
                                cformat('%{red!}Disabled%{reset}')])
-        print AsciiTable(table_data, cformat('%{white!}Periodic Tasks%{reset}')).table
+        print(AsciiTable(table_data, cformat('%{white!}Periodic Tasks%{reset}')).table)
 
 
 class _CelerySAWrapper(object):

--- a/indico/core/celery/core.py
+++ b/indico/core/celery/core.py
@@ -20,7 +20,13 @@ import logging
 import os
 from operator import itemgetter
 
+from celery import Celery
+from celery.app.log import Logging
+from celery.beat import PersistentScheduler
+from contextlib2 import ExitStack
 from flask_pluginengine import current_plugin, plugin_context
+from sqlalchemy import inspect
+from terminaltables import AsciiTable
 
 from indico.core.celery.util import locked_task
 from indico.core.config import config
@@ -31,13 +37,6 @@ from indico.util.console import cformat
 from indico.util.fossilize import clearCache
 from indico.util.string import return_ascii
 from indico.web.flask.stats import request_stats_request_started
-
-from celery import Celery
-from celery.app.log import Logging
-from celery.beat import PersistentScheduler
-from contextlib2 import ExitStack
-from sqlalchemy import inspect
-from terminaltables import AsciiTable
 
 
 class IndicoCelery(Celery):

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -150,7 +150,7 @@ def _parse_config(path):
     locals_ = {}
     with codecs.open(path, encoding='utf-8') as config_file:
         # XXX: unicode_literals is inherited from this file
-        exec compile(config_file.read(), path, 'exec') in globals_, locals_
+        exec(compile(config_file.read(), path, 'exec'), globals_, locals_)
     return {unicode(k if k.isupper() else _convert_key(k)): v
             for k, v in locals_.iteritems()
             if k[0] != '_'}

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -24,17 +24,17 @@ import socket
 import warnings
 from datetime import timedelta
 
+from indico.util.caching import make_hashable
+from indico.util.fs import resolve_link
+from indico.util.packaging import package_is_editable
+from indico.util.string import crc32, snakify
+
 import pytz
 from celery.schedules import crontab
 from flask import current_app, g
 from flask.helpers import get_root_path
 from werkzeug.datastructures import ImmutableDict
 from werkzeug.urls import url_parse
-
-from indico.util.caching import make_hashable
-from indico.util.fs import resolve_link
-from indico.util.packaging import package_is_editable
-from indico.util.string import crc32, snakify
 
 
 DEFAULTS = {

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -24,17 +24,17 @@ import socket
 import warnings
 from datetime import timedelta
 
-from indico.util.caching import make_hashable
-from indico.util.fs import resolve_link
-from indico.util.packaging import package_is_editable
-from indico.util.string import crc32, snakify
-
 import pytz
 from celery.schedules import crontab
 from flask import current_app, g
 from flask.helpers import get_root_path
 from werkzeug.datastructures import ImmutableDict
 from werkzeug.urls import url_parse
+
+from indico.util.caching import make_hashable
+from indico.util.fs import resolve_link
+from indico.util.packaging import package_is_editable
+from indico.util.string import crc32, snakify
 
 
 DEFAULTS = {

--- a/indico/core/db/sqlalchemy/migration.py
+++ b/indico/core/db/sqlalchemy/migration.py
@@ -18,6 +18,10 @@ from __future__ import print_function, unicode_literals
 
 import os
 
+import alembic.command
+from alembic.script import ScriptDirectory
+from flask import current_app
+from flask_migrate import Migrate, stamp
 from flask_pluginengine import current_plugin
 
 from indico.core.db import db
@@ -25,11 +29,6 @@ from indico.core.db.sqlalchemy.util.management import create_all_tables, get_all
 from indico.core.db.sqlalchemy.util.queries import has_extension
 from indico.core.plugins import plugin_engine
 from indico.util.console import cformat
-
-import alembic.command
-from alembic.script import ScriptDirectory
-from flask import current_app
-from flask_migrate import Migrate, stamp
 
 
 migrate = Migrate(db=db)

--- a/indico/core/db/sqlalchemy/migration.py
+++ b/indico/core/db/sqlalchemy/migration.py
@@ -15,6 +15,7 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 import os
 
@@ -61,10 +62,10 @@ def _require_extensions(*names):
     missing = sorted(name for name in names if not has_extension(db.engine, name))
     if not missing:
         return True
-    print cformat('%{red}Required Postgres extensions missing: {}').format(', '.join(missing))
-    print cformat('%{yellow}Create them using these SQL commands (as a Postgres superuser):')
+    print(cformat('%{red}Required Postgres extensions missing: {}').format(', '.join(missing)))
+    print(cformat('%{yellow}Create them using these SQL commands (as a Postgres superuser):'))
     for name in missing:
-        print cformat('%{white!}  CREATE EXTENSION {};').format(name)
+        print(cformat('%{white!}  CREATE EXTENSION {};').format(name))
     return False
 
 
@@ -75,7 +76,7 @@ def _require_pg_version(version):
     cur_version = db.engine.execute("SELECT current_setting('server_version_num')::int").scalar()
     if cur_version >= req_version:
         return True
-    print cformat('%{red}Postgres version too old; you need at least {} (or newer)').format(version)
+    print(cformat('%{red}Postgres version too old; you need at least {} (or newer)').format(version))
     return False
 
 
@@ -83,8 +84,8 @@ def _require_encoding(encoding):
     cur_encoding = db.engine.execute("SELECT current_setting('server_encoding')").scalar()
     if cur_encoding >= encoding:
         return True
-    print cformat('%{red}Database encoding must be {}; got {}').format(encoding, cur_encoding)
-    print cformat('%{yellow}Recreate your database using `createdb -E {} -T template0 ...`').format(encoding)
+    print(cformat('%{red}Database encoding must be {}; got {}').format(encoding, cur_encoding))
+    print(cformat('%{yellow}Recreate your database using `createdb -E {} -T template0 ...`').format(encoding))
     return False
 
 
@@ -100,7 +101,7 @@ def prepare_db(empty=False, root_path=None, verbose=True):
     tables = get_all_tables(db)
     if 'alembic_version' not in tables['public']:
         if verbose:
-            print cformat('%{green}Setting the alembic version to HEAD')
+            print(cformat('%{green}Setting the alembic version to HEAD'))
         stamp(directory=os.path.join(root_path, 'migrations'), revision='heads')
         PluginScriptDirectory.dir = os.path.join(root_path, 'core', 'plugins', 'alembic')
         alembic.command.ScriptDirectory = PluginScriptDirectory
@@ -110,7 +111,7 @@ def prepare_db(empty=False, root_path=None, verbose=True):
             if not os.path.exists(plugin.alembic_versions_path):
                 continue
             if verbose:
-                print plugin_msg.format(plugin.name)
+                print(plugin_msg.format(plugin.name))
             with plugin.plugin_context():
                 stamp(revision='heads')
         # Retrieve the table list again, just in case we created unexpected tables
@@ -119,12 +120,12 @@ def prepare_db(empty=False, root_path=None, verbose=True):
     tables['public'] = [t for t in tables['public'] if not t.startswith('alembic_version')]
     if any(tables.viewvalues()):
         if verbose:
-            print cformat('%{red}Your database is not empty!')
-            print cformat('%{yellow}If you just added a new table/model, create an alembic revision instead!')
-            print
-            print 'Tables in your database:'
+            print(cformat('%{red}Your database is not empty!'))
+            print(cformat('%{yellow}If you just added a new table/model, create an alembic revision instead!'))
+            print()
+            print('Tables in your database:')
             for schema, schema_tables in sorted(tables.items()):
                 for t in schema_tables:
-                    print cformat('  * %{cyan}{}%{reset}.%{cyan!}{}%{reset}').format(schema, t)
+                    print(cformat('  * %{cyan}{}%{reset}.%{cyan!}{}%{reset}').format(schema, t))
         return
     create_all_tables(db, verbose=verbose, add_initial_data=(not empty))

--- a/indico/core/db/sqlalchemy/migration.py
+++ b/indico/core/db/sqlalchemy/migration.py
@@ -14,15 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 import os
 
-import alembic.command
-from alembic.script import ScriptDirectory
-from flask import current_app
-from flask_migrate import Migrate, stamp
 from flask_pluginengine import current_plugin
 
 from indico.core.db import db
@@ -30,6 +25,11 @@ from indico.core.db.sqlalchemy.util.management import create_all_tables, get_all
 from indico.core.db.sqlalchemy.util.queries import has_extension
 from indico.core.plugins import plugin_engine
 from indico.util.console import cformat
+
+import alembic.command
+from alembic.script import ScriptDirectory
+from flask import current_app
+from flask_migrate import Migrate, stamp
 
 
 migrate = Migrate(db=db)

--- a/indico/core/db/sqlalchemy/util/management.py
+++ b/indico/core/db/sqlalchemy/util/management.py
@@ -15,6 +15,7 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 from sqlalchemy import ForeignKeyConstraint, MetaData, Table
 from sqlalchemy.engine.reflection import Inspector
@@ -100,25 +101,25 @@ def create_all_tables(db, verbose=False, add_initial_data=True):
     from indico.modules.oauth.models.applications import OAuthApplication, SystemAppType
     from indico.modules.users import User
     if verbose:
-        print cformat('%{green}Creating tables')
+        print(cformat('%{green}Creating tables'))
     db.create_all()
     if add_initial_data:
         if verbose:
-            print cformat('%{green}Creating system user')
+            print(cformat('%{green}Creating system user'))
         db.session.add(User(id=0, is_system=True, first_name='Indico', last_name='System'))
         if verbose:
-            print cformat('%{green}Creating root category')
+            print(cformat('%{green}Creating root category'))
         cat = Category(id=0, title='Home', protection_mode=ProtectionMode.public)
         db.session.add(cat)
         db.session.flush()
         if verbose:
-            print cformat('%{green}Creating default ticket template for root category ')
+            print(cformat('%{green}Creating default ticket template for root category '))
         dt = DesignerTemplate(category_id=0, title='Default ticket', type=TemplateType.badge,
                               data=DEFAULT_TEMPLATE_DATA, is_system_template=True)
         cat.default_ticket_template = dt
         db.session.add(dt)
         if verbose:
-            print cformat('%{green}Creating system oauth apps')
+            print(cformat('%{green}Creating system oauth apps'))
         for sat in SystemAppType:
             if sat != SystemAppType.none:
                 db.session.add(OAuthApplication(system_app_type=sat, **sat.default_data))

--- a/indico/core/db/sqlalchemy/util/management.py
+++ b/indico/core/db/sqlalchemy/util/management.py
@@ -16,12 +16,12 @@
 
 from __future__ import print_function, unicode_literals
 
-from indico.core.db.sqlalchemy.protection import ProtectionMode
-from indico.util.console import cformat
-
 from sqlalchemy import ForeignKeyConstraint, MetaData, Table
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql.ddl import DropConstraint, DropSchema, DropTable
+
+from indico.core.db.sqlalchemy.protection import ProtectionMode
+from indico.util.console import cformat
 
 
 DEFAULT_TEMPLATE_DATA = {

--- a/indico/core/db/sqlalchemy/util/management.py
+++ b/indico/core/db/sqlalchemy/util/management.py
@@ -14,15 +14,14 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
+
+from indico.core.db.sqlalchemy.protection import ProtectionMode
+from indico.util.console import cformat
 
 from sqlalchemy import ForeignKeyConstraint, MetaData, Table
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql.ddl import DropConstraint, DropSchema, DropTable
-
-from indico.core.db.sqlalchemy.protection import ProtectionMode
-from indico.util.console import cformat
 
 
 DEFAULT_TEMPLATE_DATA = {

--- a/indico/legacy/webinterface/common/tools.py
+++ b/indico/legacy/webinterface/common/tools.py
@@ -233,7 +233,7 @@ def escape_html(text, escape_quotes=False):
                           " => &quot;
                           ' => &#34;
     """
-    if not isinstance(text, str):
+    if type(text) != str:
         text = str(text)
     text = text.replace('&', '&amp;')
     text = text.replace('<', '&lt;')

--- a/indico/legacy/webinterface/common/tools.py
+++ b/indico/legacy/webinterface/common/tools.py
@@ -180,7 +180,7 @@ class RestrictedHTMLParser( HTMLParser ):
                 try:
                     #remove replacement characters from unescaped characters
                     val_unescaped = val_unescaped.replace(u"\ufffd", "")
-                except UnicodeDecodeError, e:
+                except UnicodeDecodeError as e:
                     Logger.get('RestrictedHTMLParser-urlProperties').exception(str(e))
                 if (re.match("^[a-z0-9][-+.a-z0-9]*:", val_unescaped) and
                     (val_unescaped.split(':')[0] not in
@@ -233,7 +233,7 @@ def escape_html(text, escape_quotes=False):
                           " => &quot;
                           ' => &#34;
     """
-    if type(text) != str:
+    if not isinstance(text, str):
         text = str(text)
     text = text.replace('&', '&amp;')
     text = text.replace('<', '&lt;')
@@ -271,7 +271,7 @@ def strip_ml_tags(in_text):
                 while s_list[i] != '>':
                     # pop everything from the the left-angle bracket until the right-angle bracket
                     s_list.pop(i)
-            except IndexError,e:
+            except IndexError as e:
                 Logger.get('strip_ml_tags').debug("Not found '>' (the end of the html tag): %s"%e)
                 continue
 

--- a/indico/migrations/versions/20181213_1110_cbe630695800_add_room_principals_table.py
+++ b/indico/migrations/versions/20181213_1110_cbe630695800_add_room_principals_table.py
@@ -8,14 +8,14 @@ from __future__ import print_function
 
 import json
 
+import sqlalchemy as sa
+from alembic import context, op
+from sqlalchemy.dialects import postgresql
+
 from indico.core.auth import multipass
 from indico.core.db.sqlalchemy import PyIntEnum
 from indico.core.db.sqlalchemy.principals import PrincipalType
 from indico.core.db.sqlalchemy.protection import ProtectionMode
-
-import sqlalchemy as sa
-from alembic import context, op
-from sqlalchemy.dialects import postgresql
 
 
 # revision identifiers, used by Alembic.

--- a/indico/migrations/versions/20181213_1110_cbe630695800_add_room_principals_table.py
+++ b/indico/migrations/versions/20181213_1110_cbe630695800_add_room_principals_table.py
@@ -4,6 +4,7 @@ Revision ID: cbe630695800
 Revises: 252c0015c9a0
 Create Date: 2018-12-13 11:10:12.684382
 """
+
 from __future__ import print_function
 
 import json

--- a/indico/migrations/versions/20181213_1110_cbe630695800_add_room_principals_table.py
+++ b/indico/migrations/versions/20181213_1110_cbe630695800_add_room_principals_table.py
@@ -4,6 +4,7 @@ Revision ID: cbe630695800
 Revises: 252c0015c9a0
 Create Date: 2018-12-13 11:10:12.684382
 """
+from __future__ import print_function
 
 import json
 
@@ -84,14 +85,14 @@ def _upgrade_permissions():
         if booking_group:
             group_kwargs = _group_to_kwargs(booking_group)
             if group_kwargs is None:
-                print 'WARNING: Invalid booking group: {}'.format(booking_group)
+                print('WARNING: Invalid booking group: {}'.format(booking_group))
             else:
                 permission = 'prebook' if reservations_need_confirmation else 'book'
                 _create_acl_entry(conn, room_id, permissions={permission}, **group_kwargs)
         if manager_group:
             group_kwargs = _group_to_kwargs(manager_group)
             if group_kwargs is None:
-                print 'WARNING: Invalid manager group: {}'.format(manager_group)
+                print('WARNING: Invalid manager group: {}'.format(manager_group))
             else:
                 _create_acl_entry(conn, room_id, full_access=True, **group_kwargs)
 

--- a/indico/migrations/versions/20181213_1110_cbe630695800_add_room_principals_table.py
+++ b/indico/migrations/versions/20181213_1110_cbe630695800_add_room_principals_table.py
@@ -8,14 +8,14 @@ from __future__ import print_function
 
 import json
 
-import sqlalchemy as sa
-from alembic import context, op
-from sqlalchemy.dialects import postgresql
-
 from indico.core.auth import multipass
 from indico.core.db.sqlalchemy import PyIntEnum
 from indico.core.db.sqlalchemy.principals import PrincipalType
 from indico.core.db.sqlalchemy.protection import ProtectionMode
+
+import sqlalchemy as sa
+from alembic import context, op
+from sqlalchemy.dialects import postgresql
 
 
 # revision identifiers, used by Alembic.

--- a/indico/modules/events/export.py
+++ b/indico/modules/events/export.py
@@ -104,7 +104,7 @@ def _exec_custom(code, **extra):
     """Execute a custom code snippet and return all non-underscored values."""
     globals_ = _make_globals(**extra)
     locals_ = {}
-    exec code in globals_, locals_
+    exec(code, globals_, locals_)
     return {unicode(k): v for k, v in locals_.iteritems() if k[0] != '_'}
 
 

--- a/indico/modules/events/export.py
+++ b/indico/modules/events/export.py
@@ -27,6 +27,11 @@ from operator import itemgetter
 from uuid import uuid4
 
 import click
+import dateutil.parser
+import yaml
+from flask import current_app
+from sqlalchemy import inspect
+from terminaltables import AsciiTable
 
 import indico
 from indico.core.config import config
@@ -46,12 +51,6 @@ from indico.modules.users.util import get_user_by_email
 from indico.util.console import cformat
 from indico.util.date_time import now_utc
 from indico.util.string import strict_unicode
-
-import dateutil.parser
-import yaml
-from flask import current_app
-from sqlalchemy import inspect
-from terminaltables import AsciiTable
 
 
 _notset = object()

--- a/indico/modules/events/export.py
+++ b/indico/modules/events/export.py
@@ -27,11 +27,6 @@ from operator import itemgetter
 from uuid import uuid4
 
 import click
-import dateutil.parser
-import yaml
-from flask import current_app
-from sqlalchemy import inspect
-from terminaltables import AsciiTable
 
 import indico
 from indico.core.config import config
@@ -51,6 +46,12 @@ from indico.modules.users.util import get_user_by_email
 from indico.util.console import cformat
 from indico.util.date_time import now_utc
 from indico.util.string import strict_unicode
+
+import dateutil.parser
+import yaml
+from flask import current_app
+from sqlalchemy import inspect
+from terminaltables import AsciiTable
 
 
 _notset = object()

--- a/indico/modules/events/layout/util.py
+++ b/indico/modules/events/layout/util.py
@@ -137,7 +137,7 @@ def _get_split_signal_entries():
     signal_entries = get_menu_entries_from_signal()
     top_data = OrderedDict((name, data)
                            for name, data in sorted(signal_entries.iteritems(),
-                                                    key=lambda (name, data): _menu_entry_key(data))
+                                                    key=lambda name_data: _menu_entry_key(name_data[1]))
                            if not data.parent)
     child_data = defaultdict(list)
     for name, data in signal_entries.iteritems():

--- a/indico/modules/events/layout/util.py
+++ b/indico/modules/events/layout/util.py
@@ -19,10 +19,6 @@ from __future__ import unicode_literals
 from collections import OrderedDict, defaultdict
 from itertools import chain, count
 
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import joinedload, load_only
-from werkzeug.urls import url_parse
-
 import indico
 from indico.core import signals
 from indico.core.config import config
@@ -35,6 +31,10 @@ from indico.util.caching import memoize_request
 from indico.util.signals import named_objects_from_signal, values_from_signal
 from indico.util.string import crc32, return_ascii
 from indico.web.flask.util import url_for
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import joinedload, load_only
+from werkzeug.urls import url_parse
 
 
 _cache = GenericCache('updated-menus')

--- a/indico/modules/events/layout/util.py
+++ b/indico/modules/events/layout/util.py
@@ -19,6 +19,10 @@ from __future__ import unicode_literals
 from collections import OrderedDict, defaultdict
 from itertools import chain, count
 
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import joinedload, load_only
+from werkzeug.urls import url_parse
+
 import indico
 from indico.core import signals
 from indico.core.config import config
@@ -31,10 +35,6 @@ from indico.util.caching import memoize_request
 from indico.util.signals import named_objects_from_signal, values_from_signal
 from indico.util.string import crc32, return_ascii
 from indico.web.flask.util import url_for
-
-from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import joinedload, load_only
-from werkzeug.urls import url_parse
 
 
 _cache = GenericCache('updated-menus')

--- a/indico/modules/rb/tasks.py
+++ b/indico/modules/rb/tasks.py
@@ -14,15 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import unicode_literals
-from __future__ import print_function
+from __future__ import print_function, unicode_literals
 
 from datetime import date, datetime
 from itertools import groupby
 from operator import attrgetter
-
-from celery.schedules import crontab
-from sqlalchemy.orm import contains_eager
 
 from indico.core.celery import celery
 from indico.core.config import config
@@ -34,6 +30,9 @@ from indico.modules.rb.models.rooms import Room
 from indico.modules.rb.notifications.reservation_occurrences import notify_upcoming_occurrences
 from indico.modules.rb.notifications.reservations import notify_about_finishing_bookings
 from indico.util.console import cformat
+
+from celery.schedules import crontab
+from sqlalchemy.orm import contains_eager
 
 
 def _make_occurrence_date_filter(date_column, default_values, room_columns):

--- a/indico/modules/rb/tasks.py
+++ b/indico/modules/rb/tasks.py
@@ -20,6 +20,9 @@ from datetime import date, datetime
 from itertools import groupby
 from operator import attrgetter
 
+from celery.schedules import crontab
+from sqlalchemy.orm import contains_eager
+
 from indico.core.celery import celery
 from indico.core.config import config
 from indico.core.db import db
@@ -30,9 +33,6 @@ from indico.modules.rb.models.rooms import Room
 from indico.modules.rb.notifications.reservation_occurrences import notify_upcoming_occurrences
 from indico.modules.rb.notifications.reservations import notify_about_finishing_bookings
 from indico.util.console import cformat
-
-from celery.schedules import crontab
-from sqlalchemy.orm import contains_eager
 
 
 def _make_occurrence_date_filter(date_column, default_values, room_columns):

--- a/indico/modules/rb/tasks.py
+++ b/indico/modules/rb/tasks.py
@@ -15,6 +15,7 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import unicode_literals
+from __future__ import print_function
 
 from datetime import date, datetime
 from itertools import groupby
@@ -57,13 +58,13 @@ def _print_occurrences(user, occurrences, _defaults={}, _overrides={}):
                            RepeatFrequency.MONTH: lambda r: r.notification_before_days_monthly,
                            RepeatFrequency.NEVER: lambda r: r.notification_before_days,
                            RepeatFrequency.DAY: lambda r: r.notification_before_days})
-    print cformat('%{grey!}*** {} ({}) ***').format(user.full_name, user.email)
+    print(cformat('%{grey!}*** {} ({}) ***').format(user.full_name, user.email))
     for occ in occurrences:
         default = _defaults[occ.reservation.repeat_frequency]
         override = _overrides[occ.reservation.repeat_frequency](occ.reservation.room)
         days = default if override is None else override
         days_until = (occ.start_dt.date() - date.today()).days
-        print cformat('  * %{yellow}{}%{reset} %{green}{:5}%{reset} {} {} {} \t %{blue!}{}%{reset} {} ({})').format(
+        print(cformat('  * %{yellow}{}%{reset} %{green}{:5}%{reset} {} {} {} \t %{blue!}{}%{reset} {} ({})').format(
             occ.start_dt.date(), occ.reservation.repeat_frequency.name,
             days,
             default if override is not None and override != default else ' ',
@@ -71,7 +72,7 @@ def _print_occurrences(user, occurrences, _defaults={}, _overrides={}):
             occ.reservation.id,
             occ.reservation.room.full_name,
             occ.reservation.room.id
-        )
+        ))
 
 
 def _notify_occurrences(user, occurrences):

--- a/indico/testing/fixtures/util.py
+++ b/indico/testing/fixtures/util.py
@@ -34,9 +34,9 @@ def monkeypatch_methods(monkeypatch):
 
     def _monkeypatch_methods(target, cls):
         for name, method in inspect.getmembers(cls, inspect.ismethod):
-            if method.im_self is None:
+            if method.__self__ is None:
                 # For unbound methods we need to copy the underlying function
-                method = method.im_func
+                method = method.__func__
             monkeypatch.setattr('{}.{}'.format(target, name), method)
 
     return _monkeypatch_methods

--- a/indico/testing/fixtures/util.py
+++ b/indico/testing/fixtures/util.py
@@ -17,8 +17,9 @@
 import inspect
 from datetime import datetime
 
-import freezegun
 import pytest
+
+import freezegun
 from sqlalchemy import DateTime, cast
 from sqlalchemy.sql.functions import _FunctionGenerator
 

--- a/indico/testing/fixtures/util.py
+++ b/indico/testing/fixtures/util.py
@@ -17,9 +17,8 @@
 import inspect
 from datetime import datetime
 
-import pytest
-
 import freezegun
+import pytest
 from sqlalchemy import DateTime, cast
 from sqlalchemy.sql.functions import _FunctionGenerator
 

--- a/indico/util/benchmark.py
+++ b/indico/util/benchmark.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import time
 from math import isinf
 
@@ -51,12 +52,12 @@ class Benchmark(object):
     def print_result(self, slow=float('inf'), veryslow=float('inf')):
         duration = float(self)
         if duration == float('-inf'):
-            print cformat('%{blue!}skipped')
+            print(cformat('%{blue!}skipped'))
         elif duration == float('inf'):
-            print cformat('%{red}running')
+            print(cformat('%{red}running'))
         elif duration >= veryslow:
-            print cformat('%{red!}{}').format(self)
+            print(cformat('%{red!}{}').format(self))
         elif duration >= slow:
-            print cformat('%{yellow!}{}').format(self)
+            print(cformat('%{yellow!}{}').format(self))
         else:
-            print cformat('%{green!}{}').format(self)
+            print(cformat('%{green!}{}').format(self))

--- a/indico/util/benchmark.py
+++ b/indico/util/benchmark.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+
 import time
 from math import isinf
 

--- a/indico/util/decorators.py
+++ b/indico/util/decorators.py
@@ -40,7 +40,7 @@ class strict_classproperty(classproperty):
 class cached_classproperty(property):
     def __get__(self, obj, objtype=None):
         # The property name is the function's name
-        name = self.fget.__get__(True).im_func.__name__
+        name = self.fget.__get__(True).__func__.__name__
         # In case of inheritance the attribute might be defined in a superclass
         for mrotype in objtype.__mro__:
             try:

--- a/indico/util/fossilize/__init__.py
+++ b/indico/util/fossilize/__init__.py
@@ -52,7 +52,7 @@ def addFossil(klazz, fossils):
     :type klass: class object
     :param fossils: a fossil class (or a list of fossil classes)
     """
-    if not type(fossils) is list:
+    if not isinstance(fossils, list):
         fossils = [fossils]
 
     for fossil in fossils:
@@ -168,7 +168,7 @@ class Fossilizable(object):
             else:
                 interface = implementedInterfaces[0]
 
-        elif type(interfaceArg) is dict:
+        elif isinstance(interfaceArg, dict):
 
             className = obj.__class__.__module__ + '.' + \
                         obj.__class__.__name__

--- a/indico/util/mdx_latex.py
+++ b/indico/util/mdx_latex.py
@@ -272,7 +272,7 @@ def latex_render_image(src, alt, strict=False):
                     raise ImageURLException("Cannot read image data. Maybe not an image file?")
             with NamedTemporaryFile(prefix='indico-latex-', suffix=extension, delete=False) as tempfile:
                 tempfile.write(resp.content)
-    except ImageURLException, e:
+    except ImageURLException as e:
         if strict:
             raise
         else:

--- a/indico/util/mdx_latex.py
+++ b/indico/util/mdx_latex.py
@@ -73,12 +73,11 @@ from mimetypes import guess_extension
 from tempfile import NamedTemporaryFile
 from urlparse import urlparse
 
+import markdown
 import requests
 from lxml.html import html5parser
-from requests.exceptions import ConnectionError, InvalidURL
-
-import markdown
 from PIL import Image
+from requests.exceptions import ConnectionError, InvalidURL
 
 
 __version__ = '2.1'

--- a/indico/util/mdx_latex.py
+++ b/indico/util/mdx_latex.py
@@ -73,11 +73,12 @@ from mimetypes import guess_extension
 from tempfile import NamedTemporaryFile
 from urlparse import urlparse
 
-import markdown
 import requests
 from lxml.html import html5parser
-from PIL import Image
 from requests.exceptions import ConnectionError, InvalidURL
+
+import markdown
+from PIL import Image
 
 
 __version__ = '2.1'

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -92,7 +92,7 @@ def test_slugify_lower(input, lower, output):
 ))
 def test_strip_tags(input, output):
     assert strip_tags(input) == output
-    assert type(input) is type(output)
+    assert isinstance(input, type(output))
 
 
 @pytest.mark.parametrize(('input', 'html', 'max_length', 'output'), (

--- a/indico/util/suggestions.py
+++ b/indico/util/suggestions.py
@@ -14,13 +14,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division, unicode_literals
-from __future__ import print_function
+from __future__ import division, print_function, unicode_literals
 
 from collections import defaultdict
 from datetime import date, timedelta
-
-from sqlalchemy.orm import joinedload, load_only
 
 from indico.modules.events import Event
 from indico.modules.events.abstracts.util import get_events_with_abstract_persons
@@ -29,6 +26,8 @@ from indico.modules.events.registration.util import get_events_registered
 from indico.modules.events.surveys.util import get_events_with_submitted_surveys
 from indico.util.date_time import now_utc, utc_to_server
 from indico.util.struct.iterables import window
+
+from sqlalchemy.orm import joinedload, load_only
 
 
 def _get_blocks(events, attended):

--- a/indico/util/suggestions.py
+++ b/indico/util/suggestions.py
@@ -15,6 +15,7 @@
 # along with Indico; if not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import division, unicode_literals
+from __future__ import print_function
 
 from collections import defaultdict
 from datetime import date, timedelta
@@ -54,7 +55,7 @@ def _query_categ_events(categ, start_dt, end_dt):
 
 def _get_category_score(user, categ, attended_events, debug=False):
     if debug:
-        print repr(categ)
+        print(repr(categ))
     # We care about events in the whole timespan where the user attended some events.
     # However, this might result in some missed events e.g. if the user was not working for
     # a year and then returned. So we throw away old blocks (or rather adjust the start time
@@ -70,7 +71,7 @@ def _get_category_score(user, categ, attended_events, debug=False):
     # Favorite categories get a higher base score
     score = int(categ in user.favorite_categories)
     if debug:
-        print '{0:+.3f} - initial'.format(score)
+        print('{0:+.3f} - initial'.format(score))
     # Attendance percentage goes to the score directly. If the attendance is high chances are good that the user
     # is either very interested in whatever goes on in the category or it's something he has to attend regularily.
     total = _query_categ_events(categ, first_event_date, last_event_date).count()
@@ -78,7 +79,7 @@ def _get_category_score(user, categ, attended_events, debug=False):
         attended_block_event_count = sum(1 for e in attended_events if e.start_dt >= first_event_date)
         score += attended_block_event_count / total
     if debug:
-        print '{0:+.3f} - attendance'.format(score)
+        print('{0:+.3f} - attendance'.format(score))
     # If there are lots/few unattended events after the last attended one we also update the score with that
     total_after = _query_categ_events(categ, last_event_date + timedelta(days=1), None).count()
     if total_after < total * 0.05:
@@ -86,7 +87,7 @@ def _get_category_score(user, categ, attended_events, debug=False):
     elif total_after > total * 0.25:
         score -= 0.5
     if debug:
-        print '{0:+.3f} - unattended new events'.format(score)
+        print('{0:+.3f} - unattended new events'.format(score))
     # Lower the score based on how long ago the last attended event was if there are no future events
     # We start applying this modifier only if the event has been more than 40 days in the past to avoid
     # it from happening in case of monthly events that are not created early enough.
@@ -94,7 +95,7 @@ def _get_category_score(user, categ, attended_events, debug=False):
     if days_since_last_event > 40:
         score -= 0.025 * days_since_last_event
     if debug:
-        print '{0:+.3f} - days since last event'.format(score)
+        print('{0:+.3f} - days since last event'.format(score))
     # For events in the future however we raise the score
     now_local = utc_to_server(now_utc())
     attending_future = (_query_categ_events(categ, now_local, last_event_date)
@@ -103,11 +104,11 @@ def _get_category_score(user, categ, attended_events, debug=False):
     if attending_future:
         score += 0.25 * len(attending_future)
         if debug:
-            print '{0:+.3f} - future event count'.format(score)
+            print('{0:+.3f} - future event count'.format(score))
         days_to_future_event = (attending_future[0].start_dt.date() - date.today()).days
         score += max(0.1, -(max(0, days_to_future_event - 2) / 4) ** (1 / 3) + 2.5)
         if debug:
-            print '{0:+.3f} - days to next future event'.format(score)
+            print('{0:+.3f} - days to next future event'.format(score))
     return score
 
 

--- a/indico/util/suggestions.py
+++ b/indico/util/suggestions.py
@@ -19,6 +19,8 @@ from __future__ import division, print_function, unicode_literals
 from collections import defaultdict
 from datetime import date, timedelta
 
+from sqlalchemy.orm import joinedload, load_only
+
 from indico.modules.events import Event
 from indico.modules.events.abstracts.util import get_events_with_abstract_persons
 from indico.modules.events.contributions.util import get_events_with_linked_contributions
@@ -26,8 +28,6 @@ from indico.modules.events.registration.util import get_events_registered
 from indico.modules.events.surveys.util import get_events_with_submitted_surveys
 from indico.util.date_time import now_utc, utc_to_server
 from indico.util.struct.iterables import window
-
-from sqlalchemy.orm import joinedload, load_only
 
 
 def _get_blocks(events, attended):

--- a/indico/web/flask/util.py
+++ b/indico/web/flask/util.py
@@ -238,7 +238,7 @@ def url_rule_to_js(endpoint):
                 ],
                 'converters': dict((key, type(converter).__name__)
                                    for key, converter in rule._converters.iteritems()
-                                   if type(converter) is not UnicodeConverter)
+                                   if not isinstance(converter, UnicodeConverter))
             } for rule in current_app.url_map.iter_rules(endpoint)
         ]
     }

--- a/indico/web/flask/util.py
+++ b/indico/web/flask/util.py
@@ -21,12 +21,6 @@ import os
 import time
 from importlib import import_module
 
-from indico.core.config import config
-from indico.util.caching import memoize
-from indico.util.fs import secure_filename
-from indico.util.locators import get_locator
-from indico.web.util import jsonify_data
-
 from flask import Blueprint, current_app, g, redirect, request
 from flask import send_file as _send_file
 from flask import url_for as _url_for
@@ -36,6 +30,12 @@ from werkzeug.exceptions import HTTPException, NotFound
 from werkzeug.routing import BaseConverter, BuildError, RequestRedirect, UnicodeConverter
 from werkzeug.urls import url_parse
 from werkzeug.wrappers import Response as WerkzeugResponse
+
+from indico.core.config import config
+from indico.util.caching import memoize
+from indico.util.fs import secure_filename
+from indico.util.locators import get_locator
+from indico.web.util import jsonify_data
 
 
 def discover_blueprints():

--- a/indico/web/flask/util.py
+++ b/indico/web/flask/util.py
@@ -21,6 +21,12 @@ import os
 import time
 from importlib import import_module
 
+from indico.core.config import config
+from indico.util.caching import memoize
+from indico.util.fs import secure_filename
+from indico.util.locators import get_locator
+from indico.web.util import jsonify_data
+
 from flask import Blueprint, current_app, g, redirect, request
 from flask import send_file as _send_file
 from flask import url_for as _url_for
@@ -30,12 +36,6 @@ from werkzeug.exceptions import HTTPException, NotFound
 from werkzeug.routing import BaseConverter, BuildError, RequestRedirect, UnicodeConverter
 from werkzeug.urls import url_parse
 from werkzeug.wrappers import Response as WerkzeugResponse
-
-from indico.core.config import config
-from indico.util.caching import memoize
-from indico.util.fs import secure_filename
-from indico.util.locators import get_locator
-from indico.web.util import jsonify_data
 
 
 def discover_blueprints():

--- a/indico/web/http_api/handlers.py
+++ b/indico/web/http_api/handlers.py
@@ -232,7 +232,7 @@ def handler(prefix, path):
             ttl = api_settings.get('cache_ttl')
             if ttl > 0:
                 cache.set(cacheKey, (result, extra, ts, complete, typeMap), ttl)
-    except HTTPAPIError, e:
+    except HTTPAPIError as e:
         error = e
         if e.getCode():
             responseUtil.status = e.getCode()

--- a/indico/web/http_api/handlers.py
+++ b/indico/web/http_api/handlers.py
@@ -27,9 +27,6 @@ import urllib
 from urlparse import parse_qs
 from uuid import UUID
 
-from flask import current_app, g, request, session
-from werkzeug.exceptions import BadRequest, NotFound
-
 from indico.core.db import db
 from indico.core.logger import Logger
 from indico.legacy.common.cache import GenericCache
@@ -45,6 +42,9 @@ from indico.web.http_api.fossils import IHTTPAPIExportResultFossil
 from indico.web.http_api.metadata.serializer import Serializer
 from indico.web.http_api.responses import HTTPAPIError, HTTPAPIResult
 from indico.web.http_api.util import get_query_parameter
+
+from flask import current_app, g, request, session
+from werkzeug.exceptions import BadRequest, NotFound
 
 
 # Remove the extension at the end or before the querystring

--- a/indico/web/http_api/handlers.py
+++ b/indico/web/http_api/handlers.py
@@ -27,6 +27,9 @@ import urllib
 from urlparse import parse_qs
 from uuid import UUID
 
+from flask import current_app, g, request, session
+from werkzeug.exceptions import BadRequest, NotFound
+
 from indico.core.db import db
 from indico.core.logger import Logger
 from indico.legacy.common.cache import GenericCache
@@ -42,9 +45,6 @@ from indico.web.http_api.fossils import IHTTPAPIExportResultFossil
 from indico.web.http_api.metadata.serializer import Serializer
 from indico.web.http_api.responses import HTTPAPIError, HTTPAPIResult
 from indico.web.http_api.util import get_query_parameter
-
-from flask import current_app, g, request, session
-from werkzeug.exceptions import BadRequest, NotFound
 
 
 # Remove the extension at the end or before the querystring

--- a/indico/web/http_api/hooks/base.py
+++ b/indico/web/http_api/hooks/base.py
@@ -115,7 +115,7 @@ class HTTPAPIHook(object):
             tzName = config.DEFAULT_TIMEZONE
         try:
             self._tz = pytz.timezone(tzName)
-        except pytz.UnknownTimeZoneError, e:
+        except pytz.UnknownTimeZoneError as e:
             raise HTTPAPIError("Bad timezone: '%s'" % e.message, 400)
         max = self.MAX_RECORDS.get(self._detail, 1000)
         self._userLimit = get_query_parameter(self._queryParams, ['n', 'limit'], 0, integer=True)
@@ -261,12 +261,12 @@ class DataFetcher(object):
 
         try:
             rel, value = cls._parseDateTime(dateTime, ctx == 'from')
-        except ArgumentParseError, e:
+        except ArgumentParseError as e:
             raise HTTPAPIError(e.message, 400)
 
         if rel == 'abs':
             return tz.localize(value) if not value.tzinfo else value
-        elif rel == 'ctx' and type(value) == timedelta:
+        elif rel == 'ctx' and isinstance(value, timedelta):
             value = now_utc() + value
 
         # from here on, 'value' has to be a datetime

--- a/indico/web/http_api/hooks/base.py
+++ b/indico/web/http_api/hooks/base.py
@@ -23,9 +23,6 @@ import urllib
 from datetime import datetime, time, timedelta
 from types import GeneratorType
 
-import pytz
-from flask import current_app, request
-
 from indico.core.config import config
 from indico.core.db import db
 from indico.core.logger import Logger
@@ -39,6 +36,9 @@ from indico.web.http_api.metadata.ical import ICalSerializer
 from indico.web.http_api.metadata.jsonp import JSONPSerializer
 from indico.web.http_api.responses import HTTPAPIError
 from indico.web.http_api.util import get_query_parameter
+
+import pytz
+from flask import current_app, request
 
 
 class HTTPAPIHook(object):

--- a/indico/web/http_api/hooks/base.py
+++ b/indico/web/http_api/hooks/base.py
@@ -23,6 +23,9 @@ import urllib
 from datetime import datetime, time, timedelta
 from types import GeneratorType
 
+import pytz
+from flask import current_app, request
+
 from indico.core.config import config
 from indico.core.db import db
 from indico.core.logger import Logger
@@ -36,9 +39,6 @@ from indico.web.http_api.metadata.ical import ICalSerializer
 from indico.web.http_api.metadata.jsonp import JSONPSerializer
 from indico.web.http_api.responses import HTTPAPIError
 from indico.web.http_api.util import get_query_parameter
-
-import pytz
-from flask import current_app, request
 
 
 class HTTPAPIHook(object):

--- a/indico/web/http_api/metadata/atom.py
+++ b/indico/web/http_api/metadata/atom.py
@@ -39,7 +39,7 @@ class AtomSerializer(Serializer):
 
     def _execute(self, fossils):
         results = fossils['results']
-        if type(results) != list:
+        if not isinstance(results, list):
             results = [results]
 
         feed = AtomFeed(

--- a/indico/web/http_api/metadata/atom.py
+++ b/indico/web/http_api/metadata/atom.py
@@ -16,12 +16,12 @@
 
 from datetime import datetime
 
+from indico.util.string import to_unicode
+from indico.web.http_api.metadata.serializer import Serializer
+
 import dateutil.parser
 from pyatom import AtomFeed
 from pytz import timezone, utc
-
-from indico.util.string import to_unicode
-from indico.web.http_api.metadata.serializer import Serializer
 
 
 def _deserialize_date(date_dict):

--- a/indico/web/http_api/metadata/atom.py
+++ b/indico/web/http_api/metadata/atom.py
@@ -16,12 +16,12 @@
 
 from datetime import datetime
 
-from indico.util.string import to_unicode
-from indico.web.http_api.metadata.serializer import Serializer
-
 import dateutil.parser
 from pyatom import AtomFeed
 from pytz import timezone, utc
+
+from indico.util.string import to_unicode
+from indico.web.http_api.metadata.serializer import Serializer
 
 
 def _deserialize_date(date_dict):

--- a/indico/web/http_api/metadata/ical.py
+++ b/indico/web/http_api/metadata/ical.py
@@ -142,7 +142,7 @@ class ICalSerializer(Serializer):
 
     def _execute(self, fossils):
         results = fossils['results']
-        if type(results) != list:
+        if not isinstance(results, list):
             results = [results]
 
         cal = ical.Calendar()

--- a/indico/web/http_api/metadata/ical.py
+++ b/indico/web/http_api/metadata/ical.py
@@ -16,18 +16,17 @@
 
 from datetime import datetime
 
+import dateutil.parser
+import icalendar as ical
 from lxml import html
 from lxml.etree import ParserError
+from pytz import timezone, utc
+from werkzeug.urls import url_parse
 
 from indico.core.config import config
 from indico.util.date_time import now_utc
 from indico.util.string import to_unicode
 from indico.web.http_api.metadata.serializer import Serializer
-
-import dateutil.parser
-import icalendar as ical
-from pytz import timezone, utc
-from werkzeug.urls import url_parse
 
 
 class vRecur(ical.vRecur):

--- a/indico/web/http_api/metadata/ical.py
+++ b/indico/web/http_api/metadata/ical.py
@@ -16,17 +16,18 @@
 
 from datetime import datetime
 
-import dateutil.parser
-import icalendar as ical
 from lxml import html
 from lxml.etree import ParserError
-from pytz import timezone, utc
-from werkzeug.urls import url_parse
 
 from indico.core.config import config
 from indico.util.date_time import now_utc
 from indico.util.string import to_unicode
 from indico.web.http_api.metadata.serializer import Serializer
+
+import dateutil.parser
+import icalendar as ical
+from pytz import timezone, utc
+from werkzeug.urls import url_parse
 
 
 class vRecur(ical.vRecur):

--- a/indico/web/http_api/metadata/xml.py
+++ b/indico/web/http_api/metadata/xml.py
@@ -83,13 +83,13 @@ class XMLSerializer(Serializer):
             if isinstance(v, dict) and set(v.viewkeys()) == {'date', 'time', 'tz'}:
                 v = _deserialize_date(v)
             if isinstance(v, (list, tuple)):
-                onlyDicts = all(type(subv) == dict for subv in v)
+                onlyDicts = all(isinstance(subv, dict) for subv in v)
                 if onlyDicts:
                     for subv in v:
                         elem.append(self._xmlForFossil(subv))
                 else:
                     for subv in v:
-                        if type(subv) == dict:
+                        if isinstance(subv, dict):
                             elem.append(self._xmlForFossil(subv))
                         else:
                             subelem = etree.SubElement(elem, 'item')
@@ -106,7 +106,7 @@ class XMLSerializer(Serializer):
         return felement
 
     def _execute(self, fossil, xml_declaration=True):
-        if type(fossil) == list:
+        if isinstance(fossil, list):
             # collection of fossils
             doc = etree.ElementTree(etree.Element("collection"))
             for elem in fossil:

--- a/indico/web/http_api/metadata/xml.py
+++ b/indico/web/http_api/metadata/xml.py
@@ -17,14 +17,13 @@
 import re
 from datetime import datetime
 
+import dateutil.parser
 from lxml import etree
+from pytz import timezone, utc
 
 from indico.core.logger import Logger
 from indico.util.string import to_unicode
 from indico.web.http_api.metadata.serializer import Serializer
-
-import dateutil.parser
-from pytz import timezone, utc
 
 
 def _deserialize_date(date_dict):

--- a/indico/web/http_api/metadata/xml.py
+++ b/indico/web/http_api/metadata/xml.py
@@ -17,13 +17,14 @@
 import re
 from datetime import datetime
 
-import dateutil.parser
 from lxml import etree
-from pytz import timezone, utc
 
 from indico.core.logger import Logger
 from indico.util.string import to_unicode
 from indico.web.http_api.metadata.serializer import Serializer
+
+import dateutil.parser
+from pytz import timezone, utc
 
 
 def _deserialize_date(date_dict):


### PR DESCRIPTION
* Use __print()__ function in both Python 2 and Python 3
    * Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.
* Use __exec()__ function in both Python 2 and Python 3
    * __exec()__ is a function in Python 3.
* Old style exceptions --> new style for Python 3
    * Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.

Related to #3834