### PR TITLE
Book from event - fix bug in timezone handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Bugfixes
 ^^^^^^^^
 
 - Remove 30s timeout from dropzone file uploads
+- Fix bug affecting room booking from an event in another timezone (:issue:`4072`)
 
 Version 2.2.2
 -------------

--- a/indico/modules/rb/util.py
+++ b/indico/modules/rb/util.py
@@ -275,7 +275,7 @@ def get_booking_params_for_event(event):
         'text': event.room.name if event.room else None,
     }
     all_times = {day: (_find_first_entry_start_dt(event, day), _find_latest_entry_end_dt(event, day))
-                 for day in event.iter_days()}
+                 for day in event.iter_days(tzinfo=event.tzinfo)}
     # if the timetable is empty on a given day, use (start_dt, end_dt) of the event
     all_times = [((day, (event.start_dt_local, event.end_dt_local)) if times[0] is None else (day, times))
                  for day, times in all_times.viewitems()]

--- a/indico/modules/rb/util_test.py
+++ b/indico/modules/rb/util_test.py
@@ -105,3 +105,26 @@ def test_get_booking_params_for_event_multiple_times(create_event, create_contri
             (date(2019, 8, 18), dict({'sd': '2019-08-18'}, **expected_params))
         ]
     }
+
+
+def test_get_booking_params_timezone(create_event):
+    chicago_tz = pytz.timezone('America/Chicago')
+    start_dt = chicago_tz.localize(datetime(2019, 8, 16, 8, 0)).astimezone(pytz.utc)
+    end_dt = chicago_tz.localize(datetime(2019, 8, 18, 22, 0)).astimezone(pytz.utc)
+    event = create_event(start_dt=start_dt, end_dt=end_dt, timezone='America/Chicago')
+
+    assert get_booking_params_for_event(event) == {
+        'type': 'same_times',
+        'params': {
+            'sd': '2019-08-16',
+            'st': '08:00',
+            'ed': '2019-08-18',
+            'et': '22:00',
+            'interval': 'week',
+            'number': 1,
+            'recurrence': 'daily',
+            'link_id': event.id,
+            'link_type': 'event',
+            'text': None
+        }
+    }


### PR DESCRIPTION
This fixes an issue reported today in CERN's server.