### PR TITLE
Implement a RoomEditModal test for checking the tab fields

### DIFF
--- a/__mocks__/axios.js
+++ b/__mocks__/axios.js
@@ -6,14 +6,4 @@
 // LICENSE file for more details.
 
 import mockAxios from 'jest-mock-axios';
-
-// https://github.com/knee-cola/jest-mock-axios/issues/42
-mockAxios.mustGetReqByUrl = url => {
-  const req = mockAxios.getReqByUrl(url);
-  if (!req) {
-    throw new Error('No request to respond to!');
-  }
-  return req;
-};
-
 export default mockAxios;

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/__tests__/FileManager.spec.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/__tests__/FileManager.spec.jsx
@@ -108,17 +108,14 @@ async function simulateFileUpload(dropzone, name, type) {
   });
 
   await act(async () => {
-    mockAxios.mockResponse(
-      {
-        data: {
-          uuid,
-          filename: name,
-          claimed: false,
-          downloadURL: 'goes://nowhere',
-        },
+    mockAxios.mockResponseFor('goes://nowhere', {
+      data: {
+        uuid,
+        filename: name,
+        claimed: false,
+        downloadURL: 'goes://nowhere',
       },
-      mockAxios.mustGetReqByUrl('goes://nowhere')
-    );
+    });
   });
 
   return uuid;
@@ -139,7 +136,7 @@ async function uploadFile(dropzone, onChange, name, type, deletedFile = null) {
     const deleteUrl = `flask://files.delete_file/uuid=${deletedFile}`;
     expect(mockAxios.delete).toHaveBeenCalledWith(deleteUrl);
     await act(async () => {
-      mockAxios.mockResponse(undefined, mockAxios.mustGetReqByUrl(deleteUrl));
+      mockAxios.mockResponseFor(deleteUrl, undefined);
     });
   } else {
     expect(mockAxios.delete).not.toHaveBeenCalled();
@@ -207,10 +204,7 @@ describe('File manager', () => {
     // perform an undo - this needs to go back to an empty file list
     await act(async () => {
       fileEntry.find('FileAction').simulate('click');
-      mockAxios.mockResponse(
-        undefined,
-        mockAxios.mustGetReqByUrl(`flask://files.delete_file/uuid=${uuid}`)
-      );
+      mockAxios.mockResponseFor(`flask://files.delete_file/uuid=${uuid}`, undefined);
     });
     expect(mockAxios.delete).toHaveBeenCalledWith(`flask://files.delete_file/uuid=${uuid}`);
     expect(onChange).toHaveBeenCalledWith({});
@@ -252,10 +246,7 @@ describe('File manager', () => {
     // perform an undo - this needs to revert to the initial file!
     await act(async () => {
       fileEntry.find('FileAction').simulate('click');
-      mockAxios.mockResponse(
-        undefined,
-        mockAxios.mustGetReqByUrl(`flask://files.delete_file/uuid=${uuid}`)
-      );
+      mockAxios.mockResponseFor(`flask://files.delete_file/uuid=${uuid}`, undefined);
     });
     expect(mockAxios.delete).toHaveBeenCalledWith(`flask://files.delete_file/uuid=${uuid}`);
     expect(onChange).toHaveBeenCalledWith({'2': ['file1']});
@@ -298,17 +289,14 @@ describe('File manager', () => {
     expect(onChange).not.toHaveBeenCalled();
 
     await act(async () => {
-      mockAxios.mockResponse(
-        {
-          data: {
-            uuid: 'newfile2',
-            filename: file1.name,
-            claimed: false,
-            downloadURL: 'goes://nowhere',
-          },
+      mockAxios.mockResponseFor('http://upload/endpoint', {
+        data: {
+          uuid: 'newfile2',
+          filename: file1.name,
+          claimed: false,
+          downloadURL: 'goes://nowhere',
         },
-        mockAxios.mustGetReqByUrl('http://upload/endpoint')
-      );
+      });
     });
 
     // once the upload finished, the state is updated

--- a/indico/modules/rb/client/js/common/rooms/__tests__/RoomEditModal.spec.jsx
+++ b/indico/modules/rb/client/js/common/rooms/__tests__/RoomEditModal.spec.jsx
@@ -1,47 +1,21 @@
 import attributesURL from 'indico-url:rb.admin_attributes';
+import permissionInfoURL from 'indico-url:rb.permission_types';
 
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 import {mount} from 'enzyme';
 import {Tab} from 'semantic-ui-react';
 import {Provider} from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import {FieldArray} from 'react-final-form-arrays';
+import axiosMock from 'jest-mock-axios';
 import {FinalField} from 'indico/react/forms';
-import {useIndicoAxios, useFavoriteUsers} from 'indico/react/hooks';
-import {usePermissionInfo} from 'indico/react/components/principals/hooks';
 import RoomEditModal from '../edit/RoomEditModal';
 
-jest.mock('indico/react/components/principals/hooks');
 jest.mock('indico/react/components/principals/ACLField', () => () => null);
-jest.mock('indico/react/hooks');
 
 describe('RoomEditModal', () => {
   const mockStore = configureMockStore();
-
-  useIndicoAxios.mockImplementation(({url}) => {
-    if (url === attributesURL()) {
-      return {data: [{name: 'foo', value: 'bar'}]};
-    }
-    return undefined;
-  });
-
-  usePermissionInfo.mockImplementation(() => {
-    const permissionManager = {
-      setPermissionForId: jest.fn(),
-    };
-
-    const permissionInfo = {
-      permissions: {},
-      tree: {},
-      default: '',
-    };
-
-    return [permissionManager, permissionInfo];
-  });
-
-  useFavoriteUsers.mockImplementation(() => {
-    return [{}, [null, null]];
-  });
 
   it('should contain fields matching the respective Tab pane', () => {
     const initialState = {
@@ -55,6 +29,11 @@ describe('RoomEditModal', () => {
         <RoomEditModal onClose={() => {}} />
       </Provider>
     );
+    act(() => {
+      axiosMock.mockResponseFor({url: permissionInfoURL()}, {data: {tree: {}, default: ''}});
+      axiosMock.mockResponseFor({url: attributesURL()}, {data: [{name: 'foo', value: 'bar'}]});
+    });
+    component.update();
     const tabCmp = component.find(Tab);
     expect(tabCmp).toBeDefined();
 

--- a/indico/modules/rb/client/js/common/rooms/__tests__/RoomEditModal.spec.jsx
+++ b/indico/modules/rb/client/js/common/rooms/__tests__/RoomEditModal.spec.jsx
@@ -42,13 +42,13 @@ describe('RoomEditModal', () => {
       expect(pane).toHaveProperty('fields');
       expect(pane.fields).toBeInstanceOf(Array);
       expect(
-        tabCmp
-          .find(pane.pane.type)
-          .findWhere(e => [FinalField, FieldArray].includes(e.type()))
-          .map(x => x.prop('name'))
-          .filter((v, i, a) => a.indexOf(v) === i)
-          .sort()
-      ).toEqual(pane.fields.sort());
+        new Set(
+          tabCmp
+            .find(pane.pane.type)
+            .findWhere(e => [FinalField, FieldArray].includes(e.type()))
+            .map(x => x.prop('name'))
+        )
+      ).toEqual(new Set(pane.fields));
     }
   });
 });

--- a/indico/modules/rb/client/js/common/rooms/__tests__/RoomEditModal.spec.jsx
+++ b/indico/modules/rb/client/js/common/rooms/__tests__/RoomEditModal.spec.jsx
@@ -1,0 +1,75 @@
+import attributesURL from 'indico-url:rb.admin_attributes';
+
+import React from 'react';
+import {mount} from 'enzyme';
+import {Tab} from 'semantic-ui-react';
+import {Provider} from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import {FieldArray} from 'react-final-form-arrays';
+import {FinalField} from 'indico/react/forms';
+import {useIndicoAxios, useFavoriteUsers} from 'indico/react/hooks';
+import {usePermissionInfo} from 'indico/react/components/principals/hooks';
+import RoomEditModal from '../edit/RoomEditModal';
+
+jest.mock('indico/react/components/principals/hooks');
+jest.mock('indico/react/components/principals/ACLField', () => () => null);
+jest.mock('indico/react/hooks');
+
+describe('RoomEditModal', () => {
+  const mockStore = configureMockStore();
+
+  useIndicoAxios.mockImplementation(({url}) => {
+    if (url === attributesURL()) {
+      return {data: [{name: 'foo', value: 'bar'}]};
+    }
+    return undefined;
+  });
+
+  usePermissionInfo.mockImplementation(() => {
+    const permissionManager = {
+      setPermissionForId: jest.fn(),
+    };
+
+    const permissionInfo = {
+      permissions: {},
+      tree: {},
+      default: '',
+    };
+
+    return [permissionManager, permissionInfo];
+  });
+
+  useFavoriteUsers.mockImplementation(() => {
+    return [{}, [null, null]];
+  });
+
+  it('should contain fields matching the respective Tab pane', () => {
+    const initialState = {
+      rooms: {
+        equipmentTypes: [],
+      },
+    };
+    const store = mockStore(initialState);
+    const component = mount(
+      <Provider store={store}>
+        <RoomEditModal onClose={() => {}} />
+      </Provider>
+    );
+    const tabCmp = component.find(Tab);
+    expect(tabCmp).toBeDefined();
+
+    for (const pane of tabCmp.prop('panes')) {
+      expect(pane).toHaveProperty('pane');
+      expect(pane).toHaveProperty('fields');
+      expect(pane.fields).toBeInstanceOf(Array);
+      expect(
+        tabCmp
+          .find(pane.pane.type)
+          .findWhere(e => [FinalField, FieldArray].includes(e.type()))
+          .map(x => x.prop('name'))
+          .filter((v, i, a) => a.indexOf(v) === i)
+          .sort()
+      ).toEqual(pane.fields.sort());
+    }
+  });
+});

--- a/indico/modules/rb/client/js/common/rooms/index.js
+++ b/indico/modules/rb/client/js/common/rooms/index.js
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import * as actions from './actions';
 import * as selectors from './selectors';
+import * as actions from './actions';
 
 export {default as reducer} from './reducers';
 export {default as RoomDetailsPreloader} from './RoomDetailsPreloader';

--- a/package-lock.json
+++ b/package-lock.json
@@ -24492,6 +24492,12 @@
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
       "dev": true
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -27782,6 +27788,15 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/redux-lazy-scroll/-/redux-lazy-scroll-0.1.1.tgz",
       "integrity": "sha512-sFMw8dUV8Vdj8/9Rl2c6F+W7+Hq2d/oMW4JgZ4OwRhj645SaDXPTk/D2U6sSb7hZi0nk3YuwlSOzMjwWwRQVFw=="
+    },
+    "redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dev": true,
+      "requires": {
+        "lodash.isplainobject": "^4.0.6"
+      }
     },
     "redux-router-querystring": {
       "version": "0.0.11",

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "prettier": "~1.18.2",
     "preval.macro": "^5.0.0",
     "progress-bar-webpack-plugin": "^2.1.0",
+    "redux-mock-store": "^1.5.4",
     "resolve-url-loader": "^3.1.1",
     "sass-loader": "^8.0.2",
     "script-loader": "^0.7.2",
@@ -173,7 +174,9 @@
   },
   "homepage": "https://github.com/indico/indico#readme",
   "jest": {
-    "transformIgnorePatterns": ["/node_modules/(?!geodesy)"],
+    "transformIgnorePatterns": [
+      "/node_modules/(?!geodesy|semantic-ui-react)"
+    ],
     "moduleNameMapper": {
       "^.+\\.(s?css)$": "identity-obj-proxy",
       "^indico/modules/events/(reviewing|util)/(.*)$": "<rootDir>/indico/modules/events/client/js/$1/$2",
@@ -185,6 +188,11 @@
       "<rootDir>/setupTests.js"
     ],
     "globals": {
+      "Indico": {
+        "Urls": {
+          "BasePath": ""
+        }
+      },
       "REACT_TRANSLATIONS": {
         "indico": {
           "": {


### PR DESCRIPTION
Related to #4408
Depends on #4456 

This PR implements a simple test for RoomEditModal to ensure the tab fields have corresponding components in each child.

While reviewing, please only consider the commits after `b5fd77` (inclusive), or simply `RoomEditModal.spec.jsx`.