### PR TITLE
Allow resetting registration moderation status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,8 @@ Improvements
 - Refactor the room edit modal to a tabbed layout and improve error
   handling (:issue:`4408`)
 - Preserve non-ascii characters in file names (:issue:`4465`)
+- Allow resetting moderation state from registration management view
+  (:issue:`4498`, thanks :user:`omegak`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -71,6 +71,8 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:regi
                  'approve_registration', reglists.RHRegistrationApprove, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/reject',
                  'reject_registration', reglists.RHRegistrationReject, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/reset',
+                 'reset_registration', reglists.RHRegistrationReset, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/check-in',
                  'registration_check_in', reglists.RHRegistrationCheckIn, methods=('PUT', 'DELETE'))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/email', 'email_registrants',

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -565,6 +565,20 @@ class RHRegistrationReject(RHManageRegistrationBase):
         return jsonify_data(html=_render_registration_details(self.registration))
 
 
+class RHRegistrationReset(RHManageRegistrationBase):
+    """Reset a registration back to a non-approved status"""
+
+    def _process(self):
+        if self.registration.state in (RegistrationState.complete, RegistrationState.unpaid):
+            self.registration.update_state(approved=False)
+        elif self.registration.state == RegistrationState.rejected:
+            self.registration.update_state(rejected=False)
+        else:
+            raise BadRequest(_('The registration cannot be reset in its current state.'))
+        logger.info('Registration %r was reset by %r', self.registration, session.user)
+        return jsonify_data(html=_render_registration_details(self.registration))
+
+
 class RHRegistrationCheckIn(RHManageRegistrationBase):
     """Set checked in state of a registration"""
 

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -470,7 +470,7 @@ class Registration(db.Model):
         moderation_required = (regform.moderation_enabled and not _skip_moderation and
                                (not invitation or not invitation.skip_moderation))
         with db.session.no_autoflush:
-            payment_required = regform.event.has_feature('payment') and self.price
+            payment_required = regform.event.has_feature('payment') and bool(self.price)
         if self.state == RegistrationState.pending:
             if approved and payment_required:
                 self.state = RegistrationState.unpaid
@@ -488,6 +488,11 @@ class Registration(db.Model):
                 self.state = RegistrationState.pending
             elif paid is False and payment_required:
                 self.state = RegistrationState.unpaid
+        elif self.state == RegistrationState.rejected:
+            if rejected is False and moderation_required:
+                self.state = RegistrationState.pending
+            elif rejected is False and not moderation_required:
+                self.state = RegistrationState.complete
         if self.state != initial_state:
             signals.event.registration_state_updated.send(self, previous_state=initial_state)
 

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -491,7 +491,9 @@ class Registration(db.Model):
         elif self.state == RegistrationState.rejected:
             if rejected is False and moderation_required:
                 self.state = RegistrationState.pending
-            elif rejected is False and not moderation_required:
+            elif rejected is False and payment_required:
+                self.state = RegistrationState.unpaid
+            elif rejected is False:
                 self.state = RegistrationState.complete
         if self.state != initial_state:
             signals.event.registration_state_updated.send(self, previous_state=initial_state)

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -189,12 +189,12 @@
 
 {% macro _render_reset_registration_button(registration, action_text) %}
     <a class="i-button warning"
-        data-update="#registration-details"
-        data-method="POST"
-        data-href="{{ url_for('.reset_registration', registration) }}"
-        data-confirm="{% trans %}Are you sure you want to reset this registration status? This action will not be notified to the registrant.{% endtrans %}"
-        data-title="{{ action_text }}">
-        {{ action_text }}
+       data-update="#registration-details"
+       data-method="POST"
+       data-href="{{ url_for('.reset_registration', registration) }}"
+       data-confirm="{% trans %}Are you sure you want to reset this registration status? This action will not be notified to the registrant.{% endtrans %}"
+       data-title="{{ action_text }}">
+       {{ action_text }}
     </a>
 {% endmacro %}
 

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -13,7 +13,7 @@
                 {% elif registration.state.name == 'complete' %}
                     {{ _render_complete_actions(registration) }}
                 {% elif registration.state.name in ('rejected', 'withdrawn') %}
-                    {{ _render_cancalled_actions(registration) }}
+                    {{ _render_cancelled_actions(registration) }}
                 {% endif %}
             </div>
             {% if registration.state.name in ('unpaid', 'complete') %}
@@ -92,7 +92,9 @@
             <a class="i-button accept"
                data-update="#registration-details"
                data-method="POST"
-               data-href="{{ url_for('.approve_registration', registration) }}">
+               data-href="{{ url_for('.approve_registration', registration) }}"
+               data-confirm="{% trans %}Are you sure you want to approve this registration? This will trigger a notification email.{% endtrans %}"
+               data-title="{% trans %}Approve registration{% endtrans %}">
                 {%- trans %}Approve{% endtrans -%}
             </a>
         </div>
@@ -101,7 +103,7 @@
                data-update="#registration-details"
                data-method="POST"
                data-href="{{ url_for('.reject_registration', registration) }}"
-               data-confirm="{% trans %}Are you sure you want to reject this registration? This action is not reversible.{% endtrans %}"
+               data-confirm="{% trans %}Are you sure you want to reject this registration? This will trigger a notification email.{% endtrans %}"
                data-title="{% trans %}Reject registration{% endtrans %}">
                 {%- trans %}Reject{% endtrans -%}
             </a>
@@ -137,6 +139,9 @@
                     {% trans %}Mark as paid{% endtrans %}
                 </a>
             </div>
+            {% if registration.registration_form.moderation_enabled %}
+                {{ _render_reset_registration_button(registration, _('Reset approval')) }}
+            {% endif %}
         </div>
     {% endif %}
 {% endmacro %}
@@ -151,17 +156,24 @@
             Submitted: {{ submitted }}
         {%- endtrans %}
     </div>
-    {% if registration.registration_form.tickets_enabled and not registration.is_ticket_blocked %}
+    {% set can_reset = registration.registration_form.moderation_enabled and not registration.is_paid %}
+    {% set can_get_ticket = registration.registration_form.tickets_enabled and not registration.is_ticket_blocked %}
+    {% if can_reset or can_get_ticket %}
         <div class="toolbar">
-            <a href="{{ url_for('.ticket_download', registration.locator.registrant) }}" class="i-button accept icon-ticket">
-                {% trans %}Get ticket{% endtrans %}
-            </a>
+            {% if can_reset %}
+                {{ _render_reset_registration_button(registration, _('Reset approval')) }}
+            {% endif %}
+            {% if can_get_ticket %}
+                <a href="{{ url_for('.ticket_download', registration.locator.registrant) }}" class="i-button accept icon-ticket">
+                    {% trans %}Get ticket{% endtrans %}
+                </a>
+            {% endif %}
         </div>
     {% endif %}
 {% endmacro %}
 
 
-{% macro _render_cancalled_actions(registration) %}
+{% macro _render_cancelled_actions(registration) %}
     <div class="text">
         <div class="label">
             {% trans state=registration.state.title|lower -%}
@@ -169,6 +181,23 @@
             {%- endtrans %}
         </div>
     </div>
+    {% if registration.registration_form.moderation_enabled %}
+        <div class="toolbar hide-if-locked">
+            {{ _render_reset_registration_button(registration, _('Reset rejection')) }}
+        </div>
+    {% endif %}
+{% endmacro %}
+
+
+{% macro _render_reset_registration_button(registration, action_text) %}
+    <a class="i-button warning"
+        data-update="#registration-details"
+        data-method="POST"
+        data-href="{{ url_for('.reset_registration', registration) }}"
+        data-confirm="{% trans %}Are you sure you want to reset this registration status? This action will not be notified to the registrant.{% endtrans %}"
+        data-title="{{ action_text }}">
+        {{ action_text }}
+    </a>
 {% endmacro %}
 
 

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -181,11 +181,9 @@
             {%- endtrans %}
         </div>
     </div>
-    {% if registration.registration_form.moderation_enabled %}
-        <div class="toolbar hide-if-locked">
-            {{ _render_reset_registration_button(registration, _('Reset rejection')) }}
-        </div>
-    {% endif %}
+    <div class="toolbar hide-if-locked">
+        {{ _render_reset_registration_button(registration, _('Reset rejection')) }}
+    </div>
 {% endmacro %}
 
 

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -153,7 +153,7 @@
                                    data-href="{{ url_for('.registrations_modify_status', regform) }}"
                                    data-flag="1"
                                    data-method="POST"
-                                   data-confirm="{% trans %}Do you really want to approve the selected registrations?{% endtrans %}">
+                                   data-confirm="{% trans %}Do you really want to approve the selected registrations? This will trigger a notification email for each registrant.{% endtrans %}">
                                     {%- trans %}Approve registrations{% endtrans -%}
                                 </a>
                             </li>
@@ -162,7 +162,7 @@
                                    data-href="{{ url_for('.registrations_modify_status', regform) }}"
                                    data-flag="0"
                                    data-method="POST"
-                                   data-confirm="{% trans %}Do you really want to reject the selected registrations?{% endtrans %}">
+                                   data-confirm="{% trans %}Do you really want to reject the selected registrations? This will trigger a notification email for each registrant.{% endtrans %}">
                                     {%- trans %}Reject registrations{% endtrans -%}
                                 </a>
                             </li>


### PR DESCRIPTION
This PR introduces the possibility for managers to reset the approval state of a given registration from the registration details view. The button is displayed as part of available actions for "complete" registrations only if registration form moderation is enabled.

## Screenshot

![image](https://user-images.githubusercontent.com/716307/84918150-892f2880-b0c0-11ea-909a-09362873c335.png)

