### PR TITLE
Enhance search for room booking for events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,8 @@ Bugfixes
 
 - Hide Book of Abstracts menu item if LaTeX is disabled
 - Use a more consistent order when cloning the timetable (:issue:`4227`)
+- Do not show unrelated rooms with similar names when booking room from an
+  event (:issue:`4089`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/rb/util.py
+++ b/indico/modules/rb/util.py
@@ -272,7 +272,7 @@ def get_booking_params_for_event(event):
     params = {
         'link_type': 'event',
         'link_id': event.id,
-        'text': event.room.name if event.room else None,
+        'text': '#{}'.format(event.room.id) if event.room else None,
     }
     all_times = {day: (_find_first_entry_start_dt(event, day), _find_latest_entry_end_dt(event, day))
                  for day in event.iter_days(tzinfo=event.tzinfo)}

--- a/indico/modules/rb/util_test.py
+++ b/indico/modules/rb/util_test.py
@@ -67,7 +67,7 @@ def test_get_booking_params_for_event_same_times(create_event, dummy_room, start
         'params': dict({
             'link_id': event.id,
             'link_type': 'event',
-            'text': dummy_room.name,
+            'text': '#{}'.format(dummy_room.id),
         }, **expected_params)
     }
 
@@ -95,7 +95,7 @@ def test_get_booking_params_for_event_multiple_times(create_event, create_contri
         'params': {
             'link_type': 'event',
             'link_id': event.id,
-            'text': dummy_room.name,
+            'text': '#{}'.format(dummy_room.id),
         },
         'time_info': [
             (date(2019, 8, 16), dict({'sd': '2019-08-16'}, **expected_params)),


### PR DESCRIPTION
Unrelated rooms with similar names will not be shown anymore when accessing room booking via event.
Closes #4089. 