### PR TITLE
Add EditingFileType model

### DIFF
--- a/indico/migrations/versions/20191108_1402_39a25a873063_add_editing_file_types_table.py
+++ b/indico/migrations/versions/20191108_1402_39a25a873063_add_editing_file_types_table.py
@@ -1,0 +1,42 @@
+"""Add editing file_types table
+
+Revision ID: 39a25a873063
+Revises: bb522e9f9066
+Create Date: 2019-11-08 14:02:33.351292
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql.ddl import CreateSchema, DropSchema
+
+
+# revision identifiers, used by Alembic.
+revision = '39a25a873063'
+down_revision = 'bb522e9f9066'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(CreateSchema('event_editing'))
+    op.create_table(
+        'file_types',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('event_id', sa.Integer(), nullable=False, index=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('extensions', postgresql.ARRAY(sa.String()), nullable=False),
+        sa.Column('allow_multiple_files', sa.Boolean(), nullable=False),
+        sa.Column('required', sa.Boolean(), nullable=False),
+        sa.Column('publishable', sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(['event_id'], ['events.events.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='event_editing'
+    )
+    op.create_index('ix_uq_file_types_event_id_name_lower', 'file_types', ['event_id', sa.text('lower(name)')],
+                    unique=True, schema='event_editing')
+
+
+def downgrade():
+    op.drop_table('file_types', schema='event_editing')
+    op.execute(DropSchema('event_editing'))

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -7,8 +7,11 @@
 
 from __future__ import unicode_literals
 
+from indico.modules.events.editing.controllers.backend import RHEditingFileTypes
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('event_editing', __name__, url_prefix='/event/<confId>', template_folder='templates',
                       virtual_template_folder='events/editing')
+
+_bp.add_url_rule('/editing/api/file-types', 'api_file_types', RHEditingFileTypes)

--- a/indico/modules/events/editing/controllers/backend.py
+++ b/indico/modules/events/editing/controllers/backend.py
@@ -6,3 +6,11 @@
 # LICENSE file for more details.
 
 from __future__ import unicode_literals
+
+from indico.modules.events.controllers.base import RHEventBase
+from indico.modules.events.editing.schemas import EditingFileTypeSchema
+
+
+class RHEditingFileTypes(RHEventBase):
+    def _process(self):
+        return EditingFileTypeSchema(many=True).jsonify(self.event.editing_file_types)

--- a/indico/modules/events/editing/models/file_types.py
+++ b/indico/modules/events/editing/models/file_types.py
@@ -1,0 +1,72 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.ext.declarative import declared_attr
+
+from indico.core.db import db
+from indico.util.string import format_repr, return_ascii
+
+
+class EditingFileType(db.Model):
+    __tablename__ = 'file_types'
+
+    @declared_attr
+    def __table_args__(cls):
+        return (db.Index('ix_uq_file_types_event_id_name_lower', cls.event_id, db.func.lower(cls.name), unique=True),
+                {'schema': 'event_editing'})
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+    event_id = db.Column(
+        db.ForeignKey('events.events.id'),
+        index=True,
+        nullable=False
+    )
+    name = db.Column(
+        db.String,
+        nullable=False
+    )
+    extensions = db.Column(
+        ARRAY(db.String),
+        nullable=False,
+        default=[]
+    )
+    allow_multiple_files = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
+    required = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
+    publishable = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
+
+    event = db.relationship(
+        'Event',
+        lazy=True,
+        backref=db.backref(
+            'editing_file_types',
+            cascade='all, delete-orphan',
+            lazy=True
+        )
+    )
+
+    @return_ascii
+    def __repr__(self):
+        return format_repr(self, 'id', 'event_id', 'extensions', allow_multiple_files=False, required=False,
+                           publishable=False, _text=self.name)

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -1,0 +1,17 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2019 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from indico.core.marshmallow import mm
+from indico.modules.events.editing.models.file_types import EditingFileType
+
+
+class EditingFileTypeSchema(mm.ModelSchema):
+    class Meta:
+        model = EditingFileType
+        fields = ('id', 'name', 'extensions', 'allow_multiple_files', 'required', 'publishable')

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -378,6 +378,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     # - contributions (Contribution.event)
     # - custom_pages (EventPage.event)
     # - designer_templates (DesignerTemplate.event)
+    # - editing_file_types (EditingFileType.event)
     # - layout_images (ImageFile.event)
     # - legacy_contribution_mappings (LegacyContributionMapping.event)
     # - legacy_mapping (LegacyEventMapping.event)


### PR DESCRIPTION
An empty `extensions` list indicates any extension is valid.

closes #4121

---

Later we will add a frontend for it (#4120); probably a simple wtforms-based form does the job well enough.

For now, create file types using `indico shell`:

```python
e = E(EVENT_ID)
e.editing_file_types = [EditingFileType(name='PDF', extensions=['pdf'], required=True, publishable=True), EditingFileType(name='Source', extensions=['tex', 'docx', 'doc', 'txt'], required=True, allow_multiple_files=True)]
db.session.commit()
```