### PR TITLE
OpenGraph: show event title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Bugfixes
   tickets are blocked (:issue:`4242`)
 - Fix event access key prompt not showing when accessing an attachment link
   (:issue:`4255`)
+- Include event title in OpenGraph metadata (:issue:`4288`)
 
 Version 2.2.5
 -------------

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -97,6 +97,7 @@ class WPEventBase(WPDecorated):
         metadata = super(WPEventBase, self).page_metadata
         return {
             'og': dict(metadata['og'], **{
+                'title': self.event.title,
                 'type': 'event',
                 'image': (self.event.logo_url if self.event.has_logo else
                           url_for('assets.image', filename='indico_square.png', _external=True)),


### PR DESCRIPTION
Indico page previews currently only show "Indico" as the title.

e.g.

![image](https://user-images.githubusercontent.com/2699/74165748-db999d80-4c25-11ea-9947-d6ac0f0dc607.png)
