### PR TITLE
Add location_info blocks in event display templates

### DIFF
--- a/indico/modules/events/templates/display/conference.html
+++ b/indico/modules/events/templates/display/conference.html
@@ -28,29 +28,31 @@
                 </div>
             </div>
 
-            {% if event.has_location_info or event.address %}
-                <div class="infoline location">
-                    <span title="{% trans %}Location{% endtrans %}" class="icon icon-location" aria-hidden="true"></span>
-                    <div class="text">
-                        <div class="place">
-                            {{ event.venue_name }}
-                        </div>
-                        {% if event.room and event.room.map_url %}
-                            <div class="room">
-                                <a href="{{ event.room.map_url }}">{{ event.room_name }}</a>
+            {% block location_info %}
+                {% if event.has_location_info or event.address %}
+                    <div class="infoline location">
+                        <span title="{% trans %}Location{% endtrans %}" class="icon icon-location" aria-hidden="true"></span>
+                        <div class="text">
+                            <div class="place">
+                                {{ event.venue_name }}
                             </div>
-                        {% elif event.room_name %}
-                            <div class="room">
-                                {{ event.room_name }}
-                            </div>
-                        {% endif %}
+                            {% if event.room and event.room.map_url %}
+                                <div class="room">
+                                    <a href="{{ event.room.map_url }}">{{ event.room_name }}</a>
+                                </div>
+                            {% elif event.room_name %}
+                                <div class="room">
+                                    {{ event.room_name }}
+                                </div>
+                            {% endif %}
 
-                        {% if event.address %}
-                            <div class="address nohtml">{{ event.address }}</div>
-                        {% endif %}
+                            {% if event.address %}
+                                <div class="address nohtml">{{ event.address }}</div>
+                            {% endif %}
+                        </div>
                     </div>
-                </div>
-            {% endif %}
+                {% endif %}
+            {% endblock %}
 
             {% if event.person_links %}
                 <div class="infoline chairs clear">

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -40,11 +40,13 @@
                 <div class="event-date">
                     {{ render_event_time(event, timezone) }}
                 </div>
-                {% if event.has_location_info or event.address %}
-                    <div class="event-location">
-                        {{ render_location(event, class='header-data') }}
-                    </div>
-                {% endif %}
+                {% block location_info %}
+                    {% if event.has_location_info or event.address %}
+                        <div class="event-location">
+                            {{ render_location(event, class='header-data') }}
+                        </div>
+                    {% endif %}
+                {% endblock %}
             </div>
         </div>
     {% endblock %}

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -30,11 +30,13 @@
                 <div class="event-date">
                     {{ render_event_time(event, timezone) }}
                 </div>
-                {% if event.has_location_info or event.address %}
-                    <div class="event-location">
-                        {{ render_location(event, class='header-data', header=true) }}
-                    </div>
-                {% endif %}
+                {% block location_info %}
+                    {% if event.has_location_info or event.address %}
+                        <div class="event-location">
+                            {{ render_location(event, class='header-data', header=true) }}
+                        </div>
+                    {% endif %}
+                {% endblock %}
                 {% set chairpersons = event.person_links | sort(attribute='display_order_key') %}
                 {% if chairpersons %}
                     <div class="event-chairs">


### PR DESCRIPTION
This allows plugins to override only location information in conference display pages rather than the whole content block. This is preferable in order to prevent overridden blocks to diverge from vanilla templates.