### PR TITLE
Update requests & pin idna version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Bugfixes
   (:issue:`4255`)
 - Include event title in OpenGraph metadata (:issue:`4288`)
 - Fix error when viewing abstract with reviews that have no scores
+- Update requests and pin idna to avoid installing incompatible dependency versions
+  (:issue:`4327`)
 
 Version 2.2.5
 -------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,8 @@ simplejson==3.16.0
 termcolor==1.1.0
 wsgiref==0.1.2
 zope.interface==3.8.0
-requests==2.22.0
+requests==2.23.0
+idna==2.9
 Werkzeug==0.15.5
 Flask==1.1.1
 bcrypt==3.1.7


### PR DESCRIPTION
idna released 2.9 and the old requests version required `idna<2.9`, resulting in errors since email-validator pulls in `idna>2.0`

fixes #4327 