### PR TITLE
Fix broken modal after a page reload

### DIFF
--- a/indico/modules/rb_new/client/js/modules/bookRoom/UnavailableRoomsModal.jsx
+++ b/indico/modules/rb_new/client/js/modules/bookRoom/UnavailableRoomsModal.jsx
@@ -57,11 +57,13 @@ class UnavailableRoomsModal extends React.Component {
             timelineDatePicker,
             isTimelineVisible
         } = this.props;
-        const selectedDate = isTimelineVisible ? timelineDatePicker.selectedDate : filters.dates.startDate;
-        const mode = isTimelineVisible ? timelineDatePicker.mode : 'days';
+
+        const {selectedDate, mode} = timelineDatePicker;
+        const initialDate = isTimelineVisible && selectedDate ? selectedDate : filters.dates.startDate;
+        const initialMode = isTimelineVisible && mode ? mode : 'days';
 
         fetchUnavailableRooms(filters);
-        initTimeline(selectedDate, mode);
+        initTimeline(initialDate, initialMode);
     }
 
     render() {


### PR DESCRIPTION
The problem here is that:
- the modal is using data related to the main timeline;
-  `ModalController` opens the modal before the main timeline had time to initialize its properties.

fixes #3898 