### PR TITLE
Fix alignment of materials for events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,7 @@ Bugfixes
 - Do not show unrelated rooms with similar names when booking room from an
   event (:issue:`4089`)
 - Stop icons from overlapping in the datetime widget (:issue:`4342`)
+- Fix alignment of materials in events (:issue:`4344`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/attachments/templates/_display.html
+++ b/indico/modules/attachments/templates/_display.html
@@ -37,12 +37,12 @@
     {% set folders = item.attached_items.folders if item else folders %}
 
     <div class="attachments-display-container toolbar">
-        <div class="folder folder-root {{ 'folder-root-empty' if not files }}">
-            {% for attachment in files %}
+        {% for attachment in files %}
+            <div class="folder">
                 {{ render_attachment(attachment, classes='i-button') }}
                 {{ template_hook('event-display-after-attachment', attachment=attachment, top_level=true, has_label=false) }}
-            {% endfor %}
-        </div>
+            </div>
+        {% endfor %}
 
         {%- for folder in folders -%}
             {{ render_folder(folder) }}

--- a/indico/web/client/styles/modules/_attachments.scss
+++ b/indico/web/client/styles/modules/_attachments.scss
@@ -333,9 +333,7 @@
         white-space: nowrap;
 
         margin-top: 0.2em;
-        &:not(:first-child) {
-            margin-left: 0.2em;
-        }
+
         &.is-protected {
             @extend %protected-colors;
         }
@@ -345,13 +343,8 @@
         }
     }
     .folder {
-        display: inline-block;
-
-        // folder-root may be invisible. In that case, we should
-        // omit the margin in the element right next to it.
-        &:not(.folder-root-empty) + * {
-            margin-left: 0.2em;
-        }
+        display: inline-flex;
+        margin-left: 0.2em;
 
         &.is-protected {
             .i-button.label {

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -566,7 +566,7 @@ div.event-details {
 
     .event-details-row {
         display: flex;
-        align-items: baseline;
+        align-items: flex-start;
         margin-bottom: 0.5em;
     }
 
@@ -588,4 +588,8 @@ div.event-details {
 
 .attachments-display-container {
     flex-wrap: wrap;
+
+    // needed to nullify the margin of the items in this flexbox
+    // for the very first items of each row
+    margin-left: -0.2em;
 }


### PR DESCRIPTION
Closes #4344.
Fixes the misalignment when only folders are present. 
Also fixes the misalignment for the second line of items.