### PR TITLE
Allow non-refresh-capable identity providers for sync

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Improvements
   which hides pages like the contribution list and timetable until
   the event organizers publish the contribution list. (:issue:`4095`)
 - Add ICS export for information in the user dashboard (:issue:`4057`)
+- Allow data syncing with multipass providers which do not support
+  refreshing identity information
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -43,8 +43,7 @@ class IndicoMultipass(Multipass):
 
         This is the identity provider used to sync user data.
         """
-        return next((p for p in self.identity_providers.itervalues()
-                     if p.supports_refresh and p.settings.get('synced_fields')), None)
+        return next((p for p in self.identity_providers.itervalues() if p.settings.get('synced_fields')), None)
 
     @property
     def synced_fields(self):
@@ -72,8 +71,7 @@ class IndicoMultipass(Multipass):
             warn('There is no default group provider but you have providers with group support. '
                  'This will break legacy ACLs referencing external groups and room ACLs will use local group IDs.')
         # Ensure that there is maximum one sync provider
-        sync_providers = [p for p in self.identity_providers.itervalues()
-                          if p.supports_refresh and p.settings.get('synced_fields')]
+        sync_providers = [p for p in self.identity_providers.itervalues() if p.settings.get('synced_fields')]
         if len(sync_providers) > 1:
             raise ValueError('There can only be one sync provider.')
         # Ensure that there is exactly one form-based default auth provider

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -610,7 +610,7 @@ class User(PersonMixin, db.Model):
         if not identities:
             return None
         identity = identities[0]
-        if refresh and identity.multipass_data is not None:
+        if refresh and identity.multipass_data is not None and sync_provider.supports_refresh:
             try:
                 identity_info = sync_provider.refresh_identity(identity.identifier, identity.multipass_data)
             except IdentityRetrievalFailed:


### PR DESCRIPTION
The OIDC auth provider doesn't support refreshing for example, but is still useful even if you want to sync.