### PR TITLE
Add watchman-based reloader

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "ignore_dirs": ["node_modules"]
+}

--- a/indico/cli/core.py
+++ b/indico/cli/core.py
@@ -139,8 +139,8 @@ def cleanup(temp, cache, verbose, dry_run, min_age):
 @click.option('--evalex-from', multiple=True,
               help='Restrict the debugger shell to the given ips (can be used multiple times)')
 @click.option('--proxy', is_flag=True, help='Use the ip and protocol provided by the proxy.')
-@click.option('--reloader', 'reloader_type', type=click.Choice(['auto', 'none', 'stat', 'watchdog']), default='auto',
-              help='The type of auto-reloader to use.')
+@click.option('--reloader', 'reloader_type', type=click.Choice(['auto', 'none', 'stat', 'watchdog', 'watchman']),
+              default='auto', help='The type of auto-reloader to use.')
 @pass_script_info
 def run(info, **kwargs):
     """Run the development webserver.

--- a/indico/cli/devserver.py
+++ b/indico/cli/devserver.py
@@ -25,16 +25,12 @@ except ImportError:
 
 
 def run_cmd(info, **kwargs):
-    inside_watchman = 'INDICO_WATCHMAN_RUN' in os.environ
-    if kwargs['reloader_type'] == 'watchman' and not inside_watchman:
+    if kwargs['reloader_type'] == 'watchman':
         if pywatchman is None:
             print('watchman is not available - you need to `pip install pywatchman`')
             return
         run_watchman()
         return
-    if inside_watchman:
-        # disable flask reloader when running inside watchman
-        kwargs['reloader_type'] = 'none'
     run_server(info, **kwargs)
 
 

--- a/indico/cli/watchman.py
+++ b/indico/cli/watchman.py
@@ -62,7 +62,11 @@ class Watcher(object):
         data = client.getSubscription(self.name)
         if data:
             files = sorted(f for record in data for f in record.get('files', []))
-            print(cformat('%{cyan}Changes found in %{cyan!}{}%{reset}%{cyan}:').format(os.path.relpath(self.path)))
+            relpath = os.path.relpath(self.path)
+            if relpath == '.':
+                print(cformat('%{cyan}Changes found:').format(relpath))
+            else:
+                print(cformat('%{cyan}Changes found in %{cyan!}{}%{reset}%{cyan}:').format(relpath))
             for f in files:
                 print(cformat(' * %{blue!}{}').format(f))
             self.triggered = True

--- a/indico/cli/watchman.py
+++ b/indico/cli/watchman.py
@@ -1,0 +1,156 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2020 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import print_function, unicode_literals
+
+import atexit
+import os
+import subprocess
+import sys
+import time
+
+import pywatchman
+from flask.helpers import get_root_path
+from werkzeug._reloader import _find_observable_paths
+
+from indico.util.console import cformat
+
+
+def _patterns_to_terms(patterns):
+    return ['anyof'] + [['match', p, 'wholename', {'includedotfiles': True}] for p in patterns]
+
+
+class Watcher(object):
+    def __init__(self, path, patterns):
+        self.path = path
+        self.name = path.replace('/', '-').strip('-')
+        self.patterns = patterns
+        self.root_dir = None
+        self.triggered = False
+
+    def start(self, client):
+        query = {
+            'expression': _patterns_to_terms(self.patterns),
+            'fields': ['name']
+        }
+        watch = client.query('watch-project', self.path)
+        if 'warning' in watch:
+            # no idea when this happens, but the example scripts have it...
+            print('watchman warning:', watch['warning'])
+        self.root_dir = watch['watch']
+        if 'relative_path' in watch:
+            query['relative_root'] = watch['relative_path']
+        # get the initial clock value so that we only get updates
+        query['since'] = client.query('clock', self.root_dir)['clock']
+        client.query('subscribe', self.root_dir, self.name, query)
+
+    def consume(self, client):
+        data = client.getSubscription(self.name)
+        if data:
+            files = sorted(f for record in data for f in record.get('files', []))
+            print(cformat('%{cyan}Changes found in %{cyan!}{}%{reset}%{cyan}:').format(os.path.relpath(self.path)))
+            for f in files:
+                print(cformat(' * %{blue!}{}').format(f))
+            self.triggered = True
+
+    def check(self):
+        triggered = self.triggered
+        self.triggered = False
+        return triggered
+
+    def __repr__(self):
+        return '<Watcher({!r}, {!r})>'.format(self.path, self.patterns)
+
+
+class Watchman(object):
+    def __init__(self):
+        self._proc = None
+        self._watchers = set()
+        self._client = None
+        atexit.register(self._terminate)
+
+    def run(self):
+        self._client = pywatchman.client(timeout=300)
+        self._client.capabilityCheck(required=['wildmatch', 'cmd-watch-project'])
+        indico_project_root = os.path.realpath(os.path.join(get_root_path('indico'), '..'))
+        paths = sorted({os.path.realpath(p) for p in _find_observable_paths() if os.path.exists(p)})
+        for path in paths:
+            patterns = ['**/*.py', '**/entry_points.txt']
+            if path == indico_project_root:
+                patterns += ['indico/indico.conf', 'indico/logging.yaml']
+            watcher = Watcher(path, patterns)
+            watcher.start(self._client)
+            self._watchers.add(watcher)
+        self._launch()
+        self._monitor()
+
+    def _monitor(self):
+        while True:
+            self._client.setTimeout(300)
+            try:
+                self._client.receive()
+                for w in self._watchers:
+                    w.consume(self._client)
+
+                self._client.setTimeout(0.1)
+                settled = False
+                while not settled:
+                    try:
+                        self._client.receive()
+                        for w in self._watchers:
+                            w.consume(self._client)
+                    except pywatchman.SocketTimeout:
+                        settled = True
+                        break
+
+                triggered = False
+                for w in self._watchers:
+                    # this cannot be done with any() since all triggered watchers
+                    # need to be reset during the check
+                    if w.check():
+                        triggered = True
+
+                if triggered:
+                    self._restart()
+
+            except pywatchman.SocketTimeout:
+                # are we still connected?
+                try:
+                    self._client.query('version')
+                except Exception as exc:
+                    print('watchman error:', exc)
+                    return
+
+            except KeyboardInterrupt:
+                print()
+                return
+
+    def _launch(self, quiet=False, retry=0):
+        assert not self._proc
+        if not quiet and not retry:
+            print(cformat('%{green!}Launching Indico'))
+        try:
+            self._proc = subprocess.Popen(sys.argv, env=dict(os.environ, INDICO_WATCHMAN_RUN='1'))
+        except OSError as exc:
+            delay = (retry + 1) * 0.5
+            print(cformat('%{red!}Could not launch Indico: {}').format(exc))
+            print(cformat('%{yellow}Retrying in {}s').format(delay))
+            time.sleep(delay)
+            self._launch(quiet=quiet, retry=(retry + 1))
+
+    def _terminate(self, quiet=False):
+        if not self._proc:
+            return
+        if not quiet:
+            print(cformat('%{red!}Terminating Indico'))
+        self._proc.terminate()
+        self._proc = None
+
+    def _restart(self):
+        print(cformat('%{yellow!}Restarting Indico'))
+        self._terminate(quiet=True)
+        self._launch(quiet=True)

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -15,3 +15,4 @@ isort
 flask_url_map_serializer
 migra
 transifex-client
+pywatchman


### PR DESCRIPTION
Since the flask reloader is not always reliable and sometimes results in a stuck zombie Indico process this one should provide a stable alternative based on [watchman](https://facebook.github.io/watchman/). It's also quite smart and detects e.g. when you do Git operations so switching branches will be a single change (and thus not trigger multiple restarts).

Since there are no precompiled versions or distro packages of `watchman` available (except for the latest version with a dependency on a specific version of boost which may not be installed), I built it myself and uploaded the binary to [my server](https://fd.aeum.net/watchman) - just drop it in `/usr/local/bin` and `chmod +x` it.

To test it, you can simply run the indico dev server using `indico run ...` with `--reloader watchman`. Once it's running you can even switch branches and it should still work fine.

---

And just in case you want to build watchman yourself... See the relevant section in the [documentation](https://facebook.github.io/watchman/docs/install#buildinstall). And don't make the same mistake as I did and try building from master (lots of nasty boost dependencies that take ages to compile or just fail)... Also use `./configure --enable-lenient --disable-statedir --without-python` to use a more straightforward install (that stores runtime state in `/tmp` instead of `/var/run/...`).