### PR TITLE
Accommodation: Allow single arrival/departure date

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Bugfixes
   an event where the last timetable entry of the day is a top-level contribution
   or break (:issue:`4134`, thanks :user:`bpedersen2`)
 - Only show public contribution fields in PDF exports (:issue:`4165`)
+- Allow single arrival/departure date in accommodation field (:issue:`4164`,
+  thanks :user:`bpedersen2`)
 
 Version 2.2.4
 -------------

--- a/indico/modules/events/registration/client/js/form/field.js
+++ b/indico/modules/events/registration/client/js/form/field.js
@@ -873,13 +873,13 @@ ndRegForm.directive('ndAccommodationField', function(url) {
     controller: function($scope) {
       $scope.tplInput = url.tpl('fields/accommodation.tpl.html');
       $scope.areArrivalDatesValid = function(data) {
-        return moment(data['arrivalDateTo'], 'DD/MM/YYYY').isAfter(
+        return moment(data['arrivalDateTo'], 'DD/MM/YYYY').isSameOrAfter(
           moment(data['arrivalDateFrom'], 'DD/MM/YYYY')
         );
       };
 
       $scope.areDepartureDatesValid = function(data) {
-        return moment(data['departureDateTo'], 'DD/MM/YYYY').isAfter(
+        return moment(data['departureDateTo'], 'DD/MM/YYYY').isSameOrAfter(
           moment(data['departureDateFrom'], 'DD/MM/YYYY')
         );
       };


### PR DESCRIPTION
Allow to restrict the date range to a single day for
arrival/departue  in the setup form.

