### PR TITLE
Fix contribution display page for event managers

### DIFF
--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -55,10 +55,10 @@ class RHContributionDisplayBase(RHDisplayEventBase):
 
     def _check_access(self):
         RHDisplayEventBase._check_access(self)
-        published = contribution_settings.get(self.event, 'published')
         if not self.contrib.can_access(session.user):
             raise Forbidden
-        if not published:
+        published = contribution_settings.get(self.event, 'published')
+        if not published and not self.event.can_manage(session.user):
             raise NotFound(_("The contributions of this event have not been published yet."))
 
     def _process_args(self):
@@ -132,6 +132,7 @@ class RHContributionDisplay(RHContributionDisplayBase):
                                                show_author_link=_author_page_active(self.event),
                                                field_values=field_values,
                                                page_title=contrib.title,
+                                               published=contribution_settings.get(self.event, 'published'),
                                                **ical_params)
 
 

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -247,6 +247,9 @@ class RHSubcontributionDisplay(RHDisplayEventBase):
         RHDisplayEventBase._check_access(self)
         if not self.subcontrib.can_access(session.user):
             raise Forbidden
+        published = contribution_settings.get(self.event, 'published')
+        if not published and not self.event.can_manage(session.user):
+            raise NotFound(_("The contributions of this event have not been published yet."))
 
     def _process_args(self):
         RHDisplayEventBase._process_args(self)

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -3,6 +3,7 @@
 {% from 'events/display/common/_conferences.html' import render_attachments %}
 {% from 'events/display/indico/_common.html' import render_location, render_users, render_speakers %}
 {% from 'events/papers/_contributions.html' import render_paper_section %}
+{% from 'message_box.html' import message_box %}
 
 {% block page_class %}conference-page item-summary{% endblock %}
 
@@ -140,6 +141,15 @@
 {%- endblock %}
 
 {% block content -%}
+    {%- if not published -%}
+        {% call message_box('warning') -%}
+            {% trans %}
+                The contributions of this event have not been published yet. You can only access
+                this page because you are an event manager.
+            {% endtrans %}
+        {%- endcall %}
+    {%- endif -%}
+
     {% if contribution.speakers %}
         {{- render_speakers(contribution) -}}
     {% endif %}


### PR DESCRIPTION
fixes #4127

This PR also adds the missing checks to APIs returning contribution/timetable information.