### PR TITLE
Add info about registration status to contributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,8 @@ Improvements
 - Warn about cancelling/rejecting whole recurring bookings instead of just
   specific occurrences (:issue:`4092`)
 - Add "quick cancel" link to room booking reminder emails (:issue:`4324`)
+- Add visual information and filtering options for participants'
+  registration status to the contribution list (:issue:`4318`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/templates/management/_contribution_list.html
+++ b/indico/modules/events/contributions/templates/management/_contribution_list.html
@@ -1,7 +1,7 @@
 {% from 'message_box.html' import message_box %}
 {% from 'attachments/_management_info_column.html' import render_attachment_info %}
 
-{% macro render_contrib_list(event, total_entries, contribs, sessions, tracks) %}
+{% macro render_contrib_list(event, total_entries, contribs, sessions, tracks, registered_persons) %}
     {% if contribs %}
         {% set has_codes = contribs|selectattr('code')|any %}
         {% set has_types = contribs|selectattr('type')|any %}
@@ -125,7 +125,20 @@
                             <td class="i-table person-row-cell" data-searchable="{{ contrib.speakers|map(attribute='name')|join(', ')|lower }}">
                                 <span class="vertical-aligner">
                                     {% for speaker in contrib.speakers | sort(attribute='display_order_key') -%}
-                                        <div class="person-row icon-user">{{ speaker.display_full_name }}</div>
+                                        {% set speaker_is_registered = speaker.person in registered_persons %}
+                                        <div class="person-row">
+                                            {% set tooltip %}
+                                                {% if speaker_is_registered %}
+                                                    {%- trans %}This speaker registered for the event{% endtrans -%}
+                                                {% else %}
+                                                    {%- trans %}This speaker did not register yet{% endtrans -%}
+                                                {% endif %}
+                                            {% endset %}
+                                            <i class="icon-user js-show-registrations {{ 'exists' if speaker_is_registered }}"
+                                               title="{{ tooltip }}"
+                                               data-qtip-position="bottom"></i>
+                                            {{ speaker.display_full_name }}
+                                        </div>
                                     {%- endfor %}
                                 </span>
                             </td>

--- a/indico/modules/events/contributions/templates/management/contributions.html
+++ b/indico/modules/events/contributions/templates/management/contributions.html
@@ -179,7 +179,7 @@
             </div>
         </div>
         <div class="list" id="contribution-list">
-            {{ render_contrib_list(event, total_entries, contribs, sessions, tracks) }}
+            {{ render_contrib_list(event, total_entries, contribs, sessions, tracks, registered_persons) }}
         </div>
         <div id="filter-placeholder"></div>
     </div>

--- a/indico/modules/events/management/templates/_event_person_list.html
+++ b/indico/modules/events/management/templates/_event_person_list.html
@@ -7,10 +7,13 @@
     <label for="filter-primary" class="i-button">{% trans %}Primary authors{% endtrans %}</label>
     <input type="checkbox" name="authors" id="filter-secondary" data-filter="secondary_author" checked>
     <label for="filter-secondary" class="i-button">{% trans %}Co-authors{% endtrans %}</label>
+    <input type="checkbox" name="authors" id="filter-no-registration" data-filter="not_registered" checked>
+    <label for="filter-no-registration" class="i-button">{% trans %}Not registered{% endtrans %}</label>
 {% endblock %}
 
 {% block table_head %}
     <th class="i-table thin-column hide-if-locked" data-sorter="false"></th>
+    <th class="i-table registration-column" data-sorter="false"></th>
     <th class="i-table name-column">{% trans %}Name{% endtrans %}</th>
     <th class="i-table email-column">{% trans %}Email{% endtrans %}</th>
     <th class="i-table affiliation-column">{% trans %}Affiliation{% endtrans %}</th>
@@ -21,11 +24,22 @@
 {% block table_body %}
     {% for event_person, person_roles in event_persons.iteritems() -%}
         {% set is_speaker = person_roles.speaker %}
+        {% set is_registered = not person_roles.not_registered %}
         <tr class="i-table" data-person-roles="{{ person_roles | tojson | forceescape }}">
             <td class="i-table thin-column hide-if-locked">
                 <input type="checkbox" value="{{ event_person.id }}" class="select-row"
                        name="{{ 'person_id' if event_person.user_id is defined else 'user_id' }}"
                        {{ 'disabled' if not event_person.email }}>
+            </td>
+            <td class="i-table registration-column">
+                {%- set registration_status -%}
+                    {%- if is_registered %}
+                        {%- trans %}This person is registered for the event{% endtrans -%}
+                    {%- else -%}
+                        {%- trans %}This person is not yet registered{% endtrans -%}
+                    {% endif -%}
+                {%- endset -%}
+                <i class="icon-ticket js-show-personregistrations {{ 'exists' if is_registered }}" title="{{ registration_status }}" data-qtip-position="bottom"></i>
             </td>
             <td class="i-table name-column">{{ event_person.full_name }}</td>
             <td class="i-table email-column">{{ event_person.email }}</td>

--- a/indico/web/client/js/jquery/extensions/global.js
+++ b/indico/web/client/js/jquery/extensions/global.js
@@ -73,6 +73,11 @@ $(document).ready(function() {
           my: 'bottom center',
           at: 'top center',
         };
+      } else if (position === 'bottom') {
+        positionOptions = {
+          my: 'top center',
+          at: 'bottom center'
+        }
       }
 
       /* Attach the qTip to a new element to avoid side-effects on all elements with "title" attributes. */

--- a/indico/web/client/styles/modules/_contributions.scss
+++ b/indico/web/client/styles/modules/_contributions.scss
@@ -59,6 +59,14 @@
         }
     }
 
+    .icon-user {
+        color: $pastel-gray;
+
+        &.exists {
+            color: $light-black;
+        }
+    }
+
     .tablesorter {
         .material-column {
             width: 5em;

--- a/indico/web/client/styles/modules/_event_management.scss
+++ b/indico/web/client/styles/modules/_event_management.scss
@@ -439,6 +439,16 @@ th.i-table {
         }
     }
 
+    .registration-column {
+        .icon-ticket {
+            color: $pastel-gray;
+
+            &.exists {
+                color: $light-black;
+            }
+        }
+    }
+
     .form-group-mail {
         display: block;
     }


### PR DESCRIPTION
- Presenters' user icons will now display their registration status in the contribution list
- Filtering contributions according to registration status of the speakers is possible
- Add column to the author list to display registration status
- Add filtering option to the author list for registration status

Closes #4318.