### PR TITLE
Add template hook to event management title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,6 +105,8 @@ Internal Changes
   :user:`omegak`)
 - Add ``extra-registration-actions`` template hook (:issue:`4500`, thanks
   :user:`omegak`)
+- Add ``event-management-after-title`` template hook (:issue: `4504`, thanks
+  :user:`meluru`)
 
 
 ----

--- a/indico/modules/events/management/templates/_management_frame.html
+++ b/indico/modules/events/management/templates/_management_frame.html
@@ -40,6 +40,7 @@
                     {% endif %}
                 </span>
             </a>
+            {{ template_hook('event-management-after-title', event=event) }}
             <div class="subtitle">
                 {{ _render_clone_info(event) }}
             </div>

--- a/indico/web/client/styles/base/_pages.scss
+++ b/indico/web/client/styles/base/_pages.scss
@@ -101,6 +101,7 @@
   $banner-color: #000;
   $banner-title-color: $dark-orange;
   $banner-subtitle-color: $dark-gray;
+  $banner-title-margin: 19px;
 
   color: $banner-color;
   max-width: 800px;
@@ -108,7 +109,7 @@
 
   &.full-width {
     max-width: none;
-    margin-bottom: -10%;
+    margin-bottom: -$banner-title-margin;
 
     .title {
       flex-grow: 1;
@@ -120,7 +121,7 @@
   }
 
   .title {
-    margin-bottom: 19px;
+    margin-bottom: $banner-title-margin;
     font-family: 'Roboto Light', sans-serif;
     font-size: 2em;
     color: $banner-title-color;


### PR DESCRIPTION
- Adds `event-management-after-title` template hook
- Fixes `banner` class margins