### PR TITLE
Add  template_hook `after_banner_actions`

### DIFF
--- a/indico/modules/categories/templates/management/base.html
+++ b/indico/modules/categories/templates/management/base.html
@@ -40,6 +40,7 @@
                 {{ move_category_button(category, classes="i-button borderless") }}
                 {{ delete_category_button(category, classes="i-button borderless") }}
             {% endif %}
+            {{ template_hook('category-management-after-banner-actions', category=category) }}
         </div>
     </div>
     <script>


### PR DESCRIPTION
Add a `template_hook` (`after_banner_actions`) in the Category management area, next to the Category title to let plugin developers add more *icon buttons*
