### PR TITLE
Rename Paper Reviewing to (Paper) Peer Reviewing

### DIFF
--- a/indico/modules/events/abstracts/__init__.py
+++ b/indico/modules/events/abstracts/__init__.py
@@ -51,7 +51,7 @@ def _extend_event_management_menu(sender, event, **kwargs):
     if not event.can_manage(session.user) or not AbstractsFeature.is_allowed_for_event(event):
         return
     return SideMenuItem('abstracts', _('Call for Abstracts'), url_for('abstracts.management', event),
-                        section='workflows')
+                        section='workflows', weight=30)
 
 
 @signals.event.get_feature_definitions.connect

--- a/indico/modules/events/editing/__init__.py
+++ b/indico/modules/events/editing/__init__.py
@@ -67,7 +67,7 @@ def _extend_event_management_menu(sender, event, **kwargs):
     if not event.can_manage(session.user, 'editing_manager') or not EditingFeature.is_allowed_for_event(event):
         return
     return SideMenuItem('editing', _('Editing'), url_for('event_editing.dashboard', event),
-                        section='workflows')
+                        section='workflows', weight=10)
 
 
 @signals.event_management.management_url.connect

--- a/indico/modules/events/papers/__init__.py
+++ b/indico/modules/events/papers/__init__.py
@@ -6,7 +6,7 @@
 # LICENSE file for more details.
 
 """
-The ``papers`` module handles the Indico's Paper Reviewing workflow.
+The ``papers`` module handles the Indico's Paper Peer Reviewing workflow.
 The "inputs" of this module are the conference papers, which will be uploaded
 by the corresponding authors/submitters.
 """
@@ -32,7 +32,7 @@ logger = Logger.get('events.papers')
 def _extend_event_management_menu(sender, event, **kwargs):
     if not event.cfp.is_manager(session.user) or not PapersFeature.is_allowed_for_event(event):
         return
-    return SideMenuItem('papers', _('Call for Papers'), url_for('papers.management', event),
+    return SideMenuItem('papers', _('Peer Reviewing'), url_for('papers.management', event),
                         section='workflows', weight=20)
 
 
@@ -43,7 +43,7 @@ def _extend_editing_menu(sender, event, **kwargs):
         return None
     if (has_contributions_with_user_paper_submission_rights(event, session.user) or
             event.cfp.is_staff(session.user)):
-        return SideMenuItem('papers', _('Call for Papers'), url_for('papers.call_for_papers', event))
+        return SideMenuItem('papers', _('Peer Reviewing'), url_for('papers.call_for_papers', event))
 
 
 @signals.event_management.management_url.connect
@@ -87,9 +87,9 @@ def _get_management_permissions(sender, **kwargs):
 
 class PapersFeature(EventFeature):
     name = 'papers'
-    friendly_name = _('Call for Papers')
-    description = _('Gives event managers the opportunity to open a "Call for Papers" and use the paper '
-                    'reviewing workflow.')
+    friendly_name = _('Paper Peer Reviewing')
+    description = _('Gives event managers the opportunity to let contribution authors '
+                    'submit papers and use the paper peer reviewing workflow.')
 
     @classmethod
     def is_allowed_for_event(cls, event):
@@ -99,7 +99,7 @@ class PapersFeature(EventFeature):
 class PaperManagerPermission(ManagementPermission):
     name = 'paper_manager'
     friendly_name = _('Paper Manager')
-    description = _('Grants management rights for paper reviewing on an event.')
+    description = _('Grants management rights for paper peer reviewing on an event.')
     user_selectable = True
 
 
@@ -142,7 +142,7 @@ def _extend_event_menu(sender, **kwargs):
         return (has_contributions_with_user_paper_submission_rights(event, session.user) or
                 event.cfp.is_staff(session.user))
 
-    yield MenuEntryData(title=_("Call for Papers"), name='call_for_papers',
+    yield MenuEntryData(title=_("Paper Peer Reviewing"), name='call_for_papers',
                         endpoint='papers.call_for_papers', position=8,
                         visible=_call_for_papers_visible)
 

--- a/indico/modules/events/papers/__init__.py
+++ b/indico/modules/events/papers/__init__.py
@@ -33,7 +33,7 @@ def _extend_event_management_menu(sender, event, **kwargs):
     if not event.cfp.is_manager(session.user) or not PapersFeature.is_allowed_for_event(event):
         return
     return SideMenuItem('papers', _('Call for Papers'), url_for('papers.management', event),
-                        section='workflows')
+                        section='workflows', weight=20)
 
 
 @signals.menu.items.connect_via('event-editing-sidemenu')

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -36,7 +36,7 @@ def make_competences_form(event):
 
 class PaperTeamsForm(IndicoForm):
     managers = PrincipalListField(_('Paper managers'), groups=True, event=lambda form: form.event,
-                                  description=_('List of users allowed to manage the call for papers'))
+                                  description=_('List of users allowed to manage the paper peer reviewing module'))
     judges = PrincipalListField(_('Judges'),
                                 description=_('List of users allowed to judge papers'))
     content_reviewers = PrincipalListField(_('Content reviewers'),

--- a/indico/modules/events/papers/templates/emails/base.html
+++ b/indico/modules/events/papers/templates/emails/base.html
@@ -5,7 +5,7 @@
 {% block footer %}{% endblock %}
 
 {% block subject -%}
-    {% block subject_message %}Call for papers{% endblock %}
+    {% block subject_message %}Paper Peer Reviewing{% endblock %}
     {%- block subject_name %}{% endblock %}
 {%- endblock %}
 
@@ -34,7 +34,7 @@
             {% endblock %}
         </div>
         <div style="text-align: center; padding: 10px; background: #ebebeb; font-size: small; color: #999;">
-            Indico :: Call for papers
+            Indico :: Paper Peer Reviewing
         </div>
     </div>
 {% endblock %}

--- a/indico/modules/events/papers/templates/management/_base.html
+++ b/indico/modules/events/papers/templates/management/_base.html
@@ -4,5 +4,5 @@
 {% block page_id %}paper-page{% endblock %}
 
 {% block title %}
-    {% trans %}Call for Papers{% endtrans %}
+    {% trans %}Paper Peer Reviewing{% endtrans %}
 {% endblock %}

--- a/indico/modules/events/papers/templates/management/assignment.html
+++ b/indico/modules/events/papers/templates/management/assignment.html
@@ -2,7 +2,7 @@
 {% from 'events/papers/_paper_list.html' import render_paper_assignment_content %}
 
 {% block title %}
-    {% trans %}Call for Papers{% endtrans %}
+    {% trans %}Paper Peer Reviewing{% endtrans %}
 {% endblock %}
 
 {% block subtitle %}

--- a/indico/modules/events/papers/templates/management/disabled.html
+++ b/indico/modules/events/papers/templates/management/disabled.html
@@ -6,11 +6,11 @@
             <div class="icon icon-file-check"></div>
             <div class="text">
                 <div class="label">
-                    {% trans %}Call for Papers disabled{% endtrans %}
+                    {% trans %}Paper Peer Reviewing disabled{% endtrans %}
                 </div>
                 {% trans -%}
-                    "Call for Papers" provides an integrated paper management and reviewing module
-                    that will allow you to set up a full paper submission and reviewing workflow.
+                    "Paper Peer Reviewing" provides an integrated paper management and peer reviewing
+                    module that will allow you to set up a full paper submission and peer reviewing workflow.
                 {%- endtrans %}
             </div>
             <div class="toolbar">

--- a/indico/translations/messages.pot
+++ b/indico/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: indico 2.3-dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-07-20 16:44+0200\n"
+"POT-Creation-Date: 2020-07-22 14:43+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -8441,14 +8441,19 @@ msgid "Do you want to delete the attached minutes?"
 msgstr ""
 
 #: indico/modules/events/papers/__init__.py:35 indico/modules/events/papers/__init__.py:46
+msgid "Peer Reviewing"
+msgstr ""
+
 #: indico/modules/events/papers/__init__.py:90 indico/modules/events/papers/__init__.py:145
 #: indico/modules/events/papers/templates/management/_base.html:7
 #: indico/modules/events/papers/templates/management/assignment.html:5
-msgid "Call for Papers"
+msgid "Paper Peer Reviewing"
 msgstr ""
 
 #: indico/modules/events/papers/__init__.py:91
-msgid "Gives event managers the opportunity to open a \"Call for Papers\" and use the paper reviewing workflow."
+msgid ""
+"Gives event managers the opportunity to let contribution authors submit papers and use the paper peer reviewing "
+"workflow."
 msgstr ""
 
 #: indico/modules/events/papers/__init__.py:101
@@ -8456,7 +8461,7 @@ msgid "Paper Manager"
 msgstr ""
 
 #: indico/modules/events/papers/__init__.py:102
-msgid "Grants management rights for paper reviewing on an event."
+msgid "Grants management rights for paper peer reviewing on an event."
 msgstr ""
 
 #: indico/modules/events/papers/__init__.py:109
@@ -8490,7 +8495,7 @@ msgid "Paper managers"
 msgstr ""
 
 #: indico/modules/events/papers/forms.py:39
-msgid "List of users allowed to manage the call for papers"
+msgid "List of users allowed to manage the paper peer reviewing module"
 msgstr ""
 
 #: indico/modules/events/papers/forms.py:40 indico/modules/events/papers/templates/_paper_list.html:52
@@ -8987,13 +8992,13 @@ msgid ""
 msgstr ""
 
 #: indico/modules/events/papers/templates/management/disabled.html:9
-msgid "Call for Papers disabled"
+msgid "Paper Peer Reviewing disabled"
 msgstr ""
 
 #: indico/modules/events/papers/templates/management/disabled.html:11
 msgid ""
-"\"Call for Papers\" provides an integrated paper management and reviewing module that will allow you to set up a full"
-" paper submission and reviewing workflow."
+"\"Paper Peer Reviewing\" provides an integrated paper management and peer reviewing module that will allow you to set"
+" up a full paper submission and peer reviewing workflow."
 msgstr ""
 
 #: indico/modules/events/papers/templates/management/overview.html:18


### PR DESCRIPTION
Also replaced some "Call for Papers" occurrences in places where "Peer Reviewing" is more meaningful and set specific menu item weights inside the "Workflows" menu to have a more logical order (Abstracts, Peer Reviewing, Editing).