### PR TITLE
Include metadata for more event log entries

### DIFF
--- a/indico/modules/events/abstracts/models/abstracts.py
+++ b/indico/modules/events/abstracts/models/abstracts.py
@@ -684,3 +684,7 @@ class Abstract(ProposalMixin, ProposalRevisionMixin, DescriptionMixin, CustomFie
         if not user:
             return None
         return user == self.submitter or any(x.person.user == user for x in self.person_links)
+
+    def log(self, *args, **kwargs):
+        """Log with prefilled metadata for the abstract."""
+        self.event.log(*args, meta={'abstract_id': self.id}, **kwargs)

--- a/indico/modules/events/abstracts/operations.py
+++ b/indico/modules/events/abstracts/operations.py
@@ -73,8 +73,8 @@ def add_abstract_files(abstract, files, log_action=True):
             msg = 'Added file to abstract {}'.format(abstract.verbose_title)
         else:
             msg = 'Added {} files to abstract {}'.format(num, abstract.verbose_title)
-        abstract.event.log(EventLogRealm.reviewing, EventLogKind.positive, 'Abstracts', msg, session.user,
-                           data={'Files': ', '.join(f.filename for f in abstract.files)})
+        abstract.log(EventLogRealm.reviewing, EventLogKind.positive, 'Abstracts', msg, session.user,
+                     data={'Files': ', '.join(f.filename for f in abstract.files)})
 
 
 def delete_abstract_files(abstract, files):
@@ -88,8 +88,8 @@ def delete_abstract_files(abstract, files):
         msg = 'Deleted file from abstract {}'.format(abstract.verbose_title)
     else:
         msg = 'Deleted {} files from abstract {}'.format(num, abstract.verbose_title)
-    abstract.event.log(EventLogRealm.reviewing, EventLogKind.negative, 'Abstracts', msg, session.user,
-                       data={'Files': ', '.join(f.filename for f in files)})
+    abstract.log(EventLogRealm.reviewing, EventLogKind.negative, 'Abstracts', msg, session.user,
+                 data={'Files': ', '.join(f.filename for f in files)})
 
 
 def create_abstract(event, abstract_data, custom_fields_data=None, send_notifications=False, submitter=None,
@@ -114,8 +114,8 @@ def create_abstract(event, abstract_data, custom_fields_data=None, send_notifica
     if send_notifications:
         send_abstract_notifications(abstract)
     logger.info('Abstract %s created by %s', abstract, session.user)
-    abstract.event.log(EventLogRealm.reviewing, EventLogKind.positive, 'Abstracts',
-                       'Abstract {} created'.format(abstract.verbose_title), session.user)
+    abstract.log(EventLogRealm.reviewing, EventLogKind.positive, 'Abstracts',
+                 'Abstract {} created'.format(abstract.verbose_title), session.user)
     return abstract
 
 
@@ -166,9 +166,9 @@ def update_abstract(abstract, abstract_data, custom_fields_data=None):
             'type': field_impl.log_type,
             'convert': lambda change, field_impl=field_impl: map(field_impl.get_friendly_value, change)
         }
-    abstract.event.log(EventLogRealm.reviewing, EventLogKind.change, 'Abstracts',
-                       'Abstract {} modified'.format(abstract.verbose_title), session.user,
-                       data={'Changes': make_diff_log(changes, log_fields)})
+    abstract.log(EventLogRealm.reviewing, EventLogKind.change, 'Abstracts',
+                 'Abstract {} modified'.format(abstract.verbose_title), session.user,
+                 data={'Changes': make_diff_log(changes, log_fields)})
 
 
 def withdraw_abstract(abstract):
@@ -181,8 +181,8 @@ def withdraw_abstract(abstract):
     db.session.flush()
     signals.event.abstract_state_changed.send(abstract)
     logger.info('Abstract %s withdrawn by %s', abstract, session.user)
-    abstract.event.log(EventLogRealm.reviewing, EventLogKind.negative, 'Abstracts',
-                       'Abstract {} withdrawn'.format(abstract.verbose_title), session.user)
+    abstract.log(EventLogRealm.reviewing, EventLogKind.negative, 'Abstracts',
+                 'Abstract {} withdrawn'.format(abstract.verbose_title), session.user)
 
 
 def delete_abstract(abstract, delete_contrib=False):
@@ -194,8 +194,8 @@ def delete_abstract(abstract, delete_contrib=False):
     db.session.flush()
     signals.event.abstract_deleted.send(abstract)
     logger.info('Abstract %s deleted by %s', abstract, session.user)
-    abstract.event.log(EventLogRealm.reviewing, EventLogKind.negative, 'Abstracts',
-                       'Abstract {} deleted'.format(abstract.verbose_title), session.user)
+    abstract.log(EventLogRealm.reviewing, EventLogKind.negative, 'Abstracts',
+                 'Abstract {} deleted'.format(abstract.verbose_title), session.user)
 
 
 def judge_abstract(abstract, abstract_data, judgment, judge, contrib_session=None, merge_persons=False,
@@ -234,8 +234,8 @@ def judge_abstract(abstract, abstract_data, judgment, judge, contrib_session=Non
     if send_notifications:
         log_data['Notifications sent'] = send_abstract_notifications(abstract)
     logger.info('Abstract %s judged by %s', abstract, judge)
-    abstract.event.log(EventLogRealm.reviewing, EventLogKind.change, 'Abstracts',
-                       'Abstract {} judged'.format(abstract.verbose_title), judge, data=log_data)
+    abstract.log(EventLogRealm.reviewing, EventLogKind.change, 'Abstracts',
+                 'Abstract {} judged'.format(abstract.verbose_title), judge, data=log_data)
 
 
 def _merge_person_links(target_abstract, source_abstract):
@@ -281,18 +281,16 @@ def update_reviewed_for_tracks(abstract, tracks):
     _update_tracks(abstract, tracks, only_reviewed_for=True)
     db.session.flush()
     logger.info('Reviewed tracks of abstract %s updated by %s', abstract, session.user)
-    abstract.event.log(EventLogRealm.reviewing, EventLogKind.change, 'Abstracts',
-                       'Reviewed tracks of abstract {} updated'.format(abstract.verbose_title),
-                       session.user)
+    abstract.log(EventLogRealm.reviewing, EventLogKind.change, 'Abstracts',
+                 'Reviewed tracks of abstract {} updated'.format(abstract.verbose_title), session.user)
 
 
 def reset_abstract_state(abstract):
     abstract.reset_state()
     db.session.flush()
     logger.info('Abstract %s state reset by %s', abstract, session.user)
-    abstract.event.log(EventLogRealm.reviewing, EventLogKind.change, 'Abstracts',
-                       'State of abstract {} reset'.format(abstract.verbose_title),
-                       session.user)
+    abstract.log(EventLogRealm.reviewing, EventLogKind.change, 'Abstracts',
+                 'State of abstract {} reset'.format(abstract.verbose_title), session.user)
 
 
 def create_abstract_comment(abstract, comment_data):
@@ -301,9 +299,8 @@ def create_abstract_comment(abstract, comment_data):
     comment.abstract = abstract
     db.session.flush()
     logger.info("Abstract %s received a comment from %s", abstract, session.user)
-    abstract.event.log(EventLogRealm.reviewing, EventLogKind.positive, 'Abstracts',
-                       'Abstract {} received a comment'.format(abstract.verbose_title),
-                       session.user)
+    abstract.log(EventLogRealm.reviewing, EventLogKind.positive, 'Abstracts',
+                 'Abstract {} received a comment'.format(abstract.verbose_title), session.user)
 
 
 def update_abstract_comment(comment, comment_data):
@@ -312,19 +309,18 @@ def update_abstract_comment(comment, comment_data):
     comment.modified_dt = now_utc()
     db.session.flush()
     logger.info("Abstract comment %s modified by %s", comment, session.user)
-    comment.abstract.event.log(EventLogRealm.reviewing, EventLogKind.change, 'Abstracts',
-                               'Comment on abstract {} modified'.format(comment.abstract.verbose_title),
-                               session.user,
-                               data={'Changes': make_diff_log(changes, {'text': 'Text', 'visibility': 'Visibility'})})
+    comment.abstract.log(EventLogRealm.reviewing, EventLogKind.change, 'Abstracts',
+                         'Comment on abstract {} modified'.format(comment.abstract.verbose_title),
+                         session.user,
+                         data={'Changes': make_diff_log(changes, {'text': 'Text', 'visibility': 'Visibility'})})
 
 
 def delete_abstract_comment(comment):
     comment.is_deleted = True
     db.session.flush()
     logger.info("Abstract comment %s deleted by %s", comment, session.user)
-    comment.abstract.event.log(EventLogRealm.reviewing, EventLogKind.negative, 'Abstracts',
-                               'Comment on abstract {} removed'.format(comment.abstract.verbose_title),
-                               session.user)
+    comment.abstract.log(EventLogRealm.reviewing, EventLogKind.negative, 'Abstracts',
+                         'Comment on abstract {} removed'.format(comment.abstract.verbose_title), session.user)
 
 
 def create_abstract_review(abstract, track, user, review_data, questions_data):
@@ -349,8 +345,8 @@ def create_abstract_review(abstract, track, user, review_data, questions_data):
         log_data['Other tracks'] = sorted(t.title for t in review.proposed_tracks)
     elif review.proposed_action in {AbstractAction.mark_as_duplicate, AbstractAction.merge}:
         log_data['Other abstract'] = review.proposed_related_abstract.verbose_title
-    abstract.event.log(EventLogRealm.reviewing, EventLogKind.positive, 'Abstracts',
-                       'Abstract {} reviewed'.format(abstract.verbose_title), user, data=log_data)
+    abstract.log(EventLogRealm.reviewing, EventLogKind.positive, 'Abstracts',
+                 'Abstract {} reviewed'.format(abstract.verbose_title), user, data=log_data)
     return review
 
 

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -412,7 +412,7 @@ class RHContributionUpdateDuration(RHManageContributionBase):
         if form.validate_on_submit():
             with track_time_changes():
                 update_contribution(self.contrib, {'duration': form.duration.data})
-            return jsonify_data(new_value=format_human_timedelta(self.contrib.duration))
+            return jsonify_data(new_value=format_human_timedelta(self.contrib.duration, narrow=True))
         return jsonify_form(form, back_button=False, disabled_until_change=True)
 
 

--- a/indico/modules/events/contributions/models/contributions.py
+++ b/indico/modules/events/contributions/models/contributions.py
@@ -568,6 +568,10 @@ class Contribution(DescriptionMixin, ProtectionManagersMixin, LocationMixin, Att
         """Get the editable of the given type."""
         return next((e for e in self.editables if e.type == editable_type), None)
 
+    def log(self, *args, **kwargs):
+        """Log with prefilled metadata for the contribution."""
+        self.event.log(*args, meta={'contribution_id': self.id}, **kwargs)
+
 
 Contribution.register_protection_events()
 

--- a/indico/modules/events/contributions/operations.py
+++ b/indico/modules/events/contributions/operations.py
@@ -65,8 +65,8 @@ def create_contribution(event, contrib_data, custom_fields_data=None, session_bl
         schedule_contribution(contrib, start_dt=start_dt, session_block=session_block, extend_parent=extend_parent)
     signals.event.contribution_created.send(contrib)
     logger.info('Contribution %s created by %s', contrib, user)
-    contrib.event.log(EventLogRealm.management, EventLogKind.positive, 'Contributions',
-                      'Contribution "{}" has been created'.format(contrib.title), user)
+    contrib.log(EventLogRealm.management, EventLogKind.positive, 'Contributions',
+                'Contribution "{}" has been created'.format(contrib.title), user)
     return contrib
 
 
@@ -105,8 +105,8 @@ def update_contribution(contrib, contrib_data, custom_fields_data=None):
     if changes:
         signals.event.contribution_updated.send(contrib, changes=changes)
         logger.info('Contribution %s updated by %s', contrib, session.user)
-        contrib.event.log(EventLogRealm.management, EventLogKind.change, 'Contributions',
-                          'Contribution "{}" has been updated'.format(contrib.title), session.user)
+        contrib.log(EventLogRealm.management, EventLogKind.change, 'Contributions',
+                    'Contribution "{}" has been updated'.format(contrib.title), session.user)
     return rv
 
 
@@ -117,8 +117,8 @@ def delete_contribution(contrib):
     db.session.flush()
     signals.event.contribution_deleted.send(contrib)
     logger.info('Contribution %s deleted by %s', contrib, session.user)
-    contrib.event.log(EventLogRealm.management, EventLogKind.negative, 'Contributions',
-                      'Contribution "{}" has been deleted'.format(contrib.title), session.user)
+    contrib.log(EventLogRealm.management, EventLogKind.negative, 'Contributions',
+                'Contribution "{}" has been deleted'.format(contrib.title), session.user)
 
 
 def create_subcontribution(contrib, data):
@@ -129,7 +129,8 @@ def create_subcontribution(contrib, data):
     signals.event.subcontribution_created.send(subcontrib)
     logger.info('Subcontribution %s created by %s', subcontrib, session.user)
     subcontrib.event.log(EventLogRealm.management, EventLogKind.positive, 'Subcontributions',
-                         'Subcontribution "{}" has been created'.format(subcontrib.title), session.user)
+                         'Subcontribution "{}" has been created'.format(subcontrib.title), session.user,
+                         meta={'subcontribution_id': subcontrib.id})
     return subcontrib
 
 
@@ -139,7 +140,8 @@ def update_subcontribution(subcontrib, data):
     signals.event.subcontribution_updated.send(subcontrib)
     logger.info('Subcontribution %s updated by %s', subcontrib, session.user)
     subcontrib.event.log(EventLogRealm.management, EventLogKind.change, 'Subcontributions',
-                         'Subcontribution "{}" has been updated'.format(subcontrib.title), session.user)
+                         'Subcontribution "{}" has been updated'.format(subcontrib.title), session.user,
+                         meta={'subcontribution_id': subcontrib.id})
 
 
 def delete_subcontribution(subcontrib):
@@ -148,7 +150,8 @@ def delete_subcontribution(subcontrib):
     signals.event.subcontribution_deleted.send(subcontrib)
     logger.info('Subcontribution %s deleted by %s', subcontrib, session.user)
     subcontrib.event.log(EventLogRealm.management, EventLogKind.negative, 'Subcontributions',
-                         'Subcontribution "{}" has been deleted'.format(subcontrib.title), session.user)
+                         'Subcontribution "{}" has been deleted'.format(subcontrib.title), session.user,
+                         meta={'subcontribution_id': subcontrib.id})
 
 
 @no_autoflush

--- a/indico/modules/events/editing/models/editable.py
+++ b/indico/modules/events/editing/models/editable.py
@@ -232,6 +232,10 @@ class Editable(db.Model):
     def timeline_url(self):
         return url_for('event_editing.editable', self)
 
+    def log(self, *args, **kwargs):
+        """Log with prefilled metadata for the editable."""
+        self.event.log(*args, meta={'editable_id': self.id}, **kwargs)
+
 
 @listens_for(orm.mapper, 'after_configured', once=True)
 def _mappers_configured():

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -330,7 +330,7 @@ def assign_editor(editable, editor):
     log_msg = '"{}" ({}) assigned to {}'.format(editable.contribution.title,
                                                 orig_string(editable.type.title),
                                                 editor.full_name)
-    editable.event.log(EventLogRealm.management, EventLogKind.positive, 'Editing', log_msg, session.user, data=log_data)
+    editable.log(EventLogRealm.management, EventLogKind.positive, 'Editing', log_msg, session.user, data=log_data)
     db.session.flush()
 
 
@@ -346,7 +346,7 @@ def unassign_editor(editable):
     log_msg = '"{}" ({}) unassigned from {}'.format(editable.contribution.title,
                                                     orig_string(editable.type.title),
                                                     editor.full_name)
-    editable.event.log(EventLogRealm.management, EventLogKind.negative, 'Editing', log_msg, session.user, data=log_data)
+    editable.log(EventLogRealm.management, EventLogKind.negative, 'Editing', log_msg, session.user, data=log_data)
     db.session.flush()
 
 

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -808,7 +808,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
 
     @memoize_request
     def has_feature(self, feature):
-        """Checks if a feature is enabled for the event"""
+        """Check if a feature is enabled for the event"""
         from indico.modules.events.features.util import is_feature_enabled
         return is_feature_enabled(self, feature)
 
@@ -819,7 +819,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         return get_scheduled_notes(self)
 
     def log(self, realm, kind, module, summary, user=None, type_='simple', data=None, meta=None):
-        """Creates a new log entry for the event
+        """Create a new log entry for the event.
 
         :param realm: A value from :class:`.EventLogRealm` indicating
                       the realm of the action.

--- a/indico/modules/events/sessions/operations.py
+++ b/indico/modules/events/sessions/operations.py
@@ -26,7 +26,8 @@ def create_session(event, data):
     event_session.populate_from_dict(data)
     db.session.flush()
     event.log(EventLogRealm.management, EventLogKind.positive, 'Sessions',
-              'Session "{}" has been created'.format(event_session.title), session.user)
+              'Session "{}" has been created'.format(event_session.title), session.user,
+              meta={'session_id': event_session.id})
     logger.info('Session %s created by %s', event_session, session.user)
     return event_session
 
@@ -37,7 +38,8 @@ def create_session_block(session_, data):
     db.session.flush()
     session_.event.log(EventLogRealm.management, EventLogKind.positive, 'Sessions',
                        'Session block "{}" for session "{}" has been created'
-                       .format(block.title, session_.title), session.user)
+                       .format(block.title, session_.title), session.user,
+                       meta={'session_block_id': block.id})
     logger.info("Session block %s created by %s", block, session.user)
     return block
 
@@ -48,7 +50,8 @@ def update_session(event_session, data):
     db.session.flush()
     signals.event.session_updated.send(event_session)
     event_session.event.log(EventLogRealm.management, EventLogKind.change, 'Sessions',
-                            'Session "{}" has been updated'.format(event_session.title), session.user)
+                            'Session "{}" has been updated'.format(event_session.title), session.user,
+                            meta={'session_id': event_session.id})
     logger.info('Session %s modified by %s', event_session, session.user)
 
 
@@ -71,6 +74,9 @@ def delete_session(event_session):
         contribution.session = None
     _delete_session_timetable_entries(event_session)
     signals.event.session_deleted.send(event_session)
+    event_session.event.log(EventLogRealm.management, EventLogKind.negative, 'Sessions',
+                            'Session "{}" has been deleted'.format(event_session.title), session.user,
+                            meta={'session_id': event_session.id})
     logger.info('Session %s deleted by %s', event_session, session.user)
 
 
@@ -85,7 +91,8 @@ def update_session_block(session_block, data):
     session_block.populate_from_dict(data)
     db.session.flush()
     session_block.event.log(EventLogRealm.management, EventLogKind.change, 'Sessions',
-                            'Session block "{}" has been updated'.format(session_block.title), session.user)
+                            'Session block "{}" has been updated'.format(session_block.title), session.user,
+                            meta={'session_block_id': session_block.id})
     logger.info('Session block %s modified by %s', session_block, session.user)
 
 
@@ -109,6 +116,9 @@ def delete_session_block(session_block):
     if not session_.blocks and session_.event.type != 'conference':
         delete_session(session_)
     db.session.flush()
+    session_block.event.log(EventLogRealm.management, EventLogKind.negative, 'Sessions',
+                            'Session block "{}" has been deleted'.format(session_block.title), session.user,
+                            meta={'session_block_id': session_block.id})
     logger.info('Session block %s deleted by %s', session_block, session.user)
 
 


### PR DESCRIPTION
Closes #4514 
Also fixes display of the duration in the contribution list, which used the long name instead of the short one directly after editing.