### PR TITLE
Force English locale in registration mail for events

### DIFF
--- a/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
@@ -40,13 +40,13 @@
 {% macro render_registration_info() %}
     for the event <strong>{{ event.title }}</strong>
     {% if event.start_dt_local.date() == event.end_dt_local.date() %}
-        ({{ event.start_dt|format_datetime(timezone=event.tzinfo) }}
+        ({{ event.start_dt|format_datetime(timezone=event.tzinfo, locale='en_GB') }}
         -
-        {{ event.end_dt|format_time(timezone=event.tzinfo) }})
+        {{ event.end_dt|format_time(timezone=event.tzinfo, locale='en_GB') }})
     {% else %}
-        ({{ event.start_dt|format_datetime(timezone=event.tzinfo) }}
+        ({{ event.start_dt|format_datetime(timezone=event.tzinfo, locale='en_GB') }}
         -
-        {{ event.end_dt|format_datetime(timezone=event.tzinfo) }})
+        {{ event.end_dt|format_datetime(timezone=event.tzinfo, locale='en_GB') }})
     {% endif %}
 {% endmacro %}
 


### PR DESCRIPTION
When registering and being registered for events the mail will now always use en_GB as locale for the date, no matter the language picked.
Closes #3801.