### PR TITLE
Add warning for accepting concurrent pre-bookings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,8 @@ Improvements
 - Add "quick cancel" link to room booking reminder emails (:issue:`4324`)
 - Add visual information and filtering options for participants'
   registration status to the contribution list (:issue:`4318`)
+- Add warning when accepting a pre-booking in case there are
+  concurrent bookings (:issue:`4129`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
@@ -717,6 +717,7 @@ class BookingDetails extends React.Component {
                 )}
                 <Button
                   onClick={() => {
+                    this.changeState('cancel');
                     this.hideConfirm();
                   }}
                   content={PluralTranslate.string(

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.module.scss
@@ -26,7 +26,7 @@
     color: $gray;
 }
 
-.booking-logs {
+.booking-logs, .concurrent-reservations {
     margin-top: 20px;
 }
 
@@ -57,4 +57,10 @@
 
 .accept-with-message {
     border-left: 1px solid darken($green, 5%) !important;
+}
+
+.concurrent-reservations-list {
+    max-height: 150px;
+    overflow: auto;
+    min-height: 20px;
 }

--- a/indico/modules/rb/util.py
+++ b/indico/modules/rb/util.py
@@ -321,3 +321,9 @@ def get_booking_params_for_event(event):
             'params': params,
             'time_info': time_info
         }
+
+
+def get_prebooking_collisions(reservation):
+    from indico.modules.rb.models.reservation_occurrences import ReservationOccurrence
+    valid_occurrences = reservation.occurrences.filter(ReservationOccurrence.is_valid).all()
+    return ReservationOccurrence.find_overlapping_with(reservation.room, valid_occurrences, reservation.id).all()


### PR DESCRIPTION
Add a modal to inform the user about the automatic rejection of concurrent bookings when accepting another one.
Closes #4129.