### PR TITLE
Add marshmallow post load

### DIFF
--- a/indico/core/marshmallow.py
+++ b/indico/core/marshmallow.py
@@ -11,7 +11,7 @@ from inspect import getmro
 
 from flask_marshmallow import Marshmallow
 from flask_marshmallow.sqla import SchemaOpts
-from marshmallow import fields, post_dump, pre_load
+from marshmallow import fields, post_dump, post_load, pre_load
 from marshmallow_enum import EnumField
 from marshmallow_sqlalchemy import ModelConverter
 from marshmallow_sqlalchemy import ModelSchema as MSQLAModelSchema
@@ -95,6 +95,11 @@ class IndicoSchema(mm.Schema):
     @pre_load
     def _call_pre_load_signal(self, data, **kwargs):
         signals.plugin.schema_pre_load.send(type(self), data=data)
+        return data
+
+    @post_load
+    def _call_post_load_signal(self, data, **kwargs):
+        signals.plugin.schema_post_load.send(type(self), data=data)
         return data
 
 

--- a/indico/core/signals/plugin.py
+++ b/indico/core/signals/plugin.py
@@ -97,3 +97,15 @@ the following arguments:
 If a plugin wants to modify the data the schema will eventually load, it may do so by
 modifying the contents of ``data``.
 """)
+
+schema_post_load = _signals.signal('schema-post-load', """
+Called after a marshmallow schema is loaded. The *sender* is the schema class
+and code using this signal should always specify it. The signal is called with
+the following arguments:
+
+- ``data`` -- the data returned by marshmallow; this is usually a dict which may contain
+              more complex data types than those valid in JSON
+
+If a plugin wants to modify the resulting data, it may do so by modifying the contents of
+``data``.
+""")

--- a/indico/modules/rb/__init__.py
+++ b/indico/modules/rb/__init__.py
@@ -26,6 +26,7 @@ logger = Logger.get('rb')
 
 
 rb_settings = SettingsProxy('roombooking', {
+    'managers_edit_rooms': False,
     'excluded_categories': [],
     'notification_before_days': 2,
     'notification_before_days_weekly': 5,

--- a/indico/modules/rb/client/js/common/config/reducers.js
+++ b/indico/modules/rb/client/js/common/config/reducers.js
@@ -37,6 +37,7 @@ export default combineReducers({
         const {
           roomsSpriteToken,
           gracePeriod,
+          managersEditRooms,
           helpURL,
           contactEmail,
           hasPrivacyPolicy,
@@ -51,6 +52,7 @@ export default combineReducers({
           languages,
           tileServerURL,
           gracePeriod,
+          managersEditRooms,
           helpURL,
           hasTOS,
           tosHTML,

--- a/indico/modules/rb/client/js/common/config/selectors.js
+++ b/indico/modules/rb/client/js/common/config/selectors.js
@@ -10,6 +10,7 @@ import {RequestState} from 'indico/utils/redux';
 export const hasLoadedConfig = ({config}) => config.request.state === RequestState.SUCCESS;
 export const getRoomsSpriteToken = ({config}) => config.data.roomsSpriteToken;
 export const getTileServerURL = ({config}) => config.data.tileServerURL;
+export const canManagersEditRooms = ({config}) => config.data.managersEditRooms;
 export const getLanguages = ({config}) => config.data.languages;
 export const getBookingGracePeriod = ({config}) => config.data.gracePeriod;
 export const getHelpURL = ({config}) => config.data.helpURL;

--- a/indico/modules/rb/client/js/common/rooms/RoomEditModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/RoomEditModal.jsx
@@ -662,17 +662,18 @@ class RoomEditModal extends React.Component {
       await this.saveEquipment(roomId, availableEquipment);
       await this.saveAttributes(roomId, attributes);
       await this.saveAvailability(roomId, changedValues, nonbookablePeriods, bookableHours);
+
+      // reload room so the form gets new initialValues
+      await this.fetchRoomData(roomId);
+      this.setState({
+        wasEverSaved: true,
+        submitState,
+      });
     } catch (e) {
       submitError = handleSubmitError(e);
       submitState = 'error';
+      this.setState({submitState});
     }
-
-    // reload room so the form gets new initialValues
-    await this.fetchRoomData(roomId);
-    this.setState({
-      wasEverSaved: true,
-      submitState,
-    });
     return camelizeKeys(submitError);
   };
 
@@ -931,7 +932,21 @@ class RoomEditModal extends React.Component {
                   <Translate>Room has been successfully updated.</Translate>
                 </Message>
                 <Message styleName="submit-message" negative hidden={submitState !== 'error'}>
-                  <Translate>Room could not be updated.</Translate>
+                  <p>
+                    <Translate>Room could not be updated.</Translate>
+                  </p>
+                  <Button
+                    type="button"
+                    icon="undo"
+                    size="mini"
+                    color="red"
+                    content={Translate.string('Reset form')}
+                    onClick={() => {
+                      // reset the form
+                      this.setState({submitState: ''});
+                      fprops.form.reset();
+                    }}
+                  />
                 </Message>
               </Grid.Column>
             </Grid>

--- a/indico/modules/rb/client/js/common/rooms/RoomEditModal.module.scss
+++ b/indico/modules/rb/client/js/common/rooms/RoomEditModal.module.scss
@@ -13,7 +13,6 @@
 }
 
 .submit-message {
-    display: flex;
     margin-bottom: 10px;
 }
 

--- a/indico/modules/rb/client/js/common/rooms/selectors.js
+++ b/indico/modules/rb/client/js/common/rooms/selectors.js
@@ -10,6 +10,7 @@ import {createSelector} from 'reselect';
 
 import {RequestState} from 'indico/utils/redux';
 import {getAllUserRoomPermissions, isUserRBAdmin} from '../user/selectors';
+import {canManagersEditRooms} from '../config/selectors';
 
 export const hasLoadedEquipmentTypes = ({rooms}) =>
   rooms.requests.equipmentTypes.state === RequestState.SUCCESS ||
@@ -62,7 +63,8 @@ export const getAllRooms = createSelector(
   getAllEquipmentTypes,
   getAllUserRoomPermissions,
   isUserRBAdmin,
-  (rawRooms, equipmentTypes, allUserPermissions, isRBAdmin) => {
+  canManagersEditRooms,
+  (rawRooms, equipmentTypes, allUserPermissions, isRBAdmin, managersEditRooms) => {
     equipmentTypes = equipmentTypes.reduce((obj, eq) => ({...obj, [eq.id]: eq}), {});
     return _.fromPairs(
       rawRooms.map(room => {
@@ -88,6 +90,7 @@ export const getAllRooms = createSelector(
           book: false,
           prebook: false,
           override: false,
+          manage: false,
         };
         return [
           room.id,
@@ -95,7 +98,7 @@ export const getAllRooms = createSelector(
             ...roomData,
             equipment: equipment.map(id => equipmentTypes[id].name).sort(),
             features: sortedFeatures,
-            canUserEdit: isRBAdmin,
+            canUserEdit: permissions.manage && (isRBAdmin || managersEditRooms),
             canUserBook: permissions.book,
             canUserPrebook: permissions.prebook,
             canUserOverride: permissions.override,

--- a/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
@@ -107,6 +107,16 @@ const SettingsPage = props => {
                 />
               </Form.Group>
             </Message>
+            <FinalCheckbox
+              name="managers_edit_rooms"
+              label={Translate.string('Allow owners/managers to edit their rooms')}
+              description={
+                <Translate>
+                  By default only admins can modify rooms, but you can allow room owners and
+                  managers to modify them as well.
+                </Translate>
+              }
+            />
             <FinalInput
               name="tileserver_url"
               label={Translate.string('Tileserver URL')}

--- a/indico/modules/rb/controllers/backend/admin.py
+++ b/indico/modules/rb/controllers/backend/admin.py
@@ -11,14 +11,12 @@ from io import BytesIO
 
 from flask import jsonify, request, session
 from marshmallow import missing, validate
-from marshmallow_enum import EnumField
 from sqlalchemy.orm import joinedload
 from webargs import fields
 from webargs.flaskparser import abort
 from werkzeug.exceptions import Forbidden, NotFound
 
 from indico.core.db import db
-from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.core.marshmallow import mm
 from indico.modules.categories.models.categories import Category
 from indico.modules.rb import logger, rb_settings
@@ -28,7 +26,6 @@ from indico.modules.rb.models.equipment import EquipmentType, RoomEquipmentAssoc
 from indico.modules.rb.models.locations import Location
 from indico.modules.rb.models.map_areas import MapArea
 from indico.modules.rb.models.photos import Photo
-from indico.modules.rb.models.principals import RoomPrincipal
 from indico.modules.rb.models.room_attributes import RoomAttribute, RoomAttributeAssociation
 from indico.modules.rb.models.room_features import RoomFeature
 from indico.modules.rb.models.rooms import Room
@@ -37,11 +34,11 @@ from indico.modules.rb.operations.admin import (create_area, delete_areas, updat
 from indico.modules.rb.schemas import (AdminRoomSchema, RoomAttributeValuesSchema, admin_equipment_type_schema,
                                        admin_locations_schema, bookable_hours_schema, map_areas_schema,
                                        nonbookable_periods_schema, room_attribute_schema, room_equipment_schema,
-                                       room_feature_schema, room_update_schema)
+                                       room_feature_schema, room_update_args_schema, room_update_schema)
 from indico.modules.rb.util import (build_rooms_spritesheet, get_resized_room_photo, rb_is_admin,
                                     remove_room_spritesheet_photo)
 from indico.util.i18n import _
-from indico.util.marshmallow import ModelList, Principal, PrincipalList, PrincipalPermissionList
+from indico.util.marshmallow import ModelList, PrincipalList
 from indico.web.args import use_args, use_kwargs
 from indico.web.flask.util import send_file
 from indico.web.util import ExpectedError
@@ -426,44 +423,11 @@ class RHUpdateRoomEquipment(RHRoomAdminBase):
         return jsonify(room_update_schema.dump(self.room, many=False))
 
 
-room_update_args = {
-    'verbose_name': fields.Str(allow_none=True),
-    'site': fields.Str(allow_none=True),
-    'building': fields.String(validate=lambda x: x is not None),
-    'floor': fields.String(validate=lambda x: x is not None),
-    'number': fields.String(validate=lambda x: x is not None),
-    'longitude': fields.Float(allow_none=True),
-    'latitude': fields.Float(allow_none=True),
-    'is_reservable': fields.Bool(allow_none=True),
-    'reservations_need_confirmation': fields.Bool(allow_none=True),
-    'notification_emails': fields.List(fields.Email()),
-    'notification_before_days': fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True),
-    'notification_before_days_weekly': fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True),
-    'notification_before_days_monthly': fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True),
-    'notifications_enabled': fields.Bool(),
-    'end_notification_daily': fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True),
-    'end_notification_weekly': fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True),
-    'end_notification_monthly': fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True),
-    'end_notifications_enabled': fields.Bool(),
-    'booking_limit_days': fields.Int(validate=lambda x: x >= 1, allow_none=True),
-    'owner': Principal(validate=lambda x: x is not None, allow_none=True),
-    'key_location': fields.Str(),
-    'telephone': fields.Str(),
-    'capacity': fields.Int(validate=lambda x: x >= 1),
-    'division': fields.Str(allow_none=True),
-    'surface_area': fields.Int(validate=lambda x: x >= 0, allow_none=True),
-    'max_advance_days': fields.Int(validate=lambda x: x >= 1, allow_none=True),
-    'comments': fields.Str(),
-    'acl_entries': PrincipalPermissionList(RoomPrincipal),
-    'protection_mode': EnumField(ProtectionMode)
-}
-
-
 class RHRoom(RHRoomAdminBase):
     def _process_GET(self):
         return jsonify(room_update_schema.dump(self.room))
 
-    @use_args(room_update_args)
+    @use_args(room_update_args_schema)
     def _process_PATCH(self, args):
         update_room(self.room, args)
         RHRoomsPermissions._jsonify_user_permissions.clear_cached(session.user)
@@ -498,11 +462,11 @@ class RHRooms(RHRoomBookingAdminBase):
         rooms = Room.query.filter_by(is_deleted=False).order_by(db.func.indico.natsort(Room.full_name)).all()
         return AdminRoomSchema().jsonify(rooms, many=True)
 
-    @use_args(dict(room_update_args, **{
-        'location_id': fields.Int(required=True),
-    }))
-    def _process_POST(self, args):
+    @use_kwargs({'location_id': fields.Int(required=True)})
+    @use_args(room_update_args_schema)
+    def _process_POST(self, args, location_id):
         room = Room()
+        args['location_id'] = location_id
         update_room(room, args)
         db.session.add(room)
         db.session.flush()

--- a/indico/modules/rb/controllers/backend/misc.py
+++ b/indico/modules/rb/controllers/backend/misc.py
@@ -47,6 +47,7 @@ class RHConfig(RHRoomBookingBase):
                        languages=get_all_locales(),
                        tileserver_url=rb_settings.get('tileserver_url'),
                        grace_period=rb_settings.get('grace_period'),
+                       managers_edit_rooms=rb_settings.get('managers_edit_rooms'),
                        help_url=config.HELP_URL,
                        contact_email=config.PUBLIC_SUPPORT_EMAIL,
                        has_tos=bool(tos_url or tos_html),

--- a/indico/modules/rb/schemas.py
+++ b/indico/modules/rb/schemas.py
@@ -85,6 +85,38 @@ class RoomUpdateSchema(RoomSchema):
                                            'acl_entries', 'protection_mode')
 
 
+class RoomUpdateArgsSchema(mm.Schema):
+    verbose_name = fields.String(allow_none=True)
+    site = fields.String(allow_none=True)
+    building = fields.String(validate=lambda x: x is not None)
+    floor = fields.String(validate=lambda x: x is not None)
+    number = fields.String(validate=lambda x: x is not None)
+    longitude = fields.Float(allow_none=True)
+    latitude = fields.Float(allow_none=True)
+    is_reservable = fields.Boolean(allow_none=True)
+    reservations_need_confirmation = fields.Boolean(allow_none=True)
+    notification_emails = fields.List(fields.Email())
+    notification_before_days = fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True)
+    notification_before_days_weekly = fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True)
+    notification_before_days_monthly = fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True)
+    notifications_enabled = fields.Boolean()
+    end_notification_daily = fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True)
+    end_notification_weekly = fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True)
+    end_notification_monthly = fields.Int(validate=lambda x: 1 <= x <= 30, allow_none=True)
+    end_notifications_enabled = fields.Boolean()
+    booking_limit_days = fields.Int(validate=lambda x: x >= 1, allow_none=True)
+    owner = Principal(validate=lambda x: x is not None, allow_none=True)
+    key_location = fields.String()
+    telephone = fields.String()
+    capacity = fields.Int(validate=lambda x: x >= 1)
+    division = fields.String(allow_none=True)
+    surface_area = fields.Int(validate=lambda x: x >= 0, allow_none=True)
+    max_advance_days = fields.Int(validate=lambda x: x >= 1, allow_none=True)
+    comments = fields.String()
+    acl_entries = PrincipalPermissionList(RoomPrincipal)
+    protection_mode = EnumField(ProtectionMode)
+
+
 class RoomEquipmentSchema(mm.ModelSchema):
     class Meta:
         model = Room
@@ -347,6 +379,7 @@ rb_user_schema = RBUserSchema()
 rooms_schema = RoomSchema(many=True)
 room_attribute_values_schema = RoomAttributeValuesSchema(many=True)
 room_update_schema = RoomUpdateSchema()
+room_update_args_schema = RoomUpdateArgsSchema()
 room_equipment_schema = RoomEquipmentSchema()
 map_areas_schema = MapAreaSchema(many=True)
 reservation_occurrences_schema = ReservationOccurrenceSchema(many=True)

--- a/indico/web/client/js/react/components/principals/PermissionTree.jsx
+++ b/indico/web/client/js/react/components/principals/PermissionTree.jsx
@@ -38,6 +38,11 @@ const PermissionTree = ({tree, permissionMap, exclude, hide, disabled, onSelect}
                 trigger={triggerFactory(id, itemDisabled)}
                 content={description}
                 position="right center"
+                popperModifiers={{
+                  preventOverflow: {
+                    enabled: false,
+                  },
+                }}
                 inverted
               />
             </div>

--- a/indico/web/client/js/react/components/principals/PrincipalPermissions.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalPermissions.jsx
@@ -61,6 +61,11 @@ const PrincipalPermissions = ({
         <Popup
           key={permission}
           position="right center"
+          popperModifiers={{
+            preventOverflow: {
+              enabled: false,
+            },
+          }}
           trigger={
             <Label as="div" size="tiny" color={permissionMap[permission].color}>
               {permissionMap[permission].title}


### PR DESCRIPTION
This PR adds a signal that will be needed for https://github.com/indico/indico-plugins-cern/pull/65.
It also makes it so that errors in the room editing modal are properly displayed. There should now be a button that allows the user to reset the form in case there are issues (the previous behaviour was to reset it by default, which also erased the error messages).

![image](https://user-images.githubusercontent.com/2699/64439112-9054ef00-d0c9-11e9-9c1f-5c3f9dfb98d0.png)
