### PR TITLE
Allow registrants to withdraw their registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,6 +106,8 @@ Improvements
   :pr:`4577`)
 - Display each news item on a separate page instead of together with all the
   other news items (:pr:`4587`)
+- Allow registrants to withdraw their application (:issue:`2715`, :pr:`4166`,
+  thanks :user:`brabemi` & :user:`omegak`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -161,6 +161,8 @@ _bp.add_url_rule('/registrations/<int:reg_form_id>/', 'display_regform', display
                  methods=('GET', 'POST'))
 _bp.add_url_rule('/registrations/<int:reg_form_id>/edit', 'edit_registration_display',
                  display.RHRegistrationDisplayEdit, methods=('GET', 'POST'))
+_bp.add_url_rule('/registrations/<int:reg_form_id>/withdraw', 'withdraw_registration',
+                 display.RHRegistrationWithdraw, methods=('POST',))
 _bp.add_url_rule('/registrations/<int:reg_form_id>/check-email', 'check_email', display.RHRegistrationFormCheckEmail)
 _bp.add_url_rule('/registrations/<int:reg_form_id>/decline-invitation', 'decline_invitation',
                  display.RHRegistrationFormDeclineInvitation, methods=('POST',))

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -335,6 +335,17 @@ class RHRegistrationDisplayEdit(RegistrationEditMixin, RHRegistrationFormRegistr
         return url_for('.display_regform', self.registration.locator.registrant)
 
 
+class RHRegistrationWithdraw(RHRegistrationFormRegistrationBase):
+    """Withdraw a registration"""
+
+    def _process(self):
+        if not self.registration.can_be_withdrawn:
+            raise Forbidden
+        self.registration.update_state(withdrawn=True)
+        flash(_('Your registration has been withdrawn.'), 'success')
+        return redirect(self.event.url)
+
+
 class RHRegistrationFormDeclineInvitation(InvitationMixin, RHRegistrationFormBase):
     """Decline an invitation to register"""
 

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -570,6 +570,9 @@ class RHRegistrationReset(RHManageRegistrationBase):
     """Reset a registration back to a non-approved status"""
 
     def _process(self):
+        if self.registration.has_conflict():
+            raise NoReportError(_('Cannot reset this registration since there is another valid registration for the '
+                                  'same user or email.'))
         if self.registration.state in (RegistrationState.complete, RegistrationState.unpaid):
             self.registration.update_state(approved=False)
         elif self.registration.state == RegistrationState.rejected:

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -574,6 +574,8 @@ class RHRegistrationReset(RHManageRegistrationBase):
             self.registration.update_state(approved=False)
         elif self.registration.state == RegistrationState.rejected:
             self.registration.update_state(rejected=False)
+        elif self.registration.state == RegistrationState.withdrawn:
+            self.registration.update_state(withdrawn=False)
         else:
             raise BadRequest(_('The registration cannot be reset in its current state.'))
         logger.info('Registration %r was reset by %r', self.registration, session.user)

--- a/indico/modules/events/registration/templates/display/registration_summary.html
+++ b/indico/modules/events/registration/templates/display/registration_summary.html
@@ -46,6 +46,20 @@
                         {% endif %}>
                         {% trans %}Modify{% endtrans %}
                     </a>
+                    {% if registration.can_be_withdrawn %}
+                        <a class="i-button icon-exit"
+                           data-href="{{ url_for('.withdraw_registration', registration.locator.registrant) }}"
+                           data-method="POST"
+                           data-title="{% trans %}Withdraw{% endtrans %}"
+                           data-confirm="{% trans %}Are you sure that you want to withdraw your registration? This action cannot be undone.{% endtrans %}">
+                            {% trans %}Withdraw{% endtrans %}
+                        </a>
+                    {% else %}
+                        <a class="i-button icon-exit disabled"
+                           title="{% trans %}The registration can no longer be withdrawn. Please contact an organizer.{% endtrans %}">
+                            {% trans %}Withdraw{% endtrans %}
+                        </a>
+                    {% endif %}
                 </div>
             {% endif %}
             {% if registration.state.name == 'complete' and registration.registration_form.tickets_enabled and

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -183,7 +183,8 @@
         </div>
     </div>
     <div class="toolbar hide-if-locked">
-        {{ _render_reset_registration_button(registration, _('Reset rejection')) }}
+        {% set action = _('Reset rejection') if registration.state.name == 'rejected' else _('Reset withdrawal') %}
+        {{ _render_reset_registration_button(registration, action) }}
     </div>
 {% endmacro %}
 

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -184,18 +184,19 @@
     </div>
     <div class="toolbar hide-if-locked">
         {% set action = _('Reset rejection') if registration.state.name == 'rejected' else _('Reset withdrawal') %}
-        {{ _render_reset_registration_button(registration, action) }}
+        {{ _render_reset_registration_button(registration, action, registration.has_conflict()) }}
     </div>
 {% endmacro %}
 
 
-{% macro _render_reset_registration_button(registration, action_text) %}
-    <a class="i-button warning"
+{% macro _render_reset_registration_button(registration, action_text, conflict=false) %}
+    <a class="i-button warning {{ 'disabled' if conflict }}"
        data-update="#registration-details"
        data-method="POST"
        data-href="{{ url_for('.reset_registration', registration) }}"
        data-confirm="{% trans %}Are you sure you want to reset this registration status? This action will not be notified to the registrant.{% endtrans %}"
-       data-title="{{ action_text }}">
+       data-title="{{ action_text }}"
+       {% if conflict %}title="{% trans %}There is another valid registration for this user so it cannot be restored.{% endtrans %}"{% endif %}>
        {{ action_text }}
     </a>
 {% endmacro %}

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -45,7 +45,8 @@
                                     #{{ registration.friendly_id }}
                                 </td>
                                 <td class="i-table">
-                                    <a href="{{ url_for('event_registration.registration_details', registration) }}">
+                                    <a href="{{ url_for('event_registration.registration_details', registration) }}"
+                                       {% if registration.state.name in ('rejected', 'withdrawn') %}style="text-decoration: line-through;"{% endif %}>
                                         {{- registration.display_full_name -}}
                                     </a>
                                 </td>


### PR DESCRIPTION
Closes: #2715
Supersedes and thus closes: #4166

Replying to @ThiefMaster's [comment on the superseded PR](https://github.com/indico/indico/pull/4166#discussion_r348124148):
> Should we check for the modification period here at all? I think withdrawal should always be possible, especially if no payment is involved. After paying it does make sense that you need to contact the organizer though (regardless of the modification setting) - and they should then have a button in the management view to mark the registration as withdrawn.

The logic I have applied to allow withdrawals:
- The registration has not been paid.
- The event the registration is associated to has not finished yet.

Regarding allowing managers to undo withdrawals, this is now possible via the "Reset registration" button in the registration management view.

## Screenshots

||
|-|
|![image](https://user-images.githubusercontent.com/716307/89433054-23ffc700-d742-11ea-966f-fc942509878f.png)|
|![image](https://user-images.githubusercontent.com/716307/89433285-6de8ad00-d742-11ea-98c1-a2c582c9b8fb.png)|