### PR TITLE
Add 'unassign/assign myself' to editable timeline

### DIFF
--- a/indico/modules/events/editing/__init__.py
+++ b/indico/modules/events/editing/__init__.py
@@ -92,18 +92,15 @@ class PaperEditorPermission(ManagementPermission):
     name = 'paper_editing'
     friendly_name = _('Paper Editor')
     description = _('Grants editor rights for paper editing on an event.')
-    user_selectable = True
 
 
 class SlidesEditorPermission(ManagementPermission):
     name = 'slides_editing'
     friendly_name = _('Slides Editor')
     description = _('Grants editor rights for slides editing on an event.')
-    user_selectable = True
 
 
 class PosterEditorPermission(ManagementPermission):
     name = 'poster_editing'
     friendly_name = _('Poster Editor')
     description = _('Grants editor rights for poster editing on an event.')
-    user_selectable = True

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -77,8 +77,14 @@ _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/assign/
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/unassign', 'unassign_editor',
                  editable_list.RHUnassignEditor, methods=('POST',))
 
-# Contribution/revision-level APIs
+# Editable-level APIs
 contrib_api_prefix = '/api' + contrib_prefix
+_bp.add_url_rule(contrib_api_prefix + '/editor/', 'api_unassign_editable', timeline.RHEditableUnassign,
+                 methods=('DELETE',))
+_bp.add_url_rule(contrib_api_prefix + '/editor/me', 'api_assign_editable_self', timeline.RHEditableAssignMe,
+                 methods=('PUT',))
+
+# Contribution/revision-level APIs
 _bp.add_url_rule(contrib_api_prefix, 'api_editable', timeline.RHEditable)
 _bp.add_url_rule(contrib_api_prefix, 'api_create_editable', timeline.RHCreateEditable, methods=('PUT',))
 _bp.add_url_rule(contrib_api_prefix + '/upload', 'api_upload', timeline.RHEditingUploadFile, methods=('POST',))

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
@@ -1,0 +1,165 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import contributionDisplayURL from 'indico-url:contributions.display_contribution';
+import assignMyselfURL from 'indico-url:event_editing.api_assign_editable_self';
+import unassignEditorURL from 'indico-url:event_editing.api_unassign_editable';
+
+import React from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import PropTypes from 'prop-types';
+
+import {Message, Icon} from 'semantic-ui-react';
+import {Param, Translate} from 'indico/react/i18n';
+import {MathJax} from 'indico/react/components';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+import {getDetails} from './selectors';
+import {loadTimeline} from './actions';
+
+export default function TimelineHeader({children, contribution, state, submitter, eventId}) {
+  const {
+    canAssignSelf,
+    canUnassign,
+    canEdit,
+    type,
+    editor,
+    editingEnabled,
+    reviewConditionsValid,
+  } = useSelector(getDetails);
+  const dispatch = useDispatch();
+
+  const unassignEditor = async () => {
+    try {
+      await indicoAxios.delete(
+        unassignEditorURL({confId: eventId, contrib_id: contribution.id, type})
+      );
+    } catch (error) {
+      return handleAxiosError(error);
+    }
+    dispatch(loadTimeline());
+  };
+
+  const assignMyself = async () => {
+    try {
+      await indicoAxios.put(assignMyselfURL({confId: eventId, contrib_id: contribution.id, type}));
+    } catch (error) {
+      return handleAxiosError(error);
+    }
+    dispatch(loadTimeline());
+  };
+
+  return (
+    <>
+      <div className="submission-title flexrow">
+        <MathJax>
+          <h3 className="f-self-strech">
+            {contribution.title} <span className="submission-id">#{contribution.friendlyId}</span>
+            {contribution.code && <span className="submission-code">{contribution.code}</span>}
+          </h3>
+        </MathJax>
+      </div>
+      <div className="editable-public">
+        <div className="review-summary flexrow f-a-center">
+          <div className="review-summary-badge">
+            {reviewConditionsValid ? (
+              <div className={`i-tag ${state.cssClass}`}>{state.title}</div>
+            ) : (
+              <div className="i-tag">
+                <Translate>Not Ready</Translate>
+              </div>
+            )}
+          </div>
+          <div className="review-summary-content f-self-stretch">
+            <div>
+              <Translate>
+                <Param name="submitterName" value={submitter.fullName} wrapper={<strong />} />{' '}
+                submitted for the contribution{' '}
+                <Param
+                  name="contributionLink"
+                  value={contribution.title}
+                  wrapper={
+                    <a
+                      href={contributionDisplayURL({contrib_id: contribution.id, confId: eventId})}
+                    />
+                  }
+                />
+              </Translate>
+              <br />
+              {editor ? (
+                <>
+                  <Translate>
+                    <Param name="editorName" value={editor.fullName} wrapper={<strong />} /> is the
+                    assigned editor
+                  </Translate>
+                  {canUnassign && (
+                    <>
+                      {' ('}
+                      <a onClick={unassignEditor}>
+                        <Translate>unassign</Translate>
+                      </a>
+                      {')'}
+                    </>
+                  )}
+                </>
+              ) : (
+                <>
+                  <Translate>No editor assigned</Translate>
+                  {canAssignSelf && (
+                    <>
+                      {' ('}
+                      <a onClick={assignMyself}>
+                        <Translate>assign myself</Translate>
+                      </a>
+                      {')'}
+                    </>
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+        {!reviewConditionsValid && (
+          <Message warning>
+            <Icon name="warning sign" />
+            <Translate>This editable is not fulfilling reviewing conditions.</Translate>
+          </Message>
+        )}
+        {!editingEnabled && (
+          <Message warning>
+            <Icon name="warning sign" />
+            <Translate>Editing is currently not enabled.</Translate>
+            {canEdit && (
+              <>
+                {' '}
+                <Translate>Since you are a manager you can edit anyway.</Translate>
+              </>
+            )}
+          </Message>
+        )}
+        <div className="review-item-content">{children}</div>
+      </div>
+    </>
+  );
+}
+
+TimelineHeader.propTypes = {
+  contribution: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    friendlyId: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    code: PropTypes.string.isRequired,
+  }).isRequired,
+  state: PropTypes.shape({
+    cssClass: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+  }).isRequired,
+  submitter: PropTypes.shape({
+    fullName: PropTypes.string.isRequired,
+  }).isRequired,
+  eventId: PropTypes.number.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
@@ -24,7 +24,7 @@ export default function TimelineHeader({children, contribution, state, submitter
   const {
     canAssignSelf,
     canUnassign,
-    canEdit,
+    canPerformEditorActions,
     type,
     editor,
     editingEnabled,
@@ -132,7 +132,7 @@ export default function TimelineHeader({children, contribution, state, submitter
           <Message warning>
             <Icon name="warning sign" />
             <Translate>Editing is currently not enabled.</Translate>
-            {canEdit && (
+            {canPerformEditorActions && (
               <>
                 {' '}
                 <Translate>Since you are a manager you can edit anyway.</Translate>

--- a/indico/modules/events/editing/client/js/editing/timeline/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/index.jsx
@@ -9,7 +9,7 @@ import React, {useEffect} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Loader} from 'semantic-ui-react';
 
-import TimelineHeader from 'indico/modules/events/reviewing/components/TimelineHeader';
+import TimelineHeader from 'indico/modules/events/editing/editing/timeline/TimelineHeader';
 import TimelineContent from 'indico/modules/events/reviewing/components/TimelineContent';
 import SubmitRevision from './SubmitRevision';
 
@@ -27,8 +27,6 @@ export default function Timeline() {
   const lastRevision = useSelector(selectors.getLastRevision);
   const timelineBlocks = useSelector(selectors.getTimelineBlocks);
   const {eventId, contributionId, editableType, fileTypes} = useSelector(selectors.getStaticData);
-  const canEdit = useSelector(selectors.canPerformEditorActions);
-  const editingEnabled = useSelector(selectors.editingEnabled);
 
   useEffect(() => {
     dispatch(actions.loadTimeline(eventId, contributionId, editableType));
@@ -47,9 +45,6 @@ export default function Timeline() {
         state={lastState}
         submitter={timelineBlocks[0].submitter}
         eventId={eventId}
-        reviewConditionsValid={details.reviewConditionsValid}
-        canEdit={canEdit}
-        editingEnabled={editingEnabled}
       >
         <FileDisplay
           fileTypes={fileTypes}

--- a/indico/modules/events/editing/models/editable.py
+++ b/indico/modules/events/editing/models/editable.py
@@ -147,12 +147,11 @@ class Editable(db.Model):
         # If the user can't even see the timeline, we never allow any modifications
         if not self.can_see_timeline(user):
             return False
-        # Editing/event managers can perform actions without being the assigned editor
-        # XXX: Do we want this? Or should they have to assign themselves first if they
-        #      want to do actions that would usually be done by the assigned editor?
-        if self.event.can_manage(user, permission='editing_manager'):
+        # Editing/event managers can perform actions when they are the assigned editor
+        # even when editing is disabled in the settings
+        if self.editor == user and self.event.can_manage(user, permission='editing_manager'):
             return True
-        # Editing needs to be enabled in the settings
+        # Editing needs to be enabled in the settings otherwise
         if not editable_type_settings[self.type].get(self.event, 'editing_enabled'):
             return False
         # Editors need the permission on the editable type and also be the assigned editor

--- a/indico/modules/events/editing/models/editable.py
+++ b/indico/modules/events/editing/models/editable.py
@@ -172,6 +172,21 @@ class Editable(db.Model):
                 or self.event.can_manage(user, permission='editing_manager')
                 or self.contribution.is_user_associated(user, check_abstract=True))
 
+    def can_assign_self(self, user):
+        """Whether the user can assign themself on the editable."""
+        from indico.modules.events.editing.settings import editable_type_settings
+        return ((self.event.can_manage(user, permission=self.type.editor_permission)
+                 and editable_type_settings[self.type].get(self.event, 'editing_enabled'))
+                or self.event.can_manage(user, permission='editing_manager'))
+
+    def can_unassign(self, user):
+        """Whether the user can unassign the editor of the editable."""
+        from indico.modules.events.editing.settings import editable_type_settings
+        return (self.event.can_manage(user, permission='editing_manager')
+                or (self.editor == user
+                    and self.event.can_manage(user, permission=self.type.editor_permission)
+                    and editable_type_settings[self.type].get(self.event, 'editing_enabled')))
+
     @property
     def review_conditions_valid(self):
         from indico.modules.events.editing.models.review_conditions import EditingReviewCondition

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -135,7 +135,7 @@ class EditableSchema(mm.ModelSchema):
         model = Editable
         fields = ('id', 'type', 'editor', 'revisions', 'contribution', 'can_comment', 'review_conditions_valid',
                   'can_perform_editor_actions', 'can_perform_submitter_actions', 'can_create_internal_comments',
-                  'editing_enabled')
+                  'can_unassign', 'can_assign_self', 'editing_enabled')
 
     contribution = fields.Nested(ContributionSchema)
     editor = fields.Nested(UserSchema, only=('id', 'avatar_bg_color', 'full_name'))
@@ -147,6 +147,10 @@ class EditableSchema(mm.ModelSchema):
     can_comment = fields.Function(lambda editable, ctx: editable.can_comment(ctx.get('user')))
     can_create_internal_comments = fields.Function(
         lambda editable, ctx: editable.can_use_internal_comments(ctx.get('user')))
+    can_unassign = fields.Function(
+        lambda editable, ctx: editable.can_unassign(ctx.get('user')))
+    can_assign_self = fields.Function(
+        lambda editable, ctx: editable.can_assign_self(ctx.get('user')))
     review_conditions_valid = fields.Boolean()
     editing_enabled = fields.Boolean()
 

--- a/indico/modules/events/papers/client/js/components/Paper.jsx
+++ b/indico/modules/events/papers/client/js/components/Paper.jsx
@@ -10,8 +10,8 @@ import PropTypes from 'prop-types';
 import {useDispatch, useSelector} from 'react-redux';
 import {Loader} from 'semantic-ui-react';
 
-import TimelineHeader from 'indico/modules/events/reviewing/components/TimelineHeader';
 import TimelineContent from 'indico/modules/events/reviewing/components/TimelineContent';
+import TimelineHeader from './TimelineHeader';
 import {fetchPaperDetails} from '../actions';
 import {getPaperDetails, isFetchingInitialPaperDetails} from '../selectors';
 import PaperDecisionForm from './PaperDecisionForm';

--- a/indico/modules/events/papers/client/js/components/TimelineHeader.jsx
+++ b/indico/modules/events/papers/client/js/components/TimelineHeader.jsx
@@ -10,20 +10,10 @@ import contributionDisplayURL from 'indico-url:contributions.display_contributio
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {Message, Icon} from 'semantic-ui-react';
 import {Param, Translate} from 'indico/react/i18n';
 import {MathJax} from 'indico/react/components';
 
-export default function TimelineHeader({
-  children,
-  contribution,
-  state,
-  submitter,
-  eventId,
-  reviewConditionsValid,
-  canEdit,
-  editingEnabled,
-}) {
+export default function TimelineHeader({children, contribution, state, submitter, eventId}) {
   return (
     <>
       <div className="submission-title flexrow">
@@ -37,13 +27,7 @@ export default function TimelineHeader({
       <div className="paper-public">
         <div className="review-summary flexrow f-a-baseline">
           <div className="review-summary-badge">
-            {reviewConditionsValid ? (
-              <div className={`i-tag ${state.cssClass}`}>{state.title}</div>
-            ) : (
-              <div className="i-tag">
-                <Translate>Not Ready</Translate>
-              </div>
-            )}
+            <div className={`i-tag ${state.cssClass}`}>{state.title}</div>
           </div>
           <div className="review-summary-content f-self-stretch">
             <div>
@@ -63,24 +47,6 @@ export default function TimelineHeader({
             </div>
           </div>
         </div>
-        {!reviewConditionsValid && (
-          <Message warning>
-            <Icon name="warning sign" />
-            <Translate>This editable is not fulfilling reviewing conditions.</Translate>
-          </Message>
-        )}
-        {!editingEnabled && (
-          <Message warning>
-            <Icon name="warning sign" />
-            <Translate>Editing is currently not enabled.</Translate>
-            {canEdit && (
-              <>
-                {' '}
-                <Translate>Since you are a manager you can edit anyway.</Translate>
-              </>
-            )}
-          </Message>
-        )}
         <div className="review-item-content">{children}</div>
       </div>
     </>
@@ -103,13 +69,4 @@ TimelineHeader.propTypes = {
   }).isRequired,
   eventId: PropTypes.number.isRequired,
   children: PropTypes.node.isRequired,
-  reviewConditionsValid: PropTypes.bool,
-  canEdit: PropTypes.bool,
-  editingEnabled: PropTypes.bool,
-};
-
-TimelineHeader.defaultProps = {
-  reviewConditionsValid: true,
-  canEdit: true,
-  editingEnabled: true,
 };


### PR DESCRIPTION
Also splits TimelineHeader for 'Call for Papers' and 'Editables' since they started diverging too much.
Closes #4474.
![Bildschirmfoto 2020-06-02 um 10 09 49](https://user-images.githubusercontent.com/23189858/83496420-5cbcbf00-a4b9-11ea-817c-9d67481726c3.png)
![Bildschirmfoto 2020-06-02 um 10 09 38](https://user-images.githubusercontent.com/23189858/83496448-67775400-a4b9-11ea-8a96-d760afc3af3d.png)

With the last commit also closes #4479.