### PR TITLE
Add more prominent draft mode indicator

### DIFF
--- a/indico/modules/events/management/controllers/settings.py
+++ b/indico/modules/events/management/controllers/settings.py
@@ -19,6 +19,7 @@ from indico.modules.events.management.forms import (EventClassificationForm, Eve
                                                     EventDatesForm, EventLocationForm, EventPersonsForm)
 from indico.modules.events.management.util import flash_if_unregistered
 from indico.modules.events.management.views import WPEventSettings, render_event_management_header_right
+from indico.modules.events.models.events import EventType
 from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
 from indico.modules.events.operations import update_event
@@ -49,6 +50,8 @@ class RHEventSettings(RHManageEventBase):
         RHManageEventBase._check_access(self)  # mainly to trigger the legacy "event locked" check
 
     def _process(self):
+        from indico.modules.events.contributions import contribution_settings
+
         show_booking_warning = False
         if (config.ENABLE_ROOMBOOKING and not self.event.has_ended and self.event.room
                 and not self.event.room_reservation_links):
@@ -69,8 +72,11 @@ class RHEventSettings(RHManageEventBase):
             show_booking_warning = not has_overlap
         has_reference_types = ReferenceType.query.has_rows()
         has_event_labels = EventLabel.query.has_rows()
+        show_draft_warning = (self.event.type_ == EventType.conference and
+                              not contribution_settings.get(self.event, 'published'))
         return WPEventSettings.render_template('settings.html', self.event, 'settings',
                                                show_booking_warning=show_booking_warning,
+                                               show_draft_warning=show_draft_warning,
                                                has_reference_types=has_reference_types,
                                                has_event_labels=has_event_labels)
 

--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -26,6 +26,27 @@
             </div>
         </div>
     {%- endif -%}
+    {%- if show_draft_warning -%}
+        <div class="action-box warning">
+            <div class="section">
+                <div class="icon icon-edit"></div>
+                <div class="text">
+                    <div class="label">{% trans %}Contributions are in draft mode{% endtrans %}</div>
+                    {% trans %}
+                        While in draft mode, regular users cannot see the contributions and timetable.
+                    {% endtrans %}
+                </div>
+                <div class="toolbar">
+                    <div class="group">
+                        <a class="i-button icon-settings"
+                           href="{{ url_for('contributions.manage_contributions', event) }}">
+                            {% trans %}Manage Contributions{% endtrans %}
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {%- endif -%}
     <div class="action-box event-settings">
         {{ render_event_settings(event, has_reference_types, has_event_labels) }}
     </div>

--- a/indico/translations/messages.pot
+++ b/indico/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: indico 2.3-dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2020-09-02 11:00+0200\n"
+"POT-Creation-Date: 2020-09-02 13:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -8498,6 +8498,18 @@ msgstr ""
 
 #: indico/modules/events/management/templates/settings.html:22
 msgid "Book the room"
+msgstr ""
+
+#: indico/modules/events/management/templates/settings.html:34
+msgid "Contributions are in draft mode"
+msgstr ""
+
+#: indico/modules/events/management/templates/settings.html:35
+msgid "While in draft mode, regular users cannot see the contributions and timetable."
+msgstr ""
+
+#: indico/modules/events/management/templates/settings.html:43
+msgid "Manage Contributions"
 msgstr ""
 
 #: indico/modules/events/models/events.py:54 indico/modules/events/templates/management/_create_event_button.html:8


### PR DESCRIPTION
We had quite a few tickets from people not realizing that draft mode is enabled (or exists) and thus wondering why their timetable was not visible. This warning should make it much clearer.

![image](https://user-images.githubusercontent.com/179599/91973806-23485980-ed1d-11ea-8d3b-911a319bb95f.png)
