### PR TITLE
Remove obsolete default_group_provider

### DIFF
--- a/docs/source/config/auth.rst
+++ b/docs/source/config/auth.rst
@@ -64,11 +64,6 @@ The following keys are available in the provider data:
   providers you have installed.
 - ``title`` -- The title of the provider (shown in the account list
   of the user profile).  If omitted, the provider name is used.
-- ``default_group_provider`` -- If you have any providers which have
-  group support (usually the case for LDAP), you should enable this
-  for exactly one provider.  This is used by legacy parts of Indico
-  such as the room booking module which support groups but only take
-  a group name and no information from which provider to get them.
 - ``trusted_email`` -- Set this to ``True`` if all email addresses
   received from the provider are trustworthy, i.e. if it is guaranteed
   that an email address actually belongs to the user (either because
@@ -193,7 +188,6 @@ for your own config and then adapt it to your own environment:
                 'phone': 'telephoneNumber'
             },
             'trusted_email': True,
-            'default_group_provider': True,
             'synced_fields': {'first_name', 'last_name', 'affiliation', 'phone', 'address'}
         }
     }

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -7,8 +7,6 @@
 
 from __future__ import unicode_literals
 
-from warnings import warn
-
 from flask import current_app, request
 from flask_multipass import InvalidCredentials, Multipass, NoSuchUser
 
@@ -30,17 +28,6 @@ class IndicoMultipass(Multipass):
         """The default form-based auth provider."""
         return next((p for p in self.auth_providers.itervalues() if not p.is_external and p.settings.get('default')),
                     None)
-
-    @property
-    def default_group_provider(self):
-        """The default group provider.
-
-        This is an identity provider which supports groups and which
-        is used in places where only a group name can be specified,
-        such as legacy data or room ACLs.
-        """
-        return next((p for p in self.identity_providers.itervalues()
-                     if p.supports_groups and p.settings.get('default_group_provider')), None)
 
     @property
     def sync_provider(self):
@@ -71,10 +58,6 @@ class IndicoMultipass(Multipass):
             self._check_default_provider()
 
     def _check_default_provider(self):
-        # Warn if there is no default group provider
-        if not self.default_group_provider and any(p.supports_groups for p in self.identity_providers.itervalues()):
-            warn('There is no default group provider but you have providers with group support. '
-                 'This will break legacy ACLs referencing external groups and room ACLs will use local group IDs.')
         # Ensure that there is maximum one sync provider
         sync_providers = [p for p in self.identity_providers.itervalues() if p.settings.get('synced_fields')]
         if len(sync_providers) > 1:

--- a/indico/modules/groups/core.py
+++ b/indico/modules/groups/core.py
@@ -108,20 +108,6 @@ class GroupProxy(object):
         raise NotImplementedError
 
     @classmethod
-    def get_named_default_group(cls, name):
-        """Gets the group with the matching name from the default group provider.
-
-        If there is no default group provider, local groups will be
-        used and `name` is the group's ID.
-
-        This method should only be used for legacy code or code that
-        gets the group name from an external source which does not
-        contain a provider identifier.
-        """
-        group_provider = multipass.default_group_provider
-        return cls(name, group_provider.name if group_provider else None)
-
-    @classmethod
     def search(cls, name, exact=False, providers=None):
         """Searches for groups
 
@@ -234,7 +220,7 @@ class _MultipassGroupProxy(GroupProxy):
     @cached_property
     def as_legacy_group(self):
         from indico.modules.groups.legacy import LDAPGroupWrapper
-        return LDAPGroupWrapper(self.name)
+        return LDAPGroupWrapper(self.name, self.provider)
 
     @property
     def provider_title(self):


### PR DESCRIPTION
It was mainly needed in the past for legacy-roombooking, but since that's long gone there is no real need for it anymore.

The legacy group search API (which is still used) now properly includes the group name without having to fall back to the default.

The updated two-year-old alembic revision is untested; it will require an x-arg when doing an `indico db upgrade` straight from 2.1 to 2.3 in case there were any rooms (not very common) with booking/manager groups set (even less common).