### PR TITLE
#4412 Make Category UI views more plugin friendly

### DIFF
--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -316,6 +316,7 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
                   'atom_feed_title': _('Events of "{}"').format(self.category.title)}
         params.update(get_base_ical_parameters(session.user, 'category',
                                                '/export/categ/{0}.ics'.format(self.category.id), {'from': '-31d'}))
+
         if not self.category.is_root:
             return WPCategory.render_template('display/category.html', self.category, **params)
 
@@ -424,7 +425,7 @@ class RHXMLExportCategoryInfo(RH):
 class RHCategoryOverview(RHDisplayCategoryBase):
     """Display the events for a particular day, week or month"""
 
-    def _get_data(self):
+    def _get_timetable(self):
         return get_category_timetable([self.category.id], self.start_dt, self.end_dt,
                                       detail_level=self.detail, tz=self.category.display_tzinfo,
                                       from_categ=self.category, grouped=False)
@@ -457,7 +458,7 @@ class RHCategoryOverview(RHDisplayCategoryBase):
             self.end_dt = self.start_dt + relativedelta(months=1)
 
     def _process(self):
-        info = self._get_data()
+        info = self._get_timetable()
         events = info['events']
 
         # Only categories with icons are listed in the sidebar

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -299,23 +299,21 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
         managers = sorted(self.category.get_manager_list(), key=attrgetter('principal_type.name', 'name'))
 
         threshold_format = '%Y-%m'
-        params = {
-            'event_count': len(events),
-            'events_by_month': events_by_month,
-            'format_event_date': self.format_event_date,
-            'future_event_count': future_event_count,
-            'show_future_events': show_future_events,
-            'future_threshold': future_threshold.strftime(threshold_format),
-            'happening_now': self.happening_now,
-            'is_recent': self.is_recent,
-            'managers': managers,
-            'past_event_count': past_event_count,
-            'show_past_events': show_past_events,
-            'past_threshold': past_threshold.strftime(threshold_format),
-            'json_ld': map(serialize_event_for_json_ld, json_ld_events),
-            'atom_feed_url': url_for('.export_atom', self.category),
-            'atom_feed_title': _('Events of "{}"').format(self.category.title)
-        }
+        params = {'event_count': len(events),
+                  'events_by_month': events_by_month,
+                  'format_event_date': self.format_event_date,
+                  'future_event_count': future_event_count,
+                  'show_future_events': show_future_events,
+                  'future_threshold': future_threshold.strftime(threshold_format),
+                  'happening_now': self.happening_now,
+                  'is_recent': self.is_recent,
+                  'managers': managers,
+                  'past_event_count': past_event_count,
+                  'show_past_events': show_past_events,
+                  'past_threshold': past_threshold.strftime(threshold_format),
+                  'json_ld': map(serialize_event_for_json_ld, json_ld_events),
+                  'atom_feed_url': url_for('.export_atom', self.category),
+                  'atom_feed_title': _('Events of "{}"').format(self.category.title)}
         params.update(get_base_ical_parameters(session.user, 'category',
                                                '/export/categ/{0}.ics'.format(self.category.id), {'from': '-31d'}))
         if not self.category.is_root:

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -299,8 +299,7 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
         managers = sorted(self.category.get_manager_list(), key=attrgetter('principal_type.name', 'name'))
 
         threshold_format = '%Y-%m'
-        params = self.params
-        params.update({
+        params = {
             'event_count': len(events),
             'events_by_month': events_by_month,
             'format_event_date': self.format_event_date,
@@ -316,7 +315,7 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
             'json_ld': map(serialize_event_for_json_ld, json_ld_events),
             'atom_feed_url': url_for('.export_atom', self.category),
             'atom_feed_title': _('Events of "{}"').format(self.category.title)
-        })
+        }
         params.update(get_base_ical_parameters(session.user, 'category',
                                                '/export/categ/{0}.ics'.format(self.category.id), {'from': '-31d'}))
         if not self.category.is_root:
@@ -478,8 +477,7 @@ class RHCategoryOverview(RHDisplayCategoryBase):
                     -mktime(event.first_occurence_start_dt.timetuple()) if ongoing else event.start_dt.time())
         events = sorted(events, key=_event_sort_key)
 
-        params = self.params
-        params.update({
+        params = {
             'detail': self.detail,
             'period': self.period,
             'subcategories': subcategories,
@@ -492,7 +490,7 @@ class RHCategoryOverview(RHDisplayCategoryBase):
             'previous_year_url': self._other_day_url(self.start_dt - relativedelta(years=1)),
             'next_year_url': self._other_day_url(self.start_dt + relativedelta(years=1)),
             'mathjax': True
-        })
+        }
 
         if self.detail != 'event':
             cte = self.category.get_protection_parent_cte()

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -299,7 +299,8 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
         managers = sorted(self.category.get_manager_list(), key=attrgetter('principal_type.name', 'name'))
 
         threshold_format = '%Y-%m'
-        params = {'event_count': len(events),
+        params = self.params
+        params.update({'event_count': len(events),
                   'events_by_month': events_by_month,
                   'format_event_date': self.format_event_date,
                   'future_event_count': future_event_count,
@@ -313,10 +314,9 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
                   'past_threshold': past_threshold.strftime(threshold_format),
                   'json_ld': map(serialize_event_for_json_ld, json_ld_events),
                   'atom_feed_url': url_for('.export_atom', self.category),
-                  'atom_feed_title': _('Events of "{}"').format(self.category.title)}
+                  'atom_feed_title': _('Events of "{}"').format(self.category.title)})
         params.update(get_base_ical_parameters(session.user, 'category',
                                                '/export/categ/{0}.ics'.format(self.category.id), {'from': '-31d'}))
-
         if not self.category.is_root:
             return WPCategory.render_template('display/category.html', self.category, **params)
 
@@ -425,6 +425,11 @@ class RHXMLExportCategoryInfo(RH):
 class RHCategoryOverview(RHDisplayCategoryBase):
     """Display the events for a particular day, week or month"""
 
+    def _get_data(self):
+        return get_category_timetable([self.category.id], self.start_dt, self.end_dt,
+                                      detail_level=self.detail, tz=self.category.display_tzinfo,
+                                      from_categ=self.category, grouped=False)
+
     def _process_args(self):
         RHDisplayCategoryBase._process_args(self)
         self.detail = request.args.get('detail', 'event')
@@ -453,8 +458,7 @@ class RHCategoryOverview(RHDisplayCategoryBase):
             self.end_dt = self.start_dt + relativedelta(months=1)
 
     def _process(self):
-        info = get_category_timetable([self.category.id], self.start_dt, self.end_dt, detail_level=self.detail,
-                                      tz=self.category.display_tzinfo, from_categ=self.category, grouped=False)
+        info = self._get_data()
         events = info['events']
 
         # Only categories with icons are listed in the sidebar
@@ -472,7 +476,8 @@ class RHCategoryOverview(RHDisplayCategoryBase):
                     -mktime(event.first_occurence_start_dt.timetuple()) if ongoing else event.start_dt.time())
         events = sorted(events, key=_event_sort_key)
 
-        params = {
+        params = self.params
+        params.update({
             'detail': self.detail,
             'period': self.period,
             'subcategories': subcategories,
@@ -485,7 +490,7 @@ class RHCategoryOverview(RHDisplayCategoryBase):
             'previous_year_url': self._other_day_url(self.start_dt - relativedelta(years=1)),
             'next_year_url': self._other_day_url(self.start_dt + relativedelta(years=1)),
             'mathjax': True
-        }
+        })
 
         if self.detail != 'event':
             cte = self.category.get_protection_parent_cte()

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -300,21 +300,23 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
 
         threshold_format = '%Y-%m'
         params = self.params
-        params.update({'event_count': len(events),
-                  'events_by_month': events_by_month,
-                  'format_event_date': self.format_event_date,
-                  'future_event_count': future_event_count,
-                  'show_future_events': show_future_events,
-                  'future_threshold': future_threshold.strftime(threshold_format),
-                  'happening_now': self.happening_now,
-                  'is_recent': self.is_recent,
-                  'managers': managers,
-                  'past_event_count': past_event_count,
-                  'show_past_events': show_past_events,
-                  'past_threshold': past_threshold.strftime(threshold_format),
-                  'json_ld': map(serialize_event_for_json_ld, json_ld_events),
-                  'atom_feed_url': url_for('.export_atom', self.category),
-                  'atom_feed_title': _('Events of "{}"').format(self.category.title)})
+        params.update({
+            'event_count': len(events),
+            'events_by_month': events_by_month,
+            'format_event_date': self.format_event_date,
+            'future_event_count': future_event_count,
+            'show_future_events': show_future_events,
+            'future_threshold': future_threshold.strftime(threshold_format),
+            'happening_now': self.happening_now,
+            'is_recent': self.is_recent,
+            'managers': managers,
+            'past_event_count': past_event_count,
+            'show_past_events': show_past_events,
+            'past_threshold': past_threshold.strftime(threshold_format),
+            'json_ld': map(serialize_event_for_json_ld, json_ld_events),
+            'atom_feed_url': url_for('.export_atom', self.category),
+            'atom_feed_title': _('Events of "{}"').format(self.category.title)
+        })
         params.update(get_base_ical_parameters(session.user, 'category',
                                                '/export/categ/{0}.ics'.format(self.category.id), {'from': '-31d'}))
         if not self.category.is_root:

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -18,7 +18,6 @@
                 {% endif %}
             {% endblock %}
         </h1>
-
         {% block cat_toolbar %}
             <div id="category-toolbar" class="toolbar">
                 <div class="group">
@@ -42,7 +41,6 @@
                             </a>
                         {% endif %}
                     {% endblock %}
-
                     {% block cat_export %}
                         <a href="#"
                            class="i-button icon-calendar arrow js-export-ical"
@@ -52,7 +50,6 @@
                             {% include 'categories/category_export_ical.html' %}
                         {%- endwith %}
                     {% endblock %}
-
                     {% block cat_view_dropdown %}
                         <a class="i-button icon-eye arrow js-dropdown"
                            title="{% trans %}View{% endtrans %}"
@@ -75,7 +72,6 @@
                             </li>
                         </ul>
                     {% endblock %}
-
                     {% block cat_manage %}
                         {% if category.can_manage(session.user) %}
                             <a href="{{ url_for('categories.manage_content', category) }}"
@@ -83,9 +79,7 @@
                                title="{% trans %}Manage category{% endtrans %}"></a>
                         {% endif %}
                     {% endblock %}
-
                 </div>
-
                 {% block cat_user_favorites %}
                     {% if session.user and not category.is_root %}
                         <div class="group">
@@ -95,9 +89,8 @@
                                     data-favorites-href="{{ url_for('users.user_favorites') }}"></button>
                         </div>
                     {% endif %}
-            {% endblock %}
-
-        </div>
+                {% endblock %}
+            </div>
         {% endblock %}
     </div>
 

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -18,22 +18,32 @@
                 {% endif %}
             {% endblock %}
         </h1>
+
+        {% block cat_toolbar %}
         <div id="category-toolbar" class="toolbar">
             <div class="group">
+                {% block cat_create_event %}
                 {{ create_event_button(category, classes="highlight", text=_("Create event"), with_tooltip=false) }}
+                {% endblock %}
             </div>
             <div class="group">
+                {% block cat_navigate %}
                 <button id="navigate-button" class="i-button icon-compass2"
                         title="{% trans %}Navigate categories{% endtrans %}">
                     {% trans %}Navigate{% endtrans %}
                 </button>
+                {% endblock %}
             </div>
             <div class="group">
+                {% block cat_parent %}
                 {% if not category.is_root %}
                     <a class="i-button icon-arrow-up" href="{{ category.parent.url }}">
                         {% trans %}Parent category{% endtrans %}
                     </a>
                 {% endif %}
+                {% endblock %}
+
+                {% block cat_export %}
                 <a href="#"
                    class="i-button icon-calendar arrow js-export-ical"
                    title="{% trans %}Export to scheduling tool{% endtrans %}"
@@ -41,6 +51,9 @@
                 {% with item=category, ics_url=url_for('categories.export_ical', category) -%}
                     {% include 'categories/category_export_ical.html' %}
                 {%- endwith %}
+                {% endblock %}
+
+                {% block cat_view_dropdown %}
                 <a class="i-button icon-eye arrow js-dropdown"
                    title="{% trans %}View{% endtrans %}"
                    data-toggle="dropdown"></a>
@@ -61,12 +74,19 @@
                         <a href="{{ url_for('.statistics', category) }}">{% trans %}Category statistics{% endtrans %}</a>
                     </li>
                 </ul>
+                {% endblock %}
+
+                {% block cat_manage %}
                 {% if category.can_manage(session.user) %}
                     <a href="{{ url_for('categories.manage_content', category) }}"
                        class="i-button icon-edit"
                        title="{% trans %}Manage category{% endtrans %}"></a>
                 {% endif %}
+                {% endblock %}
+
             </div>
+
+            {% block cat_user_favorites %}
             {% if session.user and not category.is_root %}
                 <div class="group">
                     <button type="button"
@@ -75,7 +95,10 @@
                             data-favorites-href="{{ url_for('users.user_favorites') }}"></button>
                 </div>
             {% endif %}
+            {% endblock %}
+
         </div>
+        {% endblock %}
     </div>
 
     {% if self.sidebar() %}

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -20,81 +20,81 @@
         </h1>
 
         {% block cat_toolbar %}
-        <div id="category-toolbar" class="toolbar">
-            <div class="group">
-                {% block cat_create_event %}
-                {{ create_event_button(category, classes="highlight", text=_("Create event"), with_tooltip=false) }}
-                {% endblock %}
-            </div>
-            <div class="group">
-                {% block cat_navigate %}
-                <button id="navigate-button" class="i-button icon-compass2"
-                        title="{% trans %}Navigate categories{% endtrans %}">
-                    {% trans %}Navigate{% endtrans %}
-                </button>
-                {% endblock %}
-            </div>
-            <div class="group">
-                {% block cat_parent %}
-                {% if not category.is_root %}
-                    <a class="i-button icon-arrow-up" href="{{ category.parent.url }}">
-                        {% trans %}Parent category{% endtrans %}
-                    </a>
-                {% endif %}
-                {% endblock %}
-
-                {% block cat_export %}
-                <a href="#"
-                   class="i-button icon-calendar arrow js-export-ical"
-                   title="{% trans %}Export to scheduling tool{% endtrans %}"
-                   data-id="{{ category.id }}"></a>
-                {% with item=category, ics_url=url_for('categories.export_ical', category) -%}
-                    {% include 'categories/category_export_ical.html' %}
-                {%- endwith %}
-                {% endblock %}
-
-                {% block cat_view_dropdown %}
-                <a class="i-button icon-eye arrow js-dropdown"
-                   title="{% trans %}View{% endtrans %}"
-                   data-toggle="dropdown"></a>
-                <ul class="i-dropdown">
-                    <li>
-                        <a href="{{ url_for('.upcoming_event', category) }}">{% trans %}Upcoming event{% endtrans %}</a>
-                    </li>
-                    <li>
-                        <a href="{{ url_for('.overview', category, period='day') }}">{% trans %}Today's events{% endtrans %}</a>
-                    </li>
-                    <li>
-                        <a href="{{ url_for('.overview', category, period='week') }}">{% trans %}Week's events{% endtrans %}</a>
-                    </li>
-                    <li>
-                        <a href="{{ url_for('.calendar', category) }}">{% trans %}Calendar{% endtrans %}</a>
-                    </li>
-                    <li>
-                        <a href="{{ url_for('.statistics', category) }}">{% trans %}Category statistics{% endtrans %}</a>
-                    </li>
-                </ul>
-                {% endblock %}
-
-                {% block cat_manage %}
-                {% if category.can_manage(session.user) %}
-                    <a href="{{ url_for('categories.manage_content', category) }}"
-                       class="i-button icon-edit"
-                       title="{% trans %}Manage category{% endtrans %}"></a>
-                {% endif %}
-                {% endblock %}
-
-            </div>
-
-            {% block cat_user_favorites %}
-            {% if session.user and not category.is_root %}
+            <div id="category-toolbar" class="toolbar">
                 <div class="group">
-                    <button type="button"
-                            class="i-button fav-button icon-only icon-bookmark {{ 'enabled' if category in session.user.favorite_categories }}"
-                            data-href="{{ url_for('users.user_favorites_category_api', category) }}"
-                            data-favorites-href="{{ url_for('users.user_favorites') }}"></button>
+                    {% block cat_create_event %}
+                        {{ create_event_button(category, classes="highlight", text=_("Create event"), with_tooltip=false) }}
+                    {% endblock %}
                 </div>
-            {% endif %}
+                <div class="group">
+                    {% block cat_navigate %}
+                        <button id="navigate-button" class="i-button icon-compass2"
+                                title="{% trans %}Navigate categories{% endtrans %}">
+                            {% trans %}Navigate{% endtrans %}
+                        </button>
+                    {% endblock %}
+                </div>
+                <div class="group">
+                    {% block cat_parent %}
+                        {% if not category.is_root %}
+                            <a class="i-button icon-arrow-up" href="{{ category.parent.url }}">
+                                {% trans %}Parent category{% endtrans %}
+                            </a>
+                        {% endif %}
+                    {% endblock %}
+
+                    {% block cat_export %}
+                        <a href="#"
+                           class="i-button icon-calendar arrow js-export-ical"
+                           title="{% trans %}Export to scheduling tool{% endtrans %}"
+                           data-id="{{ category.id }}"></a>
+                        {% with item=category, ics_url=url_for('categories.export_ical', category) -%}
+                            {% include 'categories/category_export_ical.html' %}
+                        {%- endwith %}
+                    {% endblock %}
+
+                    {% block cat_view_dropdown %}
+                        <a class="i-button icon-eye arrow js-dropdown"
+                           title="{% trans %}View{% endtrans %}"
+                           data-toggle="dropdown"></a>
+                        <ul class="i-dropdown">
+                            <li>
+                                <a href="{{ url_for('.upcoming_event', category) }}">{% trans %}Upcoming event{% endtrans %}</a>
+                            </li>
+                            <li>
+                                <a href="{{ url_for('.overview', category, period='day') }}">{% trans %}Today's events{% endtrans %}</a>
+                            </li>
+                            <li>
+                                <a href="{{ url_for('.overview', category, period='week') }}">{% trans %}Week's events{% endtrans %}</a>
+                            </li>
+                            <li>
+                                <a href="{{ url_for('.calendar', category) }}">{% trans %}Calendar{% endtrans %}</a>
+                            </li>
+                            <li>
+                                <a href="{{ url_for('.statistics', category) }}">{% trans %}Category statistics{% endtrans %}</a>
+                            </li>
+                        </ul>
+                    {% endblock %}
+
+                    {% block cat_manage %}
+                        {% if category.can_manage(session.user) %}
+                            <a href="{{ url_for('categories.manage_content', category) }}"
+                               class="i-button icon-edit"
+                               title="{% trans %}Manage category{% endtrans %}"></a>
+                        {% endif %}
+                    {% endblock %}
+
+                </div>
+
+                {% block cat_user_favorites %}
+                    {% if session.user and not category.is_root %}
+                        <div class="group">
+                            <button type="button"
+                                    class="i-button fav-button icon-only icon-bookmark {{ 'enabled' if category in session.user.favorite_categories }}"
+                                    data-href="{{ url_for('users.user_favorites_category_api', category) }}"
+                                    data-favorites-href="{{ url_for('users.user_favorites') }}"></button>
+                        </div>
+                    {% endif %}
             {% endblock %}
 
         </div>

--- a/indico/modules/events/timetable/util.py
+++ b/indico/modules/events/timetable/util.py
@@ -130,7 +130,8 @@ def find_next_start_dt(duration, obj, day=None, force=False):
     return start_dt
 
 
-def get_category_timetable(categ_ids, start_dt, end_dt, detail_level='event', tz=utc, from_categ=None, grouped=True):
+def get_category_timetable(categ_ids, start_dt, end_dt, detail_level='event', tz=utc, from_categ=None, grouped=True,
+                           includible=lambda item: True):
     """Retrieve time blocks that fall within a specific time interval
        for a given set of categories.
 
@@ -145,6 +146,9 @@ def get_category_timetable(categ_ids, start_dt, end_dt, detail_level='event', tz
        :param from_categ: ``Category`` that will be taken into account to calculate
                           visibility
        :param grouped: Whether to group results by start date
+       :param includible: a callable, to allow further arbitrary custom filtering on whether
+                          to include (returns True) or not (returns False) each ``detail`` item.
+                          Default always returns True.
        :returns: a dictionary containing timetable information in a
                  structured way. See source code for examples.
     """
@@ -177,6 +181,8 @@ def get_category_timetable(categ_ids, start_dt, end_dt, detail_level='event', tz
     ongoing_events = []
     events = []
     for e in query:
+        if not includible(e):
+            continue
         if grouped:
             local_start_dt = e.start_dt.astimezone(tz).date()
             local_end_dt = e.end_dt.astimezone(tz).date()

--- a/indico/modules/events/timetable/util.py
+++ b/indico/modules/events/timetable/util.py
@@ -146,9 +146,9 @@ def get_category_timetable(categ_ids, start_dt, end_dt, detail_level='event', tz
        :param from_categ: ``Category`` that will be taken into account to calculate
                           visibility
        :param grouped: Whether to group results by start date
-       :param includible: a callable, to allow further arbitrary custom filtering on whether
-                          to include (returns True) or not (returns False) each ``detail`` item.
-                          Default always returns True.
+       :param includible: a callable, to allow further arbitrary custom filtering (maybe from 3rd
+                          party plugins) on whether to include (returns True) or not (returns False)
+                          each ``detail`` item. Default always returns True.
        :returns: a dictionary containing timetable information in a
                  structured way. See source code for examples.
     """

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -77,7 +77,6 @@ class RH(object):
 
     def __init__(self):
         self.commit = True
-        self.params = {}  # dict to aggregate params to be passed to template
 
     # Methods =============================================================
 

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -77,6 +77,7 @@ class RH(object):
 
     def __init__(self):
         self.commit = True
+        self.params = {}  # dict to aggregate params to be passed to template
 
     # Methods =============================================================
 


### PR DESCRIPTION
Several non-behaviour-modifying changes to RH and template code for Category view rendering, as listed in #4412.

Overall description of changes in #4412. 

I was trying to be consistent with your code base, but please feel free to adjust any variable/parameter/template-block name chosen here as you feel is best. 

Another small aspect -- if you feel a new method is not warranted for this, the new _get_data() method on RHCategoryOverview could in practice be made part of _process_args (in base RH._process_args, the docstring actually suggests that is where data fetches should probably go). So, for example, could just make the call within _process_args(), setting the result on an instance parameter, such as self.info. However, I feel given that this is a rather hefty db data fetch & process, I feel everything is better off to having it factored out as a completely separate customizable/optimizable/cacheable method.