### PR TITLE
FileType manager interface

### DIFF
--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -16,7 +16,8 @@ _bp = IndicoBlueprint('event_editing', __name__, url_prefix='/event/<confId>', t
 
 # Frontend
 _bp.add_url_rule('/manage/editing/', 'dashboard', frontend.RHEditingDashboard)
-_bp.add_url_rule('/manage/editing/tags', 'manage_tags', frontend.RHEditingTags)
+_bp.add_url_rule('/manage/editing/tags', 'manage_tags', frontend.RHManageEditingTags)
+_bp.add_url_rule('/manage/editing/types', 'manage_file_types', frontend.RHManageEditingFileTypes)
 _bp.add_url_rule('/contributions/<int:contrib_id>/editing/<any(paper):type>', 'editable', frontend.RHEditableTimeline)
 _bp.add_url_rule('/contributions/<int:contrib_id>/editing/<any(paper):type>/<int:revision_id>/files.zip',
                  'revision_files_export', backend.RHExportRevisionFiles)

--- a/indico/modules/events/editing/client/js/components/FileTypeManager.jsx
+++ b/indico/modules/events/editing/client/js/components/FileTypeManager.jsx
@@ -30,10 +30,7 @@ export default function FileTypeManager({eventId}) {
   }
 
   return (
-    <div>
-      <h3>
-        <Translate>List of file types</Translate>
-      </h3>
+    <div styleName="file-types-container">
       {fileTypes.length === 0 && (
         <Message info>
           <Translate>There are no file types defined for this event</Translate>
@@ -57,7 +54,7 @@ export default function FileTypeManager({eventId}) {
           </div>
         </Segment>
       ))}
-      <Button primary floated="left">
+      <Button icon primary floated="right">
         <Icon name="plus" />
         <Translate>Add a new file type</Translate>
       </Button>

--- a/indico/modules/events/editing/client/js/components/FileTypeManager.jsx
+++ b/indico/modules/events/editing/client/js/components/FileTypeManager.jsx
@@ -1,0 +1,70 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2019 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import fileTypesURL from 'indico-url:event_editing.api_file_types';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Button, Icon, Loader, Message, Segment} from 'semantic-ui-react';
+import {Translate} from 'indico/react/i18n';
+import {useIndicoAxios} from 'indico/react/hooks';
+
+import './FileTypeManager.module.scss';
+
+export default function FileTypeManager({eventId}) {
+  const {data, loading: isLoadingFileTypes, lastData} = useIndicoAxios({
+    url: fileTypesURL({confId: eventId}),
+    camelize: true,
+    trigger: eventId,
+  });
+
+  const fileTypes = data || lastData;
+  if (isLoadingFileTypes && !lastData) {
+    return <Loader inline="centered" active />;
+  } else if (!fileTypes) {
+    return null;
+  }
+
+  return (
+    <div>
+      <h3>
+        <Translate>List of file types</Translate>
+      </h3>
+      {fileTypes.length === 0 && (
+        <Message info>
+          <Translate>There are no file types defined for this event</Translate>
+        </Message>
+      )}
+      {fileTypes.map(fileType => (
+        <Segment key={fileType.id} styleName="filetype-segment">
+          <div styleName="filetype">
+            <div>
+              <h3>{fileType.name}</h3>
+              <ul styleName="file-extensions">
+                {fileType.extensions.length !== 0
+                  ? fileType.extensions.map(ext => <li key={ext}>{ext}</li>)
+                  : Translate.string('(no extension restrictions)')}
+              </ul>
+            </div>
+            <div styleName="actions">
+              <Icon color="blue" name="pencil" />
+              <Icon color="red" name="trash" />
+            </div>
+          </div>
+        </Segment>
+      ))}
+      <Button primary floated="left">
+        <Icon name="plus" />
+        <Translate>Add a new file type</Translate>
+      </Button>
+    </div>
+  );
+}
+
+FileTypeManager.propTypes = {
+  eventId: PropTypes.number.isRequired,
+};

--- a/indico/modules/events/editing/client/js/components/FileTypeManager.module.scss
+++ b/indico/modules/events/editing/client/js/components/FileTypeManager.module.scss
@@ -7,37 +7,38 @@
 
 @import 'base/palette';
 
-.filetype-segment {
-    width: 290px;
+.file-types-container {
+    max-width: 300px !important;
 
-    .actions i {
-        cursor: pointer;
-    }
+    .filetype-segment {
+        .actions i {
+            cursor: pointer;
+        }
 
-    .filetype {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-    }
+        .filetype {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
 
-    .filetype h3 {
-        margin-bottom: 0;
-    }
+        .filetype h3 {
+            margin-bottom: 0;
+        }
 
-    .file-extensions {
-        font-style: italic;
-        color: $gray;
-        list-style-type: none;
-        margin: 0.2em 0;
-        padding: 0;
-    }
+        .file-extensions {
+            font-style: italic;
+            color: $gray;
+            list-style-type: none;
+            margin: 0.2em 0;
+            padding: 0;
 
-    .file-extensions li {
-        display: inline;
-    }
+            li {
+                display: inline;
+            }
 
-    .file-extensions li:not(:last-child)::after {
-        content: ', ';
+            li:not(:last-child)::after {
+                content: ', ';
+            }
+        }
     }
 }
-

--- a/indico/modules/events/editing/client/js/components/FileTypeManager.module.scss
+++ b/indico/modules/events/editing/client/js/components/FileTypeManager.module.scss
@@ -1,0 +1,43 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2019 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@import 'base/palette';
+
+.filetype-segment {
+    width: 290px;
+
+    .actions i {
+        cursor: pointer;
+    }
+
+    .filetype {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .filetype h3 {
+        margin-bottom: 0;
+    }
+
+    .file-extensions {
+        font-style: italic;
+        color: $gray;
+        list-style-type: none;
+        margin: 0.2em 0;
+        padding: 0;
+    }
+
+    .file-extensions li {
+        display: inline;
+    }
+
+    .file-extensions li:not(:last-child)::after {
+        content: ', ';
+    }
+}
+

--- a/indico/modules/events/editing/client/js/fileTypes.jsx
+++ b/indico/modules/events/editing/client/js/fileTypes.jsx
@@ -1,0 +1,20 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2019 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import FileTypeManager from './components/FileTypeManager';
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const fileTypeManager = document.querySelector('#editing-filetypes');
+  if (!fileTypeManager) {
+    return null;
+  }
+  const eventId = parseInt(fileTypeManager.dataset.eventId, 10);
+  ReactDOM.render(<FileTypeManager eventId={eventId} />, fileTypeManager);
+});

--- a/indico/modules/events/editing/client/js/index.js
+++ b/indico/modules/events/editing/client/js/index.js
@@ -7,3 +7,4 @@
 
 import './timeline';
 import './tags';
+import './fileTypes';

--- a/indico/modules/events/editing/controllers/frontend.py
+++ b/indico/modules/events/editing/controllers/frontend.py
@@ -9,7 +9,8 @@ from __future__ import unicode_literals
 
 from werkzeug.exceptions import NotFound
 
-from indico.modules.events.editing.controllers.base import RHContributionEditableBase, RHEditingBase
+from indico.modules.events.editing.controllers.base import (RHContributionEditableBase, RHEditingBase,
+                                                            RHEditingManagementBase)
 from indico.modules.events.editing.views import WPEditing
 
 
@@ -33,6 +34,11 @@ class RHEditableTimeline(RHContributionEditableBase):
         )
 
 
-class RHEditingTags(RHEditingBase):
+class RHManageEditingTags(RHEditingManagementBase):
     def _process(self):
         return WPEditing.render_template('management/tags.html', self.event)
+
+
+class RHManageEditingFileTypes(RHEditingManagementBase):
+    def _process(self):
+        return WPEditing.render_template('management/filetypes.html', self.event)

--- a/indico/modules/events/editing/templates/management/editing.html
+++ b/indico/modules/events/editing/templates/management/editing.html
@@ -17,6 +17,20 @@
                     </a>
                 </div>
             </div>
+            <div class="section">
+                <span class="icon icon-file" style="align-self: center;"></span>
+                <div class="text">
+                    <div class="label">
+                        {% trans %}File Types{% endtrans %}
+                    </div>
+                    {% trans %}Configure file types{% endtrans %}
+                </div>
+                <div class="toolbar">
+                    <a href="{{ url_for('.manage_file_types', event) }}" class="i-button icon-settings">
+                        {% trans %}Configure{% endtrans %}
+                    </a>
+                </div>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/indico/modules/events/editing/templates/management/filetypes.html
+++ b/indico/modules/events/editing/templates/management/filetypes.html
@@ -1,0 +1,9 @@
+{% extends 'events/editing/management/base.html' %}
+
+{% block subtitle %}
+    {% trans %}File Types{% endtrans %}
+{% endblock %}
+
+{% block content %}
+    <div id="editing-filetypes" data-event-id="{{ event.id }}"></div>
+{% endblock %}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/17234430/70812974-f89e2580-1dc8-11ea-8137-345c141713b7.png)


TODO

- [x] Fetch file types inside the file type manager component and not inside `index.jsx`

closes #4120 