### PR TITLE
Add minimal technical docs to paper reviewing module

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,9 @@ PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
+HOST ?= 127.0.0.1
+PORT ?= 8000
+
 .PHONY: help clean html dirhtml pickle json htmlhelp qthelp latex changes linkcheck doctest
 
 help:
@@ -36,7 +39,7 @@ html:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 livehtml:
-	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -H $(HOST) -p $(PORT)
 
 coverage:
 	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage

--- a/docs/source/api/paper.rst
+++ b/docs/source/api/paper.rst
@@ -10,6 +10,22 @@ Paper
 Models
 ++++++
 
+.. indico_uml::
+
+    User "1" --* PaperRevision : submitter
+    User "1" --* PaperRevision : judge
+    PaperRevision *-- "1" Contribution
+    PaperRevision "1" --* PaperFile
+    PaperReview *-- "1" PaperRevision
+    PaperReviewComment *-- "1" PaperRevision
+    PaperReviewComment *-- "1" User : creator
+    User "1" --* PaperReview : reviewer
+    PaperReview "1" --* PaperReviewRating
+    PaperReviewRating  *-- "1" PaperReviewQuestion
+    Contribution *--* User : judge
+    Contribution *--* User : content_reviewer
+    Contribution *--* User : layout_reviewer
+
 .. automodule:: indico.modules.events.papers.models.call_for_papers
     :members:
     :undoc-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,7 @@ import warnings
 import sphinx_rtd_theme
 from sqlalchemy.exc import SAWarning
 
+
 # silence sqlalchemy SAWarning
 warnings.simplefilter('ignore', SAWarning)
 
@@ -45,7 +46,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.imgmath',
               'sphinx.ext.intersphinx',
               'sphinx_issues',
-              'exec_directive']
+              'exec_directive',
+              'indico_uml_directive']
 
 # sphinx-issues config
 issues_github_path = 'indico/indico'
@@ -229,3 +231,14 @@ latex_documents = [
 #latex_use_modindex = True
 
 todo_include_todos = True
+
+indico_uml_prelude = """skinparam shadowing false
+skinparam defaultFontColor motivation
+skinparam defaultFontName Helvetica
+skinparam class {
+    FontColor tomato
+    BackgroundColor moccasin
+    BorderColor moccasin
+    ArrowColor slategray
+}
+skinparam classStereotypeFontSize 1"""

--- a/docs/source/indico_uml_directive.py
+++ b/docs/source/indico_uml_directive.py
@@ -1,0 +1,37 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+"""
+A simple Sphinx directive which extends plantweb's `directive`.
+
+The config setting `indico_uml_prelude` can be used to include
+additional plantuml code before every `indico_uml` block.
+"""
+
+from docutils.statemachine import StringList
+from plantweb.directive import UmlDirective
+
+
+class IndicoUMLDirective(UmlDirective):
+    def run(self):
+        env = self.state_machine.document.settings.env
+        lines = env.config.indico_uml_prelude.split('\n')
+        content = StringList()
+        for n, l in enumerate(lines):
+            content.append(l, source='diagram', offset=n)
+        for n, l in enumerate(self.content, n + 1):
+            content.append(l, source='diagram', offset=n)
+        self.content = content
+        return super(IndicoUMLDirective, self).run()
+
+    def _get_directive_name(self):
+        return 'indico_uml'
+
+
+def setup(app):
+    app.add_directive('indico_uml', IndicoUMLDirective)
+    app.add_config_value('indico_uml_prelude', '', True)

--- a/indico/modules/events/papers/__init__.py
+++ b/indico/modules/events/papers/__init__.py
@@ -5,6 +5,12 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+"""
+The ``papers`` module handles the Indico's Paper Reviewing workflow.
+The "inputs" of this module are the conference papers, which will be uploaded
+by the corresponding authors/submitters.
+"""
+
 from __future__ import unicode_literals
 
 from flask import session

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -11,3 +11,4 @@ sqlparse
 isort
 pycodestyle
 flask_url_map_serializer
+plantweb


### PR DESCRIPTION
Also adds support for rending [`plantuml`](http://www.plantuml.com) syntax using [`plantweb`](https://plantweb.readthedocs.io/). Graphviz and [ditaa](http://ditaa.sourceforge.net/) also supported out of the box.

Rendered result:

![image](https://user-images.githubusercontent.com/2699/67875903-59ceaa00-fb37-11e9-96ad-373bd2f42503.png)

