### PR TITLE
Introduce tighter controls on abstract modification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,8 @@ Improvements
 - Add "Add myself" button to person list fields (e.g. for abstract authors)
   (:issue:`4411`, thanks :user:`jgrigera`)
 - Add CfA setting to control whether authors can edit abstracts (:issue:`3431`)
+- Add CfA setting to control whether only speakers or also authors should
+  get submission rights once the abstract gets accepted (:issue:`3431`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,7 @@ Improvements
   view (:issue:`4513`)
 - Add "Add myself" button to person list fields (e.g. for abstract authors)
   (:issue:`4411`, thanks :user:`jgrigera`)
+- Add CfA setting to control whether authors can edit abstracts (:issue:`3431`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -23,8 +23,8 @@ from indico.modules.events.abstracts.fields import (AbstractField, AbstractPerso
                                                     TrackRoleField)
 from indico.modules.events.abstracts.models.abstracts import EditTrackMode
 from indico.modules.events.abstracts.models.reviews import AbstractAction, AbstractCommentVisibility
-from indico.modules.events.abstracts.settings import (BOACorrespondingAuthorType, BOALinkFormat, BOASortField,
-                                                      abstracts_settings)
+from indico.modules.events.abstracts.settings import (AllowEditingType, BOACorrespondingAuthorType, BOALinkFormat,
+                                                      BOASortField, abstracts_settings)
 from indico.modules.events.contributions.models.persons import AuthorType
 from indico.modules.events.contributions.models.types import ContributionType
 from indico.modules.events.sessions.models.sessions import Session
@@ -121,6 +121,7 @@ class AbstractSubmissionSettingsForm(IndicoForm):
                                   description=_("Allow the selection of the abstract speakers"))
     speakers_required = BooleanField(_('Require a speaker'), [HiddenUnless('allow_speakers')], widget=SwitchWidget(),
                                      description=_("Make the selection of at least one author as speaker mandatory"))
+    allow_editing = IndicoEnumSelectField(_('Allow editing'), enum=AllowEditingType, sorted=True)
     authorized_submitters = PrincipalListField(_("Authorized submitters"),
                                                description=_("These users may always submit abstracts, even outside "
                                                              "the regular submission period."))

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -24,7 +24,7 @@ from indico.modules.events.abstracts.fields import (AbstractField, AbstractPerso
 from indico.modules.events.abstracts.models.abstracts import EditTrackMode
 from indico.modules.events.abstracts.models.reviews import AbstractAction, AbstractCommentVisibility
 from indico.modules.events.abstracts.settings import (AllowEditingType, BOACorrespondingAuthorType, BOALinkFormat,
-                                                      BOASortField, abstracts_settings)
+                                                      BOASortField, SubmissionRightsType, abstracts_settings)
 from indico.modules.events.contributions.models.persons import AuthorType
 from indico.modules.events.contributions.models.types import ContributionType
 from indico.modules.events.sessions.models.sessions import Session
@@ -121,13 +121,18 @@ class AbstractSubmissionSettingsForm(IndicoForm):
                                   description=_("Allow the selection of the abstract speakers"))
     speakers_required = BooleanField(_('Require a speaker'), [HiddenUnless('allow_speakers')], widget=SwitchWidget(),
                                      description=_("Make the selection of at least one author as speaker mandatory"))
-    allow_editing = IndicoEnumSelectField(_('Allow editing'), enum=AllowEditingType, sorted=True)
+    allow_editing = IndicoEnumSelectField(_('Allow editing'), enum=AllowEditingType, sorted=True,
+                                          description=_("Specify who will be able to edit the abstract"))
+    contribution_submitters = IndicoEnumSelectField(_('Contribution submitters'),
+                                                    enum=SubmissionRightsType, sorted=True,
+                                                    description=_("Specify who will get contribution submission rights "
+                                                                  "once an abstract has been accepted"))
     authorized_submitters = PrincipalListField(_("Authorized submitters"),
                                                description=_("These users may always submit abstracts, even outside "
-                                                             "the regular submission period."))
+                                                             "the regular submission period"))
     submission_instructions = IndicoMarkdownField(_('Instructions'), editor=True,
                                                   description=_("These instructions will be displayed right before the "
-                                                                "submission form."))
+                                                                "submission form"))
 
     @generated_data
     def announcement_render_mode(self):

--- a/indico/modules/events/abstracts/models/abstracts.py
+++ b/indico/modules/events/abstracts/models/abstracts.py
@@ -596,8 +596,7 @@ class Abstract(ProposalMixin, ProposalRevisionMixin, DescriptionMixin, CustomFie
             return True
         elif editing_allowed == AllowEditingType.submitter_authors and (is_primary or is_secondary):
             return True
-        else:
-            return False
+        return False
 
     def can_withdraw(self, user, check_state=False):
         if not user:

--- a/indico/modules/events/abstracts/models/call_for_abstracts.py
+++ b/indico/modules/events/abstracts/models/call_for_abstracts.py
@@ -33,6 +33,7 @@ class CallForAbstracts(object):
                                                           'allow_contributors_in_comments')
     allow_convener_judgment = EventSettingProperty(abstracts_reviewing_settings, 'allow_convener_judgment')
     allow_editing = EventSettingProperty(abstracts_settings, 'allow_editing')
+    contribution_submitters = EventSettingProperty(abstracts_settings, 'contribution_submitters')
     submission_instructions = EventSettingProperty(abstracts_settings, 'submission_instructions')
     reviewing_instructions = EventSettingProperty(abstracts_reviewing_settings, 'reviewing_instructions')
     judgment_instructions = EventSettingProperty(abstracts_reviewing_settings, 'judgment_instructions')

--- a/indico/modules/events/abstracts/models/call_for_abstracts.py
+++ b/indico/modules/events/abstracts/models/call_for_abstracts.py
@@ -32,6 +32,7 @@ class CallForAbstracts(object):
     allow_contributors_in_comments = EventSettingProperty(abstracts_reviewing_settings,
                                                           'allow_contributors_in_comments')
     allow_convener_judgment = EventSettingProperty(abstracts_reviewing_settings, 'allow_convener_judgment')
+    allow_editing = EventSettingProperty(abstracts_settings, 'allow_editing')
     submission_instructions = EventSettingProperty(abstracts_settings, 'submission_instructions')
     reviewing_instructions = EventSettingProperty(abstracts_reviewing_settings, 'reviewing_instructions')
     judgment_instructions = EventSettingProperty(abstracts_reviewing_settings, 'judgment_instructions')

--- a/indico/modules/events/abstracts/settings.py
+++ b/indico/modules/events/abstracts/settings.py
@@ -39,6 +39,11 @@ class AllowEditingType(RichEnum):
     submitter = 'submitter'
 
 
+class SubmissionRightsType(RichEnum):
+    speakers = 'speakers'
+    all = 'all'
+
+
 class BOALinkFormat(RichEnum):
     """LaTeX book of abstracts link format setting
 
@@ -84,6 +89,11 @@ AllowEditingType.__titles__ = {
     AllowEditingType.submitter: _('Abstract submitter only')
 }
 
+SubmissionRightsType.__titles__ = {
+    SubmissionRightsType.speakers: _('Speakers'),
+    SubmissionRightsType.all: _('Speakers and authors')
+}
+
 abstracts_settings = EventSettingsProxy('abstracts', {
     'description_settings': {
         'is_active': True,
@@ -103,6 +113,7 @@ abstracts_settings = EventSettingsProxy('abstracts', {
     'allow_speakers': True,
     'speakers_required': True,
     'allow_editing': AllowEditingType.submitter_all,
+    'contribution_submitters': SubmissionRightsType.all,
     'contrib_type_required': False,
     'submission_instructions': ''
 }, acls={

--- a/indico/modules/events/abstracts/settings.py
+++ b/indico/modules/events/abstracts/settings.py
@@ -32,6 +32,13 @@ class BOACorrespondingAuthorType(RichEnum):
     speakers = 'speakers'
 
 
+class AllowEditingType(RichEnum):
+    submitter_all = 'submitter_all'
+    submitter_authors = 'submitter_authors'
+    submitter_primary = 'submitter_primary'
+    submitter = 'submitter'
+
+
 class BOALinkFormat(RichEnum):
     """LaTeX book of abstracts link format setting
 
@@ -64,11 +71,17 @@ BOACorrespondingAuthorType.__titles__ = {
     BOACorrespondingAuthorType.speakers: _('Speakers')
 }
 
-
 BOALinkFormat.__titles__ = {
     BOALinkFormat.frame: _('Border around links (screen only)'),
     BOALinkFormat.colorlinks: _('Color links'),
     BOALinkFormat.unstyled: _('Do not highlight links')
+}
+
+AllowEditingType.__titles__ = {
+    AllowEditingType.submitter_all: _('All involved people (submitter, authors, speakers)'),
+    AllowEditingType.submitter_authors: _('Abstract submitter and all authors (primary and co-authors)'),
+    AllowEditingType.submitter_primary: _('Abstract submitter and primary authors'),
+    AllowEditingType.submitter: _('Abstract submitter only')
 }
 
 abstracts_settings = EventSettingsProxy('abstracts', {
@@ -89,6 +102,7 @@ abstracts_settings = EventSettingsProxy('abstracts', {
     'copy_attachments': False,
     'allow_speakers': True,
     'speakers_required': True,
+    'allow_editing': AllowEditingType.submitter_all,
     'contrib_type_required': False,
     'submission_instructions': ''
 }, acls={
@@ -96,7 +110,8 @@ abstracts_settings = EventSettingsProxy('abstracts', {
 }, converters={
     'start_dt': DatetimeConverter,
     'end_dt': DatetimeConverter,
-    'modification_end_dt': DatetimeConverter
+    'modification_end_dt': DatetimeConverter,
+    'allow_editing': EnumConverter(AllowEditingType),
 })
 
 

--- a/indico/modules/events/abstracts/templates/reviewing/public.html
+++ b/indico/modules/events/abstracts/templates/reviewing/public.html
@@ -79,9 +79,12 @@
                     {% elif abstract.public_state.name != 'awaiting' %}
                         <a class="i-button icon-edit disabled"
                            title="{% trans %}The abstract cannot be edited because it has already been processed{% endtrans %}"></a>
-                    {% else %}
+                    {% elif abstract.modification_ended %}
                         <a class="i-button icon-edit disabled"
                            title="{% trans %}The abstract cannot be edited because the modification deadline has passed{% endtrans %}"></a>
+                    {% else %}
+                        <a class="i-button icon-edit disabled"
+                           title="{% trans %}You are not authorized to edit this abstract{% endtrans %}"></a>
                     {% endif %}
                 </div>
             {% endif %}


### PR DESCRIPTION
- [x] Speakers should have submission rights (uploading files);
- [x] Only primary authors should be able to edit the title/description and authors of the abstract (ideally configurable)

closes #3431 