### PR TITLE
Theme improvements

### DIFF
--- a/indico/modules/attachments/templates/_display.html
+++ b/indico/modules/attachments/templates/_display.html
@@ -37,7 +37,7 @@
     {% set folders = item.attached_items.folders if item else folders %}
 
     <div class="attachments-display-container toolbar">
-        <div class="folder folder-root">
+        <div class="folder folder-root {{ 'folder-root-empty' if not files }}">
             {% for attachment in files %}
                 {{ render_attachment(attachment, classes='i-button') }}
                 {{ template_hook('event-display-after-attachment', attachment=attachment, top_level=true, has_label=false) }}

--- a/indico/modules/events/timetable/templates/display/indico/_break.html
+++ b/indico/modules/events/timetable/templates/display/indico/_break.html
@@ -2,8 +2,8 @@
 {% from 'events/display/indico/_common.html' import render_location %}
 {% from 'events/timetable/display/indico/_common.html' import render_description, render_time %}
 
-{% macro render_break(item, event, theme_settings, parent=none, timezone=none, show_notes=true,
-                      hide_end_time=false, nested=false, show_location=false) %}
+{% macro render_break(item, event, theme_settings, theme_context, parent=none, timezone=none,
+                      show_notes=true, hide_end_time=false, nested=false, show_location=false) %}
     <li class="timetable-item timetable-break">
         <span class="timetable-time break {{ 'nested' if nested else 'top-level' }}">
             {{ render_time(item, timezone=timezone, hide_end_time=hide_end_time) }}

--- a/indico/modules/events/timetable/templates/display/indico/_break.html
+++ b/indico/modules/events/timetable/templates/display/indico/_break.html
@@ -2,8 +2,8 @@
 {% from 'events/display/indico/_common.html' import render_location %}
 {% from 'events/timetable/display/indico/_common.html' import render_description, render_time %}
 
-{% macro render_break(item, event, parent=none, timezone=none, show_notes=true, hide_end_time=false, nested=false,
-                      show_location=false) %}
+{% macro render_break(item, event, theme_settings, parent=none, timezone=none, show_notes=true,
+                      hide_end_time=false, nested=false, show_location=false) %}
     <li class="timetable-item timetable-break">
         <span class="timetable-time break {{ 'nested' if nested else 'top-level' }}">
             {{ render_time(item, timezone=timezone, hide_end_time=hide_end_time) }}
@@ -14,7 +14,7 @@
                 <span class="timetable-title {{ 'top-level' if not nested }} break">
                     {{- item.title -}}
                 </span>
-                {% if item.duration -%}
+                {% if item.duration and not theme_settings.hide_duration -%}
                     <span class="icon-time timetable-duration">
                         {{ item.duration | format_human_timedelta(narrow=true) }}
                     </span>

--- a/indico/modules/events/timetable/templates/display/indico/_contribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_contribution.html
@@ -4,7 +4,7 @@
 {% from 'events/timetable/display/indico/_common.html' import render_speakers, render_references, render_attachments,
                                                               render_notes, render_description, render_time %}
 
-{% macro render_contribution(contrib, event, parent=none, nested=false, hide_end_time=false, timezone=none,
+{% macro render_contribution(contrib, event, theme_settings, parent=none, nested=false, hide_end_time=false, timezone=none,
                              show_notes=false, show_location=false) -%}
     {% set anchor = slugify(contrib.friendly_id, contrib.title, maxlen=30) %}
     <li class="timetable-item timetable-contrib" id="{{ anchor }}">
@@ -17,7 +17,7 @@
                 <span class="timetable-title {{ 'nested' if nested }}" data-anchor="{{ anchor }}">
                     {{- contrib.title -}}
                 </span>
-                {% if contrib.duration -%}
+                {% if contrib.duration and not theme_settings.hide_duration -%}
                     <span class="icon-time timetable-duration">
                         {{- contrib.duration | format_human_timedelta(narrow=true) -}}
                     </span>
@@ -52,7 +52,7 @@
             {% if contrib.subcontributions %}
                 <ul class="subcontrib-list">
                     {% for subcont in contrib.subcontributions %}
-                        {{ render_subcontribution(subcont, event, show_notes=show_notes) }}
+                        {{ render_subcontribution(subcont, event, theme_settings, show_notes=show_notes) }}
                     {% endfor %}
                 </ul>
             {% endif %}

--- a/indico/modules/events/timetable/templates/display/indico/_contribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_contribution.html
@@ -4,12 +4,18 @@
 {% from 'events/timetable/display/indico/_common.html' import render_speakers, render_references, render_attachments,
                                                               render_notes, render_description, render_time %}
 
-{% macro render_contribution(contrib, event, theme_settings, parent=none, nested=false, hide_end_time=false, timezone=none,
-                             show_notes=false, show_location=false) -%}
+{% macro render_contribution(contrib, event, theme_settings, theme_context, parent=none, nested=false, hide_end_time=false,
+                             timezone=none, show_notes=false, show_location=false) -%}
     {% set anchor = slugify(contrib.friendly_id, contrib.title, maxlen=30) %}
     <li class="timetable-item timetable-contrib" id="{{ anchor }}">
         <span class="timetable-time {{ 'nested' if nested else 'top-level' }}">
-            {{ render_time(contrib, timezone=timezone, hide_end_time=hide_end_time) }}
+            {% if theme_settings.number_contributions %}
+                <span class="start-time">
+                    {{ theme_context.num_contribution }}
+                </span>
+            {% else %}
+                {{ render_time(contrib, timezone=timezone, hide_end_time=hide_end_time) }}
+            {% endif %}
         </span>
 
         <div class="timetable-item-body flexcol">
@@ -52,7 +58,8 @@
             {% if contrib.subcontributions %}
                 <ul class="subcontrib-list">
                     {% for subcont in contrib.subcontributions %}
-                        {{ render_subcontribution(subcont, event, theme_settings, show_notes=show_notes) }}
+                        {% set theme_context.num_subcontribution = loop.index %}
+                        {{ render_subcontribution(subcont, event, theme_settings, theme_context, show_notes=show_notes) }}
                     {% endfor %}
                 </ul>
             {% endif %}

--- a/indico/modules/events/timetable/templates/display/indico/_session_block.html
+++ b/indico/modules/events/timetable/templates/display/indico/_session_block.html
@@ -5,8 +5,8 @@
 {% from 'events/timetable/display/indico/_contribution.html' import render_contribution %}
 {% from 'events/timetable/display/indico/_break.html' import render_break %}
 
-{% macro render_session_block(block, event, parent=none, timezone=none, show_notes=false, hide_contribs=false,
-                              show_location=false, show_children_location=false) %}
+{% macro render_session_block(block, event, theme_settings, parent=none, timezone=none, show_notes=false,
+                              hide_contribs=false, show_location=false, show_children_location=false) %}
     {% set session_ = block.session %}
     {% set entries = block.timetable_entry.children %}
 
@@ -61,12 +61,12 @@
                     {# It's impossible to sort by `lambda:` with Jinja, hence the double-sort #}
                     {% for entry in entries|sort(attribute='object.title')|sort(attribute='start_dt') %}
                         {% if entry.type.name == 'CONTRIBUTION' and entry.object.can_access(session.user) %}
-                            {{ render_contribution(entry.contribution, event, nested=true, hide_end_time=true,
-                                                   show_notes=show_notes, timezone=timezone, parent=block,
-                                                   show_location=show_children_location) }}
+                            {{ render_contribution(entry.contribution, event, theme_settings, nested=true,
+                                                   hide_end_time=true, show_notes=show_notes, timezone=timezone,
+                                                   parent=block, show_location=show_children_location) }}
                         {% elif entry.type.name == 'BREAK' %}
-                            {{ render_break(entry.break_, event, nested=true, hide_end_time=true, timezone=timezone,
-                                            show_location=show_children_location) }}
+                            {{ render_break(entry.break_, event, theme_settings, nested=true, hide_end_time=true,
+                                            timezone=timezone, show_location=show_children_location) }}
                         {% endif %}
                     {% endfor %}
                 </ul>

--- a/indico/modules/events/timetable/templates/display/indico/_session_block.html
+++ b/indico/modules/events/timetable/templates/display/indico/_session_block.html
@@ -5,8 +5,9 @@
 {% from 'events/timetable/display/indico/_contribution.html' import render_contribution %}
 {% from 'events/timetable/display/indico/_break.html' import render_break %}
 
-{% macro render_session_block(block, event, theme_settings, parent=none, timezone=none, show_notes=false,
-                              hide_contribs=false, show_location=false, show_children_location=false) %}
+{% macro render_session_block(block, event, theme_settings, theme_context, parent=none, timezone=none,
+                              show_notes=false, hide_contribs=false, show_location=false,
+                              show_children_location=false) %}
     {% set session_ = block.session %}
     {% set entries = block.timetable_entry.children %}
 
@@ -14,7 +15,9 @@
 
     <li class="timetable-item timetable-block" id="{{ anchor }}">
         <span class="timetable-time top-level">
-            {{ render_time(block, timezone=timezone) }}
+            {% if not theme_settings.hide_session_block_time %}
+                {{ render_time(block, timezone=timezone) }}
+            {% endif %}
         </span>
         <div class="timetable-item-body flexcol">
             <div class="timetable-item-header flexrow">
@@ -61,9 +64,10 @@
                     {# It's impossible to sort by `lambda:` with Jinja, hence the double-sort #}
                     {% for entry in entries|sort(attribute='object.title')|sort(attribute='start_dt') %}
                         {% if entry.type.name == 'CONTRIBUTION' and entry.object.can_access(session.user) %}
-                            {{ render_contribution(entry.contribution, event, theme_settings, nested=true,
-                                                   hide_end_time=true, show_notes=show_notes, timezone=timezone,
-                                                   parent=block, show_location=show_children_location) }}
+                            {% set theme_context.num_contribution = theme_context.num_contribution + 1 %}
+                            {{ render_contribution(entry.contribution, event, theme_settings, theme_context,
+                                                   nested=true, hide_end_time=true, show_notes=show_notes,
+                                                   timezone=timezone, parent=block, show_location=show_children_location) }}
                         {% elif entry.type.name == 'BREAK' %}
                             {{ render_break(entry.break_, event, theme_settings, nested=true, hide_end_time=true,
                                             timezone=timezone, show_location=show_children_location) }}

--- a/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
@@ -3,7 +3,7 @@
                                                               render_notes, render_description, render_time %}
 
 
-{% macro render_subcontribution(subcontrib, event, show_notes=true) %}
+{% macro render_subcontribution(subcontrib, event, theme_settings, show_notes=true) %}
     {% set contrib = subcontrib.contribution %}
     {% set anchor = slugify('sc', contrib.friendly_id, subcontrib.friendly_id, subcontrib.title, maxlen=30) %}
     <li class="timetable-subcontrib timetable-item" id="{{ anchor }}">
@@ -12,7 +12,7 @@
                 <span class="timetable-title" data-anchor="{{ anchor }}">
                     {{- subcontrib.title -}}
                 </span>
-                {% if subcontrib.duration %}
+                {% if subcontrib.duration and not theme_settings.hide_duration %}
                     <span class="icon-time timetable-duration">
                         {{- subcontrib.duration | format_human_timedelta(narrow=true) -}}
                     </span>

--- a/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
@@ -3,13 +3,17 @@
                                                               render_notes, render_description, render_time %}
 
 
-{% macro render_subcontribution(subcontrib, event, theme_settings, show_notes=true) %}
+{% macro render_subcontribution(subcontrib, event, theme_settings, theme_context, show_notes=true) %}
     {% set contrib = subcontrib.contribution %}
     {% set anchor = slugify('sc', contrib.friendly_id, subcontrib.friendly_id, subcontrib.title, maxlen=30) %}
     <li class="timetable-subcontrib timetable-item" id="{{ anchor }}">
         <div class="timetable-item-body flexcol">
             <div class="timetable-item-header flexrow">
                 <span class="timetable-title" data-anchor="{{ anchor }}">
+                    {% if theme_settings.number_contributions %}
+                        {{- theme_context.num_contribution }}.
+                        {{- theme_context.num_subcontribution }}
+                    {% endif %}
                     {{- subcontrib.title -}}
                 </span>
                 {% if subcontrib.duration and not theme_settings.hide_duration %}

--- a/indico/modules/events/timetable/templates/display/indico/meeting.html
+++ b/indico/modules/events/timetable/templates/display/indico/meeting.html
@@ -3,6 +3,7 @@
 {% from 'events/timetable/display/indico/_break.html' import render_break %}
 
 {% if entries %}
+    {% set theme_context = namespace(num_contribution=0) %}
     <ul class="day-list">
         {% for item in entries -%}
             {% set date = item.start_dt.astimezone(tz_object).date() %}
@@ -14,6 +15,8 @@
             {%- endif -%}
 
             {%- if date_changed -%}
+                {% set theme_context.num_contribution = 0 %}
+
                 {% set anchor -%}
                     day-{{ item.start_dt.date().isoformat() }}
                 {%- endset %}
@@ -41,16 +44,17 @@
             {%- endif %}
 
             {% if item.type.name == 'CONTRIBUTION' -%}
-                {{ render_contribution(item.object, event, theme_settings, nested=false, timezone=timezone,
-                                       show_notes=theme_settings.show_notes, parent=event,
+                {% set theme_context.num_contribution = theme_context.num_contribution + 1 %}
+                {{ render_contribution(item.object, event, theme_settings, theme_context, nested=false,
+                                       timezone=timezone, show_notes=theme_settings.show_notes, parent=event,
                                        show_location=show_siblings_location) }}
             {%- elif item.type.name == 'SESSION_BLOCK' -%}
-                {{ render_session_block(item.object, event, theme_settings, timezone=timezone,
+                {{ render_session_block(item.object, event, theme_settings, theme_context, timezone=timezone,
                                         show_notes=theme_settings.show_notes, parent=event, hide_contribs=hide_contribs,
                                         show_location=show_siblings_location,
                                         show_children_location=show_children_location[item.id]) }}
             {%- elif item.type.name == 'BREAK' -%}
-                {{ render_break(item.object, event, theme_settings, nested=false, timezone=timezone,
+                {{ render_break(item.object, event, theme_settings, theme_context, nested=false, timezone=timezone,
                                 show_notes=theme_settings.show_notes, parent=event,
                                 show_location=show_siblings_location) }}
             {%- endif %}

--- a/indico/modules/events/timetable/templates/display/indico/meeting.html
+++ b/indico/modules/events/timetable/templates/display/indico/meeting.html
@@ -41,17 +41,18 @@
             {%- endif %}
 
             {% if item.type.name == 'CONTRIBUTION' -%}
-                {{ render_contribution(item.object, event, nested=false, timezone=timezone,
+                {{ render_contribution(item.object, event, theme_settings, nested=false, timezone=timezone,
                                        show_notes=theme_settings.show_notes, parent=event,
                                        show_location=show_siblings_location) }}
             {%- elif item.type.name == 'SESSION_BLOCK' -%}
-                {{ render_session_block(item.object, event, timezone=timezone, show_notes=theme_settings.show_notes,
-                                        parent=event, hide_contribs=hide_contribs,
+                {{ render_session_block(item.object, event, theme_settings, timezone=timezone,
+                                        show_notes=theme_settings.show_notes, parent=event, hide_contribs=hide_contribs,
                                         show_location=show_siblings_location,
                                         show_children_location=show_children_location[item.id]) }}
             {%- elif item.type.name == 'BREAK' -%}
-                {{ render_break(item.object, event, nested=false, timezone=timezone, show_notes=theme_settings.show_notes,
-                                parent=event, show_location=show_siblings_location) }}
+                {{ render_break(item.object, event, theme_settings, nested=false, timezone=timezone,
+                                show_notes=theme_settings.show_notes, parent=event,
+                                show_location=show_siblings_location) }}
             {%- endif %}
         {%- endfor %}
 

--- a/indico/web/client/styles/modules/_attachments.scss
+++ b/indico/web/client/styles/modules/_attachments.scss
@@ -357,6 +357,12 @@
     .folder {
         display: inline-block;
 
+        // folder-root may be invisible. In that case, we should
+        // omit the margin in the element right next to it.
+        &:not(.folder-root-empty) + * {
+            margin-left: 0.2em;
+        }
+
         &.is-protected {
             .i-button.label {
                 @extend %protected-colors;

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -406,11 +406,11 @@ ul.day-list {
 
     &.nested {
         @include transition(border-color .5s linear);
-
         margin-right: 0.5em;
         border-right: 3px solid $tt-nested-time-color;
 
         .start-time {
+            padding: 0 5px 0 10px;
             background-color: $tt-nested-time-color;
         }
     }


### PR DESCRIPTION
This is meant to pave the way for https://github.com/indico/indico-plugins-cern/pull/50.

Some of the decisions I took:
 * Passing `theme_settings` around instead of overloading the function calls with many arguments;
 * Creating `theme_context` so that the macros generating the timetable can have a shared state (once again, the alternative would have been even more argument passing);
 * Adding `hide_duration`, `hide_session_block_time` and `number_contributions` to `theme_settings`, which will be used by https://github.com/indico/indico-plugins-cern/pull/50;

I am not very sure about the approach when it comes to creating and updating the `theme_context`. The alternatives are not great, but a possibility would be a global function that just does a dict update. Ideas welcome!