### PR TITLE
Allow restricting admin privs to secure logins (e.g. 2FA)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Improvements
 - Add ICS export for information in the user dashboard (:issue:`4057`)
 - Allow data syncing with multipass providers which do not support
   refreshing identity information
+- Allow restricting admin privileges to secure logins (e.g. 2FA)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -25,6 +25,15 @@ you will get a warning about unknowing config options being defined.
 Authentication
 --------------
 
+.. data:: ADMINS_REQUIRE_SECURE_LOGIN
+
+    This setting controls whether Indico admins only have their admin
+    privileges when logging in using a "secure" method. This is only
+    supported when using an external login method which provides information
+    on whether the login was "secure" (usually using 2FA).
+
+    Default: ``False``
+
 .. data:: LOCAL_IDENTITIES
 
     This setting controls whether local Indico accounts are available.

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -29,6 +29,7 @@ from indico.util.string import crc32, snakify
 
 
 DEFAULTS = {
+    'ADMINS_REQUIRE_SECURE_LOGIN': False,
     'ATTACHMENT_STORAGE': 'default',
     'AUTH_PROVIDERS': {},
     'BASE_URL': None,

--- a/indico/modules/auth/__init__.py
+++ b/indico/modules/auth/__init__.py
@@ -71,10 +71,10 @@ def process_identity(identity_info):
         identity.data = identity_info.data
     if user.is_blocked:
         raise MultipassException(_('Your Indico profile has been blocked.'))
-    login_user(user, identity)
+    login_user(user, identity, secure_login=bool(identity_info.secure_login))
 
 
-def login_user(user, identity=None, admin_impersonation=False):
+def login_user(user, identity=None, admin_impersonation=False, secure_login=False):
     """Set the session user and performs on-login logic
 
     When specifying `identity`, the provider/identitifer information
@@ -86,6 +86,7 @@ def login_user(user, identity=None, admin_impersonation=False):
     :param admin_impersonation: Whether the login is an admin
                                 impersonating the user and thus should not
                                 be considered a login by the user.
+    :param secure_login: Whether the login was considered secure
     """
     if user.settings.get('force_timezone'):
         session.timezone = user.settings.get('timezone', config.DEFAULT_TIMEZONE)
@@ -94,6 +95,7 @@ def login_user(user, identity=None, admin_impersonation=False):
     session.user = user
     session.lang = user.settings.get('lang')
     if not admin_impersonation:
+        session['login_was_secure'] = secure_login
         if identity:
             identity.register_login(request.remote_addr)
             session['login_identity'] = identity.id

--- a/indico/modules/rb/controllers/backend/rooms.py
+++ b/indico/modules/rb/controllers/backend/rooms.py
@@ -45,7 +45,7 @@ class RHRooms(RHRoomBookingBase):
 
 class RHRoomsPermissions(RHRoomBookingBase):
     @staticmethod
-    @memoize_redis(900)
+    @memoize_redis(900, depends_on_admin=True)
     def _jsonify_user_permissions(user):
         permissions = Room.get_permissions_for_user(user, allow_admin=False)
         return jsonify(user=permissions, admin=(Room.get_permissions_for_user(user) if rb_is_admin(user) else None))


### PR DESCRIPTION
This depends on indico/flask-multipass#28, so the minimum multipass version should be bumped to 0.3 before merging this! (leaving it as draft until that's merged and released)

Also, there are of course alternatives on how to implement this, e.g. by having something less magic, but it would require changing MANY places, and often we only pass around the user