### PR TITLE
Add interface to upload editables

### DIFF
--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -8,13 +8,51 @@
 /* global showUndoWarning:false, setupListGenerator:false, setupSearchBox:false */
 /* global reloadManagementAttachmentInfoColumn:false */
 
+import fileTypesURL from 'indico-url:event_editing.api_file_types';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 
 import 'indico/modules/events/util/types_dialog';
+import EditableSubmissionButton from 'indico/modules/events/editing/components/EditableSubmissionButton';
 import {PublicationSwitch} from 'indico/react/components';
+import {camelizeKeys} from 'indico/utils/case';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 (function(global) {
+  global.setupEditableSubmissionButton = async function setupEditableSubmissionButton() {
+    const editableSubmissionButton = document.querySelector('#editable-submission-button');
+    if (!editableSubmissionButton) {
+      return;
+    }
+    const {
+      eventId,
+      contributionId,
+      apiEditableSubmitUrl,
+      type,
+      uploadUrl,
+    } = editableSubmissionButton.dataset;
+
+    let response;
+    try {
+      response = await indicoAxios.get(fileTypesURL({confId: eventId}));
+    } catch (e) {
+      handleAxiosError(e);
+    }
+    const fileTypes = camelizeKeys(response.data);
+    ReactDOM.render(
+      <EditableSubmissionButton
+        uploadURL={uploadUrl}
+        fileTypes={fileTypes}
+        type={type}
+        submitRevisionURL={apiEditableSubmitUrl}
+        eventId={eventId}
+        contributionId={contributionId}
+      />,
+      editableSubmissionButton
+    );
+  };
+
   function setupPublicationButton() {
     const element = document.querySelector('#pub-switch');
     const component = React.createElement(PublicationSwitch, {eventId: element.dataset.eventId});

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -2,7 +2,7 @@
 
 {% from 'events/display/common/_conferences.html' import render_attachments %}
 {% from 'events/display/indico/_common.html' import render_location, render_users, render_speakers %}
-{% from 'events/papers/_contributions.html' import render_paper_section %}
+{% from 'events/papers/_contributions.html' import render_paper_section, render_editables_section %}
 {% from 'message_box.html' import message_box %}
 
 {% block page_class %}conference-page item-summary{% endblock %}
@@ -258,6 +258,12 @@
     {%- endif %}
     {% if contribution.event.has_feature('papers') %}
         {{ render_paper_section(contribution) }}
+    {% endif %}
+    {% if contribution.event.has_feature('editing') %}
+        {{ render_editables_section(contribution) }}
+        <script>
+            setupEditableSubmissionButton();
+        </script>
     {% endif %}
     <script>
         setupAttachmentTreeView();

--- a/indico/modules/events/contributions/views.py
+++ b/indico/modules/events/contributions/views.py
@@ -23,7 +23,7 @@ class WPManageContributions(MathjaxMixin, WPEventManagement):
 
 class WPContributionsDisplayBase(WPConferenceDisplayBase):
     template_prefix = 'events/contributions/'
-    bundles = ('markdown.js', 'module_events.contributions.js')
+    bundles = ('markdown.js', 'module_events.contributions.js', 'module_events.contributions.css')
 
 
 class WPMyContributions(WPContributionsDisplayBase):

--- a/indico/modules/events/editing/client/js/components/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/components/EditableSubmissionButton.jsx
@@ -1,0 +1,87 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2019 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import editableURL from 'indico-url:event_editing.editable';
+import React, {useCallback, useState} from 'react';
+import PropTypes from 'prop-types';
+import {Button, Modal} from 'semantic-ui-react';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+import {Translate} from 'indico/react/i18n';
+import FileManager from './FileManager';
+import {fileTypePropTypes} from './FileManager/util';
+
+export default function EditableSubmissionButton({
+  eventId,
+  contributionId,
+  uploadURL,
+  fileTypes,
+  type,
+  submitRevisionURL,
+}) {
+  const [open, setOpen] = useState(false);
+  const [submissionFiles, setSubmissionFiles] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+  const submitRevision = async () => {
+    setSubmitting(true);
+    try {
+      await indicoAxios.put(submitRevisionURL, {
+        files: submissionFiles,
+      });
+    } catch (e) {
+      handleAxiosError(e, false, true);
+      setSubmitting(false);
+      return;
+    }
+    setSubmitting(false);
+    location.href = editableURL({confId: eventId, contrib_id: contributionId, type});
+  };
+
+  const handleChange = useCallback(files => setSubmissionFiles(files), []);
+  return (
+    <>
+      <Modal
+        open={open}
+        onClose={() => setOpen(false)}
+        closeIcon
+        closeOnDimmerClick={false}
+        closeOnEscape={false}
+      >
+        <Modal.Header>
+          {type === 'paper' && <Translate>Submit your paper</Translate>}
+          {type === 'slides' && <Translate>Submit your slides</Translate>}
+        </Modal.Header>
+        <Modal.Content>
+          <FileManager onChange={handleChange} fileTypes={fileTypes} uploadURL={uploadURL} />
+        </Modal.Content>
+        <Modal.Actions>
+          <Button onClick={() => setOpen(false)}>
+            <Translate>Cancel</Translate>
+          </Button>
+          <Button
+            primary
+            disabled={submitting || !Object.keys(submissionFiles).length}
+            onClick={submitRevision}
+          >
+            <Translate>Save</Translate>
+          </Button>
+        </Modal.Actions>
+      </Modal>
+      <button type="submit" className="i-button highlight" onClick={() => setOpen(true)}>
+        <Translate>Submit Files</Translate>
+      </button>
+    </>
+  );
+}
+
+EditableSubmissionButton.propTypes = {
+  uploadURL: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  submitRevisionURL: PropTypes.string.isRequired,
+  fileTypes: PropTypes.arrayOf(PropTypes.shape(fileTypePropTypes)).isRequired,
+  eventId: PropTypes.string.isRequired,
+  contributionId: PropTypes.string.isRequired,
+};

--- a/indico/modules/events/papers/templates/_contributions.html
+++ b/indico/modules/events/papers/templates/_contributions.html
@@ -11,6 +11,11 @@
         <section>
             <div class="header">
                 <div class="header-row">
+                    <h2>{% trans %}Peer reviewing{% endtrans %}</h2>
+                </div>
+            </div>
+            <div class="header">
+                <div class="header-row">
                     <h3 class="icon-file">{% trans %}Paper{% endtrans %}</h3>
                     {% if show_paper and paper.state.name == 'accepted' %}
                         {{ render_paper_metadata(paper, contribution_page=true) }}
@@ -31,6 +36,56 @@
     {% endif %}
 {% endmacro %}
 
+{% macro render_editables_section(contribution) %}
+    {# TODO: Support different editable types #}
+    {% set editable = contribution.editables|selectattr('type.name', 'equalto', 'paper')|first %}
+    {% set can_submit = contribution.is_user_associated(session.user, check_abstract=true) %}
+
+    {% if can_submit %}
+        <section>
+            <div class="header">
+                <div class="header-row">
+                <h2>{% trans %}Editing{% endtrans %}</h2>
+                </div>
+            </div>
+            <div class="header">
+                <div class="header-row">
+                    <h3 class="icon-file">{% trans %}Paper{% endtrans %}</h3>
+                </div>
+            </div>
+            {% if editable %}
+                <div>
+                    <a href="{{ url_for('event_editing.editable', editable) }}">
+                        {%- trans %}Go to timeline{% endtrans -%}
+                    </a>
+                </div>
+            {% else %}
+                <div class="action-box highlight">
+                    <div class="section flexrow">
+                        <div class="icon icon-file"></div>
+                            <div class="text">
+                                <div class="label">
+                                    {% trans %}Paper submission is open{% endtrans %}
+                                </div>
+                                <div>
+                                    {% trans %}You can submit a paper{% endtrans %}
+                                </div>
+                            </div>
+                        <div class="toolbar">
+                            <div id="editable-submission-button"
+                                 data-event-id="{{ contribution.event_id }}"
+                                 data-contribution-id="{{ contribution.id }}"
+                                 data-type="paper"
+                                 data-upload-url="{{ url_for('event_editing.api_upload', contribution, type='paper') }}"
+                                 data-api-editable-submit-url="{{ url_for('event_editing.api_create_editable', contribution, type='paper') }}">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endif %}
+        </section>
+    {% endif %}
+{% endmacro %}
 
 {% macro _render_paper_status_box(paper) %}
     {% set state_mapping = {'submitted': '',

--- a/indico/web/client/styles/modules/event_display/_conferences.scss
+++ b/indico/web/client/styles/modules/event_display/_conferences.scss
@@ -143,6 +143,12 @@
                 align-self: center;
             }
 
+            h2 {
+                color: $dark-orange;
+                font-size: 2em;
+                font-weight: normal;
+            }
+
             h3 {
                 flex-grow: 1;
                 color: $dark-orange;


### PR DESCRIPTION
This PR assumes that we upload papers only.

In this PR:
- [x] Add editable submission area in Contribution page
- [x] Create modal that renders an empty FileManager and creates editable when saving
- [x] When editable exists show link to timeline (draft view)
- [x] Redirect to timeline when success

closes #4140