### PR TITLE
Fix misalignment of icons in registration scheduling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,7 @@ Bugfixes
 - Use a more consistent order when cloning the timetable (:issue:`4227`)
 - Do not show unrelated rooms with similar names when booking room from an
   event (:issue:`4089`)
+- Stop icons from overlapping in the datetime widget (:issue:`4342`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/partials/_inputs.scss
+++ b/indico/web/client/styles/partials/_inputs.scss
@@ -286,8 +286,11 @@ $dropdown-transition: $dropdown-transition-step ease-out;
     }
 
     .clear-pickers {
+        @include icon-before('icon-cross');
         font-size: 1.3em;
-        vertical-align: sub;
+        position: relative;
+        left: 20px;
+        top: 4px;
 
         &:hover {
             color: $red;

--- a/indico/web/templates/forms/datetime_widget.html
+++ b/indico/web/templates/forms/datetime_widget.html
@@ -15,7 +15,7 @@
         <i class="timezone"></i>{#--#}
         {% if field.allow_clear -%}
             <span id="{{ field.id }}-reset"
-                  class="icon-close clear-pickers" style="display: none;"
+                  class="clear-pickers" style="display: none;"
                   title="{% trans %}Clear date and time{% endtrans %}"></span>
         {%- endif %}
     </div>


### PR DESCRIPTION
Closes #4342.
Will look like this:
![](https://user-images.githubusercontent.com/23189858/76205436-85a32000-61fa-11ea-8c22-8688b3ed8f29.png)
