### PR TITLE
Typos

### DIFF
--- a/indico/modules/events/registration/stats.py
+++ b/indico/modules/events/registration/stats.py
@@ -377,7 +377,7 @@ class AccommodationStats(FieldStats, StatsBase):
         return DataItem(**data)
 
     def _get_table_head(self):
-        head = [Cell(type='str', data=_("Accomodation")), Cell(type='str', data=_("Registrants"))]
+        head = [Cell(type='str', data=_("Accommodation")), Cell(type='str', data=_("Registrants"))]
 
         if self.has_capacity:
             head.append(Cell(type='str', data=_("Occupancy")))


### PR DESCRIPTION
It's a trivial typo. But as we are using the english text as index for all translations, it's better not to delay its correction too much.
I would have liked to squash it, but failed. Maybe you are luckier than me.