### PR TITLE
Do not set metadata when claiming files

### DIFF
--- a/indico/modules/events/abstracts/controllers/boa.py
+++ b/indico/modules/events/abstracts/controllers/boa.py
@@ -67,7 +67,7 @@ class RHCustomBOA(RHManageAbstractsBase):
     })
     def _process_POST(self, file):
         self.event.custom_boa = file
-        file.claim(event_id=self.event.id)
+        file.claim()
         self.event.log(EventLogRealm.reviewing, EventLogKind.positive, 'Abstracts',
                        'Custom Book of Abstracts uploaded', session.user)
         return '', 204

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -73,7 +73,7 @@ def _make_editable_files(editable, files):
         for file in file_list
     ]
     for ef in editable_files:
-        ef.file.claim(contrib_id=editable.contribution.id, editable_type=editable.type.name)
+        ef.file.claim()
     return editable_files
 
 
@@ -94,7 +94,6 @@ def delete_editable(editable):
     for revision in editable.revisions:
         for ef in revision.files:
             ef.file.claimed = False
-            ef.file.meta = {}
     db.session.delete(editable)
     db.session.flush()
 

--- a/indico/modules/files/models/files.py
+++ b/indico/modules/files/models/files.py
@@ -41,7 +41,9 @@ class File(StoredFileMixin, db.Model):
         nullable=False,
         default=False
     )
-    #: Metadata that may be set when the file gets claimed.
+    #: Arbitrary metadata related to the file. Tis may be set at any time,
+    #: but code setting it on an already-claimed file should take into account
+    #: that it may already contain some data.
     meta = db.Column(
         JSONB,
         nullable=False,
@@ -52,18 +54,12 @@ class File(StoredFileMixin, db.Model):
     # - custom_boa_of (Event.custom_boa)
     # - editing_revision_files (EditingRevisionFile.file)
 
-    def claim(self, **meta):
+    def claim(self):
         """Mark the file as claimed by some object it's linked to.
 
-        By claiming a file the linked object takes ownership of it so the
-        file will not be automatically deleted.
-
-        :param force: Whether the file can already
+        Once a file is claimed it will not be automatically deleted anymore.
         """
         self.claimed = True
-        # XXX: Should we check for conflicts with existing metadata in case the
-        # file was already claimed?
-        self.meta = meta
 
     def _build_storage_path(self):
         path_segments = list(map(strict_unicode, self.__context))


### PR DESCRIPTION
It is rather meaningless in some cases, and we have relationships (or rather their backrefs) when the File gets associated with another object, so using the metadata to store additional information regarding the claim is a bit pointless.

Besides this, the current metadata structure did not really take into account a file being claimed by more than one object, and existing metadata would have been overwritten.

---

I was actually thinking about removing the column altogether, but it's used to store if an unclaimed file failed to be deleted, and it may also be useful for future yet unknown usecases.