### PR TITLE
Add Flask-Caching

### DIFF
--- a/indico/core/cache.py
+++ b/indico/core/cache.py
@@ -1,0 +1,11 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2020 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from flask_caching import Cache
+
+
+cache = Cache()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ email-validator==1.1.1
 enum34
 feedgen==0.9.0
 Flask-BabelEx==0.9.4
+Flask-Caching==1.7.2
 flask-marshmallow==0.11.0
 Flask-Migrate==2.5.3
 Flask-Multipass>=0.2,<0.4-dev


### PR DESCRIPTION
Not used by indico itself yet, but useful if e.g. a flask-multipass extension (flask-multipass-cern ;)) wants to use caching.

It could also be the successor of the legacy GenericCache in 3.0.