### PR TITLE
Set requirement for flask_multipass to version 0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ feedgen==0.9.0
 Flask-BabelEx==0.9.4
 flask-marshmallow==0.11.0
 Flask-Migrate==2.5.3
-Flask-Multipass>=0.2,<0.4-dev
+Flask-Multipass>=0.2,<0.3
 Flask-OAuthlib==0.9.5
 Flask-PluginEngine==0.3.1
 Flask-SQLAlchemy==2.4.4


### PR DESCRIPTION
Version 0.3 breaks compatibility with oauth providers.