### PR TITLE
Prevent minutes positioning from overflowing parent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Bugfixes
   contributions or timetable entries
 - Do not show incorrect modification deadline in abstract management area if no
   such deadline has been set (:pr:`4650`)
+- Fix layout problem when minutes contain overly large embedded images (:issue:`4653`,
+  :pr:`4654`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/modules/event_display/_meetings.scss
+++ b/indico/web/client/styles/modules/event_display/_meetings.scss
@@ -65,6 +65,10 @@ li > table + .note-area-wrapper {
       color: $black;
     }
 
+    img {
+      max-width: 100%;
+    }
+
     > :first-child {
       margin-top: 0;
     }

--- a/indico/web/client/styles/partials/_paddedboxes.scss
+++ b/indico/web/client/styles/partials/_paddedboxes.scss
@@ -10,6 +10,7 @@
   @include border-all($color: $pastel-gray, $width: 2px);
   background: $pastel-gray;
   display: table;
+  table-layout: fixed;
   width: 100%;
 
   &::before {

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -320,6 +320,7 @@ ul.day-list {
 .timetable-item-body {
   flex: auto;
   padding-bottom: 0.5rem;
+  overflow: hidden;
 
   /* Without the following IE11 doesn't correctly compute the width of the element. */
   width: 100%;


### PR DESCRIPTION
Closes #4653 

- Limits image width (first image)
- Limits any content overflow (second image)
<p align="center">
<img src="https://user-images.githubusercontent.com/12183954/95312976-e0375400-088f-11eb-8627-b35d8a8c065d.png" width="70%" />
<img src="https://user-images.githubusercontent.com/12183954/95312997-e3324480-088f-11eb-988b-79e91efb453d.png" width="70%" />
</span>
