### PR TITLE
Allow choosing default badge in categories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -108,6 +108,8 @@ Improvements
   other news items (:pr:`4587`)
 - Allow registrants to withdraw their application (:issue:`2715`, :pr:`4166`,
   thanks :user:`brabemi` & :user:`omegak`)
+- Allow choosing a default badge in categories (:pr:`4574`, thanks
+  :user:`omegak`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/core/db/sqlalchemy/util/management.py
+++ b/indico/core/db/sqlalchemy/util/management.py
@@ -15,7 +15,7 @@ from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.util.console import cformat
 
 
-DEFAULT_TEMPLATE_DATA = {
+DEFAULT_TICKET_DATA = {
     'background_position': 'stretch', 'width': 850, 'height': 1350, 'items': [
         {'font_size': '24pt', 'bold': False, 'color': 'black', 'text': 'Fixed text', 'selected': False,
          'text_align': 'center', 'font_family': 'sans-serif', 'width': 400, 'italic': False, 'y': 190, 'x': 330,
@@ -38,6 +38,28 @@ DEFAULT_TEMPLATE_DATA = {
         {'font_size': '13.5pt', 'bold': False, 'color': 'black', 'text': 'Fixed text', 'selected': False,
          'text_align': 'left', 'font_family': 'sans-serif', 'width': 400, 'italic': False, 'y': 90, 'x': 50,
          'height': None, 'type': 'event_room', 'id': 6}]
+}
+
+DEFAULT_BADGE_DATA = {
+    'background_position': 'stretch', 'width': 425, 'height': 270, 'items': [
+        {'font_family': 'sans-serif', 'font_size': '10pt', 'bold': False, 'color': 'black', 'text': 'Fixed text',
+         'selected': False, 'text_align': 'right', 'height': None, 'width': 275, 'italic': False, 'y': 42, 'x': 129,
+         'type': 'event_title', 'id': 0},
+        {'font_family': 'sans-serif', 'font_size': '7pt', 'bold': False, 'color': 'black', 'text': 'Fixed text',
+         'selected': False, 'text_align': 'right', 'height': None, 'width': 275, 'italic': False, 'y': 85, 'x': 128,
+         'type': 'event_dates', 'id': 1},
+        {'font_family': 'sans-serif', 'font_size': '10pt', 'bold': False, 'color': 'black', 'text': 'Fixed text',
+         'selected': False, 'text_align': 'left', 'height': None, 'width': 385, 'italic': False, 'y': 168, 'x': 20,
+         'type': 'affiliation', 'id': 2},
+        {'font_family': 'sans-serif', 'font_size': '12pt', 'bold': True, 'color': 'black', 'text': 'Fixed text',
+         'selected': False, 'text_align': 'left', 'height': None, 'width': 385, 'italic': False, 'y': 123, 'x': 20,
+         'type': 'full_name_b', 'id': 3},
+        {'font_family': 'sans-serif', 'font_size': '7.5pt', 'bold': False, 'color': 'black', 'text': 'Fixed text',
+         'selected': False, 'text_align': 'left', 'height': None, 'width': 385, 'italic': False, 'y': 194, 'x': 20,
+         'type': 'position', 'id': 4},
+        {'font_family': 'sans-serif', 'font_size': '7pt', 'bold': False, 'color': 'black', 'text': 'Fixed text',
+         'selected': False, 'text_align': 'left', 'height': None, 'width': 385, 'italic': False, 'y': 218, 'x': 20,
+         'type': 'country', 'id': 5}]
 }
 
 
@@ -104,10 +126,14 @@ def create_all_tables(db, verbose=False, add_initial_data=True):
         db.session.flush()
         if verbose:
             print(cformat('%{green}Creating default ticket template for root category '))
-        dt = DesignerTemplate(category_id=0, title='Default ticket', type=TemplateType.badge,
-                              data=DEFAULT_TEMPLATE_DATA, is_system_template=True)
-        cat.default_ticket_template = dt
-        db.session.add(dt)
+        dtt = DesignerTemplate(category_id=0, title='Default ticket', type=TemplateType.badge,
+                               data=DEFAULT_TICKET_DATA, is_system_template=True)
+        dbt = DesignerTemplate(category_id=0, title='Default badge', type=TemplateType.badge,
+                               data=DEFAULT_BADGE_DATA, is_system_template=True)
+        cat.default_ticket_template = dtt
+        cat.default_badge_template = dbt
+        db.session.add(dtt)
+        db.session.add(dbt)
         if verbose:
             print(cformat('%{green}Creating system oauth apps'))
         for sat in SystemAppType:

--- a/indico/migrations/versions/20200805_1423_c997dc927fbc_add_default_badge_to_categories.py
+++ b/indico/migrations/versions/20200805_1423_c997dc927fbc_add_default_badge_to_categories.py
@@ -1,0 +1,52 @@
+"""Add default badge to categories
+
+Revision ID: c997dc927fbc
+Revises: 497c61b68050
+Create Date: 2020-07-30 14:23:35.808229
+"""
+
+import json
+
+import sqlalchemy as sa
+from alembic import context, op
+
+from indico.core.db.sqlalchemy.util.management import DEFAULT_BADGE_DATA
+
+
+# revision identifiers, used by Alembic.
+revision = 'c997dc927fbc'
+down_revision = '497c61b68050'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    if context.is_offline_mode():
+        raise Exception('This upgrade is only possible in online mode')
+    op.add_column('categories', sa.Column('default_badge_template_id', sa.Integer(), nullable=True),
+                  schema='categories')
+    op.create_index(None, 'categories', ['default_badge_template_id'], unique=False, schema='categories')
+    op.create_foreign_key(None, 'categories', 'designer_templates', ['default_badge_template_id'], ['id'],
+                          source_schema='categories', referent_schema='indico')
+    conn = op.get_bind()
+    root_categ_id = conn.execute('SELECT id FROM categories.categories WHERE parent_id IS NULL').scalar()
+    badge_id = conn.execute('''
+        INSERT INTO indico.designer_templates
+        (category_id, title, type, is_system_template, is_clonable, data) VALUES
+        (%s         , %s   , %s  , true              , true       , %s)
+        RETURNING id
+    ''', (root_categ_id, 'Default badge', 1, json.dumps(DEFAULT_BADGE_DATA))).scalar()
+    conn.execute('''
+        UPDATE categories.categories
+        SET default_badge_template_id = %s
+        WHERE id = %s
+    ''', (badge_id, root_categ_id))
+
+
+def downgrade():
+    if context.is_offline_mode():
+        raise Exception('This downgrade is only possible in online mode')
+    conn = op.get_bind()
+    id_ = conn.execute('SELECT default_badge_template_id FROM categories.categories WHERE parent_id IS NULL').scalar()
+    op.drop_column('categories', 'default_badge_template_id', schema='categories')
+    conn.execute('DELETE FROM indico.designer_templates WHERE is_system_template AND id = %s', (id_,))

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -172,6 +172,11 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
         nullable=True,
         index=True
     )
+    default_badge_template_id = db.Column(
+        db.ForeignKey('indico.designer_templates.id'),
+        nullable=True,
+        index=True
+    )
 
     children = db.relationship(
         'Category',
@@ -195,6 +200,12 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
         lazy=True,
         foreign_keys=default_ticket_template_id,
         backref='default_ticket_template_of'
+    )
+    default_badge_template = db.relationship(
+        'DesignerTemplate',
+        lazy=True,
+        foreign_keys=default_badge_template_id,
+        backref='default_badge_template_of'
     )
 
     # column properties:

--- a/indico/modules/designer/blueprint.py
+++ b/indico/modules/designer/blueprint.py
@@ -11,7 +11,7 @@ from indico.modules.designer.controllers import (RHAddCategoryTemplate, RHAddEve
                                                  RHCloneEventTemplate, RHDeleteDesignerTemplate,
                                                  RHDownloadTemplateImage, RHEditDesignerTemplate, RHGetTemplateData,
                                                  RHListBacksideTemplates, RHListCategoryTemplates, RHListEventTemplates,
-                                                 RHToggleBadgeDefaultOnCategory, RHToggleTemplateDefaultOnCategory,
+                                                 RHToggleBadgeDefaultOnCategory, RHToggleTicketDefaultOnCategory,
                                                  RHUploadBackgroundImage)
 from indico.util.caching import memoize
 from indico.web.flask.util import make_view_func
@@ -32,8 +32,8 @@ def _dispatch(event_rh, category_rh):
     return view_func
 
 
-_bp.add_url_rule('/category/<int:category_id>/manage/designer/<int:template_id>/toggle-default',
-                 'toggle_category_default', RHToggleTemplateDefaultOnCategory, methods=('POST',))
+_bp.add_url_rule('/category/<int:category_id>/manage/designer/<int:template_id>/toggle-default-ticket',
+                 'toggle_category_default_ticket', RHToggleTicketDefaultOnCategory, methods=('POST',))
 _bp.add_url_rule('/category/<int:category_id>/manage/designer/<int:template_id>/toggle-default-badge',
                  'toggle_category_default_badge', RHToggleBadgeDefaultOnCategory, methods=('POST',))
 

--- a/indico/modules/designer/blueprint.py
+++ b/indico/modules/designer/blueprint.py
@@ -11,7 +11,8 @@ from indico.modules.designer.controllers import (RHAddCategoryTemplate, RHAddEve
                                                  RHCloneEventTemplate, RHDeleteDesignerTemplate,
                                                  RHDownloadTemplateImage, RHEditDesignerTemplate, RHGetTemplateData,
                                                  RHListBacksideTemplates, RHListCategoryTemplates, RHListEventTemplates,
-                                                 RHToggleTemplateDefaultOnCategory, RHUploadBackgroundImage)
+                                                 RHToggleBadgeDefaultOnCategory, RHToggleTemplateDefaultOnCategory,
+                                                 RHUploadBackgroundImage)
 from indico.util.caching import memoize
 from indico.web.flask.util import make_view_func
 from indico.web.flask.wrappers import IndicoBlueprint
@@ -33,6 +34,8 @@ def _dispatch(event_rh, category_rh):
 
 _bp.add_url_rule('/category/<int:category_id>/manage/designer/<int:template_id>/toggle-default',
                  'toggle_category_default', RHToggleTemplateDefaultOnCategory, methods=('POST',))
+_bp.add_url_rule('/category/<int:category_id>/manage/designer/<int:template_id>/toggle-default-badge',
+                 'toggle_category_default_badge', RHToggleBadgeDefaultOnCategory, methods=('POST',))
 
 
 for object_type in ('event', 'category'):

--- a/indico/modules/designer/controllers.py
+++ b/indico/modules/designer/controllers.py
@@ -379,7 +379,9 @@ class RHGetTemplateData(BacksideTemplateProtectionMixin, RHModifyDesignerTemplat
 class RHToggleTicketDefaultOnCategory(RHManageCategoryBase):
     def _process(self):
         template = DesignerTemplate.get_or_404(request.view_args['template_id'])
-        if template not in get_all_templates(self.category):
+        all_ticket_templates = [tpl for tpl in get_all_templates(self.category)
+                                if tpl.type == TemplateType.badge and tpl.is_ticket]
+        if template not in all_ticket_templates:
             raise Exception('Invalid template')
         if template == self.category.default_ticket_template:
             # already the default -> clear it

--- a/indico/modules/designer/models/templates.py
+++ b/indico/modules/designer/models/templates.py
@@ -112,6 +112,7 @@ class DesignerTemplate(db.Model):
 
     # relationship backrefs:
     # - backside_template_of (DesignerTemplate.backside_template)
+    # - default_badge_template_of (Category.default_badge_template)
     # - default_ticket_template_of (Category.default_ticket_template)
     # - images (DesignerImageFile.template)
     # - ticket_for_regforms (RegistrationForm.ticket_template)

--- a/indico/modules/designer/templates/_list.html
+++ b/indico/modules/designer/templates/_list.html
@@ -63,7 +63,7 @@
         <td>
             <div class="thin toolbar right">
                 <div class="group">
-                    {% if not event and tpl.type.name == 'badge' %}
+                    {% if not event and tpl.type.name == 'badge' and tpl.is_ticket %}
                         {% set inherited_default = default_ticket == tpl and tpl.category != target and
                                 not target.default_ticket_template %}
                         {% set global_default = default_ticket == tpl and target.is_root %}

--- a/indico/modules/designer/templates/_list.html
+++ b/indico/modules/designer/templates/_list.html
@@ -41,7 +41,8 @@
     {% endif %}
 {% endmacro %}
 
-{% macro _render_template(tpl, target, inherited=false, event=none, default_template=none, not_deletable_templates=[]) -%}
+{% macro _render_template(tpl, target, inherited=false, event=none, default_template=none, default_badge=none,
+                          not_deletable_templates=[]) -%}
     <tr>
         <td class="i-table id-column">
             <i class="designer-template-type-icon template-icon-{{ tpl.type.name }}"
@@ -77,6 +78,26 @@
                             {% else %}
                                 title="{% trans %}Toggle default ticket template for this category{% endtrans %}"
                                 data-href="{{ url_for('.toggle_category_default', target, template_id=tpl.id) }}"
+                                data-method="POST"
+                                data-update="#template-list"
+                            {% endif %}>
+                        </a>
+                    {% endif %}
+                    {% if not event and tpl.type.name == 'badge' and not tpl.is_ticket %}
+                        {% set inherited_default = default_badge == tpl and tpl.category != target and
+                                not target.default_badge_template%}
+                        {% set global_default = default_badge == tpl and target.is_root %}
+                        <a class="i-button icon-tag icon-only borderless hide-if-locked toggle-default
+                            {{ 'default-on-category' if default_badge == tpl }}
+                            {{ 'inherited' if inherited_default }}
+                            {{ 'global-default' if global_default }}"
+                            {% if inherited_default %}
+                                title="{% trans %}This is the inherited default badge template{% endtrans %}"
+                            {% elif global_default %}
+                                title="{% trans %}This is the global default badge template{% endtrans %}"
+                            {% else %}
+                                title="{% trans %}Toggle default badge template for this category{% endtrans %}"
+                                data-href="{{ url_for('.toggle_category_default_badge', target, template_id=tpl.id) }}"
                                 data-method="POST"
                                 data-update="#template-list"
                             {% endif %}>
@@ -164,14 +185,17 @@
     </tr>
 {% endmacro -%}
 
-{% macro render_template_list(templates, target, inherited_templates=[], event=none, default_template=none, not_deletable_templates=[]) -%}
+{% macro render_template_list(templates, target, inherited_templates=[], event=none, default_template=none,
+                              default_badge=none, not_deletable_templates=[]) -%}
     {% if inherited_templates %}
         <section>
             <h3>{% trans %}Inherited templates{% endtrans %}</h3>
             <table class="i-table-widget">
                 <tbody>
                     {% for tpl in inherited_templates | sort(attribute='title') | sort(attribute='type') %}
-                        {{ _render_template(tpl, target, inherited=true, event=event, default_template=default_template, not_deletable_templates=not_deletable_templates) }}
+                        {{ _render_template(tpl, target, inherited=true, event=event,
+                                            default_template=default_template, default_badge=default_badge,
+                                            not_deletable_templates=not_deletable_templates) }}
                     {% endfor %}
                 </tbody>
             </table>
@@ -193,7 +217,7 @@
             <table class="i-table-widget">
                 <tbody>
                     {% for tpl in templates | sort(attribute='title') | sort(attribute='type') %}
-                        {{ _render_template(tpl, target, event=event, default_template=default_template, not_deletable_templates=not_deletable_templates) }}
+                        {{ _render_template(tpl, target, event=event, default_template=default_template, default_badge=default_badge, not_deletable_templates=not_deletable_templates) }}
                     {% endfor %}
                 </tbody>
             </table>

--- a/indico/modules/designer/templates/_list.html
+++ b/indico/modules/designer/templates/_list.html
@@ -41,7 +41,7 @@
     {% endif %}
 {% endmacro %}
 
-{% macro _render_template(tpl, target, inherited=false, event=none, default_template=none, default_badge=none,
+{% macro _render_template(tpl, target, inherited=false, event=none, default_ticket=none, default_badge=none,
                           not_deletable_templates=[]) -%}
     <tr>
         <td class="i-table id-column">
@@ -64,11 +64,11 @@
             <div class="thin toolbar right">
                 <div class="group">
                     {% if not event and tpl.type.name == 'badge' %}
-                        {% set inherited_default = default_template == tpl and tpl.category != target and
+                        {% set inherited_default = default_ticket == tpl and tpl.category != target and
                                 not target.default_ticket_template %}
-                        {% set global_default = default_template == tpl and target.is_root %}
+                        {% set global_default = default_ticket == tpl and target.is_root %}
                         <a class="i-button icon-ticket icon-only borderless hide-if-locked toggle-default
-                            {{ 'default-on-category' if default_template == tpl }}
+                            {{ 'default-on-category' if default_ticket == tpl }}
                             {{ 'inherited' if inherited_default }}
                             {{ 'global-default' if global_default }}"
                             {% if inherited_default %}
@@ -77,7 +77,7 @@
                                 title="{% trans %}This is the global default ticket template{% endtrans %}"
                             {% else %}
                                 title="{% trans %}Toggle default ticket template for this category{% endtrans %}"
-                                data-href="{{ url_for('.toggle_category_default', target, template_id=tpl.id) }}"
+                                data-href="{{ url_for('.toggle_category_default_ticket', target, template_id=tpl.id) }}"
                                 data-method="POST"
                                 data-update="#template-list"
                             {% endif %}>
@@ -185,7 +185,7 @@
     </tr>
 {% endmacro -%}
 
-{% macro render_template_list(templates, target, inherited_templates=[], event=none, default_template=none,
+{% macro render_template_list(templates, target, inherited_templates=[], event=none, default_ticket=none,
                               default_badge=none, not_deletable_templates=[]) -%}
     {% if inherited_templates %}
         <section>
@@ -194,7 +194,7 @@
                 <tbody>
                     {% for tpl in inherited_templates | sort(attribute='title') | sort(attribute='type') %}
                         {{ _render_template(tpl, target, inherited=true, event=event,
-                                            default_template=default_template, default_badge=default_badge,
+                                            default_ticket=default_ticket, default_badge=default_badge,
                                             not_deletable_templates=not_deletable_templates) }}
                     {% endfor %}
                 </tbody>
@@ -217,7 +217,9 @@
             <table class="i-table-widget">
                 <tbody>
                     {% for tpl in templates | sort(attribute='title') | sort(attribute='type') %}
-                        {{ _render_template(tpl, target, event=event, default_template=default_template, default_badge=default_badge, not_deletable_templates=not_deletable_templates) }}
+                        {{ _render_template(tpl, target, event=event, default_ticket=default_ticket,
+                                            default_badge=default_badge,
+                                            not_deletable_templates=not_deletable_templates) }}
                     {% endfor %}
                 </tbody>
             </table>

--- a/indico/modules/designer/templates/list.html
+++ b/indico/modules/designer/templates/list.html
@@ -8,7 +8,7 @@
 {% block content %}
     <div id="template-list">
         {{ render_template_list(target.designer_templates, target, inherited_templates=inherited_templates,
-                                event=event, default_template=default_template,
+                                event=event, default_template=default_template, default_badge=default_badge,
                                 not_deletable_templates=not_deletable_templates) }}
     </div>
 {% endblock %}

--- a/indico/modules/designer/templates/list.html
+++ b/indico/modules/designer/templates/list.html
@@ -8,7 +8,7 @@
 {% block content %}
     <div id="template-list">
         {{ render_template_list(target.designer_templates, target, inherited_templates=inherited_templates,
-                                event=event, default_template=default_template, default_badge=default_badge,
+                                event=event, default_ticket=default_ticket, default_badge=default_badge,
                                 not_deletable_templates=not_deletable_templates) }}
     </div>
 {% endblock %}

--- a/indico/modules/designer/util.py
+++ b/indico/modules/designer/util.py
@@ -58,7 +58,7 @@ def get_not_deletable_templates(obj):
     return set(DesignerTemplate.query.filter(DesignerTemplate.owner == obj, db.or_(*not_deletable_criteria)))
 
 
-def get_default_template_on_category(category, only_inherited=False):
+def get_default_ticket_on_category(category, only_inherited=False):
     if not only_inherited and category.default_ticket_template:
         return category.default_ticket_template
     parent_chain = category.parent_chain_query.options(joinedload('default_ticket_template')).all()

--- a/indico/modules/designer/util.py
+++ b/indico/modules/designer/util.py
@@ -64,3 +64,11 @@ def get_default_template_on_category(category, only_inherited=False):
     parent_chain = category.parent_chain_query.options(joinedload('default_ticket_template')).all()
     return next((category.default_ticket_template for
                  category in reversed(parent_chain) if category.default_ticket_template), None)
+
+
+def get_default_badge_on_category(category, only_inherited=False):
+    if not only_inherited and category.default_badge_template:
+        return category.default_badge_template
+    parent_chain = category.parent_chain_query.options(joinedload('default_badge_template')).all()
+    return next((category.default_badge_template for
+                 category in reversed(parent_chain) if category.default_badge_template), None)

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -20,7 +20,7 @@ from wtforms.widgets.html5 import NumberInput
 from indico.core import signals
 from indico.core.config import config
 from indico.modules.designer import PageLayout, PageOrientation, PageSize, TemplateType
-from indico.modules.designer.util import get_default_template_on_category, get_inherited_templates
+from indico.modules.designer.util import get_default_ticket_on_category, get_inherited_templates
 from indico.modules.events.features.util import is_feature_enabled
 from indico.modules.events.payment import payment_settings
 from indico.modules.events.registration.models.forms import ModificationMode
@@ -257,7 +257,7 @@ class TicketsForm(IndicoForm):
     def __init__(self, *args, **kwargs):
         event = kwargs.pop('event')
         super(TicketsForm, self).__init__(*args, **kwargs)
-        default_tpl = get_default_template_on_category(event.category)
+        default_tpl = get_default_ticket_on_category(event.category)
         all_templates = set(event.designer_templates) | get_inherited_templates(event)
         badge_templates = [(tpl.id, tpl.title) for tpl in all_templates
                            if tpl.type == TemplateType.badge and tpl != default_tpl]

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -520,10 +520,10 @@ def get_event_regforms_registrations(event, user, include_scheduled=True, only_i
 
 
 def generate_ticket(registration):
-    from indico.modules.designer.util import get_default_template_on_category
+    from indico.modules.designer.util import get_default_ticket_on_category
     from indico.modules.events.registration.controllers.management.tickets import DEFAULT_TICKET_PRINTING_SETTINGS
     template = (registration.registration_form.ticket_template or
-                get_default_template_on_category(registration.event.category))
+                get_default_ticket_on_category(registration.event.category))
     signals.event.designer.print_badge_template.send(template, regform=registration.registration_form,
                                                      registrations=[registration])
     pdf_class = RegistrantsListToBadgesPDFFoldable if template.backside_template else RegistrantsListToBadgesPDF


### PR DESCRIPTION
This PR introduces the notion of a default badge at the category level, analogous to the already existing default ticket functionality. The available actions and logic in the user interface are also equivalent to those related to default tickets.

Choosing a default badge will have no effect in other parts of Indico at the moment, but this enables other modules and plugins to make use of `Category.default_badge_template`. For instance this allows me to add a "Print badge" button on the registration management view that directly prints the default badge without opening the dialog.

## UI screenshot
||
|-|
|![image](https://user-images.githubusercontent.com/716307/88938290-84e05880-d285-11ea-8566-278a4af73328.png)|