### PR TITLE
Check OAuth only if `Authorization` header is OK

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Bugfixes
 - Fix an issue causing errors when using translations for languages with no plural
   forms (like Chinese).
 - Fix creating rooms without touching the longitude/latitude fields (:issue:`4115`)
+- Fix error in HTTP API when Basic auth headers are present (:issue:`4123`,
+  thanks :user:`uxmaster`)
 
 Version 2.2.4
 -------------

--- a/indico/web/http_api/handlers.py
+++ b/indico/web/http_api/handlers.py
@@ -129,8 +129,8 @@ def handler(prefix, path):
     onlyPublic = get_query_parameter(queryParams, ['op', 'onlypublic'], 'no') == 'yes'
     onlyAuthed = get_query_parameter(queryParams, ['oa', 'onlyauthed'], 'no') == 'yes'
     scope = 'read:legacy_api' if request.method == 'GET' else 'write:legacy_api'
-    authHeader = request.headers.get('Authorization')
-    if authHeader and authHeader[:5].lower() != 'basic':
+
+    if not request.headers.get('Authorization', '').lower().startswith('basic '):
         try:
             oauth_valid, oauth_request = oauth.verify_request([scope])
             if not oauth_valid and oauth_request and oauth_request.error_message != 'Bearer token not found.':

--- a/indico/web/http_api/handlers.py
+++ b/indico/web/http_api/handlers.py
@@ -129,16 +129,20 @@ def handler(prefix, path):
     onlyPublic = get_query_parameter(queryParams, ['op', 'onlypublic'], 'no') == 'yes'
     onlyAuthed = get_query_parameter(queryParams, ['oa', 'onlyauthed'], 'no') == 'yes'
     scope = 'read:legacy_api' if request.method == 'GET' else 'write:legacy_api'
-    try:
-        oauth_valid, oauth_request = oauth.verify_request([scope])
-        if not oauth_valid and oauth_request and oauth_request.error_message != 'Bearer token not found.':
-            raise BadRequest('OAuth error: {}'.format(oauth_request.error_message))
-        elif g.get('received_oauth_token') and oauth_request.error_message == 'Bearer token not found.':
-            raise BadRequest('OAuth error: Invalid token')
-    except ValueError:
-        # XXX: Dirty hack to workaround a bug in flask-oauthlib that causes it
-        #      not to properly urlencode request query strings
-        #      Related issue (https://github.com/lepture/flask-oauthlib/issues/213)
+    authHeader = request.headers.get('Authorization')
+    if authHeader and authHeader[:5].lower() != 'basic':
+        try:
+            oauth_valid, oauth_request = oauth.verify_request([scope])
+            if not oauth_valid and oauth_request and oauth_request.error_message != 'Bearer token not found.':
+                raise BadRequest('OAuth error: {}'.format(oauth_request.error_message))
+            elif g.get('received_oauth_token') and oauth_request.error_message == 'Bearer token not found.':
+                raise BadRequest('OAuth error: Invalid token')
+        except ValueError:
+            # XXX: Dirty hack to workaround a bug in flask-oauthlib that causes it
+            #      not to properly urlencode request query strings
+            #      Related issue (https://github.com/lepture/flask-oauthlib/issues/213)
+            oauth_valid = False
+    else:
         oauth_valid = False
 
     # Get our handler function and its argument and response type


### PR DESCRIPTION
So only if there is an `Authorization` header, and its value does not start with `Basic`.

This fixes the following errors:
 * https://talk.getindico.io/t/http-api-error-with-basic-auth-header/1450
 * https://talk.getindico.io/t/repeated-unexpected-exception-errors/987.