### PR TITLE
Preserve non-ASCII chars in file names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,7 @@ Improvements
   format of the user's locale (:issue:`4399`)
 - Refactor the room edit modal to a tabbed layout and improve error
   handling (:issue:`4408`)
+- Preserve non-ascii characters in file names (:issue:`4465`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/attachments/controllers/management/base.py
+++ b/indico/modules/attachments/controllers/management/base.py
@@ -21,7 +21,7 @@ from indico.modules.attachments.models.attachments import Attachment, Attachment
 from indico.modules.attachments.models.folders import AttachmentFolder
 from indico.modules.attachments.operations import add_attachment_link
 from indico.modules.attachments.util import get_attached_items
-from indico.util.fs import secure_filename
+from indico.util.fs import secure_client_filename
 from indico.util.i18n import _, ngettext
 from indico.util.string import to_unicode
 from indico.web.flask.templating import get_template_module
@@ -84,7 +84,7 @@ class AddAttachmentFilesMixin:
             files = form.files.data
             folder = form.folder.data or AttachmentFolder.get_or_create_default(linked_object=self.object)
             for f in files:
-                filename = secure_filename(f.filename, 'attachment')
+                filename = secure_client_filename(f.filename)
                 attachment = Attachment(folder=folder, user=session.user, title=to_unicode(f.filename),
                                         type=AttachmentType.file, protection_mode=form.protection_mode.data)
                 if attachment.is_self_protected:
@@ -142,7 +142,7 @@ class EditAttachmentMixin(SpecificAttachmentMixin):
                 file = form.file.data['added']
                 if file:
                     self.attachment.file = AttachmentFile(user=session.user, content_type=file.mimetype,
-                                                          filename=secure_filename(file.filename, 'attachment'))
+                                                          filename=secure_client_filename(file.filename))
                     self.attachment.file.save(file.stream)
 
             signals.attachments.attachment_updated.send(self.attachment, user=session.user)

--- a/indico/modules/attachments/models/attachments.py
+++ b/indico/modules/attachments/models/attachments.py
@@ -23,6 +23,7 @@ from indico.modules.attachments.models.principals import AttachmentPrincipal
 from indico.modules.attachments.preview import get_file_previewer
 from indico.modules.attachments.util import can_manage_attachments
 from indico.util.date_time import now_utc
+from indico.util.fs import secure_filename
 from indico.util.i18n import _
 from indico.util.string import return_ascii, strict_unicode
 from indico.util.struct.enum import RichIntEnum
@@ -99,7 +100,7 @@ class AttachmentFile(StoredFileMixin, db.Model):
                 path_segments.append(strict_unicode(folder.subcontribution.id))
         self.attachment.assign_id()
         self.assign_id()
-        filename = '{}-{}-{}'.format(self.attachment.id, self.id, self.filename)
+        filename = '{}-{}-{}'.format(self.attachment.id, self.id, secure_filename(self.filename, 'file'))
         path = posixpath.join(*(path_segments + [filename]))
         return config.ATTACHMENT_STORAGE, path
 

--- a/indico/modules/events/abstracts/models/files.py
+++ b/indico/modules/events/abstracts/models/files.py
@@ -12,6 +12,7 @@ import posixpath
 from indico.core.config import config
 from indico.core.db import db
 from indico.core.storage import StoredFileMixin
+from indico.util.fs import secure_filename
 from indico.util.string import format_repr, return_ascii, strict_unicode, text_to_repr
 
 
@@ -51,7 +52,7 @@ class AbstractFile(StoredFileMixin, db.Model):
         path_segments = ['event', strict_unicode(self.abstract.event.id),
                          'abstracts', strict_unicode(self.abstract.id)]
         self.assign_id()
-        filename = '{}-{}'.format(self.id, self.filename)
+        filename = '{}-{}'.format(self.id, secure_filename(self.filename, 'file'))
         path = posixpath.join(*(path_segments + [filename]))
         return config.ATTACHMENT_STORAGE, path
 

--- a/indico/modules/events/abstracts/operations.py
+++ b/indico/modules/events/abstracts/operations.py
@@ -29,7 +29,7 @@ from indico.modules.events.logs.models.entries import EventLogKind, EventLogReal
 from indico.modules.events.logs.util import make_diff_log
 from indico.modules.events.util import set_custom_fields
 from indico.util.date_time import now_utc
-from indico.util.fs import secure_filename
+from indico.util.fs import secure_client_filename
 from indico.util.i18n import orig_string
 
 
@@ -61,7 +61,7 @@ def add_abstract_files(abstract, files, log_action=True):
     if not files:
         return
     for f in files:
-        filename = secure_filename(f.filename, 'attachment')
+        filename = secure_client_filename(f.filename)
         content_type = mimetypes.guess_type(f.filename)[0] or f.mimetype or 'application/octet-stream'
         abstract_file = AbstractFile(filename=filename, content_type=content_type, abstract=abstract)
         abstract_file.save(f.stream)

--- a/indico/modules/events/layout/controllers/images.py
+++ b/indico/modules/events/layout/controllers/images.py
@@ -21,7 +21,7 @@ from indico.modules.events.layout.forms import AddImagesForm
 from indico.modules.events.layout.models.images import ImageFile
 from indico.modules.events.layout.views import WPImages
 from indico.modules.events.management.controllers import RHManageEventBase
-from indico.util.fs import secure_filename
+from indico.util.fs import secure_client_filename
 from indico.util.i18n import _, ngettext
 from indico.web.util import jsonify_data
 
@@ -47,7 +47,7 @@ class RHImageUpload(RHManageImagesBase):
         files = request.files.getlist('image')
         num = 0
         for f in files:
-            filename = secure_filename(f.filename, 'image')
+            filename = secure_client_filename(f.filename)
             data = BytesIO()
             shutil.copyfileobj(f, data)
             data.seek(0)

--- a/indico/modules/events/layout/models/images.py
+++ b/indico/modules/events/layout/models/images.py
@@ -12,6 +12,7 @@ import posixpath
 from indico.core.config import config
 from indico.core.db import db
 from indico.core.storage import StoredFileMixin
+from indico.util.fs import secure_filename
 from indico.util.string import return_ascii, strict_unicode
 
 
@@ -55,7 +56,7 @@ class ImageFile(StoredFileMixin, db.Model):
     def _build_storage_path(self):
         path_segments = ['event', strict_unicode(self.event.id), 'images']
         self.assign_id()
-        filename = '{}-{}'.format(self.id, self.filename)
+        filename = '{}-{}'.format(self.id, secure_filename(self.filename, 'file'))
         path = posixpath.join(*(path_segments + [filename]))
         return config.ATTACHMENT_STORAGE, path
 

--- a/indico/modules/events/papers/models/files.py
+++ b/indico/modules/events/papers/models/files.py
@@ -12,6 +12,7 @@ import posixpath
 from indico.core.config import config
 from indico.core.db import db
 from indico.core.storage.models import StoredFileMixin
+from indico.util.fs import secure_filename
 from indico.util.locators import locator_property
 from indico.util.string import format_repr, return_ascii, strict_unicode, text_to_repr
 
@@ -85,5 +86,6 @@ class PaperFile(StoredFileMixin, db.Model):
         self.assign_id()
         path_segments = ['event', strict_unicode(self._contribution.event.id), 'papers',
                          '{}_{}'.format(self.id, strict_unicode(self._contribution.id))]
-        path = posixpath.join(*(path_segments + [self.filename]))
+        filename = secure_filename(self.filename, 'paper')
+        path = posixpath.join(*(path_segments + [filename]))
         return config.ATTACHMENT_STORAGE, path

--- a/indico/modules/events/papers/models/templates.py
+++ b/indico/modules/events/papers/models/templates.py
@@ -12,6 +12,7 @@ import posixpath
 from indico.core.config import config
 from indico.core.db import db
 from indico.core.storage.models import StoredFileMixin
+from indico.util.fs import secure_filename
 from indico.util.locators import locator_property
 from indico.util.string import format_repr, return_ascii, strict_unicode
 
@@ -64,5 +65,6 @@ class PaperTemplate(StoredFileMixin, db.Model):
     def _build_storage_path(self):
         self.assign_id()
         path_segments = ['event', strict_unicode(self.event.id), 'paper_templates']
-        path = posixpath.join(*(path_segments + ['{}_{}'.format(self.id, self.filename)]))
+        filename = '{}_{}'.format(self.id, secure_filename(self.filename, 'file'))
+        path = posixpath.join(*(path_segments + [filename]))
         return config.ATTACHMENT_STORAGE, path

--- a/indico/modules/events/papers/operations.py
+++ b/indico/modules/events/papers/operations.py
@@ -34,7 +34,7 @@ from indico.modules.events.papers.settings import PaperReviewingRole, paper_revi
 from indico.modules.events.util import update_object_principals
 from indico.modules.users import User
 from indico.util.date_time import now_utc
-from indico.util.fs import secure_filename
+from indico.util.fs import secure_client_filename
 from indico.util.i18n import orig_string
 
 
@@ -143,7 +143,7 @@ def close_cfp(event):
 def create_paper_revision(paper, submitter, files):
     revision = PaperRevision(paper=paper, submitter=submitter)
     for f in files:
-        filename = secure_filename(f.filename, 'paper')
+        filename = secure_client_filename(f.filename)
         content_type = mimetypes.guess_type(f.filename)[0] or f.mimetype or 'application/octet-stream'
         pf = PaperFile(filename=filename, content_type=content_type, paper_revision=revision,
                        _contribution=paper.contribution)
@@ -189,13 +189,12 @@ def reset_paper_state(paper):
 
 def _store_paper_template_file(template, file):
     content_type = mimetypes.guess_type(file.filename)[0] or file.mimetype or 'application/octet-stream'
-    filename = secure_filename(file.filename, 'template')
     # reset fields in case an existing file is replaced so we can save() again
     template.storage_backend = None
     template.storage_file_id = None
     template.size = None
     template.content_type = content_type
-    template.filename = filename
+    template.filename = secure_client_filename(file.filename)
     template.save(file.stream)
 
 

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -19,7 +19,7 @@ from wtforms.validators import InputRequired, NumberRange, ValidationError
 from indico.modules.events.registration.fields.base import RegistrationFormBillableField, RegistrationFormFieldBase
 from indico.util.countries import get_countries, get_country
 from indico.util.date_time import strftime_all_years
-from indico.util.fs import secure_filename
+from indico.util.fs import secure_client_filename
 from indico.util.i18n import L_, _
 from indico.util.string import normalize_phone_number
 from indico.web.forms.fields import IndicoRadioField
@@ -252,7 +252,7 @@ class FileField(RegistrationFormFieldBase):
             # we have a file -> always save it
             data['file'] = {
                 'data': file_.stream,
-                'name': secure_filename(file_.filename, 'attachment'),
+                'name': secure_client_filename(file_.filename),
                 'content_type': mimetypes.guess_type(file_.filename)[0] or file_.mimetype or 'application/octet-stream'
             }
         elif not value['keep_existing']:

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -30,6 +30,7 @@ from indico.modules.events.payment.models.transactions import TransactionStatus
 from indico.modules.users.models.users import format_display_full_name
 from indico.util.date_time import now_utc
 from indico.util.decorators import classproperty
+from indico.util.fs import secure_filename
 from indico.util.i18n import L_
 from indico.util.locators import locator_property
 from indico.util.signals import values_from_signal
@@ -597,7 +598,7 @@ class RegistrationData(StoredFileMixin, db.Model):
                          strict_unicode(self.registration.registration_form.id), strict_unicode(self.registration.id)]
         assert None not in path_segments
         # add timestamp in case someone uploads the same file again
-        filename = '{}-{}-{}'.format(self.field_data.field_id, int(time.time()), self.filename)
+        filename = '{}-{}-{}'.format(self.field_data.field_id, int(time.time()), secure_filename(self.filename, 'file'))
         path = posixpath.join(*(path_segments + [filename]))
         return config.ATTACHMENT_STORAGE, path
 

--- a/indico/util/fs_test.py
+++ b/indico/util/fs_test.py
@@ -7,14 +7,30 @@
 
 import pytest
 
-from indico.util.fs import secure_filename
+from indico.util.fs import secure_client_filename, secure_filename
+
+
+@pytest.mark.parametrize(('filename', 'expected'), (
+    (u'', u'file'),
+    (None, u'file'),
+    (u'.', u'_'),
+    (u'..', u'__'),
+    (u'../', u'.._'),
+    (u'foo.txt', u'foo.txt'),
+    (u'../../../etc/passwd', u'.._.._.._etc_passwd'),
+    (u'm\xf6p.txt', u'm\xf6p.txt'),
+    (u'/m\xf6p.txt', u'_m\xf6p.txt'),
+    (ur'c:\test.txt', u'c_test.txt'),
+    (r'spacy   \filename', u'spacy _filename'),
+))
+def test_secure_client_filename(filename, expected):
+    assert secure_client_filename(filename) == expected
 
 
 @pytest.mark.parametrize(('filename', 'expected'), (
     ('', 'fallback'),
     (None, 'fallback'),
     ('foo.txt', 'foo.txt'),
-    ('', 'fallback'),
     ('../../../etc/passwd', 'etc_passwd'),
     (u'm\xf6p.txt', 'moep.txt'),
     (u'm\xf6p.txt'.encode('utf-8'), 'moep.txt'),


### PR DESCRIPTION
On disk filenames are still cleaned up and converted to ASCII, but the filename used for display purposes and the content-disposition header sent to clients now uses the original name.

closes #4465