### PR TITLE
Update new Editing view

### DIFF
--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -30,6 +30,7 @@ _bp.add_url_rule('/manage/editing/<any(paper,slides,poster):type>/review-conditi
 # Frontend (timeline)
 contrib_prefix = '/contributions/<int:contrib_id>/editing/<any(paper,slides,poster):type>'
 _bp.add_url_rule(contrib_prefix, 'editable', frontend.RHEditableTimeline)
+_bp.add_url_rule('/editing/<any(paper,slides,poster):type>/list', 'editable_type_list', frontend.RHEditableTypeList)
 _bp.add_url_rule(contrib_prefix + '/<int:revision_id>/files.zip', 'revision_files_export',
                  timeline.RHExportRevisionFiles)
 _bp.add_url_rule(contrib_prefix + '/<int:revision_id>/<int:file_id>/<filename>', 'download_file',

--- a/indico/modules/events/editing/client/js/editing/ReduxTimeline.jsx
+++ b/indico/modules/events/editing/client/js/editing/ReduxTimeline.jsx
@@ -1,0 +1,40 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Provider} from 'react-redux';
+import createReduxStore from 'indico/utils/redux';
+import {fileTypePropTypes} from './timeline/FileManager/util';
+
+import Timeline from './timeline';
+import reducer from './timeline/reducer';
+
+export default function ReduxTimeline({storeData}) {
+  const store = createReduxStore(
+    'editing-timeline',
+    {timeline: reducer},
+    {
+      staticData: storeData,
+    }
+  );
+  return (
+    <Provider store={store}>
+      <Timeline />
+    </Provider>
+  );
+}
+
+ReduxTimeline.propTypes = {
+  storeData: PropTypes.shape({
+    eventId: PropTypes.number.isRequired,
+    contributionId: PropTypes.number.isRequired,
+    contributionCode: PropTypes.string.isRequired,
+    fileTypes: PropTypes.arrayOf(PropTypes.shape(fileTypePropTypes)).isRequired,
+    editableType: PropTypes.string.isRequired,
+  }).isRequired,
+};

--- a/indico/modules/events/editing/client/js/editing/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/index.jsx
@@ -75,7 +75,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   ReactDOM.render(
     <Provider store={store}>
-      <EditingView eventId={eventId} eventTitle={eventTitle}>
+      <EditingView eventId={eventId} eventTitle={eventTitle} editableType={editableType}>
         <Timeline />
       </EditingView>
     </Provider>,

--- a/indico/modules/events/editing/client/js/editing/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/index.jsx
@@ -11,15 +11,12 @@ import tagsURL from 'indico-url:event_editing.api_tags';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {Provider} from 'react-redux';
 
 import {camelizeKeys} from 'indico/utils/case';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
-import createReduxStore from 'indico/utils/redux';
 
 import EditingView from './page_layout';
-import Timeline from './timeline';
-import reducer from './timeline/reducer';
+import ReduxTimeline from './ReduxTimeline';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const editingElement = document.querySelector('#editing-view');
@@ -53,32 +50,24 @@ document.addEventListener('DOMContentLoaded', async () => {
     return;
   }
 
-  const store = createReduxStore(
-    'editing-timeline',
-    {timeline: reducer},
-    {
-      staticData: {
-        eventId,
-        contributionId,
-        contributionCode,
-        editableType,
-        fileTypes,
-        tags,
-        editableDetailsURL: editableDetailsURL({
-          confId: eventId,
-          contrib_id: contributionId,
-          type: editableType,
-        }),
-      },
-    }
-  );
+  const storeData = {
+    eventId,
+    contributionId,
+    contributionCode,
+    editableType,
+    fileTypes,
+    tags,
+    editableDetailsURL: editableDetailsURL({
+      confId: eventId,
+      contrib_id: contributionId,
+      type: editableType,
+    }),
+  };
 
   ReactDOM.render(
-    <Provider store={store}>
-      <EditingView eventId={eventId} eventTitle={eventTitle} editableType={editableType}>
-        <Timeline />
-      </EditingView>
-    </Provider>,
+    <EditingView eventId={eventId} eventTitle={eventTitle} editableType={editableType}>
+      <ReduxTimeline storeData={storeData} />
+    </EditingView>,
     editingElement
   );
 });

--- a/indico/modules/events/editing/client/js/editing/page_layout/EditingView.jsx
+++ b/indico/modules/events/editing/client/js/editing/page_layout/EditingView.jsx
@@ -16,7 +16,7 @@ import Footer from './Footer';
 
 import './EditingView.module.scss';
 
-export default function EditingView({eventId, eventTitle, children}) {
+export default function EditingView({eventId, eventTitle, editableType, children}) {
   const {data, lastData} = useIndicoAxios({
     url: menuEntriesURL({confId: eventId}),
     trigger: eventId,
@@ -29,7 +29,12 @@ export default function EditingView({eventId, eventTitle, children}) {
 
   return (
     <div styleName="editing-view">
-      <MenuBar eventId={eventId} eventTitle={eventTitle} menuItems={menuItems} />
+      <MenuBar
+        eventId={eventId}
+        eventTitle={eventTitle}
+        menuItems={menuItems}
+        editableType={editableType}
+      />
       <div styleName="contents">
         <div styleName="timeline">
           <Header as="h2" styleName="header">
@@ -46,5 +51,6 @@ export default function EditingView({eventId, eventTitle, children}) {
 EditingView.propTypes = {
   eventId: PropTypes.number.isRequired,
   eventTitle: PropTypes.string.isRequired,
+  editableType: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
 };

--- a/indico/modules/events/editing/client/js/editing/page_layout/EditingView.jsx
+++ b/indico/modules/events/editing/client/js/editing/page_layout/EditingView.jsx
@@ -7,16 +7,20 @@
 import menuEntriesURL from 'indico-url:event_editing.api_menu_entries';
 
 import React from 'react';
+import {useParams} from 'react-router-dom';
 import PropTypes from 'prop-types';
 import {Header} from 'semantic-ui-react';
 import {useIndicoAxios} from 'indico/react/hooks';
+import {useNumericParam} from 'indico/react/util/routing';
 
 import MenuBar from './MenuBar';
 import Footer from './Footer';
 
 import './EditingView.module.scss';
 
-export default function EditingView({eventId, eventTitle, editableType, children}) {
+export default function EditingView({eventTitle, children}) {
+  const eventId = useNumericParam('confId');
+  const {type} = useParams();
   const {data, lastData} = useIndicoAxios({
     url: menuEntriesURL({confId: eventId}),
     trigger: eventId,
@@ -29,12 +33,7 @@ export default function EditingView({eventId, eventTitle, editableType, children
 
   return (
     <div styleName="editing-view">
-      <MenuBar
-        eventId={eventId}
-        eventTitle={eventTitle}
-        menuItems={menuItems}
-        editableType={editableType}
-      />
+      <MenuBar eventId={eventId} menuItems={menuItems} editableType={type} />
       <div styleName="contents">
         <div styleName="timeline">
           <Header as="h2" styleName="header">
@@ -49,8 +48,6 @@ export default function EditingView({eventId, eventTitle, editableType, children
 }
 
 EditingView.propTypes = {
-  eventId: PropTypes.number.isRequired,
   eventTitle: PropTypes.string.isRequired,
-  editableType: PropTypes.string.isRequired,
   children: PropTypes.node.isRequired,
 };

--- a/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.jsx
+++ b/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.jsx
@@ -6,8 +6,10 @@
 // LICENSE file for more details.
 import managementURL from 'indico-url:event_management.settings';
 import displayURL from 'indico-url:events.display';
+import editableTypeListURL from 'indico-url:event_editing.editable_type_list';
 
 import React from 'react';
+import {Link} from 'react-router-dom';
 import PropTypes from 'prop-types';
 import {Header, Icon, Menu} from 'semantic-ui-react';
 import {Translate} from 'indico/react/i18n';
@@ -16,12 +18,39 @@ import {EditableType, EditableEditingTitles} from '../../models';
 
 import './MenuBar.module.scss';
 
+function EditableListMenu({eventId, editableType}) {
+  if (location.pathname === editableTypeListURL({confId: eventId, type: editableType})) {
+    return (
+      <Menu vertical>
+        <Menu.Item active>
+          <Translate>Editable list</Translate>
+        </Menu.Item>
+      </Menu>
+    );
+  }
+  return (
+    <Menu vertical>
+      <Menu.Item as={Link} to={editableTypeListURL({confId: eventId, type: editableType})}>
+        <span style={{color: Palette.blue}}>
+          <Translate>Editable list</Translate>
+        </span>
+      </Menu.Item>
+    </Menu>
+  );
+}
+
+EditableListMenu.propTypes = {
+  eventId: PropTypes.number.isRequired,
+  editableType: PropTypes.oneOf(Object.values(EditableType)).isRequired,
+};
+
 export default function MenuBar({eventId, menuItems, editableType}) {
   return (
     <div styleName="menu-bar">
       <Header as="h2" styleName="header">
         {EditableEditingTitles[editableType]}
       </Header>
+      <EditableListMenu eventId={eventId} editableType={editableType} />
       <Menu vertical>
         <Menu.Item header>
           <span styleName="capitalized" style={{color: Palette.black}}>
@@ -67,5 +96,5 @@ const menuEntryPropTypes = {
 MenuBar.propTypes = {
   eventId: PropTypes.number.isRequired,
   menuItems: PropTypes.arrayOf(PropTypes.shape(menuEntryPropTypes)).isRequired,
-  editableType: PropTypes.oneOf(EditableType).isRequired,
+  editableType: PropTypes.oneOf(Object.values(EditableType)).isRequired,
 };

--- a/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.jsx
+++ b/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.jsx
@@ -9,55 +9,51 @@ import displayURL from 'indico-url:events.display';
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Header, Icon} from 'semantic-ui-react';
+import {Header, Icon, Menu} from 'semantic-ui-react';
 import {Translate} from 'indico/react/i18n';
+import Palette from 'indico/utils/palette';
+import {EditableType, EditableEditingTitles} from '../../models';
 
 import './MenuBar.module.scss';
 
-export default function MenuBar({eventId, menuItems}) {
+export default function MenuBar({eventId, menuItems, editableType}) {
   return (
     <div styleName="menu-bar">
       <Header as="h2" styleName="header">
-        <Translate>Paper Editing</Translate>
+        {EditableEditingTitles[editableType]}
       </Header>
-      <ul styleName="list">
-        <li>
-          <span styleName="capitalized">
+      <Menu vertical>
+        <Menu.Item header>
+          <span styleName="capitalized" style={{color: Palette.black}}>
             <Translate>other modules</Translate>
           </span>
-          <ul styleName="inner-list">
-            {menuItems.map(item => (
-              <a key={item.name} href={item.url}>
-                <li styleName="inner-list-item">
-                  {item.icon && <Icon name={item.icon.replace('icon-', '')} />}
-                  {item.title}
-                </li>
-              </a>
-            ))}
-          </ul>
-        </li>
-      </ul>
-      <ul styleName="list">
-        <li>
-          <span styleName="capitalized">
+        </Menu.Item>
+        {menuItems.map(item => (
+          <Menu.Item key={item.name} name={item.name} as="a" href={item.url}>
+            <span style={{color: Palette.blue}}>
+              {item.icon && <Icon name={item.icon.replace('icon-', '')} />}
+              {item.title}
+            </span>
+          </Menu.Item>
+        ))}
+      </Menu>
+      <Menu vertical>
+        <Menu.Item header>
+          <span styleName="capitalized" style={{color: Palette.black}}>
             <Translate>other views</Translate>
           </span>
-          <ul styleName="inner-list">
-            <a href={displayURL({confId: eventId})}>
-              <li styleName="inner-list-item">
-                <Icon name="tv" />
-                <Translate>Display</Translate>
-              </li>
-            </a>
-            <a href={managementURL({confId: eventId})}>
-              <li styleName="inner-list-item">
-                <Icon name="pencil" />
-                <Translate>Management</Translate>
-              </li>
-            </a>
-          </ul>
-        </li>
-      </ul>
+        </Menu.Item>
+        <Menu.Item name="display" as="a" href={displayURL({confId: eventId})}>
+          <span style={{color: Palette.blue}}>
+            <Icon name="tv" /> <Translate>Display</Translate>
+          </span>
+        </Menu.Item>
+        <Menu.Item name="management" as="a" href={managementURL({confId: eventId})}>
+          <span style={{color: Palette.blue}}>
+            <Icon name="pencil" /> <Translate>Management</Translate>
+          </span>
+        </Menu.Item>
+      </Menu>
     </div>
   );
 }
@@ -71,4 +67,5 @@ const menuEntryPropTypes = {
 MenuBar.propTypes = {
   eventId: PropTypes.number.isRequired,
   menuItems: PropTypes.arrayOf(PropTypes.shape(menuEntryPropTypes)).isRequired,
+  editableType: PropTypes.oneOf(EditableType).isRequired,
 };

--- a/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.module.scss
+++ b/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.module.scss
@@ -7,40 +7,17 @@
 
 @import 'base/palette';
 
-$header-height: calc(100vh - var(--header-height) * 1px);
-
 .menu-bar {
   color: $white;
-  background-color: $light-purple;
   padding: 20px 30px;
   margin-right: 25px;
-  max-width: 200px;
-  min-height: $header-height;
 
   .header {
+    border-radius: 3px;
+    background-color: $dark-blue;
+    text-align: center;
+    padding: 0.5rem;
     color: $white;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
-
-  .list {
-    margin-top: 15px;
-    list-style-type: none;
-    padding-inline-start: 0;
-
-    li .inner-list {
-      list-style-type: none;
-      padding-inline-start: 20px;
-    }
-
-    li .inner-list a .inner-list-item {
-      padding-top: 5px;
-      color: $light-gray;
-
-      &:hover {
-        color: $black;
-      }
-    }
   }
 }
 

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -145,7 +145,7 @@ export function processRevisions(revisions) {
   return newRevisions;
 }
 
-export const getDetails = state => state.timeline.details;
+export const getDetails = state => (state.timeline ? state.timeline.details : null);
 export const isInitialEditableDetailsLoading = state =>
   state.timeline.loading && !state.timeline.details;
 export const getTimelineBlocks = state => state.timeline.timelineBlocks;
@@ -172,15 +172,19 @@ export const needsSubmitterConfirmation = createSelector(
 export const getStaticData = state => state.staticData;
 
 export const getFileTypes = createSelector(
+  getDetails,
   getStaticData,
-  staticData => {
+  (details, staticData) => {
     return staticData.fileTypes.map(fileType => {
       if (!fileType.filenameTemplate) {
         return fileType;
       }
       return {
         ...fileType,
-        filenameTemplate: fileType.filenameTemplate.replace('{code}', staticData.contributionCode),
+        filenameTemplate: fileType.filenameTemplate.replace(
+          '{code}',
+          details ? details.contribution.code : staticData.contributionCode
+        ),
       };
     });
   }

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -15,7 +15,7 @@ import unassignEditorURL from 'indico-url:event_editing.api_unassign_editor';
 
 import React, {useState, useMemo} from 'react';
 import PropTypes from 'prop-types';
-import {useParams} from 'react-router-dom';
+import {useParams, Link} from 'react-router-dom';
 import {Button, Icon, Input, Loader, Checkbox, Message, Dropdown} from 'semantic-ui-react';
 import {Column, Table, SortDirection, WindowScroller} from 'react-virtualized';
 import _ from 'lodash';
@@ -36,7 +36,7 @@ import StateIndicator from '../../editing/timeline/StateIndicator';
 
 import './EditableList.module.scss';
 
-export default function EditableList() {
+export default function EditableList({management}) {
   const eventId = useNumericParam('confId');
   const {type} = useParams();
   const {data: contribList, loading: isLoadingContribList} = useIndicoAxios({
@@ -62,11 +62,27 @@ export default function EditableList() {
       editableType={type}
       eventId={eventId}
       editors={editors}
+      management={management}
     />
   );
 }
 
-function EditableListDisplay({initialContribList, codePresent, editableType, eventId, editors}) {
+EditableList.propTypes = {
+  management: PropTypes.bool,
+};
+
+EditableList.defaultProps = {
+  management: true,
+};
+
+function EditableListDisplay({
+  initialContribList,
+  codePresent,
+  editableType,
+  eventId,
+  editors,
+  management,
+}) {
   const [sortBy, setSortBy] = useState('friendly_id');
   const [sortDirection, setSortDirection] = useState('ASC');
 
@@ -200,11 +216,14 @@ function EditableListDisplay({initialContribList, codePresent, editableType, eve
   };
   // eslint-disable-next-line no-shadow
   const renderTitle = (title, index) => {
-    return sortedList[index].editable ? (
-      <a href={sortedList[index].editable.timelineURL}>{title}</a>
-    ) : (
-      <div>{title}</div>
-    );
+    if (sortedList[index].editable) {
+      return management ? (
+        <a href={sortedList[index].editable.timelineURL}>{title}</a>
+      ) : (
+        <Link to={sortedList[index].editable.timelineURL}>{title}</Link>
+      );
+    }
+    return <div>{title}</div>;
   };
   const renderStatus = (editable, rowIndex) => {
     return (
@@ -311,8 +330,10 @@ function EditableListDisplay({initialContribList, codePresent, editableType, eve
 
   return (
     <>
-      <ManagementPageSubTitle title={title} />
-      <ManagementPageBackButton url={editableTypeURL({confId: eventId, type: editableType})} />
+      {management && <ManagementPageSubTitle title={title} />}
+      {management && (
+        <ManagementPageBackButton url={editableTypeURL({confId: eventId, type: editableType})} />
+      )}
       <div styleName="editable-topbar">
         <div>
           <Button.Group>
@@ -470,4 +491,5 @@ EditableListDisplay.propTypes = {
   codePresent: PropTypes.bool.isRequired,
   editableType: PropTypes.oneOf(Object.values(EditableType)).isRequired,
   eventId: PropTypes.number.isRequired,
+  management: PropTypes.bool.isRequired,
 };

--- a/indico/modules/events/editing/client/js/models.js
+++ b/indico/modules/events/editing/client/js/models.js
@@ -53,3 +53,9 @@ export const EditableStatus = {
   not_submitted: Translate.string('Not submitted'),
   ready_for_review: Translate.string('Ready for review'),
 };
+
+export const EditableEditingTitles = {
+  paper: Translate.string('Paper Editing'),
+  slides: Translate.string('Slides Editing'),
+  poster: Translate.string('Poster Editing'),
+};

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -18,7 +18,8 @@ from werkzeug.exceptions import Forbidden
 from indico.core.db import db
 from indico.legacy.common.cache import GenericCache
 from indico.modules.events.contributions.models.contributions import Contribution
-from indico.modules.events.editing.controllers.base import RHEditablesBase, RHEditableTypeManagementBase
+from indico.modules.events.editing.controllers.base import (RHEditablesBase, RHEditableTypeEditorBase,
+                                                            RHEditableTypeManagementBase)
 from indico.modules.events.editing.models.editable import Editable
 from indico.modules.events.editing.models.revision_files import EditingRevisionFile
 from indico.modules.events.editing.models.revisions import EditingRevision
@@ -34,10 +35,10 @@ from indico.web.flask.util import url_for
 archive_cache = GenericCache('editables-archive')
 
 
-class RHEditableList(RHEditableTypeManagementBase):
+class RHEditableList(RHEditableTypeEditorBase):
     """Return the list of editables of the event for a given type"""
     def _process_args(self):
-        RHEditableTypeManagementBase._process_args(self)
+        RHEditableTypeEditorBase._process_args(self)
         self.contributions = (Contribution.query
                               .with_parent(self.event)
                               .options(joinedload('editables'))

--- a/indico/modules/events/editing/controllers/base.py
+++ b/indico/modules/events/editing/controllers/base.py
@@ -76,6 +76,16 @@ class RHEditableTypeManagementBase(RHEditingManagementBase):
         self.editable_type = EditableType[request.view_args['type']]
 
 
+class RHEditableTypeEditorBase(RHEditableTypeManagementBase):
+    """Base class for editable type RHs accessible by editors."""
+
+    def _check_access(self):
+        if session.user and self.event.can_manage(session.user, self.editable_type.editor_permission):
+            # editors have access here without the need for any management permission
+            return
+        RHEditableTypeManagementBase._check_access(self)
+
+
 class RHContributionEditableBase(RequireUserMixin, RHContributionDisplayBase):
     """Base class for operations on an editable."""
 

--- a/indico/modules/events/editing/controllers/frontend.py
+++ b/indico/modules/events/editing/controllers/frontend.py
@@ -7,10 +7,10 @@
 
 from __future__ import unicode_literals
 
-from flask import request, session
+from flask import session
 from werkzeug.exceptions import Forbidden, NotFound
 
-from indico.modules.events.editing.controllers.base import (EditableType, RHContributionEditableBase, RHEditingBase,
+from indico.modules.events.editing.controllers.base import (RHContributionEditableBase, RHEditableTypeEditorBase,
                                                             RHEditingManagementBase)
 from indico.modules.events.editing.views import WPEditing, WPEditingView
 
@@ -35,25 +35,9 @@ class RHEditableTimeline(RHContributionEditableBase):
             raise Forbidden
 
     def _process(self):
-        return WPEditingView.render_template(
-            'editing.html',
-            self.event,
-        )
+        return WPEditingView.render_template('editing.html', self.event)
 
 
-class RHEditableTypeList(RHEditingBase):
-    def _process_args(self):
-        RHEditingBase._process_args(self)
-        self.editable_type = EditableType[request.view_args['type']]
-
-    def _check_access(self):
-        RHEditingBase._check_access(self)
-        if (not self.event.can_manage(session.user, self.editable_type.editor_permission)
-                and not self.event.can_manage(session.user, 'editing_manager')):
-            raise Forbidden
-
+class RHEditableTypeList(RHEditableTypeEditorBase):
     def _process(self):
-        return WPEditingView.render_template(
-            'editing.html',
-            self.event,
-        )
+        return WPEditingView.render_template('editing.html', self.event)

--- a/indico/modules/events/editing/templates/editing.html
+++ b/indico/modules/events/editing/templates/editing.html
@@ -1,7 +1,1 @@
-<div id="editing-view"
-     data-event-title="{{ event.title }}"
-     data-event-id="{{ event.id }}"
-     data-contribution-id="{{ editable.contribution.id }}"
-     data-editable-type="{{ editable.type.name }}"
-     data-contribution-code="{{ editable.contribution.code }}">
-</div>
+<div id="editing-view" data-event-title="{{ event.title }}"></div>

--- a/indico/web/client/js/utils/palette.js
+++ b/indico/web/client/js/utils/palette.js
@@ -18,6 +18,7 @@ const Palette = {
   purple: '#6e5494',
   orange: '#f80',
   olive: '#b5cc18',
+  black: '#555',
 };
 
 // colors for specific purposes


### PR DESCRIPTION
closes #4484 

Changes:
- Looks
- Only Timeline is wrapped by redux store (instead of entire EditingView)
- Added router to handle links from timeline to editable list
- Information about editable type, contribution and event are taken from router params and not WP

Issues:
- How to get `contributionCode` now that `contributionId` is taken from url parameters? Use new endpoint? (currently contribution code is hardcoded)



Timeline view:
![2](https://user-images.githubusercontent.com/17234430/85310700-9f6c2880-b4b4-11ea-8e0c-da8e4c4ba0c7.png)

Editable list view:
![1](https://user-images.githubusercontent.com/17234430/85310707-a1ce8280-b4b4-11ea-8e08-d669decc2d65.png)


