### PR TITLE
Add generic file upload system

### DIFF
--- a/indico/migrations/versions/20191107_1816_bb522e9f9066_add_files_table.py
+++ b/indico/migrations/versions/20191107_1816_bb522e9f9066_add_files_table.py
@@ -1,0 +1,42 @@
+"""Add files table
+
+Revision ID: bb522e9f9066
+Revises: a2472148d2c5
+Create Date: 2019-11-07 18:16:27.097230
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from indico.core.db.sqlalchemy import UTCDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = 'bb522e9f9066'
+down_revision = 'a2472148d2c5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'files',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('uuid', postgresql.UUID(), nullable=False, index=True, unique=True),
+        sa.Column('claimed', sa.Boolean(), nullable=False),
+        sa.Column('meta', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('size', sa.BigInteger(), nullable=False),
+        sa.Column('storage_backend', sa.String(), nullable=False),
+        sa.Column('content_type', sa.String(), nullable=False),
+        sa.Column('md5', sa.String(), nullable=False),
+        sa.Column('storage_file_id', sa.String(), nullable=False),
+        sa.Column('filename', sa.String(), nullable=False),
+        sa.Column('created_dt', UTCDateTime, nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        schema='indico'
+    )
+
+
+def downgrade():
+    op.drop_table('files', schema='indico')

--- a/indico/modules/files/__init__.py
+++ b/indico/modules/files/__init__.py
@@ -1,0 +1,19 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from indico.core import signals
+from indico.core.logger import Logger
+
+
+logger = Logger.get('files')
+
+
+@signals.import_tasks.connect
+def _import_tasks(sender, **kwargs):
+    import indico.modules.files.tasks

--- a/indico/modules/files/blueprint.py
+++ b/indico/modules/files/blueprint.py
@@ -1,0 +1,17 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from indico.modules.files.controllers import RHDeleteFile, RHFileInfo
+from indico.web.flask.wrappers import IndicoBlueprint
+
+
+_bp = IndicoBlueprint('files', __name__)
+
+_bp.add_url_rule('/files/<uuid>', 'file_info', RHFileInfo)
+_bp.add_url_rule('/files/<uuid>', 'delete_file', RHDeleteFile, methods=('DELETE',))

--- a/indico/modules/files/controllers.py
+++ b/indico/modules/files/controllers.py
@@ -1,0 +1,78 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+import mimetypes
+
+from flask import request
+from marshmallow import fields
+from werkzeug.exceptions import Forbidden
+
+from indico.core.db import db
+from indico.core.logger import Logger
+from indico.modules.files.models.files import File
+from indico.modules.files.schemas import FileSchema
+from indico.web.args import use_kwargs
+from indico.web.rh import RHProtected
+
+
+logger = Logger.get('files')
+
+
+class UploadFileMixin(object):
+    """Mixin for RHs using the generic file upload system.
+
+    An RH using this mixin needs to override the ``get_file_context`` method
+    to specify how the file gets stored.
+    """
+
+    @use_kwargs({
+        'file': fields.Field(location='files', required=True)
+    })
+    def _process(self, file):
+        context = self.get_file_context()
+        content_type = mimetypes.guess_type(file.filename)[0] or file.mimetype or 'application/octet-stream'
+        f = File(filename=file.filename, content_type=content_type)
+        f.save(context, file.stream)
+        db.session.add(f)
+        db.session.flush()
+        logger.info('File %r uploaded (context: %r)', f, context)
+        return FileSchema().jsonify(f), 201
+
+    def get_file_context(self):
+        """The context of where the file is being uploaded.
+
+        :return: A tuple/list of path segments to use when storing the file.
+
+        For example, if a file is being uploaded to an event, you'd
+        return ``['event', EVENTID]`` so the file gets stored under
+        ``event/EVENTID/...`` in the storage backend.
+        """
+        raise NotImplementedError
+
+
+class RHFileBase(RHProtected):
+    def _process_args(self):
+        self.file = File.query.filter_by(uuid=request.view_args['uuid']).first_or_404()
+
+
+class RHDeleteFile(RHFileBase):
+    def _check_access(self):
+        if self.file.claimed:
+            raise Forbidden('Cannot delete claimed file')
+
+    def _process(self):
+        self.file.delete()
+        logger.info('File %r deleted', self.file)
+        db.session.delete(self.file)
+        return '', 204
+
+
+class RHFileInfo(RHFileBase):
+    def _process(self):
+        return FileSchema().jsonify(self.file)

--- a/indico/modules/files/controllers.py
+++ b/indico/modules/files/controllers.py
@@ -14,14 +14,11 @@ from marshmallow import fields
 from werkzeug.exceptions import Forbidden
 
 from indico.core.db import db
-from indico.core.logger import Logger
+from indico.modules.files import logger
 from indico.modules.files.models.files import File
 from indico.modules.files.schemas import FileSchema
 from indico.web.args import use_kwargs
 from indico.web.rh import RHProtected
-
-
-logger = Logger.get('files')
 
 
 class UploadFileMixin(object):

--- a/indico/modules/files/models/files.py
+++ b/indico/modules/files/models/files.py
@@ -1,0 +1,78 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+import posixpath
+from uuid import uuid4
+
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from indico.core.config import config
+from indico.core.db import db
+from indico.core.storage import StoredFileMixin
+from indico.util.fs import secure_filename
+from indico.util.string import format_repr, return_ascii, strict_unicode
+
+
+class File(StoredFileMixin, db.Model):
+    __tablename__ = 'files'
+    __table_args__ = {'schema': 'indico'}
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+    uuid = db.Column(
+        UUID,
+        index=True,
+        unique=True,
+        nullable=False,
+        default=lambda: unicode(uuid4())
+    )
+    #: Whether the file has been associated with something.
+    #: Unclaimed files may be deleted automatically after a while.
+    claimed = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
+    #: Metadata that may be set when the file gets claimed.
+    meta = db.Column(
+        JSONB,
+        nullable=False,
+        default={}
+    )
+
+    def claim(self, **meta):
+        """Mark the file as claimed by some object it's linked to.
+
+        By claiming a file the linked object takes ownership of it so the
+        file will not be automatically deleted.
+
+        :param force: Whether the file can already
+        """
+        self.claimed = True
+        # XXX: Should we check for conflicts with existing metadata in case the
+        # file was already claimed?
+        self.meta = meta
+
+    def _build_storage_path(self):
+        path_segments = list(map(strict_unicode, self.__context))
+        self.assign_id()
+        filename = '{}-{}'.format(self.id, secure_filename(self.filename, 'file'))
+        path = posixpath.join(*(path_segments + [filename]))
+        return config.ATTACHMENT_STORAGE, path
+
+    def save(self, context, data):
+        self.__context = context
+        super(File, self).save(data)
+        del self.__context
+
+    @return_ascii
+    def __repr__(self):
+        return format_repr(self, 'id', 'uuid', 'content_type', _text=self.filename)

--- a/indico/modules/files/schemas.py
+++ b/indico/modules/files/schemas.py
@@ -1,0 +1,17 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from indico.core.marshmallow import mm
+from indico.modules.files.models.files import File
+
+
+class FileSchema(mm.ModelSchema):
+    class Meta:
+        model = File
+        fields = ('claimed', 'content_type', 'created_dt', 'filename', 'size', 'uuid')

--- a/indico/modules/files/tasks.py
+++ b/indico/modules/files/tasks.py
@@ -13,6 +13,7 @@ from celery.schedules import crontab
 from sqlalchemy.orm.attributes import flag_modified
 
 from indico.core.celery import celery
+from indico.core.config import config
 from indico.core.db import db
 from indico.core.storage import StorageReadOnlyError
 from indico.modules.files import logger
@@ -31,6 +32,9 @@ def delete_unclaimed_files():
 
     for file in unclaimed_files:
         file_repr = repr(file)
+        if config.DEBUG:
+            logger.info('Would have removed unclaimed file %s (skipped due to debug mode)', file_repr)
+            continue
         try:
             file.delete()
             db.session.delete(file)

--- a/indico/modules/files/tasks.py
+++ b/indico/modules/files/tasks.py
@@ -1,0 +1,43 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from datetime import timedelta
+
+from celery.schedules import crontab
+from sqlalchemy.orm.attributes import flag_modified
+
+from indico.core.celery import celery
+from indico.core.db import db
+from indico.core.storage import StorageReadOnlyError
+from indico.modules.files import logger
+from indico.modules.files.models.files import File
+from indico.util.date_time import now_utc
+
+
+@celery.periodic_task(name='delete_unclaimed_files', run_every=crontab(minute='0', hour='6'))
+def delete_unclaimed_files():
+    unclaimed_files = (File.query
+                       .filter(~File.claimed,
+                               File.created_dt <= (now_utc() - timedelta(days=1)),
+                               # skip files where deleting failed in the past
+                               ~File.meta.op('?')('deletion_failed'))
+                       .all())
+
+    for file in unclaimed_files:
+        file_repr = repr(file)
+        try:
+            file.delete()
+            db.session.delete(file)
+        except StorageReadOnlyError:
+            file.meta['deletion_failed'] = True
+            flag_modified(file, 'meta')
+            logger.warn('Could not delete unclaimed file %s (read-only storage)', file_repr)
+        else:
+            logger.info('Removed unclaimed file %s', file_repr)
+        db.session.commit()


### PR DESCRIPTION
closes #4130

---

To add the upload endpoint e.g. for the editing workflow, add a RH similar to this one that uses a suitable context:

```python
class RHEditingUploadFile(UploadFileMixin, RHWhateverContributionBase):
    def get_file_context(self):
        return 'event', self.event.id, 'papers', self.contribution.id
```