### PR TITLE
Allow filtering event log by related entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -78,6 +78,8 @@ Improvements
 - Preserve non-ascii characters in file names (:issue:`4465`)
 - Allow resetting moderation state from registration management view
   (:issue:`4498`, thanks :user:`omegak`)
+- Allow filtering event log by related entries (:issue:`4503`, thanks
+  :user:`omegak`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,6 +109,8 @@ Internal Changes
   :user:`omegak`)
 - Add ``event-management-after-title`` template hook (:issue: `4504`, thanks
   :user:`meluru`)
+- Save registration id in related event log entries (:issue:`4503`, thanks
+  :user:`omegak`)
 
 
 ----

--- a/indico/migrations/versions/20200623_1718_05f227f4b938_add_metadata_to_event_logs.py
+++ b/indico/migrations/versions/20200623_1718_05f227f4b938_add_metadata_to_event_logs.py
@@ -1,0 +1,28 @@
+"""Add metadata to event logs
+
+Revision ID: 05f227f4b938
+Revises: c0fc1e46888b
+Create Date: 2020-06-23 17:18:05.171784
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '05f227f4b938'
+down_revision = 'b6dd0a4ed40d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('logs', sa.Column('meta', postgresql.JSONB(), nullable=False, server_default='{}'),
+                  schema='events')
+    op.alter_column('logs', 'meta', server_default=None, schema='events')
+    op.create_index(None, 'logs', ['meta'], unique=False, schema='events', postgresql_using='gin')
+
+
+def downgrade():
+    op.drop_column('logs', 'meta', schema='events')

--- a/indico/modules/events/logs/client/js/actions.js
+++ b/indico/modules/events/logs/client/js/actions.js
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import qs from 'qs';
+
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 export const SET_KEYWORD = 'SET_KEYWORD';
@@ -36,6 +38,32 @@ export function setDetailedView(entryIndex) {
 
 export function setMetadataQuery(metadataQuery) {
   return {type: SET_METADATA_QUERY, metadataQuery};
+}
+
+export function clearMetadataQuery() {
+  return dispatch => {
+    dispatch(setMetadataQuery({}));
+    dispatch(setPage(1));
+    dispatch(setDetailedView(null));
+    dispatch(fetchLogEntries());
+    history.replaceState({}, null, location.pathname);
+  };
+}
+
+export function showRelatedEntries() {
+  return (dispatch, getStore) => {
+    const {
+      logs: {entries, currentViewIndex},
+    } = getStore();
+
+    const entry = entries[currentViewIndex];
+    const queryString = qs.stringify({meta: entry.meta}, {allowDots: true});
+    dispatch(setMetadataQuery(entry.meta));
+    dispatch(setPage(1));
+    dispatch(setDetailedView(null));
+    dispatch(fetchLogEntries());
+    history.replaceState({}, null, `${location.pathname}?${queryString}`);
+  };
 }
 
 export function viewPrevEntry() {

--- a/indico/modules/events/logs/client/js/actions.js
+++ b/indico/modules/events/logs/client/js/actions.js
@@ -131,7 +131,7 @@ export function fetchLogEntries() {
     const params = {
       page: currentPage,
       filters: [],
-      data: JSON.stringify(metadataQuery),
+      meta: metadataQuery,
     };
     if (keyword) {
       params.q = keyword;
@@ -145,7 +145,10 @@ export function fetchLogEntries() {
 
     let response;
     try {
-      response = await indicoAxios.get(fetchLogsUrl, {params});
+      response = await indicoAxios.get(fetchLogsUrl, {
+        params,
+        paramsSerializer: p => qs.stringify(p, {arrayFormat: 'repeat', allowDots: true}),
+      });
     } catch (error) {
       handleAxiosError(error);
       dispatch(fetchFailed());

--- a/indico/modules/events/logs/client/js/actions.js
+++ b/indico/modules/events/logs/client/js/actions.js
@@ -16,6 +16,7 @@ export const FETCH_FAILED = 'FETCH_FAILED';
 export const SET_DETAILED_VIEW = 'SET_DETAILED_VIEW';
 export const VIEW_PREV_ENTRY = 'VIEW_PREV_ENTRY';
 export const VIEW_NEXT_ENTRY = 'VIEW_NEXT_ENTRY';
+export const SET_METADATA_QUERY = 'SET_METADATA_QUERY';
 
 export function setKeyword(keyword) {
   return {type: SET_KEYWORD, keyword};
@@ -31,6 +32,10 @@ export function setPage(currentPage) {
 
 export function setDetailedView(entryIndex) {
   return {type: SET_DETAILED_VIEW, currentViewIndex: entryIndex};
+}
+
+export function setMetadataQuery(metadataQuery) {
+  return {type: SET_METADATA_QUERY, metadataQuery};
 }
 
 export function viewPrevEntry() {
@@ -90,15 +95,15 @@ export function fetchFailed() {
 export function fetchLogEntries() {
   return async (dispatch, getStore) => {
     dispatch(fetchStarted());
-
     const {
-      logs: {filters, keyword, currentPage},
+      logs: {filters, keyword, currentPage, metadataQuery},
       staticData: {fetchLogsUrl},
     } = getStore();
 
     const params = {
       page: currentPage,
       filters: [],
+      data: JSON.stringify(metadataQuery),
     };
     if (keyword) {
       params.q = keyword;

--- a/indico/modules/events/logs/client/js/components/EventLog.jsx
+++ b/indico/modules/events/logs/client/js/components/EventLog.jsx
@@ -6,13 +6,46 @@
 // LICENSE file for more details.
 
 import React from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+
+import {Param, Translate} from 'indico/react/i18n';
 
 import LogEntryList from '../containers/LogEntryList';
 import Toolbar from './Toolbar';
+import {fetchLogEntries, setMetadataQuery, setPage} from '../actions';
+
+function MetadataQueryMessage() {
+  const dispatch = useDispatch();
+  const resetURLFiltering = () => {
+    dispatch(setMetadataQuery({}));
+    dispatch(setPage(1));
+    dispatch(fetchLogEntries());
+    history.replaceState({}, null, location.pathname);
+  };
+
+  return (
+    <div className="highlight-message-box">
+      <span className="icon" />
+      <div className="message-text">
+        <Translate>
+          Log entries are currently filtered by URL.{' '}
+          <Param name="link" wrapper={<a onClick={resetURLFiltering} />}>
+            Click here
+          </Param>{' '}
+          to disable the filter.
+        </Translate>
+      </div>
+    </div>
+  );
+}
+
+MetadataQueryMessage.propTypes = {};
 
 export default function EventLog() {
+  const metadataQuery = useSelector(state => state.logs.metadataQuery);
   return (
     <>
+      {Object.keys(metadataQuery).length !== 0 && <MetadataQueryMessage />}
       <Toolbar />
       <LogEntryList />
     </>

--- a/indico/modules/events/logs/client/js/components/EventLog.jsx
+++ b/indico/modules/events/logs/client/js/components/EventLog.jsx
@@ -12,15 +12,12 @@ import {Param, Translate} from 'indico/react/i18n';
 
 import LogEntryList from '../containers/LogEntryList';
 import Toolbar from './Toolbar';
-import {fetchLogEntries, setMetadataQuery, setPage} from '../actions';
+import {clearMetadataQuery} from '../actions';
 
 function MetadataQueryMessage() {
   const dispatch = useDispatch();
   const resetURLFiltering = () => {
-    dispatch(setMetadataQuery({}));
-    dispatch(setPage(1));
-    dispatch(fetchLogEntries());
-    history.replaceState({}, null, location.pathname);
+    dispatch(clearMetadataQuery());
   };
 
   return (

--- a/indico/modules/events/logs/client/js/components/LogEntryModal.jsx
+++ b/indico/modules/events/logs/client/js/components/LogEntryModal.jsx
@@ -6,7 +6,6 @@
 // LICENSE file for more details.
 
 import moment from 'moment';
-import qs from 'qs';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -66,11 +65,8 @@ export default class LogEntryModal extends React.Component {
   }
 
   relatedEntries() {
-    const {currentViewIndex, entries, relatedEntries} = this.props;
-    const entry = entries[currentViewIndex];
-    const queryString = qs.stringify({meta: entry.meta}, {allowDots: true});
-    relatedEntries(entry.meta);
-    history.replaceState({}, null, `${location.pathname}?${queryString}`);
+    const {relatedEntries} = this.props;
+    relatedEntries();
   }
 
   _isFirstEntry() {

--- a/indico/modules/events/logs/client/js/components/LogEntryModal.jsx
+++ b/indico/modules/events/logs/client/js/components/LogEntryModal.jsx
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 import moment from 'moment';
+import qs from 'qs';
 import React from 'react';
 import PropTypes from 'prop-types';
 
@@ -20,6 +21,7 @@ export default class LogEntryModal extends React.Component {
     setDetailedView: PropTypes.func.isRequired,
     prevEntry: PropTypes.func.isRequired,
     nextEntry: PropTypes.func.isRequired,
+    relatedEntries: PropTypes.func.isRequired,
     currentPage: PropTypes.number.isRequired,
     totalPageCount: PropTypes.number.isRequired,
   };
@@ -34,6 +36,7 @@ export default class LogEntryModal extends React.Component {
     this.onClose = this.onClose.bind(this);
     this.prevEntry = this.prevEntry.bind(this);
     this.nextEntry = this.nextEntry.bind(this);
+    this.relatedEntries = this.relatedEntries.bind(this);
   }
 
   componentDidUpdate() {
@@ -62,6 +65,14 @@ export default class LogEntryModal extends React.Component {
     nextEntry();
   }
 
+  relatedEntries() {
+    const {currentViewIndex, entries, relatedEntries} = this.props;
+    const entry = entries[currentViewIndex];
+    const queryString = qs.stringify({meta: entry.meta}, {allowDots: true});
+    relatedEntries(entry.meta);
+    history.replaceState({}, null, `${location.pathname}?${queryString}`);
+  }
+
   _isFirstEntry() {
     const {currentPage, currentViewIndex} = this.props;
     return currentPage === 1 && currentViewIndex === 0;
@@ -70,6 +81,12 @@ export default class LogEntryModal extends React.Component {
   _isLastEntry() {
     const {currentPage, totalPageCount, currentViewIndex, entries} = this.props;
     return currentPage === totalPageCount && currentViewIndex === entries.length - 1;
+  }
+
+  _hasRelatedEntries() {
+    const {currentViewIndex, entries} = this.props;
+    const entry = entries[currentViewIndex];
+    return Object.keys(entry.meta).length !== 0;
   }
 
   render() {
@@ -115,6 +132,10 @@ export default class LogEntryModal extends React.Component {
               disabled={this._isFirstEntry()}
             >
               <Translate>Previous</Translate>
+            </IButton>
+
+            <IButton onClick={this.relatedEntries} disabled={!this._hasRelatedEntries()}>
+              <Translate>Related entries</Translate>
             </IButton>
             <IButton
               title="Next"

--- a/indico/modules/events/logs/client/js/containers/LogEntryModal.js
+++ b/indico/modules/events/logs/client/js/containers/LogEntryModal.js
@@ -8,14 +8,7 @@
 import {connect} from 'react-redux';
 
 import LogEntryModal from '../components/LogEntryModal';
-import {
-  fetchLogEntries,
-  setDetailedView,
-  setMetadataQuery,
-  setPage,
-  viewNextEntry,
-  viewPrevEntry,
-} from '../actions';
+import {setDetailedView, showRelatedEntries, viewNextEntry, viewPrevEntry} from '../actions';
 
 const mapStateToProps = ({logs}) => ({
   currentViewIndex: logs.currentViewIndex,
@@ -33,11 +26,8 @@ const mapDispatchToProps = dispatch => ({
   nextEntry: () => {
     dispatch(viewNextEntry());
   },
-  relatedEntries: async metadataQuery => {
-    dispatch(setMetadataQuery(metadataQuery));
-    await dispatch(fetchLogEntries());
-    dispatch(setDetailedView(null));
-    dispatch(setPage(1));
+  relatedEntries: () => {
+    dispatch(showRelatedEntries());
   },
 });
 

--- a/indico/modules/events/logs/client/js/containers/LogEntryModal.js
+++ b/indico/modules/events/logs/client/js/containers/LogEntryModal.js
@@ -8,7 +8,14 @@
 import {connect} from 'react-redux';
 
 import LogEntryModal from '../components/LogEntryModal';
-import {setDetailedView, viewPrevEntry, viewNextEntry} from '../actions';
+import {
+  fetchLogEntries,
+  setDetailedView,
+  setMetadataQuery,
+  setPage,
+  viewNextEntry,
+  viewPrevEntry,
+} from '../actions';
 
 const mapStateToProps = ({logs}) => ({
   currentViewIndex: logs.currentViewIndex,
@@ -25,6 +32,12 @@ const mapDispatchToProps = dispatch => ({
   },
   nextEntry: () => {
     dispatch(viewNextEntry());
+  },
+  relatedEntries: async metadataQuery => {
+    dispatch(setMetadataQuery(metadataQuery));
+    await dispatch(fetchLogEntries());
+    dispatch(setDetailedView(null));
+    dispatch(setPage(1));
   },
 });
 

--- a/indico/modules/events/logs/client/js/index.jsx
+++ b/indico/modules/events/logs/client/js/index.jsx
@@ -12,7 +12,7 @@ import {Provider} from 'react-redux';
 import createReduxStore from 'indico/utils/redux';
 
 import EventLog from './components/EventLog';
-import {fetchLogEntries} from './actions';
+import {fetchLogEntries, setMetadataQuery} from './actions';
 import reducer from './reducers';
 
 import '../style/logs.scss';
@@ -33,6 +33,7 @@ window.addEventListener('load', () => {
     },
     initialData
   );
+  store.dispatch(setMetadataQuery(JSON.parse(rootElement.dataset.metadataQuery)));
 
   ReactDOM.render(
     <Provider store={store}>

--- a/indico/modules/events/logs/client/js/reducers.js
+++ b/indico/modules/events/logs/client/js/reducers.js
@@ -12,6 +12,7 @@ const initialState = {
   keyword: null,
   currentPage: 1,
   isFetching: false,
+  metadataQuery: {},
   filters: {
     event: true,
     management: true,
@@ -46,6 +47,8 @@ export default function logReducer(state = initialState, action) {
       return {...state, isFetching: false};
     case actions.SET_DETAILED_VIEW:
       return {...state, currentViewIndex: action.currentViewIndex};
+    case actions.SET_METADATA_QUERY:
+      return {...state, metadataQuery: action.metadataQuery};
     default:
       return state;
   }

--- a/indico/modules/events/logs/controllers.py
+++ b/indico/modules/events/logs/controllers.py
@@ -31,15 +31,17 @@ class RHEventLogs(RHManageEventBase):
     """Shows the modification/action log for the event"""
 
     def _process(self):
+        metadata_query = {k[len('meta.'):]: int(v) if v.isdigit() else v
+                          for k, v in request.args.iteritems() if k.startswith('meta.')}
         realms = {realm.name: realm.title for realm in EventLogRealm}
-        return WPEventLogs.render_template('logs.html', self.event, realms=realms)
+        return WPEventLogs.render_template('logs.html', self.event, realms=realms, metadata_query=metadata_query)
 
 
 class RHEventLogsJSON(RHManageEventBase):
     def _process(self):
         page = int(request.args.get('page', 1))
         filters = request.args.getlist('filters')
-        data = json.loads(request.args.get('data'))
+        data = json.loads(request.args.get('data', '{}'))
         text = request.args.get('q')
 
         if not filters and not data:

--- a/indico/modules/events/logs/models/entries.py
+++ b/indico/modules/events/logs/models/entries.py
@@ -7,7 +7,7 @@
 
 from __future__ import unicode_literals
 
-from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy.dialects.postgresql import JSON, JSONB
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
@@ -36,7 +36,8 @@ class EventLogKind(int, IndicoEnum):
 class EventLogEntry(db.Model):
     """Log entries for events"""
     __tablename__ = 'logs'
-    __table_args__ = {'schema': 'events'}
+    __table_args__ = (db.Index(None, 'meta', postgresql_using='gin'),
+                      {'schema': 'events'})
 
     #: The ID of the log entry
     id = db.Column(
@@ -94,6 +95,11 @@ class EventLogEntry(db.Model):
     #: Type-specific data
     data = db.Column(
         JSON,
+        nullable=False
+    )
+    #: Non-displayable data
+    meta = db.Column(
+        JSONB,
         nullable=False
     )
 

--- a/indico/modules/events/logs/templates/logs.html
+++ b/indico/modules/events/logs/templates/logs.html
@@ -7,6 +7,7 @@
 {% block content %}
     <div class="event-log"
          data-fetch-logs-url="{{ url_for('.logs', event) }}"
-         data-realms="{{ realms|tojson|forceescape }}">
+         data-realms="{{ realms|tojson|forceescape }}"
+         data-metadata-query="{{ metadata_query|tojson|forceescape }}">
     </div>
 {% endblock %}

--- a/indico/modules/events/logs/util.py
+++ b/indico/modules/events/logs/util.py
@@ -171,6 +171,7 @@ def serialize_log_entry(entry):
         'kind': entry.kind.name,
         'module': entry.module,
         'description': entry.summary,
+        'meta': entry.meta,
         'time': entry.logged_dt.astimezone(entry.event.tzinfo).isoformat(),
         'payload': entry.data,
         'user': {

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -818,7 +818,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         from indico.modules.events.notes.util import get_scheduled_notes
         return get_scheduled_notes(self)
 
-    def log(self, realm, kind, module, summary, user=None, type_='simple', data=None):
+    def log(self, realm, kind, module, summary, user=None, type_='simple', data=None, meta=None):
         """Creates a new log entry for the event
 
         :param realm: A value from :class:`.EventLogRealm` indicating
@@ -832,6 +832,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         :param type_: The type of the log entry. This is used for custom
                       rendering of the log message/data
         :param data: JSON-serializable data specific to the log type.
+        :param meta: JSON-serializable data that won't be displayed.
         :return: The newly created `EventLogEntry`
 
         In most cases the ``simple`` log type is fine. For this type,
@@ -843,7 +844,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         if self.__logging_disabled:
             return
         entry = EventLogEntry(user=user, realm=realm, kind=kind, module=module, type=type_, summary=summary,
-                              data=data or {})
+                              data=(data or {}), meta=(meta or {}))
         self.log_entries.append(entry)
         return entry
 

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -242,7 +242,8 @@ class RHRegistrationDelete(RHRegistrationsActionBase):
             logger.info('Registration %s deleted by %s', registration, session.user)
             self.event.log(EventLogRealm.management, EventLogKind.negative, 'Registration',
                            'Registration deleted: {}'.format(registration.full_name),
-                           session.user, data={'Email': registration.email})
+                           session.user, data={'Email': registration.email},
+                           meta={'registration_id': registration.id})
         num_reg_deleted = len(self.registrations)
         flash(ngettext("Registration was deleted.",
                        "{num} registrations were deleted.", num_reg_deleted).format(num=num_reg_deleted), 'success')

--- a/indico/modules/events/registration/logging.py
+++ b/indico/modules/events/registration/logging.py
@@ -27,7 +27,8 @@ def log_registration_check_in(registration, **kwargs):
     else:
         log_text = '"{}" check-in has been reset'
     registration.event.log(EventLogRealm.participants, EventLogKind.change, 'Registration',
-                           log_text.format(registration.full_name), session.user)
+                           log_text.format(registration.full_name), session.user,
+                           meta={'registration_id': registration.id})
 
 
 def log_registration_updated(registration, previous_state, **kwargs):
@@ -56,4 +57,4 @@ def log_registration_updated(registration, previous_state, **kwargs):
         log_text = 'Registration for "{{}}" has been changed from {} to {}'.format(previous_state_title, state_title)
         kind = EventLogKind.change
     registration.event.log(EventLogRealm.participants, kind, 'Registration', log_text.format(registration.full_name),
-                           session.user)
+                           session.user, meta={'registration_id': registration.id})

--- a/indico/modules/events/registration/notifications.py
+++ b/indico/modules/events/registration/notifications.py
@@ -44,7 +44,8 @@ def _notify_registration(registration, template, to_managers=False):
     from_address = registration.registration_form.sender_address if not to_managers else None
     mail = make_email(to_list=to_list, template=template, html=True, from_address=from_address, attachments=attachments)
     user = session.user if session else None
-    send_email(mail, event=registration.registration_form.event, module='Registration', user=user)
+    send_email(mail, event=registration.registration_form.event, module='Registration', user=user,
+               log_metadata={'registration_id': registration.id})
 
 
 def notify_registration_creation(registration, notify_user=True):

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -240,7 +240,8 @@ def create_registration(regform, data, invitation=None, management=False, notify
     logger.info('New registration %s by %s', registration, user)
     regform.event.log(EventLogRealm.management if management else EventLogRealm.participants,
                       EventLogKind.positive, 'Registration',
-                      'New registration: {}'.format(registration.full_name), user, data={'Email': registration.email})
+                      'New registration: {}'.format(registration.full_name), user, data={'Email': registration.email},
+                      meta={'registration_id': registration.id})
     return registration
 
 
@@ -292,7 +293,8 @@ def modify_registration(registration, data, management=False, notify_user=True):
     regform.event.log(EventLogRealm.management if management else EventLogRealm.participants,
                       EventLogKind.change, 'Registration',
                       'Registration modified: {}'.format(registration.full_name),
-                      session.user, data={'Email': registration.email})
+                      session.user, data={'Email': registration.email},
+                      meta={'registration_id': registration.id})
 
 
 def generate_spreadsheet_from_registrations(registrations, regform_items, static_items):


### PR DESCRIPTION
Event log filtering by related entries relies on the new `internal_data` column added to the `event.logs` table. For now, the only logged events that use this new column are those related to registrations.

## Screenshots
||
|-|
|![image](https://user-images.githubusercontent.com/716307/86016897-a7334c00-ba23-11ea-849e-17252a5e9fb5.png)|

||
|-|
|![image](https://user-images.githubusercontent.com/716307/86017088-e792ca00-ba23-11ea-96c5-730440a1f5a9.png)|
