### PR TITLE
Add filter_selectable_badges signal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -131,6 +131,7 @@ Internal Changes
   thanks :user:`omegak`)
 - Add ``extra-regform-settings`` template hook (:issue:`4553`, thanks
   :user:`meluru`)
+- Add ``filter_selectable_badges`` signal (:issue:`4557`, thanks :user:`omegak`)
 
 
 ----

--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -80,3 +80,10 @@ the ticket qr code is considered a ticket, and the restriction applies to
 both users trying to get their own ticket and managers trying to get a
 ticket for a registrant.
 """)
+
+filter_selectable_badges = _signals.signal('filter-selectable-badges', """
+Called when composing lists of badge templates. The `sender` may be either
+``BadgeSettingsForm``, ``RHListEventTemplates`` or ``RHListCategoryTemplates``.
+The list of badge templates is passed in the `badge_templates` kwarg.
+The signal handler is expected to mutate the list.
+""")

--- a/indico/modules/designer/controllers.py
+++ b/indico/modules/designer/controllers.py
@@ -15,6 +15,7 @@ from flask import flash, jsonify, request, session
 from PIL import Image
 from werkzeug.exceptions import Forbidden
 
+from indico.core import signals
 from indico.core.db import db
 from indico.core.errors import UserValueError
 from indico.modules.categories import Category
@@ -162,8 +163,10 @@ class TemplateListMixin(TargetFromURLMixin):
         templates = get_inherited_templates(self.target)
         not_deletable = get_not_deletable_templates(self.target)
         default_template = get_default_template_on_category(self.target) if isinstance(self.target, Category) else None
+        signals.event.filter_selectable_badges.send(type(self), badge_templates=templates)
+        signals.event.filter_selectable_badges.send(type(self), badge_templates=not_deletable)
         return self._render_template('list.html', inherited_templates=templates, not_deletable_templates=not_deletable,
-                                     default_template=default_template,)
+                                     default_template=default_template)
 
 
 class CloneTemplateMixin(TargetFromURLMixin):

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -18,6 +18,7 @@ from wtforms.fields.html5 import DecimalField, EmailField
 from wtforms.validators import DataRequired, Email, InputRequired, NumberRange, Optional, ValidationError
 from wtforms.widgets.html5 import NumberInput
 
+from indico.core import signals
 from indico.core.config import config
 from indico.modules.designer import PageLayout, PageOrientation, PageSize, TemplateType
 from indico.modules.designer.util import get_default_template_on_category, get_inherited_templates
@@ -383,6 +384,7 @@ class BadgeSettingsForm(IndicoForm):
     def __init__(self, event, **kwargs):
         all_templates = set(event.designer_templates) | get_inherited_templates(event)
         badge_templates = [tpl for tpl in all_templates if tpl.type.name == 'badge']
+        signals.event.filter_selectable_badges.send(type(self), badge_templates=badge_templates)
         tickets = kwargs.pop('tickets')
         super(BadgeSettingsForm, self).__init__(**kwargs)
         self.template.choices = sorted(((unicode(tpl.id), tpl.title)


### PR DESCRIPTION
This signal is added so that we can filter badge templates from a plugin context.