### PR TITLE
Do not escape temp event logo filenames in latex

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Version 2.2.9
 Bugfixes
 ^^^^^^^^
 
-- None so far :)
+- Fix error when building LaTeX PDFs if the temporary event logo path contained
+  an underscore (:issue:`4521`)
 
 Version 2.2.8
 -------------

--- a/indico/legacy/pdfinterface/latex_templates/inc/first_page.tex
+++ b/indico/legacy/pdfinterface/latex_templates/inc/first_page.tex
@@ -28,7 +28,7 @@
 
     \JINJA{if logo_img}
         \begin{figure}[h!]
-            \includegraphics[max width=0.85\linewidth, min width=0.5\linewidth]{\VAR{logo_img}}
+            \includegraphics[max width=0.85\linewidth, min width=0.5\linewidth]{\VAR{logo_img|rawlatex}}
             \centering
         \end{figure}
 

--- a/indico/legacy/pdfinterface/latex_templates/single_doc.tex
+++ b/indico/legacy/pdfinterface/latex_templates/single_doc.tex
@@ -28,7 +28,7 @@
 
     \JINJA{if logo_img}
         \begin{figure}[h!]
-            \includegraphics[max width=0.85\linewidth, min width=0.5\linewidth, max height=10em]{\VAR{logo_img}}
+            \includegraphics[max width=0.85\linewidth, min width=0.5\linewidth, max height=10em]{\VAR{logo_img|rawlatex}}
             \centering
         \end{figure}
     \JINJA{endif}


### PR DESCRIPTION
Autoescaping added a backslash before every underscore, but this is apparently not needed here, and having the backslash broke the PDF generation.