### PR TITLE
Add extension point to postprocess event metadata

### DIFF
--- a/indico/core/signals/event/core.py
+++ b/indico/core/signals/event/core.py
@@ -81,3 +81,15 @@ Expected to return `EventLogRenderer` classes.
 get_feature_definitions = _signals.signal('get-feature-definitions', """
 Expected to return `EventFeature` subclasses.
 """)
+
+metadata_postprocess = _signals.signal('metadata-postprocess', """
+Called right after a dict-like representation of an event is created,
+so that plugins can add their own fields.
+
+The *sender* is a string parameter specifying the source of the metadata.
+The *event* kwarg contains the event object. The metadata is passed in
+the `data` kwarg.
+
+The signal should return a dict that will be used to update the
+original representation (fields to add or override).
+""")

--- a/indico/modules/rb_new/client/js/modules/bookRoom/BookRoom.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/BookRoom.jsx
@@ -61,7 +61,6 @@ class BookRoom extends React.Component {
         isSearching: PropTypes.bool.isRequired,
         searchFinished: PropTypes.bool.isRequired,
         isTimelineVisible: PropTypes.bool.isRequired,
-        hasConflicts: PropTypes.bool.isRequired,
         totalResultCount: PropTypes.number.isRequired,
         unbookableResultCount: PropTypes.number.isRequired,
         filters: PropTypes.object.isRequired,
@@ -341,7 +340,7 @@ class BookRoom extends React.Component {
     };
 
     renderViewSwitch() {
-        const {isTimelineVisible, hasConflicts} = this.props;
+        const {isTimelineVisible} = this.props;
         const classes = toClasses({active: isTimelineVisible, disabled: !this.timelineButtonEnabled});
 
         const listBtn = (
@@ -369,9 +368,6 @@ class BookRoom extends React.Component {
                         {!isTimelineVisible ? (
                             <Popup trigger={timelineBtn} content={Translate.string('Timeline view')} />
                         ) : timelineBtn}
-                        {hasConflicts && (
-                            <Icon name="exclamation triangle" styleName="conflicts-icon" color="red" corner />
-                        )}
                     </Icon.Group>
                 </span>
             </div>
@@ -435,7 +431,6 @@ const mapStateToProps = (state) => {
         unbookableResultCount: bookRoomSelectors.getUnbookableResultCount(state),
         isSearching: bookRoomSelectors.isSearchingOrCheckingPermissions(state),
         searchFinished: bookRoomSelectors.isSearchAndPermissionCheckFinished(state),
-        hasConflicts: bookRoomSelectors.hasUnavailableRooms(state),
         queryString: stateToQueryString(state.bookRoom, qsFilterRules, qsBookRoomRules),
         showMap: mapSelectors.isMapVisible(state),
         dateRange: bookRoomSelectors.getTimelineDateRange(state),

--- a/indico/modules/rb_new/client/js/modules/bookRoom/selectors.js
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/selectors.js
@@ -159,17 +159,6 @@ export const getUnbookableResultCount = createSelector(
 );
 
 /**
- * Check whether there are rooms that the user cannot book at the
- * moment even though they are authorized to book the room at another
- * time.
- */
-export const hasUnavailableRooms = createSelector(
-    getSearchResultsWithoutUnbookable,
-    getTotalResultCountWithoutUnbookable,
-    (available, total) => available.length !== total
-);
-
-/**
  * Get the map data for the current result list without unbookable ones.
  */
 export const getSearchResultsForMap = createSelector(


### PR DESCRIPTION
I am not sure whether this is the best approach. The initial requirements were that we should be able to add the URL of the corresponding Vidyo room at the bottom of an event's description in:
 * ICS feeds
 * Exchange events

This patch tries to address those two scenarios with a single signal `event.metadata_postprocess` that is called from different places with a different string as `sender` parameter. We would then implement the same signal-based extension logic in the `outlook` (Exchange) plugin.
