### PR TITLE
Tie accept/reject comments in paper editing to revision

### DIFF
--- a/indico/modules/events/editing/client/js/components/Timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/components/Timeline/TimelineItem.jsx
@@ -84,14 +84,6 @@ export default function TimelineItem({block}) {
                   files={block.files}
                   downloadURL={block.downloadFilesURL}
                 />
-                {block.comment && (
-                  <>
-                    <div className="titled-rule">
-                      <Translate>Comment</Translate>
-                    </div>
-                    <div dangerouslySetInnerHTML={{__html: block.commentHtml}} />
-                  </>
-                )}
                 {/* TODO: Check whether the current user is submitter */}
                 {isLastBlock && needsSubmitterConfirmation && <ChangesConfirmation />}
               </div>

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -122,7 +122,7 @@ def confirm_editable_changes(revision, submitter, action, comment):
         EditingConfirmationAction.reject: FinalRevisionState.needs_submitter_changes,
     }[action]
     if comment:
-        create_revision_comment(revision, submitter, comment)
+        revision.comment = comment
     db.session.flush()
     if action == EditingConfirmationAction.accept:
         publish_editable_revision(revision)


### PR DESCRIPTION
Stop comments from staying even if accepting/rejecting gets undone.
Closes #4350.