### PR TITLE
Add event labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ Version 2.2.7
 
 *Unreleased*
 
+Improvements
+^^^^^^^^^^^^
+
+- Add support for event labels to indicate e.g. postponed or cancelled
+  events (:issue:`3199`)
+
 Bugfixes
 ^^^^^^^^
 

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -33,6 +33,8 @@ from indico.modules.categories.serialize import (serialize_categories_ical, seri
 from indico.modules.categories.util import get_category_stats, get_upcoming_events, serialize_event_for_json_ld
 from indico.modules.categories.views import WPCategory, WPCategoryCalendar, WPCategoryStatistics
 from indico.modules.events.models.events import Event
+from indico.modules.events.models.settings import EventSetting
+from indico.modules.events.settings import event_label_settings, event_labels_store
 from indico.modules.events.timetable.util import get_category_timetable
 from indico.modules.events.util import get_base_ical_parameters
 from indico.modules.news.util import get_recent_news
@@ -278,6 +280,16 @@ class RHDisplayCategoryEventsBase(RHDisplayCategoryBase):
         return dt > self.now - relativedelta(weeks=1)
 
 
+def _get_event_labels(events):
+    labels = {}
+    for setting in event_label_settings.query.filter(EventSetting.event_id.in_(e.id for e in events)):
+        value = setting.value
+        if setting.name == 'label':
+            value = event_labels_store.get(value)
+        labels.setdefault(setting.event_id, {})[setting.name] = value
+    return labels
+
+
 class RHDisplayCategory(RHDisplayCategoryEventsBase):
     """Show the contents of a category (events/subcategories)"""
 
@@ -321,9 +333,12 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
 
         managers = sorted(self.category.get_manager_list(), key=attrgetter('principal_type.name', 'name'))
 
+        labels = _get_event_labels(events)
+
         threshold_format = '%Y-%m'
         params = {'event_count': len(events),
                   'events_by_month': events_by_month,
+                  'labels': labels,
                   'format_event_date': self.format_event_date,
                   'future_event_count': future_event_count,
                   'show_future_events': show_future_events,
@@ -375,10 +390,11 @@ class RHEventList(RHDisplayCategoryEventsBase):
         self.events = event_query.all()
 
     def _process(self):
+        labels = _get_event_labels(self.events)
         events_by_month = self.group_by_month(self.events)
         tpl = get_template_module('categories/display/event_list.html')
         html = tpl.event_list_block(events_by_month=events_by_month, format_event_date=self.format_event_date,
-                                    is_recent=self.is_recent, happening_now=self.happening_now)
+                                    is_recent=self.is_recent, happening_now=self.happening_now, labels=labels)
         return jsonify_data(flash=False, html=html)
 
 

--- a/indico/modules/categories/templates/display/category.html
+++ b/indico/modules/categories/templates/display/category.html
@@ -27,7 +27,7 @@
         {{ event_list(events_by_month=events_by_month, format_event_date=format_event_date, is_recent=is_recent,
                       happening_now=happening_now, category=category, future_event_count=future_event_count,
                       past_event_count=past_event_count, future_threshold=future_threshold, past_threshold=past_threshold,
-                      show_future_events=show_future_events, show_past_events=show_past_events) }}
+                      show_future_events=show_future_events, show_past_events=show_past_events, labels=labels) }}
     {% endif %}
 {% endblock %}
 

--- a/indico/modules/categories/templates/display/event_list.html
+++ b/indico/modules/categories/templates/display/event_list.html
@@ -103,7 +103,10 @@
                                 {% endif %}
 
                                 {% if is_recent(event.created_dt) %}
-                                    <i class="icon-new new-label" title="{% trans %}This event is new.{% endtrans %}"></i>
+                                    <span class="ui label mini blue"
+                                          title="{% trans %}This event is new.{% endtrans %}">
+                                        {%- trans %}new{% endtrans -%}
+                                    </span>
                                 {% endif %}
                             </span>
                         </div>

--- a/indico/modules/categories/templates/display/event_list.html
+++ b/indico/modules/categories/templates/display/event_list.html
@@ -43,7 +43,7 @@
 
 {% macro event_list(events_by_month, format_event_date, is_recent, happening_now, category, future_event_count,
                     past_event_count, future_threshold, past_threshold, future_events_by_month=[],
-                    past_events_by_month=[], show_future_events=false, show_past_events=false) %}
+                    past_events_by_month=[], show_future_events=false, show_past_events=false, labels={}) %}
     <div class="event-list"
          data-show-future-events-url="{{ url_for('.show_future_events', category) }}"
          data-show-past-events-url="{{ url_for('.show_past_events', category) }}">
@@ -58,7 +58,7 @@
             {% endcall %}
         {% endif %}
         <div>
-            {{ event_list_block(events_by_month, format_event_date, is_recent, happening_now) }}
+            {{ event_list_block(events_by_month, format_event_date, is_recent, happening_now, labels=labels) }}
         </div>
         {% if past_event_count %}
             {% call _hidden_events_block('past-events', category, past_events_by_month, format_event_date, is_recent,
@@ -77,7 +77,7 @@
     </script>
 {% endmacro %}
 
-{% macro event_list_block(events_by_month, format_event_date, is_recent, happening_now) %}
+{% macro event_list_block(events_by_month, format_event_date, is_recent, happening_now, labels={}) %}
     {% for month in events_by_month %}
         <h4 class="{% if month.is_current %}current-month{% endif %}">
             <span>{{ month.name }}</span>
@@ -109,6 +109,13 @@
                                     </span>
                                 {% endif %}
                             </span>
+                            {% set label_data = labels.get(event.id) %}
+                            {% if label_data and label_data.label %}
+                                <span class="ui label basic mini {{ label_data.label.color }}"
+                                      title="{{ label_data.message }}">
+                                    {{- label_data.label.title -}}
+                                </span>
+                            {% endif %}
                         </div>
                     </span>
                 </li>

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -190,6 +190,8 @@ def _sidemenu_items(sender, **kwargs):
     if session.user.is_admin:
         yield SideMenuItem('reference_types', _('External ID Types'), url_for('events.reference_types'),
                            section='customization')
+        yield SideMenuItem('event_labels', _('Event Labels'), url_for('events.event_labels'),
+                           section='customization')
 
 
 @signals.menu.sections.connect_via('top-menu')

--- a/indico/modules/events/blueprint.py
+++ b/indico/modules/events/blueprint.py
@@ -7,8 +7,9 @@
 
 from __future__ import unicode_literals
 
-from indico.modules.events.controllers.admin import (RHCreateReferenceType, RHDeleteReferenceType, RHEditReferenceType,
-                                                     RHReferenceTypes)
+from indico.modules.events.controllers.admin import (RHCreateEventLabel, RHCreateReferenceType, RHDeleteEventLabel,
+                                                     RHDeleteReferenceType, RHEditEventLabel, RHEditReferenceType,
+                                                     RHEventLabels, RHReferenceTypes)
 from indico.modules.events.controllers.creation import RHCreateEvent
 from indico.modules.events.controllers.display import RHEventAccessKey, RHEventMarcXML, RHExportEventICAL
 from indico.modules.events.controllers.entry import event_or_shorturl
@@ -22,12 +23,19 @@ _bp = IndicoBlueprint('events', __name__, template_folder='templates', virtual_t
 _bp.add_url_rule('/admin/external-id-types/', 'reference_types', RHReferenceTypes, methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/external-id-types/create', 'create_reference_type', RHCreateReferenceType,
                  methods=('GET', 'POST'))
+_bp.add_url_rule('/admin/event-labels/', 'event_labels', RHEventLabels, methods=('GET', 'POST'))
+_bp.add_url_rule('/admin/event-labels/create', 'create_event_label', RHCreateEventLabel, methods=('GET', 'POST'))
 
 # Single reference type
 _bp.add_url_rule('/admin/external-id-types/<int:reference_type_id>/edit', 'update_reference_type', RHEditReferenceType,
                  methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/external-id-types/<int:reference_type_id>', 'delete_reference_type', RHDeleteReferenceType,
                  methods=('DELETE',))
+
+# Single event label
+_bp.add_url_rule('/admin/event-labels/<event_label_id>/edit', 'update_event_label', RHEditEventLabel,
+                 methods=('GET', 'POST'))
+_bp.add_url_rule('/admin/event-labels/<event_label_id>', 'delete_event_label', RHDeleteEventLabel, methods=('DELETE',))
 
 _bp.add_url_rule('/event/<confId>/event.ics', 'export_event_ical', RHExportEventICAL)
 

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -8,13 +8,16 @@
 from __future__ import unicode_literals
 
 from flask import flash, request
+from werkzeug.exceptions import NotFound
 
 from indico.core.db import db
 from indico.modules.admin import RHAdminBase
-from indico.modules.events.forms import ReferenceTypeForm
+from indico.modules.events.forms import EventLabelForm, ReferenceTypeForm
 from indico.modules.events.models.references import ReferenceType
-from indico.modules.events.operations import create_reference_type, delete_reference_type, update_reference_type
-from indico.modules.events.views import WPReferenceTypes
+from indico.modules.events.operations import (create_event_label, create_reference_type, delete_event_label,
+                                              delete_reference_type, update_event_label, update_reference_type)
+from indico.modules.events.settings import event_labels_store
+from indico.modules.events.views import WPEventAdmin
 from indico.util.i18n import _
 from indico.web.flask.templating import get_template_module
 from indico.web.forms.base import FormDefaults
@@ -43,7 +46,7 @@ class RHReferenceTypes(RHAdminBase):
 
     def _process(self):
         types = _get_all_reference_types()
-        return WPReferenceTypes.render_template('admin/reference_types.html', 'reference_types', reference_types=types)
+        return WPEventAdmin.render_template('admin/reference_types.html', 'reference_types', reference_types=types)
 
 
 class RHCreateReferenceType(RHAdminBase):
@@ -77,3 +80,63 @@ class RHDeleteReferenceType(RHManageReferenceTypeBase):
         delete_reference_type(self.reference_type)
         flash(_("External ID type '{}' successfully deleted").format(self.reference_type.name), 'success')
         return jsonify_data(html=_render_reference_type_list())
+
+
+def _get_all_event_labels():
+    return sorted(event_labels_store.get_all().values(), key=lambda x: x.title.lower())
+
+
+def _render_event_label_list():
+    tpl = get_template_module('events/admin/_event_label_list.html')
+    return tpl.render_event_label_list(_get_all_event_labels())
+
+
+class RHManageEventLabelBase(RHAdminBase):
+    """Base class for a specific event label"""
+
+    def _process_args(self):
+        RHAdminBase._process_args(self)
+        self.event_label = event_labels_store.get(request.view_args['event_label_id'])
+        if self.event_label is None:
+            raise NotFound
+
+
+class RHEventLabels(RHAdminBase):
+    """Manage event labels in server admin area"""
+
+    def _process(self):
+        labels = _get_all_event_labels()
+        return WPEventAdmin.render_template('admin/event_labels.html', 'event_labels', labels=labels)
+
+
+class RHCreateEventLabel(RHAdminBase):
+    """Create a new event label"""
+
+    def _process(self):
+        form = EventLabelForm()
+        if form.validate_on_submit():
+            event_label = create_event_label(form.data)
+            flash(_("Event label '{}' created successfully").format(event_label.title), 'success')
+            return jsonify_data(html=_render_event_label_list())
+        return jsonify_form(form)
+
+
+class RHEditEventLabel(RHManageEventLabelBase):
+    """Edit an existing event label"""
+
+    def _process(self):
+        form = EventLabelForm(obj=FormDefaults(self.event_label), event_label=self.event_label)
+        if form.validate_on_submit():
+            update_event_label(self.event_label, form.data)
+            flash(_("Event label '{}' successfully updated").format(self.event_label.title), 'success')
+            return jsonify_data(html=_render_event_label_list())
+        return jsonify_form(form)
+
+
+class RHDeleteEventLabel(RHManageEventLabelBase):
+    """Delete an existing event label"""
+
+    def _process_DELETE(self):
+        delete_event_label(self.event_label)
+        flash(_("Event label '{}' successfully deleted").format(self.event_label.title), 'success')
+        return jsonify_data(html=_render_event_label_list())

--- a/indico/modules/events/logs/util.py
+++ b/indico/modules/events/logs/util.py
@@ -44,7 +44,10 @@ def make_diff_log(changes, fields):
             field_data = {'title': field_data}
         title = field_data['title']
         convert = field_data.get('convert')
+        attr = field_data.get('attr')
         type_ = field_data.get('type')
+        if attr:
+            change = [getattr(x, attr) if x is not None else '' for x in change]
         if convert:
             change = convert(change)
         if type_ is not None:

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -16,6 +16,7 @@ from markupsafe import escape
 from pytz import timezone
 from werkzeug.datastructures import ImmutableMultiDict
 from wtforms import BooleanField, FloatField, SelectField, StringField, TextAreaField
+from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from wtforms.fields.html5 import IntegerField
 from wtforms.validators import DataRequired, InputRequired, NumberRange, Optional, ValidationError
 
@@ -32,6 +33,7 @@ from indico.modules.events.fields import EventPersonLinkListField, ReferencesFie
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.references import EventReference
 from indico.modules.events.sessions import COORDINATOR_PRIV_DESCS, COORDINATOR_PRIV_TITLES
+from indico.modules.events.settings import event_labels_store
 from indico.modules.events.timetable.util import get_top_level_entries
 from indico.modules.events.util import check_permissions
 from indico.util.date_time import format_datetime, format_human_timedelta, now_utc, relativedelta
@@ -207,12 +209,25 @@ class EventContactInfoForm(IndicoForm):
 class EventClassificationForm(IndicoForm):
     keywords = IndicoTagListField(_('Keywords'))
     references = ReferencesField(_('External IDs'), reference_class=EventReference)
+    # XXX: this is incredibly ugly but the normal SelectField doesn't have a good way to
+    # coerce into objects unless the objects can be put in `<option value=...>`
+    # we also switch to proper models in 2.3 so this is fine for now!
+    label = QuerySelectField(_('Label'), allow_blank=True, get_pk=attrgetter('id'), get_label=attrgetter('title'))
+    label_message = TextAreaField(_('Label message'),
+                                  description=_('You can optionally provide a message that is shown when hovering '
+                                                'the selected label.'))
 
     def __init__(self, *args, **kwargs):
         event = kwargs.pop('event')
         super(EventClassificationForm, self).__init__(*args, **kwargs)
         if event.type_ != EventType.meeting:
             del self.references
+        labels = event_labels_store.get_all().values()
+        if labels:
+            self.label.query = labels
+        else:
+            del self.label
+            del self.label_message
 
 
 class EventProtectionForm(IndicoForm):

--- a/indico/modules/events/management/templates/_settings.html
+++ b/indico/modules/events/management/templates/_settings.html
@@ -174,7 +174,7 @@
 
 
 {% macro render_section_classification(event, with_container=true) %}
-    {% set edit_cls_title = _('Edit keywords / references') if event.type == 'meeting' else _('Edit keywords') %}
+    {% set edit_cls_title = _('Edit keywords / references / label') if event.type == 'meeting' else _('Edit keywords / label') %}
     {% call render_section(event, 'classification', 'icon-tag', '.edit_classification', edit_cls_title,
                            with_container=with_container) %}
         <dl class="i-data-list">
@@ -200,6 +200,12 @@
                     {% endcall %}
                 </dd>
             {% endif %}
+            <dt>{% trans %}Label{% endtrans %}</dt>
+            <dd>
+                {% call with_default() %}
+                    {{ event.get_label_markup('mini') }}
+                {% endcall %}
+            </dd>
         </dl>
     {% endcall %}
 {% endmacro %}

--- a/indico/modules/events/models/labels.py
+++ b/indico/modules/events/models/labels.py
@@ -1,0 +1,37 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2020 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+import uuid
+
+from indico.util.locators import locator_property
+from indico.util.string import format_repr, return_ascii
+
+
+class EventLabel(object):
+    # TODO: convert this to a proper model in 2.3
+    id = None
+    title = None
+    color = None
+
+    def __init__(self, **kwargs):
+        if 'id' not in kwargs:
+            self.id = str(uuid.uuid4())
+        for name, value in kwargs.iteritems():
+            setattr(self, name, value)
+
+    def __eq__(self, other):
+        return isinstance(other, EventLabel) and other.id == self.id
+
+    @locator_property
+    def locator(self):
+        return {'event_label_id': self.id}
+
+    @return_ascii
+    def __repr__(self):
+        return format_repr(self, 'id', _text=self.title)

--- a/indico/modules/events/templates/admin/_event_label_list.html
+++ b/indico/modules/events/templates/admin/_event_label_list.html
@@ -1,0 +1,40 @@
+{% macro render_event_label_list(labels) %}
+    {% if labels %}
+        <table class="i-table-widget">
+            <thead>
+                <tr>
+                    <th>{% trans %}Label{% endtrans %}</th>
+                    <th class="action-column">{% trans %}Actions{% endtrans %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for label in labels %}
+                    <tr>
+                        <td>
+                            {% with label=label, message='', size='' %}
+                                {% include 'events/label.html' %}
+                            {% endwith %}
+                        </td>
+                        <td>
+                            <a href="#" class="icon-edit action-icon" title="{% trans %}Edit{% endtrans %}"
+                               data-href="{{ url_for('.update_event_label', label) }}"
+                               data-title="{% trans name=label.title %}Edit event label '{{ name }}'{% endtrans %}"
+                               data-update="#event-labels"
+                               data-ajax-dialog>
+                            </a>
+                            <a href="#" class="icon-remove action-icon" title="{% trans %}Delete{% endtrans %}"
+                               data-href="{{ url_for('.delete_event_label', label) }}"
+                               data-title="{% trans name=label.title %}Delete event label '{{ name }}'?{% endtrans %}"
+                               data-confirm="{% trans name=label.title %}Are you sure you want to permanently delete the event label '{{ name }}'? This action will remove it from all events that use it.{% endtrans %}"
+                               data-update="#event-labels"
+                               data-method="DELETE">
+                            </a>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <span class="empty">{% trans %}There are no event labels yet.{% endtrans %}</span>
+    {% endif %}
+{% endmacro %}

--- a/indico/modules/events/templates/admin/event_labels.html
+++ b/indico/modules/events/templates/admin/event_labels.html
@@ -1,0 +1,22 @@
+{% extends 'layout/admin_page.html' %}
+{% from 'events/admin/_event_label_list.html' import render_event_label_list %}
+
+{%- block content %}
+    <div class="i-box">
+        <div class="i-box-header">
+            <div class="i-box-title">{%- trans %}Existing event labels{% endtrans -%}</div>
+            <div class="i-box-buttons toolbar right">
+                <a href="#" class="i-button icon-plus"
+                   data-ajax-dialog
+                   data-href="{{ url_for('.create_event_label') }}"
+                   data-title="{% trans %}Create new event label{% endtrans %}"
+                   data-update="#event-labels">
+                    {%- trans %}Create new event label{% endtrans -%}
+                </a>
+            </div>
+        </div>
+        <div id="event-labels" class="i-box-table-widget">
+            {{ render_event_label_list(labels) }}
+        </div>
+    </div>
+{%- endblock %}

--- a/indico/modules/events/templates/display/conference/base.html
+++ b/indico/modules/events/templates/display/conference/base.html
@@ -42,7 +42,10 @@
                     <div class="confSubTitle f-self-stretch" style="{{ conf_layout_params.text_color_css }}">
                         {{ template_hook('conference-header', event=event) }}
                         <div class="datePlace">
-                            <div class="date">{{ _format_event_date(event) }}</div>
+                            <div class="date">
+                                {{- _format_event_date(event) -}}
+                                {{- event.get_label_markup() -}}
+                            </div>
                             <div class="place">{{ event.venue_name }}</div>
                             <div class="timezone">
                                 {%- trans tz=event.display_tzinfo.zone %}{{ tz }} timezone{% endtrans -%}

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -25,7 +25,10 @@
                 {{ render_manage_button(event, 'EVENT', show_button=show_button, toggle_notes=false) }}
             </div>
 
-            <h1>{{ event.get_verbose_title(show_series_pos=true) }}</h1>
+            <h1>
+                {{- event.get_verbose_title(show_series_pos=true) -}}
+                {{- event.get_label_markup() -}}
+            </h1>
             {% set chairpersons = event.person_links %}
             {% if chairpersons %}
                 <h2>

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -24,6 +24,7 @@
 
             <h1 itemprop="name">
                 {{- event.title -}}
+                {{- event.get_label_markup() -}}
             </h1>
             <div class="details">
                 <div class="event-date">

--- a/indico/modules/events/templates/label.html
+++ b/indico/modules/events/templates/label.html
@@ -1,0 +1,3 @@
+<span class="event-label ui label basic {{ label.color }} {{ size }}" title="{{ message }}">
+    {{- label.title -}}
+</span>

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -84,7 +84,7 @@ def render_event_footer(event, dark=False):
                            google_calendar_params=google_calendar_params)
 
 
-class WPReferenceTypes(WPAdmin):
+class WPEventAdmin(WPAdmin):
     template_prefix = 'events/'
 
 

--- a/indico/web/client/styles/_partials.scss
+++ b/indico/web/client/styles/_partials.scss
@@ -23,6 +23,7 @@
 @import "partials/jquery-indico-colorpicker";
 @import "partials/jquery-indico-locationpicker";
 @import "partials/labels";
+@import "partials/labels-sui";
 @import "partials/links";
 @import "partials/lists";
 @import "partials/main";

--- a/indico/web/client/styles/legacy/Conf_Basic.scss
+++ b/indico/web/client/styles/legacy/Conf_Basic.scss
@@ -26,6 +26,11 @@
     background: #1a64a0;
 }
 
+.confheader .event-label {
+    margin-left: 1em !important;
+    text-transform: uppercase;
+}
+
 .confLogoBox {
     height: 100%;
     float: left;

--- a/indico/web/client/styles/modules/_admin.scss
+++ b/indico/web/client/styles/modules/_admin.scss
@@ -31,3 +31,7 @@ table.ip-network-group .actions {
     width: 3em;
     text-align: right;
 }
+
+#event-labels .event-label {
+    text-transform: uppercase;
+}

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -319,13 +319,6 @@ ul.category-resource-qtip {
     line-height: 15px;
 }
 
-.new-label {
-    font-size: 2em;
-    vertical-align: middle;
-    color: $yellow;
-    margin-left: 0.2em;
-}
-
 
 #eventCreationForm {
     .form-group {

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -416,6 +416,10 @@ ul.category-resource-qtip {
             font-size: smaller;
             color: $dark-gray;
         }
+
+        .ui.label {
+            text-transform: uppercase;
+        }
     }
 }
 

--- a/indico/web/client/styles/modules/_event_management.scss
+++ b/indico/web/client/styles/modules/_event_management.scss
@@ -580,6 +580,10 @@ th.i-table {
                 color: $gray;
                 font-style: italic;
             }
+
+            .event-label {
+                text-transform: uppercase;
+            }
         }
     }
 }

--- a/indico/web/client/styles/partials/_labels-sui.scss
+++ b/indico/web/client/styles/partials/_labels-sui.scss
@@ -1,0 +1,703 @@
+// taken from Semantic UI (MIT-licensed)
+// to be removed again in 2.3 where SUI is available globally
+
+.ui.label {
+  display: inline-block;
+  line-height: 1;
+  vertical-align: baseline;
+  margin: 0em 0.14285714em;
+  background-color: #E8E8E8;
+  background-image: none;
+  padding: 0.5833em 0.833em;
+  color: rgba(0, 0, 0, 0.6);
+  text-transform: none;
+  font-weight: bold;
+  border: 0px solid transparent;
+  border-radius: 0.28571429rem;
+  -webkit-transition: background 0.1s ease;
+  transition: background 0.1s ease;
+}
+
+.ui.label:first-child {
+  margin-left: 0em;
+}
+
+.ui.label:last-child {
+  margin-right: 0em;
+}
+
+/*-------------------
+       Colors
+--------------------*/
+
+/*--- Red ---*/
+
+.ui.red.labels .label,
+.ui.red.label {
+  background-color: #CC0000 !important;
+  border-color: #CC0000 !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.red.labels .label:hover,
+a.ui.red.label:hover {
+  background-color: #b30000 !important;
+  border-color: #b30000 !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.red.corner.label,
+.ui.red.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.red.ribbon.label {
+  border-color: #990000 !important;
+}
+
+/* Basic */
+
+.ui.basic.red.label {
+  background: none #FFFFFF !important;
+  color: #CC0000 !important;
+  border-color: #CC0000 !important;
+}
+
+.ui.basic.red.labels a.label:hover,
+a.ui.basic.red.label:hover {
+  background-color: #FFFFFF !important;
+  color: #b30000 !important;
+  border-color: #b30000 !important;
+}
+
+/*--- Orange ---*/
+
+.ui.orange.labels .label,
+.ui.orange.label {
+  background-color: #FF8800 !important;
+  border-color: #FF8800 !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.orange.labels .label:hover,
+a.ui.orange.label:hover {
+  background-color: #e67a00 !important;
+  border-color: #e67a00 !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.orange.corner.label,
+.ui.orange.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.orange.ribbon.label {
+  border-color: #cc6d00 !important;
+}
+
+/* Basic */
+
+.ui.basic.orange.label {
+  background: none #FFFFFF !important;
+  color: #FF8800 !important;
+  border-color: #FF8800 !important;
+}
+
+.ui.basic.orange.labels a.label:hover,
+a.ui.basic.orange.label:hover {
+  background-color: #FFFFFF !important;
+  color: #e67a00 !important;
+  border-color: #e67a00 !important;
+}
+
+/*--- Yellow ---*/
+
+.ui.yellow.labels .label,
+.ui.yellow.label {
+  background-color: #ffcf00 !important;
+  border-color: #ffcf00 !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.yellow.labels .label:hover,
+a.ui.yellow.label:hover {
+  background-color: #e6ba00 !important;
+  border-color: #e6ba00 !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.yellow.corner.label,
+.ui.yellow.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.yellow.ribbon.label {
+  border-color: #cca600 !important;
+}
+
+/* Basic */
+
+.ui.basic.yellow.label {
+  background: none #FFFFFF !important;
+  color: #ffcf00 !important;
+  border-color: #ffcf00 !important;
+}
+
+.ui.basic.yellow.labels a.label:hover,
+a.ui.basic.yellow.label:hover {
+  background-color: #FFFFFF !important;
+  color: #e6ba00 !important;
+  border-color: #e6ba00 !important;
+}
+
+/*--- Olive ---*/
+
+.ui.olive.labels .label,
+.ui.olive.label {
+  background-color: #B5CC18 !important;
+  border-color: #B5CC18 !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.olive.labels .label:hover,
+a.ui.olive.label:hover {
+  background-color: #a7bd0d !important;
+  border-color: #a7bd0d !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.olive.corner.label,
+.ui.olive.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.olive.ribbon.label {
+  border-color: #00953c !important;
+}
+
+/* Basic */
+
+.ui.basic.olive.label {
+  background: none #FFFFFF !important;
+  color: #B5CC18 !important;
+  border-color: #B5CC18 !important;
+}
+
+.ui.basic.olive.labels a.label:hover,
+a.ui.basic.olive.label:hover {
+  background-color: #FFFFFF !important;
+  color: #a7bd0d !important;
+  border-color: #a7bd0d !important;
+}
+
+/*--- Green ---*/
+
+.ui.green.labels .label,
+.ui.green.label {
+  background-color: #00C851 !important;
+  border-color: #00C851 !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.green.labels .label:hover,
+a.ui.green.label:hover {
+  background-color: #00af47 !important;
+  border-color: #00af47 !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.green.corner.label,
+.ui.green.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.green.ribbon.label {
+  border-color: #00953c !important;
+}
+
+/* Basic */
+
+.ui.basic.green.label {
+  background: none #FFFFFF !important;
+  color: #00C851 !important;
+  border-color: #00C851 !important;
+}
+
+.ui.basic.green.labels a.label:hover,
+a.ui.basic.green.label:hover {
+  background-color: #FFFFFF !important;
+  color: #00af47 !important;
+  border-color: #00af47 !important;
+}
+
+/*--- Teal ---*/
+
+.ui.teal.labels .label,
+.ui.teal.label {
+  background-color: #45ba97 !important;
+  border-color: #45ba97 !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.teal.labels .label:hover,
+a.ui.teal.label:hover {
+  background-color: #39ad8a !important;
+  border-color: #39ad8a !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.teal.corner.label,
+.ui.teal.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.teal.ribbon.label {
+  border-color: #379579 !important;
+}
+
+/* Basic */
+
+.ui.basic.teal.label {
+  background: none #FFFFFF !important;
+  color: #45ba97 !important;
+  border-color: #45ba97 !important;
+}
+
+.ui.basic.teal.labels a.label:hover,
+a.ui.basic.teal.label:hover {
+  background-color: #FFFFFF !important;
+  color: #39ad8a !important;
+  border-color: #39ad8a !important;
+}
+
+/*--- Blue ---*/
+
+.ui.blue.labels .label,
+.ui.blue.label {
+  background-color: #0099CC !important;
+  border-color: #0099CC !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.blue.labels .label:hover,
+a.ui.blue.label:hover {
+  background-color: #0086b3 !important;
+  border-color: #0086b3 !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.blue.corner.label,
+.ui.blue.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.blue.ribbon.label {
+  border-color: #007399 !important;
+}
+
+/* Basic */
+
+.ui.basic.blue.label {
+  background: none #FFFFFF !important;
+  color: #0099CC !important;
+  border-color: #0099CC !important;
+}
+
+.ui.basic.blue.labels a.label:hover,
+a.ui.basic.blue.label:hover {
+  background-color: #FFFFFF !important;
+  color: #0086b3 !important;
+  border-color: #0086b3 !important;
+}
+
+/*--- Violet ---*/
+
+.ui.violet.labels .label,
+.ui.violet.label {
+  background-color: #6435C9 !important;
+  border-color: #6435C9 !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.violet.labels .label:hover,
+a.ui.violet.label:hover {
+  background-color: #5829bb !important;
+  border-color: #5829bb !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.violet.corner.label,
+.ui.violet.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.violet.ribbon.label {
+  border-color: #502aa1 !important;
+}
+
+/* Basic */
+
+.ui.basic.violet.label {
+  background: none #FFFFFF !important;
+  color: #6435C9 !important;
+  border-color: #6435C9 !important;
+}
+
+.ui.basic.violet.labels a.label:hover,
+a.ui.basic.violet.label:hover {
+  background-color: #FFFFFF !important;
+  color: #5829bb !important;
+  border-color: #5829bb !important;
+}
+
+/*--- Purple ---*/
+
+.ui.purple.labels .label,
+.ui.purple.label {
+  background-color: #6e5494 !important;
+  border-color: #6e5494 !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.purple.labels .label:hover,
+a.ui.purple.label:hover {
+  background-color: #614887 !important;
+  border-color: #614887 !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.purple.corner.label,
+.ui.purple.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.purple.ribbon.label {
+  border-color: #564273 !important;
+}
+
+/* Basic */
+
+.ui.basic.purple.label {
+  background: none #FFFFFF !important;
+  color: #6e5494 !important;
+  border-color: #6e5494 !important;
+}
+
+.ui.basic.purple.labels a.label:hover,
+a.ui.basic.purple.label:hover {
+  background-color: #FFFFFF !important;
+  color: #614887 !important;
+  border-color: #614887 !important;
+}
+
+/*--- Pink ---*/
+
+.ui.pink.labels .label,
+.ui.pink.label {
+  background-color: #E03997 !important;
+  border-color: #E03997 !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.pink.labels .label:hover,
+a.ui.pink.label:hover {
+  background-color: #e61a8d !important;
+  border-color: #e61a8d !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.pink.corner.label,
+.ui.pink.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.pink.ribbon.label {
+  border-color: #c71f7e !important;
+}
+
+/* Basic */
+
+.ui.basic.pink.label {
+  background: none #FFFFFF !important;
+  color: #E03997 !important;
+  border-color: #E03997 !important;
+}
+
+.ui.basic.pink.labels a.label:hover,
+a.ui.basic.pink.label:hover {
+  background-color: #FFFFFF !important;
+  color: #e61a8d !important;
+  border-color: #e61a8d !important;
+}
+
+/*--- Brown ---*/
+
+.ui.brown.labels .label,
+.ui.brown.label {
+  background-color: #A5673F !important;
+  border-color: #A5673F !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.brown.labels .label:hover,
+a.ui.brown.label:hover {
+  background-color: #975b33 !important;
+  border-color: #975b33 !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.brown.corner.label,
+.ui.brown.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.brown.ribbon.label {
+  border-color: #805031 !important;
+}
+
+/* Basic */
+
+.ui.basic.brown.label {
+  background: none #FFFFFF !important;
+  color: #A5673F !important;
+  border-color: #A5673F !important;
+}
+
+.ui.basic.brown.labels a.label:hover,
+a.ui.basic.brown.label:hover {
+  background-color: #FFFFFF !important;
+  color: #975b33 !important;
+  border-color: #975b33 !important;
+}
+
+/*--- Grey ---*/
+
+.ui.grey.labels .label,
+.ui.grey.label {
+  background-color: #bbbbbb !important;
+  border-color: #bbbbbb !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.grey.labels .label:hover,
+a.ui.grey.label:hover {
+  background-color: #c8c8c8 !important;
+  border-color: #c8c8c8 !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.grey.corner.label,
+.ui.grey.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.grey.ribbon.label {
+  border-color: #805031 !important;
+}
+
+/* Basic */
+
+.ui.basic.grey.label {
+  background: none #FFFFFF !important;
+  color: #bbbbbb !important;
+  border-color: #bbbbbb !important;
+}
+
+.ui.basic.grey.labels a.label:hover,
+a.ui.basic.grey.label:hover {
+  background-color: #FFFFFF !important;
+  color: #c8c8c8 !important;
+  border-color: #c8c8c8 !important;
+}
+
+/*--- Black ---*/
+
+.ui.black.labels .label,
+.ui.black.label {
+  background-color: #31393c !important;
+  border-color: #31393c !important;
+  color: #FFFFFF !important;
+}
+
+/* Link */
+
+.ui.black.labels .label:hover,
+a.ui.black.label:hover {
+  background-color: #3c464a !important;
+  border-color: #3c464a !important;
+  color: #FFFFFF !important;
+}
+
+/* Corner */
+
+.ui.black.corner.label,
+.ui.black.corner.label:hover {
+  background-color: transparent !important;
+}
+
+/* Ribbon */
+
+.ui.black.ribbon.label {
+  border-color: #805031 !important;
+}
+
+/* Basic */
+
+.ui.basic.black.label {
+  background: none #FFFFFF !important;
+  color: #31393c !important;
+  border-color: #31393c !important;
+}
+
+.ui.basic.black.labels a.label:hover,
+a.ui.basic.black.label:hover {
+  background-color: #FFFFFF !important;
+  color: #3c464a !important;
+  border-color: #3c464a !important;
+}
+
+/*-------------------
+        Basic
+--------------------*/
+
+.ui.basic.label {
+  background: none #FFFFFF;
+  border: 1px solid rgba(34, 36, 38, 0.15);
+  color: rgba(0, 0, 0, 0.87);
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+
+/* Link */
+
+a.ui.basic.label:hover {
+  text-decoration: none;
+  background: none #FFFFFF;
+  color: #1e70bf;
+  -webkit-box-shadow: 1px solid rgba(34, 36, 38, 0.15);
+  box-shadow: 1px solid rgba(34, 36, 38, 0.15);
+  -webkit-box-shadow: none;
+  box-shadow: none;
+}
+
+/* Pointing */
+
+.ui.basic.pointing.label:before {
+  border-color: inherit;
+}
+
+/*-------------------
+        Sizes
+--------------------*/
+
+.ui.mini.labels .label,
+.ui.mini.label {
+  font-size: 0.64285714rem;
+}
+
+.ui.tiny.labels .label,
+.ui.tiny.label {
+  font-size: 0.71428571rem;
+}
+
+.ui.small.labels .label,
+.ui.small.label {
+  font-size: 0.78571429rem;
+}
+
+.ui.labels .label,
+.ui.label {
+  font-size: 0.85714286rem;
+}
+
+.ui.large.labels .label,
+.ui.large.label {
+  font-size: 1rem;
+}
+
+.ui.big.labels .label,
+.ui.big.label {
+  font-size: 1.28571429rem;
+}
+
+.ui.huge.labels .label,
+.ui.huge.label {
+  font-size: 1.42857143rem;
+}
+
+.ui.massive.labels .label,
+.ui.massive.label {
+  font-size: 1.71428571rem;
+}

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -207,6 +207,11 @@ div.event-header {
 
 .event-header {
     @extend %font-family-title-light;
+
+    .event-label {
+        margin-left: 1em !important;
+        text-transform: uppercase;
+    }
 }
 
 .meeting-timetable, .meeting-sub-timetable {

--- a/indico/web/forms/colors.py
+++ b/indico/web/forms/colors.py
@@ -33,3 +33,21 @@ def get_colors():
         ColorTuple('#000000', '#D0C296'),
         ColorTuple('#202020', '#EFEBC2')
     ]
+
+
+def get_sui_colors():
+    return [
+        'red',
+        'orange',
+        'yellow',
+        'olive',
+        'green',
+        'teal',
+        'blue',
+        'violet',
+        'purple',
+        'pink',
+        'brown',
+        'grey',
+        'black'
+    ]


### PR DESCRIPTION
The implementation using the SettingsProxy for storage is somewhat dirty, but I don't want to introduce new alembic revisions in patch releases (2.3 will move it to a proper DB model), especially now ones that would need to add a column to the `Event` models and thus may be rather expensive on large databases.

closes #3199

---

![image](https://user-images.githubusercontent.com/179599/76940956-765b5b00-68fb-11ea-987c-22c2c3f1d1f2.png)

![image](https://user-images.githubusercontent.com/179599/76941121-c2a69b00-68fb-11ea-9c21-073198fa3005.png)

![image](https://user-images.githubusercontent.com/179599/76941138-c76b4f00-68fb-11ea-8884-41fbcfc48664.png)

![image](https://user-images.githubusercontent.com/179599/76941009-88d59480-68fb-11ea-9ba6-242dc0831a61.png)

![image](https://user-images.githubusercontent.com/179599/76941038-9854dd80-68fb-11ea-9f04-714bb4a2dce8.png)

![image](https://user-images.githubusercontent.com/179599/76941076-ac004400-68fb-11ea-9abd-20048400bce2.png)
