### PR TITLE
Add code placeholder in filename template of paper editing

### DIFF
--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -32,6 +32,7 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
     const {
       eventId,
       contributionId,
+      contributionCode,
       apiEditableSubmitUrl,
       type,
       uploadUrl,
@@ -52,6 +53,7 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
         submitRevisionURL={apiEditableSubmitUrl}
         eventId={eventId}
         contributionId={contributionId}
+        contributionCode={contributionCode}
       />,
       editableSubmissionButton
     );

--- a/indico/modules/events/editing/client/js/components/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/components/EditableSubmissionButton.jsx
@@ -18,14 +18,18 @@ import {Translate} from 'indico/react/i18n';
 import {FinalFileManager} from './FileManager';
 import {fileTypePropTypes} from './FileManager/util';
 
+import {getFileTypes} from '../selectors';
+
 export default function EditableSubmissionButton({
   eventId,
   contributionId,
+  contributionCode,
   uploadURL,
   fileTypes,
   type,
   submitRevisionURL,
 }) {
+  fileTypes = getFileTypes({staticData: {fileTypes, contributionCode}});
   const [open, setOpen] = useState(false);
 
   const submitRevision = async formData => {
@@ -85,4 +89,5 @@ EditableSubmissionButton.propTypes = {
   fileTypes: PropTypes.arrayOf(PropTypes.shape(fileTypePropTypes)).isRequired,
   eventId: PropTypes.string.isRequired,
   contributionId: PropTypes.string.isRequired,
+  contributionCode: PropTypes.string.isRequired,
 };

--- a/indico/modules/events/editing/client/js/components/FileTypeModal.jsx
+++ b/indico/modules/events/editing/client/js/components/FileTypeModal.jsx
@@ -16,7 +16,7 @@ import {
   FinalSubmitButton,
   unsortedArraysEqual,
 } from 'indico/react/forms';
-import {Translate} from 'indico/react/i18n';
+import {Param, Translate} from 'indico/react/i18n';
 import ExtensionList from './ExtensionList';
 
 export default function FileTypeModal({onClose, onSubmit, fileType, header}) {
@@ -67,9 +67,15 @@ export default function FileTypeModal({onClose, onSubmit, fileType, header}) {
               <FinalInput
                 name="filename_template"
                 label={Translate.string('Filename template')}
-                description={Translate.string(
-                  'Glob-style filename template that all files of this type have to conform to (e.g. *_paper). No dots allowed.'
-                )}
+                description={
+                  <Translate>
+                    Glob-style filename template that all files of this type have to conform to
+                    (e.g. <Param name="example" value="*_paper" wrapper={<code />} />
+                    ). No dots allowed. It is possible to use{' '}
+                    <Param name="placeholder" value="{code}" wrapper={<code />} /> as a placeholder
+                    for the contribution programme code.
+                  </Translate>
+                }
                 pattern="^[^.]*$"
                 nullIfEmpty
               />

--- a/indico/modules/events/editing/client/js/components/Timeline/SubmitRevision.jsx
+++ b/indico/modules/events/editing/client/js/components/Timeline/SubmitRevision.jsx
@@ -22,7 +22,8 @@ import {createRevision} from '../../actions';
 import {getFilesFromRevision} from '../FileManager/util';
 
 export default function SubmitRevision() {
-  const {eventId, contributionId, fileTypes, editableType} = useSelector(selectors.getStaticData);
+  const {eventId, contributionId, editableType} = useSelector(selectors.getStaticData);
+  const fileTypes = useSelector(selectors.getFileTypes);
   const lastRevision = useSelector(selectors.getLastRevision);
   const dispatch = useDispatch();
   const currentUser = {fullName: Indico.User.full_name, avatarBgColor: Indico.User.avatar_bg_color};

--- a/indico/modules/events/editing/client/js/components/Timeline/judgment/UpdateFilesForm.jsx
+++ b/indico/modules/events/editing/client/js/components/Timeline/judgment/UpdateFilesForm.jsx
@@ -27,10 +27,10 @@ import FinalTagInput from './TagInput';
 import './JudgmentBox.module.scss';
 
 export default function UpdateFilesForm({setLoading}) {
-  const {fileTypes} = useSelector(selectors.getStaticData);
   const lastRevision = useSelector(selectors.getLastRevision);
   const staticData = useSelector(selectors.getStaticData);
   const {eventId, contributionId, editableType} = staticData;
+  const fileTypes = useSelector(selectors.getFileTypes);
   const dispatch = useDispatch();
   const files = getFilesFromRevision(fileTypes, lastRevision);
 

--- a/indico/modules/events/editing/client/js/selectors.js
+++ b/indico/modules/events/editing/client/js/selectors.js
@@ -173,6 +173,21 @@ export const needsSubmitterConfirmation = createSelector(
 );
 export const getStaticData = state => state.staticData;
 
+export const getFileTypes = createSelector(
+  getStaticData,
+  staticData => {
+    return staticData.fileTypes.map(fileType => {
+      if (!fileType.filenameTemplate) {
+        return fileType;
+      }
+      return {
+        ...fileType,
+        filenameTemplate: fileType.filenameTemplate.replace('{code}', staticData.contributionCode),
+      };
+    });
+  }
+);
+
 export const getLastRevertableRevisionId = createSelector(
   getDetails,
   details => {

--- a/indico/modules/events/editing/client/js/timeline.jsx
+++ b/indico/modules/events/editing/client/js/timeline.jsx
@@ -42,10 +42,12 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   const contributionId = parseInt(timelineElement.dataset.contributionId, 10);
+  const contributionCode = timelineElement.dataset.contributionCode;
   const editableType = timelineElement.dataset.editableType;
   const store = storeFactory({
     eventId,
     contributionId,
+    contributionCode,
     editableType,
     fileTypes,
     tags,

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -99,7 +99,7 @@ class RHCreateEditable(RHContributionEditableBase):
             raise UserValueError(_('Editable already exists'))
 
         args = parser.parse({
-            'files': EditingFilesField(self.event, required=True)
+            'files': EditingFilesField(self.event, self.contrib, required=True)
         })
 
         create_new_editable(self.contrib, self.editable_type, session.user, args['files'])
@@ -116,7 +116,7 @@ class RHReviewEditable(RHContributionEditableRevisionBase):
     def _process(self, action, comment):
         argmap = {'tags': EditingTagsField(self.event, missing=set())}
         if action == EditingReviewAction.update:
-            argmap['files'] = EditingFilesField(self.event, allow_claimed_files=True, required=True)
+            argmap['files'] = EditingFilesField(self.event, self.contrib, allow_claimed_files=True, required=True)
         args = parser.parse(argmap)
         review_editable_revision(self.revision, session.user, action, comment, args['tags'], args.get('files'))
         return '', 204
@@ -148,7 +148,7 @@ class RHReplaceRevision(RHContributionEditableRevisionBase):
     })
     def _process(self, comment):
         args = parser.parse({
-            'files': EditingFilesField(self.event, allow_claimed_files=True, required=True)
+            'files': EditingFilesField(self.event, self.contrib, allow_claimed_files=True, required=True)
         })
 
         replace_revision(self.revision, session.user, comment, args['files'])
@@ -163,7 +163,7 @@ class RHCreateSubmitterRevision(RHContributionEditableRevisionBase):
 
     def _process(self):
         args = parser.parse({
-            'files': EditingFilesField(self.event, allow_claimed_files=True, required=True)
+            'files': EditingFilesField(self.event, self.contrib, allow_claimed_files=True, required=True)
         })
 
         create_submitter_revision(self.revision, session.user, args['files'])

--- a/indico/modules/events/editing/templates/timeline.html
+++ b/indico/modules/events/editing/templates/timeline.html
@@ -8,6 +8,7 @@
     <div id="editing-timeline"
          data-event-id="{{ event.id }}"
          data-contribution-id="{{ editable.contribution.id }}"
+         data-contribution-code="{{ editable.contribution.code }}"
          data-editable-type="{{ editable.type.name }}">
     </div>
 {% endblock %}

--- a/indico/modules/events/papers/templates/_contributions.html
+++ b/indico/modules/events/papers/templates/_contributions.html
@@ -75,6 +75,7 @@
                             <div id="editable-submission-button"
                                  data-event-id="{{ contribution.event_id }}"
                                  data-contribution-id="{{ contribution.id }}"
+                                 data-contribution-code="{{ contribution.code }}"
                                  data-type="paper"
                                  data-upload-url="{{ url_for('event_editing.api_upload', contribution, type='paper') }}"
                                  data-api-editable-submit-url="{{ url_for('event_editing.api_create_editable', contribution, type='paper') }}">


### PR DESCRIPTION
Give the ability to use the contribution code as placeholder in the filename template for paper editing.
Closes #4320.