### PR TITLE
Fix FileManager issues

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -5,4 +5,15 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-export {default} from 'jest-mock-axios';
+import mockAxios from 'jest-mock-axios';
+
+// https://github.com/knee-cola/jest-mock-axios/issues/42
+mockAxios.mustGetReqByUrl = url => {
+  const req = mockAxios.getReqByUrl(url);
+  if (!req) {
+    throw new Error('No request to respond to!');
+  }
+  return req;
+};
+
+export default mockAxios;

--- a/__mocks__/indico-url.js
+++ b/__mocks__/indico-url.js
@@ -1,8 +1,0 @@
-// This file is part of Indico.
-// Copyright (C) 2002 - 2019 CERN
-//
-// Indico is free software; you can redistribute it and/or
-// modify it under the terms of the MIT License; see the
-// LICENSE file for more details.
-
-export default 'goes://nowhere';

--- a/indico/modules/events/editing/client/js/__tests__/FileManager.spec.jsx
+++ b/indico/modules/events/editing/client/js/__tests__/FileManager.spec.jsx
@@ -28,19 +28,19 @@ const fileTypes = [
   {
     id: 1,
     name: 'Source file',
-    extensions: ['.txt', '.md', '.tex'],
+    extensions: ['txt', 'md', 'tex'],
     allowMultipleFiles: false,
   },
   {
     id: 2,
     name: 'PDF file',
-    extensions: ['.pdf'],
+    extensions: ['pdf'],
     allowMultipleFiles: false,
   },
   {
     id: 3,
     name: 'Image files',
-    extensions: ['.png'],
+    extensions: ['png'],
     allowMultipleFiles: true,
   },
 ];
@@ -143,7 +143,7 @@ async function uploadFile(dropzone, onChange, name, type, deletedFile = null) {
 }
 
 function getFileEntryForFileType(wrapper, fileTypeId) {
-  return wrapper.find('FileEntry').find({fileTypeId});
+  return wrapper.find('FileEntry').filterWhere(x => x.prop('fileType').id === fileTypeId);
 }
 
 function checkFileEntry(fileEntry, name, icon) {

--- a/indico/modules/events/editing/client/js/__tests__/FileManager.spec.jsx
+++ b/indico/modules/events/editing/client/js/__tests__/FileManager.spec.jsx
@@ -134,7 +134,7 @@ async function uploadFile(dropzone, onChange, name, type, deletedFile = null) {
   const uuid = await simulateFileUpload(dropzone, name, type);
   expect(onChange).toHaveBeenCalledWith({'2': [uuid]});
   if (deletedFile) {
-    const deleteUrl = `/files/${deletedFile}`;
+    const deleteUrl = `flask://files.delete_file/uuid=${deletedFile}`;
     expect(mockAxios.delete).toHaveBeenCalledWith(deleteUrl);
     await act(async () => {
       mockAxios.mockResponse(undefined, mockAxios.mustGetReqByUrl(deleteUrl));
@@ -204,9 +204,12 @@ describe('File manager', () => {
     // perform an undo - this needs to go back to an empty file list
     await act(async () => {
       fileEntry.find('FileAction').simulate('click');
-      mockAxios.mockResponse(undefined, mockAxios.mustGetReqByUrl(`/files/${uuid}`));
+      mockAxios.mockResponse(
+        undefined,
+        mockAxios.mustGetReqByUrl(`flask://files.delete_file/uuid=${uuid}`)
+      );
     });
-    expect(mockAxios.delete).toHaveBeenCalledWith('/files/newtest2.pdf');
+    expect(mockAxios.delete).toHaveBeenCalledWith(`flask://files.delete_file/uuid=${uuid}`);
     expect(onChange).toHaveBeenCalledWith({});
   });
 
@@ -246,9 +249,12 @@ describe('File manager', () => {
     // perform an undo - this needs to revert to the initial file!
     await act(async () => {
       fileEntry.find('FileAction').simulate('click');
-      mockAxios.mockResponse(undefined, mockAxios.mustGetReqByUrl(`/files/${uuid}`));
+      mockAxios.mockResponse(
+        undefined,
+        mockAxios.mustGetReqByUrl(`flask://files.delete_file/uuid=${uuid}`)
+      );
     });
-    expect(mockAxios.delete).toHaveBeenCalledWith('/files/newtest2.pdf');
+    expect(mockAxios.delete).toHaveBeenCalledWith(`flask://files.delete_file/uuid=${uuid}`);
     expect(onChange).toHaveBeenCalledWith({'2': ['file1']});
   });
 

--- a/indico/modules/events/editing/client/js/components/FileManager/index.jsx
+++ b/indico/modules/events/editing/client/js/components/FileManager/index.jsx
@@ -26,7 +26,7 @@ import {getFiles} from './selectors';
 
 import './FileManager.module.scss';
 
-export function Dropzone({uploadURL, fileType: {id, allowMultipleFiles, files}}) {
+export function Dropzone({uploadURL, fileType: {id, allowMultipleFiles, files, extensions}}) {
   const dispatch = useContext(FileManagerContext);
   // we only want to modify the existing file if we do not allow multiple files and
   // there is exactly one file that is not in the 'added' state (which would imply
@@ -43,7 +43,7 @@ export function Dropzone({uploadURL, fileType: {id, allowMultipleFiles, files}})
   // multiple files are supported for the file type
   const showNewFileIcon = files.length === 0 || allowMultipleFiles;
 
-  const onDrop = useCallback(
+  const onDropAccepted = useCallback(
     async acceptedFiles => {
       if (!allowMultipleFiles) {
         acceptedFiles = acceptedFiles.splice(0, 1);
@@ -64,7 +64,11 @@ export function Dropzone({uploadURL, fileType: {id, allowMultipleFiles, files}})
     [fileToReplace, fileToDelete, allowMultipleFiles, id, uploadURL, dispatch]
   );
 
-  const {getRootProps, getInputProps, isDragActive} = useDropzone({onDrop});
+  const {getRootProps, getInputProps, isDragActive} = useDropzone({
+    onDropAccepted,
+    multiple: allowMultipleFiles,
+    accept: extensions.map(ext => `.${ext}`).join(','),
+  });
 
   return (
     <div {...getRootProps()}>
@@ -86,12 +90,7 @@ function FileType({uploadURL, fileType, uploads}) {
   return (
     <div styleName="file-type">
       <h3>{fileType.name}</h3>
-      <FileList
-        files={fileType.files}
-        fileTypeId={fileType.id}
-        allowMultipleFiles={fileType.allowMultipleFiles}
-        uploadURL={uploadURL}
-      />
+      <FileList files={fileType.files} fileType={fileType} uploadURL={uploadURL} />
       {!_.isEmpty(uploads) && <Uploads uploads={uploads} />}
       <Dropzone dropzoneRef={ref} fileType={fileType} uploadURL={uploadURL} />
     </div>

--- a/indico/modules/events/editing/client/js/components/FileManager/reducer.js
+++ b/indico/modules/events/editing/client/js/components/FileManager/reducer.js
@@ -23,6 +23,7 @@ function replaceFile(files, uuid, func) {
  * Reducer for arrays of files within a fileType (`fileType.files`).
  * @param {Array} state - the array of file objects which will be reduced
  * @param {Object} action - the action which will be processed
+ * @param {boolean} allowMultipleFiles - whether the file type allows multiple files
  */
 function fileListReducer(state, action, allowMultipleFiles) {
   switch (action.type) {
@@ -38,7 +39,7 @@ function fileListReducer(state, action, allowMultipleFiles) {
 
     case actions.MARK_MODIFIED:
       return replaceFile(state, action.fileId, file =>
-        file.claimed
+        file.claimed || file.state === 'modified'
           ? {
               ...action.file,
               state: 'modified',

--- a/indico/modules/events/editing/client/js/components/FileManager/util.js
+++ b/indico/modules/events/editing/client/js/components/FileManager/util.js
@@ -80,8 +80,7 @@ export function uploadFiles(action, fileTypeId, acceptedFiles, uploadURL, dispat
 
 export async function deleteFile(uuid) {
   try {
-    const {data} = await indicoAxios.delete(deleteFileURL({uuid}));
-    return data;
+    await indicoAxios.delete(deleteFileURL({uuid}));
   } catch (e) {
     handleAxiosError(e, false, true);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2666,9 +2666,9 @@
       }
     },
     "babel-plugin-flask-urls": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-flask-urls/-/babel-plugin-flask-urls-0.0.2.tgz",
-      "integrity": "sha512-A2oKUFc68oYpfiefT9C3S36B1kZYDJWl7jp1huM8oboZxR9QHCXVjVbHSRISTOn25gnT0v5jCP9w7ST3WtppxQ==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-flask-urls/-/babel-plugin-flask-urls-0.1.0.tgz",
+      "integrity": "sha512-DIv9ATH8T/KbvAnw8xtiLQg1RKKUkeLH9/XLVrDTo5Gtnx3zZvJisODTsj3n77bksUBOuvTJz0PV7Bi+EiQcng==",
       "dev": true
     },
     "babel-plugin-istanbul": {
@@ -5818,9 +5818,9 @@
       }
     },
     "flask-urls": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/flask-urls/-/flask-urls-0.1.0.tgz",
-      "integrity": "sha512-ql10zLn5i7d/m8rmkBwgdKHIJOCiJXP3gVi+QA5oKA/K2E1JXBtCGY8+lxL1dxnyP583q2V0dPD+Pu95AOm/SA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/flask-urls/-/flask-urls-0.2.0.tgz",
+      "integrity": "sha512-SOy+nUA8zFbPvELfVNPGyGz0Qmo5HdKPWU9OaCx4dSIGfycpSLi37HTBYgsNhazwKqcnj8TtSkW3l4b028Mkbg==",
       "requires": {
         "lodash": "^4.17.11",
         "qs": "^6.7.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "final-form": "^4.18.6",
     "final-form-arrays": "^3.0.2",
     "final-form-calculate": "^1.3.1",
-    "flask-urls": "^0.1.0",
+    "flask-urls": "^0.2.0",
     "fullcalendar": "^3.10.1",
     "geodesy": "^2.2.0",
     "history": "^4.10.1",
@@ -96,7 +96,7 @@
     "autoprefixer": "^9.7.2",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",
-    "babel-plugin-flask-urls": "^0.0.2",
+    "babel-plugin-flask-urls": "^0.1.0",
     "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-macros": "^2.7.0",
     "browserslist": "^4.7.3",
@@ -165,7 +165,6 @@
   "homepage": "https://github.com/indico/indico#readme",
   "jest": {
     "moduleNameMapper": {
-      "^indico-url:.*$": "<rootDir>/__mocks__/indico-url",
       "^.+\\.(s?css)$": "identity-obj-proxy",
       "^indico/modules/events/(reviewing|util)/(.*)$": "<rootDir>/indico/modules/events/client/js/$1/$2",
       "^indico/modules/events/([\\w]+)/(.*)$": "<rootDir>/indico/modules/events/$1/client/js/$2",
@@ -177,10 +176,20 @@
     ],
     "globals": {
       "REACT_TRANSLATIONS": {
-        "indico": {"": {"domain": "indico", "lang": "en_GB"}}
+        "indico": {
+          "": {
+            "domain": "indico",
+            "lang": "en_GB"
+          }
+        }
       },
       "TRANSLATIONS": {
-        "indico": {"": {"domain": "indico", "lang": "en_GB"}}
+        "indico": {
+          "": {
+            "domain": "indico",
+            "lang": "en_GB"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
- Replacing a file and then uploading a new file in the same (multi-file) type deletes the file uploaded as a replacement.
- Replacing a freshly uploaded file in a single-file type results in both files disappearing, and the old file does not get deleted
- Replacing an existing file twice in a single-file type is broken
- Extensions / multiple aren't checked in the dropzones

We should ideally add some unit tests to cover those cases!