### PR TITLE
Extract logic of registration form display to util

### DIFF
--- a/indico/modules/events/registration/__init__.py
+++ b/indico/modules/events/registration/__init__.py
@@ -67,16 +67,14 @@ def _inject_regform_announcement(event, **kwargs):
 
 @template_hook('event-header')
 def _inject_event_header(event, **kwargs):
-    from indico.modules.events.registration.util import get_event_regforms
+    from indico.modules.events.registration.util import get_event_regforms_registrations
     if event.has_feature('registration'):
-        all_regforms = get_event_regforms(event, session.user, with_registrations=True)
-        open_and_registered_regforms = [regform for regform, registration in all_regforms
-                                        if regform.is_open or registration]
-        user_registrations = {regform: registration for regform, registration in all_regforms}
+        displayed_regforms, user_registrations = get_event_regforms_registrations(event, session.user,
+                                                                                  include_scheduled=False)
         # A participant could appear more than once in the list in case he register to multiple registration form.
         # This is deemed very unlikely in the case of meetings and lectures and thus not worth the extra complexity.
         return render_template('events/registration/display/event_header.html', event=event,
-                               regforms=open_and_registered_regforms, user_registrations=user_registrations)
+                               regforms=displayed_regforms, user_registrations=user_registrations)
 
 
 @signals.event.sidemenu.connect

--- a/indico/modules/events/registration/clone_test.py
+++ b/indico/modules/events/registration/clone_test.py
@@ -5,31 +5,18 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from indico.core.db import db
+import pytest
+
 from indico.modules.events.cloning import EventCloner
 from indico.modules.events.features.util import set_feature_enabled
-from indico.modules.events.registration.models.registrations import Registration, RegistrationState
 
 
 pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
 
 
+@pytest.mark.usefixtures('dummy_reg')
 def test_registration_clone(dummy_event, dummy_regform, create_event, dummy_user):
     set_feature_enabled(dummy_event, 'registration', True)
-
-    reg1 = Registration(
-        event_id=dummy_event.id,
-        registration_form_id=dummy_regform.id,
-        first_name="Guinea",
-        last_name="Pig",
-        checked_in=True,
-        state=RegistrationState.complete,
-        currency="USD",
-        email="1337@example.com",
-        user=dummy_user
-    )
-    dummy_event.registrations.append(reg1)
-    db.session.flush()
 
     assert dummy_regform.event == dummy_event
     assert dummy_event.registrations.one().user == dummy_user

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -25,8 +25,8 @@ from indico.modules.events.registration.models.invitations import InvitationStat
 from indico.modules.events.registration.models.items import PersonalDataType
 from indico.modules.events.registration.models.registrations import Registration, RegistrationState
 from indico.modules.events.registration.util import (check_registration_email, create_registration, generate_ticket,
-                                                     get_event_regforms, get_event_section_data, get_title_uuid,
-                                                     make_registration_form)
+                                                     get_event_regforms_registrations, get_event_section_data,
+                                                     get_title_uuid, make_registration_form)
 from indico.modules.events.registration.views import (WPDisplayRegistrationFormConference,
                                                       WPDisplayRegistrationFormSimpleEvent,
                                                       WPDisplayRegistrationParticipantList)
@@ -71,14 +71,11 @@ class RHRegistrationFormList(RHRegistrationFormDisplayBase):
     """List of all registration forms in the event"""
 
     def _process(self):
-        all_regforms = get_event_regforms(self.event, session.user)
-        scheduled_and_registered_regforms = [regform[0] for regform in all_regforms
-                                             if regform[0].is_scheduled or regform[1]]
-        user_registrations = [regform[0].id for regform in all_regforms if regform[1]]
-        if len(scheduled_and_registered_regforms) == 1:
-            return redirect(url_for('.display_regform', scheduled_and_registered_regforms[0]))
+        displayed_regforms, user_registrations = get_event_regforms_registrations(self.event, session.user)
+        if len(displayed_regforms) == 1:
+            return redirect(url_for('.display_regform', displayed_regforms[0]))
         return self.view_class.render_template('display/regform_list.html', self.event,
-                                               regforms=scheduled_and_registered_regforms,
+                                               regforms=displayed_regforms,
                                                user_registrations=user_registrations)
 
 

--- a/indico/modules/events/registration/templates/display/regform_list.html
+++ b/indico/modules/events/registration/templates/display/regform_list.html
@@ -54,7 +54,7 @@
                         {% endif %}
                     {% endif %}
                     <td class="regform-actions">
-                        {% if session.user and regform.id in user_registrations %}
+                        {% if user_registrations[regform] %}
                             <a href="{{ url_for('.display_regform', regform) }}"
                                class="i-button highlight"
                                title="{% trans %}You have already registered{% endtrans %}">

--- a/indico/modules/events/registration/testing/fixtures.py
+++ b/indico/modules/events/registration/testing/fixtures.py
@@ -8,11 +8,13 @@
 import pytest
 
 from indico.modules.events.registration.models.forms import RegistrationForm
+from indico.modules.events.registration.models.registrations import Registration, RegistrationState
 from indico.modules.events.registration.util import create_personal_data_fields
 
 
 @pytest.fixture
 def dummy_regform(db, dummy_event):
+    """Create a dummy registration form for the dummy event"""
     regform = RegistrationForm(event=dummy_event, title='Registration Form', currency='USD')
     create_personal_data_fields(regform)
 
@@ -22,3 +24,21 @@ def dummy_regform(db, dummy_event):
     db.session.add(regform)
     db.session.flush()
     return regform
+
+
+@pytest.fixture
+def dummy_reg(db, dummy_event, dummy_regform, dummy_user):
+    """Create a dummy registration for the dummy event"""
+    reg = Registration(
+        registration_form_id=dummy_regform.id,
+        first_name="Guinea",
+        last_name="Pig",
+        checked_in=True,
+        state=RegistrationState.complete,
+        currency="USD",
+        email="1337@example.com",
+        user=dummy_user
+    )
+    dummy_event.registrations.append(reg)
+    db.session.flush()
+    return reg

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -488,6 +488,27 @@ def get_event_regforms(event, user, with_registrations=False):
     return query.all()
 
 
+def get_event_regforms_registrations(event, user, include_scheduled=True):
+    """Get regforms and the associated registrations for an event+user.
+
+    :param event: the `Event` to get registration forms for
+    :param user: A `User`
+    :param include_scheduled: Whether to include scheduled
+                              but not open registration forms
+    :return: A tuple, which includes:
+            - All registration forms which are scheduled, open or registered.
+            - A dict mapping all registration forms to the user's registration if they have one.
+    """
+    all_regforms = get_event_regforms(event, user, with_registrations=True)
+    if include_scheduled:
+        displayed_regforms = [regform for regform, registration in all_regforms
+                              if regform.is_scheduled or registration]
+    else:
+        displayed_regforms = [regform for regform, registration in all_regforms
+                              if regform.is_open or registration]
+    return displayed_regforms, dict(all_regforms)
+
+
 def generate_ticket(registration):
     from indico.modules.designer.util import get_default_template_on_category
     from indico.modules.events.registration.controllers.management.tickets import DEFAULT_TICKET_PRINTING_SETTINGS

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -7,12 +7,14 @@
 
 from __future__ import unicode_literals
 
+from datetime import datetime
 from io import BytesIO
 
 import pytest
 
 from indico.core.errors import UserValueError
-from indico.modules.events.registration.util import create_registration, import_registrations_from_csv
+from indico.modules.events.registration.util import (create_registration, get_event_regforms_registrations,
+                                                     import_registrations_from_csv)
 
 
 pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
@@ -109,3 +111,51 @@ def test_import_error(dummy_regform):
         import_registrations_from_csv(dummy_regform, BytesIO(csv))
     assert 'missing first' in str(e.value)
     assert 'Row 2' in str(e.value)
+
+
+@pytest.mark.parametrize(('start_dt', 'end_dt', 'include_scheduled', 'expected_regform_flag'), (
+    (datetime(2007, 1, 1, 1, 0, 0), datetime(2007, 2, 1, 1, 0, 0), False, False),
+    (datetime(2019, 1, 1, 1, 0, 0), datetime(2020, 2, 1, 1, 0, 0), False, True),
+    (datetime(2007, 1, 1, 1, 0, 0), datetime(2007, 2, 1, 1, 0, 0), True, True),
+    (datetime(2019, 1, 1, 1, 0, 0), datetime(2020, 2, 1, 1, 0, 0), True, True),
+    (None, datetime(2020, 2, 1, 1, 0, 0), False, False),
+    (None, datetime(2020, 2, 1, 1, 0, 0), True, False),
+    (datetime(2019, 1, 1, 1, 0, 0), None, False, True),
+    (None, None, False, False),
+    (None, None, True, False)
+))
+def test_get_event_regforms_no_registration(dummy_event, dummy_user, dummy_regform, freeze_time, start_dt, end_dt,
+                                            include_scheduled, expected_regform_flag):
+    freeze_time(datetime(2019, 12, 13, 8, 0, 0))
+    if start_dt:
+        dummy_regform.start_dt = dummy_event.tzinfo.localize(start_dt)
+    if end_dt:
+        dummy_regform.end_dt = dummy_event.tzinfo.localize(end_dt)
+
+    regforms, registrations = get_event_regforms_registrations(dummy_event, dummy_user, include_scheduled)
+
+    assert (dummy_regform in regforms) == expected_regform_flag
+    assert registrations.values() == [None]
+
+
+@pytest.mark.parametrize(('start_dt', 'end_dt', 'include_scheduled'), (
+    (datetime(2019, 1, 1, 1, 0, 0), datetime(2019, 2, 1, 1, 0, 0), True),
+    (datetime(2018, 1, 1, 1, 0, 0), datetime(2018, 12, 1, 1, 0, 0), False),
+    (datetime(2019, 1, 1, 1, 0, 0), datetime(2020, 2, 1, 1, 0, 0), False),
+    (None, None, False),
+    (datetime(2008, 1, 1, 1, 0, 0), None, False),
+    (None, datetime(2020, 12, 1, 1, 0, 0), True),
+))
+@pytest.mark.usefixtures('dummy_reg')
+def test_get_event_regforms_registration(dummy_event, dummy_user, dummy_regform, start_dt, end_dt, include_scheduled,
+                                         freeze_time):
+    freeze_time(datetime(2019, 12, 13, 8, 0, 0))
+    if start_dt:
+        dummy_regform.start_dt = dummy_event.tzinfo.localize(start_dt)
+    if end_dt:
+        dummy_regform.end_dt = dummy_event.tzinfo.localize(end_dt)
+
+    regforms, registrations = get_event_regforms_registrations(dummy_event, dummy_user, include_scheduled=False)
+
+    assert registrations.values()[0].user == dummy_user
+    assert dummy_regform in regforms


### PR DESCRIPTION
Logic which was used both for conferences and meeting/lectures now is placed in a util function.
The template for conferences was fixed to work with these changes.

Probably closes #4122. 
The requested behavior is implemented in the conference display. Since meetings/lectures do not show opening and closing dates of scheduling it was not changed here to avoid confusion.