### PR TITLE
Enhance making changes to files in paper editing

### DIFF
--- a/indico/modules/events/editing/client/js/components/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/components/EditableSubmissionButton.jsx
@@ -63,7 +63,12 @@ export default function EditableSubmissionButton({
             </Modal.Header>
             <Modal.Content>
               <Form id="submit-editable-form" onSubmit={handleSubmit}>
-                <FinalFileManager name="files" fileTypes={fileTypes} uploadURL={uploadURL} />
+                <FinalFileManager
+                  name="files"
+                  fileTypes={fileTypes}
+                  uploadURL={uploadURL}
+                  mustChange
+                />
               </Form>
             </Modal.Content>
             <Modal.Actions style={{display: 'flex', justifyContent: 'flex-end'}}>

--- a/indico/modules/events/editing/client/js/components/FileManager/actions.js
+++ b/indico/modules/events/editing/client/js/components/FileManager/actions.js
@@ -16,6 +16,7 @@ export const CLEAR_DIRTY = 'CLEAR_DIRTY';
 export const UPLOAD_ERROR = 'UPLOAD_ERROR';
 export const RESET = 'RESET';
 export const INVALID_TEMPLATE = 'INVALID_TEMPLATE';
+export const REMOVE_INVALID_FILENAME = 'REMOVE_INVALID_FILENAME';
 
 export const startUploads = (fileTypeId, files, tmpFileIds) => ({
   type: START_UPLOADS,
@@ -82,6 +83,12 @@ export const reset = fileTypes => ({
 
 export const invalidTemplate = (fileTypeId, filename) => ({
   type: INVALID_TEMPLATE,
+  fileTypeId,
+  filename,
+});
+
+export const removeInvalidFilename = (fileTypeId, filename) => ({
+  type: REMOVE_INVALID_FILENAME,
   fileTypeId,
   filename,
 });

--- a/indico/modules/events/editing/client/js/components/FileManager/reducer.js
+++ b/indico/modules/events/editing/client/js/components/FileManager/reducer.js
@@ -78,6 +78,18 @@ export default combineReducers({
     if (action.type === actions.RESET) {
       return action.fileTypes;
     }
+    if (action.type === actions.REMOVE_INVALID_FILENAME) {
+      return state.map(fileType => {
+        if (fileType.id === action.fileTypeId) {
+          return {
+            ...fileType,
+            invalidFiles: fileType.invalidFiles.filter(name => name !== action.filename),
+          };
+        } else {
+          return fileType;
+        }
+      });
+    }
     return state.map(fileType => {
       if (fileType.id === action.fileTypeId) {
         return {

--- a/indico/modules/events/editing/client/js/components/FileManager/selectors.js
+++ b/indico/modules/events/editing/client/js/components/FileManager/selectors.js
@@ -35,6 +35,18 @@ export const getUploadedFileUUIDs = state => {
 export const getValidationError = createSelector(
   state => state.fileTypes,
   fileTypes => {
+    const invalid = fileTypes
+      .filter(ft => ft.invalidFiles.some(f => f.length > 0))
+      .map(ft => ft.invalidFiles)
+      .flat();
+    if (invalid.length > 0) {
+      return PluralTranslate.string(
+        'Invalid file name: {files}',
+        'Invalid file names: {files}',
+        invalid.length,
+        {files: invalid.sort().join(', ')}
+      );
+    }
     const missing = fileTypes
       .filter(ft => ft.required)
       .filter(ft => !ft.files.some(f => f.state !== 'deleted'))

--- a/indico/modules/events/editing/client/js/components/Timeline/SubmitRevision.jsx
+++ b/indico/modules/events/editing/client/js/components/Timeline/SubmitRevision.jsx
@@ -72,6 +72,7 @@ export default function SubmitRevision() {
                       contrib_id: contributionId,
                       type: editableType,
                     })}
+                    mustChange
                   />
                   <FinalSubmitButton label={Translate.string('Submit new revision')} />
                 </div>

--- a/indico/modules/events/editing/client/js/components/Timeline/judgment/UpdateFilesForm.jsx
+++ b/indico/modules/events/editing/client/js/components/Timeline/judgment/UpdateFilesForm.jsx
@@ -67,6 +67,7 @@ export default function UpdateFilesForm({setLoading}) {
                 contrib_id: contributionId,
                 type: editableType,
               })}
+              mustChange
             />
             <FinalTextArea
               name="comment"


### PR DESCRIPTION
Closes #4362.
It is no longer possible to create a new revision without changing at least one file.
It is no longer possible to click 'Confirm' when there are errors regarding the file name according to the filename template.