### PR TITLE
Use consistent order for JS imports

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -33,6 +33,7 @@ settings:
         - ['indico/modules/events/util', './indico/modules/events/client/js/util']
         - ['indico', './indico/web/client/js']
       extensions: [.js, .jsx, .json]
+  import/internal-regex: ^indico/
   react:
     version: detect
 
@@ -45,6 +46,21 @@ rules:
     - ignore: ['^indico-url:']
   import/no-cycle:
     - warn
+  import/order:
+    - error
+    - groups: [builtin, external, internal, parent, sibling, index]
+      alphabetize:
+        order: asc
+        caseInsensitive: true
+      pathGroups:
+        - pattern: indico-url:*
+          group: external
+          position: before
+        - pattern: '{.,..,../..,../../..}/**/*.+(css|scss)' # eslint-plugin-import#1239
+          group: sibling
+          position: after
+      pathGroupsExcludedImportTypes: [builtin]
+      newlines-between: always
   new-cap:
     - error
     - capIsNewExceptionPattern: '\$\.(Event|Deferred)$'

--- a/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
@@ -5,26 +5,26 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import editableURL from 'indico-url:event_editing.editable';
+import apiUploadExistingURL from 'indico-url:event_editing.api_add_paper_file';
 import submitRevisionURL from 'indico-url:event_editing.api_create_editable';
 import apiUploadURL from 'indico-url:event_editing.api_upload';
-import apiUploadExistingURL from 'indico-url:event_editing.api_add_paper_file';
+import editableURL from 'indico-url:event_editing.editable';
 
 import _ from 'lodash';
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {Button, Dropdown, Form, Modal} from 'semantic-ui-react';
+import React, {useState} from 'react';
 import {Form as FinalForm} from 'react-final-form';
+import {Button, Dropdown, Form, Modal} from 'semantic-ui-react';
 
-import {indicoAxios} from 'indico/utils/axios';
 import {FinalSubmitButton, handleSubmitError} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
+import {indicoAxios} from 'indico/utils/axios';
 
-import {fileTypePropTypes, uploadablePropTypes} from './timeline/FileManager/util';
-import {FinalFileManager} from './timeline/FileManager';
-
-import {getFileTypes} from './timeline/selectors';
 import {EditableTypeTitles} from '../models';
+
+import {FinalFileManager} from './timeline/FileManager';
+import {fileTypePropTypes, uploadablePropTypes} from './timeline/FileManager/util';
+import {getFileTypes} from './timeline/selectors';
 
 export default function EditableSubmissionButton({
   eventId,

--- a/indico/modules/events/editing/client/js/editing/ReduxTimeline.jsx
+++ b/indico/modules/events/editing/client/js/editing/ReduxTimeline.jsx
@@ -5,17 +5,18 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import fileTypesURL from 'indico-url:event_editing.api_file_types';
 import editableDetailsURL from 'indico-url:event_editing.api_editable';
+import fileTypesURL from 'indico-url:event_editing.api_file_types';
 import tagsURL from 'indico-url:event_editing.api_tags';
 
 import React from 'react';
-import {useParams} from 'react-router-dom';
 import {Provider} from 'react-redux';
+import {useParams} from 'react-router-dom';
 import {Loader} from 'semantic-ui-react';
-import createReduxStore from 'indico/utils/redux';
-import {useNumericParam} from 'indico/react/util/routing';
+
 import {useIndicoAxios} from 'indico/react/hooks';
+import {useNumericParam} from 'indico/react/util/routing';
+import createReduxStore from 'indico/utils/redux';
 
 import Timeline from './timeline';
 import reducer from './timeline/reducer';

--- a/indico/modules/events/editing/client/js/editing/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/index.jsx
@@ -11,11 +11,13 @@ import editableTypeListURL from 'indico-url:event_editing.editable_type_list';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {BrowserRouter as Router, Route, Switch} from 'react-router-dom';
+
 import {routerPathFromFlask} from 'indico/react/util/routing';
+
+import {EditableList} from '../management/editable_type';
 
 import EditingView from './page_layout';
 import ReduxTimeline from './ReduxTimeline';
-import {EditableList} from '../management/editable_type';
 
 document.addEventListener('DOMContentLoaded', async () => {
   const editingElement = document.querySelector('#editing-view');

--- a/indico/modules/events/editing/client/js/editing/page_layout/EditingView.jsx
+++ b/indico/modules/events/editing/client/js/editing/page_layout/EditingView.jsx
@@ -6,10 +6,11 @@
 // LICENSE file for more details.
 import menuEntriesURL from 'indico-url:event_editing.api_menu_entries';
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {useParams} from 'react-router-dom';
-import PropTypes from 'prop-types';
 import {Header} from 'semantic-ui-react';
+
 import {useIndicoAxios} from 'indico/react/hooks';
 import {useNumericParam} from 'indico/react/util/routing';
 

--- a/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.jsx
+++ b/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.jsx
@@ -5,17 +5,19 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import displayURL from 'indico-url:events.display';
 import contribDisplayURL from 'indico-url:contributions.display_contribution';
-import manageEditableTypeURL from 'indico-url:event_editing.manage_editable_type';
 import editableTypeListURL from 'indico-url:event_editing.editable_type_list';
+import manageEditableTypeURL from 'indico-url:event_editing.manage_editable_type';
+import displayURL from 'indico-url:events.display';
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Link} from 'react-router-dom';
-import PropTypes from 'prop-types';
 import {Header, Icon, Menu} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 import Palette from 'indico/utils/palette';
+
 import {EditableType, EditableEditingTitles} from '../../models';
 
 import './MenuBar.module.scss';

--- a/indico/modules/events/editing/client/js/editing/timeline/ChangesConfirmation.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ChangesConfirmation.jsx
@@ -6,11 +6,13 @@
 // LICENSE file for more details.
 
 import React from 'react';
-import {useDispatch, useSelector} from 'react-redux';
 import {Field, Form as FinalForm} from 'react-final-form';
+import {useDispatch, useSelector} from 'react-redux';
 import {Divider, Form, Message} from 'semantic-ui-react';
+
 import {FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
+
 import {confirmEditableChanges} from './actions';
 import {getLastRevision} from './selectors';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -5,14 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {useSelector} from 'react-redux';
+import React, {useState} from 'react';
 import {Form as FinalForm} from 'react-final-form';
+import {useSelector} from 'react-redux';
 import {Button, Form} from 'semantic-ui-react';
 
-import {Translate} from 'indico/react/i18n';
 import {FinalCheckbox, FinalInput, FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
+import {Translate} from 'indico/react/i18n';
 
 import {getDetails} from './selectors';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentItem.jsx
@@ -6,17 +6,17 @@
 // LICENSE file for more details.
 
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-import PropTypes from 'prop-types';
 import {Button, Confirm} from 'semantic-ui-react';
 
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {Param, Translate} from 'indico/react/i18n';
 import {serializeDate} from 'indico/utils/date';
 
-import CommentForm from './CommentForm';
 import {deleteRevisionComment, modifyRevisionComment} from './actions';
+import CommentForm from './CommentForm';
 import {getLastRevision} from './selectors';
 
 const INDICO_BOT_USER = {

--- a/indico/modules/events/editing/client/js/editing/timeline/CustomActions.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CustomActions.jsx
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {useDispatch} from 'react-redux';
-import PropTypes from 'prop-types';
 import {Button, Confirm, Divider} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+
 import {loadTimeline} from './actions';
 
 import './CustomActions.module.scss';

--- a/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
@@ -6,16 +6,16 @@
 // LICENSE file for more details.
 
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {useSelector} from 'react-redux';
-import PropTypes from 'prop-types';
 
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {serializeDate} from 'indico/utils/date';
 
+import ResetReview from './ResetReview';
 import * as selectors from './selectors';
 import StateIndicator from './StateIndicator';
-import ResetReview from './ResetReview';
 
 export default function CustomItem({header, user, createdDt, html, revisionId, state}) {
   const lastRevertableRevisionId = useSelector(selectors.getLastRevertableRevisionId);

--- a/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/index.jsx
@@ -5,11 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Button, Icon, Label} from 'semantic-ui-react';
+
 import {TooltipIfTruncated} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
+
 import {fileTypePropTypes, filePropTypes, mapFileTypes} from '../FileManager/util';
 import './FileDisplay.module.scss';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
@@ -5,14 +5,16 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useContext, useCallback, useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useContext, useCallback, useState} from 'react';
 import {useDropzone} from 'react-dropzone';
 import {Icon} from 'semantic-ui-react';
+
 import {TooltipIfTruncated} from 'indico/react/components';
 import {uploadFile, deleteFile} from 'indico/react/components/files/util';
-import {FileManagerContext, filePropTypes, uploadFiles, fileTypePropTypes} from './util';
+
 import * as actions from './actions';
+import {FileManagerContext, filePropTypes, uploadFiles, fileTypePropTypes} from './util';
 
 import './FileManager.module.scss';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/Uploads.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/Uploads.jsx
@@ -6,8 +6,8 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Icon, Popup, Progress, Segment} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/__tests__/FileManager.spec.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/__tests__/FileManager.spec.jsx
@@ -6,15 +6,14 @@
 // LICENSE file for more details.
 
 import {shallow, mount} from 'enzyme';
-import {act} from 'react-dom/test-utils';
-
 import mockAxios from 'jest-mock-axios';
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 
 import * as axiosUtils from 'indico/utils/axios';
 
-import * as actions from '../actions';
 import FileManager, {Dropzone} from '..';
+import * as actions from '../actions';
 
 expect.extend({
   toContainFile(received, file) {

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/index.jsx
@@ -5,17 +5,24 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
-import React, {useCallback, useReducer, useContext, useRef, useMemo, useEffect} from 'react';
-import globToRegExp from 'glob-to-regexp';
-import PropTypes from 'prop-types';
 import {fromEvent} from 'file-selector';
+import globToRegExp from 'glob-to-regexp';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, {useCallback, useReducer, useContext, useRef, useMemo, useEffect} from 'react';
 import {useDropzone} from 'react-dropzone';
 import {Field} from 'react-final-form';
 import {Dropdown, Icon, Message, Popup} from 'semantic-ui-react';
+
 import {TooltipIfTruncated} from 'indico/react/components';
 import {uploadFile, deleteFile} from 'indico/react/components/files/util';
 import {Param, Translate} from 'indico/react/i18n';
+
+import * as actions from './actions';
+import FileList from './FileList';
+import reducer from './reducer';
+import {getFiles, getUploadedFileUUIDs, getValidationError, isUploading} from './selectors';
+import Uploads from './Uploads';
 import {
   FileManagerContext,
   filePropTypes,
@@ -26,11 +33,6 @@ import {
   mapFileTypes,
   getFileToDelete,
 } from './util';
-import FileList from './FileList';
-import Uploads from './Uploads';
-import reducer from './reducer';
-import * as actions from './actions';
-import {getFiles, getUploadedFileUUIDs, getValidationError, isUploading} from './selectors';
 
 import './FileManager.module.scss';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/reducer.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/reducer.js
@@ -7,6 +7,7 @@
 
 import _ from 'lodash';
 import {combineReducers} from 'redux';
+
 import * as actions from './actions';
 
 /**

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/selectors.js
@@ -7,6 +7,7 @@
 
 import _ from 'lodash';
 import {createSelector} from 'reselect';
+
 import {PluralTranslate} from 'indico/react/i18n';
 
 export const getFiles = state => {

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/util.js
@@ -6,10 +6,12 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {snakifyKeys} from 'indico/utils/case';
+
 import * as actions from './actions';
 import {getFiles} from './selectors';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
@@ -7,15 +7,16 @@
 
 import resetReviewsURL from 'indico-url:event_editing.api_undo_review';
 
+import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
-import PropTypes from 'prop-types';
 import {Icon, Popup} from 'semantic-ui-react';
+
 import {RequestConfirm} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 
-import * as selectors from './selectors';
 import {resetReviews} from './actions';
+import * as selectors from './selectors';
 
 import './ResetReviews.module.scss';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -5,21 +5,22 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-import PropTypes from 'prop-types';
 import {Dropdown} from 'semantic-ui-react';
 
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {Translate} from 'indico/react/i18n';
 
+import {EditingReviewAction} from '../../models';
+
+import {createRevisionComment} from './actions';
+import CommentForm from './CommentForm';
 import JudgmentBox from './judgment/JudgmentBox';
 import JudgmentDropdownItems from './judgment/JudgmentDropdownItems';
-import CommentForm from './CommentForm';
-import {blockPropTypes} from './util';
-import {createRevisionComment} from './actions';
-import {EditingReviewAction} from '../../models';
 import {getLastRevision, canJudgeLastRevision} from './selectors';
+import {blockPropTypes} from './util';
 
 import './ReviewForm.module.scss';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/RevisionLog.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/RevisionLog.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import CommentItem from './CommentItem';
 import CustomItem from './CustomItem';

--- a/indico/modules/events/editing/client/js/editing/timeline/StateIndicator.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/StateIndicator.jsx
@@ -5,10 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Label, Popup} from 'semantic-ui-react';
+
 import Palette from 'indico/utils/palette';
+
 import {EditableStatus} from '../../models';
 
 import './StateIndicator.module.scss';

--- a/indico/modules/events/editing/client/js/editing/timeline/SubmitRevision.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/SubmitRevision.jsx
@@ -5,21 +5,23 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import uploadURL from 'indico-url:event_editing.api_upload';
 import createSubmitterRevisionURL from 'indico-url:event_editing.api_create_submitter_revision';
+import uploadURL from 'indico-url:event_editing.api_upload';
 
 import _ from 'lodash';
 import React from 'react';
-import {useSelector, useDispatch} from 'react-redux';
 import {Form as FinalForm} from 'react-final-form';
+import {useSelector, useDispatch} from 'react-redux';
 import {Form} from 'semantic-ui-react';
-import {Translate} from 'indico/react/i18n';
-import {FinalSubmitButton} from 'indico/react/forms';
+
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
+import {FinalSubmitButton} from 'indico/react/forms';
+import {Translate} from 'indico/react/i18n';
+
+import {createRevision} from './actions';
 import {FinalFileManager} from './FileManager';
 import {getFilesFromRevision} from './FileManager/util';
 import * as selectors from './selectors';
-import {createRevision} from './actions';
 
 export default function SubmitRevision() {
   const {eventId, contributionId, editableType} = useSelector(selectors.getStaticData);

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
@@ -9,16 +9,17 @@ import contributionDisplayURL from 'indico-url:contributions.display_contributio
 import assignMyselfURL from 'indico-url:event_editing.api_assign_editable_self';
 import unassignEditorURL from 'indico-url:event_editing.api_unassign_editable';
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-import PropTypes from 'prop-types';
-
 import {Message, Icon} from 'semantic-ui-react';
-import {Param, Translate} from 'indico/react/i18n';
+
 import {MathJax} from 'indico/react/components';
+import {Param, Translate} from 'indico/react/i18n';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
-import {getDetails} from './selectors';
+
 import {loadTimeline} from './actions';
+import {getDetails} from './selectors';
 
 export default function TimelineHeader({children, contribution, state, submitter, eventId}) {
   const {

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -5,23 +5,23 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useEffect, useState} from 'react';
-import {useSelector} from 'react-redux';
 import moment from 'moment';
 import PropTypes from 'prop-types';
+import React, {useEffect, useState} from 'react';
+import {useSelector} from 'react-redux';
 
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {Param, Translate} from 'indico/react/i18n';
 import {serializeDate} from 'indico/utils/date';
 
 import ChangesConfirmation from './ChangesConfirmation';
-import RevisionLog from './RevisionLog';
-import ReviewForm from './ReviewForm';
-import {blockPropTypes} from './util';
-import * as selectors from './selectors';
-import FileDisplay from './FileDisplay';
-import StateIndicator from './StateIndicator';
 import CustomActions from './CustomActions';
+import FileDisplay from './FileDisplay';
+import ReviewForm from './ReviewForm';
+import RevisionLog from './RevisionLog';
+import * as selectors from './selectors';
+import StateIndicator from './StateIndicator';
+import {blockPropTypes} from './util';
 
 import './TimelineItem.module.scss';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 import {FinalRevisionState, InitialRevisionState} from 'indico/modules/events/editing/models';
+
 import {processRevisions} from '../selectors';
 
 describe('timeline selectors', () => {

--- a/indico/modules/events/editing/client/js/editing/timeline/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/index.jsx
@@ -12,12 +12,12 @@ import {Loader, Message} from 'semantic-ui-react';
 import TimelineHeader from 'indico/modules/events/editing/editing/timeline/TimelineHeader';
 import TimelineContent from 'indico/modules/events/reviewing/components/TimelineContent';
 import {Param, Translate} from 'indico/react/i18n';
-import SubmitRevision from './SubmitRevision';
 
 import * as actions from './actions';
-import * as selectors from './selectors';
-import TimelineItem from './TimelineItem';
 import FileDisplay from './FileDisplay';
+import * as selectors from './selectors';
+import SubmitRevision from './SubmitRevision';
+import TimelineItem from './TimelineItem';
 
 const POLLING_SECONDS = 10;
 

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/AcceptRejectForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/AcceptRejectForm.jsx
@@ -6,10 +6,10 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
-import {useDispatch, useSelector} from 'react-redux';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
+import {useDispatch, useSelector} from 'react-redux';
 import {Form} from 'semantic-ui-react';
 
 import {FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
@@ -17,6 +17,7 @@ import {Translate} from 'indico/react/i18n';
 
 import {reviewEditable} from '../actions';
 import {getLastRevision, getNonSystemTags} from '../selectors';
+
 import FinalTagInput from './TagInput';
 
 import './JudgmentBox.module.scss';

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/JudgmentBox.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/JudgmentBox.jsx
@@ -5,18 +5,19 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Button, Dropdown} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 
-import {blockPropTypes} from '../util';
 import {EditingReviewAction} from '../../../models';
+import {blockPropTypes} from '../util';
+
 import AcceptRejectForm from './AcceptRejectForm';
+import JudgmentDropdownItems from './JudgmentDropdownItems';
 import RequestChangesForm from './RequestChangesForm';
 import UpdateFilesForm from './UpdateFilesForm';
-import JudgmentDropdownItems from './JudgmentDropdownItems';
 
 import './JudgmentBox.module.scss';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/JudgmentDropdownItems.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/JudgmentDropdownItems.jsx
@@ -5,12 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {Dropdown, Popup} from 'semantic-ui-react';
+import React from 'react';
 import {useSelector} from 'react-redux';
+import {Dropdown, Popup} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
+
 import {hasPublishableFiles} from '../selectors';
 
 import './JudgmentDropdownItems.module.scss';

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/RequestChangesForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/RequestChangesForm.jsx
@@ -6,10 +6,10 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
-import {useDispatch, useSelector} from 'react-redux';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
+import {useDispatch, useSelector} from 'react-redux';
 import {Form} from 'semantic-ui-react';
 
 import {FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
@@ -18,6 +18,7 @@ import {Translate} from 'indico/react/i18n';
 import {EditingReviewAction} from '../../../models';
 import {reviewEditable} from '../actions';
 import {getLastRevision, getNonSystemTags} from '../selectors';
+
 import FinalTagInput from './TagInput';
 
 export default function RequestChangesForm({setLoading, onSuccess}) {

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/TagInput.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/TagInput.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Dropdown} from 'semantic-ui-react';
+
 import {FinalField, unsortedArraysEqual} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesForm.jsx
@@ -8,20 +8,21 @@
 import uploadURL from 'indico-url:event_editing.api_upload';
 
 import _ from 'lodash';
-import React, {useState} from 'react';
-import {useDispatch, useSelector} from 'react-redux';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Field, Form as FinalForm} from 'react-final-form';
+import {useDispatch, useSelector} from 'react-redux';
 import {Form, Dropdown, Button, Message} from 'semantic-ui-react';
 
 import {FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
 import {Translate, Param, Plural, PluralTranslate, Singular} from 'indico/react/i18n';
 
-import {reviewEditable} from '../actions';
-import * as selectors from '../selectors';
 import {EditingReviewAction} from '../../../models';
+import {reviewEditable} from '../actions';
 import {FinalFileManager} from '../FileManager';
 import {getFilesFromRevision} from '../FileManager/util';
+import * as selectors from '../selectors';
+
 import FinalTagInput from './TagInput';
 
 import './JudgmentBox.module.scss';

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -9,6 +9,7 @@ import _ from 'lodash';
 import {createSelector} from 'reselect';
 
 import {Translate} from 'indico/react/i18n';
+
 import {InitialRevisionState, FinalRevisionState} from '../../models';
 
 function shouldCreateNewRevision({initialState, finalState}) {

--- a/indico/modules/events/editing/client/js/management/EditableTypeList.jsx
+++ b/indico/modules/events/editing/client/js/management/EditableTypeList.jsx
@@ -9,15 +9,17 @@ import enabledEditableTypesURL from 'indico-url:event_editing.api_enabled_editab
 import manageEditableTypeURL from 'indico-url:event_editing.manage_editable_type';
 import manageEditableTypeListURL from 'indico-url:event_editing.manage_editable_type_list';
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {Button, Checkbox, Form, Loader, Popup} from 'semantic-ui-react';
-import {Link} from 'react-router-dom';
+import React, {useState} from 'react';
 import {Form as FinalForm} from 'react-final-form';
-import {Translate} from 'indico/react/i18n';
-import {useIndicoAxios} from 'indico/react/hooks';
+import {Link} from 'react-router-dom';
+import {Button, Checkbox, Form, Loader, Popup} from 'semantic-ui-react';
+
 import {FinalCheckbox, FinalSubmitButton, handleSubmitError} from 'indico/react/forms';
+import {useIndicoAxios} from 'indico/react/hooks';
+import {Translate} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
+
 import {editableTypeOrder, EditableTypeTitles} from '../models';
 
 import './EditableTypeList.module.scss';

--- a/indico/modules/events/editing/client/js/management/EditingManagement.jsx
+++ b/indico/modules/events/editing/client/js/management/EditingManagement.jsx
@@ -5,25 +5,26 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import manageTagsURL from 'indico-url:event_editing.manage_tags';
 import dashboardURL from 'indico-url:event_editing.dashboard';
 import editableTypeURL from 'indico-url:event_editing.manage_editable_type';
 import editableListURL from 'indico-url:event_editing.manage_editable_type_list';
 import manageFileTypesURL from 'indico-url:event_editing.manage_file_types';
 import manageReviewConditionsURL from 'indico-url:event_editing.manage_review_conditions';
+import manageTagsURL from 'indico-url:event_editing.manage_tags';
 
 import React from 'react';
 import {BrowserRouter as Router, Route, Switch} from 'react-router-dom';
+
 import {routerPathFromFlask} from 'indico/react/util/routing';
 
-import EditingManagementDashboard from './EditingManagementDashboard';
-import EditingTagManagement from './tags';
 import {
   EditableTypeDashboard,
   FileTypeManagement,
   ReviewConditionsManagement,
   EditableList,
 } from './editable_type';
+import EditingManagementDashboard from './EditingManagementDashboard';
+import EditingTagManagement from './tags';
 
 export default function EditingManagement() {
   return (

--- a/indico/modules/events/editing/client/js/management/EditingManagementDashboard.jsx
+++ b/indico/modules/events/editing/client/js/management/EditingManagementDashboard.jsx
@@ -9,11 +9,13 @@ import manageTagsURL from 'indico-url:event_editing.manage_tags';
 
 import React from 'react';
 import {Link} from 'react-router-dom';
+
 import {Translate} from 'indico/react/i18n';
 import {useNumericParam} from 'indico/react/util/routing';
+
 import EditableTypeList from './EditableTypeList';
-import Section from './Section';
 import ManageService from './ManageService';
+import Section from './Section';
 
 export default function EditingManagementDashboard() {
   const eventId = useNumericParam('confId');

--- a/indico/modules/events/editing/client/js/management/ManageService.jsx
+++ b/indico/modules/events/editing/client/js/management/ManageService.jsx
@@ -6,25 +6,27 @@
 // LICENSE file for more details.
 
 import checkServiceURL from 'indico-url:event_editing.api_check_service_url';
-import checkServiceStatusURL from 'indico-url:event_editing.api_service_status';
 import connectServiceURL from 'indico-url:event_editing.api_service_connect';
 import disconnectServiceURL from 'indico-url:event_editing.api_service_disconnect';
+import checkServiceStatusURL from 'indico-url:event_editing.api_service_status';
 
-import React, {useState} from 'react';
-import PropTypes from 'prop-types';
 import {FORM_ERROR} from 'final-form';
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {Confirm, Modal, Button, Form, Loader, Message} from 'semantic-ui-react';
-import {Translate, Param} from 'indico/react/i18n';
+
 import {
   FinalSubmitButton,
   FinalInput,
   handleSubmitError,
   validators as v,
 } from 'indico/react/forms';
-import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {useIndicoAxios} from 'indico/react/hooks';
+import {Translate, Param} from 'indico/react/i18n';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {makeAsyncDebounce} from 'indico/utils/debounce';
+
 import Section from './Section';
 
 const debounce = makeAsyncDebounce(250);

--- a/indico/modules/events/editing/client/js/management/Section.jsx
+++ b/indico/modules/events/editing/client/js/management/Section.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function Section({icon, label, description, children}) {
   return (

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -5,35 +5,38 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import editableTypeURL from 'indico-url:event_editing.manage_editable_type';
-import editorsURL from 'indico-url:event_editing.api_editable_type_editors';
-import editableListURL from 'indico-url:event_editing.api_editable_list';
-import editablesArchiveURL from 'indico-url:event_editing.api_prepare_editables_archive';
 import assignEditorURL from 'indico-url:event_editing.api_assign_editor';
 import assignSelfEditorURL from 'indico-url:event_editing.api_assign_myself';
-import unassignEditorURL from 'indico-url:event_editing.api_unassign_editor';
+import editableListURL from 'indico-url:event_editing.api_editable_list';
+import editorsURL from 'indico-url:event_editing.api_editable_type_editors';
 import canAssignSelfURL from 'indico-url:event_editing.api_editor_self_assign_allowed';
+import editablesArchiveURL from 'indico-url:event_editing.api_prepare_editables_archive';
+import unassignEditorURL from 'indico-url:event_editing.api_unassign_editor';
+import editableTypeURL from 'indico-url:event_editing.manage_editable_type';
 
-import React, {useState, useMemo} from 'react';
-import PropTypes from 'prop-types';
-import {useParams, Link} from 'react-router-dom';
-import {Button, Icon, Input, Loader, Checkbox, Message, Dropdown} from 'semantic-ui-react';
-import {Column, Table, SortDirection, WindowScroller} from 'react-virtualized';
 import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, {useState, useMemo} from 'react';
+import {useParams, Link} from 'react-router-dom';
+import {Column, Table, SortDirection, WindowScroller} from 'react-virtualized';
+import {Button, Icon, Input, Loader, Checkbox, Message, Dropdown} from 'semantic-ui-react';
+
 import {
   TooltipIfTruncated,
   ManagementPageSubTitle,
   ManagementPageBackButton,
 } from 'indico/react/components';
-import {useNumericParam} from 'indico/react/util/routing';
-import {Translate} from 'indico/react/i18n';
 import {useIndicoAxios} from 'indico/react/hooks';
+import {Translate} from 'indico/react/i18n';
+import {useNumericParam} from 'indico/react/util/routing';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
 import Palette from 'indico/utils/palette';
+
+import StateIndicator from '../../editing/timeline/StateIndicator';
 import {userPropTypes} from '../../editing/timeline/util';
 import {EditableType, GetNextEditableTitles} from '../../models';
-import StateIndicator from '../../editing/timeline/StateIndicator';
+
 import NextEditable from './NextEditable';
 
 import './EditableList.module.scss';

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
@@ -6,27 +6,29 @@
 // LICENSE file for more details.
 /* global ajaxDialog:false */
 
+import enableEditingURL from 'indico-url:event_editing.api_editing_enabled';
+import selfAssignURL from 'indico-url:event_editing.api_self_assign_enabled';
+import enableSubmissionURL from 'indico-url:event_editing.api_submission_enabled';
+import contactEditingTeamURL from 'indico-url:event_editing.contact_team';
 import dashboardURL from 'indico-url:event_editing.dashboard';
 import manageEditableTypeListURL from 'indico-url:event_editing.manage_editable_type_list';
 import manageFileTypesURL from 'indico-url:event_editing.manage_file_types';
 import manageReviewConditionsURL from 'indico-url:event_editing.manage_review_conditions';
-import selfAssignURL from 'indico-url:event_editing.api_self_assign_enabled';
-import enableSubmissionURL from 'indico-url:event_editing.api_submission_enabled';
-import enableEditingURL from 'indico-url:event_editing.api_editing_enabled';
-import contactEditingTeamURL from 'indico-url:event_editing.contact_team';
 
 import React, {useState} from 'react';
 import {useParams, Link} from 'react-router-dom';
 import {Checkbox, Loader} from 'semantic-ui-react';
 
-import {Translate} from 'indico/react/i18n';
 import {ManagementPageSubTitle, ManagementPageBackButton} from 'indico/react/components';
-import {useNumericParam} from 'indico/react/util/routing';
 import {useTogglableValue} from 'indico/react/hooks';
+import {Translate} from 'indico/react/i18n';
+import {useNumericParam} from 'indico/react/util/routing';
+
 import {EditableTypeTitles, GetNextEditableTitles} from '../../models';
 import Section from '../Section';
-import TeamManager from './TeamManager';
+
 import NextEditable from './NextEditable';
+import TeamManager from './TeamManager';
 
 import './EditableTypeDashboard.module.scss';
 

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableTypeSubPageNav.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableTypeSubPageNav.jsx
@@ -7,17 +7,18 @@
 
 import editableTypeURL from 'indico-url:event_editing.manage_editable_type';
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {useParams} from 'react-router-dom';
 
-import {useNumericParam} from 'indico/react/util/routing';
 import {
   ManagementPageBackButton,
   ManagementPageTitle,
   ManagementPageSubTitle,
 } from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
+import {useNumericParam} from 'indico/react/util/routing';
+
 import {EditableTypeTitles} from '../../models';
 
 export default function EditableTypeSubPageNav({title}) {

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -5,21 +5,23 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import editableListURL from 'indico-url:event_editing.api_filter_editables_by_filetypes';
 import assignMyselfURL from 'indico-url:event_editing.api_assign_editable_self';
 import fileTypesURL from 'indico-url:event_editing.api_file_types';
+import editableListURL from 'indico-url:event_editing.api_filter_editables_by_filetypes';
 
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React, {useState, useEffect} from 'react';
 import {useHistory} from 'react-router-dom';
-import PropTypes from 'prop-types';
 import {Button, Loader, Modal, Table, Checkbox, Dimmer} from 'semantic-ui-react';
-import {camelizeKeys} from 'indico/utils/case';
+
+import {useIndicoAxios} from 'indico/react/hooks';
 import {Translate} from 'indico/react/i18n';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
-import {useIndicoAxios} from 'indico/react/hooks';
-import {EditableType, GetNextEditableTitles} from '../../models';
+import {camelizeKeys} from 'indico/utils/case';
+
 import {fileTypePropTypes} from '../../editing/timeline/FileManager/util';
+import {EditableType, GetNextEditableTitles} from '../../models';
 
 import './NextEditable.module.scss';
 

--- a/indico/modules/events/editing/client/js/management/editable_type/TeamManager.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/TeamManager.jsx
@@ -8,11 +8,11 @@
 import principalsURL from 'indico-url:event_editing.api_editable_type_principals';
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {Button, Form, Loader, Message, Modal} from 'semantic-ui-react';
-import {Translate} from 'indico/react/i18n';
+
 import {FinalPrincipalList} from 'indico/react/components';
 import {
   getChangedValues,
@@ -20,9 +20,10 @@ import {
   FinalSubmitButton,
   FinalUnloadPrompt,
 } from 'indico/react/forms';
-import {indicoAxios} from 'indico/utils/axios';
 import {useFavoriteUsers, useIndicoAxios} from 'indico/react/hooks';
+import {Translate} from 'indico/react/i18n';
 import {useNumericParam} from 'indico/react/util/routing';
+import {indicoAxios} from 'indico/utils/axios';
 
 export default function TeamManager({editableType, onClose}) {
   const eventId = useNumericParam('confId');

--- a/indico/modules/events/editing/client/js/management/editable_type/file_types/ExtensionList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/file_types/ExtensionList.jsx
@@ -6,9 +6,10 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Dropdown} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 
 export default function ExtensionList({value, disabled, onChange, onFocus, onBlur}) {

--- a/indico/modules/events/editing/client/js/management/editable_type/file_types/FileTypeManager.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/file_types/FileTypeManager.jsx
@@ -5,20 +5,23 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import fileTypesURL from 'indico-url:event_editing.api_file_types';
 import createFileTypeURL from 'indico-url:event_editing.api_add_file_type';
 import editFileTypeURL from 'indico-url:event_editing.api_edit_file_type';
+import fileTypesURL from 'indico-url:event_editing.api_file_types';
 
-import React, {useReducer} from 'react';
 import PropTypes from 'prop-types';
+import React, {useReducer} from 'react';
 import {Button, Icon, Loader, Message, Segment, Popup, Label} from 'semantic-ui-react';
+
 import {RequestConfirm, TooltipIfTruncated} from 'indico/react/components';
-import {Param, Translate} from 'indico/react/i18n';
 import {getChangedValues, handleSubmitError} from 'indico/react/forms';
 import {useIndicoAxios} from 'indico/react/hooks';
+import {Param, Translate} from 'indico/react/i18n';
 import {handleAxiosError, indicoAxios} from 'indico/utils/axios';
-import FileTypeModal from './FileTypeModal';
+
 import {EditableType} from '../../../models';
+
+import FileTypeModal from './FileTypeModal';
 
 import './FileTypeManager.module.scss';
 

--- a/indico/modules/events/editing/client/js/management/editable_type/file_types/FileTypeModal.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/file_types/FileTypeModal.jsx
@@ -5,10 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {Button, Form, Header, Icon, Modal, Message} from 'semantic-ui-react';
+
 import {
   FinalCheckbox,
   FinalField,
@@ -17,6 +18,7 @@ import {
   unsortedArraysEqual,
 } from 'indico/react/forms';
 import {Param, Translate} from 'indico/react/i18n';
+
 import ExtensionList from './ExtensionList';
 
 export default function FileTypeModal({onClose, onSubmit, fileType, header}) {

--- a/indico/modules/events/editing/client/js/management/editable_type/file_types/index.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/file_types/index.jsx
@@ -7,9 +7,12 @@
 
 import React from 'react';
 import {useParams} from 'react-router-dom';
-import {useNumericParam} from 'indico/react/util/routing';
+
 import {Translate} from 'indico/react/i18n';
+import {useNumericParam} from 'indico/react/util/routing';
+
 import EditableTypeSubPageNav from '../EditableTypeSubPageNav';
+
 import FileTypeManager from './FileTypeManager';
 
 export default function FileTypeManagement() {

--- a/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ConditionInfo.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ConditionInfo.jsx
@@ -7,18 +7,19 @@
 
 import editReviewConditionURL from 'indico-url:event_editing.api_edit_review_condition';
 
-import React, {useState, useContext} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState, useContext} from 'react';
 import {Icon, Label} from 'semantic-ui-react';
 
 import {RequestConfirm, TooltipIfTruncated} from 'indico/react/components';
-import {Translate} from 'indico/react/i18n';
 import {handleSubmitError} from 'indico/react/forms';
+import {Translate} from 'indico/react/i18n';
 import {handleAxiosError, indicoAxios} from 'indico/utils/axios';
 
-import ReviewConditionForm from './ReviewConditionForm';
 import {EditableType} from '../../../models';
+
 import ReviewConditionsContext from './context';
+import ReviewConditionForm from './ReviewConditionForm';
 
 import './ConditionInfo.module.scss';
 

--- a/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ReviewConditionForm.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ReviewConditionForm.jsx
@@ -5,13 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useContext} from 'react';
 import PropTypes from 'prop-types';
+import React, {useContext} from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {Button, Form} from 'semantic-ui-react';
 
 import {FinalDropdown, FinalSubmitButton} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
+
 import ReviewConditionsContext from './context';
 
 import './ReviewConditionForm.module.scss';

--- a/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ReviewConditionsManager.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ReviewConditionsManager.jsx
@@ -16,8 +16,8 @@ import {Translate} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
 
 import ConditionInfo from './ConditionInfo';
-import ReviewConditionForm from './ReviewConditionForm';
 import ReviewConditionsContext from './context';
+import ReviewConditionForm from './ReviewConditionForm';
 
 import './ReviewConditionsManager.module.scss';
 

--- a/indico/modules/events/editing/client/js/management/editable_type/review_conditions/index.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/review_conditions/index.jsx
@@ -9,12 +9,15 @@ import fileTypesURL from 'indico-url:event_editing.api_file_types';
 
 import React from 'react';
 import {useParams} from 'react-router-dom';
-import {useNumericParam} from 'indico/react/util/routing';
-import {Translate} from 'indico/react/i18n';
+
 import {useIndicoAxios} from 'indico/react/hooks';
+import {Translate} from 'indico/react/i18n';
+import {useNumericParam} from 'indico/react/util/routing';
+
 import EditableTypeSubPageNav from '../EditableTypeSubPageNav';
-import ReviewConditionsManager from './ReviewConditionsManager';
+
 import ReviewConditionsContext from './context';
+import ReviewConditionsManager from './ReviewConditionsManager';
 
 export default function ReviewConditionManagement() {
   const eventId = useNumericParam('confId');

--- a/indico/modules/events/editing/client/js/management/tags/TagManager.jsx
+++ b/indico/modules/events/editing/client/js/management/tags/TagManager.jsx
@@ -5,19 +5,20 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import tagsURL from 'indico-url:event_editing.api_tags';
 import createTagURL from 'indico-url:event_editing.api_create_tag';
 import editTagURL from 'indico-url:event_editing.api_edit_tag';
+import tagsURL from 'indico-url:event_editing.api_tags';
 
-import React, {useReducer} from 'react';
 import PropTypes from 'prop-types';
+import React, {useReducer} from 'react';
 import {Button, Icon, Label, Loader, Message, Segment, Popup} from 'semantic-ui-react';
 
-import {Param, Translate} from 'indico/react/i18n';
 import {RequestConfirm} from 'indico/react/components';
 import {getChangedValues, handleSubmitError} from 'indico/react/forms';
 import {useIndicoAxios} from 'indico/react/hooks';
+import {Param, Translate} from 'indico/react/i18n';
 import {handleAxiosError, indicoAxios} from 'indico/utils/axios';
+
 import TagModal from './TagModal';
 
 import './TagManager.module.scss';

--- a/indico/modules/events/editing/client/js/management/tags/TagModal.jsx
+++ b/indico/modules/events/editing/client/js/management/tags/TagModal.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {Button, Form, Label, Modal} from 'semantic-ui-react';
 

--- a/indico/modules/events/editing/client/js/management/tags/index.js
+++ b/indico/modules/events/editing/client/js/management/tags/index.js
@@ -8,9 +8,11 @@
 import dashboardURL from 'indico-url:event_editing.dashboard';
 
 import React from 'react';
+
 import {ManagementPageBackButton, ManagementPageSubTitle} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {useNumericParam} from 'indico/react/util/routing';
+
 import TagManager from './TagManager';
 
 export default function EditingTagManagement() {

--- a/indico/modules/events/logs/client/js/components/EventLog.jsx
+++ b/indico/modules/events/logs/client/js/components/EventLog.jsx
@@ -10,9 +10,10 @@ import {useDispatch, useSelector} from 'react-redux';
 
 import {Param, Translate} from 'indico/react/i18n';
 
-import LogEntryList from '../containers/LogEntryList';
-import Toolbar from './Toolbar';
 import {clearMetadataQuery} from '../actions';
+import LogEntryList from '../containers/LogEntryList';
+
+import Toolbar from './Toolbar';
 
 function MetadataQueryMessage() {
   const dispatch = useDispatch();

--- a/indico/modules/events/logs/client/js/components/Filter.jsx
+++ b/indico/modules/events/logs/client/js/components/Filter.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 export default class Filter extends React.Component {
   static propTypes = {

--- a/indico/modules/events/logs/client/js/components/LogEntryModal.jsx
+++ b/indico/modules/events/logs/client/js/components/LogEntryModal.jsx
@@ -6,8 +6,8 @@
 // LICENSE file for more details.
 
 import moment from 'moment';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import {IButton, Modal} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';

--- a/indico/modules/events/logs/client/js/components/SearchBox.jsx
+++ b/indico/modules/events/logs/client/js/components/SearchBox.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 export default class SearchBox extends React.Component {
   static propTypes = {

--- a/indico/modules/events/logs/client/js/components/Toolbar.jsx
+++ b/indico/modules/events/logs/client/js/components/Toolbar.jsx
@@ -5,9 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import PropTypes from 'prop-types';
 
 import Filter from '../containers/Filter';
 import SearchBox from '../containers/SearchBox';

--- a/indico/modules/events/logs/client/js/containers/Filter.js
+++ b/indico/modules/events/logs/client/js/containers/Filter.js
@@ -6,8 +6,9 @@
 // LICENSE file for more details.
 
 import {connect} from 'react-redux';
-import Filter from '../components/Filter';
+
 import {setFilter, fetchLogEntries, setPage} from '../actions';
+import Filter from '../components/Filter';
 
 const mapStateToProps = ({logs}) => ({
   filters: logs.filters,

--- a/indico/modules/events/logs/client/js/containers/LogEntryList.js
+++ b/indico/modules/events/logs/client/js/containers/LogEntryList.js
@@ -6,8 +6,9 @@
 // LICENSE file for more details.
 
 import {connect} from 'react-redux';
-import LogEntryList from '../components/LogEntryList';
+
 import {setPage, fetchLogEntries, setDetailedView} from '../actions';
+import LogEntryList from '../components/LogEntryList';
 
 const mapStateToProps = ({logs}) => ({
   entries: logs.entries,

--- a/indico/modules/events/logs/client/js/containers/LogEntryModal.js
+++ b/indico/modules/events/logs/client/js/containers/LogEntryModal.js
@@ -7,8 +7,8 @@
 
 import {connect} from 'react-redux';
 
-import LogEntryModal from '../components/LogEntryModal';
 import {setDetailedView, showRelatedEntries, viewNextEntry, viewPrevEntry} from '../actions';
+import LogEntryModal from '../components/LogEntryModal';
 
 const mapStateToProps = ({logs}) => ({
   currentViewIndex: logs.currentViewIndex,

--- a/indico/modules/events/logs/client/js/containers/SearchBox.js
+++ b/indico/modules/events/logs/client/js/containers/SearchBox.js
@@ -7,8 +7,9 @@
 
 import debounce from 'lodash/debounce';
 import {connect} from 'react-redux';
-import SearchBox from '../components/SearchBox';
+
 import {setKeyword, fetchLogEntries, setPage} from '../actions';
+import SearchBox from '../components/SearchBox';
 
 const mapDispatchToProps = dispatch => ({
   setKeyword: debounce(keyword => {

--- a/indico/modules/events/logs/client/js/index.jsx
+++ b/indico/modules/events/logs/client/js/index.jsx
@@ -11,8 +11,8 @@ import {Provider} from 'react-redux';
 
 import createReduxStore from 'indico/utils/redux';
 
-import EventLog from './components/EventLog';
 import {fetchLogEntries, setMetadataQuery} from './actions';
+import EventLog from './components/EventLog';
 import reducer from './reducers';
 
 import '../style/logs.scss';

--- a/indico/modules/rb/client/js/actions.js
+++ b/indico/modules/rb/client/js/actions.js
@@ -5,8 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import qs from 'qs';
 import {push} from 'connected-react-router';
+import qs from 'qs';
+
 import {history} from './history';
 
 // Page state

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
@@ -9,11 +9,11 @@ import bookingLinkURL from 'indico-url:rb.booking_link';
 
 import _ from 'lodash';
 import moment from 'moment';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
-import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {
   Button,
   Confirm,
@@ -28,25 +28,27 @@ import {
   Popup,
 } from 'semantic-ui-react';
 
-import {toMoment, serializeDate} from 'indico/utils/date';
-import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
-import {FinalCheckbox, FinalTextArea} from 'indico/react/forms';
-import {Responsive} from 'indico/react/util';
 import {ClipboardButton} from 'indico/react/components';
-import {DailyTimelineContent, TimelineLegend} from '../timeline';
+import {FinalCheckbox, FinalTextArea} from 'indico/react/forms';
+import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
+import {Responsive} from 'indico/react/util';
+import {toMoment, serializeDate} from 'indico/utils/date';
+
+import {openModal} from '../../actions';
+import RoomBasicDetails from '../../components/RoomBasicDetails';
+import RoomKeyLocation from '../../components/RoomKeyLocation';
+import TimeInformation from '../../components/TimeInformation';
 import {
   getRecurrenceInfo,
   PopupParam,
   getOccurrenceTypes,
   transformToLegendLabels,
 } from '../../util';
-import RoomBasicDetails from '../../components/RoomBasicDetails';
-import RoomKeyLocation from '../../components/RoomKeyLocation';
-import TimeInformation from '../../components/TimeInformation';
-import {openModal} from '../../actions';
+import {DailyTimelineContent, TimelineLegend} from '../timeline';
+
+import * as bookingsActions from './actions';
 import LazyBookingObjectLink from './LazyBookingObjectLink';
 import * as bookingsSelectors from './selectors';
-import * as bookingsActions from './actions';
 
 import './BookingDetails.module.scss';
 

--- a/indico/modules/rb/client/js/common/bookings/BookingDetailsModal.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetailsModal.jsx
@@ -5,10 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {connect} from 'react-redux';
 import {Button} from 'semantic-ui-react';
+
 import BookingDetails from './BookingDetails';
 import BookingEdit from './BookingEdit';
 import * as bookingsSelectors from './selectors';

--- a/indico/modules/rb/client/js/common/bookings/BookingDetailsPreloader.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetailsPreloader.jsx
@@ -5,13 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Dimmer, Loader} from 'semantic-ui-react';
 
 import {Preloader} from 'indico/react/util';
+
 import * as bookingsActions from './actions';
 import * as bookingsSelectors from './selectors';
 

--- a/indico/modules/rb/client/js/common/bookings/BookingEdit.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEdit.jsx
@@ -7,24 +7,26 @@
 
 import bookingEditTimelineURL from 'indico-url:rb.booking_edit_calendars';
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Button, Checkbox, Grid, Icon, Message, Modal, Segment} from 'semantic-ui-react';
 
+import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
-import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
 import {serializeDate, serializeTime} from 'indico/utils/date';
+
+import RoomBasicDetails from '../../components/RoomBasicDetails';
+import {getRecurrenceInfo, preProcessParameters, serializeRecurrenceInfo} from '../../util';
 import {ajax as ajaxFilterRules} from '../roomSearch/serializers';
 import {selectors as userSelectors} from '../user';
-import {getRecurrenceInfo, preProcessParameters, serializeRecurrenceInfo} from '../../util';
-import RoomBasicDetails from '../../components/RoomBasicDetails';
-import BookingEditForm from './BookingEditForm';
-import BookingEditCalendar from './BookingEditCalendar';
+
 import * as bookingsActions from './actions';
+import BookingEditCalendar from './BookingEditCalendar';
+import BookingEditForm from './BookingEditForm';
 import * as bookingsSelectors from './selectors';
 
 import './BookingEdit.module.scss';

--- a/indico/modules/rb/client/js/common/bookings/BookingEditCalendar.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditCalendar.jsx
@@ -13,10 +13,12 @@ import {Header, Icon, List, Message, Popup} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 import {serializeDate} from 'indico/utils/date';
+
+import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
 import {DailyTimelineContent, TimelineLegend} from '../timeline';
+
 import OccurrencesCounter from './OccurrencesCounter';
 import * as bookingsSelectors from './selectors';
-import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
 
 import './BookingEditCalendar.module.scss';
 

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -6,14 +6,15 @@
 // LICENSE file for more details.
 
 import moment from 'moment';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+import {START_DATE} from 'react-dates/constants';
+import {Field, FormSpy} from 'react-final-form';
+import Overridable from 'react-overridable';
 import {connect} from 'react-redux';
 import {Form, Message, Segment} from 'semantic-ui-react';
-import {Field, FormSpy} from 'react-final-form';
-import {START_DATE} from 'react-dates/constants';
-import Overridable from 'react-overridable';
 
+import {FinalSingleDatePicker, FinalDatePeriod, FinalPrincipal} from 'indico/react/components';
 import {
   FieldCondition,
   FinalDropdown,
@@ -24,12 +25,12 @@ import {
   validators as v,
 } from 'indico/react/forms';
 import {FavoritesProvider} from 'indico/react/hooks';
-import {FinalSingleDatePicker, FinalDatePeriod, FinalPrincipal} from 'indico/react/components';
-import {serializeDate} from 'indico/utils/date';
 import {PluralTranslate, Translate} from 'indico/react/i18n';
+import {serializeDate} from 'indico/utils/date';
+
 import {FinalTimeRangePicker} from '../../components/TimeRangePicker';
-import {selectors as userSelectors} from '../user';
 import {sanitizeRecurrence} from '../../util';
+import {selectors as userSelectors} from '../user';
 
 import './BookingEditForm.module.scss';
 

--- a/indico/modules/rb/client/js/common/bookings/BookingExportModal.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingExportModal.jsx
@@ -8,21 +8,21 @@
 import exportBookingsURL from 'indico-url:rb.export_bookings';
 
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {Button, Form, Modal} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
 
-import {Translate} from 'indico/react/i18n';
-import {indicoAxios} from 'indico/utils/axios';
 import {FinalDatePeriod} from 'indico/react/components';
-import {snakifyKeys} from 'indico/utils/case';
 import {
   validators as v,
   FinalRadio,
   handleSubmitError,
   FinalSubmitButton,
 } from 'indico/react/forms';
+import {Translate} from 'indico/react/i18n';
+import {indicoAxios} from 'indico/utils/axios';
+import {snakifyKeys} from 'indico/utils/case';
 
 import FinalRoomSelector from '../../components/RoomSelector';
 

--- a/indico/modules/rb/client/js/common/bookings/BookingObjectLink.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingObjectLink.jsx
@@ -5,10 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Message, Icon, Segment} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
+
 import {linkDataShape} from '../linking';
 
 import './BookingObjectLink.module.scss';

--- a/indico/modules/rb/client/js/common/bookings/LazyBookingObjectLink.jsx
+++ b/indico/modules/rb/client/js/common/bookings/LazyBookingObjectLink.jsx
@@ -8,11 +8,13 @@
 import getLinkedObjectDataURL from 'indico-url:rb.linked_object_data';
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Placeholder, Segment} from 'semantic-ui-react';
+
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
+
 import BookingObjectLink from './BookingObjectLink';
 
 /**

--- a/indico/modules/rb/client/js/common/bookings/OccurrencesCounter.jsx
+++ b/indico/modules/rb/client/js/common/bookings/OccurrencesCounter.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Label, Popup} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';

--- a/indico/modules/rb/client/js/common/bookings/actions.js
+++ b/indico/modules/rb/client/js/common/bookings/actions.js
@@ -6,13 +6,14 @@
 // LICENSE file for more details.
 
 import fetchBookingDetailsURL from 'indico-url:rb.booking_details';
+import bookingOccurrenceStateActionsURL from 'indico-url:rb.booking_occurrence_state_actions';
 import bookingStateActionsURL from 'indico-url:rb.booking_state_actions';
 import bookingDeleteURL from 'indico-url:rb.delete_booking';
 import bookingUpdateURL from 'indico-url:rb.update_booking';
-import bookingOccurrenceStateActionsURL from 'indico-url:rb.booking_occurrence_state_actions';
 
 import {indicoAxios} from 'indico/utils/axios';
 import {ajaxAction, submitFormAction} from 'indico/utils/redux';
+
 import {openModal} from '../../actions';
 
 export const BOOKING_DETAILS_RECEIVED = 'bookings/BOOKING_DETAILS_RECEIVED';

--- a/indico/modules/rb/client/js/common/bookings/modals.jsx
+++ b/indico/modules/rb/client/js/common/bookings/modals.jsx
@@ -6,8 +6,9 @@
 // LICENSE file for more details.
 
 import React from 'react';
-import BookingDetailsPreloader from './BookingDetailsPreloader';
+
 import BookingDetailsModal from './BookingDetailsModal';
+import BookingDetailsPreloader from './BookingDetailsPreloader';
 
 export default {
   /* eslint-disable react/display-name */

--- a/indico/modules/rb/client/js/common/bookings/reducers.js
+++ b/indico/modules/rb/client/js/common/bookings/reducers.js
@@ -6,8 +6,10 @@
 // LICENSE file for more details.
 
 import {combineReducers} from 'redux';
+
 import {camelizeKeys} from 'indico/utils/case';
 import {requestReducer} from 'indico/utils/redux';
+
 import * as bookingsActions from './actions';
 
 export default combineReducers({

--- a/indico/modules/rb/client/js/common/bookings/selectors.js
+++ b/indico/modules/rb/client/js/common/bookings/selectors.js
@@ -8,7 +8,9 @@
 import _ from 'lodash';
 import moment from 'moment';
 import {createSelector} from 'reselect';
+
 import {RequestState} from 'indico/utils/redux';
+
 import {selectors as roomsSelectors} from '../rooms';
 import {isUserAdminOverrideEnabled} from '../user/selectors';
 

--- a/indico/modules/rb/client/js/common/config/actions.js
+++ b/indico/modules/rb/client/js/common/config/actions.js
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 import fetchConfigURL from 'indico-url:rb.config';
+
 import {indicoAxios} from 'indico/utils/axios';
 import {ajaxAction} from 'indico/utils/redux';
 

--- a/indico/modules/rb/client/js/common/config/reducers.js
+++ b/indico/modules/rb/client/js/common/config/reducers.js
@@ -9,8 +9,10 @@ import {combineReducers} from 'redux';
 
 import {camelizeKeys} from 'indico/utils/case';
 import {requestReducer} from 'indico/utils/redux';
-import * as configActions from './actions';
+
 import {actions as adminActions} from '../../modules/admin';
+
+import * as configActions from './actions';
 
 export const initialState = {
   roomsSpriteToken: '',

--- a/indico/modules/rb/client/js/common/filters/FilterBar.jsx
+++ b/indico/modules/rb/client/js/common/filters/FilterBar.jsx
@@ -5,8 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+
 import FilterDropdown from './FilterDropdown';
 
 export const FilterBarContext = React.createContext();

--- a/indico/modules/rb/client/js/common/filters/FilterDropdown.jsx
+++ b/indico/modules/rb/client/js/common/filters/FilterDropdown.jsx
@@ -6,9 +6,10 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Button, Icon, Popup} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
+
 import {Translate} from 'indico/react/i18n';
 
 import './FilterDropdown.module.scss';

--- a/indico/modules/rb/client/js/common/filters/FilterFormComponent.jsx
+++ b/indico/modules/rb/client/js/common/filters/FilterFormComponent.jsx
@@ -7,8 +7,8 @@
 
 /* eslint "react/no-unused-prop-types": "off" */
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 export default class FilterFormComponent extends React.Component {
   static propTypes = {

--- a/indico/modules/rb/client/js/common/filters/reducers.js
+++ b/indico/modules/rb/client/js/common/filters/reducers.js
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 import * as globalActions from '../../actions';
+
 import * as filtersActions from './actions';
 
 export function filterReducerFactory(namespace, initialState, postprocess = x => x) {

--- a/indico/modules/rb/client/js/common/filters/validation.js
+++ b/indico/modules/rb/client/js/common/filters/validation.js
@@ -6,9 +6,11 @@
 // LICENSE file for more details.
 
 import {push} from 'connected-react-router';
-import {toMoment} from 'indico/utils/date';
-import {Translate} from 'indico/react/i18n';
+
 import showReactErrorDialog from 'indico/react/errors';
+import {Translate} from 'indico/react/i18n';
+import {toMoment} from 'indico/utils/date';
+
 import {resetPageState} from '../../actions';
 
 /**

--- a/indico/modules/rb/client/js/common/linking/LinkBar.jsx
+++ b/indico/modules/rb/client/js/common/linking/LinkBar.jsx
@@ -5,15 +5,17 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Icon, Popup} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
+
 import * as linkingActions from './actions';
-import * as linkingSelectors from './selectors';
 import {linkDataShape} from './props';
+import * as linkingSelectors from './selectors';
 
 import './LinkBar.module.scss';
 

--- a/indico/modules/rb/client/js/common/linking/actions.js
+++ b/indico/modules/rb/client/js/common/linking/actions.js
@@ -9,6 +9,7 @@ import getLinkedObjectDataURL from 'indico-url:rb.linked_object_data';
 
 import _ from 'lodash';
 import qs from 'qs';
+
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
 

--- a/indico/modules/rb/client/js/common/linking/reducers.js
+++ b/indico/modules/rb/client/js/common/linking/reducers.js
@@ -5,8 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import * as linkingActions from './actions';
 import {actions as bookRoomActions} from '../../modules/bookRoom';
+
+import * as linkingActions from './actions';
 
 const initialState = {
   type: null,

--- a/indico/modules/rb/client/js/common/map/MapController.jsx
+++ b/indico/modules/rb/client/js/common/map/MapController.jsx
@@ -6,18 +6,20 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import PropTypes from 'prop-types';
 import {Button, Checkbox, Dimmer, Dropdown, Loader, Popup, Sticky} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 
-import {getAreaBounds, getMapBounds, getRoomListBounds, checkRoomsInBounds} from './util';
+import {actions as filtersActions} from '../filters';
+
+import * as mapActions from './actions';
 import RoomBookingMap from './RoomBookingMap';
 import RoomBookingMapControl from './RoomBookingMapControl';
-import {actions as filtersActions} from '../filters';
-import * as mapActions from './actions';
 import * as mapSelectors from './selectors';
+import {getAreaBounds, getMapBounds, getRoomListBounds, checkRoomsInBounds} from './util';
 
 import './MapController.module.scss';
 

--- a/indico/modules/rb/client/js/common/map/MapMarkers.jsx
+++ b/indico/modules/rb/client/js/common/map/MapMarkers.jsx
@@ -5,13 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import Leaflet from 'leaflet';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {connect} from 'react-redux';
 import {Marker, Tooltip} from 'react-leaflet';
-import Leaflet from 'leaflet';
 import MarkerClusterGroup from 'react-leaflet-markercluster';
+import {connect} from 'react-redux';
+
 import * as mapSelectors from './selectors';
 
 function groupIconCreateFunction(cluster) {

--- a/indico/modules/rb/client/js/common/map/RoomBookingMap.jsx
+++ b/indico/modules/rb/client/js/common/map/RoomBookingMap.jsx
@@ -8,10 +8,12 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {connect} from 'react-redux';
 import {Map, TileLayer} from 'react-leaflet';
 import Overridable from 'react-overridable';
+import {connect} from 'react-redux';
+
 import {selectors as configSelectors} from '../config';
+
 import MapMarkers from './MapMarkers';
 
 import 'leaflet/dist/leaflet.css';

--- a/indico/modules/rb/client/js/common/map/RoomBookingMapControl.jsx
+++ b/indico/modules/rb/client/js/common/map/RoomBookingMapControl.jsx
@@ -5,11 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import Leaflet from 'leaflet';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {MapControl, withLeaflet} from 'react-leaflet';
-import Leaflet from 'leaflet';
 
 class RoomBookingMapControl extends MapControl {
   static propTypes = {

--- a/indico/modules/rb/client/js/common/map/actions.js
+++ b/indico/modules/rb/client/js/common/map/actions.js
@@ -5,12 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import getMapAreasURL from 'indico-url:rb.map_areas';
 import adminMapAreasActionsURL from 'indico-url:rb.admin_map_areas';
+import getMapAreasURL from 'indico-url:rb.map_areas';
 
 import {indicoAxios} from 'indico/utils/axios';
 import {snakifyKeys} from 'indico/utils/case';
 import {ajaxAction} from 'indico/utils/redux';
+
 import * as mapSelectors from './selectors';
 
 export const UPDATE_LOCATION = 'map/UPDATE_LOCATION';

--- a/indico/modules/rb/client/js/common/map/reducers.js
+++ b/indico/modules/rb/client/js/common/map/reducers.js
@@ -6,9 +6,12 @@
 // LICENSE file for more details.
 
 import {combineReducers} from 'redux';
+
 import {requestReducer} from 'indico/utils/redux';
-import * as mapActions from './actions';
+
 import * as globalActions from '../../actions';
+
+import * as mapActions from './actions';
 import {getAreaBounds} from './util';
 
 const initialUiState = {

--- a/indico/modules/rb/client/js/common/map/selectors.js
+++ b/indico/modules/rb/client/js/common/map/selectors.js
@@ -6,7 +6,9 @@
 // LICENSE file for more details.
 
 import {createSelector} from 'reselect';
+
 import {RequestState} from 'indico/utils/redux';
+
 import {selectors as configSelectors} from '../config';
 
 const isFetching = ({map}) => map.request === RequestState.STARTED;

--- a/indico/modules/rb/client/js/common/map/util.js
+++ b/indico/modules/rb/client/js/common/map/util.js
@@ -5,16 +5,15 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import LatLon from 'geodesy/latlon-nvector-spherical';
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 
-import LatLon from 'geodesy/latlon-nvector-spherical';
-
-import * as mapSelectors from './selectors';
 import * as mapActions from './actions';
+import * as mapSelectors from './selectors';
 
 export function getAreaBounds(area) {
   return {

--- a/indico/modules/rb/client/js/common/roomSearch/actions.js
+++ b/indico/modules/rb/client/js/common/roomSearch/actions.js
@@ -6,12 +6,15 @@
 // LICENSE file for more details.
 
 import searchRoomsURL from 'indico-url:rb.search_rooms';
+
 import {indicoAxios} from 'indico/utils/axios';
 import {ajaxAction} from 'indico/utils/redux';
-import {preProcessParameters} from '../../util';
-import {ajax as ajaxFilterRules} from './serializers';
-import {validateFilters} from '../filters';
+
 import {selectors as userSelectors} from '../../common/user';
+import {preProcessParameters} from '../../util';
+import {validateFilters} from '../filters';
+
+import {ajax as ajaxFilterRules} from './serializers';
 
 export function roomSearchActionsFactory(namespace) {
   const SEARCH_RESULTS_RECEIVED = `${namespace}/SEARCH_RESULTS_RECEIVED`;

--- a/indico/modules/rb/client/js/common/roomSearch/queryString.js
+++ b/indico/modules/rb/client/js/common/roomSearch/queryString.js
@@ -5,14 +5,15 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import {LOCATION_CHANGE} from 'connected-react-router';
 import _ from 'lodash';
 import {createQueryStringReducer, validator as v} from 'redux-router-querystring';
-import {LOCATION_CHANGE} from 'connected-react-router';
 
-import {history} from '../../history';
 import * as actions from '../../actions';
-import {initialRoomFilterStateFactory} from './reducers';
+import {history} from '../../history';
 import {boolStateField} from '../../util';
+
+import {initialRoomFilterStateFactory} from './reducers';
 
 export const rules = {
   recurrence: {

--- a/indico/modules/rb/client/js/common/roomSearch/reducers.js
+++ b/indico/modules/rb/client/js/common/roomSearch/reducers.js
@@ -6,15 +6,17 @@
 // LICENSE file for more details.
 
 import {combineReducers} from 'redux';
+
 import {camelizeKeys} from 'indico/utils/case';
 import {requestReducer} from 'indico/utils/redux';
 
+import {actions as adminActions} from '../../modules/admin';
+import * as bookRoomActions from '../../modules/bookRoom/actions';
+import {sanitizeRecurrence} from '../../util';
 import {filterReducerFactory} from '../filters';
 import {mapSearchReducerFactory} from '../map';
+
 import {roomSearchActionsFactory} from './actions';
-import * as bookRoomActions from '../../modules/bookRoom/actions';
-import {actions as adminActions} from '../../modules/admin';
-import {sanitizeRecurrence} from '../../util';
 
 export function processRoomFilters(filters, param) {
   if (param === 'recurrence') {

--- a/indico/modules/rb/client/js/common/roomSearch/selectors.js
+++ b/indico/modules/rb/client/js/common/roomSearch/selectors.js
@@ -6,7 +6,9 @@
 // LICENSE file for more details.
 
 import {createSelector} from 'reselect';
+
 import {RequestState} from 'indico/utils/redux';
+
 import {selectors as roomsSelectors} from '../rooms';
 
 export function roomSearchSelectorFactory(namespace) {

--- a/indico/modules/rb/client/js/common/rooms/RoomDetailsModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/RoomDetailsModal.jsx
@@ -5,31 +5,34 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
-import qs from 'qs';
-import moment from 'moment';
-import React from 'react';
 import {push as pushRoute} from 'connected-react-router';
-import {bindActionCreators} from 'redux';
+import _ from 'lodash';
+import moment from 'moment';
 import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
+import qs from 'qs';
+import React from 'react';
 import Overridable from 'react-overridable';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Button, Grid, Icon, Modal, Header, Message, List, Segment, Popup} from 'semantic-ui-react';
+
 import {Translate, Param} from 'indico/react/i18n';
 import {IndicoPropTypes, Markdown, Responsive, useResponsive} from 'indico/react/util';
 import {serializeDate} from 'indico/utils/date';
-import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
+
+import * as globalActions from '../../actions';
+import {actions as bookingsActions} from '../../common/bookings';
+import {actions as filtersActions} from '../../common/filters';
 import RoomBasicDetails from '../../components/RoomBasicDetails';
 import RoomKeyLocation from '../../components/RoomKeyLocation';
-import RoomStats from './RoomStats';
-import {DailyTimelineContent, TimelineLegend} from '../timeline';
-import * as roomsSelectors from './selectors';
-import * as globalActions from '../../actions';
 import {actions as bookRoomActions} from '../../modules/bookRoom';
 import {actions as calendarActions} from '../../modules/calendar';
-import {actions as filtersActions} from '../../common/filters';
-import {actions as bookingsActions} from '../../common/bookings';
+import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
+import {DailyTimelineContent, TimelineLegend} from '../timeline';
+
 import RoomEditModal from './edit/RoomEditModal';
+import RoomStats from './RoomStats';
+import * as roomsSelectors from './selectors';
 
 import './RoomDetailsModal.module.scss';
 

--- a/indico/modules/rb/client/js/common/rooms/RoomDetailsPreloader.jsx
+++ b/indico/modules/rb/client/js/common/rooms/RoomDetailsPreloader.jsx
@@ -5,13 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Dimmer, Loader} from 'semantic-ui-react';
 
 import {Preloader} from 'indico/react/util';
+
 import * as roomsActions from './actions';
 import * as roomsSelectors from './selectors';
 

--- a/indico/modules/rb/client/js/common/rooms/RoomRenderer.jsx
+++ b/indico/modules/rb/client/js/common/rooms/RoomRenderer.jsx
@@ -5,11 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {Button, Card} from 'semantic-ui-react';
+import React from 'react';
 import Overridable from 'react-overridable';
+import {Button, Card} from 'semantic-ui-react';
+
 import {Slot} from 'indico/react/util';
+
 import Room from '../../components/Room';
 import {withHoverListener} from '../map/util';
 

--- a/indico/modules/rb/client/js/common/rooms/RoomStats.jsx
+++ b/indico/modules/rb/client/js/common/rooms/RoomStats.jsx
@@ -5,11 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
-import React from 'react';
-import PropTypes from 'prop-types';
-import {Header, Grid, Placeholder} from 'semantic-ui-react';
 import getRoomStatsDataURL from 'indico-url:rb.room_stats';
+
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Header, Grid, Placeholder} from 'semantic-ui-react';
+
 import {Translate, Param, PluralTranslate, Singular, Plural} from 'indico/react/i18n';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';

--- a/indico/modules/rb/client/js/common/rooms/__tests__/RoomEditModal.spec.jsx
+++ b/indico/modules/rb/client/js/common/rooms/__tests__/RoomEditModal.spec.jsx
@@ -8,15 +8,17 @@
 import attributesURL from 'indico-url:rb.admin_attributes';
 import permissionInfoURL from 'indico-url:rb.permission_types';
 
+import {mount} from 'enzyme';
+import axiosMock from 'jest-mock-axios';
 import React from 'react';
 import {act} from 'react-dom/test-utils';
-import {mount} from 'enzyme';
-import {Tab} from 'semantic-ui-react';
+import {FieldArray} from 'react-final-form-arrays';
 import {Provider} from 'react-redux';
 import configureMockStore from 'redux-mock-store';
-import {FieldArray} from 'react-final-form-arrays';
-import axiosMock from 'jest-mock-axios';
+import {Tab} from 'semantic-ui-react';
+
 import {FinalField} from 'indico/react/forms';
+
 import RoomEditModal from '../edit/RoomEditModal';
 
 jest.mock('indico/react/components/principals/ACLField', () => () => null);

--- a/indico/modules/rb/client/js/common/rooms/actions.js
+++ b/indico/modules/rb/client/js/common/rooms/actions.js
@@ -7,13 +7,14 @@
 
 import fetchEquipmentTypesURL from 'indico-url:rb.equipment_types';
 import fetchRoomURL from 'indico-url:rb.room';
-import fetchRoomsURL from 'indico-url:rb.rooms';
-import fetchRoomAvailabilityURL from 'indico-url:rb.room_availability';
 import fetchRoomAttributesURL from 'indico-url:rb.room_attributes';
+import fetchRoomAvailabilityURL from 'indico-url:rb.room_availability';
+import fetchRoomsURL from 'indico-url:rb.rooms';
 
 import {indicoAxios} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
 import {ajaxAction} from 'indico/utils/redux';
+
 import {openModal} from '../../actions';
 
 export const FETCH_EQUIPMENT_TYPES_REQUEST = 'rooms/FETCH_EQUIPMENT_TYPES_REQUEST';

--- a/indico/modules/rb/client/js/common/rooms/edit/DailyAvailability.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/DailyAvailability.jsx
@@ -5,13 +5,15 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
-import PropTypes from 'prop-types';
 import moment from 'moment';
-import shortid from 'shortid';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {Button, Icon} from 'semantic-ui-react';
+import shortid from 'shortid';
+
 import {Translate} from 'indico/react/i18n';
 import {serializeTime} from 'indico/utils/date';
+
 import TimeRangePicker from '../../../components/TimeRangePicker';
 
 import './DailyAvailability.module.scss';

--- a/indico/modules/rb/client/js/common/rooms/edit/EquipmentList.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/EquipmentList.jsx
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
-import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
 import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
 import {Dropdown, Icon, List} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
+
 import * as roomsSelectors from '../selectors';
 
 import './EquipmentList.module.scss';

--- a/indico/modules/rb/client/js/common/rooms/edit/NonBookablePeriods.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/NonBookablePeriods.jsx
@@ -5,14 +5,15 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import moment from 'moment';
 import PropTypes from 'prop-types';
-import shortid from 'shortid';
-import {Icon, Button} from 'semantic-ui-react';
+import React from 'react';
 import {ANCHOR_RIGHT} from 'react-dates/constants';
-import {Translate} from 'indico/react/i18n';
+import {Icon, Button} from 'semantic-ui-react';
+import shortid from 'shortid';
+
 import {DateRangePicker} from 'indico/react/components';
+import {Translate} from 'indico/react/i18n';
 import {serializeDate} from 'indico/utils/date';
 
 export default class NonBookablePeriods extends React.Component {

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditDetails.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditDetails.jsx
@@ -5,12 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Form, Header, Tab} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
+
 import {FinalPrincipal} from 'indico/react/components';
-import {Translate} from 'indico/react/i18n';
 import {FinalInput, FinalTextArea, validators as v} from 'indico/react/forms';
+import {Translate} from 'indico/react/i18n';
 
 export default function RoomEditDetails({active, favoriteUsersController}) {
   return (

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditLocation.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditLocation.jsx
@@ -5,11 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Form, Header, Tab} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
-import {Translate} from 'indico/react/i18n';
+
 import {FinalInput, parsers as p, validators as v} from 'indico/react/forms';
+import {Translate} from 'indico/react/i18n';
 
 export default function RoomEditLocation({active}) {
   return (

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
@@ -5,39 +5,40 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import attributesURL from 'indico-url:rb.admin_attributes';
 import roomURL from 'indico-url:rb.admin_room';
-import roomsURL from 'indico-url:rb.admin_rooms';
 import roomAttributesURL from 'indico-url:rb.admin_room_attributes';
 import roomAvailabilityURL from 'indico-url:rb.admin_room_availability';
-import attributesURL from 'indico-url:rb.admin_attributes';
-import updateRoomEquipmentURL from 'indico-url:rb.admin_update_room_equipment';
+import roomsURL from 'indico-url:rb.admin_rooms';
 import updateRoomAttributesURL from 'indico-url:rb.admin_update_room_attributes';
 import updateRoomAvailabilityURL from 'indico-url:rb.admin_update_room_availability';
+import updateRoomEquipmentURL from 'indico-url:rb.admin_update_room_equipment';
 
-import _ from 'lodash';
-import React, {useEffect, useState, useCallback, useMemo} from 'react';
-import {useDispatch, useSelector} from 'react-redux';
-import PropTypes from 'prop-types';
-import {Form as FinalForm, FormSpy} from 'react-final-form';
-import {Button, Dimmer, Form, Grid, Loader, Menu, Message, Modal, Tab} from 'semantic-ui-react';
 import arrayMutators from 'final-form-arrays';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React, {useEffect, useState, useCallback, useMemo} from 'react';
+import {Form as FinalForm, FormSpy} from 'react-final-form';
+import {useDispatch, useSelector} from 'react-redux';
+import {Button, Dimmer, Form, Grid, Loader, Menu, Message, Modal, Tab} from 'semantic-ui-react';
 
-import {snakifyKeys} from 'indico/utils/case';
-import {Translate} from 'indico/react/i18n';
-import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+import {usePermissionInfo} from 'indico/react/components/principals/hooks';
 import {getChangedValues, handleSubmitError} from 'indico/react/forms';
 import {useFavoriteUsers, useIndicoAxios} from 'indico/react/hooks';
-import {usePermissionInfo} from 'indico/react/components/principals/hooks';
+import {Translate} from 'indico/react/i18n';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+import {snakifyKeys} from 'indico/utils/case';
 
 import {actions as roomsActions} from '../../../common/rooms';
 import {actions as userActions} from '../../../common/user';
 import {getAllEquipmentTypes} from '../selectors';
-import RoomPhoto from './RoomPhoto';
+
 import RoomEditDetails from './RoomEditDetails';
-import RoomEditNotifications from './RoomEditNotifications';
 import RoomEditLocation from './RoomEditLocation';
-import RoomEditPermissions from './RoomEditPermissions';
+import RoomEditNotifications from './RoomEditNotifications';
 import RoomEditOptions from './RoomEditOptions';
+import RoomEditPermissions from './RoomEditPermissions';
+import RoomPhoto from './RoomPhoto';
 import TabPaneError from './TabPaneError';
 
 import './RoomEditModal.module.scss';

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditNotifications.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditNotifications.jsx
@@ -5,12 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Form, Header, Tab} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
-import {Translate} from 'indico/react/i18n';
-import {FieldCondition, FinalCheckbox, FinalInput, validators as v} from 'indico/react/forms';
+
 import {FinalEmailList} from 'indico/react/components';
+import {FieldCondition, FinalCheckbox, FinalInput, validators as v} from 'indico/react/forms';
+import {Translate} from 'indico/react/i18n';
 
 export default function RoomEditNotifications({active}) {
   return (

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditOptions.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditOptions.jsx
@@ -5,15 +5,17 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useMemo} from 'react';
-import {Dropdown, Form, Header, Tab} from 'semantic-ui-react';
 import _ from 'lodash';
-import {FieldArray} from 'react-final-form-arrays';
 import PropTypes from 'prop-types';
-import {Translate} from 'indico/react/i18n';
+import React, {useMemo} from 'react';
+import {FieldArray} from 'react-final-form-arrays';
+import {Dropdown, Form, Header, Tab} from 'semantic-ui-react';
+
 import {FinalCheckbox, FinalField, FinalInput, validators as v} from 'indico/react/forms';
-import EquipmentList from './EquipmentList';
+import {Translate} from 'indico/react/i18n';
+
 import DailyAvailability from './DailyAvailability';
+import EquipmentList from './EquipmentList';
 import NonBookablePeriods from './NonBookablePeriods';
 
 export default function RoomEditOptions({active, showEquipment, globalAttributes}) {

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditPermissions.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditPermissions.jsx
@@ -5,13 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
-import {Form, Header, Tab} from 'semantic-ui-react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
+import React from 'react';
+import {Form, Header, Tab} from 'semantic-ui-react';
+
 import {ACLField} from 'indico/react/components';
-import {Translate} from 'indico/react/i18n';
 import {FinalField, FinalRadio, parsers as p} from 'indico/react/forms';
+import {Translate} from 'indico/react/i18n';
 
 export default function RoomEditPermissions({
   active,

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomPhoto.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomPhoto.jsx
@@ -7,13 +7,15 @@
 
 import roomPhotoURL from 'indico-url:rb.admin_room_photo';
 
-import React, {useCallback, useState, useEffect, useRef} from 'react';
-import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
+import React, {useCallback, useState, useEffect, useRef} from 'react';
 import Dropzone from 'react-dropzone';
+import {connect} from 'react-redux';
 import {Button, Dimmer, Image, Popup, Loader} from 'semantic-ui-react';
-import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+
 import {Translate} from 'indico/react/i18n';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+
 import {actions as configActions} from '../../config';
 
 import './RoomPhoto.module.scss';

--- a/indico/modules/rb/client/js/common/rooms/edit/TabPaneError.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/TabPaneError.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {useFormState} from 'react-final-form';
 import {Icon} from 'semantic-ui-react';
 

--- a/indico/modules/rb/client/js/common/rooms/index.js
+++ b/indico/modules/rb/client/js/common/rooms/index.js
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import * as selectors from './selectors';
 import * as actions from './actions';
+import * as selectors from './selectors';
 
 export {default as reducer} from './reducers';
 export {default as RoomDetailsPreloader} from './RoomDetailsPreloader';

--- a/indico/modules/rb/client/js/common/rooms/modals.jsx
+++ b/indico/modules/rb/client/js/common/rooms/modals.jsx
@@ -7,8 +7,8 @@
 
 import React from 'react';
 
-import RoomDetailsPreloader from './RoomDetailsPreloader';
 import RoomDetailsModal from './RoomDetailsModal';
+import RoomDetailsPreloader from './RoomDetailsPreloader';
 
 export default {
   /* eslint-disable react/display-name */

--- a/indico/modules/rb/client/js/common/rooms/reducers.js
+++ b/indico/modules/rb/client/js/common/rooms/reducers.js
@@ -9,9 +9,11 @@ import {combineReducers} from 'redux';
 
 import {camelizeKeys} from 'indico/utils/case';
 import {requestReducer} from 'indico/utils/redux';
-import * as roomsActions from './actions';
-import * as bookingActions from '../bookings/actions';
+
 import * as bookRoomActions from '../../modules/bookRoom/actions';
+import * as bookingActions from '../bookings/actions';
+
+import * as roomsActions from './actions';
 
 function filterAvailability(roomAvailability, bookingId) {
   return roomAvailability.map(availability => {

--- a/indico/modules/rb/client/js/common/rooms/selectors.js
+++ b/indico/modules/rb/client/js/common/rooms/selectors.js
@@ -9,8 +9,9 @@ import _ from 'lodash';
 import {createSelector} from 'reselect';
 
 import {RequestState} from 'indico/utils/redux';
-import {getAllUserRoomPermissions, isUserRBAdmin} from '../user/selectors';
+
 import {canManagersEditRooms} from '../config/selectors';
+import {getAllUserRoomPermissions, isUserRBAdmin} from '../user/selectors';
 
 export const hasLoadedEquipmentTypes = ({rooms}) =>
   rooms.requests.equipmentTypes.state === RequestState.SUCCESS ||

--- a/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
+++ b/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
@@ -9,19 +9,19 @@ import _ from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {AutoSizer, List, WindowScroller} from 'react-virtualized';
-import {Icon, Message, Popup, Placeholder} from 'semantic-ui-react';
-import LazyScroll from 'redux-lazy-scroll';
 import Overridable from 'react-overridable';
+import {AutoSizer, List, WindowScroller} from 'react-virtualized';
+import LazyScroll from 'redux-lazy-scroll';
+import {Icon, Message, Popup, Placeholder} from 'semantic-ui-react';
 
-import {Translate} from 'indico/react/i18n';
-import {toMoment} from 'indico/utils/date';
 import {TooltipIfTruncated} from 'indico/react/components';
+import {Translate} from 'indico/react/i18n';
 import {Responsive} from 'indico/react/util';
+import {toMoment} from 'indico/utils/date';
 
+import EditableTimelineItem from './EditableTimelineItem';
 import RowActionsDropdown from './RowActionsDropdown';
 import TimelineItem from './TimelineItem';
-import EditableTimelineItem from './EditableTimelineItem';
 
 import './TimelineContent.module.scss';
 

--- a/indico/modules/rb/client/js/common/timeline/DateNavigator.jsx
+++ b/indico/modules/rb/client/js/common/timeline/DateNavigator.jsx
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Button, Popup} from 'semantic-ui-react';
+
 import {CalendarSingleDatePicker} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {serializeDate, toMoment} from 'indico/utils/date';
+
 import {isDateWithinRange} from '../../util';
 
 import './DateNavigator.module.scss';

--- a/indico/modules/rb/client/js/common/timeline/EditableTimelineItem.jsx
+++ b/indico/modules/rb/client/js/common/timeline/EditableTimelineItem.jsx
@@ -8,6 +8,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Popup} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 
 import TimelineItem from './TimelineItem';

--- a/indico/modules/rb/client/js/common/timeline/ElasticTimeline.jsx
+++ b/indico/modules/rb/client/js/common/timeline/ElasticTimeline.jsx
@@ -6,14 +6,16 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Message} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 import {dayRange, serializeDate, toMoment} from 'indico/utils/date';
+
 import DailyTimelineContent from './DailyTimelineContent';
-import WeeklyTimelineContent from './WeeklyTimelineContent';
 import MonthlyTimelineContent from './MonthlyTimelineContent';
+import WeeklyTimelineContent from './WeeklyTimelineContent';
 
 import './Timeline.module.scss';
 

--- a/indico/modules/rb/client/js/common/timeline/MonthlyTimelineContent.jsx
+++ b/indico/modules/rb/client/js/common/timeline/MonthlyTimelineContent.jsx
@@ -7,8 +7,10 @@
 
 import _ from 'lodash';
 import React from 'react';
-import {toMoment} from 'indico/utils/date';
+
 import {toClasses} from 'indico/react/util';
+import {toMoment} from 'indico/utils/date';
+
 import WeeklyTimelineContent from './DailyTimelineContent';
 
 /* eslint-disable no-unused-vars */

--- a/indico/modules/rb/client/js/common/timeline/RowActionsDropdown.jsx
+++ b/indico/modules/rb/client/js/common/timeline/RowActionsDropdown.jsx
@@ -5,19 +5,20 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Button, Confirm, Dropdown, Form, Icon} from 'semantic-ui-react';
 
-import {serializeDate} from 'indico/utils/date';
 import {PopoverDropdownMenu} from 'indico/react/components';
 import {FinalTextArea} from 'indico/react/forms';
 import {Param, Translate} from 'indico/react/i18n';
+import {serializeDate} from 'indico/utils/date';
 
 import {actions as bookingsActions} from '../bookings';
+
 import SingleRoomTimelineModal from './SingleRoomTimelineModal';
 
 import './RowActionsDropdown.module.scss';

--- a/indico/modules/rb/client/js/common/timeline/SingleRoomTimelineModal.jsx
+++ b/indico/modules/rb/client/js/common/timeline/SingleRoomTimelineModal.jsx
@@ -6,17 +6,19 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React, {useEffect} from 'react';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import PropTypes from 'prop-types';
 import {Modal, Icon, Popup} from 'semantic-ui-react';
 
 import {serializeDate} from 'indico/utils/date';
-import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
+
 import {actions as bookRoomActions, selectors as bookRoomSelectors} from '../../modules/bookRoom';
-import TimelineLegend from './TimelineLegend';
+import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
+
 import DailyTimelineContent from './DailyTimelineContent';
+import TimelineLegend from './TimelineLegend';
 
 import './SingleRoomTimelineModal.module.scss';
 

--- a/indico/modules/rb/client/js/common/timeline/TimelineHeader.jsx
+++ b/indico/modules/rb/client/js/common/timeline/TimelineHeader.jsx
@@ -5,12 +5,15 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+
 import {useResponsive} from 'indico/react/util';
-import TimelineLegend from './TimelineLegend';
+
 import {legendLabelShape} from '../../props';
+
 import DateNavigator from './DateNavigator';
+import TimelineLegend from './TimelineLegend';
 
 export default function TimelineHeader({
   datePicker,

--- a/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
+++ b/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
@@ -8,13 +8,15 @@
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Overridable from 'react-overridable';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import Overridable from 'react-overridable';
 import {List, Popup} from 'semantic-ui-react';
+
+import {ResponsivePopup} from 'indico/react/components';
 import {Translate, Param} from 'indico/react/i18n';
 import {fullyOverlaps, serializeTime} from 'indico/utils/date';
-import {ResponsivePopup} from 'indico/react/components';
+
 import {openModal} from '../../actions';
 
 import './TimelineItem.module.scss';

--- a/indico/modules/rb/client/js/common/timeline/TimelineLegend.jsx
+++ b/indico/modules/rb/client/js/common/timeline/TimelineLegend.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 import {Label, Segment, List} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
+
 import {legendLabelShape} from '../../props';
 
 import './TimelineLegend.module.scss';

--- a/indico/modules/rb/client/js/common/timeline/WeeklyTimelineContent.jsx
+++ b/indico/modules/rb/client/js/common/timeline/WeeklyTimelineContent.jsx
@@ -8,8 +8,10 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {toMoment} from 'indico/utils/date';
+
 import {toClasses} from 'indico/react/util';
+import {toMoment} from 'indico/utils/date';
+
 import DailyTimelineContent from './DailyTimelineContent';
 
 /* eslint-disable no-unused-vars */

--- a/indico/modules/rb/client/js/common/user/actions.js
+++ b/indico/modules/rb/client/js/common/user/actions.js
@@ -5,10 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import fetchUserInfoURL from 'indico-url:rb.user_info';
 import favoriteRoomsURL from 'indico-url:rb.favorite_rooms';
 import roomPermissionsURL from 'indico-url:rb.room_permissions';
 import roomsPermissionsURL from 'indico-url:rb.rooms_permissions';
+import fetchUserInfoURL from 'indico-url:rb.user_info';
 
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {setMomentLocale} from 'indico/utils/date';

--- a/indico/modules/rb/client/js/common/user/reducers.js
+++ b/indico/modules/rb/client/js/common/user/reducers.js
@@ -8,6 +8,7 @@
 import {combineReducers} from 'redux';
 
 import {requestReducer} from 'indico/utils/redux';
+
 import * as actions from './actions';
 
 const initialUserInfoState = {

--- a/indico/modules/rb/client/js/components/AdminOverrideBar.jsx
+++ b/indico/modules/rb/client/js/components/AdminOverrideBar.jsx
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Icon, Popup} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
+
 import {actions as userActions, selectors as userSelectors} from '../common/user';
 
 import './AdminOverrideBar.module.scss';

--- a/indico/modules/rb/client/js/components/App.jsx
+++ b/indico/modules/rb/client/js/components/App.jsx
@@ -5,34 +5,35 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
-import {connect} from 'react-redux';
-import PropTypes from 'prop-types';
-import {Link, Redirect, Route, Switch} from 'react-router-dom';
 import {ConnectedRouter} from 'connected-react-router';
-import {Dimmer, Header, Icon, Loader, Responsive, Segment, Sidebar} from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Overridable from 'react-overridable';
+import {connect} from 'react-redux';
+import {Link, Redirect, Route, Switch} from 'react-router-dom';
+import {Dimmer, Header, Icon, Loader, Responsive, Segment, Sidebar} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 import {ConditionalRoute} from 'indico/react/util';
-import SidebarMenu, {SidebarTrigger} from './SidebarMenu';
-import AdminArea from '../modules/admin';
-import Landing from '../modules/landing';
-import Calendar from '../modules/calendar';
-import BookRoom from '../modules/bookRoom';
-import RoomList from '../modules/roomList';
-import BlockingList from '../modules/blockings';
-import ModalController from '../modals';
-import Menu from './Menu';
-import AdminOverrideBar from './AdminOverrideBar';
-import {LinkBar} from '../common/linking';
+
+import * as globalActions from '../actions';
 import {actions as configActions} from '../common/config';
+import {LinkBar} from '../common/linking';
 import {actions as mapActions} from '../common/map';
 import {actions as roomsActions} from '../common/rooms';
 import {actions as userActions} from '../common/user';
-import * as globalActions from '../actions';
-
+import ModalController from '../modals';
+import AdminArea from '../modules/admin';
+import BlockingList from '../modules/blockings';
+import BookRoom from '../modules/bookRoom';
+import Calendar from '../modules/calendar';
+import Landing from '../modules/landing';
+import RoomList from '../modules/roomList';
 import * as globalSelectors from '../selectors';
+
+import AdminOverrideBar from './AdminOverrideBar';
+import Menu from './Menu';
+import SidebarMenu, {SidebarTrigger} from './SidebarMenu';
 import './App.module.scss';
 
 class App extends React.Component {

--- a/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
+++ b/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
@@ -9,9 +9,10 @@ import _ from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {connect} from 'react-redux';
 import Overridable from 'react-overridable';
+import {connect} from 'react-redux';
 import {Button, Form, Select} from 'semantic-ui-react';
+
 import {SingleDatePicker, DateRangePicker} from 'indico/react/components';
 import {PluralTranslate, Translate} from 'indico/react/i18n';
 import {
@@ -24,10 +25,12 @@ import {
   toMoment,
   initialEndTime,
 } from 'indico/utils/date';
-import TimeRangePicker from './TimeRangePicker';
-import {selectors as userSelectors} from '../common/user';
+
 import {selectors as configSelectors} from '../common/config';
+import {selectors as userSelectors} from '../common/user';
 import {sanitizeRecurrence} from '../util';
+
+import TimeRangePicker from './TimeRangePicker';
 
 import './BookingBootstrapForm.module.scss';
 

--- a/indico/modules/rb/client/js/components/CardPlaceholder.jsx
+++ b/indico/modules/rb/client/js/components/CardPlaceholder.jsx
@@ -6,8 +6,8 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Card, Placeholder} from 'semantic-ui-react';
 
 export default function CardPlaceholder({withImage}) {

--- a/indico/modules/rb/client/js/components/DimmableImage.jsx
+++ b/indico/modules/rb/client/js/components/DimmableImage.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import {Responsive} from 'indico/react/util';
 

--- a/indico/modules/rb/client/js/components/ItemPlaceholder.jsx
+++ b/indico/modules/rb/client/js/components/ItemPlaceholder.jsx
@@ -6,8 +6,8 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Item, Placeholder} from 'semantic-ui-react';
 
 export default function ItemPlaceholder() {

--- a/indico/modules/rb/client/js/components/Menu.jsx
+++ b/indico/modules/rb/client/js/components/Menu.jsx
@@ -5,12 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Icon} from 'semantic-ui-react';
-import {Responsive} from 'indico/react/util';
 
 import {Translate} from 'indico/react/i18n';
+import {Responsive} from 'indico/react/util';
+
 import MenuItem from './MenuItem';
 
 import './Menu.module.scss';

--- a/indico/modules/rb/client/js/components/MenuItem.jsx
+++ b/indico/modules/rb/client/js/components/MenuItem.jsx
@@ -5,10 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import PropTypes from 'prop-types';
 import {Link, Route} from 'react-router-dom';
+
 import * as globalActions from '../actions';
 
 import './MenuItem.module.scss';

--- a/indico/modules/rb/client/js/components/Room.jsx
+++ b/indico/modules/rb/client/js/components/Room.jsx
@@ -6,19 +6,21 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Card, Icon, Label, Loader, Popup, Button} from 'semantic-ui-react';
 
+import {TooltipIfTruncated, ResponsivePopup} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {Markdown, Slot} from 'indico/react/util';
-import {TooltipIfTruncated, ResponsivePopup} from 'indico/react/components';
-import SpriteImage from './SpriteImage';
-import DimmableImage from './DimmableImage';
+
 import {actions as userActions, selectors as userSelectors} from '../common/user';
+
+import DimmableImage from './DimmableImage';
 import RoomFeatureEntry from './RoomFeatureEntry';
+import SpriteImage from './SpriteImage';
 
 import './Room.module.scss';
 

--- a/indico/modules/rb/client/js/components/RoomBasicDetails.jsx
+++ b/indico/modules/rb/client/js/components/RoomBasicDetails.jsx
@@ -7,10 +7,12 @@
 
 import roomImageURL from 'indico-url:rb.room_photo';
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Dimmer, Grid, Header, Icon, Image, Loader, Modal, Popup} from 'semantic-ui-react';
+
 import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
+
 import {formatLatLon} from '../common/map/util';
 
 import RoomFeatureEntry from './RoomFeatureEntry';

--- a/indico/modules/rb/client/js/components/RoomFeatureEntry.jsx
+++ b/indico/modules/rb/client/js/components/RoomFeatureEntry.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Icon, Popup} from 'semantic-ui-react';
 
 export default function RoomFeatureEntry({feature, color, size}) {

--- a/indico/modules/rb/client/js/components/RoomKeyLocation.jsx
+++ b/indico/modules/rb/client/js/components/RoomKeyLocation.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Icon, Message} from 'semantic-ui-react';
+
 import {Markdown} from 'indico/react/util';
 
 import './RoomKeyLocation.module.scss';

--- a/indico/modules/rb/client/js/components/RoomSelector.jsx
+++ b/indico/modules/rb/client/js/components/RoomSelector.jsx
@@ -5,15 +5,18 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
-import React from 'react';
-import PropTypes from 'prop-types';
-import {Button, Dropdown, Grid, Icon, List, Message, Segment} from 'semantic-ui-react';
 import getLocationsURL from 'indico-url:rb.locations';
-import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Button, Dropdown, Grid, Icon, List, Message, Segment} from 'semantic-ui-react';
+
 import {FinalField} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
+
 import SpriteImage from './SpriteImage';
 
 import './RoomSelector.module.scss';

--- a/indico/modules/rb/client/js/components/SearchBar.jsx
+++ b/indico/modules/rb/client/js/components/SearchBar.jsx
@@ -5,12 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Icon, Input} from 'semantic-ui-react';
 import {DebounceInput} from 'react-debounce-input';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import {Icon, Input} from 'semantic-ui-react';
+
 import {actions as filtersActions} from '../common/filters';
 
 import './SearchBar.module.scss';

--- a/indico/modules/rb/client/js/components/SidebarFooter.jsx
+++ b/indico/modules/rb/client/js/components/SidebarFooter.jsx
@@ -6,16 +6,18 @@
 // LICENSE file for more details.
 
 import contactURL from 'indico-url:core.contact';
-import tosURL from 'indico-url:legal.display_tos';
 import privacyPolicyURL from 'indico-url:legal.display_privacy';
+import tosURL from 'indico-url:legal.display_tos';
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
-import {Icon, Menu, Modal} from 'semantic-ui-react';
+import React, {useState} from 'react';
 import {connect} from 'react-redux';
+import {Icon, Menu, Modal} from 'semantic-ui-react';
+
+import {ResponsivePopup} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {Responsive} from 'indico/react/util';
-import {ResponsivePopup} from 'indico/react/components';
+
 import {selectors as configSelectors} from '../common/config';
 
 const buildMenuItems = (helpURL, hasTOS, hasPrivacyPolicy, contactEmail) => {

--- a/indico/modules/rb/client/js/components/SidebarMenu.jsx
+++ b/indico/modules/rb/client/js/components/SidebarMenu.jsx
@@ -5,19 +5,21 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
-import React from 'react';
-import PropTypes from 'prop-types';
-import {Icon, Sidebar, Menu} from 'semantic-ui-react';
-import {connect} from 'react-redux';
 import {push as pushRoute} from 'connected-react-router';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 import Overridable from 'react-overridable';
+import {connect} from 'react-redux';
+import {Icon, Sidebar, Menu} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 
+import * as globalActions from '../actions';
+import {actions as filtersActions} from '../common/filters';
 import {selectors as userSelectors, actions as userActions} from '../common/user';
 import {actions as blockingsActions} from '../modules/blockings';
-import {actions as filtersActions} from '../common/filters';
-import * as globalActions from '../actions';
+
 import SidebarFooter from './SidebarFooter';
 
 import './SidebarMenu.module.scss';

--- a/indico/modules/rb/client/js/components/SpriteImage.jsx
+++ b/indico/modules/rb/client/js/components/SpriteImage.jsx
@@ -7,8 +7,8 @@
 
 import roomsSpriteURL from 'indico-url:rb.sprite';
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {connect} from 'react-redux';
 
 import * as configSelectors from '../common/config/selectors';

--- a/indico/modules/rb/client/js/components/TimeInformation.jsx
+++ b/indico/modules/rb/client/js/components/TimeInformation.jsx
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import Overridable from 'react-overridable';
 import {Button, Icon, Segment} from 'semantic-ui-react';
+
 import {Param, Translate} from 'indico/react/i18n';
 import {toMoment} from 'indico/utils/date';
+
 import {renderRecurrence} from '../util';
 
 import './TimeInformation.module.scss';

--- a/indico/modules/rb/client/js/components/TimeRangePicker.jsx
+++ b/indico/modules/rb/client/js/components/TimeRangePicker.jsx
@@ -7,12 +7,13 @@
 
 import _ from 'lodash';
 import moment from 'moment';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Dropdown} from 'semantic-ui-react';
+
+import {FinalField} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 import {serializeTime, toMoment} from 'indico/utils/date';
-import {FinalField} from 'indico/react/forms';
 
 import './TimeRangePicker.module.scss';
 

--- a/indico/modules/rb/client/js/modals/ModalController.jsx
+++ b/indico/modules/rb/client/js/modals/ModalController.jsx
@@ -5,17 +5,17 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import {push} from 'connected-react-router';
+import PropTypes from 'prop-types';
 import qs from 'qs';
 import React from 'react';
-import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
-import PropTypes from 'prop-types';
-import {push} from 'connected-react-router';
+import {bindActionCreators} from 'redux';
 
+import {modalHandlers as bookingsModalHandlers} from '../common/bookings';
+import {modalHandlers as roomsModalHandlers} from '../common/rooms';
 import {modalHandlers as blockingModalHandlers} from '../modules/blockings';
 import {modalHandlers as bookRoomModalHandlers} from '../modules/bookRoom';
-import {modalHandlers as roomsModalHandlers} from '../common/rooms';
-import {modalHandlers as bookingsModalHandlers} from '../common/bookings';
 import * as globalSelectors from '../selectors';
 
 class ModalController extends React.PureComponent {

--- a/indico/modules/rb/client/js/modules/admin/AdminArea.jsx
+++ b/indico/modules/rb/client/js/modules/admin/AdminArea.jsx
@@ -5,23 +5,26 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
 import {Route} from 'react-router-dom';
 import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
 import {Container, Grid} from 'semantic-ui-react';
+
 import {ConditionalRoute} from 'indico/react/util';
-import {selectors as userSelectors} from '../../common/user';
+
 import {selectors as mapSelectors} from '../../common/map';
-import AdminMenu from './AdminMenu';
-import AdminLocationRooms from './AdminLocationRooms';
-import EquipmentPage from './EquipmentPage';
-import AttributesPage from './AttributesPage';
-import LocationPage from './LocationPage';
-import SettingsPage from './SettingsPage';
-import MapAreasPage from './MapAreasPage';
+import {selectors as userSelectors} from '../../common/user';
+
 import * as adminActions from './actions';
+import AdminLocationRooms from './AdminLocationRooms';
+import AdminMenu from './AdminMenu';
+import AttributesPage from './AttributesPage';
+import EquipmentPage from './EquipmentPage';
+import LocationPage from './LocationPage';
+import MapAreasPage from './MapAreasPage';
+import SettingsPage from './SettingsPage';
 
 import './AdminArea.module.scss';
 

--- a/indico/modules/rb/client/js/modules/admin/AdminLocationRooms.jsx
+++ b/indico/modules/rb/client/js/modules/admin/AdminLocationRooms.jsx
@@ -5,19 +5,22 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {connect} from 'react-redux';
 import {Button, Header, Item, Message} from 'semantic-ui-react';
+
 import {Translate, Param} from 'indico/react/i18n';
-import ItemPlaceholder from '../../components/ItemPlaceholder';
-import AdminRoomItem from './AdminRoomItem';
-import searchBarFactory from '../../components/SearchBar';
-import * as adminSelectors from './selectors';
+
 import {RoomEditModal} from '../../common/rooms';
+import ItemPlaceholder from '../../components/ItemPlaceholder';
+import searchBarFactory from '../../components/SearchBar';
+
+import * as adminActions from './actions';
+import AdminRoomItem from './AdminRoomItem';
+import * as adminSelectors from './selectors';
 
 import './AdminLocationRooms.module.scss';
-import * as adminActions from './actions';
 
 const SearchBar = searchBarFactory('admin', adminSelectors);
 

--- a/indico/modules/rb/client/js/modules/admin/AdminMenu.jsx
+++ b/indico/modules/rb/client/js/modules/admin/AdminMenu.jsx
@@ -5,16 +5,19 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
-import {Link, NavLink, withRouter} from 'react-router-dom';
-import {Icon, Menu, Placeholder} from 'semantic-ui-react';
+import React from 'react';
 import {connect} from 'react-redux';
+import {Link, NavLink, withRouter} from 'react-router-dom';
+import {bindActionCreators} from 'redux';
+import {Icon, Menu, Placeholder} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
+
 import {selectors as mapSelectors} from '../../common/map';
-import * as adminSelectors from './selectors';
+
 import * as adminActions from './actions';
+import * as adminSelectors from './selectors';
 
 import './AdminMenu.module.scss';
 

--- a/indico/modules/rb/client/js/modules/admin/AdminRoomItem.jsx
+++ b/indico/modules/rb/client/js/modules/admin/AdminRoomItem.jsx
@@ -5,13 +5,16 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {connect} from 'react-redux';
-import PropTypes from 'prop-types';
 import {Button, Confirm, Item} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
-import SpriteImage from '../../components/SpriteImage';
+
 import {RoomEditModal} from '../../common/rooms';
+import SpriteImage from '../../components/SpriteImage';
+
 import * as adminActions from './actions';
 
 import './AdminRoomItem.module.scss';

--- a/indico/modules/rb/client/js/modules/admin/AttributesPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/AttributesPage.jsx
@@ -5,16 +5,18 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Icon, List, Popup} from 'semantic-ui-react';
-import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
+
 import {formatters, FinalCheckbox, FinalInput} from 'indico/react/forms';
+import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
+
 import * as adminActions from './actions';
-import * as adminSelectors from './selectors';
 import EditableList from './EditableList';
+import * as adminSelectors from './selectors';
 
 import './EditableList.module.scss';
 

--- a/indico/modules/rb/client/js/modules/admin/CategoryList.jsx
+++ b/indico/modules/rb/client/js/modules/admin/CategoryList.jsx
@@ -6,9 +6,10 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Dropdown} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 
 const isValid = value => +value >= 0;

--- a/indico/modules/rb/client/js/modules/admin/EditableList.jsx
+++ b/indico/modules/rb/client/js/modules/admin/EditableList.jsx
@@ -6,11 +6,13 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {Button, Form, Header, List, Modal, Placeholder} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
+
 import EditableListItem from './EditableListItem';
 
 import './EditableList.module.scss';

--- a/indico/modules/rb/client/js/modules/admin/EditableListItem.jsx
+++ b/indico/modules/rb/client/js/modules/admin/EditableListItem.jsx
@@ -6,12 +6,13 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {Button, Confirm, Form, List} from 'semantic-ui-react';
-import {Translate} from 'indico/react/i18n';
+
 import {getChangedValues} from 'indico/react/forms';
+import {Translate} from 'indico/react/i18n';
 
 import './EditableList.module.scss';
 

--- a/indico/modules/rb/client/js/modules/admin/EquipmentPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/EquipmentPage.jsx
@@ -5,14 +5,15 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Grid} from 'semantic-ui-react';
+
 import * as adminActions from './actions';
-import RoomFeatureList from './RoomFeatureList';
 import EquipmentTypeList from './EquipmentTypeList';
+import RoomFeatureList from './RoomFeatureList';
 
 class EquipmentPage extends React.PureComponent {
   static propTypes = {

--- a/indico/modules/rb/client/js/modules/admin/EquipmentTypeList.jsx
+++ b/indico/modules/rb/client/js/modules/admin/EquipmentTypeList.jsx
@@ -5,16 +5,18 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Icon, List, Popup} from 'semantic-ui-react';
+
 import {FinalDropdown, FinalInput} from 'indico/react/forms';
 import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
+
 import * as adminActions from './actions';
-import * as adminSelectors from './selectors';
 import EditableList from './EditableList';
+import * as adminSelectors from './selectors';
 
 import './EditableList.module.scss';
 

--- a/indico/modules/rb/client/js/modules/admin/LocationPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/LocationPage.jsx
@@ -5,20 +5,22 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
-import React from 'react';
-import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
 import createDecorator from 'final-form-calculate';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
 import {Field} from 'react-final-form';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {List} from 'semantic-ui-react';
-import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
+
 import {validators as v, FinalDropdown, FinalInput} from 'indico/react/forms';
+import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
 import {snakifyKeys} from 'indico/utils/case';
+
 import * as adminActions from './actions';
-import * as adminSelectors from './selectors';
 import EditableList from './EditableList';
+import * as adminSelectors from './selectors';
 
 import './EditableList.module.scss';
 

--- a/indico/modules/rb/client/js/modules/admin/MapAreasPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/MapAreasPage.jsx
@@ -5,22 +5,22 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
-import React from 'react';
-import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
-import {Form as FinalForm} from 'react-final-form';
 import Leaflet from 'leaflet';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Form as FinalForm} from 'react-final-form';
 import {FeatureGroup, Map, Rectangle, TileLayer, Tooltip, ZoomControl} from 'react-leaflet';
 import {EditControl} from 'react-leaflet-draw';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Button, Form, Header, Modal} from 'semantic-ui-react';
 
 import {FinalCheckbox, FinalInput, FinalSubmitButton} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-import {selectors as mapSelectors, actions as mapActions} from '../../common/map';
 import {selectors as configSelectors} from '../../common/config';
+import {selectors as mapSelectors, actions as mapActions} from '../../common/map';
 
 import 'leaflet/dist/leaflet.css';
 import 'leaflet-draw/dist/leaflet.draw.css';

--- a/indico/modules/rb/client/js/modules/admin/RoomFeatureList.jsx
+++ b/indico/modules/rb/client/js/modules/admin/RoomFeatureList.jsx
@@ -5,17 +5,19 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {List, Icon} from 'semantic-ui-react';
 import {ICONS_AND_ALIASES} from 'semantic-ui-react/dist/commonjs/lib/SUI';
+
 import {formatters, FinalDropdown, FinalInput} from 'indico/react/forms';
 import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
+
 import * as adminActions from './actions';
-import * as adminSelectors from './selectors';
 import EditableList from './EditableList';
+import * as adminSelectors from './selectors';
 
 import './EditableList.module.scss';
 

--- a/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
@@ -6,13 +6,13 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
+import React, {useEffect} from 'react';
 import {Form as FinalForm} from 'react-final-form';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Form, Header, Message, Placeholder} from 'semantic-ui-react';
-import {PluralTranslate, Translate} from 'indico/react/i18n';
+
 import {FinalPrincipalList} from 'indico/react/components';
 import {
   getChangedValues,
@@ -25,9 +25,11 @@ import {
   validators as v,
 } from 'indico/react/forms';
 import {useFavoriteUsers} from 'indico/react/hooks';
+import {PluralTranslate, Translate} from 'indico/react/i18n';
+
 import * as adminActions from './actions';
-import * as adminSelectors from './selectors';
 import CategoryList from './CategoryList';
+import * as adminSelectors from './selectors';
 
 import './SettingsPage.module.scss';
 

--- a/indico/modules/rb/client/js/modules/admin/actions.js
+++ b/indico/modules/rb/client/js/modules/admin/actions.js
@@ -5,18 +5,19 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import settingsURL from 'indico-url:rb.admin_settings';
-import locationsURL from 'indico-url:rb.admin_locations';
-import roomsURL from 'indico-url:rb.admin_rooms';
-import roomURL from 'indico-url:rb.admin_room';
+import attributesURL from 'indico-url:rb.admin_attributes';
 import equipmentTypesURL from 'indico-url:rb.admin_equipment_types';
 import featuresURL from 'indico-url:rb.admin_features';
-import attributesURL from 'indico-url:rb.admin_attributes';
+import locationsURL from 'indico-url:rb.admin_locations';
+import roomURL from 'indico-url:rb.admin_room';
+import roomsURL from 'indico-url:rb.admin_rooms';
+import settingsURL from 'indico-url:rb.admin_settings';
 
 import _ from 'lodash';
 
 import {indicoAxios} from 'indico/utils/axios';
 import {ajaxAction, submitFormAction} from 'indico/utils/redux';
+
 import {actions as filtersActions} from '../../common/filters';
 
 export const FETCH_SETTINGS_REQUEST = 'admin/FETCH_SETTINGS_REQUEST';

--- a/indico/modules/rb/client/js/modules/admin/reducers.js
+++ b/indico/modules/rb/client/js/modules/admin/reducers.js
@@ -6,9 +6,12 @@
 // LICENSE file for more details.
 
 import {combineReducers} from 'redux';
-import {requestReducer} from 'indico/utils/redux';
+
 import {camelizeKeys} from 'indico/utils/case';
+import {requestReducer} from 'indico/utils/redux';
+
 import {filterReducerFactory} from '../../common/filters';
+
 import * as adminActions from './actions';
 
 export const initialFilterStateFactory = () => ({

--- a/indico/modules/rb/client/js/modules/admin/selectors.js
+++ b/indico/modules/rb/client/js/modules/admin/selectors.js
@@ -7,6 +7,7 @@
 
 import _ from 'lodash';
 import {createSelector} from 'reselect';
+
 import {RequestState} from 'indico/utils/redux';
 
 const makeSorter = attr => (a, b) => a[attr].localeCompare(b[attr]);

--- a/indico/modules/rb/client/js/modules/blockings/BlockingCard.jsx
+++ b/indico/modules/rb/client/js/modules/blockings/BlockingCard.jsx
@@ -6,11 +6,13 @@
 // LICENSE file for more details.
 
 import moment from 'moment';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Card} from 'semantic-ui-react';
+
 import {TooltipIfTruncated} from 'indico/react/components';
 import {Translate, Param, PluralTranslate} from 'indico/react/i18n';
+
 import SpriteImage from '../../components/SpriteImage';
 
 import './BlockingCard.module.scss';

--- a/indico/modules/rb/client/js/modules/blockings/BlockingFilterBar.jsx
+++ b/indico/modules/rb/client/js/modules/blockings/BlockingFilterBar.jsx
@@ -5,15 +5,16 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
+import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {Button, Dropdown} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
 
-import {toClasses} from 'indico/react/util';
-import {Translate} from 'indico/react/i18n';
 import {ResponsivePopup} from 'indico/react/components';
+import {Translate} from 'indico/react/i18n';
+import {toClasses} from 'indico/react/util';
+
 import * as blockingsActions from './actions';
 import * as blockingsSelectors from './selectors';
 

--- a/indico/modules/rb/client/js/modules/blockings/BlockingList.jsx
+++ b/indico/modules/rb/client/js/modules/blockings/BlockingList.jsx
@@ -5,19 +5,20 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Card, Container, Message} from 'semantic-ui-react';
 
-import {Translate} from 'indico/react/i18n';
 import {StickyWithScrollBack} from 'indico/react/components';
+import {Translate} from 'indico/react/i18n';
 
-import BlockingCard from './BlockingCard';
 import CardPlaceholder from '../../components/CardPlaceholder';
-import BlockingFilterBar from './BlockingFilterBar';
+
 import * as blockingsActions from './actions';
+import BlockingCard from './BlockingCard';
+import BlockingFilterBar from './BlockingFilterBar';
 import * as blockingsSelectors from './selectors';
 
 import './BlockingList.module.scss';

--- a/indico/modules/rb/client/js/modules/blockings/BlockingModal.jsx
+++ b/indico/modules/rb/client/js/modules/blockings/BlockingModal.jsx
@@ -6,18 +6,21 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
-import {Button, Confirm, Form, Grid, Message, Icon, Modal, Popup} from 'semantic-ui-react';
+import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
-import {Param, Translate} from 'indico/react/i18n';
-import {FinalTextArea} from 'indico/react/forms';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import {Button, Confirm, Form, Grid, Message, Icon, Modal, Popup} from 'semantic-ui-react';
+
 import {FinalDatePeriod, FinalPrincipalList} from 'indico/react/components';
+import {FinalTextArea} from 'indico/react/forms';
 import {FavoritesProvider} from 'indico/react/hooks';
-import FinalRoomSelector from '../../components/RoomSelector';
+import {Param, Translate} from 'indico/react/i18n';
+
 import {selectors as userSelectors} from '../../common/user';
+import FinalRoomSelector from '../../components/RoomSelector';
+
 import * as blockingsActions from './actions';
 
 import './BlockingModal.module.scss';

--- a/indico/modules/rb/client/js/modules/blockings/BlockingPreloader.jsx
+++ b/indico/modules/rb/client/js/modules/blockings/BlockingPreloader.jsx
@@ -5,11 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
+import React from 'react';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Dimmer, Loader} from 'semantic-ui-react';
+
 import * as blockingsActions from './actions';
 import * as blockingsSelectors from './selectors';
 

--- a/indico/modules/rb/client/js/modules/blockings/actions.js
+++ b/indico/modules/rb/client/js/modules/blockings/actions.js
@@ -5,19 +5,21 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import fetchBlockingsURL from 'indico-url:rb.blockings';
 import fetchBlockingURL from 'indico-url:rb.blocking';
-import createBlockingURL from 'indico-url:rb.create_blocking';
-import updateBlockingURL from 'indico-url:rb.update_blocking';
 import blockingActionsURL from 'indico-url:rb.blocking_actions';
+import fetchBlockingsURL from 'indico-url:rb.blockings';
+import createBlockingURL from 'indico-url:rb.create_blocking';
 import deleteBlockingURL from 'indico-url:rb.delete_blocking';
+import updateBlockingURL from 'indico-url:rb.update_blocking';
 
 import {indicoAxios} from 'indico/utils/axios';
 import {ajaxAction, submitFormAction} from 'indico/utils/redux';
-import {preProcessParameters} from '../../util';
-import {ajax as ajaxRules} from './serializers';
-import {actions as filtersActions} from '../../common/filters';
+
 import {openModal} from '../../actions';
+import {actions as filtersActions} from '../../common/filters';
+import {preProcessParameters} from '../../util';
+
+import {ajax as ajaxRules} from './serializers';
 
 export const FETCH_BLOCKINGS_REQUEST = 'blockings/FETCH_BLOCKINGS_REQUEST';
 export const FETCH_BLOCKINGS_SUCCESS = 'blockings/FETCH_BLOCKINGS_SUCCESS';

--- a/indico/modules/rb/client/js/modules/blockings/modals.jsx
+++ b/indico/modules/rb/client/js/modules/blockings/modals.jsx
@@ -7,8 +7,8 @@
 
 import React from 'react';
 
-import BlockingPreloader from './BlockingPreloader';
 import BlockingModal from './BlockingModal';
+import BlockingPreloader from './BlockingPreloader';
 
 export default {
   /* eslint-disable react/display-name */

--- a/indico/modules/rb/client/js/modules/blockings/queryString.js
+++ b/indico/modules/rb/client/js/modules/blockings/queryString.js
@@ -8,11 +8,12 @@
 import _ from 'lodash';
 import {createQueryStringReducer, validator as v} from 'redux-router-querystring';
 
-import {history} from '../../history';
-import {initialFilterStateFactory} from './reducers';
 import * as actions from '../../actions';
-import {boolStateField} from '../../util';
 import {actions as filtersActions} from '../../common/filters';
+import {history} from '../../history';
+import {boolStateField} from '../../util';
+
+import {initialFilterStateFactory} from './reducers';
 
 const rules = {
   my_rooms: {

--- a/indico/modules/rb/client/js/modules/blockings/reducers.js
+++ b/indico/modules/rb/client/js/modules/blockings/reducers.js
@@ -8,9 +8,11 @@
 import _ from 'lodash';
 import {combineReducers} from 'redux';
 
-import {requestReducer} from 'indico/utils/redux';
 import {camelizeKeys} from 'indico/utils/case';
+import {requestReducer} from 'indico/utils/redux';
+
 import {filterReducerFactory} from '../../common/filters';
+
 import * as blockingsActions from './actions';
 
 export const initialFilterStateFactory = () => ({

--- a/indico/modules/rb/client/js/modules/blockings/selectors.js
+++ b/indico/modules/rb/client/js/modules/blockings/selectors.js
@@ -7,7 +7,9 @@
 
 import _ from 'lodash';
 import {createSelector} from 'reselect';
+
 import {RequestState} from 'indico/utils/redux';
+
 import {isUserAdminOverrideEnabled} from '../../common/user/selectors';
 
 const _getAllBlockings = ({blockings}) => blockings.blockings;

--- a/indico/modules/rb/client/js/modules/bookRoom/BookFromListModal.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookFromListModal.jsx
@@ -5,21 +5,22 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Grid, Icon, Modal, Message} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 import {IndicoPropTypes} from 'indico/react/util';
 import {createDT, isBookingStartDTValid} from 'indico/utils/date';
 
-import RoomBasicDetails from '../../components/RoomBasicDetails';
-import BookingBootstrapForm from '../../components/BookingBootstrapForm';
+import {selectors as configSelectors} from '../../common/config';
 import {selectors as roomsSelectors} from '../../common/rooms';
 import {selectors as userSelectors} from '../../common/user';
-import {selectors as configSelectors} from '../../common/config';
+import BookingBootstrapForm from '../../components/BookingBootstrapForm';
+import RoomBasicDetails from '../../components/RoomBasicDetails';
+
 import * as bookRoomActions from './actions';
 import * as bookRoomSelectors from './selectors';
 

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoom.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoom.jsx
@@ -5,39 +5,40 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import {connect} from 'react-redux';
-import {stateToQueryString} from 'redux-router-querystring';
+import _ from 'lodash';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {bindActionCreators} from 'redux';
-import _ from 'lodash';
-import {Button, Card, Grid, Header, Icon, Popup, Divider} from 'semantic-ui-react';
-import LazyScroll from 'redux-lazy-scroll';
 import Overridable from 'react-overridable';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
+import LazyScroll from 'redux-lazy-scroll';
+import {stateToQueryString} from 'redux-router-querystring';
+import {Button, Card, Grid, Header, Icon, Popup, Divider} from 'semantic-ui-react';
 
+import {StickyWithScrollBack, ResponsivePopup} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {Slot, toClasses, IndicoPropTypes, Responsive} from 'indico/react/util';
 import {serializeTime, serializeDate} from 'indico/utils/date';
-import {StickyWithScrollBack, ResponsivePopup} from 'indico/react/components';
 
-import searchBarFactory from '../../components/SearchBar';
-import CardPlaceholder from '../../components/CardPlaceholder';
-import BookingFilterBar from './BookingFilterBar';
-import {roomFilterBarFactory} from '../../modules/roomList';
-import BookingTimeline from './BookingTimeline';
-import SearchResultCount from './SearchResultCount';
-import {TimelineHeader} from '../../common/timeline';
-import {rules as qsFilterRules} from '../../common/roomSearch/queryString';
-import {rules as qsBookRoomRules} from './queryString';
-import * as bookRoomActions from './actions';
 import {actions as filtersActions} from '../../common/filters';
-import {actions as roomsActions, RoomRenderer} from '../../common/rooms';
-import {selectors as userSelectors} from '../../common/user';
-import * as bookRoomSelectors from './selectors';
 import {mapControllerFactory, selectors as mapSelectors} from '../../common/map';
-import BookingSuggestion from './BookingSuggestion';
+import {actions as roomsActions, RoomRenderer} from '../../common/rooms';
+import {rules as qsFilterRules} from '../../common/roomSearch/queryString';
+import {TimelineHeader} from '../../common/timeline';
+import {selectors as userSelectors} from '../../common/user';
+import CardPlaceholder from '../../components/CardPlaceholder';
+import searchBarFactory from '../../components/SearchBar';
+import {roomFilterBarFactory} from '../../modules/roomList';
 import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
+
+import * as bookRoomActions from './actions';
+import BookingFilterBar from './BookingFilterBar';
+import BookingSuggestion from './BookingSuggestion';
+import BookingTimeline from './BookingTimeline';
+import {rules as qsBookRoomRules} from './queryString';
+import SearchResultCount from './SearchResultCount';
+import * as bookRoomSelectors from './selectors';
 
 import './BookRoom.module.scss';
 

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
@@ -5,16 +5,18 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import createDecorator from 'final-form-calculate';
 import _ from 'lodash';
 import moment from 'moment';
+import PropTypes from 'prop-types';
 import React from 'react';
+import {Form as FinalForm} from 'react-final-form';
+import Overridable from 'react-overridable';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import PropTypes from 'prop-types';
-import Overridable from 'react-overridable';
 import {Button, Checkbox, Form, Grid, Icon, List, Message, Modal, Segment} from 'semantic-ui-react';
-import {Form as FinalForm} from 'react-final-form';
-import createDecorator from 'final-form-calculate';
+
+import {FinalPrincipal} from 'indico/react/components';
 import {
   FinalCheckbox,
   FinalDropdown,
@@ -22,22 +24,23 @@ import {
   FinalTextArea,
   FieldCondition,
 } from 'indico/react/forms';
-import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
-import {FinalPrincipal} from 'indico/react/components';
 import {FavoritesProvider} from 'indico/react/hooks';
+import {Param, Plural, PluralTranslate, Singular, Translate} from 'indico/react/i18n';
 import {IndicoPropTypes} from 'indico/react/util';
 import {createDT, isBookingStartDTValid, serializeTime} from 'indico/utils/date';
-import TimeInformation from '../../components/TimeInformation';
-import {selectors as roomsSelectors} from '../../common/rooms';
-import {selectors as linkingSelectors, linkDataShape} from '../../common/linking';
-import RoomBasicDetails from '../../components/RoomBasicDetails';
-import * as actions from './actions';
+
 import {openModal} from '../../actions';
-import {selectors as userSelectors} from '../../common/user';
-import {selectors as configSelectors} from '../../common/config';
-import * as bookRoomSelectors from './selectors';
 import {BookingObjectLink} from '../../common/bookings';
+import {selectors as configSelectors} from '../../common/config';
+import {selectors as linkingSelectors, linkDataShape} from '../../common/linking';
+import {selectors as roomsSelectors} from '../../common/rooms';
 import SingleRoomTimelineModal from '../../common/timeline/SingleRoomTimelineModal';
+import {selectors as userSelectors} from '../../common/user';
+import RoomBasicDetails from '../../components/RoomBasicDetails';
+import TimeInformation from '../../components/TimeInformation';
+
+import * as actions from './actions';
+import * as bookRoomSelectors from './selectors';
 
 import './BookRoomModal.module.scss';
 

--- a/indico/modules/rb/client/js/modules/bookRoom/BookingFilterBar.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookingFilterBar.jsx
@@ -5,26 +5,26 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
-import {Button} from 'semantic-ui-react';
-import {connect} from 'react-redux';
+import React from 'react';
 import Overridable from 'react-overridable';
+import {connect} from 'react-redux';
+import {Button} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 import {isBookingStartDateValid, getMinimumBookingStartTime, createDT} from 'indico/utils/date';
-import {FilterBarController, FilterDropdownFactory} from '../../common/filters/FilterBar';
 
-import RecurrenceForm from './filters/RecurrenceForm';
-import DateForm from './filters/DateForm';
-import TimeForm from './filters/TimeForm';
-
-import {renderRecurrence} from '../../util';
-import dateRenderer from './filters/DateRenderer';
-import timeRenderer from './filters/TimeRenderer';
-import {actions as filtersActions} from '../../common/filters';
-import {selectors as userSelectors} from '../../common/user';
 import {selectors as configSelectors} from '../../common/config';
+import {actions as filtersActions} from '../../common/filters';
+import {FilterBarController, FilterDropdownFactory} from '../../common/filters/FilterBar';
+import {selectors as userSelectors} from '../../common/user';
+import {renderRecurrence} from '../../util';
+
+import DateForm from './filters/DateForm';
+import dateRenderer from './filters/DateRenderer';
+import RecurrenceForm from './filters/RecurrenceForm';
+import TimeForm from './filters/TimeForm';
+import timeRenderer from './filters/TimeRenderer';
 import * as bookRoomSelectors from './selectors';
 
 class BookingFilterBar extends React.Component {

--- a/indico/modules/rb/client/js/modules/bookRoom/BookingSuggestion.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookingSuggestion.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Grid, Icon, Label, Message, Popup} from 'semantic-ui-react';
+
 import {PluralTranslate, Translate, Singular, Param, Plural} from 'indico/react/i18n';
 import {Slot, IndicoPropTypes} from 'indico/react/util';
 

--- a/indico/modules/rb/client/js/modules/bookRoom/BookingTimeline.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookingTimeline.jsx
@@ -8,13 +8,16 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Message} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
-import {ElasticTimeline} from '../../common/timeline';
+
 import {actions as roomsActions} from '../../common/rooms';
+import {ElasticTimeline} from '../../common/timeline';
 import {selectors as userSelectors} from '../../common/user';
+
 import * as bookRoomActions from './actions';
 import * as bookRoomSelectors from './selectors';
 

--- a/indico/modules/rb/client/js/modules/bookRoom/SearchResultCount.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/SearchResultCount.jsx
@@ -5,16 +5,17 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import PropTypes from 'prop-types';
 import {Icon, Label, Menu, Message, Popup} from 'semantic-ui-react';
 
 import {Translate, Param} from 'indico/react/i18n';
 import {Responsive} from 'indico/react/util';
 
 import {actions as bookRoomActions} from '../../modules/bookRoom';
+
 import * as selectors from './selectors';
 
 import './BookRoom.module.scss';

--- a/indico/modules/rb/client/js/modules/bookRoom/UnavailableRoomsModal.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/UnavailableRoomsModal.jsx
@@ -6,20 +6,23 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
-import {bindActionCreators} from 'redux';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Dimmer, Icon, Loader, Modal, Popup} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
-import {serializeDate} from 'indico/utils/date';
 import {Responsive} from 'indico/react/util';
-import * as selectors from './selectors';
+import {serializeDate} from 'indico/utils/date';
+
+import {actions as bookingsActions} from '../../common/bookings';
+import {DateNavigator, TimelineLegend} from '../../common/timeline';
+import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
+
 import * as unavailableRoomsActions from './actions';
 import {BookingTimelineComponent} from './BookingTimeline';
-import {DateNavigator, TimelineLegend} from '../../common/timeline';
-import {actions as bookingsActions} from '../../common/bookings';
-import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
+import * as selectors from './selectors';
 
 class UnavailableRoomsModal extends React.Component {
   static propTypes = {

--- a/indico/modules/rb/client/js/modules/bookRoom/actions.js
+++ b/indico/modules/rb/client/js/modules/bookRoom/actions.js
@@ -6,20 +6,21 @@
 // LICENSE file for more details.
 
 import createBookingURL from 'indico-url:rb.create_booking';
-import fetchTimelineURL from 'indico-url:rb.timeline';
-import fetchSuggestionsURL from 'indico-url:rb.suggestions';
-import searchRoomsURL from 'indico-url:rb.search_rooms';
 import fetchEventsURL from 'indico-url:rb.events';
+import searchRoomsURL from 'indico-url:rb.search_rooms';
+import fetchSuggestionsURL from 'indico-url:rb.suggestions';
+import fetchTimelineURL from 'indico-url:rb.timeline';
 
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {ajaxAction, submitFormAction} from 'indico/utils/redux';
-import {ajax as ajaxRules} from './serializers';
-import {validateFilters} from '../../common/filters';
-import {preProcessParameters} from '../../util';
-import {openModal} from '../../actions';
 
+import {openModal} from '../../actions';
+import {validateFilters} from '../../common/filters';
 import {roomSearchActionsFactory, ajaxRules as ajaxFilterRules} from '../../common/roomSearch';
 import {selectors as userSelectors} from '../../common/user';
+import {preProcessParameters} from '../../util';
+
+import {ajax as ajaxRules} from './serializers';
 
 // Booking creation
 export const CREATE_BOOKING_REQUEST = 'bookRoom/CREATE_BOOKING_REQUEST';

--- a/indico/modules/rb/client/js/modules/bookRoom/filters/DateForm.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/filters/DateForm.jsx
@@ -6,10 +6,12 @@
 // LICENSE file for more details.
 
 import moment from 'moment';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+
 import {CalendarSingleDatePicker, CalendarRangeDatePicker} from 'indico/react/components';
 import {serializeDate, toMoment} from 'indico/utils/date';
+
 import {FilterFormComponent} from '../../../common/filters';
 
 export default class DateForm extends FilterFormComponent {

--- a/indico/modules/rb/client/js/modules/bookRoom/filters/RecurrenceForm.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/filters/RecurrenceForm.jsx
@@ -5,9 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Form, Input, Radio, Select} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
 
 import {PluralTranslate, Translate} from 'indico/react/i18n';
 

--- a/indico/modules/rb/client/js/modules/bookRoom/filters/TimeForm.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/filters/TimeForm.jsx
@@ -5,10 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import {serializeTime, toMoment} from 'indico/utils/date';
+
 import {FilterFormComponent} from '../../../common/filters';
 import TimeRangePicker from '../../../components/TimeRangePicker';
 

--- a/indico/modules/rb/client/js/modules/bookRoom/modals.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/modals.jsx
@@ -6,16 +6,18 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
+import moment from 'moment';
 import React from 'react';
 import {connect} from 'react-redux';
-import moment from 'moment';
 
 import {toMoment} from 'indico/utils/date';
-import * as bookRoomSelectors from './selectors';
-import BookRoomModal from './BookRoomModal';
-import BookFromListModal from './BookFromListModal';
-import UnavailableRoomsModal from './UnavailableRoomsModal';
+
 import {RoomDetailsPreloader} from '../../common/rooms';
+
+import BookFromListModal from './BookFromListModal';
+import BookRoomModal from './BookRoomModal';
+import * as bookRoomSelectors from './selectors';
+import UnavailableRoomsModal from './UnavailableRoomsModal';
 
 const BookingDataProvider = connect(state => ({
   bookRoomFilters: bookRoomSelectors.getFilters(state),

--- a/indico/modules/rb/client/js/modules/bookRoom/queryString.js
+++ b/indico/modules/rb/client/js/modules/bookRoom/queryString.js
@@ -7,14 +7,15 @@
 
 import _ from 'lodash';
 import {createQueryStringReducer, validator as v} from 'redux-router-querystring';
-import {boolStateField, defaultStateField} from '../../util';
 
 import * as globalActions from '../../actions';
-import * as actions from './actions';
-import {history} from '../../history';
-import {initialTimelineState} from './reducers';
 import {actions as filtersActions} from '../../common/filters';
 import {rules as queryFilterRules} from '../../common/roomSearch/queryString';
+import {history} from '../../history';
+import {boolStateField, defaultStateField} from '../../util';
+
+import * as actions from './actions';
+import {initialTimelineState} from './reducers';
 
 export const rules = {
   timeline: {

--- a/indico/modules/rb/client/js/modules/bookRoom/reducers.js
+++ b/indico/modules/rb/client/js/modules/bookRoom/reducers.js
@@ -9,10 +9,12 @@ import {combineReducers} from 'redux';
 
 import {camelizeKeys} from 'indico/utils/case';
 import {requestReducer} from 'indico/utils/redux';
-import * as actions from './actions';
+
 import * as globalActions from '../../actions';
 import {roomSearchReducerFactory} from '../../common/roomSearch/reducers';
 import {initialDatePickerState} from '../../common/timeline/reducers';
+
+import * as actions from './actions';
 
 export const initialTimelineState = {
   availability: [],

--- a/indico/modules/rb/client/js/modules/bookRoom/selectors.js
+++ b/indico/modules/rb/client/js/modules/bookRoom/selectors.js
@@ -7,9 +7,11 @@
 
 import moment from 'moment';
 import {createSelector} from 'reselect';
+
 import {RequestState} from 'indico/utils/redux';
-import {roomSearchSelectorFactory} from '../../common/roomSearch';
+
 import {selectors as roomsSelectors} from '../../common/rooms';
+import {roomSearchSelectorFactory} from '../../common/roomSearch';
 import {selectors as userSelectors} from '../../common/user';
 
 const {

--- a/indico/modules/rb/client/js/modules/calendar/Calendar.jsx
+++ b/indico/modules/rb/client/js/modules/calendar/Calendar.jsx
@@ -8,27 +8,28 @@
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
+import Overridable from 'react-overridable';
+import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {Button, Container, Grid, Icon, Popup} from 'semantic-ui-react';
-import {connect} from 'react-redux';
-import Overridable from 'react-overridable';
 
+import {StickyWithScrollBack, ResponsivePopup} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {Responsive} from 'indico/react/util';
-import {StickyWithScrollBack, ResponsivePopup} from 'indico/react/components';
 import {serializeDate} from 'indico/utils/date';
 
-import searchBarFactory from '../../components/SearchBar';
-import * as calendarActions from './actions';
-import * as calendarSelectors from './selectors';
 import {actions as bookingsActions} from '../../common/bookings';
 import {actions as filtersActions} from '../../common/filters';
 import {actions as roomsActions} from '../../common/rooms';
 import {ElasticTimeline, TimelineHeader} from '../../common/timeline';
-import CalendarListView from './CalendarListView';
+import searchBarFactory from '../../components/SearchBar';
+import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
 import {actions as bookRoomActions} from '../bookRoom';
 import {roomFilterBarFactory} from '../roomList';
-import {getOccurrenceTypes, transformToLegendLabels} from '../../util';
+
+import * as calendarActions from './actions';
+import CalendarListView from './CalendarListView';
+import * as calendarSelectors from './selectors';
 
 import './Calendar.module.scss';
 

--- a/indico/modules/rb/client/js/modules/calendar/CalendarListView.jsx
+++ b/indico/modules/rb/client/js/modules/calendar/CalendarListView.jsx
@@ -7,19 +7,21 @@
 
 import _ from 'lodash';
 import moment from 'moment';
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
 import {connect} from 'react-redux';
-import {Card, Divider, Header, Icon, Label, Message, Popup} from 'semantic-ui-react';
+import {bindActionCreators} from 'redux';
 import LazyScroll from 'redux-lazy-scroll';
+import {Card, Divider, Header, Icon, Label, Message, Popup} from 'semantic-ui-react';
 
 import {TooltipIfTruncated} from 'indico/react/components';
 import {Param, Translate} from 'indico/react/i18n';
+
 import {actions as bookingsActions} from '../../common/bookings';
 import CardPlaceholder from '../../components/CardPlaceholder';
-import * as calendarSelectors from './selectors';
+
 import * as calendarActions from './actions';
+import * as calendarSelectors from './selectors';
 
 import './CalendarListView.module.scss';
 

--- a/indico/modules/rb/client/js/modules/calendar/actions.js
+++ b/indico/modules/rb/client/js/modules/calendar/actions.js
@@ -11,13 +11,16 @@ import searchRoomsURL from 'indico-url:rb.search_rooms';
 
 import _ from 'lodash';
 import moment from 'moment';
+
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {ajaxAction} from 'indico/utils/redux';
-import {preProcessParameters} from '../../util';
+
 import {ajaxRules as roomSearchAjaxRules} from '../../common/roomSearch';
-import {ajax as ajaxRules} from './serializers';
-import {getRoomFilters, getCalendarFilters} from './selectors';
 import {selectors as userSelectors} from '../../common/user';
+import {preProcessParameters} from '../../util';
+
+import {getRoomFilters, getCalendarFilters} from './selectors';
+import {ajax as ajaxRules} from './serializers';
 
 export const CHANGE_VIEW = 'calendar/CHANGE_VIEW';
 export const SET_DATE = 'calendar/SET_DATE';

--- a/indico/modules/rb/client/js/modules/calendar/queryString.js
+++ b/indico/modules/rb/client/js/modules/calendar/queryString.js
@@ -10,12 +10,13 @@ import moment from 'moment';
 import {createQueryStringReducer, validator as v} from 'redux-router-querystring';
 
 import * as actions from '../../actions';
-import {history} from '../../history';
-import {initialState} from './reducers';
-import {defaultStateField, boolStateField} from '../../util';
 import {actions as filtersActions} from '../../common/filters';
 import {rules as roomSearchQueryStringRules} from '../../common/roomSearch/queryString';
+import {history} from '../../history';
+import {defaultStateField, boolStateField} from '../../util';
+
 import * as calendarActions from './actions';
+import {initialState} from './reducers';
 
 const rules = {
   ...roomSearchQueryStringRules,

--- a/indico/modules/rb/client/js/modules/calendar/reducers.js
+++ b/indico/modules/rb/client/js/modules/calendar/reducers.js
@@ -12,14 +12,16 @@ import {combineReducers} from 'redux';
 import {camelizeKeys} from 'indico/utils/case';
 import {serializeDate, serializeTime} from 'indico/utils/date';
 import {requestReducer} from 'indico/utils/redux';
-import {actions as bookRoomActions} from '../../modules/bookRoom';
+
 import * as actions from '../../actions';
-import * as calendarActions from './actions';
 import {actions as bookingActions} from '../../common/bookings';
 import {filterReducerFactory} from '../../common/filters';
 import {initialRoomFilterStateFactory, processRoomFilters} from '../../common/roomSearch/reducers';
 import {initialDatePickerState} from '../../common/timeline/reducers';
+import {actions as bookRoomActions} from '../../modules/bookRoom';
 import {actions as adminActions} from '../admin';
+
+import * as calendarActions from './actions';
 
 const datePickerState = () => ({...initialDatePickerState, selectedDate: serializeDate(moment())});
 

--- a/indico/modules/rb/client/js/modules/calendar/selectors.js
+++ b/indico/modules/rb/client/js/modules/calendar/selectors.js
@@ -7,7 +7,9 @@
 
 import _ from 'lodash';
 import {createSelector} from 'reselect';
+
 import {RequestState} from 'indico/utils/redux';
+
 import {selectors as roomsSelectors} from '../../common/rooms';
 import {selectors as userSelectors} from '../../common/user';
 

--- a/indico/modules/rb/client/js/modules/landing/Landing.jsx
+++ b/indico/modules/rb/client/js/modules/landing/Landing.jsx
@@ -6,24 +6,26 @@
 // LICENSE file for more details.
 
 import moment from 'moment';
-import React from 'react';
-import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
+import React from 'react';
 import Overridable from 'react-overridable';
+import {connect} from 'react-redux';
 import {Card, Checkbox, Form, Grid} from 'semantic-ui-react';
-import {Translate} from 'indico/react/i18n';
+
 import {Carousel} from 'indico/react/components';
+import {Translate} from 'indico/react/i18n';
 import {Responsive} from 'indico/react/util';
 import {toMoment} from 'indico/utils/date';
 
 import {actions as filtersActions} from '../../common/filters';
-import BookingBootstrapForm from '../../components/BookingBootstrapForm';
-import LandingStatistics from './LandingStatistics';
-import UpcomingBookings from './UpcomingBookings';
 import {selectors as userSelectors} from '../../common/user';
+import BookingBootstrapForm from '../../components/BookingBootstrapForm';
 import {selectors as bookRoomSelectors} from '../bookRoom';
+
 import * as landingActions from './actions';
+import LandingStatistics from './LandingStatistics';
 import * as landingSelectors from './selectors';
+import UpcomingBookings from './UpcomingBookings';
 
 import './Landing.module.scss';
 

--- a/indico/modules/rb/client/js/modules/landing/LandingStatistics.jsx
+++ b/indico/modules/rb/client/js/modules/landing/LandingStatistics.jsx
@@ -5,12 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
-import {bindActionCreators} from 'redux';
-import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
+import React from 'react';
 import Overridable from 'react-overridable';
+import {connect} from 'react-redux';
+import {bindActionCreators} from 'redux';
 import {Loader, Statistic} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 
 import * as landingActions from './actions';

--- a/indico/modules/rb/client/js/modules/landing/UpcomingBookings.jsx
+++ b/indico/modules/rb/client/js/modules/landing/UpcomingBookings.jsx
@@ -7,13 +7,15 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {Header, List, Popup, Label} from 'semantic-ui-react';
-import {connect} from 'react-redux';
-import {toMoment} from 'indico/utils/date';
+
 import {Translate} from 'indico/react/i18n';
-import SpriteImage from '../../components/SpriteImage';
+import {toMoment} from 'indico/utils/date';
+
 import {actions as bookingActions} from '../../common/bookings';
+import SpriteImage from '../../components/SpriteImage';
 
 import './UpcomingBookings.module.scss';
 

--- a/indico/modules/rb/client/js/modules/landing/actions.js
+++ b/indico/modules/rb/client/js/modules/landing/actions.js
@@ -5,8 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import fetchStatsURL from 'indico-url:rb.stats';
 import fetchUpcomingBookingsURL from 'indico-url:rb.my_bookings';
+import fetchStatsURL from 'indico-url:rb.stats';
+
 import {indicoAxios} from 'indico/utils/axios';
 import {ajaxAction} from 'indico/utils/redux';
 

--- a/indico/modules/rb/client/js/modules/landing/reducers.js
+++ b/indico/modules/rb/client/js/modules/landing/reducers.js
@@ -6,11 +6,13 @@
 // LICENSE file for more details.
 
 import {combineReducers} from 'redux';
+
 import {camelizeKeys} from 'indico/utils/case';
 import {requestReducer} from 'indico/utils/redux';
 
-import * as landingActions from './actions';
 import {actions as adminActions} from '../admin';
+
+import * as landingActions from './actions';
 
 export default combineReducers({
   stats: combineReducers({

--- a/indico/modules/rb/client/js/modules/landing/selectors.js
+++ b/indico/modules/rb/client/js/modules/landing/selectors.js
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 import {createSelector} from 'reselect';
+
 import {selectors as roomSelectors} from '../../common/rooms';
 
 export const getStatistics = ({landing}) => landing.stats.data;

--- a/indico/modules/rb/client/js/modules/roomList/RoomFilterBar.jsx
+++ b/indico/modules/rb/client/js/modules/roomList/RoomFilterBar.jsx
@@ -5,25 +5,26 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
-import {Button, Icon, Label} from 'semantic-ui-react';
 import PropTypes from 'prop-types';
+import React from 'react';
+import Overridable from 'react-overridable';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
-import Overridable from 'react-overridable';
+import {Button, Icon, Label} from 'semantic-ui-react';
 
 import {Translate, Param} from 'indico/react/i18n';
 import {Responsive} from 'indico/react/util';
 
-import CapacityForm from './filters/CapacityForm';
-import EquipmentForm from './filters/EquipmentForm';
-import BuildingForm from './filters/BuildingForm';
-import ShowOnlyForm from './filters/ShowOnlyForm';
-import {FilterBarController, FilterDropdownFactory} from '../../common/filters/FilterBar';
 import {actions as filtersActions} from '../../common/filters';
+import {FilterBarController, FilterDropdownFactory} from '../../common/filters/FilterBar';
+import {selectors as roomsSelectors} from '../../common/rooms';
 import {selectors as userSelectors} from '../../common/user';
 
-import {selectors as roomsSelectors} from '../../common/rooms';
+import BuildingForm from './filters/BuildingForm';
+import CapacityForm from './filters/CapacityForm';
+import EquipmentForm from './filters/EquipmentForm';
+import ShowOnlyForm from './filters/ShowOnlyForm';
+
 import './RoomFilterBar.module.scss';
 
 /* eslint-disable react/prop-types */

--- a/indico/modules/rb/client/js/modules/roomList/RoomList.jsx
+++ b/indico/modules/rb/client/js/modules/roomList/RoomList.jsx
@@ -6,31 +6,32 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
-import {bindActionCreators} from 'redux';
+import React from 'react';
+import Overridable from 'react-overridable';
 import {connect} from 'react-redux';
-import {Button, Dropdown, Grid} from 'semantic-ui-react';
 import {Route} from 'react-router-dom';
+import {bindActionCreators} from 'redux';
 import LazyScroll from 'redux-lazy-scroll';
 import {stateToQueryString} from 'redux-router-querystring';
-import Overridable from 'react-overridable';
+import {Button, Dropdown, Grid} from 'semantic-ui-react';
 
-import {Responsive, Slot} from 'indico/react/util';
 import {StickyWithScrollBack, ResponsivePopup} from 'indico/react/components';
 import {Param, Plural, PluralTranslate, Translate, Singular} from 'indico/react/i18n';
+import {Responsive, Slot} from 'indico/react/util';
 import {camelizeKeys} from 'indico/utils/case';
 
-import {pushStateMergeProps} from '../../util';
-import roomFilterBarFactory from './RoomFilterBar';
-import searchBarFactory from '../../components/SearchBar';
-import CardPlaceholder from '../../components/CardPlaceholder';
-import {BlockingModal} from '../blockings';
 import {BookingExportModal} from '../../common/bookings';
-import {rules as queryStringSerializer} from '../../common/roomSearch/queryString';
 import {mapControllerFactory, selectors as mapSelectors} from '../../common/map';
 import {actions as roomsActions, RoomRenderer} from '../../common/rooms';
+import {rules as queryStringSerializer} from '../../common/roomSearch/queryString';
+import CardPlaceholder from '../../components/CardPlaceholder';
+import searchBarFactory from '../../components/SearchBar';
+import {pushStateMergeProps} from '../../util';
+import {BlockingModal} from '../blockings';
+
 import * as roomsListActions from './actions';
+import roomFilterBarFactory from './RoomFilterBar';
 import * as roomsListSelectors from './selectors';
 
 import './RoomList.module.scss';

--- a/indico/modules/rb/client/js/modules/roomList/filters/BuildingForm.jsx
+++ b/indico/modules/rb/client/js/modules/roomList/filters/BuildingForm.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Form} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 
 import {FilterFormComponent} from '../../../common/filters';

--- a/indico/modules/rb/client/js/modules/roomList/filters/CapacityForm.jsx
+++ b/indico/modules/rb/client/js/modules/roomList/filters/CapacityForm.jsx
@@ -6,7 +6,6 @@
 // LICENSE file for more details.
 
 import React from 'react';
-
 import {Icon, Input} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';

--- a/indico/modules/rb/client/js/modules/roomList/filters/EquipmentForm.jsx
+++ b/indico/modules/rb/client/js/modules/roomList/filters/EquipmentForm.jsx
@@ -6,10 +6,10 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Accordion, Form, Icon} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 
 import {FilterFormComponent} from '../../../common/filters';

--- a/indico/modules/rb/client/js/modules/roomList/filters/ShowOnlyForm.jsx
+++ b/indico/modules/rb/client/js/modules/roomList/filters/ShowOnlyForm.jsx
@@ -11,8 +11,8 @@ import {Checkbox, Icon} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 
-import {selectors as userSelectors} from '../../../common/user';
 import {FilterFormComponent} from '../../../common/filters';
+import {selectors as userSelectors} from '../../../common/user';
 import * as roomsSelectors from '../selectors';
 
 import './ShowOnlyForm.module.scss';

--- a/indico/modules/rb/client/js/reducers.js
+++ b/indico/modules/rb/client/js/reducers.js
@@ -7,18 +7,18 @@
 
 import {connectRouter} from 'connected-react-router';
 
+import {reducer as bookingReducer} from './common/bookings';
 import {reducer as configReducer} from './common/config';
+import {reducer as linkingReducer} from './common/linking';
 import {reducer as mapReducer} from './common/map';
 import {reducer as roomsReducer} from './common/rooms';
-import {reducer as bookRoomReducer} from './modules/bookRoom';
 import {reducer as userReducer} from './common/user';
+import {reducer as adminReducer} from './modules/admin';
 import {reducer as blockingsReducer} from './modules/blockings';
+import {reducer as bookRoomReducer} from './modules/bookRoom';
 import {reducer as calendarReducer} from './modules/calendar';
 import {reducer as landingReducer} from './modules/landing';
 import {reducer as roomListReducer} from './modules/roomList';
-import {reducer as bookingReducer} from './common/bookings';
-import {reducer as adminReducer} from './modules/admin';
-import {reducer as linkingReducer} from './common/linking';
 
 export default history => ({
   router: connectRouter(history),

--- a/indico/modules/rb/client/js/setup.jsx
+++ b/indico/modules/rb/client/js/setup.jsx
@@ -6,21 +6,21 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import ReactDOM from 'react-dom';
 import React from 'react';
-import {Provider} from 'react-redux';
+import ReactDOM from 'react-dom';
 import {OverridableContext} from 'react-overridable';
+import {Provider} from 'react-redux';
 
 import setupUserMenu from 'indico/react/containers/UserMenu';
 
-import App from './components/App';
-import createRBStore from './store';
-import {history} from './history';
 import {init} from './actions';
 import {actions as configActions, selectors as configSelectors} from './common/config';
-import {selectors as userSelectors, actions as userActions} from './common/user';
-import {actions as roomsActions} from './common/rooms';
 import {actions as linkingActions} from './common/linking';
+import {actions as roomsActions} from './common/rooms';
+import {selectors as userSelectors, actions as userActions} from './common/user';
+import App from './components/App';
+import {history} from './history';
+import createRBStore from './store';
 
 import 'indico-sui-theme/semantic.css';
 import '../styles/main.scss';

--- a/indico/modules/rb/client/js/store.js
+++ b/indico/modules/rb/client/js/store.js
@@ -5,14 +5,17 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import {queryStringMiddleware} from 'redux-router-querystring';
 import {routerMiddleware} from 'connected-react-router';
+import {queryStringMiddleware} from 'redux-router-querystring';
+
 import createReduxStore from 'indico/utils/redux';
 
-import getReducers from './reducers';
-import {history} from './history';
 import {queryStringReducer as qsRoomSearchReducer} from './common/roomSearch/queryString';
-import {routeConfig as roomListRouteConfig} from './modules/roomList/queryString';
+import {history} from './history';
+import {
+  routeConfig as blockingsRouteConfig,
+  queryStringReducer as qsBlockingsReducer,
+} from './modules/blockings/queryString';
 import {
   routeConfig as bookRoomRouteConfig,
   queryStringReducer as qsBookRoomReducer,
@@ -21,10 +24,8 @@ import {
   routeConfig as calendarRouteConfig,
   queryStringReducer as qsCalendarReducer,
 } from './modules/calendar/queryString';
-import {
-  routeConfig as blockingsRouteConfig,
-  queryStringReducer as qsBlockingsReducer,
-} from './modules/blockings/queryString';
+import {routeConfig as roomListRouteConfig} from './modules/roomList/queryString';
+import getReducers from './reducers';
 
 function getRouteConfig() {
   return {

--- a/indico/modules/rb/client/js/util.jsx
+++ b/indico/modules/rb/client/js/util.jsx
@@ -5,15 +5,16 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
 import {push} from 'connected-react-router';
+import _ from 'lodash';
 import moment from 'moment';
-import {Popup} from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {serializeDate} from 'indico/utils/date';
-import {Responsive} from 'indico/react/util';
+import {Popup} from 'semantic-ui-react';
+
 import {PluralTranslate, Translate, Param} from 'indico/react/i18n';
+import {Responsive} from 'indico/react/util';
+import {serializeDate} from 'indico/utils/date';
 
 export function preProcessParameters(params, rules) {
   return _pruneNullLeaves(

--- a/indico/modules/users/client/js/ICSCalendarLink.jsx
+++ b/indico/modules/users/client/js/ICSCalendarLink.jsx
@@ -7,8 +7,8 @@
 
 import signURL from 'indico-url:core.sign_url';
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Button, Dropdown, Icon, Input, Label, Grid, Popup, Header} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';

--- a/indico/modules/users/client/js/ProfilePicture.jsx
+++ b/indico/modules/users/client/js/ProfilePicture.jsx
@@ -5,21 +5,21 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import saveURL from 'indico-url:users.save_profile_picture';
 import previewURL from 'indico-url:users.profile_picture_preview';
+import saveURL from 'indico-url:users.save_profile_picture';
 
+import createDecorator from 'final-form-calculate';
+import PropTypes from 'prop-types';
 import React, {useState, useCallback} from 'react';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
-import {Form as FinalForm, useField, useFormState} from 'react-final-form';
 import {useDropzone} from 'react-dropzone';
+import {Form as FinalForm, useField, useFormState} from 'react-final-form';
 import {Button, Form, Icon, Image, Card} from 'semantic-ui-react';
-import createDecorator from 'final-form-calculate';
-import {FinalSubmitButton} from 'indico/react/forms';
-import {TooltipIfTruncated} from 'indico/react/components';
-import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
+import {TooltipIfTruncated} from 'indico/react/components';
+import {FinalSubmitButton} from 'indico/react/forms';
 import {Translate, Param} from 'indico/react/i18n';
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 import './ProfilePicture.module.scss';
 

--- a/indico/web/client/js/react/components/ClipboardButton.jsx
+++ b/indico/web/client/js/react/components/ClipboardButton.jsx
@@ -5,11 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Popup, Button} from 'semantic-ui-react';
-import {Translate} from 'indico/react/i18n';
+
 import {useTimeout} from 'indico/react/hooks';
+import {Translate} from 'indico/react/i18n';
 
 export default function ClipboardButton({text, successText}) {
   const [copied, setCopied] = useState(false);

--- a/indico/web/client/js/react/components/EmailListField.jsx
+++ b/indico/web/client/js/react/components/EmailListField.jsx
@@ -6,10 +6,12 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Dropdown} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
+
 import {FinalField} from '../forms';
 
 const isValid = value => /^\S+@\S+\.\S+$/.test(value);

--- a/indico/web/client/js/react/components/IButton.jsx
+++ b/indico/web/client/js/react/components/IButton.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 import {toClasses} from 'indico/react/util';
 

--- a/indico/web/client/js/react/components/ManagementPageBackButton.jsx
+++ b/indico/web/client/js/react/components/ManagementPageBackButton.jsx
@@ -5,9 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
 import {Link} from 'react-router-dom';
 
 export default function ManagementPageBackButton({url}) {

--- a/indico/web/client/js/react/components/ManagementPageSubTitle.jsx
+++ b/indico/web/client/js/react/components/ManagementPageSubTitle.jsx
@@ -5,9 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
 
 export default function ManagementPageSubTitle({title}) {
   // we assume there is no subtitle on a page where this component is used,

--- a/indico/web/client/js/react/components/ManagementPageTitle.jsx
+++ b/indico/web/client/js/react/components/ManagementPageTitle.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import {useEffect} from 'react';
 import PropTypes from 'prop-types';
+import {useEffect} from 'react';
 
 export default function ManagementPageTitle({title}) {
   // the title always exists so we just replace its content

--- a/indico/web/client/js/react/components/MathJax.jsx
+++ b/indico/web/client/js/react/components/MathJax.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useEffect, useRef} from 'react';
 import PropTypes from 'prop-types';
+import React, {useEffect, useRef} from 'react';
 
 export default function MathJax({children}) {
   const wrapperRef = useRef(null);

--- a/indico/web/client/js/react/components/MessageBox.jsx
+++ b/indico/web/client/js/react/components/MessageBox.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 export default class MessageBox extends React.Component {
   static propTypes = {

--- a/indico/web/client/js/react/components/Modal.jsx
+++ b/indico/web/client/js/react/components/Modal.jsx
@@ -5,9 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactModal from 'react-modal';
-import PropTypes from 'prop-types';
 
 import {Slot, toClasses} from 'indico/react/util';
 

--- a/indico/web/client/js/react/components/Paginator.jsx
+++ b/indico/web/client/js/react/components/Paginator.jsx
@@ -5,8 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
+
 import IButton from './IButton';
 
 import './style/paginator.scss';

--- a/indico/web/client/js/react/components/PopoverDropdownMenu.jsx
+++ b/indico/web/client/js/react/components/PopoverDropdownMenu.jsx
@@ -6,10 +6,10 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React, {useRef} from 'react';
 import PropTypes from 'prop-types';
-import {Dropdown, Portal} from 'semantic-ui-react';
+import React, {useRef} from 'react';
 import {Manager, Popper} from 'react-popper';
+import {Dropdown, Portal} from 'semantic-ui-react';
 
 import './PopoverDropdownMenu.module.scss';
 

--- a/indico/web/client/js/react/components/RequestConfirm.jsx
+++ b/indico/web/client/js/react/components/RequestConfirm.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Button, Confirm} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';

--- a/indico/web/client/js/react/components/ResponsivePopup.jsx
+++ b/indico/web/client/js/react/components/ResponsivePopup.jsx
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import {Popup} from 'semantic-ui-react';
+
 import {useResponsive} from 'indico/react/util';
 
 export default function ResponsivePopup(props) {

--- a/indico/web/client/js/react/components/ReviewRating.jsx
+++ b/indico/web/client/js/react/components/ReviewRating.jsx
@@ -6,8 +6,8 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Rating} from 'semantic-ui-react';
 
 import {FinalField} from 'indico/react/forms';

--- a/indico/web/client/js/react/components/ScrollButton.jsx
+++ b/indico/web/client/js/react/components/ScrollButton.jsx
@@ -5,12 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {Button} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
 
-import {Translate} from 'indico/react/i18n';
 import {ResponsivePopup} from 'indico/react/components';
+import {Translate} from 'indico/react/i18n';
 
 import './ScrollButton.module.scss';
 

--- a/indico/web/client/js/react/components/StickyWithScrollBack.jsx
+++ b/indico/web/client/js/react/components/StickyWithScrollBack.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState, useEffect} from 'react';
 import {Sticky} from 'semantic-ui-react';
 
 import {ScrollButton} from 'indico/react/components';

--- a/indico/web/client/js/react/components/TooltipIfTruncated.jsx
+++ b/indico/web/client/js/react/components/TooltipIfTruncated.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useRef} from 'react';
 import PropTypes from 'prop-types';
+import React, {useRef} from 'react';
 
 /*
  * Show a tooltip if the contents were truncated/ellipsized via CSS.

--- a/indico/web/client/js/react/components/UserMenu.jsx
+++ b/indico/web/client/js/react/components/UserMenu.jsx
@@ -5,24 +5,26 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import qs from 'qs';
-import React from 'react';
-import PropTypes from 'prop-types';
-import {Dropdown, Icon, Label} from 'semantic-ui-react';
-
-import userDashboard from 'indico-url:users.user_dashboard';
-import userPreferences from 'indico-url:users.user_preferences';
 import authLogout from 'indico-url:auth.logout';
 import adminDashboard from 'indico-url:core.admin_dashboard';
 import changeLanguage from 'indico-url:core.change_lang';
+import userDashboard from 'indico-url:users.user_dashboard';
+import userPreferences from 'indico-url:users.user_preferences';
 
+import PropTypes from 'prop-types';
+import qs from 'qs';
+import React from 'react';
+import {Dropdown, Icon, Label} from 'semantic-ui-react';
+
+import {impersonateUser} from 'indico/modules/core/impersonation';
 import {Translate} from 'indico/react/i18n';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
-import {impersonateUser} from 'indico/modules/core/impersonation';
+
+import {useFavoriteUsers} from '../hooks';
+
 import {UserSearch} from './principals/Search';
 
 import './UserMenu.module.scss';
-import {useFavoriteUsers} from '../hooks';
 
 async function postAndReload(selectedLanguage) {
   try {

--- a/indico/web/client/js/react/components/WTFDateField.jsx
+++ b/indico/web/client/js/react/components/WTFDateField.jsx
@@ -6,9 +6,10 @@
 // LICENSE file for more details.
 
 import 'react-dates/initialize';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, {useEffect, useMemo, useRef, useState, useCallback} from 'react';
-import moment from 'moment';
+
 import {SingleDatePicker} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {toMoment} from 'indico/utils/date';

--- a/indico/web/client/js/react/components/WTFDateTimeField.jsx
+++ b/indico/web/client/js/react/components/WTFDateTimeField.jsx
@@ -6,11 +6,12 @@
 // LICENSE file for more details.
 
 import 'react-dates/initialize';
-import TimePicker from 'rc-time-picker';
-import PropTypes from 'prop-types';
-import React, {useEffect, useMemo, useRef, useState, useCallback} from 'react';
-import moment from 'moment';
 import _ from 'lodash';
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import TimePicker from 'rc-time-picker';
+import React, {useEffect, useMemo, useRef, useState, useCallback} from 'react';
+
 import {SingleDatePicker} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {toMoment} from 'indico/utils/date';

--- a/indico/web/client/js/react/components/WTFOccurrencesField.jsx
+++ b/indico/web/client/js/react/components/WTFOccurrencesField.jsx
@@ -6,12 +6,13 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React, {useState, useEffect, useMemo, useRef} from 'react';
 import moment from 'moment';
-import TimePicker from 'rc-time-picker';
 import PropTypes from 'prop-types';
-import {Translate} from 'indico/react/i18n';
+import TimePicker from 'rc-time-picker';
+import React, {useState, useEffect, useMemo, useRef} from 'react';
+
 import {SingleDatePicker} from 'indico/react/components';
+import {Translate} from 'indico/react/i18n';
 
 function triggerChange(field) {
   field.dispatchEvent(new Event('change', {bubbles: true}));

--- a/indico/web/client/js/react/components/WTFPrincipalField.jsx
+++ b/indico/web/client/js/react/components/WTFPrincipalField.jsx
@@ -5,8 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useCallback, useMemo, useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useCallback, useMemo, useState} from 'react';
+
 import {PrincipalField} from 'indico/react/components/principals';
 import {useFavoriteUsers} from 'indico/react/hooks';
 

--- a/indico/web/client/js/react/components/WTFPrincipalListField.jsx
+++ b/indico/web/client/js/react/components/WTFPrincipalListField.jsx
@@ -5,8 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useCallback, useEffect, useMemo, useState} from 'react';
+
 import {PrincipalListField} from 'indico/react/components/principals';
 import {useFavoriteUsers} from 'indico/react/hooks';
 

--- a/indico/web/client/js/react/components/WTFTimeField.jsx
+++ b/indico/web/client/js/react/components/WTFTimeField.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import TimePicker from 'rc-time-picker';
 import PropTypes from 'prop-types';
+import TimePicker from 'rc-time-picker';
 import React, {useEffect, useMemo, useRef, useState, useCallback} from 'react';
+
 import {toMoment} from 'indico/utils/date';
 
 export default function WTFTimeField({timeId, uses24HourFormat, required, disabled}) {

--- a/indico/web/client/js/react/components/dates/CalendarRangeDatePicker.jsx
+++ b/indico/web/client/js/react/components/dates/CalendarRangeDatePicker.jsx
@@ -6,8 +6,8 @@
 // LICENSE file for more details.
 
 import 'react-dates/initialize';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {DayPickerRangeController as RangePicker} from 'react-dates';
 
 import 'react-dates/lib/css/_datepicker.css';

--- a/indico/web/client/js/react/components/dates/CalendarSingleDatePicker.jsx
+++ b/indico/web/client/js/react/components/dates/CalendarSingleDatePicker.jsx
@@ -6,8 +6,8 @@
 // LICENSE file for more details.
 
 import 'react-dates/initialize';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {DayPickerSingleDateController as DayPicker} from 'react-dates';
 
 import 'react-dates/lib/css/_datepicker.css';

--- a/indico/web/client/js/react/components/dates/DatePeriodField.jsx
+++ b/indico/web/client/js/react/components/dates/DatePeriodField.jsx
@@ -7,11 +7,13 @@
 
 import _ from 'lodash';
 import moment from 'moment';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {START_DATE, END_DATE} from 'react-dates/constants';
+
 import {DateRangePicker} from 'indico/react/components';
 import {serializeDate} from 'indico/utils/date';
+
 import {FinalField} from '../../forms';
 
 import './DatePeriodField.module.scss';

--- a/indico/web/client/js/react/components/dates/DateRangePicker.jsx
+++ b/indico/web/client/js/react/components/dates/DateRangePicker.jsx
@@ -8,6 +8,7 @@
 import 'react-dates/initialize';
 import {useState} from 'react';
 import {DateRangePicker as ReactDatesRangePicker} from 'react-dates';
+
 import {responsiveReactDates} from './util';
 
 import 'react-dates/lib/css/_datepicker.css';

--- a/indico/web/client/js/react/components/dates/SingleDatePicker.jsx
+++ b/indico/web/client/js/react/components/dates/SingleDatePicker.jsx
@@ -10,8 +10,10 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {SingleDatePicker as ReactDatesSinglePicker} from 'react-dates';
-import {serializeDate, toMoment} from 'indico/utils/date';
+
 import {FinalField} from 'indico/react/forms';
+import {serializeDate, toMoment} from 'indico/utils/date';
+
 import {responsiveReactDates} from './util';
 
 import 'react-dates/lib/css/_datepicker.css';

--- a/indico/web/client/js/react/components/dates/util.jsx
+++ b/indico/web/client/js/react/components/dates/util.jsx
@@ -6,8 +6,8 @@
 // LICENSE file for more details.
 
 import React from 'react';
-
 import {VERTICAL_ORIENTATION, HORIZONTAL_ORIENTATION} from 'react-dates/constants';
+
 import {Responsive} from 'indico/react/util';
 
 /**

--- a/indico/web/client/js/react/components/files/FileArea.jsx
+++ b/indico/web/client/js/react/components/files/FileArea.jsx
@@ -5,11 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Button, Card, Divider, Grid, Header, Segment, Icon, Progress} from 'semantic-ui-react';
+
 import {TooltipIfTruncated} from 'indico/react/components';
 import {Translate, Param} from 'indico/react/i18n';
+
 import {fileDetailsShape} from './props';
 
 import './FileArea.module.scss';

--- a/indico/web/client/js/react/components/files/FileSubmission.jsx
+++ b/indico/web/client/js/react/components/files/FileSubmission.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useCallback, useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useCallback, useState} from 'react';
 import {useDropzone} from 'react-dropzone';
 
 import {FileArea} from './FileArea';

--- a/indico/web/client/js/react/components/files/SingleFileManager.jsx
+++ b/indico/web/client/js/react/components/files/SingleFileManager.jsx
@@ -5,14 +5,16 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useCallback, useReducer} from 'react';
 import PropTypes from 'prop-types';
+import React, {useCallback, useReducer} from 'react';
 import {useDropzone} from 'react-dropzone';
 import {Field} from 'react-final-form';
+
 import {FinalField} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
-import {fileDetailsShape} from './props';
+
 import {SingleFileArea} from './FileArea';
+import {fileDetailsShape} from './props';
 import {deleteFile, uploadFile, UploadState} from './util';
 
 function reducer(state, action) {

--- a/indico/web/client/js/react/components/files/util.js
+++ b/indico/web/client/js/react/components/files/util.js
@@ -8,6 +8,7 @@
 import deleteFileURL from 'indico-url:files.delete_file';
 
 import _ from 'lodash';
+
 import {handleAxiosError, indicoAxios} from 'indico/utils/axios';
 
 export async function uploadFile(url, file, onUploadProgress) {

--- a/indico/web/client/js/react/components/principals/ACLField.jsx
+++ b/indico/web/client/js/react/components/principals/ACLField.jsx
@@ -6,13 +6,15 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Button, Dropdown, List} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
-import {DefaultUserSearch, GroupSearch} from '../principals/Search';
+
 import {useFetchPrincipals} from '../principals/hooks';
 import {PendingPrincipalListItem, PrincipalListItem} from '../principals/items';
+import {DefaultUserSearch, GroupSearch} from '../principals/Search';
 import {getPrincipalList, PrincipalType} from '../principals/util';
 
 import '../principals/PrincipalListField.module.scss';

--- a/indico/web/client/js/react/components/principals/PermissionTree.jsx
+++ b/indico/web/client/js/react/components/principals/PermissionTree.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Button, Popup} from 'semantic-ui-react';
 
 import './PermissionTree.module.scss';

--- a/indico/web/client/js/react/components/principals/PrincipalField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalField.jsx
@@ -7,14 +7,17 @@
 
 import principalsURL from 'indico-url:core.principals';
 
-import React, {useEffect, useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useEffect, useState} from 'react';
 import {Icon, List} from 'semantic-ui-react';
+
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
-import {UserSearch} from './Search';
-import {EmptyPrincipalListItem, PendingPrincipalListItem, PrincipalListItem} from './items';
+
 import {FinalField} from '../../forms';
+
+import {EmptyPrincipalListItem, PendingPrincipalListItem, PrincipalListItem} from './items';
+import {UserSearch} from './Search';
 
 import './items.module.scss';
 

--- a/indico/web/client/js/react/components/principals/PrincipalListField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalListField.jsx
@@ -6,15 +6,18 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Button, Dropdown, List} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
-import {UserSearch, GroupSearch} from './Search';
+
+import {FinalField} from '../../forms';
+
 import {useFetchPrincipals, useFetchAvailablePrincipals} from './hooks';
 import {PendingPrincipalListItem, PrincipalListItem} from './items';
+import {UserSearch, GroupSearch} from './Search';
 import {getPrincipalList, PrincipalType} from './util';
-import {FinalField} from '../../forms';
 
 import './PrincipalListField.module.scss';
 

--- a/indico/web/client/js/react/components/principals/PrincipalPermissions.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalPermissions.jsx
@@ -6,8 +6,8 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Button, Dropdown, Icon, Label, Popup} from 'semantic-ui-react';
 
 import {PopoverDropdownMenu} from 'indico/react/components';

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -5,13 +5,16 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import groupSearchURL from 'indico-url:groups.group_search';
 import userSearchURL from 'indico-url:users.user_search';
 import userSearchInfoURL from 'indico-url:users.user_search_info';
-import groupSearchURL from 'indico-url:groups.group_search';
 
+import {FORM_ERROR} from 'final-form';
 import _ from 'lodash';
-import React, {useContext, useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useContext, useState} from 'react';
+import {Form as FinalForm} from 'react-final-form';
+import Overridable from 'react-overridable';
 import {
   Button,
   Divider,
@@ -24,14 +27,13 @@ import {
   Modal,
   Popup,
 } from 'semantic-ui-react';
-import {FORM_ERROR} from 'final-form';
-import {Form as FinalForm} from 'react-final-form';
-import Overridable from 'react-overridable';
+
 import {FinalCheckbox, FinalInput, handleSubmitError} from 'indico/react/forms';
-import {Translate, PluralTranslate, Singular, Plural, Param} from 'indico/react/i18n';
 import {useIndicoAxios} from 'indico/react/hooks';
+import {Translate, PluralTranslate, Singular, Plural, Param} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
+
 import {PrincipalType} from './util';
 
 import './items.module.scss';

--- a/indico/web/client/js/react/components/principals/TrackACLField.jsx
+++ b/indico/web/client/js/react/components/principals/TrackACLField.jsx
@@ -5,12 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 
 import {ACLField} from 'indico/react/components';
-import {useFavoriteUsers} from 'indico/react/hooks';
 import {PermissionManager} from 'indico/react/components/principals/util';
+import {useFavoriteUsers} from 'indico/react/hooks';
 
 export default function TrackACLField({
   value,

--- a/indico/web/client/js/react/components/principals/hooks.js
+++ b/indico/web/client/js/react/components/principals/hooks.js
@@ -5,15 +5,16 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import permissionInfoURL from 'indico-url:rb.permission_types';
 import principalsURL from 'indico-url:core.principals';
-import eventPrincipalsURL from 'indico-url:event_management.api_principals';
-import eventRolesURL from 'indico-url:event_management.api_event_roles';
 import eventCategoryRolesURL from 'indico-url:event_management.api_category_roles';
+import eventRolesURL from 'indico-url:event_management.api_event_roles';
+import eventPrincipalsURL from 'indico-url:event_management.api_principals';
 import registrationFormsURL from 'indico-url:event_registration.api_registration_forms';
+import permissionInfoURL from 'indico-url:rb.permission_types';
 
 import _ from 'lodash';
 import {useState, useEffect} from 'react';
+
 import {useIndicoAxios} from 'indico/react/hooks';
 
 import {PermissionManager} from './util';

--- a/indico/web/client/js/react/components/principals/items.jsx
+++ b/indico/web/client/js/react/components/principals/items.jsx
@@ -5,10 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Icon, List, Loader, Popup} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
+
 import {PrincipalType} from './util';
 
 import './items.module.scss';

--- a/indico/web/client/js/react/components/principals/util.js
+++ b/indico/web/client/js/react/components/principals/util.js
@@ -7,6 +7,7 @@
 
 import _ from 'lodash';
 import PropTypes from 'prop-types';
+
 import {Translate} from 'indico/react/i18n';
 
 /**

--- a/indico/web/client/js/react/containers/UserMenu.jsx
+++ b/indico/web/client/js/react/containers/UserMenu.jsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider, connect} from 'react-redux';
+
 import UserMenu from '../components/UserMenu';
 
 export default function setupUserMenu(element, store, userInfoSelectors, configSelectors) {

--- a/indico/web/client/js/react/errors/component.jsx
+++ b/indico/web/client/js/react/errors/component.jsx
@@ -5,15 +5,16 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
-import PropTypes from 'prop-types';
-import {Button, Form, Icon, Message, Modal} from 'semantic-ui-react';
-import {Form as FinalForm} from 'react-final-form';
 import reportErrorURL from 'indico-url:core.report_error_api';
 
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Form as FinalForm} from 'react-final-form';
+import {Button, Form, Icon, Message, Modal} from 'semantic-ui-react';
+
+import {handleSubmissionError, FinalInput, FinalTextArea} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
-import {handleSubmissionError, FinalInput, FinalTextArea} from 'indico/react/forms';
 
 export default class ErrorDialog extends React.Component {
   static propTypes = {

--- a/indico/web/client/js/react/errors/container.js
+++ b/indico/web/client/js/react/errors/container.js
@@ -7,8 +7,8 @@
 
 import {connect} from 'react-redux';
 
-import ErrorDialog from './component';
 import {clearError, showReportForm} from './actions';
+import ErrorDialog from './component';
 
 const mapStateToProps = ({errors: {errorList, formVisible}}) => ({
   errorData: errorList[0],

--- a/indico/web/client/js/react/errors/index.jsx
+++ b/indico/web/client/js/react/errors/index.jsx
@@ -11,9 +11,10 @@ import {Provider} from 'react-redux';
 
 // eslint-disable-next-line import/no-cycle
 import createReduxStore from 'indico/utils/redux';
+
 import {addError, showReportForm} from './actions';
-import reducer from './reducers';
 import ErrorDialog from './container';
+import reducer from './reducers';
 
 let store;
 export default function showReactErrorDialog(error, instantReport = false) {

--- a/indico/web/client/js/react/forms/errors.js
+++ b/indico/web/client/js/react/forms/errors.js
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
 import {FORM_ERROR} from 'final-form';
+import _ from 'lodash';
 
 function flatten(value) {
   // marshmallow's List returns an object with the index as the key

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -6,11 +6,11 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import React from 'react';
 import PropTypes from 'prop-types';
-import {Button, Checkbox, Dropdown, Form, Input, Popup, Radio, TextArea} from 'semantic-ui-react';
+import React from 'react';
 import {Field, useFormState} from 'react-final-form';
 import {OnChange} from 'react-final-form-listeners';
+import {Button, Checkbox, Dropdown, Form, Input, Popup, Radio, TextArea} from 'semantic-ui-react';
 
 import formatters from './formatters';
 import parsers from './parsers';

--- a/indico/web/client/js/react/forms/final-form.jsx
+++ b/indico/web/client/js/react/forms/final-form.jsx
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
-import React from 'react';
-import PropTypes from 'prop-types';
-import {Field} from 'react-final-form';
 import {FORM_ERROR} from 'final-form';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Field} from 'react-final-form';
+
 import {handleAxiosError} from '../../utils/axios';
+
 import {handleSubmissionError} from './errors';
 
 export function getChangedValues(data, form) {

--- a/indico/web/client/js/react/forms/unload.jsx
+++ b/indico/web/client/js/react/forms/unload.jsx
@@ -5,10 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useEffect} from 'react';
 import PropTypes from 'prop-types';
-import {Prompt} from 'react-router';
+import React, {useEffect} from 'react';
 import {FormSpy} from 'react-final-form';
+import {Prompt} from 'react-router';
+
 import {Translate} from '../../react/i18n';
 
 const UnloadPrompt = ({active, router, message}) => {

--- a/indico/web/client/js/react/hooks.js
+++ b/indico/web/client/js/react/hooks.js
@@ -5,13 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import favoriteUsersURL from 'indico-url:users.favorites_api';
 import principalsURL from 'indico-url:core.principals';
+import favoriteUsersURL from 'indico-url:users.favorites_api';
 
-import _ from 'lodash';
-import {useEffect, useRef, useState} from 'react';
-import PropTypes from 'prop-types';
 import useAxios from '@use-hooks/axios';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import {useEffect, useRef, useState} from 'react';
+
 import {handleAxiosError, indicoAxios} from '../utils/axios';
 import {camelizeKeys} from '../utils/case';
 

--- a/indico/web/client/js/react/util/ConditionalRoute.jsx
+++ b/indico/web/client/js/react/util/ConditionalRoute.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Route} from 'react-router-dom';
 
 export default function ConditionalRoute({active, component, render, ...props}) {

--- a/indico/web/client/js/react/util/Markdown.jsx
+++ b/indico/web/client/js/react/util/Markdown.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import ReactMarkdown from 'react-markdown';
 
 // eslint-disable-next-line react/prop-types

--- a/indico/web/client/js/react/util/Preloader.jsx
+++ b/indico/web/client/js/react/util/Preloader.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {connect} from 'react-redux';
 
 class Preloader extends React.Component {

--- a/indico/web/client/js/react/util/Slot.jsx
+++ b/indico/web/client/js/react/util/Slot.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 
 export default class Slot extends React.Component {
   static split(children) {


### PR DESCRIPTION
This is very similar to indico/newdle#296, except that here we separate blocks because we have `indico-url:` imports and many more `indico/...` imports so it increases readability especially in larger files.