### PR TITLE
Quick-fix room booking un-scrollable content

### DIFF
--- a/indico/modules/rb/client/js/components/App.module.scss
+++ b/indico/modules/rb/client/js/components/App.module.scss
@@ -101,5 +101,6 @@
 
   .rb-pusher:global(.pusher) {
     min-height: calc(100vh - #{$menu-height} - var(--extra-bars, 0) * 50px - 50px);
+    overflow-y: unset;
   }
 }

--- a/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
+++ b/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
@@ -291,6 +291,7 @@ class BookingBootstrapForm extends React.Component {
               isOutsideRange={dt => {
                 return !isBookingStartDateValid(dt, isAdminOverrideEnabled, bookingGracePeriod);
               }}
+              withFullScreenPortal={window.innerHeight < 730}
             />
           </Form.Group>
         )}
@@ -302,6 +303,7 @@ class BookingBootstrapForm extends React.Component {
               disabledDate={dt => {
                 return !isBookingStartDateValid(dt, isAdminOverrideEnabled, bookingGracePeriod);
               }}
+              withFullScreenPortal={window.innerHeight < 730} // Temporary fix to ensure vertical responsiveness
             />
           </Form.Group>
         )}


### PR DESCRIPTION
Quick-fixes a problem causing the room booking to disable overflow even when the content is too small. 
This is being caused by the side-bar. We should come back to this in #4589.