### PR TITLE
Allow request workflows to set their own Reply-To

### DIFF
--- a/indico/modules/events/requests/base.py
+++ b/indico/modules/events/requests/base.py
@@ -39,7 +39,7 @@ class RequestManagerForm(IndicoForm):
 
 
 class RequestDefinitionBase(object):
-    """Defines a service request which can be sent by event managers."""
+    """A service request which can be sent by event managers."""
 
     #: the plugin containing this request definition - assigned automatically
     plugin = None
@@ -56,7 +56,7 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def render_form(cls, event, **kwargs):
-        """Renders the request form
+        """Render the request form.
 
         :param event: the event the request is for
         :param kwargs: arguments passed to the template
@@ -66,7 +66,7 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def create_form(cls, event, existing_request=None):
-        """Creates the request form
+        """Create the request form.
 
         :param event: the event the request is for
         :param existing_request: the :class:`Request` if there's an existing request of this type
@@ -78,7 +78,7 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def create_manager_form(cls, req):
-        """Creates the request management form
+        """Create the request management form.
 
         :param req: the :class:`Request` of the request
         :return: an instance of an :class:`IndicoForm` subclass
@@ -89,7 +89,7 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def get_notification_template(cls, name, **context):
-        """Gets the template module for a notification email
+        """Get the template module for a notification email.
 
         :param name: the template name
         :param context: data passed to the template
@@ -100,7 +100,7 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def can_be_managed(cls, user):
-        """Checks whether the user is allowed to manage this request type
+        """Check whether the user is allowed to manage this request type.
 
         :param user: a :class:`.User`
         """
@@ -108,7 +108,7 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def get_manager_notification_emails(cls):
-        """Returns the email addresses of users who manage requests of this type
+        """Return the email addresses of users who manage requests of this type.
 
         The email addresses are used only for notifications.
         It usually makes sense to return the email addresses of the users who
@@ -120,12 +120,12 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def get_notification_reply_email(cls):
-        """Return the `Reply-To:` e-mail address for notifications."""
+        """Return the *Reply-To* e-mail address for notifications."""
         return config.SUPPORT_EMAIL
 
     @classmethod
     def send(cls, req, data):
-        """Sends a new/modified request
+        """Send a new/modified request.
 
         :param req: the :class:`Request` of the request
         :param data: the form data from the request form
@@ -139,7 +139,7 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def withdraw(cls, req, notify_event_managers=True):
-        """Withdraws the request
+        """Withdraw the request.
 
         :param req: the :class:`Request` of the request
         :param notify_event_managers: if event managers should be notified
@@ -150,7 +150,7 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def accept(cls, req, data, user):
-        """Accepts the request
+        """Accept the request.
 
         To ensure that additional data is saved, this method should
         call :method:`manager_save`.
@@ -168,7 +168,7 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def reject(cls, req, data, user):
-        """Rejects the request
+        """Reject the request.
 
         To ensure that additional data is saved, this method should
         call :method:`manager_save`.
@@ -186,7 +186,7 @@ class RequestDefinitionBase(object):
 
     @classmethod
     def manager_save(cls, req, data):
-        """Saves management-specific data
+        """Save management-specific data.
 
         This method is called when the management form is submitted without
         accepting/rejecting the request (which is guaranteed to be already

--- a/indico/modules/events/requests/base.py
+++ b/indico/modules/events/requests/base.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals
 from flask_pluginengine import plugin_context
 from wtforms.fields import SubmitField, TextAreaField
 
+from indico.core.config import config
 from indico.core.db import db
 from indico.modules.events.requests.notifications import (notify_accepted_request, notify_new_modified_request,
                                                           notify_rejected_request, notify_withdrawn_request)
@@ -116,6 +117,11 @@ class RequestDefinitionBase(object):
         :return: set of email addresses
         """
         return set()
+
+    @classmethod
+    def get_notification_reply_email(cls):
+        """Return the `Reply-To:` e-mail address for notifications."""
+        return config.SUPPORT_EMAIL
 
     @classmethod
     def send(cls, req, data):

--- a/indico/modules/events/timetable/templates/display/indico/meeting.html
+++ b/indico/modules/events/timetable/templates/display/indico/meeting.html
@@ -15,8 +15,6 @@
             {%- endif -%}
 
             {%- if date_changed -%}
-                {% set theme_context.num_contribution = 0 %}
-
                 {% set anchor -%}
                     day-{{ item.start_dt.date().isoformat() }}
                 {%- endset %}

--- a/indico/modules/events/timetable/templates/display/indico/meeting.html
+++ b/indico/modules/events/timetable/templates/display/indico/meeting.html
@@ -56,7 +56,7 @@
             {%- elif item.type.name == 'BREAK' -%}
                 {{ render_break(item.object, event, theme_settings, theme_context, nested=false, timezone=timezone,
                                 show_notes=theme_settings.show_notes, parent=event,
-                                show_location=show_siblings_location) }}
+                                show_location=show_siblings_location, hide_end_time=theme_settings.hide_end_time) }}
             {%- endif %}
         {%- endfor %}
 

--- a/indico/modules/events/timetable/templates/display/indico/meeting.html
+++ b/indico/modules/events/timetable/templates/display/indico/meeting.html
@@ -20,23 +20,25 @@
                 {%- endset %}
                 <li id="{{ anchor }}">
                     {% if multiple_days %}
-                        <div class="day-header" style="width: 100%;">
-                            <div class="day-title" data-anchor="{{ anchor }}">
-                                {{ item.start_dt | format_date(format='EEEE, d MMMM', timezone=timezone) }}
+                        {% block day_header scoped %}
+                            <div class="day-header" style="width: 100%;">
+                                <div class="day-title" data-anchor="{{ anchor }}">
+                                    {{ item.start_dt | format_date(format='EEEE, d MMMM', timezone=timezone) }}
+                                </div>
+                                {% if days %}
+                                    <a class="js-go-to-day icon-calendar arrow js-dropdown" data-toggle="dropdown"></a>
+                                    <ul class="dropdown days-dropdown">
+                                        {% for day, _ in days %}
+                                            <li>
+                                                <a href="#day-{{ day.isoformat() }}">
+                                                    {{ day | format_date(format='EEE, d MMM', timezone=timezone) }}
+                                                </a>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
                             </div>
-                            {% if days|length > 1 %}
-                                <a href="" class="js-go-to-day icon-calendar arrow js-dropdown" data-toggle="dropdown"></a>
-                                <ul class="dropdown days-dropdown">
-                                    {% for day, _ in days %}
-                                        <li>
-                                            <a href="#day-{{ day.isoformat() }}">
-                                                {{ day | format_date(format='EEE, d MMM', timezone=timezone) }}
-                                            </a>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                            {% endif %}
-                        </div>
+                        {% endblock %}
                     {% endif %}
                     <ul class="meeting-timetable">
             {%- endif %}

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -371,6 +371,10 @@ ul.day-list {
         border-left: 2px dotted $gray;
         padding-left: 1em;
 
+        .timetable-title {
+            font-weight: normal;
+        }
+
         .speaker-list {
             padding-top: 0.5em;
         }


### PR DESCRIPTION
This PR should set more user-friendly defaults when it comes to e-mail notifications sent by request (e.g. Webcast/Recording, in CERN plugins) workflows.

Messages sent to the event manager:
 * `From:` *no-reply address*
 * `Reply-To`:  Defined by Request Definition, *support e-mail* otherwise

This is because the user will normally want to reply back to a service-specific address, which each plugin can define.

Messages sent to the request managers (e.g. Webcast manager):
 * `From:` *no-reply address*
 * `Reply-To`: *support e-mail*

This is the same as before, only that we send the message from a *no-reply* address, which is more a more standard way of doing things.