### PR TITLE
Editing: add required file indicator

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/FileDisplay.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/FileDisplay.module.scss
@@ -40,6 +40,12 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+
+      a {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
     }
   }
 }

--- a/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/FileDisplay.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/FileDisplay.module.scss
@@ -40,12 +40,6 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-
-      a {
-        display: block;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
     }
   }
 }

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
@@ -9,6 +9,7 @@ import React, {useContext, useCallback, useState} from 'react';
 import PropTypes from 'prop-types';
 import {useDropzone} from 'react-dropzone';
 import {Icon} from 'semantic-ui-react';
+import {TooltipIfTruncated} from 'indico/react/components';
 import {
   FileManagerContext,
   filePropTypes,
@@ -73,15 +74,17 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
 
   return (
     <>
-      <span styleName="file-state" className={state || ''}>
-        {downloadURL ? (
-          <a href={downloadURL} target="_blank" rel="noopener noreferrer">
-            {filename}
-          </a>
-        ) : (
-          filename
-        )}
-      </span>
+      <TooltipIfTruncated>
+        <span styleName="file-state" className={state || ''}>
+          {downloadURL ? (
+            <a href={downloadURL} target="_blank" rel="noopener noreferrer">
+              {filename}
+            </a>
+          ) : (
+            filename
+          )}
+        </span>
+      </TooltipIfTruncated>
       <span>
         {!state && fileType.allowMultipleFiles && (
           <>

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
@@ -108,6 +108,12 @@
   text-overflow: ellipsis;
   flex: 4;
 
+  a {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
   &:global(.added) {
     color: $green;
   }

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
@@ -7,6 +7,10 @@
 
 @import 'base/palette';
 
+.outer-dropzone {
+  margin-top: auto;
+}
+
 .dropzone {
   width: 100%;
   border: 2px dashed $gray;
@@ -32,35 +36,26 @@
 .file-manager {
   display: flex;
   flex-wrap: wrap;
+  margin-left: -0.9em;
 
   .file-type {
+    display: flex;
+    flex-direction: column;
     margin-bottom: 1em;
     border: 1px solid $gray;
     border-radius: 3px;
     padding: 1em;
-    flex: 0 0 32%;
+    width: 31%;
+    margin-left: 0.9em;
 
-    &:not(:nth-child(3n)) {
-      margin-right: 0.9em;
-    }
-
-    .file-extensions {
+    .file-requirements {
       font-style: italic;
       color: $gray;
-      list-style-type: none;
       margin: 0.2em 0;
       padding: 0;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-
-      li {
-        display: inline;
-
-        &:not(:last-child)::after {
-          content: ', ';
-        }
-      }
     }
   }
 

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
@@ -108,12 +108,6 @@
   text-overflow: ellipsis;
   flex: 4;
 
-  a {
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
   &:global(.added) {
     color: $green;
   }

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/__tests__/FileManager.spec.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/__tests__/FileManager.spec.jsx
@@ -151,7 +151,7 @@ function getFileEntryForFileType(wrapper, fileTypeId) {
 }
 
 function checkFileEntry(fileEntry, name, icon) {
-  expect(fileEntry.find('span:first-child').text()).toEqual(name);
+  expect(fileEntry.find('TooltipIfTruncated > span').text()).toEqual(name);
   expect(fileEntry.find('FileAction').prop('icon')).toEqual(icon);
 }
 
@@ -311,7 +311,7 @@ describe('File manager', () => {
 
     // modified file renders properly
     const fileEntry = getFileEntryForFileType(wrapper, 2);
-    expect(fileEntry.find('span:first-child').text()).toEqual('test.pdf');
+    expect(fileEntry.find('TooltipIfTruncated > span').text()).toEqual('test.pdf');
     expect(fileEntry.find('FileAction').prop('icon')).toEqual('undo');
   });
 

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/index.jsx
@@ -145,6 +145,15 @@ function FileType({
     <div styleName="file-type">
       <h3>
         {fileType.name}
+        {fileType.required && (
+          <Popup
+            position="bottom center"
+            content={<Translate>This file type is required</Translate>}
+            trigger={
+              <Icon corner="top right" name="asterisk" color={files.length ? 'black' : 'red'} />
+            }
+          />
+        )}
         {fileType.filenameTemplate !== null && (
           <Popup
             position="bottom center"

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/index.jsx
@@ -96,7 +96,7 @@ export function Dropzone({
   });
 
   return (
-    <div {...getRootProps()}>
+    <div {...getRootProps()} styleName="outer-dropzone">
       <input {...getInputProps()} />
       <div styleName="dropzone" className={isDragActive ? 'active' : ''}>
         <Icon color="grey" size="big" name={showNewFileIcon ? 'plus circle' : 'exchange'} />
@@ -154,26 +154,8 @@ function FileType({
             }
           />
         )}
-        {fileType.filenameTemplate !== null && (
-          <Popup
-            position="bottom center"
-            content={
-              <Translate>
-                Filenames must have the format{' '}
-                <Param name="template" value={fileType.filenameTemplate} wrapper={<code />} />
-              </Translate>
-            }
-            trigger={<Icon corner="top right" name="info" />}
-          />
-        )}
       </h3>
-      <TooltipIfTruncated tooltip={fileType.extensions.join(', ')}>
-        <ul styleName="file-extensions">
-          {fileType.extensions.length !== 0
-            ? fileType.extensions.map(ext => <li key={ext}>{ext}</li>)
-            : Translate.string('(no extension restrictions)')}
-        </ul>
-      </TooltipIfTruncated>
+      <FileRequirements fileType={fileType} />
       <FileList files={files} fileType={fileType} uploadURL={uploadURL} />
       {!_.isEmpty(uploads) && <Uploads uploads={uploads} />}
       {!_.isEmpty(fileType.invalidFiles) && (
@@ -243,6 +225,45 @@ FileType.defaultProps = {
   uploads: {},
   uploadableFiles: [],
   uploadExistingURL: null,
+};
+
+function FileRequirements({fileType}) {
+  let extensionInfo = null;
+  let templateInfo = null;
+  if (fileType.filenameTemplate !== null) {
+    const pattern = fileType.filenameTemplate;
+    const extension = fileType.extensions.length === 1 ? fileType.extensions[0] : '*';
+    templateInfo = (
+      <Translate>
+        Filename pattern:{' '}
+        <Param name="pattern" wrapper={<code />} value={`${pattern}.${extension}`} />
+      </Translate>
+    );
+  }
+  if (
+    fileType.extensions.length > 1 ||
+    (fileType.extensions.length !== 0 && fileType.filenameTemplate === null)
+  ) {
+    extensionInfo = fileType.extensions.join(', ');
+  }
+  return (
+    <>
+      {extensionInfo && (
+        <TooltipIfTruncated>
+          <div styleName="file-requirements">{extensionInfo}</div>
+        </TooltipIfTruncated>
+      )}
+      {templateInfo && (
+        <TooltipIfTruncated>
+          <div styleName="file-requirements">{templateInfo}</div>
+        </TooltipIfTruncated>
+      )}
+    </>
+  );
+}
+
+FileRequirements.propTypes = {
+  fileType: PropTypes.shape(fileTypePropTypes).isRequired,
 };
 
 export default function FileManager({

--- a/indico/web/client/js/jquery/extensions/global.js
+++ b/indico/web/client/js/jquery/extensions/global.js
@@ -53,7 +53,7 @@ $(document).ready(function() {
         (!qtipHTML && !title) ||
         this.disabled ||
         $target.data('no-qtip') ||
-        $target.closest('.ui:not(.ui-qtip)').length
+        ($target.closest('.ui:not(.ui-qtip)').length && !$target.hasClass('ui-qtip'))
       ) {
         return;
       }
@@ -81,8 +81,8 @@ $(document).ready(function() {
       } else if (position === 'bottom') {
         positionOptions = {
           my: 'top center',
-          at: 'bottom center'
-        }
+          at: 'bottom center',
+        };
       }
 
       /* Attach the qTip to a new element to avoid side-effects on all elements with "title" attributes. */

--- a/indico/web/client/js/react/components/TooltipIfTruncated.jsx
+++ b/indico/web/client/js/react/components/TooltipIfTruncated.jsx
@@ -5,33 +5,31 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
+import React, {useRef} from 'react';
 import PropTypes from 'prop-types';
 
-export default class TooltipIfTruncated extends React.Component {
-  static propTypes = {
-    children: PropTypes.any.isRequired,
-    tooltip: PropTypes.string,
-  };
+export default function TooltipIfTruncated({children, tooltip}) {
+  const ref = useRef();
 
-  static defaultProps = {
-    tooltip: null,
-  };
-
-  mouseEnter(event) {
-    const {tooltip} = this.props;
-    const element = event.target;
+  const handleMouseEnter = () => {
+    const element = ref.current;
     const overflows =
       element.offsetWidth < element.scrollWidth || element.offsetHeight < element.scrollHeight;
 
     if (overflows && !element.getAttribute('title')) {
       element.setAttribute('title', tooltip || element.innerText);
     }
-  }
+  };
 
-  render() {
-    const {children} = this.props;
-    const child = React.Children.only(children);
-    return React.cloneElement(child, {onMouseEnter: event => this.mouseEnter(event)});
-  }
+  const child = React.Children.only(children);
+  return React.cloneElement(child, {onMouseEnter: handleMouseEnter, ref});
 }
+
+TooltipIfTruncated.propTypes = {
+  children: PropTypes.any.isRequired,
+  tooltip: PropTypes.string,
+};
+
+TooltipIfTruncated.defaultProps = {
+  tooltip: null,
+};

--- a/indico/web/client/js/react/components/TooltipIfTruncated.jsx
+++ b/indico/web/client/js/react/components/TooltipIfTruncated.jsx
@@ -18,6 +18,7 @@ export default function TooltipIfTruncated({children, tooltip}) {
 
     if (overflows && !element.getAttribute('title')) {
       element.setAttribute('title', tooltip || element.innerText);
+      element.classList.add('ui-qtip');
     }
   };
 


### PR DESCRIPTION
Closes #4515.

Combines display of file templates with the requirements for the file extension.
Fixes to the layout of the different file types in editing and fixes to the *TooltipIfTruncated` to work with links in file names.

![Bildschirmfoto 2020-07-07 um 17 00 34](https://user-images.githubusercontent.com/23189858/86801054-edb42680-c073-11ea-8130-a39fc38a0efe.png)
![Bildschirmfoto 2020-07-07 um 17 00 07](https://user-images.githubusercontent.com/23189858/86801090-f4db3480-c073-11ea-816f-0630c95b6303.png)
