### PR TITLE
Event delete: add log entry and optional info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,7 @@ Improvements
 - Show warning when trying to merge a blocked user (:issue:`3845`)
 - Allow importing event role members from a CSV file (:issue:`4301`)
 - Allow optional comment when accepting a pre-booking (:issue:`4086`)
+- Log event restores in event log (:issue:`4309`)
 
 Bugfixes
 ^^^^^^^^


### PR DESCRIPTION
Closes #4309 

Example:

![image](https://user-images.githubusercontent.com/2699/75053321-58076880-54d1-11ea-8023-663e8449dd35.png)

Optional args:
 * `-u USER_ID` - identity of the user shown on the log
 * `-m MESSAGE` - additional message to display on the log (e.g. "requested by user")