### PR TITLE
Fix legacy time table pdf page breaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,9 @@ Bugfixes
 - Fix incorrect font size in some room booking dropdowns (:issue:`4156`)
 - Add missing email validation in some places (:issue:`4158`)
 - Reject requests containing NUL bytes in the POST data (:issue:`4159`)
+- Fix truncated timetable PDF when using "Print each session on a separate page" in
+  an event where the last timetable entry of the day is a top-level contribution
+  or break (:issue:`4134`, thanks :user:`bpedersen2`)
 
 Version 2.2.4
 -------------

--- a/indico/legacy/pdfinterface/conference.py
+++ b/indico/legacy/pdfinterface/conference.py
@@ -8,7 +8,6 @@
 import re
 from copy import deepcopy
 from datetime import timedelta
-from itertools import takewhile
 from operator import attrgetter
 
 from reportlab.lib import colors
@@ -678,7 +677,6 @@ class TimeTablePlain(PDFWithTOC):
                     p3 = Paragraph(escape(unicode(contrib.description)), self._styles["contrib_description"])
                     res.append(p3)
                 if entry == entries[-1]:  # if it is the last one, we do the page break and remove the previous one.
-                    res = list(takewhile(lambda x: not isinstance(x, PageBreak), res))
                     if self._ttPDFFormat.showNewPagePerSession():
                         res.append(PageBreak())
             # break
@@ -700,7 +698,6 @@ class TimeTablePlain(PDFWithTOC):
                     self._indexedFlowable[p1] = {'text': escape(break_.title.encode('utf-8')), 'level': 2}
 
                 if entry == entries[-1]:  # if it is the last one, we do the page break and remove the previous one.
-                    res = list(takewhile(lambda x: not isinstance(x, PageBreak), res))
                     if self._ttPDFFormat.showNewPagePerSession():
                         res.append(PageBreak())
         return res


### PR DESCRIPTION
If 'Each session on a separate page' was selected,
only the first of many parallel sessions appeared in the
pdf.

Do not try to remove the previous page breaks.

The takewhile would only consider entries up to the first page break,
effectivly hiding all other parallel sessions instead of removing
only the last page break.

