### PR TITLE
Include IE11 as outdated browser

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,7 @@
   "presets": [
     ["@babel/preset-env", {
       "targets": {
-        "browsers": ["last 2 versions", "firefox esr", "not ie<11", "not ie_mob>0"]
+        "browsers": ["last 2 versions", "firefox esr", "not ie>0", "not ie_mob>0"]
       }
     }]
   ],

--- a/indico/modules/rb/templates/room_booking.html
+++ b/indico/modules/rb/templates/room_booking.html
@@ -2,4 +2,5 @@
 
 {% block body %}
     <div id="rb-app-container"></div>
+    {% include '_outdated_browser.html' %}
 {% endblock %}

--- a/indico/modules/rb_new/views/base.py
+++ b/indico/modules/rb_new/views/base.py
@@ -25,7 +25,7 @@ class WPRoomBookingBase(WPNewBase):
     template_prefix = 'rb/'
     title = _('Room Booking')
     bundles = ('common.js', 'common.css', 'react.js', 'react.css', 'semantic-ui.js', 'semantic-ui.css',
-               'module_rb_new.js', 'module_rb_new.css')
+               'module_rb_new.js', 'module_rb_new.css', 'outdatedbrowser.js', 'outdatedbrowser.css')
 
 
 class WPEventBookingList(WPEventManagement):

--- a/indico/modules/rb_new/views/base.py
+++ b/indico/modules/rb_new/views/base.py
@@ -25,7 +25,7 @@ class WPRoomBookingBase(WPNewBase):
     template_prefix = 'rb/'
     title = _('Room Booking')
     bundles = ('common.js', 'common.css', 'react.js', 'react.css', 'semantic-ui.js', 'semantic-ui.css',
-               'module_rb_new.js', 'module_rb_new.css', 'outdatedbrowser.js', 'outdatedbrowser.css')
+               'module_rb_new.js', 'module_rb_new.css')
 
 
 class WPEventBookingList(WPEventManagement):

--- a/indico/web/client/js/outdatedbrowser.js
+++ b/indico/web/client/js/outdatedbrowser.js
@@ -1,5 +1,5 @@
 /* This file is part of Indico.
- * Copyright (C) 2002 - 2018 European Organization for Nuclear Research (CERN).
+ * Copyright (C) 2002 - 2019 European Organization for Nuclear Research (CERN).
  *
  * Indico is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -15,10 +15,9 @@
  * along with Indico; if not, see <http://www.gnu.org/licenses/>.
  */
 
-import '@babel/polyfill';
+import 'outdatedbrowser/outdatedbrowser/outdatedbrowser.css';
 
-import './legacy/presentation.js';
-import './legacy/indico.js';
-import './legacy/timetable.js';
 
-import '../styles/screen.scss';
+// outdatedbrowser has to be loaded with exports-loader
+// in order to be available from 'window.outdatedBrowser'
+window.outdatedBrowser = require('exports-loader?outdatedBrowser!outdatedbrowser');

--- a/indico/web/templates/_outdated_browser.html
+++ b/indico/web/templates/_outdated_browser.html
@@ -6,12 +6,12 @@
 </div>
 
 <script>
-    $(document).ready(function() {
+    window.addEventListener('load', function() {
         outdatedBrowser({
             bgColor: '#0b63a5',
             color: '#ffffff',
-            lowerThan: 'IE11',
+            lowerThan: 'object-fit', // Edge
             languagePath: ''
-        });
-    })
+        })
+    });
 </script>

--- a/indico/web/templates/_outdated_browser.html
+++ b/indico/web/templates/_outdated_browser.html
@@ -12,6 +12,6 @@
             color: '#ffffff',
             lowerThan: 'object-fit', // Edge
             languagePath: ''
-        })
+        });
     });
 </script>

--- a/indico/web/templates/base.html
+++ b/indico/web/templates/base.html
@@ -20,6 +20,8 @@
     {{ webpack['jquery.css'] }}
     {{ webpack['main.js'] }}
     {{ webpack['main.css'] }}
+    {{ webpack['outdatedbrowser.js'] }}
+    {{ webpack['outdatedbrowser.css'] }}
     {{ webpack['__custom.js'] }}
     {{ webpack['__custom.css'] }}
 

--- a/indico/web/views.py
+++ b/indico/web/views.py
@@ -209,7 +209,7 @@ class WPBase(WPBundleMixin):
     @classmethod
     def bundles(cls):
         _bundles = ('common.css', 'common.js', 'jquery.css', 'jquery.js', 'main.css', 'main.js', 'module_core.js',
-                    'module_events.creation.js', 'module_attachments.js')
+                    'module_events.creation.js', 'module_attachments.js', 'outdatedbrowser.js', 'outdatedbrowser.css')
         if not g.get('static_site'):
             _bundles += ('ckeditor.js',)
         return _bundles

--- a/indico/web/views.py
+++ b/indico/web/views.py
@@ -271,7 +271,7 @@ class WPBase(WPBundleMixin):
 
 class WPNewBase(WPJinjaMixin):
     title = ''
-    bundles = ()
+    bundles = ('outdatedbrowser.js', 'outdatedbrowser.css')
     print_bundles = tuple()
 
     @classproperty

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -35,7 +35,8 @@ let entryPoints = {
     markdown: ['./js/jquery/markdown.js'],
     mathjax: ['./js/jquery/compat/mathjax.js'],
     statistics: ['./js/jquery/statistics.js'],
-    fonts: ['./styles/partials/_fonts.scss']
+    fonts: ['./styles/partials/_fonts.scss'],
+    outdatedbrowser: ['./js/outdatedbrowser.js']
 };
 
 const modulesDir = path.join(config.build.rootPath, '..', 'node_modules');


### PR DESCRIPTION
closes #3914 

`'object-fit'` works as `'Edge'` (https://github.com/burocratik/outdated-browser/issues/198#issuecomment-431383916)