### PR TITLE
Add user profile picture

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Major Features
   permissions in any of these categories and events within such categories.
 - Events marked as "Invisible" are now hidden from the category's event list
   for everyone except managers (:issue:`4419`, thanks :user:`openprojects`)
+- Introduce profile picture, which is for now only visible on the user dashboard
+  (:issue:`4431`, thanks :user:`omegak`)
 
 Improvements
 ^^^^^^^^^^^^

--- a/indico/migrations/versions/20200428_1807_532f0ea25bb1_add_user_profile_picture.py
+++ b/indico/migrations/versions/20200428_1807_532f0ea25bb1_add_user_profile_picture.py
@@ -1,0 +1,31 @@
+"""Add user profile picture
+
+Revision ID: 532f0ea25bb1
+Revises: 7f56252c73ab
+Create Date: 2020-04-28 18:07:51.879932
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '532f0ea25bb1'
+down_revision = '7f56252c73ab'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('picture', sa.LargeBinary(), nullable=True), schema='users')
+    op.add_column('users', sa.Column('picture_metadata', postgresql.JSONB(), nullable=False, server_default='null'),
+                  schema='users')
+    op.alter_column('users', 'picture_metadata', server_default=None, schema='users')
+    op.create_check_constraint('valid_picture', 'users', "(picture IS NULL) = (picture_metadata::text = 'null')",
+                               schema='users')
+
+
+def downgrade():
+    op.drop_column('users', 'picture_metadata', schema='users')
+    op.drop_column('users', 'picture', schema='users')

--- a/indico/modules/users/blueprint.py
+++ b/indico/modules/users/blueprint.py
@@ -11,10 +11,11 @@ from flask import request
 
 from indico.modules.users.api import RHUserFavoritesAPI, fetch_authenticated_user
 from indico.modules.users.controllers import (RHAcceptRegistrationRequest, RHAdmins, RHExportDashboardICS,
-                                              RHPersonalData, RHRegistrationRequestList, RHRejectRegistrationRequest,
-                                              RHUserBlock, RHUserDashboard, RHUserEmails, RHUserEmailsDelete,
-                                              RHUserEmailsSetPrimary, RHUserEmailsVerify, RHUserFavorites,
-                                              RHUserFavoritesCategoryAPI, RHUserFavoritesUserRemove,
+                                              RHPersonalData, RHProfilePicture, RHProfilePictureDelete,
+                                              RHProfilePictureDisplay, RHRegistrationRequestList,
+                                              RHRejectRegistrationRequest, RHUserBlock, RHUserDashboard, RHUserEmails,
+                                              RHUserEmailsDelete, RHUserEmailsSetPrimary, RHUserEmailsVerify,
+                                              RHUserFavorites, RHUserFavoritesCategoryAPI, RHUserFavoritesUserRemove,
                                               RHUserFavoritesUsersAdd, RHUserPreferences, RHUsersAdmin,
                                               RHUsersAdminCreate, RHUsersAdminMerge, RHUsersAdminMergeCheck,
                                               RHUsersAdminSettings, RHUserSearch, RHUserSearchInfo,
@@ -46,6 +47,9 @@ with _bp.add_prefixed_rules('/<int:user_id>'):
     _bp.add_url_rule('/suggestions/categories/<int:category_id>', 'user_suggestions_remove', RHUserSuggestionsRemove,
                      methods=('DELETE',))
     _bp.add_url_rule('/profile/', 'user_profile', RHPersonalData, methods=('GET', 'POST'))
+    _bp.add_url_rule('/profile/picture-<slug>.png', 'profile_picture_display', RHProfilePictureDisplay)
+    _bp.add_url_rule('/profile/picture', 'upload_profile_picture', RHProfilePicture, methods=('POST',))
+    _bp.add_url_rule('/profile/picture', 'delete_profile_picture', RHProfilePictureDelete, methods=('DELETE',))
     _bp.add_url_rule('/preferences/', 'user_preferences', RHUserPreferences, methods=('GET', 'POST'))
     _bp.add_url_rule('/favorites/', 'user_favorites', RHUserFavorites)
     _bp.add_url_rule('/favorites/users/', 'user_favorites_users_add', RHUserFavoritesUsersAdd, methods=('POST',))

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -20,9 +20,10 @@ from indico.modules.auth.forms import LocalRegistrationForm, _check_existing_ema
 from indico.modules.users import User
 from indico.modules.users.models.emails import UserEmail
 from indico.modules.users.models.users import NameFormat, UserTitle
+from indico.modules.users.util import get_picture_data
 from indico.util.i18n import _, get_all_locales
 from indico.web.forms.base import IndicoForm, SyncedInputsMixin
-from indico.web.forms.fields import IndicoEnumSelectField, PrincipalField, PrincipalListField
+from indico.web.forms.fields import EditableFileField, IndicoEnumSelectField, PrincipalField, PrincipalListField
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, used_if_not_synced
 from indico.web.forms.widgets import SwitchWidget, SyncedInputWidget
@@ -35,6 +36,11 @@ class UserDetailsForm(SyncedInputsMixin, IndicoForm):
     affiliation = StringField(_('Affiliation'), widget=SyncedInputWidget())
     address = TextAreaField(_('Address'), widget=SyncedInputWidget(textarea=True))
     phone = StringField(_('Phone number'), widget=SyncedInputWidget())
+
+
+class UserPictureForm(IndicoForm):
+    picture = EditableFileField(_('Profile picture'), accepted_file_types='image/jpeg,image/jpg,image/png,image/gif',
+                                add_remove_links=False, handle_flashes=True, get_metadata=get_picture_data)
 
 
 class UserPreferencesForm(IndicoForm):

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -37,9 +37,13 @@
             <div class="dashboard-col">
                 <div class="your-details">
                     <div class="avatar-image">
-                        <span class="ui large circular label" style="{{ user.avatar_css }}">
-                            {{ user.first_name[0] }}
-                        </span>
+                        {% if user.has_picture %}
+                            <img src="{{ user.picture_url }}" alt="" class="ui large circular label">
+                        {% else %}
+                            <span class="ui large circular label default-avatar" style="{{ user.avatar_css }}">
+                                {{ user.first_name[0] }}
+                            </span>
+                        {% endif %}
                     </div>
                     <div class="your-details-wrapper">
                         <h3>{{ user.full_name }}</h3>

--- a/indico/modules/users/templates/personal_data.html
+++ b/indico/modules/users/templates/personal_data.html
@@ -37,6 +37,21 @@
                 {% endif %}
             </div>
             <div class="i-box-content">
+                {# Profile picture form #}
+                {{ form_header(pic_form, action=url_for('.upload_profile_picture', event), classes='pic-form') }}
+                <div class="flashed-messages"></div>
+                {{ form_rows(pic_form) }}
+                {% call form_footer(pic_form) %}
+                    <button class="ui primary button" data-disabled-until-change>
+                        {% trans %}Upload{% endtrans %}
+                    </button>
+                    <button class="ui button negative js-remove-button danger{% if not pic_form.picture._value() %} hidden{% endif %}"
+                            data-href="{{ url_for('.delete_profile_picture', event) }}" data-method="DELETE">
+                        {% trans %}Delete{% endtrans %}
+                    </button>
+                {% endcall %}
+
+                {# Personal details form #}
                 {{ form_header(form) }}
                 {{ form_rows(form) }}
                 {% call form_footer(form) %}
@@ -48,4 +63,29 @@
             </div>
         </div>
     </div>
+
+    <script>
+        $('.pic-form').on('indico:fieldsSaved', function(e, response) {
+            const hidden = !response.content;
+            const $this = $(this);
+            $this.find('.js-remove-button').toggleClass('hidden', hidden).prop('disabled', hidden);
+        }).on('click', '.js-remove-button', function(e) {
+            const $this = $(this);
+            const $form = $this.closest('form');
+            const dropzone = $form.get(0).dropzone;
+            $this.prop('disabled', true);
+            e.preventDefault();
+            $.ajax({
+                url: $this.data('href'),
+                method: $this.data('method'),
+                complete: IndicoUI.Dialogs.Util.progress(),
+                error: handleAjaxError,
+                success: function(data) {
+                    handleFlashes(data, true, $form.find('.flashed-messages'));
+                    dropzone.removeAllFiles();
+                    $form.trigger('indico:fieldsSaved', data);
+                }
+            });
+        });
+    </script>
 {% endblock %}

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -370,3 +370,12 @@ def merge_users(source, target, force=False):
 
 def get_color_for_username(username):
     return user_colors[crc32(username) % len(user_colors)]
+
+
+def get_picture_data(user):
+    return {
+        'url': user.picture_url,
+        'filename': user.picture_metadata['filename'],
+        'size': user.picture_metadata['size'],
+        'content_type': user.picture_metadata['content_type']
+    }

--- a/indico/util/images.py
+++ b/indico/util/images.py
@@ -1,0 +1,28 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2020 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+"""
+Image processing functions
+"""
+
+
+def square(image):
+    """Return a squared image.
+
+    :param image: a `PIL.Image` object
+    """
+    width, height = image.size
+    if width == height:
+        return image
+    side = min(width, height)
+    overflow = max(width, height) - side
+    margin = overflow / 2
+    if width > height:
+        box = (margin, 0, margin + side, side)
+    else:
+        box = (0, margin, side, margin + side)
+    return image.crop(box)

--- a/indico/web/client/styles/modules/_dashboard.scss
+++ b/indico/web/client/styles/modules/_dashboard.scss
@@ -193,9 +193,16 @@
         }
 
         .ui.label {
-            font-size: 70px;
             color: $light-gray;
             margin-right: 34px;
+
+            &.default-avatar {
+                font-size: 70px;
+            }
+
+            &:not(.default-avatar) {
+                height: 140px;
+            }
         }
     }
 


### PR DESCRIPTION
Partially addresses #936.

This PR adds:
- A file upload field in the user personal details form.
- Display of the profile picture in the user profile dashboard.

## Functional testing instructions

Upload profile pic:
1. Go to user profile settings (`user/<user_id>/profile/`)
2. Upload a file from your computer
3. Verify that the picture is uploaded successfully
4. Verify that the profile picture is displayed in the user profile dashboard (`user/<user_id>/dashboard/`)

Delete profile pic:
1. Go to user profile settings (`user/<user_id>/profile/`)
2. Delete the profile picture
3. Verify that the profile picture is not displayed in the user profile dashboard (`user/<user_id>/dashboard/`)

## Screenshots

![image](https://user-images.githubusercontent.com/716307/80621100-1c47cc80-8a47-11ea-8829-5250e7565f58.png)

![image](https://user-images.githubusercontent.com/716307/80621917-4ea5f980-8a48-11ea-93a2-4543bbf5cd7f.png)

![image](https://user-images.githubusercontent.com/716307/80699912-20262e00-8add-11ea-97b8-ce60e563963f.png)
