### PR TITLE
Catch requests.TooManyRedirects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -142,6 +142,7 @@ Bugfixes
 - Fix empty entries in corresponding authors (:pr:`4604`)
 - Actually prevent users from editing registrations if modification is
   disabled
+- Handle latex images with broken redirects (:pr:`4623`, thanks :user:`bcc`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -142,7 +142,7 @@ Bugfixes
 - Fix empty entries in corresponding authors (:pr:`4604`)
 - Actually prevent users from editing registrations if modification is
   disabled
-- Handle latex images with broken redirects (:pr:`4623`, thanks :user:`bcc`)
+- Handle LaTeX images with broken redirects (:pr:`4623`, thanks :user:`bcc`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/util/mdx_latex.py
+++ b/indico/util/mdx_latex.py
@@ -264,6 +264,8 @@ def latex_render_image(src, alt, tmpdir, strict=False):
                 raise ImageURLException("Cannot understand URL '{}'".format(src))
             except (requests.Timeout, ConnectionError):
                 raise ImageURLException("Problem downloading image ({})".format(src))
+            except requests.TooManyRedirects:
+                raise ImageURLException("Too many redirects downloading image ({})".format(src))
             extension = None
 
             if resp.status_code != 200:


### PR DESCRIPTION
Simple fix to catch requests.TooManyRedirects exception and put a ‘broken image’ placeholder in the pdf, much like already happens when a downloaded image isn’t a valid image.

The current handling results in an exception email that doesn't identify the failing URL, nor does the feedback to the user help them identify the problematic content. We see this every few weeks on a moderately popular Indico installation.