### PR TITLE
Remove occurrences of data-tooltip

### DIFF
--- a/indico/modules/categories/client/js/index.js
+++ b/indico/modules/categories/client/js/index.js
@@ -40,7 +40,7 @@ import './display';
           highlighter: {
             location: 'n',
             tooltipAxes: 'yx',
-            tooltipSeparator: $this.data('tooltip'),
+            tooltipSeparator: $this.data('qbubble'),
           },
           series: [
             {

--- a/indico/modules/events/abstracts/templates/management/_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/_abstract_list.html
@@ -33,7 +33,7 @@
 {% macro _render_abstract_state(abstract) %}
     {% set abstract_css_class = abstract.reviewing_state.css_class if abstract.can_convene(session.user) else abstract.public_state.css_class %}
     <div class="i-tag outline semantic-text state-badge {{ abstract_css_class }}"
-         data-tooltip="{{ render_num_reviews_tooltip(abstract, _render_proposed_contrib_types)|trim|forceescape }}">
+         data-qbubble="{{ render_num_reviews_tooltip(abstract, _render_proposed_contrib_types)|trim|forceescape }}">
         {% if abstract.public_state.name == 'under_review' and abstract.can_judge(session.user) %}
             {% trans count=abstract.reviews|length -%}
                 {{- count }} review

--- a/indico/modules/events/client/js/util/list_generator.js
+++ b/indico/modules/events/client/js/util/list_generator.js
@@ -219,7 +219,7 @@
         at: 'top center',
       },
       content: {
-        attr: 'data-tooltip',
+        attr: 'data-qbubble',
       },
     });
 

--- a/indico/modules/events/papers/templates/_paper_list.html
+++ b/indico/modules/events/papers/templates/_paper_list.html
@@ -4,7 +4,7 @@
 {% macro _render_paper_state(paper) %}
     {% set paper_css_class = paper.state.css_class %}
     <div class="i-tag outline semantic-text state-badge {{ paper_css_class }}"
-         data-tooltip="{{ render_num_reviews_tooltip(paper.last_revision)|trim|forceescape }}">
+         data-qbubble="{{ render_num_reviews_tooltip(paper.last_revision)|trim|forceescape }}">
         {% if paper.state.name == 'submitted' and paper.can_judge(session.user) %}
             {% trans count=paper.last_revision.reviews|length -%}
                 {{- count }} review

--- a/indico/web/templates/_statistics.html
+++ b/indico/web/templates/_statistics.html
@@ -31,7 +31,7 @@
         data-max-y="{{ data.max_y }}"
         data-label-yaxis="{{ data.label_y }}"
         data-label-xaxis="{{ data.label_x }}"
-        data-tooltip="{{ data.tooltip }}"
+        data-qbubble="{{ data.tooltip }}"
         data-values="{{ data['values']|tojson|forceescape }}">
     </div>
 {% endmacro %}


### PR DESCRIPTION
Replace `data-tooltip` with something else since it is used by `semantic.css`. That results in redundant tooltips being created.