### PR TITLE
Convert exec statements to exec() function calls

### DIFF
--- a/docs/source/exec_directive.py
+++ b/docs/source/exec_directive.py
@@ -19,7 +19,7 @@ class ExecDirective(Directive):
         old_stdout, sys.stdout = sys.stdout, StringIO()
 
         try:
-            exec '\n'.join(self.content)
+            exec('\n'.join(self.content))
             text = sys.stdout.getvalue()
             lines = string2lines(text, tab_width, convert_whitespace=True)
             self.state_machine.insert_input(lines, source)

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -141,7 +141,7 @@ def _parse_config(path):
     locals_ = {}
     with codecs.open(path, encoding='utf-8') as config_file:
         # XXX: unicode_literals is inherited from this file
-        exec compile(config_file.read(), path, 'exec') in globals_, locals_
+        exec(compile(config_file.read(), path, 'exec'), globals_, locals_)
     return {unicode(k if k.isupper() else _convert_key(k)): v
             for k, v in locals_.iteritems()
             if k[0] != '_'}

--- a/indico/modules/events/export.py
+++ b/indico/modules/events/export.py
@@ -95,7 +95,7 @@ def _exec_custom(code, **extra):
     """Execute a custom code snippet and return all non-underscored values."""
     globals_ = _make_globals(**extra)
     locals_ = {}
-    exec code in globals_, locals_
+    exec(code, globals_, locals_)
     return {unicode(k): v for k, v in locals_.iteritems() if k[0] != '_'}
 
 


### PR DESCRIPTION
__exec__ statements are syntax errors in Python 3 but __exec()__ function works as expected in both Python 2 and Python 3.  https://portingguide.readthedocs.io/en/latest/builtins.html#the-exec-function

After this PR lands, the only remaining Python 3 syntax errors that I can detect are [__reraise__](https://portingguide.readthedocs.io/en/latest/exceptions.html#the-new-raise-syntax) issues at:
* ./indico/core/storage/backend.py:236 and
* ./indico/core/db/sqlalchemy/core.py:57
