### PR TITLE
Fix Firefox printing only 1 page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,6 +59,7 @@ Bugfixes
 - Fix sorting book of abstracts by board number (:issue:`3429`, thanks
   :user:`bpedersen2`)
 - Enforce survey submission limit (:issue:`3256`)
+- Fix Firefox printing only 1 page issue (:issue:`3782`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,7 +59,8 @@ Bugfixes
 - Fix sorting book of abstracts by board number (:issue:`3429`, thanks
   :user:`bpedersen2`)
 - Enforce survey submission limit (:issue:`3256`)
-- Fix Firefox printing only 1 page issue (:issue:`3782`)
+- Fix Firefox printing only 1 page issue (:issue:`3782`, thanks
+  :user:`bnavigator`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -59,8 +59,7 @@ Bugfixes
 - Fix sorting book of abstracts by board number (:issue:`3429`, thanks
   :user:`bpedersen2`)
 - Enforce survey submission limit (:issue:`3256`)
-- Fix Firefox printing only 1 page issue (:issue:`3782`, thanks
-  :user:`bnavigator`)
+- Fix Firefox printing only first page (:issue:`3782`, thanks  :user:`bnavigator`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/base/_layout.scss
+++ b/indico/web/client/styles/base/_layout.scss
@@ -9,6 +9,14 @@ body {
     @extend .flexcol;
 }
 
+/* Work arond issues with Firefox which only displays the first page when
+ * printing */
+@media print {
+    body {
+        display: block;
+    }
+}
+
 body > .main {
     flex-grow: 1;
 }

--- a/indico/web/client/styles/base/_layout.scss
+++ b/indico/web/client/styles/base/_layout.scss
@@ -9,7 +9,7 @@ body {
     @extend .flexcol;
 }
 
-/* Work arond issues with Firefox which only displays the first page when
+/* Work around issues with Firefox which only displays the first page when
  * printing
  */
 @media print {

--- a/indico/web/client/styles/base/_layout.scss
+++ b/indico/web/client/styles/base/_layout.scss
@@ -9,9 +9,7 @@ body {
     @extend .flexcol;
 }
 
-/* Work around issues with Firefox which only displays the first page when
- * printing
- */
+// Work around issues with Firefox which only displays the first page when printing
 @media print {
     body {
         display: block;
@@ -22,11 +20,10 @@ body > .main {
     flex-grow: 1;
 }
 
-/* Work around issues in WebKit (used by Safari) which shrinks the contained
- * elements instead of growing the container. The following prevents the
- * children of the flexbox to be shrinked which is ok since we want the page to
- * scroll anyway.
- */
+// Work around issues in WebKit (used by Safari) which shrinks the contained
+// elements instead of growing the container. The following prevents the
+// children of the flexbox to be shrinked which is ok since we want the page to
+// scroll anyway.
 body > * {
     flex-shrink: 0;
 }

--- a/indico/web/client/styles/base/_layout.scss
+++ b/indico/web/client/styles/base/_layout.scss
@@ -10,7 +10,8 @@ body {
 }
 
 /* Work arond issues with Firefox which only displays the first page when
- * printing */
+ * printing
+ */
 @media print {
     body {
         display: block;
@@ -24,7 +25,8 @@ body > .main {
 /* Work around issues in WebKit (used by Safari) which shrinks the contained
  * elements instead of growing the container. The following prevents the
  * children of the flexbox to be shrinked which is ok since we want the page to
- * scroll anyway. */
+ * scroll anyway.
+ */
 body > * {
     flex-shrink: 0;
 }


### PR DESCRIPTION
Fix for #3782 

This fixes not only to print all pages in timetable but on all other sites, too.