### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/indico/core/settings/proxy_test.py
+++ b/indico/core/settings/proxy_test.py
@@ -102,7 +102,7 @@ def test_proxy_preload(count_queries):
         assert proxy.get('foo', 'bar') == 'bar'
     assert cnt() == 0
     with count_queries() as cnt:
-        assert proxy.get('bar') is 'test'
+        assert proxy.get('bar') == 'test'
     assert cnt() == 0
 
 


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/indico/indico on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./indico/core/settings/proxy_test.py:105:16: F632 use ==/!= to compare str, bytes, and int literals
        assert proxy.get('bar') is 'test'
               ^
```