### PR TITLE
Notify the user of new changes in the active editable

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/actions.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/actions.js
@@ -13,10 +13,16 @@ import {getStaticData} from './selectors';
 export const SET_LOADING = 'SET_LOADING';
 export const SET_DETAILS = 'SET_DETAILS';
 
-export function loadTimeline() {
+export function loadTimeline(transformData = d => d) {
   return async (dispatch, getStore) => {
     const {editableDetailsURL: url} = getStaticData(getStore());
-    return await ajaxAction(() => indicoAxios.get(url), SET_LOADING, SET_DETAILS)(dispatch);
+    return await ajaxAction(
+      () => indicoAxios.get(url),
+      SET_LOADING,
+      SET_DETAILS,
+      null,
+      transformData
+    )(dispatch);
   };
 }
 

--- a/indico/modules/events/editing/client/js/editing/timeline/actions.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/actions.js
@@ -8,21 +8,32 @@
 import {indicoAxios} from 'indico/utils/axios';
 import {ajaxAction, submitFormAction} from 'indico/utils/redux';
 
-import {getStaticData} from './selectors';
+import {getStaticData, getNewDetails} from './selectors';
 
 export const SET_LOADING = 'SET_LOADING';
 export const SET_DETAILS = 'SET_DETAILS';
+export const SET_NEW_DETAILS = 'SET_NEW_DETAILS';
 
-export function loadTimeline(transformData = d => d) {
+export function loadTimeline() {
   return async (dispatch, getStore) => {
     const {editableDetailsURL: url} = getStaticData(getStore());
-    return await ajaxAction(
-      () => indicoAxios.get(url),
-      SET_LOADING,
-      SET_DETAILS,
-      null,
-      transformData
-    )(dispatch);
+    return await ajaxAction(() => indicoAxios.get(url), SET_LOADING, SET_DETAILS)(dispatch);
+  };
+}
+
+export function checkTimelineUpdates() {
+  return async (dispatch, getStore) => {
+    const {editableDetailsURL: url} = getStaticData(getStore());
+    return await ajaxAction(() => indicoAxios.get(url), null, SET_NEW_DETAILS)(dispatch);
+  };
+}
+
+export function useUpdatedTimeline() {
+  return (dispatch, getStore) => {
+    dispatch({
+      type: SET_DETAILS,
+      data: getNewDetails(getStore()),
+    });
   };
 }
 

--- a/indico/modules/events/editing/client/js/editing/timeline/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/index.jsx
@@ -8,11 +8,12 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Loader, Message} from 'semantic-ui-react';
-
 import _ from 'lodash';
+
 import TimelineHeader from 'indico/modules/events/editing/editing/timeline/TimelineHeader';
 import TimelineContent from 'indico/modules/events/reviewing/components/TimelineContent';
 import {indicoAxios} from 'indico/utils/axios';
+import {Param, Translate} from 'indico/react/i18n';
 import SubmitRevision from './SubmitRevision';
 
 import * as actions from './actions';
@@ -20,7 +21,7 @@ import * as selectors from './selectors';
 import TimelineItem from './TimelineItem';
 import FileDisplay from './FileDisplay';
 
-const POOLING_SECONDS = 10;
+const POLLING_SECONDS = 10;
 
 export default function Timeline() {
   const dispatch = useDispatch();
@@ -52,7 +53,7 @@ export default function Timeline() {
         newDetails.current = resp.data;
         setIsOutdated(true);
       }
-    }, POOLING_SECONDS * 1000);
+    }, POLLING_SECONDS * 1000);
     return () => {
       clearInterval(task);
     };
@@ -74,11 +75,14 @@ export default function Timeline() {
       {isOutdated && (
         <Message
           warning
-          header="This revision has been updated"
+          header={Translate.string('This revision has been updated')}
           content={
-            <span>
-              <a onClick={refresh}>Click here to refresh</a> and see the most recent changes.
-            </span>
+            <Translate>
+              <Param name="link" wrapper={<a onClick={refresh} />}>
+                Click here to refresh
+              </Param>{' '}
+              and see the most recent version.
+            </Translate>
           }
         />
       )}

--- a/indico/modules/events/editing/client/js/editing/timeline/reducer.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/reducer.js
@@ -7,11 +7,12 @@
 
 import {camelizeKeys} from 'indico/utils/case';
 
-import {SET_LOADING, SET_DETAILS} from './actions';
+import {SET_LOADING, SET_DETAILS, SET_NEW_DETAILS} from './actions';
 import {processRevisions} from './selectors';
 
 export const initialState = {
   details: null,
+  newDetails: null,
   timelineBlocks: null,
   loading: false,
 };
@@ -25,9 +26,14 @@ export default function reducer(state = initialState, action) {
       return {
         ...state,
         details,
+        newDetails: details,
         loading: false,
         timelineBlocks: processRevisions(details.revisions),
       };
+    }
+    case SET_NEW_DETAILS: {
+      const newDetails = camelizeKeys(action.data);
+      return {...state, newDetails};
     }
     default:
       return state;

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -40,7 +40,8 @@ export function processRevisions(revisions) {
   let items = [];
   let currRevision = null;
 
-  for (const [index, revision] of revisions.entries()) {
+  for (const [index, _revision] of revisions.entries()) {
+    const revision = {..._revision};
     const {initialState, finalState} = revision;
     if (!currRevision) {
       currRevision = revision;
@@ -136,8 +137,14 @@ export function processRevisions(revisions) {
 }
 
 export const getDetails = state => (state.timeline ? state.timeline.details : null);
+export const getNewDetails = state => (state.timeline ? state.timeline.newDetails : null);
 export const isInitialEditableDetailsLoading = state =>
   state.timeline.loading && !state.timeline.details;
+export const isTimelineOutdated = createSelector(
+  getDetails,
+  getNewDetails,
+  (details, newDetails) => newDetails !== null && !_.isEqual(details, newDetails)
+);
 export const getTimelineBlocks = state => state.timeline.timelineBlocks;
 export const getLastTimelineBlock = createSelector(
   getTimelineBlocks,

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -146,6 +146,11 @@ class EditingRevisionSchema(mm.ModelSchema):
                     if not comment.internal or revision.editable.can_use_internal_comments(self.context.get('user'))]
         return EditingRevisionCommentSchema(context=self.context).dump(comments, many=True)
 
+    @post_dump()
+    def sort_tags(self, data, **kwargs):
+        data['tags'].sort(key=lambda tag: natural_sort_key(tag['verbose_title']))
+        return data
+
 
 class EditableSchema(mm.ModelSchema):
     class Meta:

--- a/indico/translations/messages-react.pot
+++ b/indico/translations/messages-react.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2020-08-20 22:38+0200\n"
+"POT-Creation-Date: 2020-08-20 13:15+0200\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "MIME-Version: 1.0\n"
@@ -508,6 +508,14 @@ msgstr ""
 msgid "Show old revision"
 msgstr ""
 
+#: indico/modules/events/editing/client/js/editing/timeline/index.jsx:63
+msgid "This revision has been updated"
+msgstr ""
+
+#: indico/modules/events/editing/client/js/editing/timeline/index.jsx:65
+msgid "{link}Click here to refresh{/link} and see the most recent version."
+msgstr ""
+
 #: indico/modules/events/editing/client/js/editing/timeline/judgment/AcceptRejectForm.jsx:63
 #: indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesForm.jsx:32
 #: indico/web/client/js/react/components/RequestConfirm.jsx:60
@@ -543,39 +551,39 @@ msgstr[1] ""
 msgid "There is no publishable file uploaded."
 msgstr ""
 
-#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:52
+#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:53
 msgid "{editorName} (editor) has made some changes to the paper"
 msgstr ""
 
-#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:63
+#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:64
 msgid "Revision has been replaced"
 msgstr ""
 
-#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:76
+#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:77
 msgid "Editor has accepted after making some changes"
 msgstr ""
 
-#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:78
+#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:79
 msgid "Submitter has accepted proposed changes"
 msgstr ""
 
-#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:80
+#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:81
 msgid "Revision has been accepted"
 msgstr ""
 
-#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:93
+#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:94
 msgid "Revision has been rejected"
 msgstr ""
 
-#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:101
+#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:102
 msgid "Submitter rejected proposed changes"
 msgstr ""
 
-#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:103
+#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:104
 msgid "Submitter has been asked to make some changes"
 msgstr ""
 
-#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:118
+#: indico/modules/events/editing/client/js/editing/timeline/selectors.js:119
 msgid "Editor made some changes"
 msgstr ""
 


### PR DESCRIPTION
Closes #4583 

Implements simple polling that compares with the previous response data (before going into the reducer).
Will display a message such as:
![image](https://user-images.githubusercontent.com/12183954/89628147-2d04ab80-d89c-11ea-8978-917eb39d78ef.png)

The interval is flexible, currently defaults to 10 seconds.