### PR TITLE
Fix creating breaks

### DIFF
--- a/indico/modules/events/timetable/operations.py
+++ b/indico/modules/events/timetable/operations.py
@@ -43,7 +43,9 @@ def create_break_entry(event, data, session_block=None):
     break_ = Break()
     entry_data = {'object': break_,
                   'start_dt': data.pop('start_dt')}
-    break_.populate_from_dict(data)
+    # XXX: disable change tracking since `location_data` cannot be read back at this point
+    #      due to the break having no valid `location_parent`
+    break_.populate_from_dict(data, track_changes=False)
     parent = session_block.timetable_entry if session_block else None
     return create_timetable_entry(event, entry_data, parent=parent, extend_parent=True)
 


### PR DESCRIPTION
It was broken (no pun intended) by #4534 because reading back the `location_data` property fails if the break's has no timetable entry yet, but the timetable entry can only be created after populating the break at least partially.

```python
Traceback (most recent call last):
  File "/home/adrian/dev/indico/env/lib/python2.7/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/adrian/dev/indico/env/lib/python2.7/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/home/adrian/dev/indico/src/indico/web/flask/util.py", line 83, in wrapper
    return obj().process()
  File "/home/adrian/dev/indico/src/indico/web/rh.py", line 275, in process
    res = self._do_process()
  File "/home/adrian/dev/indico/src/indico/web/rh.py", line 245, in _do_process
    rv = self._process()
  File "/home/adrian/dev/indico/src/indico/modules/events/timetable/controllers/legacy.py", line 92, in _process
    entry = create_break_entry(self.event, form.data, session_block=self.session_block)
  File "/home/adrian/dev/indico/src/indico/modules/events/timetable/operations.py", line 46, in create_break_entry
    break_.populate_from_dict(data)
  File "/home/adrian/dev/indico/src/indico/core/db/sqlalchemy/util/models.py", line 216, in populate_from_dict
    new_value = getattr(self, key)
  File "/home/adrian/dev/indico/src/indico/core/db/sqlalchemy/locations.py", line 254, in location_data
    data_source = data_source.location_parent
  File "/home/adrian/dev/indico/src/indico/modules/events/timetable/models/breaks.py", line 66, in location_parent
    if self.timetable_entry.parent_id is None
AttributeError: 'NoneType' object has no attribute 'parent_id'
```

To avoid having to create the break in two steps we simply opt-out from tracking changes, since we do not even use them here anyway.