### PR TITLE
Allow more digits in registration prices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Improvements
 - Show more verbose error when email validation fails during event
   registration (:issue:`4177`)
 - Add link to external map in room details view (:issue:`4146`)
+- Allow up to 9 digits (instead of 6) before the decimal point in
+  registration fees
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20200120_1055_e01c48de5a5e_allow_more_digits_in_prices.py
+++ b/indico/migrations/versions/20200120_1055_e01c48de5a5e_allow_more_digits_in_prices.py
@@ -1,0 +1,41 @@
+"""Allow more digits in prices
+
+Revision ID: e01c48de5a5e
+Revises: 2496c4adc7e9
+Create Date: 2020-01-20 10:55:03.139046
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'e01c48de5a5e'
+down_revision = '2496c4adc7e9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('''
+        ALTER TABLE event_registration.forms
+            ALTER COLUMN base_price SET DATA TYPE numeric(11,2) USING base_price::numeric(11,2);
+        ALTER TABLE event_registration.registrations
+            ALTER COLUMN base_price SET DATA TYPE numeric(11,2) USING base_price::numeric(11,2);
+        ALTER TABLE event_registration.registrations
+            ALTER COLUMN price_adjustment SET DATA TYPE numeric(11,2) USING price_adjustment::numeric(11,2);
+        ALTER TABLE events.payment_transactions
+            ALTER COLUMN amount SET DATA TYPE numeric(11,2) USING amount::numeric(11,2);
+    ''')
+
+
+def downgrade():
+    op.execute('''
+        ALTER TABLE event_registration.forms
+            ALTER COLUMN base_price SET DATA TYPE numeric(8,2) USING base_price::numeric(8,2);
+        ALTER TABLE event_registration.registrations
+            ALTER COLUMN base_price SET DATA TYPE numeric(8,2) USING base_price::numeric(8,2);
+        ALTER TABLE event_registration.registrations
+            ALTER COLUMN price_adjustment SET DATA TYPE numeric(8,2) USING price_adjustment::numeric(8,2);
+        ALTER TABLE events.payment_transactions
+            ALTER COLUMN amount SET DATA TYPE numeric(8,2) USING amount::numeric(8,2);
+    ''')

--- a/indico/modules/events/payment/models/transactions.py
+++ b/indico/modules/events/payment/models/transactions.py
@@ -155,7 +155,7 @@ class PaymentTransaction(db.Model):
     )
     #: the base amount the user needs to pay (without payment-specific fees)
     amount = db.Column(
-        db.Numeric(8, 2),  # max. 999999.99
+        db.Numeric(11, 2),  # max. 999999999.99
         nullable=False
     )
     #: the currency of the payment (ISO string, e.g. EUR or USD)

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -151,7 +151,7 @@ class RegistrationForm(db.Model):
     )
     #: The base fee users have to pay when registering
     base_price = db.Column(
-        db.Numeric(8, 2),  # max. 999999.99
+        db.Numeric(11, 2),  # max. 999999999.99
         nullable=False,
         default=0
     )

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -123,13 +123,13 @@ class Registration(db.Model):
     )
     #: The base registration fee (that is not specific to form items)
     base_price = db.Column(
-        db.Numeric(8, 2),  # max. 999999.99
+        db.Numeric(11, 2),  # max. 999999999.99
         nullable=False,
         default=0
     )
     #: The price modifier applied to the final calculated price
     price_adjustment = db.Column(
-        db.Numeric(8, 2),  # max. 999999.99
+        db.Numeric(11, 2),  # max. 999999999.99
         nullable=False,
         default=0
     )


### PR DESCRIPTION
In some currencies registration fees can be in the millions, so 6 digits aren't enough there...