### PR TITLE
Expose user blocking in the admin UI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,9 @@ Improvements
   thanks :user:`giusedb` & :user:`omegak`)
 - Add category navigation dialog on category display page (:issue:`4282`,
   thanks :user:`omegak`)
+- Add UI for admins to block/unblock users (:issue:`3243`)
+- Show labels indicating whether a user is an admin, blocked or soft-deleted
+  (:issue:`4363`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/cli/user.py
+++ b/indico/cli/user.py
@@ -62,6 +62,8 @@ def _safe_lower(s):
               help='Include deleted users in the results')
 @click.option('--include-pending', '-P', is_flag=True,
               help='Include pending users in the results')
+@click.option('--include-blocked', '-B', is_flag=True,
+              help='Include blocked users in the results')
 @click.option('--include-external', '-X', is_flag=True,
               help='Also include external users (e.g. from LDAP). This is potentially very slow in substring mode')
 @click.option('--include-system', '-S', is_flag=True,
@@ -70,12 +72,13 @@ def _safe_lower(s):
 @click.option('--last-name', '-s', help='Last name of the user')
 @click.option('--email', '-e', help='Email address of the user')
 @click.option('--affiliation', '-a', help='Affiliation of the user')
-def search(substring, include_deleted, include_pending, include_external, include_system, **criteria):
+def search(substring, include_deleted, include_pending, include_blocked, include_external, include_system, **criteria):
     """Searches users matching some criteria"""
     assert set(criteria.viewkeys()) == {'first_name', 'last_name', 'email', 'affiliation'}
     criteria = {k: v for k, v in criteria.viewitems() if v is not None}
     res = search_users(exact=(not substring), include_deleted=include_deleted, include_pending=include_pending,
-                       external=include_external, allow_system_user=include_system, **criteria)
+                       include_blocked=include_blocked, external=include_external,
+                       allow_system_user=include_system, **criteria)
     if not res:
         print(cformat('%{yellow}No results found'))
         return

--- a/indico/modules/api/templates/user_profile.html
+++ b/indico/modules/api/templates/user_profile.html
@@ -12,15 +12,17 @@
                 {% if key and can_modify %}
                     <div class="i-box-buttons toolbar">
                         <div class="group">
-                            <button type="button" class="i-button warning icon-plus" data-href="{{ url_for('.key_create') }}" data-method="post"
+                            <button type="button" class="ui orange button" data-href="{{ url_for('.key_create') }}" data-method="post"
                                     data-params='{"force": "1"}'
                                     data-title="{% trans %}Create new API key{% endtrans %}"
                                     data-confirm="{% trans %}Do you really want to create a new API key? Your old key will stop working immediately!{% endtrans %}">
+                                <i aria-hidden="true" class="icon plus"></i>
                                 {%- trans %}Create new API key{% endtrans -%}
                             </button>
-                            <button type="button" class="i-button danger icon-remove" data-href="{{ url_for('.key_delete') }}" data-method="post"
+                            <button type="button" class="ui negative button" data-href="{{ url_for('.key_delete') }}" data-method="post"
                                     data-title="{% trans %}Delete API key{% endtrans %}"
                                     data-confirm="{% trans %}Do you really want to delete your API key?{% endtrans %}">
+                                <i aria-hidden="true" class="icon trash alternate"></i>
                                 {%- trans %}Delete API key{% endtrans -%}
                             </button>
                         </div>
@@ -36,7 +38,7 @@
                         {%- endtrans -%}
                     </p>
 
-                    <button type="button" class="i-button highlight" data-href="{{ url_for('.key_create') }}" data-method="post">
+                    <button type="button" class="ui primary button" data-href="{{ url_for('.key_create') }}" data-method="post">
                         {%- trans %}Create API key{% endtrans -%}
                     </button>
                 {% else %}
@@ -99,10 +101,11 @@
                 <div class="i-box-buttons toolbar">
                     <div class="group">
                         <button type="button"
-                                class="i-button warning icon-remove"
+                                class="ui warning button"
                                 data-href="{{ url_for('core.reset_signature_tokens') }}"
                                 data-method="POST"
                                 data-confirm="{% trans %}Are you sure you'd like to invalidate all your token-based links?{% endtrans %}">
+                            <i aria-hidden="true" class="icon trash alternate"></i>
                             {%- trans %}Invalidate all links{% endtrans -%}
                         </button>
                     </div>
@@ -128,13 +131,14 @@
                         <div class="i-box-buttons toolbar">
                             <div class="group">
                                 {% if key.is_blocked %}
-                                    <button type="button" class="i-button accept" data-href="{{ url_for('.key_block') }}"
+                                    <button type="button" class="ui positive button" data-href="{{ url_for('.key_block') }}"
                                             data-method="post">
                                         {%- trans %}Unblock API key{% endtrans -%}
                                     </button>
                                 {% else %}
-                                    <button type="button" class="i-button warning icon-disable" data-href="{{ url_for('.key_block') }}"
+                                    <button type="button" class="ui negative button" data-href="{{ url_for('.key_block') }}"
                                             data-method="post">
+                                        <i aria-hidden="true" class="icon ban"></i>
                                         {%- trans %}Block API key{% endtrans -%}
                                     </button>
                                 {% endif %}

--- a/indico/modules/api/templates/user_profile.html
+++ b/indico/modules/api/templates/user_profile.html
@@ -12,14 +12,21 @@
                 {% if key and can_modify %}
                     <div class="i-box-buttons toolbar">
                         <div class="group">
-                            <button type="button" class="ui orange button" data-href="{{ url_for('.key_create') }}" data-method="post"
+                            <button type="button"
+                                    class="ui orange button"
+                                    data-href="{{ url_for('.key_create') }}"
+                                    data-method="post"
                                     data-params='{"force": "1"}'
                                     data-title="{% trans %}Create new API key{% endtrans %}"
-                                    data-confirm="{% trans %}Do you really want to create a new API key? Your old key will stop working immediately!{% endtrans %}">
+                                    data-confirm="{% trans %}Do you really want to create a new API key?
+                                    Your old key will stop working immediately!{% endtrans %}">
                                 <i aria-hidden="true" class="icon plus"></i>
                                 {%- trans %}Create new API key{% endtrans -%}
                             </button>
-                            <button type="button" class="ui negative button" data-href="{{ url_for('.key_delete') }}" data-method="post"
+                            <button type="button"
+                                    class="ui negative button"
+                                    data-href="{{ url_for('.key_delete') }}"
+                                    data-method="post"
                                     data-title="{% trans %}Delete API key{% endtrans %}"
                                     data-confirm="{% trans %}Do you really want to delete your API key?{% endtrans %}">
                                 <i aria-hidden="true" class="icon trash alternate"></i>
@@ -38,7 +45,10 @@
                         {%- endtrans -%}
                     </p>
 
-                    <button type="button" class="ui primary button" data-href="{{ url_for('.key_create') }}" data-method="post">
+                    <button type="button"
+                            class="ui primary button"
+                            data-href="{{ url_for('.key_create') }}"
+                            data-method="post">
                         {%- trans %}Create API key{% endtrans -%}
                     </button>
                 {% else %}
@@ -47,7 +57,10 @@
                         <dd>
                             {{ key.token }}
                             {% if key.is_blocked %}
-                                <i class="icon-warning warningText" title="{% trans %}Your API key has been blocked. Please contact an administrator for further details.{% endtrans %}"></i>
+                                <i class="icon-warning warningText"
+                                   title="{% trans %}Your API key has been blocked.
+                                   Please contact an administrator for further details.{% endtrans %}">
+                                </i>
                             {% endif %}
                         </dd>
                         {% if use_signatures %}
@@ -71,9 +84,13 @@
                             <dd>
                                 {{ key.last_used_uri }}
                                 {% if key.last_used_auth %}
-                                    <i class="icon-shield" title="{% trans %}Last request could access private data.{% endtrans %}"></i>
+                                    <i class="icon-shield"
+                                       title="{% trans %}Last request could access private data.{% endtrans %}">
+                                    </i>
                                 {% else %}
-                                    <i class="icon-earth" title="{% trans %}Last request could only access public data.{% endtrans %}"></i>
+                                    <i class="icon-earth"
+                                       title="{% trans %}Last request could only access public data.{% endtrans %}">
+                                    </i>
                                 {% endif %}
                             </dd>
                         {% endif %}
@@ -104,7 +121,8 @@
                                 class="ui warning button"
                                 data-href="{{ url_for('core.reset_signature_tokens') }}"
                                 data-method="POST"
-                                data-confirm="{% trans %}Are you sure you'd like to invalidate all your token-based links?{% endtrans %}">
+                                data-confirm="{% trans %}Are you sure you'd like to invalidate all your
+                                token-based links?{% endtrans %}">
                             <i aria-hidden="true" class="icon trash alternate"></i>
                             {%- trans %}Invalidate all links{% endtrans -%}
                         </button>
@@ -131,12 +149,16 @@
                         <div class="i-box-buttons toolbar">
                             <div class="group">
                                 {% if key.is_blocked %}
-                                    <button type="button" class="ui positive button" data-href="{{ url_for('.key_block') }}"
+                                    <button type="button"
+                                            class="ui positive button"
+                                            data-href="{{ url_for('.key_block') }}"
                                             data-method="post">
                                         {%- trans %}Unblock API key{% endtrans -%}
                                     </button>
                                 {% else %}
-                                    <button type="button" class="ui negative button" data-href="{{ url_for('.key_block') }}"
+                                    <button type="button"
+                                            class="ui negative button"
+                                            data-href="{{ url_for('.key_block') }}"
                                             data-method="post">
                                         <i aria-hidden="true" class="icon ban"></i>
                                         {%- trans %}Block API key{% endtrans -%}

--- a/indico/modules/api/templates/user_profile.html
+++ b/indico/modules/api/templates/user_profile.html
@@ -13,7 +13,7 @@
                     <div class="i-box-buttons toolbar">
                         <div class="group">
                             <button type="button"
-                                    class="ui orange button"
+                                    class="ui orange small button"
                                     data-href="{{ url_for('.key_create') }}"
                                     data-method="post"
                                     data-params='{"force": "1"}'
@@ -24,7 +24,7 @@
                                 {%- trans %}Create new API key{% endtrans -%}
                             </button>
                             <button type="button"
-                                    class="ui negative button"
+                                    class="ui negative small button"
                                     data-href="{{ url_for('.key_delete') }}"
                                     data-method="post"
                                     data-title="{% trans %}Delete API key{% endtrans %}"
@@ -118,7 +118,7 @@
                 <div class="i-box-buttons toolbar">
                     <div class="group">
                         <button type="button"
-                                class="ui warning button"
+                                class="ui negative small button"
                                 data-href="{{ url_for('core.reset_signature_tokens') }}"
                                 data-method="POST"
                                 data-confirm="{% trans %}Are you sure you'd like to invalidate all your
@@ -150,14 +150,14 @@
                             <div class="group">
                                 {% if key.is_blocked %}
                                     <button type="button"
-                                            class="ui positive button"
+                                            class="ui positive small button"
                                             data-href="{{ url_for('.key_block') }}"
                                             data-method="post">
                                         {%- trans %}Unblock API key{% endtrans -%}
                                     </button>
                                 {% else %}
                                     <button type="button"
-                                            class="ui negative button"
+                                            class="ui negative small button"
                                             data-href="{{ url_for('.key_block') }}"
                                             data-method="post">
                                         <i aria-hidden="true" class="icon ban"></i>

--- a/indico/modules/auth/templates/accounts.html
+++ b/indico/modules/auth/templates/accounts.html
@@ -20,9 +20,9 @@
                             {{ form_header(form, orientation='vertical', classes='no-block-padding') }}
                             {{ form_rows(form) }}
                             {% call form_footer(form) %}
-                                <input class="i-button big highlight" type="submit"
+                                <input class="ui primary button" type="submit"
                                        value="{% trans %}Create account{% endtrans %}" data-disabled-until-change>
-                                <a href="#" class="i-button big js-hide-form">
+                                <a href="#" class="ui negative button js-hide-form">
                                     {% trans %}Cancel{% endtrans %}
                                 </a>
                             {% endcall %}
@@ -31,7 +31,7 @@
                         {{ form_header(form, orientation='vertical', classes='no-block-padding') }}
                         {{ form_rows(form) }}
                         {% call form_footer(form) %}
-                            <input class="i-button big highlight" type="submit" value="{% trans %}Modify credentials{% endtrans %}" data-disabled-until-change>
+                            <input class="ui primary button" type="submit" value="{% trans %}Modify credentials{% endtrans %}" data-disabled-until-change>
                         {% endcall %}
                     {% endif %}
                     {% if user.secondary_local_identities %}
@@ -70,7 +70,7 @@
                                                 </span>
                                             </span>
                                         </span>
-                                        <button class="i-button"
+                                        <button class="ui negative button"
                                             data-href="{{ url_for('.remove_account', identity) }}"
                                             data-method="post"
                                             data-title="{% trans %}Remove account{% endtrans %}"
@@ -122,12 +122,12 @@
                                         </span>
                                     </span>
                                     {% if identity.id == session.login_identity %}
-                                        <button class="i-button" disabled
+                                        <button class="ui primary button" disabled
                                             title="{% trans %}The account used to log in cannot be unlinked{% endtrans %}">
                                             {% trans %}Unlink{% endtrans %}
                                         </button>
                                     {% else %}
-                                        <button class="i-button right"
+                                        <button class="ui primary button right"
                                             data-href="{{ url_for('.remove_account', identity) }}"
                                             data-method="post"
                                             data-title="{% trans %}Unlink account{% endtrans %}"

--- a/indico/modules/auth/templates/accounts.html
+++ b/indico/modules/auth/templates/accounts.html
@@ -99,35 +99,35 @@
                 <ul class="group-list with-buttons">
                     {% if user.external_identities %}
                         {% for identity in user.external_identities | sort(attribute='safe_last_login_dt', reverse=True) %}
-                            <li>
+                            <li class="flexrow f-a-center">
                                 <span class="list-item-title">
                                     {{ provider_titles[identity.provider] }}
                                 </span>
-                                <small>
-                                    ({{ identity.identifier }})
-                                </small>
+                                <span>
+                                    <small>
+                                        ({{ identity.identifier }})
+                                    </small>
+                                </span>
                                 <span class="right">
                                     <span class="list-item-info">
-                                        <span>
-                                            <span class="label">
-                                                {% trans %}Last login:{% endtrans %}
-                                            </span>
-                                            <span class="content">
-                                                {% if identity.last_login_dt %}
-                                                    {{ identity.last_login_dt | format_datetime('short') }}
-                                                {% else %}
-                                                    {% trans %}Never{% endtrans %}
-                                                {% endif %}
-                                            </span>
+                                        <span class="label">
+                                            {% trans %}Last login:{% endtrans %}
+                                        </span>
+                                        <span class="content">
+                                            {% if identity.last_login_dt %}
+                                                {{ identity.last_login_dt | format_datetime('short') }}
+                                            {% else %}
+                                                {% trans %}Never{% endtrans %}
+                                            {% endif %}
                                         </span>
                                     </span>
                                     {% if identity.id == session.login_identity %}
-                                        <button class="ui primary small button" disabled
+                                        <button class="ui primary tiny button" disabled
                                             title="{% trans %}The account used to log in cannot be unlinked{% endtrans %}">
                                             {% trans %}Unlink{% endtrans %}
                                         </button>
                                     {% else %}
-                                        <button class="ui primary small button right"
+                                        <button class="ui primary tiny button right"
                                             data-href="{{ url_for('.remove_account', identity) }}"
                                             data-method="post"
                                             data-title="{% trans %}Unlink account{% endtrans %}"

--- a/indico/modules/auth/templates/accounts.html
+++ b/indico/modules/auth/templates/accounts.html
@@ -70,7 +70,7 @@
                                                 </span>
                                             </span>
                                         </span>
-                                        <button class="ui negative button"
+                                        <button class="ui negative small button"
                                             data-href="{{ url_for('.remove_account', identity) }}"
                                             data-method="post"
                                             data-title="{% trans %}Remove account{% endtrans %}"
@@ -122,12 +122,12 @@
                                         </span>
                                     </span>
                                     {% if identity.id == session.login_identity %}
-                                        <button class="ui primary button" disabled
+                                        <button class="ui primary small button" disabled
                                             title="{% trans %}The account used to log in cannot be unlinked{% endtrans %}">
                                             {% trans %}Unlink{% endtrans %}
                                         </button>
                                     {% else %}
-                                        <button class="ui primary button right"
+                                        <button class="ui primary small button right"
                                             data-href="{{ url_for('.remove_account', identity) }}"
                                             data-method="post"
                                             data-title="{% trans %}Unlink account{% endtrans %}"

--- a/indico/modules/events/features/controllers.py
+++ b/indico/modules/events/features/controllers.py
@@ -37,8 +37,7 @@ class RHFeatures(RHFeaturesBase):
         for name, feature in sorted(get_feature_definitions().iteritems(), key=lambda x: x[1].friendly_name):
             if name in disallowed:
                 continue
-            field = BooleanField(feature.friendly_name, widget=SwitchWidget(),
-                                 description=feature.description)
+            field = BooleanField(feature.friendly_name, widget=SwitchWidget(), description=feature.description)
             setattr(form_class, name, field)
         defaults = {name: True for name in get_enabled_features(self.event)}
         return form_class(csrf_enabled=False, obj=FormDefaults(defaults))

--- a/indico/modules/events/features/controllers.py
+++ b/indico/modules/events/features/controllers.py
@@ -17,7 +17,7 @@ from indico.modules.events.features.util import (format_feature_names, get_disal
 from indico.modules.events.features.views import WPFeatures
 from indico.modules.events.logs import EventLogKind, EventLogRealm
 from indico.modules.events.management.controllers import RHManageEventBase
-from indico.util.i18n import _, ngettext
+from indico.util.i18n import ngettext
 from indico.web.forms.base import FormDefaults, IndicoForm
 from indico.web.forms.widgets import SwitchWidget
 from indico.web.menu import render_sidemenu
@@ -37,7 +37,7 @@ class RHFeatures(RHFeaturesBase):
         for name, feature in sorted(get_feature_definitions().iteritems(), key=lambda x: x[1].friendly_name):
             if name in disallowed:
                 continue
-            field = BooleanField(feature.friendly_name, widget=SwitchWidget(on_label=_('On'), off_label=_('Off')),
+            field = BooleanField(feature.friendly_name, widget=SwitchWidget(),
                                  description=feature.description)
             setattr(form_class, name, field)
         defaults = {name: True for name in get_enabled_features(self.event)}

--- a/indico/modules/events/layout/forms.py
+++ b/indico/modules/events/layout/forms.py
@@ -68,7 +68,7 @@ class ConferenceLayoutForm(LoggedLayoutForm):
                                  description=_("Enable search within the event"))
     show_nav_bar = BooleanField(_("Show navigation bar"), widget=SwitchWidget(),
                                 description=_("Show the navigation bar at the top"))
-    show_banner = BooleanField(_("\"Now happening\""), widget=SwitchWidget(on_label=_("ON"), off_label=_("OFF")),
+    show_banner = BooleanField(_("\"Now happening\""), widget=SwitchWidget(),
                                description=_("Show a banner with the current entries from the timetable"))
     show_social_badges = BooleanField(_("Show social badges"), widget=SwitchWidget())
     name_format = IndicoEnumSelectField(_('Name format'), enum=NameFormat, none=_('Inherit from user preferences'),

--- a/indico/modules/events/sessions/templates/display/session_list.html
+++ b/indico/modules/events/sessions/templates/display/session_list.html
@@ -16,7 +16,7 @@
                                     {{- sess.title -}}
                                 </a>
                             </span>
-                            <div class="group">
+                            <div class="group f-self-no-shrink">
                                 {% if sess.can_manage(session.user) %}
                                     <a href="#" class="icon-edit" title="{% trans %}Edit session{% endtrans %}"
                                        data-title="{% trans title=sess.title %}Edit session '{{ title }}'{% endtrans %}"

--- a/indico/modules/oauth/templates/user_profile.html
+++ b/indico/modules/oauth/templates/user_profile.html
@@ -9,7 +9,7 @@
             </div>
         </div>
         <div class="i-box-content">
-            <p>{% trans %}This is the list of applications your authorized to access your Indico data.{% endtrans %}</p>
+            <p>{% trans %}This is the list of applications you authorized to access your Indico data.{% endtrans %}</p>
             <ul class="group-list with-buttons">
                 {% if not tokens %}
                     <li class="italic">
@@ -17,7 +17,7 @@
                     </li>
                 {% endif %}
                 {% for token in tokens|sort(attribute='application.name') %}
-                    <li>
+                    <li class="flexrow f-a-center">
                         <span class="list-item-title">{{ token.application.name }}</span>
                         <span class="right">
                             <span class="list-item-info">
@@ -30,7 +30,7 @@
                                     {% endif %}
                                 </span>
                             </span>
-                            <button class="ui negative button"
+                            <button class="ui negative small button"
                                     data-href="{{ url_for('.user_token_revoke', token) }}"
                                     data-method="POST"
                                     data-confirm="{% trans app_name=token.application.name %}{{ app_name }} will no longer have access to your Indico data.<br>

--- a/indico/modules/oauth/templates/user_profile.html
+++ b/indico/modules/oauth/templates/user_profile.html
@@ -30,7 +30,7 @@
                                     {% endif %}
                                 </span>
                             </span>
-                            <button class="i-button"
+                            <button class="ui negative button"
                                     data-href="{{ url_for('.user_token_revoke', token) }}"
                                     data-method="POST"
                                     data-confirm="{% trans app_name=token.application.name %}{{ app_name }} will no longer have access to your Indico data.<br>

--- a/indico/modules/users/blueprint.py
+++ b/indico/modules/users/blueprint.py
@@ -12,12 +12,13 @@ from flask import request
 from indico.modules.users.api import RHUserFavoritesAPI, fetch_authenticated_user
 from indico.modules.users.controllers import (RHAcceptRegistrationRequest, RHAdmins, RHExportDashboardICS,
                                               RHPersonalData, RHRegistrationRequestList, RHRejectRegistrationRequest,
-                                              RHUserDashboard, RHUserEmails, RHUserEmailsDelete, RHUserEmailsSetPrimary,
-                                              RHUserEmailsVerify, RHUserFavorites, RHUserFavoritesCategoryAPI,
-                                              RHUserFavoritesUserRemove, RHUserFavoritesUsersAdd, RHUserPreferences,
-                                              RHUsersAdmin, RHUsersAdminCreate, RHUsersAdminMerge,
-                                              RHUsersAdminMergeCheck, RHUsersAdminSettings, RHUserSearch,
-                                              RHUserSearchInfo, RHUserSuggestionsRemove)
+                                              RHUserBlock, RHUserDashboard, RHUserEmails, RHUserEmailsDelete,
+                                              RHUserEmailsSetPrimary, RHUserEmailsVerify, RHUserFavorites,
+                                              RHUserFavoritesCategoryAPI, RHUserFavoritesUserRemove,
+                                              RHUserFavoritesUsersAdd, RHUserPreferences, RHUsersAdmin,
+                                              RHUsersAdminCreate, RHUsersAdminMerge, RHUsersAdminMergeCheck,
+                                              RHUsersAdminSettings, RHUserSearch, RHUserSearchInfo,
+                                              RHUserSuggestionsRemove)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
@@ -56,6 +57,7 @@ with _bp.add_prefixed_rules('/<int:user_id>'):
     _bp.add_url_rule('/emails/verify/<token>', 'user_emails_verify', RHUserEmailsVerify)
     _bp.add_url_rule('/emails/<email>', 'user_emails_delete', RHUserEmailsDelete, methods=('DELETE',))
     _bp.add_url_rule('/emails/make-primary', 'user_emails_set_primary', RHUserEmailsSetPrimary, methods=('POST',))
+    _bp.add_url_rule('/blocked', 'user_block', RHUserBlock, methods=('PUT', 'DELETE'))
 
 _bp.add_url_rule('/<int:user_id>/dashboard.ics', 'export_dashboard_ics', RHExportDashboardICS)
 

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -642,6 +642,11 @@ class RHUserSearchInfo(RHProtected):
 
 
 class RHUserBlock(RHUserBase):
+    def _check_access(self):
+        RHUserBase._check_access(self)
+        if not session.user.is_admin:
+            raise Forbidden
+
     def _process_PUT(self):
         if self.user == session.user:
             raise Forbidden(_('You cannot block yourself'))

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -639,3 +639,17 @@ class RHUserSearchInfo(RHProtected):
     def _process(self):
         external_users_available = any(auth.supports_search for auth in multipass.identity_providers.itervalues())
         return jsonify(external_users_available=external_users_available)
+
+
+class RHUserBlock(RHUserBase):
+    def _process_PUT(self):
+        self.user.is_blocked = True
+        logger.info("User %s blocked %s", session.user, self.user)
+        flash(_('{name} has been blocked.').format(name=self.user.name), 'success')
+        return jsonify(flash=False)
+
+    def _process_DELETE(self):
+        self.user.is_blocked = False
+        logger.info("User %s unblocked %s", session.user, self.user)
+        flash(_('{name} has been unblocked.').format(name=self.user.name), 'success')
+        return jsonify(flash=False)

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -643,6 +643,8 @@ class RHUserSearchInfo(RHProtected):
 
 class RHUserBlock(RHUserBase):
     def _process_PUT(self):
+        if self.user == session.user:
+            raise Forbidden(_('You cannot block yourself'))
         self.user.is_blocked = True
         logger.info('User %s blocked %s', session.user, self.user)
         flash(_('{name} has been blocked.').format(name=self.user.name), 'success')

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -402,7 +402,7 @@ class RHUsersAdmin(RHAdminBase):
             external = form_data.pop('external')
             form_data = {k: v for (k, v) in form_data.iteritems() if v and v.strip()}
             matches = search_users(exact=exact, include_deleted=include_deleted, include_pending=include_pending,
-                                   external=external, allow_system_user=True, **form_data)
+                                   include_blocked=True, external=external, allow_system_user=True, **form_data)
             for entry in matches:
                 if isinstance(entry, User):
                     search_results.append(UserEntry(

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -644,12 +644,12 @@ class RHUserSearchInfo(RHProtected):
 class RHUserBlock(RHUserBase):
     def _process_PUT(self):
         self.user.is_blocked = True
-        logger.info("User %s blocked %s", session.user, self.user)
+        logger.info('User %s blocked %s', session.user, self.user)
         flash(_('{name} has been blocked.').format(name=self.user.name), 'success')
-        return jsonify(flash=False)
+        return jsonify(success=True)
 
     def _process_DELETE(self):
         self.user.is_blocked = False
-        logger.info("User %s unblocked %s", session.user, self.user)
+        logger.info('User %s unblocked %s', session.user, self.user)
         flash(_('{name} has been unblocked.').format(name=self.user.name), 'success')
-        return jsonify(flash=False)
+        return jsonify(success=True)

--- a/indico/modules/users/templates/_category.html
+++ b/indico/modules/users/templates/_category.html
@@ -17,15 +17,13 @@
 {% endmacro %}
 
 {% macro _category_item(category, truncated_path, extra_info='') %}
-    <li class="category-box">
-        <div>
-            <span class="category-box-info">
-                <a href="{{ category.url }}">{{ category.title }}</a>
-                {{ _category_path(category, truncated_path) }}
-                {{ caller() }}
-            {# The caller must provide the closing span tag (</span>). #}
-            {# TODO This should be changed once Jinja is updated to 2.8 with support for set block. #}
-        </div>
+    <li class="category-box flexrow f-a-center">
+        <span class="category-box-info">
+            <a href="{{ category.url }}">{{ category.title }}</a>
+            {{ _category_path(category, truncated_path) }}
+            {{ caller() }}
+        {# The caller must provide the closing span tag (</span>). #}
+        {# TODO This should be changed once Jinja is updated to 2.8 with support for set block. #}
     </li>
 {% endmacro %}
 
@@ -33,9 +31,13 @@
     {% call _category_item(category, truncated_path) %}
         </span>
         {% if is_manager %}
-            <span title="{% trans %}You have management rights{% endtrans %}" class="category-action icon-medal active"></span>
+            <span title="{% trans %}You have management rights{% endtrans %}"
+                  class="category-action right icon-medal active">
+            </span>
         {% else %}
-            <span title="{% trans %}You have favourited this category{% endtrans %}" class="category-action icon-star active"></span>
+            <span title="{% trans %}You have favourited this category{% endtrans %}"
+                  class="category-action right icon-star active">
+            </span>
         {% endif %}
     {% endcall %}
 {% endmacro %}
@@ -53,7 +55,8 @@
         <a href="#"
            data-href="{{ url_for('.user_suggestions_remove', category_id=category.id) }}"
            title="{% trans %}Click here to remove this suggestion. It will not be suggested again.{% endtrans %}"
-           class="category-action icon-close active suggestion-remove">
+           class="category-action right active suggestion-remove">
+            <i class="close icon"></i>
         </a>
     {% endcall %}
 {% endmacro %}
@@ -64,7 +67,8 @@
         <a href="#"
            data-href="{{ url_for('.user_favorites_category_api', category_id=category.id) }}"
            title="{% trans %}Remove from favourites{% endtrans %}"
-           class="category-action icon-close js-delete-category">
+           class="right js-delete-category">
+            <i class="close icon"></i>
         </a>
     {% endcall %}
 {% endmacro %}

--- a/indico/modules/users/templates/_category.html
+++ b/indico/modules/users/templates/_category.html
@@ -16,20 +16,19 @@
     </span>
 {% endmacro %}
 
-{% macro _category_item(category, truncated_path, extra_info='') %}
+{% macro _category_item(category, truncated_path, extra_info) %}
     <li class="category-box flexrow f-a-center">
-        <span class="category-box-info">
+        <div class="category-box-info">
             <a href="{{ category.url }}">{{ category.title }}</a>
             {{ _category_path(category, truncated_path) }}
-            {{ caller() }}
-        {# The caller must provide the closing span tag (</span>). #}
-        {# TODO This should be changed once Jinja is updated to 2.8 with support for set block. #}
+            {{ extra_info }}
+        </div>
+        {{ caller() }}
     </li>
 {% endmacro %}
 
 {% macro user_category(category, truncated_path, is_manager) %}
     {% call _category_item(category, truncated_path) %}
-        </span>
         {% if is_manager %}
             <span title="{% trans %}You have management rights{% endtrans %}"
                   class="category-action right icon-medal active">
@@ -43,7 +42,7 @@
 {% endmacro %}
 
 {% macro suggested_category(category, truncated_path) %}
-    {% call _category_item(category, truncated_path) %}
+    {% set category_action_extra %}
         <div class="category-action-extra">
             <a href="#"
                data-href="{{ url_for('.user_favorites_category_api', category_id=category.id) }}"
@@ -51,7 +50,9 @@
                class="icon-star active suggestion-favorite">
                 <span>{% trans %}Add to favourites{% endtrans %}</span>
             </a>
-        </div></span>
+        </div>
+    {% endset %}
+    {% call _category_item(category, truncated_path, category_action_extra) %}
         <a href="#"
            data-href="{{ url_for('.user_suggestions_remove', category_id=category.id) }}"
            title="{% trans %}Click here to remove this suggestion. It will not be suggested again.{% endtrans %}"
@@ -63,7 +64,6 @@
 
 {% macro favorite_category(category, truncated_path) %}
     {% call _category_item(category, truncated_path) %}
-        </span>
         <a href="#"
            data-href="{{ url_for('.user_favorites_category_api', category_id=category.id) }}"
            title="{% trans %}Remove from favourites{% endtrans %}"

--- a/indico/modules/users/templates/_category.html
+++ b/indico/modules/users/templates/_category.html
@@ -16,7 +16,7 @@
     </span>
 {% endmacro %}
 
-{% macro _category_item(category, truncated_path, extra_info) %}
+{% macro _category_item(category, truncated_path, extra_info='') %}
     <li class="category-box flexrow f-a-center">
         <div class="category-box-info">
             <a href="{{ category.url }}">{{ category.title }}</a>

--- a/indico/modules/users/templates/_favorites.html
+++ b/indico/modules/users/templates/_favorites.html
@@ -1,9 +1,12 @@
 {% macro favorite_users_list(user) %}
     {% for fav in user.favorite_users|sort(attribute='full_name') %}
-        <li data-user-id="{{ fav.id }}" class="js-user-row">
+        <li data-user-id="{{ fav.id }}" class="flexrow f-a-center js-user-row">
             <span>{{ fav.full_name }}</span>
-            <a class="toggle icon-close right js-delete-user" title="{% trans %}Remove from favourites{% endtrans %}" href="#"
-               data-href="{{ url_for('.user_favorites_user_remove', fav_user_id=fav.id) }}"></a>
+            <a class="right js-delete-user"
+               title="{% trans %}Remove from favourites{% endtrans %}"
+               data-href="{{ url_for('.user_favorites_user_remove', fav_user_id=fav.id) }}">
+                <i class="close icon"></i>
+            </a>
         </li>
     {% endfor %}
 {% endmacro %}

--- a/indico/modules/users/templates/_labels.html
+++ b/indico/modules/users/templates/_labels.html
@@ -1,16 +1,16 @@
 {% macro labels(user) %}
     {% if user.is_admin %}
-        <span class="ui blue label">
+        <span class="ui blue small label">
             {%- trans %}Admin{% endtrans -%}
         </span>
     {% endif %}
     {% if user.is_blocked %}
-        <span class="ui orange label">
+        <span class="ui orange small label">
             {%- trans %}Blocked{% endtrans -%}
         </span>
     {% endif %}
     {% if user.is_deleted %}
-        <span class="ui red label">
+        <span class="ui red small label">
             {%- trans %}Deleted{% endtrans -%}
         </span>
     {% endif %}

--- a/indico/modules/users/templates/_labels.html
+++ b/indico/modules/users/templates/_labels.html
@@ -1,0 +1,17 @@
+{% macro labels(user) %}
+    {% if user.is_admin %}
+        <span class="ui blue label">
+            {%- trans %}Admin{% endtrans -%}
+        </span>
+    {% endif %}
+    {% if user.is_blocked %}
+        <span class="ui orange label">
+            {%- trans %}Blocked{% endtrans -%}
+        </span>
+    {% endif %}
+    {% if user.is_deleted %}
+        <span class="ui red label">
+            {%- trans %}Deleted{% endtrans -%}
+        </span>
+    {% endif %}
+{% endmacro %}

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -45,9 +45,9 @@
                         <h3>{{ user.full_name }}</h3>
                         <div class="your-labels">
                             {% if config.DEBUG %}
-                                <div class="ui label">
-                                  ID
-                                  <div class="detail">{{ user.id }}</div>
+                                <div class="ui small label">
+                                    ID
+                                    <div class="detail">{{ user.id }}</div>
                                 </div>
                             {% endif %}
                             {{ labels(user) }}
@@ -79,12 +79,12 @@
                     </h3>
                     <ol>
                         {% for event, roles in linked_events %}
-                            <li id="event-{{ event.id }}" class="truncate">
+                            <li id="event-{{ event.id }}" class="flexrow">
                                 <span class="event-date" title="{{ _format_event_times(event) }}">
                                     {{ _format_event_time(event) }}
                                 </span>
-                                <span class="event-title truncate-target">
-                                    <a href="{{ event.url }}" class="truncate">
+                                <span class="event-title ellipsis f-self-stretch">
+                                    <a href="{{ event.url }}">
                                         {{ event.get_verbose_title(show_series_pos=true) }}
                                     </a>
                                 </span>
@@ -106,7 +106,7 @@
                         {% endfor %}
                     </ol>
                 </div>
-                {% if suggested_categories %}
+                {% if suggested_categories and user == session.user %}
                     <div id="suggestedCategories" class="dashboard-box suggestions">
                         <h3>{% trans %}You might be interested in the following categories...{% endtrans %}</h3>
                         <ol>
@@ -123,7 +123,9 @@
                     <ol>
                         {% if not categories %}
                             <li class="no-event">
-                                <span class="event-title italic text-superfluous">{% trans %}You have no categories.{% endtrans %}</span>
+                                <span class="event-title italic text-superfluous">
+                                    {% trans %}You have no categories.{% endtrans %}
+                                </span>
                             </li>
                         {% else %}
                             {% for category in categories.itervalues() %}
@@ -149,18 +151,21 @@
                             </li>
                         {% else %}
                             {% for event in categories_events %}
-                                <li class="truncate">
-                                    <a href="{{ event.url }}" class="truncate">
-                                        <span class="event-date" title="{{ _format_event_times(event) }}">
-                                            {{ _format_event_time(event) }}
-                                        </span>
-                                        <span class="event-title truncate-target">
-                                            {{ event.get_verbose_title(show_series_pos=true) }}
+                                <li class="flexrow">
+                                    <span class="event-date f-self-no-shrink"
+                                          title="{{ _format_event_times(event) }}">
+                                        {{ _format_event_time(event) }}
+                                    </span>
+                                    <div class="flexcol ellipsis">
+                                        <span class="event-title ellipsis">
+                                            <a href="{{ event.url }}">
+                                                {{ event.get_verbose_title(show_series_pos=true) }}
+                                            </a>
                                         </span>
                                         <span class="event-category">
                                             {{ event.category.title }}
                                         </span>
-                                    </a>
+                                    </div>
                                 </li>
                             {% endfor %}
                         {% endif %}

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -106,7 +106,7 @@
                         {% endfor %}
                     </ol>
                 </div>
-                {% if suggested_categories and user == session.user %}
+                {% if suggested_categories %}
                     <div id="suggestedCategories" class="dashboard-box suggestions">
                         <h3>{% trans %}You might be interested in the following categories...{% endtrans %}</h3>
                         <ol>

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -1,5 +1,6 @@
 {% extends 'layout/management_page.html' %}
 {% from 'users/_category.html' import suggested_category, user_category %}
+{% from 'users/_labels.html' import labels %}
 
 {% macro _format_event_times(event) %}
     {% if event.start_dt.astimezone(session.tzinfo).date() != event.end_dt.astimezone(session.tzinfo).date() %}
@@ -42,11 +43,15 @@
                     </div>
                     <div class="your-details-wrapper">
                         <h3>{{ user.full_name }}</h3>
-                        {% if config.DEBUG %}
-                            <div>
-                                <i class="icon-info" title="{% trans %}User ID{% endtrans %}"></i><span>{{ user.id }}</span>
-                            </div>
-                        {% endif %}
+                        <div class="your-labels">
+                            {% if config.DEBUG %}
+                                <div class="ui label">
+                                  ID
+                                  <div class="detail">{{ user.id }}</div>
+                                </div>
+                            {% endif %}
+                            {{ labels(user) }}
+                        </div>
                         {% if user.affiliation %}
                             <div>
                                 <i class="icon-users"></i><span>{{ user.affiliation }}</span>

--- a/indico/modules/users/templates/emails.html
+++ b/indico/modules/users/templates/emails.html
@@ -18,15 +18,24 @@
                 <ul class="group-list with-buttons content-after">
                     <li>
                         <span><strong>{{ user.email }}</strong></span>
-                        <span class="i-label">{% trans %}Primary{% endtrans %}</span>
+                        <span class="ui label">{% trans %}Primary{% endtrans %}</span>
                     </li>
                     {% for email in user.secondary_emails|sort %}
-                        <li class="js-email-row">
+                        <li class="flexrow f-a-center js-email-row">
                             <span>{{ email }}</span>
-                            <a class="toggle icon-remove right js-delete-email" href="#" data-href="{{ url_for('.user_emails_delete', email=email) }}" style="margin-left: 10px;"></a>
-                            <button type="button" class="ui primary button right" data-href="{{ url_for('.user_emails_set_primary') }}" data-method='POST' data-params="{{ {'email': email} | tojson | forceescape }}">
-                                {%- trans %}Set as primary{% endtrans -%}
-                            </button>
+                            <span class="right">
+                                <button type="button"
+                                        class="ui primary small button"
+                                        data-href="{{ url_for('.user_emails_set_primary') }}"
+                                        data-method="POST"
+                                        data-params="{{ {'email': email} | tojson | forceescape }}">
+                                    {%- trans %}Set as primary{% endtrans -%}
+                                </button>
+                                <button class="ui icon small button js-delete-email"
+                                        data-href="{{ url_for('.user_emails_delete', email=email) }}">
+                                    <i class="trash alternate icon"></i>
+                                </button>
+                            </span>
                         </li>
                     {% endfor %}
                 </ul>

--- a/indico/modules/users/templates/emails.html
+++ b/indico/modules/users/templates/emails.html
@@ -24,7 +24,7 @@
                         <li class="js-email-row">
                             <span>{{ email }}</span>
                             <a class="toggle icon-remove right js-delete-email" href="#" data-href="{{ url_for('.user_emails_delete', email=email) }}" style="margin-left: 10px;"></a>
-                            <button type="button" class="i-button right" data-href="{{ url_for('.user_emails_set_primary') }}" data-method='POST' data-params="{{ {'email': email} | tojson | forceescape }}">
+                            <button type="button" class="ui primary button right" data-href="{{ url_for('.user_emails_set_primary') }}" data-method='POST' data-params="{{ {'email': email} | tojson | forceescape }}">
                                 {%- trans %}Set as primary{% endtrans -%}
                             </button>
                         </li>
@@ -33,7 +33,7 @@
                 {{ form_header(form, orientation='vertical', classes='no-block-padding') }}
                 {{ form_rows(form) }}
                 {% call form_footer(form) %}
-                    <input class="i-button big highlight" type="submit" value="{% trans %}Add{% endtrans %}" data-disabled-until-change>
+                    <input class="ui primary button" type="submit" value="{% trans %}Add{% endtrans %}" data-disabled-until-change>
                 {% endcall %}
             </div>
         </div>

--- a/indico/modules/users/templates/favorites.html
+++ b/indico/modules/users/templates/favorites.html
@@ -22,7 +22,7 @@
                         {% endif %}
                     </div>
                 </div>
-                <button class="i-button highlight js-add-user" style="margin-top: 15px;">{% trans %}Add Indico user{% endtrans %}</button>
+                <button class="ui primary button js-add-user" style="margin-top: 15px;">{% trans %}Add Indico user{% endtrans %}</button>
             </div>
             <div class="column col-50">
                 <div class="i-box just-group-list">

--- a/indico/modules/users/templates/favorites.html
+++ b/indico/modules/users/templates/favorites.html
@@ -18,11 +18,15 @@
                                 {{ favorite_users_list(user) }}
                             </ul>
                         {% else %}
-                            <span class="empty">{% trans %}You have not marked any user as favourite.{% endtrans %}</span>
+                            <span class="empty">
+                                {% trans %}You have not marked any user as favourite.{% endtrans %}
+                            </span>
                         {% endif %}
                     </div>
                 </div>
-                <button class="ui primary button js-add-user" style="margin-top: 15px;">{% trans %}Add Indico user{% endtrans %}</button>
+                <button class="ui primary button js-add-user" style="margin-top: 15px;">
+                    {% trans %}Add Indico user{% endtrans %}
+                </button>
             </div>
             <div class="column col-50">
                 <div class="i-box just-group-list">
@@ -39,7 +43,9 @@
                                 {% endfor %}
                             </ul>
                         {% else %}
-                            <span class="empty">{% trans %}You have not marked any category as favourite.{% endtrans %}</span>
+                            <span class="empty">
+                                {% trans %}You have not marked any category as favourite.{% endtrans %}
+                            </span>
                         {% endif %}
                     </div>
                 </div>

--- a/indico/modules/users/templates/personal_data.html
+++ b/indico/modules/users/templates/personal_data.html
@@ -11,7 +11,7 @@
                 </div>
                 <div class="i-box-buttons">
                     {% if not user.is_blocked %}
-                        <button class="ui negative button"
+                        <button class="ui negative small button"
                                 data-href="{{ url_for('.user_block') }}"
                                 data-method="PUT"
                                 data-confirm="{% trans %}This user will no longer have access to Indico.<br>
@@ -20,7 +20,7 @@
                             {% trans %}Block User{% endtrans %}
                         </button>
                     {% else %}
-                        <button class="ui button"
+                        <button class="ui small button"
                                 data-href="{{ url_for('.user_block') }}"
                                 data-method="DELETE"
                                 data-confirm="{% trans %}This user will regain access to Indico.<br>

--- a/indico/modules/users/templates/personal_data.html
+++ b/indico/modules/users/templates/personal_data.html
@@ -11,14 +11,17 @@
                 </div>
                 <div class="i-box-buttons">
                     {% if not user.is_blocked %}
-                        <button class="ui negative small button"
-                                data-href="{{ url_for('.user_block') }}"
-                                data-method="PUT"
-                                data-confirm="{% trans %}This user will no longer have access to Indico.<br>
-                                Are you sure you want to revoke their access?{% endtrans %}"
-                                data-reload-after>
-                            {% trans %}Block User{% endtrans %}
-                        </button>
+                        <div {%- if user == session.user %} title="{% trans %}You cannot block yourself{% endtrans %}"{% endif %}>
+                            <button class="ui negative small button"
+                                    data-href="{{ url_for('.user_block') }}"
+                                    data-method="PUT"
+                                    data-confirm="{% trans %}This user will no longer have access to Indico.<br>
+                                    Are you sure you want to revoke their access?{% endtrans %}"
+                                    data-reload-after
+                                    {% if user == session.user %}disabled{% endif %}>
+                                {% trans %}Block User{% endtrans %}
+                            </button>
+                        </div>
                     {% else %}
                         <button class="ui small button"
                                 data-href="{{ url_for('.user_block') }}"

--- a/indico/modules/users/templates/personal_data.html
+++ b/indico/modules/users/templates/personal_data.html
@@ -9,12 +9,36 @@
                 <div class="i-box-title">
                     {%- trans %}Details{% endtrans -%}
                 </div>
+                <div class="i-box-buttons">
+                    {% if not user.is_blocked %}
+                        <button class="ui negative button"
+                                data-href="{{ url_for('.user_block') }}"
+                                data-method="PUT"
+                                data-confirm="{% trans %}This user will no longer have access to Indico.<br>
+                                Are you sure you want to revoke their access?{% endtrans %}"
+                                data-reload-after>
+                            {% trans %}Block User{% endtrans %}
+                        </button>
+                    {% else %}
+                        <button class="ui button"
+                                data-href="{{ url_for('.user_block') }}"
+                                data-method="DELETE"
+                                data-confirm="{% trans %}This user will regain access to Indico.<br>
+                                Are you sure you want to restore their access?{% endtrans %}"
+                                data-reload-after>
+                            {% trans %}Unblock User{% endtrans %}
+                        </button>
+                    {% endif %}
+                </div>
             </div>
             <div class="i-box-content">
                 {{ form_header(form) }}
                 {{ form_rows(form) }}
                 {% call form_footer(form) %}
-                    <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}" data-disabled-until-change>
+                    <input class="ui primary button"
+                           type="submit"
+                           value="{% trans %}Save{% endtrans %}"
+                           data-disabled-until-change>
                 {% endcall %}
             </div>
         </div>

--- a/indico/modules/users/templates/personal_data.html
+++ b/indico/modules/users/templates/personal_data.html
@@ -9,30 +9,32 @@
                 <div class="i-box-title">
                     {%- trans %}Details{% endtrans -%}
                 </div>
-                <div class="i-box-buttons">
-                    {% if not user.is_blocked %}
-                        <div {%- if user == session.user %} title="{% trans %}You cannot block yourself{% endtrans %}"{% endif %}>
-                            <button class="ui negative small button"
+                {% if user.is_admin %}
+                    <div class="i-box-buttons">
+                        {% if not user.is_blocked %}
+                            <div {%- if user == session.user %} title="{% trans %}You cannot block yourself{% endtrans %}"{% endif %}>
+                                <button class="ui negative small button"
+                                        data-href="{{ url_for('.user_block') }}"
+                                        data-method="PUT"
+                                        data-confirm="{% trans %}This user will no longer have access to Indico.<br>
+                                        Are you sure you want to revoke their access?{% endtrans %}"
+                                        data-reload-after
+                                        {% if user == session.user %}disabled{% endif %}>
+                                    {% trans %}Block User{% endtrans %}
+                                </button>
+                            </div>
+                        {% else %}
+                            <button class="ui small button"
                                     data-href="{{ url_for('.user_block') }}"
-                                    data-method="PUT"
-                                    data-confirm="{% trans %}This user will no longer have access to Indico.<br>
-                                    Are you sure you want to revoke their access?{% endtrans %}"
-                                    data-reload-after
-                                    {% if user == session.user %}disabled{% endif %}>
-                                {% trans %}Block User{% endtrans %}
+                                    data-method="DELETE"
+                                    data-confirm="{% trans %}This user will regain access to Indico.<br>
+                                    Are you sure you want to restore their access?{% endtrans %}"
+                                    data-reload-after>
+                                {% trans %}Unblock User{% endtrans %}
                             </button>
-                        </div>
-                    {% else %}
-                        <button class="ui small button"
-                                data-href="{{ url_for('.user_block') }}"
-                                data-method="DELETE"
-                                data-confirm="{% trans %}This user will regain access to Indico.<br>
-                                Are you sure you want to restore their access?{% endtrans %}"
-                                data-reload-after>
-                            {% trans %}Unblock User{% endtrans %}
-                        </button>
-                    {% endif %}
-                </div>
+                        {% endif %}
+                    </div>
+                {% endif %}
             </div>
             <div class="i-box-content">
                 {{ form_header(form) }}

--- a/indico/modules/users/templates/preferences.html
+++ b/indico/modules/users/templates/preferences.html
@@ -13,7 +13,7 @@
             {{ form_header(form) }}
             {{ form_rows(form) }}
             {% call form_footer(form) %}
-                <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}" data-disabled-until-change>
+                <input class="ui primary button" type="submit" value="{% trans %}Save{% endtrans %}" data-disabled-until-change>
             {% endcall %}
         </div>
     </div>

--- a/indico/modules/users/templates/users_admin.html
+++ b/indico/modules/users/templates/users_admin.html
@@ -55,7 +55,7 @@
             <span class="i-box-content">
                 <div class="info-message-box">
                     <div class="message-text">
-                        {%- trans num_of_users=num_of_users -%}
+                        {%- trans -%}
                             There are {{ num_of_users }} users, {{ num_deleted_users }} of which are deleted
                         {%- endtrans -%}
                     </div>

--- a/indico/modules/users/templates/users_admin.html
+++ b/indico/modules/users/templates/users_admin.html
@@ -1,5 +1,6 @@
 {% extends 'layout/admin_page.html' %}
 {% from 'forms/_form.html' import form_header, form_rows, form_footer, simple_form %}
+{% from 'users/_labels.html' import labels %}
 
 {% block title %}{% trans %}Users{% endtrans %}{% endblock %}
 
@@ -27,7 +28,10 @@
                 </div>
                 <div class="i-box-buttons toolbar right">
                     <div class="group">
-                        <a class="i-button icon-users" href="{{ url_for('.users_merge') }}">{% trans %}Merge users{% endtrans %}</a>
+                        <a class="i-button icon-users"
+                           href="{{ url_for('.users_merge') }}">
+                            {% trans %}Merge users{% endtrans %}
+                        </a>
                     </div>
                     <div class="group">
                         <a href="#"
@@ -50,7 +54,11 @@
             </div>
             <div class="i-box-content">
                 <div class="info-message-box">
-                    <div class="message-text">{% trans num_of_users=num_of_users %}There are {{ num_of_users }} users, {{ num_deleted_users }} of which are deleted{% endtrans %}</div>
+                    <div class="message-text">
+                        {%- trans num_of_users=num_of_users -%}
+                            There are {{ num_of_users }} users, {{ num_deleted_users }} of which are deleted
+                        {%- endtrans -%}
+                    </div>
                 </div>
                 <h2>{% trans %}Search users{% endtrans %}</h2>
                 {{ form_header(form) }}
@@ -79,11 +87,14 @@
                                             {{ user_entry.full_name }}
                                         {%- endif -%}
                                     </span>
+                                    {% if user_entry.user %}
+                                        {{ labels(user_entry.user) }}
+                                    {% endif %}
                                     <span class="right">
                                         {% if user_entry.user and user_entry.user.is_system %}
-                                            <em title="{% trans %}This is the system user.{% endtrans %}">
+                                            <span class="ui tiny label">
                                                 {%- trans %}System{% endtrans -%}
-                                            </em>
+                                            </span>
                                         {% else %}
                                             {{ user_entry.email }}
                                         {% endif %}

--- a/indico/modules/users/templates/users_admin.html
+++ b/indico/modules/users/templates/users_admin.html
@@ -52,7 +52,7 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="i-box-content">
+            <span class="i-box-content">
                 <div class="info-message-box">
                     <div class="message-text">
                         {%- trans num_of_users=num_of_users -%}
@@ -79,7 +79,7 @@
                         </h3>
                         <ul class="group-list">
                             {% for user_entry in search_results -%}
-                                <li>
+                                <li class="flexrow f-a-center">
                                     <span>
                                         {%- if user_entry.profile_url -%}
                                             <a href="{{ user_entry.profile_url }}">{{ user_entry.full_name }}</a>
@@ -88,9 +88,11 @@
                                         {%- endif -%}
                                     </span>
                                     {% if user_entry.user %}
-                                        {{ labels(user_entry.user) }}
+                                        <span>
+                                            {{ labels(user_entry.user) }}
+                                        </span>
                                     {% endif %}
-                                    <span class="right">
+                                    <span class="right text-right">
                                         {% if user_entry.user and user_entry.user.is_system %}
                                             <span class="ui tiny label">
                                                 {%- trans %}System{% endtrans -%}

--- a/indico/web/client/styles/base/_animation.scss
+++ b/indico/web/client/styles/base/_animation.scss
@@ -78,7 +78,7 @@
     }
 }
 
-:not(.ui) > .open {
+:not(.ui) > .slide.open {
     overflow: hidden;
     opacity: 1;
     transition-property: all;
@@ -86,7 +86,7 @@
     transition-timing-function: ease-out;
 }
 
-:not(.ui) > .close {
+:not(.ui) > .slide.close {
     overflow: hidden;
     max-height: 0 !important;
     opacity: 0;

--- a/indico/web/client/styles/base/_typography.scss
+++ b/indico/web/client/styles/base/_typography.scss
@@ -13,6 +13,10 @@
     font-family: "Roboto", sans-serif;
 }
 
+%font-family-sui {
+    font-family: "Muli", "Helvetica Neue", Arial, Helvetica, sans-serif;
+}
+
 %font-family-title {
     font-family: "Roboto", sans-serif;
 }
@@ -62,35 +66,36 @@ body {
     background: #fff;
     padding: 0px;
     margin: 0px;
-}
-
-body > :not(.rb-app-container) {
     @extend %font-family-body;
     @extend %font-size-body;
+}
+
+.ui {
+    @extend %font-family-sui;
 }
 
 h1, h2, h3, h4, h5, h6, td, dl, ol, blockquote {
     color: $black;
 }
 
-body > :not(.rb-app-container) h1 {
+body > h1 {
     @extend %font-family-title;
     font-size: 1.7em;
 }
 
-body > :not(.rb-app-container) h1.category-title {
+body > h1.category-title {
     font-size: 2em;
 }
 
-body > :not(.rb-app-container) h2, h3, h4 {
+body > h2, h3, h4 {
     @extend %font-family-title-light;
 }
 
-body > :not(.rb-app-container) h2 {
+body > h2 {
     font-size: 1.6em;
 }
 
-body > :not(.rb-app-container) h3 {
+body > h3 {
     font-size: 1.2em;
 }
 

--- a/indico/web/client/styles/base/_typography.scss
+++ b/indico/web/client/styles/base/_typography.scss
@@ -78,24 +78,24 @@ h1, h2, h3, h4, h5, h6, td, dl, ol, blockquote {
     color: $black;
 }
 
-body > h1 {
+h1 {
     @extend %font-family-title;
     font-size: 1.7em;
 }
 
-body > h1.category-title {
+h1.category-title {
     font-size: 2em;
 }
 
-body > h2, h3, h4 {
+h2, h3, h4 {
     @extend %font-family-title-light;
 }
 
-body > h2 {
+h2 {
     font-size: 1.6em;
 }
 
-body > h3 {
+h3 {
     font-size: 1.2em;
 }
 
@@ -266,4 +266,8 @@ textarea.log {
 
 .underline {
     text-decoration: underline;
+}
+
+.ellipsis {
+    @include ellipsis;
 }

--- a/indico/web/client/styles/modules/_dashboard.scss
+++ b/indico/web/client/styles/modules/_dashboard.scss
@@ -89,7 +89,6 @@
 }
 
 .dashboard-box ol li {
-    display: block;
     border-bottom: 1px solid #e5e5e5;
     padding: 10px 10px 5px 10px;
 }
@@ -106,7 +105,7 @@
 }
 
 .dashboard-box.suggestions ol li > a {
-    margin-right: 35px;
+    margin-right: 15px;
 }
 
 .dashboard-box ol li .actions {
@@ -151,7 +150,6 @@
 .dashboard-box ol .event-category {
     display: block;
     font-size: 0.8em;
-    margin-left: 89px;
 }
 
 .dashboard-box ol .item-legend {
@@ -173,19 +171,6 @@
     display: inline-block;
 }
 
-.truncate .truncate-target {
-    @include ellipsis();
-    display: inline-block;
-}
-
-.dashboard-box .event-title.truncate-target {
-    max-width: 90%;
-}
-
-#happeningCategories .event-title.truncate-target { // sass-lint:disable-line no-ids id-name-format
-    max-width: 90%;
-}
-
 .item-legend [class*='icon-'] {
     color: #ddd;
     font-size: 18px;
@@ -197,7 +182,7 @@
 
 .your-details {
     display: flex;
-    flex-wrap: wrap;
+    flex-flow: row nowrap;
     margin-bottom: 15px;
 
     .avatar-image {
@@ -219,10 +204,11 @@
         font-size: 1.2em;
         line-height: 1.5;
         max-width: 300px;
+        margin-right: 5px;
 
         h3 {
             margin-top: 0;
-            margin-bottom: 5px;
+            margin-bottom: 10px;
         }
 
         i {
@@ -231,11 +217,18 @@
         }
 
         .your-labels {
+            display: flex;
+            flex-flow: row wrap;
             margin-bottom: 1rem;
+
+            .label {
+                margin: 0 7px 7px 0;
+            }
         }
     }
 
     .actions {
+        flex-shrink: 0;
         margin-left: auto;
     }
 }

--- a/indico/web/client/styles/modules/_dashboard.scss
+++ b/indico/web/client/styles/modules/_dashboard.scss
@@ -58,7 +58,7 @@
 }
 
 .dashboard-box {
-    border: 1px solid #DDD;
+    border: 1px solid #ddd;
     border-radius: 0.3em;
     box-sizing: border-box;
     -moz-box-sizing: border-box;
@@ -67,8 +67,8 @@
 }
 
 .dashboard-box h3 {
-    background: #F7F7F7;
-    border-bottom: 1px solid #DDD;
+    background: #f7f7f7;
+    border-bottom: 1px solid #ddd;
     border-top-left-radius: 0.3em;
     border-top-right-radius: 0.3em;
     font-size: 14px;
@@ -85,12 +85,12 @@
     list-style: none;
     margin: 0;
     padding: 0;
-    border: 0;
+    border: none;
 }
 
 .dashboard-box ol li {
     display: block;
-    border-bottom: 1px solid #E5E5E5;
+    border-bottom: 1px solid #e5e5e5;
     padding: 10px 10px 5px 10px;
 }
 
@@ -101,7 +101,6 @@
     user-select: none;
     -webkit-touch-callout: none;
     -webkit-user-select: none;
-    -khtml-user-select: none;
     -moz-user-select: none;
     -ms-user-select: none;
 }
@@ -175,8 +174,7 @@
 }
 
 .truncate .truncate-target {
-    @include ellipsis;
-
+    @include ellipsis();
     display: inline-block;
 }
 
@@ -184,16 +182,16 @@
     max-width: 90%;
 }
 
-#happeningCategories .event-title.truncate-target {
+#happeningCategories .event-title.truncate-target { // sass-lint:disable-line no-ids id-name-format
     max-width: 90%;
 }
 
-.item-legend [class*=icon-] {
-    color: #DDD;
+.item-legend [class*='icon-'] {
+    color: #ddd;
     font-size: 18px;
 }
 
-.item-legend [class*=icon-].active {
+.item-legend [class*='icon-'].active {
     color: #777;
 }
 
@@ -224,11 +222,16 @@
 
         h3 {
             margin-top: 0;
+            margin-bottom: 5px;
         }
 
         i {
             color: $dark-gray;
             margin-right: 10px;
+        }
+
+        .your-labels {
+            margin-bottom: 1rem;
         }
     }
 

--- a/indico/web/client/styles/modules/_users.scss
+++ b/indico/web/client/styles/modules/_users.scss
@@ -232,7 +232,6 @@
 
 .category-box {
     position: relative;
-    display: block;
     box-sizing: border-box;
     padding: 0.5rem !important;
 

--- a/indico/web/client/styles/partials/_boxes.scss
+++ b/indico/web/client/styles/partials/_boxes.scss
@@ -122,20 +122,21 @@ $i-box-padding: 10px;
     margin-top: -18px; // Pure magic number to align the rule with the i-box border
 }
 
-@mixin single-box-shadow($hoff: $default-box-shadow-h-offset, $voff: $default-box-shadow-v-offset, $blur: $default-box-shadow-blur,
-                         $spread: $default-box-shadow-spread, $color: $default-box-shadow-color, $inset: $default-box-shadow-inset) {
-    box-shadow: $inset $hoff $voff $blur $spread $color ;
+@mixin single-box-shadow($hoff: $default-box-shadow-h-offset, $voff: $default-box-shadow-v-offset,
+    $blur: $default-box-shadow-blur, $spread: $default-box-shadow-spread,
+    $color: $default-box-shadow-color, $inset: $default-box-shadow-inset) {
+    box-shadow: $inset $hoff $voff $blur $spread $color;
 }
 
 .i-box {
     @extend %i-box-padding;
-    @include border-all();
     @extend %default-border-radius;
-    box-sizing: border-box;
+    @include border-all();
     @include single-box-shadow();
     @include transition();
     @include transition(padding-bottom);
 
+    box-sizing: border-box;
     background: white;
     color: $black;
 
@@ -171,8 +172,8 @@ $i-box-padding: 10px;
         }
 
         &::before {
-            transform: rotate(90deg);
             @include transition(top);
+            transform: rotate(90deg);
             display: inline-block;
             position: relative;
             top: -3px;
@@ -208,6 +209,10 @@ $i-box-padding: 10px;
         @extend %i-box-padding;
         @include border-bottom();
         @include transition(margin-bottom);
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
         background-color: $light-gray;
         overflow: hidden;
         margin-bottom: $i-box-padding;
@@ -226,7 +231,6 @@ $i-box-padding: 10px;
         }
 
         .i-box-buttons {
-            float: right;
             margin: 0;
             padding: 0;
         }

--- a/indico/web/client/styles/partials/_boxes.scss
+++ b/indico/web/client/styles/partials/_boxes.scss
@@ -402,10 +402,30 @@ $i-box-padding: 10px;
     > li {
         @include border-top();
         padding: 10px;
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        overflow: hidden;
+
+        > span:not(:last-child) {
+            margin-right: 10px;
+        }
+
+        .list-item-title {
+            font-weight: bold;
+        }
+
+        .list-item-info {
+            margin: 0 1em;
+
+            > span:not(:last-child) {
+                margin-right: 0.7em;
+            }
+
+            .label {
+                font-weight: bold;
+            }
+
+            .content {
+                font-style: italic;
+            }
+        }
 
         // Sortable row with handle on the left
         &.ui-sortable {
@@ -465,27 +485,6 @@ $i-box-padding: 10px;
 
         .i-button {
             margin-top: 0;
-        }
-    }
-
-    .list-item-title {
-        font-weight: bold;
-        margin-right: 5px;
-    }
-
-    .list-item-info {
-        margin: 0 1em;
-
-        > span:not(:last-child) {
-            margin-right: 0.7em;
-        }
-
-        .label {
-            font-weight: bold;
-        }
-
-        .content {
-            font-style: italic;
         }
     }
 }

--- a/indico/web/client/styles/partials/_boxes.scss
+++ b/indico/web/client/styles/partials/_boxes.scss
@@ -402,7 +402,9 @@ $i-box-padding: 10px;
     > li {
         @include border-top();
         padding: 10px;
-        position: relative;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
         overflow: hidden;
 
         // Sortable row with handle on the left
@@ -468,6 +470,7 @@ $i-box-padding: 10px;
 
     .list-item-title {
         font-weight: bold;
+        margin-right: 5px;
     }
 
     .list-item-info {

--- a/indico/web/client/styles/partials/_core.scss
+++ b/indico/web/client/styles/partials/_core.scss
@@ -9,6 +9,7 @@
 
 .right {
     float: right;
+    margin-left: auto;
 }
 
 .left {

--- a/indico/web/forms/widgets.py
+++ b/indico/web/forms/widgets.py
@@ -126,24 +126,18 @@ class CKEditorWidget(JinjaWidget):
 class SwitchWidget(JinjaWidget):
     """Renders a switch widget
 
-    :param on_label: Text to override default ON label
-    :param off_label: Text to override default OFF label
     :param confirm_enable: Text to prompt when enabling the switch
     :param confirm_disable: Text to prompt when disabling the switch
     """
 
-    def __init__(self, on_label=None, off_label=None, confirm_enable=None, confirm_disable=None):
+    def __init__(self, confirm_enable=None, confirm_disable=None):
         super(SwitchWidget, self).__init__('forms/switch_widget.html')
-        self.on_label = on_label
-        self.off_label = off_label
         self.confirm_enable = confirm_enable
         self.confirm_disable = confirm_disable
 
     def __call__(self, field, **kwargs):
         kwargs.update({
-            'checked': getattr(field, 'checked', field.data),
-            'on_label': self.on_label,
-            'off_label': self.off_label
+            'checked': getattr(field, 'checked', field.data)
         })
         return super(SwitchWidget, self).__call__(field, kwargs=kwargs, confirm_enable=self.confirm_enable,
                                                   confirm_disable=self.confirm_disable)

--- a/indico/web/templates/_switch.html
+++ b/indico/web/templates/_switch.html
@@ -1,12 +1,8 @@
-{% macro switch(value='1', id=none, name=none, on_label=none, off_label=none) -%}
-    {%- set on_label = _('Yes') if on_label is none else on_label -%}
-    {%- set off_label = _('No') if off_label is none else off_label -%}
-
-    <label class="switch">
-        <input type="checkbox" class="switch-input" value="{{ value }}" {{ kwargs | html_params }}
+{% macro switch(value='1', id=none, name=none) -%}
+    <div class="ui toggle checkbox">
+        <input type="checkbox" value="{{ value }}" {{ kwargs | html_params }}
                {%- if id %} id="{{ id }}"{% endif -%}
                {%- if name %} name="{{ name }}"{% endif -%}>
-        <span class="switch-label" data-on="{{ on_label }}" data-off="{{ off_label }}"></span>
-        <span class="switch-handle"></span>
-    </label>
+        <label></label> {# ui toggle always requires a label #}
+    </div>
 {%- endmacro %}


### PR DESCRIPTION
Closes #3243

This PR will expose the endpoint and UI ability to block/unblock users, and:
- [x] Show that a user account is blocked ~~when viewing their profile~~ and maybe also in the user search results
- [x] *Filter out blocked users when searching in non-admin areas* - RFC

![image](https://user-images.githubusercontent.com/12183954/77085466-45ad1b80-69f8-11ea-8422-9e7e8cd0fe62.png)
---
![image](https://user-images.githubusercontent.com/12183954/77313398-b9526f80-6cfb-11ea-9f3d-f1aa050d07f5.png)
---
![image](https://user-images.githubusercontent.com/12183954/77086261-70e43a80-69f9-11ea-9481-5e69073799ca.png)


### Side-effects

Since this commit used some semantic-ui raw elements, I took the opportunity to upgrade most of the previous custom CSS within the user profile section. These include, but not limited to, toggles, buttons and header panels (alignment refactoring only).

![image](https://user-images.githubusercontent.com/12183954/77086100-31b5e980-69f9-11ea-9407-5f3bd6e2ea2f.png)
