### PR TITLE
Use PrincipalListField for blocking ACLs

### DIFF
--- a/indico/modules/rb_new/client/js/common/rooms/RoomEditModal.jsx
+++ b/indico/modules/rb_new/client/js/common/rooms/RoomEditModal.jsx
@@ -103,7 +103,7 @@ function validate(fields) {
         errors.nonbookablePeriods = Translate.string('Please provide valid non-bookable periods.');
     }
     if (!owner) {
-        errors.owner = Translate.string('You need to specify the owner of the toom.');
+        errors.owner = Translate.string('You need to specify the owner of the room.');
     }
     return errors;
 }

--- a/indico/modules/rb_new/client/js/modules/blockings/serializers.js
+++ b/indico/modules/rb_new/client/js/modules/blockings/serializers.js
@@ -35,14 +35,9 @@ export const ajax = {
         onlyIf: ({rooms}) => rooms && rooms.length,
         serializer: ({rooms}) => rooms.map((room) => room.id)
     },
-    allowed_principals: {
+    allowed: {
         onlyIf: ({allowed}) => !!allowed,
-        serializer: ({allowed}) => allowed.map((obj) => ({
-            id: obj.id,
-            is_group: obj.isGroup,
-            provider: obj.provider,
-            name: obj.name
-        }))
+        serializer: ({allowed}) => allowed,
     },
     reason: {
         onlyIf: ({reason}) => !!reason,

--- a/indico/modules/rb_new/controllers/backend/blockings.py
+++ b/indico/modules/rb_new/controllers/backend/blockings.py
@@ -27,6 +27,7 @@ from indico.modules.rb.models.blocked_rooms import BlockedRoom
 from indico.modules.rb.models.blockings import Blocking
 from indico.modules.rb_new.operations.blockings import create_blocking, get_room_blockings, update_blocking
 from indico.modules.rb_new.schemas import blockings_schema
+from indico.util.marshmallow import PrincipalList
 
 
 class RHCreateRoomBlocking(RHRoomBookingBase):
@@ -35,7 +36,7 @@ class RHCreateRoomBlocking(RHRoomBookingBase):
         'start_date': fields.Date(required=True),
         'end_date': fields.Date(required=True),
         'reason': fields.Str(required=True),
-        'allowed_principals': fields.List(fields.Dict(), missing=[])
+        'allowed': PrincipalList(allow_groups=True, required=True),
     })
     def _process(self, args):
         blocking = create_blocking(created_by=session.user, **args)
@@ -54,7 +55,7 @@ class RHUpdateRoomBlocking(RHRoomBookingBase):
     @use_args({
         'room_ids': fields.List(fields.Int(), required=True),
         'reason': fields.Str(required=True),
-        'allowed_principals': fields.List(fields.Dict(), missing=[])
+        'allowed': PrincipalList(allow_groups=True, required=True),
     })
     def _process(self, args):
         update_blocking(self.blocking, **args)

--- a/indico/modules/rb_new/schemas.py
+++ b/indico/modules/rb_new/schemas.py
@@ -27,7 +27,6 @@ from indico.core.db.sqlalchemy.links import LinkType
 from indico.core.marshmallow import mm
 from indico.modules.events.sessions.models.blocks import SessionBlock
 from indico.modules.rb.models.blocked_rooms import BlockedRoom, BlockedRoomState
-from indico.modules.rb.models.blocking_principals import BlockingPrincipal
 from indico.modules.rb.models.blockings import Blocking
 from indico.modules.rb.models.equipment import EquipmentType
 from indico.modules.rb.models.locations import Location
@@ -43,7 +42,7 @@ from indico.modules.rb.models.rooms import Room
 from indico.modules.rb.util import rb_is_admin
 from indico.modules.users.schemas import UserSchema
 from indico.util.i18n import _
-from indico.util.marshmallow import NaiveDateTime
+from indico.util.marshmallow import NaiveDateTime, PrincipalList
 from indico.util.string import natural_sort_key
 
 
@@ -219,21 +218,9 @@ class BlockedRoomSchema(mm.ModelSchema):
         return data
 
 
-class BlockingPrincipalSchema(mm.ModelSchema):
-    identifier = Function(lambda blocking_principal: blocking_principal.identifier)
-    full_name = String()
-    provider = String(missing=None)
-    email = String(missing=None)
-    is_group = Boolean(missing=False)
-
-    class Meta:
-        model = BlockingPrincipal
-        fields = ('id', 'identifier', 'name', 'is_group', 'email', 'full_name', 'provider')
-
-
 class BlockingSchema(mm.ModelSchema):
     blocked_rooms = Nested(BlockedRoomSchema, many=True)
-    allowed = Nested(BlockingPrincipalSchema, many=True)
+    allowed = PrincipalList()
     permissions = Method('_get_permissions')
     created_by = Pluck(UserSchema, 'full_name', attribute='created_by_user')
 

--- a/indico/web/client/js/react/components/principals/PrincipalListField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalListField.jsx
@@ -30,10 +30,14 @@ import './PrincipalListField.module.scss';
 
 
 /**
- * A field that lets the user select a list of users/groups
+ * A field that lets the user select a list of users/groups.
+ *
+ * Setting the `readOnly` prop hides all UI elements used to modify
+ * the entries, so it can be used to just display the current contents
+ * outside editing mode.
  */
 const PrincipalListField = (props) => {
-    const {value, disabled, onChange, onFocus, onBlur, withGroups, favoriteUsersController} = props;
+    const {value, disabled, readOnly, onChange, onFocus, onBlur, withGroups, favoriteUsersController} = props;
     const [favoriteUsers, [handleAddFavorite, handleDelFavorite]] = favoriteUsersController;
 
     // keep track of details for each entry
@@ -99,7 +103,8 @@ const PrincipalListField = (props) => {
                                        onDelete={() => !disabled && handleDelete(data.identifier)}
                                        onAddFavorite={() => !disabled && handleAddFavorite(data.userId)}
                                        onDelFavorite={() => !disabled && handleDelFavorite(data.userId)}
-                                       disabled={disabled} />
+                                       disabled={disabled}
+                                       readOnly={readOnly} />
                 ))}
                 {pendingEntries.map(data => (
                     <PendingPrincipalListItem key={data.identifier} isGroup={data.group} />
@@ -112,12 +117,14 @@ const PrincipalListField = (props) => {
                     </List.Item>
                 )}
             </List>
-            <Button.Group>
-                <Button icon="add" as="div" disabled />
-                <UserSearch existing={value} onAddItems={handleAddItems} favorites={favoriteUsers}
-                            disabled={disabled} />
-                {withGroups && <GroupSearch existing={value} onAddItems={handleAddItems} disabled={disabled} />}
-            </Button.Group>
+            {!readOnly && (
+                <Button.Group>
+                    <Button icon="add" as="div" disabled />
+                    <UserSearch existing={value} onAddItems={handleAddItems} favorites={favoriteUsers}
+                                disabled={disabled} />
+                    {withGroups && <GroupSearch existing={value} onAddItems={handleAddItems} disabled={disabled} />}
+                </Button.Group>
+            )}
         </>
     );
 };
@@ -125,6 +132,7 @@ const PrincipalListField = (props) => {
 PrincipalListField.propTypes = {
     value: PropTypes.arrayOf(PropTypes.string).isRequired,
     disabled: PropTypes.bool.isRequired,
+    readOnly: PropTypes.bool,
     onChange: PropTypes.func.isRequired,
     onFocus: PropTypes.func.isRequired,
     onBlur: PropTypes.func.isRequired,
@@ -134,6 +142,7 @@ PrincipalListField.propTypes = {
 
 PrincipalListField.defaultProps = {
     withGroups: false,
+    readOnly: false,
 };
 
 // eslint-disable-next-line react/prop-types
@@ -157,8 +166,10 @@ const PendingPrincipalListItem = ({isGroup}) => (
     </List.Item>
 );
 
-// eslint-disable-next-line react/prop-types
-const PrincipalListItem = ({isGroup, name, detail, onDelete, onAddFavorite, onDelFavorite, disabled, favorite}) => (
+const PrincipalListItem = (
+    // eslint-disable-next-line react/prop-types
+    {isGroup, name, detail, onDelete, onAddFavorite, onDelFavorite, disabled, readOnly, favorite}
+) => (
     <List.Item>
         <div styleName="item">
             <div styleName="icon">
@@ -174,19 +185,21 @@ const PrincipalListItem = ({isGroup, name, detail, onDelete, onAddFavorite, onDe
                     </List.Description>
                 )}
             </div>
-            <div styleName="actions">
-                {!isGroup && (
-                    favorite ? (
-                        <Icon styleName="button favorite active" name="star" size="large"
-                              onClick={onDelFavorite} disabled={disabled} />
-                    ) : (
-                        <Icon styleName="button favorite" name="star outline" size="large"
-                              onClick={onAddFavorite} disabled={disabled} />
-                    )
-                )}
-                <Icon styleName="button delete" name="remove" size="large"
-                      onClick={onDelete} disabled={disabled} />
-            </div>
+            {!readOnly && (
+                <div styleName="actions">
+                    {!isGroup && (
+                        favorite ? (
+                            <Icon styleName="button favorite active" name="star" size="large"
+                                  onClick={onDelFavorite} disabled={disabled} />
+                        ) : (
+                            <Icon styleName="button favorite" name="star outline" size="large"
+                                  onClick={onAddFavorite} disabled={disabled} />
+                        )
+                    )}
+                    <Icon styleName="button delete" name="remove" size="large"
+                          onClick={onDelete} disabled={disabled} />
+                </div>
+            )}
         </div>
     </List.Item>
 );

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -214,7 +214,7 @@ const searchFactory = config => {
                    dimmer="inverted"
                    centered={false}
                    open={open}
-                   onClose={() => setOpen(false)}
+                   onClose={handleCancelButtonClick}
                    closeIcon>
                 <Modal.Header>
                     {modalTitle}

--- a/indico/web/client/js/react/hooks.js
+++ b/indico/web/client/js/react/hooks.js
@@ -20,6 +20,7 @@ import principalsURL from 'indico-url:core.principals';
 
 import _ from 'lodash';
 import {useEffect, useState} from 'react';
+import PropTypes from 'prop-types';
 import {handleAxiosError, indicoAxios} from '../utils/axios';
 import {camelizeKeys} from '../utils/case';
 
@@ -106,4 +107,21 @@ export const useFavoriteUsers = () => {
     }, []);
 
     return [favorites, [add, del]];
+};
+
+
+/**
+ * FavoritesProvider can be used to get the favorite controller
+ * in a class-based component.
+ *
+ * Do not use this for new components; write them as functional
+ * components instead!
+ */
+export const FavoritesProvider = ({children}) => {
+    const favoriteUsersController = useFavoriteUsers();
+    return children(favoriteUsersController);
+};
+
+FavoritesProvider.propTypes = {
+    children: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
Needed so the PrincipalSearchField can be removed once the booking forms ("booked for someone else") also uses the new field.