### PR TITLE
Withdraw popup in registration summary

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Improvements
 - Add ICS export for information in the user dashboard (:issue:`4057`)
 - Allow data syncing with multipass providers which do not support
   refreshing identity information
+- Add withdraw popup in registration summary (:issue:`2715`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -159,6 +159,8 @@ _bp.add_url_rule('/registrations/<int:reg_form_id>/', 'display_regform', display
                  methods=('GET', 'POST'))
 _bp.add_url_rule('/registrations/<int:reg_form_id>/edit', 'edit_registration_display',
                  display.RHRegistrationDisplayEdit, methods=('GET', 'POST'))
+_bp.add_url_rule('/registrations/<int:reg_form_id>/withdraw', 'withdraw_registration',
+                 display.RHRegistrationWithdraw, methods=('POST',))
 _bp.add_url_rule('/registrations/<int:reg_form_id>/check-email', 'check_email', display.RHRegistrationFormCheckEmail)
 _bp.add_url_rule('/registrations/<int:reg_form_id>/decline-invitation', 'decline_invitation',
                  display.RHRegistrationFormDeclineInvitation, methods=('POST',))

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -308,6 +308,24 @@ class RHRegistrationDisplayEdit(RegistrationEditMixin, RHRegistrationFormRegistr
         return url_for('.display_regform', self.registration.locator.registrant)
 
 
+class RHRegistrationWithdraw(RHRegistrationFormRegistrationBase):
+    """Withdraw a registration"""
+
+    def _process(self):
+        if not self.registration.can_be_modified:
+            if not self.registration.registration_form.is_modification_open:
+                flash(_("The modification/withdrawal period is over"), "warning")
+            elif self.registration.registration_form.modification_mode.name == 'allowed_until_payment':
+                flash(_("Withdrawal is not allowed after payment"), "warning")
+            else:
+                flash(_("The registration cannot be modified/withdrawn"), "warning")
+            return redirect(url_for('.display_regform', self.registration.locator.registrant))
+
+        self.registration.state = RegistrationState.withdrawn
+        flash(_("Your registration has been withdrawn"), "success")
+        return redirect(self.event.url)
+
+
 class RHRegistrationFormDeclineInvitation(InvitationMixin, RHRegistrationFormBase):
     """Decline an invitation to register"""
 

--- a/indico/modules/events/registration/templates/display/registration_summary.html
+++ b/indico/modules/events/registration/templates/display/registration_summary.html
@@ -46,6 +46,21 @@
                        {% endif %}>
                        {% trans %}Modify{% endtrans %}
                    </a>
+                   <a href="#"
+                      class="i-button icon-remove {% if not registration.can_be_modified %}disabled{% endif %}"
+                      data-method="POST"
+                      data-href="{{ url_for('.withdraw_registration', registration.locator.registrant) }}"
+                      data-title="{% trans %}Withdraw{% endtrans %}"
+                      data-confirm="{% trans %}Do you want to withdraw your registration?{% endtrans %}"
+                       {% if not registration.can_be_modified %}
+                           {% if not registration.registration_form.is_modification_open -%}
+                               title="{% trans %}The modification/withdrawal period is over{% endtrans %}"
+                           {%- elif registration.registration_form.modification_mode.name == 'allowed_until_payment' -%}
+                               title="{% trans %}Withdrawal is not allowed after payment{% endtrans %}"
+                           {%- endif %}
+                       {% endif %}>
+                       {% trans %}Withdraw{% endtrans %}
+                    </a>
                </div>
            {% endif %}
            {% if registration.state.name == 'complete' and registration.registration_form.tickets_enabled and


### PR DESCRIPTION
Add withdraw button with confirmation popup into registration detail view. Behavior is the same as for the modify button.

closes: #2715 
CC: @ThiefMaster @bpedersen2 

![indico_02](https://user-images.githubusercontent.com/6898184/69178179-5e202e80-0b09-11ea-9b81-e30cef1333fc.png)
