### PR TITLE
Update AccessControlListField principal list to React

### DIFF
--- a/indico/modules/attachments/forms.py
+++ b/indico/modules/attachments/forms.py
@@ -32,7 +32,8 @@ class AttachmentFormBase(IndicoForm):
                               description=_("Adding materials to folders allow grouping and easier permission "
                                             "management."))
     acl = AccessControlListField(_("Access control list"), [UsedIf(lambda form, field: form.protected.data)],
-                                 groups=True, allow_external=True, default_text=_('Restrict access to this material'),
+                                 allow_groups=True, allow_external_users=True,
+                                 default_text=_('Restrict access to this material'),
                                  description=_("The list of users and groups allowed to access the material"))
 
     def __init__(self, *args, **kwargs):
@@ -90,7 +91,8 @@ class AttachmentFolderForm(IndicoForm):
     description = TextAreaField(_("Description"), description=_("Description of the folder and its content"))
     protected = BooleanField(_("Protected"), widget=SwitchWidget())
     acl = AccessControlListField(_("Access control list"), [UsedIf(lambda form, field: form.protected.data)],
-                                 groups=True, allow_external=True, default_text=_('Restrict access to this folder'),
+                                 allow_groups=True, allow_external_users=True,
+                                 default_text=_('Restrict access to this folder'),
                                  description=_("The list of users and groups allowed to access the folder"))
     is_always_visible = BooleanField(_("Always Visible"),
                                      [HiddenUnless('is_hidden', value=False)],

--- a/indico/modules/attachments/forms.py
+++ b/indico/modules/attachments/forms.py
@@ -32,12 +32,15 @@ class AttachmentFormBase(IndicoForm):
                               description=_("Adding materials to folders allow grouping and easier permission "
                                             "management."))
     acl = AccessControlListField(_("Access control list"), [UsedIf(lambda form, field: form.protected.data)],
-                                 allow_groups=True, allow_external_users=True,
+                                 allow_groups=True, allow_external_users=True, allow_event_roles=True,
+                                 allow_category_roles=True, allow_registration_forms=True,
+                                 event=lambda form: form.event,
                                  default_text=_('Restrict access to this material'),
                                  description=_("The list of users and groups allowed to access the material"))
 
     def __init__(self, *args, **kwargs):
         linked_object = kwargs.pop('linked_object')
+        self.event = getattr(linked_object, 'event', None)  # not present in categories
         super(AttachmentFormBase, self).__init__(*args, **kwargs)
         self.folder.query = (AttachmentFolder
                              .find(object=linked_object, is_default=False, is_deleted=False)

--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -249,6 +249,11 @@ class PrincipalsMixin(object):
                     'type': 'registration_form',
                     'invalid': principal.is_deleted,
                     'name': principal.title}
+        elif principal.principal_type == PrincipalType.email:
+            return {'identifier': identifier,
+                    'type': 'email',
+                    'invalid': False,
+                    'name': principal.name}
 
     def _process(self):
         return jsonify({identifier: self._serialize_principal(identifier, principal)
@@ -264,7 +269,7 @@ class RHPrincipals(PrincipalsMixin, RHProtected):
     """
 
     @use_kwargs({
-        'values': PrincipalDict(allow_groups=True, allow_external_users=True, missing={})
+        'values': PrincipalDict(allow_groups=True, allow_external_users=True, allow_emails=True, missing={})
     })
     def _process_args(self, values):
         self.values = values

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -36,7 +36,7 @@ from indico.web.forms.base import FormDefaults, IndicoForm, generated_data
 from indico.web.forms.fields import (EditableFileField, EmailListField, HiddenEnumField, HiddenFieldList,
                                      IndicoDateTimeField, IndicoEnumSelectField, IndicoMarkdownField,
                                      IndicoQuerySelectMultipleCheckboxField, IndicoQuerySelectMultipleField,
-                                     IndicoRadioField, PrincipalField, PrincipalListField)
+                                     IndicoRadioField, PrincipalField, _LegacyPrincipalListField)
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, LinkedDateTime, SoftLength, UsedIf, WordCount
 from indico.web.forms.widgets import JinjaWidget, SwitchWidget
@@ -127,9 +127,9 @@ class AbstractSubmissionSettingsForm(IndicoForm):
                                                     enum=SubmissionRightsType, sorted=True,
                                                     description=_("Specify who will get contribution submission rights "
                                                                   "once an abstract has been accepted"))
-    authorized_submitters = PrincipalListField(_("Authorized submitters"),
-                                               description=_("These users may always submit abstracts, even outside "
-                                                             "the regular submission period"))
+    authorized_submitters = _LegacyPrincipalListField(_("Authorized submitters"),
+                                                      description=_("These users may always submit abstracts, "
+                                                                    "even outside the regular submission period."))
     submission_instructions = IndicoMarkdownField(_('Instructions'), editor=True,
                                                   description=_("These instructions will be displayed right before the "
                                                                 "submission form"))

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -36,7 +36,8 @@ from indico.web.forms.base import FormDefaults, IndicoForm, generated_data
 from indico.web.forms.fields import (EditableFileField, EmailListField, HiddenEnumField, HiddenFieldList,
                                      IndicoDateTimeField, IndicoEnumSelectField, IndicoMarkdownField,
                                      IndicoQuerySelectMultipleCheckboxField, IndicoQuerySelectMultipleField,
-                                     IndicoRadioField, PrincipalField, _LegacyPrincipalListField)
+                                     IndicoRadioField, PrincipalField)
+from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, LinkedDateTime, SoftLength, UsedIf, WordCount
 from indico.web.forms.widgets import JinjaWidget, SwitchWidget
@@ -127,9 +128,9 @@ class AbstractSubmissionSettingsForm(IndicoForm):
                                                     enum=SubmissionRightsType, sorted=True,
                                                     description=_("Specify who will get contribution submission rights "
                                                                   "once an abstract has been accepted"))
-    authorized_submitters = _LegacyPrincipalListField(_("Authorized submitters"),
-                                                      description=_("These users may always submit abstracts, "
-                                                                    "even outside the regular submission period."))
+    authorized_submitters = PrincipalListField(_("Authorized submitters"),
+                                               description=_("These users may always submit abstracts, "
+                                                             "even outside the regular submission period."))
     submission_instructions = IndicoMarkdownField(_('Instructions'), editor=True,
                                                   description=_("These instructions will be displayed right before the "
                                                                 "submission form"))

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -617,7 +617,8 @@ class InvitedAbstractMixin(object):
                                              choices=(('existing', _('Existing user')),
                                                       ('new', _('New user'))))
     submitter = PrincipalField(_('Submitter'),
-                               [HiddenUnless('users_with_no_account', 'existing'), DataRequired()], allow_external=True,
+                               [HiddenUnless('users_with_no_account', 'existing'), DataRequired()],
+                               allow_external_users=True,
                                description=_('The person invited to submit the abstract'))
     first_name = StringField(_('First name'), [HiddenUnless('users_with_no_account', 'new'), DataRequired()])
     last_name = StringField(_('Family name'), [HiddenUnless('users_with_no_account', 'new'), DataRequired()])

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -23,7 +23,7 @@ from indico.modules.events.util import serialize_person_link
 from indico.modules.users.models.users import UserTitle
 from indico.modules.users.util import get_user_by_email
 from indico.util.i18n import _, orig_string
-from indico.web.forms.fields import MultipleItemsField, PrincipalListField
+from indico.web.forms.fields import MultipleItemsField, _LegacyPrincipalListField
 from indico.web.forms.widgets import JinjaWidget
 
 
@@ -70,7 +70,7 @@ class ReferencesField(MultipleItemsField):
             return [{'id': r.id, 'type': unicode(r.reference_type_id), 'value': r.value} for r in self.data]
 
 
-class EventPersonListField(PrincipalListField):
+class EventPersonListField(_LegacyPrincipalListField):
     """A field that lets you select a list Indico user and EventPersons
 
     Requires its form to have an event set.

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -23,7 +23,8 @@ from indico.modules.events.util import serialize_person_link
 from indico.modules.users.models.users import UserTitle
 from indico.modules.users.util import get_user_by_email
 from indico.util.i18n import _, orig_string
-from indico.web.forms.fields import MultipleItemsField, _LegacyPrincipalListField
+from indico.web.forms.fields import MultipleItemsField
+from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.widgets import JinjaWidget
 
 
@@ -70,7 +71,7 @@ class ReferencesField(MultipleItemsField):
             return [{'id': r.id, 'type': unicode(r.reference_type_id), 'value': r.value} for r in self.data]
 
 
-class EventPersonListField(_LegacyPrincipalListField):
+class EventPersonListField(PrincipalListField):
     """A field that lets you select a list Indico user and EventPersons
 
     Requires its form to have an event set.
@@ -82,7 +83,7 @@ class EventPersonListField(_LegacyPrincipalListField):
 
     def __init__(self, *args, **kwargs):
         self.event_person_conversions = {}
-        super(EventPersonListField, self).__init__(*args, groups=False, allow_external=True, **kwargs)
+        super(EventPersonListField, self).__init__(*args, allow_groups=False, allow_external_users=True, **kwargs)
 
     @property
     def event(self):
@@ -102,10 +103,6 @@ class EventPersonListField(_LegacyPrincipalListField):
         if not isinstance(principal, EventPerson):
             return super(EventPersonListField, self)._serialize_principal(principal)
         return serialize_event_person(principal)
-
-    def pre_validate(self, form):
-        # Override parent behavior
-        pass
 
     def process_formdata(self, valuelist):
         if valuelist:

--- a/indico/modules/events/management/controllers/protection.py
+++ b/indico/modules/events/management/controllers/protection.py
@@ -129,7 +129,8 @@ class RHEventPrincipals(PrincipalsMixin, RHManageEventBase):
 
     @use_rh_kwargs({
         'values': PrincipalDict(allow_groups=True, allow_external_users=True, allow_event_roles=True,
-                                allow_category_roles=True, allow_registration_forms=True, missing={})
+                                allow_category_roles=True, allow_registration_forms=True, allow_emails=True,
+                                missing={})
     }, rh_context=('event',))
     def _process(self, values):
         self.values = values

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -19,8 +19,8 @@ from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.fields import (EditableFileField, FileField, HiddenEnumField, HiddenFieldList,
-                                     IndicoDateTimeField, IndicoMarkdownField, IndicoTagListField,
-                                     _LegacyPrincipalListField)
+                                     IndicoDateTimeField, IndicoMarkdownField, IndicoTagListField)
+from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, LinkedDateTime, UsedIf
 from indico.web.forms.widgets import SwitchWidget
@@ -36,16 +36,16 @@ def make_competences_form(event):
 
 
 class PaperTeamsForm(IndicoForm):
-    managers = _LegacyPrincipalListField(_('Paper managers'), groups=True, event=lambda form: form.event,
-                                         description=_('List of users allowed to manage the paper peer reviewing module'))
-    judges = _LegacyPrincipalListField(_('Judges'),
-                                       description=_('List of users allowed to judge papers'))
-    content_reviewers = _LegacyPrincipalListField(_('Content reviewers'),
-                                                  description=_('List of users allowed to review the content of '
-                                                                'the assigned papers'))
-    layout_reviewers = _LegacyPrincipalListField(_('Layout reviewers'),
-                                                 description=_('List of users allowed to review the layout of the '
-                                                               'assigned papers'))
+    managers = PrincipalListField(_('Paper managers'), with_groups=True, event=lambda form: form.event,
+                                  description=_('List of users allowed to manage the paper peer reviewing module'))
+    judges = PrincipalListField(_('Judges'),
+                                description=_('List of users allowed to judge papers'))
+    content_reviewers = PrincipalListField(_('Content reviewers'),
+                                           description=_('List of users allowed to review the content of '
+                                                         'the assigned papers'))
+    layout_reviewers = PrincipalListField(_('Layout reviewers'),
+                                          description=_('List of users allowed to review the layout of the '
+                                                        'assigned papers'))
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -19,7 +19,8 @@ from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.fields import (EditableFileField, FileField, HiddenEnumField, HiddenFieldList,
-                                     IndicoDateTimeField, IndicoMarkdownField, IndicoTagListField, PrincipalListField)
+                                     IndicoDateTimeField, IndicoMarkdownField, IndicoTagListField,
+                                     _LegacyPrincipalListField)
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, LinkedDateTime, UsedIf
 from indico.web.forms.widgets import SwitchWidget
@@ -35,16 +36,16 @@ def make_competences_form(event):
 
 
 class PaperTeamsForm(IndicoForm):
-    managers = PrincipalListField(_('Paper managers'), groups=True, event=lambda form: form.event,
-                                  description=_('List of users allowed to manage the paper peer reviewing module'))
-    judges = PrincipalListField(_('Judges'),
-                                description=_('List of users allowed to judge papers'))
-    content_reviewers = PrincipalListField(_('Content reviewers'),
-                                           description=_('List of users allowed to review the content of the assigned '
-                                                         'papers'))
-    layout_reviewers = PrincipalListField(_('Layout reviewers'),
-                                          description=_('List of users allowed to review the layout of the assigned '
-                                                        'papers'))
+    managers = _LegacyPrincipalListField(_('Paper managers'), groups=True, event=lambda form: form.event,
+                                         description=_('List of users allowed to manage the paper peer reviewing module'))
+    judges = _LegacyPrincipalListField(_('Judges'),
+                                       description=_('List of users allowed to judge papers'))
+    content_reviewers = _LegacyPrincipalListField(_('Content reviewers'),
+                                                  description=_('List of users allowed to review the content of '
+                                                                'the assigned papers'))
+    layout_reviewers = _LegacyPrincipalListField(_('Layout reviewers'),
+                                                 description=_('List of users allowed to review the layout of the '
+                                                               'assigned papers'))
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -36,7 +36,7 @@ def make_competences_form(event):
 
 
 class PaperTeamsForm(IndicoForm):
-    managers = PrincipalListField(_('Paper managers'), allow_groups=True, event=lambda form: form.event,
+    managers = PrincipalListField(_('Paper managers'), allow_groups=True, allow_emails=True,
                                   description=_('List of users allowed to manage the call for papers'))
     judges = PrincipalListField(_('Judges'),
                                 description=_('List of users allowed to judge papers'))

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -36,8 +36,8 @@ def make_competences_form(event):
 
 
 class PaperTeamsForm(IndicoForm):
-    managers = PrincipalListField(_('Paper managers'), with_groups=True, event=lambda form: form.event,
-                                  description=_('List of users allowed to manage the paper peer reviewing module'))
+    managers = PrincipalListField(_('Paper managers'), allow_groups=True, event=lambda form: form.event,
+                                  description=_('List of users allowed to manage the call for papers'))
     judges = PrincipalListField(_('Judges'),
                                 description=_('List of users allowed to judge papers'))
     content_reviewers = PrincipalListField(_('Content reviewers'),

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -28,8 +28,7 @@ from indico.modules.events.registration.models.registrations import Registration
 from indico.util.i18n import _
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
 from indico.web.forms.base import IndicoForm, generated_data
-from indico.web.forms.fields import (EmailListField, FileField, IndicoDateTimeField, IndicoEnumSelectField, JSONField,
-                                     _LegacyPrincipalListField)
+from indico.web.forms.fields import EmailListField, FileField, IndicoDateTimeField, IndicoEnumSelectField, JSONField
 from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.fields.simple import HiddenFieldList, IndicoEmailRecipientsField
 from indico.web.forms.validators import HiddenUnless, IndicoEmail, LinkedDateTime
@@ -314,10 +313,10 @@ class ParticipantsDisplayFormColumnsForm(IndicoForm):
 class RegistrationManagersForm(IndicoForm):
     """Form to manage users with privileges to modify registration-related items"""
 
-    managers = _LegacyPrincipalListField(_('Registration managers'), groups=True, allow_emails=True,
-                                         allow_external=True,
-                                         description=_('List of users allowed to modify registrations'),
-                                         event=lambda form: form.event)
+    managers = PrincipalListField(_('Registration managers'), allow_groups=True, allow_emails=True,
+                                  allow_external_users=True,
+                                  description=_('List of users allowed to modify registrations'),
+                                  event=lambda form: form.event)
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -30,7 +30,7 @@ from indico.util.i18n import _
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
 from indico.web.forms.base import IndicoForm, generated_data
 from indico.web.forms.fields import (EmailListField, FileField, IndicoDateTimeField, IndicoEnumSelectField, JSONField,
-                                     PrincipalListField)
+                                     _LegacyPrincipalListField)
 from indico.web.forms.fields.simple import HiddenFieldList, IndicoEmailRecipientsField
 from indico.web.forms.validators import HiddenUnless, IndicoEmail, LinkedDateTime
 from indico.web.forms.widgets import CKEditorWidget, SwitchWidget
@@ -125,7 +125,7 @@ class RegistrationFormScheduleForm(IndicoForm):
         super(RegistrationFormScheduleForm, self).__init__(*args, **kwargs)
 
 
-class _UsersField(PrincipalListField):
+class _UsersField(_LegacyPrincipalListField):
     def __init__(self, *args, **kwargs):
         super(_UsersField, self).__init__(*args, allow_external=True, **kwargs)
 
@@ -328,9 +328,10 @@ class ParticipantsDisplayFormColumnsForm(IndicoForm):
 class RegistrationManagersForm(IndicoForm):
     """Form to manage users with privileges to modify registration-related items"""
 
-    managers = PrincipalListField(_('Registration managers'), groups=True, allow_emails=True, allow_external=True,
-                                  description=_('List of users allowed to modify registrations'),
-                                  event=lambda form: form.event)
+    managers = _LegacyPrincipalListField(_('Registration managers'), groups=True, allow_emails=True,
+                                         allow_external=True,
+                                         description=_('List of users allowed to modify registrations'),
+                                         event=lambda form: form.event)
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')
@@ -340,7 +341,7 @@ class RegistrationManagersForm(IndicoForm):
 class CreateMultipleRegistrationsForm(IndicoForm):
     """Form to create multiple registrations of Indico users at the same time."""
 
-    user_principals = PrincipalListField(_("Indico users"), [DataRequired()])
+    user_principals = _LegacyPrincipalListField(_("Indico users"), [DataRequired()])
     notify_users = BooleanField(_("Send e-mail notifications"),
                                 default=True,
                                 description=_("Notify the users about the registration."),

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -7,7 +7,6 @@
 
 from __future__ import unicode_literals
 
-import json
 from datetime import time
 from operator import itemgetter
 
@@ -31,6 +30,7 @@ from indico.util.placeholders import get_missing_placeholders, render_placeholde
 from indico.web.forms.base import IndicoForm, generated_data
 from indico.web.forms.fields import (EmailListField, FileField, IndicoDateTimeField, IndicoEnumSelectField, JSONField,
                                      _LegacyPrincipalListField)
+from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.fields.simple import HiddenFieldList, IndicoEmailRecipientsField
 from indico.web.forms.validators import HiddenUnless, IndicoEmail, LinkedDateTime
 from indico.web.forms.widgets import CKEditorWidget, SwitchWidget
@@ -125,21 +125,6 @@ class RegistrationFormScheduleForm(IndicoForm):
         super(RegistrationFormScheduleForm, self).__init__(*args, **kwargs)
 
 
-class _UsersField(_LegacyPrincipalListField):
-    def __init__(self, *args, **kwargs):
-        super(_UsersField, self).__init__(*args, allow_external=True, **kwargs)
-
-    def process_formdata(self, valuelist):
-        if valuelist:
-            self.data = json.loads(valuelist[0])
-
-    def _value(self):
-        return self._get_data()
-
-    def pre_validate(self, form):
-        pass
-
-
 class InvitationFormBase(IndicoForm):
     _invitation_fields = ('skip_moderation',)
     _email_fields = ('email_from', 'email_subject', 'email_body')
@@ -191,7 +176,8 @@ class InvitationFormNew(InvitationFormBase):
 
 class InvitationFormExisting(InvitationFormBase):
     _invitation_fields = ('users_field',) + InvitationFormBase._invitation_fields
-    users_field = _UsersField(_('Users'), [DataRequired()], description=_("Select the users to invite."))
+    users_field = PrincipalListField(_('Users'), [DataRequired()], allow_external_users=True,
+                                     description=_("Select the users to invite."))
 
     @generated_data
     def users(self):
@@ -341,7 +327,7 @@ class RegistrationManagersForm(IndicoForm):
 class CreateMultipleRegistrationsForm(IndicoForm):
     """Form to create multiple registrations of Indico users at the same time."""
 
-    user_principals = _LegacyPrincipalListField(_("Indico users"), [DataRequired()])
+    user_principals = PrincipalListField(_("Indico users"), [DataRequired()])
     notify_users = BooleanField(_("Send e-mail notifications"),
                                 default=True,
                                 description=_("Notify the users about the registration."),

--- a/indico/modules/groups/forms.py
+++ b/indico/modules/groups/forms.py
@@ -14,7 +14,7 @@ from indico.core.db import db
 from indico.modules.groups.models.groups import LocalGroup
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm
-from indico.web.forms.fields import PrincipalListField
+from indico.web.forms.fields import _LegacyPrincipalListField
 
 
 class SearchForm(IndicoForm):
@@ -25,7 +25,7 @@ class SearchForm(IndicoForm):
 
 class EditGroupForm(IndicoForm):
     name = StringField(_('Group name'), [DataRequired()])
-    members = PrincipalListField(_('Group members'))
+    members = _LegacyPrincipalListField(_('Group members'))
 
     def __init__(self, *args, **kwargs):
         self.group = kwargs.pop('group', None)

--- a/indico/modules/groups/forms.py
+++ b/indico/modules/groups/forms.py
@@ -14,7 +14,7 @@ from indico.core.db import db
 from indico.modules.groups.models.groups import LocalGroup
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm
-from indico.web.forms.fields import _LegacyPrincipalListField
+from indico.web.forms.fields.principals import PrincipalListField
 
 
 class SearchForm(IndicoForm):
@@ -25,7 +25,7 @@ class SearchForm(IndicoForm):
 
 class EditGroupForm(IndicoForm):
     name = StringField(_('Group name'), [DataRequired()])
-    members = _LegacyPrincipalListField(_('Group members'))
+    members = PrincipalListField(_('Group members'))
 
     def __init__(self, *args, **kwargs):
         self.group = kwargs.pop('group', None)

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -51,7 +51,7 @@ from indico.util.event import truncate_path
 from indico.util.fs import secure_filename
 from indico.util.i18n import _
 from indico.util.images import square
-from indico.util.marshmallow import HumanizedDate, validate_with_message
+from indico.util.marshmallow import HumanizedDate, Principal, validate_with_message
 from indico.util.signals import values_from_signal
 from indico.util.string import crc32, make_unique_token
 from indico.web.args import use_kwargs
@@ -571,11 +571,13 @@ class RHUsersAdminMerge(RHAdminBase):
 
 
 class RHUsersAdminMergeCheck(RHAdminBase):
-    def _process(self):
-        source = User.get_or_404(request.args['source'])
-        target = User.get_or_404(request.args['target'])
+    @use_kwargs({
+        'source': Principal(allow_external_users=True, required=True),
+        'target': Principal(allow_external_users=True, required=True),
+    })
+    def _process(self, source, target):
         errors, warnings = _get_merge_problems(source, target)
-        return jsonify(errors=errors, warnings=warnings)
+        return jsonify(errors=errors, warnings=warnings, source=serialize_user(source), target=serialize_user(target))
 
 
 class RHRegistrationRequestList(RHAdminBase):

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -23,7 +23,8 @@ from indico.modules.users.models.users import NameFormat, UserTitle
 from indico.modules.users.util import get_picture_data
 from indico.util.i18n import _, get_all_locales
 from indico.web.forms.base import IndicoForm, SyncedInputsMixin
-from indico.web.forms.fields import EditableFileField, IndicoEnumSelectField, PrincipalField, _LegacyPrincipalListField
+from indico.web.forms.fields import EditableFileField, IndicoEnumSelectField, PrincipalField
+from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, used_if_not_synced
 from indico.web.forms.widgets import SwitchWidget, SyncedInputWidget
@@ -132,4 +133,4 @@ class AdminAccountRegistrationForm(LocalRegistrationForm):
 
 
 class AdminsForm(IndicoForm):
-    admins = _LegacyPrincipalListField(_('Admins'), [DataRequired()])
+    admins = PrincipalListField(_('Admins'), [DataRequired()])

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -23,7 +23,7 @@ from indico.modules.users.models.users import NameFormat, UserTitle
 from indico.modules.users.util import get_picture_data
 from indico.util.i18n import _, get_all_locales
 from indico.web.forms.base import IndicoForm, SyncedInputsMixin
-from indico.web.forms.fields import EditableFileField, IndicoEnumSelectField, PrincipalField, PrincipalListField
+from indico.web.forms.fields import EditableFileField, IndicoEnumSelectField, PrincipalField, _LegacyPrincipalListField
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, used_if_not_synced
 from indico.web.forms.widgets import SwitchWidget, SyncedInputWidget
@@ -132,4 +132,4 @@ class AdminAccountRegistrationForm(LocalRegistrationForm):
 
 
 class AdminsForm(IndicoForm):
-    admins = PrincipalListField(_('Admins'), [DataRequired()])
+    admins = _LegacyPrincipalListField(_('Admins'), [DataRequired()])

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -23,8 +23,7 @@ from indico.modules.users.models.users import NameFormat, UserTitle
 from indico.modules.users.util import get_picture_data
 from indico.util.i18n import _, get_all_locales
 from indico.web.forms.base import IndicoForm, SyncedInputsMixin
-from indico.web.forms.fields import EditableFileField, IndicoEnumSelectField, PrincipalField
-from indico.web.forms.fields.principals import PrincipalListField
+from indico.web.forms.fields import EditableFileField, IndicoEnumSelectField, PrincipalField, PrincipalListField
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, used_if_not_synced
 from indico.web.forms.widgets import SwitchWidget, SyncedInputWidget

--- a/indico/modules/users/templates/users_merge.html
+++ b/indico/modules/users/templates/users_merge.html
@@ -19,7 +19,7 @@
                 return $('<ul class="merge-info">').append(
                     _.map(FIELDS, function(caption, field) {
                         return $('<li>').append($('<span class="caption">').text(caption + ': '),
-                                                $('<span>').text(data[field]));
+                                                $('<span>').text(data[field] || '-'));
                     }));
             }
 
@@ -29,12 +29,12 @@
         }
 
         function check_users() {
-            var source = JSON.parse($('#source_user').val()),
-                target = JSON.parse($('#target_user').val()),
+            var source = $('#source_user').val(),
+                target = $('#target_user').val(),
                 $form = $('#merge-form'),
                 $submit = $form.find('input[type=submit]');
 
-            if (!source.length || !target.length) {
+            if (!source || !target) {
                 $submit.prop('disabled', true);
                 return;
             }
@@ -42,12 +42,9 @@
             $.ajax({
                 method: 'GET',
                 url: {{ url_for('.users_merge_check') | tojson }},
-                data: {
-                    source: source[0].id,
-                    target: target[0].id
-                }
+                data: {source, target}
             }).done(function(result) {
-                update_data(source[0], target[0]);
+                update_data(result.source, result.target);
 
                 var allow_submit = true,
                     warnings = false;

--- a/indico/modules/vc/forms.py
+++ b/indico/modules/vc/forms.py
@@ -22,7 +22,7 @@ from indico.modules.vc.models import VCRoom, VCRoomStatus
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm, generated_data
-from indico.web.forms.fields import EmailListField, IndicoDateField, IndicoRadioField, PrincipalListField
+from indico.web.forms.fields import EmailListField, IndicoDateField, IndicoRadioField, _LegacyPrincipalListField
 from indico.web.forms.validators import Exclusive, UsedIf
 from indico.web.forms.widgets import JinjaWidget, SelectizeWidget, SwitchWidget
 
@@ -52,9 +52,9 @@ class LinkingWidget(JinjaWidget):
 
 
 class VCPluginSettingsFormBase(IndicoForm):
-    managers = PrincipalListField(_('Managers'), groups=True, description=_('Service managers'))
-    acl = PrincipalListField(_('ACL'), groups=True,
-                             description=_('Users and Groups authorised to create videoconference rooms'))
+    managers = _LegacyPrincipalListField(_('Managers'), groups=True, description=_('Service managers'))
+    acl = _LegacyPrincipalListField(_('ACL'), groups=True,
+                                    description=_('Users and Groups authorised to create videoconference rooms'))
     notification_emails = EmailListField(_('Notification email addresses'),
                                          description=_('Notifications about videoconference rooms are sent to '
                                                        'these email addresses (one per line).'))

--- a/indico/modules/vc/forms.py
+++ b/indico/modules/vc/forms.py
@@ -53,8 +53,8 @@ class LinkingWidget(JinjaWidget):
 
 
 class VCPluginSettingsFormBase(IndicoForm):
-    managers = PrincipalListField(_('Managers'), with_groups=True, description=_('Service managers'))
-    acl = PrincipalListField(_('ACL'), with_groups=True,
+    managers = PrincipalListField(_('Managers'), allow_groups=True, description=_('Service managers'))
+    acl = PrincipalListField(_('ACL'), allow_groups=True,
                              description=_('Users and Groups authorised to create videoconference rooms'))
     notification_emails = EmailListField(_('Notification email addresses'),
                                          description=_('Notifications about videoconference rooms are sent to '

--- a/indico/modules/vc/forms.py
+++ b/indico/modules/vc/forms.py
@@ -22,7 +22,8 @@ from indico.modules.vc.models import VCRoom, VCRoomStatus
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm, generated_data
-from indico.web.forms.fields import EmailListField, IndicoDateField, IndicoRadioField, _LegacyPrincipalListField
+from indico.web.forms.fields import EmailListField, IndicoDateField, IndicoRadioField
+from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.validators import Exclusive, UsedIf
 from indico.web.forms.widgets import JinjaWidget, SelectizeWidget, SwitchWidget
 
@@ -52,9 +53,9 @@ class LinkingWidget(JinjaWidget):
 
 
 class VCPluginSettingsFormBase(IndicoForm):
-    managers = _LegacyPrincipalListField(_('Managers'), groups=True, description=_('Service managers'))
-    acl = _LegacyPrincipalListField(_('ACL'), groups=True,
-                                    description=_('Users and Groups authorised to create videoconference rooms'))
+    managers = PrincipalListField(_('Managers'), with_groups=True, description=_('Service managers'))
+    acl = PrincipalListField(_('ACL'), with_groups=True,
+                             description=_('Users and Groups authorised to create videoconference rooms'))
     notification_emails = EmailListField(_('Notification email addresses'),
                                          description=_('Notifications about videoconference rooms are sent to '
                                                        'these email addresses (one per line).'))

--- a/indico/util/marshmallow.py
+++ b/indico/util/marshmallow.py
@@ -206,12 +206,13 @@ class PrincipalList(Field):
     """Marshmallow field for a list of principals."""
 
     def __init__(self, allow_groups=False, allow_external_users=False, allow_event_roles=False,
-                 allow_category_roles=False, allow_registration_forms=False, **kwargs):
+                 allow_category_roles=False, allow_registration_forms=False, allow_emails=False, **kwargs):
         self.allow_groups = allow_groups
         self.allow_external_users = allow_external_users
         self.allow_event_roles = allow_event_roles
         self.allow_category_roles = allow_category_roles
         self.allow_registration_forms = allow_registration_forms
+        self.allow_emails = allow_emails
         super(PrincipalList, self).__init__(**kwargs)
 
     def _serialize(self, value, attr, obj):
@@ -228,6 +229,7 @@ class PrincipalList(Field):
                                                  allow_event_roles=self.allow_event_roles,
                                                  allow_category_roles=self.allow_category_roles,
                                                  allow_registration_forms=self.allow_registration_forms,
+                                                 allow_emails=self.allow_emails,
                                                  event_id=event_id)
                        for identifier in value)
         except ValueError as exc:
@@ -248,6 +250,7 @@ class PrincipalDict(PrincipalList):
                                                           allow_event_roles=self.allow_event_roles,
                                                           allow_category_roles=self.allow_category_roles,
                                                           allow_registration_forms=self.allow_registration_forms,
+                                                          allow_emails=self.allow_emails,
                                                           event_id=event_id,
                                                           soft_fail=True)
                     for identifier in value}

--- a/indico/util/user.py
+++ b/indico/util/user.py
@@ -121,8 +121,8 @@ def principal_from_fossil(fossil, allow_pending=False, allow_groups=True, allow_
 
 
 def principal_from_identifier(identifier, allow_groups=False, allow_external_users=False, allow_event_roles=False,
-                              allow_category_roles=False, allow_registration_forms=False, event_id=None,
-                              soft_fail=False):
+                              allow_category_roles=False, allow_registration_forms=False, allow_emails=False,
+                              event_id=None, soft_fail=False):
     # XXX: this is currently only used in PrincipalList
     # if we ever need to support more than just users, groups, event roles,
     # category roles and registration forms
@@ -198,7 +198,6 @@ def principal_from_identifier(identifier, allow_groups=False, allow_external_use
     elif type_ == 'CategoryRole':
         if not allow_category_roles:
             raise ValueError('Category roles are not allowed')
-
         event = Event.get(event_id)
         if event is None:
             raise ValueError('Invalid event id: {}'.format(event_id))
@@ -226,5 +225,9 @@ def principal_from_identifier(identifier, allow_groups=False, allow_external_use
         if registration_form is None or registration_form.event_id != event_id:
             raise ValueError('Invalid registration form: {}'.format(reg_form_id))
         return registration_form
+    elif type_ == 'Email':
+        if not allow_emails:
+            raise ValueError('Emails are not allowed')
+        return EmailPrincipal(data)
     else:
         raise ValueError('Invalid data')

--- a/indico/util/user.py
+++ b/indico/util/user.py
@@ -123,10 +123,6 @@ def principal_from_fossil(fossil, allow_pending=False, allow_groups=True, allow_
 def principal_from_identifier(identifier, allow_groups=False, allow_external_users=False, allow_event_roles=False,
                               allow_category_roles=False, allow_registration_forms=False, allow_emails=False,
                               event_id=None, soft_fail=False):
-    # XXX: this is currently only used in PrincipalList
-    # if we ever need to support more than just users, groups, event roles,
-    # category roles and registration forms
-    # make sure to add it in here as well
     from indico.modules.events.models.events import Event
     from indico.modules.events.models.roles import EventRole
     from indico.modules.categories.models.roles import CategoryRole

--- a/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
@@ -9,28 +9,24 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {WTFPrincipalListField} from 'indico/react/components/WTFPrincipalListField';
 
-(function(global) {
-  'use strict';
-
-  global.setupPrincipalListWidget = function setupPrincipalListWidget({fieldId, ...options}) {
-    options = {
-      ...{
-        eventId: null,
-        withGroups: false,
-        withExternalUsers: false,
-        withEventRoles: false,
-        withCategoryRoles: false,
-        withRegistrationForms: false,
-        withEmails: true,
-      },
-      ...options,
-    };
-    const field = document.getElementById(fieldId);
-    const principals = JSON.parse(field.value);
-
-    ReactDOM.render(
-      <WTFPrincipalListField fieldId={fieldId} defaultValue={principals} {...options} />,
-      document.getElementById('userGroupList-' + fieldId)
-    );
+window.setupPrincipalListWidget = function setupPrincipalListWidget({fieldId, ...options}) {
+  options = {
+    ...{
+      eventId: null,
+      withGroups: false,
+      withExternalUsers: false,
+      withEventRoles: false,
+      withCategoryRoles: false,
+      withRegistrants: false,
+      withEmails: true,
+    },
+    ...options,
   };
-})(window);
+  const field = document.getElementById(fieldId);
+  const principals = JSON.parse(field.value);
+
+  ReactDOM.render(
+    <WTFPrincipalListField fieldId={fieldId} defaultValue={principals} {...options} />,
+    document.getElementById(`userGroupList-${fieldId}`)
+  );
+};

--- a/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
@@ -1,3 +1,10 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {WTFPrincipalListField} from 'indico/react/components/WTFPrincipalListField';
@@ -21,9 +28,7 @@ import {WTFPrincipalListField} from 'indico/react/components/WTFPrincipalListFie
       },
       ...options,
     };
-    options.legacy
-      ? _setupLegacyPrincipalListWidget(options)
-      : _setupPrincipalListWidget(options);
+    options.legacy ? _setupLegacyPrincipalListWidget(options) : _setupPrincipalListWidget(options);
   };
 
   function _setupPrincipalListWidget({fieldId, ...options}) {
@@ -31,13 +36,7 @@ import {WTFPrincipalListField} from 'indico/react/components/WTFPrincipalListFie
     const principals = JSON.parse(field.value);
 
     ReactDOM.render(
-      <WTFPrincipalListField
-        fieldId={fieldId}
-        defaultValue={principals}
-        {...options}
-        // TBR: I eventually changed this to spread because I thought we might wanted to add new props
-        // in the future and avoid modifying the widget and WTF component just to add a new definition
-      />,
+      <WTFPrincipalListField fieldId={fieldId} defaultValue={principals} {...options} />,
       document.getElementById('userGroupList-' + fieldId)
     );
   }

--- a/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
@@ -1,28 +1,49 @@
-// This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
-//
-// Indico is free software; you can redistribute it and/or
-// modify it under the terms of the MIT License; see the
-// LICENSE file for more details.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {WTFPrincipalListField} from 'indico/react/components/WTFPrincipalListField';
 
 (function(global) {
   'use strict';
 
   global.setupPrincipalListWidget = function setupPrincipalListWidget(options) {
-    options = $.extend(
-      true,
-      {
+    options = {
+      ...{
         fieldId: null,
         eventId: null,
         openImmediately: false,
-        groups: null,
-        allowExternal: false,
-        allowNetworks: false,
+        withGroups: false,
+        withExternalUsers: false,
+        withEventRoles: false,
+        withCategoryRoles: false,
+        withRegistrationForms: false,
+        withNetworks: false,
         networks: [],
       },
-      options
-    );
+      ...options,
+    };
+    return options.legacy
+      ? _setupLegacyPrincipalListWidget(options)
+      : _setupPrincipalListWidget(options);
+  };
 
+  function _setupPrincipalListWidget(options) {
+    const field = document.getElementById(options.fieldId);
+    const principals = JSON.parse(field.value);
+
+    ReactDOM.render(
+      <WTFPrincipalListField
+        fieldId={options.fieldId}
+        defaultValue={principals}
+        protectedFieldId={options.protectedFieldId}
+        {...options}
+        // TBR: I eventually changed this to spread because I thought we might wanted to add new props
+        // in the future and avoid modifying the widget and WTF component just to add a new definition
+      />,
+      document.getElementById('userGroupList-' + options.fieldId)
+    );
+  }
+
+  function _setupLegacyPrincipalListWidget(options) {
     var field = $('#' + options.fieldId);
     var principals = JSON.parse(field.val());
 
@@ -67,7 +88,7 @@
       true,
       null,
       true,
-      options.groups,
+      options.withGroups,
       options.eventId,
       null,
       false,
@@ -78,8 +99,8 @@
       addPrincipal,
       userListNothing,
       removePrincipal,
-      options.allowExternal,
-      options.allowNetworks,
+      options.withExternalUsers,
+      options.withNetworks,
       options.networks
     );
 
@@ -88,5 +109,5 @@
     if (options.openImmediately) {
       $('#userGroupList-' + options.fieldId + ' input[type=button]').trigger('click');
     }
-  };
+  }
 })(window);

--- a/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
@@ -7,7 +7,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {WTFPrincipalListField} from 'indico/react/components/WTFPrincipalListField';
+import {WTFPrincipalListField} from 'indico/react/components';
 
 window.setupPrincipalListWidget = function setupPrincipalListWidget({fieldId, ...options}) {
   options = {

--- a/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
@@ -21,25 +21,24 @@ import {WTFPrincipalListField} from 'indico/react/components/WTFPrincipalListFie
       },
       ...options,
     };
-    return options.legacy
+    options.legacy
       ? _setupLegacyPrincipalListWidget(options)
       : _setupPrincipalListWidget(options);
   };
 
-  function _setupPrincipalListWidget(options) {
-    const field = document.getElementById(options.fieldId);
+  function _setupPrincipalListWidget({fieldId, ...options}) {
+    const field = document.getElementById(fieldId);
     const principals = JSON.parse(field.value);
 
     ReactDOM.render(
       <WTFPrincipalListField
-        fieldId={options.fieldId}
+        fieldId={fieldId}
         defaultValue={principals}
-        protectedFieldId={options.protectedFieldId}
         {...options}
         // TBR: I eventually changed this to spread because I thought we might wanted to add new props
         // in the future and avoid modifying the widget and WTF component just to add a new definition
       />,
-      document.getElementById('userGroupList-' + options.fieldId)
+      document.getElementById('userGroupList-' + fieldId)
     );
   }
 

--- a/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
@@ -12,26 +12,19 @@ import {WTFPrincipalListField} from 'indico/react/components/WTFPrincipalListFie
 (function(global) {
   'use strict';
 
-  global.setupPrincipalListWidget = function setupPrincipalListWidget(options) {
+  global.setupPrincipalListWidget = function setupPrincipalListWidget({fieldId, ...options}) {
     options = {
       ...{
-        fieldId: null,
         eventId: null,
-        openImmediately: false,
         withGroups: false,
         withExternalUsers: false,
         withEventRoles: false,
         withCategoryRoles: false,
         withRegistrationForms: false,
-        withNetworks: false,
-        networks: [],
+        withEmails: true,
       },
       ...options,
     };
-    options.legacy ? _setupLegacyPrincipalListWidget(options) : _setupPrincipalListWidget(options);
-  };
-
-  function _setupPrincipalListWidget({fieldId, ...options}) {
     const field = document.getElementById(fieldId);
     const principals = JSON.parse(field.value);
 
@@ -39,73 +32,5 @@ import {WTFPrincipalListField} from 'indico/react/components/WTFPrincipalListFie
       <WTFPrincipalListField fieldId={fieldId} defaultValue={principals} {...options} />,
       document.getElementById('userGroupList-' + fieldId)
     );
-  }
-
-  function _setupLegacyPrincipalListWidget(options) {
-    var field = $('#' + options.fieldId);
-    var principals = JSON.parse(field.val());
-
-    function addPrincipal(newPrincipals, setResult) {
-      // remove existing ones first to avoid duplicates
-      newPrincipals = _.filter(newPrincipals, function(principal) {
-        return !_.findWhere(principals, {identifier: principal.identifier});
-      });
-      principals = _.sortBy(principals.concat(newPrincipals), function(principal) {
-        var weight =
-          principal._type == 'Avatar'
-            ? 0
-            : principal._type == 'Email'
-            ? 1
-            : principal.isGroup
-            ? 2
-            : 3;
-        var name = principal._type !== 'Email' ? principal.name : principal.email;
-        return [weight, name.toLowerCase()];
-      });
-      field.val(JSON.stringify(principals));
-      field.trigger('change');
-      setResult(true, principals);
-    }
-
-    function removePrincipal(principal, setResult) {
-      principals = _.without(
-        principals,
-        _.findWhere(principals, {
-          identifier: principal.get('identifier'),
-        })
-      );
-      field.val(JSON.stringify(principals));
-      field.trigger('change');
-      setResult(true);
-    }
-
-    var widget = new UserListField(
-      'PluginOptionPeopleListDiv',
-      'user-list',
-      principals,
-      true,
-      null,
-      true,
-      options.withGroups,
-      options.eventId,
-      null,
-      false,
-      false,
-      false,
-      // Disable favorite button for EventPerson mode
-      options.eventId !== null,
-      addPrincipal,
-      userListNothing,
-      removePrincipal,
-      options.withExternalUsers,
-      options.withNetworks,
-      options.networks
-    );
-
-    $E('userGroupList-' + options.fieldId).set(widget.draw());
-
-    if (options.openImmediately) {
-      $('#userGroupList-' + options.fieldId + ' input[type=button]').trigger('click');
-    }
-  }
+  };
 })(window);

--- a/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
@@ -18,7 +18,7 @@ window.setupPrincipalListWidget = function setupPrincipalListWidget({fieldId, ..
       withEventRoles: false,
       withCategoryRoles: false,
       withRegistrants: false,
-      withEmails: true,
+      withEmails: false,
     },
     ...options,
   };

--- a/indico/web/client/js/jquery/widgets/jinja/principal_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_widget.js
@@ -15,7 +15,7 @@
         fieldId: null,
         eventId: null,
         required: false,
-        allowExternal: false,
+        withExternalUsers: false,
       },
       options
     );
@@ -36,7 +36,8 @@
 
     field.principalfield({
       eventId: options.eventId,
-      allowExternalUsers: options.allowExternal,
+      allowExternalUsers: options.withExternalUsers,
+      groups: true,
       enableGroupsTab: false,
       render: function(users) {
         var name = users[0] ? users[0].name : '';

--- a/indico/web/client/js/jquery/widgets/jinja/principal_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_widget.js
@@ -5,52 +5,24 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-(function(global) {
-  'use strict';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {WTFPrincipalField} from 'indico/react/components';
 
-  global.setupPrincipalWidget = function setupPrincipalWidget(options) {
-    options = $.extend(
-      true,
-      {
-        fieldId: null,
-        eventId: null,
-        required: false,
-        withExternalUsers: false,
-      },
-      options
-    );
+window.setupPrincipalWidget = function setupPrincipalWidget({
+  fieldId,
+  required,
+  withExternalUsers,
+}) {
+  const field = document.getElementById(fieldId);
 
-    var field = $('#' + options.fieldId);
-    var button = $('#choose-' + options.fieldId);
-    var display = $('#display-' + options.fieldId);
-
-    if (!options.required) {
-      display.clearableinput({
-        clearOnEscape: false,
-        focusOnClear: false,
-        onClear: function() {
-          field.principalfield('remove');
-        },
-      });
-    }
-
-    field.principalfield({
-      eventId: options.eventId,
-      allowExternalUsers: options.withExternalUsers,
-      groups: true,
-      enableGroupsTab: false,
-      render: function(users) {
-        var name = users[0] ? users[0].name : '';
-        if (!options.required) {
-          display.clearableinput('setValue', name);
-        } else {
-          display.val(name);
-        }
-      },
-    });
-
-    display.add(button).on('click', function() {
-      field.principalfield('choose');
-    });
-  };
-})(window);
+  ReactDOM.render(
+    <WTFPrincipalField
+      fieldId={fieldId}
+      defaultValue={field.value}
+      required={required}
+      withExternalUsers={withExternalUsers}
+    />,
+    document.getElementById(`principalField-${fieldId}`)
+  );
+};

--- a/indico/web/client/js/react/components/WTFPrincipalField.jsx
+++ b/indico/web/client/js/react/components/WTFPrincipalField.jsx
@@ -1,0 +1,54 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React, {useCallback, useMemo, useState} from 'react';
+import PropTypes from 'prop-types';
+import {PrincipalField} from 'indico/react/components/principals';
+import {useFavoriteUsers} from 'indico/react/hooks';
+
+import './WTFPrincipalField.module.scss';
+
+export default function WTFPrincipalField({fieldId, defaultValue, required, withExternalUsers}) {
+  const favoriteUsersController = useFavoriteUsers();
+  const inputField = useMemo(() => document.getElementById(fieldId), [fieldId]);
+  const [value, setValue] = useState(defaultValue);
+
+  const onChangePrincipal = useCallback(
+    principal => {
+      inputField.value = principal;
+      setValue(principal);
+      inputField.dispatchEvent(new Event('change', {bubbles: true}));
+    },
+    [inputField]
+  );
+
+  return (
+    <PrincipalField
+      favoriteUsersController={favoriteUsersController}
+      withExternalUsers={withExternalUsers}
+      required={required}
+      onChange={onChangePrincipal}
+      onFocus={() => {}}
+      onBlur={() => {}}
+      value={value}
+      styleName="fixed-width"
+    />
+  );
+}
+
+WTFPrincipalField.propTypes = {
+  fieldId: PropTypes.string.isRequired,
+  defaultValue: PropTypes.string,
+  withExternalUsers: PropTypes.bool,
+  required: PropTypes.bool,
+};
+
+WTFPrincipalField.defaultProps = {
+  defaultValue: [],
+  withExternalUsers: false,
+  required: false,
+};

--- a/indico/web/client/js/react/components/WTFPrincipalField.module.scss
+++ b/indico/web/client/js/react/components/WTFPrincipalField.module.scss
@@ -1,0 +1,10 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+.fixed-width {
+  width: 400px;
+}

--- a/indico/web/client/js/react/components/WTFPrincipalListField.jsx
+++ b/indico/web/client/js/react/components/WTFPrincipalListField.jsx
@@ -35,7 +35,7 @@ export function WTFPrincipalListField({fieldId, defaultValue, protectedFieldId, 
     principals => {
       inputField.value = JSON.stringify(principals);
       setValue(principals);
-      inputField.dispatchEvent(new Event('change'));
+      inputField.dispatchEvent(new Event('change', {bubbles: true}));
     },
     [inputField]
   );

--- a/indico/web/client/js/react/components/WTFPrincipalListField.jsx
+++ b/indico/web/client/js/react/components/WTFPrincipalListField.jsx
@@ -14,17 +14,19 @@ export function WTFPrincipalListField({fieldId, defaultValue, protectedFieldId, 
   const [disabled, setDisabled] = useState(!!protectedField && !protectedField.checked);
 
   useEffect(() => {
-    if (!protectedField) return;
-    function onChangeProtected() {
-      setDisabled(!protectedField.checked);
+    if (!protectedField) {
+      return;
     }
+    const onChangeProtected = () => {
+      setDisabled(!protectedField.checked);
+    };
     protectedField.addEventListener('change', onChangeProtected);
     return () => protectedField.removeEventListener('change', onChangeProtected);
   }, [protectedField]);
 
   const onChangePrincipal = useCallback(
     principals => {
-      inputField.value = principals;
+      inputField.value = JSON.stringify(principals);
       setValue(principals);
       inputField.dispatchEvent(new Event('change'));
     },
@@ -48,7 +50,7 @@ export function WTFPrincipalListField({fieldId, defaultValue, protectedFieldId, 
 WTFPrincipalListField.propTypes = {
   fieldId: PropTypes.string.isRequired,
   defaultValue: PropTypes.arrayOf(PropTypes.string),
-  protectedFieldId: PropTypes.instanceOf(Element),
+  protectedFieldId: PropTypes.instanceOf(PropTypes.string),
 };
 
 WTFPrincipalListField.defaultProps = {

--- a/indico/web/client/js/react/components/WTFPrincipalListField.jsx
+++ b/indico/web/client/js/react/components/WTFPrincipalListField.jsx
@@ -1,3 +1,10 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import PropTypes from 'prop-types';
 import {PrincipalListField} from 'indico/react/components/principals';
@@ -41,7 +48,6 @@ export function WTFPrincipalListField({fieldId, defaultValue, protectedFieldId, 
       onFocus={() => {}}
       onBlur={() => {}}
       value={value}
-      required
       {...otherProps}
     />
   );
@@ -50,7 +56,7 @@ export function WTFPrincipalListField({fieldId, defaultValue, protectedFieldId, 
 WTFPrincipalListField.propTypes = {
   fieldId: PropTypes.string.isRequired,
   defaultValue: PropTypes.arrayOf(PropTypes.string),
-  protectedFieldId: PropTypes.instanceOf(PropTypes.string),
+  protectedFieldId: PropTypes.string,
 };
 
 WTFPrincipalListField.defaultProps = {

--- a/indico/web/client/js/react/components/WTFPrincipalListField.jsx
+++ b/indico/web/client/js/react/components/WTFPrincipalListField.jsx
@@ -10,7 +10,12 @@ import PropTypes from 'prop-types';
 import {PrincipalListField} from 'indico/react/components/principals';
 import {useFavoriteUsers} from 'indico/react/hooks';
 
-export function WTFPrincipalListField({fieldId, defaultValue, protectedFieldId, ...otherProps}) {
+export default function WTFPrincipalListField({
+  fieldId,
+  defaultValue,
+  protectedFieldId,
+  ...otherProps
+}) {
   const favoriteUsersController = useFavoriteUsers();
   const protectedField = useMemo(
     () => protectedFieldId && document.getElementById(protectedFieldId),

--- a/indico/web/client/js/react/components/WTFPrincipalListField.jsx
+++ b/indico/web/client/js/react/components/WTFPrincipalListField.jsx
@@ -1,0 +1,57 @@
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import PropTypes from 'prop-types';
+import {PrincipalListField} from 'indico/react/components/principals';
+import {useFavoriteUsers} from 'indico/react/hooks';
+
+export function WTFPrincipalListField({fieldId, defaultValue, protectedFieldId, ...otherProps}) {
+  const favoriteUsersController = useFavoriteUsers();
+  const protectedField = useMemo(
+    () => protectedFieldId && document.getElementById(protectedFieldId),
+    [protectedFieldId]
+  );
+  const inputField = useMemo(() => document.getElementById(fieldId), [fieldId]);
+  const [value, setValue] = useState(defaultValue);
+  const [disabled, setDisabled] = useState(!!protectedField && !protectedField.checked);
+
+  useEffect(() => {
+    if (!protectedField) return;
+    function onChangeProtected() {
+      setDisabled(!protectedField.checked);
+    }
+    protectedField.addEventListener('change', onChangeProtected);
+    return () => protectedField.removeEventListener('change', onChangeProtected);
+  }, [protectedField]);
+
+  const onChangePrincipal = useCallback(
+    principals => {
+      inputField.value = principals;
+      setValue(principals);
+      inputField.dispatchEvent(new Event('change'));
+    },
+    [inputField]
+  );
+
+  return (
+    <PrincipalListField
+      favoriteUsersController={favoriteUsersController}
+      disabled={disabled}
+      onChange={onChangePrincipal}
+      onFocus={() => {}}
+      onBlur={() => {}}
+      value={value}
+      required
+      {...otherProps}
+    />
+  );
+}
+
+WTFPrincipalListField.propTypes = {
+  fieldId: PropTypes.string.isRequired,
+  defaultValue: PropTypes.arrayOf(PropTypes.string),
+  protectedFieldId: PropTypes.instanceOf(Element),
+};
+
+WTFPrincipalListField.defaultProps = {
+  defaultValue: [],
+  protectedFieldId: null,
+};

--- a/indico/web/client/js/react/components/index.js
+++ b/indico/web/client/js/react/components/index.js
@@ -41,3 +41,4 @@ export {default as WTFDateField} from './WTFDateField';
 export {default as WTFDateTimeField} from './WTFDateTimeField';
 export {default as WTFOccurrencesField} from './WTFOccurrencesField';
 export {default as WTFPrincipalListField} from './WTFPrincipalListField';
+export {default as WTFPrincipalField} from './WTFPrincipalField';

--- a/indico/web/client/js/react/components/index.js
+++ b/indico/web/client/js/react/components/index.js
@@ -40,3 +40,4 @@ export {default as ManagementPageTitle} from './ManagementPageTitle';
 export {default as WTFDateField} from './WTFDateField';
 export {default as WTFDateTimeField} from './WTFDateTimeField';
 export {default as WTFOccurrencesField} from './WTFOccurrencesField';
+export {default as WTFPrincipalListField} from './WTFPrincipalListField';

--- a/indico/web/client/js/react/components/principals/PrincipalField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalField.jsx
@@ -14,9 +14,9 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
 import {UserSearch} from './Search';
 import {EmptyPrincipalListItem, PendingPrincipalListItem, PrincipalListItem} from './items';
+import {FinalField} from '../../forms';
 
 import './items.module.scss';
-import {FinalField} from '../../forms';
 
 /**
  * A field that lets the user select a user.
@@ -31,6 +31,7 @@ const PrincipalField = props => {
     onBlur,
     favoriteUsersController,
     withExternalUsers,
+    className,
   } = props;
   const [favoriteUsers, [handleAddFavorite, handleDelFavorite]] = favoriteUsersController;
 
@@ -103,7 +104,7 @@ const PrincipalField = props => {
   return (
     <div className="ui input">
       <div className="fake-input">
-        <List relaxed>
+        <List relaxed className={className}>
           {!value ? (
             <EmptyPrincipalListItem search={userSearch} />
           ) : details ? (
@@ -138,12 +139,14 @@ PrincipalField.propTypes = {
   onBlur: PropTypes.func.isRequired,
   favoriteUsersController: PropTypes.array.isRequired,
   withExternalUsers: PropTypes.bool,
+  className: PropTypes.string,
 };
 
 PrincipalField.defaultProps = {
   value: null,
   required: false,
   withExternalUsers: false,
+  className: '',
 };
 
 export default React.memo(PrincipalField);

--- a/indico/web/client/js/react/components/principals/PrincipalListField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalListField.jsx
@@ -135,6 +135,7 @@ const PrincipalListField = props => {
               text={Translate.string('Event Role')}
               options={asOptions(eventRoles)}
               onChange={handleAddItems}
+              disabled={disabled}
             />
           )}
           {categoryRoles.length !== 0 && (
@@ -142,6 +143,7 @@ const PrincipalListField = props => {
               text={Translate.string('Category Role')}
               options={asOptions(categoryRoles)}
               onChange={handleAddItems}
+              disabled={disabled}
             />
           )}
           {registrationForms.length !== 0 && (
@@ -151,6 +153,7 @@ const PrincipalListField = props => {
                 Translate.string('Registrants in "{form}"', {form})
               )}
               onChange={handleAddItems}
+              disabled={disabled}
             />
           )}
         </Button.Group>
@@ -187,14 +190,14 @@ PrincipalListField.defaultProps = {
 
 export default React.memo(PrincipalListField);
 
-function AddPrincipalDropdown({text, options, onChange}) {
+function AddPrincipalDropdown({text, options, disabled, onChange}) {
   return (
     <Dropdown
       text={text}
       button
       upward
       floating
-      disabled={options.length === 0}
+      disabled={disabled || options.length === 0}
       options={options}
       openOnFocus={false}
       selectOnBlur={false}
@@ -208,6 +211,7 @@ AddPrincipalDropdown.propTypes = {
   text: PropTypes.string.isRequired,
   options: PropTypes.array.isRequired,
   onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool.isRequired,
 };
 
 /**

--- a/indico/web/client/js/react/components/principals/items.module.scss
+++ b/indico/web/client/js/react/components/principals/items.module.scss
@@ -39,6 +39,7 @@
   width: 3.5em;
   text-align: center;
   color: $light-black;
+  flex-shrink: 0;
 }
 
 .content {

--- a/indico/web/client/js/react/components/principals/util.js
+++ b/indico/web/client/js/react/components/principals/util.js
@@ -99,6 +99,7 @@ export class PrincipalType {
   static eventRole = 'event_role';
   static categoryRole = 'category_role';
   static registrationForm = 'registration_form';
+  static email = 'email';
   /* eslint-enable lines-between-class-members */
 
   static propType = PropTypes.oneOf([
@@ -108,6 +109,7 @@ export class PrincipalType {
     PrincipalType.eventRole,
     PrincipalType.categoryRole,
     PrincipalType.registrationForm,
+    PrincipalType.email,
   ]);
 
   static getPendingText(type) {
@@ -145,6 +147,7 @@ export class PrincipalType {
       [PrincipalType.localGroup]: 'users',
       [PrincipalType.multipassGroup]: 'users',
       [PrincipalType.registrationForm]: 'id badge outline',
+      [PrincipalType.email]: 'envelope outline',
       // event/category roles have no icon but their code
     }[type];
   }
@@ -157,6 +160,7 @@ export class PrincipalType {
       [PrincipalType.categoryRole]: 2,
       [PrincipalType.registrationForm]: 3,
       [PrincipalType.user]: 4,
+      [PrincipalType.email]: 5,
     }[type];
   }
 }
@@ -174,6 +178,8 @@ export function getTypeFromIdentifier(identifier) {
     return PrincipalType.categoryRole;
   } else if (identifier.startsWith('RegistrationForm:')) {
     return PrincipalType.registrationForm;
+  } else if (identifier.startsWith('Email:')) {
+    return PrincipalType.email;
   } else {
     throw new Error(`Identifier ${identifier} has unknown type`);
   }

--- a/indico/web/forms/fields/__init__.py
+++ b/indico/web/forms/fields/__init__.py
@@ -24,7 +24,7 @@ from .files import EditableFileField, FileField
 from .itemlists import MultipleItemsField, MultiStringField, OverrideMultipleItemsField
 from .location import IndicoLocationField
 from .markdown import IndicoMarkdownField
-from .principals import AccessControlListField, PrincipalField, PrincipalListField
+from .principals import AccessControlListField, PrincipalField, _LegacyPrincipalListField
 from .protection import IndicoProtectionField
 from .sqlalchemy import IndicoQuerySelectMultipleCheckboxField, IndicoQuerySelectMultipleField
 
@@ -34,7 +34,7 @@ __all__ = ('IndicoSelectMultipleCheckboxField', 'IndicoRadioField', 'JSONField',
            'IndicoPalettePickerField', 'IndicoSinglePalettePickerField', 'TimeDeltaField', 'IndicoDateTimeField',
            'OccurrencesField', 'IndicoTimezoneSelectField', 'IndicoEnumSelectField', 'IndicoEnumRadioField',
            'HiddenEnumField', 'FileField', 'MultiStringField', 'MultipleItemsField', 'OverrideMultipleItemsField',
-           'PrincipalListField', 'PrincipalField', 'AccessControlListField', 'IndicoQuerySelectMultipleField',
+           '_LegacyPrincipalListField', 'PrincipalField', 'AccessControlListField', 'IndicoQuerySelectMultipleField',
            'EditableFileField', 'IndicoQuerySelectMultipleCheckboxField', 'IndicoLocationField', 'IndicoMarkdownField',
            'IndicoDateField', 'IndicoProtectionField', 'IndicoSelectMultipleCheckboxBooleanField', 'RelativeDeltaField',
            'IndicoWeekDayRepetitionField', 'IndicoEmailRecipientsField')

--- a/indico/web/forms/fields/__init__.py
+++ b/indico/web/forms/fields/__init__.py
@@ -24,7 +24,7 @@ from .files import EditableFileField, FileField
 from .itemlists import MultipleItemsField, MultiStringField, OverrideMultipleItemsField
 from .location import IndicoLocationField
 from .markdown import IndicoMarkdownField
-from .principals import AccessControlListField, PrincipalField, _LegacyPrincipalListField
+from .principals import AccessControlListField, PrincipalField, PrincipalListField
 from .protection import IndicoProtectionField
 from .sqlalchemy import IndicoQuerySelectMultipleCheckboxField, IndicoQuerySelectMultipleField
 
@@ -34,7 +34,7 @@ __all__ = ('IndicoSelectMultipleCheckboxField', 'IndicoRadioField', 'JSONField',
            'IndicoPalettePickerField', 'IndicoSinglePalettePickerField', 'TimeDeltaField', 'IndicoDateTimeField',
            'OccurrencesField', 'IndicoTimezoneSelectField', 'IndicoEnumSelectField', 'IndicoEnumRadioField',
            'HiddenEnumField', 'FileField', 'MultiStringField', 'MultipleItemsField', 'OverrideMultipleItemsField',
-           '_LegacyPrincipalListField', 'PrincipalField', 'AccessControlListField', 'IndicoQuerySelectMultipleField',
+           'PrincipalListField', 'PrincipalField', 'AccessControlListField', 'IndicoQuerySelectMultipleField',
            'EditableFileField', 'IndicoQuerySelectMultipleCheckboxField', 'IndicoLocationField', 'IndicoMarkdownField',
            'IndicoDateField', 'IndicoProtectionField', 'IndicoSelectMultipleCheckboxBooleanField', 'RelativeDeltaField',
            'IndicoWeekDayRepetitionField', 'IndicoEmailRecipientsField')

--- a/indico/web/forms/fields/principals.py
+++ b/indico/web/forms/fields/principals.py
@@ -54,27 +54,29 @@ class PrincipalListField(HiddenField):
     Principals are users or other objects represending users such as
     groups or roles that can be added to ACLs.
 
-    :param allow_groups: If groups should be selectable.
-    :param allow_registration_forms: If registration form associated
-                                     to an event should be selectable.
-    :param allow_event_roles: If event roles should be selectable.
-    :param allow_category_roles: If category roles should be selectable.
     :param allow_external_users: If "search users with no indico account"
                                  should be available. Selecting such a user
                                  will automatically create a pending user once
                                  the form is submitted, even if other fields
                                  in the form fail to validate!
+    :param allow_groups: If groups should be selectable.
+    :param allow_event_roles: If event roles should be selectable.
+    :param allow_category_roles: If category roles should be selectable.
+    :param allow_registration_forms: If registration form associated
+                                     to an event should be selectable.
+    :param allow_emails: If the field should allow bare emails. Those are not
+                         selectable in the widget, but may be added to an ACL
+                         through other means.
     """
 
     widget = JinjaWidget('forms/principal_list_widget.html', single_kwargs=True)
 
     def __init__(self, *args, **kwargs):
-        self.allow_groups = kwargs.pop('allow_groups', False)
-        # Whether it is allowed to search for external users with no indico account
         self.allow_external_users = kwargs.pop('allow_external_users', False)
-        self.allow_registration_forms = kwargs.pop('allow_registration_forms', False)
+        self.allow_groups = kwargs.pop('allow_groups', False)
         self.allow_event_roles = kwargs.pop('allow_event_roles', False)
         self.allow_category_roles = kwargs.pop('allow_category_roles', False)
+        self.allow_registration_forms = kwargs.pop('allow_registration_forms', False)
         self.allow_emails = kwargs.pop('allow_emails', False)
         self._event = kwargs.pop('event')(kwargs['_form']) if 'event' in kwargs else None
         super(PrincipalListField, self).__init__(*args, **kwargs)

--- a/indico/web/forms/fields/principals.py
+++ b/indico/web/forms/fields/principals.py
@@ -49,7 +49,10 @@ def serialize_principal(principal):
 
 
 class PrincipalListField(HiddenField):
-    """A field that lets you select a list Indico user/group ("principal")
+    """A field that lets you select a list of principals.
+
+    Principals are users or other objects represending users such as
+    groups or roles that can be added to ACLs.
 
     :param allow_groups: If groups should be selectable.
     :param allow_registration_forms: If registration form associated

--- a/indico/web/forms/fields/principals.py
+++ b/indico/web/forms/fields/principals.py
@@ -77,7 +77,8 @@ class PrincipalListField(HiddenField):
         super(PrincipalListField, self).__init__(*args, **kwargs)
 
     def _convert_principal(self, principal):
-        return principal_from_identifier(principal, event_id=self._event, allow_groups=self.allow_groups,
+        event_id = self._event.id if self._event else None
+        return principal_from_identifier(principal, event_id=event_id, allow_groups=self.allow_groups,
                                          allow_external_users=self.allow_external_users,
                                          allow_event_roles=self.allow_event_roles,
                                          allow_category_roles=self.allow_category_roles,

--- a/indico/web/forms/fields/principals.py
+++ b/indico/web/forms/fields/principals.py
@@ -68,7 +68,6 @@ class PrincipalListField(HiddenField):
     widget = JinjaWidget('forms/principal_list_widget.html', single_kwargs=True)
 
     def __init__(self, *args, **kwargs):
-        self.data = []
         self.allow_groups = kwargs.pop('allow_groups', False)
         # Whether it is allowed to search for external users with no indico account
         self.allow_external_users = kwargs.pop('allow_external_users', False)

--- a/indico/web/forms/fields/principals.py
+++ b/indico/web/forms/fields/principals.py
@@ -160,7 +160,7 @@ class AccessControlListField(PrincipalListField):
         super(AccessControlListField, self).__init__(*args, **kwargs)
 
 
-class PrincipalField(_LegacyPrincipalListField):
+class PrincipalField(PrincipalListField):
     """A field that lets you select an Indico user/group ("principal")"""
 
     widget = JinjaWidget('forms/principal_widget.html', single_line=True, single_kwargs=True)

--- a/indico/web/forms/fields/principals.py
+++ b/indico/web/forms/fields/principals.py
@@ -87,10 +87,14 @@ class PrincipalListField(HiddenField):
 
     def process_formdata(self, valuelist):
         if valuelist:
-            self.data = {self._convert_principal(x) for x in json.loads(valuelist[0])}
+            self._submitted_data = json.loads(valuelist[0])
+            self.data = {self._convert_principal(x) for x in self._submitted_data}
 
     def _value(self):
-        return [x.identifier for x in self._get_data()]
+        try:
+            return self._submitted_data
+        except AttributeError:
+            return [x.identifier for x in self._get_data()]
 
     def _get_data(self):
         return sorted(self.data) if self.data else []

--- a/indico/web/templates/forms/principal_list_widget.html
+++ b/indico/web/templates/forms/principal_list_widget.html
@@ -25,12 +25,12 @@
     <script>
         setupPrincipalListWidget({
             fieldId: {{ field.id | tojson }},
-            eventId: {{ (field.event.id if field.event else none) | tojson }},
+            eventId: {{ (field._event.id if field._event else none) | tojson }},
             withGroups: {{  field.allow_groups | tojson }},
             withExternalUsers: {{ field.allow_external_users | tojson }},
             withEventRoles: {{ field.allow_event_roles | tojson }},
             withCategoryRoles: {{ field.allow_category_roles | tojson }},
-            withRegistrationForms: {{ field.allow_registration_forms | tojson }},
+            withRegistrants: {{ field.allow_registration_forms | tojson }},
             withEmails: {{ field.allow_emails | tojson }},
             protectedFieldId: {{ field.protected_field_id | default(none) | tojson }},
         });

--- a/indico/web/templates/forms/principal_list_widget.html
+++ b/indico/web/templates/forms/principal_list_widget.html
@@ -33,7 +33,7 @@
             withCategoryRoles: {{ field.allow_category_roles | default(False) | tojson }},
             withRegistrationForms: {{ field.allow_registration_forms | default(False) | tojson }},
             withNetworks: {{ field.allow_networks | default(False) | tojson }},
-            protectedFieldId: {{ field.protected_field | default(None) | tojson }},
+            protectedFieldId: {{ field.protected_field_id | default(None) | tojson }},
             legacy: {{ field.legacy | default(False) | tojson }}
         });
     </script>

--- a/indico/web/templates/forms/principal_list_widget.html
+++ b/indico/web/templates/forms/principal_list_widget.html
@@ -26,11 +26,15 @@
         setupPrincipalListWidget({
             fieldId: {{ field.id | tojson }},
             eventId: {{ (field.event.id if field.event else none) | tojson }},
-            openImmediately: {{ field.open_immediately | tojson }},
-            groups: {{ field.groups | tojson }},
-            allowExternal: {{ field.allow_external | tojson }},
-            allowNetworks: {{ field.allow_networks | tojson }},
-            networks: {{ field.ip_networks | sort(attribute='name') | tojson }}
+            openImmediately: {{ field.open_immediately | default(False) | tojson }},
+            withGroups: {{  (field.groups or field.allow_groups) | tojson }},
+            withExternalUsers: {{ (field.allow_external or field.allow_external_users) | tojson }},
+            withEventRoles: {{ field.allow_event_roles | default(False) | tojson }},
+            withCategoryRoles: {{ field.allow_category_roles | default(False) | tojson }},
+            withRegistrationForms: {{ field.allow_registration_forms | default(False) | tojson }},
+            withNetworks: {{ field.allow_networks | default(False) | tojson }},
+            protectedFieldId: {{ field.protected_field | default(None) | tojson }},
+            legacy: {{ field.legacy | default(False) | tojson }}
         });
     </script>
 {% endblock %}

--- a/indico/web/templates/forms/principal_list_widget.html
+++ b/indico/web/templates/forms/principal_list_widget.html
@@ -31,7 +31,7 @@
             withExternalUsers: {{ (field.allow_external or field.allow_external_users) | tojson }},
             withEventRoles: {{ field.allow_event_roles | default(False) | tojson }},
             withCategoryRoles: {{ field.allow_category_roles | default(False) | tojson }},
-            withRegistrationForms: {{ field.allow_registration_forms | default(False) | tojson }},
+            withRegistrationForms: {{ field.allow_registration_forms | tojson }},
             withNetworks: {{ field.allow_networks | default(False) | tojson }},
             protectedFieldId: {{ field.protected_field_id | default(None) | tojson }},
             legacy: {{ field.legacy | default(False) | tojson }}

--- a/indico/web/templates/forms/principal_list_widget.html
+++ b/indico/web/templates/forms/principal_list_widget.html
@@ -26,15 +26,13 @@
         setupPrincipalListWidget({
             fieldId: {{ field.id | tojson }},
             eventId: {{ (field.event.id if field.event else none) | tojson }},
-            openImmediately: {{ field.open_immediately | default(False) | tojson }},
-            withGroups: {{  (field.groups or field.allow_groups) | tojson }},
-            withExternalUsers: {{ (field.allow_external or field.allow_external_users) | tojson }},
-            withEventRoles: {{ field.allow_event_roles | default(False) | tojson }},
-            withCategoryRoles: {{ field.allow_category_roles | default(False) | tojson }},
+            withGroups: {{  field.allow_groups | tojson }},
+            withExternalUsers: {{ field.allow_external_users | tojson }},
+            withEventRoles: {{ field.allow_event_roles | tojson }},
+            withCategoryRoles: {{ field.allow_category_roles | tojson }},
             withRegistrationForms: {{ field.allow_registration_forms | tojson }},
-            withNetworks: {{ field.allow_networks | default(False) | tojson }},
-            protectedFieldId: {{ field.protected_field_id | default(None) | tojson }},
-            legacy: {{ field.legacy | default(False) | tojson }}
+            withEmails: {{ field.allow_emails | tojson }},
+            protectedFieldId: {{ field.protected_field_id | default(none) | tojson }},
         });
     </script>
 {% endblock %}

--- a/indico/web/templates/forms/principal_widget.html
+++ b/indico/web/templates/forms/principal_widget.html
@@ -16,8 +16,7 @@
             fieldId: {{ field.id | tojson }},
             eventId: {{ (field.event.id if field.event else none) | tojson }},
             required: {{ field.flags.required | tojson }},
-            allowExternal: {{ field.allow_external | tojson }}
+            withExternalUsers: {{ field.allow_external_users | default(False) | tojson }}
         });
     </script>
 {% endblock %}
-

--- a/indico/web/templates/forms/principal_widget.html
+++ b/indico/web/templates/forms/principal_widget.html
@@ -2,11 +2,9 @@
 
 
 {% block html %}
-    <input type="hidden" id="{{ field.id }}" name="{{ field.name }}"
-           value="{{ field._value() | tojson | forceescape }}"
+    <input type="hidden" id="{{ field.id }}" name="{{ field.name }}" value="{{ field._value() }}"
            {{ input_args | html_params }}>
-    <input type="text" id="display-{{ field.id }}" placeholder="{% trans %}Choose user...{% endtrans %}" readonly>
-    <button type="button" id="choose-{{ field.id }}" class="i-button" data-tooltip-anchor>{% trans %}Choose{% endtrans %}</button>
+    <div id="principalField-{{ field.id }}"></div>
 {% endblock %}
 
 
@@ -14,8 +12,7 @@
     <script>
         setupPrincipalWidget({
             fieldId: {{ field.id | tojson }},
-            eventId: {{ (field.event.id if field.event else none) | tojson }},
-            required: {{ field.flags.required | tojson }},
+            required: {{ input_args.required | default(false) | tojson }},
             withExternalUsers: {{ field.allow_external_users | tojson }}
         });
     </script>

--- a/indico/web/templates/forms/principal_widget.html
+++ b/indico/web/templates/forms/principal_widget.html
@@ -16,7 +16,7 @@
             fieldId: {{ field.id | tojson }},
             eventId: {{ (field.event.id if field.event else none) | tojson }},
             required: {{ field.flags.required | tojson }},
-            withExternalUsers: {{ field.allow_external_users | default(False) | tojson }}
+            withExternalUsers: {{ field.allow_external_users | tojson }}
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Closes #4505 

- [x] Requires testing
- [x] Checking which legacy classes can already re-use the new version.
- [x] Update WTFPrincipalListField spreaded props
- [x] Update PrincipalListField props (such as required, onFocus, blur)