### PR TITLE
Disallow overlap checks with no occurrences

### DIFF
--- a/indico/modules/rb/models/reservation_occurrences.py
+++ b/indico/modules/rb/models/reservation_occurrences.py
@@ -160,6 +160,8 @@ class ReservationOccurrence(db.Model, Serializer):
 
     @staticmethod
     def filter_overlap(occurrences):
+        if not occurrences:
+            raise RuntimeError('Cannot check for overlap with empty occurrence list')
         return or_(db_dates_overlap(ReservationOccurrence, 'start_dt', occ.start_dt, 'end_dt', occ.end_dt)
                    for occ in occurrences)
 


### PR DESCRIPTION
If there's a race condition when cancelling and accepting a booking, it's possible that the booking has no valid occurrences anymore, in which case `filter_overlap` matches all occurrences, which will then result in every single reservation occurrence for the whole room being rejected.