### PR TITLE
Add `registrations` to `print_badge_template` signal

### DIFF
--- a/indico/core/signals/event/designer.py
+++ b/indico/core/signals/event/designer.py
@@ -11,5 +11,7 @@ from blinker import Namespace
 _signals = Namespace()
 
 print_badge_template = _signals.signal('print-badge-template', """
-Called when printing a badge template. The registration form is passed in the `regform` kwarg.
+Called when printing a badge template.
+The registration form is passed in the `regform` kwargs.
+The registration objects are passed in the `registrations` kwargs
 """)

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -411,7 +411,9 @@ class RHRegistrationsPrintBadges(RHRegistrationsActionBase):
         else:
             pdf_class = RegistrantsListToBadgesPDF
         registration_ids = config_params.pop('registration_ids')
-        signals.event.designer.print_badge_template.send(self.template, regform=self.regform)
+        registrations = Registration.query.filter(Registration.id.in_(registration_ids)).all()
+        signals.event.designer.print_badge_template.send(self.template, regform=self.regform,
+                                                         registrations=registrations)
         pdf = pdf_class(self.template, config_params, self.event, registration_ids)
         return send_file('Badges-{}.pdf'.format(self.event.id), pdf.get_pdf(), 'application/pdf')
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -493,7 +493,8 @@ def generate_ticket(registration):
     from indico.modules.events.registration.controllers.management.tickets import DEFAULT_TICKET_PRINTING_SETTINGS
     template = (registration.registration_form.ticket_template or
                 get_default_template_on_category(registration.event.category))
-    signals.event.designer.print_badge_template.send(template, regform=registration.registration_form)
+    signals.event.designer.print_badge_template.send(template, regform=registration.registration_form,
+                                                     registrations=[registration])
     pdf_class = RegistrantsListToBadgesPDFFoldable if template.backside_template else RegistrantsListToBadgesPDF
     pdf = pdf_class(template, DEFAULT_TICKET_PRINTING_SETTINGS, registration.event, [registration.id])
     return pdf.get_pdf()


### PR DESCRIPTION
This PR adds an argument `registrations` to the `indico.core.signals.events.designer.print_badge_template`.
The newly added argument `registrations` contains the list of `Registration` objects for which badges are printed.