### PR TITLE
Clearly log when a booking gets split in its log

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Bugfixes
 - Add missing slash to the ``template_prefix`` of the ``designer`` module
 - Always use HH:MM time format in book-from-event link
 - Fix timetable theme when set to "indico weeks view" before 2.2 (:issue:`4027`)
+- Avoid flickering of booking edit details tooltip
 
 Version 2.2
 -----------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Improvements
 ^^^^^^^^^^^^
 
 - Make list of event room bookings sortable (:issue:`4022`)
+- Log when a booking is split during editing (:issue:`4031`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/rb/client/js/util.jsx
+++ b/indico/modules/rb/client/js/util.jsx
@@ -143,7 +143,7 @@ export function isDateWithinRange(date, dateRange, _toMoment) {
 
 export function PopupParam({content, children}) {
   const trigger = <span>{children}</span>;
-  return <Popup trigger={trigger} content={content} />;
+  return <Popup trigger={trigger} content={content} position="right center" />;
 }
 
 PopupParam.propTypes = {

--- a/indico/modules/rb/operations/bookings.py
+++ b/indico/modules/rb/operations/bookings.py
@@ -24,6 +24,7 @@ from indico.core.errors import NoReportError
 from indico.modules.events.models.events import Event
 from indico.modules.events.models.principals import EventPrincipal
 from indico.modules.rb import rb_settings
+from indico.modules.rb.models.reservation_edit_logs import ReservationEditLog
 from indico.modules.rb.models.reservation_occurrences import ReservationOccurrence
 from indico.modules.rb.models.reservations import RepeatFrequency, Reservation, ReservationLink
 from indico.modules.rb.models.room_nonbookable_periods import NonBookablePeriod
@@ -419,6 +420,15 @@ def split_booking(booking, new_booking_data):
             new_occ.cancel(None, silent=True)
         if new_occ_start in rejected_occs:
             new_occ.reject(None, rejected_occs[new_occ_start], silent=True)
+
+    booking.edit_logs.append(ReservationEditLog(user_name=session.user.full_name, info=[
+        'Split into a new booking',
+        'booking_link:{}'.format(resv.id)
+    ]))
+    resv.edit_logs.append(ReservationEditLog(user_name=session.user.full_name, info=[
+        'Split from another booking',
+        'booking_link:{}'.format(booking.id)
+    ]))
     return resv
 
 


### PR DESCRIPTION
Right now we have absolutely nothing in the log of any of the bookings when editing it resulted in a split, which leads to confused users (team members: see `INC2082467`) and wasted time for everyone involved when trying to figure out what happened.

We should log:

- that the old booking has been split (ideally including the new booking ID even though we can't easily make it clickable). Maybe also log the new repetition/dates/times in the old booking?
- in the new booking that it has been split from another booking (ideally also including the old booking ID)

Instead of the booking ID we could also include the link to the other booking... again, probably not clickable, but makes figuring out what happened so much easier...