### PR TITLE
Allow overriding language territory names

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -121,6 +121,8 @@ Improvements
 - Allow registrants to check details for non-active registrations and prevent
   them from registering twice with the same registration form (:issue:`4594`,
   :pr:`4595`, thanks :user:`omegak`)
+- Add a new :data:`CUSTOM_LANGUAGES` setting to ``indico.conf`` to override the
+  name/territory of a language or disable it altogether (:pr:`4620`)
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -38,8 +38,8 @@ Authentication
 
     This setting controls whether local Indico groups are available.
     If no centralized authentication infrastructure that supports groups
-    (e.g. LDAP) is used, local groups are the only way to define groups in 
-    Indico, but if you do have central groups it may be useful to disable 
+    (e.g. LDAP) is used, local groups are the only way to define groups in
+    Indico, but if you do have central groups it may be useful to disable
     local ones to have all groups in one central place.
 
     Default: ``True``
@@ -305,6 +305,30 @@ Customization
     .. code-block:: python
 
         CUSTOM_COUNTRIES = {'KP': 'North Korea'}
+
+    Default: ``{}``
+
+.. data:: CUSTOM_LANGUAGES
+
+    A dict with language/territory name overrides.  This can be useful if the
+    official territory name that goes along with a language does not match what
+    your Indico instance's target audience expects for a country, e.g. due to
+    political situations.
+
+    For example, to use "Chinese (Simplified)" instead of "Chinese (China)",
+    you would use this
+
+    .. code-block:: python
+
+        CUSTOM_LANGUAGES = {'zh_Hans_CN': ('Chinese', 'Simplified')}
+
+    Note that the language and territory name should be written in that
+    particular language to be consistent with the defaults. So in the example
+    above, you would write "Chinese" and "Simplified" in Simplified Chinese.
+
+    Setting the territory (second element in the tuple) to ``None`` will hide
+    it and only show the language name itself.  Setting the dict value to ``None``
+    will effectively hide the language altogether.
 
     Default: ``{}``
 

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -315,8 +315,8 @@ Customization
     your Indico instance's target audience expects for a country, e.g. due to
     political situations.
 
-    For example, to use "Chinese (Simplified)" instead of "Chinese (China)",
-    you would use this
+    For example, to replace "Chinese (Simplified)" with "Chinese (China)",
+    you would use:
 
     .. code-block:: python
 

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -42,6 +42,7 @@ DEFAULTS = {
     'CUSTOMIZATION_DEBUG': False,
     'CUSTOMIZATION_DIR': None,
     'CUSTOM_COUNTRIES': {},
+    'CUSTOM_LANGUAGES': {},
     'DB_LOG': False,
     'DEBUG': False,
     'DEFAULT_LOCALE': 'en_GB',

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -22,6 +22,7 @@ from flask_pluginengine import current_plugin
 from speaklater import is_lazy_string, make_lazy_string
 from werkzeug.utils import cached_property
 
+from indico.core.config import config
 from indico.util.caching import memoize_request
 
 
@@ -259,12 +260,15 @@ def get_current_locale():
 
 def get_all_locales():
     """
-    List all available locales/names e.g. {'pt_PT': 'Portuguese'}
+    List all available locales/names e.g. ``{'pt_PT': ('Portuguese', 'Portugal)}``
     """
     if babel.app is None:
         return {}
     else:
-        return {str(t): (t.language_name.title(), t.territory_name) for t in babel.list_translations()}
+        missing = object()
+        return {str(t): config.CUSTOM_LANGUAGES.get(str(t), (t.language_name.title(), t.territory_name))
+                for t in babel.list_translations()
+                if config.CUSTOM_LANGUAGES.get(str(t), missing) is not None}
 
 
 def set_session_lang(lang):


### PR DESCRIPTION
Apparently "Chinese (China)" is not acceptable in some communities for political reasons, and they want "Chinese (Simplified)" instead.