### PR TITLE
Display only public contrib fields in pdf exports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,7 @@ Bugfixes
 - Fix truncated timetable PDF when using "Print each session on a separate page" in
   an event where the last timetable entry of the day is a top-level contribution
   or break (:issue:`4134`, thanks :user:`bpedersen2`)
+- Only show public contribution fields in PDF exports (:issue:`4165`)
 
 Version 2.2.4
 -------------

--- a/indico/legacy/pdfinterface/latex.py
+++ b/indico/legacy/pdfinterface/latex.py
@@ -457,7 +457,6 @@ class ContributionBook(PDFLaTeXBase):
             'event': event,
             'tz': timezone(tz or event.timezone),
             'url': event.url,
-            'fields': [f for f in event.contribution_fields if f.is_active],
             'sorted_by': sort_by,
             'user': user,
             'boa_text': boa_settings.get(event, 'extra_text'),

--- a/indico/legacy/pdfinterface/latex_templates/inc/abstract.tex
+++ b/indico/legacy/pdfinterface/latex_templates/inc/abstract.tex
@@ -46,7 +46,7 @@
         \vspace{1.5em}
     \end{addmargin}
 
-    \JINJA{for field in abstract.event.contribution_fields if field.is_active}
+    \JINJA{for field in abstract.event.contribution_fields if field.is_active and (management or field.is_public)}
         {\bf
             \noindent
             \large

--- a/indico/legacy/pdfinterface/latex_templates/inc/contribution.tex
+++ b/indico/legacy/pdfinterface/latex_templates/inc/contribution.tex
@@ -48,11 +48,12 @@
     \end{addmargin}
 
 
-    \JINJA{for field in contrib.event.contribution_fields if field.is_active}
+    \JINJA{for field_value in contrib.field_values
+           if field_value.contribution_field.is_active and field_value.contribution_field.is_public}
         {\bf
             \noindent
             \large
-            \VAR{field.title}
+            \VAR{field_value.contribution_field.title}
         }
 
         \begin{addmargin}[1em]{1em}
@@ -62,7 +63,7 @@
                 \sectionfont{\normalsize\rmfamily}
                 \subsectionfont{\small\rmfamily}
                 \small
-                \VAR{contrib.get_field_value(field.id) | markdown}
+                \VAR{field_value.friendly_data | markdown}
             }
             \vspace{1.5em}
         \end{addmargin}
@@ -180,8 +181,9 @@
         \setlength{\leftskip}{0pt}
     \JINJA{endif}
 
-    \JINJA{for field_value in contrib.field_values}
-        \textbf{\VAR{ field_value.contribution_field.title}}:
+    \JINJA{for field_value in contrib.field_values
+           if field_value.contribution_field.is_active and field_value.contribution_field.is_public}
+        \textbf{\VAR{field_value.contribution_field.title}}:
 
         %% Markdown content
         \rmfamily {
@@ -189,7 +191,9 @@
             \sectionfont{\normalsize\rmfamily}
             \subsectionfont{\small\rmfamily}
             \small
-            \VAR{field_value.friendly_data|markdown}
+            \VAR{field_value.friendly_data | markdown}
         }
+        \vspace{1em}
+        \newline
     \JINJA{endfor}
 \JINJA{endmacro}

--- a/indico/modules/events/contributions/models/fields.py
+++ b/indico/modules/events/contributions/models/fields.py
@@ -128,6 +128,10 @@ class ContributionField(db.Model):
         return self._get_field(management=True)
 
     @property
+    def is_public(self):
+        return self.visibility == ContributionFieldVisibility.public
+
+    @property
     def filter_choices(self):
         return {x['id']: x['option'] for x in self.field_data.get('options', {})}
 


### PR DESCRIPTION
Fix contrib fields display in pdf exports
