### PR TITLE
Connect revision endpoints to the service mixin

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
@@ -1,0 +1,83 @@
+import {FinalRevisionState, InitialRevisionState} from 'indico/modules/events/editing/models';
+import {processRevisions} from '../selectors';
+
+describe('timeline selectors', () => {
+  it('should aggregate actions on the same revision', () => {
+    const revisions = [
+      {
+        id: 1,
+        comments: '',
+        initialState: {
+          name: InitialRevisionState.new,
+        },
+        finalState: {
+          name: FinalRevisionState.replaced,
+        },
+      },
+      {
+        id: 2,
+        comments: '',
+        initialState: {
+          name: InitialRevisionState.ready_for_review,
+        },
+        finalState: {
+          name: FinalRevisionState.needs_submitter_changes,
+        },
+      },
+    ];
+    const result = processRevisions(revisions);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+    expect(result[0].items).toStrictEqual([
+      expect.objectContaining({state: FinalRevisionState.replaced}),
+      expect.objectContaining({state: FinalRevisionState.needs_submitter_changes}),
+    ]);
+  });
+
+  it('should order revisions correctly', () => {
+    const revisions = [
+      {
+        id: 1,
+        comments: '',
+        initialState: {
+          name: InitialRevisionState.ready_for_review,
+        },
+        finalState: {
+          name: FinalRevisionState.needs_submitter_confirmation,
+        },
+      },
+      {
+        id: 2,
+        comments: '',
+        initialState: {
+          name: InitialRevisionState.needs_submitter_confirmation,
+        },
+        finalState: {
+          name: FinalRevisionState.needs_submitter_changes,
+        },
+      },
+      {
+        id: 3,
+        comments: '',
+        initialState: {
+          name: InitialRevisionState.ready_for_review,
+        },
+        finalState: {
+          name: FinalRevisionState.none,
+        },
+      },
+    ];
+    const result = processRevisions(revisions);
+    expect(result).toHaveLength(3);
+    expect(result[0].id).toBe(1);
+    expect(result[0].items).toStrictEqual([
+      expect.objectContaining({state: FinalRevisionState.needs_submitter_confirmation}),
+    ]);
+    expect(result[1].id).toBe(2);
+    expect(result[1].items).toStrictEqual([
+      expect.objectContaining({state: FinalRevisionState.needs_submitter_changes}),
+    ]);
+    expect(result[2].id).toBe(3);
+    expect(result[2].items).toHaveLength(0);
+  });
+});

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/AcceptRejectForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/AcceptRejectForm.jsx
@@ -5,6 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import _ from 'lodash';
 import React from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import PropTypes from 'prop-types';
@@ -15,19 +16,23 @@ import {FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
 import {reviewEditable} from '../actions';
-import {getLastRevision, getStaticData} from '../selectors';
+import {getLastRevision, getNonSystemTags} from '../selectors';
 import FinalTagInput from './TagInput';
 
 import './JudgmentBox.module.scss';
 
 export default function AcceptRejectForm({action, setLoading}) {
   const lastRevision = useSelector(getLastRevision);
-  const {tags: tagOptions} = useSelector(getStaticData);
+  const tagOptions = useSelector(getNonSystemTags);
   const dispatch = useDispatch();
 
   return (
     <FinalForm
-      initialValues={{comment: '', tags: lastRevision.tags.map(t => t.id)}}
+      initialValues={{
+        comment: '',
+        tags: lastRevision.tags.filter(t => !t.system).map(t => t.id),
+      }}
+      initialValuesEqual={_.isEqual}
       onSubmit={async formData => {
         setLoading(true);
         const rv = await dispatch(reviewEditable(lastRevision, {...formData, action}));

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/RequestChangesForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/RequestChangesForm.jsx
@@ -5,6 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 import {useDispatch, useSelector} from 'react-redux';
@@ -16,13 +17,13 @@ import {Translate} from 'indico/react/i18n';
 
 import {EditingReviewAction} from '../../../models';
 import {reviewEditable} from '../actions';
-import {getLastRevision, getStaticData} from '../selectors';
+import {getLastRevision, getNonSystemTags} from '../selectors';
 import FinalTagInput from './TagInput';
 
 export default function RequestChangesForm({setLoading, onSuccess}) {
   const dispatch = useDispatch();
   const lastRevision = useSelector(getLastRevision);
-  const {tags: tagOptions} = useSelector(getStaticData);
+  const tagOptions = useSelector(getNonSystemTags);
 
   const requestChanges = async formData => {
     setLoading(true);
@@ -45,7 +46,11 @@ export default function RequestChangesForm({setLoading, onSuccess}) {
     <FinalForm
       onSubmit={requestChanges}
       subscription={{}}
-      initialValues={{comment: '', tags: lastRevision.tags.map(t => t.id)}}
+      initialValues={{
+        comment: '',
+        tags: lastRevision.tags.filter(t => !t.system).map(t => t.id),
+      }}
+      initialValuesEqual={_.isEqual}
     >
       {fprops => (
         <Form onSubmit={fprops.handleSubmit}>

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesForm.jsx
@@ -47,6 +47,7 @@ export default function UpdateFilesForm({setLoading}) {
   const dispatch = useDispatch();
   const files = getFilesFromRevision(fileTypes, lastRevision);
   const option = confirmOptions.find(x => x.value === confirmationType);
+  const tagOptions = useSelector(selectors.getNonSystemTags);
 
   const submitReview = async formData => {
     setLoading(true);
@@ -67,7 +68,11 @@ export default function UpdateFilesForm({setLoading}) {
 
   return (
     <FinalForm
-      initialValues={{comment: '', tags: lastRevision.tags.map(t => t.id), files}}
+      initialValues={{
+        comment: '',
+        tags: lastRevision.tags.filter(t => !t.system).map(t => t.id),
+        files,
+      }}
       initialValuesEqual={_.isEqual}
       subscription={{}}
       onSubmit={submitReview}
@@ -131,7 +136,7 @@ export default function UpdateFilesForm({setLoading}) {
               hideValidationError
               autoFocus
             />
-            <FinalTagInput name="tags" options={staticData.tags} />
+            <FinalTagInput name="tags" options={tagOptions} />
           </Form>
           <div styleName="judgment-submit-button">
             <Button.Group color="blue">

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -158,6 +158,11 @@ export const needsSubmitterConfirmation = createSelector(
 );
 export const getStaticData = state => state.staticData;
 
+export const getNonSystemTags = createSelector(
+  getStaticData,
+  staticData => staticData.tags.filter(t => !t.system)
+);
+
 export const getFileTypes = createSelector(
   getDetails,
   getStaticData,

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -58,6 +58,7 @@ export function processRevisions(revisions) {
         createNewCustomItemFromRevision(updatedRevision, {
           header: Translate.string('Revision has been replaced'),
           state: FinalRevisionState.replaced,
+          html: revision.commentHtml,
         })
       );
 

--- a/indico/modules/events/editing/client/js/models.js
+++ b/indico/modules/events/editing/client/js/models.js
@@ -19,6 +19,7 @@ export const FinalRevisionState = {
 export const InitialRevisionState = {
   ready_for_review: 'ready_for_review',
   needs_submitter_confirmation: 'needs_submitter_confirmation',
+  new: 'new',
 };
 
 export const EditingReviewAction = {

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -196,12 +196,13 @@ class RHReplaceRevision(RHContributionEditableRevisionBase):
     })
     def _process(self, comment, state):
         args = parser.parse({
+            'tags': EditingTagsField(self.event, allow_system_tags=self.is_service_call, missing=set()),
             'files': EditingFilesField(self.event, self.contrib, self.editable_type, allow_claimed_files=True,
                                        required=True)
         })
 
         user = User.get_system_user() if self.is_service_call else session.user
-        replace_revision(self.revision, user, comment, args['files'], state)
+        replace_revision(self.revision, user, comment, args['files'], args['tags'], state)
         return '', 204
 
 

--- a/indico/modules/events/editing/controllers/base.py
+++ b/indico/modules/events/editing/controllers/base.py
@@ -25,6 +25,10 @@ from indico.web.rh import RequireUserMixin
 class TokenAccessMixin(object):
     SERVICE_ALLOWED = False
 
+    def __init__(self):
+        super(TokenAccessMixin, self).__init__()
+        self.is_service_call = False
+
     def _token_can_access(self):
         # we need to "fish" the event here because at this point _check_params
         # hasn't run yet
@@ -36,7 +40,8 @@ class TokenAccessMixin(object):
         if request.bearer_token != event_token:
             raise Unauthorized('Invalid bearer token')
 
-        return True
+        self.is_service_call = True
+        return self.is_service_call
 
     def _check_csrf(self):
         # check CSRF if there is no bearer token or there's a session cookie
@@ -50,8 +55,7 @@ class RHEditingBase(TokenAccessMixin, RequireUserMixin, RHDisplayEventBase):
     EVENT_FEATURE = 'editing'
 
     def _check_access(self):
-        self.is_service_call = TokenAccessMixin._token_can_access(self)
-        if not self.is_service_call:
+        if not TokenAccessMixin._token_can_access(self):
             RHDisplayEventBase._check_access(self)
             RequireUserMixin._check_access(self)
 
@@ -63,8 +67,7 @@ class RHEditingManagementBase(TokenAccessMixin, RHManageEventBase):
     PERMISSION = 'editing_manager'
 
     def _check_access(self):
-        self.is_service_call = TokenAccessMixin._token_can_access(self)
-        if not self.is_service_call:
+        if not TokenAccessMixin._token_can_access(self):
             super(RHEditingManagementBase, self)._check_access()
 
 
@@ -102,8 +105,7 @@ class RHContributionEditableBase(TokenAccessMixin, RequireUserMixin, RHContribut
     _editable_query_options = ()
 
     def _check_access(self):
-        self.is_service_call = TokenAccessMixin._token_can_access(self)
-        if not self.is_service_call:
+        if not TokenAccessMixin._token_can_access(self):
             RequireUserMixin._check_access(self)
             RHContributionDisplayBase._check_access(self)
 

--- a/indico/modules/events/editing/controllers/base.py
+++ b/indico/modules/events/editing/controllers/base.py
@@ -86,7 +86,7 @@ class RHEditableTypeEditorBase(RHEditableTypeManagementBase):
         RHEditableTypeManagementBase._check_access(self)
 
 
-class RHContributionEditableBase(RequireUserMixin, RHContributionDisplayBase):
+class RHContributionEditableBase(TokenAccessMixin, RequireUserMixin, RHContributionDisplayBase):
     """Base class for operations on an editable."""
 
     EVENT_FEATURE = 'editing'
@@ -102,8 +102,10 @@ class RHContributionEditableBase(RequireUserMixin, RHContributionDisplayBase):
     _editable_query_options = ()
 
     def _check_access(self):
-        RequireUserMixin._check_access(self)
-        RHContributionDisplayBase._check_access(self)
+        self.is_service_call = TokenAccessMixin._token_can_access(self)
+        if not self.is_service_call:
+            RequireUserMixin._check_access(self)
+            RHContributionDisplayBase._check_access(self)
 
     def _process_args(self):
         RHContributionDisplayBase._process_args(self)

--- a/indico/modules/events/editing/controllers/base.py
+++ b/indico/modules/events/editing/controllers/base.py
@@ -24,10 +24,7 @@ from indico.web.rh import RequireUserMixin
 
 class TokenAccessMixin(object):
     SERVICE_ALLOWED = False
-
-    def __init__(self):
-        super(TokenAccessMixin, self).__init__()
-        self.is_service_call = False
+    is_service_call = False
 
     def _token_can_access(self):
         # we need to "fish" the event here because at this point _check_params
@@ -41,7 +38,7 @@ class TokenAccessMixin(object):
             raise Unauthorized('Invalid bearer token')
 
         self.is_service_call = True
-        return self.is_service_call
+        return True
 
     def _check_csrf(self):
         # check CSRF if there is no bearer token or there's a session cookie

--- a/indico/modules/events/editing/models/revision_files.py
+++ b/indico/modules/events/editing/models/revision_files.py
@@ -73,3 +73,7 @@ class EditingRevisionFile(db.Model):
     @property
     def download_url(self):
         return url_for('event_editing.download_file', self)
+
+    @property
+    def external_download_url(self):
+        return url_for('event_editing.download_file', self, _external=True)

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -167,12 +167,13 @@ def confirm_editable_changes(revision, submitter, action, comment):
 
 
 @no_autoflush
-def replace_revision(revision, user, comment, files, initial_state=None):
+def replace_revision(revision, user, comment, files, tags, initial_state=None):
     _ensure_latest_revision(revision)
     _ensure_state(revision,
                   initial=(InitialRevisionState.new, InitialRevisionState.ready_for_review),
                   final=FinalRevisionState.none)
     revision.comment = comment
+    revision.tags = tags
     revision.final_state = FinalRevisionState.replaced
     new_revision = EditingRevision(submitter=user,
                                    initial_state=(initial_state or revision.initial_state),

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -89,6 +89,14 @@ def create_new_editable(contrib, type_, submitter, files, initial_state=InitialR
     return editable
 
 
+def delete_editable(editable):
+    db.session.delete(editable)
+    for revision in editable.revisions:
+        for ef in revision.files:
+            ef.file.unclaim()
+    db.session.flush()
+
+
 def publish_editable_revision(revision):
     _ensure_latest_revision(revision)
     revision.editable.published_revision = revision
@@ -165,7 +173,7 @@ def replace_revision(revision, user, comment, files, initial_state=None):
     revision.comment = comment
     revision.final_state = FinalRevisionState.replaced
     new_revision = EditingRevision(submitter=user,
-                                   initial_state=initial_state or revision.initial_state,
+                                   initial_state=(initial_state or revision.initial_state),
                                    files=_make_editable_files(revision.editable, files))
     revision.editable.revisions.append(new_revision)
     db.session.flush()

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -90,11 +90,12 @@ def create_new_editable(contrib, type_, submitter, files, initial_state=InitialR
 
 
 def delete_editable(editable):
-    db.session.delete(editable)
+    db.session.expire(editable)
     for revision in editable.revisions:
         for ef in revision.files:
             ef.file.claimed = False
             ef.file.meta = {}
+    db.session.delete(editable)
     db.session.flush()
 
 

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -93,7 +93,8 @@ def delete_editable(editable):
     db.session.delete(editable)
     for revision in editable.revisions:
         for ef in revision.files:
-            ef.file.unclaim()
+            ef.file.claimed = False
+            ef.file.meta = {}
     db.session.flush()
 
 

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -78,10 +78,10 @@ def _make_editable_files(editable, files):
 
 
 @no_autoflush
-def create_new_editable(contrib, type_, submitter, files):
+def create_new_editable(contrib, type_, submitter, files, initial_state=InitialRevisionState.ready_for_review):
     editable = Editable(contribution=contrib, type=type_)
     revision = EditingRevision(submitter=submitter,
-                               initial_state=InitialRevisionState.ready_for_review,
+                               initial_state=initial_state,
                                files=_make_editable_files(editable, files))
     editable.revisions.append(revision)
     db.session.flush()
@@ -157,7 +157,7 @@ def confirm_editable_changes(revision, submitter, action, comment):
 
 
 @no_autoflush
-def replace_revision(revision, user, comment, files):
+def replace_revision(revision, user, comment, files, initial_state=None):
     _ensure_latest_revision(revision)
     _ensure_state(revision,
                   initial=(InitialRevisionState.new, InitialRevisionState.ready_for_review),
@@ -165,7 +165,7 @@ def replace_revision(revision, user, comment, files):
     revision.comment = comment
     revision.final_state = FinalRevisionState.replaced
     new_revision = EditingRevision(submitter=user,
-                                   initial_state=revision.initial_state,
+                                   initial_state=initial_state or revision.initial_state,
                                    files=_make_editable_files(revision.editable, files))
     revision.editable.revisions.append(new_revision)
     db.session.flush()

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -94,13 +94,14 @@ class EditingTagSchema(mm.ModelSchema):
 class EditingRevisionFileSchema(mm.ModelSchema):
     class Meta:
         model = EditingRevisionFile
-        fields = ('uuid', 'filename', 'size', 'content_type', 'file_type', 'download_url')
+        fields = ('uuid', 'filename', 'size', 'content_type', 'file_type', 'download_url', 'external_download_url')
 
     uuid = fields.String(attribute='file.uuid')
     filename = fields.String(attribute='file.filename')
     size = fields.Int(attribute='file.size')
     content_type = fields.String(attribute='file.content_type')
     download_url = fields.String()
+    external_download_url = fields.String()
 
 
 class EditingRevisionCommentSchema(mm.ModelSchema):

--- a/indico/modules/events/editing/service.py
+++ b/indico/modules/events/editing/service.py
@@ -126,7 +126,7 @@ def service_get_status(event):
     return {'status': resp.json(), 'error': None}
 
 
-def service_handle_editable(editable):
+def service_handle_new_editable(editable):
     revision = editable.revisions[-1]
     data = {
         'files': EditingRevisionFileSchema().dump(revision.files, many=True),
@@ -134,7 +134,7 @@ def service_handle_editable(editable):
             'revisions': {
                 'replace': url_for('.api_replace_revision', revision, _external=True)
             },
-            'file_upload': url_for('.api_upload', editable.contribution, type=editable.type.name, _external=True)
+            'file_upload': url_for('.api_upload', editable, _external=True)
         }
     }
     try:

--- a/indico/modules/events/editing/service.py
+++ b/indico/modules/events/editing/service.py
@@ -138,10 +138,10 @@ def service_handle_new_editable(editable):
         }
     }
     try:
-        path = '/event/{}/contributions/{}/editing/{}'.format(
+        path = '/event/{}/editable/{}/{}'.format(
             _get_event_identifier(editable.event),
+            editable.type.name,
             editable.contribution_id,
-            editable.type.name
         )
         resp = requests.put(_build_url(editable.event, path), headers=_get_headers(editable.event), json=data)
         resp.raise_for_status()

--- a/indico/modules/events/editing/service.py
+++ b/indico/modules/events/editing/service.py
@@ -132,20 +132,18 @@ def service_handle_editable(editable):
         'files': EditingRevisionFileSchema().dump(revision.files, many=True),
         'endpoints': {
             'revisions': {
-                'replace': url_for('.api_replace_revision', editable.event,
-                                   contrib_id=editable.contribution_id, type=editable.type.name,
-                                   revision_id=revision.id, _external=True)
+                'replace': url_for('.api_replace_revision', revision, _external=True)
             },
-            'file_upload': url_for('.api_upload', editable.event,
-                                   contrib_id=editable.contribution_id, type=editable.type.name,
-                                   _external=True)
+            'file_upload': url_for('.api_upload', editable.contribution, type=editable.type.name, _external=True)
         }
     }
     try:
-        resp = requests.post(_build_url(editable.event, '/event/{}/contributions/{}/editing/{}'
-                                        .format(_get_event_identifier(editable.event),
-                                                editable.contribution_id, editable.type.name)),
-                             headers=_get_headers(editable.event), json=data)
+        path = '/event/{}/contributions/{}/editing/{}'.format(
+            _get_event_identifier(editable.event),
+            editable.contribution_id,
+            editable.type.name
+        )
+        resp = requests.post(_build_url(editable.event, path), headers=_get_headers(editable.event), json=data)
         resp.raise_for_status()
     except requests.RequestException as exc:
         logger.exception('Failed calling listener for editable')

--- a/indico/modules/events/editing/service.py
+++ b/indico/modules/events/editing/service.py
@@ -143,7 +143,7 @@ def service_handle_new_editable(editable):
             editable.contribution_id,
             editable.type.name
         )
-        resp = requests.post(_build_url(editable.event, path), headers=_get_headers(editable.event), json=data)
+        resp = requests.put(_build_url(editable.event, path), headers=_get_headers(editable.event), json=data)
         resp.raise_for_status()
     except requests.RequestException as exc:
         logger.exception('Failed calling listener for editable')

--- a/indico/modules/files/models/files.py
+++ b/indico/modules/files/models/files.py
@@ -64,10 +64,6 @@ class File(StoredFileMixin, db.Model):
         # file was already claimed?
         self.meta = meta
 
-    def unclaim(self):
-        self.claimed = False
-        self.meta = {}
-
     def _build_storage_path(self):
         path_segments = list(map(strict_unicode, self.__context))
         self.assign_id()

--- a/indico/modules/files/models/files.py
+++ b/indico/modules/files/models/files.py
@@ -64,6 +64,10 @@ class File(StoredFileMixin, db.Model):
         # file was already claimed?
         self.meta = meta
 
+    def unclaim(self):
+        self.claimed = False
+        self.meta = {}
+
     def _build_storage_path(self):
         path_segments = list(map(strict_unicode, self.__context))
         self.assign_id()


### PR DESCRIPTION
Closes #4502 

- [ ] Have the micro-service store an initial state before it sets the editable as ready for review (do we really need this?)
- [x] Possibly deleting the editable if the micro-service is not available/fails

Known bugs:
- [x] Creating a revision right after the service replacement causes the front-end to crash. For some reason, it tries to get the editor from the previous revision (which is System) while showing the new dialog.

Service for testing:
- [Openreferee](https://github.com/indico/openreferee) (recommended)
- [Dummy service](https://gist.github.com/plourenco/930bfc440f3f88b591840ab4f51513bd).