### PR TITLE
Track groups

### DIFF
--- a/indico/migrations/versions/20190821_1515_eefba82b42c5_add_track_groups_table.py
+++ b/indico/migrations/versions/20190821_1515_eefba82b42c5_add_track_groups_table.py
@@ -1,0 +1,38 @@
+"""Add track_groups table
+
+Revision ID: eefba82b42c5
+Revises: 620b312814f3
+Create Date: 2019-07-31 15:15:48.350924
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'eefba82b42c5'
+down_revision = '620b312814f3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'track_groups',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('position', sa.Integer(), nullable=False),
+        sa.Column('description', sa.Text(), nullable=False, server_default=''),
+        sa.Column('event_id', sa.Integer(), nullable=False, index=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['event_id'], ['events.events.id']),
+        schema='events'
+    )
+    op.add_column('tracks', sa.Column('track_group_id', sa.Integer(), nullable=True, index=True), schema='events')
+    op.create_foreign_key(None, 'tracks', 'track_groups', ['track_group_id'], ['id'], source_schema='events',
+                          referent_schema='events', ondelete='SET NULL')
+
+
+def downgrade():
+    op.drop_column('tracks', 'track_group_id', schema='events')
+    op.drop_table('track_groups', schema='events')

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -30,11 +30,11 @@ from indico.modules.categories.legacy import XMLCategorySerializer
 from indico.modules.categories.models.categories import Category
 from indico.modules.categories.serialize import (serialize_categories_ical, serialize_category, serialize_category_atom,
                                                  serialize_category_chain)
-from indico.modules.categories.util import get_category_stats, get_upcoming_events, serialize_event_for_json_ld
+from indico.modules.categories.util import get_category_stats, get_upcoming_events
 from indico.modules.categories.views import WPCategory, WPCategoryCalendar, WPCategoryStatistics
 from indico.modules.events.models.events import Event
 from indico.modules.events.timetable.util import get_category_timetable
-from indico.modules.events.util import get_base_ical_parameters
+from indico.modules.events.util import get_base_ical_parameters, serialize_event_for_json_ld
 from indico.modules.news.util import get_recent_news
 from indico.modules.users import User
 from indico.modules.users.models.favorites import favorite_category_table

--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -20,13 +20,12 @@ from indico.core.db.sqlalchemy.links import LinkType
 from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.attachments import Attachment
 from indico.modules.attachments.models.folders import AttachmentFolder
-from indico.modules.categories import Category, upcoming_events_settings
+from indico.modules.categories import upcoming_events_settings
 from indico.modules.events import Event
 from indico.modules.events.contributions import Contribution
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.sessions import Session
 from indico.modules.events.timetable.models.entries import TimetableEntry, TimetableEntryType
-from indico.modules.events.util import serialize_event_for_json_ld
 from indico.util.caching import memoize_redis
 from indico.util.date_time import now_utc
 from indico.util.i18n import _, ngettext

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -404,6 +404,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     # - static_sites (StaticSite.event)
     # - surveys (Survey.event)
     # - timetable_entries (TimetableEntry.event)
+    # - track_groups (TrackGroup.event)
     # - tracks (Track.event)
     # - vc_room_associations (VCRoomEventAssociation.linked_event)
 

--- a/indico/modules/events/tracks/blueprint.py
+++ b/indico/modules/events/tracks/blueprint.py
@@ -7,8 +7,10 @@
 
 from __future__ import unicode_literals
 
-from indico.modules.events.tracks.controllers import (RHCreateTrack, RHDeleteTrack, RHDisplayTracks, RHEditProgram,
-                                                      RHEditTrack, RHManageTracks, RHSortTracks, RHTracksPDF)
+from indico.modules.events.tracks.controllers import (RHCreateTrack, RHCreateTrackGroup, RHDeleteTrack,
+                                                      RHDeleteTrackGroup, RHDisplayTracks, RHEditProgram, RHEditTrack,
+                                                      RHEditTrackGroup, RHManageTracks, RHSortTracks, RHTrackGroups,
+                                                      RHTracksPDF)
 from indico.web.flask.util import make_compat_redirect_func
 from indico.web.flask.wrappers import IndicoBlueprint
 
@@ -22,6 +24,13 @@ _bp.add_url_rule('/manage/tracks/create', 'create_track', RHCreateTrack, methods
 _bp.add_url_rule('/manage/tracks/sort', 'sort_tracks', RHSortTracks, methods=('POST',))
 _bp.add_url_rule('/manage/tracks/<int:track_id>', 'edit_track', RHEditTrack, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/tracks/<int:track_id>', 'delete_track', RHDeleteTrack, methods=('DELETE',))
+
+_bp.add_url_rule('/manage/track-groups', 'track_groups', RHTrackGroups)
+_bp.add_url_rule('/manage/track-groups/create', 'create_track_group', RHCreateTrackGroup, methods=('GET', 'POST'))
+_bp.add_url_rule('/manage/track-groups/<int:track_group_id>', 'edit_track_group', RHEditTrackGroup,
+                 methods=('GET', 'POST'))
+_bp.add_url_rule('/manage/track-groups/<int:track_group_id>', 'delete_track_group', RHDeleteTrackGroup,
+                 methods=('DELETE',))
 
 _bp.add_url_rule('/program', 'program', RHDisplayTracks)
 _bp.add_url_rule('/program.pdf', 'program_pdf', RHTracksPDF)

--- a/indico/modules/events/tracks/forms.py
+++ b/indico/modules/events/tracks/forms.py
@@ -13,6 +13,7 @@ from wtforms.validators import DataRequired
 
 from indico.core.db.sqlalchemy.descriptions import RenderMode
 from indico.modules.events.sessions.models.sessions import Session
+from indico.modules.events.tracks.models.groups import TrackGroup
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm, generated_data
 from indico.web.forms.fields import IndicoMarkdownField
@@ -21,6 +22,8 @@ from indico.web.forms.fields import IndicoMarkdownField
 class TrackForm(IndicoForm):
     title = StringField(_('Title'), [DataRequired()])
     code = StringField(_('Code'))
+    track_group = QuerySelectField(_('Track group'), default='', allow_blank=True, get_label='title',
+                                   description=_('Select a track group to which this track should belong'))
     default_session = QuerySelectField(_('Default session'), default='', allow_blank=True, get_label='title',
                                        description=_('Indico will preselect this session whenever an abstract is '
                                                      'accepted for the track'))
@@ -30,6 +33,7 @@ class TrackForm(IndicoForm):
         event = kwargs.pop('event')
         super(TrackForm, self).__init__(*args, **kwargs)
         self.default_session.query = Session.query.with_parent(event)
+        self.track_group.query = TrackGroup.query.with_parent(event)
 
 
 class ProgramForm(IndicoForm):

--- a/indico/modules/events/tracks/forms.py
+++ b/indico/modules/events/tracks/forms.py
@@ -42,3 +42,8 @@ class ProgramForm(IndicoForm):
     @generated_data
     def program_render_mode(self):
         return RenderMode.markdown
+
+
+class TrackGroupForm(IndicoForm):
+    title = StringField(_('Title'), [DataRequired()])
+    description = IndicoMarkdownField(_('Description'), editor=True)

--- a/indico/modules/events/tracks/models/groups.py
+++ b/indico/modules/events/tracks/models/groups.py
@@ -1,0 +1,67 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from indico.core.db.sqlalchemy import db
+from indico.core.db.sqlalchemy.descriptions import DescriptionMixin, RenderMode
+from indico.modules.events.tracks.models.tracks import get_next_position
+from indico.util.locators import locator_property
+from indico.util.string import format_repr, return_ascii, text_to_repr
+
+
+class TrackGroup(DescriptionMixin, db.Model):
+    __tablename__ = 'track_groups'
+    __table_args__ = {'schema': 'events'}
+
+    possible_render_modes = {RenderMode.markdown}
+    default_render_mode = RenderMode.markdown
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+
+    title = db.Column(
+        db.String,
+        nullable=False
+    )
+
+    position = db.Column(
+        db.Integer,
+        nullable=False,
+        default=get_next_position
+    )
+
+    event_id = db.Column(
+        db.Integer,
+        db.ForeignKey('events.events.id'),
+        index=True,
+        nullable=False
+    )
+
+    event = db.relationship(
+        'Event',
+        lazy=True,
+        backref=db.backref(
+            'track_groups',
+            cascade='all, delete-orphan',
+            lazy=True,
+            order_by=id
+        )
+    )
+
+    # relationship backrefs:
+    # - tracks (Track.track_group)
+
+    @locator_property
+    def locator(self):
+        return dict(self.event.locator, track_group_id=self.id)
+
+    @return_ascii
+    def __repr__(self):
+        return format_repr(self, 'id', _text=text_to_repr(self.title))

--- a/indico/modules/events/tracks/operations.py
+++ b/indico/modules/events/tracks/operations.py
@@ -12,6 +12,7 @@ from flask import session
 from indico.core.db import db
 from indico.modules.events.logs import EventLogKind, EventLogRealm
 from indico.modules.events.tracks import logger
+from indico.modules.events.tracks.models.groups import TrackGroup
 from indico.modules.events.tracks.models.tracks import Track
 from indico.modules.events.tracks.settings import track_settings
 
@@ -43,3 +44,26 @@ def update_program(event, data):
     track_settings.set_multi(event, data)
     logger.info('Program of %r updated by %r', event, session.user)
     event.log(EventLogRealm.management, EventLogKind.change, 'Tracks', 'The program has been updated', session.user)
+
+
+def create_track_group(event, data):
+    track_group = TrackGroup()
+    track_group.event = event
+    track_group.populate_from_dict(data)
+    db.session.flush()
+    logger.info('Track group %r created by %r', track_group, session.user)
+    event.log(EventLogRealm.management, EventLogKind.positive, 'Track Groups',
+              'Track group "{}" has been created.'.format(track_group.title), session.user)
+
+
+def update_track_group(track_group, data):
+    track_group.populate_from_dict(data)
+    db.session.flush()
+    logger.info('Track group %r updated by %r', track_group, session.user)
+    track_group.event.log(EventLogRealm.management, EventLogKind.positive, 'Track Groups',
+                          'Track group "{}" has been updated.'.format(track_group.title), session.user)
+
+
+def delete_track_group(track_group):
+    db.session.delete(track_group)
+    logger.info('Track group deleted by %r: %r', session.user, track_group)


### PR DESCRIPTION
So, `update/create` operations are just stubs for now since I am not sure at the moment how we will let users assign tracks to track groups.

At the moment I see two options:
- Using one form to `create/update` a `TrackGroup` which would proabably include a new field allowing to select which tracks belong to the new/updated track group;
- Using the `TrackGroupForm` only for stuff like e.g. `title` and then have a separate place in which users would assign tracks to track groups.