### PR TITLE
Wrap regform AngularJS directive in jinja block

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -175,6 +175,9 @@ Internal Changes
   :user:`meluru`)
 - Allow extending polymorphic models in plugins (:pr:`4608`, thanks
   :user:`omegak`)
+- Wrap registration form AngularJS directive in jinja block for more easily
+  overriding arguments passed to the app in plugins (:pr:`4624`, thanks
+  :user:`omegak`)
 
 
 ----

--- a/indico/modules/events/registration/templates/display/regform_display.html
+++ b/indico/modules/events/registration/templates/display/regform_display.html
@@ -107,17 +107,19 @@
 
         {{ template_hook('before-regform', event=event, regform=regform, management=management, registration=none) }}
         <div ng-app="nd" ng-controller="AppCtrl">
-            <div nd-reg-form
-                 conf-id="{{ event.id }}"
-                 conf-sections="{{ sections | tojson | forceescape }}"
-                 conf-currency="{{ regform.currency }}"
-                 user-info="{{ user_data | tojson | forceescape }}"
-                 post-url="{{ request.url | tojson | forceescape }}"
-                 check-email-url="{{ url_for('.check_email', regform, management=management) | tojson | forceescape }}"
-                 management="{{ management | tojson | forceescape }}"
-                 is-moderated="{{ moderated | tojson | forceescape }}"
-                 notify-default="{{ session.get('registration_notify_user_default', true) | tojson | forceescape }}">
-            </div>
+            {% block regform %}
+                <div nd-reg-form
+                     conf-id="{{ event.id }}"
+                     conf-sections="{{ sections | tojson | forceescape }}"
+                     conf-currency="{{ regform.currency }}"
+                     user-info="{{ user_data | tojson | forceescape }}"
+                     post-url="{{ request.url | tojson | forceescape }}"
+                     check-email-url="{{ url_for('.check_email', regform, management=management) | tojson | forceescape }}"
+                     management="{{ management | tojson | forceescape }}"
+                     is-moderated="{{ moderated | tojson | forceescape }}"
+                     notify-default="{{ session.get('registration_notify_user_default', true) | tojson | forceescape }}">
+                </div>
+            {% endblock %}
         </div>
         {{ template_hook('after-regform', event=event, regform=regform, management=management, registration=none) }}
     {% endif %}

--- a/indico/modules/events/registration/templates/display/registration_modify.html
+++ b/indico/modules/events/registration/templates/display/registration_modify.html
@@ -19,17 +19,19 @@
         {{ template_hook('before-regform', event=event, regform=registration.registration_form,
                          registration=registration, management=false) }}
         <div ng-app="nd" ng-controller="AppCtrl">
-            <div nd-reg-form
-                 conf-id="{{ event.id }}"
-                 conf-sections="{{ sections | tojson | forceescape }}"
-                 conf-currency="{{ registration.currency }}"
-                 post-url="{{ request.url | tojson | forceescape }}"
-                 check-email-url="{{ url_for('.check_email', regform) | tojson | forceescape }}"
-                 registration-data="{{ registration_data | tojson | forceescape }}"
-                 registration-meta-data="{{ registration_metadata | tojson | forceescape }}"
-                 registration-uuid="{{ registration.uuid }}"
-                 update-mode="true">
-            </div>
+            {% block regform %}
+                <div nd-reg-form
+                     conf-id="{{ event.id }}"
+                     conf-sections="{{ sections | tojson | forceescape }}"
+                     conf-currency="{{ registration.currency }}"
+                     post-url="{{ request.url | tojson | forceescape }}"
+                     check-email-url="{{ url_for('.check_email', regform) | tojson | forceescape }}"
+                     registration-data="{{ registration_data | tojson | forceescape }}"
+                     registration-meta-data="{{ registration_metadata | tojson | forceescape }}"
+                     registration-uuid="{{ registration.uuid }}"
+                     update-mode="true">
+                </div>
+            {% endblock %}
         </div>
         {{ template_hook('after-regform', event=event, regform=registration.registration_form,
                          registration=registration, management=false) }}

--- a/indico/modules/events/registration/templates/management/regform_modify.html
+++ b/indico/modules/events/registration/templates/management/regform_modify.html
@@ -8,14 +8,16 @@
 
 {% block content %}
     <div ng-app="nd" ng-controller="AppCtrl">
-        <div nd-reg-form
-             conf-id="{{ event.id }}"
-             conf-form-id="{{ regform.id }}"
-             conf-sections="{{ sections | tojson | forceescape }}"
-             conf-currency="{{ regform.currency }}"
-             event-start-date="{{ event.start_dt }}"
-             event-end-date="{{ event.end_dt }}"
-             edit-mode="true"></div>
+        {% block regform %}
+            <div nd-reg-form
+                 conf-id="{{ event.id }}"
+                 conf-form-id="{{ regform.id }}"
+                 conf-sections="{{ sections | tojson | forceescape }}"
+                 conf-currency="{{ regform.currency }}"
+                 event-start-date="{{ event.start_dt }}"
+                 event-end-date="{{ event.end_dt }}"
+                 edit-mode="true"></div>
+        {% endblock %}
     </div>
     <div class="toolbar right">
         <a href="{{ url_for('.manage_regform', regform) }}" class="i-button big">

--- a/indico/modules/events/registration/templates/management/registration_modify.html
+++ b/indico/modules/events/registration/templates/management/registration_modify.html
@@ -9,18 +9,20 @@
 {% block content %}
     {{ template_hook('before-regform', event=event, regform=regform, registration=registration, management=true) }}
     <div ng-app="nd" ng-controller="AppCtrl">
-        <div nd-reg-form
-             conf-id="{{ event.id }}"
-             conf-sections="{{ sections | tojson | forceescape }}"
-             conf-currency="{{ regform.currency }}"
-             post-url="{{ request.url | tojson | forceescape }}"
-             check-email-url="{{ url_for('.check_email', regform, management=true) | tojson | forceescape }}"
-             registration-data="{{ registration_data | tojson | forceescape }}"
-             registration-meta-data="{{ registration_metadata | tojson | forceescape }}"
-             registration-uuid="{{ registration.uuid }}"
-             update-mode="true"
-             management="true"
-             notify-default="{{ session.get('registration_notify_user_default', true) | tojson | forceescape }}"></div>
+        {% block regform %}
+            <div nd-reg-form
+                 conf-id="{{ event.id }}"
+                 conf-sections="{{ sections | tojson | forceescape }}"
+                 conf-currency="{{ regform.currency }}"
+                 post-url="{{ request.url | tojson | forceescape }}"
+                 check-email-url="{{ url_for('.check_email', regform, management=true) | tojson | forceescape }}"
+                 registration-data="{{ registration_data | tojson | forceescape }}"
+                 registration-meta-data="{{ registration_metadata | tojson | forceescape }}"
+                 registration-uuid="{{ registration.uuid }}"
+                 update-mode="true"
+                 management="true"
+                 notify-default="{{ session.get('registration_notify_user_default', true) | tojson | forceescape }}"></div>
+        {% endblock %}
     </div>
     {{ template_hook('after-regform', event=event, regform=regform, registration=registration, management=true) }}
 {% endblock %}


### PR DESCRIPTION
This allows for plugins to specifically override the arguments passed to the registration form AngularJS app.
