### PR TITLE
Make docstrings conform to PEP 257

### DIFF
--- a/bin/maintenance/build-assets.py
+++ b/bin/maintenance/build-assets.py
@@ -165,7 +165,7 @@ def _clean(webpack_build_config, plugin_dir=None):
 @cli.command('indico', short_help='Builds assets of Indico.')
 @_common_build_options()
 def build_indico(dev, clean, watch, url_root):
-    """Run webpack to build assets"""
+    """Run webpack to build assets."""
     clean = clean or (clean is None and not dev)
     webpack_build_config_file = 'webpack-build-config.json'
     webpack_build_config = _get_webpack_build_config(url_root)
@@ -219,7 +219,7 @@ def _chdir(path):
                 callback=_validate_plugin_dir)
 @_common_build_options()
 def build_plugin(plugin_dir, dev, clean, watch, url_root):
-    """Run webpack to build plugin assets"""
+    """Run webpack to build plugin assets."""
     clean = clean or (clean is None and not dev)
     webpack_build_config_file = os.path.join(plugin_dir, 'webpack-build-config.json')
     webpack_build_config = _get_plugin_webpack_build_config(plugin_dir, url_root)
@@ -261,7 +261,7 @@ def build_plugin(plugin_dir, dev, clean, watch, url_root):
 @_common_build_options(allow_watch=False)
 @click.pass_context
 def build_all_plugins(ctx, plugins_dir, dev, clean, url_root):
-    """Run webpack to build plugin assets"""
+    """Run webpack to build plugin assets."""
     plugins = sorted(d for d in os.listdir(plugins_dir) if _is_plugin_dir(os.path.join(plugins_dir, d)))
     for plugin in plugins:
         step('plugin: {}', plugin)

--- a/bin/maintenance/build-wheel.py
+++ b/bin/maintenance/build-wheel.py
@@ -237,7 +237,7 @@ def cli(obj, target_dir):
 @click.option('--ignore-unclean', is_flag=True, help='Ignore unclean working tree')
 @click.pass_obj
 def build_indico(obj, assets, add_version_suffix, ignore_unclean):
-    """Builds the indico wheel."""
+    """Build the indico wheel."""
     target_dir = obj['target_dir']
     # check for unclean git status
     clean, output = git_is_clean_indico()
@@ -280,7 +280,7 @@ def _plugin_has_assets(plugin_dir):
 @click.option('--ignore-unclean', is_flag=True, help='Ignore unclean working tree')
 @click.pass_obj
 def build_plugin(obj, assets, plugin_dir, add_version_suffix, ignore_unclean):
-    """Builds a plugin wheel.
+    """Build a plugin wheel.
 
     PLUGIN_DIR is the path to the folder containing the plugin's setup.py
     """
@@ -312,7 +312,7 @@ def build_plugin(obj, assets, plugin_dir, add_version_suffix, ignore_unclean):
 @click.option('--ignore-unclean', is_flag=True, help='Ignore unclean working tree')
 @click.pass_context
 def build_all_plugins(ctx, plugins_dir, add_version_suffix, ignore_unclean):
-    """Builds all plugin wheels in a directory.
+    """Build all plugin wheels in a directory.
 
     PLUGINS_DIR is the path to the folder containing the plugin directories
     """

--- a/bin/maintenance/dump_url_map.py
+++ b/bin/maintenance/dump_url_map.py
@@ -39,7 +39,8 @@ def get_rules(plugins):
 @click.option('-p', '--plugin', 'plugins', multiple=True, help='Include URLs from the specified plugins')
 def main(force, output, plugins):
     """
-    Dumps the URL routing map to JSON for use by the `babel-flask-url` babel plugin.
+    Dump the URL routing map to JSON for use by the `babel-flask-url`
+    babel plugin.
     """
     try:
         with open(output) as f:

--- a/bin/utils/db_diff.py
+++ b/bin/utils/db_diff.py
@@ -106,7 +106,7 @@ def _which(program):
 @click.option('-r', '--reverse', help='Reverse - return instead the SQL to go from target to base', is_flag=True)
 def main(dbname, verbose, reverse):
     """
-    Compares the structure of the database against what's created from the
+    Compare the structure of the database against what's created from the
     models during `indico db prepare`.
 
     By default the current database is assumed to be named `indico`, but it

--- a/docs/source/exec_directive.py
+++ b/docs/source/exec_directive.py
@@ -10,7 +10,10 @@ from docutils.statemachine import string2lines
 
 
 class ExecDirective(Directive):
-    """Execute the specified python code and insert the output into the document"""
+    """
+    Execute the specified python code and insert the output into the document.
+    """
+
     has_content = True
 
     def run(self):

--- a/indico/cli/database.py
+++ b/indico/cli/database.py
@@ -45,7 +45,7 @@ def cli(ctx, plugin=None, all_plugins=False):
 
 @cli.command()
 def prepare():
-    """Initializes a new database (creates tables, sets alembic rev to HEAD)"""
+    """Initialize a new database (creates tables, sets alembic rev to HEAD)."""
     return prepare_db()
 
 
@@ -58,7 +58,7 @@ def _stamp(plugin=None, revision=None):
 
 @cli.command()
 def reset_alembic():
-    """Resets the alembic state carried over from 1.9.x
+    """Reset the alembic state carried over from 1.9.x.
 
     Only run this command right after upgrading from a 1.9.x version
     so the references to old alembic revisions (which were removed in

--- a/indico/cli/event.py
+++ b/indico/cli/event.py
@@ -32,7 +32,7 @@ def cli():
               help="The user which will be shown on the log as having restored the event (default: no user).")
 @click.option('-m', '--message', 'message', metavar="MESSAGE", help="An additional message for the log")
 def restore(event_id, user_id, message):
-    """Restores a deleted event."""
+    """Restore a deleted event."""
     event = Event.get(event_id)
     user = User.get(user_id) if user_id else None
     if event is None:
@@ -52,7 +52,7 @@ def restore(event_id, user_id, message):
 @click.argument('event_id', type=int)
 @click.argument('target_file', type=click.File('wb'))
 def export(event_id, target_file):
-    """Exports all data associated with an event.
+    """Export all data associated with an event.
 
     This exports the whole event as an archive which can be imported
     on another other Indico instance.  Importing an event is only
@@ -79,7 +79,7 @@ def export(event_id, target_file):
 @click.option('-c', '--category', 'category_id', type=int, default=0, metavar='ID',
               help='ID of the target category. Defaults to the root category.')
 def import_(source_file, create_users, force, verbose, yes, category_id):
-    """Imports an event exported from another Indico instance."""
+    """Import an event exported from another Indico instance."""
     click.echo('Importing event...')
     event = import_event(source_file, category_id, create_users=create_users, verbose=verbose, force=force)
     if event is None:

--- a/indico/cli/maintenance.py
+++ b/indico/cli/maintenance.py
@@ -49,7 +49,7 @@ def _fix_role_principals(principals, get_event):
 
 @cli.command()
 def fix_event_role_acls():
-    """Fixes ACLs referencing event roles from other events.
+    """Fix ACLs referencing event roles from other events.
 
     This happened due to a bug prior to 2.2.3 when cloning an event
     which had event roles in its ACL.

--- a/indico/cli/setup.py
+++ b/indico/cli/setup.py
@@ -175,12 +175,12 @@ def _confirm(message, default=False, abort=False, help=None):
 
 @click.group()
 def cli():
-    """This script helps with the initial steps of installing Indico"""
+    """This script helps with the initial steps of installing Indico."""
 
 
 @cli.command()
 def list_plugins():
-    """Lists the available indico plugins."""
+    """List the available Indico plugins."""
     import_all_models()
     table_data = [['Name', 'Title']]
     for ep in sorted(iter_entry_points('indico.plugins'), key=attrgetter('name')):
@@ -193,7 +193,7 @@ def list_plugins():
 @cli.command()
 @click.argument('target_dir')
 def create_symlinks(target_dir):
-    """Creates useful symlinks to run Indico from a webserver.
+    """Create useful symlinks to run Indico from a webserver.
 
     This lets you use static paths for the WSGI file and the htdocs
     folder so you do not need to update your webserver config when
@@ -207,7 +207,7 @@ def create_symlinks(target_dir):
 @cli.command()
 @click.argument('target_dir')
 def create_logging_config(target_dir):
-    """Creates the default logging config file for Indico.
+    """Create the default logging config file for Indico.
 
     If a file already exists it is left untouched. This command is
     usually only used when doing a fresh indico installation when
@@ -220,7 +220,7 @@ def create_logging_config(target_dir):
 @cli.command()
 @click.option('--dev', is_flag=True)
 def wizard(dev):
-    """Runs a setup wizard to configure Indico from scratch."""
+    """Run a setup wizard to configure Indico from scratch."""
     SetupWizard().run(dev=dev)
 
 

--- a/indico/cli/user.py
+++ b/indico/cli/user.py
@@ -73,7 +73,7 @@ def _safe_lower(s):
 @click.option('--email', '-e', help='Email address of the user')
 @click.option('--affiliation', '-a', help='Affiliation of the user')
 def search(substring, include_deleted, include_pending, include_blocked, include_external, include_system, **criteria):
-    """Searches users matching some criteria"""
+    """Search users matching some criteria."""
     assert set(criteria.viewkeys()) == {'first_name', 'last_name', 'email', 'affiliation'}
     criteria = {k: v for k, v in criteria.viewitems() if v is not None}
     res = search_users(exact=(not substring), include_deleted=include_deleted, include_pending=include_pending,
@@ -111,7 +111,7 @@ def search(substring, include_deleted, include_pending, include_blocked, include
 @cli.command()
 @click.option('--admin/--no-admin', '-a/', 'grant_admin', is_flag=True, help='Grant admin rights')
 def create(grant_admin):
-    """Creates a new user"""
+    """Create a new user."""
     user_type = 'user' if not grant_admin else 'admin'
     while True:
         email = prompt_email()
@@ -149,7 +149,7 @@ def create(grant_admin):
 @cli.command()
 @click.argument('user_id', type=int)
 def grant_admin(user_id):
-    """Grants administration rights to a given user"""
+    """Grant administration rights to a given user."""
     user = User.get(user_id)
     if user is None:
         print(cformat("%{red}This user does not exist"))
@@ -167,7 +167,7 @@ def grant_admin(user_id):
 @cli.command()
 @click.argument('user_id', type=int)
 def revoke_admin(user_id):
-    """Revokes administration rights from a given user"""
+    """Revoke administration rights from a given user."""
     user = User.get(user_id)
     if user is None:
         print(cformat("%{red}This user does not exist"))
@@ -185,7 +185,7 @@ def revoke_admin(user_id):
 @cli.command()
 @click.argument('user_id', type=int)
 def block(user_id):
-    """Blocks a given user"""
+    """Block a given user."""
     user = User.get(user_id)
     if user is None:
         print(cformat("%{red}This user does not exist"))
@@ -203,7 +203,7 @@ def block(user_id):
 @cli.command()
 @click.argument('user_id', type=int)
 def unblock(user_id):
-    """Unblocks a given user"""
+    """Unblock a given user."""
     user = User.get(user_id)
     if user is None:
         print(cformat("%{red}This user does not exist"))

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -33,7 +33,7 @@ class IndicoMultipass(Multipass):
 
     @property
     def synced_fields(self):
-        """The keys to be synchronized
+        """The keys to be synchronized.
 
         This is the set of keys to be synced to user data.
         The ``email`` can never be synchronized.

--- a/indico/core/celery/core.py
+++ b/indico/core/celery/core.py
@@ -31,7 +31,7 @@ from indico.web.flask.stats import request_stats_request_started
 
 
 class IndicoCelery(Celery):
-    """Celery sweetened with some Indico/Flask-related sugar
+    """Celery sweetened with some Indico/Flask-related sugar.
 
     The following extra params are available on the `task` decorator:
 
@@ -100,7 +100,7 @@ class IndicoCelery(Celery):
         return decorator
 
     def _patch_task(self):
-        """Patches the `task` decorator to run tasks inside the indico environment"""
+        """Patch the `task` decorator to run tasks inside the indico environment."""
         class IndicoTask(self.Task):
             abstract = True
 
@@ -151,7 +151,7 @@ class IndicoCeleryLogging(Logging):
 
 
 class IndicoPersistentScheduler(PersistentScheduler):
-    """Celery scheduler that allows indico.conf to override specific entries"""
+    """Celery scheduler that allows indico.conf to override specific entries."""
 
     def setup_schedule(self):
         deleted = set()

--- a/indico/core/db/sqlalchemy/attachments.py
+++ b/indico/core/db/sqlalchemy/attachments.py
@@ -15,8 +15,10 @@ from indico.util.caching import memoize_request
 
 
 class AttachedItemsMixin(object):
-    """Allows for easy retrieval of structured information about
-       items attached to the object"""
+    """
+    Allow for easy retrieval of structured information about
+    items attached to the object.
+    """
 
     #: When set to ``True`` will preload all items that exist for the same event.
     #: Should be set to False when not applicable (no object.event[_new] property).

--- a/indico/core/db/sqlalchemy/colors.py
+++ b/indico/core/db/sqlalchemy/colors.py
@@ -95,7 +95,7 @@ class ColorMixin(object):
 
     @property
     def colors(self):
-        """The current set of colors or None if no colors are set"""
+        """The current set of colors or None if no colors are set."""
         colors = ColorTuple(self.text_color, self.background_color)
         return colors or self.default_colors
 

--- a/indico/core/db/sqlalchemy/core.py
+++ b/indico/core/db/sqlalchemy/core.py
@@ -27,14 +27,14 @@ from indico.core.db.sqlalchemy.util.models import IndicoBaseQuery, IndicoModel
 
 
 class ConstraintViolated(Exception):
-    """Indicates that a constraint trigger was violated"""
+    """Indicate that a constraint trigger was violated."""
     def __init__(self, message, orig):
         super(ConstraintViolated, self).__init__(message)
         self.orig = orig
 
 
 def handle_sqlalchemy_database_error():
-    """Handle a SQLAlchemy DatabaseError exception nicely
+    """Handle a SQLAlchemy DatabaseError exception nicely.
 
     Currently this only takes care of custom INDX exception
     raised from constraint triggers.  It must be invoked from an
@@ -75,7 +75,7 @@ class IndicoSQLAlchemy(SQLAlchemy):
         return session
 
     def enforce_constraints(self):
-        """Enables immedaite enforcing of deferred constraints.
+        """Enable immediate enforcing of deferred constraints.
 
         This should be done at the end of normal request processing
         and exceptions should be handled in a clean way that goes
@@ -98,7 +98,7 @@ class IndicoSQLAlchemy(SQLAlchemy):
 
     @contextmanager
     def tmp_session(self):
-        """Provides a contextmanager with a temporary SQLAlchemy session.
+        """Provide a contextmanager with a temporary SQLAlchemy session.
 
         This allows you to use SQLAlchemy e.g. in a `after_this_request`
         callback without having to worry about things like the ZODB extension,

--- a/indico/core/db/sqlalchemy/custom/unaccent.py
+++ b/indico/core/db/sqlalchemy/custom/unaccent.py
@@ -41,7 +41,7 @@ def create_unaccent_function(conn):
 
 
 def define_unaccented_lowercase_index(column):
-    """Defines an index that uses the indico_unaccent function.
+    """Define an index that uses the indico_unaccent function.
 
     Since this is usually used for searching, the column's value is
     also converted to lowercase before being unaccented. To make proper

--- a/indico/core/db/sqlalchemy/descriptions.py
+++ b/indico/core/db/sqlalchemy/descriptions.py
@@ -33,7 +33,7 @@ RENDER_MODE_WRAPPER_MAP = {
 
 
 class RenderModeMixin(object):
-    """Mixin to add a  plaintext/html/markdown-enabled column."""
+    """Mixin to add a plaintext/html/markdown-enabled column."""
 
     possible_render_modes = {RenderMode.plain_text}
     default_render_mode = RenderMode.plain_text

--- a/indico/core/db/sqlalchemy/links.py
+++ b/indico/core/db/sqlalchemy/links.py
@@ -95,7 +95,7 @@ class LinkMixin(object):
 
     @classmethod
     def register_link_events(cls):
-        """Registers sqlalchemy events needed by this mixin.
+        """Register sqlalchemy events needed by this mixin.
 
         Call this method after the definition of a model which uses
         this mixin class.
@@ -345,7 +345,7 @@ class LinkMixin(object):
 
     @property
     def link_repr(self):
-        """A kwargs-style string suitable for the object's repr"""
+        """A kwargs-style string suitable for the object's repr."""
         info = [('link_type', self.link_type.name if self.link_type is not None else 'None')]
         info.extend((key, getattr(self, key)) for key in _all_columns if getattr(self, key) is not None)
         return ', '.join('{}={}'.format(key, value) for key, value in info)
@@ -353,7 +353,7 @@ class LinkMixin(object):
     @property
     def link_event_log_data(self):
         """
-        Returns a dict containing information about the linked object
+        Return a dict containing information about the linked object
         suitable for the event log.
 
         It does not return any information for an object linked to a

--- a/indico/core/db/sqlalchemy/locations.py
+++ b/indico/core/db/sqlalchemy/locations.py
@@ -51,7 +51,7 @@ class LocationMixin(object):
 
     @classmethod
     def register_location_events(cls):
-        """Registers sqlalchemy events needed by this mixin.
+        """Register sqlalchemy events needed by this mixin.
 
         Call this method after the definition of a model which uses
         this mixin class.
@@ -235,7 +235,7 @@ class LocationMixin(object):
 
     @property
     def has_location_info(self):
-        """Whether the object has basic location information set"""
+        """Whether the object has basic location information set."""
         return bool(self.venue_name or self.room_name)
 
     @property

--- a/indico/core/db/sqlalchemy/notes.py
+++ b/indico/core/db/sqlalchemy/notes.py
@@ -13,8 +13,10 @@ from indico.util.caching import memoize_request
 
 
 class AttachedNotesMixin(object):
-    """Allows for easy retrieval of structured information about
-       items attached to the object"""
+    """
+    Allow for easy retrieval of structured information about
+    items attached to the object.
+    """
     # When set to ``True`` .has_note preload all notes that exist for the same event
     # Should be set to False when not applicable (no object.event property)
     PRELOAD_EVENT_NOTES = False

--- a/indico/core/db/sqlalchemy/principals.py
+++ b/indico/core/db/sqlalchemy/principals.py
@@ -54,7 +54,7 @@ def _make_check(type_, allow_emails, allow_networks, allow_event_roles, allow_ca
 
 
 def serialize_email_principal(email):
-    """Serialize email principal to a simple dict"""
+    """Serialize email principal to a simple dict."""
     return {
         '_type': 'Email',
         'email': email.email,
@@ -83,7 +83,7 @@ class IEmailPrincipalFossil(IFossil):
 
 
 class EmailPrincipal(Fossilizable):
-    """Wrapper for email principals
+    """Wrapper for email principals.
 
     :param email: The email address.
     """
@@ -488,7 +488,7 @@ class PrincipalMixin(object):
         return set()
 
     def merge_privs(self, other):
-        """Merges the privileges of another principal
+        """Merge the privileges of another principal.
 
         :param other: Another principal object.
         """
@@ -499,7 +499,7 @@ class PrincipalMixin(object):
 
     @classmethod
     def merge_users(cls, target, source, relationship_attr):
-        """Merges two users in the ACL.
+        """Merge two users in the ACL.
 
         :param target: The target user of the merge.
         :param source: The user that is being merged into `target`.
@@ -523,8 +523,9 @@ class PrincipalMixin(object):
     @classmethod
     def replace_email_with_user(cls, user, relationship_attr):
         """
-        Replaces all email-based entries matching the user's email
+        Replace all email-based entries matching the user's email
         addresses with user-based entries.
+
         If the user is already in the ACL, the two entries are merged.
 
         :param user: A User object.
@@ -606,7 +607,7 @@ class PrincipalPermissionsMixin(PrincipalMixin):
 
     @hybrid_method
     def has_management_permission(self, permission=None, explicit=False):
-        """Checks whether a principal has a certain management permission.
+        """Check whether a principal has a certain management permission.
 
         The check always succeeds if the user is a full manager; in
         that case the list of permissions is ignored.

--- a/indico/core/db/sqlalchemy/protection.py
+++ b/indico/core/db/sqlalchemy/protection.py
@@ -60,7 +60,7 @@ class ProtectionMixin(object):
 
     @classmethod
     def register_protection_events(cls):
-        """Registers sqlalchemy events needed by this mixin.
+        """Register sqlalchemy events needed by this mixin.
 
         Call this method after the definition of a model which uses
         this mixin class.
@@ -120,7 +120,7 @@ class ProtectionMixin(object):
 
     @hybrid_property
     def is_self_protected(self):
-        """Checks whether the object itself is protected.
+        """Check whether the object itself is protected.
 
         If you also care about inherited protection from a parent,
         use `is_protected` instead.
@@ -132,7 +132,7 @@ class ProtectionMixin(object):
     @property
     def is_protected(self):
         """
-        Checks whether ths object is protected, either by itself or
+        Check whether this object is protected, either by itself or
         by inheriting from a protected object.
         """
         if self.disable_protection_mode:
@@ -151,7 +151,7 @@ class ProtectionMixin(object):
 
     @property
     def protection_parent(self):
-        """The parent object to consult for ProtectionMode.inheriting"""
+        """The parent object to consult for ProtectionMode.inheriting."""
         raise NotImplementedError
 
     def _check_can_access_override(self, user, allow_admin, authorized=None):
@@ -169,7 +169,7 @@ class ProtectionMixin(object):
 
     @memoize_request
     def can_access(self, user, allow_admin=True):
-        """Checks if the user can access the object.
+        """Check if the user can access the object.
 
         :param user: The :class:`.User` to check. May be None if the
                      user is not logged in.
@@ -264,7 +264,7 @@ class ProtectionMixin(object):
         return '{}-{}'.format(cls.__name__, '-'.join(map(unicode, pks)))
 
     def update_principal(self, principal, read_access=None, quiet=False):
-        """Updates access privileges for the given principal.
+        """Update access privileges for the given principal.
 
         :param principal: A `User`, `GroupProxy` or `EmailPrincipal` instance.
         :param read_access: If the principal should have explicit read
@@ -300,7 +300,7 @@ class ProtectionMixin(object):
         return entry
 
     def remove_principal(self, principal, quiet=False):
-        """Revokes all access privileges for the given principal.
+        """Revoke all access privileges for the given principal.
 
         This method doesn't do anything if the user is not in the
         object's ACL.
@@ -327,7 +327,7 @@ class ProtectionMixin(object):
 class ProtectionManagersMixin(ProtectionMixin):
     @property
     def all_manager_emails(self):
-        """Return the emails of all managers"""
+        """Return the emails of all managers."""
         # We ignore email principals here. They never signed up in indico anyway...
         return {p.principal.email
                 for p in self.acl_entries
@@ -335,7 +335,7 @@ class ProtectionManagersMixin(ProtectionMixin):
 
     @memoize_request
     def can_manage(self, user, permission=None, allow_admin=True, check_parent=True, explicit_permission=False):
-        """Checks if the user can manage the object.
+        """Check if the user can manage the object.
 
         :param user: The :class:`.User` to check. May be None if the
                      user is not logged in.
@@ -408,7 +408,7 @@ class ProtectionManagersMixin(ProtectionMixin):
 
     def update_principal(self, principal, read_access=None, full_access=None, permissions=None, add_permissions=None,
                          del_permissions=None, quiet=False):
-        """Updates access privileges for the given principal.
+        """Update access privileges for the given principal.
 
         If the principal is not in the ACL, it will be added if
         necessary.  If the changes remove all its privileges, it
@@ -515,7 +515,7 @@ class ProtectionManagersMixin(ProtectionMixin):
 
 
 def _get_acl_data(obj, principal):
-    """Helper function to get the necessary data for ACL modifications
+    """Helper function to get the necessary data for ACL modifications.
 
     :param obj: A `ProtectionMixin` instance
     :param principal: A User or GroupProxy uinstance
@@ -528,7 +528,7 @@ def _get_acl_data(obj, principal):
 
 
 def _resolve_principal(principal):
-    """Helper function to convert an email principal to a user if possible
+    """Helper function to convert an email principal to a user if possible.
 
     :param principal: A `User`, `GroupProxy` or `EmailPrincipal` instance.
     """

--- a/indico/core/db/sqlalchemy/util/management.py
+++ b/indico/core/db/sqlalchemy/util/management.py
@@ -64,14 +64,14 @@ DEFAULT_BADGE_DATA = {
 
 
 def get_all_tables(db):
-    """Returns a dict containing all tables grouped by schema"""
+    """Return a dict containing all tables grouped by schema."""
     inspector = Inspector.from_engine(db.engine)
     schemas = sorted(set(inspector.get_schema_names()) - {'information_schema'})
     return dict(zip(schemas, (inspector.get_table_names(schema=schema) for schema in schemas)))
 
 
 def delete_all_tables(db):
-    """Drops all tables in the database"""
+    """Drop all tables in the database."""
     conn = db.engine.connect()
     transaction = conn.begin()
     inspector = Inspector.from_engine(db.engine)
@@ -106,7 +106,7 @@ def delete_all_tables(db):
 
 
 def create_all_tables(db, verbose=False, add_initial_data=True):
-    """Create all tables and required initial objects"""
+    """Create all tables and required initial objects."""
     from indico.modules.categories import Category
     from indico.modules.designer import TemplateType
     from indico.modules.designer.models.templates import DesignerTemplate

--- a/indico/core/db/sqlalchemy/util/models.py
+++ b/indico/core/db/sqlalchemy/util/models.py
@@ -60,7 +60,7 @@ class IndicoBaseQuery(BaseQuery):
 
 
 class IndicoModel(Model):
-    """Indico DB model"""
+    """Indico DB model."""
 
     #: Whether relationship preloading is allowed.  If disabled,
     #: the on-load event that populates relationship from the preload
@@ -169,7 +169,7 @@ class IndicoModel(Model):
                 set_committed_value(target, rel, value)
 
     def assign_id(self):
-        """Immediately assigns an ID to the object.
+        """Immediately assign an ID to the object.
 
         This only works if the table has exactly one serial column.
         It also "wastes" the ID if the new object is not actually
@@ -196,7 +196,7 @@ class IndicoModel(Model):
         setattr(self, attr_name, id_)
 
     def populate_from_dict(self, data, keys=None, skip=None, track_changes=True):
-        """Populates the object with values in a dictionary
+        """Populate the object with values in a dictionary.
 
         :param data: a dict containing values to populate the object.
         :param keys: If set, only keys from that list are populated.
@@ -227,7 +227,7 @@ class IndicoModel(Model):
         return changed if track_changes else None
 
     def populate_from_attrs(self, obj, attrs):
-        """Populates the object from another object's attributes
+        """Populate the object from another object's attributes.
 
         :param obj: an object
         :param attrs: a set containing the attributes to copy
@@ -248,7 +248,7 @@ def _mappers_configured():
 
 
 def import_all_models(package_name='indico'):
-    """Utility that imports all modules in indico/**/models/
+    """Utility that imports all modules in indico/**/models/.
 
     :param package_name: Package name to scan for models. If unset,
                          the top-level package containing this file
@@ -270,7 +270,7 @@ def import_all_models(package_name='indico'):
 
 
 def attrs_changed(obj, *attrs):
-    """Checks if the given fields have been changed since the last flush
+    """Check if the given fields have been changed since the last flush.
 
     :param obj: SQLAlchemy-mapped object
     :param attrs: attribute names
@@ -279,8 +279,10 @@ def attrs_changed(obj, *attrs):
 
 
 def get_default_values(model):
-    """Returns a dict containing all static default values of a model.
+    """Return a dict containing all static default values of a model.
+
     This only takes `default` into account, not `server_default`.
+
     :param model: A SQLAlchemy model
     """
     return {attr.key: attr.columns[0].default.arg
@@ -290,7 +292,7 @@ def get_default_values(model):
 
 def get_simple_column_attrs(model):
     """
-    Returns a set containing all "simple" column attributes, i.e.
+    Return a set containing all "simple" column attributes, i.e.
     attributes which map to a table column and are neither primary
     key nor foreign key.
 
@@ -308,7 +310,7 @@ def get_simple_column_attrs(model):
 
 
 def auto_table_args(cls, **extra_kwargs):
-    """Merges SQLAlchemy ``__table_args__`` values.
+    """Merge SQLAlchemy ``__table_args__`` values.
 
     This is useful when using mixins to compose model classes if the
     mixins need to define custom ``__table_args__``. Since defining
@@ -361,7 +363,7 @@ def _get_backref_name(relationship):
 
 
 def populate_one_to_one_backrefs(model, *relationships):
-    """Populates the backref of a one-to-one relationship on load
+    """Populate the backref of a one-to-one relationship on load.
 
     See this post in the SQLAlchemy docs on why it's useful/necessary:
     http://docs.sqlalchemy.org/en/latest/orm/loading_relationships.html#creating-custom-load-rules

--- a/indico/core/db/sqlalchemy/util/queries.py
+++ b/indico/core/db/sqlalchemy/util/queries.py
@@ -17,8 +17,7 @@ TS_REGEX = re.compile(r'([@<>!()&|:\'])')
 
 
 def limit_groups(query, model, partition_by, order_by, limit=None, offset=0):
-    """Limits the number of rows returned for each group
-
+    """Limit the number of rows returned for each group.
 
     This utility allows you to apply a limit/offset to grouped rows of a query.
     Note that the query will only contain the data from `model`; i.e. you cannot
@@ -51,7 +50,7 @@ def db_dates_overlap(entity, start_column, start, end_column, end, inclusive=Fal
 
 
 def escape_like(value):
-    """Escapes a string to be used as a plain string in LIKE"""
+    """Escape a string to be used as a plain string in LIKE."""
     escape_char = '\\'
     return (value
             .replace(escape_char, escape_char * 2)  # literal escape char needs to be escaped
@@ -65,7 +64,7 @@ def preprocess_ts_string(text, prefix=True):
 
 
 def has_extension(conn, name):
-    """Checks if the postgres database has a certain extension installed"""
+    """Check if the postgres database has a certain extension installed."""
     return conn.execute("SELECT EXISTS(SELECT TRUE FROM pg_extension WHERE extname = %s)", (name,)).scalar()
 
 
@@ -76,7 +75,7 @@ def get_postgres_version():
 
 
 def increment_and_get(col, filter_, n=1):
-    """Increments and returns a numeric column.
+    """Increment and returns a numeric column.
 
     This is committed to the database immediately in a separate
     transaction to avoid possible conflicts.

--- a/indico/core/db/sqlalchemy/util/session.py
+++ b/indico/core/db/sqlalchemy/util/session.py
@@ -13,7 +13,7 @@ from indico.core.db import db
 
 
 def no_autoflush(fn):
-    """Wraps the decorated function in a no-autoflush block"""
+    """Wrap the decorated function in a no-autoflush block."""
     @wraps(fn)
     def wrapper(*args, **kwargs):
         with db.session.no_autoflush:

--- a/indico/core/errors.py
+++ b/indico/core/errors.py
@@ -16,7 +16,7 @@ from indico.util.string import to_unicode
 
 
 def get_error_description(exception):
-    """Gets a user-friendy description for an exception
+    """Get a user-friendy description for an exception.
 
     This overrides some HTTPException messages to be more suitable
     for end-users.

--- a/indico/core/notifications.py
+++ b/indico/core/notifications.py
@@ -39,7 +39,7 @@ def email_sender(fn):
 
 
 def send_email(email, event=None, module=None, user=None, log_metadata=None):
-    """Sends an email created by :func:`make_email`.
+    """Send an email created by :func:`make_email`.
 
     When called while inside a RH, the email will be queued and only
     sent or passed on to celery once the database commit succeeded.
@@ -122,7 +122,7 @@ def flush_email_queue():
 
 def make_email(to_list=None, cc_list=None, bcc_list=None, from_address=None, reply_address=None, attachments=None,
                subject=None, body=None, template=None, html=False):
-    """Creates an email.
+    """Create an email.
 
     The preferred way to specify the email content is using the
     `template` argument. To do so, use :func:`.get_template_module` on

--- a/indico/core/permissions.py
+++ b/indico/core/permissions.py
@@ -41,13 +41,13 @@ class ManagementPermission(object):
 
 @memoize_request
 def get_available_permissions(type_):
-    """Gets a dict containing all permissions for a given object type"""
+    """Get a dict containing all permissions for a given object type."""
     return named_objects_from_signal(signals.acl.get_management_permissions.send(type_))
 
 
 def check_permissions(type_):
     """
-    Retrieves the permissions for an object type and ensures they are
+    Retrieve the permissions for an object type and ensure they are
     defined properly.
 
     This function should be executed from a function connected to the
@@ -62,7 +62,10 @@ def check_permissions(type_):
 
 
 def get_permissions_info(_type):
-    """Retrieve the permissions that can be set in the protection page and related information
+    """
+    Retrieve the permissions that can be set in the protection page
+    and related information.
+
     :param _type: The type of the permissions retrieved (e.g. Event, Category)
     :return: A tuple containing a dict with the available permissions and a dict with the permissions tree
     """
@@ -163,7 +166,10 @@ def get_unified_permissions(principal, all_permissions=False):
 
 
 def get_split_permissions(permissions):
-    """Split a list of permissions into a `has_full_access, has_read_access, list_with_others` tuple."""
+    """
+    Split a list of permissions into a `has_full_access, has_read_access,
+    list_with_others` tuple.
+    """
     full_access_permission = FULL_ACCESS_PERMISSION in permissions
     read_access_permission = READ_ACCESS_PERMISSION in permissions
     other_permissions = permissions - {FULL_ACCESS_PERMISSION, READ_ACCESS_PERMISSION}
@@ -204,7 +210,8 @@ def update_permissions(obj, form):
 
 
 def update_principals_permissions(obj, current, new):
-    """Handle the updates of permissions and creations/deletions of acl principals.
+    """
+    Handle the updates of permissions and creations/deletions of acl principals.
 
     :param obj: The object to update. Must have ``acl_entries``
     :param current: A dict mapping principals to a set with its current permissions

--- a/indico/core/plugins/__init__.py
+++ b/indico/core/plugins/__init__.py
@@ -46,7 +46,7 @@ class PluginCategory(unicode, IndicoEnum):
 
 
 class IndicoPlugin(Plugin):
-    """Base class for an Indico plugin
+    """Base class for an Indico plugin.
 
     All your plugins need to inherit from this class. It extends the
     `Plugin` class from Flask-PluginEngine with useful indico-specific
@@ -131,7 +131,7 @@ class IndicoPlugin(Plugin):
         signal.connect(func, **connect_kwargs)
 
     def get_blueprints(self):
-        """Return blueprints to be registered on the application
+        """Return blueprints to be registered on the application.
 
         A single blueprint can be returned directly, for multiple blueprint you need
         to yield them or return an iterable.
@@ -139,21 +139,21 @@ class IndicoPlugin(Plugin):
         pass
 
     def get_vars_js(self):
-        """Return a dictionary with variables to be added to vars.js file"""
+        """Return a dictionary with variables to be added to vars.js file."""
         return None
 
     @cached_property
     def translation_path(self):
-        """
-        Return translation files to be used by the plugin.
-        By default, get <root_path>/translations, unless it does not exist
+        """Return translation files to be used by the plugin.
+
+        By default, get <root_path>/translations, unless it does not exist.
         """
         translations_path = os.path.join(self.root_path, 'translations')
         return translations_path if os.path.exists(translations_path) else None
 
     @cached_property
     def translation_domain(self):
-        """Return the domain for this plugin's translation_path"""
+        """Return the domain for this plugin's translation_path."""
         path = self.translation_path
         return Domain(path) if path else NullDomain()
 
@@ -178,7 +178,7 @@ class IndicoPlugin(Plugin):
         return self._get_manifest()
 
     def inject_bundle(self, name, view_class=None, subclasses=True, condition=None):
-        """Injects an asset bundle into Indico's pages
+        """Inject an asset bundle into Indico's pages.
 
         :param name: Name of the bundle
         :param view_class: If a WP class is specified, only inject it into pages using that class
@@ -203,15 +203,18 @@ class IndicoPlugin(Plugin):
             self.connect(signals.plugin.inject_bundle, _func)
 
     def inject_vars_js(self):
-        """Returns a string that will define variables for the plugin in the vars.js file"""
+        """
+        Return a string that will define variables for the plugin in
+        the vars.js file.
+        """
         vars_js = self.get_vars_js()
         if vars_js:
             return 'var {}Plugin = {};'.format(self.name.title(), json.dumps(vars_js))
 
     def template_hook(self, name, receiver, priority=50, markup=True):
-        """Registers a function to be called when a template hook is invoked.
+        """Register a function to be called when a template hook is invoked.
 
-        For details see :func:`~indico.web.flask.templating.register_template_hook`
+        For details see :func:`~indico.web.flask.templating.register_template_hook`.
         """
         register_template_hook(name, receiver, priority, markup, self)
 
@@ -223,7 +226,7 @@ class IndicoPlugin(Plugin):
     @cached_classproperty
     @classmethod
     def settings(cls):
-        """:class:`SettingsProxy` for the plugin's settings"""
+        """:class:`SettingsProxy` for the plugin's settings."""
         if cls.name is None:
             raise RuntimeError('Plugin has not been loaded yet')
         instance = cls.instance
@@ -234,7 +237,7 @@ class IndicoPlugin(Plugin):
     @cached_classproperty
     @classmethod
     def event_settings(cls):
-        """:class:`EventSettingsProxy` for the plugin's event-specific settings"""
+        """:class:`EventSettingsProxy` for the plugin's event-specific settings."""
         if cls.name is None:
             raise RuntimeError('Plugin has not been loaded yet')
         instance = cls.instance
@@ -246,7 +249,7 @@ class IndicoPlugin(Plugin):
     @cached_classproperty
     @classmethod
     def user_settings(cls):
-        """:class:`UserSettingsProxy` for the plugin's user-specific settings"""
+        """:class:`UserSettingsProxy` for the plugin's user-specific settings."""
         if cls.name is None:
             raise RuntimeError('Plugin has not been loaded yet')
         instance = cls.instance

--- a/indico/core/plugins/alembic/env.py
+++ b/indico/core/plugins/alembic/env.py
@@ -59,7 +59,6 @@ def run_migrations_offline():
 
     Calls to context.execute() here emit the given string to the
     script output.
-
     """
     url = config.get_main_option('sqlalchemy.url')
     context.configure(url=url, target_metadata=target_metadata, include_schemas=True,
@@ -75,7 +74,6 @@ def run_migrations_online():
 
     In this scenario we need to create an Engine
     and associate a connection with the context.
-
     """
     engine = engine_from_config(config.get_section(config.config_ini_section),
                                 prefix='sqlalchemy.',

--- a/indico/core/settings/models/base.py
+++ b/indico/core/settings/models/base.py
@@ -25,7 +25,7 @@ def _coerce_value(value):
 
 
 class SettingsBase(object):
-    """Base class for any kind of setting tables"""
+    """Base class for any kind of setting tables."""
 
     id = db.Column(
         db.Integer,
@@ -86,7 +86,7 @@ class SettingsBase(object):
 
 
 class JSONSettingsBase(SettingsBase):
-    """Base class for setting tables with a JSON value"""
+    """Base class for setting tables with a JSON value."""
 
     __tablename__ = 'settings'
 
@@ -143,7 +143,7 @@ class JSONSettingsBase(SettingsBase):
 
 
 class PrincipalSettingsBase(PrincipalMixin, SettingsBase):
-    """Base class for principal setting tables"""
+    """Base class for principal setting tables."""
 
     __tablename__ = 'settings_principals'
     # Additional columns used to identitfy a setting (e.g. user/event id)

--- a/indico/core/settings/proxy.py
+++ b/indico/core/settings/proxy.py
@@ -19,7 +19,7 @@ from indico.util.string import return_ascii
 
 
 class ACLProxyBase(object):
-    """Base Proxy class for ACL settings"""
+    """Base Proxy class for ACL settings."""
 
     def __init__(self, proxy):
         self.proxy = proxy
@@ -37,7 +37,7 @@ class ACLProxyBase(object):
 
 
 class SettingsProxyBase(object):
-    """Base proxy class to access settings for a certain module
+    """Base proxy class to access settings for a certain module.
 
     :param module: the module to use
     :param defaults: default values to use if there's nothing in the db
@@ -77,7 +77,7 @@ class SettingsProxyBase(object):
             return '<{}({})>'.format(type(self).__name__, self.module)
 
     def bind(self, *args):
-        """Returns a version of this proxy that is bound to some arguments.
+        """Return a version of this proxy that is bound to some arguments.
 
         This is useful for specialized versions of the proxy such as
         EventSettingsProxy where one might want to provide an easy-to-use
@@ -87,7 +87,6 @@ class SettingsProxyBase(object):
         :param args: The positional argument that are prepended to each
                      function call.
         """
-
         self_type = type(self)
         bound = self_type(self.module, self.defaults, self.strict)
         bound._bound_args = args
@@ -158,10 +157,10 @@ class SettingsProxyBase(object):
 
 
 class ACLProxy(ACLProxyBase):
-    """Proxy class for core ACL settings"""
+    """Proxy class for core ACL settings."""
 
     def get(self, name):
-        """Retrieves an ACL setting
+        """Retrieve an ACL setting.
 
         :param name: Setting name
         """
@@ -169,7 +168,7 @@ class ACLProxy(ACLProxyBase):
         return get_setting_acl(SettingPrincipal, self, name, self._cache)
 
     def set(self, name, acl):
-        """Replaces an ACL with a new one
+        """Replace an ACL with a new one.
 
         :param name: Setting name
         :param acl: A set containing principals (users/groups)
@@ -179,7 +178,7 @@ class ACLProxy(ACLProxyBase):
         self._flush_cache()
 
     def contains_user(self, name, user):
-        """Checks if a user is in an ACL.
+        """Check if a user is in an ACL.
 
         To pass this check, the user can either be in the ACL itself
         or in a group in the ACL.
@@ -191,7 +190,7 @@ class ACLProxy(ACLProxyBase):
         return any(user in principal for principal in iter_acl(self.get(name)))
 
     def add_principal(self, name, principal):
-        """Adds a principal to an ACL
+        """Add a principal to an ACL.
 
         :param name: Setting name
         :param principal: A :class:`.User` or a :class:`.GroupProxy`
@@ -201,7 +200,7 @@ class ACLProxy(ACLProxyBase):
         self._flush_cache()
 
     def remove_principal(self, name, principal):
-        """Removes a principal from an ACL
+        """Remove a principal from an ACL.
 
         :param name: Setting name
         :param principal: A :class:`.User` or a :class:`.GroupProxy`
@@ -211,18 +210,18 @@ class ACLProxy(ACLProxyBase):
         self._flush_cache()
 
     def merge_users(self, target, source):
-        """Replaces all ACL user entries for `source` with `target`"""
+        """Replace all ACL user entries for `source` with `target`."""
         SettingPrincipal.merge_users(self.module, target, source)
         self._flush_cache()
 
 
 class SettingsProxy(SettingsProxyBase):
-    """Proxy class to access settings for a certain module"""
+    """Proxy class to access settings for a certain module."""
 
     acl_proxy_class = ACLProxy
 
     def get_all(self, no_defaults=False):
-        """Retrieves all settings, including ACLs
+        """Retrieve all settings, including ACLs.
 
         :param no_defaults: Only return existing settings and ignore defaults.
         :return: Dict containing the settings
@@ -230,7 +229,7 @@ class SettingsProxy(SettingsProxyBase):
         return get_all_settings(Setting, SettingPrincipal, self, no_defaults)
 
     def get(self, name, default=SettingsProxyBase.default_sentinel):
-        """Retrieves the value of a single setting.
+        """Retrieve the value of a single setting.
 
         :param name: Setting name
         :param default: Default value in case the setting does not exist
@@ -240,7 +239,7 @@ class SettingsProxy(SettingsProxyBase):
         return get_setting(Setting, self, name, default, self._cache)
 
     def set(self, name, value):
-        """Sets a single setting.
+        """Set a single setting.
 
         :param name: Setting name
         :param value: Setting value; must be JSON-serializable
@@ -250,7 +249,7 @@ class SettingsProxy(SettingsProxyBase):
         self._flush_cache()
 
     def set_multi(self, items):
-        """Sets multiple settings at once.
+        """Set multiple settings at once.
 
         :param items: Dict containing the new settings
         """
@@ -261,7 +260,7 @@ class SettingsProxy(SettingsProxyBase):
         self._flush_cache()
 
     def delete(self, *names):
-        """Deletes settings.
+        """Delete settings.
 
         :param names: One or more names of settings to delete
         """
@@ -271,7 +270,7 @@ class SettingsProxy(SettingsProxyBase):
         self._flush_cache()
 
     def delete_all(self):
-        """Deletes all settings."""
+        """Delete all settings."""
         Setting.delete_all(self.module)
         SettingPrincipal.delete_all(self.module)
         self._flush_cache()
@@ -336,7 +335,7 @@ class AttributeProxyProperty(object):
 
 
 class PrefixSettingsProxy(object):
-    """A SettingsProxy that exposes settings with prefixes
+    """A SettingsProxy that exposes settings with prefixes.
 
     This allows for simple form handling when a single form contains
     settings from more than one proxy.

--- a/indico/core/settings/util.py
+++ b/indico/core/settings/util.py
@@ -30,7 +30,7 @@ def _preload_settings(cls, proxy, cache, **kwargs):
 
 
 def get_all_settings(cls, acl_cls, proxy, no_defaults, **kwargs):
-    """Helper function for SettingsProxy.get_all"""
+    """Helper function for SettingsProxy.get_all."""
     if no_defaults:
         rv = cls.get_all(proxy.module, **kwargs)
         if acl_cls and proxy.acl_names:
@@ -48,7 +48,7 @@ def get_all_settings(cls, acl_cls, proxy, no_defaults, **kwargs):
 
 
 def get_setting(cls, proxy, name, default, cache, **kwargs):
-    """Helper function for SettingsProxy.get"""
+    """Helper function for SettingsProxy.get."""
     from indico.core.settings import SettingsProxyBase
 
     cache_key = _get_cache_key(proxy, name, kwargs)
@@ -67,7 +67,7 @@ def get_setting(cls, proxy, name, default, cache, **kwargs):
 
 
 def get_setting_acl(cls, proxy, name, cache, **kwargs):
-    """Helper function for ACLProxy.get"""
+    """Helper function for ACLProxy.get."""
     cache_key = _get_cache_key(proxy, name, kwargs)
     try:
         return cache[cache_key]

--- a/indico/core/storage/backend.py
+++ b/indico/core/storage/backend.py
@@ -24,7 +24,7 @@ from indico.web.flask.util import send_file
 
 
 def get_storage(backend_name):
-    """Returns an FS object for the given backend.
+    """Return an FS object for the given backend.
 
     The backend must be defined in the STORAGE_BACKENDS dict in the
     indico config.  Once a backend has been used it is assumed to
@@ -51,15 +51,15 @@ def get_storage_backends():
 
 
 class StorageError(Exception):
-    """Exception used when a storage operation fails for any reason"""
+    """Exception used when a storage operation fails for any reason."""
 
 
 class StorageReadOnlyError(StorageError):
-    """Exception used when trying to write to a read-only storage"""
+    """Exception used when trying to write to a read-only storage."""
 
 
 class Storage(object):
-    """Base class for storage backends
+    """Base class for storage backends.
 
     To create a new storage backend, subclass this class and register
     it using the `get_storage_backends` signal.
@@ -79,6 +79,7 @@ class Storage(object):
                  key-value pairs: ``key=value,key2=value2,..``
 
     """
+
     #: unique name of the storage backend
     name = None
     #: plugin containing this backend - assigned automatically
@@ -90,11 +91,11 @@ class Storage(object):
         pass
 
     def _parse_data(self, data):
-        """Util to parse a key=value data string to a dict"""
+        """Util to parse a key=value data string to a dict."""
         return dict((x.strip() for x in item.split('=', 1)) for item in data.split(',')) if data else {}
 
     def _ensure_fileobj(self, fileobj):
-        """Ensures that fileobj is a file-like object and not a string"""
+        """Ensure that fileobj is a file-like object and not a string."""
         return BytesIO(fileobj) if not hasattr(fileobj, 'read') else fileobj
 
     def _copy_file(self, source, target, chunk_size=1024*1024):
@@ -112,7 +113,7 @@ class Storage(object):
         return checksum.hexdigest().decode('ascii')
 
     def open(self, file_id):  # pragma: no cover
-        """Opens a file in the storage for reading.
+        """Open a file in the storage for reading.
 
         This returns a file-like object which contains the content of
         the file.
@@ -123,7 +124,7 @@ class Storage(object):
 
     @contextmanager
     def get_local_path(self, file_id):
-        """Returns a local path for the file.
+        """Return a local path for the file.
 
         While this path MAY point to the permanent location of the
         stored file, it MUST NOT be used for anything but read
@@ -139,7 +140,7 @@ class Storage(object):
                 yield tmpfile.name
 
     def save(self, name, content_type, filename, fileobj):  # pragma: no cover
-        """Creates a new file in the storage.
+        """Create a new file in the storage.
 
         This returns a a string identifier which can be used later to
         retrieve the file from the storage.
@@ -168,21 +169,21 @@ class Storage(object):
         raise NotImplementedError
 
     def delete(self, file_id):  # pragma: no cover
-        """Deletes a file from the storage.
+        """Delete a file from the storage.
 
         :param file_id: The ID of the file within the storage backend.
         """
         raise NotImplementedError
 
     def getsize(self, file_id):  # pragma: no cover
-        """Gets the size in bytes of a file
+        """Get the size in bytes of a file.
 
         :param file_id: The ID of the file within the storage backend.
         """
         raise NotImplementedError
 
     def send_file(self, file_id, content_type, filename, inline=True):  # pragma: no cover
-        """Sends the file to the client.
+        """Send the file to the client.
 
         This returns a flask response that will eventually result in
         the user being offered to download the file (or view it in the
@@ -207,7 +208,7 @@ class Storage(object):
 
 
 class ReadOnlyStorageMixin(object):
-    """Mixin that makes write operations fail with an error"""
+    """Mixin that makes write operations fail with an error."""
 
     def save(self, name, content_type, filename, fileobj):
         raise StorageReadOnlyError('Cannot write to read-only storage')

--- a/indico/core/storage/models.py
+++ b/indico/core/storage/models.py
@@ -47,8 +47,10 @@ class VersionedResourceMixin(object):
 
     @classmethod
     def register_versioned_resource_events(cls):
-        """Register SQLAlchemy events. Should be called
-           right after class definition."""
+        """Register SQLAlchemy events.
+
+        Should be called right after class definition.
+        """
         listen(cls.file, 'set', cls._add_file_to_relationship)
 
     #: The ID of the latest file for a file resource
@@ -101,7 +103,7 @@ class StoredFileMixin(object):
 
     @declared_attr
     def filename(cls):
-        """The name of the file"""
+        """The name of the file."""
         return db.Column(
             db.String,
             nullable=not cls.file_required
@@ -109,12 +111,12 @@ class StoredFileMixin(object):
 
     @declared_attr
     def extension(cls):
-        """The extension of the file"""
+        """The extension of the file."""
         return column_property(db.func.regexp_replace(cls.filename, r'^.*\.', ''), deferred=True)
 
     @declared_attr
     def content_type(cls):
-        """The MIME type of the file"""
+        """The MIME type of the file."""
         return db.Column(
             db.String,
             nullable=not cls.file_required
@@ -122,8 +124,7 @@ class StoredFileMixin(object):
 
     @declared_attr
     def size(cls):
-        """
-        The size of the file (in bytes).
+        """The size of the file (in bytes).
 
         Automatically assigned when `save()` is called.
         """
@@ -134,8 +135,7 @@ class StoredFileMixin(object):
 
     @declared_attr
     def md5(cls):
-        """
-        An MD5 hash of the file.
+        """An MD5 hash of the file.
 
         Automatically assigned when `save()` is called.
         """
@@ -160,7 +160,7 @@ class StoredFileMixin(object):
 
     @declared_attr
     def created_dt(cls):
-        """The date/time when the file was uploaded"""
+        """The date/time when the file was uploaded."""
         if not cls.add_file_date_column:
             return None
         return db.Column(
@@ -178,17 +178,21 @@ class StoredFileMixin(object):
 
     def get_local_path(self):
         """Return context manager that will yield physical path.
-           This should be avoided in favour of using the actual file contents"""
+
+        This should be avoided in favour of using the actual file contents.
+        """
         return self.storage.get_local_path(self.storage_file_id)
 
     def _build_storage_path(self):
-        """Should return a tuple containing the name of the storage backend
+        """
+        Should return a tuple containing the name of the storage backend
         to use and the actual path of that will be used to store the resource
-        using the former."""
+        using the former.
+        """
         raise NotImplementedError
 
     def save(self, data):
-        """Saves a file in the file storage.
+        """Save a file in the file storage.
 
         This requires the AttachmentFile to be associated with
         an Attachment which needs to be associated with a Folder since
@@ -205,19 +209,19 @@ class StoredFileMixin(object):
         self.size = self.storage.getsize(self.storage_file_id)
 
     def open(self):
-        """Returns the stored file as a file-like object"""
+        """Return the stored file as a file-like object."""
         if self.storage_file_id is None:
             raise Exception('There is no file to open')
         return self.storage.open(self.storage_file_id)
 
     def send(self, inline=True):
-        """Sends the file to the user"""
+        """Send the file to the user."""
         if self.storage_file_id is None:
             raise Exception('There is no file to send')
         return self.storage.send_file(self.storage_file_id, self.content_type, self.filename, inline=inline)
 
     def delete(self, delete_from_db=False):
-        """Delete the file from storage"""
+        """Delete the file from storage."""
         if self.storage_file_id is None:
             raise Exception('There is no file to delete')
         self.storage.delete(self.storage_file_id)

--- a/indico/legacy/common/cache.py
+++ b/indico/legacy/common/cache.py
@@ -27,17 +27,19 @@ from indico.util.string import truncate
 class _NoneValue(object):
     @classmethod
     def replace(cls, value):
-        """Replaces `None` with a `_NoneValue`"""
+        """Replace `None` with a `_NoneValue`."""
         return cls() if value is None else value
 
     @classmethod
     def restore(cls, value):
-        """Replaces `_NoneValue` with `None`"""
+        """Replace `_NoneValue` with `None`."""
         return None if isinstance(value, cls) else value
 
 
 class CacheClient(object):
-    """This is an abstract class. A cache client provide a simple API to get/set/delete cache entries.
+    """
+    This is an abstract class. A cache client provide a simple API to
+    get/set/delete cache entries.
 
     Implementation must provide the following methods:
     - set(self, key, val, ttl)
@@ -46,6 +48,7 @@ class CacheClient(object):
 
     The unit for the ttl arguments is a second.
     """
+
     def set_multi(self, mapping, ttl=0):
         for key, val in mapping.iteritems():
             self.set(key, val, ttl)
@@ -73,7 +76,7 @@ class CacheClient(object):
 
 
 class NullCacheClient(CacheClient):
-    """Does nothing"""
+    """Do nothing."""
 
     def set(self, key, val, ttl=0):
         pass
@@ -86,7 +89,7 @@ class NullCacheClient(CacheClient):
 
 
 class RedisCacheClient(CacheClient):
-    """Redis-based cache client with a simple API"""
+    """Redis-based cache client with a simple API."""
 
     key_prefix = 'cache/gen/'
 
@@ -222,7 +225,7 @@ class FileCacheClient(CacheClient):
 
 
 class MemcachedCacheClient(CacheClient):
-    """Memcached-based cache client"""
+    """Memcached-based cache client."""
 
     @staticmethod
     def convert_ttl(ttl):
@@ -248,6 +251,7 @@ class GenericCache(object):
 
     The backends are accessed through the CacheClient interface.
     """
+
     def __init__(self, namespace):
         self._client = None
         self._namespace = namespace

--- a/indico/legacy/common/output.py
+++ b/indico/legacy/common/output.py
@@ -46,9 +46,7 @@ class outputGenerator(object):
             return "INDICOSEARCH.PUBLIC"
 
     def _generateACLDatafield(self, eType, memberList, objId, out):
-        """
-        Generates a specific MARCXML 506 field containing the ACL
-        """
+        """Generate a specific MARCXML 506 field containing the ACL."""
         if eType:
             out.openTag("datafield", [["tag", "506"],
                                       ["ind1", "1"], ["ind2", " "]])
@@ -75,7 +73,6 @@ class outputGenerator(object):
         obj could be a Conference, Session, Contribution, Material, Resource
         or SubContribution object.
         """
-
         if acl is None:
             acl = obj.get_access_list()
 

--- a/indico/legacy/common/utils.py
+++ b/indico/legacy/common/utils.py
@@ -37,7 +37,7 @@ def encodeUnicode(text, sourceEncoding="utf-8"):
 
 
 def unicodeSlice(s, start, end, encoding='utf-8'):
-    """Returns a slice of the string s, based on its encoding."""
+    """Return a slice of the string s, based on its encoding."""
     return s.decode(encoding, 'replace')[start:end]
 
 
@@ -49,16 +49,12 @@ class OSSpecific(object):
 
     @classmethod
     def _lockFilePosix(cls, f, lockType):
-        """
-        Locks file f with lock type lockType
-        """
+        """Lock file f with lock type lockType."""
         fcntl.flock(f, lockType)
 
     @classmethod
     def _lockFileOthers(cls, f, lockType):
-        """
-        Win32/others file locking could be implemented here
-        """
+        """Win32/others file locking could be implemented here."""
         pass
 
     @classmethod

--- a/indico/legacy/pdfinterface/base.py
+++ b/indico/legacy/pdfinterface/base.py
@@ -145,8 +145,10 @@ def int_to_roman(value):
 
 class Paragraph(platypus.Paragraph):
     """
-    add a part attribute for drawing the name of the current part on the laterPages function
+    Add a part attribute for drawing the name of the current part
+    on the laterPages function.
     """
+
     def __init__(self, text, style, part="", bulletText=None, frags=None, caseSensitive=1):
         platypus.Paragraph.__init__(self, to_unicode(text), style, bulletText, frags, caseSensitive)
         self._part = part
@@ -158,11 +160,12 @@ class Paragraph(platypus.Paragraph):
         return self._part
 
 class SimpleParagraph(platypus.Flowable):
-    """  Simple and fast paragraph.
+    """Simple and fast paragraph.
 
     WARNING! This paragraph cannot break the line and doesn't have almost any formatting methods.
              It's used only to increase PDF performance in places where normal paragraph is not needed.
     """
+
     def __init__(self, text, fontSize = 10, indent = 0, spaceAfter = 2):
         platypus.Flowable.__init__(self)
         self.text = text
@@ -180,10 +183,11 @@ class SimpleParagraph(platypus.Flowable):
         self.canv.drawString(self.indent, self.spaceAfter, self.text)
 
 class TableOfContentsEntry(Paragraph):
+    """Class used to create table of contents entry with its number.
+
+    Much faster than table of table of contents from platypus lib
     """
-        Class used to create table of contents entry with its number.
-        Much faster than table of table of contents from platypus lib
-    """
+
     def __init__(self, text, pageNumber, style, part="", bulletText=None, frags=None, caseSensitive=1):
         Paragraph.__init__(self, to_unicode(text), style, part, bulletText, frags, caseSensitive)
         self._part = part
@@ -191,7 +195,7 @@ class TableOfContentsEntry(Paragraph):
 
     def _drawDots(self):
         """
-        Draws row of dots from the end of the abstract title to the page number.
+        Draw row of dots from the end of the abstract title to the page number.
         """
         try:
             freeSpace = int(self.blPara.lines[-1][0])
@@ -390,20 +394,21 @@ class PDFBase:
         setTTFonts()
 
     def firstPage(self, c, doc):
-        """set the first page of the document
-        This function is call by doc.build method for the first page
+        """Set the first page of the document.
+
+        This function is called by doc.build method for the first page.
         """
         pass
 
     def laterPages(self, c, doc):
-        """set the layout of the page after the first
-        This function is call by doc.build method one each page after the first
+        """Set the layout of the page after the first.
+
+        This function is called by doc.build method one each page after the first.
         """
         pass
 
     def getBody(self, story=None):
-        """add the content to the story
-        """
+        """Add the content to the story."""
         pass
 
     def getPDFBin(self):
@@ -479,7 +484,7 @@ class PDFBase:
 
 
 def _doNothing(canvas, doc):
-    "Dummy callback for onPage"
+    "Dummy callback for onPage."
     pass
 
 
@@ -587,10 +592,7 @@ class DocTemplateWithTOC(SimpleDocTemplate):
 
 
 class PDFWithTOC(PDFBase):
-    """
-    create a PDF with a Table of Contents
-
-    """
+    """Create a PDF with a Table of Contents."""
 
     def __init__(self, story=None, pagesize='A4', fontsize='normal', firstPageNumber=1, include_toc=True):
         self._fontsize = fontsize
@@ -613,9 +615,9 @@ class PDFWithTOC(PDFBase):
         setTTFonts()
 
     def _processTOCPage(self):
-        """ Generates page with table of contents.
+        """Generates page with table of contents.
 
-        Not used, because table of contents is generated automatically inside DocTemplateWithTOC class
+        Not used, because table of contents is generated automatically inside DocTemplateWithTOC class.
         """
         style1 = ParagraphStyle({})
         style1.fontName = "Times-Bold"
@@ -630,7 +632,7 @@ class PDFWithTOC(PDFBase):
         self._story.append(PageBreak())
 
     def getBody(self, story=None):
-        """add the content to the story
+        """Add the content to the story.
         When you want to put a paragraph p in the toc, add it to the self._indexedFlowable as this:
             self._indexedFlowable[p] = {"text":"my title", "level":1}
         """

--- a/indico/legacy/pdfinterface/conference.py
+++ b/indico/legacy/pdfinterface/conference.py
@@ -798,7 +798,7 @@ class SimplifiedTimeTablePlain(PDFBase):
         self._styles["day"] = dayStl
 
     def _haveSessionSlotsTitles(self, session):
-        """Checks if the session has slots with titles or not"""
+        """Check if the session has slots with titles or not."""
         for ss in session.blocks:
             if ss.title.strip():
                 return True

--- a/indico/legacy/pdfinterface/latex.py
+++ b/indico/legacy/pdfinterface/latex.py
@@ -93,7 +93,7 @@ class LaTeXRuntimeException(Exception):
 
 
 class LatexEscapeExtension(Extension):
-    """Ensures all strings in Jinja are latex-escaped"""
+    """Ensure all strings in Jinja are latex-escaped."""
 
     def filter_stream(self, stream):
         in_trans = False
@@ -134,7 +134,7 @@ def _latex_escape(s, ignore_braces=False):
 
 
 class LatexRunner(object):
-    """Handles the PDF generation from a chosen LaTeX template"""
+    """Handle the PDF generation from a chosen LaTeX template."""
 
     def __init__(self, source_dir, has_toc=False):
         self.source_dir = source_dir

--- a/indico/legacy/services/implementation/base.py
+++ b/indico/legacy/services/implementation/base.py
@@ -27,7 +27,7 @@ class ServiceBase(object):
 
     def process(self):
         """
-        Processes the request, analyzing the parameters, and feeding them to the
+        Process the request, analyzing the parameters, and feeding them to the
         _getAnswer() method (implemented by derived classes)
         """
 

--- a/indico/migrations/env.py
+++ b/indico/migrations/env.py
@@ -52,7 +52,6 @@ def run_migrations_offline():
 
     Calls to context.execute() here emit the given string to the
     script output.
-
     """
     url = config.get_main_option('sqlalchemy.url')
     context.configure(url=url, target_metadata=target_metadata, include_schemas=True,
@@ -68,7 +67,6 @@ def run_migrations_online():
 
     In this scenario we need to create an Engine
     and associate a connection with the context.
-
     """
     engine = engine_from_config(config.get_section(config.config_ini_section),
                                 prefix='sqlalchemy.',

--- a/indico/modules/admin/controllers/base.py
+++ b/indico/modules/admin/controllers/base.py
@@ -15,7 +15,7 @@ from indico.web.rh import RHProtected
 
 
 class RHAdminBase(RHProtected):
-    """Base class for all admin-only RHs"""
+    """Base class for all admin-only RHs."""
 
     DENY_FRAMES = True
 

--- a/indico/modules/api/controllers.py
+++ b/indico/modules/api/controllers.py
@@ -30,7 +30,7 @@ from indico.web.util import jsonify_data
 
 
 class RHAPIAdminSettings(RHAdminBase):
-    """API settings (admin)"""
+    """API settings (admin)."""
 
     def _process(self):
         form = AdminSettingsForm(obj=FormDefaults(**api_settings.get_all()))
@@ -43,7 +43,7 @@ class RHAPIAdminSettings(RHAdminBase):
 
 
 class RHAPIAdminKeys(RHAdminBase):
-    """API key list (admin)"""
+    """API key list (admin)."""
 
     def _process(self):
         keys = sorted(APIKey.find_all(is_active=True), key=lambda ak: (ak.use_count == 0, ak.user.full_name))
@@ -51,13 +51,13 @@ class RHAPIAdminKeys(RHAdminBase):
 
 
 class RHUserAPIBase(RHUserBase):
-    """Base class for user API management"""
+    """Base class for user API management."""
 
     allow_system_user = True
 
 
 class RHAPIUserProfile(RHUserAPIBase):
-    """API key details (user)"""
+    """API key details (user)."""
 
     def _process(self):
         key = self.user.api_key
@@ -72,7 +72,7 @@ class RHAPIUserProfile(RHUserAPIBase):
 
 
 class RHAPICreateKey(RHUserAPIBase):
-    """API key creation"""
+    """API key creation."""
 
     def _process(self):
         quiet = request.form.get('quiet') == '1'
@@ -105,7 +105,7 @@ class RHAPICreateKey(RHUserAPIBase):
 
 
 class RHAPIDeleteKey(RHUserAPIBase):
-    """API key deletion"""
+    """API key deletion."""
 
     def _process(self):
         key = self.user.api_key
@@ -115,7 +115,7 @@ class RHAPIDeleteKey(RHUserAPIBase):
 
 
 class RHAPITogglePersistent(RHUserAPIBase):
-    """API key - persistent signatures on/off"""
+    """API key - persistent signatures on/off."""
 
     def _process(self):
         quiet = request.form.get('quiet') == '1'
@@ -130,7 +130,7 @@ class RHAPITogglePersistent(RHUserAPIBase):
 
 
 class RHAPIBlockKey(RHUserAPIBase):
-    """API key blocking/unblocking"""
+    """API key blocking/unblocking."""
 
     def _check_access(self):
         RHUserAPIBase._check_access(self)

--- a/indico/modules/api/models/keys.py
+++ b/indico/modules/api/models/keys.py
@@ -18,7 +18,7 @@ from indico.util.string import return_ascii
 
 
 class APIKey(db.Model):
-    """API keys for users"""
+    """API keys for users."""
     __tablename__ = 'api_keys'
     __table_args__ = (db.Index(None, 'user_id', unique=True, postgresql_where=db.text('is_active')),
                       {'schema': 'users'})
@@ -110,7 +110,7 @@ class APIKey(db.Model):
         return '<APIKey({}, {}, {})>'.format(self.token, self.user_id, self.last_used_dt or 'never')
 
     def register_used(self, ip, uri, authenticated):
-        """Updates the last used information"""
+        """Update the last used information."""
         self.last_used_dt = now_utc()
         self.last_used_ip = ip
         self.last_used_uri = uri

--- a/indico/modules/attachments/controllers/display/base.py
+++ b/indico/modules/attachments/controllers/display/base.py
@@ -20,7 +20,7 @@ from indico.web.util import jsonify_template
 
 
 class DownloadAttachmentMixin(SpecificAttachmentMixin):
-    """Download an attachment"""
+    """Download an attachment."""
 
     def _check_access(self):
         if not self.attachment.can_access(session.user):

--- a/indico/modules/attachments/controllers/management/base.py
+++ b/indico/modules/attachments/controllers/management/base.py
@@ -61,7 +61,7 @@ def _get_folders_protection_info(linked_object):
 
 
 class ManageAttachmentsMixin:
-    """Shows the attachment management page"""
+    """Show the attachment management page."""
     wp = None
 
     def _process(self):
@@ -76,7 +76,7 @@ class ManageAttachmentsMixin:
 
 
 class AddAttachmentFilesMixin:
-    """Upload file attachments"""
+    """Upload file attachments."""
 
     def _process(self):
         form = AddAttachmentFilesForm(linked_object=self.object)
@@ -105,7 +105,7 @@ class AddAttachmentFilesMixin:
 
 
 class AddAttachmentLinkMixin:
-    """Add link attachment"""
+    """Add link attachment."""
 
     def _process(self):
         form = AddAttachmentLinkForm(linked_object=self.object)
@@ -119,7 +119,7 @@ class AddAttachmentLinkMixin:
 
 
 class EditAttachmentMixin(SpecificAttachmentMixin):
-    """Edit an attachment"""
+    """Edit an attachment."""
 
     def _process(self):
         defaults = FormDefaults(self.attachment, protected=self.attachment.is_self_protected, skip_attrs={'file'})
@@ -158,7 +158,7 @@ class EditAttachmentMixin(SpecificAttachmentMixin):
 
 
 class CreateFolderMixin:
-    """Create a new empty folder"""
+    """Create a new empty folder."""
 
     def _process(self):
         form = AttachmentFolderForm(obj=FormDefaults(is_always_visible=True), linked_object=self.object)
@@ -177,7 +177,7 @@ class CreateFolderMixin:
 
 
 class EditFolderMixin(SpecificFolderMixin):
-    """Edit a folder"""
+    """Edit a folder."""
 
     def _process(self):
         defaults = FormDefaults(self.folder, protected=self.folder.is_self_protected)
@@ -197,7 +197,7 @@ class EditFolderMixin(SpecificFolderMixin):
 
 
 class DeleteFolderMixin(SpecificFolderMixin):
-    """Delete a folder"""
+    """Delete a folder."""
 
     def _process(self):
         self.folder.is_deleted = True
@@ -208,7 +208,7 @@ class DeleteFolderMixin(SpecificFolderMixin):
 
 
 class DeleteAttachmentMixin(SpecificAttachmentMixin):
-    """Delete an attachment"""
+    """Delete an attachment."""
 
     def _process(self):
         self.attachment.is_deleted = True

--- a/indico/modules/attachments/controllers/util.py
+++ b/indico/modules/attachments/controllers/util.py
@@ -15,7 +15,7 @@ from indico.modules.attachments.models.folders import AttachmentFolder
 
 
 class SpecificAttachmentMixin:
-    """Mixin for RHs that reference a specific attachment"""
+    """Mixin for RHs that reference a specific attachment."""
 
     normalize_url_spec = {
         'args': {
@@ -36,7 +36,7 @@ class SpecificAttachmentMixin:
 
 
 class SpecificFolderMixin:
-    """Mixin for RHs that reference a specific folder"""
+    """Mixin for RHs that reference a specific folder."""
 
     normalize_url_spec = {
         'locators': {

--- a/indico/modules/attachments/logging.py
+++ b/indico/modules/attachments/logging.py
@@ -28,7 +28,7 @@ def connect_log_signals():
 
 def _ignore_non_loggable(f):
     """
-    Only calls the decorated function the attachment/folder is not
+    Only call the decorated function if the attachment/folder is not
     linked to a category.
     """
     @wraps(f)

--- a/indico/modules/attachments/models/attachments.py
+++ b/indico/modules/attachments/models/attachments.py
@@ -224,7 +224,7 @@ class Attachment(ProtectionMixin, VersionedResourceMixin, db.Model):
         return dict(self.folder.locator, attachment_id=self.id)
 
     def get_download_url(self, absolute=False):
-        """Returns the download url for the attachment.
+        """Return the download url for the attachment.
 
         During static site generation this returns a local URL for the
         file or the target URL for the link.
@@ -239,16 +239,16 @@ class Attachment(ProtectionMixin, VersionedResourceMixin, db.Model):
 
     @property
     def download_url(self):
-        """The download url for the attachment"""
+        """The download url for the attachment."""
         return self.get_download_url()
 
     @property
     def absolute_download_url(self):
-        """The absolute download url for the attachment"""
+        """The absolute download url for the attachment."""
         return self.get_download_url(absolute=True)
 
     def can_access(self, user, *args, **kwargs):
-        """Checks if the user is allowed to access the attachment.
+        """Check if the user is allowed to access the attachment.
 
         This is the case if the user has access to see the attachment
         or if the user can manage attachments for the linked object.

--- a/indico/modules/attachments/models/folders.py
+++ b/indico/modules/attachments/models/folders.py
@@ -118,7 +118,7 @@ class AttachmentFolder(LinkMixin, ProtectionMixin, db.Model):
 
     @classmethod
     def get_or_create_default(cls, linked_object):
-        """Gets the default folder for the given object or creates it."""
+        """Get the default folder for the given object or creates it."""
         folder = cls.find_first(is_default=True, object=linked_object)
         if folder is None:
             folder = cls(is_default=True, object=linked_object)
@@ -126,7 +126,7 @@ class AttachmentFolder(LinkMixin, ProtectionMixin, db.Model):
 
     @classmethod
     def get_or_create(cls, linked_object, title=None):
-        """Gets a folder for the given object or creates it.
+        """Get a folder for the given object or create it.
 
         If no folder title is specified, the default folder will be
         used.  It is the caller's responsibility to add the folder
@@ -144,7 +144,7 @@ class AttachmentFolder(LinkMixin, ProtectionMixin, db.Model):
         return dict(self.object.locator, folder_id=self.id)
 
     def can_access(self, user, *args, **kwargs):
-        """Checks if the user is allowed to access the folder.
+        """Check if the user is allowed to access the folder.
 
         This is the case if the user has access the folder or if the
         user can manage attachments for the linked object.
@@ -153,7 +153,7 @@ class AttachmentFolder(LinkMixin, ProtectionMixin, db.Model):
                 can_manage_attachments(self.object, user))
 
     def can_view(self, user):
-        """Checks if the user can see the folder.
+        """Check if the user can see the folder.
 
         This does not mean the user can actually access its contents.
         It just determines if it is visible to him or not.
@@ -166,7 +166,7 @@ class AttachmentFolder(LinkMixin, ProtectionMixin, db.Model):
 
     @classmethod
     def get_for_linked_object(cls, linked_object, preload_event=False):
-        """Gets the attachments for the given object.
+        """Get the attachments for the given object.
 
         This only returns attachments that haven't been deleted.
 

--- a/indico/modules/attachments/models/legacy_mapping.py
+++ b/indico/modules/attachments/models/legacy_mapping.py
@@ -60,14 +60,14 @@ class _LegacyLinkMixin(object):
 
     @property
     def link_repr(self):
-        """A kwargs-style string suitable for the object's repr"""
+        """A kwargs-style string suitable for the object's repr."""
         _all_columns = {'event_id', 'contribution_id', 'subcontribution_id', 'session_id'}
         info = [(key, getattr(self, key)) for key in _all_columns if getattr(self, key) is not None]
         return ', '.join('{}={}'.format(key, value) for key, value in info)
 
 
 class LegacyAttachmentFolderMapping(_LegacyLinkMixin, db.Model):
-    """Legacy attachmentfolder id mapping
+    """Legacy attachmentfolder id mapping.
 
     Legacy folders ("materials") had ids unique only within their
     linked object.  This table maps those ids for a specific object
@@ -105,7 +105,7 @@ class LegacyAttachmentFolderMapping(_LegacyLinkMixin, db.Model):
 
 
 class LegacyAttachmentMapping(_LegacyLinkMixin, db.Model):
-    """Legacy attachment id mapping
+    """Legacy attachment id mapping.
 
     Legacy attachments ("resources") had ids unique only within their
     folder and its linked object.  This table maps those ids for a

--- a/indico/modules/attachments/operations.py
+++ b/indico/modules/attachments/operations.py
@@ -17,7 +17,7 @@ from indico.modules.attachments.models.folders import AttachmentFolder
 
 
 def add_attachment_link(data, linked_object):
-    """Add a link attachment to linked_object"""
+    """Add a link attachment to linked_object."""
     folder = data.pop('folder', None)
     if not folder:
         folder = AttachmentFolder.get_or_create_default(linked_object=linked_object)

--- a/indico/modules/attachments/preview.py
+++ b/indico/modules/attachments/preview.py
@@ -17,25 +17,27 @@ from indico.util.string import fix_broken_string
 
 
 class Previewer(object):
-    """Base class for file previewers
+    """Base class for file previewers.
 
     To create a new file prewiewer, subclass this class and register it using
     the `get_file_previewers` signal.
     """
+
     ALLOWED_CONTENT_TYPE = None
     TEMPLATES_DIR = 'attachments/previewers/'
     TEMPATE = None
 
     @classmethod
     def can_preview(cls, attachment_file):
-        """Checks if the content type of the file matches the allowed content
+        """
+        Check if the content type of the file matches the allowed content
         type of files that the previewer can be used for.
         """
         return cls.ALLOWED_CONTENT_TYPE.search(attachment_file.content_type) is not None
 
     @classmethod
     def generate_content(cls, attachment):
-        """Generates the HTML output of the file preview"""
+        """Generate the HTML output of the file preview."""
         return render_template(cls.TEMPLATES_DIR + cls.TEMPLATE, attachment=attachment)
 
 
@@ -76,7 +78,8 @@ class TextPreviewer(Previewer):
 
 
 def get_file_previewer(attachment_file):
-    """Returns a file previewer for the given attachment file based on the
+    """
+    Return a file previewer for the given attachment file based on the
     file's content type.
     """
     for previewer in get_file_previewers():

--- a/indico/modules/attachments/util.py
+++ b/indico/modules/attachments/util.py
@@ -13,8 +13,7 @@ from indico.core.db import db
 
 
 def get_attached_folders(linked_object, include_empty=True, include_hidden=True, preload_event=False):
-    """
-    Return a list of all the folders linked to an object.
+    """Return a list of all the folders linked to an object.
 
     :param linked_object: The object whose attachments are to be returned
     :param include_empty: Whether to return empty folders as well.
@@ -64,7 +63,7 @@ def get_attached_items(linked_object, include_empty=True, include_hidden=True, p
 
 def get_nested_attached_items(obj):
     """
-    Returns a structured representation of all attachments linked to an object
+    Return a structured representation of all attachments linked to an object
     and all its nested objects.
 
     :param obj: A :class:`Event`, :class:`Session`, :class:`Contribution`
@@ -88,7 +87,7 @@ def get_nested_attached_items(obj):
 
 
 def can_manage_attachments(obj, user):
-    """Checks if a user can manage attachments for the object"""
+    """Check if a user can manage attachments for the object."""
     if not user:
         return False
     if obj.can_manage(user):

--- a/indico/modules/auth/__init__.py
+++ b/indico/modules/auth/__init__.py
@@ -75,7 +75,7 @@ def process_identity(identity_info):
 
 
 def login_user(user, identity=None, admin_impersonation=False):
-    """Set the session user and performs on-login logic
+    """Set the session user and performs on-login logic.
 
     When specifying `identity`, the provider/identitifer information
     is saved in the session so the identity management page can prevent

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -49,7 +49,7 @@ def _get_provider(name, external):
 
 
 class RHLogin(RH):
-    """The login page"""
+    """The login page."""
 
     # Disable global CSRF check. The form might not be an IndicoForm
     # but a normal WTForm from Flask-WTF which does not use the same
@@ -100,7 +100,7 @@ class RHLogin(RH):
 
 
 class RHLoginForm(RH):
-    """Retrieves a login form (json)"""
+    """Retrieve a login form (json)."""
 
     def _process(self):
         provider = _get_provider(request.view_args['provider'], False)
@@ -110,7 +110,7 @@ class RHLoginForm(RH):
 
 
 class RHLogout(RH):
-    """Logs the user out"""
+    """Log the user out."""
 
     def _process(self):
         return multipass.logout(request.args.get('next') or url_for_index(), clear_session=True)
@@ -129,7 +129,7 @@ def _send_confirmation(email, salt, endpoint, template, template_args=None, url_
 
 
 class RHLinkAccount(RH):
-    """Links a new identity with an existing user.
+    """Link a new identity with an existing user.
 
     This RH is only used if the identity information contains an
     email address and an existing user was found.
@@ -196,7 +196,7 @@ class RHLinkAccount(RH):
 
 
 class RHRegister(RH):
-    """Creates a new indico user.
+    """Create a new indico user.
 
     This handles two cases:
     - creation of a new user with a locally stored username and password
@@ -220,7 +220,7 @@ class RHRegister(RH):
             raise Forbidden('Local registration is disabled')
 
     def _get_verified_email(self):
-        """Checks if there is an email verification token."""
+        """Check if there is an email verification token."""
         try:
             token = request.args['token']
         except KeyError:
@@ -317,7 +317,7 @@ class RHRegister(RH):
 
 
 class RHAccounts(RHUserBase):
-    """Displays user accounts"""
+    """Display user accounts."""
 
     def _create_form(self):
         if self.user.local_identity:
@@ -352,7 +352,7 @@ class RHAccounts(RHUserBase):
 
 
 class RHRemoveAccount(RHUserBase):
-    """Removes an identity linked to a user"""
+    """Remove an identity linked to a user."""
 
     def _process_args(self):
         RHUserBase._process_args(self)
@@ -547,7 +547,7 @@ class LocalRegistrationHandler(RegistrationHandler):
 
 
 class RHResetPassword(RH):
-    """Resets the password for a local identity."""
+    """Reset the password for a local identity."""
 
     def _process_args(self):
         if not config.LOCAL_IDENTITIES:

--- a/indico/modules/auth/models/identities.py
+++ b/indico/modules/auth/models/identities.py
@@ -20,7 +20,7 @@ from indico.util.string import return_ascii
 
 
 class Identity(db.Model):
-    """Identities of Indico users"""
+    """Identities of Indico users."""
     __tablename__ = 'identities'
     __table_args__ = (db.UniqueConstraint('provider', 'identifier'),
                       {'schema': 'users'})
@@ -93,11 +93,11 @@ class Identity(db.Model):
 
     @property
     def safe_last_login_dt(self):
-        """last_login_dt that is safe for sorting (no None values)"""
+        """last_login_dt that is safe for sorting (no None values)."""
         return self.last_login_dt or as_utc(datetime(1970, 1, 1))
 
     def register_login(self, ip):
-        """Updates the last login information"""
+        """Update the last login information."""
         self.last_login_dt = now_utc()
         self.last_login_ip = ip
 

--- a/indico/modules/auth/util.py
+++ b/indico/modules/auth/util.py
@@ -19,7 +19,7 @@ from indico.web.flask.util import url_for
 
 
 def save_identity_info(identity_info, user):
-    """Saves information from IdentityInfo in the session"""
+    """Save information from IdentityInfo in the session."""
     trusted_email = identity_info.provider.settings.get('trusted_email', False)
     session['login_identity_info'] = {
         'provider': identity_info.provider.name,
@@ -34,7 +34,7 @@ def save_identity_info(identity_info, user):
 
 
 def load_identity_info():
-    """Retrieves identity information from the session"""
+    """Retrieve identity information from the session."""
     try:
         info = session['login_identity_info'].copy()
     except KeyError:
@@ -48,7 +48,7 @@ def load_identity_info():
 
 def register_user(email, extra_emails, user_data, identity_data, settings, from_moderation=False):
     """
-    Create a user based on the registration data provided during te
+    Create a user based on the registration data provided during the
     user registration process (via `RHRegister` and `RegistrationHandler`).
 
     This method is not meant to be used for generic user creation, the
@@ -62,7 +62,7 @@ def register_user(email, extra_emails, user_data, identity_data, settings, from_
 
 
 def impersonate_user(user):
-    """Impersonate another user as an admin"""
+    """Impersonate another user as an admin."""
     from indico.modules.auth import login_user, logger
 
     current_user = session.user
@@ -79,7 +79,7 @@ def impersonate_user(user):
 
 
 def undo_impersonate_user():
-    """Undo an admin impersonation login and revert to the old user"""
+    """Undo an admin impersonation login and revert to the old user."""
     from indico.modules.auth import logger
     from indico.modules.users import User
 
@@ -95,7 +95,7 @@ def undo_impersonate_user():
 
 
 def redirect_to_login(next_url=None, reason=None):
-    """Redirects to the login page.
+    """Redirect to the login page.
 
     :param next_url: URL to be redirected upon successful login. If not
                      specified, it will be set to ``request.relative_url``.

--- a/indico/modules/categories/controllers/base.py
+++ b/indico/modules/categories/controllers/base.py
@@ -39,7 +39,7 @@ class RHCategoryBase(RH):
 
 
 class RHDisplayCategoryBase(RHCategoryBase):
-    """Base class for category display pages"""
+    """Base class for category display pages."""
 
     def _check_access(self):
         if not self.category.can_access(session.user):

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -206,7 +206,7 @@ class RHSubcatInfo(RHDisplayCategoryBase):
 
 
 class RHDisplayCategoryEventsBase(RHDisplayCategoryBase):
-    """Base class for display pages displaying an event list"""
+    """Base class for display pages displaying an event list."""
 
     _category_query_options = (joinedload('children').load_only('id', 'title', 'protection_mode'),
                                undefer('attachment_count'), undefer('has_events'))
@@ -257,7 +257,7 @@ class RHDisplayCategoryEventsBase(RHDisplayCategoryBase):
 
 
 class RHDisplayCategory(RHDisplayCategoryEventsBase):
-    """Show the contents of a category (events/subcategories)"""
+    """Show the contents of a category (events/subcategories)."""
 
     def _process(self):
         # Current events, which are always shown by default are events of this month and of the previous month.
@@ -334,7 +334,7 @@ class RHDisplayCategory(RHDisplayCategoryEventsBase):
 
 
 class RHEventList(RHDisplayCategoryEventsBase):
-    """Return the HTML for the event list before/after a specific month"""
+    """Return the HTML for the event list before/after a specific month."""
 
     def _parse_year_month(self, string):
         try:
@@ -369,7 +369,9 @@ class RHEventList(RHDisplayCategoryEventsBase):
 
 
 class RHShowEventsInCategoryBase(RHDisplayCategoryBase):
-    """Set whether the events in a category are automatically displayed or not"""
+    """
+    Set whether the events in a category are automatically displayed or not.
+    """
 
     session_field = ''
 
@@ -389,13 +391,17 @@ class RHShowEventsInCategoryBase(RHDisplayCategoryBase):
 
 
 class RHShowFutureEventsInCategory(RHShowEventsInCategoryBase):
-    """Set whether the past events in a category are automatically displayed or not"""
+    """
+    Set whether the past events in a category are automatically displayed or not.
+    """
 
     session_field = 'fetch_future_events_in'
 
 
 class RHShowPastEventsInCategory(RHShowEventsInCategoryBase):
-    """Set whether the past events in a category are automatically displayed or not"""
+    """
+    Set whether the past events in a category are automatically displayed or not.
+    """
 
     session_field = 'fetch_past_events_in'
 
@@ -432,7 +438,7 @@ class RHXMLExportCategoryInfo(RH):
 
 
 class RHCategoryOverview(RHDisplayCategoryBase):
-    """Display the events for a particular day, week or month"""
+    """Display the events for a particular day, week or month."""
 
     def _get_timetable(self):
         return get_category_timetable([self.category.id], self.start_dt, self.end_dt,

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -293,7 +293,7 @@ class RHMoveCategory(RHMoveCategoryBase):
 
 
 class RHDeleteSubcategories(RHManageCategoryBase):
-    """Bulk-delete subcategories"""
+    """Bulk-delete subcategories."""
 
     def _process_args(self):
         RHManageCategoryBase._process_args(self)
@@ -346,7 +346,7 @@ class RHSortSubcategories(RHManageCategoryBase):
 
 
 class RHManageCategorySelectedEventsBase(RHManageCategoryBase):
-    """Base RH to manage selected events in a category"""
+    """Base RH to manage selected events in a category."""
 
     def _process_args(self):
         RHManageCategoryBase._process_args(self)
@@ -359,7 +359,7 @@ class RHManageCategorySelectedEventsBase(RHManageCategoryBase):
 
 
 class RHDeleteEvents(RHManageCategorySelectedEventsBase):
-    """Delete multiple events"""
+    """Delete multiple events."""
 
     def _process(self):
         is_submitted = 'confirmed' in request.form
@@ -425,7 +425,7 @@ class RHMoveEvents(RHManageCategorySelectedEventsBase):
 
 
 class RHCategoryRoles(RHManageCategoryBase):
-    """Category role management"""
+    """Category role management."""
 
     def _process(self):
         return WPCategoryManagement.render_template('management/roles.html', self.category, 'roles',
@@ -433,7 +433,7 @@ class RHCategoryRoles(RHManageCategoryBase):
 
 
 class RHAddCategoryRole(RHManageCategoryBase):
-    """Add a new category role"""
+    """Add a new category role."""
 
     def _process(self):
         form = CategoryRoleForm(category=self.category, color=self._get_color())
@@ -452,7 +452,7 @@ class RHAddCategoryRole(RHManageCategoryBase):
 
 
 class RHManageCategoryRole(RHManageCategoryBase):
-    """Base class to manage a specific category role"""
+    """Base class to manage a specific category role."""
 
     normalize_url_spec = {
         'locators': {
@@ -466,7 +466,7 @@ class RHManageCategoryRole(RHManageCategoryBase):
 
 
 class RHEditCategoryRole(RHManageCategoryRole):
-    """Edit a category role"""
+    """Edit a category role."""
 
     def _process(self):
         form = CategoryRoleForm(obj=self.role, category=self.category)
@@ -479,7 +479,7 @@ class RHEditCategoryRole(RHManageCategoryRole):
 
 
 class RHDeleteCategoryRole(RHManageCategoryRole):
-    """Delete a category role"""
+    """Delete a category role."""
 
     def _process(self):
         db.session.delete(self.role)
@@ -488,7 +488,7 @@ class RHDeleteCategoryRole(RHManageCategoryRole):
 
 
 class RHRemoveCategoryRoleMember(RHManageCategoryRole):
-    """Remove a user from a category role"""
+    """Remove a user from a category role."""
 
     normalize_url_spec = dict(RHManageCategoryRole.normalize_url_spec, preserved_args={'user_id'})
 
@@ -504,7 +504,7 @@ class RHRemoveCategoryRoleMember(RHManageCategoryRole):
 
 
 class RHAddCategoryRoleMembers(RHManageCategoryRole):
-    """Add users to a category role"""
+    """Add users to a category role."""
 
     def _process(self):
         for data in request.json['users']:
@@ -516,6 +516,6 @@ class RHAddCategoryRoleMembers(RHManageCategoryRole):
 
 
 class RHCategoryRoleMembersImportCSV(ImportRoleMembersMixin, RHManageCategoryRole):
-    """Add users to a category role from CSV"""
+    """Add users to a category role from CSV."""
 
     logger = logger

--- a/indico/modules/categories/forms.py
+++ b/indico/modules/categories/forms.py
@@ -122,7 +122,7 @@ class CategoryProtectionForm(IndicoForm):
 
 
 class CreateCategoryForm(IndicoForm):
-    """Form to create a new Category"""
+    """Form to create a new Category."""
 
     title = StringField(_("Title"), [DataRequired()])
     description = IndicoMarkdownField(_("Description"))

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -57,7 +57,7 @@ class EventMessageMode(RichIntEnum):
 
 
 class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, AttachedItemsMixin, db.Model):
-    """An Indico category"""
+    """An Indico category."""
 
     __tablename__ = 'categories'
     disallowed_protection_modes = frozenset()
@@ -248,7 +248,7 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
 
     @classmethod
     def get_root(cls):
-        """Get the root category"""
+        """Get the root category."""
         return cls.query.filter(cls.is_root).one()
 
     @property
@@ -289,7 +289,7 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
 
     @property
     def display_tzinfo(self):
-        """The tzinfo of the category or the one specified by the user"""
+        """The tzinfo of the category or the one specified by the user."""
         return get_display_tz(self, as_timezone=True)
 
     def can_create_events(self, user):
@@ -459,7 +459,10 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
 
     @property
     def own_visibility_horizon(self):
-        """Get the highest category this one would like to be visible from (configured visibility)."""
+        """
+        Get the highest category this one would like to be visible
+        from (configured visibility).
+        """
         if self.visibility is None:
             return Category.get_root()
         else:
@@ -467,7 +470,10 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
 
     @property
     def real_visibility_horizon(self):
-        """Get the highest category this one is actually visible from (as limited by categories above)."""
+        """
+        Get the highest category this one is actually visible
+        from (as limited by categories above).
+        """
         horizon_id, final_visibility = self.visibility_horizon_query.one()
         if final_visibility is not None and final_visibility < 0:
             return None  # Category is invisible

--- a/indico/modules/categories/models/legacy_mapping.py
+++ b/indico/modules/categories/models/legacy_mapping.py
@@ -12,7 +12,7 @@ from indico.util.string import return_ascii
 
 
 class LegacyCategoryMapping(db.Model):
-    """Legacy category ID mapping
+    """Legacy category ID mapping.
 
     Legacy categories have non-numeric IDs which are not supported by
     any new code. This mapping maps them to proper integer IDs to

--- a/indico/modules/categories/serialize.py
+++ b/indico/modules/categories/serialize.py
@@ -26,7 +26,7 @@ from indico.util.string import sanitize_html
 
 
 def serialize_categories_ical(category_ids, user, event_filter=True, event_filter_fn=None, update_query=None):
-    """Export the events in a category to iCal
+    """Export the events in a category to iCal.
 
     :param category_ids: Category IDs to export
     :param user: The user who needs to be able to access the events
@@ -103,7 +103,7 @@ def serialize_categories_ical(category_ids, user, event_filter=True, event_filte
 
 
 def serialize_category_atom(category, url, user, event_filter):
-    """Export the events in a category to Atom
+    """Export the events in a category to Atom.
 
     :param category: The category to export
     :param url: The URL of the feed

--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -132,7 +132,7 @@ def get_category_stats(category_id=None):
 @memoize_redis(3600)
 @materialize_iterable()
 def get_upcoming_events():
-    """Get the global list of upcoming events"""
+    """Get the global list of upcoming events."""
     from indico.modules.events import Event
     data = upcoming_events_settings.get_all()
     if not data['max_entries'] or not data['entries']:
@@ -210,7 +210,7 @@ def get_image_data(image_type, category):
 
 
 def serialize_category_role(role, legacy=True):
-    """Serialize role to JSON-like object"""
+    """Serialize role to JSON-like object."""
     if legacy:
         return {
             'id': role.id,

--- a/indico/modules/categories/views.py
+++ b/indico/modules/categories/views.py
@@ -21,7 +21,7 @@ class WPManageUpcomingEvents(WPAdmin):
 
 
 class WPCategory(MathjaxMixin, WPJinjaMixin, WPDecorated):
-    """WP for category display pages"""
+    """WP for category display pages."""
 
     template_prefix = 'categories/'
     ALLOW_JSON = False
@@ -61,13 +61,13 @@ class WPCategory(MathjaxMixin, WPJinjaMixin, WPDecorated):
 
 
 class WPCategoryCalendar(WPCategory):
-    """WP for category calendar page"""
+    """WP for category calendar page."""
 
     bundles = ('module_categories.calendar.js', 'module_categories.calendar.css')
 
 
 class WPCategoryManagement(WPCategory):
-    """WP for category management pages"""
+    """WP for category management pages."""
 
     MANAGEMENT = True
     bundles = ('module_categories.management.js',)

--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -105,7 +105,7 @@ class RHReportErrorAPI(RH):
 
 
 class RHSettings(RHAdminBase):
-    """General settings"""
+    """General settings."""
 
     def _get_cephalopod_data(self):
         if not cephalopod_settings.get('joined'):
@@ -140,7 +140,7 @@ class RHSettings(RHAdminBase):
 
 
 class RHChangeTimezone(RH):
-    """Update the session/user timezone"""
+    """Update the session/user timezone."""
 
     def _process(self):
         mode = request.form['tz_mode']
@@ -163,7 +163,7 @@ class RHChangeTimezone(RH):
 
 
 class RHChangeLanguage(RH):
-    """Update the session/user language"""
+    """Update the session/user language."""
 
     def _process(self):
         language = request.form['lang']
@@ -176,7 +176,7 @@ class RHChangeLanguage(RH):
 
 
 class RHVersionCheck(RHAdminBase):
-    """Check the installed indico version against pypi"""
+    """Check the installed indico version against pypi."""
 
     def _check_version(self, distribution, current_version=None):
         try:

--- a/indico/modules/designer/controllers.py
+++ b/indico/modules/designer/controllers.py
@@ -89,8 +89,7 @@ def _render_template_list(target, event=None):
 
 
 class TemplateDesignerMixin:
-    """
-    Basic class for all template designer mixins.
+    """Basic class for all template designer mixins.
 
     It resolves the target object type from the blueprint URL.
     """
@@ -109,8 +108,7 @@ class TemplateDesignerMixin:
 
 
 class SpecificTemplateMixin(TemplateDesignerMixin):
-    """
-    Mixin that accepts a target template passed in the URL.
+    """Mixin that accepts a target template passed in the URL.
 
     The target category/event will be the owner of that template.
     """

--- a/indico/modules/designer/pdf.py
+++ b/indico/modules/designer/pdf.py
@@ -74,7 +74,7 @@ class DesignerPDFBase(object):
                        **tpl_data)
 
     def _remove_transparency(self, fd):
-        """Remove transparency from an image and replace it with white"""
+        """Remove transparency from an image and replace it with white."""
         img = Image.open(fd)
         # alpha-channel PNG: replace the transparent areas with plain white
         if img.mode == 'RGBA':

--- a/indico/modules/designer/util.py
+++ b/indico/modules/designer/util.py
@@ -37,19 +37,18 @@ def get_image_placeholder_types():
 
 
 def get_all_templates(obj):
-    """Get all templates usable by an event/category"""
+    """Get all templates usable by an event/category."""
     category = obj.category if isinstance(obj, Event) else obj
     return set(DesignerTemplate.find_all(DesignerTemplate.category_id.in_(categ['id'] for categ in category.chain)))
 
 
 def get_inherited_templates(obj):
-    """Get all templates inherited by a given event/category"""
+    """Get all templates inherited by a given event/category."""
     return get_all_templates(obj) - set(obj.designer_templates)
 
 
 def get_not_deletable_templates(obj):
-    """Get all non-deletable templates for an event/category"""
-
+    """Get all non-deletable templates for an event/category."""
     not_deletable_criteria = [
         DesignerTemplate.is_system_template,
         DesignerTemplate.backside_template_of != None,  # noqa

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -134,7 +134,7 @@ def _log_acl_changes(sender, obj, principal, entry, is_new, old_data, quiet, **k
 @signals.app_created.connect
 def _handle_legacy_ids(app, **kwargs):
     """
-    Handles the redirect from broken legacy event ids such as a12345
+    Handle the redirect from broken legacy event ids such as a12345
     or 0123 which cannot be converted to an integer without an error
     or losing relevant information (0123 and 123 may be different
     events).

--- a/indico/modules/events/abstracts/controllers/abstract.py
+++ b/indico/modules/events/abstracts/controllers/abstract.py
@@ -81,7 +81,7 @@ class RHAbstractsDownloadAttachment(RHAbstractBase):
 
 
 class RHAbstractNotificationLog(RHAbstractBase):
-    """Show the notifications sent for an abstract"""
+    """Show the notifications sent for an abstract."""
 
     def _check_abstract_protection(self):
         return self.abstract.can_judge(session.user)
@@ -100,7 +100,7 @@ class RHAbstractExportPDF(RHAbstractBase):
 
 
 class RHAbstractExportFullPDF(RHAbstractBase):
-    """Export an abstract as PDF (with review details)"""
+    """Export an abstract as PDF (with review details)."""
 
     def _check_abstract_protection(self):
         return self.abstract.can_see_reviews(session.user)

--- a/indico/modules/events/abstracts/controllers/abstract_list.py
+++ b/indico/modules/events/abstracts/controllers/abstract_list.py
@@ -34,7 +34,7 @@ from indico.web.util import jsonify_data, jsonify_form, jsonify_template
 
 
 class RHAbstractListBase(RHManageAbstractsBase):
-    """Base class for all RHs using the abstract list generator"""
+    """Base class for all RHs using the abstract list generator."""
 
     def _process_args(self):
         RHManageAbstractsBase._process_args(self)
@@ -42,7 +42,7 @@ class RHAbstractListBase(RHManageAbstractsBase):
 
 
 class RHManageAbstractsActionsBase(RHAbstractListBase):
-    """Base class for RHs performing actions on selected abstracts"""
+    """Base class for RHs performing actions on selected abstracts."""
 
     _abstract_query_options = ()
 
@@ -60,7 +60,7 @@ class RHManageAbstractsActionsBase(RHAbstractListBase):
 
 
 class RHBulkAbstractJudgment(RHManageAbstractsActionsBase):
-    """Perform bulk judgment operations on selected abstracts"""
+    """Perform bulk judgment operations on selected abstracts."""
 
     def _process(self):
         form = BulkAbstractJudgmentForm(event=self.event, abstract_id=[a.id for a in self.abstracts],
@@ -100,7 +100,7 @@ class RHAbstractListCustomize(CustomizeAbstractListMixin, RHAbstractListBase):
 
 
 class RHAbstractListStaticURL(RHAbstractListBase):
-    """Generate a static URL for the configuration of the abstract list"""
+    """Generate a static URL for the configuration of the abstract list."""
 
     ALLOW_LOCKED = True
 
@@ -169,7 +169,7 @@ class RHDeleteAbstracts(RHManageAbstractsActionsBase):
 
 
 class RHAbstractPersonList(RHManageAbstractsActionsBase):
-    """List of persons somehow related to abstracts (co-authors, speakers...)"""
+    """List of persons somehow related to abstracts (co-authors, speakers...)."""
 
     ALLOW_LOCKED = True
 

--- a/indico/modules/events/abstracts/controllers/base.py
+++ b/indico/modules/events/abstracts/controllers/base.py
@@ -20,7 +20,7 @@ from indico.util.decorators import classproperty
 
 
 class SpecificAbstractMixin:
-    """Mixin for RHs that deal with a specific abstract"""
+    """Mixin for RHs that deal with a specific abstract."""
 
     # whether the RH should use Abstract's UUID when querying
     USE_ABSTRACT_UUID = False
@@ -64,7 +64,7 @@ class SpecificAbstractMixin:
 
 
 class RHAbstractsBase(RHDisplayEventBase):
-    """Base class for all abstract-related RHs"""
+    """Base class for all abstract-related RHs."""
 
     EVENT_FEATURE = 'abstracts'
 
@@ -77,21 +77,21 @@ class RHAbstractsBase(RHDisplayEventBase):
 
     @property
     def management(self):
-        """Whether the RH is currently used in the management area"""
+        """Whether the RH is currently used in the management area."""
         return request.view_args.get('management', False)
 
 
 class RHManageAbstractsBase(ManageEventMixin, RHAbstractsBase):
     """
     Base class for all abstract-related RHs that require full event
-    management permissions
+    management permissions.
     """
 
     DENY_FRAMES = True
 
     @property
     def management(self):
-        """Whether the RH is currently used in the management area"""
+        """Whether the RH is currently used in the management area."""
         return request.view_args.get('management', True)
 
 

--- a/indico/modules/events/abstracts/controllers/boa.py
+++ b/indico/modules/events/abstracts/controllers/boa.py
@@ -29,7 +29,7 @@ from indico.web.util import jsonify_data, jsonify_form
 
 
 class RHBOASettings(RHManageAbstractsBase):
-    """Configure book of abstracts"""
+    """Configure book of abstracts."""
 
     def _process(self):
         form = BOASettingsForm(obj=FormDefaults(**boa_settings.get_all(self.event)))
@@ -80,7 +80,7 @@ class RHCustomBOA(RHManageAbstractsBase):
 
 
 class RHExportBOA(RHAbstractsBase):
-    """Export the book of abstracts"""
+    """Export the book of abstracts."""
 
     def _check_access(self):
         RHAbstractsBase._check_access(self)
@@ -99,7 +99,7 @@ class RHExportBOA(RHAbstractsBase):
 
 
 class RHExportBOATeX(RHManageAbstractsBase):
-    """Export a zip file with the book of abstracts in TeX format"""
+    """Export a zip file with the book of abstracts in TeX format."""
 
     def _process(self):
         return send_file('book-of-abstracts.zip', create_boa_tex(self.event), 'application/zip', inline=False)

--- a/indico/modules/events/abstracts/controllers/common.py
+++ b/indico/modules/events/abstracts/controllers/common.py
@@ -25,7 +25,7 @@ from indico.web.util import jsonify_data, jsonify_template
 
 
 class DisplayAbstractListMixin:
-    """Display the list of abstracts"""
+    """Display the list of abstracts."""
 
     view_class = None
     template = None
@@ -46,7 +46,7 @@ class DisplayAbstractListMixin:
 
 
 class CustomizeAbstractListMixin:
-    """Filter options and columns to display for the abstract list of an event"""
+    """Filter options and columns to display for the abstract list of an event."""
 
     view_class = None
 
@@ -65,7 +65,7 @@ class CustomizeAbstractListMixin:
 
 
 class AbstractsExportPDFMixin:
-    """Export list of abstracts as PDF"""
+    """Export list of abstracts as PDF."""
 
     def _process(self):
         if not config.LATEX_ENABLED:
@@ -77,7 +77,7 @@ class AbstractsExportPDFMixin:
 
 
 class _AbstractsExportBaseMixin:
-    """Base mixin for all abstract list spreadsheet export mixins"""
+    """Base mixin for all abstract list spreadsheet export mixins."""
 
     def _generate_spreadsheet(self):
         export_config = self.list_generator.get_list_export_config()
@@ -86,21 +86,21 @@ class _AbstractsExportBaseMixin:
 
 
 class AbstractsExportCSV(_AbstractsExportBaseMixin):
-    """Export list of abstracts to CSV"""
+    """Export list of abstracts to CSV."""
 
     def _process(self):
         return send_csv('abstracts.csv', *self._generate_spreadsheet())
 
 
 class AbstractsExportExcel(_AbstractsExportBaseMixin):
-    """Export list of abstracts to XLSX"""
+    """Export list of abstracts to XLSX."""
 
     def _process(self):
         return send_xlsx('abstracts.xlsx', *self._generate_spreadsheet(), tz=self.event.tzinfo)
 
 
 class AbstractsDownloadAttachmentsMixin(ZipGeneratorMixin):
-    """Generate a ZIP file with attachment files for a given list of abstracts"""
+    """Generate a ZIP file with attachment files for a given list of abstracts."""
 
     def _prepare_folder_structure(self, item):
         abstract_title = secure_filename('{}_{}'.format(unicode(item.abstract.friendly_id), item.abstract.title),

--- a/indico/modules/events/abstracts/controllers/display.py
+++ b/indico/modules/events/abstracts/controllers/display.py
@@ -26,7 +26,7 @@ from indico.web.util import jsonify_data, jsonify_form, jsonify_template
 
 
 class RHCallForAbstracts(RHAbstractsBase):
-    """Show the main CFA page"""
+    """Show the main CFA page."""
 
     def _process(self):
         abstracts = get_user_abstracts(self.event, session.user) if session.user else []
@@ -35,7 +35,7 @@ class RHCallForAbstracts(RHAbstractsBase):
 
 
 class RHMyAbstractsExportPDF(RHAbstractsBase):
-    """Export the list of the user's abstracts as PDF"""
+    """Export the list of the user's abstracts as PDF."""
 
     def _check_access(self):
         if not session.user:

--- a/indico/modules/events/abstracts/controllers/management.py
+++ b/indico/modules/events/abstracts/controllers/management.py
@@ -42,7 +42,7 @@ from indico.web.util import jsonify_data, jsonify_form, jsonify_template
 
 
 class RHAbstractsDashboard(RHManageAbstractsBase):
-    """Dashboard of the abstracts module"""
+    """Dashboard of the abstracts module."""
 
     # Allow access even if the feature is disabled
     EVENT_FEATURE = None
@@ -61,7 +61,7 @@ class RHAbstractsDashboard(RHManageAbstractsBase):
 
 
 class RHScheduleCFA(RHManageAbstractsBase):
-    """Schedule the call for abstracts"""
+    """Schedule the call for abstracts."""
 
     def _process(self):
         form = AbstractsScheduleForm(obj=FormDefaults(**abstracts_settings.get_all(self.event)),
@@ -78,7 +78,7 @@ class RHScheduleCFA(RHManageAbstractsBase):
 
 
 class RHOpenCFA(RHManageAbstractsBase):
-    """Open the call for abstracts"""
+    """Open the call for abstracts."""
 
     def _process(self):
         open_cfa(self.event)
@@ -87,7 +87,7 @@ class RHOpenCFA(RHManageAbstractsBase):
 
 
 class RHCloseCFA(RHManageAbstractsBase):
-    """Close the call for abstracts"""
+    """Close the call for abstracts."""
 
     def _process(self):
         close_cfa(self.event)
@@ -96,7 +96,7 @@ class RHCloseCFA(RHManageAbstractsBase):
 
 
 class RHManageAbstractSubmission(RHManageAbstractsBase):
-    """Configure abstract submission"""
+    """Configure abstract submission."""
 
     def _process(self):
         settings = abstracts_settings.get_all(self.event)
@@ -113,7 +113,7 @@ class RHManageAbstractSubmission(RHManageAbstractsBase):
 
 
 class RHManageAbstractReviewing(RHManageAbstractsBase):
-    """Configure abstract reviewing"""
+    """Configure abstract reviewing."""
 
     def _process(self):
         has_ratings = (AbstractReviewRating.query

--- a/indico/modules/events/abstracts/controllers/reviewing.py
+++ b/indico/modules/events/abstracts/controllers/reviewing.py
@@ -34,7 +34,9 @@ from indico.web.util import _pop_injected_js, jsonify_data, jsonify_template
 
 
 class RHListOtherAbstracts(RHAbstractsBase):
-    """AJAX endpoint that lists all abstracts in the event (dict representation)."""
+    """
+    AJAX endpoint that lists all abstracts in the event (dict representation).
+    """
 
     ALLOW_LOCKED = True
 
@@ -109,7 +111,7 @@ class RHWithdrawAbstract(RHAbstractBase):
 
 
 class RHDisplayAbstractListBase(RHAbstractsBase):
-    """Base class for all abstract list operations"""
+    """Base class for all abstract list operations."""
 
     normalize_url_spec = {
         'locators': {
@@ -128,7 +130,7 @@ class RHDisplayAbstractListBase(RHAbstractsBase):
 
 
 class RHSubmitAbstractReview(RHAbstractBase):
-    """Review an abstract in a specific track"""
+    """Review an abstract in a specific track."""
 
     normalize_url_spec = {
         'locators': {
@@ -252,7 +254,7 @@ class RHDisplayAbstractListCustomize(CustomizeAbstractListMixin, RHDisplayAbstra
 
 
 class RHDisplayAbstractsActionsBase(RHDisplayAbstractListBase):
-    """Base class for classes performing actions on abstract"""
+    """Base class for classes performing actions on abstract."""
 
     def _process_args(self):
         RHDisplayAbstractListBase._process_args(self)

--- a/indico/modules/events/abstracts/fields.py
+++ b/indico/modules/events/abstracts/fields.py
@@ -94,7 +94,7 @@ class EmailRuleListField(JSONField):
 
 
 class AbstractPersonLinkListField(PersonLinkListFieldBase):
-    """A field to configure a list of abstract persons"""
+    """A field to configure a list of abstract persons."""
 
     person_link_cls = AbstractPersonLink
     linked_object_attr = 'abstract'

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -44,7 +44,7 @@ from indico.web.forms.widgets import JinjaWidget, SwitchWidget
 
 
 def make_review_form(event):
-    """Extends the abstract WTForm to add the extra fields.
+    """Extend the abstract WTForm to add the extra fields.
 
     Each extra field will use a field named ``custom_ID``.
 
@@ -79,7 +79,7 @@ def build_review_form(abstract=None, track=None, review=None):
 
 
 class AbstractContentSettingsForm(IndicoForm):
-    """Configure the content field of abstracts"""
+    """Configure the content field of abstracts."""
 
     is_active = BooleanField(_('Active'), widget=SwitchWidget(),
                              description=_("Whether the content field is available."))
@@ -90,7 +90,7 @@ class AbstractContentSettingsForm(IndicoForm):
 
 
 class BOASettingsForm(IndicoForm):
-    """Settings form for the 'Book of Abstracts'"""
+    """Settings form for the 'Book of Abstracts'."""
 
     extra_text = IndicoMarkdownField(_('Additional text'), editor=True, mathjax=True)
     extra_text_end = IndicoMarkdownField(_('Additional text at end'), editor=True, mathjax=True)
@@ -105,7 +105,7 @@ class BOASettingsForm(IndicoForm):
 
 
 class AbstractSubmissionSettingsForm(IndicoForm):
-    """Settings form for abstract submission"""
+    """Settings form for abstract submission."""
 
     announcement = IndicoMarkdownField(_('Announcement'), editor=True)
     allow_multiple_tracks = BooleanField(_('Multiple tracks'), widget=SwitchWidget(),
@@ -149,7 +149,7 @@ class AbstractSubmissionSettingsForm(IndicoForm):
 
 
 class AbstractReviewingSettingsForm(IndicoForm):
-    """Settings form for abstract reviewing"""
+    """Settings form for abstract reviewing."""
 
     RATING_FIELDS = ('scale_lower', 'scale_upper')
 
@@ -201,7 +201,7 @@ class AbstractReviewingSettingsForm(IndicoForm):
 
 
 class AbstractJudgmentFormBase(IndicoForm):
-    """Form base class for abstract judgment operations"""
+    """Form base class for abstract judgment operations."""
 
     _order = ('judgment', 'accepted_track', 'accepted_contrib_type', 'session', 'duplicate_of', 'merged_into',
               'merge_persons', 'judgment_comment', 'send_notifications')
@@ -260,7 +260,7 @@ class AbstractJudgmentFormBase(IndicoForm):
 
 
 class AbstractJudgmentForm(AbstractJudgmentFormBase):
-    """Form for judging an abstract"""
+    """Form for judging an abstract."""
 
     judgment = IndicoEnumSelectField(_("Judgment"), [DataRequired()], enum=AbstractAction,
                                      skip={AbstractAction.change_tracks})
@@ -282,7 +282,7 @@ class AbstractJudgmentForm(AbstractJudgmentFormBase):
 
 
 class AbstractReviewForm(IndicoForm):
-    """Form for reviewing an abstract"""
+    """Form for reviewing an abstract."""
 
     _order = ('proposed_action', 'proposed_contribution_type', 'proposed_related_abstract', 'proposed_tracks',
               'comment')
@@ -399,7 +399,7 @@ BulkAbstractJudgmentForm._add_contrib_type_hidden_unless()
 
 
 class AbstractReviewingRolesForm(IndicoForm):
-    """Settings form for abstract reviewing roles"""
+    """Settings form for abstract reviewing roles."""
 
     roles = TrackRoleField()
 

--- a/indico/modules/events/abstracts/lists.py
+++ b/indico/modules/events/abstracts/lists.py
@@ -72,11 +72,14 @@ class AbstractListGeneratorBase(ListGeneratorBase):
         return [{'id': id_, 'caption': self.static_items[id_]['title']} for id_ in self.static_items if id_ in ids]
 
     def get_all_contribution_fields(self):
-        """Return the list of contribution fields for the event"""
+        """Return the list of contribution fields for the event."""
         return self.event.contribution_fields if self.show_contribution_fields else []
 
     def _get_sorted_contribution_fields(self, item_ids):
-        """Return the contribution fields ordered by their position in the abstract form."""
+        """
+        Return the contribution fields ordered by their position in
+        the abstract form.
+        """
 
         if not item_ids or not self.show_contribution_fields:
             return []
@@ -209,7 +212,10 @@ class AbstractListGeneratorBase(ListGeneratorBase):
 
 
 class AbstractListGeneratorManagement(AbstractListGeneratorBase):
-    """Listing and filtering actions in the abstract list in the management view"""
+    """
+    Listing and filtering actions in the abstract list in the
+    management view.
+    """
 
     list_link_type = 'abstract_management'
     endpoint = '.manage_abstract_list'
@@ -226,7 +232,9 @@ class AbstractListGeneratorManagement(AbstractListGeneratorBase):
 
 
 class AbstractListGeneratorDisplay(AbstractListGeneratorBase):
-    """Listing and filtering actions in the abstract list in the display view"""
+    """
+    Listing and filtering actions in the abstract list in the display view.
+    """
 
     list_link_type = 'abstract_display'
     endpoint = '.display_reviewable_track_abstracts'

--- a/indico/modules/events/abstracts/models/abstracts.py
+++ b/indico/modules/events/abstracts/models/abstracts.py
@@ -84,7 +84,7 @@ class EditTrackMode(int, IndicoEnum):
 
 class Abstract(ProposalMixin, ProposalRevisionMixin, DescriptionMixin, CustomFieldsMixin, AuthorsSpeakersMixin,
                db.Model):
-    """Represents an abstract that can be associated to a Contribution."""
+    """An abstract that can be associated to a Contribution."""
 
     __tablename__ = 'abstracts'
     __auto_table_args = (db.Index(None, 'friendly_id', 'event_id', unique=True,

--- a/indico/modules/events/abstracts/models/call_for_abstracts.py
+++ b/indico/modules/events/abstracts/models/call_for_abstracts.py
@@ -15,7 +15,7 @@ from indico.util.string import return_ascii
 
 
 class CallForAbstracts(object):
-    """Proxy class to facilitate access to the call for abstracts settings"""
+    """Proxy class to facilitate access to the call for abstracts settings."""
 
     def __init__(self, event):
         self.event = event

--- a/indico/modules/events/abstracts/models/email_logs.py
+++ b/indico/modules/events/abstracts/models/email_logs.py
@@ -95,7 +95,7 @@ class AbstractEmailLogEntry(db.Model):
 
     @classmethod
     def create_from_email(cls, email_data, email_tpl, user=None):
-        """Create a new log entry from the data used to send an email
+        """Create a new log entry from the data used to send an email.
 
         :param email_data: email data as returned from `make_email`
         :param email_tpl: the abstract email template that created the

--- a/indico/modules/events/abstracts/models/email_templates.py
+++ b/indico/modules/events/abstracts/models/email_templates.py
@@ -22,7 +22,7 @@ def _get_next_position(context):
 
 
 class AbstractEmailTemplate(db.Model):
-    """Represents an email template for abstracts notifications."""
+    """An email template for abstracts notifications."""
 
     __tablename__ = 'email_templates'
     __table_args__ = {'schema': 'event_abstracts'}

--- a/indico/modules/events/abstracts/models/reviews.py
+++ b/indico/modules/events/abstracts/models/reviews.py
@@ -28,7 +28,7 @@ class AbstractAction(RichIntEnum):
 
 
 class AbstractReview(ProposalReviewMixin, RenderModeMixin, db.Model):
-    """Represents an abstract review, emitted by a reviewer"""
+    """An abstract review, emitted by a reviewer."""
 
     possible_render_modes = {RenderMode.markdown}
     default_render_mode = RenderMode.markdown
@@ -200,7 +200,7 @@ class AbstractReview(ProposalReviewMixin, RenderModeMixin, db.Model):
 
 
 class AbstractCommentVisibility(RichIntEnum):
-    """Most to least restrictive visibility for abstract comments"""
+    """Most to least restrictive visibility for abstract comments."""
     __titles__ = [None,
                   _("Visible only to judges"),
                   _("Visible to conveners and judges"),

--- a/indico/modules/events/abstracts/notifications.py
+++ b/indico/modules/events/abstracts/notifications.py
@@ -132,7 +132,7 @@ class ContributionTypeCondition(EmailNotificationCondition):
 
 
 def get_abstract_notification_tpl_module(email_tpl, abstract):
-    """Get the Jinja template module for a notification email
+    """Get the Jinja template module for a notification email.
 
     :param email_tpl: the abstract email template used to populate the
                       email subject/body

--- a/indico/modules/events/abstracts/operations.py
+++ b/indico/modules/events/abstracts/operations.py
@@ -239,8 +239,7 @@ def judge_abstract(abstract, abstract_data, judgment, judge, contrib_session=Non
 
 
 def _merge_person_links(target_abstract, source_abstract):
-    """
-    Merge `person_links` of different abstracts.
+    """Merge `person_links` of different abstracts.
 
     Add to `target_abstract` new `AbstractPersonLink`s whose `EventPerson`
     exists in the `source_abstract` but is not yet in the `target_abstract`.

--- a/indico/modules/events/abstracts/settings.py
+++ b/indico/modules/events/abstracts/settings.py
@@ -45,7 +45,7 @@ class SubmissionRightsType(RichEnum):
 
 
 class BOALinkFormat(RichEnum):
-    """LaTeX book of abstracts link format setting
+    """LaTeX book of abstracts link format setting.
 
     value is a 2-tuple of strings:
     first is the hyperref option to use

--- a/indico/modules/events/abstracts/util.py
+++ b/indico/modules/events/abstracts/util.py
@@ -34,7 +34,10 @@ from indico.web.flask.templating import get_template_module
 
 
 def build_default_email_template(event, tpl_type):
-    """Build a default e-mail template based on a notification type provided by the user."""
+    """
+    Build a default e-mail template based on a notification type
+    provided by the user.
+    """
     email = get_template_module('events/abstracts/emails/default_{}_notification.txt'.format(tpl_type))
     tpl = AbstractEmailTemplate(body=email.get_body(),
                                 extra_cc_emails=[],
@@ -47,7 +50,7 @@ def build_default_email_template(event, tpl_type):
 
 
 def generate_spreadsheet_from_abstracts(abstracts, static_item_ids, dynamic_items):
-    """Generates a spreadsheet data from a given abstract list.
+    """Generate a spreadsheet data from a given abstract list.
 
     :param abstracts: The list of abstracts to include in the file
     :param static_item_ids: The abstract properties to be used as columns
@@ -168,7 +171,7 @@ def create_mock_abstract(event):
 
 
 def make_abstract_form(event, user, notification_option=False, management=False, invited=False):
-    """Extends the abstract WTForm to add the extra fields.
+    """Extend the abstract WTForm to add the extra fields.
 
     Each extra field will use a field named ``custom_ID``.
 
@@ -208,7 +211,7 @@ def make_abstract_form(event, user, notification_option=False, management=False,
 
 
 def get_user_abstracts(event, user):
-    """Get the list of abstracts where the user is a reviewer/convener"""
+    """Get the list of abstracts where the user is a reviewer/convener."""
     return (Abstract.query.with_parent(event)
             .options(joinedload('reviews'),
                      joinedload('person_links'))
@@ -230,7 +233,7 @@ def get_visible_reviewed_for_tracks(abstract, user):
 
 
 def get_user_tracks(event, user):
-    """Get the list of tracks where the user is a reviewer/convener"""
+    """Get the list of tracks where the user is a reviewer/convener."""
     tracks = Track.query.with_parent(event).order_by(Track.title).all()
     if (event.can_manage(user, permission='review_all_abstracts', explicit_permission=True) or
             event.can_manage(user, permission='convene_all_abstracts', explicit_permission=True)):
@@ -277,7 +280,7 @@ def get_track_reviewer_abstract_counts(event, user):
 
 
 def create_boa(event):
-    """Create the book of abstracts if necessary
+    """Create the book of abstracts if necessary.
 
     :return: The path to the PDF file
     """
@@ -307,7 +310,7 @@ def create_boa_tex(event):
 
 
 def clear_boa_cache(event):
-    """Delete the cached book of abstract"""
+    """Delete the cached book of abstract."""
     path = boa_settings.get(event, 'cache_path')
     if path:
         try:

--- a/indico/modules/events/agreements/base.py
+++ b/indico/modules/events/agreements/base.py
@@ -49,7 +49,7 @@ class AgreementPersonInfo(object):
 
 
 class AgreementDefinitionBase(object):
-    """Base class for agreement definitions"""
+    """Base class for agreement definitions."""
 
     #: unique name of the agreement definition
     name = None
@@ -82,12 +82,12 @@ class AgreementDefinitionBase(object):
 
     @classmethod
     def can_access_api(cls, user, event):
-        """Checks if a user can list the agreements for an event"""
+        """Check if a user can list the agreements for an event."""
         return event.can_manage(user)
 
     @classmethod
     def extend_api_data(cls, event, person, agreement, data):  # pragma: no cover
-        """Extends the data returned in the HTTP API
+        """Extend the data returned in the HTTP API.
 
         :param event: the event
         :param person: the :class:`AgreementPersonInfo`
@@ -98,7 +98,9 @@ class AgreementDefinitionBase(object):
 
     @classmethod
     def get_email_body_template(cls, event, **kwargs):
-        """Returns the template of the email body for this agreement definition"""
+        """
+        Return the template of the email body for this agreement definition.
+        """
         template_name = cls.email_body_template_name or 'emails/agreement_default_body.html'
         template_path = get_overridable_template_name(template_name, cls.plugin, 'events/agreements/')
         return get_template_module(template_path, event=event)
@@ -106,7 +108,9 @@ class AgreementDefinitionBase(object):
     @classmethod
     @memoize_request
     def get_people(cls, event):
-        """Returns a dictionary of :class:`AgreementPersonInfo` required to sign agreements"""
+        """
+        Return a dictionary of :class:`AgreementPersonInfo` required to sign agreements.
+        """
         people = cls.iter_people(event)
         if people is None:
             return {}
@@ -114,14 +118,16 @@ class AgreementDefinitionBase(object):
 
     @classmethod
     def get_people_not_notified(cls, event):
-        """Returns a dictionary of :class:`AgreementPersonInfo` yet to be notified"""
+        """
+        Return a dictionary of :class:`AgreementPersonInfo` yet to be notified.
+        """
         people = cls.get_people(event)
         sent_agreements = {a.identifier for a in event.agreements.filter_by(type=cls.name)}
         return {k: v for k, v in people.items() if v.identifier not in sent_agreements}
 
     @classmethod
     def get_stats_for_signed_agreements(cls, event):
-        """Returns a digest of signed agreements on an event
+        """Return a digest of signed agreements on an event.
 
         :param event: the event
         :return: (everybody_signed, num_accepted, num_rejected)
@@ -136,12 +142,12 @@ class AgreementDefinitionBase(object):
 
     @classmethod
     def is_active(cls, event):
-        """Checks if the agreement type is active for a given event"""
+        """Check if the agreement type is active for a given event."""
         return bool(cls.get_people(event))
 
     @classmethod
     def is_agreement_orphan(cls, event, agreement):
-        """Checks if the agreement no longer has a corresponding person info record"""
+        """Check if the agreement no longer has a corresponding person info record."""
         return agreement.identifier not in cls.get_people(event)
 
     @classmethod
@@ -152,7 +158,7 @@ class AgreementDefinitionBase(object):
 
     @classmethod
     def render_data(cls, event, data):  # pragma: no cover
-        """Returns extra data to display in the agreement list
+        """Return extra data to display in the agreement list.
 
         If you want a column to be rendered as HTML, use a :class:`~markupsafe.Markup`
         object instead of a plain string.
@@ -165,20 +171,20 @@ class AgreementDefinitionBase(object):
 
     @classmethod
     def handle_accepted(cls, agreement):  # pragma: no cover
-        """Handles logic on agreement accepted"""
+        """Handle logic on agreement accepted."""
         pass
 
     @classmethod
     def handle_rejected(cls, agreement):  # pragma: no cover
-        """Handles logic on agreement rejected"""
+        """Handle logic on agreement rejected."""
         pass
 
     @classmethod
     def handle_reset(cls, agreement):  # pragma: no cover
-        """Handles logic on agreement reset"""
+        """Handle logic on agreement reset."""
         pass
 
     @classmethod
     def iter_people(cls, event):  # pragma: no cover
-        """Yields :class:`AgreementPersonInfo` required to sign agreements"""
+        """Yield :class:`AgreementPersonInfo` required to sign agreements."""
         raise NotImplementedError

--- a/indico/modules/events/agreements/controllers.py
+++ b/indico/modules/events/agreements/controllers.py
@@ -32,11 +32,11 @@ from indico.web.views import WPJinjaMixin
 
 
 class RHAgreementManagerBase(RHManageEventBase):
-    """Base class for agreement management RHs"""
+    """Base class for agreement management RHs."""
 
 
 class RHAgreementForm(RHDisplayEventBase):
-    """Agreement form page"""
+    """Agreement form page."""
 
     normalize_url_spec = {
         'locators': {
@@ -85,7 +85,7 @@ class RHAgreementForm(RHDisplayEventBase):
 
 
 class RHAgreementManager(RHAgreementManagerBase):
-    """Agreements types page (admin)"""
+    """Agreements types page (admin)."""
 
     def _process(self):
         definitions = get_agreement_definitions().values()
@@ -93,7 +93,7 @@ class RHAgreementManager(RHAgreementManagerBase):
 
 
 class RHAgreementManagerDetails(RHAgreementManagerBase):
-    """Management page for all agreements of a certain type (admin)"""
+    """Management page for all agreements of a certain type (admin)."""
 
     def _process_args(self):
         RHAgreementManagerBase._process_args(self)
@@ -116,7 +116,7 @@ class RHAgreementManagerDetails(RHAgreementManagerBase):
 
 
 class RHAgreementManagerDetailsToggleNotifications(RHAgreementManagerDetails):
-    """Toggles notifications to managers for an agreement type on an event"""
+    """Toggle notifications to managers for an agreement type on an event."""
 
     def _process(self):
         enabled = request.form['enabled'] == '1'
@@ -214,7 +214,7 @@ class RHAgreementManagerDetailsAgreementBase(RHAgreementManagerDetails):
 
 
 class RHAgreementManagerDetailsSubmitAnswer(RHAgreementManagerDetails):
-    """Submits the answer of an agreement on behalf of the person"""
+    """Submit the answer of an agreement on behalf of the person."""
 
     def _process_args(self):
         RHAgreementManagerDetails._process_args(self)

--- a/indico/modules/events/agreements/models/agreements.py
+++ b/indico/modules/events/agreements/models/agreements.py
@@ -33,7 +33,7 @@ class AgreementState(RichIntEnum):
 
 
 class Agreement(db.Model):
-    """Agreements between a person and Indico"""
+    """Agreements between a person and Indico."""
     __tablename__ = 'agreements'
     __table_args__ = (db.UniqueConstraint('event_id', 'type', 'identifier'),
                       {'schema': 'events'})

--- a/indico/modules/events/agreements/testing/fixtures.py
+++ b/indico/modules/events/agreements/testing/fixtures.py
@@ -15,7 +15,7 @@ from indico.modules.events.agreements.models.agreements import Agreement, Agreem
 
 @pytest.fixture
 def create_person():
-    """Returns a callable which lets you create AgreementPersonInfo"""
+    """Return a callable which lets you create AgreementPersonInfo."""
 
     def _create_person(name, email, data=None):
         person = AgreementPersonInfo(name=name, email=email, data=data)
@@ -26,7 +26,7 @@ def create_person():
 
 @pytest.fixture
 def create_agreement(db, dummy_event, dummy_person):
-    """Returns a a callable which lets you create agreements"""
+    """Return a a callable which lets you create agreements."""
 
     def _create_agreement(state):
         agreement = Agreement(uuid=str(uuid4()), event=dummy_event, type='dummy',
@@ -46,7 +46,7 @@ def dummy_person(create_person):
 
 @pytest.fixture
 def dummy_agreement(create_agreement):
-    """Gives you a dummy agreement with pending state"""
+    """Give you a dummy agreement with pending state."""
     return create_agreement(state=AgreementState.pending)
 
 

--- a/indico/modules/events/agreements/util.py
+++ b/indico/modules/events/agreements/util.py
@@ -19,7 +19,7 @@ def get_agreement_definitions():
 
 
 def send_new_agreements(event, name, people, email_body, cc_addresses, from_address):
-    """Creates and send agreements for a list of people on a given event.
+    """Create and send agreements for a list of people on a given event.
 
     :param event: The `Event` associated with the agreement
     :param name: The agreement type matcing a :class:`AgreementDefinition` name

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -149,7 +149,7 @@ class CategoryEventHook(HTTPAPIHook):
 
 
 class SerializerBase(object):
-    """Common methods for different serializers"""
+    """Common methods for different serializers."""
 
     def _serialize_access_list(self, obj):
         data = {'users': [], 'groups': []}
@@ -170,7 +170,7 @@ class SerializerBase(object):
             }
 
     def _serialize_person(self, person, person_type, can_manage=False):
-        """Serialize an event associated person"""
+        """Serialize an event associated person."""
 
         if person:
             data = {
@@ -342,7 +342,7 @@ class SerializerBase(object):
 
     @staticmethod
     def serialize_reference(reference):
-        """Return the data for a reference"""
+        """Return the data for a reference."""
         return {
             'type': reference.reference_type.name,
             'value': reference.value,
@@ -696,7 +696,7 @@ class SessionFetcher(SessionContribFetcher, SerializerBase):
         return self._build_sessions_api_data(sessions)
 
     def _build_sessions_api_data(self, sessions):
-        """Returns an aggregated list of session blocks given the sessions."""
+        """Return an aggregated list of session blocks given the sessions."""
 
         session_blocks = []
         for session_ in sessions:

--- a/indico/modules/events/cloning.py
+++ b/indico/modules/events/cloning.py
@@ -64,7 +64,7 @@ class EventCloner(object):
 
     @classmethod
     def get_cloners(cls, old_event):
-        """Return the list of cloners (sorted for display)"""
+        """Return the list of cloners (sorted for display)."""
         return sorted((cloner_cls(old_event) for cloner_cls in get_event_cloners().itervalues()),
                       key=attrgetter('friendly_name'))
 

--- a/indico/modules/events/contributions/contrib_fields.py
+++ b/indico/modules/events/contributions/contrib_fields.py
@@ -21,7 +21,7 @@ from indico.web.forms.widgets import SwitchWidget
 
 
 def get_contrib_field_types():
-    """Get a dict containing all contribution field types"""
+    """Get a dict containing all contribution field types."""
     return get_field_definitions(ContributionField)
 
 

--- a/indico/modules/events/contributions/controllers/common.py
+++ b/indico/modules/events/contributions/controllers/common.py
@@ -13,7 +13,7 @@ from indico.modules.events.contributions import contribution_settings
 
 
 class ContributionListMixin:
-    """Display list of contributions"""
+    """Display list of contributions."""
 
     view_class = None
     template = None

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -35,7 +35,10 @@ from indico.web.util import jsonify_template
 
 
 def _get_persons(event, condition):
-    """Queries event persons linked to contributions in the event, filtered using the condition provided."""
+    """
+    Query event persons linked to contributions in the event,
+    filtered using the condition provided.
+    """
     return (event.persons.filter(EventPerson.contribution_links.any(
             db.and_(condition,
                     ContributionPersonLink.contribution.has(~Contribution.is_deleted))))
@@ -80,7 +83,7 @@ class RHDisplayProtectionBase(RHDisplayEventBase):
 
 
 class RHMyContributions(RHDisplayProtectionBase):
-    """Display list of current user contributions"""
+    """Display list of current user contributions."""
 
     MENU_ENTRY_NAME = 'my_contributions'
 
@@ -96,7 +99,7 @@ class RHMyContributions(RHDisplayProtectionBase):
 
 
 class RHContributionList(RHDisplayProtectionBase):
-    """Display list of event contributions"""
+    """Display list of event contributions."""
 
     MENU_ENTRY_NAME = 'contributions'
     view_class = WPContributions
@@ -112,7 +115,7 @@ class RHContributionList(RHDisplayProtectionBase):
 
 
 class RHContributionDisplay(RHContributionDisplayBase):
-    """Display page with contribution details """
+    """Display page with contribution details."""
 
     view_class = WPContributions
 
@@ -157,7 +160,7 @@ class RHSpeakerList(RHDisplayProtectionBase):
 
 
 class RHContributionAuthor(RHContributionDisplayBase):
-    """Display info about an author"""
+    """Display info about an author."""
 
     normalize_url_spec = {
         'locators': {
@@ -206,7 +209,7 @@ class RHContributionsExportToPDF(RHContributionList):
 
 
 class RHContributionExportToICAL(RHContributionDisplayBase):
-    """Export contribution to ICS"""
+    """Export contribution to ICS."""
 
     def _process(self):
         if not self.contrib.is_scheduled:
@@ -215,7 +218,7 @@ class RHContributionExportToICAL(RHContributionDisplayBase):
 
 
 class RHContributionListFilter(RHContributionList):
-    """Display dialog with filters"""
+    """Display dialog with filters."""
 
     def _process(self):
         return RH._process(self)
@@ -231,7 +234,7 @@ class RHContributionListFilter(RHContributionList):
 
 
 class RHContributionListDisplayStaticURL(RHContributionList):
-    """Generate static URL for the current set of filters"""
+    """Generate static URL for the current set of filters."""
 
     def _process(self):
         return jsonify(url=self.list_generator.generate_static_url())

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -77,7 +77,7 @@ def _render_subcontribution_list(contrib):
 
 
 class RHManageContributionsBase(RHManageEventBase):
-    """Base class for all contributions management RHs"""
+    """Base class for all contributions management RHs."""
 
     def _process_args(self):
         RHManageEventBase._process_args(self)
@@ -85,7 +85,7 @@ class RHManageContributionsBase(RHManageEventBase):
 
 
 class RHManageContributionBase(RHManageContributionsBase):
-    """Base class for a specific contribution"""
+    """Base class for a specific contribution."""
 
     normalize_url_spec = {
         'locators': {
@@ -104,7 +104,7 @@ class RHManageContributionBase(RHManageContributionsBase):
 
 
 class RHManageSubContributionBase(RHManageContributionBase):
-    """Base RH for a specific subcontribution"""
+    """Base RH for a specific subcontribution."""
 
     normalize_url_spec = {
         'locators': {
@@ -118,7 +118,7 @@ class RHManageSubContributionBase(RHManageContributionBase):
 
 
 class RHManageContributionsActionsBase(RHManageContributionsBase):
-    """Base class for classes performing actions on event contributions"""
+    """Base class for classes performing actions on event contributions."""
 
     def _process_args(self):
         RHManageContributionsBase._process_args(self)
@@ -127,7 +127,7 @@ class RHManageContributionsActionsBase(RHManageContributionsBase):
 
 
 class RHManageSubContributionsActionsBase(RHManageContributionBase):
-    """Base class for RHs performing actions on subcontributions"""
+    """Base class for RHs performing actions on subcontributions."""
 
     def _process_args(self):
         RHManageContributionBase._process_args(self)
@@ -139,14 +139,14 @@ class RHManageSubContributionsActionsBase(RHManageContributionBase):
 
 
 class RHContributions(ContributionListMixin, RHManageContributionsBase):
-    """Display contributions management page"""
+    """Display contributions management page."""
 
     template = 'management/contributions.html'
     view_class = WPManageContributions
 
 
 class RHContributionListCustomize(RHManageContributionsBase):
-    """Filter options for the contributions list of an event"""
+    """Filter options for the contributions list of an event."""
 
     ALLOW_LOCKED = True
 
@@ -161,7 +161,7 @@ class RHContributionListCustomize(RHManageContributionsBase):
 
 
 class RHContributionListStaticURL(RHManageContributionsBase):
-    """Generate a static URL for the configuration of the contribution list"""
+    """Generate a static URL for the configuration of the contribution list."""
 
     ALLOW_LOCKED = True
 
@@ -225,14 +225,14 @@ class RHDeleteContributions(RHManageContributionsActionsBase):
 
 
 class RHContributionACL(RHManageContributionBase):
-    """Display the ACL of the contribution"""
+    """Display the ACL of the contribution."""
 
     def _process(self):
         return render_acl(self.contrib)
 
 
 class RHContributionACLMessage(RHManageContributionBase):
-    """Render the inheriting ACL message"""
+    """Render the inheriting ACL message."""
 
     def _process(self):
         mode = ProtectionMode[request.args['mode']]
@@ -286,7 +286,7 @@ class RHContributionREST(RHManageContributionBase):
 
 
 class RHContributionPersonList(RHContributionPersonListMixin, RHManageContributionsActionsBase):
-    """List of persons in the contribution"""
+    """List of persons in the contribution."""
 
     template = 'events/contributions/management/contribution_person_list.html'
     ALLOW_LOCKED = True
@@ -298,7 +298,7 @@ class RHContributionPersonList(RHContributionPersonListMixin, RHManageContributi
 
 
 class RHContributionProtection(RHManageContributionBase):
-    """Manage contribution protection"""
+    """Manage contribution protection."""
 
     def _process(self):
         form = ContributionProtectionForm(obj=FormDefaults(**self._get_defaults()), contrib=self.contrib,
@@ -317,14 +317,14 @@ class RHContributionProtection(RHManageContributionBase):
 
 
 class RHContributionSubContributions(RHManageContributionBase):
-    """Get a list of subcontributions"""
+    """Get a list of subcontributions."""
 
     def _process(self):
         return jsonify_data(html=_render_subcontribution_list(self.contrib))
 
 
 class RHCreateSubContribution(RHManageContributionBase):
-    """Create a subcontribution"""
+    """Create a subcontribution."""
 
     def _process(self):
         form = SubContributionForm(event=self.event)
@@ -336,7 +336,7 @@ class RHCreateSubContribution(RHManageContributionBase):
 
 
 class RHEditSubContribution(RHManageSubContributionBase):
-    """Edit the subcontribution"""
+    """Edit the subcontribution."""
 
     def _process(self):
         form = SubContributionForm(obj=FormDefaults(self.subcontrib), event=self.event, subcontrib=self.subcontrib)
@@ -351,7 +351,7 @@ class RHEditSubContribution(RHManageSubContributionBase):
 
 
 class RHSubContributionREST(RHManageSubContributionBase):
-    """REST endpoint for management of a single subcontribution"""
+    """REST endpoint for management of a single subcontribution."""
 
     def _process_DELETE(self):
         delete_subcontribution(self.subcontrib)
@@ -360,7 +360,7 @@ class RHSubContributionREST(RHManageSubContributionBase):
 
 
 class RHCreateSubContributionREST(RHManageContributionBase):
-    """REST endpoint to create a subcontribution"""
+    """REST endpoint to create a subcontribution."""
 
     def _process_POST(self):
         form = SubContributionForm(event=self.event)
@@ -427,7 +427,7 @@ class RHManageContributionsExportActionsBase(RHManageContributionsActionsBase):
 
 
 class RHContributionsMaterialPackage(RHManageContributionsExportActionsBase, AttachmentPackageGeneratorMixin):
-    """Generate a ZIP file with materials for a given list of contributions"""
+    """Generate a ZIP file with materials for a given list of contributions."""
 
     ALLOW_UNSCHEDULED = True
     ALLOW_LOCKED = True
@@ -441,7 +441,7 @@ class RHContributionsMaterialPackage(RHManageContributionsExportActionsBase, Att
 
 
 class RHContributionsExportCSV(RHManageContributionsExportActionsBase):
-    """Export list of contributions to CSV"""
+    """Export list of contributions to CSV."""
 
     def _process(self):
         headers, rows = generate_spreadsheet_from_contributions(self.contribs)
@@ -449,7 +449,7 @@ class RHContributionsExportCSV(RHManageContributionsExportActionsBase):
 
 
 class RHContributionsExportExcel(RHManageContributionsExportActionsBase):
-    """Export list of contributions to XLSX"""
+    """Export list of contributions to XLSX."""
 
     def _process(self):
         headers, rows = generate_spreadsheet_from_contributions(self.contribs)
@@ -472,7 +472,7 @@ class RHContributionsExportTeX(RHManageContributionsExportActionsBase):
 
 
 class RHContributionExportTexConfig(RHManageContributionsExportActionsBase):
-    """Configure Export via LaTeX"""
+    """Configure Export via LaTeX."""
 
     ALLOW_LOCKED = True
 
@@ -491,7 +491,7 @@ class RHContributionExportTexConfig(RHManageContributionsExportActionsBase):
 
 
 class RHContributionsExportTeXBook(RHManageContributionsExportActionsBase):
-    """Handle export contributions via LaTeX"""
+    """Handle export contributions via LaTeX."""
 
     def _process(self):
         config_params = export_list_cache.get(request.view_args['uuid'])
@@ -506,7 +506,7 @@ class RHContributionsExportTeXBook(RHManageContributionsExportActionsBase):
 
 
 class RHContributionsImportCSV(RHManageContributionsBase):
-    """Import contributions from a CSV file"""
+    """Import contributions from a CSV file."""
 
     def _process(self):
         form = ImportContributionsForm()
@@ -524,7 +524,7 @@ class RHContributionsImportCSV(RHManageContributionsBase):
 
 
 class RHManageContributionTypes(RHManageContributionsBase):
-    """Dialog to manage the ContributionTypes of an event"""
+    """Dialog to manage the ContributionTypes of an event."""
 
     def _process(self):
         contrib_types = self.event.contribution_types.order_by(db.func.lower(ContributionType.name)).all()
@@ -533,7 +533,7 @@ class RHManageContributionTypes(RHManageContributionsBase):
 
 
 class RHManageDefaultContributionDuration(RHManageContributionsBase):
-    """Dialog to manage the default contribution duration"""
+    """Dialog to manage the default contribution duration."""
 
     def _process(self):
         form = ContributionDefaultDurationForm(duration=contribution_settings.get(self.event, 'default_duration'))
@@ -545,7 +545,7 @@ class RHManageDefaultContributionDuration(RHManageContributionsBase):
 
 
 class RHManageContributionPublicationREST(RHManageContributionsBase):
-    """Manage contribution publication setting"""
+    """Manage contribution publication setting."""
 
     def _process_GET(self):
         return jsonify(contribution_settings.get(self.event, 'published'))
@@ -564,7 +564,7 @@ class RHManageContributionPublicationREST(RHManageContributionsBase):
 
 
 class RHManageContributionTypeBase(RHManageContributionsBase):
-    """Manage a contribution type of an event"""
+    """Manage a contribution type of an event."""
 
     normalize_url_spec = {
         'locators': {
@@ -578,7 +578,7 @@ class RHManageContributionTypeBase(RHManageContributionsBase):
 
 
 class RHEditContributionType(RHManageContributionTypeBase):
-    """Dialog to edit a ContributionType"""
+    """Dialog to edit a ContributionType."""
 
     def _process(self):
         form = ContributionTypeForm(event=self.event, obj=self.contrib_type)
@@ -593,7 +593,7 @@ class RHEditContributionType(RHManageContributionTypeBase):
 
 
 class RHCreateContributionType(RHManageContributionsBase):
-    """Dialog to add a ContributionType"""
+    """Dialog to add a ContributionType."""
 
     def _process(self):
         form = ContributionTypeForm(event=self.event)
@@ -609,7 +609,7 @@ class RHCreateContributionType(RHManageContributionsBase):
 
 
 class RHDeleteContributionType(RHManageContributionTypeBase):
-    """Dialog to delete a ContributionType"""
+    """Dialog to delete a ContributionType."""
 
     def _process(self):
         db.session.delete(self.contrib_type)
@@ -620,7 +620,7 @@ class RHDeleteContributionType(RHManageContributionTypeBase):
 
 
 class RHManageContributionFields(RHManageContributionsBase):
-    """Dialog to manage the custom contribution fields of an event"""
+    """Dialog to manage the custom contribution fields of an event."""
 
     def _process(self):
         custom_fields = self.event.contribution_fields.order_by(ContributionField.position)
@@ -630,7 +630,7 @@ class RHManageContributionFields(RHManageContributionsBase):
 
 
 class RHSortContributionFields(RHManageContributionsBase):
-    """Sort the custom contribution fields of an event"""
+    """Sort the custom contribution fields of an event."""
 
     def _process(self):
         field_by_id = {field.id: field for field in self.event.contribution_fields}
@@ -647,7 +647,7 @@ class RHSortContributionFields(RHManageContributionsBase):
 
 
 class RHCreateContributionField(RHManageContributionsBase):
-    """Dialog to create a new custom field"""
+    """Dialog to create a new custom field."""
 
     def _process_args(self):
         RHManageContributionsBase._process_args(self)
@@ -673,7 +673,7 @@ class RHCreateContributionField(RHManageContributionsBase):
 
 
 class RHManageContributionFieldBase(RHManageContributionsBase):
-    """Manage a custom contribution field of an event"""
+    """Manage a custom contribution field of an event."""
 
     normalize_url_spec = {
         'locators': {
@@ -687,7 +687,7 @@ class RHManageContributionFieldBase(RHManageContributionsBase):
 
 
 class RHEditContributionField(RHManageContributionFieldBase):
-    """Dialog to edit a custom field"""
+    """Dialog to edit a custom field."""
 
     def _process(self):
         field_class = get_contrib_field_types()[self.contrib_field.field_type]
@@ -703,7 +703,7 @@ class RHEditContributionField(RHManageContributionFieldBase):
 
 
 class RHDeleteContributionField(RHManageContributionFieldBase):
-    """Dialog to delete a custom contribution field"""
+    """Dialog to delete a custom contribution field."""
 
     def _process(self):
         db.session.delete(self.contrib_field)
@@ -713,7 +713,7 @@ class RHDeleteContributionField(RHManageContributionFieldBase):
 
 
 class RHManageDescriptionField(RHManageContributionsBase):
-    """Manage the description field used by the abstracts"""
+    """Manage the description field used by the abstracts."""
 
     def _process(self):
         description_settings = abstracts_settings.get(self.event, 'description_settings')
@@ -725,7 +725,10 @@ class RHManageDescriptionField(RHManageContributionsBase):
 
 
 class RHCreateReferenceMixin:
-    """Common methods for RH class creating a ContibutionReference or SubContributionReference"""
+    """
+    Common methods for RH class creating a ContibutionReference
+    or SubContributionReference.
+    """
 
     def _process_args(self):
         self.reference_value = request.form['value']
@@ -738,7 +741,7 @@ class RHCreateReferenceMixin:
 
 
 class RHCreateContributionReferenceREST(RHCreateReferenceMixin, RHManageContributionBase):
-    """REST endpoint to add a reference to a Contribution"""
+    """REST endpoint to add a reference to a Contribution."""
 
     def _process_args(self):
         RHManageContributionBase._process_args(self)
@@ -752,7 +755,7 @@ class RHCreateContributionReferenceREST(RHCreateReferenceMixin, RHManageContribu
 
 
 class RHCreateSubContributionReferenceREST(RHCreateReferenceMixin, RHManageSubContributionBase):
-    """REST endpoint to add a reference to a SubContribution"""
+    """REST endpoint to add a reference to a SubContribution."""
 
     def _process_args(self):
         RHManageSubContributionBase._process_args(self)

--- a/indico/modules/events/contributions/fields.py
+++ b/indico/modules/events/contributions/fields.py
@@ -17,7 +17,7 @@ from indico.web.forms.widgets import JinjaWidget
 
 
 class ContributionPersonLinkListField(PersonLinkListFieldBase):
-    """A field to configure a list of contribution persons"""
+    """A field to configure a list of contribution persons."""
 
     person_link_cls = ContributionPersonLink
     linked_object_attr = 'contrib'
@@ -57,7 +57,7 @@ class ContributionPersonLinkListField(PersonLinkListFieldBase):
 
 
 class SubContributionPersonLinkListField(ContributionPersonLinkListField):
-    """A field to configure a list of subcontribution persons"""
+    """A field to configure a list of subcontribution persons."""
 
     person_link_cls = SubContributionPersonLink
     linked_object_attr = 'subcontrib'

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -186,7 +186,7 @@ class ContributionDefaultDurationForm(IndicoForm):
 
 
 class ContributionTypeForm(IndicoForm):
-    """Form to create or edit a ContributionType"""
+    """Form to create or edit a ContributionType."""
 
     name = StringField(_("Name"), [DataRequired()])
     is_private = BooleanField(_("Private"), widget=SwitchWidget(),

--- a/indico/modules/events/contributions/models/legacy_mapping.py
+++ b/indico/modules/events/contributions/models/legacy_mapping.py
@@ -12,7 +12,7 @@ from indico.util.string import format_repr, return_ascii
 
 
 class LegacyContributionMapping(db.Model):
-    """Legacy contribution id mapping
+    """Legacy contribution id mapping.
 
     Legacy contributions had ids unique only within their event.
     Additionally, some very old contributions had non-numeric IDs.
@@ -65,7 +65,7 @@ class LegacyContributionMapping(db.Model):
 
 
 class LegacySubContributionMapping(db.Model):
-    """Legacy subcontribution id mapping
+    """Legacy subcontribution id mapping.
 
     Legacy subcontributions had ids unique only within their event
     and contribution.  This table maps those ids to the new globally

--- a/indico/modules/events/contributions/models/subcontributions.py
+++ b/indico/modules/events/contributions/models/subcontributions.py
@@ -130,12 +130,12 @@ class SubContribution(DescriptionMixin, AttachedItemsMixin, AttachedNotesMixin, 
 
     @property
     def session(self):
-        """Convenience property so all event entities have it"""
+        """Convenience property so all event entities have it."""
         return self.contribution.session if self.contribution.session_id is not None else None
 
     @property
     def timetable_entry(self):
-        """Convenience property so all event entities have it"""
+        """Convenience property so all event entities have it."""
         return self.contribution.timetable_entry
 
     @property

--- a/indico/modules/events/contributions/operations.py
+++ b/indico/modules/events/contributions/operations.py
@@ -26,7 +26,7 @@ from indico.modules.events.util import set_custom_fields
 
 
 def _ensure_consistency(contrib):
-    """Unschedule contribution if not consistent with timetable
+    """Unschedule contribution if not consistent with timetable.
 
     A contribution that has no session assigned, may not be scheduled
     inside a session.  A contribution that has a session assigned may
@@ -72,7 +72,7 @@ def create_contribution(event, contrib_data, custom_fields_data=None, session_bl
 
 @no_autoflush
 def update_contribution(contrib, contrib_data, custom_fields_data=None):
-    """Update a contribution
+    """Update a contribution.
 
     :param contrib: The `Contribution` to update
     :param contrib_data: A dict containing the data to update

--- a/indico/modules/events/contributions/util.py
+++ b/indico/modules/events/contributions/util.py
@@ -42,8 +42,9 @@ from indico.web.util import jsonify_data
 
 
 def get_events_with_linked_contributions(user, dt=None):
-    """Returns a dict with keys representing event_id and the values containing
-    data about the user rights for contributions within the event
+    """
+    Return a dict with keys representing event_id and the values containing
+    data about the user rights for contributions within the event.
 
     :param user: A `User`
     :param dt: Only include events taking place on/after that date
@@ -88,7 +89,7 @@ def get_events_with_linked_contributions(user, dt=None):
 
 
 def serialize_contribution_person_link(person_link, is_submitter=None):
-    """Serialize ContributionPersonLink to JSON-like object"""
+    """Serialize ContributionPersonLink to JSON-like object."""
     data = serialize_person_link(person_link)
     data['isSpeaker'] = person_link.is_speaker
     if not isinstance(person_link, SubContributionPersonLink):
@@ -130,8 +131,10 @@ def sort_contribs(contribs, sort_by):
 
 
 def generate_spreadsheet_from_contributions(contributions):
-    """Return a tuple consisting of spreadsheet columns and respective
-    contribution values"""
+    """
+    Return a tuple consisting of spreadsheet columns and respective
+    contribution values.
+    """
 
     has_board_number = any(c.board_number for c in contributions)
     has_authors = any(pl.author_type != AuthorType.none for c in contributions for pl in c.person_links)
@@ -174,7 +177,7 @@ def generate_spreadsheet_from_contributions(contributions):
 
 
 def make_contribution_form(event):
-    """Extends the contribution WTForm to add the extra fields.
+    """Extend the contribution WTForm to add the extra fields.
 
     Each extra field will use a field named ``custom_ID``.
 
@@ -207,7 +210,7 @@ def _query_contributions_with_user_as_submitter(event, user):
 
 
 def get_contributions_with_user_as_submitter(event, user):
-    """Get a list of contributions in which the `user` has submission rights"""
+    """Get a list of contributions in which the `user` has submission rights."""
     return (_query_contributions_with_user_as_submitter(event, user)
             .options(joinedload('acl_entries'))
             .order_by(db.func.lower(Contribution.title))

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -33,7 +33,7 @@ def _render_reference_type_list():
 
 
 class RHManageReferenceTypeBase(RHAdminBase):
-    """Base class for a specific reference type"""
+    """Base class for a specific reference type."""
 
     def _process_args(self):
         RHAdminBase._process_args(self)
@@ -41,7 +41,7 @@ class RHManageReferenceTypeBase(RHAdminBase):
 
 
 class RHReferenceTypes(RHAdminBase):
-    """Manage reference types in server admin area"""
+    """Manage reference types in server admin area."""
 
     def _process(self):
         types = _get_all_reference_types()
@@ -49,7 +49,7 @@ class RHReferenceTypes(RHAdminBase):
 
 
 class RHCreateReferenceType(RHAdminBase):
-    """Create a new reference type"""
+    """Create a new reference type."""
 
     def _process(self):
         form = ReferenceTypeForm()
@@ -61,7 +61,7 @@ class RHCreateReferenceType(RHAdminBase):
 
 
 class RHEditReferenceType(RHManageReferenceTypeBase):
-    """Edit an existing reference type"""
+    """Edit an existing reference type."""
 
     def _process(self):
         form = ReferenceTypeForm(obj=FormDefaults(self.reference_type), reference_type=self.reference_type)
@@ -73,7 +73,7 @@ class RHEditReferenceType(RHManageReferenceTypeBase):
 
 
 class RHDeleteReferenceType(RHManageReferenceTypeBase):
-    """Delete an existing reference type"""
+    """Delete an existing reference type."""
 
     def _process_DELETE(self):
         delete_reference_type(self.reference_type)
@@ -91,7 +91,7 @@ def _render_event_label_list():
 
 
 class RHManageEventLabelBase(RHAdminBase):
-    """Base class for a specific event label"""
+    """Base class for a specific event label."""
 
     def _process_args(self):
         RHAdminBase._process_args(self)
@@ -99,7 +99,7 @@ class RHManageEventLabelBase(RHAdminBase):
 
 
 class RHEventLabels(RHAdminBase):
-    """Manage event labels in server admin area"""
+    """Manage event labels in server admin area."""
 
     def _process(self):
         labels = _get_all_event_labels()
@@ -107,7 +107,7 @@ class RHEventLabels(RHAdminBase):
 
 
 class RHCreateEventLabel(RHAdminBase):
-    """Create a new event label"""
+    """Create a new event label."""
 
     def _process(self):
         form = EventLabelForm()
@@ -119,7 +119,7 @@ class RHCreateEventLabel(RHAdminBase):
 
 
 class RHEditEventLabel(RHManageEventLabelBase):
-    """Edit an existing event label"""
+    """Edit an existing event label."""
 
     def _process(self):
         form = EventLabelForm(obj=FormDefaults(self.event_label), event_label=self.event_label)
@@ -131,7 +131,7 @@ class RHEditEventLabel(RHManageEventLabelBase):
 
 
 class RHDeleteEventLabel(RHManageEventLabelBase):
-    """Delete an existing event label"""
+    """Delete an existing event label."""
 
     def _process_DELETE(self):
         delete_event_label(self.event_label)

--- a/indico/modules/events/controllers/base_test.py
+++ b/indico/modules/events/controllers/base_test.py
@@ -15,9 +15,7 @@ from indico.modules.events.controllers.base import AccessKeyRequired, RHDisplayE
 
 @pytest.mark.usefixtures('request_context')
 def test_event_public_access(db, create_event):
-    """
-    Ensure if a null user can access a public event
-    """
+    """Ensure if a null user can access a public event."""
     rh = RHProtectedEventBase()
     rh.event = create_event(1, protection_mode=ProtectionMode.public)
     rh._check_access()
@@ -26,8 +24,8 @@ def test_event_public_access(db, create_event):
 @pytest.mark.usefixtures('request_context')
 def test_event_protected_access(db, create_user, create_event):
     """
-    Ensure a null user cannot access a protected event
-    Ensure a user with respective ACL entry can access a protected event
+    Ensure a null user cannot access a protected event. Ensure a user
+    with respective ACL entry can access a protected event.
     """
     rh = RHProtectedEventBase()
     rh.event = create_event(2, protection_mode=ProtectionMode.protected)
@@ -44,7 +42,7 @@ def test_event_protected_access(db, create_user, create_event):
 @pytest.mark.usefixtures('request_context')
 def test_event_key_access(create_user, create_event):
     """
-    Ensure the event doesn't reject the user if an access key is required
+    Ensure the event doesn't reject the user if an access key is required.
     """
     rh = RHDisplayEventBase()
     rh.event = create_event(2, protection_mode=ProtectionMode.protected, access_key='abc')

--- a/indico/modules/events/controllers/creation.py
+++ b/indico/modules/events/controllers/creation.py
@@ -35,7 +35,7 @@ from indico.web.util import jsonify_data, jsonify_template, url_for_index
 
 
 class RHCreateEvent(RHProtected):
-    """Create a new event"""
+    """Create a new event."""
 
     def _process_args(self):
         self.event_type = EventType[request.view_args['event_type']]

--- a/indico/modules/events/controllers/display.py
+++ b/indico/modules/events/controllers/display.py
@@ -64,15 +64,15 @@ class RHDisplayEvent(RHDisplayEventBase):
             return self._display_simple()
 
     def _display_conference_page(self):
-        """Display the custom conference home page"""
+        """Display the custom conference home page."""
         return WPPage.render_template('page.html', self.event, page=self.event.default_page)
 
     def _display_conference(self):
-        """Display the conference overview page"""
+        """Display the conference overview page."""
         return WPConferenceDisplay(self, self.event).display()
 
     def _display_simple(self):
-        """Display a simple single-page event (meeting/lecture)"""
+        """Display a simple single-page event (meeting/lecture)."""
         return WPSimpleEventDisplay(self, self.event, self.theme_id, self.theme_override).display()
 
 

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -36,7 +36,7 @@ archive_cache = GenericCache('editables-archive')
 
 
 class RHEditableList(RHEditableTypeEditorBase):
-    """Return the list of editables of the event for a given type"""
+    """Return the list of editables of the event for a given type."""
     def _process_args(self):
         RHEditableTypeEditorBase._process_args(self)
         self.contributions = (Contribution.query

--- a/indico/modules/events/editing/controllers/backend/service.py
+++ b/indico/modules/events/editing/controllers/backend/service.py
@@ -102,7 +102,7 @@ class RHDisconnectService(RHEditingManagementBase):
 
 
 class RHServiceStatus(RHEditingManagementBase):
-    """Get the status of the currently connected service"""
+    """Get the status of the currently connected service."""
 
     def _process(self):
         if not editing_settings.get(self.event, 'service_url'):

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -310,7 +310,7 @@ class RHUndoReview(RHContributionEditableRevisionBase):
 
 
 class RHCreateRevisionComment(RHContributionEditableRevisionBase):
-    """Create new revision comment"""
+    """Create new revision comment."""
 
     SERVICE_ALLOWED = True
 
@@ -371,7 +371,7 @@ class RHEditRevisionComment(RHContributionEditableRevisionBase):
 
 
 class RHExportRevisionFiles(RHContributionEditableRevisionBase):
-    """Export revision files as a ZIP archive"""
+    """Export revision files as a ZIP archive."""
 
     def _check_revision_access(self):
         return self.editable.can_see_timeline(session.user)
@@ -393,7 +393,7 @@ class RHExportRevisionFiles(RHContributionEditableRevisionBase):
 
 
 class RHDownloadRevisionFile(RHContributionEditableRevisionBase):
-    """Download a revision file"""
+    """Download a revision file."""
 
     SERVICE_ALLOWED = True
 

--- a/indico/modules/events/editing/util.py
+++ b/indico/modules/events/editing/util.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+
 def get_editors(event, editable_type):
     """Get all users who are editors in the event.
 

--- a/indico/modules/events/export.py
+++ b/indico/modules/events/export.py
@@ -76,7 +76,7 @@ def import_event(source_file, category_id=0, create_users=None, verbose=False, f
 
 
 def _model_to_table(name):
-    """Resolve a model name to a full table name (unless it's already one)"""
+    """Resolve a model name to a full table name (unless it's already one)."""
     return getattr(db.m, name).__table__.fullname if name[0].isupper() else name
 
 
@@ -133,7 +133,7 @@ def _has_single_pk(table):
 
 
 def _get_inserted_pk(result):
-    """Get the single PK value inserted by a query"""
+    """Get the single PK value inserted by a query."""
     assert len(result.inserted_primary_key) == 1
     return result.inserted_primary_key[0]
 
@@ -191,7 +191,7 @@ class EventExporter(object):
         return {_model_to_table(k): _process_tablespec(_model_to_table(k), v) for k, v in spec['export'].iteritems()}
 
     def _get_reverse_fk_map(self):
-        """Build a mapping between columns and incoming FKs"""
+        """Build a mapping between columns and incoming FKs."""
         legacy_tables = {'events.legacy_contribution_id_map', 'events.legacy_subcontribution_id_map',
                          'attachments.legacy_attachment_id_map', 'event_registration.legacy_registration_map',
                          'events.legacy_session_block_id_map', 'events.legacy_image_id_map',

--- a/indico/modules/events/features/base.py
+++ b/indico/modules/events/features/base.py
@@ -53,22 +53,22 @@ class EventFeature(object):
 
     @classmethod
     def is_default_for_event(cls, event):  # pragma: no cover
-        """Checks if the feature should be enabled by default"""
+        """Check if the feature should be enabled by default."""
         return False
 
     @classmethod
     def is_allowed_for_event(cls, event):  # pragma: no cover
-        """Check if the feature can be enabled in an event"""
+        """Check if the feature can be enabled in an event."""
         return True
 
     @classmethod
     def enabled(cls, event, cloning):  # pragma: no cover
-        """Called when the feature is enabled for an event"""
+        """Called when the feature is enabled for an event."""
         pass
 
     @classmethod
     def disabled(cls, event):  # pragma: no cover
-        """Called when the feature is disabled for an event"""
+        """Called when the feature is disabled for an event."""
         pass
 
     @cached_classproperty

--- a/indico/modules/events/features/controllers.py
+++ b/indico/modules/events/features/controllers.py
@@ -29,7 +29,7 @@ class RHFeaturesBase(RHManageEventBase):
 
 
 class RHFeatures(RHFeaturesBase):
-    """Shows the list of available event features"""
+    """Show the list of available event features."""
 
     def _make_form(self):
         form_class = type(b'FeaturesForm', (IndicoForm,), {})
@@ -49,7 +49,7 @@ class RHFeatures(RHFeaturesBase):
 
 
 class RHSwitchFeature(RHFeaturesBase):
-    """Enables/disables a feature"""
+    """Enable/disable a feature."""
 
     def render_event_menu(self):
         return render_sidemenu('event-management-sidemenu', active_item=WPFeatures.sidemenu_option,

--- a/indico/modules/events/features/util.py
+++ b/indico/modules/events/features/util.py
@@ -19,12 +19,12 @@ from indico.util.signals import named_objects_from_signal
 
 
 def get_feature_definitions():
-    """Gets a dict containing all feature definitions"""
+    """Get a dict containing all feature definitions."""
     return named_objects_from_signal(signals.event.get_feature_definitions.send(), plugin_attr='plugin')
 
 
 def get_feature_definition(name):
-    """Gets a feature definition"""
+    """Get a feature definition."""
     try:
         return get_feature_definitions()[name]
     except KeyError:
@@ -32,7 +32,7 @@ def get_feature_definition(name):
 
 
 def get_enabled_features(event, only_explicit=False):
-    """Returns a set of enabled feature names for an event"""
+    """Return a set of enabled feature names for an event."""
     enabled_features = features_event_settings.get(event, 'enabled')
     if enabled_features is not None:
         return set(enabled_features)
@@ -43,7 +43,7 @@ def get_enabled_features(event, only_explicit=False):
 
 
 def set_feature_enabled(event, name, state):
-    """Enables/disables a feature for an event
+    """Enable/disable a feature for an event.
 
     :param event: The event.
     :param name: The name of the feature.
@@ -88,7 +88,7 @@ def get_disallowed_features(event):
 
 
 def is_feature_enabled(event, name):
-    """Checks if a feature is enabled for an event.
+    """Check if a feature is enabled for an event.
 
     :param event: The event (or event ID) to check.
     :param name: The name of the feature.
@@ -104,7 +104,7 @@ def is_feature_enabled(event, name):
 
 
 def require_feature(event, name):
-    """Raises a NotFound error if a feature is not enabled
+    """Raise a NotFound error if a feature is not enabled.
 
     :param event: The event (or event ID) to check.
     :param name: The name of the feature.

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -72,9 +72,9 @@ class ReferencesField(MultipleItemsField):
 
 
 class EventPersonListField(PrincipalListField):
-    """A field that lets you select a list Indico user and EventPersons
+    """A field that lets you select a list Indico user and EventPersons.
 
-    Requires its form to have an event set.
+    This requires its form to have an event set.
     """
 
     #: Whether new event persons created by the field should be
@@ -172,7 +172,7 @@ class PersonLinkListFieldBase(EventPersonListField):
 
 
 class EventPersonLinkListField(PersonLinkListFieldBase):
-    """A field to manage event's chairpersons"""
+    """A field to manage event's chairpersons."""
 
     person_link_cls = EventPersonLink
     linked_object_attr = 'event'

--- a/indico/modules/events/layout/models/legacy_mapping.py
+++ b/indico/modules/events/layout/models/legacy_mapping.py
@@ -12,7 +12,7 @@ from indico.util.string import format_repr, return_ascii
 
 
 class LegacyImageMapping(db.Model):
-    """Legacy image id mapping
+    """Legacy image id mapping.
 
     Legacy images had event-unique numeric ids. Using this
     mapping we can resolve old ones to their new id.
@@ -58,7 +58,7 @@ class LegacyImageMapping(db.Model):
 
 
 class LegacyPageMapping(db.Model):
-    """Legacy page id mapping
+    """Legacy page id mapping.
 
     Legacy pages had event-unique numeric ids. Using this
     mapping we can resolve old ones to their new id.

--- a/indico/modules/events/layout/util.py
+++ b/indico/modules/events/layout/util.py
@@ -41,7 +41,7 @@ def get_menu_entries_from_signal():
 
 
 def build_menu_entry_name(name, plugin=None):
-    """ Builds the proper name for a menu entry.
+    """Build the proper name for a menu entry.
 
     Given a menu entry's name and optionally a plugin, returns the
     correct name of the menu entry.
@@ -58,7 +58,7 @@ def build_menu_entry_name(name, plugin=None):
 
 
 class MenuEntryData(object):
-    """Container to transmit menu entry-related data via signals
+    """Container to transmit menu entry-related data via signals.
 
     The data contained is transmitted via the `sidemenu` signal and used
     to build the side menu of an event.
@@ -128,7 +128,7 @@ class MenuEntryData(object):
 
 
 def _get_split_signal_entries():
-    """Get the top-level and child menu entry data"""
+    """Get the top-level and child menu entry data."""
     signal_entries = get_menu_entries_from_signal()
     top_data = OrderedDict((name, data)
                            for name, data in sorted(signal_entries.iteritems(),
@@ -152,19 +152,19 @@ def _get_menu_cache_data(event):
 
 
 def _menu_needs_recheck(event):
-    """Check whether the menu needs to be checked for missing items"""
+    """Check whether the menu needs to be checked for missing items."""
     cache_key, cache_version = _get_menu_cache_data(event)
     return _cache.get(cache_key) != cache_version
 
 
 def _set_menu_checked(event):
-    """Mark the menu as up to date"""
+    """Mark the menu as up to date."""
     cache_key, cache_version = _get_menu_cache_data(event)
     _cache.set(cache_key, cache_version)
 
 
 def _save_menu_entries(entries):
-    """Save new menu entries using a separate SA session"""
+    """Save new menu entries using a separate SA session."""
     with db.tmp_session() as sess:
         sess.add_all(entries)
         try:
@@ -183,7 +183,7 @@ def _save_menu_entries(entries):
 
 
 def _rebuild_menu(event):
-    """Create all menu entries in the database"""
+    """Create all menu entries in the database."""
     top_data, child_data = _get_split_signal_entries()
     pos_gen = count()
     entries = [_build_menu_entry(event, True, data, next(pos_gen), children=child_data.get(data.name))
@@ -192,7 +192,7 @@ def _rebuild_menu(event):
 
 
 def _check_menu(event):
-    """Create missing menu items in the database"""
+    """Create missing menu items in the database."""
     top_data, child_data = _get_split_signal_entries()
 
     query = (MenuEntry.query
@@ -305,7 +305,7 @@ def get_menu_entry_by_name(name, event):
 
 
 def is_menu_entry_enabled(entry_name, event):
-    """Check whether the MenuEntry is enabled"""
+    """Check whether the MenuEntry is enabled."""
     return get_menu_entry_by_name(entry_name, event).is_enabled
 
 
@@ -328,7 +328,7 @@ def _build_css_url(theme):
 
 
 def get_css_url(event, force_theme=None, for_preview=False):
-    """Builds the URL of a CSS resource.
+    """Build the URL of a CSS resource.
 
     :param event: The `Event` to get the CSS url for
     :param force_theme: The ID of the theme to override the custom CSS resource

--- a/indico/modules/events/logs/controllers.py
+++ b/indico/modules/events/logs/controllers.py
@@ -32,7 +32,7 @@ def _get_metadata_query():
 
 
 class RHEventLogs(RHManageEventBase):
-    """Shows the modification/action log for the event"""
+    """Show the modification/action log for the event."""
 
     def _process(self):
         metadata_query = _get_metadata_query()

--- a/indico/modules/events/logs/models/entries.py
+++ b/indico/modules/events/logs/models/entries.py
@@ -34,7 +34,7 @@ class EventLogKind(int, IndicoEnum):
 
 
 class EventLogEntry(db.Model):
-    """Log entries for events"""
+    """Log entries for events."""
     __tablename__ = 'logs'
     __table_args__ = (db.Index(None, 'meta', postgresql_using='gin'),
                       {'schema': 'events'})
@@ -132,7 +132,7 @@ class EventLogEntry(db.Model):
         return get_log_renderers().get(self.type)
 
     def render(self):
-        """Renders the log entry to be displayed.
+        """Render the log entry to be displayed.
 
         If the renderer is not available anymore, e.g. because of a
         disabled plugin, ``None`` is returned.

--- a/indico/modules/events/logs/renderers.py
+++ b/indico/modules/events/logs/renderers.py
@@ -26,7 +26,7 @@ class EventLogRendererBase(object):
 
     @classmethod
     def render_entry(cls, entry):
-        """Renders the log entry row
+        """Render the log entry row.
 
         :param entry: A :class:`.EventLogEntry`
         """
@@ -35,7 +35,7 @@ class EventLogRendererBase(object):
 
     @classmethod
     def get_data(cls, entry):
-        """Returns the entry data in a format suitable for the template.
+        """Return the entry data in a format suitable for the template.
 
         This method may be overridden if the entry's data needs to be
         preprocessed before being passed to the template.

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -39,7 +39,7 @@ class RHDeleteEvent(RHManageEventBase):
 
 
 class RHChangeEventType(RHManageEventBase):
-    """Change the type of an event"""
+    """Change the type of an event."""
 
     def _process(self):
         type_ = EventType[request.form['type']]
@@ -79,7 +79,7 @@ class RHUnlockEvent(RHManageEventBase):
 
 
 class RHMoveEvent(RHManageEventBase):
-    """Move event to a different category"""
+    """Move event to a different category."""
 
     def _process_args(self):
         RHManageEventBase._process_args(self)

--- a/indico/modules/events/management/controllers/base.py
+++ b/indico/modules/events/management/controllers/base.py
@@ -38,7 +38,7 @@ class ManageEventMixin(object):
 
 
 class RHManageEventBase(RHEventBase, ManageEventMixin):
-    """Base class for event management RHs"""
+    """Base class for event management RHs."""
 
     DENY_FRAMES = True
 
@@ -47,7 +47,9 @@ class RHManageEventBase(RHEventBase, ManageEventMixin):
 
 
 class RHContributionPersonListMixin:
-    """List of persons somehow related to contributions (co-authors, speakers...)"""
+    """
+    List of persons somehow related to contributions (co-authors, speakers...).
+    """
 
     @property
     def _membership_filter(self):

--- a/indico/modules/events/management/controllers/cloning.py
+++ b/indico/modules/events/management/controllers/cloning.py
@@ -80,7 +80,7 @@ class CloneCalculator(object):
         return args
 
     def calculate(self, formdata):
-        """Calculate dates of cloned events
+        """Calculate dates of cloned events.
 
         :return: a ``(dates, last_day_of_month)`` tuple
         """

--- a/indico/modules/events/management/controllers/protection.py
+++ b/indico/modules/events/management/controllers/protection.py
@@ -40,7 +40,7 @@ from indico.web.util import jsonify_template
 
 
 class RHShowNonInheriting(RHManageEventBase):
-    """Show a list of non-inheriting child objects"""
+    """Show a list of non-inheriting child objects."""
 
     def _process_args(self):
         RHManageEventBase._process_args(self)
@@ -54,14 +54,14 @@ class RHShowNonInheriting(RHManageEventBase):
 
 
 class RHEventACL(RHManageEventBase):
-    """Display the inherited ACL of the event"""
+    """Display the inherited ACL of the event."""
 
     def _process(self):
         return render_acl(self.event)
 
 
 class RHEventACLMessage(RHManageEventBase):
-    """Render the inheriting ACL message"""
+    """Render the inheriting ACL message."""
 
     def _process(self):
         mode = ProtectionMode[request.args['mode']]
@@ -70,7 +70,7 @@ class RHEventACLMessage(RHManageEventBase):
 
 
 class RHEventProtection(RHManageEventBase):
-    """Show event protection"""
+    """Show event protection."""
 
     def _process(self):
         form = EventProtectionForm(obj=FormDefaults(**self._get_defaults()), event=self.event)

--- a/indico/modules/events/management/controllers/settings.py
+++ b/indico/modules/events/management/controllers/settings.py
@@ -36,7 +36,7 @@ from indico.web.util import jsonify_data, jsonify_form, jsonify_template
 
 
 class RHEventSettings(RHManageEventBase):
-    """Event settings dashboard"""
+    """Event settings dashboard."""
 
     def _check_access(self):
         if not session.user:

--- a/indico/modules/events/management/util.py
+++ b/indico/modules/events/management/util.py
@@ -72,7 +72,7 @@ class _ProtectedObjectWrapper(object):
 
 @materialize_iterable(set)
 def get_non_inheriting_objects(root):
-    """Get a set of child objects that do not inherit protection
+    """Get a set of child objects that do not inherit protection.
 
     :param root: An event object (`Event`, `Session`, `Contribution`
                  or `AttachmentFolder`) which may contain objects
@@ -172,7 +172,7 @@ def get_non_inheriting_objects(root):
 
 @contextmanager
 def flash_if_unregistered(event, get_person_links):
-    """Flash message when adding users with no indico account
+    """Flash message when adding users with no Indico account.
 
     :param event: Current event
     :param get_person_links: Callable returning list of person links to

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -68,7 +68,7 @@ class _EventSettingProperty(EventSettingProperty):
 
 class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionManagersMixin, AttachedItemsMixin,
             AttachedNotesMixin, PersonLinkDataMixin, db.Model):
-    """An Indico event
+    """An Indico event.
 
     This model contains the most basic information related to an event.
 
@@ -468,7 +468,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
 
     @property
     def event(self):
-        """Convenience property so all event entities have it"""
+        """Convenience property so all event entities have it."""
         return self
 
     @property
@@ -594,7 +594,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
 
     @property
     def display_tzinfo(self):
-        """The tzinfo of the event as preferred by the current user"""
+        """The tzinfo of the event as preferred by the current user."""
         return get_display_tz(self, as_timezone=True)
 
     @property
@@ -617,7 +617,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     @property
     @contextmanager
     def logging_disabled(self):
-        """Temporarily disables event logging
+        """Temporarily disable event logging.
 
         This is useful when performing actions e.g. during event
         creation or at other times where adding entries to the event
@@ -631,7 +631,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
 
     @hybrid_method
     def happens_between(self, from_dt=None, to_dt=None):
-        """Check whether the event takes place within two dates"""
+        """Check whether the event takes place within two dates."""
         if from_dt is not None and to_dt is not None:
             # any event that takes place during the specified range
             return overlaps((self.start_dt, self.end_dt), (from_dt, to_dt), inclusive=True)
@@ -660,7 +660,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
 
     @hybrid_method
     def starts_between(self, from_dt=None, to_dt=None):
-        """Check whether the event starts within two dates"""
+        """Check whether the event starts within two dates."""
         if from_dt is not None and to_dt is not None:
             return from_dt <= self.start_dt <= to_dt
         elif from_dt is not None:
@@ -683,7 +683,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
 
     @hybrid_method
     def ends_after(self, dt):
-        """Check whether the event ends on/after the specified date"""
+        """Check whether the event ends on/after the specified date."""
         return self.end_dt >= dt if dt is not None else True
 
     @ends_after.expression
@@ -695,7 +695,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         return self.end_dt - self.start_dt
 
     def can_lock(self, user):
-        """Check whether the user can lock/unlock the event"""
+        """Check whether the user can lock/unlock the event."""
         return user and (user.is_admin or user == self.creator or self.category.can_manage(user))
 
     def can_display(self, user):
@@ -731,7 +731,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         return rv
 
     def get_verbose_title(self, show_speakers=False, show_series_pos=False):
-        """Get the event title with some additional information
+        """Get the event title with some additional information.
 
         :param show_speakers: Whether to prefix the title with the
                               speakers of the event.
@@ -754,21 +754,21 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         return Markup(render_template('events/label.html', label=label, message=self.label_message, size=size))
 
     def get_non_inheriting_objects(self):
-        """Get a set of child objects that do not inherit protection"""
+        """Get a set of child objects that do not inherit protection."""
         return get_non_inheriting_objects(self)
 
     def get_contribution(self, id_):
-        """Get a contribution of the event"""
+        """Get a contribution of the event."""
         return get_related_object(self, 'contributions', {'id': id_})
 
     def get_sorted_tracks(self):
-        """Return tracks and track groups in the correct order"""
+        """Return tracks and track groups in the correct order."""
         track_groups = self.track_groups
         tracks = [track for track in self.tracks if not track.track_group]
         return sorted(tracks + track_groups, key=attrgetter('position'))
 
     def get_session(self, id_=None, friendly_id=None):
-        """Get a session of the event"""
+        """Get a session of the event."""
         if friendly_id is None and id_ is not None:
             criteria = {'id': id_}
         elif id_ is None and friendly_id is not None:
@@ -778,7 +778,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         return get_related_object(self, 'sessions', criteria)
 
     def get_session_block(self, id_, scheduled_only=False):
-        """Get a session block of the event"""
+        """Get a session block of the event."""
         from indico.modules.events.sessions.models.blocks import SessionBlock
         query = SessionBlock.query.filter(SessionBlock.id == id_,
                                           SessionBlock.session.has(event=self, is_deleted=False))
@@ -837,7 +837,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
 
     @memoize_request
     def has_feature(self, feature):
-        """Check if a feature is enabled for the event"""
+        """Check if a feature is enabled for the event."""
         from indico.modules.events.features.util import is_feature_enabled
         return is_feature_enabled(self, feature)
 
@@ -881,7 +881,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         return next((v for v in self.contribution_fields if v.id == field_id), '')
 
     def move_start_dt(self, start_dt):
-        """Set event start_dt and adjust its timetable entries"""
+        """Set event start_dt and adjust its timetable entries."""
         diff = start_dt - self.start_dt
         for entry in self.timetable_entries.filter(TimetableEntry.parent_id.is_(None)):
             new_dt = entry.start_dt + diff

--- a/indico/modules/events/models/legacy_mapping.py
+++ b/indico/modules/events/models/legacy_mapping.py
@@ -12,7 +12,7 @@ from indico.util.string import return_ascii
 
 
 class LegacyEventMapping(db.Model):
-    """Legacy event ID mapping
+    """Legacy event ID mapping.
 
     Legacy events (imported from CDS agenda) have non-numeric IDs
     which are not supported by any new code. This mapping maps them

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -195,7 +195,7 @@ class EventPerson(PersonMixin, db.Model):
 
     @classmethod
     def for_user(cls, user, event=None, is_untrusted=False):
-        """Return EventPerson for a matching User in Event creating if needed"""
+        """Return EventPerson for a matching User in Event creating if needed."""
         person = event.persons.filter_by(user=user).first() if event else None
         return person or cls.create_from_user(user, event, is_untrusted=is_untrusted)
 
@@ -219,7 +219,7 @@ class EventPerson(PersonMixin, db.Model):
     @classmethod
     def link_user_by_email(cls, user):
         """
-        Links all email-based persons matching the user's
+        Link all email-based persons matching the user's
         email addresses with the user.
 
         :param user: A User object.
@@ -301,7 +301,7 @@ class EventPerson(PersonMixin, db.Model):
         db.session.flush()
 
     def has_role(self, role, obj):
-        """Whether the person has a role in the ACL list of a given object"""
+        """Whether the person has a role in the ACL list of a given object."""
         principals = [x for x in obj.acl_entries if x.has_management_permission(role, explicit=True)]
         return any(x
                    for x in principals

--- a/indico/modules/events/models/reviews.py
+++ b/indico/modules/events/models/reviews.py
@@ -15,7 +15,7 @@ from indico.web.flask.util import url_for
 
 
 class ProposalGroupProxy(object):
-    """Represents the object that the proposals can be grouped by.
+    """The object that the proposals can be grouped by.
 
     It provides all necessary methods for building the URLs, displaying the
     grouping information, etc.
@@ -60,7 +60,8 @@ class ProposalGroupProxy(object):
 
 
 class ProposalRevisionMixin(object):
-    """ Properties and methods of a proposal revision."""
+    """Properties and methods of a proposal revision."""
+
     #: The attribute  of the revision used to fetch the proposal object.
     proposal_attr = None
     #: Whether the reviewing process supports multiple revisions per proposal.
@@ -101,9 +102,11 @@ class ProposalRevisionMixin(object):
 
 
 class ProposalMixin(object):
-    """Classes that represent a proposal object should extend this class (ex:
+    """
+    Classes that represent a proposal object should extend this class (ex:
     Abstract, Paper).
     """
+
     #: A unique identifier to handle rendering differences between proposal
     #: types
     proposal_type = None
@@ -171,11 +174,12 @@ class ProposalCommentMixin(object):
 
 
 class ProposalReviewMixin(object):
-    """Mixin for proposal reviews
+    """Mixin for proposal reviews.
 
     Classes that represent a review of a proposal should extend this class
     (ex: AbstractReview, PaperReview).
     """
+
     #: A unique identifier to handle rendering differences between timeline
     #: items
     timeline_item_type = 'review'

--- a/indico/modules/events/models/static_list_links.py
+++ b/indico/modules/events/models/static_list_links.py
@@ -75,7 +75,7 @@ class StaticListLink(db.Model):
 
     @classmethod
     def load(cls, event, type_, uuid):
-        """Load the data associated with a link
+        """Load the data associated with a link.
 
         :param event: the `Event` the link belongs to
         :param type_: the type of the link

--- a/indico/modules/events/notes/controllers.py
+++ b/indico/modules/events/notes/controllers.py
@@ -26,7 +26,7 @@ from indico.web.util import jsonify_template
 
 
 class RHNoteBase(RHProtected):
-    """Base handler for notes attached to an object inside an event"""
+    """Base handler for notes attached to an object inside an event."""
 
     def _process_args(self):
         self.object_type, self.event, self.object = get_object_from_args()
@@ -35,7 +35,7 @@ class RHNoteBase(RHProtected):
 
 
 class RHManageNoteBase(RHNoteBase):
-    """Base handler for managing notes attached to an object inside an event"""
+    """Base handler for managing notes attached to an object inside an event."""
 
     def _check_access(self):
         RHNoteBase._check_access(self)
@@ -45,7 +45,7 @@ class RHManageNoteBase(RHNoteBase):
 
 
 class RHEditNote(RHManageNoteBase):
-    """Create/edit a note attached to an object inside an event"""
+    """Create/edit a note attached to an object inside an event."""
 
     def _get_defaults(self, note=None, source=None):
         if source:
@@ -92,7 +92,7 @@ class RHEditNote(RHManageNoteBase):
 
 
 class RHCompileNotes(RHEditNote):
-    """Handle note edits a note attached to an object inside an event"""
+    """Handle note edits a note attached to an object inside an event."""
 
     def _process(self):
         source = render_template('events/notes/compiled_notes.html', notes=get_scheduled_notes(self.event))
@@ -101,7 +101,7 @@ class RHCompileNotes(RHEditNote):
 
 
 class RHDeleteNote(RHManageNoteBase):
-    """Handles deletion of a note attached to an object inside an event"""
+    """Handle deletion of a note attached to an object inside an event."""
 
     def _process(self):
         note = EventNote.get_for_linked_object(self.object, preload_event=False)
@@ -115,7 +115,7 @@ class RHDeleteNote(RHManageNoteBase):
 
 
 class RHViewNote(RHNoteBase):
-    """Handles display of a note attached to an object inside an event"""
+    """Handle display of a note attached to an object inside an event."""
 
     def _check_access(self):
         if not self.object.can_access(session.user):

--- a/indico/modules/events/notes/models/notes.py
+++ b/indico/modules/events/notes/models/notes.py
@@ -86,7 +86,7 @@ class EventNote(LinkMixin, db.Model):
 
     @classmethod
     def get_for_linked_object(cls, linked_object, preload_event=True):
-        """Gets the note for the given object.
+        """Get the note for the given object.
 
         This only returns a note that hasn't been deleted.
 
@@ -115,7 +115,7 @@ class EventNote(LinkMixin, db.Model):
 
     @classmethod
     def get_or_create(cls, linked_object):
-        """Gets the note for the given object or creates a new one.
+        """Get the note for the given object or creates a new one.
 
         If there is an existing note for the object, it will be returned
         even.  Otherwise a new note is created.
@@ -126,12 +126,12 @@ class EventNote(LinkMixin, db.Model):
         return note
 
     def delete(self, user):
-        """Marks the note as deleted and adds a new empty revision"""
+        """Mark the note as deleted and adds a new empty revision."""
         self.create_revision(self.current_revision.render_mode, '', user)
         self.is_deleted = True
 
     def create_revision(self, render_mode, source, user):
-        """Creates a new revision if needed and marks it as undeleted if it was
+        """Create a new revision if needed and marks it as undeleted if it was.
 
         Any change to the render mode or the source causes a new
         revision to be created.  The user is not taken into account

--- a/indico/modules/events/notes/util.py
+++ b/indico/modules/events/notes/util.py
@@ -42,7 +42,7 @@ def build_note_legacy_api_data(note):
 
 
 def get_scheduled_notes(event):
-    """Gets all notes of scheduled items inside an event"""
+    """Get all notes of scheduled items inside an event."""
     def _sort_note_by(note):
         obj = note.object
         if hasattr(obj, 'start_dt'):
@@ -73,7 +73,7 @@ def get_scheduled_notes(event):
 
 
 def can_edit_note(obj, user):
-    """Checks if a user can edit the object's note"""
+    """Check if a user can edit the object's note."""
     if not user:
         return False
     if obj.can_manage(user):

--- a/indico/modules/events/notifications.py
+++ b/indico/modules/events/notifications.py
@@ -15,7 +15,7 @@ from indico.web.flask.templating import get_template_module
 
 
 def notify_event_creation(event, occurrences=None):
-    """Send email notifications when a new Event is created
+    """Send email notifications when a new Event is created.
 
     :param event: The `Event` that has been created.
     :param occurrences: A list of event occurrences in case of a

--- a/indico/modules/events/papers/controllers/base.py
+++ b/indico/modules/events/papers/controllers/base.py
@@ -17,7 +17,7 @@ from indico.modules.events.util import check_event_locked
 
 
 class RHPapersBase(RHDisplayEventBase):
-    """Base class for all paper-related RHs"""
+    """Base class for all paper-related RHs."""
 
     EVENT_FEATURE = 'papers'
 
@@ -29,14 +29,14 @@ class RHPapersBase(RHDisplayEventBase):
 
     @property
     def management(self):
-        """Whether the RH is currently used in the management area"""
+        """Whether the RH is currently used in the management area."""
         return request.view_args.get('management', False)
 
 
 class RHManagePapersBase(ManageEventMixin, RHPapersBase):
     """
     Base class for all paper-related RHs that require full event
-    management permissions
+    management permissions.
     """
 
     PERMISSION = 'paper_manager'
@@ -44,12 +44,12 @@ class RHManagePapersBase(ManageEventMixin, RHPapersBase):
 
     @property
     def management(self):
-        """Whether the RH is currently used in the management area"""
+        """Whether the RH is currently used in the management area."""
         return request.view_args.get('management', True)
 
 
 class RHJudgingAreaBase(RHPapersBase):
-    """Base class for all paper-related RHs only available to judges/managers"""
+    """Base class for all paper-related RHs only available to judges/managers."""
 
     def _check_access(self):
         RHPapersBase._check_access(self)

--- a/indico/modules/events/papers/controllers/display.py
+++ b/indico/modules/events/papers/controllers/display.py
@@ -57,7 +57,7 @@ class RHPaperTimeline(RHPaperBase):
 
 
 class RHDownloadPaperFile(RHPaperBase):
-    """Download a paper file"""
+    """Download a paper file."""
 
     normalize_url_spec = {
         'locators': {
@@ -90,7 +90,7 @@ class RHReviewingArea(RHPapersBase):
 
 
 class RHCallForPapers(RHPapersBase):
-    """Show the main CFP page"""
+    """Show the main CFP page."""
 
     def _check_access(self):
         if not session.user:
@@ -112,7 +112,7 @@ class RHCallForPapers(RHPapersBase):
 
 
 class RHSelectContribution(RHCallForPapers):
-    """Select a contribution for which the user wants to submit a paper"""
+    """Select a contribution for which the user wants to submit a paper."""
 
     def _process(self):
         return jsonify_template('events/papers/display/select_contribution.html', contributions=self.contribs)

--- a/indico/modules/events/papers/controllers/management.py
+++ b/indico/modules/events/papers/controllers/management.py
@@ -41,7 +41,7 @@ def _render_paper_dashboard(event, view_class=None):
 
 
 class RHPapersDashboard(RHManagePapersBase):
-    """Dashboard of the papers module"""
+    """Dashboard of the papers module."""
 
     # Allow access even if the feature is disabled
     EVENT_FEATURE = None
@@ -54,7 +54,7 @@ class RHPapersDashboard(RHManagePapersBase):
 
 
 class RHManagePaperTeams(RHManagePapersBase):
-    """Modify managers of the papers module"""
+    """Modify managers of the papers module."""
 
     def _process(self):
         cfp = self.event.cfp
@@ -87,7 +87,7 @@ class RHManagePaperTeams(RHManagePapersBase):
 
 
 class RHSwitchReviewingType(RHManagePapersBase):
-    """Enable/disable the paper reviewing types"""
+    """Enable/disable the paper reviewing types."""
 
     def _process_PUT(self):
         set_reviewing_state(self.event, PaperReviewType[request.view_args['reviewing_type']], True)
@@ -99,7 +99,7 @@ class RHSwitchReviewingType(RHManagePapersBase):
 
 
 class RHManageCompetences(RHManagePapersBase):
-    """Manage the competences of the call for papers ACLs"""
+    """Manage the competences of the call for papers ACLs."""
 
     def _process(self):
         form_class = make_competences_form(self.event)
@@ -122,7 +122,7 @@ class RHManageCompetences(RHManagePapersBase):
 
 
 class RHContactStaff(RHManagePapersBase):
-    """Send emails to reviewing staff"""
+    """Send emails to reviewing staff."""
 
     def _process(self):
         paper_persons_dict = {}
@@ -156,7 +156,7 @@ class RHScheduleCFP(RHManagePapersBase):
 
 
 class RHOpenCFP(RHManagePapersBase):
-    """Open the call for papers"""
+    """Open the call for papers."""
 
     def _process(self):
         open_cfp(self.event)
@@ -165,7 +165,7 @@ class RHOpenCFP(RHManagePapersBase):
 
 
 class RHCloseCFP(RHManagePapersBase):
-    """Close the call for papers"""
+    """Close the call for papers."""
 
     def _process(self):
         close_cfp(self.event)

--- a/indico/modules/events/papers/controllers/paper.py
+++ b/indico/modules/events/papers/controllers/paper.py
@@ -46,7 +46,7 @@ CONTRIB_ROLE_MAP = {
 
 
 class RHPapersListBase(RHJudgingAreaBase):
-    """Base class for assignment/judging paper lists"""
+    """Base class for assignment/judging paper lists."""
 
     @cached_property
     def list_generator(self):
@@ -57,7 +57,7 @@ class RHPapersListBase(RHJudgingAreaBase):
 
 
 class RHPapersList(RHPapersListBase):
-    """Display the paper list for assignment/judging"""
+    """Display the paper list for assignment/judging."""
 
     @cached_property
     def view_class(self):
@@ -72,7 +72,7 @@ class RHPapersList(RHPapersListBase):
 
 
 class RHCustomizePapersList(RHPapersListBase):
-    """Filter options and columns to display for the paper list"""
+    """Filter options and columns to display for the paper list."""
 
     ALLOW_LOCKED = True
 
@@ -90,7 +90,7 @@ class RHCustomizePapersList(RHPapersListBase):
 
 
 class RHPapersActionBase(RHPapersListBase):
-    """Base class for actions on selected papers"""
+    """Base class for actions on selected papers."""
 
     def _get_contrib_query_options(self):
         return ()
@@ -105,7 +105,9 @@ class RHPapersActionBase(RHPapersListBase):
 
 
 class RHDownloadPapers(ZipGeneratorMixin, RHPapersActionBase):
-    """Generate a ZIP file with paper files for a given list of contributions"""
+    """
+    Generate a ZIP file with paper files for a given list of contributions.
+    """
 
     ALLOW_LOCKED = True
 
@@ -126,7 +128,7 @@ class RHDownloadPapers(ZipGeneratorMixin, RHPapersActionBase):
 
 
 class RHJudgePapers(RHPapersActionBase):
-    """Bulk judgment of papers"""
+    """Bulk judgment of papers."""
 
     def _process(self):
         form = BulkPaperJudgmentForm(event=self.event, judgment=request.form.get('judgment'),
@@ -153,7 +155,7 @@ class RHJudgePapers(RHPapersActionBase):
 
 
 class RHAssignPapersBase(RHPapersActionBase):
-    """Base class for assigning/unassigning paper reviewing roles"""
+    """Base class for assigning/unassigning paper reviewing roles."""
 
     def _get_contrib_query_options(self):
         return [selectinload('person_links')]
@@ -204,7 +206,7 @@ class RHAssignPapersBase(RHPapersActionBase):
 
 
 class RHAssignPapers(RHAssignPapersBase):
-    """Render the user list to assign paper reviewing roles"""
+    """Render the user list to assign paper reviewing roles."""
 
     def _process(self):
         if self.users:
@@ -214,7 +216,7 @@ class RHAssignPapers(RHAssignPapersBase):
 
 
 class RHUnassignPapers(RHAssignPapersBase):
-    """Render the user list to unassign paper reviewing roles"""
+    """Render the user list to unassign paper reviewing roles."""
 
     def _process(self):
         if self.users:

--- a/indico/modules/events/papers/controllers/templates.py
+++ b/indico/modules/events/papers/controllers/templates.py
@@ -20,14 +20,14 @@ from indico.web.util import jsonify_data, jsonify_form, jsonify_template
 
 
 class RHManagePaperTemplates(RHManagePapersBase):
-    """Manage the available paper templates"""
+    """Manage the available paper templates."""
 
     def _process(self):
         return jsonify_template('events/papers/management/templates.html', event=self.event)
 
 
 class RHManagePaperTemplateBase(RHManagePapersBase):
-    """Base class to manage a specific paper template"""
+    """Base class to manage a specific paper template."""
 
     normalize_url_spec = {
         'locators': {
@@ -46,7 +46,7 @@ def _render_teplate_list(event):
 
 
 class RHUploadPaperTemplate(RHManagePapersBase):
-    """Upload a new paper template"""
+    """Upload a new paper template."""
 
     def _process(self):
         form = PaperTemplateForm()
@@ -58,7 +58,7 @@ class RHUploadPaperTemplate(RHManagePapersBase):
 
 
 class RHEditPaperTemplate(RHManagePaperTemplateBase):
-    """Edit a paper template"""
+    """Edit a paper template."""
 
     def _process(self):
         form = PaperTemplateForm(template=self.template, obj=FormDefaults(self.template, template=self.template))
@@ -71,7 +71,7 @@ class RHEditPaperTemplate(RHManagePaperTemplateBase):
 
 
 class RHDeletePaperTemplate(RHManagePaperTemplateBase):
-    """Delete a paper template"""
+    """Delete a paper template."""
 
     def _process(self):
         delete_paper_template(self.template)
@@ -80,7 +80,7 @@ class RHDeletePaperTemplate(RHManagePaperTemplateBase):
 
 
 class RHDownloadPaperTemplate(RHPapersBase):
-    """Download a paper template"""
+    """Download a paper template."""
 
     normalize_url_spec = {
         'locators': {

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -83,7 +83,7 @@ class BulkPaperJudgmentForm(IndicoForm):
 
 
 class PaperReviewingSettingsForm(IndicoForm):
-    """Settings form for paper reviewing"""
+    """Settings form for paper reviewing."""
 
     RATING_FIELDS = ('scale_lower', 'scale_upper')
 

--- a/indico/modules/events/papers/lists.py
+++ b/indico/modules/events/papers/lists.py
@@ -177,7 +177,9 @@ class PaperAssignmentListGenerator(PaperListGeneratorBase):
 
 
 class PaperJudgingAreaListGeneratorDisplay(PaperListGeneratorBase):
-    """Listing and filtering actions in paper judging area list in the display view"""
+    """
+    Listing and filtering actions in paper judging area list in the display view.
+    """
 
     endpoint = '.papers_list'
     list_link_type = 'paper_judging_display'

--- a/indico/modules/events/papers/models/call_for_papers.py
+++ b/indico/modules/events/papers/models/call_for_papers.py
@@ -17,7 +17,7 @@ from indico.util.string import MarkdownText, return_ascii
 
 
 class CallForPapers(object):
-    """Proxy class to facilitate access to the call for papers settings"""
+    """Proxy class to facilitate access to the call for papers settings."""
 
     def __init__(self, event):
         self.event = event

--- a/indico/modules/events/papers/models/papers.py
+++ b/indico/modules/events/papers/models/papers.py
@@ -15,7 +15,7 @@ from indico.util.string import return_ascii
 
 
 class Paper(ProposalMixin):
-    """Proxy class to facilitate access to all paper-related properties"""
+    """Proxy class to facilitate access to all paper-related properties."""
 
     proxied_attr = 'contribution'
 

--- a/indico/modules/events/papers/models/reviews.py
+++ b/indico/modules/events/papers/models/reviews.py
@@ -38,7 +38,7 @@ class PaperTypeProxy(ProposalGroupProxy):
 
 
 class PaperJudgmentProxy(object):
-    """Represents a timeline item for the non final judgments"""
+    """A timeline item for the non final judgments."""
 
     timeline_item_type = 'judgment'
 
@@ -55,7 +55,7 @@ class PaperJudgmentProxy(object):
 
 
 class PaperCommentVisibility(RichIntEnum):
-    """Most to least restrictive visibility for paper comments"""
+    """Most to least restrictive visibility for paper comments."""
     __titles__ = [None,
                   _("Visible only to judges"),
                   _("Visible to reviewers and judges"),
@@ -68,7 +68,7 @@ class PaperCommentVisibility(RichIntEnum):
 
 
 class PaperReview(ProposalReviewMixin, RenderModeMixin, db.Model):
-    """Represents a paper review, emitted by a layout or content reviewer"""
+    """A paper review, emitted by a layout or content reviewer."""
 
     possible_render_modes = {RenderMode.markdown}
     default_render_mode = RenderMode.markdown

--- a/indico/modules/events/papers/util.py
+++ b/indico/modules/events/papers/util.py
@@ -30,14 +30,14 @@ def _query_contributions_with_user_as_reviewer(event, user):
 
 
 def get_user_reviewed_contributions(event, user):
-    """Get the list of contributions where user already reviewed paper"""
+    """Get the list of contributions where user already reviewed paper."""
     contribs = _query_contributions_with_user_as_reviewer(event, user).all()
     contribs = [contrib for contrib in contribs if contrib.paper.last_revision.has_user_reviewed(user)]
     return contribs
 
 
 def get_user_contributions_to_review(event, user):
-    """Get the list of contributions where user has paper to review"""
+    """Get the list of contributions where user has paper to review."""
     contribs = _query_contributions_with_user_as_reviewer(event, user).all()
     contribs = [contrib for contrib in contribs if not contrib.paper.last_revision.has_user_reviewed(user)]
     return contribs

--- a/indico/modules/events/payment/controllers.py
+++ b/indico/modules/events/payment/controllers.py
@@ -27,7 +27,7 @@ from indico.web.util import jsonify_data, jsonify_form, jsonify_template
 
 
 class RHPaymentAdminSettings(RHAdminBase):
-    """Payment settings in server admin area"""
+    """Payment settings in server admin area."""
 
     def _process(self):
         form = AdminSettingsForm(obj=FormDefaults(**payment_settings.get_all()))
@@ -40,23 +40,23 @@ class RHPaymentAdminSettings(RHAdminBase):
 
 
 class RHPaymentAdminPluginSettings(RHPluginDetails):
-    """Payment plugin settings in server admin area"""
+    """Payment plugin settings in server admin area."""
     back_button_endpoint = 'payment.admin_settings'
 
 
 class RHPaymentManagementBase(RHManageEventBase):
-    """Base RH for event management pages"""
+    """Base RH for event management pages."""
 
     EVENT_FEATURE = 'payment'
 
 
 class RHPaymentBase(RHRegistrationFormRegistrationBase):
-    """Base RH for non-management payment pages"""
+    """Base RH for non-management payment pages."""
     EVENT_FEATURE = 'payment'
 
 
 class RHPaymentSettings(RHPaymentManagementBase):
-    """Display payment settings"""
+    """Display payment settings."""
 
     def _process(self):
         methods = get_payment_plugins()
@@ -68,7 +68,7 @@ class RHPaymentSettings(RHPaymentManagementBase):
 
 
 class RHPaymentSettingsEdit(RHPaymentManagementBase):
-    """Edit payment settings"""
+    """Edit payment settings."""
 
     def _process(self):
         current_event_settings = payment_event_settings.get_all(self.event)
@@ -82,7 +82,7 @@ class RHPaymentSettingsEdit(RHPaymentManagementBase):
 
 
 class RHPaymentPluginEdit(RHPaymentManagementBase):
-    """Configure a payment plugin for an event"""
+    """Configure a payment plugin for an event."""
 
     def _process_args(self):
         RHPaymentManagementBase._process_args(self)
@@ -124,7 +124,7 @@ class RHPaymentPluginEdit(RHPaymentManagementBase):
 
 
 class RHPaymentCheckout(RHPaymentBase):
-    """Display payment checkout page"""
+    """Display payment checkout page."""
 
     def _process(self):
         if self.registration.state != RegistrationState.unpaid:
@@ -140,7 +140,7 @@ class RHPaymentCheckout(RHPaymentBase):
 
 
 class RHPaymentForm(RHPaymentBase):
-    """Load the form for the selected payment plugin"""
+    """Load the form for the selected payment plugin."""
 
     def _process_args(self):
         RHPaymentBase._process_args(self)

--- a/indico/modules/events/payment/models/transactions.py
+++ b/indico/modules/events/payment/models/transactions.py
@@ -131,7 +131,7 @@ class TransactionStatusTransition(object):
 
 
 class PaymentTransaction(db.Model):
-    """Payment transactions"""
+    """Payment transactions."""
     __tablename__ = 'payment_transactions'
     __table_args__ = (db.CheckConstraint('amount > 0', 'positive_amount'),
                       {'schema': 'events'})
@@ -209,7 +209,7 @@ class PaymentTransaction(db.Model):
         return format_repr(self, 'id', 'registration_id', 'provider', 'amount', 'currency', 'timestamp', status=status)
 
     def render_details(self):
-        """Renders the transaction details"""
+        """Render the transaction details."""
         if self.is_manual:
             return render_template('events/payment/transaction_details_manual.html', transaction=self)
         plugin = self.plugin

--- a/indico/modules/events/payment/plugins.py
+++ b/indico/modules/events/payment/plugins.py
@@ -68,7 +68,7 @@ class PaymentPluginMixin(object):
         return config.IMAGES_BASE_URL + '/payment_logo.png'
 
     def can_be_modified(self, user, event):
-        """Checks if the user is allowed to enable/disable/modify the payment method.
+        """Check if the user is allowed to enable/disable/modify the payment method.
 
         :param user: the :class:`.User` repesenting the user
         :param event: the :class:`Event`
@@ -85,7 +85,7 @@ class PaymentPluginMixin(object):
             return url_for('payment.event_plugin_edit', event, method=re.sub(r'^payment_', '', self.name))
 
     def get_invalid_regforms(self, event):
-        """Return registration forms with incompatible currencies"""
+        """Return registration forms with incompatible currencies."""
         from indico.modules.events.registration.models.forms import RegistrationForm
         invalid_regforms = []
         if self.valid_currencies is not None:
@@ -100,11 +100,11 @@ class PaymentPluginMixin(object):
         return currency in self.valid_currencies
 
     def get_method_name(self, event):
-        """Returns the (customized) name of the payment method."""
+        """Return the (customized) name of the payment method."""
         return self.event_settings.get(event, 'method_name')
 
     def adjust_payment_form_data(self, data):
-        """Updates the payment form data if necessary.
+        """Update the payment form data if necessary.
 
         This method can be overridden to update e.g. the amount based on choices the user makes
         in the payment form or to provide additional data to the form. To do so, `data` must
@@ -116,7 +116,7 @@ class PaymentPluginMixin(object):
         pass
 
     def render_payment_form(self, registration):
-        """Returns the payment form shown to the user.
+        """Return the payment form shown to the user.
 
         :param registration: a :class:`Registration` object
         """
@@ -133,7 +133,7 @@ class PaymentPluginMixin(object):
         return render_plugin_template('event_payment_form.html', **data)
 
     def render_transaction_details(self, transaction):
-        """Renders the transaction details in event management
+        """Render the transaction details in event management.
 
         Override this (or inherit from the template) to show more useful data such as transaction IDs
 

--- a/indico/modules/events/payment/testing/fixtures.py
+++ b/indico/modules/events/payment/testing/fixtures.py
@@ -12,7 +12,7 @@ from indico.modules.events.payment.models.transactions import PaymentTransaction
 
 @pytest.fixture
 def create_transaction():
-    """Returns a callable which lets you create transactions"""
+    """Return a callable which lets you create transactions."""
 
     def _create_transaction(status, **params):
         params.setdefault('amount', 10)
@@ -26,5 +26,5 @@ def create_transaction():
 
 @pytest.fixture
 def dummy_transaction(create_transaction):
-    """Gives you a dummy successful transaction"""
+    """Return a dummy successful transaction."""
     return create_transaction(status=TransactionStatus.successful)

--- a/indico/modules/events/payment/util.py
+++ b/indico/modules/events/payment/util.py
@@ -20,19 +20,19 @@ remove_prefix_re = re.compile('^payment_')
 
 
 def get_payment_plugins():
-    """Returns a dict containing the available payment plugins."""
+    """Return a dict containing the available payment plugins."""
     return {remove_prefix_re.sub('', p.name): p for p in plugin_engine.get_active_plugins().itervalues()
             if isinstance(p, PaymentPluginMixin)}
 
 
 def get_active_payment_plugins(event):
-    """Returns a dict containing the active payment plugins of an event."""
+    """Return a dict containing the active payment plugins of an event."""
     return {name: plugin for name, plugin in get_payment_plugins().iteritems()
             if plugin.event_settings.get(event, 'enabled')}
 
 
 def register_transaction(registration, amount, currency, action, provider=None, data=None):
-    """Creates a new transaction for a certain transaction action.
+    """Create a new transaction for a certain transaction action.
 
     :param registration: the `Registration` associated to the transaction
     :param amount: the (strictly positive) amount of the transaction

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -214,7 +214,7 @@ class RHPersonsList(RHPersonsBase):
 
 
 class RHEmailEventPersons(RHManageEventBase):
-    """Send emails to selected EventPersons"""
+    """Send emails to selected EventPersons."""
 
     def _process_args(self):
         self.no_account = request.args.get('no_account') == '1'
@@ -281,7 +281,7 @@ class RHEmailEventPersons(RHManageEventBase):
 
 
 class RHGrantSubmissionRights(RHManageEventBase):
-    """Grants submission rights to all contribution speakers"""
+    """Grant submission rights to all contribution speakers."""
 
     def _process(self):
         count = 0
@@ -302,7 +302,7 @@ class RHGrantSubmissionRights(RHManageEventBase):
 
 
 class RHGrantModificationRights(RHManageEventBase):
-    """Grants session modification rights to all session conveners"""
+    """Grant session modification rights to all session conveners."""
 
     def _process(self):
         count = 0
@@ -320,7 +320,7 @@ class RHGrantModificationRights(RHManageEventBase):
 
 
 class RHRevokeSubmissionRights(RHManageEventBase):
-    """Revokes submission rights"""
+    """Revoke submission rights."""
 
     def _process(self):
         count = 0

--- a/indico/modules/events/posters.py
+++ b/indico/modules/events/posters.py
@@ -55,7 +55,9 @@ class PosterPDF(DesignerPDFBase):
             self._draw_item(canvas, item, tpl_data, text, config.margin_horizontal, config.margin_vertical)
 
     def _draw_poster(self, canvas, registration, pos_x, pos_y):
-        """Draw a badge for a given registration, at position pos_x, pos_y (top-left corner).
+        """
+        Draw a badge for a given registration, at position pos_x,
+        pos_y (top-left corner).
         """
         config = self.config
         tpl_data = self.tpl_data

--- a/indico/modules/events/registration/api.py
+++ b/indico/modules/events/registration/api.py
@@ -20,7 +20,7 @@ from indico.web.rh import RH
 
 
 class RHAPIRegistrant(RH):
-    """RESTful registrant API"""
+    """RESTful registrant API."""
 
     CSRF_ENABLED = False
 
@@ -56,7 +56,7 @@ class RHAPIRegistrant(RH):
 
 
 class RHAPIRegistrants(RH):
-    """RESTful registrants API"""
+    """RESTful registrants API."""
 
     @oauth.require_oauth('registrants')
     def _check_access(self):

--- a/indico/modules/events/registration/badges.py
+++ b/indico/modules/events/registration/badges.py
@@ -63,7 +63,10 @@ class RegistrantsListToBadgesPDF(DesignerPDFBase):
             self._draw_badge(canvas, registration, self.template, self.tpl_data, x * cm, y * cm)
 
     def _draw_badge(self, canvas, registration, template, tpl_data, pos_x, pos_y):
-        """Draw a badge for a given registration, at position pos_x, pos_y (top-left corner)."""
+        """
+        Draw a badge for a given registration, at position pos_x,
+        pos_y (top-left corner).
+        """
         config = self.config
         badge_rect = (pos_x, self.height - pos_y - tpl_data.height_cm * cm,
                       tpl_data.width_cm * cm, tpl_data.height_cm * cm)

--- a/indico/modules/events/registration/controllers/__init__.py
+++ b/indico/modules/events/registration/controllers/__init__.py
@@ -16,7 +16,7 @@ from indico.util.string import camelize_keys
 
 
 class RegistrationFormMixin:
-    """Mixin for single registration form RH"""
+    """Mixin for single registration form RH."""
 
     normalize_url_spec = {
         'locators': {

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -71,7 +71,7 @@ class RHRegistrationFormBase(RegistrationFormMixin, RHRegistrationFormDisplayBas
 
 
 class RHRegistrationFormRegistrationBase(RHRegistrationFormBase):
-    """Base for RHs handling individual registrations"""
+    """Base for RHs handling individual registrations."""
 
     REGISTRATION_REQUIRED = True
 
@@ -89,7 +89,7 @@ class RHRegistrationFormRegistrationBase(RHRegistrationFormBase):
 
 
 class RHRegistrationFormList(RHRegistrationFormDisplayBase):
-    """List of all registration forms in the event"""
+    """List of all registration forms in the event."""
 
     ALLOW_PROTECTED_EVENT = True
 
@@ -105,7 +105,7 @@ class RHRegistrationFormList(RHRegistrationFormDisplayBase):
 
 
 class RHParticipantList(RHRegistrationFormDisplayBase):
-    """List of all public registrations"""
+    """List of all public registrations."""
 
     view_class = WPDisplayRegistrationParticipantList
 
@@ -221,7 +221,7 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
 
 
 class InvitationMixin:
-    """Mixin for RHs that accept an invitation token"""
+    """Mixin for RHs that accept an invitation token."""
 
     def _process_args(self):
         self.invitation = None
@@ -240,7 +240,7 @@ class InvitationMixin:
 
 
 class RHRegistrationFormCheckEmail(RHRegistrationFormBase):
-    """Checks how an email will affect the registration"""
+    """Check how an email will affect the registration."""
 
     ALLOW_PROTECTED_EVENT = True
 
@@ -257,7 +257,7 @@ class RHRegistrationFormCheckEmail(RHRegistrationFormBase):
 
 
 class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
-    """Display a registration form and registrations, and process submissions"""
+    """Display a registration form and registrations, and process submissions."""
 
     REGISTRATION_REQUIRED = False
     ALLOW_PROTECTED_EVENT = True
@@ -317,7 +317,7 @@ class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
 
 
 class RHRegistrationDisplayEdit(RegistrationEditMixin, RHRegistrationFormRegistrationBase):
-    """Submit a registration form"""
+    """Submit a registration form."""
 
     template_file = 'display/registration_modify.html'
     management = False
@@ -347,7 +347,7 @@ class RHRegistrationDisplayEdit(RegistrationEditMixin, RHRegistrationFormRegistr
 
 
 class RHRegistrationWithdraw(RHRegistrationFormRegistrationBase):
-    """Withdraw a registration"""
+    """Withdraw a registration."""
 
     def _check_access(self):
         RHRegistrationFormRegistrationBase._check_access(self)
@@ -361,7 +361,7 @@ class RHRegistrationWithdraw(RHRegistrationFormRegistrationBase):
 
 
 class RHRegistrationFormDeclineInvitation(InvitationMixin, RHRegistrationFormBase):
-    """Decline an invitation to register"""
+    """Decline an invitation to register."""
 
     ALLOW_PROTECTED_EVENT = True
 
@@ -377,7 +377,7 @@ class RHRegistrationFormDeclineInvitation(InvitationMixin, RHRegistrationFormBas
 
 
 class RHTicketDownload(RHRegistrationFormRegistrationBase):
-    """Generate ticket for a given registration"""
+    """Generate ticket for a given registration."""
 
     def _check_access(self):
         RHRegistrationFormRegistrationBase._check_access(self)

--- a/indico/modules/events/registration/controllers/management/__init__.py
+++ b/indico/modules/events/registration/controllers/management/__init__.py
@@ -18,13 +18,13 @@ from indico.modules.events.registration.models.registrations import Registration
 
 
 class RHManageRegFormsBase(RHManageEventBase):
-    """Base class for all registration management RHs"""
+    """Base class for all registration management RHs."""
 
     PERMISSION = 'registration'
 
 
 class RHManageRegFormBase(RegistrationFormMixin, RHManageRegFormsBase):
-    """Base class for a specific registration form"""
+    """Base class for a specific registration form."""
 
     def _process_args(self):
         RHManageRegFormsBase._process_args(self)
@@ -33,7 +33,7 @@ class RHManageRegFormBase(RegistrationFormMixin, RHManageRegFormsBase):
 
 
 class RHManageRegistrationBase(RHManageRegFormBase):
-    """Base class for a specific registration"""
+    """Base class for a specific registration."""
 
     normalize_url_spec = {
         'locators': {

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -34,7 +34,7 @@ def _fill_form_field_with_data(field, field_data, set_data=True):
 
 
 class RHManageRegFormFieldBase(RHManageRegFormSectionBase):
-    """Base class for a specific field within a registration form"""
+    """Base class for a specific field within a registration form."""
 
     field_class = RegistrationFormField
     normalize_url_spec = {
@@ -49,7 +49,7 @@ class RHManageRegFormFieldBase(RHManageRegFormSectionBase):
 
 
 class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
-    """Enable/Disable a field"""
+    """Enable/Disable a field."""
 
     def _process(self):
         enabled = request.args.get('enable') == 'true'
@@ -64,7 +64,7 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
 
 
 class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
-    """Remove/Modify a field"""
+    """Remove/Modify a field."""
 
     def _process_DELETE(self):
         if self.field.type == RegistrationFormItemType.field_pd:
@@ -87,7 +87,7 @@ class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
 
 
 class RHRegistrationFormMoveField(RHManageRegFormFieldBase):
-    """Change position of a field within the section"""
+    """Change position of a field within the section."""
 
     def _process(self):
         new_position = request.json['endPos'] + 1
@@ -113,7 +113,7 @@ class RHRegistrationFormMoveField(RHManageRegFormFieldBase):
 
 
 class RHRegistrationFormAddField(RHManageRegFormSectionBase):
-    """Add a field to the section"""
+    """Add a field to the section."""
 
     def _process(self):
         field_data = snakify_keys(request.json['fieldData'])
@@ -125,12 +125,12 @@ class RHRegistrationFormAddField(RHManageRegFormSectionBase):
 
 
 class RHRegistrationFormToggleTextState(RHRegistrationFormToggleFieldState):
-    """Enable/Disable a static text field"""
+    """Enable/Disable a static text field."""
     field_class = RegistrationFormText
 
 
 class RHRegistrationFormModifyText(RHRegistrationFormModifyField):
-    """Remove/Modify a static text field"""
+    """Remove/Modify a static text field."""
     field_class = RegistrationFormText
 
     def _process_PATCH(self):
@@ -141,12 +141,12 @@ class RHRegistrationFormModifyText(RHRegistrationFormModifyField):
 
 
 class RHRegistrationFormMoveText(RHRegistrationFormMoveField):
-    """Change position of a static text field within the section"""
+    """Change position of a static text field within the section."""
     field_class = RegistrationFormText
 
 
 class RHRegistrationFormAddText(RHManageRegFormSectionBase):
-    """Add a static text field to a section"""
+    """Add a static text field to a section."""
 
     def _process(self):
         field_data = snakify_keys(request.json['fieldData'])

--- a/indico/modules/events/registration/controllers/management/invitations.py
+++ b/indico/modules/events/registration/controllers/management/invitations.py
@@ -38,7 +38,7 @@ def _render_invitation_list(regform):
 
 
 class RHRegistrationFormInvitations(RHManageRegFormBase):
-    """Overview of all registration invitations"""
+    """Overview of all registration invitations."""
 
     def _process(self):
         invitations = _query_invitation_list(self.regform)
@@ -47,7 +47,7 @@ class RHRegistrationFormInvitations(RHManageRegFormBase):
 
 
 class RHRegistrationFormInvite(RHManageRegFormBase):
-    """Invite someone to register"""
+    """Invite someone to register."""
 
     def _create_invitation(self, user, skip_moderation, email_from, email_subject, email_body):
         invitation = RegistrationInvitation(
@@ -94,7 +94,7 @@ class RHRegistrationFormInvitationBase(RHManageRegFormBase):
 
 
 class RHRegistrationFormDeleteInvitation(RHRegistrationFormInvitationBase):
-    """Delete a registration invitation"""
+    """Delete a registration invitation."""
 
     def _process(self):
         db.session.delete(self.invitation)

--- a/indico/modules/events/registration/controllers/management/regforms.py
+++ b/indico/modules/events/registration/controllers/management/regforms.py
@@ -38,7 +38,7 @@ from indico.web.util import jsonify_data, jsonify_form, jsonify_template
 
 
 class RHManageRegistrationForms(RHManageRegFormsBase):
-    """List all registrations forms for an event"""
+    """List all registrations forms for an event."""
 
     def _process(self):
         regforms = (RegistrationForm.query
@@ -49,7 +49,7 @@ class RHManageRegistrationForms(RHManageRegFormsBase):
 
 
 class RHManageRegistrationFormsDisplay(RHManageRegFormsBase):
-    """Customize the display of registrations on the public page"""
+    """Customize the display of registrations on the public page."""
 
     def _process(self):
         regforms = sorted(self.event.registration_forms, key=lambda f: f.title.lower())
@@ -104,7 +104,10 @@ class RHManageRegistrationFormsDisplay(RHManageRegFormsBase):
 
 
 class RHManageRegistrationFormDisplay(RHManageRegFormBase):
-    """Choose the columns to be shown on the participant list for a particular form"""
+    """
+    Choose the columns to be shown on the participant list for
+    a particular form.
+    """
 
     def _process(self):
         form = ParticipantsDisplayFormColumnsForm()
@@ -129,7 +132,7 @@ class RHManageRegistrationFormDisplay(RHManageRegFormBase):
 
 
 class RHManageParticipants(RHManageRegFormsBase):
-    """Show and enable the dummy registration form for participants"""
+    """Show and enable the dummy registration form for participants."""
 
     def _process_POST(self):
         regform = self.event.participation_regform
@@ -155,7 +158,7 @@ class RHManageParticipants(RHManageRegFormsBase):
 
 
 class RHRegistrationFormCreate(RHManageRegFormsBase):
-    """Creates a new registration form"""
+    """Create a new registration form."""
 
     def _process(self):
         form = RegistrationFormForm(event=self.event,
@@ -176,14 +179,14 @@ class RHRegistrationFormCreate(RHManageRegFormsBase):
 
 
 class RHRegistrationFormManage(RHManageRegFormBase):
-    """Specific registration form management"""
+    """Specific registration form management."""
 
     def _process(self):
         return WPManageRegistration.render_template('management/regform.html', self.event, regform=self.regform)
 
 
 class RHRegistrationFormEdit(RHManageRegFormBase):
-    """Edit a registration form"""
+    """Edit a registration form."""
 
     def _get_form_defaults(self):
         return FormDefaults(self.regform, limit_registrations=self.regform.registration_limit is not None)
@@ -201,7 +204,7 @@ class RHRegistrationFormEdit(RHManageRegFormBase):
 
 
 class RHRegistrationFormDelete(RHManageRegFormBase):
-    """Delete a registration form"""
+    """Delete a registration form."""
 
     def _process(self):
         self.regform.is_deleted = True
@@ -212,7 +215,7 @@ class RHRegistrationFormDelete(RHManageRegFormBase):
 
 
 class RHRegistrationFormOpen(RHManageRegFormBase):
-    """Opens registration for a registration form"""
+    """Open registration for a registration form."""
 
     def _process(self):
         old_dts = (self.regform.start_dt, self.regform.end_dt)
@@ -233,7 +236,7 @@ class RHRegistrationFormOpen(RHManageRegFormBase):
 
 
 class RHRegistrationFormClose(RHManageRegFormBase):
-    """Closes registrations for a registration form"""
+    """Close registrations for a registration form."""
 
     def _process(self):
         self.regform.end_dt = now_utc()
@@ -247,7 +250,7 @@ class RHRegistrationFormClose(RHManageRegFormBase):
 
 
 class RHRegistrationFormSchedule(RHManageRegFormBase):
-    """Schedules registrations for a registration form"""
+    """Schedule registrations for a registration form."""
 
     def _process(self):
         form = RegistrationFormScheduleForm(obj=FormDefaults(self.regform), regform=self.regform)
@@ -262,7 +265,7 @@ class RHRegistrationFormSchedule(RHManageRegFormBase):
 
 
 class RHRegistrationFormModify(RHManageRegFormBase):
-    """Modify the form of a registration form"""
+    """Modify the form of a registration form."""
 
     def _process(self):
         return WPManageRegistration.render_template('management/regform_modify.html', self.event,
@@ -271,7 +274,7 @@ class RHRegistrationFormModify(RHManageRegFormBase):
 
 
 class RHRegistrationFormStats(RHManageRegFormBase):
-    """Display registration form stats page"""
+    """Display registration form stats page."""
 
     def _process(self):
         regform_stats = [OverviewStats(self.regform)]
@@ -281,7 +284,7 @@ class RHRegistrationFormStats(RHManageRegFormBase):
 
 
 class RHManageRegistrationManagers(RHManageRegFormsBase):
-    """Modify event managers with registration role"""
+    """Modify event managers with registration role."""
 
     def _process(self):
         reg_managers = {p.principal for p in self.event.acl_entries

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -66,7 +66,7 @@ def _render_registration_details(registration):
 
 
 class RHRegistrationsListManage(RHManageRegFormBase):
-    """List all registrations of a specific registration form of an event"""
+    """List all registrations of a specific registration form of an event."""
 
     def _process(self):
         if self.list_generator.static_link_used:
@@ -81,7 +81,7 @@ class RHRegistrationsListManage(RHManageRegFormBase):
 
 
 class RHRegistrationsListCustomize(RHManageRegFormBase):
-    """Filter options and columns to display for a registrations list of an event"""
+    """Filter options and columns to display for a registrations list of an event."""
 
     ALLOW_LOCKED = True
 
@@ -100,7 +100,7 @@ class RHRegistrationsListCustomize(RHManageRegFormBase):
 
 
 class RHRegistrationListStaticURL(RHManageRegFormBase):
-    """Generate a static URL for the configuration of the registrations list"""
+    """Generate a static URL for the configuration of the registrations list."""
 
     ALLOW_LOCKED = True
 
@@ -109,7 +109,7 @@ class RHRegistrationListStaticURL(RHManageRegFormBase):
 
 
 class RHRegistrationDetails(RHManageRegistrationBase):
-    """Displays information about a registration"""
+    """Display information about a registration."""
 
     def _process(self):
         registration_details_html = _render_registration_details(self.registration)
@@ -119,7 +119,7 @@ class RHRegistrationDetails(RHManageRegistrationBase):
 
 
 class RHRegistrationDownloadAttachment(RHManageRegFormsBase):
-    """Download a file attached to a registration"""
+    """Download a file attached to a registration."""
 
     normalize_url_spec = {
         'locators': {
@@ -159,7 +159,7 @@ class RHRegistrationEdit(RegistrationEditMixin, RHManageRegistrationBase):
 
 
 class RHRegistrationsActionBase(RHManageRegFormBase):
-    """Base class for classes performing actions on registrations"""
+    """Base class for classes performing actions on registrations."""
 
     registration_query_options = ()
 
@@ -175,7 +175,7 @@ class RHRegistrationsActionBase(RHManageRegFormBase):
 
 
 class RHRegistrationEmailRegistrantsPreview(RHRegistrationsActionBase):
-    """Previews the email that will be sent to registrants"""
+    """Preview the email that will be sent to registrants."""
 
     def _process(self):
         if not self.registrations:
@@ -193,7 +193,7 @@ class RHRegistrationEmailRegistrantsPreview(RHRegistrationsActionBase):
 
 
 class RHRegistrationEmailRegistrants(RHRegistrationsActionBase):
-    """Send email to selected registrants"""
+    """Send email to selected registrants."""
 
     def _send_emails(self, form):
         for registration in self.registrations:
@@ -233,7 +233,7 @@ class RHRegistrationEmailRegistrants(RHRegistrationsActionBase):
 
 
 class RHRegistrationDelete(RHRegistrationsActionBase):
-    """Delete selected registrations"""
+    """Delete selected registrations."""
 
     def _process(self):
         for registration in self.registrations:
@@ -250,7 +250,7 @@ class RHRegistrationDelete(RHRegistrationsActionBase):
 
 
 class RHRegistrationCreate(RHManageRegFormBase):
-    """Create new registration (management area)"""
+    """Create new registration (management area)."""
 
     def _get_user_data(self):
         user_id = request.args.get('user')
@@ -286,7 +286,7 @@ class RHRegistrationCreate(RHManageRegFormBase):
 
 
 class RHRegistrationCreateMultiple(RHManageRegFormBase):
-    """Create multiple registrations for Indico users (management area)"""
+    """Create multiple registrations for Indico users (management area)."""
 
     def _register_user(self, user, notify):
         # Fill only the personal data fields, custom fields are left empty.
@@ -309,7 +309,7 @@ class RHRegistrationCreateMultiple(RHManageRegFormBase):
 
 
 class RHRegistrationsExportBase(RHRegistrationsActionBase):
-    """Base class for all registration list export RHs"""
+    """Base class for all registration list export RHs."""
 
     ALLOW_LOCKED = True
     registration_query_options = (subqueryload('data'),)
@@ -320,7 +320,7 @@ class RHRegistrationsExportBase(RHRegistrationsActionBase):
 
 
 class RHRegistrationsExportPDFTable(RHRegistrationsExportBase):
-    """Export registration list to a PDF in table style"""
+    """Export registration list to a PDF in table style."""
 
     def _process(self):
         pdf = RegistrantsListToPDF(self.event, reglist=self.registrations, display=self.export_config['regform_items'],
@@ -336,7 +336,7 @@ class RHRegistrationsExportPDFTable(RHRegistrationsExportBase):
 
 
 class RHRegistrationsExportPDFBook(RHRegistrationsExportBase):
-    """Export registration list to a PDF in book style"""
+    """Export registration list to a PDF in book style."""
 
     def _process(self):
         static_item_ids, item_ids = self.list_generator.get_item_ids()
@@ -345,7 +345,7 @@ class RHRegistrationsExportPDFBook(RHRegistrationsExportBase):
 
 
 class RHRegistrationsExportCSV(RHRegistrationsExportBase):
-    """Export registration list to a CSV file"""
+    """Export registration list to a CSV file."""
 
     def _process(self):
         headers, rows = generate_spreadsheet_from_registrations(self.registrations, self.export_config['regform_items'],
@@ -354,7 +354,7 @@ class RHRegistrationsExportCSV(RHRegistrationsExportBase):
 
 
 class RHRegistrationsExportExcel(RHRegistrationsExportBase):
-    """Export registration list to an XLSX file"""
+    """Export registration list to an XLSX file."""
 
     def _process(self):
         headers, rows = generate_spreadsheet_from_registrations(self.registrations, self.export_config['regform_items'],
@@ -427,7 +427,7 @@ class RHRegistrationsPrintBadges(RHRegistrationsActionBase):
 
 
 class RHRegistrationsConfigBadges(RHRegistrationsActionBase):
-    """Print badges for the selected registrations"""
+    """Print badges for the selected registrations."""
 
     ALLOW_LOCKED = True
     TICKET_BADGES = False
@@ -511,7 +511,7 @@ class RHRegistrationsConfigBadges(RHRegistrationsActionBase):
 
 
 class RHRegistrationsConfigTickets(RHRegistrationsConfigBadges):
-    """Print tickets for selected registrations"""
+    """Print tickets for selected registrations."""
 
     TICKET_BADGES = True
 
@@ -524,7 +524,7 @@ class RHRegistrationsConfigTickets(RHRegistrationsConfigBadges):
 
 
 class RHRegistrationTogglePayment(RHManageRegistrationBase):
-    """Modify the payment status of a registration"""
+    """Modify the payment status of a registration."""
 
     def _process(self):
         pay = request.form.get('pay') == '1'
@@ -555,7 +555,7 @@ def _modify_registration_status(registration, approve):
 
 
 class RHRegistrationApprove(RHManageRegistrationBase):
-    """Accept a registration"""
+    """Accept a registration."""
 
     def _process(self):
         _modify_registration_status(self.registration, approve=True)
@@ -563,7 +563,7 @@ class RHRegistrationApprove(RHManageRegistrationBase):
 
 
 class RHRegistrationReject(RHManageRegistrationBase):
-    """Reject a registration"""
+    """Reject a registration."""
 
     def _process(self):
         _modify_registration_status(self.registration, approve=False)
@@ -571,7 +571,7 @@ class RHRegistrationReject(RHManageRegistrationBase):
 
 
 class RHRegistrationReset(RHManageRegistrationBase):
-    """Reset a registration back to a non-approved status"""
+    """Reset a registration back to a non-approved status."""
 
     def _process(self):
         if self.registration.has_conflict():
@@ -604,7 +604,7 @@ class RHRegistrationManageWithdraw(RHManageRegistrationBase):
 
 
 class RHRegistrationCheckIn(RHManageRegistrationBase):
-    """Set checked in state of a registration"""
+    """Set checked in state of a registration."""
 
     def _process_PUT(self):
         self.registration.checked_in = True
@@ -618,7 +618,7 @@ class RHRegistrationCheckIn(RHManageRegistrationBase):
 
 
 class RHRegistrationBulkCheckIn(RHRegistrationsActionBase):
-    """Bulk apply check-in/not checked-in state to registrations"""
+    """Bulk apply check-in/not checked-in state to registrations."""
 
     def _process(self):
         check_in = request.form['flag'] == '1'
@@ -632,7 +632,7 @@ class RHRegistrationBulkCheckIn(RHRegistrationsActionBase):
 
 
 class RHRegistrationsModifyStatus(RHRegistrationsActionBase):
-    """Accept/Reject selected registrations"""
+    """Accept/Reject selected registrations."""
 
     def _process(self):
         approve = request.form['flag'] == '1'
@@ -643,7 +643,7 @@ class RHRegistrationsModifyStatus(RHRegistrationsActionBase):
 
 
 class RHRegistrationsExportAttachments(RHRegistrationsExportBase, ZipGeneratorMixin):
-    """Export registration attachments in a zip file"""
+    """Export registration attachments in a zip file."""
 
     def _prepare_folder_structure(self, attachment):
         registration = attachment.registration

--- a/indico/modules/events/registration/controllers/management/sections.py
+++ b/indico/modules/events/registration/controllers/management/sections.py
@@ -19,7 +19,7 @@ from indico.web.util import jsonify_data
 
 
 class RHManageRegFormSectionBase(RHManageRegFormBase):
-    """Base class for a specific registration form section"""
+    """Base class for a specific registration form section."""
 
     normalize_url_spec = {
         'locators': {
@@ -33,7 +33,7 @@ class RHManageRegFormSectionBase(RHManageRegFormBase):
 
 
 class RHRegistrationFormAddSection(RHManageRegFormBase):
-    """Add a section to the registration form"""
+    """Add a section to the registration form."""
 
     def _process(self):
         section = RegistrationFormSection(registration_form=self.regform)
@@ -47,7 +47,7 @@ class RHRegistrationFormAddSection(RHManageRegFormBase):
 
 
 class RHRegistrationFormModifySection(RHManageRegFormSectionBase):
-    """Delete/modify a section"""
+    """Delete/modify a section."""
 
     def _process_DELETE(self):
         if self.section.type == RegistrationFormItemType.section_pd:
@@ -69,7 +69,7 @@ class RHRegistrationFormModifySection(RHManageRegFormSectionBase):
 
 
 class RHRegistrationFormToggleSection(RHManageRegFormSectionBase):
-    """Enable/disable a section"""
+    """Enable/disable a section."""
 
     def _process_POST(self):
         enabled = request.args.get('enable') == 'true'
@@ -86,7 +86,7 @@ class RHRegistrationFormToggleSection(RHManageRegFormSectionBase):
 
 
 class RHRegistrationFormMoveSection(RHManageRegFormSectionBase):
-    """Move a section within the registration form"""
+    """Move a section within the registration form."""
 
     def _process(self):
         new_position = request.json['endPos'] + 1

--- a/indico/modules/events/registration/fields/__init__.py
+++ b/indico/modules/events/registration/fields/__init__.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 
 
 def get_field_types():
-    """Get a dict with all registration field types"""
+    """Get a dict with all registration field types."""
     from .simple import (TextField, NumberField, TextAreaField, CheckboxField, DateField, BooleanField, PhoneField,
                          CountryField, FileField, EmailField)
     from .choices import SingleChoiceField, AccommodationField, MultiChoiceField

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -15,7 +15,7 @@ from indico.modules.events.registration.models.registrations import Registration
 
 
 class RegistrationFormFieldBase(object):
-    """Base class for a registration form field definition"""
+    """Base class for a registration form field definition."""
 
     #: unique name of the field type
     name = None
@@ -39,7 +39,7 @@ class RegistrationFormFieldBase(object):
 
     @property
     def validators(self):
-        """Returns a list of validators for this field"""
+        """Return a list of validators for this field."""
         return None
 
     @property
@@ -47,7 +47,7 @@ class RegistrationFormFieldBase(object):
         return None
 
     def calculate_price(self, reg_data, versioned_data):
-        """Calculates the price of the field
+        """Calculate the price of the field.
 
         :param reg_data: The user data for the field
         :param versioned_data: The versioned field data to use
@@ -56,7 +56,7 @@ class RegistrationFormFieldBase(object):
 
     def create_sql_filter(self, data_list):
         """
-        Creates a SQL criterion to check whether the field's value is
+        Create a SQL criterion to check whether the field's value is
         in `data_list`.  The function is expected to return an
         operation on ``Registrationdata.data``.
         """
@@ -94,7 +94,7 @@ class RegistrationFormFieldBase(object):
 
     @classmethod
     def process_field_data(cls, data, old_data=None, old_versioned_data=None):
-        """Processes the settings of the field.
+        """Process the settings of the field.
 
         :param data: The field data from the client
         :param old_data: The old unversioned field data (if available)
@@ -118,7 +118,7 @@ class RegistrationFormFieldBase(object):
         return self.unprocess_field_data(self.form_item.versioned_data, self.form_item.data)
 
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):
-        """Return the data contained in the field
+        """Return the data contained in the field.
 
         If for_humans is True, return a human-readable string representation.
         If for_search is True, return a string suitable for comparison in search.
@@ -132,7 +132,7 @@ class RegistrationFormFieldBase(object):
         return self.get_friendly_data(data)
 
     def get_places_used(self):
-        """Returns the number of used places for the field"""
+        """Return the number of used places for the field."""
         return 0
 
 

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -292,7 +292,10 @@ class ParticipantsDisplayForm(IndicoForm):
 
 
 class ParticipantsDisplayFormColumnsForm(IndicoForm):
-    """Form to customize the columns for a particular registration form on the participant list."""
+    """
+    Form to customize the columns for a particular registration form
+    on the participant list.
+    """
     json = JSONField()
 
     def validate_json(self, field):
@@ -312,7 +315,9 @@ class ParticipantsDisplayFormColumnsForm(IndicoForm):
 
 
 class RegistrationManagersForm(IndicoForm):
-    """Form to manage users with privileges to modify registration-related items"""
+    """
+    Form to manage users with privileges to modify registration-related items.
+    """
 
     managers = PrincipalListField(_('Registration managers'), allow_groups=True, allow_emails=True,
                                   allow_external_users=True,
@@ -325,7 +330,9 @@ class RegistrationManagersForm(IndicoForm):
 
 
 class CreateMultipleRegistrationsForm(IndicoForm):
-    """Form to create multiple registrations of Indico users at the same time."""
+    """
+    Form to create multiple registrations of Indico users at the same time.
+    """
 
     user_principals = PrincipalListField(_("Indico users"), [DataRequired()])
     notify_users = BooleanField(_("Send e-mail notifications"),

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -99,7 +99,9 @@ class RegistrationListGenerator(ListGeneratorBase):
         return result
 
     def _get_sorted_regform_items(self, item_ids):
-        """Return the form items ordered by their position in the registration form."""
+        """
+        Return the form items ordered by their position in the registration form.
+        """
 
         if not item_ids:
             return []

--- a/indico/modules/events/registration/models/form_fields.py
+++ b/indico/modules/events/registration/models/form_fields.py
@@ -18,7 +18,7 @@ from indico.util.string import camelize_keys, return_ascii
 
 
 class RegistrationFormFieldData(db.Model):
-    """Description of a registration form field"""
+    """Description of a registration form field."""
 
     __tablename__ = 'form_field_data'
     __table_args__ = {'schema': 'event_registration'}
@@ -51,7 +51,7 @@ class RegistrationFormFieldData(db.Model):
 
 
 class RegistrationFormField(RegistrationFormItem):
-    """A registration form field"""
+    """A registration form field."""
 
     __mapper_args__ = {
         'polymorphic_identity': RegistrationFormItemType.field

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -39,7 +39,7 @@ class ModificationMode(RichIntEnum):
 
 
 class RegistrationForm(db.Model):
-    """A registration form for an event"""
+    """A registration form for an event."""
 
     __tablename__ = 'forms'
     principal_type = PrincipalType.registration_form
@@ -401,7 +401,7 @@ class RegistrationForm(db.Model):
         return '<RegistrationForm({}, {}, {})>'.format(self.id, self.event_id, self.title)
 
     def is_modification_allowed(self, registration):
-        """Checks whether a registration may be modified"""
+        """Check whether a registration may be modified."""
         if not registration.is_active:
             return False
         elif self.modification_mode == ModificationMode.allowed_always:
@@ -416,7 +416,7 @@ class RegistrationForm(db.Model):
 
     @memoize_request
     def get_registration(self, user=None, uuid=None, email=None):
-        """Retrieves registrations for this registration form by user or uuid"""
+        """Retrieve registrations for this registration form by user or uuid."""
         if (bool(user) + bool(uuid) + bool(email)) != 1:
             raise ValueError("Exactly one of `user`, `uuid` and `email` must be specified")
         if user:
@@ -434,7 +434,7 @@ class RegistrationForm(db.Model):
         return format_currency(self.base_price, self.currency, locale=session.lang or 'en_GB')
 
     def get_personal_data_field_id(self, personal_data_type):
-        """Returns the field id corresponding to the personal data field with the given name."""
+        """Return the field id corresponding to the personal data field with the given name."""
         for field in self.active_fields:
             if (isinstance(field, RegistrationFormPersonalDataField) and
                     field.personal_data_type == personal_data_type):

--- a/indico/modules/events/registration/models/invitations.py
+++ b/indico/modules/events/registration/models/invitations.py
@@ -27,7 +27,7 @@ class InvitationState(RichIntEnum):
 
 
 class RegistrationInvitation(db.Model):
-    """An invitation for someone to register"""
+    """An invitation for someone to register."""
     __tablename__ = 'invitations'
     __table_args__ = (db.CheckConstraint("(state = {state}) OR (registration_id IS NULL)"
                                          .format(state=InvitationState.accepted), name='registration_state'),
@@ -117,7 +117,7 @@ class RegistrationInvitation(db.Model):
     def locator(self):
         """A locator suitable for 'display' pages.
 
-        Instead of the numeric ID it uses the UUID
+        Instead of the numeric ID it uses the UUID.
         """
         assert self.uuid is not None
         return dict(self.registration_form.locator, invitation=self.uuid)

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -43,7 +43,9 @@ class RegistrationFormItemType(int, IndicoEnum):
 
 # We are not using a RichIntEnum since one of the instances is named "title".
 class PersonalDataType(int, IndicoEnum):
-    """Description of the personal data items that exist on every registration form"""
+    """
+    Description of the personal data items that exist on every registration form.
+    """
 
     __titles__ = [None, 'Email Address', 'First Name', 'Last Name', 'Affiliation', 'Title', 'Address',
                   'Phone Number', 'Country', 'Position']
@@ -138,7 +140,7 @@ class PersonalDataType(int, IndicoEnum):
 
 
 class RegistrationFormItem(db.Model):
-    """Generic registration form item"""
+    """Generic registration form item."""
 
     __tablename__ = 'form_items'
     __table_args__ = (
@@ -309,7 +311,7 @@ class RegistrationFormItem(db.Model):
 
     @property
     def view_data(self):
-        """Returns object with data that Angular can understand"""
+        """Return object with data that Angular can understand."""
         return dict(id=self.id, description=self.description, position=self.position)
 
     @hybrid_property
@@ -349,7 +351,7 @@ class RegistrationFormItem(db.Model):
 
 
 class RegistrationFormSection(RegistrationFormItem):
-    """Registration form section that can contain fields and text"""
+    """Registration form section that can contain fields and text."""
 
     __mapper_args__ = {
         'polymorphic_identity': RegistrationFormItemType.section
@@ -396,7 +398,7 @@ class RegistrationFormPersonalDataSection(RegistrationFormSection):
 
 
 class RegistrationFormText(RegistrationFormItem):
-    """Text to be displayed in registration form sections"""
+    """Text to be displayed in registration form sections."""
 
     __mapper_args__ = {
         'polymorphic_identity': RegistrationFormItemType.text

--- a/indico/modules/events/registration/models/legacy_mapping.py
+++ b/indico/modules/events/registration/models/legacy_mapping.py
@@ -12,7 +12,7 @@ from indico.util.string import format_repr, return_ascii
 
 
 class LegacyRegistrationMapping(db.Model):
-    """Legacy registration id/token mapping
+    """Legacy registration id/token mapping.
 
     Legacy registrations had tokens which are not compatible with the
     new UUID-based ones.

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -56,7 +56,7 @@ def _get_next_friendly_id(context):
 
 
 class Registration(db.Model):
-    """Somebody's registration for an event through a registration form"""
+    """Somebody's registration for an event through a registration form."""
     __tablename__ = 'registrations'
     __table_args__ = (db.CheckConstraint('email = lower(email)', 'lowercase_email'),
                       db.Index(None, 'friendly_id', 'event_id', unique=True,
@@ -281,7 +281,7 @@ class Registration(db.Model):
 
     @locator.uuid
     def locator(self):
-        """A locator that uses uuid instead of id"""
+        """A locator that uses uuid instead of id."""
         return dict(self.registration_form.locator, token=self.uuid)
 
     @property
@@ -315,7 +315,7 @@ class Registration(db.Model):
 
     @property
     def full_name(self):
-        """Returns the user's name in 'Firstname Lastname' notation."""
+        """Return the user's name in 'Firstname Lastname' notation."""
         return self.get_full_name(last_name_first=False)
 
     @property
@@ -325,18 +325,18 @@ class Registration(db.Model):
 
     @property
     def is_ticket_blocked(self):
-        """Check whether the ticket is blocked by a plugin"""
+        """Check whether the ticket is blocked by a plugin."""
         return any(values_from_signal(signals.event.is_ticket_blocked.send(self), single_value=True))
 
     @property
     def is_paid(self):
-        """Returns whether the registration has been paid for."""
+        """Return whether the registration has been paid for."""
         paid_states = {TransactionStatus.successful, TransactionStatus.pending}
         return self.transaction is not None and self.transaction.status in paid_states
 
     @property
     def payment_dt(self):
-        """The date/time when the registration has been paid for"""
+        """The date/time when the registration has been paid for."""
         return self.transaction.timestamp if self.is_paid else None
 
     @property
@@ -360,7 +360,7 @@ class Registration(db.Model):
 
     @property
     def summary_data(self):
-        """Export registration data nested in sections and fields"""
+        """Export registration data nested in sections and fields."""
 
         def _fill_from_regform():
             for section in self.registration_form.sections:
@@ -405,7 +405,7 @@ class Registration(db.Model):
                            user_id=None, is_deleted=False, _text=self.full_name)
 
     def get_full_name(self, last_name_first=True, last_name_upper=False, abbrev_first_name=False):
-        """Returns the user's in the specified notation.
+        """Return the user's in the specified notation.
 
         If not format options are specified, the name is returned in
         the 'Lastname, Firstname' notation.
@@ -448,7 +448,7 @@ class Registration(db.Model):
         return self._render_price(self.price_adjustment)
 
     def sync_state(self, _skip_moderation=True):
-        """Sync the state of the registration"""
+        """Sync the state of the registration."""
         initial_state = self.state
         regform = self.registration_form
         invitation = self.invitation
@@ -473,7 +473,7 @@ class Registration(db.Model):
             signals.event.registration_state_updated.send(self, previous_state=initial_state)
 
     def update_state(self, approved=None, paid=None, rejected=None, withdrawn=None, _skip_moderation=False):
-        """Update the state of the registration for a given action
+        """Update the state of the registration for a given action.
 
         The accepted kwargs are the possible actions. ``True`` means that the
         action occured and ``False`` that it was reverted.
@@ -551,7 +551,7 @@ class Registration(db.Model):
 
 
 class RegistrationData(StoredFileMixin, db.Model):
-    """Data entry within a registration for a field in a registration form"""
+    """Data entry within a registration for a field in a registration form."""
 
     __tablename__ = 'registration_data'
     __table_args__ = {'schema': 'event_registration'}

--- a/indico/modules/events/registration/settings.py
+++ b/indico/modules/events/registration/settings.py
@@ -33,7 +33,7 @@ BADGE_SETTING_CONVERTERS = {
 
 
 class RegistrationSettingsProxy(EventSettingsProxy):
-    """Store per-event registration settings"""
+    """Store per-event registration settings."""
 
     def get_participant_list_columns(self, event, form=None):
         if form is None:

--- a/indico/modules/events/registration/stats.py
+++ b/indico/modules/events/registration/stats.py
@@ -17,7 +17,7 @@ from indico.util.i18n import _
 
 class StatsBase(object):
     def __init__(self, title, subtitle, type, **kwargs):
-        """Base class for registration form statistics
+        """Base class for registration form statistics.
 
         :param title: str -- the title for the stats box
         :param subtitle: str -- the subtitle for the stats box
@@ -34,7 +34,7 @@ class StatsBase(object):
 
 
 class Cell(namedtuple('Cell', ['type', 'data', 'colspan', 'classes', 'qtip'])):
-    """Hold data and type for a cell of a stats table"""
+    """Hold data and type for a cell of a stats table."""
 
     _type_defaults = {
         'str': '',
@@ -88,7 +88,7 @@ class DataItem(namedtuple('DataItem', ['regs', 'attendance', 'capacity', 'billab
     def __new__(cls, regs=0, attendance=0, capacity=0, billable=False, cancelled=False, price=0, fixed_price=False,
                 paid=0, paid_amount=0, unpaid=0, unpaid_amount=0):
         """
-        Holds the aggregation of some data, intended for stats tables as
+        Hold the aggregation of some data, intended for stats tables as
         a aggregation from which to generate cells.
 
         :param regs: int -- number of registrant
@@ -113,7 +113,7 @@ class DataItem(namedtuple('DataItem', ['regs', 'attendance', 'capacity', 'billab
 
 
 class FieldStats(object):
-    """Holds stats for a registration form field"""
+    """Hold stats for a registration form field."""
 
     def __init__(self, field, **kwargs):
         kwargs.setdefault('type', 'table')
@@ -138,7 +138,7 @@ class FieldStats(object):
                                          RegistrationData.data != {})
 
     def _build_data(self):
-        """Build data from registration data and field choices
+        """Build data from registration data and field choices.
 
         :returns: (dict, bool) -- the data and a boolean to indicate
                   whether the data contains billing information or not.
@@ -158,7 +158,7 @@ class FieldStats(object):
         return data, bool(choices['billed'])
 
     def get_table(self):
-        """Returns a table containing the stats for each item.
+        """Return a table containing the stats for each item.
 
         :return: dict -- A table with a list of head cells
                  (key: `'head'`) and a list of rows (key: `'rows'`)
@@ -180,7 +180,7 @@ class FieldStats(object):
         return table
 
     def _get_billing_cells(self, data_items):
-        """Return cells with billing information from data items
+        """Return cells with billing information from data items.
 
         :params data_items: [DataItem] -- Data items containing billing info
         :returns: [Cell] -- Cells containing billing information.
@@ -203,7 +203,7 @@ class FieldStats(object):
                 Cell(type='currency', data=total_amount)]
 
     def _get_billing_details_cells(self, detail):
-        """Return cells with detailed billing information
+        """Return cells with detailed billing information.
 
         :params item_details: DataItem -- Data items containing billing info
         :returns: [Cell] -- Cells containing billing information.
@@ -225,7 +225,7 @@ class FieldStats(object):
                 Cell(type='currency', data=detail.paid_amount + detail.unpaid_amount)]
 
     def _build_key(self, item):
-        """Return the key to sort and group field choices
+        """Return the key to sort and group field choices.
 
         It must include the caption and the id of the item as well as other
         billing information by which to aggregate.
@@ -236,7 +236,7 @@ class FieldStats(object):
         raise NotImplementedError
 
     def _build_regitems_data(self, key, regitems):
-        """Return a `DataItem` aggregating data from registration items
+        """Return a `DataItem` aggregating data from registration items.
 
         :param regitems: list -- list of registrations items to be aggregated
         :returns: DataItem -- the data aggregation
@@ -245,7 +245,7 @@ class FieldStats(object):
 
     def _build_choice_data(self, item):
         """
-        Returns a `DataItem` containing the aggregation of an item which
+        Return a `DataItem` containing the aggregation of an item which
         is billed to the registrants.
 
         :param item: list -- item to be aggregated
@@ -255,7 +255,7 @@ class FieldStats(object):
 
     def _get_table_head(self):
         """
-        Returns a list of `Cell` corresponding to the headers of a the
+        Return a list of `Cell` corresponding to the headers of a the
         table.
 
         :returns: [Cell] -- the headers of the table.
@@ -264,7 +264,7 @@ class FieldStats(object):
 
     def _get_main_row_cells(self, item_details, choice_caption, total_regs):
         """
-        Returns the cells of the main (header or single) row of the table.
+        Return the cells of the main (header or single) row of the table.
 
         Each `item` has a main row. The row is a list of `Cell` which matches
         the table head.
@@ -280,7 +280,7 @@ class FieldStats(object):
 
     def _get_sub_row_cells(self, details, total_regs):
         """
-        Returns the cells of the sub row of the table.
+        Return the cells of the sub row of the table.
 
         An `item` can have a sub row. The row is a list of `Cell` which
         matches the table head.
@@ -294,7 +294,7 @@ class FieldStats(object):
 
 
 class OverviewStats(StatsBase):
-    """Generic stats for a registration form"""
+    """Generic stats for a registration form."""
 
     def __init__(self, regform):
         super(OverviewStats, self).__init__(title=_("Overview"), subtitle="", type='overview')

--- a/indico/modules/events/registration/testing/fixtures.py
+++ b/indico/modules/events/registration/testing/fixtures.py
@@ -14,7 +14,7 @@ from indico.modules.events.registration.util import create_personal_data_fields
 
 @pytest.fixture
 def dummy_regform(db, dummy_event):
-    """Create a dummy registration form for the dummy event"""
+    """Create a dummy registration form for the dummy event."""
     regform = RegistrationForm(event=dummy_event, title='Registration Form', currency='USD')
     create_personal_data_fields(regform)
 
@@ -28,7 +28,7 @@ def dummy_regform(db, dummy_event):
 
 @pytest.fixture
 def dummy_reg(db, dummy_event, dummy_regform, dummy_user):
-    """Create a dummy registration for the dummy event"""
+    """Create a dummy registration for the dummy event."""
     reg = Registration(
         registration_form_id=dummy_regform.id,
         first_name="Guinea",

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -51,7 +51,7 @@ from indico.web.forms.widgets import SwitchWidget
 
 
 def get_title_uuid(regform, title):
-    """Convert a string title to its UUID value
+    """Convert a string title to its UUID value.
 
     If the title does not exist in the title PD field, it will be
     ignored and returned as ``None``.
@@ -95,7 +95,7 @@ def get_event_section_data(regform, management=False, registration=None):
 
 
 def check_registration_email(regform, email, registration=None, management=False):
-    """Checks whether an email address is suitable for registration.
+    """Check whether an email address is suitable for registration.
 
     :param regform: The registration form
     :param email: The email address
@@ -144,7 +144,7 @@ def check_registration_email(regform, email, registration=None, management=False
 
 
 def make_registration_form(regform, management=False, registration=None):
-    """Creates a WTForm based on registration form fields"""
+    """Create a WTForm based on registration form fields."""
 
     class RegistrationFormWTF(IndicoForm):
         if management:
@@ -169,7 +169,7 @@ def make_registration_form(regform, management=False, registration=None):
 
 
 def create_personal_data_fields(regform):
-    """Creates the special section/fields for personal data."""
+    """Create the special section/fields for personal data."""
     section = next((s for s in regform.sections if s.type == RegistrationFormItemType.section_pd), None)
     if section is None:
         section = RegistrationFormPersonalDataSection(registration_form=regform, title='Personal Data')
@@ -192,7 +192,7 @@ def create_personal_data_fields(regform):
 
 
 def url_rule_to_angular(endpoint):
-    """Converts a flask-style rule to angular style"""
+    """Convert a flask-style rule to angular style."""
     mapping = {
         'reg_form_id': 'confFormId',
         'section_id': 'sectionId',
@@ -298,7 +298,7 @@ def modify_registration(registration, data, management=False, notify_user=True):
 
 
 def generate_spreadsheet_from_registrations(registrations, regform_items, static_items):
-    """Generates a spreadsheet data from a given registration list.
+    """Generate a spreadsheet data from a given registration list.
 
     :param registrations: The list of registrations to include in the file
     :param regform_items: The registration form items to be used as columns
@@ -382,7 +382,7 @@ def get_published_registrations(event):
 
 
 def get_events_registered(user, dt=None):
-    """Gets the IDs of events where the user is registered.
+    """Get the IDs of events where the user is registered.
 
     :param user: A `User`
     :param dt: Only include events taking place on/after that date
@@ -537,7 +537,7 @@ def get_ticket_attachments(registration):
 
 
 def update_regform_item_positions(regform):
-    """Update positions when deleting/disabling an item in order to prevent gaps"""
+    """Update positions when deleting/disabling an item in order to prevent gaps."""
     section_positions = itertools.count(1)
     disabled_section_positions = itertools.count(1000)
     for section in sorted(regform.sections, key=attrgetter('position')):
@@ -600,7 +600,7 @@ def get_registered_event_persons(event):
 
 
 def serialize_registration_form(regform):
-    """Serialize registration form to JSON-like object"""
+    """Serialize registration form to JSON-like object."""
     return {
         'id': regform.id,
         'name': regform.title,

--- a/indico/modules/events/reminders/controllers.py
+++ b/indico/modules/events/reminders/controllers.py
@@ -29,7 +29,7 @@ class RHRemindersBase(RHManageEventBase):
 
 
 class RHSpecificReminderBase(RHRemindersBase):
-    """Base class for pages related to a specific reminder"""
+    """Base class for pages related to a specific reminder."""
 
     normalize_url_spec = {
         'locators': {
@@ -43,7 +43,7 @@ class RHSpecificReminderBase(RHRemindersBase):
 
 
 class RHListReminders(RHRemindersBase):
-    """Shows the list of event reminders"""
+    """Show the list of event reminders."""
 
     def _process(self):
         reminders = EventReminder.query.with_parent(self.event).order_by(EventReminder.scheduled_dt.desc()).all()
@@ -51,7 +51,7 @@ class RHListReminders(RHRemindersBase):
 
 
 class RHDeleteReminder(RHSpecificReminderBase):
-    """Deletes a reminder"""
+    """Delete a reminder."""
 
     def _process(self):
         if self.reminder.is_sent:
@@ -65,14 +65,14 @@ class RHDeleteReminder(RHSpecificReminderBase):
 
 
 def _send_reminder(reminder):
-    """Send reminder immediately"""
+    """Send reminder immediately."""
     reminder.send()
     logger.info('Reminder sent by %s: %s', session.user, reminder)
     flash(_('The reminder has been sent.'), 'success')
 
 
 class RHEditReminder(RHSpecificReminderBase):
-    """Modifies an existing reminder"""
+    """Modify an existing reminder."""
 
     def _get_defaults(self):
         reminder = self.reminder
@@ -105,7 +105,7 @@ class RHEditReminder(RHSpecificReminderBase):
 
 
 class RHAddReminder(RHRemindersBase):
-    """Adds a new reminder"""
+    """Add a new reminder."""
 
     def _process(self):
         form = ReminderForm(event=self.event, schedule_type='relative')
@@ -126,7 +126,7 @@ class RHAddReminder(RHRemindersBase):
 
 
 class RHPreviewReminder(RHRemindersBase):
-    """Previews the email for a reminder"""
+    """Preview the email for a reminder."""
 
     def _process(self):
         include_summary = request.form.get('include_summary') == '1'

--- a/indico/modules/events/reminders/models/reminders.py
+++ b/indico/modules/events/reminders/models/reminders.py
@@ -21,7 +21,7 @@ from indico.util.string import format_repr, return_ascii
 
 
 class EventReminder(db.Model):
-    """Email reminders for events"""
+    """Email reminders for events."""
     __tablename__ = 'reminders'
     __table_args__ = (db.Index(None, 'scheduled_dt', postgresql_where=db.text('not is_sent')),
                       {'schema': 'events'})
@@ -130,7 +130,7 @@ class EventReminder(db.Model):
 
     @property
     def all_recipients(self):
-        """Returns all recipients of the notifications.
+        """Return all recipients of the notifications.
 
         This includes both explicit recipients and, if enabled,
         participants of the event.
@@ -143,7 +143,7 @@ class EventReminder(db.Model):
 
     @hybrid_property
     def is_relative(self):
-        """Returns if the reminder is relative to the event time"""
+        """Return if the reminder is relative to the event time."""
         return self.event_start_delta is not None
 
     @is_relative.expression
@@ -155,7 +155,7 @@ class EventReminder(db.Model):
         return not self.is_sent and self.scheduled_dt <= now_utc()
 
     def send(self):
-        """Sends the reminder to its recipients."""
+        """Send the reminder to its recipients."""
         self.is_sent = True
         recipients = self.all_recipients
         if not recipients:

--- a/indico/modules/events/reminders/util.py
+++ b/indico/modules/events/reminders/util.py
@@ -12,7 +12,7 @@ from indico.web.flask.templating import get_template_module
 
 
 def make_reminder_email(event, with_agenda, with_description, note):
-    """Returns the template module for the reminder email.
+    """Return the template module for the reminder email.
 
     :param event: The event
     :param with_agenda: If the event's agenda should be included

--- a/indico/modules/events/requests/controllers.py
+++ b/indico/modules/events/requests/controllers.py
@@ -37,7 +37,7 @@ class EventOrRequestManagerMixin:
 
 
 class RHRequestsEventRequests(EventOrRequestManagerMixin, RHManageEventBase):
-    """Overview of existing requests (event)"""
+    """Overview of existing requests (event)."""
 
     def _process(self):
         definitions = get_request_definitions()
@@ -53,7 +53,7 @@ class RHRequestsEventRequests(EventOrRequestManagerMixin, RHManageEventBase):
 
 
 class RHRequestsEventRequestBase(RHManageEventBase):
-    """Base class for pages handling a specific request type"""
+    """Base class for pages handling a specific request type."""
 
     #: if a request must be present in the database
     _require_request = True
@@ -70,7 +70,7 @@ class RHRequestsEventRequestBase(RHManageEventBase):
 
 
 class RHRequestsEventRequestDetailsBase(EventOrRequestManagerMixin, RHRequestsEventRequestBase):
-    """Base class for the details/edit/manage views of a specific request"""
+    """Base class for the details/edit/manage views of a specific request."""
 
     def _process(self):
         self.is_manager = self.definition.can_be_managed(session.user)
@@ -99,7 +99,7 @@ class RHRequestsEventRequestDetailsBase(EventOrRequestManagerMixin, RHRequestsEv
 
 
 class RHRequestsEventRequestDetails(RHRequestsEventRequestDetailsBase):
-    """Details/form for a specific request"""
+    """Details/form for a specific request."""
 
     _require_request = False
 
@@ -135,7 +135,7 @@ class RHRequestsEventRequestDetails(RHRequestsEventRequestDetailsBase):
 
 
 class RHRequestsEventRequestProcess(RHRequestsEventRequestDetailsBase):
-    """Accept/Reject a request"""
+    """Accept/Reject a request."""
 
     def _check_access(self):
         self._require_user()
@@ -173,7 +173,7 @@ class RHRequestsEventRequestProcess(RHRequestsEventRequestDetailsBase):
 
 
 class RHRequestsEventRequestWithdraw(EventOrRequestManagerMixin, RHRequestsEventRequestBase):
-    """Withdraw a request"""
+    """Withdraw a request."""
 
     def _check_access(self):
         EventOrRequestManagerMixin._check_access(self)

--- a/indico/modules/events/requests/models/requests.py
+++ b/indico/modules/events/requests/models/requests.py
@@ -28,7 +28,7 @@ class RequestState(RichIntEnum):
 
 
 class Request(db.Model):
-    """Event-related requests, e.g. for a webcast"""
+    """Event-related requests, e.g. for a webcast."""
     __tablename__ = 'requests'
     __table_args__ = {'schema': 'events'}
 
@@ -133,7 +133,7 @@ class Request(db.Model):
 
     @property
     def can_be_modified(self):
-        """Determines if the request can be modified or if a new one must be sent"""
+        """Determine if the request can be modified or if a new one must be sent."""
         return self.state in {RequestState.pending, RequestState.accepted}
 
     @property
@@ -147,7 +147,7 @@ class Request(db.Model):
 
     @classmethod
     def find_latest_for_event(cls, event, type_=None):
-        """Returns the latest requests for a given event.
+        """Return the latest requests for a given event.
 
         :param event: the event to find the requests for
         :param type_: the request type to retrieve, or `None` to get all

--- a/indico/modules/events/requests/notifications.py
+++ b/indico/modules/events/requests/notifications.py
@@ -20,13 +20,16 @@ def _get_request_manager_emails(req):
 
 
 def _get_notification_reply_email(req):
-    """Get the e-mail address that should be the `Reply-To:` of user notifications."""
+    """
+    Get the e-mail address that should be the `Reply-To:` of
+    user notifications.
+    """
     with plugin_context(req.definition.plugin):
         return req.definition.get_notification_reply_email()
 
 
 def _get_template_module(name, req, **context):
-    """Get template module for a request email notification template
+    """Get template module for a request email notification template.
 
     :param name: template name
     :param req: :class:`Request` instance
@@ -37,7 +40,7 @@ def _get_template_module(name, req, **context):
 
 
 def notify_request_managers(req, template, **context):
-    """Notifies request managers about something
+    """Notify request managers about something.
 
     :param req: the :class:`Request`
     :param template: the template for the notification
@@ -56,7 +59,7 @@ def notify_request_managers(req, template, **context):
 
 
 def notify_event_managers(req, template, **context):
-    """Notifies event managers about something
+    """Notify event managers about something.
 
     :param req: the :class:`Request`
     :param template: the template for the notification
@@ -73,7 +76,7 @@ def notify_event_managers(req, template, **context):
 
 @email_sender
 def notify_new_modified_request(req, new):
-    """Notifies event managers and request managers about a new/modified request
+    """Notify event managers and request managers about a new/modified request.
 
     :param req: the :class:`Request`
     :param new: True if it's a new request
@@ -84,7 +87,7 @@ def notify_new_modified_request(req, new):
 
 @email_sender
 def notify_withdrawn_request(req, email_event_managers):
-    """Notifies event managers and request managers about a withdrawn request
+    """Notify event managers and request managers about a withdrawn request.
 
     :param req: the :class:`Request`
     :param email_event_managers: if event managers should be notified
@@ -96,7 +99,7 @@ def notify_withdrawn_request(req, email_event_managers):
 
 @email_sender
 def notify_accepted_request(req):
-    """Notifies event managers and request managers about a accepted request
+    """Notify event managers and request managers about a accepted request.
 
     :param req: the :class:`Request`
     """
@@ -106,7 +109,7 @@ def notify_accepted_request(req):
 
 @email_sender
 def notify_rejected_request(req):
-    """Notifies event managers and request managers about a rejected request
+    """Notify event managers and request managers about a rejected request.
 
     :param req: the :class:`Request`
     """

--- a/indico/modules/events/requests/util.py
+++ b/indico/modules/events/requests/util.py
@@ -12,12 +12,12 @@ from indico.util.signals import named_objects_from_signal
 
 
 def get_request_definitions():
-    """Returns a dict of request definitions"""
+    """Return a dict of request definitions."""
     return named_objects_from_signal(signals.plugin.get_event_request_definitions.send(), plugin_attr='plugin')
 
 
 def is_request_manager(user):
-    """Checks if the user manages any request types"""
+    """Check if the user manages any request types."""
     if not user:
         return False
     return any(def_.can_be_managed(user) for def_ in get_request_definitions().itervalues())

--- a/indico/modules/events/roles/controllers.py
+++ b/indico/modules/events/roles/controllers.py
@@ -45,14 +45,14 @@ def _render_role(role, collapsed=True):
 
 
 class RHEventRoles(RHManageEventBase):
-    """Event role management"""
+    """Event role management."""
 
     def _process(self):
         return WPEventRoles.render_template('roles.html', self.event, roles=_get_roles(self.event))
 
 
 class RHAddEventRole(RHManageEventBase):
-    """Add a new event role"""
+    """Add a new event role."""
 
     def _process(self):
         form = EventRoleForm(event=self.event, color=self._get_color())
@@ -73,7 +73,7 @@ class RHAddEventRole(RHManageEventBase):
 
 
 class RHManageEventRole(RHManageEventBase):
-    """Base class to manage a specific event role"""
+    """Base class to manage a specific event role."""
 
     normalize_url_spec = {
         'locators': {
@@ -87,7 +87,7 @@ class RHManageEventRole(RHManageEventBase):
 
 
 class RHEditEventRole(RHManageEventRole):
-    """Edit an event role"""
+    """Edit an event role."""
 
     def _process(self):
         form = EventRoleForm(obj=self.role, event=self.event)
@@ -102,7 +102,7 @@ class RHEditEventRole(RHManageEventRole):
 
 
 class RHDeleteEventRole(RHManageEventRole):
-    """Delete an event role"""
+    """Delete an event role."""
 
     def _process(self):
         db.session.delete(self.role)
@@ -113,7 +113,7 @@ class RHDeleteEventRole(RHManageEventRole):
 
 
 class RHRemoveEventRoleMember(RHManageEventRole):
-    """Remove a user from an event role"""
+    """Remove a user from an event role."""
 
     normalize_url_spec = dict(RHManageEventRole.normalize_url_spec, preserved_args={'user_id'})
 
@@ -133,7 +133,7 @@ class RHRemoveEventRoleMember(RHManageEventRole):
 
 
 class RHAddEventRoleMembers(RHManageEventRole):
-    """Add users to an event role"""
+    """Add users to an event role."""
 
     def _process(self):
         for data in request.json['users']:
@@ -149,6 +149,6 @@ class RHAddEventRoleMembers(RHManageEventRole):
 
 
 class RHEventRoleMembersImportCSV(ImportRoleMembersMixin, RHManageEventRole):
-    """Add users to an event role from CSV"""
+    """Add users to an event role from CSV."""
 
     logger = logger

--- a/indico/modules/events/roles/util.py
+++ b/indico/modules/events/roles/util.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 
 
 def serialize_event_role(role, legacy=True):
-    """Serialize role to JSON-like object"""
+    """Serialize role to JSON-like object."""
     if legacy:
         return {
             'id': role.id,

--- a/indico/modules/events/sessions/controllers/management/__init__.py
+++ b/indico/modules/events/sessions/controllers/management/__init__.py
@@ -15,11 +15,11 @@ from indico.modules.events.sessions.models.sessions import Session
 
 
 class RHManageSessionsBase(RHManageEventBase):
-    """Base RH for all session management RHs"""
+    """Base RH for all session management RHs."""
 
 
 class RHManageSessionBase(RHManageSessionsBase):
-    """Base RH for management of a single session"""
+    """Base RH for management of a single session."""
 
     normalize_url_spec = {
         'locators': {
@@ -37,7 +37,7 @@ class RHManageSessionBase(RHManageSessionsBase):
 
 
 class RHManageSessionsActionsBase(RHManageSessionsBase):
-    """Base class for classes performing actions on sessions"""
+    """Base class for classes performing actions on sessions."""
 
     def _process_args(self):
         RHManageSessionsBase._process_args(self)

--- a/indico/modules/events/sessions/controllers/management/sessions.py
+++ b/indico/modules/events/sessions/controllers/management/sessions.py
@@ -58,7 +58,7 @@ def _render_session_list(event):
 
 
 class RHSessionsList(RHManageSessionsBase):
-    """Display list of all sessions within the event"""
+    """Display list of all sessions within the event,"""
 
     def _process(self):
         selected_entry = request.args.get('selected')
@@ -69,7 +69,7 @@ class RHSessionsList(RHManageSessionsBase):
 
 
 class RHCreateSession(RHManageSessionsBase):
-    """Create a session in the event"""
+    """Create a session in the event."""
 
     def _get_response(self, new_session):
         sessions = [{'id': s.id, 'title': s.title, 'colors': s.colors} for s in self.event.sessions]
@@ -90,7 +90,7 @@ class RHCreateSession(RHManageSessionsBase):
 
 
 class RHModifySession(RHManageSessionBase):
-    """Modify a session"""
+    """Modify a session."""
 
     def _process(self):
         form = SessionForm(obj=self.session, event=self.event)
@@ -101,7 +101,7 @@ class RHModifySession(RHManageSessionBase):
 
 
 class RHDeleteSessions(RHManageSessionsActionsBase):
-    """Remove multiple sessions"""
+    """Remove multiple sessions."""
 
     def _process(self):
         for sess in self.sessions:
@@ -114,7 +114,7 @@ class RHManageSessionsExportBase(RHManageSessionsActionsBase):
 
 
 class RHExportSessionsCSV(RHManageSessionsExportBase):
-    """Export list of sessions to a CSV"""
+    """Export list of sessions to a CSV."""
 
     def _process(self):
         headers, rows = generate_spreadsheet_from_sessions(self.sessions)
@@ -122,7 +122,7 @@ class RHExportSessionsCSV(RHManageSessionsExportBase):
 
 
 class RHExportSessionsExcel(RHManageSessionsExportBase):
-    """Export list of sessions to a XLSX"""
+    """Export list of sessions to a XLSX."""
 
     def _process(self):
         headers, rows = generate_spreadsheet_from_sessions(self.sessions)
@@ -130,7 +130,7 @@ class RHExportSessionsExcel(RHManageSessionsExportBase):
 
 
 class RHExportSessionsPDF(RHManageSessionsExportBase):
-    """Export list of sessions to a PDF"""
+    """Export list of sessions to a PDF."""
 
     def _process(self):
         pdf_file = generate_pdf_from_sessions(self.sessions)
@@ -138,7 +138,7 @@ class RHExportSessionsPDF(RHManageSessionsExportBase):
 
 
 class RHSessionREST(RHManageSessionBase):
-    """Perform update or removal of a session"""
+    """Perform update or removal of a session."""
 
     def _process_DELETE(self):
         delete_session(self.session)
@@ -173,7 +173,7 @@ class RHSessionREST(RHManageSessionBase):
 
 
 class RHSessionPersonList(RHContributionPersonListMixin, RHManageSessionsActionsBase):
-    """List of persons in the session's contributions"""
+    """List of persons in the session's contributions."""
 
     template = 'events/sessions/management/session_person_list.html'
     ALLOW_LOCKED = True
@@ -185,7 +185,7 @@ class RHSessionPersonList(RHContributionPersonListMixin, RHManageSessionsActions
 
 
 class RHSessionProtection(RHManageSessionBase):
-    """Manage session protection"""
+    """Manage session protection."""
 
     def _process(self):
         form = SessionProtectionForm(obj=FormDefaults(**self._get_defaults()), session=self.session,
@@ -204,14 +204,14 @@ class RHSessionProtection(RHManageSessionBase):
 
 
 class RHSessionACL(RHManageSessionBase):
-    """Display the ACL of the session"""
+    """Display the ACL of the session."""
 
     def _process(self):
         return render_acl(self.session)
 
 
 class RHSessionACLMessage(RHManageSessionBase):
-    """Render the inheriting ACL message"""
+    """Render the inheriting ACL message."""
 
     def _process(self):
         mode = ProtectionMode[request.args['mode']]
@@ -220,7 +220,7 @@ class RHSessionACLMessage(RHManageSessionBase):
 
 
 class RHManageSessionBlock(RHManageSessionBase):
-    """Manage a block of a session"""
+    """Manage a block of a session."""
 
     normalize_url_spec = {
         'locators': {
@@ -258,7 +258,7 @@ class RHSessionBlocks(RHManageSessionBase):
 
 
 class RHManageSessionTypes(RHManageSessionsBase):
-    """Dialog to manage the session types of an event"""
+    """Dialog to manage the session types of an event."""
 
     def _process(self):
         return jsonify_template('events/sessions/management/types_dialog.html', event=self.event,
@@ -266,7 +266,7 @@ class RHManageSessionTypes(RHManageSessionsBase):
 
 
 class RHManageSessionTypeBase(RHManageSessionsBase):
-    """Manage a session type of an event"""
+    """Manage a session type of an event."""
 
     normalize_url_spec = {
         'locators': {
@@ -280,7 +280,7 @@ class RHManageSessionTypeBase(RHManageSessionsBase):
 
 
 class RHEditSessionType(RHManageSessionTypeBase):
-    """Dialog to edit a SessionType"""
+    """Dialog to edit a SessionType."""
 
     def _process(self):
         form = SessionTypeForm(event=self.event, obj=self.session_type)
@@ -295,7 +295,7 @@ class RHEditSessionType(RHManageSessionTypeBase):
 
 
 class RHCreateSessionType(RHManageSessionsBase):
-    """Dialog to add a SessionType"""
+    """Dialog to add a SessionType."""
 
     def _process(self):
         form = SessionTypeForm(event=self.event)
@@ -313,7 +313,7 @@ class RHCreateSessionType(RHManageSessionsBase):
 
 
 class RHDeleteSessionType(RHManageSessionTypeBase):
-    """Dialog to delete a SessionType"""
+    """Dialog to delete a SessionType."""
 
     def _process(self):
         db.session.delete(self.session_type)

--- a/indico/modules/events/sessions/forms.py
+++ b/indico/modules/events/sessions/forms.py
@@ -99,7 +99,7 @@ class MeetingSessionBlockForm(IndicoForm):
 
 
 class SessionTypeForm(IndicoForm):
-    """Form to create or edit a SessionType"""
+    """Form to create or edit a SessionType."""
 
     name = StringField(_("Name"), [DataRequired()])
     is_poster = BooleanField(_("Poster"), widget=SwitchWidget(),

--- a/indico/modules/events/sessions/models/legacy_mapping.py
+++ b/indico/modules/events/sessions/models/legacy_mapping.py
@@ -12,7 +12,7 @@ from indico.util.string import format_repr, return_ascii
 
 
 class LegacySessionMapping(db.Model):
-    """Legacy session id mapping
+    """Legacy session id mapping.
 
     Legacy sessions had ids unique only within their event.
     Additionally, some very old sessions had non-numeric IDs.
@@ -65,7 +65,7 @@ class LegacySessionMapping(db.Model):
 
 
 class LegacySessionBlockMapping(db.Model):
-    """Legacy session block id mapping
+    """Legacy session block id mapping.
 
     Legacy sessions blocks had ids unique only within their session.
     """

--- a/indico/modules/events/sessions/models/persons.py
+++ b/indico/modules/events/sessions/models/persons.py
@@ -15,7 +15,7 @@ from indico.util.string import format_repr, return_ascii
 class SessionBlockPersonLink(PersonLinkBase):
     """Association between EventPerson and SessionBlock.
 
-    Also known as a 'session convener'
+    Also known as a 'session convener'.
     """
 
     __tablename__ = 'session_block_person_links'

--- a/indico/modules/events/sessions/models/sessions.py
+++ b/indico/modules/events/sessions/models/sessions.py
@@ -163,7 +163,7 @@ class Session(DescriptionMixin, ColorMixin, ProtectionManagersMixin, LocationMix
 
     @property
     def session(self):
-        """Convenience property so all event entities have it"""
+        """Convenience property so all event entities have it."""
         return self
 
     @property
@@ -206,7 +206,7 @@ class Session(DescriptionMixin, ColorMixin, ProtectionManagersMixin, LocationMix
         return dict(self.event.locator, session_id=self.id)
 
     def get_non_inheriting_objects(self):
-        """Get a set of child objects that do not inherit protection"""
+        """Get a set of child objects that do not inherit protection."""
         return get_non_inheriting_objects(self)
 
     @return_ascii

--- a/indico/modules/events/sessions/operations.py
+++ b/indico/modules/events/sessions/operations.py
@@ -21,7 +21,9 @@ from indico.util.i18n import orig_string
 
 
 def create_session(event, data):
-    """Create a new session with the information passed in the `data` argument"""
+    """
+    Create a new session with the information passed in the `data` argument.
+    """
     event_session = Session(event=event)
     event_session.populate_from_dict(data)
     db.session.flush()
@@ -45,7 +47,7 @@ def create_session_block(session_, data):
 
 
 def update_session(event_session, data):
-    """Update a session based on the information in the `data`"""
+    """Update a session based on the information in the `data`."""
     event_session.populate_from_dict(data)
     db.session.flush()
     signals.event.session_updated.send(event_session)
@@ -68,7 +70,7 @@ def _delete_session_timetable_entries(event_session):
 
 
 def delete_session(event_session):
-    """Delete session from the event"""
+    """Delete session from the event."""
     event_session.is_deleted = True
     for contribution in event_session.contributions[:]:
         contribution.session = None
@@ -81,7 +83,7 @@ def delete_session(event_session):
 
 
 def update_session_block(session_block, data):
-    """Update a session block with data passed in the `data` argument"""
+    """Update a session block with data passed in the `data` argument."""
     from indico.modules.events.timetable.operations import update_timetable_entry
 
     start_dt = data.pop('start_dt', None)

--- a/indico/modules/events/sessions/util.py
+++ b/indico/modules/events/sessions/util.py
@@ -29,7 +29,7 @@ from indico.web.flask.util import url_for
 
 
 def can_manage_sessions(user, event, permission=None):
-    """Check whether a user can manage any sessions in an event"""
+    """Check whether a user can manage any sessions in an event."""
     if event.can_manage(user):
         return True
     return any(s.can_manage(user, permission)
@@ -95,7 +95,7 @@ class SessionListToPDF(PDFBase):
 
 
 def generate_pdf_from_sessions(sessions):
-    """Generate a PDF file from a given session list"""
+    """Generate a PDF file from a given session list."""
     pdf = SessionListToPDF(sessions)
     return BytesIO(pdf.getPDFBin())
 
@@ -116,8 +116,9 @@ def session_coordinator_priv_enabled(event, priv):
 
 
 def get_events_with_linked_sessions(user, dt=None):
-    """Returns a dict with keys representing event_id and the values containing
-    data about the user rights for sessions within the event
+    """
+    Return a dict with keys representing event_id and the values containing
+    data about the user rights for sessions within the event.
 
     :param user: A `User`
     :param dt: Only include events taking place on/after that date

--- a/indico/modules/events/settings.py
+++ b/indico/modules/events/settings.py
@@ -36,7 +36,7 @@ def event_or_id(f):
 
 
 class EventACLProxy(ACLProxyBase):
-    """Proxy class for event-specific ACL settings"""
+    """Proxy class for event-specific ACL settings."""
 
     @event_or_id
     def get(self, event, name):
@@ -50,7 +50,7 @@ class EventACLProxy(ACLProxyBase):
 
     @event_or_id
     def set(self, event, name, acl):
-        """Replaces an ACL with a new one
+        """Replace an ACL with a new one.
 
         :param event: Event (or its ID)
         :param name: Setting name
@@ -62,7 +62,7 @@ class EventACLProxy(ACLProxyBase):
 
     @event_or_id
     def contains_user(self, event, name, user):
-        """Checks if a user is in an ACL.
+        """Check if a user is in an ACL.
 
         To pass this check, the user can either be in the ACL itself
         or in a group in the ACL.
@@ -75,7 +75,7 @@ class EventACLProxy(ACLProxyBase):
 
     @event_or_id
     def add_principal(self, event, name, principal):
-        """Adds a principal to an ACL
+        """Add a principal to an ACL.
 
         :param event: Event (or its ID)
         :param name: Setting name
@@ -87,7 +87,7 @@ class EventACLProxy(ACLProxyBase):
 
     @event_or_id
     def remove_principal(self, event, name, principal):
-        """Removes a principal from an ACL
+        """Remove a principal from an ACL.
 
         :param event: Event (or its ID)
         :param name: Setting name
@@ -98,24 +98,24 @@ class EventACLProxy(ACLProxyBase):
         self._flush_cache()
 
     def merge_users(self, target, source):
-        """Replaces all ACL user entries for `source` with `target`"""
+        """Replace all ACL user entries for `source` with `target`."""
         EventSettingPrincipal.merge_users(self.module, target, source)
         self._flush_cache()
 
 
 class EventSettingsProxy(SettingsProxyBase):
-    """Proxy class to access event-specific settings for a certain module"""
+    """Proxy class to access event-specific settings for a certain module."""
 
     acl_proxy_class = EventACLProxy
 
     @property
     def query(self):
-        """Returns a query object filtering by the proxy's module."""
+        """Return a query object filtering by the proxy's module."""
         return EventSetting.find(module=self.module)
 
     @event_or_id
     def get_all(self, event, no_defaults=False):
-        """Retrieves all settings
+        """Retrieve all settings.
 
         :param event: Event (or its ID)
         :param no_defaults: Only return existing settings and ignore defaults.
@@ -125,7 +125,7 @@ class EventSettingsProxy(SettingsProxyBase):
 
     @event_or_id
     def get(self, event, name, default=SettingsProxyBase.default_sentinel):
-        """Retrieves the value of a single setting.
+        """Retrieve the value of a single setting.
 
         :param event: Event (or its ID)
         :param name: Setting name
@@ -137,7 +137,7 @@ class EventSettingsProxy(SettingsProxyBase):
 
     @event_or_id
     def set(self, event, name, value):
-        """Sets a single setting.
+        """Set a single setting.
 
         :param event: Event (or its ID)
         :param name: Setting name
@@ -149,7 +149,7 @@ class EventSettingsProxy(SettingsProxyBase):
 
     @event_or_id
     def set_multi(self, event, items):
-        """Sets multiple settings at once.
+        """Set multiple settings at once.
 
         :param event: Event (or its ID)
         :param items: Dict containing the new settings
@@ -162,7 +162,7 @@ class EventSettingsProxy(SettingsProxyBase):
 
     @event_or_id
     def delete(self, event, *names):
-        """Deletes settings.
+        """Delete settings.
 
         :param event: Event (or its ID)
         :param names: One or more names of settings to delete
@@ -174,7 +174,7 @@ class EventSettingsProxy(SettingsProxyBase):
 
     @event_or_id
     def delete_all(self, event):
-        """Deletes all settings.
+        """Delete all settings.
 
         :param event: Event (or its ID)
         """

--- a/indico/modules/events/static/offline.py
+++ b/indico/modules/events/static/offline.py
@@ -53,9 +53,9 @@ from indico.web.rh import RH
 def create_static_site(rh, event):
     """Create a static (offline) version of an Indico event.
 
-       :param rh: Request handler object
-       :param event: Event in question
-       :return: Path to the resulting ZIP file
+    :param rh: Request handler object
+    :param event: Event in question
+    :return: Path to the resulting ZIP file
     """
     try:
         g.static_site = True

--- a/indico/modules/events/static/tasks.py
+++ b/indico/modules/events/static/tasks.py
@@ -61,7 +61,7 @@ def notify_static_site_success(static_site):
 
 @celery.periodic_task(name='static_sites_cleanup', run_every=crontab(minute='30', hour='3', day_of_week='monday'))
 def static_sites_cleanup(days=30):
-    """Clean up old static sites
+    """Clean up old static sites.
 
     :param days: number of days after which to remove static sites
     """

--- a/indico/modules/events/surveys/controllers/management/__init__.py
+++ b/indico/modules/events/surveys/controllers/management/__init__.py
@@ -14,7 +14,7 @@ from indico.modules.events.surveys.models.surveys import Survey
 
 
 class RHManageSurveysBase(RHManageEventBase):
-    """Base class for all survey management RHs"""
+    """Base class for all survey management RHs."""
 
     PERMISSION = 'surveys'
 

--- a/indico/modules/events/surveys/controllers/management/questionnaire.py
+++ b/indico/modules/events/surveys/controllers/management/questionnaire.py
@@ -33,7 +33,7 @@ from indico.web.util import jsonify_data, jsonify_form, jsonify_template
 
 
 class RHManageSurveyQuestionnaire(RHManageSurveyBase):
-    """Manage the questionnaire of a survey (question overview page)"""
+    """Manage the questionnaire of a survey (question overview page)."""
 
     def _process(self):
         field_types = get_field_types()
@@ -43,7 +43,7 @@ class RHManageSurveyQuestionnaire(RHManageSurveyBase):
 
 
 class RHExportSurveyQuestionnaire(RHManageSurveyBase):
-    """Export the questionnaire to JSON format"""
+    """Export the questionnaire to JSON format."""
 
     def _process(self):
         sections = [section.to_dict() for section in self.survey.sections]
@@ -53,7 +53,7 @@ class RHExportSurveyQuestionnaire(RHManageSurveyBase):
 
 
 class RHImportSurveyQuestionnaire(RHManageSurveyBase):
-    """Import a questionnaire in JSON format"""
+    """Import a questionnaire in JSON format."""
 
     def _remove_false_values(self, data):
         # The forms consider a missing key as False (and a False value as True)
@@ -119,7 +119,7 @@ class RHImportSurveyQuestionnaire(RHManageSurveyBase):
 
 
 class RHManageSurveySectionBase(RHManageSurveysBase):
-    """Base class for RHs that deal with a specific survey section"""
+    """Base class for RHs that deal with a specific survey section."""
 
     normalize_url_spec = {
         'locators': {
@@ -136,7 +136,7 @@ class RHManageSurveySectionBase(RHManageSurveysBase):
 
 
 class RHManageSurveyTextBase(RHManageSurveysBase):
-    """Base class for RHs that deal with a specific survey text item"""
+    """Base class for RHs that deal with a specific survey text item."""
 
     normalize_url_spec = {
         'locators': {
@@ -152,7 +152,7 @@ class RHManageSurveyTextBase(RHManageSurveysBase):
 
 
 class RHManageSurveyQuestionBase(RHManageSurveysBase):
-    """Base class for RHs that deal with a specific survey question"""
+    """Base class for RHs that deal with a specific survey question."""
 
     normalize_url_spec = {
         'locators': {
@@ -169,7 +169,7 @@ class RHManageSurveyQuestionBase(RHManageSurveysBase):
 
 
 class RHAddSurveySection(RHManageSurveyBase):
-    """Add a new section to a survey"""
+    """Add a new section to a survey."""
 
     def _process(self):
         form = SectionForm()
@@ -185,7 +185,7 @@ class RHAddSurveySection(RHManageSurveyBase):
 
 
 class RHEditSurveySection(RHManageSurveySectionBase):
-    """Edit a survey section"""
+    """Edit a survey section."""
 
     def _process(self):
         form = SectionForm(obj=FormDefaults(self.section))
@@ -204,7 +204,7 @@ class RHEditSurveySection(RHManageSurveySectionBase):
 
 
 class RHDeleteSurveySection(RHManageSurveySectionBase):
-    """Delete a survey section and all its questions"""
+    """Delete a survey section and all its questions."""
 
     def _process(self):
         db.session.delete(self.section)
@@ -219,7 +219,7 @@ class RHDeleteSurveySection(RHManageSurveySectionBase):
 
 
 class RHAddSurveyText(RHManageSurveySectionBase):
-    """Add a new text item to a survey"""
+    """Add a new text item to a survey."""
 
     def _process(self):
         form = TextForm()
@@ -231,7 +231,7 @@ class RHAddSurveyText(RHManageSurveySectionBase):
 
 
 class RHEditSurveyText(RHManageSurveyTextBase):
-    """Edit a survey text item"""
+    """Edit a survey text item."""
 
     def _process(self):
         form = TextForm(obj=FormDefaults(self.text))
@@ -245,7 +245,7 @@ class RHEditSurveyText(RHManageSurveyTextBase):
 
 
 class RHDeleteSurveyText(RHManageSurveyTextBase):
-    """Delete a survey text item"""
+    """Delete a survey text item."""
 
     def _process(self):
         db.session.delete(self.text)
@@ -256,7 +256,7 @@ class RHDeleteSurveyText(RHManageSurveyTextBase):
 
 
 class RHAddSurveyQuestion(RHManageSurveySectionBase):
-    """Add a new question to a survey"""
+    """Add a new question to a survey."""
 
     def _process(self):
         try:
@@ -285,7 +285,7 @@ class RHAddSurveyQuestion(RHManageSurveySectionBase):
 
 
 class RHEditSurveyQuestion(RHManageSurveyQuestionBase):
-    """Edit a survey question"""
+    """Edit a survey question."""
 
     def _process(self):
         form = self.question.field.create_config_form(obj=FormDefaults(self.question, **self.question.field_data))
@@ -300,7 +300,7 @@ class RHEditSurveyQuestion(RHManageSurveyQuestionBase):
 
 
 class RHDeleteSurveyQuestion(RHManageSurveyQuestionBase):
-    """Delete a survey question"""
+    """Delete a survey question."""
 
     def _process(self):
         db.session.delete(self.question)
@@ -311,7 +311,7 @@ class RHDeleteSurveyQuestion(RHManageSurveyQuestionBase):
 
 
 class RHSortSurveyItems(RHManageSurveyBase):
-    """Sort survey items/sections and/or move items them between sections"""
+    """Sort survey items/sections and/or move items them between sections."""
 
     def _sort_sections(self):
         sections = {section.id: section for section in self.survey.sections}

--- a/indico/modules/events/surveys/controllers/management/results.py
+++ b/indico/modules/events/surveys/controllers/management/results.py
@@ -24,7 +24,7 @@ from indico.web.flask.util import url_for
 
 
 class RHSurveyResults(RHManageSurveyBase):
-    """Displays summarized results of the survey"""
+    """Display summarized results of the survey."""
 
     def _process_args(self):
         RHManageSurveysBase._process_args(self)
@@ -39,7 +39,7 @@ class RHSurveyResults(RHManageSurveyBase):
 
 
 class RHExportSubmissionsBase(RHManageSurveyBase):
-    """Export submissions from the survey"""
+    """Export submissions from the survey."""
 
     CSRF_ENABLED = False
     ALLOW_LOCKED = True
@@ -59,14 +59,14 @@ class RHExportSubmissionsBase(RHManageSurveyBase):
 
 
 class RHExportSubmissionsCSV(RHExportSubmissionsBase):
-    """Export submissions as CSV"""
+    """Export submissions as CSV."""
 
     def _export(self, filename, headers, rows):
         return send_csv(filename + '.csv', headers, rows)
 
 
 class RHExportSubmissionsExcel(RHExportSubmissionsBase):
-    """Export submissions as XLSX"""
+    """Export submissions as XLSX."""
 
     def _export(self, filename, headers, rows):
         return send_xlsx(filename + '.xlsx', headers, rows, tz=self.event.tzinfo)
@@ -91,7 +91,7 @@ class RHSurveySubmissionBase(RHManageSurveysBase):
 
 
 class RHDeleteSubmissions(RHManageSurveyBase):
-    """Remove submissions from the survey"""
+    """Remove submissions from the survey."""
 
     def _process(self):
         submission_ids = set(map(int, request.form.getlist('submission_ids')))
@@ -107,7 +107,7 @@ class RHDeleteSubmissions(RHManageSurveyBase):
 
 
 class RHDisplaySubmission(RHSurveySubmissionBase):
-    """Display a single submission-page"""
+    """Display a single submission-page."""
 
     def _process(self):
         answers = {answer.question_id: answer for answer in self.submission.answers}

--- a/indico/modules/events/surveys/controllers/management/survey.py
+++ b/indico/modules/events/surveys/controllers/management/survey.py
@@ -26,7 +26,7 @@ from indico.web.util import jsonify_data, jsonify_form, jsonify_template
 
 
 class RHManageSurveys(RHManageSurveysBase):
-    """Survey management overview (list of surveys)"""
+    """Survey management overview (list of surveys)."""
 
     def _process(self):
         surveys = (Survey.query.with_parent(self.event)
@@ -37,7 +37,7 @@ class RHManageSurveys(RHManageSurveysBase):
 
 
 class RHManageSurvey(RHManageSurveyBase):
-    """Specific survey management (overview)"""
+    """Specific survey management (overview)."""
 
     def _process(self):
         submitted_surveys = [s for s in self.survey.submissions if s.is_submitted]
@@ -46,7 +46,7 @@ class RHManageSurvey(RHManageSurveyBase):
 
 
 class RHEditSurvey(RHManageSurveyBase):
-    """Edit a survey's basic data/settings"""
+    """Edit a survey's basic data/settings."""
 
     def _get_form_defaults(self):
         return FormDefaults(self.survey, limit_submissions=self.survey.submission_limit is not None)
@@ -64,7 +64,7 @@ class RHEditSurvey(RHManageSurveyBase):
 
 
 class RHDeleteSurvey(RHManageSurveyBase):
-    """Delete a survey"""
+    """Delete a survey."""
 
     def _process(self):
         self.survey.is_deleted = True
@@ -74,7 +74,7 @@ class RHDeleteSurvey(RHManageSurveyBase):
 
 
 class RHCreateSurvey(RHManageSurveysBase):
-    """Create a new survey"""
+    """Create a new survey."""
 
     def _process(self):
         form = SurveyForm(obj=FormDefaults(require_user=True), event=self.event)
@@ -93,7 +93,7 @@ class RHCreateSurvey(RHManageSurveysBase):
 
 
 class RHScheduleSurvey(RHManageSurveyBase):
-    """Schedule a survey's start/end dates"""
+    """Schedule a survey's start/end dates."""
 
     def _get_form_defaults(self):
         return FormDefaults(self.survey)
@@ -117,7 +117,7 @@ class RHScheduleSurvey(RHManageSurveyBase):
 
 
 class RHCloseSurvey(RHManageSurveyBase):
-    """Close a survey (prevent users from submitting responses)"""
+    """Close a survey (prevent users from submitting responses)."""
 
     def _process(self):
         self.survey.close()
@@ -127,7 +127,7 @@ class RHCloseSurvey(RHManageSurveyBase):
 
 
 class RHOpenSurvey(RHManageSurveyBase):
-    """Open a survey (allows users to submit responses)"""
+    """Open a survey (allows users to submit responses)."""
 
     def _process(self):
         if self.survey.state == SurveyState.finished:
@@ -142,7 +142,7 @@ class RHOpenSurvey(RHManageSurveyBase):
 
 
 class RHSendSurveyLinks(RHManageSurveyBase):
-    """Send emails with URL of the survey"""
+    """Send emails with URL of the survey."""
 
     def _process(self):
         tpl = get_template_module('events/surveys/emails/survey_link_email.html', event=self.event)

--- a/indico/modules/events/surveys/fields/__init__.py
+++ b/indico/modules/events/surveys/fields/__init__.py
@@ -13,7 +13,7 @@ from indico.web.fields import get_field_definitions
 
 
 def get_field_types():
-    """Gets a dict containing all field types"""
+    """Get a dict containing all field types."""
     return get_field_definitions(SurveyField)
 
 

--- a/indico/modules/events/surveys/fields/choices.py
+++ b/indico/modules/events/surveys/fields/choices.py
@@ -20,7 +20,7 @@ from indico.web.fields.choices import MultiSelectField, SingleChoiceField
 class _AddUUIDMixin(object):
     @staticmethod
     def process_imported_data(data):
-        """Generate the options' IDs"""
+        """Generate the options' IDs."""
         data = deepcopy(data)
         if 'options' in data:
             for option in data['options']:

--- a/indico/modules/events/surveys/models/items.py
+++ b/indico/modules/events/surveys/models/items.py
@@ -171,7 +171,7 @@ class SurveyQuestion(SurveyItem):
         return [a for a in self.answers if not a.is_empty]
 
     def get_summary(self, **kwargs):
-        """Returns the summary of answers submitted for this question."""
+        """Return the summary of answers submitted for this question."""
         if self.field:
             return self.field.get_summary(**kwargs)
 

--- a/indico/modules/events/surveys/models/surveys.py
+++ b/indico/modules/events/surveys/models/surveys.py
@@ -221,7 +221,7 @@ class Survey(db.Model):
 
     @locator.token
     def locator(self):
-        """A locator that adds the UUID if the survey is private"""
+        """A locator that adds the UUID if the survey is private."""
         token = self.uuid if self.private else None
         return dict(self.locator, token=token)
 
@@ -243,7 +243,7 @@ class Survey(db.Model):
 
     @property
     def start_notification_recipients(self):
-        """Returns all recipients of the notifications.
+        """Return all recipients of the notifications.
 
         This includes both explicit recipients and, if enabled,
         participants of the event.

--- a/indico/modules/events/surveys/util.py
+++ b/indico/modules/events/surveys/util.py
@@ -21,7 +21,7 @@ from indico.web.forms.base import IndicoForm
 
 
 def make_survey_form(survey):
-    """Creates a WTForm from survey questions.
+    """Create a WTForm from survey questions.
 
     Each question will use a field named ``question_ID``.
 
@@ -41,14 +41,14 @@ def make_survey_form(survey):
 
 
 def save_submitted_survey_to_session(submission):
-    """Save submission of a survey to session for further checks"""
+    """Save submission of a survey to session for further checks."""
     session.setdefault('submitted_surveys', {})[submission.survey.id] = submission.id
     session.modified = True
 
 
 @memoize_request
 def was_survey_submitted(survey):
-    """Check whether the current user has submitted a survey"""
+    """Check whether the current user has submitted a survey."""
     from indico.modules.events.surveys.models.surveys import Survey
     query = (Survey.query.with_parent(survey.event)
              .filter(Survey.submissions.any(db.and_(SurveySubmission.is_submitted,
@@ -63,7 +63,7 @@ def was_survey_submitted(survey):
 
 
 def is_submission_in_progress(survey):
-    """Check whether the current user has a survey submission in progress"""
+    """Check whether the current user has a survey submission in progress."""
     from indico.modules.events.surveys.models.surveys import Survey
     if session.user:
         query = (Survey.query.with_parent(survey.event)
@@ -76,7 +76,7 @@ def is_submission_in_progress(survey):
 
 
 def generate_spreadsheet_from_survey(survey, submission_ids):
-    """Generates spreadsheet data from a given survey.
+    """Generate spreadsheet data from a given survey.
 
     :param survey: `Survey` for which the user wants to export submissions
     :param submission_ids: The list of submissions to include in the file
@@ -116,7 +116,7 @@ def _filter_submissions(survey, submission_ids):
 
 
 def get_events_with_submitted_surveys(user, dt=None):
-    """Gets the IDs of events where the user submitted a survey.
+    """Get the IDs of events where the user submitted a survey.
 
     :param user: A `User`
     :param dt: Only include events taking place on/after that date

--- a/indico/modules/events/timetable/controllers/__init__.py
+++ b/indico/modules/events/timetable/controllers/__init__.py
@@ -25,7 +25,7 @@ class SessionManagementLevel(Enum):
 
 
 class RHManageTimetableBase(RHManageEventBase):
-    """Base class for all timetable management RHs"""
+    """Base class for all timetable management RHs."""
 
     session_management_level = SessionManagementLevel.none
 

--- a/indico/modules/events/timetable/controllers/legacy.py
+++ b/indico/modules/events/timetable/controllers/legacy.py
@@ -405,7 +405,7 @@ class RHLegacyTimetableFitBlock(RHManageTimetableBase):
 
 
 class RHLegacyTimetableMoveEntry(RHManageTimetableEntryBase):
-    """Moves a TimetableEntry into a Session or top-level timetable"""
+    """Move a TimetableEntry into a Session or top-level timetable."""
 
     def _process_GET(self):
         current_day = dateutil.parser.parse(request.args.get('day')).date()
@@ -483,7 +483,7 @@ class RHLegacyTimetableSwapEntries(RHManageTimetableEntryBase):
 
 
 class RHLegacyTimetableEditEntryDateTime(RHManageTimetableEntryBase):
-    """Changes the start_dt of a `TimetableEntry`"""
+    """Change the start_dt of a `TimetableEntry`."""
 
     @property
     def session_management_level(self):

--- a/indico/modules/events/timetable/controllers/manage.py
+++ b/indico/modules/events/timetable/controllers/manage.py
@@ -31,7 +31,7 @@ from indico.web.util import jsonify_data
 
 
 class RHManageTimetable(RHManageTimetableBase):
-    """Display timetable management page"""
+    """Display timetable management page."""
 
     session_management_level = SessionManagementLevel.coordinate
 
@@ -63,7 +63,7 @@ class RHManageSessionTimetable(RHManageTimetableBase):
 
 
 class RHTimetableREST(RHManageTimetableEntryBase):
-    """RESTful timetable actions"""
+    """RESTful timetable actions."""
 
     def _get_contribution_updates(self, data):
         updates = {'parent': None}
@@ -89,7 +89,7 @@ class RHTimetableREST(RHManageTimetableEntryBase):
         return updates
 
     def _process_POST(self):
-        """Create new timetable entry"""
+        """Create new timetable entry."""
         data = request.json
         required_keys = {'start_dt'}
         allowed_keys = {'start_dt', 'contribution_id', 'session_block_id', 'force'}
@@ -107,7 +107,7 @@ class RHTimetableREST(RHManageTimetableEntryBase):
         return jsonify(start_dt=entry.start_dt.isoformat(), id=entry.id)
 
     def _process_PATCH(self):
-        """Update a timetable entry"""
+        """Update a timetable entry."""
         data = request.json
         # TODO: support breaks
         if set(data.viewkeys()) > {'start_dt'}:
@@ -121,7 +121,7 @@ class RHTimetableREST(RHManageTimetableEntryBase):
         return jsonify()
 
     def _process_DELETE(self):
-        """Delete a timetable entry"""
+        """Delete a timetable entry."""
         if self.entry.type == TimetableEntryType.SESSION_BLOCK:
             delete_session_block(self.entry.session_block)
         elif self.event.type != 'conference' and self.entry.type == TimetableEntryType.CONTRIBUTION:
@@ -173,7 +173,7 @@ class RHBreakREST(RHManageTimetableBase):
 
 
 class RHCloneContribution(RHManageTimetableBase):
-    """Clone a contribution and schedule it at the same position"""
+    """Clone a contribution and schedule it at the same position."""
 
     def _process_args(self):
         RHManageTimetableBase._process_args(self)

--- a/indico/modules/events/timetable/legacy.py
+++ b/indico/modules/events/timetable/legacy.py
@@ -321,7 +321,7 @@ def serialize_event_info(event):
 
 
 def serialize_session(sess):
-    """Return data for a single session"""
+    """Return data for a single session."""
     data = {
         '_type': 'Session',
         'address': sess.address,

--- a/indico/modules/events/timetable/models/entries.py
+++ b/indico/modules/events/timetable/models/entries.py
@@ -261,7 +261,7 @@ class TimetableEntry(db.Model):
         return format_repr(self, 'id', 'type', 'start_dt', 'end_dt', _repr=self.object)
 
     def can_view(self, user):
-        """Checks whether the user will see this entry in the timetable."""
+        """Check whether the user will see this entry in the timetable."""
         if self.type in (TimetableEntryType.CONTRIBUTION, TimetableEntryType.BREAK):
             return self.object.can_access(user)
         elif self.type == TimetableEntryType.SESSION_BLOCK:

--- a/indico/modules/events/timetable/operations.py
+++ b/indico/modules/events/timetable/operations.py
@@ -133,7 +133,7 @@ def fit_session_block_entry(entry, log=True):
 
 
 def move_timetable_entry(entry, parent=None, day=None):
-    """Move the `entry` to another session or top-level timetable
+    """Move the `entry` to another session or top-level timetable.
 
     :param entry: `TimetableEntry` to be moved
     :param parent: If specified then the entry will be set as a child
@@ -171,7 +171,7 @@ def move_timetable_entry(entry, parent=None, day=None):
 
 
 def update_timetable_entry_object(entry, data):
-    """Update the `object` of a timetable entry according to its type"""
+    """Update the `object` of a timetable entry according to its type."""
     from indico.modules.events.contributions.operations import update_contribution
     obj = entry.object
     if entry.type == TimetableEntryType.CONTRIBUTION:
@@ -184,7 +184,7 @@ def update_timetable_entry_object(entry, data):
 
 
 def swap_timetable_entry(entry, direction, session_=None):
-    """Swap entry with closest gap or non-parallel sibling"""
+    """Swap entry with closest gap or non-parallel sibling."""
     in_session = session_ is not None
     sibling = get_sibling_entry(entry, direction=direction, in_session=in_session)
     if not sibling:

--- a/indico/modules/events/timetable/reschedule.py
+++ b/indico/modules/events/timetable/reschedule.py
@@ -39,7 +39,7 @@ class RescheduleMode(unicode, RichEnum):
 
 class Rescheduler(object):
     """
-    Compacts the the schedule of an event day by either adjusting
+    Compact the the schedule of an event day by either adjusting
     start times or durations of timetable entries.
 
     :param event: The event of which the timetable entries should
@@ -74,7 +74,7 @@ class Rescheduler(object):
         self.gap = gap
 
     def run(self):
-        """Perform the rescheduling"""
+        """Perform the rescheduling."""
         if self.fit_blocks:
             self._fit_blocks()
         if self.mode == RescheduleMode.time:

--- a/indico/modules/events/timetable/testing/fixtures.py
+++ b/indico/modules/events/timetable/testing/fixtures.py
@@ -14,7 +14,7 @@ from indico.modules.events.timetable.models.entries import TimetableEntry
 
 @pytest.fixture
 def create_entry(db):
-    """Returns a a callable which lets you create timetable"""
+    """Return a a callable which lets you create timetable."""
 
     def _create_entry(obj, start_dt):
         entry = TimetableEntry(event=obj.event, object=obj, start_dt=start_dt)

--- a/indico/modules/events/timetable/util.py
+++ b/indico/modules/events/timetable/util.py
@@ -286,7 +286,7 @@ def render_session_timetable(session, timetable_layout=None, management=False):
 
 
 def get_session_block_entries(event, day):
-    """Returns a list of event top-level session blocks for the given `day`"""
+    """Return a list of event top-level session blocks for the given `day`."""
     return (event.timetable_entries
             .filter(db.cast(TimetableEntry.start_dt.astimezone(event.tzinfo), db.Date) == day.date(),
                     TimetableEntry.type == TimetableEntryType.SESSION_BLOCK)
@@ -294,7 +294,7 @@ def get_session_block_entries(event, day):
 
 
 def shift_following_entries(entry, shift, session_=None):
-    """Reschedules entries starting after the given entry by the given shift."""
+    """Reschedule entries starting after the given entry by the given shift."""
     query = entry.siblings_query.filter(TimetableEntry.start_dt >= entry.end_dt)
     if session_ and not entry.parent:
         query.filter(TimetableEntry.type == TimetableEntryType.SESSION_BLOCK,

--- a/indico/modules/events/tracks/controllers.py
+++ b/indico/modules/events/tracks/controllers.py
@@ -38,11 +38,11 @@ def _render_track_list(event):
 
 
 class RHManageTracksBase(RHManageEventBase):
-    """Base class for all track management RHs"""
+    """Base class for all track management RHs."""
 
 
 class RHManageTrackBase(RHManageTracksBase):
-    """Base class for track management RHs related to a specific track"""
+    """Base class for track management RHs related to a specific track."""
 
     normalize_url_spec = {
         'locators': {

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -58,7 +58,7 @@ def check_event_locked(rh, event, force=False):
 
 
 def get_object_from_args(args=None):
-    """Retrieves an event object from request arguments.
+    """Retrieve an event object from request arguments.
 
     This utility is meant to be used in cases where the same controller
     can deal with objects attached to various parts of an event which
@@ -123,7 +123,7 @@ def get_theme(event, override_theme_id=None):
 
 
 def get_events_managed_by(user, dt=None):
-    """Gets the IDs of events where the user has management privs.
+    """Get the IDs of events where the user has management privs.
 
     :param user: A `User`
     :param dt: Only include events taking place on/after that date
@@ -138,7 +138,7 @@ def get_events_managed_by(user, dt=None):
 
 
 def get_events_created_by(user, dt=None):
-    """Gets the IDs of events created by the user
+    """Get the IDs of events created by the user.
 
     :param user: A `User`
     :param dt: Only include events taking place on/after that date
@@ -152,7 +152,7 @@ def get_events_created_by(user, dt=None):
 
 def get_events_with_linked_event_persons(user, dt=None):
     """
-    Returns a dict containing the event ids and role for all events
+    Return a dict containing the event ids and role for all events
     where the user is a chairperson or (in case of a lecture) speaker.
 
     :param user: A `User`
@@ -175,7 +175,7 @@ def get_random_color(event):
 
 
 def serialize_event_person(person):
-    """Serialize EventPerson to JSON-like object"""
+    """Serialize EventPerson to JSON-like object."""
     return {'_type': 'EventPerson',
             'id': person.id,
             'email': person.email,
@@ -190,7 +190,7 @@ def serialize_event_person(person):
 
 
 def serialize_person_link(person_link):
-    """Serialize PersonLink to JSON-like object"""
+    """Serialize PersonLink to JSON-like object."""
     data = {'email': person_link.person.email,
             'name': person_link.display_full_name,
             'fullName': person_link.display_full_name,
@@ -216,7 +216,7 @@ def serialize_person_link(person_link):
 
 
 def update_object_principals(obj, new_principals, read_access=False, full_access=False, permission=None):
-    """Updates an object's ACL with a new list of principals
+    """Update an object's ACL with a new list of principals.
 
     Exactly one argument out of `read_access`, `full_access` and `role` must be specified.
 
@@ -299,7 +299,7 @@ class ListGeneratorBase(object):
         return session.get(session_key, self.default_list_config)
 
     def _split_item_ids(self, item_ids, separator_type=None):
-        """Separate the dynamic item ids from the static
+        """Separate the dynamic item ids from the static.
 
         :param item_ids: The list of ids to be splitted.
         :param separator_type: The type of the item to base the partitioning on.
@@ -384,7 +384,7 @@ class ListGeneratorBase(object):
 
 
 def get_base_ical_parameters(user, detail, path, params=None):
-    """Returns a dict of all parameters expected by iCal template"""
+    """Return a dict of all parameters expected by iCal template."""
 
     from indico.web.http_api.util import generate_public_auth_request
 
@@ -410,7 +410,7 @@ def get_base_ical_parameters(user, detail, path, params=None):
 
 
 def create_event_logo_tmp_file(event, tmpdir=None):
-    """Creates a temporary file with the event's logo
+    """Create a temporary file with the event's logo.
 
     If `tmpdir` is specified, the logo file is created in there and
     a path relative to that directory is returned.
@@ -486,7 +486,7 @@ def track_time_changes(auto_extend=False, user=None):
 
 
 def register_time_change(entry):
-    """Register a time-related change for a timetable entry
+    """Register a time-related change for a timetable entry.
 
     This is an internal helper function used in the models to record
     changes of the start time or duration.  The changes are exposed
@@ -513,7 +513,7 @@ def register_time_change(entry):
 
 
 def register_event_time_change(event):
-    """Register a time-related change for an event
+    """Register a time-related change for an event.
 
     This is an internal helper function used in the model to record
     changes of the start time or end time.  The changes are exposed
@@ -586,7 +586,7 @@ def serialize_person_for_json_ld(person):
 
 
 def get_field_values(form_data):
-    """Split the form fields between custom and static"""
+    """Split the form fields between custom and static."""
     fields = {x: form_data[x] for x in form_data.iterkeys() if not x.startswith('custom_')}
     custom_fields = {x: form_data[x] for x in form_data.iterkeys() if x.startswith('custom_')}
     return fields, custom_fields
@@ -634,11 +634,10 @@ def get_event_from_url(url):
 
 
 class ZipGeneratorMixin(object):
-    """Mixin for RHs that generate zip with files"""
+    """Mixin for RHs that generate zip with files."""
 
     def _adjust_path_length(self, segments):
-        """
-        Shorten the path length to < 260 chars.
+        """Shorten the path length to < 260 chars.
 
         Windows' built-in ZIP tool doesn't like files whose
         total path exceeds ~260 chars. Here we progressively

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -130,7 +130,7 @@ class WPEventBase(WPDecorated):
 
 
 class WPSimpleEventDisplayBase(MathjaxMixin, WPEventBase):
-    """Base class for displaying something on a lecture/meeting page"""
+    """Base class for displaying something on a lecture/meeting page."""
 
     def __init__(self, rh, event_, **kwargs):
         self.event = event_

--- a/indico/modules/files/controllers.py
+++ b/indico/modules/files/controllers.py
@@ -93,7 +93,7 @@ class RHFileInfo(RHFileBase):
 
 
 class RHFileDownload(RHFileBase):
-    """Download a file using a unique token"""
+    """Download a file using a unique token."""
 
     def _check_access(self):
         uuid = secure_serializer.loads(request.args['token'], salt='file-download', max_age=86400)

--- a/indico/modules/groups/controllers.py
+++ b/indico/modules/groups/controllers.py
@@ -33,7 +33,7 @@ from indico.web.rh import RHProtected
 
 
 class RHGroups(RHAdminBase):
-    """Admin group overview"""
+    """Admin group overview."""
 
     def _process(self):
         query = LocalGroup.query.options(joinedload(LocalGroup.members)).order_by(db.func.lower(LocalGroup.name))
@@ -77,7 +77,7 @@ class RHGroupBase(RHAdminBase):
 
 
 class RHGroupDetails(RHGroupBase):
-    """Admin group details"""
+    """Admin group details."""
 
     def _process(self):
         group = self.group
@@ -86,7 +86,7 @@ class RHGroupDetails(RHGroupBase):
 
 
 class RHGroupMembers(RHGroupBase):
-    """Admin group memberlist (json)"""
+    """Admin group memberlist (json)."""
 
     def _process(self):
         group = self.group
@@ -95,7 +95,7 @@ class RHGroupMembers(RHGroupBase):
 
 
 class RHGroupEdit(RHAdminBase):
-    """Admin group modification/creation"""
+    """Admin group modification/creation."""
 
     def _process_args(self):
         if not config.LOCAL_GROUPS:
@@ -135,7 +135,7 @@ class RHLocalGroupBase(RHAdminBase):
 
 
 class RHGroupDelete(RHLocalGroupBase):
-    """Admin group deletion"""
+    """Admin group deletion."""
 
     def _process(self):
         db.session.delete(self.group)
@@ -144,7 +144,7 @@ class RHGroupDelete(RHLocalGroupBase):
 
 
 class RHGroupDeleteMember(RHLocalGroupBase):
-    """Admin group member deletion (ajax)"""
+    """Admin group member deletion (ajax)."""
 
     def _process(self):
         self.group.members.discard(User.get(request.view_args['user_id']))

--- a/indico/modules/groups/core.py
+++ b/indico/modules/groups/core.py
@@ -24,7 +24,7 @@ from indico.util.string import return_ascii
 
 
 class GroupProxy(object):
-    """Provides a generic interface for both local and multipass groups.
+    """Provide a generic interface for both local and multipass groups.
 
     Creating an instance of this class actually creates either a
     ``LocalGroupProxy`` or a ``MultipassGroupProxy``, but they expose
@@ -45,7 +45,7 @@ class GroupProxy(object):
     principal_order = 3
 
     def __new__(cls, name_or_id, provider=None, _group=None):
-        """Creates the correct GroupProxy for the group type"""
+        """Create the correct GroupProxy for the group type."""
         if provider is None or provider == 'indico':
             obj = object.__new__(_LocalGroupProxy)
             obj.id = int(name_or_id)
@@ -74,12 +74,12 @@ class GroupProxy(object):
 
     @cached_property
     def group(self):
-        """The underlying group object"""
+        """The underlying group object."""
         raise NotImplementedError
 
     @cached_property
     def as_principal(self):
-        """The serializable principal identifier of this group"""
+        """The serializable principal identifier of this group."""
         raise NotImplementedError
 
     @property
@@ -89,7 +89,7 @@ class GroupProxy(object):
 
     @cached_property
     def as_legacy_group(self):
-        """The legacy-style group wrapper"""
+        """The legacy-style group wrapper."""
         # TODO: remove once groups are gone from ZODB
         raise NotImplementedError
 
@@ -98,19 +98,19 @@ class GroupProxy(object):
         return self.as_legacy_group
 
     def has_member(self, user):
-        """Checks if the user is a member of the group.
+        """Check if the user is a member of the group.
 
         This can also be accessed using the ``in`` operator.
         """
         raise NotImplementedError
 
     def get_members(self):
-        """Gets the list of users who are members of the group"""
+        """Get the list of users who are members of the group."""
         raise NotImplementedError
 
     @classmethod
     def search(cls, name, exact=False, providers=None):
-        """Searches for groups
+        """Search for groups.
 
         :param name: The group name to search for.
         :param exact: If only exact matches should be found (much faster)
@@ -207,7 +207,7 @@ class _MultipassGroupProxy(GroupProxy):
 
     @cached_property
     def group(self):
-        """The underlying :class:`~flask_multipass.Group`"""
+        """The underlying :class:`~flask_multipass.Group`."""
         try:
             return multipass.get_group(self.provider, self.name)
         except MultipassException as e:

--- a/indico/modules/groups/legacy.py
+++ b/indico/modules/groups/legacy.py
@@ -23,7 +23,7 @@ class GroupWrapper(Fossilizable):
 
     @property
     def group(self):
-        """Returns the underlying GroupProxy
+        """Return the underlying GroupProxy.
 
         :rtype: indico.modules.groups.core.GroupProxy
         """

--- a/indico/modules/groups/models/groups.py
+++ b/indico/modules/groups/models/groups.py
@@ -61,7 +61,7 @@ class LocalGroup(db.Model):
 
     @property
     def proxy(self):
-        """Returns a GroupProxy wrapping this group"""
+        """Return a GroupProxy wrapping this group."""
         from indico.modules.groups import GroupProxy
         return GroupProxy(self.id, _group=self)
 

--- a/indico/modules/groups/util.py
+++ b/indico/modules/groups/util.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 
 
 def serialize_group(group):
-    """Serialize group to JSON-like object"""
+    """Serialize group to JSON-like object."""
     return {
         'id': group.id if group.is_local else group.name,
         'name': group.name,

--- a/indico/modules/networks/controllers.py
+++ b/indico/modules/networks/controllers.py
@@ -26,7 +26,7 @@ class RHNetworkBase(RHAdminBase):
 
 
 class RHManageNetworks(RHNetworkBase):
-    """Management list for IPNetworks"""
+    """Management list for IPNetworks."""
 
     def _process(self):
         network_groups = IPNetworkGroup.find().order_by(IPNetworkGroup.name).all()
@@ -34,7 +34,7 @@ class RHManageNetworks(RHNetworkBase):
 
 
 class RHCreateNetworkGroup(RHNetworkBase):
-    """Dialog to create an IPNetworkGroup"""
+    """Dialog to create an IPNetworkGroup."""
 
     def _process(self):
         form = IPNetworkGroupForm()
@@ -49,14 +49,14 @@ class RHCreateNetworkGroup(RHNetworkBase):
 
 
 class RHAdminNetworkGroupBase(RHNetworkBase):
-    """Base class for managing in IPNetworkGroup"""
+    """Base class for managing in IPNetworkGroup."""
 
     def _process_args(self):
         self.network_group = IPNetworkGroup.get_or_404(request.view_args['network_group_id'])
 
 
 class RHEditNetworkGroup(RHAdminNetworkGroupBase):
-    """Dialog to edit an IPNetworkGroup"""
+    """Dialog to edit an IPNetworkGroup."""
 
     def _process(self):
         form = IPNetworkGroupForm(obj=self.network_group)
@@ -68,7 +68,7 @@ class RHEditNetworkGroup(RHAdminNetworkGroupBase):
 
 
 class RHDeleteNetworkGroup(RHAdminNetworkGroupBase):
-    """Dialog to delete an IPNetworkGroup"""
+    """Dialog to delete an IPNetworkGroup."""
 
     def _process_GET(self):
         query = (self.network_group.in_event_acls

--- a/indico/modules/networks/forms.py
+++ b/indico/modules/networks/forms.py
@@ -23,7 +23,7 @@ attachment_access_override_warning = _('Do you really want to grant everyone wit
 
 
 class IPNetworkGroupForm(IndicoForm):
-    """Form to create or edit an IPNetworkGroup"""
+    """Form to create or edit an IPNetworkGroup."""
 
     name = StringField(_("Name"), [DataRequired()])
     description = TextAreaField(_("Description"))

--- a/indico/modules/networks/util.py
+++ b/indico/modules/networks/util.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 
 
 def serialize_ip_network_group(group):
-    """Serialize group to JSON-like object"""
+    """Serialize group to JSON-like object."""
     return {
         'id': group.id,
         'name': group.name,

--- a/indico/modules/news/util.py
+++ b/indico/modules/news/util.py
@@ -18,7 +18,7 @@ from indico.util.date_time import now_utc
 
 @memoize_redis(3600)
 def get_recent_news():
-    """Get a list of recent news for the home page"""
+    """Get a list of recent news for the home page."""
     settings = news_settings.get_all()
     if not settings['show_recent']:
         return []

--- a/indico/modules/oauth/controllers.py
+++ b/indico/modules/oauth/controllers.py
@@ -73,7 +73,7 @@ class RHOAuthToken(RH):
 
 
 class RHOAuthAdmin(RHAdminBase):
-    """OAuth server administration settings"""
+    """OAuth server administration settings."""
 
     def _process(self):
         applications = OAuthApplication.find().order_by(db.func.lower(OAuthApplication.name)).all()
@@ -81,13 +81,13 @@ class RHOAuthAdmin(RHAdminBase):
 
 
 class RHOAuthAdminApplicationBase(RHAdminBase):
-    """Base class for single OAuth application RHs"""
+    """Base class for single OAuth application RHs."""
     def _process_args(self):
         self.application = OAuthApplication.get(request.view_args['id'])
 
 
 class RHOAuthAdminApplication(RHOAuthAdminApplicationBase):
-    """Handles application details page"""
+    """Handle application details page."""
 
     def _process(self):
         form = ApplicationForm(obj=self.application, application=self.application)
@@ -102,7 +102,7 @@ class RHOAuthAdminApplication(RHOAuthAdminApplicationBase):
 
 
 class RHOAuthAdminApplicationDelete(RHOAuthAdminApplicationBase):
-    """Handles OAuth application deletion"""
+    """Handle OAuth application deletion."""
 
     def _check_access(self):
         RHOAuthAdminApplicationBase._check_access(self)
@@ -117,7 +117,7 @@ class RHOAuthAdminApplicationDelete(RHOAuthAdminApplicationBase):
 
 
 class RHOAuthAdminApplicationNew(RHAdminBase):
-    """Handles OAuth application registration"""
+    """Handle OAuth application registration."""
 
     def _process(self):
         form = ApplicationForm(obj=FormDefaults(is_enabled=True))
@@ -133,7 +133,7 @@ class RHOAuthAdminApplicationNew(RHAdminBase):
 
 
 class RHOAuthAdminApplicationReset(RHOAuthAdminApplicationBase):
-    """Resets the client secret of the OAuth application"""
+    """Reset the client secret of the OAuth application."""
 
     def _process(self):
         self.application.reset_client_secret()
@@ -143,7 +143,7 @@ class RHOAuthAdminApplicationReset(RHOAuthAdminApplicationBase):
 
 
 class RHOAuthAdminApplicationRevoke(RHOAuthAdminApplicationBase):
-    """Revokes all user tokens associated to the OAuth application"""
+    """Revoke all user tokens associated to the OAuth application."""
 
     def _process(self):
         self.application.tokens.delete()
@@ -153,7 +153,7 @@ class RHOAuthAdminApplicationRevoke(RHOAuthAdminApplicationBase):
 
 
 class RHOAuthUserProfile(RHUserBase):
-    """OAuth overview (user)"""
+    """OAuth overview (user)."""
 
     def _process(self):
         tokens = self.user.oauth_tokens.all()
@@ -161,7 +161,7 @@ class RHOAuthUserProfile(RHUserBase):
 
 
 class RHOAuthUserTokenRevoke(RHUserBase):
-    """Revokes user token"""
+    """Revoke user token."""
 
     def _process_args(self):
         RHUserBase._process_args(self)

--- a/indico/modules/oauth/models/applications.py
+++ b/indico/modules/oauth/models/applications.py
@@ -61,7 +61,7 @@ class SystemAppType(int, IndicoEnum):
 
 
 class OAuthApplication(db.Model):
-    """OAuth applications registered in Indico"""
+    """OAuth applications registered in Indico."""
 
     __tablename__ = 'applications'
 

--- a/indico/modules/oauth/models/tokens.py
+++ b/indico/modules/oauth/models/tokens.py
@@ -18,7 +18,7 @@ from indico.util.string import return_ascii
 
 
 class OAuthToken(db.Model):
-    """OAuth tokens"""
+    """OAuth tokens."""
 
     __tablename__ = 'tokens'
     __table_args__ = (db.UniqueConstraint('application_id', 'user_id'),
@@ -107,7 +107,7 @@ class OAuthToken(db.Model):
 
 
 class OAuthGrant(object):
-    """OAuth grant token"""
+    """OAuth grant token."""
 
     #: cache entry to store grant tokens
     _cache = GenericCache('oauth-grant-tokens')

--- a/indico/modules/oauth/testing/fixtures.py
+++ b/indico/modules/oauth/testing/fixtures.py
@@ -15,7 +15,7 @@ from indico.modules.oauth.models.tokens import OAuthToken
 
 @pytest.fixture
 def create_application(db):
-    """Returns a callable which lets you create applications"""
+    """Return a callable which lets you create applications."""
 
     def _create_application(name, **params):
         params.setdefault('client_id', unicode(uuid4()))
@@ -32,7 +32,7 @@ def create_application(db):
 
 @pytest.fixture
 def create_token(db, dummy_application, dummy_user):
-    """Returns a callable which lets you create tokens"""
+    """Return a callable which lets you create tokens."""
 
     def _create_tokens(**params):
         params.setdefault('access_token', unicode(uuid4()))
@@ -49,11 +49,11 @@ def create_token(db, dummy_application, dummy_user):
 
 @pytest.fixture
 def dummy_application(create_application):
-    """Gives you a dummy application"""
+    """Return a dummy application."""
     return create_application(name='dummy')
 
 
 @pytest.fixture
 def dummy_token(create_token):
-    """Returns a dummy token"""
+    """Return a dummy token."""
     return create_token()

--- a/indico/modules/rb/api.py
+++ b/indico/modules/rb/api.py
@@ -223,7 +223,7 @@ class BookRoomHook(HTTPAPIHook):
 
 
 def _export_reservations(hook, limit_per_room, include_rooms, extra_filters=None):
-    """Exports reservations.
+    """Export reservations.
 
     :param hook: The HTTPAPIHook instance
     :param limit_per_room: Should the limit/offset be applied per room
@@ -260,7 +260,7 @@ def _export_reservations(hook, limit_per_room, include_rooms, extra_filters=None
 
 
 def _serializable_room(room_data, reservations=None):
-    """Serializable room data
+    """Serializable room data.
 
     :param room_data: Room data
     :param reservations: MultiDict mapping for room id => reservations
@@ -273,7 +273,7 @@ def _serializable_room(room_data, reservations=None):
 
 
 def _serializable_room_minimal(room):
-    """Serializable minimal room data (inside reservations)
+    """Serializable minimal room data (inside reservations).
 
     :param room: A `Room`
     """
@@ -283,7 +283,7 @@ def _serializable_room_minimal(room):
 
 
 def _serializable_reservation(reservation_data, include_room=False):
-    """Serializable reservation (standalone or inside room)
+    """Serializable reservation (standalone or inside room).
 
     :param reservation_data: Reservation data
     :param include_room: Include minimal room information

--- a/indico/modules/rb/controllers/__init__.py
+++ b/indico/modules/rb/controllers/__init__.py
@@ -17,7 +17,7 @@ from indico.web.rh import RHProtected
 
 
 class RHRoomBookingBase(RHProtected):
-    """Base class for room booking RHs"""
+    """Base class for room booking RHs."""
 
     def _check_access(self):
         if not config.ENABLE_ROOMBOOKING:

--- a/indico/modules/rb/controllers/backend/bookings.py
+++ b/indico/modules/rb/controllers/backend/bookings.py
@@ -261,7 +261,7 @@ class RHDeleteBooking(RHBookingBase):
 
 
 class RHLinkedObjectData(RHRoomBookingBase):
-    """Fetch data from event, contribution or session block"""
+    """Fetch data from event, contribution or session block."""
 
     def _process_args(self):
         type_ = LinkType[request.view_args['type']]

--- a/indico/modules/rb/event/fields.py
+++ b/indico/modules/rb/event/fields.py
@@ -38,14 +38,18 @@ class LinkedObjectField(Field):
 
 
 class ContributionField(LinkedObjectField):
-    """A selectize-based field to select a contribution that has no reservation yet."""
+    """
+    A selectize-based field to select a contribution that has no reservation yet.
+    """
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('render_kw', {}).setdefault('placeholder', _('Enter contribution title or #id'))
         super(ContributionField, self).__init__(*args, **kwargs)
 
 
 class SessionBlockField(LinkedObjectField):
-    """A selectize-based field to select a session block that has no reservation yet."""
+    """
+    A selectize-based field to select a session block that has no reservation yet.
+    """
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('render_kw', {}).setdefault('placeholder', _('Enter session block title'))
         super(SessionBlockField, self).__init__(*args, **kwargs)

--- a/indico/modules/rb/models/blockings.py
+++ b/indico/modules/rb/models/blockings.py
@@ -95,7 +95,7 @@ class Blocking(db.Model):
         return user == self.created_by_user or (allow_admin and rb_is_admin(user))
 
     def can_override(self, user, room=None, explicit_only=False, allow_admin=True):
-        """Check if a user can override the blocking
+        """Check if a user can override the blocking.
 
         The following persons are authorized to override a blocking:
         - the creator of the blocking

--- a/indico/modules/rb/models/reservations.py
+++ b/indico/modules/rb/models/reservations.py
@@ -319,7 +319,7 @@ class Reservation(Serializer, db.Model):
 
     @classmethod
     def create_from_data(cls, room, data, user, prebook=None, ignore_admin=False):
-        """Creates a new reservation.
+        """Create a new reservation.
 
         :param room: The Room that's being booked.
         :param data: A dict containing the booking data, usually from a :class:`NewBookingConfirmForm` instance
@@ -565,7 +565,7 @@ class Reservation(Serializer, db.Model):
         return self.created_by_user == user
 
     def modify(self, data, user):
-        """Modifies an existing reservation.
+        """Modify an existing reservation.
 
         :param data: A dict containing the booking data, usually from a :class:`ModifyBookingForm` instance
         :param user: The :class:`.User` who modifies the booking.

--- a/indico/modules/rb/models/rooms.py
+++ b/indico/modules/rb/models/rooms.py
@@ -399,14 +399,14 @@ class Room(ProtectionManagersMixin, db.Model, Serializer):
 
     @classmethod
     def find_all(cls, *args, **kwargs):
-        """Retrieves rooms, sorted by location and full name"""
+        """Retrieve rooms, sorted by location and full name."""
         rooms = super(Room, cls).find_all(*args, **kwargs)
         rooms.sort(key=lambda r: natural_sort_key(r.location_name + r.full_name))
         return rooms
 
     @classmethod
     def find_with_attribute(cls, attribute):
-        """Search rooms which have a specific attribute"""
+        """Search rooms which have a specific attribute."""
         return (Room.query
                 .with_entities(Room, RoomAttributeAssociation.value)
                 .join(Room.attributes, RoomAttributeAssociation.attribute)
@@ -447,7 +447,7 @@ class Room(ProtectionManagersMixin, db.Model, Serializer):
     @staticmethod
     def filter_available(start_dt, end_dt, repetition, include_blockings=True, include_pre_bookings=True,
                          include_pending_blockings=False):
-        """Returns a SQLAlchemy filter criterion ensuring that the room is available during the given time."""
+        """Return a SQLAlchemy filter criterion ensuring that the room is available during the given time."""
         # Check availability against reservation occurrences
         dummy_occurrences = ReservationOccurrence.create_series(start_dt, end_dt, repetition)
         overlap_criteria = ReservationOccurrence.filter_overlap(dummy_occurrences)

--- a/indico/modules/rb/models/util.py
+++ b/indico/modules/rb/models/util.py
@@ -9,7 +9,7 @@ from functools import wraps
 
 
 def proxy_to_reservation_if_last_valid_occurrence(f):
-    """Forwards a method call to `self.reservation` if there is only one occurrence."""
+    """Forward a method call to `self.reservation` if there is only one occurrence."""
     @wraps(f)
     def wrapper(self, *args, **kwargs):
         from indico.modules.rb.models.reservation_occurrences import ReservationOccurrence

--- a/indico/modules/rb/notifications/blockings.py
+++ b/indico/modules/rb/notifications/blockings.py
@@ -12,9 +12,9 @@ from indico.core.notifications import email_sender, make_email
 
 @email_sender
 def notify_request(owner, blocking, blocked_rooms):
-    """
-    Notifies room owner about blockings he has to approve.
-    Expects only blockings for rooms owned by the specified owner
+    """Notify room owner about blockings he has to approve.
+
+    Expect only blockings for rooms owned by the specified owner.
     """
     subject = 'Confirm room blockings'
     body = render_template('rb/emails/blockings/awaiting_confirmation_email_to_manager.txt',
@@ -25,8 +25,8 @@ def notify_request(owner, blocking, blocked_rooms):
 @email_sender
 def notify_request_response(blocked_room):
     """
-    Notifies blocking creator about approval/rejection of his
-    blocking request for a room
+    Notify blocking creator about approval/rejection of his
+    blocking request for a room.
     """
     to = blocked_room.blocking.created_by_user.email
     verb = blocked_room.State(blocked_room.state).title.upper()

--- a/indico/modules/rb/testing/fixtures.py
+++ b/indico/modules/rb/testing/fixtures.py
@@ -21,7 +21,7 @@ from indico.modules.rb.models.rooms import Room
 
 @pytest.fixture
 def create_location(db):
-    """Returns a callable which lets you create locations"""
+    """Return a callable which lets you create locations."""
 
     def _create_location(name, **params):
         location = Location(name=name, **params)
@@ -34,7 +34,7 @@ def create_location(db):
 
 @pytest.fixture
 def dummy_location(db, create_location):
-    """Gives you a dummy default location"""
+    """Give you a dummy default location."""
     loc = create_location(u'Test')
     db.session.flush()
     return loc
@@ -42,7 +42,7 @@ def dummy_location(db, create_location):
 
 @pytest.fixture
 def create_reservation(db, dummy_room, dummy_user):
-    """Returns a callable which lets you create reservations"""
+    """Return a callable which lets you create reservations."""
     def _create_reservation(**params):
         params.setdefault('start_dt', date.today() + relativedelta(hour=8, minute=30))
         params.setdefault('end_dt', date.today() + relativedelta(hour=17, minute=30))
@@ -63,13 +63,13 @@ def create_reservation(db, dummy_room, dummy_user):
 
 @pytest.fixture
 def dummy_reservation(create_reservation):
-    """Gives you a dummy reservation"""
+    """Give you a dummy reservation."""
     return create_reservation()
 
 
 @pytest.fixture
 def create_occurrence(create_reservation):
-    """Returns a callable which lets you create reservation occurrences"""
+    """Return a callable which lets you create reservation occurrences."""
     def _create_occurrence(start_dt=None, end_dt=None, room=None):
         params = {}
         if start_dt is not None:
@@ -86,13 +86,13 @@ def create_occurrence(create_reservation):
 
 @pytest.fixture
 def dummy_occurrence(create_occurrence):
-    """Gives you a dummy reservation occurrence"""
+    """Give you a dummy reservation occurrence."""
     return create_occurrence()
 
 
 @pytest.fixture
 def create_room(db, dummy_location, dummy_user):
-    """Returns a callable which lets you create rooms"""
+    """Return a callable which lets you create rooms."""
     def _create_room(**params):
         params.setdefault('building', u'1')
         params.setdefault('floor', u'2')
@@ -110,13 +110,13 @@ def create_room(db, dummy_location, dummy_user):
 
 @pytest.fixture
 def dummy_room(create_room):
-    """Gives you a dummy room"""
+    """Give you a dummy room."""
     return create_room()
 
 
 @pytest.fixture
 def create_room_attribute(db):
-    """Returns a callable which let you create room attributes"""
+    """Return a callable which let you create room attributes."""
 
     def _create_attribute(name):
         attr = RoomAttribute(name=name, title=name)
@@ -129,7 +129,7 @@ def create_room_attribute(db):
 
 @pytest.fixture
 def create_equipment_type(db):
-    """Returns a callable which let you create equipment types"""
+    """Return a callable which let you create equipment types."""
 
     def _create_equipment_type(name):
         eq = EquipmentType(name=name)
@@ -142,7 +142,7 @@ def create_equipment_type(db):
 
 @pytest.fixture
 def create_blocking(db, dummy_room, dummy_user):
-    """Returns a callable which lets you create blockings"""
+    """Return a callable which lets you create blockings."""
     def _create_blocking(**params):
         room = params.pop('room', dummy_room)
         state = params.pop('state', BlockedRoom.State.pending)
@@ -164,5 +164,5 @@ def create_blocking(db, dummy_room, dummy_user):
 
 @pytest.fixture
 def dummy_blocking(create_blocking):
-    """Gives you a dummy blocking"""
+    """Give you a dummy blocking."""
     return create_blocking()

--- a/indico/modules/rb/util.py
+++ b/indico/modules/rb/util.py
@@ -43,7 +43,7 @@ _cache = GenericCache('Rooms')
 
 @memoize_request
 def rb_check_user_access(user):
-    """Checks if the user has access to the room booking system"""
+    """Check if the user has access to the room booking system."""
     from indico.modules.rb import rb_settings
     if rb_is_admin(user):
         return True
@@ -54,7 +54,7 @@ def rb_check_user_access(user):
 
 @memoize_request
 def rb_is_admin(user):
-    """Checks if the user is a room booking admin"""
+    """Check if the user is a room booking admin."""
     from indico.modules.rb import rb_settings
     if user.is_admin:
         return True
@@ -260,8 +260,7 @@ def _find_latest_entry_end_dt(event, day):
 
 
 def get_booking_params_for_event(event):
-    """
-    Get a set of RB interface parameters suitable for this event.
+    """Get a set of RB interface parameters suitable for this event.
 
     These parameters can then be used to construct a URL that will lead to a
     pre-filled search that matches the start/end times for a given day.

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -464,7 +464,7 @@ class RHUserEmailsSetPrimary(RHUserBase):
 
 
 class RHAdmins(RHAdminBase):
-    """Show Indico administrators"""
+    """Show Indico administrators."""
 
     def _process(self):
         admins = set(User.query
@@ -489,7 +489,7 @@ class RHAdmins(RHAdminBase):
 
 
 class RHUsersAdmin(RHAdminBase):
-    """Admin users overview"""
+    """Admin users overview."""
 
     def _process(self):
         form = SearchForm(obj=FormDefaults(exact=True))
@@ -541,7 +541,7 @@ class RHUsersAdminSettings(RHAdminBase):
 
 
 class RHUsersAdminCreate(RHAdminBase):
-    """Create user (admin)"""
+    """Create user (admin)."""
 
     def _process(self):
         form = AdminAccountRegistrationForm()
@@ -594,7 +594,7 @@ def _get_merge_problems(source, target):
 
 
 class RHUsersAdminMerge(RHAdminBase):
-    """Merge users (admin)"""
+    """Merge users (admin)."""
 
     def _process(self):
         form = MergeForm()
@@ -627,7 +627,7 @@ class RHUsersAdminMergeCheck(RHAdminBase):
 
 
 class RHRegistrationRequestList(RHAdminBase):
-    """List all registration requests"""
+    """List all registration requests."""
 
     def _process(self):
         requests = RegistrationRequest.query.order_by(RegistrationRequest.email).all()
@@ -635,7 +635,7 @@ class RHRegistrationRequestList(RHAdminBase):
 
 
 class RHRegistrationRequestBase(RHAdminBase):
-    """Base class to process a registration request"""
+    """Base class to process a registration request."""
 
     def _process_args(self):
         RHAdminBase._process_args(self)
@@ -643,7 +643,7 @@ class RHRegistrationRequestBase(RHAdminBase):
 
 
 class RHAcceptRegistrationRequest(RHRegistrationRequestBase):
-    """Accept a registration request"""
+    """Accept a registration request."""
 
     def _process(self):
         user, identity = register_user(self.request.email, self.request.extra_emails, self.request.user_data,
@@ -655,7 +655,7 @@ class RHAcceptRegistrationRequest(RHRegistrationRequestBase):
 
 
 class RHRejectRegistrationRequest(RHRegistrationRequestBase):
-    """Reject a registration request"""
+    """Reject a registration request."""
 
     def _process(self):
         db.session.delete(self.request)
@@ -675,7 +675,7 @@ search_result_schema = UserSearchResultSchema()
 
 
 class RHUserSearch(RHProtected):
-    """Search for users based on given criteria"""
+    """Search for users based on given criteria."""
 
     def _serialize_pending_user(self, entry):
         first_name = entry.data.get('first_name') or ''

--- a/indico/modules/users/ext.py
+++ b/indico/modules/users/ext.py
@@ -9,7 +9,7 @@ from __future__ import unicode_literals
 
 
 class ExtraUserPreferences(object):
-    """Defines additional user preferences
+    """Define additional user preferences.
 
     To use this class, subclass it and override `defaults`,
     `fields` and `save` to implement your custom logic.
@@ -39,7 +39,7 @@ class ExtraUserPreferences(object):
     # to be called/used when implementing custom settings.
 
     def extend_defaults(self, defaults):
-        """Adds values to the FormDefaults."""
+        """Add values to the FormDefaults."""
         for key, value in self.load().iteritems():
             key = self._prefix + key
             if hasattr(defaults, key):
@@ -58,7 +58,7 @@ class ExtraUserPreferences(object):
         self.save(local_data)
 
     def extend_form(self, form_class):
-        """Create a subclass of the form containing the extra field"""
+        """Create a subclass of the form containing the extra field."""
         form_class = type(b'ExtendedUserPreferencesForm', (form_class,), {})
         for name, field in self.fields.iteritems():
             name = self._prefix + name

--- a/indico/modules/users/legacy.py
+++ b/indico/modules/users/legacy.py
@@ -250,9 +250,7 @@ class AvatarUserWrapper(Fossilizable):
 
 
 class AvatarProvisionalWrapper(Fossilizable):
-    """
-    Wraps provisional data for users that are not in the DB yet
-    """
+    """Wrap provisional data for users that are not in the DB yet."""
 
     fossilizes(IAvatarFossil, IAvatarMinimalFossil)
 

--- a/indico/modules/users/models/settings.py
+++ b/indico/modules/users/models/settings.py
@@ -17,7 +17,7 @@ from indico.util.string import return_ascii
 
 
 class UserSetting(JSONSettingsBase, db.Model):
-    """User-specific settings"""
+    """User-specific settings."""
     __table_args__ = (db.Index(None, 'user_id', 'module', 'name'),
                       db.Index(None, 'user_id', 'module'),
                       db.UniqueConstraint('user_id', 'module', 'name'),
@@ -67,16 +67,16 @@ def user_or_id(f):
 
 
 class UserSettingsProxy(SettingsProxyBase):
-    """Proxy class to access user-specific settings for a certain module"""
+    """Proxy class to access user-specific settings for a certain module."""
 
     @property
     def query(self):
-        """Returns a query object filtering by the proxy's module."""
+        """Return a query object filtering by the proxy's module."""
         return UserSetting.find(module=self.module)
 
     @user_or_id
     def get_all(self, user, no_defaults=False):
-        """Retrieves all settings
+        """Retrieve all settings.
 
         :param user: ``{'user': user}`` or ``{'user_id': id}``
         :param no_defaults: Only return existing settings and ignore defaults.
@@ -86,7 +86,7 @@ class UserSettingsProxy(SettingsProxyBase):
 
     @user_or_id
     def get(self, user, name, default=SettingsProxyBase.default_sentinel):
-        """Retrieves the value of a single setting.
+        """Retrieve the value of a single setting.
 
         :param user: ``{'user': user}`` or ``{'user_id': id}``
         :param name: Setting name
@@ -98,7 +98,7 @@ class UserSettingsProxy(SettingsProxyBase):
 
     @user_or_id
     def set(self, user, name, value):
-        """Sets a single setting.
+        """Set a single setting.
 
         :param user: ``{'user': user}`` or ``{'user_id': id}``
         :param name: Setting name
@@ -110,7 +110,7 @@ class UserSettingsProxy(SettingsProxyBase):
 
     @user_or_id
     def set_multi(self, user, items):
-        """Sets multiple settings at once.
+        """Set multiple settings at once.
 
         :param user: ``{'user': user}`` or ``{'user_id': id}``
         :param items: Dict containing the new settings
@@ -123,7 +123,7 @@ class UserSettingsProxy(SettingsProxyBase):
 
     @user_or_id
     def delete(self, user, *names):
-        """Deletes settings.
+        """Delete settings.
 
         :param user: ``{'user': user}`` or ``{'user_id': id}``
         :param names: One or more names of settings to delete
@@ -135,7 +135,7 @@ class UserSettingsProxy(SettingsProxyBase):
 
     @user_or_id
     def delete_all(self, user):
-        """Deletes all settings.
+        """Delete all settings.
 
         :param user: ``{'user': user}`` or ``{'user_id': id}``
         """

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -77,7 +77,7 @@ class PersonMixin(object):
     """
 
     def _get_title(self):
-        """Return title text"""
+        """Return title text."""
         if self._title is None:
             return get_default_values(type(self)).get('_title', UserTitle.none).title
         return self._title.title
@@ -161,7 +161,7 @@ def format_display_full_name(user, obj):
 
 
 class User(PersonMixin, db.Model):
-    """Indico users"""
+    """Indico users."""
 
     # Useful when dealing with both users and groups in the same code
     is_group = False
@@ -447,7 +447,7 @@ class User(PersonMixin, db.Model):
 
     @property
     def as_principal(self):
-        """The serializable principal identifier of this user"""
+        """The serializable principal identifier of this user."""
         return 'User', self.id
 
     @property
@@ -477,23 +477,23 @@ class User(PersonMixin, db.Model):
 
     @property
     def external_identities(self):
-        """The external identities of the user"""
+        """The external identities of the user."""
         return {x for x in self.identities if x.provider != 'indico'}
 
     @property
     def local_identities(self):
-        """The local identities of the user"""
+        """The local identities of the user."""
         return {x for x in self.identities if x.provider == 'indico'}
 
     @property
     def local_identity(self):
-        """The main (most recently used) local identity"""
+        """The main (most recently used) local identity."""
         identities = sorted(self.local_identities, key=attrgetter('safe_last_login_dt'), reverse=True)
         return identities[0] if identities else None
 
     @property
     def secondary_local_identities(self):
-        """The local identities of the user except the main one"""
+        """The local identities of the user except the main one."""
         return self.local_identities - {self.local_identity}
 
     @locator_property
@@ -502,7 +502,7 @@ class User(PersonMixin, db.Model):
 
     @cached_property
     def settings(self):
-        """Returns the user settings proxy for this user"""
+        """Return the user settings proxy for this user."""
         from indico.modules.users import user_settings
         return user_settings.bind(self)
 
@@ -558,7 +558,7 @@ class User(PersonMixin, db.Model):
         return format_repr(self, 'id', 'email', is_deleted=False, is_pending=False, _text=self.full_name)
 
     def can_be_modified(self, user):
-        """If this user can be modified by the given user"""
+        """If this user can be modified by the given user."""
         return self == user or user.is_admin
 
     def iter_identifiers(self, check_providers=False, providers=None):
@@ -587,13 +587,15 @@ class User(PersonMixin, db.Model):
 
     @property
     def can_get_all_multipass_groups(self):
-        """Check whether it is possible to get all multipass groups the user is in."""
+        """
+        Check whether it is possible to get all multipass groups the user is in.
+        """
         return all(multipass.identity_providers[x.provider].supports_get_identity_groups
                    for x in self.identities
                    if x.provider != 'indico' and x.provider in multipass.identity_providers)
 
     def iter_all_multipass_groups(self):
-        """Iterate over all multipass groups the user is in"""
+        """Iterate over all multipass groups the user is in."""
         return itertools.chain.from_iterable(multipass.identity_providers[x.provider].get_identity_groups(x.identifier)
                                              for x in self.identities
                                              if x.provider != 'indico' and x.provider in multipass.identity_providers)
@@ -603,7 +605,7 @@ class User(PersonMixin, db.Model):
         return super(User, self).get_full_name(*args, **kwargs)
 
     def make_email_primary(self, email):
-        """Promotes a secondary email address to the primary email address
+        """Promote a secondary email address to the primary email address.
 
         :param email: an email address that is currently a secondary email
         """

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -49,12 +49,12 @@ user_colors = ['#e06055', '#ff8a65', '#e91e63', '#f06292', '#673ab7', '#ba68c8',
 
 
 def get_admin_emails():
-    """Get the email addresses of all Indico admins"""
+    """Get the email addresses of all Indico admins."""
     return {u.email for u in User.query.filter_by(is_admin=True, is_deleted=False)}
 
 
 def get_related_categories(user, detailed=True):
-    """Gets the related categories of a user for the dashboard"""
+    """Get the related categories of a user for the dashboard."""
     favorites = set()
     if user.favorite_categories:
         favorites = set(Category.query
@@ -81,7 +81,7 @@ def get_related_categories(user, detailed=True):
 
 
 def get_suggested_categories(user):
-    """Gets the suggested categories of a user for the dashboard"""
+    """Get the suggested categories of a user for the dashboard."""
     related = set(get_related_categories(user, detailed=False))
     res = []
     category_strategy = contains_eager('category')
@@ -108,7 +108,7 @@ def get_suggested_categories(user):
 
 
 def get_linked_events(user, dt, limit=None, load_also=()):
-    """Get the linked events and the user's roles in them
+    """Get the linked events and the user's roles in them.
 
     :param user: A `User`
     :param dt: Only include events taking place on/after that date
@@ -164,7 +164,7 @@ def get_linked_events(user, dt, limit=None, load_also=()):
 
 
 def serialize_user(user):
-    """Serialize user to JSON-like object"""
+    """Serialize user to JSON-like object."""
     return {
         'id': user.id,
         'title': user.title,
@@ -232,7 +232,7 @@ def build_user_search_query(criteria, exact=False, include_deleted=False, includ
 
 def search_users(exact=False, include_deleted=False, include_pending=False, include_blocked=False,
                  external=False, allow_system_user=False, **criteria):
-    """Searches for users.
+    """Search for users.
 
     :param exact: Indicates if only exact matches should be returned.
                   This is MUCH faster than a non-exact saerch,
@@ -294,7 +294,7 @@ def search_users(exact=False, include_deleted=False, include_pending=False, incl
 
 
 def get_user_by_email(email, create_pending=False):
-    """finds a user based on his email address.
+    """Find a user based on his email address.
 
     :param email: The email address of the user.
     :param create_pending: If True, this function searches for external
@@ -328,7 +328,7 @@ def get_user_by_email(email, create_pending=False):
 
 
 def merge_users(source, target, force=False):
-    """Merge two users together, unifying all related data
+    """Merge two users together, unifying all related data.
 
     :param source: source user (will be set as deleted)
     :param target: target user (final)

--- a/indico/modules/vc/controllers.py
+++ b/indico/modules/vc/controllers.py
@@ -86,7 +86,7 @@ class RHEventVCRoomMixin:
 
 
 class RHVCManageEvent(RHVCManageEventBase):
-    """Lists the available videoconference rooms"""
+    """List the available videoconference rooms."""
 
     def _process(self):
         room_event_assocs = VCRoomEventAssociation.find_for_event(self.event, include_hidden=True,
@@ -97,7 +97,10 @@ class RHVCManageEvent(RHVCManageEventBase):
 
 
 class RHVCManageEventSelectService(RHVCManageEventBase):
-    """List available videoconference plugins to create a new videoconference room"""
+    """
+    List available videoconference plugins to create a new
+    videoconference room.
+    """
 
     def _process(self):
         action = request.args.get('vc_room_action', '.manage_vc_rooms_create')
@@ -116,7 +119,7 @@ class RHVCManageEventCreateBase(RHVCManageEventBase):
 
 
 class RHVCManageEventCreate(RHVCManageEventCreateBase):
-    """Loads the form for the selected VC plugin"""
+    """Load the form for the selected VC plugin."""
 
     def _process(self):
         if not self.plugin.can_manage_vc_rooms(session.user, self.event):
@@ -172,7 +175,7 @@ class RHVCSystemEventBase(RHEventVCRoomMixin, RHVCManageEventBase):
 
 
 class RHVCManageEventModify(RHVCSystemEventBase):
-    """Modifies an existing VC room"""
+    """Modify an existing VC room."""
 
     def _process(self):
         if not self.plugin.can_manage_vc_rooms(session.user, self.event):
@@ -224,7 +227,7 @@ class RHVCManageEventModify(RHVCSystemEventBase):
 
 
 class RHVCManageEventRefresh(RHVCSystemEventBase):
-    """Refreshes an existing VC room, fetching information from the VC system"""
+    """Refresh an existing VC room, fetching information from the VC system."""
 
     def _process(self):
         if not self.plugin.can_manage_vc_rooms(session.user, self.event):
@@ -248,7 +251,7 @@ class RHVCManageEventRefresh(RHVCSystemEventBase):
 
 
 class RHVCManageEventRemove(RHVCSystemEventBase):
-    """Removes an existing VC room"""
+    """Remove an existing VC room."""
 
     def _process(self):
         if not self.plugin.can_manage_vc_rooms(session.user, self.event):
@@ -264,7 +267,7 @@ class RHVCManageEventRemove(RHVCSystemEventBase):
 
 
 class RHVCEventPage(RHDisplayEventBase):
-    """Lists the VC rooms in an event page"""
+    """List the VC rooms in an event page."""
 
     def _process(self):
         event_vc_rooms = VCRoomEventAssociation.find_for_event(self.event).all()
@@ -279,7 +282,7 @@ class RHVCEventPage(RHDisplayEventBase):
 
 
 class RHVCManageAttach(RHVCManageEventCreateBase):
-    """Attaches a room to the event"""
+    """Attach a room to the event."""
 
     def _process(self):
         defaults = FormDefaults(self.plugin.get_vc_room_attach_form_defaults(self.event))
@@ -306,7 +309,7 @@ class RHVCManageAttach(RHVCManageEventCreateBase):
 
 
 class RHVCManageSearch(RHVCManageEventCreateBase):
-    """Searches for a room based on its name"""
+    """Search for a room based on its name."""
 
     def _process_args(self):
         RHVCManageEventCreateBase._process_args(self)
@@ -336,7 +339,7 @@ class RHVCManageSearch(RHVCManageEventCreateBase):
 
 
 class RHVCRoomList(RHProtected):
-    """Provides a list of videoconference rooms"""
+    """Provide a list of videoconference rooms."""
 
     def _check_access(self):
         RHProtected._check_access(self)

--- a/indico/modules/vc/forms.py
+++ b/indico/modules/vc/forms.py
@@ -40,7 +40,7 @@ class VCRoomField(HiddenField):
 
 
 class LinkingWidget(JinjaWidget):
-    """Renders a composite radio/select field"""
+    """Render a composite radio/select field."""
 
     def __init__(self, **context):
         super(LinkingWidget, self).__init__('forms/linking_widget.html', single_line=True, **context)

--- a/indico/modules/vc/models/vc_rooms.py
+++ b/indico/modules/vc/models/vc_rooms.py
@@ -299,7 +299,7 @@ class VCRoomEventAssociation(db.Model):
 
     @classmethod
     def find_for_event(cls, event, include_hidden=False, include_deleted=False, only_linked_to_event=False, **kwargs):
-        """Returns a Query that retrieves the videoconference rooms for an event
+        """Return a Query that retrieves the videoconference rooms for an event.
 
         :param event: an indico Event
         :param only_linked_to_event: only retrieve the vc rooms linked to the whole event
@@ -319,11 +319,11 @@ class VCRoomEventAssociation(db.Model):
     @classmethod
     @memoize_request
     def get_linked_for_event(cls, event):
-        """Get a dict mapping link objects to event vc rooms"""
+        """Get a dict mapping link objects to event vc rooms."""
         return {vcr.link_object: vcr for vcr in cls.find_for_event(event)}
 
     def delete(self, user, delete_all=False):
-        """Deletes a VC room from an event
+        """Delete a VC room from an event.
 
         If the room is not used anywhere else, the room itself is also deleted.
 

--- a/indico/modules/vc/notifications.py
+++ b/indico/modules/vc/notifications.py
@@ -13,7 +13,7 @@ from indico.web.flask.templating import get_overridable_template_name, get_templ
 
 
 def notify_created(plugin, room, room_assoc, event, user):
-    """Notifies about the creation of a vc_room.
+    """Notify about the creation of a vc_room.
 
     :param room: the vc_room
     :param event: the event
@@ -27,7 +27,7 @@ def notify_created(plugin, room, room_assoc, event, user):
 
 
 def notify_deleted(plugin, room, room_assoc, event, user):
-    """Notifies about the deletion of a vc_room from the system.
+    """Notify about the deletion of a vc_room from the system.
 
     :param room: the vc_room
     :param event: the event

--- a/indico/modules/vc/plugins.py
+++ b/indico/modules/vc/plugins.py
@@ -85,13 +85,15 @@ class VCPluginMixin(object):
         return set(self.settings.get('notification_emails', set()))
 
     def render_form(self, **kwargs):
-        """Renders the videoconference room form
+        """Render the videoconference room form.
+
         :param kwargs: arguments passed to the template
         """
         return render_template('vc/manage_event_create_room.html', **kwargs)
 
     def render_info_box(self, vc_room, event_vc_room, event, **kwargs):
-        """Renders the information shown in the expandable box of a VC room row
+        """Render the information shown in the expandable box of a VC room row.
+
         :param vc_room: the VC room object
         :param event_vc_room: the association of an event and a VC room
         :param event: the event with the current VC room attached to it
@@ -101,7 +103,9 @@ class VCPluginMixin(object):
                                       event=event, vc_room=vc_room, settings=self.settings, **kwargs)
 
     def render_manage_event_info_box(self, vc_room, event_vc_room, event, **kwargs):
-        """Renders the information shown in the expandable box on a VC room in the management area
+        """
+        Render the information shown in the expandable box on a
+        VC room in the management area.
 
         :param vc_room: the VC room object
         :param event_vc_room: the association of an event and a VC room
@@ -113,7 +117,9 @@ class VCPluginMixin(object):
                                       settings=self.settings, **kwargs)
 
     def render_buttons(self, vc_room, event_vc_room, **kwargs):
-        """Renders a list of plugin specific buttons (eg: Join URL, etc) in the management area
+        """
+        Render a list of plugin specific buttons (eg: Join URL, etc)
+        in the management area.
 
         :param vc_room: the VC room object
         :param event_vc_room: the association of an event and a VC room
@@ -123,7 +129,9 @@ class VCPluginMixin(object):
         return render_template(name, plugin=self, vc_room=vc_room, event_vc_room=event_vc_room, **kwargs)
 
     def render_event_buttons(self, vc_room, event_vc_room, **kwargs):
-        """Renders a list of plugin specific buttons (eg: Join URL, etc) in the event page
+        """
+        Render a list of plugin specific buttons (eg: Join URL, etc)
+        in the event page.
 
         :param vc_room: the VC room object
         :param event_vc_room: the association of an event and a VC room
@@ -134,7 +142,7 @@ class VCPluginMixin(object):
                                event=event_vc_room.event, **kwargs)
 
     def create_form(self, event, existing_vc_room=None, existing_event_vc_room=None):
-        """Creates the videoconference room form
+        """Create the videoconference room form.
 
         :param event: the event the videoconference room is for
         :param existing_vc_room: a vc_room from which to retrieve data for the form
@@ -188,7 +196,7 @@ class VCPluginMixin(object):
         raise NotImplementedError('Plugin must implement create_room()')
 
     def can_manage_vc_rooms(self, user, event):
-        """Checks if a user can manage vc rooms on an event"""
+        """Check if a user can manage vc rooms on an event."""
         if self.can_manage_vc(user):
             return True
 
@@ -197,13 +205,13 @@ class VCPluginMixin(object):
         return self.settings.acls.contains_user('acl', user)
 
     def can_manage_vc_room(self, user, room):
-        """Checks if a user can manage a vc room"""
+        """Check if a user can manage a vc room."""
         return (user.is_admin or
                 self.can_manage_vc(user) or
                 any(evt_assoc.event.can_manage(user) for evt_assoc in room.events))
 
     def can_manage_vc(self, user):
-        """Checks if a user has management rights on this VC system"""
+        """Check if a user has management rights on this VC system."""
         if user.is_admin:
             return True
         return self.settings.acls.contains_user('managers', user)

--- a/indico/modules/vc/util.py
+++ b/indico/modules/vc/util.py
@@ -16,7 +16,7 @@ from indico.util.i18n import _
 
 
 def get_vc_plugins():
-    """Returns a dict containing the available videoconference plugins."""
+    """Return a dict containing the available videoconference plugins."""
     from indico.modules.vc import VCPluginMixin
     return {p.service_name: p for p in plugin_engine.get_active_plugins().itervalues() if isinstance(p, VCPluginMixin)}
 
@@ -34,12 +34,12 @@ def get_linked_to_description(obj):
 
 
 def get_managed_vc_plugins(user):
-    """Returns the plugins the user can manage"""
+    """Return the plugins the user can manage."""
     return [p for p in get_vc_plugins().itervalues() if p.can_manage_vc(user)]
 
 
 def find_event_vc_rooms(from_dt=None, to_dt=None, distinct=False):
-    """Finds VC rooms matching certain criteria
+    """Find VC rooms matching certain criteria.
 
     :param from_dt: earliest event/contribution to include
     :param to_dt: latest event/contribution to include

--- a/indico/testing/fixtures/app.py
+++ b/indico/testing/fixtures/app.py
@@ -16,7 +16,7 @@ from indico.web.flask.app import make_app
 
 @pytest.fixture(scope='session')
 def app(request):
-    """Creates the flask app"""
+    """Create the flask app."""
     config_override = {
         'BASE_URL': 'http://localhost',
         'SMTP_SERVER': ('localhost', 0),  # invalid port - just in case so we NEVER send emails!
@@ -34,13 +34,13 @@ def app(request):
 
 @pytest.fixture(autouse=True)
 def app_context(app):
-    """Creates a flask app context"""
+    """Create a flask app context."""
     with app.app_context():
         yield app
 
 
 @pytest.fixture
 def request_context(app_context):
-    """Creates a flask request context"""
+    """Create a flask request context."""
     with app_context.test_request_context():
         yield

--- a/indico/testing/fixtures/category.py
+++ b/indico/testing/fixtures/category.py
@@ -14,7 +14,7 @@ from indico.modules.categories import Category
 
 @pytest.fixture
 def create_category(db):
-    """Returns a callable which lets you create dummy events"""
+    """Return a callable which lets you create dummy events."""
 
     def _create_category(id_=None, **kwargs):
         kwargs.setdefault('title', u'cat#{}'.format(id_) if id_ is not None else u'dummy')
@@ -28,5 +28,5 @@ def create_category(db):
 
 @pytest.fixture
 def dummy_category(create_category):
-    """Creates a mocked dummy category"""
+    """Create a mocked dummy category."""
     return create_category(title='dummy')

--- a/indico/testing/fixtures/contribution.py
+++ b/indico/testing/fixtures/contribution.py
@@ -16,7 +16,7 @@ from indico.modules.events.contributions.models.contributions import Contributio
 
 @pytest.fixture
 def create_contribution(db):
-    """Returns a a callable that lets you create a contribution"""
+    """Return a callable that lets you create a contribution."""
 
     def _create_contribution(event, title, duration):
         entry = Contribution(event=event, title=title, duration=duration)

--- a/indico/testing/fixtures/database.py
+++ b/indico/testing/fixtures/database.py
@@ -25,7 +25,7 @@ from indico.web.flask.app import configure_db
 
 @pytest.fixture(scope='session')
 def postgresql():
-    """Provides a clean temporary PostgreSQL server/database.
+    """Provide a clean temporary PostgreSQL server/database.
 
     If the environment variable `INDICO_TEST_DATABASE_URI` is set, this fixture
     will do nothing and simply return the connection string from that variable
@@ -79,7 +79,7 @@ def postgresql():
 
 @pytest.fixture(scope='session')
 def database(app, postgresql):
-    """Creates a test database which is destroyed afterwards
+    """Create a test database which is destroyed afterwards.
 
     Used only internally, if you need to access the database use `db` instead to ensure
     your modifications are not persistent!
@@ -99,7 +99,7 @@ def database(app, postgresql):
 
 @pytest.fixture
 def db(database, monkeypatch):
-    """Provides database access and ensures changes do not persist"""
+    """Provide database access and ensure changes do not persist."""
     # Prevent database/session modifications
     monkeypatch.setattr(database.session, 'commit', database.session.flush)
     monkeypatch.setattr(database.session, 'remove', lambda: None)
@@ -120,7 +120,7 @@ def db(database, monkeypatch):
 @pytest.fixture
 @pytest.mark.usefixtures('db')
 def count_queries():
-    """Provides a query counter.
+    """Provide a query counter.
 
     Usage::
 

--- a/indico/testing/fixtures/disallow.py
+++ b/indico/testing/fixtures/disallow.py
@@ -12,9 +12,9 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def disallow_emails(monkeypatch):
-    """Prevents any code from connecting to a SMTP server.
+    """Prevent any code from connecting to a SMTP server.
 
-    Returns a set where you can add `(host, port)` combinations that
+    Return a set where you can add `(host, port)` combinations that
     should be exempt from the SMTP restriction.
     """
 

--- a/indico/testing/fixtures/event.py
+++ b/indico/testing/fixtures/event.py
@@ -16,7 +16,7 @@ from indico.util.date_time import now_utc
 
 @pytest.fixture
 def create_event(dummy_user, dummy_category, db):
-    """Returns a callable which lets you create dummy events"""
+    """Return a callable which lets you create dummy events."""
 
     def _create_event(id_=None, **kwargs):
         # we specify `acl_entries` so SA doesn't load it when accessing it for
@@ -37,5 +37,5 @@ def create_event(dummy_user, dummy_category, db):
 
 @pytest.fixture
 def dummy_event(create_event):
-    """Creates a mocked dummy event"""
+    """Create a mocked dummy event."""
     return create_event(0)

--- a/indico/testing/fixtures/user.py
+++ b/indico/testing/fixtures/user.py
@@ -14,7 +14,7 @@ from indico.modules.users import User
 
 @pytest.fixture
 def create_user(db):
-    """Returns a callable which lets you create dummy users"""
+    """Return a callable which lets you create dummy users."""
     def _create_user(id_, first_name=u'Guinea', last_name=u'Pig', rb_admin=False, admin=False, email=None, groups=None,
                      legacy=False):
         user = User.get(id_)
@@ -39,13 +39,13 @@ def create_user(db):
 
 @pytest.fixture
 def dummy_user(create_user):
-    """Creates a mocked user"""
+    """Create a mocked user."""
     return create_user(1337, legacy=False)
 
 
 @pytest.fixture
 def create_group(db):
-    """Returns a callable which lets you create dummy groups"""
+    """Return a callable which lets you create dummy groups."""
     def _create_group(id_):
         group = LocalGroup()
         group.id = id_
@@ -59,5 +59,5 @@ def create_group(db):
 
 @pytest.fixture
 def dummy_group(create_group):
-    """Creates a mocked dummy group"""
+    """Create a mocked dummy group."""
     return create_group(1337)

--- a/indico/testing/fixtures/util.py
+++ b/indico/testing/fixtures/util.py
@@ -16,7 +16,7 @@ from sqlalchemy.sql.functions import _FunctionGenerator
 
 @pytest.fixture
 def monkeypatch_methods(monkeypatch):
-    """Monkeypatches all methods from `cls` onto `target`
+    """Monkeypatch all methods from `cls` onto `target`.
 
     This utility lets you easily mock multiple methods in an existing class.
     In case of classmethods the binding will not be changed, i.e. `cls` will
@@ -35,7 +35,7 @@ def monkeypatch_methods(monkeypatch):
 
 @pytest.fixture
 def freeze_time(monkeypatch):
-    """Returns a function that freezes the current time
+    """Return a function that freezes the current time.
 
     It affects datetime.now, date.today, etc. and also SQLAlchemy's `func.now()`
     which simply returns the current time from `datetime.now()` instead of

--- a/indico/testing/util.py
+++ b/indico/testing/util.py
@@ -11,7 +11,7 @@ from itertools import imap, product
 
 
 def bool_matrix(template, mask=None, expect=None):
-    """Creates a boolean matrix suitable for parametrized tests.
+    """Create a boolean matrix suitable for parametrized tests.
 
     This function lets you create a boolean matrix with certain columns being
     fixed to a static value or certain combinations being skipped. It also adds
@@ -109,7 +109,7 @@ def bool_matrix(template, mask=None, expect=None):
 
 
 def extract_emails(smtp, required=True, count=None, one=False, regex=False, **kwargs):
-    """Extracts emails from an smtp outbox.
+    """Extract emails from an smtp outbox.
 
     :param smtp: The `smtp` fixture from the testcase
     :param required: Fail if no matching emails were found
@@ -144,7 +144,7 @@ def extract_emails(smtp, required=True, count=None, one=False, regex=False, **kw
 
 
 def extract_logs(caplog, required=True, count=None, one=False, regex=False, **kwargs):
-    """Extracts log records from python's logging system.
+    """Extract log records from python's logging system.
 
     :param caplog: The `caplog` fixture from the testcase
     :param required: Fail if no matching records were found

--- a/indico/util/benchmark.py
+++ b/indico/util/benchmark.py
@@ -14,7 +14,7 @@ from indico.util.console import cformat
 
 
 class Benchmark(object):
-    """Simple benchmark class
+    """Simple benchmark class.
 
     Can be used manually or as a contextmanager:
 

--- a/indico/util/caching.py
+++ b/indico/util/caching.py
@@ -41,7 +41,7 @@ def memoize(obj):
 
 
 def memoize_request(f):
-    """Memoize a function during the current request"""
+    """Memoize a function during the current request."""
     @wraps(f)
     def memoizer(*args, **kwargs):
         if not has_request_context() or current_app.config['TESTING'] or current_app.config.get('REPL'):
@@ -62,7 +62,7 @@ def memoize_request(f):
 
 
 def memoize_redis(ttl):
-    """Memoize a function in redis
+    """Memoize a function in redis.
 
     The cached value can be cleared by calling the method
     ``clear_cached()`` of the decorated function with the same

--- a/indico/util/console.py
+++ b/indico/util/console.py
@@ -53,12 +53,12 @@ def terminal_size():
 
 
 def clear_line():
-    """Clears the current line in the terminal"""
+    """Clear the current line in the terminal."""
     print('\r', ' ' * terminal_size()[0], '\r', end='', sep='')
 
 
 def verbose_iterator(iterable, total, get_id, get_title, print_every=10):
-    """Iterates large iterables verbosely
+    """Iterate large iterables verbosely.
 
     :param iterable: An iterable
     :param total: The number of items in `iterable`
@@ -96,9 +96,9 @@ def _cformat_sub(m):
 
 
 def cformat(string):
-    """Replaces %{color} and %{color,bgcolor} with ansi colors.
+    """Replace %{color} and %{color,bgcolor} with ansi colors.
 
-    Bold foreground can be achieved by suffixing the color with a '!'
+    Bold foreground can be achieved by suffixing the color with a '!'.
     """
     reset = colored(u'')
     string = string.replace(u'%{reset}', reset)

--- a/indico/util/date_time.py
+++ b/indico/util/date_time.py
@@ -27,7 +27,7 @@ from indico.util.string import inject_unicode_debug
 
 
 class relativedelta(_relativedelta):
-    """Improved `relativedelta`"""
+    """Improved `relativedelta`."""
 
     def __abs__(self):
         return self.__class__(years=abs(self.years),
@@ -49,7 +49,7 @@ class relativedelta(_relativedelta):
 
 
 def now_utc(exact=True):
-    """Get the current date/time in UTC
+    """Get the current date/time in UTC.
 
     :param exact: Set to ``False`` to set seconds/microseconds to 0.
     :return: A timezone-aware `datetime` object
@@ -61,14 +61,14 @@ def now_utc(exact=True):
 
 
 def as_utc(dt):
-    """Returns the given naive datetime with tzinfo=UTC."""
+    """Return the given naive datetime with tzinfo=UTC."""
     if dt.tzinfo and dt.tzinfo != pytz.utc:
         raise ValueError("{} already contains non-UTC tzinfo data".format(dt))
     return pytz.utc.localize(dt) if dt.tzinfo is None else dt
 
 
 def localize_as_utc(dt, timezone='UTC'):
-    """Localizes a naive datetime with the timezone and returns it as UTC.
+    """Localize a naive datetime with the timezone and returns it as UTC.
 
     :param dt: A naive :class:`datetime.datetime` object.
     :param timezone: The timezone from which to localize.  UTC by default.
@@ -78,24 +78,23 @@ def localize_as_utc(dt, timezone='UTC'):
 
 
 def server_to_utc(dt):
-    """Converts the given datetime in the server's TZ to UTC.
+    """Convert the given datetime in the server's TZ to UTC.
 
-    The given datetime **MUST** be naive but already contain the correct time in the server's TZ.
+    The given datetime **MUST** be naive but already contain the
+    correct time in the server's TZ.
     """
     server_tz = get_timezone(config.DEFAULT_TIMEZONE)
     return server_tz.localize(dt).astimezone(pytz.utc)
 
 
 def utc_to_server(dt):
-    """Converts the given UTC datetime to the server's TZ."""
+    """Convert the given UTC datetime to the server's TZ."""
     server_tz = get_timezone(config.DEFAULT_TIMEZONE)
     return dt.astimezone(server_tz)
 
 
 def format_datetime(dt, format='medium', locale=None, timezone=None, as_unicode=False):
-    """
-    Basically a wrapper around Babel's own format_datetime
-    """
+    """Basically a wrapper around Babel's own format_datetime."""
     inject_unicode = True
     if format == 'code':
         format = 'dd/MM/yyyy HH:mm'
@@ -112,9 +111,7 @@ def format_datetime(dt, format='medium', locale=None, timezone=None, as_unicode=
 
 
 def format_date(d, format='medium', locale=None, timezone=None, as_unicode=False):
-    """
-    Basically a wrapper around Babel's own format_date
-    """
+    """Basically a wrapper around Babel's own format_date."""
     inject_unicode = True
     if format == 'code':
         format = 'dd/MM/yyyy'
@@ -131,9 +128,7 @@ def format_date(d, format='medium', locale=None, timezone=None, as_unicode=False
 
 
 def format_time(t, format='short', locale=None, timezone=None, server_tz=False, as_unicode=False):
-    """
-    Basically a wrapper around Babel's own format_time
-    """
+    """Basically a wrapper around Babel's own format_time."""
     inject_unicode = True
     if format == 'code':
         format = 'HH:mm'
@@ -153,9 +148,7 @@ def format_time(t, format='short', locale=None, timezone=None, server_tz=False, 
 
 
 def format_timedelta(td, format='short', threshold=0.85, locale=None, as_unicode=False):
-    """
-    Basically a wrapper around Babel's own format_timedelta
-    """
+    """Basically a wrapper around Babel's own format_timedelta."""
     if not locale:
         locale = get_current_locale()
 
@@ -166,7 +159,7 @@ def format_timedelta(td, format='short', threshold=0.85, locale=None, as_unicode
 
 
 def format_human_timedelta(delta, granularity='seconds', narrow=False):
-    """Formats a timedelta in a human-readable way
+    """Format a timedelta in a human-readable way.
 
     :param delta: the timedelta to format
     :param granularity: the granularity, i.e. the lowest unit that is
@@ -222,6 +215,7 @@ def format_human_timedelta(delta, granularity='seconds', narrow=False):
 def format_human_date(dt, format='medium', locale=None, as_unicode=False):
     """
     Return the date in a human-like format for yesterday, today and tomorrow.
+
     Format the date otherwise.
     """
     today = now_utc().date()
@@ -309,8 +303,8 @@ def format_number(number, locale=None):
 
 def timedelta_split(delta):
     """
-    Decomposes a timedelta into hours, minutes and seconds
-    (timedelta only stores days and seconds)n
+    Decompose a timedelta into hours, minutes and seconds
+    (timedelta only stores days and seconds).
     """
     sec = delta.seconds + delta.days * 24 * 3600
     hours, remainder = divmod(sec, 3600)
@@ -389,7 +383,7 @@ def get_day_end(day, tzinfo=None):
 
 
 def strftime_all_years(dt, fmt):
-    """Exactly like datetime.strftime but supports year<1900"""
+    """Exactly like datetime.strftime but supports year<1900."""
     assert '%%Y' not in fmt  # unlikely but just in case
     if dt.year >= 1900:
         return dt.strftime(fmt)

--- a/indico/util/emails/backend.py
+++ b/indico/util/emails/backend.py
@@ -24,8 +24,7 @@ from indico.util.emails.message import sanitize_address
 
 
 class BaseEmailBackend(object):
-    """
-    Base class for email backend implementations.
+    """Base class for email backend implementations.
 
     Subclasses must at least overwrite send_messages().
 
@@ -36,6 +35,7 @@ class BaseEmailBackend(object):
             # do something with connection
             pass
     """
+
     def __init__(self, fail_silently=False, **kwargs):
         self.fail_silently = fail_silently
 
@@ -74,16 +74,15 @@ class BaseEmailBackend(object):
 
     def send_messages(self, email_messages):
         """
-        Sends one or more EmailMessage objects and returns the number of email
+        Send one or more EmailMessage objects and return the number of email
         messages sent.
         """
         raise NotImplementedError('subclasses of BaseEmailBackend must override send_messages() method')
 
 
 class EmailBackend(BaseEmailBackend):
-    """
-    A wrapper that manages the SMTP network connection.
-    """
+    """A wrapper that manages the SMTP network connection."""
+
     def __init__(self, host=None, port=None, username=None, password=None,
                  use_tls=None, fail_silently=False, use_ssl=False, timeout=None,
                  ssl_keyfile=None, ssl_certfile=None,
@@ -111,10 +110,10 @@ class EmailBackend(BaseEmailBackend):
         return smtplib.SMTP_SSL if self.use_ssl else smtplib.SMTP
 
     def open(self):
-        """
-        Ensure an open connection to the email server. Return whether or not a
-        new connection was required (True or False) or None if an exception
-        passed silently.
+        """Ensure an open connection to the email server.
+
+        Return whether or not a new connection was required
+        (True or False) or None if an exception passed silently.
         """
         if self.connection:
             # Nothing to do if the connection is already open.
@@ -143,7 +142,7 @@ class EmailBackend(BaseEmailBackend):
                 raise
 
     def close(self):
-        """Closes the connection to the email server."""
+        """Close the connection to the email server."""
         if self.connection is None:
             return
         try:
@@ -163,7 +162,7 @@ class EmailBackend(BaseEmailBackend):
 
     def send_messages(self, email_messages):
         """
-        Sends one or more EmailMessage objects and returns the number of email
+        Send one or more EmailMessage objects and returns the number of email
         messages sent.
         """
         if not email_messages:

--- a/indico/util/emails/message.py
+++ b/indico/util/emails/message.py
@@ -65,7 +65,7 @@ class BadHeaderError(ValueError):
 # Copied from Python 3.2+ standard library, with the following modification:
 # * Uses hostname from indico's BASE_URL as the default domain
 def make_msgid(idstring=None, domain=None):
-    """Returns a string suitable for RFC 2822 compliant Message-ID, e.g:
+    """Return a string suitable for RFC 2822 compliant Message-ID, e.g:
 
     <142480216486.20800.16526388040877946887@nightshade.la.mastaler.com>
 
@@ -104,7 +104,7 @@ ADDRESS_HEADERS = {
 
 
 def forbid_multi_line_headers(name, val, encoding):
-    """Forbids multi-line headers, to prevent header injection."""
+    """Forbid multi-line headers, to prevent header injection."""
     val = force_text(val)
     if '\n' in val or '\r' in val:
         raise BadHeaderError("Header values can't contain newlines (got %r for header %r)" % (val, name))
@@ -122,8 +122,7 @@ def forbid_multi_line_headers(name, val, encoding):
 
 
 def split_addr(addr, encoding):
-    """
-    Split the address into local part and domain, properly encoded.
+    """Split the address into local part and domain, properly encoded.
 
     When non-ascii characters are present in the local part, it must be
     MIME-word encoded. The domain name must be idna-encoded if it contains
@@ -146,9 +145,7 @@ def split_addr(addr, encoding):
 
 
 def sanitize_address(addr, encoding):
-    """
-    Format a pair of (name, address) or an email address string.
-    """
+    """Format a pair of (name, address) or an email address string."""
     if not isinstance(addr, tuple):
         addr = parseaddr(force_text(addr))
     nm, addr = addr
@@ -168,6 +165,7 @@ def sanitize_address(addr, encoding):
 class MIMEMixin:
     def as_string(self, unixfrom=False, linesep='\n'):
         """Return the entire formatted message as a string.
+
         Optional `unixfrom' when True, means include the Unix From_ envelope
         header.
 
@@ -221,9 +219,7 @@ class SafeMIMEMultipart(MIMEMixin, MIMEMultipart):
 
 
 class EmailMessage(object):
-    """
-    A container for email information.
-    """
+    """A container for email information."""
     content_subtype = 'plain'
     mixed_subtype = 'mixed'
     encoding = 'utf-8'
@@ -312,7 +308,7 @@ class EmailMessage(object):
 
     def recipients(self):
         """
-        Returns a list of all recipients of the email (includes direct
+        Return a list of all recipients of the email (includes direct
         addressees as well as Cc and Bcc entries).
         """
         return [email for email in (self.to + self.cc + self.bcc) if email]
@@ -327,7 +323,7 @@ class EmailMessage(object):
 
     def attach(self, filename=None, content=None, mimetype=None):
         """
-        Attaches a file with the given filename and content. The filename can
+        Attach a file with the given filename and content. The filename can
         be omitted and the mimetype is guessed, if not provided.
 
         If the first parameter is a MIMEBase subclass it is inserted directly
@@ -363,8 +359,7 @@ class EmailMessage(object):
             self.attachments.append((filename, content, mimetype))
 
     def attach_file(self, path, mimetype=None):
-        """
-        Attaches a file from the filesystem.
+        """Attach a file from the filesystem.
 
         The mimetype will be set to the DEFAULT_ATTACHMENT_MIME_TYPE if it is
         not specified and cannot be guessed.
@@ -397,7 +392,7 @@ class EmailMessage(object):
 
     def _create_mime_attachment(self, content, mimetype):
         """
-        Converts the content, mimetype pair into a MIME attachment object.
+        Convert the content, mimetype pair into a MIME attachment object.
 
         If the mimetype is message/rfc822, content may be an
         email.Message or EmailMessage object, as well as a str.
@@ -426,7 +421,7 @@ class EmailMessage(object):
 
     def _create_attachment(self, filename, content, mimetype=None):
         """
-        Converts the filename, content, mimetype triple into a MIME attachment
+        Convert the filename, content, mimetype triple into a MIME attachment
         object.
         """
         attachment = self._create_mime_attachment(content, mimetype)

--- a/indico/util/fossilize/__init__.py
+++ b/indico/util/fossilize/__init__.py
@@ -30,16 +30,13 @@ import zope.interface
 _fossil_cache = threading.local()
 
 def fossilizes(*classList):
-    """
-    Simple wrapper around 'implements'
-    """
+    """Simple wrapper around 'implements'."""
     zope.interface.declarations._implements("fossilizes",
                                             classList,
                                             zope.interface.classImplements)
 
 def addFossil(klazz, fossils):
-    """
-    Declares fossils for a class
+    """Declare fossils for a class.
 
     :param klazz: a class object
     :type klass: class object
@@ -53,34 +50,29 @@ def addFossil(klazz, fossils):
 
 
 def clearCache():
-    """
-    Shortcut for Fossilizable.clearCache()
-    """
+    """Shortcut for Fossilizable.clearCache()"""
     Fossilizable.clearCache()
 
 
 class NonFossilizableException(Exception):
-    """
-    Object is not fossilizable (doesn't implement Fossilizable)
-    """
+    """Object is not fossilizable (doesn't implement Fossilizable)."""
 
 
 class InvalidFossilException(Exception):
     """
     The fossil name doesn't follow the convention I(\w+)Fossil
-    or has an invalid method name and did not declare a .name tag for it
+    or has an invalid method name and did not declare a .name tag for it.
     """
 
 
 class IFossil(zope.interface.Interface):
-    """
-    Fossil base interface. All fossil classes should derive from this one.
+    """Fossil base interface.
+
+    All fossil classes should derive from this one.
     """
 
 class Fossilizable(object):
-    """
-    Base class for all the objects that can be fossilized
-    """
+    """Base class for all the objects that can be fossilized."""
 
     __fossilNameRE = re.compile('^I(\w+)Fossil$')
     __methodNameRE = re.compile('^get(\w+)|(has\w+)|(is\w+)$')
@@ -108,9 +100,8 @@ class Fossilizable(object):
 
     @classmethod
     def __extractFossilName(cls, name):
-        """
-        Extracts the fossil name from a I(.*)Fossil
-        class name.
+        """Extract the fossil name from a I(.*)Fossil class name.
+
         IMyObjectBasicFossil -> myObjectBasic
         """
 
@@ -131,8 +122,7 @@ class Fossilizable(object):
 
     @classmethod
     def __obtainInterface(cls, obj, interfaceArg):
-        """
-        Obtains the appropriate interface for this object.
+        """Obtain the appropriate interface for this object.
 
         :param interfaceArg: the target fossile type
         :type interfaceArg: IFossil, NoneType, or dict
@@ -143,7 +133,7 @@ class Fossilizable(object):
         * If a dict, we will use the objects class, class name, or full class name
         as key.
 
-        Also verifies that the interface obtained through these 3 methods is
+        Also verify that the interface obtained through these 3 methods is
         effectively provided by the object.
         """
 
@@ -184,9 +174,7 @@ class Fossilizable(object):
 
     @classmethod
     def clearCache(cls):
-        """
-        Clears the fossil attribute cache
-        """
+        """Clear the fossil attribute cache."""
         _fossil_cache.methodName = {}
         _fossil_cache.fossilName = {}
         _fossil_cache.fossilInterface = {}
@@ -197,9 +185,8 @@ class Fossilizable(object):
 
     @classmethod
     def fossilizeIterable(cls, target, interface, useAttrCache=False, filterBy=None, **kwargs):
-        """
-        Fossilizes an object, be it a 'direct' fossilizable
-        object, or an iterable (dict, list, set);
+        """Fossilize an object, be it a 'direct' fossilizable
+        object, or an iterable (dict, list, set).
         """
         if isinstance(target, Fossilizable):
             return target.fossilize(interface, useAttrCache, **kwargs)
@@ -248,7 +235,7 @@ class Fossilizable(object):
     @classmethod
     def fossilize_obj(cls, obj, interfaceArg=None, useAttrCache=False, mapClassType=None, **kwargs):
         """
-        Fossilizes the object, using the fossil provided by `interface`.
+        Fossilize the object, using the fossil provided by `interface`.
 
         :param interfaceArg: the target fossile type
         :type interfaceArg: IFossil, NoneType, or dict

--- a/indico/util/fs.py
+++ b/indico/util/fs.py
@@ -34,7 +34,7 @@ def silentremove(filename):
 
 
 def secure_filename(filename, fallback):
-    """Returns a secure version of a filename.
+    """Return a secure version of a filename.
 
     This removes possibly dangerous characters and also converts the
     filename to plain ASCII for maximum compatibility. It should only

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -34,7 +34,7 @@ _use_context = object()
 
 
 def get_translation_domain(plugin_name=_use_context):
-    """Get the translation domain for the given plugin
+    """Get the translation domain for the given plugin.
 
     If `plugin_name` is omitted, the plugin will be taken from current_plugin.
     If `plugin_name` is None, the core translation domain ('indico') will be used.
@@ -79,7 +79,7 @@ def lazy_gettext(string, plugin_name=None):
 
 
 def orig_string(lazy_string):
-    """Get the original string from a lazy string"""
+    """Get the original string from a lazy string."""
     return lazy_string._args[0] if is_lazy_string(lazy_string) else lazy_string
 
 
@@ -105,12 +105,16 @@ def smart_func(func_name, plugin_name=None, force_unicode=False):
 
 
 def make_bound_gettext(plugin_name, force_unicode=False):
-    """Creates a smart gettext callable bound to the domain of the specified plugin"""
+    """
+    Create a smart gettext callable bound to the domain of the specified plugin.
+    """
     return smart_func('ugettext', plugin_name=plugin_name, force_unicode=force_unicode)
 
 
 def make_bound_ngettext(plugin_name, force_unicode=False):
-    """Creates a smart ngettext callable bound to the domain of the specified plugin"""
+    """
+    Create a smart ngettext callable bound to the domain of the specified plugin.
+    """
     return smart_func('ungettext', plugin_name=plugin_name, force_unicode=force_unicode)
 
 
@@ -129,7 +133,7 @@ N_ = lambda text: text  # noqa
 
 
 class NullDomain(Domain):
-    """A `Domain` that doesn't contain any translations"""
+    """A `Domain` that doesn't contain any translations."""
 
     def __init__(self):
         super(NullDomain, self).__init__()
@@ -140,14 +144,10 @@ class NullDomain(Domain):
 
 
 class IndicoLocale(Locale):
-    """
-    Extends the Babel Locale class with some utility methods
-    """
+    """Extend the Babel Locale class with some utility methods."""
 
     def weekday(self, daynum, short=True):
-        """
-        Returns the week day given the index
-        """
+        """Return the week day given the index."""
         return self.days['format']['abbreviated' if short else 'wide'][daynum].encode('utf-8')
 
     @cached_property
@@ -160,7 +160,7 @@ class IndicoLocale(Locale):
 
 class IndicoTranslations(Translations):
     """
-    Routes translations through the 'smart' translators defined above
+    Route translations through the 'smart' translators defined above.
     """
 
     def _check_stack(self):
@@ -203,11 +203,12 @@ def _remove_locale_script(locale):
 
 @babel.localeselector
 def set_best_lang(check_session=True):
-    """
-    Get the best language/locale for the current user. This means that first
-    the session will be checked, and then in the absence of an explicitly-set
-    language, we will try to guess it from the browser settings and only
-    after that fall back to the server's default.
+    """Get the best language/locale for the current user.
+
+    This means that first the session will be checked, and then in the
+    absence of an explicitly-set language, we will try to guess it from
+    the browser settings and only after that fall back to
+    the server's default.
     """
     from indico.core.config import config
 
@@ -260,7 +261,7 @@ def get_current_locale():
 
 def get_all_locales():
     """
-    List all available locales/names e.g. ``{'pt_PT': ('Portuguese', 'Portugal)}``
+    List all available locales/names e.g. ``{'pt_PT': ('Portuguese', 'Portugal)}``.
     """
     if babel.app is None:
         return {}
@@ -272,17 +273,13 @@ def get_all_locales():
 
 
 def set_session_lang(lang):
-    """
-    Set the current language in the current request context
-    """
+    """Set the current language in the current request context."""
     session.lang = lang
 
 
 @contextmanager
 def session_language(lang):
-    """
-    Context manager that temporarily sets session language
-    """
+    """Context manager that temporarily sets session language."""
     old_lang = session.lang
 
     set_session_lang(lang)
@@ -291,9 +288,7 @@ def session_language(lang):
 
 
 def parse_locale(locale):
-    """
-    Get a Locale object from a locale id
-    """
+    """Get a Locale object from a locale id."""
     return IndicoLocale.parse(locale)
 
 
@@ -310,9 +305,7 @@ def extract_node(node, keywords, commentTags, options, parents=[None]):
 
 
 def po_to_json(po_file, locale=None, domain=None):
-    """
-    Converts *.po file to a json-like data structure
-    """
+    """Convert *.po file to a json-like data structure."""
     with open(po_file, 'rb') as f:
         po_data = read_po(f, locale=locale, domain=domain)
 

--- a/indico/util/json.py
+++ b/indico/util/json.py
@@ -20,8 +20,8 @@ except ImportError:
 
 
 class IndicoJSONEncoder(_json.JSONEncoder):
-    """
-    Custom JSON encoder that supports more types
+    """Custom JSON encoder that supports more types.
+
      * datetime objects
     """
     def __init__(self, *args, **kwargs):
@@ -42,9 +42,7 @@ class IndicoJSONEncoder(_json.JSONEncoder):
 
 
 def dumps(obj, **kwargs):
-    """
-    Simple wrapper around json.dumps()
-    """
+    """Simple wrapper around json.dumps()."""
     if kwargs.pop('pretty', False):
         kwargs['indent'] = 4 * ' '
     textarea = kwargs.pop('textarea', False)
@@ -57,7 +55,5 @@ def dumps(obj, **kwargs):
 
 
 def loads(string):
-    """
-    Simple wrapper around json.decode()
-    """
+    """Simple wrapper around json.decode()."""
     return _json.loads(string)

--- a/indico/util/locators.py
+++ b/indico/util/locators.py
@@ -13,7 +13,7 @@ from werkzeug.utils import cached_property
 
 
 class locator_property(object):
-    """Defines a smart locator property.
+    """Define a smart locator property.
 
     This behaves pretty much like a normal read-only property and the
     decorated function should return a dict containing the necessary
@@ -62,7 +62,7 @@ class locator_property(object):
 
 
 def get_locator(obj):
-    """Retrieves the locator data from an object.
+    """Retrieve the locator data from an object.
 
     The object may be a dictionary (in case a locator is passed) or
     an object with a ``locator`` property.

--- a/indico/util/marshmallow.py
+++ b/indico/util/marshmallow.py
@@ -32,7 +32,7 @@ HUMANIZED_UNIT_MAP = {
 
 
 def validate_with_message(fn, reason):
-    """Create a validation function with a custom error message"""
+    """Create a validation function with a custom error message."""
 
     def validate(args):
         if not fn(args):
@@ -303,9 +303,9 @@ class PrincipalPermissionList(Field):
 class HumanizedDate(Field):
     """Marshmallow field for human-written dates used in REST APIs.
 
-       This field allows for simple time deltas, e.g.: ``1d`` = "1 day`, ``1w`` = "1 week",
-       ``-2M`` = "2 months ago";
-       Simple ISO dates are also accepted (``YYYY-MM-DD``).
+    This field allows for simple time deltas, e.g.: ``1d`` = "1 day`, ``1w`` = "1 week",
+    ``-2M`` = "2 months ago";
+    Simple ISO dates are also accepted (``YYYY-MM-DD``).
     """
 
     def _serialize(self, value, attr, obj):
@@ -326,7 +326,7 @@ class HumanizedDate(Field):
 
 
 class FilesField(ModelList):
-    """Marshmallow field for a list of previously-uploaded files"""
+    """Marshmallow field for a list of previously-uploaded files."""
 
     default_error_messages = dict(ModelList.default_error_messages, **{
         'claimed': 'File has already been claimed',
@@ -345,7 +345,7 @@ class FilesField(ModelList):
 
 
 class FileField(ModelField):
-    """Marshmallow field for one previously-uploaded file"""
+    """Marshmallow field for one previously-uploaded file."""
 
     default_error_messages = dict(ModelList.default_error_messages, **{
         'claimed': 'File has already been claimed',

--- a/indico/util/mdx_latex.py
+++ b/indico/util/mdx_latex.py
@@ -226,8 +226,7 @@ def unescape_latex_entities(text):
 
 
 def latex_render_error(message):
-    """
-    Generate nice error box in LaTeX document.
+    """Generate nice error box in LaTeX document.
 
     :param message: The error message
     :returns: LaTeX code for error box
@@ -239,8 +238,7 @@ def latex_render_error(message):
 
 
 def latex_render_image(src, alt, tmpdir, strict=False):
-    """
-    Generate LaTeX code that includes an arbitrary image from a URL.
+    """Generate LaTeX code that includes an arbitrary image from a URL.
 
     This involves fetching the image from a web server and figuring out its
     MIME type. A temporary file will be created, which is not immediately
@@ -337,7 +335,7 @@ class LaTeXExtension(markdown.Extension):
 
 
 class NonEncodedAutoMailPattern(markdown.inlinepatterns.Pattern):
-    """Reimplementation of AutoMailPattern to avoid URL-encoded links"""
+    """Reimplementation of AutoMailPattern to avoid URL-encoded links."""
 
     def handleMatch(self, m):
         el = markdown.util.etree.Element('a')
@@ -357,8 +355,10 @@ class LaTeXTreeProcessor(markdown.treeprocessors.Treeprocessor):
         self.configs = configs
 
     def run(self, doc):
-        """Walk the dom converting relevant nodes to text nodes with relevant
-        content."""
+        """
+        Walk the dom converting relevant nodes to text nodes with relevant
+        content.
+        """
         latex_text = self.tolatex(doc)
         doc.clear()
         doc.text = latex_text
@@ -452,7 +452,8 @@ class UnescapeHtmlTextPostProcessor(markdown.postprocessors.Postprocessor):
 class MathTextPostProcessor(markdown.postprocessors.Postprocessor):
 
     def run(self, instr):
-        """Convert all math sections in {text} whether latex, asciimathml or
+        """
+        Convert all math sections in {text} whether latex, asciimathml or
         latexmathml formatted to latex.
 
         This assumes you are using $$ as your mathematics delimiter (*not* the

--- a/indico/util/mimetypes.py
+++ b/indico/util/mimetypes.py
@@ -65,7 +65,7 @@ _regex_mapping = [(re.compile(regex), icon) for regex, icon in _regex_mapping]
 
 
 def icon_from_mimetype(mimetype, default_icon='icon-file-filled'):
-    """Gets the most suitable icon for a MIME type."""
+    """Get the most suitable icon for a MIME type."""
     mimetype = mimetype.lower()
     try:
         return _exact_mapping[mimetype]
@@ -77,7 +77,7 @@ def icon_from_mimetype(mimetype, default_icon='icon-file-filled'):
 
 
 def register_custom_mimetypes():
-    """Registers additional extension/mimetype mappings.
+    """Register additional extension/mimetype mappings.
 
     This is used for mimetypes/extensions that are not in the official
     mapping but useful, e.g. because indico has special handling for

--- a/indico/util/packaging.py
+++ b/indico/util/packaging.py
@@ -15,7 +15,7 @@ import pkg_resources
 
 
 def package_is_editable(package):
-    """Check whether the Python package is installed in 'editable' mode"""
+    """Check whether the Python package is installed in 'editable' mode."""
     # based on pip.dist_is_editable
     dist = pkg_resources.get_distribution(package)
     for path_item in sys.path:
@@ -26,7 +26,7 @@ def package_is_editable(package):
 
 
 def get_package_root_path(import_name):
-    """Get the root path of a package
+    """Get the root path of a package.
 
     Returns ``None`` if the specified import name is invalid or
     points to a module instead of a package.

--- a/indico/util/passwords.py
+++ b/indico/util/passwords.py
@@ -39,7 +39,7 @@ class BCryptPassword(object):
 
 
 class PasswordProperty(object):
-    """Defines a hashed password property.
+    """Define a hashed password property.
 
     When reading this property, it will return an object which will
     let you use the ``==`` operator to compare  the password against

--- a/indico/util/placeholders.py
+++ b/indico/util/placeholders.py
@@ -67,12 +67,12 @@ class Placeholder(object):
 
     @classmethod
     def is_in(cls, text, **kwargs):
-        """Checks whether the placeholder is used in a string"""
+        """Check whether the placeholder is used in a string."""
         return cls.get_regex(**kwargs).search(text) is not None
 
     @classmethod
     def is_empty(cls, text, **kwargs):
-        """Checks whether the placeholder renders an empty string
+        """Check whether the placeholder renders an empty string.
 
         :param text: The text to replace placeholders in
         :param kwargs: arguments specific to the placeholder's context
@@ -89,7 +89,7 @@ class Placeholder(object):
 
     @classmethod
     def render(cls, **kwargs):
-        """Converts the placeholder to a string
+        """Convert the placeholder to a string.
 
         When a placeholder contains HTML that should not be escaped,
         the returned value should be returned as a
@@ -104,7 +104,7 @@ class Placeholder(object):
 
 
 class ParametrizedPlaceholder(Placeholder):
-    """Base class for placeholders that can take an argument
+    """Base class for placeholders that can take an argument.
 
     Such placeholders are used like this: ``{something:arg}`` with
     ``:arg`` being optional; if omitted the argument will be ``None``.
@@ -137,7 +137,7 @@ class ParametrizedPlaceholder(Placeholder):
 
     @classmethod
     def iter_param_info(cls, **kwargs):
-        """Yields information for known params.
+        """Yield information for known params.
 
         Each item yielded must be a ``(value, description)`` tuple.
 
@@ -157,7 +157,7 @@ class ParametrizedPlaceholder(Placeholder):
 
     @classmethod
     def is_empty(cls, text, **kwargs):
-        """Checks whether the placeholder renders an empty string
+        """Check whether the placeholder renders an empty string.
 
         :param text: The text to replace placeholders in
         :param kwargs: arguments specific to the placeholder's context
@@ -182,7 +182,7 @@ def get_placeholders(context, **kwargs):
 
 
 def replace_placeholders(context, text, escape_html=True, **kwargs):
-    """Replaces placeholders in a string.
+    """Replace placeholders in a string.
 
     :param context: the context where the placeholders are used
     :param text: the text to replace placeholders in
@@ -220,7 +220,7 @@ def get_missing_placeholders(context, text, **kwargs):
 
 
 def render_placeholder_info(context, **kwargs):
-    """Renders the list of available placeholders.
+    """Render the list of available placeholders.
 
     :param context: the context where the placeholders are used
     :param kwargs: arguments specific to the context

--- a/indico/util/rules.py
+++ b/indico/util/rules.py
@@ -37,14 +37,14 @@ class Condition(object):
 
     @classmethod
     def is_used(cls, rule):
-        """Check whether the condition is used in a rule"""
+        """Check whether the condition is used in a rule."""
         return rule.get(cls.name) is not None
 
     @classmethod
     def is_none(cls, **kwargs):
         """Check whether the condition requires a null value.
 
-            Inheriting methods should overload this
+        Inheriting methods should overload this
         """
         raise NotImplementedError
 

--- a/indico/util/signals.py
+++ b/indico/util/signals.py
@@ -11,7 +11,7 @@ from types import GeneratorType
 
 def values_from_signal(signal_response, single_value=False, skip_none=True, as_list=False,
                        multi_value_types=GeneratorType, return_plugins=False):
-    """Combines the results from both single-value and multi-value signals.
+    """Combine the results from both single-value and multi-value signals.
 
     The signal needs to return either a single object (which is not a
     generator) or a generator (usually by returning its values using
@@ -50,7 +50,7 @@ def values_from_signal(signal_response, single_value=False, skip_none=True, as_l
 
 
 def named_objects_from_signal(signal_response, name_attr='name', plugin_attr=None):
-    """Returns a dict of objects based on an unique attribute on each object.
+    """Return a dict of objects based on an unique attribute on each object.
 
     The signal needs to return either a single object (which is not a
     generator) or a generator (usually by returning its values using

--- a/indico/util/spreadsheets.py
+++ b/indico/util/spreadsheets.py
@@ -61,7 +61,7 @@ def _prepare_csv_data(data, _linebreak_re=re.compile(r'(\r?\n)+'), _dangerous_ch
 
 
 def generate_csv(headers, rows):
-    """Generates a CSV file from a list of headers and rows.
+    """Generate a CSV file from a list of headers and rows.
 
     While CSV cells may contain multiline data, we replace linebreaks
     with spaces in case someone wants to use it in Excel which does
@@ -97,7 +97,7 @@ def _prepare_excel_data(data, tz=None):
 
 
 def generate_xlsx(headers, rows, tz=None):
-    """Generates an XLSX file from a list of headers and rows.
+    """Generate an XLSX file from a list of headers and rows.
 
     :param headers: a list of cell captions
     :param rows: a list of dicts mapping captions to values
@@ -122,7 +122,7 @@ def generate_xlsx(headers, rows, tz=None):
 
 
 def send_csv(filename, headers, rows):
-    """Sends a CSV file to the client
+    """Send a CSV file to the client.
 
     :param filename: The name of the CSV file
     :param headers: a list of cell captions
@@ -134,7 +134,7 @@ def send_csv(filename, headers, rows):
 
 
 def send_xlsx(filename, headers, rows, tz=None):
-    """Sends an XLSX file to the client
+    """Send an XLSX file to the client.
 
     :param filename: The name of the CSV file
     :param headers: a list of cell captions

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -109,7 +109,7 @@ def fix_broken_string(text, as_unicode=False):
 
 
 def to_unicode(text):
-    """Converts a string to unicode if it isn't already unicode."""
+    """Convert a string to unicode if it isn't already unicode."""
     return fix_broken_string(text, as_unicode=True) if isinstance(text, str) else unicode(text)
 
 
@@ -137,7 +137,7 @@ def strict_unicode(value):
 
 
 def slugify(*args, **kwargs):
-    """Joins a series of strings into a URL slug.
+    """Join a series of strings into a URL slug.
 
     - normalizes unicode to proper ascii repesentations
     - removes non-alphanumeric characters
@@ -169,7 +169,8 @@ def return_ascii(f):
     """Decorator to normalize all unicode characters.
 
     This is useful for __repr__ methods which **MUST** return a plain string to
-    avoid encoding to utf8 or ascii all the time."""
+    avoid encoding to utf8 or ascii all the time.
+    """
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         return unicode_to_ascii(f(*args, **kwargs))
@@ -206,14 +207,15 @@ def strip_tags(text):
 
 
 def render_markdown(text, escape_latex_math=True, md=None, **kwargs):
-    """ Mako markdown to HTML filter
-        :param text: Markdown source to convert to HTML
-        :param escape_latex_math: Whether math expression should be left untouched or a function that will be called
-                                  to replace math-mode segments.
-        :param md: An alternative markdown processor (can be used
-                   to generate e.g. a different format)
-        :param kwargs: Extra arguments to pass on to the markdown
-                       processor
+    """Mako markdown to HTML filter.
+
+    :param text: Markdown source to convert to HTML
+    :param escape_latex_math: Whether math expression should be left untouched or a function that will be called
+                              to replace math-mode segments.
+    :param md: An alternative markdown processor (can be used
+               to generate e.g. a different format)
+    :param kwargs: Extra arguments to pass on to the markdown
+                   processor
     """
     if escape_latex_math:
         math_segments = []
@@ -240,7 +242,7 @@ def render_markdown(text, escape_latex_math=True, md=None, **kwargs):
 
 
 def sanitize_for_platypus(text):
-    """Sanitize HTML to be used in platypus"""
+    """Sanitize HTML to be used in platypus."""
     tags = ['b', 'br', 'em', 'font', 'i', 'img', 'strike', 'strong', 'sub', 'sup', 'u', 'span', 'div', 'p']
     attrs = {
         'font': ['size', 'face', 'color'],
@@ -319,9 +321,7 @@ def strip_control_chars(text):
 
 
 def html_color_to_rgb(hexcolor):
-    """
-    convert #RRGGBB to an (R, G, B) tuple
-    """
+    """Convert #RRGGBB to an (R, G, B) tuple."""
 
     if not hexcolor.startswith('#'):
         raise ValueError("Invalid color string '{}' (should start with '#')".format(hexcolor))
@@ -338,7 +338,7 @@ def html_color_to_rgb(hexcolor):
 
 
 def strip_whitespace(s):
-    """Removes trailing/leading whitespace if a string was passed.
+    """Remove trailing/leading whitespace if a string was passed.
 
     This utility is useful in cases where you might get None or
     non-string values such as WTForms filters.
@@ -349,7 +349,7 @@ def strip_whitespace(s):
 
 
 def make_unique_token(is_unique):
-    """Create a unique UUID4-based token
+    """Create a unique UUID4-based token.
 
     :param is_unique: a callable invoked with the token which should
                       return a boolean indicating if the token is actually
@@ -374,7 +374,7 @@ def encode_utf8(f):
 
 
 def is_legacy_id(id_):
-    """Checks if an ID is a broken legacy ID.
+    """Check if an ID is a broken legacy ID.
 
     These IDs are not compatible with new code since they are not
     numeric or have a leading zero, resulting in different objects
@@ -384,7 +384,7 @@ def is_legacy_id(id_):
 
 
 def text_to_repr(text, html=False, max_length=50):
-    """Converts text to a suitable string for a repr
+    """Convert text to a suitable string for a repr.
 
     :param text: A string which might contain html and/or linebreaks
     :param html: If True, HTML tags are stripped.
@@ -409,7 +409,7 @@ def alpha_enum(value):
 
 
 def format_repr(obj, *args, **kwargs):
-    """Creates a pretty repr string from object attributes
+    """Create a pretty repr string from object attributes.
 
     :param obj: The object to show the repr for.
     :param args: The names of arguments to include in the repr.
@@ -465,14 +465,14 @@ def format_repr(obj, *args, **kwargs):
 
 
 def snakify(name):
-    """Converts a camelCased name to snake_case"""
+    """Convert a camelCased name to snake_case."""
     # from http://stackoverflow.com/a/1176023/298479
     name = re.sub(r'(.)([A-Z][a-z]+)', r'\1_\2', name)
     return re.sub(r'([a-z0-9])([A-Z])', r'\1_\2', name).lower()
 
 
 def camelize(name):
-    """Converts a snake_cased name to camelCase."""
+    """Convert a snake_cased name to camelCase."""
     parts = name.split('_')
     underscore = ''
     if name.startswith('_'):
@@ -490,17 +490,17 @@ def _convert_keys(value, convert_func):
 
 
 def camelize_keys(dict_):
-    """Convert the keys of a dict to camelCase"""
+    """Convert the keys of a dict to camelCase."""
     return _convert_keys(dict_, camelize)
 
 
 def snakify_keys(dict_):
-    """Convert the keys of a dict to snake_case"""
+    """Convert the keys of a dict to snake_case."""
     return _convert_keys(dict_, snakify)
 
 
 def crc32(data):
-    """Calculates a CRC32 checksum.
+    """Calculate a CRC32 checksum.
 
     When a unicode object is passed, it is encoded as UTF-8.
     """
@@ -510,7 +510,7 @@ def crc32(data):
 
 
 def normalize_phone_number(value):
-    """Normalize phone number so it doesn't contain invalid characters
+    """Normalize phone number so it doesn't contain invalid characters.
 
     This removes all characters besides a leading +, digits and x as
     described here: http://stackoverflow.com/a/123681/298479
@@ -520,7 +520,7 @@ def normalize_phone_number(value):
 
 def format_full_name(first_name, last_name, title=None, last_name_first=True, last_name_upper=True,
                      abbrev_first_name=True, show_title=False):
-    """Returns the user's name in the specified notation.
+    """Return the user's name in the specified notation.
 
     Note: Do not use positional arguments (except for the names/title)
     when calling this method.  Always use keyword arguments!
@@ -600,7 +600,7 @@ def inject_unicode_debug(s, level=1):
 
 
 class RichMarkup(Markup):
-    """unicode/Markup subclass that detects preformatted text
+    """Unicode/Markup subclass that detects preformatted text.
 
     Note that HTML in this string will NOT be escaped when displaying
     it in a jinja template.
@@ -635,14 +635,14 @@ class RichMarkup(Markup):
 
 
 class MarkdownText(Markup):
-    """unicode/Markup class that renders markdown."""
+    """Unicode/Markup class that renders markdown."""
 
     def __html__(self):
         return render_markdown(unicode(self), extensions=('nl2br', 'tables'))
 
 
 class PlainText(Markup):
-    """unicode/Markup class that renders plain text."""
+    """Unicode/Markup class that renders plain text."""
 
     def __html__(self):
         return u'<div class="preformatted">{}</div>'.format(escape(unicode(self)))

--- a/indico/util/struct/enum.py
+++ b/indico/util/struct/enum.py
@@ -11,7 +11,7 @@ from enum import Enum
 
 
 class IndicoEnum(Enum):
-    """Enhanced Enum
+    """Enhanced Enum.
 
     You can use SomeEnum.get('some_name') like you could with a dict.
     """

--- a/indico/util/struct/iterables.py
+++ b/indico/util/struct/iterables.py
@@ -15,9 +15,9 @@ def group_list(data, key=None, sort_by=None, sort_reverse=False):
 
 
 def committing_iterator(iterable, n=100):
-    """Iterates over *iterable* and commits every *n* items.
+    """Iterate over *iterable* and commits every *n* items.
 
-    It also issues a commit after the iterator has been exhausted.
+    Also issue a commit after the iterator has been exhausted.
 
     :param iterable: An iterable object
     :param n: Number of items to commit after
@@ -32,7 +32,7 @@ def committing_iterator(iterable, n=100):
 
 
 def grouper(iterable, n, fillvalue=None, skip_missing=False):
-    """Collect data into fixed-length chunks or blocks
+    """Collect data into fixed-length chunks or blocks.
 
     :param iterable: an iterable object
     :param n: number of items per chunk
@@ -76,7 +76,7 @@ def materialize_iterable(type_=list):
 
 def window(seq, n=2):
     """
-    Return a sliding window (of width n) over data from the iterable
+    Return a sliding window (of width n) over data from the iterable.
 
         s -> (s0,s1,...s[n-1]), (s1,s2,...,sn), ...
     """

--- a/indico/util/tasks.py
+++ b/indico/util/tasks.py
@@ -30,7 +30,7 @@ def _log_deleted(logger, msg, files):
 
 @celery.periodic_task(name='temp_cleanup', run_every=crontab(minute='0', hour='4'))
 def temp_cleanup():
-    """Cleanup temp/cache dirs"""
+    """Cleanup temp/cache dirs."""
     from indico.core.config import config
     from indico.core.logger import Logger
     logger = Logger.get()

--- a/indico/web/assets/blueprint.py
+++ b/indico/web/assets/blueprint.py
@@ -51,8 +51,8 @@ def root(filename):
 
 @assets_blueprint.route('/js-vars/global.js')
 def js_vars_global():
-    """
-    Provides a JS file with global definitions (all users)
+    """Provide a JS file with global definitions (all users).
+
     Useful for server-wide config options, URLs, etc...
     """
     cache_file = os.path.join(config.CACHE_DIR, 'assets_global_{}_{}.js'.format(indico.__version__, config.hash))
@@ -67,8 +67,8 @@ def js_vars_global():
 
 @assets_blueprint.route('/js-vars/user.js')
 def js_vars_user():
-    """
-    Provides a JS file with user-specific definitions
+    """Provide a JS file with user-specific definitions.
+
     Useful for favorites, settings etc.
     """
     return Response(generate_user_file(), mimetype='application/javascript')
@@ -85,7 +85,7 @@ def i18n_locale_react(locale_name):
 
 
 def _get_i18n_locale(locale_name, react=False):
-    """Retrieve a locale in a Jed-compatible format"""
+    """Retrieve a locale in a Jed-compatible format."""
 
     react_suffix = '-react' if react else ''
     cache_file = os.path.join(config.CACHE_DIR, 'assets_i18n_{}{}_{}_{}.js'.format(

--- a/indico/web/fields/__init__.py
+++ b/indico/web/fields/__init__.py
@@ -16,7 +16,7 @@ __all__ = ('BaseField', 'get_field_definitions')
 
 
 def get_field_definitions(for_):
-    """Gets a dict containing all field definitions
+    """Get a dict containing all field definitions.
 
     :param for_: The identifier/object passed to the `get_fields`
                  signal to identify which fields to get.

--- a/indico/web/fields/base.py
+++ b/indico/web/fields/base.py
@@ -62,21 +62,21 @@ class BaseField(object):
 
     @property
     def validators(self):
-        """Return a list of validators for this field"""
+        """Return a list of validators for this field."""
         return None
 
     @property
     def wtf_field_kwargs(self):
-        """Return a dict of kwargs for this field's wtforms field"""
+        """Return a dict of kwargs for this field's wtforms field."""
         return {}
 
     def create_wtf_field(self):
-        """Return a WTForms field for this field"""
+        """Return a WTForms field for this field."""
         return self._make_wtforms_field(self.wtf_field_class, self.validators, **self.wtf_field_kwargs)
 
     @classmethod
     def create_config_form(cls, *args, **kwargs):
-        """Create the WTForm to configure this field"""
+        """Create the WTForm to configure this field."""
         bases = (cls.config_form_base, cls.config_form) if cls.config_form is not None else (cls.config_form_base,)
         form_cls = type(b'_FieldConfigForm', bases, {})
         form = form_cls(*args, **kwargs)
@@ -84,7 +84,7 @@ class BaseField(object):
         return form
 
     def copy_field_data(self):
-        """Return a copy of the field's configuration data"""
+        """Return a copy of the field's configuration data."""
         return deepcopy(self.object.field_data)
 
     def is_value_empty(self, value):
@@ -109,7 +109,7 @@ class BaseField(object):
                                   if name not in self.common_settings and name != 'csrf_token'}
 
     def get_friendly_value(self, value):
-        """Return the human-friendly version of the field's value
+        """Return the human-friendly version of the field's value.
 
         :param value: The database object containing the value of
                       the field

--- a/indico/web/flask/templating.py
+++ b/indico/web/flask/templating.py
@@ -41,13 +41,15 @@ def markdown(value):
 
 
 def dedent(value):
-    """Removes leading whitespace from each line"""
+    """Remove leading whitespace from each line."""
     return indentation_re.sub('', value)
 
 
 @environmentfilter
 def natsort(environment, value, reverse=False, case_sensitive=False, attribute=None):
-    """Sort an iterable in natural order.  Per default it sorts ascending,
+    """Sort an iterable in natural order.
+
+    Per default it sorts ascending,
     if you pass it true as first argument it will reverse the sorting.
 
     If the iterable is made of strings the third parameter can be used to
@@ -93,7 +95,7 @@ def decodeprincipal(value, **kwargs):
 
 
 def instanceof(value, type_):
-    """Checks if `value` is an instance of `type_`
+    """Check if `value` is an instance of `type_`.
 
     :param value: an object
     :param type_: a type
@@ -102,7 +104,7 @@ def instanceof(value, type_):
 
 
 def subclassof(value, type_):
-    """Checks if `value` is a subclass of `type_`
+    """Check if `value` is a subclass of `type_`.
 
     :param value: a type
     :param type_: a type
@@ -111,7 +113,7 @@ def subclassof(value, type_):
 
 
 def get_overridable_template_name(name, plugin, core_prefix='', plugin_prefix=''):
-    """Returns template names for templates that may be overridden in a plugin.
+    """Return template names for templates that may be overridden in a plugin.
 
     :param name: the name of the template
     :param plugin: the :class:`IndicoPlugin` that may override it (can be none)
@@ -127,7 +129,7 @@ def get_overridable_template_name(name, plugin, core_prefix='', plugin_prefix=''
 
 
 def get_template_module(template_name_or_list, **context):
-    """Returns the python module of a template.
+    """Return the python module of a template.
 
     This allows you to call e.g. macros inside it from Python code."""
     current_app.update_template_context(context)
@@ -136,7 +138,7 @@ def get_template_module(template_name_or_list, **context):
 
 
 def register_template_hook(name, receiver, priority=50, markup=True, plugin=None):
-    """Registers a function to be called when a template hook is invoked.
+    """Register a function to be called when a template hook is invoked.
 
     The receiver function should always support arbitrary ``**kwargs``
     to prevent breakage in future Indico versions which might add new
@@ -165,7 +167,7 @@ def register_template_hook(name, receiver, priority=50, markup=True, plugin=None
 
 
 def template_hook(name, priority=50, markup=True):
-    """Decorator for register_template_hook"""
+    """Decorator for register_template_hook."""
     def decorator(func):
         register_template_hook(name, func, priority, markup)
         return func
@@ -254,13 +256,14 @@ class CustomizationLoader(BaseLoader):
 
 
 class EnsureUnicodeExtension(Extension):
-    """Ensures all strings in Jinja are unicode"""
+    """Ensure all strings in Jinja are unicode."""
 
     @classmethod
     def wrap_func(cls, f):
-        """Wraps a function to make sure it returns unicode.
+        """Wrap a function to make sure it returns unicode.
 
-        Useful for custom filters."""
+        Useful for custom filters.
+        """
 
         @functools.wraps(f)
         def wrapper(*args, **kwargs):
@@ -270,7 +273,10 @@ class EnsureUnicodeExtension(Extension):
 
     @staticmethod
     def ensure_unicode(s):
-        """Converts a bytestring to unicode. Must be registered as a filter!"""
+        """Convert a bytestring to unicode.
+
+        Must be registered as a filter!
+        """
         if isinstance(s, str):
             return s.decode('utf-8')
         return s

--- a/indico/web/flask/templating_test.py
+++ b/indico/web/flask/templating_test.py
@@ -70,29 +70,29 @@ def _render(template, raises=None):
 
 
 def test_ensure_unicode_simple_vars():
-    """Test simple variables"""
+    """Test simple variables."""
     _render('{{ val }}')
 
 
 def test_ensure_unicode_func_args():
-    """Test function arguments (no automated unicode conversion!)"""
+    """Test function arguments (no automated unicode conversion!)."""
     _render('{{ func(val | ensure_unicode) }}')
     _render('{{ func(val) }}', UnicodeDecodeError)
 
 
 def test_ensure_unicode_filter_vars():
-    """Test variables with filters"""
+    """Test variables with filters."""
     _render('{{ val | ensure_unicode }}')  # Redundant but needs to work nonetheless
     _render('{{ val | safe }}')
 
 
 def test_ensure_unicode_inline_if():
-    """Test variables with inline if"""
+    """Test variables with inline if."""
     _render('x {{ val if true else val }} x {{ val if false else val }} x')
     _render('x {{ val|safe if true else val|safe }} x {{ val|safe if false else val|safe }} x')
 
 
 def test_ensure_unicode_trans():
-    """Test trans tag which need explicit unicode conversion"""
+    """Test trans tag which need explicit unicode conversion."""
     _render('{% trans x=val | ensure_unicode %}{{ x }}}{% endtrans %}')
     _render('{% trans x=val %}{{ x }}}{% endtrans %}', UnicodeDecodeError)

--- a/indico/web/flask/util.py
+++ b/indico/web/flask/util.py
@@ -28,7 +28,7 @@ from indico.web.util import jsonify_data
 
 
 def discover_blueprints():
-    """Discovers all blueprints inside the indico package
+    """Discover all blueprints inside the indico package.
 
     Only blueprints in a ``blueprint.py`` module or inside a
     ``blueprints`` package are loaded. Any other files are not touched
@@ -69,7 +69,7 @@ def discover_blueprints():
 
 @memoize
 def make_view_func(obj):
-    """Turns an object in to a view function.
+    """Turn an object in to a view function.
 
     This function is called on each view_func passed to IndicoBlueprint.add_url_route().
     It handles RH classes and normal functions.
@@ -97,7 +97,7 @@ def make_view_func(obj):
 
 @memoize
 def redirect_view(endpoint, code=302):
-    """Creates a view function that redirects to the given endpoint."""
+    """Create a view function that redirects to the given endpoint."""
     def _redirect(**kwargs):
         params = dict(request.args.to_dict(), **kwargs)
         return redirect(_url_for(endpoint, **params), code=code)
@@ -169,7 +169,7 @@ def url_for(endpoint, *targets, **values):
 
 
 def url_rule_to_js(endpoint):
-    """Converts the rule(s) of an endpoint to a JavaScript object.
+    """Convert the rule(s) of an endpoint to a JavaScript object.
 
     Use this if you need to build an URL in JavaScript, but only if
     you really have to do that instead of e.g. building the URL on
@@ -211,7 +211,7 @@ def url_rule_to_js(endpoint):
 
 
 def redirect_or_jsonify(location, flash=True, **json_data):
-    """Returns a redirect or json response.
+    """Return a redirect or json response.
 
     If the request was an XHR we return JSON, otherwise we redirect.
     Unless set to another value, the JSON data includes `success=True`
@@ -251,7 +251,7 @@ def make_content_disposition_args(attachment_filename):
 
 def send_file(name, path_or_fd, mimetype, last_modified=None, no_cache=True, inline=None, conditional=False, safe=True,
               **kwargs):
-    """Sends a file to the user.
+    """Send a file to the user.
 
     `name` is required and should be the filename visible to the user.
     `path_or_fd` is either the physical path to the file or a file-like object (e.g. a StringIO).
@@ -325,7 +325,7 @@ def endpoint_for_url(url, base_url=None):
 # Note: When adding custom converters please do not forget to add them to converter_functions in routing.js
 # if they need any custom processing (i.e. not just encodeURIComponent) in JavaScript.
 class ListConverter(BaseConverter):
-    """Matches a dash-separated list"""
+    """Match a dash-separated list."""
 
     def __init__(self, map):
         BaseConverter.__init__(self, map)

--- a/indico/web/flask/wrappers.py
+++ b/indico/web/flask/wrappers.py
@@ -172,9 +172,11 @@ class IndicoBlueprint(Blueprint):
 
     @contextmanager
     def add_prefixed_rules(self, prefix, default_prefix=''):
-        """Creates prefixed rules in addition to the normal ones.
+        """Create prefixed rules in addition to the normal ones.
+
         When specifying a default_prefix, too, the normally "unprefixed" rules
-        are prefixed with it."""
+        are prefixed with it.
+        """
         assert self.__prefix is None and not self.__default_prefix
         self.__prefix = prefix
         self.__default_prefix = default_prefix

--- a/indico/web/forms/base.py
+++ b/indico/web/forms/base.py
@@ -27,7 +27,7 @@ from indico.web.flask.util import url_for
 
 
 class _DataWrapper(object):
-    """Wrapper for the return value of generated_data properties"""
+    """Wrapper for the return value of generated_data properties."""
     def __init__(self, data):
         self.data = data
 
@@ -37,7 +37,7 @@ class _DataWrapper(object):
 
 
 class generated_data(property):
-    """property decorator for generated data in forms"""
+    """Property decorator for generated data in forms."""
 
     def __get__(self, obj, objtype=None):
         if obj is None:
@@ -154,7 +154,7 @@ class IndicoForm(FlaskForm):
         """
 
     def populate_obj(self, obj, fields=None, skip=None, existing_only=False):
-        """Populates the given object with form data.
+        """Populate the given object with form data.
 
         If `fields` is set, only fields from that list are populated.
         If `skip` is set, fields in that list are skipped.
@@ -208,7 +208,7 @@ class IndicoForm(FlaskForm):
 
     @property
     def generated_data(self):
-        """Returns a dict containing all generated data"""
+        """Return a dict containing all generated data."""
         cls = type(self)
         return {field: getattr(self, field).data
                 for field in dir(cls)
@@ -216,7 +216,7 @@ class IndicoForm(FlaskForm):
 
     @property
     def data(self):
-        """Extends form.data with generated data from properties"""
+        """Extend form.data with generated data from properties."""
         data = {k: v
                 for k, v in super(IndicoForm, self).data.iteritems()
                 if k != self.meta.csrf_field_name and not k.startswith('ext__')}
@@ -244,7 +244,7 @@ class FormDefaults(object):
         self.__defaults = defaults
 
     def __valid_attr(self, name):
-        """Checks if an attr may be retrieved from the object"""
+        """Check if an attr may be retrieved from the object."""
         if self.__obj is None:
             return False
         if self.__obj_attrs is not None and name not in self.__obj_attrs:

--- a/indico/web/forms/colors.py
+++ b/indico/web/forms/colors.py
@@ -54,7 +54,7 @@ def get_sui_colors():
 
 
 def get_role_colors():
-    """Get the list of colors available for event/category roles"""
+    """Get the list of colors available for event/category roles."""
     return ['005272', '007cac', '5d95ea',
             'af0000', 'a76766',
             '999999', '555555', '777777',

--- a/indico/web/forms/fields/colors.py
+++ b/indico/web/forms/fields/colors.py
@@ -14,7 +14,7 @@ from indico.web.forms.widgets import JinjaWidget
 
 
 class IndicoPalettePickerField(JSONField):
-    """Field allowing user to pick a color from a set of predefined values"""
+    """Field allowing user to pick a color from a set of predefined values."""
 
     widget = JinjaWidget('forms/palette_picker_widget.html')
     CAN_POPULATE = True

--- a/indico/web/forms/fields/datetime.py
+++ b/indico/web/forms/fields/datetime.py
@@ -61,7 +61,7 @@ class TimeDeltaField(Field):
 
     @property
     def best_unit(self):
-        """Return the largest unit that covers the current timedelta"""
+        """Return the largest unit that covers the current timedelta."""
         if self.data is None:
             return None
         seconds = int(self.data.total_seconds())
@@ -373,7 +373,7 @@ class IndicoTimezoneSelectField(SelectField):
 
 
 class IndicoWeekDayRepetitionField(Field):
-    """ Field that lets you select an ordinal day of the week."""
+    """Field that lets you select an ordinal day of the week."""
 
     widget = JinjaWidget('forms/week_day_repetition_widget.html', single_line=True)
 

--- a/indico/web/forms/fields/enums.py
+++ b/indico/web/forms/fields/enums.py
@@ -32,7 +32,7 @@ class _EnumFieldMixin(object):
 
 
 class IndicoEnumSelectField(_EnumFieldMixin, SelectFieldBase):
-    """Select field backed by a :class:`RichEnum`"""
+    """Select field backed by a :class:`RichEnum`."""
 
     widget = Select()
 
@@ -64,7 +64,7 @@ class IndicoEnumRadioField(IndicoEnumSelectField):
 
 
 class HiddenEnumField(_EnumFieldMixin, HiddenField):
-    """Hidden field that only accepts values from an Enum"""
+    """Hidden field that only accepts values from an Enum."""
 
     def __init__(self, label=None, validators=None, enum=None, only=None, skip=None, none=None, **kwargs):
         super(HiddenEnumField, self).__init__(label, validators, **kwargs)

--- a/indico/web/forms/fields/files.py
+++ b/indico/web/forms/fields/files.py
@@ -17,7 +17,7 @@ from indico.web.forms.widgets import JinjaWidget
 
 
 class FileField(Field):
-    """A dropzone field"""
+    """A dropzone field."""
 
     widget = JinjaWidget('forms/dropzone_widget.html', editable=False)
 

--- a/indico/web/forms/fields/itemlists.py
+++ b/indico/web/forms/fields/itemlists.py
@@ -223,10 +223,10 @@ class OverrideMultipleItemsField(HiddenField):
         return self.data or {}
 
     def get_overridden_value(self, row, name):
-        """Utility for the widget to get the entered value for an editable field"""
+        """Utility for the widget to get the entered value for an editable field."""
         key = self.get_row_key(row)
         return self._value().get(key, {}).get(name, '')
 
     def get_row_key(self, row):
-        """Utility for the widget to get the unique value for a row"""
+        """Utility for the widget to get the unique value for a row."""
         return row[self.unique_field]

--- a/indico/web/forms/fields/simple.py
+++ b/indico/web/forms/fields/simple.py
@@ -123,7 +123,7 @@ class IndicoPasswordField(PasswordField):
 
 
 class IndicoStaticTextField(Field):
-    """Return an html element with text taken from this field's value"""
+    """Return an html element with text taken from this field's value."""
 
     widget = JinjaWidget('forms/static_text_widget.html')
 

--- a/indico/web/forms/jinja_helpers.py
+++ b/indico/web/forms/jinja_helpers.py
@@ -77,7 +77,7 @@ def _attrs_for_validators(field, validators):
 
 
 def render_field(field, widget_attrs, disabled=None):
-    """Renders a WTForms field, taking into account validators"""
+    """Render a WTForms field, taking into account validators."""
     if not widget_attrs.get('placeholder'):
         widget_attrs = dict(widget_attrs)
         widget_attrs.pop('placeholder', None)
@@ -92,7 +92,7 @@ def render_field(field, widget_attrs, disabled=None):
 
 
 def iter_form_fields(form, fields=None, skip=None, hidden_fields=False):
-    """Iterates over the fields in a WTForm
+    """Iterate over the fields in a WTForm.
 
     :param fields: If specified only fields that are in this list are
                    yielded. This also overrides the field order.

--- a/indico/web/forms/util.py
+++ b/indico/web/forms/util.py
@@ -14,7 +14,7 @@ from wtforms.fields.core import UnboundField
 
 
 def get_form_field_names(form_class):
-    """Returns the list of field names of a WTForm
+    """Return the list of field names of a WTForm.
 
     :param form_class: A `Form` subclass
     """

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -19,10 +19,11 @@ from indico.util.string import is_valid_mail
 
 
 class UsedIf(object):
-    """Makes a WTF field "used" if a given condition evaluates to True.
+    """Make a WTF field "used" if a given condition evaluates to True.
 
     If the field is not used, validation stops.
     """
+
     field_flags = ('conditional',)
 
     def __init__(self, condition):
@@ -39,7 +40,7 @@ class UsedIf(object):
 
 
 class HiddenUnless(object):
-    """Hides and disables a field unless another field has a certain value.
+    """Hide and disable a field unless another field has a certain value.
 
     :param field: The name of the other field to check
     :param value: The value to check for.  If unspecified, any truthy
@@ -48,6 +49,7 @@ class HiddenUnless(object):
                           ``object_data`` it had before (i.e. data set
                           via `FormDefaults`).
     """
+
     field_flags = ('initially_hidden',)
 
     def __init__(self, field, value=None, preserve_data=False):
@@ -75,10 +77,11 @@ class HiddenUnless(object):
 
 
 class Exclusive(object):
-    """Makes a WTF field mutually exclusive with other fields.
+    """Make a WTF field mutually exclusive with other fields.
 
     If any of the given fields have a value, the validated field may not have one.
     """
+
     def __init__(self, *fields):
         self.fields = fields
 
@@ -99,7 +102,8 @@ class ConfirmPassword(EqualTo):
 
 
 class IndicoEmail(object):
-    """Validates one or more email addresses"""
+    """Validate one or more email addresses."""
+
     def __init__(self, multi=False):
         self.multi = multi
 
@@ -110,7 +114,7 @@ class IndicoEmail(object):
 
 
 class DateRange(object):
-    """Validates that a date is within the specified boundaries"""
+    """Validate that a date is within the specified boundaries."""
 
     field_flags = ('date_range',)
 
@@ -157,7 +161,7 @@ class DateRange(object):
 
 
 class DateTimeRange(object):
-    """Validates that a datetime is within the specified boundaries"""
+    """Validate that a datetime is within the specified boundaries."""
 
     field_flags = ('datetime_range',)
 
@@ -206,7 +210,7 @@ class DateTimeRange(object):
 
 
 class LinkedDate(object):
-    """Validates that a date field happens before or/and after another.
+    """Validate that a date field happens before or/and after another.
 
     If both ``not_before`` and ``not_after`` are set to ``True``, both fields have to
     be equal.
@@ -239,7 +243,7 @@ class LinkedDate(object):
 
 
 class LinkedDateTime(object):
-    """Validates that a datetime field happens before or/and after another.
+    """Validate that a datetime field happens before or/and after another.
 
     If both ``not_before`` and ``not_after`` are set to ``True``, both fields have to
     be equal.
@@ -291,7 +295,7 @@ class UsedIfChecked(UsedIf):
 
 
 class MaxDuration(object):
-    """Validates if TimeDeltaField value doesn't exceed `max_duration`"""
+    """Validate if TimeDeltaField value doesn't exceed `max_duration`."""
 
     def __init__(self, max_duration=None, **kwargs):
         assert max_duration or kwargs
@@ -327,7 +331,7 @@ class TimeRange(object):
 
 
 class WordCount(object):
-    """Validates the word count of a string.
+    """Validate the word count of a string.
 
     :param min: The minimum number of words in the string.  If not
                 provided, the minimum word count will not be checked.

--- a/indico/web/forms/widgets.py
+++ b/indico/web/forms/widgets.py
@@ -24,7 +24,7 @@ html_comment_re = re.compile(r'<!--.*?-->', re.MULTILINE)
 
 
 class ConcatWidget(object):
-    """Renders a list of fields as a simple string joined by an optional separator."""
+    """Render a list of fields as a simple string joined by an optional separator."""
     def __init__(self, separator='', prefix_label=True):
         self.separator = separator
         self.prefix_label = prefix_label
@@ -40,7 +40,7 @@ class ConcatWidget(object):
 
 
 class HiddenInputs(HiddenInput):
-    """Renders hidden inputs for list elements"""
+    """Render hidden inputs for list elements."""
     item_widget = HiddenInput()
 
     def __call__(self, field, **kwargs):
@@ -49,7 +49,7 @@ class HiddenInputs(HiddenInput):
 
 
 class HiddenCheckbox(CheckboxInput, HiddenInput):
-    """Renders an invisible checkbox.
+    """Render an invisible checkbox.
 
     This widget also inherits from HiddenInput to avoid creating
     a form row when rendering the form containing it.
@@ -61,7 +61,7 @@ class HiddenCheckbox(CheckboxInput, HiddenInput):
 
 
 class JinjaWidget(object):
-    """Renders a field using a custom Jinja template
+    """Render a field using a custom Jinja template
 
     :param template: The template to render
     :param plugin: The plugin or plugin name containing the template
@@ -103,7 +103,7 @@ class JinjaWidget(object):
 
 
 class PasswordWidget(JinjaWidget):
-    """Renders a password input"""
+    """Render a password input."""
 
     def __init__(self):
         super(PasswordWidget, self).__init__('forms/password_widget.html', single_line=True)
@@ -113,7 +113,7 @@ class PasswordWidget(JinjaWidget):
 
 
 class CKEditorWidget(JinjaWidget):
-    """Renders a CKEditor WYSIWYG editor
+    """Render a CKEditor WYSIWYG editor.
 
     :param simple: Use a simpler version with less options.
     :param images: Whether to allow images in simple mode.
@@ -124,7 +124,7 @@ class CKEditorWidget(JinjaWidget):
 
 
 class SwitchWidget(JinjaWidget):
-    """Renders a switch widget
+    """Render a switch widget.
 
     :param confirm_enable: Text to prompt when enabling the switch
     :param confirm_disable: Text to prompt when disabling the switch
@@ -144,7 +144,7 @@ class SwitchWidget(JinjaWidget):
 
 
 class SyncedInputWidget(JinjaWidget):
-    """Renders a text input with a sync button when needed."""
+    """Render a text input with a sync button when needed."""
 
     def __init__(self, textarea=False):
         super(SyncedInputWidget, self).__init__('forms/synced_input_widget.html', single_line=not textarea)
@@ -160,7 +160,7 @@ class SyncedInputWidget(JinjaWidget):
 
 
 class SelectizeWidget(JinjaWidget):
-    """Renders a selectize-based widget
+    """Render a selectize-based widget.
 
     :param search_url: The URL used to retrieve items.
     :param search_method: The method used to retrieve items.
@@ -216,7 +216,7 @@ class SelectizeWidget(JinjaWidget):
 
 
 class TypeaheadWidget(JinjaWidget):
-    """Renders a text field enhanced with jquery-typeahead
+    """Render a text field enhanced with jquery-typeahead.
 
     :param search_url: The URL used to retrieve AJAX-based suggestions.
     :param min_trigger_length: Number of characters needed to start
@@ -241,7 +241,7 @@ class TypeaheadWidget(JinjaWidget):
 
 
 class LocationWidget(JinjaWidget):
-    """Renders a collection of fields to represent location"""
+    """Render a collection of fields to represent location."""
 
     def __init__(self):
         super(LocationWidget, self).__init__('forms/location_widget.html', single_line=True)
@@ -283,7 +283,7 @@ class LocationWidget(JinjaWidget):
 
 
 class ColorPickerWidget(JinjaWidget):
-    """Renders a colorpicker input field"""
+    """Render a colorpicker input field."""
 
     def __init__(self, show_field=True):
         super(ColorPickerWidget, self).__init__('forms/color_picker_widget.html', single_line=True,

--- a/indico/web/http_api/handlers.py
+++ b/indico/web/http_api/handlers.py
@@ -42,7 +42,7 @@ RE_REMOVE_EXTENSION = re.compile(r'\.(\w+)(?:$|(?=\?))')
 
 
 def normalizeQuery(path, query, remove=('signature',), separate=False):
-    """Normalize request path and query so it can be used for caching and signing
+    """Normalize request path and query so it can be used for caching and signing.
 
     Returns a string consisting of path and sorted query string.
     Dynamic arguments like signature and timestamp are removed from the query string.

--- a/indico/web/http_api/hooks/base.py
+++ b/indico/web/http_api/hooks/base.py
@@ -164,7 +164,7 @@ class HTTPAPIHook(object):
         return False, resultList, complete, extra
 
     def __call__(self, user):
-        """Perform the actual exporting"""
+        """Perform the actual exporting."""
         if self.HTTP_POST != (request.method == 'POST'):
             # XXX: this should never happen, since HTTP_POST is only used within /api/,
             # where the flask url rule requires POST

--- a/indico/web/http_api/metadata/ical.py
+++ b/indico/web/http_api/metadata/ical.py
@@ -21,7 +21,7 @@ from indico.web.http_api.metadata.serializer import Serializer
 
 
 class vRecur(ical.vRecur):
-    """Fix vRecur so the frequency comes first"""
+    """Fix vRecur so the frequency comes first."""
     def ical(self):
         # SequenceTypes
         result = ['FREQ=%s' % self.types['FREQ'](self['FREQ']).ical()]

--- a/indico/web/http_api/metadata/json.py
+++ b/indico/web/http_api/metadata/json.py
@@ -10,10 +10,7 @@ from indico.web.http_api.metadata.serializer import Serializer
 
 
 class JSONSerializer(Serializer):
-
-    """
-    Does basically direct translation from the fossi
-    """
+    """Basically direct translation from the fossil."""
 
     _mime = 'application/json'
 

--- a/indico/web/http_api/metadata/jsonp.py
+++ b/indico/web/http_api/metadata/jsonp.py
@@ -9,9 +9,7 @@ from indico.web.http_api.metadata.json import JSONSerializer
 
 
 class JSONPSerializer(JSONSerializer):
-    """
-    Just adds prefix
-    """
+    """Add prefix."""
 
     _mime = 'application/javascript'
 

--- a/indico/web/http_api/metadata/serializer.py
+++ b/indico/web/http_api/metadata/serializer.py
@@ -30,9 +30,7 @@ class Serializer(object):
 
     @classmethod
     def create(cls, dformat, query_params=None, **kwargs):
-        """
-        A serializer factory
-        """
+        """A serializer factory."""
 
         query_params = query_params or {}
 

--- a/indico/web/http_api/metadata/xml.py
+++ b/indico/web/http_api/metadata/xml.py
@@ -24,9 +24,8 @@ def _deserialize_date(date_dict):
 
 
 class XMLSerializer(Serializer):
-
     """
-    Receives a fossil (or a collection of them) and converts them to XML
+    Receive a fossil (or a collection of them) and converts them to XML.
     """
 
     _mime = 'text/xml'

--- a/indico/web/menu.py
+++ b/indico/web/menu.py
@@ -37,7 +37,7 @@ class _MenuSectionBase(object):
 
 
 class SideMenuSection(_MenuSectionBase):
-    """Defines a side menu section (item set).
+    """Define a side menu section (item set).
 
     :param name: the unique name of the section
     :param title: the title of the section (displayed)
@@ -61,7 +61,7 @@ class SideMenuSection(_MenuSectionBase):
 
 
 class SideMenuItem(object):
-    """Defines a side menu item.
+    """Define a side menu item.
 
     :param name: the unique name (within the menu) of the item
     :param title: the title of the menu item (displayed)
@@ -91,7 +91,7 @@ class SideMenuItem(object):
 
 
 class TopMenuSection(_MenuSectionBase):
-    """Defines a top menu section (dropdown).
+    """Define a top menu section (dropdown).
 
     :param name: the unique name of the section
     :param title: the title of the section (displayed)
@@ -104,7 +104,7 @@ class TopMenuSection(_MenuSectionBase):
 
 
 class TopMenuItem(object):
-    """Defines a top menu item.
+    """Define a top menu item.
 
     :param name: the unique name (within the menu) of the item
     :param title: the title of the menu item (displayed)

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -81,7 +81,7 @@ class RH(object):
     # Methods =============================================================
 
     def validate_json(self, schema, json=None):
-        """Validates the request's JSON payload using a JSON schema.
+        """Validate the request's JSON payload using a JSON schema.
 
         :param schema: The JSON schema used for validation.
         :param json: The JSON object (defaults to ``request.json``)
@@ -99,7 +99,7 @@ class RH(object):
         return session.csrf_token if session.csrf_protected else ''
 
     def normalize_url(self):
-        """Performs URL normalization.
+        """Perform URL normalization.
 
         This uses the :attr:`normalize_url_spec` to check if the URL
         params are what they should be and redirects or fails depending
@@ -301,7 +301,7 @@ class RH(object):
 
 
 class RHSimple(RH):
-    """A simple RH that calls a function to build the response
+    """A simple RH that calls a function to build the response.
 
     The preferred way to use this class is by using the
     `RHSimple.wrap_function` decorator.

--- a/indico/web/util.py
+++ b/indico/web/util.py
@@ -20,7 +20,7 @@ from indico.web.flask.templating import get_template_module
 
 
 def inject_js(js):
-    """Injects JavaScript into the current page.
+    """Inject JavaScript into the current page.
 
     :param js: Code wrapped in a ``<script>`` tag.
     """
@@ -40,9 +40,9 @@ def _pop_injected_js():
 def jsonify_form(form, fields=None, submit=None, back=None, back_url=None, back_button=True, disabled_until_change=True,
                  disabled_fields=(), form_header_kwargs=None, skip_labels=False, save_reminder=False,
                  footer_align_right=False, disable_if_locked=True, message=None):
-    """Returns a json response containing a rendered WTForm.
+    """Return a json response containing a rendered WTForm.
 
-    This ia shortcut to the ``simple_form`` jinja macro to avoid
+    This is shortcut to the ``simple_form`` jinja macro to avoid
     adding new templates that do nothing besides importing and
     calling this macro.
 
@@ -82,7 +82,7 @@ def jsonify_form(form, fields=None, submit=None, back=None, back_url=None, back_
 
 
 def jsonify_template(template, _render_func=render_template, _success=None, **context):
-    """Returns a json response containing a rendered template"""
+    """Return a json response containing a rendered template."""
     html = _render_func(template, **context)
     jsonify_kw = {}
     if _success is not None:
@@ -91,7 +91,7 @@ def jsonify_template(template, _render_func=render_template, _success=None, **co
 
 
 def jsonify_data(flash=True, **json_data):
-    """Returns a json response with some default fields.
+    """Return a json response with some default fields.
 
     This behaves similar to :func:`~flask.jsonify`, but includes
     ``success=True`` and flashed messages by default.
@@ -136,7 +136,7 @@ def _format_request_data(data, hide_passwords=False):
 
 
 def get_request_info(hide_passwords=True):
-    """Gets various information about the current HTTP request.
+    """Get various information about the current HTTP request.
 
     This is especially useful for logging purposes where you want
     as many information as possible.

--- a/indico/web/views.py
+++ b/indico/web/views.py
@@ -110,7 +110,7 @@ class WPJinjaMixin(object):
 
     @classmethod
     def render_template(cls, template_name_or_list=None, *wp_args, **context):
-        """Renders a jinja template inside the WP
+        """Render a jinja template inside the WP.
 
         :param template_name_or_list: the name of the template - if unsed, the
                                       `_template` attribute of the class is used.
@@ -129,7 +129,7 @@ class WPJinjaMixin(object):
 
     @classmethod
     def render_string(cls, html, *wp_args):
-        """Renders a string inside the WP
+        """Render a string inside the WP.
 
         :param html: a string containing html
         :param wp_args: list of arguments to be passed to the WP's' constructor
@@ -211,7 +211,7 @@ class WPBase(WPBundleMixin):
         self._kwargs = kwargs
 
     def get_extra_css_files(self):
-        """Return CSS urls that will be included after all other CSS"""
+        """Return CSS urls that will be included after all other CSS."""
         return []
 
     @classproperty
@@ -225,10 +225,9 @@ class WPBase(WPBundleMixin):
         return _bundles
 
     def _get_head_content(self):
-        """
-        Returns _additional_ content between <head></head> tags.
-        Please note that <title>, <meta> and standard CSS are always included.
+        """Return _additional_ content between <head></head> tags.
 
+        Please note that <title>, <meta> and standard CSS are always included.
         Override this method to add your own, page-specific loading of
         JavaScript, CSS and other legal content for HTML <head> tag.
         """


### PR DESCRIPTION
Docstrings should now conform to [PEP 257](https://www.python.org/dev/peps/pep-0257/).

This includes:
- descriptions as command (`Return` vs `Returns`)
- docstring phrases ending in a period
- correct indentation and line breaks for multi-line comments
- blank lines after docstrings for classes
- docstrings that were too long were split into several lines instead

Especially in newer code these things were already mostly present. The older code was changed accordingly.