### PR TITLE
Add link from event menu to editing hybrid view

### DIFF
--- a/indico/modules/events/layout/models/menu.py
+++ b/indico/modules/events/layout/models/menu.py
@@ -68,7 +68,7 @@ class MenuEntryMixin(object):
             data = self.default_data
             if data.static_site and isinstance(data.static_site, basestring) and g.get('static_site'):
                 return data.static_site
-            kwargs = {}
+            kwargs = dict(data.url_kwargs)
             if self.name == 'timetable':
                 from indico.modules.events. layout import layout_settings
                 if layout_settings.get(self.event_ref, 'timetable_by_room'):

--- a/indico/modules/events/layout/util.py
+++ b/indico/modules/events/layout/util.py
@@ -94,11 +94,13 @@ class MenuEntryData(object):
         be shown in the menu of a static site.  When set to a string,
         the string will be used instead of a mangled version of the
         endpoint's URL.
+    :param url_kwargs: dict -- Additional data passed to ``url_for``
+        when building the url the menu item points to.
     """
     plugin = None
 
     def __init__(self, title, name, endpoint=None, position=-1, is_enabled=True, visible=None, parent=None,
-                 static_site=False):
+                 static_site=False, url_kwargs=None):
         self.title = title
         self._name = name
         self.endpoint = endpoint
@@ -107,6 +109,7 @@ class MenuEntryData(object):
         self.is_enabled = is_enabled
         self.parent = parent
         self.static_site = static_site
+        self.url_kwargs = url_kwargs or {}
 
     @property
     def name(self):

--- a/indico/modules/events/layout/util.py
+++ b/indico/modules/events/layout/util.py
@@ -201,7 +201,7 @@ def _check_menu(event):
                       joinedload('children').load_only('id', 'parent_id', 'name', 'position')))
 
     existing = {entry.name: entry for entry in query}
-    pos_gen = count(start=(max(x.position for x in existing.itervalues() if not x.parent)))
+    pos_gen = count(start=(max(x.position for x in existing.itervalues() if not x.parent) + 1))
     entries = []
     top_created = set()
     for name, data in top_data.iteritems():


### PR DESCRIPTION
Currently the only way to get there is by going to an editable timeline and then using the link in the menu there...

We probably need a top-level menu entry with submenus for the editable types (otherwise we'd have to add some kind of dashboard).

Editing
- Papers
- Posters
- Slides

Alternatively we could also add a single link to Editing which goes to the editing view. But then we need a way to change the editable type there, and also add some page the user ends up when going there (since going to any specific editable type would be a bit weird, especially if more than one is enabled).

---

Note when testing: If event menu customization is enabled for an event, chances are good that you need to temporarily return `True` from `_menu_needs_recheck` and load the event page once since the event menu update logic only runs once for each indico version and event.