### PR TITLE
Fix item sorting in badge designer

### DIFF
--- a/indico/modules/designer/templates/template.html
+++ b/indico/modules/designer/templates/template.html
@@ -301,7 +301,7 @@
                         {% for group_id, group in placeholders.viewitems() | sort(attribute='1.title') %}
                             {% if group_id not in config.disallow_groups %}
                                 <optgroup label="{{ group.title }}">
-                                    {% for option_id, option in group.options|dictsort(by='value') %}
+                                    {% for option_id, option in group.options|dictsort(by='key') %}
                                         <option value="{{ option_id }}">{{ option }}</option>
                                     {% endfor %}
                                 </optgroup>

--- a/indico/modules/designer/templates/template.html
+++ b/indico/modules/designer/templates/template.html
@@ -301,7 +301,7 @@
                         {% for group_id, group in placeholders.viewitems() | sort(attribute='1.title') %}
                             {% if group_id not in config.disallow_groups %}
                                 <optgroup label="{{ group.title }}">
-                                    {% for option_id, option in group.options|dictsort(by='key') %}
+                                    {% for option_id, option in group.options|dictsort(by='value') %}
                                         <option value="{{ option_id }}">{{ option }}</option>
                                     {% endfor %}
                                 </optgroup>

--- a/indico/modules/designer/util.py
+++ b/indico/modules/designer/util.py
@@ -28,7 +28,7 @@ def get_placeholder_options():
 def get_nested_placeholder_options():
     groups = {group_id: {'title': group_title, 'options': {}} for group_id, group_title in GROUP_TITLES.viewitems()}
     for name, placeholder in get_placeholder_options().viewitems():
-        groups[placeholder.group]['options'][name] = placeholder.description
+        groups[placeholder.group]['options'][name] = unicode(placeholder.description)
     return groups
 
 


### PR DESCRIPTION
Fix sorting items in "Insert element" combo: additional custom items (not "fields") are not correctly sorted.