### PR TITLE
Clone timetable entries in more consistent order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Bugfixes
 ^^^^^^^^
 
 - Hide Book of Abstracts menu item if LaTeX is disabled
+- Use a more consistent order when cloning the timetable (:issue:`4227`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This ensures that some rather uncommon ways of organizing the timetable don't result in entries moving around between the original event and a clone since the JS object holding the timetable data on the client is sorted by its keys.

fixes #4227