### PR TITLE
Separate revision 'comment' into 'initial_comment' and 'final_comment'

### DIFF
--- a/indico/migrations/versions/20200316_1515_aad32911e9df_separate_comment_into_initial_and_final.py
+++ b/indico/migrations/versions/20200316_1515_aad32911e9df_separate_comment_into_initial_and_final.py
@@ -1,0 +1,27 @@
+"""Separate comment into initial and final
+
+Revision ID: aad32911e9df
+Revises: b3ce69ab24d9
+Create Date: 2020-03-16 15:15:40.885457
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'aad32911e9df'
+down_revision = 'b3ce69ab24d9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(table_name='revisions', column_name='comment', new_column_name='initial_comment', schema='event_editing')
+    op.add_column('revisions', sa.Column('final_comment', sa.Text(), nullable=False, server_default=''), schema='event_editing')
+    op.alter_column('revisions', column_name='final_comment', server_default=None, schema='event_editing')
+
+
+def downgrade():
+    op.drop_column('revisions', 'final_comment', schema='event_editing')
+    op.alter_column('revisions', 'initial_comment', new_column_name='comment', schema='event_editing')

--- a/indico/modules/events/editing/client/js/components/Timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/components/Timeline/TimelineItem.jsx
@@ -33,7 +33,8 @@ export default function TimelineItem({block}) {
   const {fileTypes} = useSelector(selectors.getStaticData);
   const isLastBlock = lastBlock.id === block.id;
   const [visible, setVisible] = useState(isLastBlock);
-  const headerOnly = !visible || (!isLastBlock && block.items.length === 0 && !block.comment);
+  const headerOnly =
+    !visible || (!isLastBlock && block.items.length === 0 && !block.initialComment);
 
   return (
     <>
@@ -84,12 +85,12 @@ export default function TimelineItem({block}) {
                   files={block.files}
                   downloadURL={block.downloadFilesURL}
                 />
-                {block.comment && (
+                {block.initialComment && (
                   <>
                     <div className="titled-rule">
                       <Translate>Comment</Translate>
                     </div>
-                    <div dangerouslySetInnerHTML={{__html: block.commentHtml}} />
+                    <div dangerouslySetInnerHTML={{__html: block.initialCommentHtml}} />
                   </>
                 )}
                 {/* TODO: Check whether the current user is submitter */}

--- a/indico/modules/events/editing/client/js/components/Timeline/util.js
+++ b/indico/modules/events/editing/client/js/components/Timeline/util.js
@@ -41,6 +41,8 @@ export const blockPropTypes = {
   items: PropTypes.arrayOf(PropTypes.shape(blockItemPropTypes)).isRequired,
   initialState: PropTypes.shape(statePropTypes).isRequired,
   finalState: PropTypes.shape(statePropTypes).isRequired,
-  comment: PropTypes.string.isRequired,
-  commentHtml: PropTypes.string.isRequired,
+  initialComment: PropTypes.string.isRequired,
+  initialCommentHtml: PropTypes.string.isRequired,
+  finalComment: PropTypes.string,
+  finalCommentHtml: PropTypes.string,
 };

--- a/indico/modules/events/editing/client/js/selectors.js
+++ b/indico/modules/events/editing/client/js/selectors.js
@@ -70,11 +70,10 @@ export function processRevisions(revisions) {
       } else {
         header = Translate.string('Revision has been accepted');
       }
-
       items.push(
         createNewCustomItemFromRevision(revision, {
           state: 'accepted',
-          html: revision.commentHtml,
+          html: revision.finalCommentHtml,
           header,
         })
       );
@@ -83,7 +82,7 @@ export function processRevisions(revisions) {
         createNewCustomItemFromRevision(revision, {
           header: Translate.string('Revision has been rejected'),
           state: 'rejected',
-          html: revision.commentHtml,
+          html: revision.initialCommentHtml,
         })
       );
     } else if (finalState.name === FinalRevisionState.needs_submitter_changes) {
@@ -98,7 +97,7 @@ export function processRevisions(revisions) {
         createNewCustomItemFromRevision(revision, {
           user: revisions[0].submitter,
           state: 'needs_submitter_changes',
-          html: revision.commentHtml,
+          html: revision.finalCommentHtml,
           header,
         })
       );
@@ -108,7 +107,7 @@ export function processRevisions(revisions) {
           user: revisions[0].submitter,
           header: Translate.string('Editor made some changes and awaits submitter confirmation'),
           state: 'needs_submitter_confirmation',
-          html: revision.commentHtml,
+          html: revision.initialCommentHtml,
         })
       );
     }

--- a/indico/modules/events/editing/models/revisions.py
+++ b/indico/modules/events/editing/models/revisions.py
@@ -103,8 +103,14 @@ class EditingRevision(RenderModeMixin, db.Model):
         nullable=False,
         default=FinalRevisionState.none
     )
-    _comment = db.Column(
-        'comment',
+    _initial_comment = db.Column(
+        'initial_comment',
+        db.Text,
+        nullable=False,
+        default=''
+    )
+    _final_comment = db.Column(
+        'final_comment',
         db.Text,
         nullable=False,
         default=''
@@ -152,7 +158,8 @@ class EditingRevision(RenderModeMixin, db.Model):
     )
 
     #: A comment provided by whoever assigned the final state of the revision.
-    comment = RenderModeMixin.create_hybrid_property('_comment')
+    initial_comment = RenderModeMixin.create_hybrid_property('_initial_comment')
+    final_comment = RenderModeMixin.create_hybrid_property('_final_comment')
 
     # relationship backrefs:
     # - comments (EditingRevisionComment.revision)

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -91,7 +91,7 @@ def review_editable_revision(revision, editor, action, comment, tags, files=None
     _ensure_latest_revision(revision)
     _ensure_state(revision, initial=InitialRevisionState.ready_for_review, final=FinalRevisionState.none)
     revision.editor = editor
-    revision.comment = comment
+    revision.initial_comment = comment
     revision.tags = tags
     revision.final_state = {
         EditingReviewAction.accept: FinalRevisionState.accepted,
@@ -122,7 +122,7 @@ def confirm_editable_changes(revision, submitter, action, comment):
         EditingConfirmationAction.reject: FinalRevisionState.needs_submitter_changes,
     }[action]
     if comment:
-        create_revision_comment(revision, submitter, comment)
+        revision.final_comment = comment
     db.session.flush()
     if action == EditingConfirmationAction.accept:
         publish_editable_revision(revision)
@@ -136,7 +136,7 @@ def replace_revision(revision, user, comment, files):
     _ensure_state(revision,
                   initial=(InitialRevisionState.new, InitialRevisionState.ready_for_review),
                   final=FinalRevisionState.none)
-    revision.comment = comment
+    revision.initial_comment = comment
     revision.final_state = FinalRevisionState.replaced
     new_revision = EditingRevision(submitter=user,
                                    initial_state=revision.initial_state,
@@ -181,7 +181,8 @@ def undo_review(revision):
         revision.editable.published_revision = None
     db.session.flush()
     revision.final_state = FinalRevisionState.none
-    revision.comment = ''
+    revision.initial_comment = ''
+    revision.final_comment = ''
     db.session.flush()
     logger.info('Revision %r review undone', revision)
 

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -98,11 +98,12 @@ class EditingRevisionCommentSchema(mm.ModelSchema):
 class EditingRevisionSchema(mm.ModelSchema):
     class Meta:
         model = EditingRevision
-        fields = ('id', 'created_dt', 'submitter', 'editor', 'files', 'comment', 'comment_html', 'comments',
-                  'initial_state', 'final_state', 'tags', 'create_comment_url', 'download_files_url', 'review_url',
-                  'confirm_url')
+        fields = ('id', 'created_dt', 'submitter', 'editor', 'files', 'initial_comment', 'initial_comment_html',
+                  'final_comment', 'final_comment_html', 'comments', 'initial_state', 'final_state', 'tags',
+                  'create_comment_url', 'download_files_url', 'review_url', 'confirm_url')
 
-    comment_html = fields.Function(lambda rev: escape(rev.comment))
+    initial_comment_html = fields.Function(lambda rev: escape(rev.initial_comment))
+    final_comment_html = fields.Function(lambda rev: escape(rev.final_comment))
     submitter = fields.Nested(UserSchema, only=('id', 'avatar_bg_color', 'full_name'))
     editor = fields.Nested(UserSchema, only=('id', 'avatar_bg_color', 'full_name'))
     files = fields.List(fields.Nested(EditingRevisionFileSchema))


### PR DESCRIPTION
This allows the comment to be tied to the revision instead and delete it once the decision is undone.
Closes #4350.