### PR TITLE
Use a proper model for event labels

### DIFF
--- a/indico/migrations/versions/20200324_0926_266d78b1c5db_add_table_for_event_labels.py
+++ b/indico/migrations/versions/20200324_0926_266d78b1c5db_add_table_for_event_labels.py
@@ -1,0 +1,40 @@
+"""Add table for event labels
+
+Revision ID: 266d78b1c5db
+Revises: 18a1088f1ea8
+Create Date: 2020-03-24 09:26:07.095052
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '266d78b1c5db'
+down_revision = '18a1088f1ea8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'labels',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('color', sa.String(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        schema='events'
+    )
+    op.create_index('ix_uq_labels_title_lower', 'labels', [sa.text('lower(title)')], unique=True, schema='events')
+    op.add_column('events', sa.Column('label_id', sa.Integer(), nullable=True), schema='events')
+    op.add_column('events', sa.Column('label_message', sa.Text(), nullable=False, server_default=''), schema='events')
+    op.alter_column('events', 'label_message', server_default=None, schema='events')
+    op.create_foreign_key(None, 'events', 'labels', ['label_id'], ['id'], source_schema='events',
+                          referent_schema='events')
+    op.create_index(None, 'events', ['label_id'], unique=False, schema='events')
+
+
+def downgrade():
+    op.drop_column('events', 'label_id', schema='events')
+    op.drop_column('events', 'label_message', schema='events')
+    op.drop_table('labels', schema='events')

--- a/indico/migrations/versions/20200324_1004_a3295d628e3b_migrate_event_labels_from_settings.py
+++ b/indico/migrations/versions/20200324_1004_a3295d628e3b_migrate_event_labels_from_settings.py
@@ -1,0 +1,77 @@
+"""Migrate event labels from settings
+
+Revision ID: a3295d628e3b
+Revises: 266d78b1c5db
+Create Date: 2020-03-24 10:04:10.926079
+"""
+
+import json
+from collections import defaultdict
+from uuid import uuid4
+
+from alembic import context, op
+
+
+# revision identifiers, used by Alembic.
+revision = 'a3295d628e3b'
+down_revision = '266d78b1c5db'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if context.is_offline_mode():
+        raise Exception('This upgrade is only possible in online mode')
+    conn = op.get_bind()
+    # label definitions
+    mapping = {}
+    res = conn.execute("SELECT name, value FROM indico.settings WHERE module = 'event_labels'")
+    for uuid, data in res:
+        assert uuid == data['id']
+        res2 = conn.execute("INSERT INTO events.labels (title, color) VALUES (%s, %s) RETURNING id",
+                            (data['title'], data['color']))
+        mapping[uuid] = res2.fetchone()[0]
+    # event label assignments
+    res = conn.execute('''
+        SELECT event_id, name, value
+        FROM events.settings
+        WHERE module = 'label' AND name IN ('label', 'message');
+    ''')
+    event_data = defaultdict(dict)
+    for event_id, name, value in res:
+        event_data[event_id][name] = value
+    for event_id, data in event_data.items():
+        if not data['label']:
+            continue
+        label_id = mapping[data['label']]
+        label_message = data['message']
+        conn.execute("UPDATE events.events SET label_id = %s, label_message = %s WHERE id = %s",
+                     (label_id, label_message, event_id))
+    # cleanup
+    conn.execute("DELETE FROM indico.settings WHERE module = 'event_labels'")
+    conn.execute("DELETE FROM events.settings WHERE module = 'label'")
+
+
+def downgrade():
+    if context.is_offline_mode():
+        raise Exception('This downgrade is only possible in online mode')
+    conn = op.get_bind()
+    # label definitions
+    mapping = {}
+    res = conn.execute("SELECT id, title, color FROM events.labels")
+    for label_id, title, color in res:
+        uuid = unicode(uuid4())
+        conn.execute("INSERT INTO indico.settings (module, name, value) VALUES ('event_labels', %s, %s)",
+                     (uuid, json.dumps({'id': uuid, 'title': title, 'color': color})))
+        mapping[label_id] = uuid
+    # event label assignments
+    res = conn.execute("SELECT id, label_id, label_message FROM events.events WHERE label_id IS NOT NULL")
+    for event_id, label_id, label_message in res:
+        uuid = mapping[label_id]
+        stmt = "INSERT INTO events.settings (event_id, module, name, value) VALUES (%s, 'label', %s, %s)"
+        conn.execute(stmt, (event_id, 'label', json.dumps(uuid)))
+        if label_message:
+            conn.execute(stmt, (event_id, 'message', json.dumps(label_message)))
+    # cleanup
+    conn.execute("UPDATE events.events SET label_id = NULL, label_message = '' WHERE label_id IS NOT NULL")
+    conn.execute("DELETE FROM events.labels")

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -33,8 +33,6 @@ from indico.modules.categories.serialize import (serialize_categories_ical, seri
 from indico.modules.categories.util import get_category_stats, get_upcoming_events
 from indico.modules.categories.views import WPCategory, WPCategoryCalendar, WPCategoryStatistics
 from indico.modules.events.models.events import Event
-from indico.modules.events.models.settings import EventSetting
-from indico.modules.events.settings import event_label_settings, event_labels_store
 from indico.modules.events.timetable.util import get_category_timetable
 from indico.modules.events.util import get_base_ical_parameters, serialize_event_for_json_ld
 from indico.modules.news.util import get_recent_news
@@ -237,9 +235,10 @@ class RHDisplayCategoryEventsBase(RHDisplayCategoryBase):
     _category_query_options = (joinedload('children').load_only('id', 'title', 'protection_mode'),
                                undefer('attachment_count'), undefer('has_events'))
     _event_query_options = (joinedload('person_links'), joinedload('series'), undefer_group('series'),
+                            joinedload('label'),
                             load_only('id', 'category_id', 'created_dt', 'start_dt', 'end_dt', 'timezone',
                                       'protection_mode', 'title', 'type_', 'series_pos', 'series_count',
-                                      'own_address', 'own_venue_id', 'own_venue_name'))
+                                      'own_address', 'own_venue_id', 'own_venue_name', 'label_id', 'label_message'))
 
     def _process_args(self):
         RHDisplayCategoryBase._process_args(self)
@@ -278,16 +277,6 @@ class RHDisplayCategoryEventsBase(RHDisplayCategoryBase):
 
     def is_recent(self, dt):
         return dt > self.now - relativedelta(weeks=1)
-
-
-def _get_event_labels(events):
-    labels = {}
-    for setting in event_label_settings.query.filter(EventSetting.event_id.in_(e.id for e in events)):
-        value = setting.value
-        if setting.name == 'label':
-            value = event_labels_store.get(value)
-        labels.setdefault(setting.event_id, {})[setting.name] = value
-    return labels
 
 
 class RHDisplayCategory(RHDisplayCategoryEventsBase):
@@ -333,12 +322,9 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
 
         managers = sorted(self.category.get_manager_list(), key=attrgetter('principal_type.name', 'name'))
 
-        labels = _get_event_labels(events)
-
         threshold_format = '%Y-%m'
         params = {'event_count': len(events),
                   'events_by_month': events_by_month,
-                  'labels': labels,
                   'format_event_date': self.format_event_date,
                   'future_event_count': future_event_count,
                   'show_future_events': show_future_events,
@@ -390,11 +376,10 @@ class RHEventList(RHDisplayCategoryEventsBase):
         self.events = event_query.all()
 
     def _process(self):
-        labels = _get_event_labels(self.events)
         events_by_month = self.group_by_month(self.events)
         tpl = get_template_module('categories/display/event_list.html')
         html = tpl.event_list_block(events_by_month=events_by_month, format_event_date=self.format_event_date,
-                                    is_recent=self.is_recent, happening_now=self.happening_now, labels=labels)
+                                    is_recent=self.is_recent, happening_now=self.happening_now)
         return jsonify_data(flash=False, html=html)
 
 

--- a/indico/modules/categories/templates/display/category.html
+++ b/indico/modules/categories/templates/display/category.html
@@ -27,7 +27,7 @@
         {{ event_list(events_by_month=events_by_month, format_event_date=format_event_date, is_recent=is_recent,
                       happening_now=happening_now, category=category, future_event_count=future_event_count,
                       past_event_count=past_event_count, future_threshold=future_threshold, past_threshold=past_threshold,
-                      show_future_events=show_future_events, show_past_events=show_past_events, labels=labels) }}
+                      show_future_events=show_future_events, show_past_events=show_past_events) }}
     {% endif %}
 {% endblock %}
 

--- a/indico/modules/categories/templates/display/event_list.html
+++ b/indico/modules/categories/templates/display/event_list.html
@@ -43,7 +43,7 @@
 
 {% macro event_list(events_by_month, format_event_date, is_recent, happening_now, category, future_event_count,
                     past_event_count, future_threshold, past_threshold, future_events_by_month=[],
-                    past_events_by_month=[], show_future_events=false, show_past_events=false, labels={}) %}
+                    past_events_by_month=[], show_future_events=false, show_past_events=false) %}
     <div class="event-list"
          data-show-future-events-url="{{ url_for('.show_future_events', category) }}"
          data-show-past-events-url="{{ url_for('.show_past_events', category) }}">
@@ -58,7 +58,7 @@
             {% endcall %}
         {% endif %}
         <div>
-            {{ event_list_block(events_by_month, format_event_date, is_recent, happening_now, labels=labels) }}
+            {{ event_list_block(events_by_month, format_event_date, is_recent, happening_now) }}
         </div>
         {% if past_event_count %}
             {% call _hidden_events_block('past-events', category, past_events_by_month, format_event_date, is_recent,
@@ -77,7 +77,7 @@
     </script>
 {% endmacro %}
 
-{% macro event_list_block(events_by_month, format_event_date, is_recent, happening_now, labels={}) %}
+{% macro event_list_block(events_by_month, format_event_date, is_recent, happening_now) %}
     {% for month in events_by_month %}
         <h4 class="{% if month.is_current %}current-month{% endif %}">
             <span>{{ month.name }}</span>
@@ -109,11 +109,10 @@
                                     </span>
                                 {% endif %}
                             </span>
-                            {% set label_data = labels.get(event.id) %}
-                            {% if label_data and label_data.label %}
-                                <span class="ui label basic mini {{ label_data.label.color }}"
-                                      title="{{ label_data.message }}">
-                                    {{- label_data.label.title -}}
+                            {% if event.label %}
+                                <span class="ui label basic mini {{ event.label.color }}"
+                                      title="{{ event.label_message }}">
+                                    {{- event.label.title -}}
                                 </span>
                             {% endif %}
                         </div>

--- a/indico/modules/events/blueprint.py
+++ b/indico/modules/events/blueprint.py
@@ -33,9 +33,10 @@ _bp.add_url_rule('/admin/external-id-types/<int:reference_type_id>', 'delete_ref
                  methods=('DELETE',))
 
 # Single event label
-_bp.add_url_rule('/admin/event-labels/<event_label_id>/edit', 'update_event_label', RHEditEventLabel,
+_bp.add_url_rule('/admin/event-labels/<int:event_label_id>/edit', 'update_event_label', RHEditEventLabel,
                  methods=('GET', 'POST'))
-_bp.add_url_rule('/admin/event-labels/<event_label_id>', 'delete_event_label', RHDeleteEventLabel, methods=('DELETE',))
+_bp.add_url_rule('/admin/event-labels/<int:event_label_id>', 'delete_event_label', RHDeleteEventLabel,
+                 methods=('DELETE',))
 
 _bp.add_url_rule('/event/<confId>/event.ics', 'export_event_ical', RHExportEventICAL)
 

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -8,15 +8,14 @@
 from __future__ import unicode_literals
 
 from flask import flash, request
-from werkzeug.exceptions import NotFound
 
 from indico.core.db import db
 from indico.modules.admin import RHAdminBase
 from indico.modules.events.forms import EventLabelForm, ReferenceTypeForm
+from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
 from indico.modules.events.operations import (create_event_label, create_reference_type, delete_event_label,
                                               delete_reference_type, update_event_label, update_reference_type)
-from indico.modules.events.settings import event_labels_store
 from indico.modules.events.views import WPEventAdmin
 from indico.util.i18n import _
 from indico.web.flask.templating import get_template_module
@@ -83,7 +82,7 @@ class RHDeleteReferenceType(RHManageReferenceTypeBase):
 
 
 def _get_all_event_labels():
-    return sorted(event_labels_store.get_all().values(), key=lambda x: x.title.lower())
+    return EventLabel.query.order_by(db.func.lower(EventLabel.title)).all()
 
 
 def _render_event_label_list():
@@ -96,9 +95,7 @@ class RHManageEventLabelBase(RHAdminBase):
 
     def _process_args(self):
         RHAdminBase._process_args(self)
-        self.event_label = event_labels_store.get(request.view_args['event_label_id'])
-        if self.event_label is None:
-            raise NotFound
+        self.event_label = EventLabel.get_one(request.view_args['event_label_id'])
 
 
 class RHEventLabels(RHAdminBase):

--- a/indico/modules/events/export.yaml
+++ b/indico/modules/events/export.yaml
@@ -44,6 +44,8 @@ export:
       cloned_from_id: ~
       category_id: ~
       url_shortcut: ~
+      label_id: ~
+      label_message: ~
     fks:
       - EventPerson.event_id
       - EventPersonLink.event_id

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -20,8 +20,8 @@ from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.categories.fields import CategoryField
 from indico.modules.events.fields import EventPersonLinkListField, IndicoThemeSelectField
 from indico.modules.events.models.events import EventType
+from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
-from indico.modules.events.settings import event_labels_store
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.colors import get_sui_colors
@@ -63,9 +63,10 @@ class EventLabelForm(IndicoForm):
         super(EventLabelForm, self).__init__(*args, **kwargs)
 
     def validate_title(self, field):
-        conflict = next((x for x in event_labels_store.get_all().values() if x.title.lower() == field.data.lower()),
-                        None)
-        if conflict and (not self.event_label or conflict.id != self.event_label.id):
+        query = EventLabel.query.filter(db.func.lower(EventLabel.title) == field.data.lower())
+        if self.event_label:
+            query = query.filter(EventLabel.id != self.event_label.id)
+        if query.has_rows():
             raise ValidationError(_('This title is already in use.'))
 
 

--- a/indico/modules/events/management/controllers/settings.py
+++ b/indico/modules/events/management/controllers/settings.py
@@ -19,6 +19,7 @@ from indico.modules.events.management.forms import (EventClassificationForm, Eve
                                                     EventDatesForm, EventLocationForm, EventPersonsForm)
 from indico.modules.events.management.util import flash_if_unregistered
 from indico.modules.events.management.views import WPEventSettings, render_event_management_header_right
+from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
 from indico.modules.events.operations import update_event
 from indico.modules.events.util import track_time_changes
@@ -67,9 +68,11 @@ class RHEventSettings(RHManageEventBase):
                            .has_rows())
             show_booking_warning = not has_overlap
         has_reference_types = ReferenceType.query.has_rows()
+        has_event_labels = EventLabel.query.has_rows()
         return WPEventSettings.render_template('settings.html', self.event, 'settings',
                                                show_booking_warning=show_booking_warning,
-                                               has_reference_types=has_reference_types)
+                                               has_reference_types=has_reference_types,
+                                               has_event_labels=has_event_labels)
 
 
 class RHEditEventDataBase(RHManageEventBase):
@@ -83,7 +86,8 @@ class RHEditEventDataBase(RHManageEventBase):
         tpl = get_template_module('events/management/_settings.html')
         assert self.section_name
         has_reference_types = ReferenceType.query.has_rows()
-        return tpl.render_event_settings(self.event, has_reference_types,
+        has_event_labels = EventLabel.query.has_rows()
+        return tpl.render_event_settings(self.event, has_reference_types, has_event_labels,
                                          section=self.section_name, with_container=False)
 
     def jsonify_success(self):

--- a/indico/modules/events/management/templates/_settings.html
+++ b/indico/modules/events/management/templates/_settings.html
@@ -173,7 +173,7 @@
 {% endmacro %}
 
 
-{% macro render_section_classification(event, has_reference_types, with_container=true) %}
+{% macro render_section_classification(event, has_reference_types, has_event_labels, with_container=true) %}
     {% set edit_cls_title = _('Edit keywords / references / label') if event.type == 'meeting' else _('Edit keywords / label') %}
     {% call render_section(event, 'classification', 'icon-tag', '.edit_classification', edit_cls_title,
                            with_container=with_container) %}
@@ -200,18 +200,20 @@
                     {% endcall %}
                 </dd>
             {% endif %}
-            <dt>{% trans %}Label{% endtrans %}</dt>
-            <dd>
-                {% call with_default() %}
-                    {{ event.get_label_markup('mini') }}
-                {% endcall %}
-            </dd>
+            {% if has_event_labels %}
+                <dt>{% trans %}Label{% endtrans %}</dt>
+                <dd>
+                    {% call with_default() %}
+                        {{ event.get_label_markup('mini') }}
+                    {% endcall %}
+                </dd>
+            {% endif %}
         </dl>
     {% endcall %}
 {% endmacro %}
 
 
-{% macro render_event_settings(event, has_reference_types, section=none, with_container=true) %}
+{% macro render_event_settings(event, has_reference_types, has_event_labels, section=none, with_container=true) %}
     {% if section is none or section == 'data' %}
         {{ render_section_data(event, with_container=with_container) }}
     {% endif %}
@@ -228,6 +230,6 @@
         {{ render_section_contact_info(event, with_container=with_container) }}
     {% endif %}
     {% if section is none or section == 'classification' %}
-        {{ render_section_classification(event, has_reference_types, with_container=with_container) }}
+        {{ render_section_classification(event, has_reference_types, has_event_labels, with_container=with_container) }}
     {% endif %}
 {% endmacro %}

--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -27,6 +27,6 @@
         </div>
     {%- endif -%}
     <div class="action-box event-settings">
-        {{ render_event_settings(event, has_reference_types) }}
+        {{ render_event_settings(event, has_reference_types, has_event_labels) }}
     </div>
 {%- endblock %}

--- a/indico/modules/events/models/labels.py
+++ b/indico/modules/events/models/labels.py
@@ -7,26 +7,36 @@
 
 from __future__ import unicode_literals
 
-import uuid
+from sqlalchemy.ext.declarative import declared_attr
 
+from indico.core.db import db
 from indico.util.locators import locator_property
 from indico.util.string import format_repr, return_ascii
 
 
-class EventLabel(object):
-    # TODO: convert this to a proper model in 2.3
-    id = None
-    title = None
-    color = None
+class EventLabel(db.Model):
+    __tablename__ = 'labels'
 
-    def __init__(self, **kwargs):
-        if 'id' not in kwargs:
-            self.id = str(uuid.uuid4())
-        for name, value in kwargs.iteritems():
-            setattr(self, name, value)
+    @declared_attr
+    def __table_args__(cls):
+        return (db.Index('ix_uq_labels_title_lower', db.func.lower(cls.title), unique=True),
+                {'schema': 'events'})
 
-    def __eq__(self, other):
-        return isinstance(other, EventLabel) and other.id == self.id
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+    title = db.Column(
+        db.String,
+        nullable=False
+    )
+    color = db.Column(
+        db.String,
+        nullable=False
+    )
+
+    # relationship backrefs:
+    # - events (Event.label)
 
     @locator_property
     def locator(self):

--- a/indico/modules/events/settings.py
+++ b/indico/modules/events/settings.py
@@ -15,10 +15,9 @@ import yaml
 from flask.helpers import get_root_path
 
 from indico.core import signals
-from indico.core.settings import ACLProxyBase, SettingProperty, SettingsProxy, SettingsProxyBase
-from indico.core.settings.converters import DatetimeConverter, SettingConverter
+from indico.core.settings import ACLProxyBase, SettingProperty, SettingsProxyBase
+from indico.core.settings.converters import DatetimeConverter
 from indico.core.settings.util import get_all_settings, get_setting, get_setting_acl
-from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.settings import EventSetting, EventSettingPrincipal
 from indico.util.caching import memoize
 from indico.util.signals import values_from_signal
@@ -253,44 +252,3 @@ event_contact_settings = EventSettingsProxy('contact', {
     'emails': [],
     'phones': []
 })
-
-
-# TODO: remove all this when switching to a real model in 2.3
-class _EventLabelConverter(SettingConverter):
-    def from_python(self, value):
-        if value is None:
-            return None
-        return value.id
-
-    def to_python(self, value):
-        if value is None:
-            return None
-        return event_labels_store.get(value)
-
-
-class _LabelDataConverter(SettingConverter):
-    def from_python(self, value):
-        if value is None:
-            return None
-        assert isinstance(value, EventLabel)
-        return {'id': value.id, 'title': value.title, 'color': value.color}
-
-    def to_python(self, value):
-        if value is None:
-            return None
-        return EventLabel(id=value['id'], title=value['title'], color=value['color'])
-
-
-class _LabelDataConverterProvider(object):
-    def get(self, key):
-        return _LabelDataConverter()
-
-
-event_label_settings = EventSettingsProxy('label', {
-    'label': None,
-    'message': '',
-}, converters={
-    'label': _EventLabelConverter(),
-})
-
-event_labels_store = SettingsProxy('event_labels', strict=False, converters=_LabelDataConverterProvider())

--- a/indico/modules/events/templates/label.html
+++ b/indico/modules/events/templates/label.html
@@ -1,3 +1,3 @@
-<span class="event-label ui label basic {{ label.color }} {{ size }}" title="{{ message }}">
+<span class="event-label ui-qtip ui label basic {{ label.color }} {{ size }}" title="{{ message }}">
     {{- label.title -}}
 </span>

--- a/indico/web/client/js/jquery/extensions/global.js
+++ b/indico/web/client/js/jquery/extensions/global.js
@@ -49,7 +49,12 @@ $(document).ready(function() {
         qtipHTMLContainer && qtipHTMLContainer.length ? $(this).next(qtipHTMLContainer) : null;
 
       // qtip not applied if it's empty, the element is disabled or it's inside a SemanticUI widget
-      if ((!qtipHTML && !title) || this.disabled || $target.data('no-qtip') || $target.closest('.ui').length) {
+      if (
+        (!qtipHTML && !title) ||
+        this.disabled ||
+        $target.data('no-qtip') ||
+        $target.closest('.ui:not(.ui-qtip)').length
+      ) {
         return;
       }
 

--- a/indico/web/client/styles/partials/_tables.scss
+++ b/indico/web/client/styles/partials/_tables.scss
@@ -251,7 +251,7 @@ td, th {
     }
 
     a.action-icon {
-        margin: 0 0.5em;
+        margin-right: 5px;
 
         &:first-child {
             margin-left: 0;


### PR DESCRIPTION
Get rid of all the dirty workarounds used when implementing the feature in 2.2 without the need for a new alembic revision.