### PR TITLE
Editable list: Action button functionality

### DIFF
--- a/indico/core/db/sqlalchemy/principals.py
+++ b/indico/core/db/sqlalchemy/principals.py
@@ -413,13 +413,29 @@ class PrincipalMixin(object):
         """Get a set of all unique emails associated with this principal.
 
         For users, this is just the primary email (or nothing for the system user).
-        For groups it is the primary email address of each group members who have
-        an Indico account.
+        For anything group-like it is the primary email address of each group member
+        who has an Indico account.
         """
         if self.type == PrincipalType.user and not self.user.is_system:
             return {self.user.email}
         elif self.type in (PrincipalType.local_group, PrincipalType.multipass_group):
             return {x.email for x in self.principal.get_members() if not x.is_system}
+        elif self.type in (PrincipalType.event_role, PrincipalType.category_role):
+            return {x.email for x in self.principal.members if not x.is_system}
+        return set()
+
+    def get_users(self):
+        """Get a set of all users associated with this principal.
+
+        For users this is just the user itself. For anything group-like this
+        returns all members.
+        """
+        if self.type == PrincipalType.user:
+            return {self.user}
+        elif self.type in (PrincipalType.local_group, PrincipalType.multipass_group):
+            return {x for x in self.principal.get_members() if not x.is_system}
+        elif self.type in (PrincipalType.event_role, PrincipalType.category_role):
+            return {x for x in self.principal.members if not x.is_system}
         return set()
 
     def merge_privs(self, other):

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -78,6 +78,8 @@ _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/assign/
                  editable_list.RHAssignMyselfAsEditor, methods=('POST',))
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/unassign', 'api_unassign_editor',
                  editable_list.RHUnassignEditor, methods=('POST',))
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editors', 'api_editable_type_editors',
+                 management.RHEditableTypeEditors)
 
 # Editable-level APIs
 contrib_api_prefix = '/api' + contrib_prefix

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -68,15 +68,15 @@ _bp.add_url_rule('/editing/api/service/connect', 'api_service_connect', service.
 _bp.add_url_rule('/editing/api/service/disconnect', 'api_service_disconnect', service.RHDisconnectService,
                  methods=('POST',))
 _bp.add_url_rule('/editing/api/service/status', 'api_service_status', service.RHServiceStatus)
-_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/prepare-archive', 'prepare_editables_archive',
-                 editable_list.RHPrepareEditablesArchive, methods=('POST',))
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/prepare-archive',
+                 'api_prepare_editables_archive', editable_list.RHPrepareEditablesArchive, methods=('POST',))
 _bp.add_url_rule('/editing/<any(paper,slides,poster):type>/editables/archive/<uuid:uuid>.zip', 'download_archive',
                  editable_list.RHDownloadArchive)
-_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/assign', 'assign_editor',
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/assign', 'api_assign_editor',
                  editable_list.RHAssignEditor, methods=('POST',))
-_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/assign/me', 'assign_myself',
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/assign/me', 'api_assign_myself',
                  editable_list.RHAssignMyselfAsEditor, methods=('POST',))
-_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/unassign', 'unassign_editor',
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/unassign', 'api_unassign_editor',
                  editable_list.RHUnassignEditor, methods=('POST',))
 
 # Editable-level APIs

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 import {filePropTypes} from './FileManager/util';
 
 export const userPropTypes = {
+  identifier: PropTypes.string.isRequired,
   fullName: PropTypes.string.isRequired,
   avatarBgColor: PropTypes.string.isRequired,
   id: PropTypes.number.isRequired,

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -270,6 +270,7 @@ function EditableListDisplay({initialEditableList, codePresent, editableType, ev
             <Dropdown
               disabled={!hasCheckedEditables || !editors.length || !!activeRequest}
               options={editorOptions}
+              scrolling
               icon={null}
               value={null}
               selectOnBlur={false}

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -58,7 +58,8 @@ function EditableListDisplay({editableList, codePresent, editableType, eventId})
   const [sortDirection, setSortDirection] = useState('ASC');
   const [sortedList, setSortedList] = useState(editableList);
   const [checked, setChecked] = useState([]);
-  const hasCheckedRows = checked.length === 0;
+  const editables = sortedList.filter(x => x.editable);
+  const hasCheckedEditables = checked.length > 0;
   const title = {
     [EditableType.paper]: Translate.string('List of papers'),
     [EditableType.slides]: Translate.string('List of slides'),
@@ -158,14 +159,14 @@ function EditableListDisplay({editableList, codePresent, editableType, eventId})
 
   const toggleSelectAll = dataChecked => {
     if (dataChecked) {
-      setChecked(sortedList.map(row => row.id));
+      setChecked(editables.map(row => row.editable.id));
     } else {
       setChecked([]);
     }
   };
 
   const toggleSelectRow = dataIndex => {
-    const newRow = sortedList[dataIndex].id;
+    const newRow = sortedList[dataIndex].editable.id;
     if (checked.includes(newRow)) {
       setChecked(old => old.filter(row => row !== newRow));
     } else {
@@ -179,15 +180,18 @@ function EditableListDisplay({editableList, codePresent, editableType, eventId})
       <ManagementPageBackButton url={dashboardURL({confId: eventId})} />
       <div styleName="editable-topbar">
         <div>
-          <Button disabled={hasCheckedRows} content={Translate.string('Assign')} />
-          <Button disabled={hasCheckedRows} content={Translate.string('Unassign')} />
-          <Button disabled={hasCheckedRows} content={Translate.string('Set status')} />
+          <Button disabled={!hasCheckedEditables} content={Translate.string('Assign')} />
+          <Button disabled={!hasCheckedEditables} content={Translate.string('Unassign')} />
+          <Button disabled={!hasCheckedEditables} content={Translate.string('Set status')} />
           <Button
-            disabled={hasCheckedRows}
+            disabled={!hasCheckedEditables}
             color="blue"
             content={Translate.string('Assign to myself')}
           />
-          <Button disabled={hasCheckedRows} content={Translate.string('Download all files')} />
+          <Button
+            disabled={!hasCheckedEditables}
+            content={Translate.string('Download all files')}
+          />
         </div>
         <Search disabled={!sortedList.length} />
       </div>
@@ -217,14 +221,19 @@ function EditableListDisplay({editableList, codePresent, editableType, eventId})
                   width={30}
                   headerRenderer={() => (
                     <Checkbox
-                      indeterminate={checked.length > 0 && checked.length < sortedList.length}
-                      checked={checked.length === sortedList.length}
+                      indeterminate={checked.length > 0 && checked.length < editables.length}
+                      checked={checked.length === editables.length}
                       onChange={(e, data) => toggleSelectAll(data.checked)}
                     />
                   )}
                   cellRenderer={({rowIndex}) => (
                     <Checkbox
-                      checked={checked.includes(sortedList[rowIndex].id)}
+                      disabled={!sortedList[rowIndex].editable}
+                      checked={
+                        sortedList[rowIndex].editable
+                          ? checked.includes(sortedList[rowIndex].editable.id)
+                          : false
+                      }
                       onChange={(e, data) => toggleSelectRow(data.index)}
                       index={rowIndex}
                     />

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -41,12 +41,12 @@ export default function EditableList() {
   const {data: editableList, loading: isLoadingEditableList} = useIndicoAxios({
     url: editableListURL({confId: eventId, type}),
     camelize: true,
-    trigger: eventId,
+    trigger: [eventId, type],
   });
   const {data: editors, loading: isLoadingEditors} = useIndicoAxios({
     url: editorsURL({confId: eventId, type}),
     camelize: true,
-    trigger: eventId,
+    trigger: [eventId, type],
   });
   if (isLoadingEditableList || isLoadingEditors) {
     return <Loader inline="centered" active />;

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -194,7 +194,7 @@ function EditableListDisplay({editableList, codePresent, editableType, eventId})
   return (
     <>
       <ManagementPageSubTitle title={title} />
-      <ManagementPageBackButton url={dashboardURL({confId: eventId})} />
+      <ManagementPageBackButton url={editableTypeURL({confId: eventId, type: editableType})} />
       <div styleName="editable-topbar">
         <div>
           <Button disabled={!hasCheckedEditables} content={Translate.string('Assign')} />

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -7,6 +7,7 @@
 
 import dashboardURL from 'indico-url:event_editing.dashboard';
 import editableListURL from 'indico-url:event_editing.api_editable_list';
+import editablesArchiveURL from 'indico-url:event_editing.api_prepare_editables_archive';
 
 import React, {useState} from 'react';
 import PropTypes from 'prop-types';
@@ -22,6 +23,7 @@ import {
 import {useNumericParam} from 'indico/react/util/routing';
 import {Translate} from 'indico/react/i18n';
 import {useIndicoAxios} from 'indico/react/hooks';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {userPropTypes} from '../../editing/timeline/util';
 import {EditableType} from '../../models';
 import StateIndicator from '../../editing/timeline/StateIndicator';
@@ -174,6 +176,21 @@ function EditableListDisplay({editableList, codePresent, editableType, eventId})
     }
   };
 
+  const downloadAllFiles = async () => {
+    let response;
+    try {
+      response = await indicoAxios.post(
+        editablesArchiveURL({confId: eventId, type: editableType}),
+        {editables: checked}
+      );
+    } catch (error) {
+      handleAxiosError(error);
+      return;
+    }
+
+    location.href = response.data.download_url;
+  };
+
   return (
     <>
       <ManagementPageSubTitle title={title} />
@@ -191,6 +208,7 @@ function EditableListDisplay({editableList, codePresent, editableType, eventId})
           <Button
             disabled={!hasCheckedEditables}
             content={Translate.string('Download all files')}
+            onClick={downloadAllFiles}
           />
         </div>
         <Search disabled={!sortedList.length} />

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -56,7 +56,7 @@ export default function EditableList() {
   const codePresent = Object.values(editableList).some(c => c.code);
   return (
     <EditableListDisplay
-      editableList={editableList}
+      initialEditableList={editableList}
       codePresent={codePresent}
       editableType={type}
       eventId={eventId}
@@ -65,16 +65,10 @@ export default function EditableList() {
   );
 }
 
-function EditableListDisplay({
-  editableList: origEditableList,
-  codePresent,
-  editableType,
-  eventId,
-  editors,
-}) {
+function EditableListDisplay({initialEditableList, codePresent, editableType, eventId, editors}) {
   const [sortBy, setSortBy] = useState('friendly_id');
   const [sortDirection, setSortDirection] = useState('ASC');
-  const [editableList, setEditableList] = useState(origEditableList);
+  const [editableList, setEditableList] = useState(initialEditableList);
   const [sortedList, setSortedList] = useState(editableList);
   const [checked, setChecked] = useState([]);
   const editables = editableList.filter(x => x.editable);
@@ -246,28 +240,24 @@ function EditableListDisplay({
     }
   };
 
-  const assignEditor = async editor => {
-    setActiveRequest('assign');
-    const rv = await checkedEditablesRequest(assignEditorURL, {editor});
+  const updateCheckedEditablesRequest = async (type, urlFunc, data = {}) => {
+    setActiveRequest(type);
+    const rv = await checkedEditablesRequest(urlFunc, data);
     if (rv) {
       patchList(rv);
     }
   };
 
-  const assignSelfEditor = async () => {
-    setActiveRequest('assign-self');
-    const rv = await checkedEditablesRequest(assignSelfEditorURL);
-    if (rv) {
-      patchList(rv);
-    }
+  const assignEditor = editor => {
+    updateCheckedEditablesRequest('assign', assignEditorURL, {editor});
+  };
+
+  const assignSelfEditor = () => {
+    updateCheckedEditablesRequest('assign-self', assignSelfEditorURL);
   };
 
   const unassignEditor = async () => {
-    setActiveRequest('unassign');
-    const rv = await checkedEditablesRequest(unassignEditorURL);
-    if (rv) {
-      patchList(rv);
-    }
+    updateCheckedEditablesRequest('unassign', unassignEditorURL);
   };
 
   return (
@@ -284,9 +274,7 @@ function EditableListDisplay({
               value={null}
               selectOnBlur={false}
               selectOnNavigation={false}
-              onChange={(evt, {value}) => {
-                assignEditor(value);
-              }}
+              onChange={(evt, {value}) => assignEditor(value)}
               trigger={
                 <Button icon loading={activeRequest === 'assign'}>
                   <Translate>Assign</Translate>
@@ -386,7 +374,7 @@ function EditableListDisplay({
 }
 
 EditableListDisplay.propTypes = {
-  editableList: PropTypes.arrayOf(
+  initialEditableList: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.number.isRequired,
       friendlyId: PropTypes.number.isRequired,

--- a/indico/modules/events/editing/controllers/backend/management.py
+++ b/indico/modules/events/editing/controllers/backend/management.py
@@ -21,8 +21,9 @@ from indico.modules.events.editing.operations import (create_new_file_type, crea
                                                       update_file_type, update_review_condition, update_tag)
 from indico.modules.events.editing.schemas import (EditableFileTypeArgs, EditableTagArgs, EditableTypeArgs,
                                                    EditableTypePrincipalsSchema, EditingFileTypeSchema,
-                                                   EditingReviewConditionArgs, EditingTagSchema)
+                                                   EditingReviewConditionArgs, EditingTagSchema, EditingUserSchema)
 from indico.modules.events.editing.settings import editable_type_settings, editing_settings
+from indico.modules.events.editing.util import get_editors
 from indico.modules.events.logs import EventLogKind, EventLogRealm
 from indico.util.i18n import _, orig_string
 from indico.web.args import use_kwargs, use_rh_args, use_rh_kwargs
@@ -189,6 +190,12 @@ class RHEditableTypePrincipals(RHEditableTypeManagementBase):
         for p in old_principals - principals:
             self.event.update_principal(p, del_permissions={permission_name})
         return '', 204
+
+
+class RHEditableTypeEditors(RHEditableTypeManagementBase):
+    def _process(self):
+        users = get_editors(self.event, self.editable_type)
+        return EditingUserSchema(many=True).jsonify(users)
 
 
 class RHEditableSetSubmission(RHEditableTypeManagementBase):

--- a/indico/modules/events/editing/util.py
+++ b/indico/modules/events/editing/util.py
@@ -1,0 +1,19 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2020 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+def get_editors(event, editable_type):
+    """Get all users who are editors in the event.
+
+    Other principal types are automatically resolved to the actual users
+    contained in them.
+    """
+    users = set()
+    for principal in event.acl_entries:
+        if not principal.has_management_permission(editable_type.editor_permission, explicit=True):
+            continue
+        users.update(principal.get_users())
+    return users

--- a/indico/web/client/js/jquery/widgets/misc.js
+++ b/indico/web/client/js/jquery/widgets/misc.js
@@ -190,10 +190,10 @@
         }
 
         if (windowpos > eloffset.top) {
-          elem.addClass('scrolling');
+          elem.addClass('sticky-scrolling');
           return false;
         } else {
-          elem.removeClass('scrolling');
+          elem.removeClass('sticky-scrolling');
           return true;
         }
       };

--- a/indico/web/client/js/legacy/libs/indico/Core/Effects.js
+++ b/indico/web/client/js/legacy/libs/indico/Core/Effects.js
@@ -15,20 +15,20 @@ IndicoUI.Effect = {
       var eloffset = $(this).data('original-offset');
       var windowpos = $(window).scrollTop();
       if (windowpos > eloffset.top) {
-        if (!$(this).hasClass('scrolling')) {
+        if (!$(this).hasClass('sticky-scrolling')) {
           $(this).data({
             'original-left': $(this).css('left'),
             'original-width': $(this).css('width'),
           });
           $(this).css('width', $(this).width());
           $(this).css('left', eloffset.left);
-          $(this).addClass('scrolling');
+          $(this).addClass('sticky-scrolling');
         }
       } else {
-        if ($(this).hasClass('scrolling')) {
+        if ($(this).hasClass('sticky-scrolling')) {
           $(this).css('left', $(this).data('original-left'));
           $(this).css('width', $(this).data('original-width'));
-          $(this).removeClass('scrolling');
+          $(this).removeClass('sticky-scrolling');
         }
       }
     });

--- a/indico/web/client/styles/legacy/Default.css
+++ b/indico/web/client/styles/legacy/Default.css
@@ -654,7 +654,7 @@ body.cke_show_borders {
   color: red;
 }
 
-.scrolling {
+.sticky-scrolling {
   background-color: #fff;
   box-shadow: 0 12px 6px -6px rgba(0, 0, 0, 0.2);
   position: fixed;

--- a/indico/web/client/styles/modules/_timetable.scss
+++ b/indico/web/client/styles/modules/_timetable.scss
@@ -68,7 +68,7 @@
   z-index: 1;
   box-sizing: initial;
 
-  &.scrolling {
+  &.sticky-scrolling {
     @include single-box-shadow();
     position: fixed;
     top: 1px;

--- a/indico/web/client/styles/partials/_main.scss
+++ b/indico/web/client/styles/partials/_main.scss
@@ -183,7 +183,7 @@ div.session-bar {
     }
   }
 
-  &.scrolling {
+  &.sticky-scrolling {
     background-color: transparent;
     box-shadow: none;
     right: 0;

--- a/indico/web/client/styles/partials/_toolbars.scss
+++ b/indico/web/client/styles/partials/_toolbars.scss
@@ -10,7 +10,7 @@ $toolbar-thin-height: 1.9em;
 $toolbar-spacing: 10px;
 $i-button-spacing: 0.3rem;
 
-.scrolling .toolbar {
+.sticky-scrolling .toolbar {
   margin: 0.5em 0 0.5em 0;
 }
 


### PR DESCRIPTION
Connect the action buttons above the editable list to the actions (which have already been implemented in the backend).

We also need to find a solution for updating the displayed list after performing an action. I don't think reloading the whole list after every action would be OK here since it may be large and thus take a few moments.

depends on #4460

---

Keeping the list in state is a bit ugly, but I didn't want to spend time on any kind of big refactoring in this component during the task. And since we never change the `eventId` prop we won't have a case where the initial list is reloaded but the state still has a stale version.