### PR TITLE
webargs: strip() whitespace everywhere

### DIFF
--- a/indico/core/marshmallow.py
+++ b/indico/core/marshmallow.py
@@ -21,6 +21,7 @@ from webargs.flaskparser import parser as webargs_flask_parser
 
 from indico.core import signals
 from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+from indico.web.args import parser as indico_webargs_flask_parser
 
 
 mm = Marshmallow()
@@ -109,4 +110,5 @@ class IndicoModelSchema(MSQLAModelSchema, IndicoSchema):
 
 mm.Schema = IndicoSchema
 mm.ModelSchema = IndicoModelSchema
-webargs_flask_parser.schema_class = IndicoSchema
+webargs_flask_parser.schema_class = IndicoSchema  # just in case someone uses the wrong import
+indico_webargs_flask_parser.schema_class = IndicoSchema

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -11,7 +11,6 @@ from flask import flash, jsonify, redirect, render_template, request, session
 from itsdangerous import BadData, BadSignature
 from markupsafe import Markup
 from webargs import fields
-from webargs.flaskparser import use_kwargs
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from indico.core import signals
@@ -31,6 +30,7 @@ from indico.modules.users import User
 from indico.modules.users.controllers import RHUserBase
 from indico.util.i18n import _
 from indico.util.signing import secure_serializer
+from indico.web.args import use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults, IndicoForm

--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -16,7 +16,6 @@ from packaging.version import Version
 from pkg_resources import DistributionNotFound, get_distribution
 from pytz import common_timezones_set
 from webargs import fields
-from webargs.flaskparser import use_kwargs
 from werkzeug.exceptions import NotFound, ServiceUnavailable
 from werkzeug.urls import url_join, url_parse
 
@@ -35,6 +34,7 @@ from indico.modules.core.views import WPContact, WPSettings
 from indico.util.i18n import _, get_all_locales
 from indico.util.marshmallow import PrincipalList
 from indico.util.user import principal_from_identifier
+from indico.web.args import use_kwargs
 from indico.web.errors import load_error_data
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for

--- a/indico/modules/groups/controllers.py
+++ b/indico/modules/groups/controllers.py
@@ -10,10 +10,8 @@ from __future__ import unicode_literals
 from operator import attrgetter
 
 from flask import flash, jsonify, redirect, request
-from marshmallow import validate
 from sqlalchemy.orm import joinedload
 from webargs import fields
-from webargs.flaskparser import use_kwargs
 from werkzeug.exceptions import NotFound
 
 from indico.core.auth import multipass
@@ -26,6 +24,7 @@ from indico.modules.groups.util import serialize_group
 from indico.modules.groups.views import WPGroupsAdmin
 from indico.modules.users import User
 from indico.util.i18n import _
+from indico.web.args import use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults

--- a/indico/modules/rb/controllers/backend/admin.py
+++ b/indico/modules/rb/controllers/backend/admin.py
@@ -14,7 +14,7 @@ from marshmallow import missing, validate
 from marshmallow_enum import EnumField
 from sqlalchemy.orm import joinedload
 from webargs import fields
-from webargs.flaskparser import abort, use_args, use_kwargs
+from webargs.flaskparser import abort
 from werkzeug.exceptions import Forbidden, NotFound
 
 from indico.core.db import db
@@ -42,6 +42,7 @@ from indico.modules.rb.util import (build_rooms_spritesheet, get_resized_room_ph
                                     remove_room_spritesheet_photo)
 from indico.util.i18n import _
 from indico.util.marshmallow import ModelList, Principal, PrincipalList, PrincipalPermissionList
+from indico.web.args import use_args, use_kwargs
 from indico.web.flask.util import send_file
 from indico.web.util import ExpectedError
 

--- a/indico/modules/rb/controllers/backend/blockings.py
+++ b/indico/modules/rb/controllers/backend/blockings.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 
 from flask import jsonify, request, session
 from webargs import fields
-from webargs.flaskparser import use_args, use_kwargs
 from werkzeug.exceptions import Forbidden
 
 from indico.core.db import db
@@ -19,6 +18,7 @@ from indico.modules.rb.models.blockings import Blocking
 from indico.modules.rb.operations.blockings import create_blocking, get_room_blockings, update_blocking
 from indico.modules.rb.schemas import blockings_schema
 from indico.util.marshmallow import PrincipalList
+from indico.web.args import use_args, use_kwargs
 
 
 class RHCreateRoomBlocking(RHRoomBookingBase):

--- a/indico/modules/rb/controllers/backend/bookings.py
+++ b/indico/modules/rb/controllers/backend/bookings.py
@@ -13,7 +13,6 @@ import dateutil
 from flask import jsonify, request, session
 from marshmallow import fields
 from marshmallow_enum import EnumField
-from webargs.flaskparser import use_args, use_kwargs
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from indico.core import signals
@@ -37,6 +36,7 @@ from indico.modules.rb.util import (get_linked_object, group_by_occurrence_date,
                                     serialize_availability, serialize_booking_details, serialize_occurrences)
 from indico.util.date_time import now_utc, utc_to_server
 from indico.util.i18n import _
+from indico.web.args import use_args, use_kwargs
 from indico.web.util import ExpectedError
 
 

--- a/indico/modules/rb/controllers/backend/rooms.py
+++ b/indico/modules/rb/controllers/backend/rooms.py
@@ -13,7 +13,6 @@ from io import BytesIO
 from flask import jsonify, request, session
 from sqlalchemy.orm import subqueryload
 from webargs import fields
-from webargs.flaskparser import use_args, use_kwargs
 from werkzeug.exceptions import NotFound, UnprocessableEntity
 
 from indico.core.db import db
@@ -31,6 +30,7 @@ from indico.modules.rb.util import rb_is_admin
 from indico.util.caching import memoize_redis
 from indico.util.marshmallow import NaiveDateTime
 from indico.util.string import natural_sort_key
+from indico.web.args import use_args, use_kwargs
 from indico.web.flask.util import send_file
 
 

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -18,7 +18,6 @@ from marshmallow import fields
 from sqlalchemy.orm import joinedload, load_only, subqueryload, undefer
 from sqlalchemy.orm.exc import StaleDataError
 from webargs import validate
-from webargs.flaskparser import use_kwargs
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from indico.core import signals
@@ -48,6 +47,7 @@ from indico.util.i18n import _
 from indico.util.marshmallow import validate_with_message
 from indico.util.signals import values_from_signal
 from indico.util.string import make_unique_token
+from indico.web.args import use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults

--- a/indico/web/args.py
+++ b/indico/web/args.py
@@ -1,0 +1,31 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from webargs.flaskparser import FlaskParser
+
+from indico.util.string import strip_whitespace
+
+
+class IndicoFlaskParser(FlaskParser):
+    """
+    A custom webargs flask parser that strips surrounding whitespace.
+    """
+
+    def parse_arg(self, name, field, req, locations=None):
+        rv = super(IndicoFlaskParser, self).parse_arg(name, field, req, locations=locations)
+        if isinstance(rv, basestring):
+            return rv.strip()
+        elif isinstance(rv, (list, set)):
+            return type(rv)(map(strip_whitespace, rv))
+        return rv
+
+
+parser = IndicoFlaskParser()
+use_args = parser.use_args
+use_kwargs = parser.use_kwargs


### PR DESCRIPTION
Like this length validation works properly, and even if the client doesn't strip whitespace it won't end up being saved.