### PR TITLE
Move the timetable logic to ellipsize entries to CSS

### DIFF
--- a/indico/web/client/js/legacy/libs/timetable/Base.js
+++ b/indico/web/client/js/legacy/libs/timetable/Base.js
@@ -1341,37 +1341,6 @@ type(
     },
 
     _legendPostDraw: function() {
-      var self = this;
-      // loop for truncation of too long session titles,
-      // the text next a coloured box in the "session legend".
-      var initialTruncing = null;
-      var i = 0;
-
-      // Loop through each legend item
-      $('.legendItem').each(function() {
-        var titleIsTruncated = false;
-        var fullTitle = $(this).text();
-        initialTruncing = fullTitle.length;
-        // Keep truncating the title until its short enough to be written in
-        // one line and still less wide than the
-        // "maximum legend item width".
-
-        var span = $(this).children('span');
-
-        while (span.get(0).offsetHeight > 25 || span.get(0).offsetWidth > 130) {
-          titleIsTruncated = true;
-          var truncSessionTitle = TimetableBlockBase.prototype.truncateTitle(
-            --initialTruncing,
-            fullTitle
-          );
-          span.html(truncSessionTitle);
-        }
-
-        if (titleIsTruncated) {
-          $(this).qtip({content: fullTitle, position: {my: 'top middle', at: 'bottom middle'}});
-        }
-      });
-
       if ($('#detailsButton').length) {
         $('#legendMainToggle').position({
           my: 'left top',

--- a/indico/web/client/styles/legacy/Default.css
+++ b/indico/web/client/styles/legacy/Default.css
@@ -334,40 +334,8 @@ div.exclusivePopup .printLink {
     -moz-border-radius-topright: 3px;
 }
 
-div.ui-draggable.timetableBlock {
-    /* border: 3px solid #9F883B;*/
-}
-
-div.ui-draggable.timetableBlock:hover {
-    cursor: move;
-}
-
-div.ui-draggable-dragging.timetableBlock {
-    z-index: 9000;
-    opacity: 0.5;
-}
-
 /* Timetable drag n drop,
    droppable styles ends here. */
-
-div.timetableBlockTitle {
-    font-weight: bold;
-    font-size: 11px;
-    padding: 4px;
-}
-
-a.entry-attachments + div.timetableBlockPresenters {
-    margin-right: 24px;
-}
-
-div.timetableBlockPresenters {
-    float: right;
-    margin: 4px;
-    margin-right: 6px;
-    margin-left: 6px;
-    font-size: 11px;
-    font-style: italic;
-}
 
 div.timetableBlockMaterial {
     cursor: pointer;
@@ -377,39 +345,6 @@ div.timetableBlockMaterial {
     width: 12px;
     height: 12px;
     background: transparent url(static:images/material_folder.png) scroll no-repeat 3px 3px;
-}
-
-div.timetableBlockTime {
-    position: absolute;
-    bottom: 4px;
-    right: 6px;
-    padding-top: 4px;
-    font-size: 11px;
-}
-
-div.timetableBlockTimeDiscreet {
-    float: left;
-    margin: 4px;
-    margin-right: 6px;
-    margin-left: 6px;
-    font-size: 11px;
-}
-
-div.timetableBlockLocation {
-    position: absolute;
-    bottom: 4px;
-    left: 4px;
-    font-style: italic;
-    padding-top: 4px;
-    font-size: 11px;
-}
-
-div.timetableBlockConvener {
-    position: absolute;
-    left: 4px;
-    font-style: italic;
-    padding-top: 4px;
-    font-size: 11px;
 }
 
 div.balloonPopupCloseButton {
@@ -433,69 +368,6 @@ div.balloonPopupCloseButton {
     text-align: center;
     font-family: Verdana;
     padding-top: 80px;
-}
-
-div.timetablePreLoading {
-    background: transparent url('static:images/load_big.gif') scroll no-repeat center center;
-}
-
-div.timetablePreLoading .text {
-    color: #777;
-    text-align: center;
-    font-family: Verdana;
-    letter-spacing: 2px;
-}
-
-div.timetableLoading {
-    position: absolute;
-    top: 40px;
-    left: 0px;
-    padding: 10px 0 6px 35px;
-    background: transparent url('static:images/loading.gif') scroll no-repeat 10px center;
-    color: #444;
-}
-
-.timetableFilter {
-    width: 100%;
-    position: fixed;
-    bottom: 0;
-    left: 0;
-}
-
-.timetableFilter .content {
-    width: 900px;
-    margin: 0 auto;
-    background: #ECECEC;
-    border: 1px solid #777;
-    border-bottom: none;
-    position: relative;
-}
-
-.timetableFilter .content table {
-    background: white;
-    width: 100%;
-}
-
-.timetableFilter .content td {
-    padding: 13px 30px;
-    white-space: nowrap;
-    background-color: #ECECEC;
-    vertical-align: middle;
-    width: 1px;
-}
-
-.timetableFilter .closeButton {
-    position: absolute;
-    top: 15px;
-    right: 15px;
-    width: 16px;
-    height: 16px;
-    cursor: pointer;
-    background: transparent url('static:images/close_button.png') scroll no-repeat 0 0;
-}
-
-.timetableFilter .closeButton:hover {
-    background-position: 0 -16px;
 }
 
 ul.popupList {

--- a/indico/web/client/styles/legacy/timetable.css
+++ b/indico/web/client/styles/legacy/timetable.css
@@ -115,10 +115,33 @@ div.ui-draggable-dragging.timetableBlock {
     opacity: 0.5;
 }
 
+div.entry-content {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    overflow: hidden;
+    line-height: normal;
+    padding: 4px;
+}
+
+div.timetableBlockWrapper {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    margin-right: 4px;
+    width: 100%;
+}
+
+div.timetableBlockWrapper > * {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 div.timetableBlockTitle {
     font-weight: bold;
     font-size: 11px;
-    padding: 4px;
+    order: 1;
 }
 
 a.entry-attachments + div.timetableBlockPresenters {
@@ -127,48 +150,39 @@ a.entry-attachments + div.timetableBlockPresenters {
 
 div.timetableBlockPresenters {
     float: right;
-    margin: 4px;
-    margin-right: 6px;
-    margin-left: 6px;
+    margin-right: 7px;
     font-size: 11px;
     font-style: italic;
     max-width: 50%;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
+    order: 2;
 }
 
 div.timetableBlockTime {
-    position: absolute;
-    bottom: 4px;
-    right: 6px;
+    margin-right: 7px;
     padding-top: 4px;
     font-size: 11px;
+    order: 3;
 }
 
-div.timetableBlockTimeDiscreet{
+div.timetableBlockTimeDiscreet {
     float: left;
-    margin: 4px;
-    margin-right: 6px;
-    margin-left: 6px;
+    margin: 4px 7px;
     font-size: 11px;
 }
 
 div.timetableBlockLocation {
-    position: absolute;
     bottom: 4px;
     left: 4px;
     font-style: italic;
     padding-top: 4px;
     font-size: 11px;
+    order: 2;
 }
 
 div.timetableBlockConvener {
-    position: absolute;
-    left: 4px;
     font-style: italic;
-    padding-top: 4px;
     font-size: 11px;
+    order: 2;
 }
 
 div.timetablePreLoading {

--- a/indico/web/client/styles/modules/_timetable.scss
+++ b/indico/web/client/styles/modules/_timetable.scss
@@ -283,7 +283,7 @@
 
 %timetable-entry-button {
     background: white;
-    height: 14px;
+    height: 19px;
     padding: 2px;
 }
 
@@ -322,4 +322,5 @@
     @include icon-before(icon-attachment);
     position: absolute;
     right: 0;
+    top: 0;
 }


### PR DESCRIPTION
Closes #4326 

The timetable truncation logic has been rewritten to CSS with the following structure:

![Captura de ecrã 2020-03-12, às 17 00 00](https://user-images.githubusercontent.com/12183954/76546195-f78d9a80-6482-11ea-94d5-aa57cb8b8106.png)
- Each timetable block contains a header and footer (.timetableBlockWrapper).
  - The header contains, respectively, the title, presenter and convener (if any).
  - The footer contains, respectively, the location and the time.
  - Header/footer wrappers are disposed of as columns and styled with `flex-wrap: wrap`. Which means that the footer (location and time) will be hidden if they do not fully fit inside the timetable block.

- Inside each wrapper, the entries will also `wrap` to display evenly when the width of the block is too small.

With `flex-wrap: wrap`      | Without
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/12183954/76546654-cbbee480-6483-11ea-8bb3-ee6b129e2704.png) | ![image](https://user-images.githubusercontent.com/12183954/76546695-dc6f5a80-6483-11ea-91b7-f14e4f891efe.png)

- If the header is too big to fit inside the timetable block, line wrappings will be removed to attempt to recover some spacing (handled by JS <sup>[1](#myfootnote1)</sup>) (ellipsis will also be applied):

With `white-space: nowrap`  | Without
:----------------------------:|:----------------------------:
![image](https://user-images.githubusercontent.com/12183954/76547015-661f2800-6484-11ea-96f5-50e66f10e6bc.png) | ![image](https://user-images.githubusercontent.com/12183954/76546943-40921e80-6484-11ea-85fc-3a8a2d8bc26d.png)

- To conclude, if the content still doesn't fit because the timetable block is too small, we'll reduce the content to a single line (handled by JS <sup>[1](#myfootnote1)</sup>):

With `flex-wrap: nowrap`       | Without
:----------------------------:|:----------------------------:
![image](https://user-images.githubusercontent.com/12183954/76547570-4d634200-6485-11ea-9714-f8f95af8ef42.png) | ![image](https://user-images.githubusercontent.com/12183954/76547558-4805f780-6485-11ea-9819-911e90582ddc.png)

<a name="myfootnote1">1</a>: The last two approaches need to be handled by JS because, at the time of this issue, I couldn't find any bulletproof CSS approach to prevent multi-line text from being cut with `overflow: hidden`. For future reference, this [article](http://hackingui.com/front-end/a-pure-css-solution-for-multiline-text-truncation/) includes the alternatives I considered.