### PR TITLE
Show event labels in dashboard as well

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,7 @@ Improvements
   thanks :user:`brabemi` & :user:`omegak`)
 - Allow choosing a default badge in categories (:pr:`4574`, thanks
   :user:`omegak`)
+- Display event labels on the user's dashboard as well (:pr:`4592`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -77,9 +77,11 @@ def get_events_in_categories(category_ids, user, limit=10):
                      Event.start_dt.astimezone(session.tzinfo) >= today)
              .options(joinedload('category').load_only('id', 'title'),
                       joinedload('series'),
+                      joinedload('label'),
                       subqueryload('acl_entries'),
                       load_only('id', 'category_id', 'start_dt', 'end_dt', 'title', 'access_key',
-                                'protection_mode', 'series_id', 'series_pos', 'series_count'))
+                                'protection_mode', 'series_id', 'series_pos', 'series_count',
+                                'label_id', 'label_message'))
              .order_by(Event.start_dt, Event.id))
     return get_n_matching(query, limit, lambda x: x.can_access(user))
 

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -91,6 +91,7 @@
                                     <a href="{{ event.url }}">
                                         {{ event.get_verbose_title(show_series_pos=true) }}
                                     </a>
+                                    {{ event.get_label_markup('mini') }}
                                 </span>
                                 <span class="item-legend">
                                     <span {% if roles.management %}title="{% trans %}You have management rights{% endtrans %}"{% endif %}
@@ -165,6 +166,7 @@
                                             <a href="{{ event.url }}">
                                                 {{ event.get_verbose_title(show_series_pos=true) }}
                                             </a>
+                                            {{ event.get_label_markup('mini') }}
                                         </span>
                                         <span class="event-category">
                                             {{ event.category.title }}

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -143,8 +143,10 @@ def get_linked_events(user, dt, limit=None, load_also=()):
              .filter(~Event.is_deleted,
                      Event.id.in_(links))
              .options(joinedload('series'),
+                      joinedload('label'),
                       load_only('id', 'category_id', 'title', 'start_dt', 'end_dt',
-                                'series_id', 'series_pos', 'series_count', *load_also))
+                                'series_id', 'series_pos', 'series_count', 'label_id', 'label_message',
+                                *load_also))
              .order_by(Event.start_dt, Event.id))
     if limit is not None:
         query = query.limit(limit)


### PR DESCRIPTION
In "my events at hand" knowing that an event has been cancelled is quite useful.

(suggested in `RQF1633512`)