### PR TITLE
removed ur'' strings (resolves #3838)

### DIFF
--- a/indico/legacy/pdfinterface/conference.py
+++ b/indico/legacy/pdfinterface/conference.py
@@ -111,7 +111,7 @@ class ProgrammeToPDF(PDFBase):
         event_program = sanitize_for_platypus(render_markdown(track_settings.get(self.event, 'program')))
         parts = []
         for i, part in enumerate(re.split(r'\n+', event_program)):
-            if i > 0 and re.match(ur'<(p|ul|ol)\b[^>]*>', part):
+            if i > 0 and re.match(r'<(p|ul|ol)\b[^>]*>', part):
                 # extra spacing before a block-level element
                 parts.append(u'<br/>')
             parts.append(part)

--- a/indico/util/console.py
+++ b/indico/util/console.py
@@ -102,7 +102,7 @@ def cformat(string):
     """
     reset = colored(u'')
     string = string.replace(u'%{reset}', reset)
-    string = re.sub(ur'%\{(?P<fg>[a-z]+)(?P<fg_bold>!?)(?:,(?P<bg>[a-z]+))?}', _cformat_sub, string)
+    string = re.sub(r'%\{(?P<fg>[a-z]+)(?P<fg_bold>!?)(?:,(?P<bg>[a-z]+))?}', _cformat_sub, string)
     if not string.endswith(reset):
         string += reset
     return Color(string)

--- a/indico/util/mdx_latex.py
+++ b/indico/util/mdx_latex.py
@@ -631,11 +631,11 @@ class Table2Latex:
 
 class LinkTextPostProcessor(markdown.postprocessors.Postprocessor):
     def run(self, instr):
-        new_blocks = [re.sub(ur'<a[^>]*>([^<]+)</a>', lambda m: convert_link_to_latex(m.group(0)).strip(), block)
+        new_blocks = [re.sub(r'<a[^>]*>([^<]+)</a>', lambda m: convert_link_to_latex(m.group(0)).strip(), block)
                       for block in instr.split("\n\n")]
         return '\n\n'.join(new_blocks)
 
 
 def convert_link_to_latex(instr):
     dom = html5parser.fragment_fromstring(instr)
-    return ur'\href{%s}{%s}' % (dom.get('href'), dom.text)
+    return u'\\href{%s}{%s}' % (dom.get('href'), dom.text)

--- a/indico/util/spreadsheets.py
+++ b/indico/util/spreadsheets.py
@@ -43,7 +43,7 @@ def _prepare_header(header, as_unicode=True):
 _prepare_header_utf8 = partial(_prepare_header, as_unicode=False)
 
 
-def _prepare_csv_data(data, _linebreak_re=re.compile(ur'(\r?\n)+')):
+def _prepare_csv_data(data, _linebreak_re=re.compile(r'(\r?\n)+')):
     if isinstance(data, (list, tuple)):
         data = '; '.join(data)
     elif isinstance(data, set):

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -152,11 +152,11 @@ def slugify(*args, **kwargs):
 
     value = u'-'.join(to_unicode(val) for val in args)
     value = value.encode('translit/long')
-    value = re.sub(ur'[^\w\s-]', u'', value).strip()
+    value = re.sub(r'[^\w\s-]', u'', value).strip()
 
     if lower:
         value = value.lower()
-    value = re.sub(ur'[-\s]+', u'-', value)
+    value = re.sub(r'[-\s]+', u'-', value)
     if maxlen:
         value = value[0:maxlen].rstrip(u'-')
 
@@ -279,7 +279,7 @@ def validate_email(email):
 def validate_emails(emails):
     """Validate a space/semicolon/comma-separated list of email addresses."""
     emails = to_unicode(emails)
-    emails = re.split(ur'[\s;,]+', emails)
+    emails = re.split(r'[\s;,]+', emails)
     return all(validate_email(email) for email in emails if email)
 
 
@@ -373,7 +373,7 @@ def text_to_repr(text, html=False, max_length=50):
         text = u''
     if html:
         text = bleach.clean(text, tags=[], strip=True)
-    text = re.sub(ur'\s+', u' ', text)
+    text = re.sub(r'\s+', u' ', text)
     if max_length is not None and len(text) > max_length:
         text = text[:max_length] + u'...'
     return text.strip()

--- a/indico/web/http_api/metadata/xml.py
+++ b/indico/web/http_api/metadata/xml.py
@@ -35,7 +35,7 @@ class XMLSerializer(Serializer):
         self._typeMap = kwargs.pop('typeMap', {})
         super(XMLSerializer, self).__init__(query_params, pretty, **kwargs)
 
-    def _convert(self, value, _control_char_re=re.compile(ur'[\x00-\x08\x0b\x0c\x0e-\x1f]')):
+    def _convert(self, value, _control_char_re=re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f]')):
         if isinstance(value, datetime):
             return value.isoformat()
         elif isinstance(value, (int, long, float, bool)):


### PR DESCRIPTION
The only difference between `re.compile(ur'')` and `re.compile(r'')` that I know of is that they are not equal in `re.compile(ur'') != re.compile(r'')`. Otherwise the behavior will be the same - on Python 2 they will happily parse both `str` and `unicode` objects alike.