### PR TITLE
Enable flake8-quotes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,12 @@ max-line-length = 120
 # colored output
 format = ${cyan}%(path)s${reset}:${yellow_bold}%(row)d${reset}:${green_bold}%(col)d${reset}: ${red_bold}%(code)s${reset} %(text)s
 
+# decent quote styles
+inline-quotes = single
+multiline-quotes = single
+docstring-quotes = double
+avoid-escape = true
+
 exclude =
     build
     dist
@@ -25,6 +31,10 @@ ignore =
     W504
     # allow assigning lambdas (it's useful for single-line functions defined inside other functions)
     E731
+    # while single quotes are nicer, we have double quotes in way too many places
+    Q000
+    # for non-docstring multiline strings we don't really enforce a quote style
+    Q001
 
 per-file-ignores =
     # signals use wildcard imports to expose everything in `indico.core.signals`

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,7 @@
 babel
 flake8
 flake8-colors
+flake8-quotes
 pojson>=0.4
 termcolor
 sphinx


### PR DESCRIPTION
Only enforcing docstring quotes and not using avoidable backslash escapes since we have too many cases where strings use different quote styles.