### PR TITLE
Create a closer link between peer reviewing and editing

### DIFF
--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -49,19 +49,19 @@ import PublicationSwitch from './PublicationSwitch';
 
     let lastRevFiles;
     if (tasks[1].status === 'fulfilled') {
-      const paperInfo = camelizeKeys(tasks[1].value.data);
-      if (paperInfo.lastRevision) {
-        lastRevFiles = paperInfo.lastRevision.files;
+      const {isInFinalState, lastRevision} = camelizeKeys(tasks[1].value.data);
+      if (isInFinalState && lastRevision) {
+        lastRevFiles = lastRevision.files;
       }
     }
 
     ReactDOM.render(
       <EditableSubmissionButton
         fileTypes={fileTypes}
-        eventId={eventId}
-        contributionId={contributionId}
+        eventId={Number(eventId)}
+        contributionId={Number(contributionId)}
         contributionCode={contributionCode}
-        existingFiles={lastRevFiles}
+        uploadableFiles={lastRevFiles}
       />,
       editableSubmissionButton
     );

--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -39,10 +39,9 @@ import PublicationSwitch from './PublicationSwitch';
         Promise.all(
           availableTypes.map(type => indicoAxios.get(fileTypesURL({confId: eventId, type})))
         ),
-        indicoAxios
-          .get(paperInfoURL({confId: eventId, contrib_id: contributionId}))
-          // eslint-disable-next-line no-unused-vars
-          .catch(e => undefined),
+        indicoAxios.get(paperInfoURL({confId: eventId, contrib_id: contributionId}), {
+          validateStatus: status => status >= 200 && status <= 404,
+        }),
       ]);
     } catch (e) {
       handleAxiosError(e);
@@ -62,8 +61,8 @@ import PublicationSwitch from './PublicationSwitch';
     ReactDOM.render(
       <EditableSubmissionButton
         fileTypes={fileTypes}
-        eventId={Number(eventId)}
-        contributionId={Number(contributionId)}
+        eventId={+eventId}
+        contributionId={+contributionId}
         contributionCode={contributionCode}
         uploadableFiles={lastRevFiles}
       />,

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -93,7 +93,7 @@ _bp.add_url_rule(contrib_api_prefix + '/editor/me', 'api_assign_editable_self', 
                  methods=('PUT',))
 
 # Contribution/revision-level APIs
-_bp.add_url_rule(contrib_api_prefix, 'api_editable', timeline.RHEditable, methods=('GET',))
+_bp.add_url_rule(contrib_api_prefix, 'api_editable', timeline.RHEditable)
 _bp.add_url_rule(contrib_api_prefix, 'api_create_editable', timeline.RHCreateEditable, methods=('PUT',))
 _bp.add_url_rule(contrib_api_prefix + '/upload', 'api_upload', timeline.RHEditingUploadFile, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/add-paper-file', 'api_add_paper_file',

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -93,9 +93,11 @@ _bp.add_url_rule(contrib_api_prefix + '/editor/me', 'api_assign_editable_self', 
                  methods=('PUT',))
 
 # Contribution/revision-level APIs
-_bp.add_url_rule(contrib_api_prefix, 'api_editable', timeline.RHEditable)
+_bp.add_url_rule(contrib_api_prefix, 'api_editable', timeline.RHEditable, methods=('GET',))
 _bp.add_url_rule(contrib_api_prefix, 'api_create_editable', timeline.RHCreateEditable, methods=('PUT',))
 _bp.add_url_rule(contrib_api_prefix + '/upload', 'api_upload', timeline.RHEditingUploadFile, methods=('POST',))
+_bp.add_url_rule(contrib_api_prefix + '/upload_last_revision', 'api_upload_last_revision',
+                 timeline.RHEditingUploadFromLastRevision, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/review', 'api_review_editable',
                  timeline.RHReviewEditable, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/confirm', 'api_confirm_changes',

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -96,8 +96,8 @@ _bp.add_url_rule(contrib_api_prefix + '/editor/me', 'api_assign_editable_self', 
 _bp.add_url_rule(contrib_api_prefix, 'api_editable', timeline.RHEditable, methods=('GET',))
 _bp.add_url_rule(contrib_api_prefix, 'api_create_editable', timeline.RHCreateEditable, methods=('PUT',))
 _bp.add_url_rule(contrib_api_prefix + '/upload', 'api_upload', timeline.RHEditingUploadFile, methods=('POST',))
-_bp.add_url_rule(contrib_api_prefix + '/upload_last_revision', 'api_upload_last_revision',
-                 timeline.RHEditingUploadFromLastRevision, methods=('POST',))
+_bp.add_url_rule(contrib_api_prefix + '/add-paper-file', 'api_add_paper_file',
+                 timeline.RHEditingUploadPaperLastRevision, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/review', 'api_review_editable',
                  timeline.RHReviewEditable, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/confirm', 'api_confirm_changes',

--- a/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
@@ -8,7 +8,7 @@
 import editableURL from 'indico-url:event_editing.editable';
 import submitRevisionURL from 'indico-url:event_editing.api_create_editable';
 import apiUploadURL from 'indico-url:event_editing.api_upload';
-import apiUploadExistingURL from 'indico-url:event_editing.api_upload_last_revision';
+import apiUploadExistingURL from 'indico-url:event_editing.api_add_paper_file';
 
 import _ from 'lodash';
 import React, {useState} from 'react';
@@ -31,7 +31,7 @@ export default function EditableSubmissionButton({
   contributionId,
   contributionCode,
   fileTypes,
-  existingFiles,
+  uploadableFiles,
 }) {
   const [currentType, setCurrentType] = useState(null);
   const submitRevision = async formData => {
@@ -89,7 +89,7 @@ export default function EditableSubmissionButton({
                       contrib_id: contributionId,
                       type: currentType,
                     })}
-                    existingFiles={existingFiles}
+                    uploadableFiles={uploadableFiles}
                     mustChange
                   />
                 </Form>
@@ -131,12 +131,12 @@ export default function EditableSubmissionButton({
 
 EditableSubmissionButton.propTypes = {
   fileTypes: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape(fileTypePropTypes))).isRequired,
-  eventId: PropTypes.string.isRequired,
-  contributionId: PropTypes.string.isRequired,
+  eventId: PropTypes.number.isRequired,
+  contributionId: PropTypes.number.isRequired,
   contributionCode: PropTypes.string.isRequired,
-  existingFiles: PropTypes.arrayOf(PropTypes.shape(uploadablePropTypes)),
+  uploadableFiles: PropTypes.arrayOf(PropTypes.shape(uploadablePropTypes)),
 };
 
 EditableSubmissionButton.defaultProps = {
-  existingFiles: [],
+  uploadableFiles: [],
 };

--- a/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
@@ -18,13 +18,13 @@ import {Form as FinalForm} from 'react-final-form';
 
 import {indicoAxios} from 'indico/utils/axios';
 import {FinalSubmitButton, handleSubmitError} from 'indico/react/forms';
-import {Param, Translate} from 'indico/react/i18n';
+import {Translate} from 'indico/react/i18n';
 
 import {fileTypePropTypes, uploadablePropTypes} from './timeline/FileManager/util';
 import {FinalFileManager} from './timeline/FileManager';
 
 import {getFileTypes} from './timeline/selectors';
-import {EditableTypeTitles, EditableType} from '../models';
+import {EditableTypeTitles} from '../models';
 
 export default function EditableSubmissionButton({
   eventId,
@@ -32,6 +32,7 @@ export default function EditableSubmissionButton({
   contributionCode,
   fileTypes,
   uploadableFiles,
+  text,
 }) {
   const [currentType, setCurrentType] = useState(null);
   const submitRevision = async formData => {
@@ -46,6 +47,11 @@ export default function EditableSubmissionButton({
     location.href = editableURL({confId: eventId, contrib_id: contributionId, type: currentType});
   };
   const editableTypes = Object.keys(fileTypes);
+  const textByType = {
+    paper: Translate.string('Submit paper'),
+    poster: Translate.string('Submit poster'),
+    slides: Translate.string('Submit slides'),
+  };
 
   return (
     <>
@@ -63,11 +69,7 @@ export default function EditableSubmissionButton({
             closeOnDimmerClick={false}
             closeOnEscape={false}
           >
-            <Modal.Header>
-              {currentType === EditableType.paper && <Translate>Submit your paper</Translate>}
-              {currentType === EditableType.slides && <Translate>Submit your slides</Translate>}
-              {currentType === EditableType.poster && <Translate>Submit your poster</Translate>}
-            </Modal.Header>
+            <Modal.Header>{textByType[currentType]}</Modal.Header>
             <Modal.Content>
               {currentType !== null && (
                 <Form id="submit-editable-form" onSubmit={handleSubmit}>
@@ -106,9 +108,7 @@ export default function EditableSubmissionButton({
       </FinalForm>
       {editableTypes.length === 1 ? (
         <Button onClick={() => setCurrentType(editableTypes[0])} primary>
-          <Translate>
-            Submit <Param name="editableType" value={editableTypes[0]} />
-          </Translate>
+          {text || textByType[editableTypes[0]]}
         </Button>
       ) : (
         <Dropdown
@@ -130,6 +130,7 @@ export default function EditableSubmissionButton({
 }
 
 EditableSubmissionButton.propTypes = {
+  text: PropTypes.string,
   fileTypes: PropTypes.objectOf(PropTypes.arrayOf(PropTypes.shape(fileTypePropTypes))).isRequired,
   eventId: PropTypes.number.isRequired,
   contributionId: PropTypes.number.isRequired,
@@ -138,5 +139,6 @@ EditableSubmissionButton.propTypes = {
 };
 
 EditableSubmissionButton.defaultProps = {
+  text: undefined,
   uploadableFiles: [],
 };

--- a/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
@@ -20,7 +20,7 @@ import {indicoAxios} from 'indico/utils/axios';
 import {FinalSubmitButton, handleSubmitError} from 'indico/react/forms';
 import {Param, Translate} from 'indico/react/i18n';
 
-import {fileTypePropTypes} from 'indico/modules/events/editing/editing/timeline/FileManager/util';
+import {fileTypePropTypes, uploadablePropTypes} from './timeline/FileManager/util';
 import {FinalFileManager} from './timeline/FileManager';
 
 import {getFileTypes} from './timeline/selectors';
@@ -134,7 +134,7 @@ EditableSubmissionButton.propTypes = {
   eventId: PropTypes.string.isRequired,
   contributionId: PropTypes.string.isRequired,
   contributionCode: PropTypes.string.isRequired,
-  existingFiles: PropTypes.any, // TODO: derive a props shape from fileTypePropTypes
+  existingFiles: PropTypes.arrayOf(PropTypes.shape(uploadablePropTypes)),
 };
 
 EditableSubmissionButton.defaultProps = {

--- a/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
@@ -8,6 +8,7 @@
 import editableURL from 'indico-url:event_editing.editable';
 import submitRevisionURL from 'indico-url:event_editing.api_create_editable';
 import apiUploadURL from 'indico-url:event_editing.api_upload';
+import apiUploadExistingURL from 'indico-url:event_editing.api_upload_last_revision';
 
 import _ from 'lodash';
 import React, {useState} from 'react';
@@ -19,8 +20,9 @@ import {indicoAxios} from 'indico/utils/axios';
 import {FinalSubmitButton, handleSubmitError} from 'indico/react/forms';
 import {Param, Translate} from 'indico/react/i18n';
 
+import {fileTypePropTypes} from 'indico/modules/events/editing/editing/timeline/FileManager/util';
 import {FinalFileManager} from './timeline/FileManager';
-import {fileTypePropTypes} from './timeline/FileManager/util';
+
 import {getFileTypes} from './timeline/selectors';
 import {EditableTypeTitles, EditableType} from '../models';
 
@@ -29,6 +31,7 @@ export default function EditableSubmissionButton({
   contributionId,
   contributionCode,
   fileTypes,
+  existingFiles,
 }) {
   const [currentType, setCurrentType] = useState(null);
   const submitRevision = async formData => {
@@ -81,6 +84,12 @@ export default function EditableSubmissionButton({
                       contrib_id: contributionId,
                       type: currentType,
                     })}
+                    uploadExistingURL={apiUploadExistingURL({
+                      confId: eventId,
+                      contrib_id: contributionId,
+                      type: currentType,
+                    })}
+                    existingFiles={existingFiles}
                     mustChange
                   />
                 </Form>
@@ -125,4 +134,9 @@ EditableSubmissionButton.propTypes = {
   eventId: PropTypes.string.isRequired,
   contributionId: PropTypes.string.isRequired,
   contributionCode: PropTypes.string.isRequired,
+  existingFiles: PropTypes.any, // TODO: derive a props shape from fileTypePropTypes
+};
+
+EditableSubmissionButton.defaultProps = {
+  existingFiles: [],
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
@@ -50,15 +50,15 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
   const onDropAccepted = useCallback(
     async acceptedFiles => {
       setActiveButton('replace');
-      await uploadFiles(
-        actions.markModified,
-        fileType.id,
+      await uploadFiles({
+        action: actions.markModified,
+        fileTypeId: fileType.id,
         acceptedFiles,
-        uploadFile.bind(null, uploadURL),
+        uploadFunc: uploadFile.bind(null, uploadURL),
         dispatch,
-        uuid,
-        () => setActiveButton(null)
-      );
+        replaceFileId: uuid,
+        onError: () => setActiveButton(null),
+      });
       // when we're done, the component will have been unmounted,
       // so there's no need to unset the active button
     },

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
@@ -13,6 +13,7 @@ import {
   FileManagerContext,
   filePropTypes,
   uploadFiles,
+  uploadFile,
   deleteFile,
   fileTypePropTypes,
 } from './util';
@@ -53,7 +54,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
         actions.markModified,
         fileType.id,
         acceptedFiles,
-        uploadURL,
+        uploadFile.bind(null, uploadURL),
         dispatch,
         uuid,
         () => setActiveButton(null)

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
@@ -34,7 +34,7 @@
   flex-wrap: wrap;
 
   .file-type {
-    overflow: hidden;
+    // overflow: hidden;
     margin-bottom: 1em;
     border: 1px solid $gray;
     border-radius: 3px;

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
@@ -34,7 +34,6 @@
   flex-wrap: wrap;
 
   .file-type {
-    // overflow: hidden;
     margin-bottom: 1em;
     border: 1px solid $gray;
     border-radius: 3px;

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/__tests__/FileManager.spec.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/__tests__/FileManager.spec.jsx
@@ -172,6 +172,7 @@ describe('File manager', () => {
         ...fileTypes[i],
         files: fileList.filter(f => f.fileType === i + 1),
         invalidFiles: [],
+        uploadableFiles: [],
       });
       expect(node.prop('uploads')).toEqual({});
     });

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/index.jsx
@@ -187,7 +187,11 @@ function FileType({
           className="primary"
           style={{marginTop: '1em'}}
           text={Translate.string('Use an existing file')}
-          options={uploadableFiles.map((f, i) => ({text: f.filename, value: i}))}
+          options={uploadableFiles.map((uf, i) => ({
+            text: uf.filename,
+            value: i,
+            disabled: files.some(f => f.id === uf.id),
+          }))}
           onChange={(__, {value}) =>
             uploadFiles(
               actions.markUploaded,
@@ -195,7 +199,10 @@ function FileType({
               // Use a fake file handle to seamlessly refer to an existing uploadable
               [new File([], uploadableFiles[value].filename)],
               uploadAnExistingFile.bind(null, uploadExistingURL, uploadableFiles[value]),
-              dispatch
+              dispatch,
+              null,
+              null,
+              uploadableFiles[value].id
             )
           }
           selectOnNavigation={false}

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/util.js
@@ -72,8 +72,9 @@ export async function uploadAnExistingFile(url, file) {
  * @param {Array} acceptedFiles - the "accepted files" array sent by react-dropzone
  * @param {Function} uploadCallback - the function to be called on file upload
  * @param {Function} dispatch - the dispatch function for reducer actions
- * @param {String?} fileId - the ID of the file to modify, if any
+ * @param {String?} replaceFileId - the ID of the file to modify, if any
  * @param {Function} onError - the function to be called on file upload error
+ * @param {Number} fileId - the id of the file, if any, used to cross-reference uploadables
  */
 export function uploadFiles(
   action,
@@ -81,8 +82,9 @@ export function uploadFiles(
   acceptedFiles,
   uploadCallback,
   dispatch,
-  fileId = null,
-  onError = null
+  replaceFileId = null,
+  onError = null,
+  fileId = null
 ) {
   const tmpFileIds = acceptedFiles.map(() => _.uniqueId(_.now()));
 
@@ -103,8 +105,9 @@ export function uploadFiles(
         return null;
       } else {
         dispatch(
-          action(fileTypeId, fileId, tmpFileId, {
+          action(fileTypeId, replaceFileId, tmpFileId, {
             filename: uploadedFile.filename,
+            id: fileId,
             uuid: uploadedFile.uuid,
             claimed: false,
             fileType: fileTypeId,

--- a/indico/modules/events/editing/controllers/base.py
+++ b/indico/modules/events/editing/controllers/base.py
@@ -8,7 +8,7 @@
 from __future__ import unicode_literals
 
 from flask import request, session
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import NotFound, Unauthorized
 
 from indico.modules.events.contributions.controllers.display import RHContributionDisplayBase
 from indico.modules.events.controllers.base import RHDisplayEventBase
@@ -80,6 +80,7 @@ class RHContributionEditableBase(RequireUserMixin, RHContributionDisplayBase):
     """Base class for operations on an editable."""
 
     EVENT_FEATURE = 'editing'
+    EDITABLE_REQUIRED = True
 
     normalize_url_spec = {
         'locators': {
@@ -102,6 +103,8 @@ class RHContributionEditableBase(RequireUserMixin, RHContributionDisplayBase):
                          .filter_by(type=self.editable_type)
                          .options(*self._editable_query_options)
                          .first())
+        if self.editable is None and self.EDITABLE_REQUIRED:
+            raise NotFound
 
 
 class RHEditablesBase(RHEditingManagementBase):

--- a/indico/modules/events/papers/client/js/components/Paper.jsx
+++ b/indico/modules/events/papers/client/js/components/Paper.jsx
@@ -8,20 +8,39 @@
 import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
 import {useDispatch, useSelector} from 'react-redux';
-import {Loader} from 'semantic-ui-react';
+import {Loader, Step} from 'semantic-ui-react';
 
+import fileTypesURL from 'indico-url:event_editing.api_file_types';
+import editableURL from 'indico-url:event_editing.api_editable';
 import TimelineContent from 'indico/modules/events/reviewing/components/TimelineContent';
+import {useIndicoAxios} from 'indico/react/hooks';
+import EditableSubmissionButton from 'indico/modules/events/editing/editing/EditableSubmissionButton';
+import {EditableType} from 'indico/modules/events/editing/models';
+import {Translate} from 'indico/react/i18n';
+import {fileTypePropTypes} from 'indico/modules/events/editing/editing/timeline/FileManager/util';
 import TimelineHeader from './TimelineHeader';
 import {fetchPaperDetails} from '../actions';
 import {getPaperDetails, isFetchingInitialPaperDetails} from '../selectors';
 import PaperDecisionForm from './PaperDecisionForm';
 import PaperContent from './PaperContent';
 import TimelineItem from './TimelineItem';
+import {PaperState} from '../models';
 
 export default function Paper({eventId, contributionId}) {
   const dispatch = useDispatch();
   const paper = useSelector(getPaperDetails);
   const isInitialPaperDetailsLoading = useSelector(isFetchingInitialPaperDetails);
+  const {data: fileTypes} = useIndicoAxios({
+    url: fileTypesURL({confId: eventId, type: EditableType.paper}),
+    trigger: eventId,
+    camelize: true,
+  });
+  const {data: editable} = useIndicoAxios({
+    url: editableURL({confId: eventId, contrib_id: contributionId, type: 'paper'}),
+    trigger: [eventId, contributionId],
+    unHandledErrors: [404],
+    camelize: true,
+  });
 
   useEffect(() => {
     dispatch(fetchPaperDetails(eventId, contributionId));
@@ -35,7 +54,8 @@ export default function Paper({eventId, contributionId}) {
 
   const {
     contribution,
-    lastRevision: {submitter},
+    lastRevision: {submitter, files},
+    revisions,
     state,
   } = paper;
 
@@ -49,7 +69,13 @@ export default function Paper({eventId, contributionId}) {
       >
         <PaperContent />
       </TimelineHeader>
-      <TimelineContent itemComponent={TimelineItem} blocks={paper.revisions} />
+      <PaperSteps
+        isAccepted={state.name === PaperState.accepted}
+        hasEditable={!!editable}
+        fileTypes={fileTypes}
+        existingFiles={files}
+      />
+      <TimelineContent itemComponent={TimelineItem} blocks={revisions} />
       <PaperDecisionForm />
     </>
   );
@@ -58,4 +84,55 @@ export default function Paper({eventId, contributionId}) {
 Paper.propTypes = {
   eventId: PropTypes.number.isRequired,
   contributionId: PropTypes.number.isRequired,
+};
+
+function PaperSteps({isAccepted, hasEditable, fileTypes, existingFiles}) {
+  const {event, contribution} = useSelector(getPaperDetails);
+
+  return (
+    <Step.Group ordered fluid>
+      <Step completed={isAccepted}>
+        <Step.Content>
+          <Step.Title>Peer Reviewing</Step.Title>
+          <Step.Description style={{marginBottom: '0'}}>
+            {isAccepted ? (
+              <Translate>The paper was accepted</Translate>
+            ) : (
+              <Translate>Your paper is under review</Translate>
+            )}
+          </Step.Description>
+        </Step.Content>
+      </Step>
+      <Step completed={hasEditable}>
+        <Step.Content>
+          <Step.Title>
+            {hasEditable || !isAccepted ? ( // TODO: editing not enabled
+              <p>
+                <Translate>Submit for Editing</Translate>
+              </p>
+            ) : (
+              <EditableSubmissionButton
+                eventId={event.id}
+                contributionId={contribution.id}
+                contributionCode={contribution.code}
+                fileTypes={{[EditableType.paper]: fileTypes}}
+                existingFiles={existingFiles}
+              />
+            )}
+          </Step.Title>
+        </Step.Content>
+      </Step>
+    </Step.Group>
+  );
+}
+
+PaperSteps.propTypes = {
+  isAccepted: PropTypes.bool.isRequired,
+  hasEditable: PropTypes.bool.isRequired,
+  fileTypes: PropTypes.arrayOf(PropTypes.shape(fileTypePropTypes)).isRequired,
+  existingFiles: PropTypes.any,
+};
+
+PaperSteps.defaultProps = {
+  existingFiles: [],
 };

--- a/indico/modules/events/papers/client/js/components/Paper.jsx
+++ b/indico/modules/events/papers/client/js/components/Paper.jsx
@@ -17,14 +17,16 @@ import {useIndicoAxios} from 'indico/react/hooks';
 import EditableSubmissionButton from 'indico/modules/events/editing/editing/EditableSubmissionButton';
 import {EditableType} from 'indico/modules/events/editing/models';
 import {Translate} from 'indico/react/i18n';
-import {fileTypePropTypes} from 'indico/modules/events/editing/editing/timeline/FileManager/util';
+import {
+  fileTypePropTypes,
+  uploadablePropTypes,
+} from 'indico/modules/events/editing/editing/timeline/FileManager/util';
 import TimelineHeader from './TimelineHeader';
 import {fetchPaperDetails} from '../actions';
 import {getPaperDetails, isFetchingInitialPaperDetails} from '../selectors';
 import PaperDecisionForm from './PaperDecisionForm';
 import PaperContent from './PaperContent';
 import TimelineItem from './TimelineItem';
-import {PaperState} from '../models';
 
 export default function Paper({eventId, contributionId}) {
   const dispatch = useDispatch();
@@ -38,7 +40,7 @@ export default function Paper({eventId, contributionId}) {
   const {data: editable} = useIndicoAxios({
     url: editableURL({confId: eventId, contrib_id: contributionId, type: 'paper'}),
     trigger: [eventId, contributionId],
-    unHandledErrors: [404],
+    unhandledErrors: [404],
     camelize: true,
   });
 
@@ -57,6 +59,7 @@ export default function Paper({eventId, contributionId}) {
     lastRevision: {submitter, files},
     revisions,
     state,
+    isInFinalState,
   } = paper;
 
   return (
@@ -70,10 +73,10 @@ export default function Paper({eventId, contributionId}) {
         <PaperContent />
       </TimelineHeader>
       <PaperSteps
-        isAccepted={state.name === PaperState.accepted}
+        isAccepted={isInFinalState}
         hasEditable={!!editable}
         fileTypes={fileTypes}
-        existingFiles={files}
+        uploadableFiles={files}
       />
       <TimelineContent itemComponent={TimelineItem} blocks={revisions} />
       <PaperDecisionForm />
@@ -86,7 +89,7 @@ Paper.propTypes = {
   contributionId: PropTypes.number.isRequired,
 };
 
-function PaperSteps({isAccepted, hasEditable, fileTypes, existingFiles}) {
+function PaperSteps({isAccepted, hasEditable, fileTypes, uploadableFiles}) {
   const {event, contribution} = useSelector(getPaperDetails);
 
   return (
@@ -94,7 +97,7 @@ function PaperSteps({isAccepted, hasEditable, fileTypes, existingFiles}) {
       <Step completed={isAccepted}>
         <Step.Content>
           <Step.Title>Peer Reviewing</Step.Title>
-          <Step.Description style={{marginBottom: '0'}}>
+          <Step.Description style={{marginBottom: 0}}>
             {isAccepted ? (
               <Translate>The paper was accepted</Translate>
             ) : (
@@ -116,7 +119,7 @@ function PaperSteps({isAccepted, hasEditable, fileTypes, existingFiles}) {
                 contributionId={contribution.id}
                 contributionCode={contribution.code}
                 fileTypes={{[EditableType.paper]: fileTypes}}
-                existingFiles={existingFiles}
+                uploadableFiles={uploadableFiles}
               />
             )}
           </Step.Title>
@@ -130,9 +133,9 @@ PaperSteps.propTypes = {
   isAccepted: PropTypes.bool.isRequired,
   hasEditable: PropTypes.bool.isRequired,
   fileTypes: PropTypes.arrayOf(PropTypes.shape(fileTypePropTypes)).isRequired,
-  existingFiles: PropTypes.any,
+  uploadableFiles: PropTypes.arrayOf(PropTypes.shape(uploadablePropTypes)),
 };
 
 PaperSteps.defaultProps = {
-  existingFiles: [],
+  uploadableFiles: [],
 };

--- a/indico/modules/events/papers/client/js/components/RevisionJudgment.jsx
+++ b/indico/modules/events/papers/client/js/components/RevisionJudgment.jsx
@@ -9,7 +9,7 @@ import React, {useState} from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
 import {useDispatch, useSelector} from 'react-redux';
-import {Button, Confirm, Popup} from 'semantic-ui-react';
+import {Button, Confirm, Icon, Popup} from 'semantic-ui-react';
 
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {Param, Translate} from 'indico/react/i18n';
@@ -65,7 +65,7 @@ export default function RevisionJudgment({revision}) {
                   position="bottom center"
                   content={Translate.string('Reset judgment')}
                   trigger={
-                    <a className="i-link icon-remove" onClick={() => setConfirmOpen(true)} />
+                    <Icon link className="undo" color="grey" onClick={() => setConfirmOpen(true)} />
                   }
                 />
               </div>

--- a/indico/modules/events/papers/schemas.py
+++ b/indico/modules/events/papers/schemas.py
@@ -14,6 +14,8 @@ from marshmallow_enum import EnumField
 
 from indico.core.marshmallow import mm
 from indico.modules.events.contributions.schemas import ContributionSchema
+from indico.modules.events.editing.models.editable import EditableType
+from indico.modules.events.editing.settings import editable_type_settings
 from indico.modules.events.models.events import Event
 from indico.modules.events.papers.models.comments import PaperReviewComment
 from indico.modules.events.papers.models.files import PaperFile
@@ -192,6 +194,10 @@ class PaperSchema(mm.Schema):
     can_judge = Function(lambda paper, ctx: paper.can_judge(ctx.get('user')))
     can_comment = Function(lambda paper, ctx: paper.can_comment(ctx.get('user'), check_state=True))
     can_review = Function(lambda paper, ctx: paper.can_review(ctx.get('user')))
+    can_submit_proceedings = Function(lambda paper, ctx: paper.contribution.can_submit_proceedings(ctx.get('user')))
+    editing_enabled = Function(
+        lambda paper, : editable_type_settings[EditableType.paper].get(paper.event, 'editing_enabled')
+    )
 
 
 paper_schema = PaperSchema()

--- a/indico/modules/events/papers/schemas.py
+++ b/indico/modules/events/papers/schemas.py
@@ -15,7 +15,7 @@ from marshmallow_enum import EnumField
 from indico.core.marshmallow import mm
 from indico.modules.events.contributions.schemas import ContributionSchema
 from indico.modules.events.editing.models.editable import EditableType
-from indico.modules.events.editing.settings import editable_type_settings
+from indico.modules.events.editing.settings import editable_type_settings, editing_settings
 from indico.modules.events.models.events import Event
 from indico.modules.events.papers.models.comments import PaperReviewComment
 from indico.modules.events.papers.models.files import PaperFile
@@ -195,8 +195,11 @@ class PaperSchema(mm.Schema):
     can_comment = Function(lambda paper, ctx: paper.can_comment(ctx.get('user'), check_state=True))
     can_review = Function(lambda paper, ctx: paper.can_review(ctx.get('user')))
     can_submit_proceedings = Function(lambda paper, ctx: paper.contribution.can_submit_proceedings(ctx.get('user')))
+    editing_open = Function(
+        lambda paper, ctx: editable_type_settings[EditableType.paper].get(paper.event, 'submission_enabled')
+    )
     editing_enabled = Function(
-        lambda paper, ctx: editable_type_settings[EditableType.paper].get(paper.event, 'editing_enabled')
+        lambda paper, ctx: 'paper' in editing_settings.get(paper.event, 'editable_types')
     )
 
 

--- a/indico/modules/events/papers/schemas.py
+++ b/indico/modules/events/papers/schemas.py
@@ -196,7 +196,7 @@ class PaperSchema(mm.Schema):
     can_review = Function(lambda paper, ctx: paper.can_review(ctx.get('user')))
     can_submit_proceedings = Function(lambda paper, ctx: paper.contribution.can_submit_proceedings(ctx.get('user')))
     editing_enabled = Function(
-        lambda paper, : editable_type_settings[EditableType.paper].get(paper.event, 'editing_enabled')
+        lambda paper, ctx: editable_type_settings[EditableType.paper].get(paper.event, 'editing_enabled')
     )
 
 

--- a/indico/modules/events/papers/schemas.py
+++ b/indico/modules/events/papers/schemas.py
@@ -199,7 +199,8 @@ class PaperSchema(mm.Schema):
         lambda paper, ctx: editable_type_settings[EditableType.paper].get(paper.event, 'submission_enabled')
     )
     editing_enabled = Function(
-        lambda paper, ctx: 'paper' in editing_settings.get(paper.event, 'editable_types')
+        lambda paper, ctx: paper.event.has_feature('editing')
+        and 'paper' in editing_settings.get(paper.event, 'editable_types')
     )
 
 

--- a/indico/modules/files/controllers.py
+++ b/indico/modules/files/controllers.py
@@ -32,10 +32,13 @@ class UploadFileMixin(object):
         'file': fields.Field(location='files', required=True)
     })
     def _process(self, file):
+        return self._save_file(file, file.stream)
+
+    def _save_file(self, file, stream):
         context = self.get_file_context()
         content_type = mimetypes.guess_type(file.filename)[0] or file.mimetype or 'application/octet-stream'
         f = File(filename=file.filename, content_type=content_type)
-        f.save(context, file.stream)
+        f.save(context, stream)
         db.session.add(f)
         db.session.flush()
         logger.info('File %r uploaded (context: %r)', f, context)

--- a/indico/web/client/js/react/hooks.js
+++ b/indico/web/client/js/react/hooks.js
@@ -103,11 +103,11 @@ FavoritesProvider.propTypes = {
   children: PropTypes.func.isRequired,
 };
 
-export function useIndicoAxios({camelize, unHandledErrors, ...args}) {
+export function useIndicoAxios({camelize, unhandledErrors = [], ...args}) {
   const lastData = useRef(null);
   const {response, error, loading, reFetch} = useAxios({
     customHandler: err =>
-      err && !unHandledErrors.includes(err.response.status) && handleAxiosError(err),
+      err && !unhandledErrors.includes(err.response.status) && handleAxiosError(err),
     ...args,
     axios: indicoAxios,
   });

--- a/indico/web/client/js/react/hooks.js
+++ b/indico/web/client/js/react/hooks.js
@@ -107,7 +107,9 @@ export function useIndicoAxios({camelize, unhandledErrors = [], ...args}) {
   const lastData = useRef(null);
   const {response, error, loading, reFetch} = useAxios({
     customHandler: err =>
-      err && !unhandledErrors.includes(err.response.status) && handleAxiosError(err),
+      err &&
+      (!err.response || !unhandledErrors.includes(err.response.status)) &&
+      handleAxiosError(err),
     ...args,
     axios: indicoAxios,
   });

--- a/indico/web/client/js/react/hooks.js
+++ b/indico/web/client/js/react/hooks.js
@@ -103,10 +103,11 @@ FavoritesProvider.propTypes = {
   children: PropTypes.func.isRequired,
 };
 
-export function useIndicoAxios({camelize, ...args}) {
+export function useIndicoAxios({camelize, unHandledErrors, ...args}) {
   const lastData = useRef(null);
   const {response, error, loading, reFetch} = useAxios({
-    customHandler: err => err && handleAxiosError(err),
+    customHandler: err =>
+      err && !unHandledErrors.includes(err.response.status) && handleAxiosError(err),
     ...args,
     axios: indicoAxios,
   });


### PR DESCRIPTION
Closes #4303 
Under development

TODOs:
- [x] Re-uploading existing files results in multiple copies (if multiple files are enabled)
- [x] Confirm if the copies of the files are deleted accordingly
- [x] Add a link to the editable from the paper reviewing
- [ ] Add a warning if the editable was rejected in peer-reviewing? - probably for another task
- [x] Check the slow loadings
- [x] Disable the editing step if editing is not enabled
- [x] Restrict the steps view to authors only
- [x] Decide between uploading files from any last revision or only when the peer reviewing finished
- [x] Consider whether it is worth merging the `existingFiles` inside `_fileTypes` for FileManager children

PS: We considered re-using the `files` property in the `FileManager` like we do when submitting revisions. However, PaperFiles use `ids`, while editables use `uuids`, it's very complicated to merge them within the `FileManager`. To avoid a complete refactoring, I had to make this a new feature.