### PR TITLE
Allow extending polymorphic models in plugins

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -170,6 +170,8 @@ Internal Changes
   thanks :user:`omegak`)
 - Add ``extra-registration-settings`` template hook (:pr:`4596`, thanks
   :user:`meluru`)
+- Allow extending polymorphic models in plugins (:pr:`4608`, thanks
+  :user:`omegak`)
 
 
 ----

--- a/indico/core/plugins/__init__.py
+++ b/indico/core/plugins/__init__.py
@@ -116,6 +116,10 @@ class IndicoPlugin(Plugin):
         # which could contain more than one plugin this is not easily possible.
         for name, model in added_models:
             schema = model.__table__.schema
+            # Allow models with non-plugin schema if they specify `polymorphic_identity` without a dedicated table
+            if ('polymorphic_identity' in getattr(model, '__mapper_args__', ())
+                    and '__tablename__' not in model.__dict__):
+                continue
             if not schema.startswith('plugin_'):
                 raise Exception("Plugin '{}' added a model which is not in a plugin schema ('{}' in '{}')"
                                 .format(self.name, name, schema))


### PR DESCRIPTION
Subclassing polymorphic models is not currently allowed from plugins. Example:

```python
class RegistrationFormSessionsSection(RegistrationFormSection):
    __mapper_args__ = {
        'polymorphic_identity': RegistrationFormItemType.section_sessions
    }
```

Blows up like this:

```
Exception: Plugin 'un' added a model which is not in a plugin schema ('RegistrationFormSessionsSection' in 'event_registration')
```

This PR solves it.