### PR TITLE
Added ticket_price field to registration api response

### DIFF
--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -436,6 +436,7 @@ def _build_personal_data(registration):
 def build_registration_api_data(registration):
     registration_info = _build_base_registration_info(registration)
     registration_info['amount_paid'] = registration.price if registration.is_paid else 0
+    registration_info['ticket_price'] = registration.price
     registration_info['registration_date'] = registration.submitted_dt.isoformat()
     registration_info['paid'] = registration.is_paid
     registration_info['checkin_date'] = registration.checked_in_dt.isoformat() if registration.checked_in_dt else ''


### PR DESCRIPTION
Issue: Indico-checkin app does not display the ticket amount if it is not paid.

Use case: Collect the amount at the checkin counter if not already paid.

Since this field is not shown, this work flow is not possible. 
With help from `ub|k` on Freenode `#indico`, I have added an extra field to the API.
The field is named "ticket_price". No changes have been made to "amount_paid".

Will be sending a separate PR to `indico-checkin` to use ticket_price instead of amount_paid.

Thank you!
Aditya Jain