### PR TITLE
Provide valid link to book room on multi-day event

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Improvements
 
 - Make list of event room bookings sortable (:issue:`4022`)
 - Log when a booking is split during editing (:issue:`4031`)
+- Improve "Book" button in multi-day events (:issue:`4021`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -825,7 +825,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         if tzinfo:
             start_dt = start_dt.astimezone(tzinfo)
             end_dt = end_dt.astimezone(tzinfo)
-        duration = (end_dt - start_dt).days
+        duration = (end_dt.replace(hour=23, minute=59) - start_dt.replace(hour=0, minute=0)).days
         for offset in xrange(duration + 1):
             yield (start_dt + timedelta(days=offset)).date()
 

--- a/indico/modules/events/timetable/testing/fixtures.py
+++ b/indico/modules/events/timetable/testing/fixtures.py
@@ -13,11 +13,11 @@ from indico.modules.events.timetable.models.entries import TimetableEntry
 
 
 @pytest.fixture
-def create_entry(db, dummy_event):
+def create_entry(db):
     """Returns a a callable which lets you create timetable"""
 
     def _create_entry(obj, start_dt):
-        entry = TimetableEntry(event=dummy_event, object=obj, start_dt=start_dt)
+        entry = TimetableEntry(event=obj.event, object=obj, start_dt=start_dt)
         db.session.add(entry)
         db.session.flush()
         return entry

--- a/indico/modules/events/timetable/util_test.py
+++ b/indico/modules/events/timetable/util_test.py
@@ -13,9 +13,6 @@ from pytz import utc
 from indico.modules.events.timetable.util import find_latest_entry_end_dt
 
 
-pytest_plugins = ('indico.modules.events.timetable.testing.fixtures',)
-
-
 @pytest.mark.parametrize(('event_start_dt', 'event_end_dt', 'day', 'valid'), (
     (datetime(2016, 1, 2, tzinfo=utc), datetime(2016, 1, 4, 23, 59, tzinfo=utc), date(2016, 1, 2), True),
     (datetime(2016, 1, 2, tzinfo=utc), datetime(2016, 1, 4, 23, 59, tzinfo=utc), date(2016, 1, 3), True),

--- a/indico/modules/rb/event/client/js/index.js
+++ b/indico/modules/rb/event/client/js/index.js
@@ -31,4 +31,18 @@ $(document).ready(() => {
     }
     $bookBtn.toggleClass('disabled', !objectId).attr('href', rbURL({path: 'book', ...params}));
   });
+
+  const eventDay = document.querySelector('#event-day');
+
+  if (eventDay) {
+    eventDay.addEventListener('change', e => {
+      const target = e.target;
+      const link = target.closest('.toolbar').querySelector('a');
+      const defaultParams = link.dataset.defaultParams;
+      link.href = rbURL({
+        path: 'book',
+        ...Object.assign(JSON.parse(defaultParams), JSON.parse(target.value)),
+      });
+    });
+  }
 });

--- a/indico/modules/rb/event/client/js/index.js
+++ b/indico/modules/rb/event/client/js/index.js
@@ -31,18 +31,4 @@ $(document).ready(() => {
     }
     $bookBtn.toggleClass('disabled', !objectId).attr('href', rbURL({path: 'book', ...params}));
   });
-
-  const eventDay = document.querySelector('#event-day');
-
-  if (eventDay) {
-    eventDay.addEventListener('change', e => {
-      const target = e.target;
-      const link = target.closest('.toolbar').querySelector('a');
-      const defaultParams = link.dataset.defaultParams;
-      link.href = rbURL({
-        path: 'book',
-        ...Object.assign(JSON.parse(defaultParams), JSON.parse(target.value)),
-      });
-    });
-  }
 });

--- a/indico/modules/rb/event/controllers.py
+++ b/indico/modules/rb/event/controllers.py
@@ -18,6 +18,7 @@ from indico.modules.events.timetable import TimetableEntry
 from indico.modules.rb.controllers import RHRoomBookingBase
 from indico.modules.rb.event.forms import BookingListForm
 from indico.modules.rb.models.reservations import Reservation, ReservationLink
+from indico.modules.rb.util import get_booking_params_for_event
 from indico.modules.rb.views import WPEventBookingList
 from indico.util.date_time import format_datetime, now_utc
 from indico.util.string import to_unicode
@@ -67,17 +68,7 @@ class RHEventBookingList(RHRoomBookingEventBase):
         session_blocks_data = {sb.id: {'start_dt': sb.start_dt.isoformat(), 'end_dt': sb.end_dt.isoformat()}
                                for sb in _session_block_query(self.event)}
         is_past_event = self.event.end_dt < now_utc()
-        is_single_day = self.event.start_dt.date() == self.event.end_dt.date()
-        event_rb_params = {'link_type': 'event',
-                           'link_id': self.event.id,
-                           'recurrence': 'single' if is_single_day else 'daily',
-                           'number': 1,
-                           'interval': 'week',
-                           'sd': self.event.start_dt_local.date().isoformat(),
-                           'ed': None if is_single_day else self.event.end_dt_local.date().isoformat(),
-                           'st': self.event.start_dt_local.strftime('%H:%M'),
-                           'et': self.event.end_dt_local.strftime('%H:%M'),
-                           'text': self.event.room.name if self.event.room else None}
+        event_rb_params = get_booking_params_for_event(self.event)
         return WPEventBookingList.render_template('booking_list.html', self.event,
                                                   form=form,
                                                   links=links,

--- a/indico/modules/rb/templates/booking_list.html
+++ b/indico/modules/rb/templates/booking_list.html
@@ -16,25 +16,33 @@
                     {{ event.title }}
                 </div>
                 <div class="toolbar">
+                    {% set past_title = _('Event has already finished') %}
                     {% if event_rb_params.type == 'mixed_times' %}
-                        <select id="event-day" autocomplete="off">
-                            {% for day, params in event_rb_params.time_info %}
-                                <option value="{{ params | tojson | forceescape }}">
-                                    {{ day | format_date(timezone=event.tz) }}
-                                </option>
+                        <button type="button"
+                                class="i-button highlight js-dropdown arrow"
+                                title="{{ past_title if is_past_event }}"
+                                data-toggle="dropdown"
+                                {% if is_past_event %}disabled{% endif %}>
+                            {%- trans %}Book{% endtrans -%}
+                        </button>
+                        <ul class="dropdown">
+                            {% for day, day_params in event_rb_params.time_info %}
+                                {% set params = dict(event_rb_params.params, **day_params) %}
+                                <li>
+                                    <a href="{{ url_for('rb.roombooking', path='book', **params) }}" target="_blank">
+                                        {{ day | format_date(timezone=event.tz) }}
+                                    </a>
+                                </li>
                             {% endfor %}
-                        </select>
-                        {% set params = dict(event_rb_params.params, **event_rb_params.time_info[0][1]) %}
+                        </ul>
                     {% else %}
-                        {% set params = event_rb_params.params %}
+                        <a href="{{ url_for('rb.roombooking', path='book', **event_rb_params.params) }}"
+                           target="_blank"
+                           class="i-button highlight {{ 'disabled' if is_past_event }}"
+                           title="{{ past_title if is_past_event }}">
+                            {%- trans %}Book{% endtrans -%}
+                        </a>
                     {% endif %}
-                    {% set title = _('Event has already finished') %}
-                    <a href="{{ url_for('rb.roombooking', path='book', **params) }}"
-                       data-default-params="{{ event_rb_params.params | tojson | forceescape }}"
-                       target="_blank" class="i-button highlight {{ 'disabled' if is_past_event }}"
-                       title="{{ title if is_past_event }}">
-                        {%- trans %}Book{% endtrans -%}
-                    </a>
                 </div>
             </div>
             {% if has_contribs %}

--- a/indico/modules/rb/templates/booking_list.html
+++ b/indico/modules/rb/templates/booking_list.html
@@ -17,7 +17,7 @@
                 </div>
                 <div class="toolbar">
                     {% if event_rb_params.type == 'mixed_times' %}
-                        <select id="event-day">
+                        <select id="event-day" autocomplete="off">
                             {% for day, params in event_rb_params.time_info %}
                                 <option value="{{ params | tojson | forceescape }}">
                                     {{ day | format_date(timezone=event.tz) }}
@@ -30,7 +30,7 @@
                     {% endif %}
                     {% set title = _('Event has already finished') %}
                     <a href="{{ url_for('rb.roombooking', path='book', **params) }}"
-                       data-default-params="{{ event_rb_params.params | tojson | forceescape }}""
+                       data-default-params="{{ event_rb_params.params | tojson | forceescape }}"
                        target="_blank" class="i-button highlight {{ 'disabled' if is_past_event }}"
                        title="{{ title if is_past_event }}">
                         {%- trans %}Book{% endtrans -%}

--- a/indico/modules/rb/templates/booking_list.html
+++ b/indico/modules/rb/templates/booking_list.html
@@ -16,8 +16,21 @@
                     {{ event.title }}
                 </div>
                 <div class="toolbar">
+                    {% if event_rb_params.type == 'mixed_times' %}
+                        <select id="event-day">
+                            {% for day, params in event_rb_params.time_info %}
+                                <option value="{{ params | tojson | forceescape }}">
+                                    {{ day | format_date(timezone=event.tz) }}
+                                </option>
+                            {% endfor %}
+                        </select>
+                        {% set params = dict(event_rb_params.params, **event_rb_params.time_info[0][1]) %}
+                    {% else %}
+                        {% set params = event_rb_params.params %}
+                    {% endif %}
                     {% set title = _('Event has already finished') %}
-                    <a href="{{ url_for('rb.roombooking', path='book', **event_rb_params) }}"
+                    <a href="{{ url_for('rb.roombooking', path='book', **params) }}"
+                       data-default-params="{{ event_rb_params.params | tojson | forceescape }}""
                        target="_blank" class="i-button highlight {{ 'disabled' if is_past_event }}"
                        title="{{ title if is_past_event }}">
                         {%- trans %}Book{% endtrans -%}

--- a/indico/modules/rb/util_test.py
+++ b/indico/modules/rb/util_test.py
@@ -5,11 +5,19 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from __future__ import unicode_literals
+
+from datetime import date, datetime, time, timedelta
+
 import pytest
+import pytz
 
 from indico.modules.rb import rb_settings
-from indico.modules.rb.util import rb_check_user_access, rb_is_admin
+from indico.modules.rb.util import get_booking_params_for_event, rb_check_user_access, rb_is_admin
 from indico.testing.util import bool_matrix
+
+
+pytest_plugins = ('indico.modules.rb.testing.fixtures', 'indico.modules.events.timetable.testing.fixtures')
 
 
 @pytest.mark.parametrize(('is_rb_admin', 'acl_empty', 'in_acl', 'expected'), bool_matrix('...', expect=any))
@@ -27,3 +35,73 @@ def test_rb_check_user_access(db, mocker, dummy_user, dummy_group, is_rb_admin, 
 def test_rb_is_admin(create_user, is_admin, is_rb_admin, expected):
     user = create_user(1, admin=is_admin, rb_admin=is_rb_admin)
     assert rb_is_admin(user) == expected
+
+
+@pytest.mark.parametrize(('start_dt', 'end_dt', 'expected_params'), (
+    # single-day event
+    (datetime(2019, 8, 16, 10, 0), datetime(2019, 8, 16, 13, 0), {'recurrence': 'single',
+                                                                  'interval': 'week',
+                                                                  'number': 1,
+                                                                  'sd': '2019-08-16',
+                                                                  'ed': None,
+                                                                  'st': '10:00',
+                                                                  'et': '13:00'}),
+    # multi-day event
+    (datetime(2019, 8, 16, 10, 0), datetime(2019, 8, 18, 13, 0), {'recurrence': 'daily',
+                                                                  'interval': 'week',
+                                                                  'number': 1,
+                                                                  'sd': '2019-08-16',
+                                                                  'ed': '2019-08-18',
+                                                                  'st': '10:00',
+                                                                  'et': '13:00'}),
+    # end time < start time
+    (datetime(2019, 8, 16, 16, 0), datetime(2019, 8, 18, 13, 0), {'sd': '2019-08-16'})
+))
+def test_get_booking_params_for_event_same_times(create_event, dummy_room, start_dt, end_dt, expected_params):
+    start_dt = pytz.utc.localize(start_dt)
+    end_dt = pytz.utc.localize(end_dt)
+    event = create_event(start_dt=start_dt, end_dt=end_dt, room=dummy_room)
+    params = get_booking_params_for_event(event)
+    assert params == {
+        'type': 'same_times',
+        'params': dict({
+            'link_id': event.id,
+            'link_type': 'event',
+            'text': dummy_room.name,
+        }, **expected_params)
+    }
+
+
+@pytest.mark.parametrize(('start_time', 'end_time', 'expected_params'), (
+    # start time < end time
+    (time(10), time(13), {'interval': 'week', 'number': 1, 'recurrence': 'single', 'st': '10:00', 'et': '13:00'}),
+    # end time < start time
+    (time(15), time(13), {}),
+))
+def test_get_booking_params_for_event_multiple_times(create_event, create_contribution, create_entry, dummy_room,
+                                                     start_time, end_time, expected_params):
+    start_dt = pytz.utc.localize(datetime.combine(date(2019, 8, 16), start_time))
+    end_dt = pytz.utc.localize(datetime.combine(date(2019, 8, 18), end_time))
+    event = create_event(start_dt=start_dt, end_dt=end_dt, room=dummy_room)
+    c1 = create_contribution(event, 'C1', timedelta(minutes=30))
+    c2 = create_contribution(event, 'C2', timedelta(minutes=120))
+    c3 = create_contribution(event, 'C3', timedelta(minutes=30))
+    create_entry(c1, pytz.utc.localize(datetime(2019, 8, 17, 9, 0)))
+    create_entry(c2, pytz.utc.localize(datetime(2019, 8, 17, 18, 0)))
+    create_entry(c3, pytz.utc.localize(datetime(2019, 8, 17, 19, 0)))
+    params = get_booking_params_for_event(event)
+    assert params == {
+        'type': 'mixed_times',
+        'params': {
+            'link_type': 'event',
+            'link_id': event.id,
+            'text': dummy_room.name,
+        },
+        'time_info': [
+            (date(2019, 8, 16), dict({'sd': '2019-08-16'}, **expected_params)),
+            # this day has timetable entries -> not using the event defaults
+            (date(2019, 8, 17), {'interval': 'week', 'number': 1, 'recurrence': 'single',
+                                 'sd': '2019-08-17', 'st': '09:00', 'et': '20:00'}),
+            (date(2019, 8, 18), dict({'sd': '2019-08-18'}, **expected_params))
+        ]
+    }


### PR DESCRIPTION
Still to do:
 * [x] Unit tests to make sure `get_booking_params_for_event` behaves OK
 * [x] Making the select box for the days nicer (styling + spacing)
 * [x] Final cleanup (sorry, finished this in a rush!)

![image](https://user-images.githubusercontent.com/2699/63110521-f13a4d00-bf8b-11e9-8cf6-3b677dfd8385.png)

To discuss:
 * Should we use the timezone of the RB system instead of the one of the event?
    - I know it would be silly to create an event that takes place on the campus and isn't in the same time zone, but shouldn't that be the right way to do it?


Closes #4021 