### PR TITLE
Add map URL to events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,8 @@ Improvements
 - Add UI for admins to block/unblock users (:issue:`3243`)
 - Show labels indicating whether a user is an admin, blocked or soft-deleted
   (:issue:`4363`)
+- Add map URL to events, allowing also to override room map URL (:issue:`4402`,
+  thanks :user:`omegak`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20200409_1711_7f56252c73ab_add_map_url_to_events_table.py
+++ b/indico/migrations/versions/20200409_1711_7f56252c73ab_add_map_url_to_events_table.py
@@ -1,0 +1,25 @@
+"""Add map_url to events table
+
+Revision ID: 7f56252c73ab
+Revises: 933665578547
+Create Date: 2020-04-09 17:11:13.685047
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '7f56252c73ab'
+down_revision = '933665578547'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('events', sa.Column('map_url', sa.String(), nullable=False, server_default=''), schema='events')
+    op.alter_column('events', 'map_url', server_default=None, schema='events')
+
+
+def downgrade():
+    op.drop_column('events', 'map_url', schema='events')

--- a/indico/modules/events/export_test_1.yaml
+++ b/indico/modules/events/export_test_1.yaml
@@ -26,6 +26,7 @@
     !!python/unicode 'last_friendly_session_id': 1
     !!python/unicode 'logo': null
     !!python/unicode 'logo_metadata': null
+    !!python/unicode 'map_url': !!python/unicode ''
     !!python/unicode 'no_access_contact': !!python/unicode ''
     !!python/unicode 'protection_mode': !!python/object/apply:indico.core.db.sqlalchemy.protection.ProtectionMode
     - 1

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -17,8 +17,8 @@ from pytz import timezone
 from werkzeug.datastructures import ImmutableMultiDict
 from wtforms import BooleanField, FloatField, SelectField, StringField, TextAreaField
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
-from wtforms.fields.html5 import IntegerField
-from wtforms.validators import DataRequired, InputRequired, NumberRange, Optional, ValidationError
+from wtforms.fields.html5 import IntegerField, URLField
+from wtforms.validators import URL, DataRequired, InputRequired, NumberRange, Optional, ValidationError
 
 from indico.core.config import config
 from indico.core.db import db
@@ -168,6 +168,13 @@ class EventDatesForm(IndicoForm):
 
 class EventLocationForm(IndicoForm):
     location_data = IndicoLocationField(_('Location'), allow_location_inheritance=False)
+    own_map_url = URLField(_('Map URL'), [Optional(), URL()])
+
+    def __init__(self, *args, **kwargs):
+        event = kwargs['event']
+        super(EventLocationForm, self).__init__(*args, **kwargs)
+        if event.room:
+            self.own_map_url.render_kw = {'placeholder': event.room.map_url}
 
 
 class EventPersonsForm(IndicoForm):

--- a/indico/modules/events/management/templates/_settings.html
+++ b/indico/modules/events/management/templates/_settings.html
@@ -111,6 +111,9 @@
 
             <dt>{% trans %}Address{% endtrans %}</dt>
             <dd>{{ with_default(event.address|replace('\n', '<br>'|safe)) }}</dd>
+
+            <dt>{% trans %}Map URL{% endtrans %}</dt>
+            <dd>{{ with_default(event.map_url) }}</dd>
         </dl>
     {% endcall %}
 

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -244,6 +244,14 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         index=True,
         nullable=True
     )
+    #: The url to a map for the event
+    own_map_url = db.Column(
+        'map_url',
+        db.String,
+        nullable=False,
+        default=''
+    )
+
     #: The last user-friendly registration ID
     _last_friendly_registration_id = db.deferred(db.Column(
         'last_friendly_registration_id',
@@ -554,6 +562,14 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     def short_external_url(self):
         id_ = self.url_shortcut or self.id
         return url_for('events.shorturl', confId=id_, _external=True)
+
+    @property
+    def map_url(self):
+        if self.own_map_url:
+            return self.own_map_url
+        elif not self.room:
+            return ''
+        return self.room.map_url or ''
 
     @property
     def tzinfo(self):

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -129,7 +129,8 @@ def update_event(event, update_timetable=False, **data):
     assert set(data.viewkeys()) <= {'title', 'description', 'url_shortcut', 'location_data', 'keywords',
                                     'person_link_data', 'start_dt', 'end_dt', 'timezone', 'keywords', 'references',
                                     'organizer_info', 'additional_info', 'contact_title', 'contact_emails',
-                                    'contact_phones', 'start_dt_override', 'end_dt_override', 'label', 'label_message'}
+                                    'contact_phones', 'start_dt_override', 'end_dt_override', 'label', 'label_message',
+                                    'own_map_url'}
     old_person_links = event.person_links[:]
     changes = {}
     if (update_timetable or event.type == EventType.lecture) and 'start_dt' in data:
@@ -168,6 +169,7 @@ def clone_event(event, start_dt, cloners, category=None):
         'timezone': event.timezone,
         'title': event.title,
         'description': event.description,
+        'own_map_url': event.own_map_url
     }
     new_event = create_event(category or event.category, event.type_, data,
                              features=features_event_settings.get(event, 'enabled'),
@@ -212,7 +214,8 @@ def _log_event_update(event, changes, visible_person_link_changes=False):
         'contact_emails': 'Contact emails',
         'contact_phones': 'Contact phone numbers',
         'label': {'title': 'Label', 'type': 'string', 'attr': 'title'},
-        'label_message': 'Label message'
+        'label_message': 'Label message',
+        'own_map_url': {'title': 'Map URL', 'type': 'string'}
     }
     _split_location_changes(changes)
     if not visible_person_link_changes:

--- a/indico/modules/events/templates/display/conference.html
+++ b/indico/modules/events/templates/display/conference.html
@@ -36,11 +36,7 @@
                             <div class="place">
                                 {{ event.venue_name }}
                             </div>
-                            {% if event.room and event.room.map_url %}
-                                <div class="room">
-                                    <a href="{{ event.room.map_url }}">{{ event.room_name }}</a>
-                                </div>
-                            {% elif event.room_name %}
+                            {% if event.room_name %}
                                 <div class="room">
                                     {{ event.room_name }}
                                 </div>
@@ -48,6 +44,12 @@
 
                             {% if event.address %}
                                 <div class="address nohtml">{{ event.address }}</div>
+                            {% endif %}
+
+                            {% if event.map_url %}
+                                <a href="{{ event.map_url }}" target="_blank" rel="noopener noreferrer">
+                                    {% trans %}Go to map{% endtrans %}
+                                </a>
                             {% endif %}
                         </div>
                     </div>


### PR DESCRIPTION
This allows adding a map URL to an event regardless of room booking being enabled or not. In case the event takes place in a room with with map URL associated, this one overrides it.

# UI changes

<img width="1680" alt="Screen Shot 2020-04-09 at 18 06 25" src="https://user-images.githubusercontent.com/716307/78915987-189ad880-7a8d-11ea-9095-7efbc7286f61.png">
<img width="1680" alt="Screen Shot 2020-04-09 at 18 06 14" src="https://user-images.githubusercontent.com/716307/78915991-19336f00-7a8d-11ea-95d4-da5541908b35.png">
<img width="1680" alt="Screen Shot 2020-04-09 at 18 05 52" src="https://user-images.githubusercontent.com/716307/78915995-1a649c00-7a8d-11ea-9f9b-caada37bb1f2.png">



