### PR TITLE
Allow microservices to configure editing workflow

### DIFF
--- a/indico/core/db/sqlalchemy/util/models.py
+++ b/indico/core/db/sqlalchemy/util/models.py
@@ -120,7 +120,14 @@ class IndicoModel(Model):
         return obj
 
     @classmethod
-    def get_one(cls, oid, is_deleted=None):
+    def get_or_404(cls, oid, is_deleted=None):
+        """Get an object based on its primary key, raising a 404 if not found.
+
+        :param oid: The primary key of the object
+        :param is_deleted: If specified, a 404 error will be returned if the
+                           `is_deleted` attribute of the object does not match
+                           the specified value.
+        """
         obj = cls.get(oid, is_deleted=is_deleted)
         if obj is None:
             raise NoResultFound()

--- a/indico/modules/api/controllers.py
+++ b/indico/modules/api/controllers.py
@@ -152,13 +152,13 @@ class RHAPIBuildURLs(RH):
         data = request.json
         self.object = None
         if 'categId' in data:
-            self.object = Category.get_one(data['categId'])
+            self.object = Category.get_or_404(data['categId'])
         elif 'contribId' in data:
-            self.object = Contribution.get_one(data['contribId'])
+            self.object = Contribution.get_or_404(data['contribId'])
         elif 'sessionId' in data:
-            self.object = Session.get_one(data['sessionId'])
+            self.object = Session.get_or_404(data['sessionId'])
         elif 'confId' in data:
-            self.object = Event.get_one(data['confId'])
+            self.object = Event.get_or_404(data['confId'])
 
         if self.object is None:
             raise BadRequest

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -356,7 +356,7 @@ class RHRemoveAccount(RHUserBase):
 
     def _process_args(self):
         RHUserBase._process_args(self)
-        self.identity = Identity.get_one(request.view_args['identity'])
+        self.identity = Identity.get_or_404(request.view_args['identity'])
         if self.identity.user != self.user:
             raise NotFound()
 
@@ -600,7 +600,7 @@ class RHAdminImpersonate(RHAdminBase):
     })
     def _process_args(self, undo, user_id):
         RHAdminBase._process_args(self)
-        self.user = None if undo else User.get_one(user_id, is_deleted=False)
+        self.user = None if undo else User.get_or_404(user_id, is_deleted=False)
 
     def _check_access(self):
         if self.user:

--- a/indico/modules/auth/util.py
+++ b/indico/modules/auth/util.py
@@ -88,7 +88,7 @@ def undo_impersonate_user():
     except KeyError:
         # The user probably already switched back from another tab
         return
-    user = User.get_one(entry['user_id'])
+    user = User.get_or_404(entry['user_id'])
     logger.info('Admin %r stopped impersonating user %r', user, session.user)
     session.user = user
     session.update(entry['session_data'])

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -424,7 +424,7 @@ class RHXMLExportCategoryInfo(RH):
             id_ = int(request.args['id'])
         except ValueError:
             raise BadRequest('Invalid Category ID')
-        self.category = Category.get_one(id_, is_deleted=False)
+        self.category = Category.get_or_404(id_, is_deleted=False)
 
     def _process(self):
         category_xml_info = XMLCategorySerializer(self.category).serialize_category()

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -266,7 +266,7 @@ class RHMoveCategoryBase(RHManageCategoryBase):
         if target_category_id is None:
             self.target_category = None
         else:
-            self.target_category = Category.get_one(int(target_category_id), is_deleted=False)
+            self.target_category = Category.get_or_404(int(target_category_id), is_deleted=False)
             if not self.target_category.can_manage(session.user):
                 raise Forbidden(_("You are not allowed to manage the selected destination."))
             if self.target_category.events:
@@ -411,7 +411,7 @@ class RHSplitCategory(RHManageCategorySelectedEventsBase):
 class RHMoveEvents(RHManageCategorySelectedEventsBase):
     def _process_args(self):
         RHManageCategorySelectedEventsBase._process_args(self)
-        self.target_category = Category.get_one(int(request.form['target_category_id']), is_deleted=False)
+        self.target_category = Category.get_or_404(int(request.form['target_category_id']), is_deleted=False)
         if not self.target_category.can_create_events(session.user):
             raise Forbidden(_("You may only move events to categories where you are allowed to create events."))
 
@@ -462,7 +462,7 @@ class RHManageCategoryRole(RHManageCategoryBase):
 
     def _process_args(self):
         RHManageCategoryBase._process_args(self)
-        self.role = CategoryRole.get_one(request.view_args['role_id'])
+        self.role = CategoryRole.get_or_404(request.view_args['role_id'])
 
 
 class RHEditCategoryRole(RHManageCategoryRole):
@@ -494,7 +494,7 @@ class RHRemoveCategoryRoleMember(RHManageCategoryRole):
 
     def _process_args(self):
         RHManageCategoryRole._process_args(self)
-        self.user = User.get_one(request.view_args['user_id'])
+        self.user = User.get_or_404(request.view_args['user_id'])
 
     def _process(self):
         if self.user in self.role.members:

--- a/indico/modules/designer/controllers.py
+++ b/indico/modules/designer/controllers.py
@@ -130,7 +130,7 @@ class SpecificTemplateMixin(TemplateDesignerMixin):
             check_event_locked(self, self.target)
 
     def _process_args(self):
-        self.template = DesignerTemplate.get_one(request.view_args['template_id'])
+        self.template = DesignerTemplate.get_or_404(request.view_args['template_id'])
 
 
 class BacksideTemplateProtectionMixin(object):
@@ -172,7 +172,7 @@ class CloneTemplateMixin(TargetFromURLMixin):
             raise Forbidden
 
     def _process_args(self):
-        self.template = DesignerTemplate.get_one(request.view_args['template_id'])
+        self.template = DesignerTemplate.get_or_404(request.view_args['template_id'])
 
     def _process(self):
         title = "{} (copy)".format(self.template.title)
@@ -367,7 +367,7 @@ class RHGetTemplateData(BacksideTemplateProtectionMixin, RHModifyDesignerTemplat
 
 class RHToggleTemplateDefaultOnCategory(RHManageCategoryBase):
     def _process(self):
-        template = DesignerTemplate.get_one(request.view_args['template_id'])
+        template = DesignerTemplate.get_or_404(request.view_args['template_id'])
         if template not in get_all_templates(self.category):
             raise Exception('Invalid template')
         if template == self.category.default_ticket_template:

--- a/indico/modules/events/abstracts/controllers/abstract.py
+++ b/indico/modules/events/abstracts/controllers/abstract.py
@@ -74,7 +74,7 @@ class RHAbstractsDownloadAttachment(RHAbstractBase):
 
     def _process_args(self):
         RHAbstractBase._process_args(self)
-        self.abstract_file = AbstractFile.get_one(request.view_args['file_id'])
+        self.abstract_file = AbstractFile.get_or_404(request.view_args['file_id'])
 
     def _process(self):
         return self.abstract_file.send()

--- a/indico/modules/events/abstracts/controllers/email_templates.py
+++ b/indico/modules/events/abstracts/controllers/email_templates.py
@@ -66,7 +66,7 @@ class RHEditEmailTemplateBase(RHManageAbstractsBase):
 
     def _process_args(self):
         RHManageAbstractsBase._process_args(self)
-        self.email_tpl = AbstractEmailTemplate.get_one(request.view_args['email_tpl_id'])
+        self.email_tpl = AbstractEmailTemplate.get_or_404(request.view_args['email_tpl_id'])
 
 
 class RHEditEmailTemplateRules(RHEditEmailTemplateBase):

--- a/indico/modules/events/abstracts/controllers/management.py
+++ b/indico/modules/events/abstracts/controllers/management.py
@@ -237,7 +237,7 @@ class RHReviewingQuestionBase(RHManageAbstractsBase):
 
     def _process_args(self):
         RHManageAbstractsBase._process_args(self)
-        self.question = AbstractReviewQuestion.get_one(request.view_args['question_id'])
+        self.question = AbstractReviewQuestion.get_or_404(request.view_args['question_id'])
 
 
 class RHEditAbstractReviewingQuestion(RHReviewingQuestionBase):

--- a/indico/modules/events/abstracts/controllers/reviewing.py
+++ b/indico/modules/events/abstracts/controllers/reviewing.py
@@ -119,7 +119,7 @@ class RHDisplayAbstractListBase(RHAbstractsBase):
 
     def _process_args(self):
         RHAbstractsBase._process_args(self)
-        self.track = Track.get_one(request.view_args['track_id'])
+        self.track = Track.get_or_404(request.view_args['track_id'])
         self.list_generator = AbstractListGeneratorDisplay(event=self.event, track=self.track)
 
     def _check_access(self):
@@ -144,7 +144,7 @@ class RHSubmitAbstractReview(RHAbstractBase):
 
     def _process_args(self):
         RHAbstractBase._process_args(self)
-        self.track = Track.get_one(request.view_args['track_id'])
+        self.track = Track.get_or_404(request.view_args['track_id'])
 
     def _process(self):
         form = build_review_form(self.abstract, self.track)
@@ -168,7 +168,7 @@ class RHEditAbstractReview(RHAbstractBase):
 
     def _process_args(self):
         RHAbstractBase._process_args(self)
-        self.review = AbstractReview.get_one(request.view_args['review_id'])
+        self.review = AbstractReview.get_or_404(request.view_args['review_id'])
 
     def _process(self):
         form = build_review_form(review=self.review)
@@ -201,7 +201,7 @@ class RHAbstractCommentBase(RHAbstractBase):
 
     def _process_args(self):
         RHAbstractBase._process_args(self)
-        self.comment = AbstractComment.get_one(request.view_args['comment_id'], is_deleted=False)
+        self.comment = AbstractComment.get_or_404(request.view_args['comment_id'], is_deleted=False)
 
     def _check_access(self):
         RHAbstractBase._check_access(self)

--- a/indico/modules/events/agreements/controllers.py
+++ b/indico/modules/events/agreements/controllers.py
@@ -47,7 +47,7 @@ class RHAgreementForm(RHDisplayEventBase):
 
     def _process_args(self):
         RHDisplayEventBase._process_args(self)
-        self.agreement = Agreement.get_one(request.view_args['id'])
+        self.agreement = Agreement.get_or_404(request.view_args['id'])
         if self.agreement.is_orphan():
             raise NotFound('The agreement is not active anymore')
 
@@ -210,7 +210,7 @@ class RHAgreementManagerDetailsAgreementBase(RHAgreementManagerDetails):
 
     def _process_args(self):
         RHAgreementManagerDetails._process_args(self)
-        self.agreement = Agreement.get_one(request.view_args['id'])
+        self.agreement = Agreement.get_or_404(request.view_args['id'])
 
 
 class RHAgreementManagerDetailsSubmitAnswer(RHAgreementManagerDetails):
@@ -219,7 +219,7 @@ class RHAgreementManagerDetailsSubmitAnswer(RHAgreementManagerDetails):
     def _process_args(self):
         RHAgreementManagerDetails._process_args(self)
         if 'id' in request.view_args:
-            self.agreement = Agreement.get_one(request.view_args['id'])
+            self.agreement = Agreement.get_or_404(request.view_args['id'])
             if self.event != self.agreement.event:
                 raise NotFound
             if not self.agreement.pending:

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -65,7 +65,7 @@ class RHContributionDisplayBase(RHDisplayEventBase):
 
     def _process_args(self):
         RHDisplayEventBase._process_args(self)
-        self.contrib = Contribution.get_one(request.view_args['contrib_id'], is_deleted=False)
+        self.contrib = Contribution.get_or_404(request.view_args['contrib_id'], is_deleted=False)
 
 
 class RHDisplayProtectionBase(RHDisplayEventBase):
@@ -256,7 +256,7 @@ class RHSubcontributionDisplay(RHDisplayEventBase):
 
     def _process_args(self):
         RHDisplayEventBase._process_args(self)
-        self.subcontrib = SubContribution.get_one(request.view_args['subcontrib_id'], is_deleted=False)
+        self.subcontrib = SubContribution.get_or_404(request.view_args['subcontrib_id'], is_deleted=False)
 
     def _process(self):
         return self.view_class.render_template('display/subcontribution_display.html', self.event,

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -114,7 +114,7 @@ class RHManageSubContributionBase(RHManageContributionBase):
 
     def _process_args(self):
         RHManageContributionBase._process_args(self)
-        self.subcontrib = SubContribution.get_one(request.view_args['subcontrib_id'], is_deleted=False)
+        self.subcontrib = SubContribution.get_or_404(request.view_args['subcontrib_id'], is_deleted=False)
 
 
 class RHManageContributionsActionsBase(RHManageContributionsBase):
@@ -574,7 +574,7 @@ class RHManageContributionTypeBase(RHManageContributionsBase):
 
     def _process_args(self):
         RHManageContributionsBase._process_args(self)
-        self.contrib_type = ContributionType.get_one(request.view_args['contrib_type_id'])
+        self.contrib_type = ContributionType.get_or_404(request.view_args['contrib_type_id'])
 
 
 class RHEditContributionType(RHManageContributionTypeBase):
@@ -683,7 +683,7 @@ class RHManageContributionFieldBase(RHManageContributionsBase):
 
     def _process_args(self):
         RHManageContributionsBase._process_args(self)
-        self.contrib_field = ContributionField.get_one(request.view_args['contrib_field_id'])
+        self.contrib_field = ContributionField.get_or_404(request.view_args['contrib_field_id'])
 
 
 class RHEditContributionField(RHManageContributionFieldBase):

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -95,7 +95,7 @@ class RHManageEventLabelBase(RHAdminBase):
 
     def _process_args(self):
         RHAdminBase._process_args(self)
-        self.event_label = EventLabel.get_one(request.view_args['event_label_id'])
+        self.event_label = EventLabel.get_or_404(request.view_args['event_label_id'])
 
 
 class RHEventLabels(RHAdminBase):

--- a/indico/modules/events/editing/controllers/backend/common.py
+++ b/indico/modules/events/editing/controllers/backend/common.py
@@ -19,6 +19,9 @@ from indico.util.signals import named_objects_from_signal
 
 class RHEditingFileTypes(RHEditingBase):
     """Return all editing file types defined in the event for the editable type."""
+
+    SERVICE_ALLOWED = True
+
     def _process_args(self):
         RHEditingBase._process_args(self)
         self.editable_type = EditableType[request.view_args['type']]
@@ -30,6 +33,8 @@ class RHEditingFileTypes(RHEditingBase):
 
 class RHEditingTags(RHEditingBase):
     """Return all editing tags defined in the event."""
+
+    SERVICE_ALLOWED = True
 
     def _process(self):
         return EditingTagSchema(many=True).jsonify(self.event.editing_tags)

--- a/indico/modules/events/editing/controllers/backend/management.py
+++ b/indico/modules/events/editing/controllers/backend/management.py
@@ -30,6 +30,8 @@ from indico.web.args import use_kwargs, use_rh_args, use_rh_kwargs
 class RHCreateTag(RHEditingManagementBase):
     """Create a new tag."""
 
+    SERVICE_ALLOWED = True
+
     @use_rh_args(EditableTagArgs)
     def _process(self, data):
         tag = create_new_tag(self.event, **data)
@@ -38,6 +40,8 @@ class RHCreateTag(RHEditingManagementBase):
 
 class RHEditTag(RHEditingManagementBase):
     """Delete/update a tag."""
+
+    SERVICE_ALLOWED = True
 
     def _process_args(self):
         RHEditingManagementBase._process_args(self)
@@ -58,6 +62,9 @@ class RHEditTag(RHEditingManagementBase):
 
 class RHCreateFileType(RHEditingManagementBase):
     """Create a new file type."""
+
+    SERVICE_ALLOWED = True
+
     def _process_args(self):
         RHEditingManagementBase._process_args(self)
         self.editable_type = EditableType[request.view_args['type']]
@@ -70,6 +77,8 @@ class RHCreateFileType(RHEditingManagementBase):
 
 class RHEditFileType(RHEditingManagementBase):
     """Delete/update a file type."""
+
+    SERVICE_ALLOWED = True
 
     def _process_args(self):
         RHEditingManagementBase._process_args(self)
@@ -138,6 +147,8 @@ class RHEditingEditReviewCondition(RHEditingManagementBase):
 
 
 class RHEnabledEditableTypes(RHEditingManagementBase):
+    SERVICE_ALLOWED = True
+
     def _process_GET(self):
         return jsonify(editing_settings.get(self.event, 'editable_types'))
 

--- a/indico/modules/events/editing/controllers/base.py
+++ b/indico/modules/events/editing/controllers/base.py
@@ -7,30 +7,62 @@
 
 from __future__ import unicode_literals
 
-from flask import request
+from flask import request, session
+from werkzeug.exceptions import Unauthorized
 
 from indico.modules.events.contributions.controllers.display import RHContributionDisplayBase
 from indico.modules.events.controllers.base import RHDisplayEventBase
 from indico.modules.events.editing.models.editable import Editable, EditableType
+from indico.modules.events.editing.settings import editing_settings
 from indico.modules.events.management.controllers.base import RHManageEventBase
+from indico.modules.events.models.events import Event
 from indico.web.rh import RequireUserMixin
 
 
-class RHEditingBase(RequireUserMixin, RHDisplayEventBase):
+class TokenAccessMixin(object):
+    SERVICE_ALLOWED = False
+
+    def _token_can_access(self):
+        # we need to "fish" the event here because at this point _check_params
+        # hasn't run yet
+        event = Event.get_one(int(request.view_args['confId']), is_deleted=False)
+        if not self.SERVICE_ALLOWED or not request.bearer_token:
+            return False
+
+        event_token = editing_settings.get(event, 'service_token')
+        if request.bearer_token != event_token:
+            raise Unauthorized('Invalid bearer token')
+
+        return True
+
+    def _check_csrf(self):
+        # check CSRF if there is no bearer token or there's a session cookie
+        if session.user or not request.bearer_token:
+            super(TokenAccessMixin, self)._check_csrf()
+
+
+class RHEditingBase(TokenAccessMixin, RequireUserMixin, RHDisplayEventBase):
     """Base class for editing RHs that don't reference an editable."""
 
     EVENT_FEATURE = 'editing'
 
     def _check_access(self):
-        RHDisplayEventBase._check_access(self)
-        RequireUserMixin._check_access(self)
+        self.is_service_call = TokenAccessMixin._token_can_access(self)
+        if not self.is_service_call:
+            RHDisplayEventBase._check_access(self)
+            RequireUserMixin._check_access(self)
 
 
-class RHEditingManagementBase(RHManageEventBase):
+class RHEditingManagementBase(TokenAccessMixin, RHManageEventBase):
     """Base class for editing RHs that don't reference an editable."""
 
     EVENT_FEATURE = 'editing'
     PERMISSION = 'editing_manager'
+
+    def _check_access(self):
+        self.is_service_call = TokenAccessMixin._token_can_access(self)
+        if not self.is_service_call:
+            super(RHEditingManagementBase, self)._check_access()
 
 
 class RHEditableTypeManagementBase(RHEditingManagementBase):

--- a/indico/modules/events/editing/controllers/base.py
+++ b/indico/modules/events/editing/controllers/base.py
@@ -25,7 +25,7 @@ class TokenAccessMixin(object):
     def _token_can_access(self):
         # we need to "fish" the event here because at this point _check_params
         # hasn't run yet
-        event = Event.get_one(int(request.view_args['confId']), is_deleted=False)
+        event = Event.get_or_404(int(request.view_args['confId']), is_deleted=False)
         if not self.SERVICE_ALLOWED or not request.bearer_token:
             return False
 

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -225,8 +225,8 @@ def delete_revision_comment(comment):
     logger.info('Comment on revision %r deleted: %r', comment.revision, comment)
 
 
-def create_new_tag(event, code, title, color, is_system=False):
-    tag = EditingTag(code=code, title=title, color=color, system=is_system, event=event)
+def create_new_tag(event, code, title, color, system=False):
+    tag = EditingTag(code=code, title=title, color=color, system=system, event=event)
     db.session.flush()
     logger.info('Tag %r created by %r', tag, session.user)
     return tag

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -174,11 +174,12 @@ class EditingConfirmationAction(IndicoEnum):
 
 class EditableTagArgs(mm.Schema):
     class Meta:
-        rh_context = ('event', 'tag')
+        rh_context = ('event', 'tag', 'is_service_call')
 
     code = fields.String(required=True, validate=not_empty)
     title = fields.String(required=True, validate=not_empty)
     color = fields.String(required=True, validate=validate.OneOf(get_sui_colors()))
+    system = fields.Bool(missing=False)
 
     @validates('code')
     def _check_for_unique_tag_code(self, code):
@@ -189,6 +190,11 @@ class EditableTagArgs(mm.Schema):
             query = query.filter(EditingTag.id != tag.id)
         if query.has_rows():
             raise ValidationError(_('Tag code must be unique'))
+
+    @validates('system')
+    def _check_only_services_set_system_tags(self, value):
+        if not self.context['is_service_call']:
+            raise ValidationError('Only custom editing workflows can set system tags')
 
 
 class EditableFileTypeArgs(mm.Schema):

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -42,10 +42,14 @@ class EditingFileTypeSchema(mm.ModelSchema):
     class Meta:
         model = EditingFileType
         fields = ('id', 'name', 'extensions', 'allow_multiple_files', 'required', 'publishable', 'is_used',
-                  'filename_template', 'is_used_in_condition')
+                  'filename_template', 'is_used_in_condition', 'url')
 
     is_used = fields.Function(lambda ft: EditingRevisionFile.query.with_parent(ft).has_rows())
     is_used_in_condition = fields.Function(lambda ft: EditingReviewCondition.query.with_parent(ft).has_rows())
+    url = fields.Function(lambda ft: url_for('.api_edit_file_type',
+                                             ft.event, type=ft.type.name,
+                                             file_type_id=ft.id,
+                                             _external=True))
 
     @post_dump(pass_many=True)
     def sort_list(self, data, many, **kwargs):
@@ -57,7 +61,12 @@ class EditingFileTypeSchema(mm.ModelSchema):
 class EditingTagSchema(mm.ModelSchema):
     class Meta:
         model = EditingTag
-        fields = ('id', 'code', 'title', 'color', 'system', 'verbose_title')
+        fields = (
+            'id', 'code', 'title', 'color', 'system', 'verbose_title', 'is_used_in_revision', 'url'
+        )
+
+    is_used_in_revision = fields.Function(lambda tag: EditingRevision.query.with_parent(tag).has_rows())
+    url = fields.Function(lambda tag: url_for('.api_edit_tag', tag.event, tag_id=tag.id, _external=True))
 
     @post_dump(pass_many=True)
     def sort_list(self, data, many, **kwargs):

--- a/indico/modules/events/layout/controllers/images.py
+++ b/indico/modules/events/layout/controllers/images.py
@@ -101,7 +101,7 @@ class RHImageDisplay(RHDisplayEventBase):
     def _process_args(self):
         RHDisplayEventBase._process_args(self)
         image_id = request.view_args['image_id']
-        self.image = ImageFile.get_one(image_id)
+        self.image = ImageFile.get_or_404(image_id)
 
     def _process(self):
         return self.image.send()

--- a/indico/modules/events/layout/controllers/menu.py
+++ b/indico/modules/events/layout/controllers/menu.py
@@ -86,7 +86,7 @@ class RHMenuEntryEditBase(RHMenuBase):
 
     def _process_args(self):
         RHMenuBase._process_args(self)
-        self.entry = MenuEntry.get_one(request.view_args['menu_entry_id'])
+        self.entry = MenuEntry.get_or_404(request.view_args['menu_entry_id'])
 
 
 class RHMenuEntryEdit(RHMenuEntryEditBase):
@@ -244,7 +244,7 @@ class RHPageDisplay(RHDisplayEventBase):
 
     def _process_args(self):
         RHDisplayEventBase._process_args(self)
-        self.page = EventPage.get_one(request.view_args['page_id'])
+        self.page = EventPage.get_or_404(request.view_args['page_id'])
 
     def _process(self):
         return WPPage.render_template('page.html', self.event, page=self.page)

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -83,7 +83,7 @@ class RHMoveEvent(RHManageEventBase):
 
     def _process_args(self):
         RHManageEventBase._process_args(self)
-        self.target_category = Category.get_one(int(request.form['target_category_id']), is_deleted=False)
+        self.target_category = Category.get_or_404(int(request.form['target_category_id']), is_deleted=False)
         if not self.target_category.can_create_events(session.user):
             raise Forbidden(_("You may only move events to categories where you are allowed to create events."))
 

--- a/indico/modules/events/management/controllers/posters.py
+++ b/indico/modules/events/management/controllers/posters.py
@@ -48,7 +48,7 @@ class RHPosterPrintSettings(RHManageEventBase):
 class RHPrintEventPoster(RHManageEventBase):
     def _process_args(self):
         RHManageEventBase._process_args(self)
-        self.template = DesignerTemplate.get_one(request.view_args['template_id'])
+        self.template = DesignerTemplate.get_or_404(request.view_args['template_id'])
 
     def _check_access(self):
         RHManageEventBase._check_access(self)

--- a/indico/modules/events/papers/controllers/base.py
+++ b/indico/modules/events/papers/controllers/base.py
@@ -69,7 +69,7 @@ class RHPaperBase(RHPapersBase):
 
     def _process_args(self):
         RHPapersBase._process_args(self)
-        self.contribution = Contribution.get_one(request.view_args['contrib_id'], is_deleted=False)
+        self.contribution = Contribution.get_or_404(request.view_args['contrib_id'], is_deleted=False)
         self.paper = self.contribution.paper
         if self.paper is None and self.PAPER_REQUIRED:
             raise NotFound

--- a/indico/modules/events/papers/controllers/display.py
+++ b/indico/modules/events/papers/controllers/display.py
@@ -67,7 +67,7 @@ class RHDownloadPaperFile(RHPaperBase):
 
     def _process_args(self):
         RHPaperBase._process_args(self)
-        self.file = PaperFile.get_one(request.view_args['file_id'])
+        self.file = PaperFile.get_or_404(request.view_args['file_id'])
 
     def _process(self):
         return self.file.send()

--- a/indico/modules/events/papers/controllers/templates.py
+++ b/indico/modules/events/papers/controllers/templates.py
@@ -37,7 +37,7 @@ class RHManagePaperTemplateBase(RHManagePapersBase):
 
     def _process_args(self):
         RHManagePapersBase._process_args(self)
-        self.template = PaperTemplate.get_one(request.view_args['template_id'])
+        self.template = PaperTemplate.get_or_404(request.view_args['template_id'])
 
 
 def _render_teplate_list(event):
@@ -90,7 +90,7 @@ class RHDownloadPaperTemplate(RHPapersBase):
 
     def _process_args(self):
         RHPapersBase._process_args(self)
-        self.template = PaperTemplate.get_one(request.view_args['template_id'])
+        self.template = PaperTemplate.get_or_404(request.view_args['template_id'])
 
     def _process(self):
         return self.template.send()

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -45,7 +45,7 @@ class RHManageRegFormFieldBase(RHManageRegFormSectionBase):
 
     def _process_args(self):
         RHManageRegFormSectionBase._process_args(self)
-        self.field = self.field_class.get_one(request.view_args['field_id'])
+        self.field = self.field_class.get_or_404(request.view_args['field_id'])
 
 
 class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):

--- a/indico/modules/events/registration/controllers/management/invitations.py
+++ b/indico/modules/events/registration/controllers/management/invitations.py
@@ -90,7 +90,7 @@ class RHRegistrationFormInvitationBase(RHManageRegFormBase):
 
     def _process_args(self):
         RHManageRegFormBase._process_args(self)
-        self.invitation = RegistrationInvitation.get_one(request.view_args['invitation_id'])
+        self.invitation = RegistrationInvitation.get_or_404(request.view_args['invitation_id'])
 
 
 class RHRegistrationFormDeleteInvitation(RHRegistrationFormInvitationBase):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -393,7 +393,7 @@ class RHRegistrationsPrintBadges(RHRegistrationsActionBase):
 
     def _process_args(self):
         RHRegistrationsActionBase._process_args(self)
-        self.template = DesignerTemplate.get_one(request.view_args['template_id'])
+        self.template = DesignerTemplate.get_or_404(request.view_args['template_id'])
 
     def _check_access(self):
         RHRegistrationsActionBase._check_access(self)

--- a/indico/modules/events/registration/controllers/management/sections.py
+++ b/indico/modules/events/registration/controllers/management/sections.py
@@ -29,7 +29,7 @@ class RHManageRegFormSectionBase(RHManageRegFormBase):
 
     def _process_args(self):
         RHManageRegFormBase._process_args(self)
-        self.section = RegistrationFormSection.get_one(request.view_args['section_id'])
+        self.section = RegistrationFormSection.get_or_404(request.view_args['section_id'])
 
 
 class RHRegistrationFormAddSection(RHManageRegFormBase):

--- a/indico/modules/events/reminders/controllers.py
+++ b/indico/modules/events/reminders/controllers.py
@@ -39,7 +39,7 @@ class RHSpecificReminderBase(RHRemindersBase):
 
     def _process_args(self):
         RHRemindersBase._process_args(self)
-        self.reminder = EventReminder.get_one(request.view_args['reminder_id'])
+        self.reminder = EventReminder.get_or_404(request.view_args['reminder_id'])
 
 
 class RHListReminders(RHRemindersBase):

--- a/indico/modules/events/roles/controllers.py
+++ b/indico/modules/events/roles/controllers.py
@@ -83,7 +83,7 @@ class RHManageEventRole(RHManageEventBase):
 
     def _process_args(self):
         RHManageEventBase._process_args(self)
-        self.role = EventRole.get_one(request.view_args['role_id'])
+        self.role = EventRole.get_or_404(request.view_args['role_id'])
 
 
 class RHEditEventRole(RHManageEventRole):
@@ -119,7 +119,7 @@ class RHRemoveEventRoleMember(RHManageEventRole):
 
     def _process_args(self):
         RHManageEventRole._process_args(self)
-        self.user = User.get_one(request.view_args['user_id'])
+        self.user = User.get_or_404(request.view_args['user_id'])
 
     def _process(self):
         if self.user in self.role.members:

--- a/indico/modules/events/sessions/controllers/display.py
+++ b/indico/modules/events/sessions/controllers/display.py
@@ -45,7 +45,7 @@ class RHDisplaySessionBase(RHDisplayEventBase):
 
     def _process_args(self):
         RHDisplayEventBase._process_args(self)
-        self.session = Session.get_one(request.view_args['session_id'], is_deleted=False)
+        self.session = Session.get_or_404(request.view_args['session_id'], is_deleted=False)
 
 
 class RHDisplaySession(RHDisplaySessionBase):

--- a/indico/modules/events/sessions/controllers/management/__init__.py
+++ b/indico/modules/events/sessions/controllers/management/__init__.py
@@ -29,7 +29,7 @@ class RHManageSessionBase(RHManageSessionsBase):
 
     def _process_args(self):
         RHManageSessionsBase._process_args(self)
-        self.session = Session.get_one(request.view_args['session_id'], is_deleted=False)
+        self.session = Session.get_or_404(request.view_args['session_id'], is_deleted=False)
 
     def _check_access(self):
         if not self.session.can_manage(session.user):

--- a/indico/modules/events/sessions/controllers/management/sessions.py
+++ b/indico/modules/events/sessions/controllers/management/sessions.py
@@ -230,7 +230,7 @@ class RHManageSessionBlock(RHManageSessionBase):
 
     def _process_args(self):
         RHManageSessionBase._process_args(self)
-        self.session_block = SessionBlock.get_one(request.view_args['block_id'])
+        self.session_block = SessionBlock.get_or_404(request.view_args['block_id'])
 
     def _process(self):
         form = MeetingSessionBlockForm(obj=FormDefaults(**self._get_form_defaults()), event=self.event,
@@ -276,7 +276,7 @@ class RHManageSessionTypeBase(RHManageSessionsBase):
 
     def _process_args(self):
         RHManageSessionsBase._process_args(self)
-        self.session_type = SessionType.get_one(request.view_args['session_type_id'])
+        self.session_type = SessionType.get_or_404(request.view_args['session_type_id'])
 
 
 class RHEditSessionType(RHManageSessionTypeBase):

--- a/indico/modules/events/static/controllers.py
+++ b/indico/modules/events/static/controllers.py
@@ -48,7 +48,7 @@ class RHStaticSiteDownload(RHStaticSiteBase):
 
     def _process_args(self):
         RHStaticSiteBase._process_args(self)
-        self.static_site = StaticSite.get_one(request.view_args['id'])
+        self.static_site = StaticSite.get_or_404(request.view_args['id'])
 
     def _process(self):
         if self.static_site.state != StaticSiteState.success:

--- a/indico/modules/events/timetable/controllers/legacy.py
+++ b/indico/modules/events/timetable/controllers/legacy.py
@@ -281,7 +281,7 @@ class RHLegacyTimetableGetUnscheduledContributions(RHManageTimetableBase):
         RHManageTimetableBase._process_args(self)
         self.session_id = None
         if 'session_block_id' in request.args:
-            self.session_id = SessionBlock.get_one(request.args['session_block_id']).session_id
+            self.session_id = SessionBlock.get_or_404(request.args['session_block_id']).session_id
             if self.session and self.session.id != self.session_id:
                 raise BadRequest
 

--- a/indico/modules/events/tracks/controllers.py
+++ b/indico/modules/events/tracks/controllers.py
@@ -52,7 +52,7 @@ class RHManageTrackBase(RHManageTracksBase):
 
     def _process_args(self):
         RHManageTracksBase._process_args(self)
-        self.track = Track.get_one(request.view_args['track_id'])
+        self.track = Track.get_or_404(request.view_args['track_id'])
 
 
 class RHManageTrackGroupBase(RHManageEventBase):
@@ -64,7 +64,7 @@ class RHManageTrackGroupBase(RHManageEventBase):
 
     def _process_args(self):
         RHManageEventBase._process_args(self)
-        self.track_group = TrackGroup.get_one(request.view_args['track_group_id'])
+        self.track_group = TrackGroup.get_or_404(request.view_args['track_group_id'])
 
 
 class RHManageTracks(RHManageTracksBase):

--- a/indico/modules/networks/controllers.py
+++ b/indico/modules/networks/controllers.py
@@ -52,7 +52,7 @@ class RHAdminNetworkGroupBase(RHNetworkBase):
     """Base class for managing in IPNetworkGroup"""
 
     def _process_args(self):
-        self.network_group = IPNetworkGroup.get_one(request.view_args['network_group_id'])
+        self.network_group = IPNetworkGroup.get_or_404(request.view_args['network_group_id'])
 
 
 class RHEditNetworkGroup(RHAdminNetworkGroupBase):

--- a/indico/modules/news/controllers.py
+++ b/indico/modules/news/controllers.py
@@ -78,7 +78,7 @@ class RHCreateNews(RHManageNewsBase):
 class RHManageNewsItemBase(RHManageNewsBase):
     def _process_args(self):
         RHManageNewsBase._process_args(self)
-        self.item = NewsItem.get_one(request.view_args['news_id'])
+        self.item = NewsItem.get_or_404(request.view_args['news_id'])
 
 
 class RHEditNews(RHManageNewsItemBase):

--- a/indico/modules/rb/controllers/backend/admin.py
+++ b/indico/modules/rb/controllers/backend/admin.py
@@ -71,7 +71,7 @@ class RHSettings(RHRoomBookingAdminBase):
 class RHLocations(RHRoomBookingAdminBase):
     def _process_args(self):
         id_ = request.view_args.get('location_id')
-        self.location = Location.get_one(id_, is_deleted=False) if id_ is not None else None
+        self.location = Location.get_or_404(id_, is_deleted=False) if id_ is not None else None
 
     def _jsonify_one(self, location):
         return jsonify(admin_locations_schema.dump(location, many=False))
@@ -124,7 +124,7 @@ class RHLocations(RHRoomBookingAdminBase):
 class RHFeatures(RHRoomBookingAdminBase):
     def _process_args(self):
         id_ = request.view_args.get('feature_id')
-        self.feature = RoomFeature.get_one(id_) if id_ is not None else None
+        self.feature = RoomFeature.get_or_404(id_) if id_ is not None else None
 
     def _dump_features(self):
         query = RoomFeature.query.order_by(RoomFeature.title)
@@ -169,7 +169,7 @@ class RHFeatures(RHRoomBookingAdminBase):
 class RHEquipmentTypes(RHRoomBookingAdminBase):
     def _process_args(self):
         id_ = request.view_args.get('equipment_type_id')
-        self.equipment_type = EquipmentType.get_one(id_) if id_ is not None else None
+        self.equipment_type = EquipmentType.get_or_404(id_) if id_ is not None else None
 
     def _dump_equipment_types(self):
         query = EquipmentType.query.options(joinedload('features')).order_by(EquipmentType.name)
@@ -229,7 +229,7 @@ class RHAttributes(RHRoomBookingAdminBase):
 
     def _process_args(self):
         id_ = request.view_args.get('attribute_id')
-        self.attribute = RoomAttribute.get_one(id_) if id_ is not None else None
+        self.attribute = RoomAttribute.get_or_404(id_) if id_ is not None else None
 
     def _dump_attributes(self):
         query = RoomAttribute.query.order_by(RoomAttribute.title)
@@ -285,7 +285,7 @@ class RHAttributes(RHRoomBookingAdminBase):
 
 class RHRoomAdminBase(RHRoomBookingAdminBase):
     def _process_args(self):
-        self.room = Room.get_one(request.view_args['room_id'], is_deleted=False)
+        self.room = Room.get_or_404(request.view_args['room_id'], is_deleted=False)
 
     def _skip_admin_check(self):
         return rb_settings.get('managers_edit_rooms') and self.room.can_manage(session.user)

--- a/indico/modules/rb/controllers/backend/blockings.py
+++ b/indico/modules/rb/controllers/backend/blockings.py
@@ -41,7 +41,7 @@ class RHUpdateRoomBlocking(RHRoomBookingBase):
             raise Forbidden
 
     def _process_args(self):
-        self.blocking = Blocking.get_one(request.view_args['blocking_id'])
+        self.blocking = Blocking.get_or_404(request.view_args['blocking_id'])
 
     @use_args({
         'room_ids': fields.List(fields.Int(), required=True),
@@ -68,7 +68,7 @@ class RHRoomBlockings(RHRoomBookingBase):
 
 class RHRoomBlockingBase(RHRoomBookingBase):
     def _process_args(self):
-        self.blocking = Blocking.get_one(request.view_args['blocking_id'])
+        self.blocking = Blocking.get_or_404(request.view_args['blocking_id'])
 
 
 class RHRoomBlocking(RHRoomBlockingBase):

--- a/indico/modules/rb/controllers/backend/bookings.py
+++ b/indico/modules/rb/controllers/backend/bookings.py
@@ -56,7 +56,7 @@ class RHTimeline(RHRoomBookingBase):
     def _process_args(self):
         self.room = None
         if 'room_id' in request.view_args:
-            self.room = Room.get_one(request.view_args['room_id'], is_deleted=False)
+            self.room = Room.get_or_404(request.view_args['room_id'], is_deleted=False)
 
     @use_kwargs({
         'start_dt': fields.DateTime(required=True),
@@ -132,7 +132,7 @@ class RHCreateBooking(RHRoomBookingBase):
     def _process_args(self, args):
         self.args = args
         self.prebook = args.pop('is_prebooking')
-        self.room = Room.get_one(self.args.pop('room_id'), is_deleted=False)
+        self.room = Room.get_or_404(self.args.pop('room_id'), is_deleted=False)
 
     def _check_access(self):
         RHRoomBookingBase._check_access(self)
@@ -194,7 +194,7 @@ class RHRoomSuggestions(RHRoomBookingBase):
 
 class RHBookingBase(RHRoomBookingBase):
     def _process_args(self):
-        self.booking = Reservation.get_one(request.view_args['booking_id'])
+        self.booking = Reservation.get_or_404(request.view_args['booking_id'])
         if self.booking.room.is_deleted:
             raise NotFound(_('The room has been deleted'))
 

--- a/indico/modules/rb/controllers/backend/rooms.py
+++ b/indico/modules/rb/controllers/backend/rooms.py
@@ -116,7 +116,7 @@ class RHSearchRooms(RHRoomBookingBase):
 
 class RHRoomBase(RHRoomBookingBase):
     def _process_args(self):
-        self.room = Room.get_one(request.view_args['room_id'], is_deleted=False)
+        self.room = Room.get_or_404(request.view_args['room_id'], is_deleted=False)
 
 
 class RHRoom(RHRoomBase):
@@ -162,7 +162,7 @@ class RHRoomFavorites(RHRoomBookingBase):
     def _process_args(self):
         self.room = None
         if 'room_id' in request.view_args:
-            self.room = Room.get_one(request.view_args['room_id'])
+            self.room = Room.get_or_404(request.view_args['room_id'])
 
     def _process_GET(self):
         query = (db.session.query(favorite_room_table.c.room_id)

--- a/indico/modules/rb/operations/admin.py
+++ b/indico/modules/rb/operations/admin.py
@@ -86,7 +86,7 @@ def create_area(bounds, name, default=False):
 def update_area(area_id, area_data):
     top = area_data['bounds']['north_east']
     bottom = area_data['bounds']['south_west']
-    map_area = MapArea.get_one(area_id)
+    map_area = MapArea.get_or_404(area_id)
     if 'name' in area_data:
         map_area.name = area_data['name']
     if 'default' in area_data:

--- a/indico/modules/rb/operations/bookings.py
+++ b/indico/modules/rb/operations/bookings.py
@@ -323,7 +323,7 @@ def check_room_available(room, start_dt, end_dt):
 
 def create_booking_for_event(room_id, event):
     try:
-        room = Room.get_one(room_id)
+        room = Room.get_or_404(room_id)
         default_timezone = timezone(config.DEFAULT_TIMEZONE)
         start_dt = event.start_dt.astimezone(default_timezone).replace(tzinfo=None)
         end_dt = event.end_dt.astimezone(default_timezone).replace(tzinfo=None)

--- a/indico/modules/rb/operations/conflicts.py
+++ b/indico/modules/rb/operations/conflicts.py
@@ -56,14 +56,14 @@ def get_rooms_conflicts(rooms, start_dt, end_dt, repeat_frequency, repeat_interv
 
     if not (allow_admin and rb_is_admin(session.user)):
         for room_id, occurrences in nonbookable_periods.iteritems():
-            room = Room.get_one(room_id)
+            room = Room.get_or_404(room_id)
             if not room.can_override(session.user, allow_admin=allow_admin):
                 conflicts, conflicting_candidates = get_room_nonbookable_periods_conflicts(candidates, occurrences)
                 rooms_conflicts[room_id] |= conflicts
                 rooms_conflicting_candidates[room_id] |= conflicting_candidates
 
         for room_id, occurrences in unbookable_hours.iteritems():
-            room = Room.get_one(room_id)
+            room = Room.get_or_404(room_id)
             if not room.can_override(session.user, allow_admin=allow_admin):
                 conflicts, conflicting_candidates = get_room_unbookable_hours_conflicts(candidates, occurrences)
                 rooms_conflicts[room_id] |= conflicts

--- a/indico/modules/users/api.py
+++ b/indico/modules/users/api.py
@@ -48,7 +48,7 @@ class UserInfoHook(HTTPAPIHook):
 
 class RHUserFavoritesAPI(RHProtected):
     def _process_args(self):
-        self.user = User.get_one(request.view_args['user_id']) if 'user_id' in request.view_args else None
+        self.user = User.get_or_404(request.view_args['user_id']) if 'user_id' in request.view_args else None
 
     def _process_GET(self):
         return jsonify(sorted(u.id for u in session.user.favorite_users))

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -301,7 +301,7 @@ class RHUserFavoritesUserRemove(RHUserBase):
 class RHUserFavoritesCategoryAPI(RHUserBase):
     def _process_args(self):
         RHUserBase._process_args(self)
-        self.category = Category.get_one(request.view_args['category_id'])
+        self.category = Category.get_or_404(request.view_args['category_id'])
         self.suggestion = self.user.suggested_categories.filter_by(category=self.category).first()
 
     def _process_PUT(self):
@@ -572,8 +572,8 @@ class RHUsersAdminMerge(RHAdminBase):
 
 class RHUsersAdminMergeCheck(RHAdminBase):
     def _process(self):
-        source = User.get_one(request.args['source'])
-        target = User.get_one(request.args['target'])
+        source = User.get_or_404(request.args['source'])
+        target = User.get_or_404(request.args['target'])
         errors, warnings = _get_merge_problems(source, target)
         return jsonify(errors=errors, warnings=warnings)
 
@@ -591,7 +591,7 @@ class RHRegistrationRequestBase(RHAdminBase):
 
     def _process_args(self):
         RHAdminBase._process_args(self)
-        self.request = RegistrationRequest.get_one(request.view_args['request_id'])
+        self.request = RegistrationRequest.get_or_404(request.view_args['request_id'])
 
 
 class RHAcceptRegistrationRequest(RHRegistrationRequestBase):

--- a/indico/modules/vc/controllers.py
+++ b/indico/modules/vc/controllers.py
@@ -81,7 +81,7 @@ class RHEventVCRoomMixin:
     }
 
     def _process_args(self):
-        self.event_vc_room = VCRoomEventAssociation.get_one(request.view_args['event_vc_room_id'])
+        self.event_vc_room = VCRoomEventAssociation.get_or_404(request.view_args['event_vc_room_id'])
         self.vc_room = self.event_vc_room.vc_room
 
 

--- a/indico/modules/vc/plugins.py
+++ b/indico/modules/vc/plugins.py
@@ -170,9 +170,9 @@ class VCPluginMixin(object):
         if link_type == VCRoomLinkType.event:
             event_vc_room.link_object = event
         elif link_type == VCRoomLinkType.contribution:
-            event_vc_room.link_object = Contribution.get_one(contribution_id)
+            event_vc_room.link_object = Contribution.get_or_404(contribution_id)
         elif link_type == VCRoomLinkType.block:
-            event_vc_room.link_object = SessionBlock.get_one(block_id)
+            event_vc_room.link_object = SessionBlock.get_or_404(block_id)
         event_vc_room.vc_room = vc_room
         event_vc_room.show = data.pop('show')
         if event_vc_room.data is None:

--- a/indico/web/assets/blueprint.py
+++ b/indico/web/assets/blueprint.py
@@ -62,7 +62,7 @@ def js_vars_global():
         with open(cache_file, 'wb') as f:
             f.write(data)
 
-    return send_file('global.js', cache_file, mimetype='application/javascript', no_cache=False, conditional=True)
+    return send_file('global.js', cache_file, mimetype='application/javascript', conditional=True)
 
 
 @assets_blueprint.route('/js-vars/user.js')
@@ -97,7 +97,7 @@ def _get_i18n_locale(locale_name, react=False):
             f.write("window.{} = {};".format('REACT_TRANSLATIONS' if react else 'TRANSLATIONS', i18n_data))
 
     return send_file('{}{}.js'.format(locale_name, react_suffix), cache_file, mimetype='application/javascript',
-                     no_cache=False, conditional=True)
+                     conditional=True)
 
 
 @assets_blueprint.route('!/static/custom/<any(css,js):folder>/<path:filename>', endpoint='custom')

--- a/indico/web/flask/util.py
+++ b/indico/web/flask/util.py
@@ -258,12 +258,12 @@ def send_file(name, path_or_fd, mimetype, last_modified=None, no_cache=True, inl
     `path_or_fd` is either the physical path to the file or a file-like object (e.g. a StringIO).
     `mimetype` SHOULD be a proper MIME type such as image/png. It may also be an indico-style file type such as JPG.
     `last_modified` may contain a unix timestamp or datetime object indicating the last modification of the file.
-    `no_cache` can be set to False to disable no-cache headers.
+    `no_cache` can be set to False to disable no-cache headers. Setting `conditional` to `True` overrides it (`False`).
     `inline` defaults to true except for certain filetypes like XML and CSV. It SHOULD be set to false only when you
     want to force the user's browser to download the file. Usually it is much nicer if e.g. a PDF file can be displayed
     inline so don't disable it unless really necessary.
     `conditional` is very useful when sending static files such as CSS/JS/images. It will allow the browser to retrieve
-    the file only if it has been modified (based on mtime and size).
+    the file only if it has been modified (based on mtime and size). Setting it will override `no_cache`.
     `safe` adds some basic security features such a adding a content-security-policy and forcing inline=False for
     text/html mimetypes
     """
@@ -295,7 +295,8 @@ def send_file(name, path_or_fd, mimetype, last_modified=None, no_cache=True, inl
         if not isinstance(last_modified, int):
             last_modified = int(time.mktime(last_modified.timetuple()))
         rv.last_modified = last_modified
-    if no_cache:
+    # if the request is conditional, then caching shouldn't be disabled
+    if not conditional and no_cache:
         del rv.expires
         del rv.cache_control.max_age
         rv.cache_control.public = False

--- a/indico/web/flask/wrappers.py
+++ b/indico/web/flask/wrappers.py
@@ -8,6 +8,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import re
 from contextlib import contextmanager
 from uuid import uuid4
 
@@ -28,6 +29,7 @@ from indico.web.flask.templating import CustomizationLoader
 from indico.web.flask.util import make_view_func
 
 
+AUTH_BEARER_RE = re.compile(r'^Bearer (.+)$')
 _notset = object()
 
 
@@ -50,6 +52,16 @@ class IndicoRequest(Request):
             # convert ipv6-style ipv4 to the regular ipv4 notation
             ip = ip[7:]
         return ip
+
+    @cached_property
+    def bearer_token(self):
+        """Bearer token included in the request, if any."""
+        auth_header = request.headers.get('Authorization')
+        if not auth_header:
+            return None
+
+        m = AUTH_BEARER_RE.match(auth_header)
+        return m.group(1) if m else None
 
     def __repr__(self):
         rv = super(IndicoRequest, self).__repr__()

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -345,7 +345,7 @@ class RHTokenProtected(RH):
     """A request handler which is protected through a signature token parameter."""
 
     def _process_args(self):
-        self.user = db.m.User.get_one(request.view_args['user_id'])
+        self.user = db.m.User.get_or_404(request.view_args['user_id'])
 
     def _check_access(self):
         token = request.args.get('token')


### PR DESCRIPTION
This closes #4422 

I have also updated @ThiefMaster's little service to reflect the changes (and do some setting up):         https://gist.github.com/pferreir/a1ca1c68b95ebc4dceb990ba441e3729

The service should be able to set up:
 * Tags
 * Active editables;
 * File types within each editable

Once the service is disconnected from the event, it should also do some tidying up, removing tags and file types which it created and are not used.