### PR TITLE
Cloning ACL involving event roles links to role from source event.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Bugfixes
 - Fix confirmation prompt when disabling conference menu customizations
   (:issue:`4085`)
 - Fix incorrect days shown as weekend in in room booking for some locales
+- Fix ACL entries referencing event roles from the old event when cloning an
+  event with event roles in the ACL (:issue:`4090`)
 
 Version 2.2.2
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,8 @@ Bugfixes
   (:issue:`4085`)
 - Fix incorrect days shown as weekend in in room booking for some locales
 - Fix ACL entries referencing event roles from the old event when cloning an
-  event with event roles in the ACL (:issue:`4090`)
+  event with event roles in the ACL. Run ``indico maint fix-event-role-acls``
+  after updating to fix any affected ACLs (:issue:`4090`)
 
 Version 2.2.2
 -------------

--- a/indico/cli/core.py
+++ b/indico/cli/core.py
@@ -81,6 +81,11 @@ def db():
     """Perform database operations."""
 
 
+@cli.group(cls=LazyGroup, import_name='indico.cli.maintenance:cli')
+def maint():
+    """Perform maintenance operations."""
+
+
 @cli.command(context_settings={'ignore_unknown_options': True, 'allow_extra_args': True}, add_help_option=False)
 @click.pass_context
 def celery(ctx):

--- a/indico/cli/maintenance.py
+++ b/indico/cli/maintenance.py
@@ -1,0 +1,108 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+import click
+
+from indico.cli.core import cli_group
+from indico.core.db import db
+from indico.core.db.sqlalchemy.principals import PrincipalType
+from indico.core.db.sqlalchemy.util.models import get_simple_column_attrs
+from indico.modules.attachments import Attachment, AttachmentFolder
+from indico.modules.attachments.models.principals import AttachmentFolderPrincipal, AttachmentPrincipal
+from indico.modules.events.contributions import Contribution
+from indico.modules.events.contributions.models.principals import ContributionPrincipal
+from indico.modules.events.models.principals import EventPrincipal
+from indico.modules.events.models.roles import EventRole
+from indico.modules.events.sessions import Session
+from indico.modules.events.sessions.models.principals import SessionPrincipal
+
+
+click.disable_unicode_literals_warning = True
+
+
+@cli_group()
+def cli():
+    pass
+
+
+def _fix_role_principals(principals, get_event):
+    role_attrs = get_simple_column_attrs(EventRole) | {'members'}
+    for p in principals:
+        click.echo('Fixing {}'.format(p))
+        event = get_event(p)
+        try:
+            event_role = [r for r in event.roles if r.code == p.event_role.code][0]
+        except IndexError:
+            event_role = EventRole(event=event)
+            event_role.populate_from_attrs(p.event_role, role_attrs)
+        else:
+            click.echo('  using existing role {}'.format(event_role))
+        p.event_role = event_role
+    db.session.flush()
+
+
+@cli.command()
+def fix_event_role_acls():
+    """Fixes ACLs referencing event roles from other events.
+
+    This happened due to a bug prior to 2.2.3 when cloning an event
+    which had event roles in its ACL.
+    """
+    fixed_something = False
+    broken = (EventPrincipal.query
+              .join(EventRole, EventRole.id == EventPrincipal.event_role_id)
+              .filter(EventPrincipal.type == PrincipalType.event_role, EventPrincipal.event_id != EventRole.event_id)
+              .all())
+    _fix_role_principals(broken, lambda p: p.event)
+    fixed_something = fixed_something or bool(broken)
+
+    broken = (SessionPrincipal.query
+              .join(Session, Session.id == SessionPrincipal.session_id)
+              .join(EventRole, EventRole.id == SessionPrincipal.event_role_id)
+              .filter(SessionPrincipal.type == PrincipalType.event_role, Session.event_id != EventRole.event_id)
+              .all())
+    _fix_role_principals(broken, lambda p: p.session.event)
+    fixed_something = fixed_something or bool(broken)
+
+    broken = (ContributionPrincipal.query
+              .join(Contribution, Contribution.id == ContributionPrincipal.contribution_id)
+              .join(EventRole, EventRole.id == ContributionPrincipal.event_role_id)
+              .filter(ContributionPrincipal.type == PrincipalType.event_role,
+                      Contribution.event_id != EventRole.event_id)
+              .all())
+    _fix_role_principals(broken, lambda p: p.contribution.event)
+    fixed_something = fixed_something or bool(broken)
+
+    broken = (AttachmentFolderPrincipal.query
+              .join(AttachmentFolder, AttachmentFolder.id == AttachmentFolderPrincipal.folder_id)
+              .join(EventRole, EventRole.id == AttachmentFolderPrincipal.event_role_id)
+              .filter(AttachmentFolderPrincipal.type == PrincipalType.event_role,
+                      AttachmentFolder.event_id != EventRole.event_id)
+              .all())
+    _fix_role_principals(broken, lambda p: p.folder.event)
+    fixed_something = fixed_something or bool(broken)
+
+    broken = (AttachmentPrincipal.query
+              .join(Attachment, Attachment.id == AttachmentPrincipal.attachment_id)
+              .join(AttachmentFolder, AttachmentFolder.id == Attachment.folder_id)
+              .join(EventRole, EventRole.id == AttachmentPrincipal.event_role_id)
+              .filter(AttachmentPrincipal.type == PrincipalType.event_role,
+                      AttachmentFolder.event_id != EventRole.event_id)
+              .all())
+    _fix_role_principals(broken, lambda p: p.attachment.folder.event)
+    fixed_something = fixed_something or bool(broken)
+
+    if not fixed_something:
+        click.secho('Nothing to fix :)', fg='green')
+        return
+
+    click.confirm(click.style('Do you want to commit the fixes shown above?', fg='white', bold=True),
+                  default=True, abort=True)
+    db.session.commit()
+    click.secho('Success!', fg='green')

--- a/indico/modules/events/clone.py
+++ b/indico/modules/events/clone.py
@@ -96,8 +96,10 @@ class EventProtectionCloner(EventCloner):
     name = 'event_protection'
     friendly_name = _('ACLs and protection settings')
     is_default = True
+    uses = {'event_roles'}
 
     def run(self, new_event, cloners, shared_data):
+        self._event_role_map = shared_data['event_roles']['event_role_map'] if 'event_roles' in cloners else None
         with db.session.no_autoflush:
             self._clone_protection(new_event)
             self._clone_session_coordinator_privs(new_event)
@@ -120,4 +122,4 @@ class EventProtectionCloner(EventCloner):
         })
 
     def _clone_acl(self, new_event):
-        new_event.acl_entries = clone_principals(EventPrincipal, self.old_event.acl_entries)
+        new_event.acl_entries = clone_principals(EventPrincipal, self.old_event.acl_entries, self._event_role_map)

--- a/indico/modules/events/contributions/clone.py
+++ b/indico/modules/events/contributions/clone.py
@@ -78,6 +78,7 @@ class ContributionCloner(EventCloner):
     name = 'contributions'
     friendly_name = _('Contributions')
     requires = {'event_persons', 'sessions', 'contribution_types', 'contribution_fields'}
+    uses = {'event_roles'}
     is_internal = True
 
     # We do not override `is_available` as we have cloners depending
@@ -112,6 +113,7 @@ class ContributionCloner(EventCloner):
         return new_contribution
 
     def run(self, new_event, cloners, shared_data):
+        self._event_role_map = shared_data['event_roles']['event_role_map'] if 'event_roles' in cloners else None
         self._person_map = shared_data['event_persons']['person_map']
         self._session_map = shared_data['sessions']['session_map']
         self._session_block_map = shared_data['sessions']['session_block_map']
@@ -132,7 +134,7 @@ class ContributionCloner(EventCloner):
         new_contrib = Contribution()
         new_contrib.populate_from_attrs(old_contrib, attrs)
         new_contrib.subcontributions = list(self._clone_subcontribs(old_contrib.subcontributions))
-        new_contrib.acl_entries = clone_principals(ContributionPrincipal, old_contrib.acl_entries)
+        new_contrib.acl_entries = clone_principals(ContributionPrincipal, old_contrib.acl_entries, self._event_role_map)
         new_contrib.references = list(self._clone_references(ContributionReference, old_contrib.references))
         new_contrib.person_links = list(self._clone_person_links(ContributionPersonLink, old_contrib.person_links))
         new_contrib.field_values = list(self._clone_fields(old_contrib.field_values))

--- a/indico/modules/events/roles/__init__.py
+++ b/indico/modules/events/roles/__init__.py
@@ -24,3 +24,9 @@ def _sidemenu_items(sender, event, **kwargs):
     if event.can_manage(session.user):
         roles_section = 'organization' if event.type == 'conference' else 'advanced'
         return SideMenuItem('roles', _('Roles Setup'), url_for('event_roles.manage', event), section=roles_section)
+
+
+@signals.event_management.get_cloners.connect
+def _get_event_roles_cloner(sender, **kwargs):
+    from indico.modules.events.roles.clone import EventRoleCloner
+    return EventRoleCloner

--- a/indico/modules/events/roles/clone.py
+++ b/indico/modules/events/roles/clone.py
@@ -1,0 +1,45 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from indico.core.db import db
+from indico.core.db.sqlalchemy.util.models import get_simple_column_attrs
+from indico.core.db.sqlalchemy.util.session import no_autoflush
+from indico.modules.events.cloning import EventCloner
+from indico.modules.events.models.events import EventType
+from indico.modules.events.models.roles import EventRole
+from indico.util.i18n import _
+
+
+class EventRoleCloner(EventCloner):
+    name = 'event_roles'
+    friendly_name = _('Event roles')
+    is_default = True
+
+    @property
+    def is_visible(self):
+        return self.old_event.type_ == EventType.conference
+
+    @property
+    def is_available(self):
+        return bool(self.old_event.roles)
+
+    def run(self, new_event, cloners, shared_data):
+        self._event_role_map = {}
+        self._clone_event_roles(new_event)
+        db.session.flush()
+        return {'event_role_map': self._event_role_map}
+
+    @no_autoflush
+    def _clone_event_roles(self, new_event):
+        attrs = get_simple_column_attrs(EventRole) | {'members'}
+        for old_event_role in self.old_event.roles:
+            event_role = EventRole()
+            event_role.populate_from_attrs(old_event_role, attrs)
+            new_event.roles.append(event_role)
+            self._event_role_map[old_event_role] = event_role

--- a/indico/modules/events/sessions/clone.py
+++ b/indico/modules/events/sessions/clone.py
@@ -24,12 +24,14 @@ class SessionCloner(EventCloner):
     name = 'sessions'
     friendly_name = _('Sessions')
     requires = {'event_persons'}
+    uses = {'event_roles'}
     is_internal = True
 
     # We do not override `is_available` as we have cloners depending
     # on this internal cloner even if it won't clone anything.
 
     def run(self, new_event, cloners, shared_data):
+        self._event_role_map = shared_data['event_roles']['event_role_map'] if 'event_roles' in cloners else None
         self._person_map = shared_data['event_persons']['person_map']
         self._session_map = {}
         self._session_block_map = {}
@@ -50,7 +52,7 @@ class SessionCloner(EventCloner):
             sess = Session()
             sess.populate_from_attrs(old_sess, attrs)
             sess.blocks = list(self._clone_session_blocks(old_sess.blocks))
-            sess.acl_entries = clone_principals(SessionPrincipal, old_sess.acl_entries)
+            sess.acl_entries = clone_principals(SessionPrincipal, old_sess.acl_entries, self._event_role_map)
             new_event.sessions.append(sess)
             self._session_map[old_sess] = sess
 


### PR DESCRIPTION
When cloning an event that has event roles in the ACL, the new event will still reference the event roles from the old event. We need to clone any event roles that are used in an ACL instead (or just clone all of them when using the `EventProtectionCloner` since they are kind of related to "ACLs and protection settings" anyway)

https://talk.getindico.io/t/participant-role-clone-problem/1452

---

Added an explicit "Event roles" cloner option, and depending on whether it's selected or not, role entries in the ACLs will either be skipped or correctly cloned (with a reference to the cloned event role).

Also added a new CLI command `indico maint fix-event-role-acls` which fixes any ACL entries that reference a role from another event.