### PR TITLE
Fix convener affiliation

### DIFF
--- a/indico/modules/events/sessions/templates/display/session_display.html
+++ b/indico/modules/events/sessions/templates/display/session_display.html
@@ -91,13 +91,13 @@
                             {% for convener in block.person_links -%}
                                 <li class="icon-user">
                                     {% if sess.can_manage(session.user) %}
-                                        <a href="mailto:{{ convener.person.email }}">
-                                            {{ convener.person.full_name }}
+                                        <a href="mailto:{{ convener.email }}">
+                                            {{ convener.full_name }}
                                         </a>
                                     {% else %}
-                                        {{ convener.person.full_name }}
+                                        {{ convener.full_name }}
                                     {% endif %}
-                                    ({{ convener.person.affiliation }})
+                                    ({{ convener.affiliation }})
                                 </li>
                             {%- else -%}
                                 <li>{% trans %}There are no conveners in this block{% endtrans %}</li>


### PR DESCRIPTION
This was triggered by a CERN support ticket. We should be displaying the `SessionBlockPersonLink`'s attributes, not the `EventPerson`'s.