### PR TITLE
Refactor processRevisions selector logic

### DIFF
--- a/indico/modules/events/client/js/reviewing/components/TimelineContent.jsx
+++ b/indico/modules/events/client/js/reviewing/components/TimelineContent.jsx
@@ -19,7 +19,7 @@ export default function TimelineContent({blocks, itemComponent: Component}) {
             </div>
           </div>
         )}
-        <Component block={block} />
+        <Component block={block} index={index} />
       </React.Fragment>
     );
   });

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentItem.jsx
@@ -6,11 +6,11 @@
 // LICENSE file for more details.
 
 import moment from 'moment';
-import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Button, Confirm} from 'semantic-ui-react';
 
+import {blockItemPropTypes} from 'indico/modules/events/editing/editing/timeline/util';
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {Param, Translate} from 'indico/react/i18n';
 import {serializeDate} from 'indico/utils/date';
@@ -146,25 +146,4 @@ export default function Comment({
   );
 }
 
-Comment.propTypes = {
-  revisionId: PropTypes.number.isRequired,
-  createdDt: PropTypes.string.isRequired,
-  html: PropTypes.string.isRequired,
-  text: PropTypes.string.isRequired,
-  canModify: PropTypes.bool.isRequired,
-  modifyCommentURL: PropTypes.string.isRequired,
-  user: PropTypes.shape({
-    fullName: PropTypes.string.isRequired,
-    avatarBgColor: PropTypes.string.isRequired,
-  }),
-  modifiedDt: PropTypes.string,
-  internal: PropTypes.bool,
-  system: PropTypes.bool,
-};
-
-Comment.defaultProps = {
-  user: null,
-  modifiedDt: null,
-  internal: false,
-  system: false,
-};
+Comment.propTypes = blockItemPropTypes;

--- a/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
@@ -16,8 +16,9 @@ import {serializeDate} from 'indico/utils/date';
 import ResetReview from './ResetReview';
 import * as selectors from './selectors';
 import StateIndicator from './StateIndicator';
+import {blockItemPropTypes} from './util';
 
-export default function CustomItem({header, user, createdDt, html, revisionId, state}) {
+export default function CustomItem({item: {header, user, createdDt, html, revisionId}, state}) {
   const lastRevertableRevisionId = useSelector(selectors.getLastRevertableRevisionId);
 
   return (
@@ -50,18 +51,10 @@ export default function CustomItem({header, user, createdDt, html, revisionId, s
 }
 
 CustomItem.propTypes = {
-  createdDt: PropTypes.string.isRequired,
-  html: PropTypes.string,
+  item: PropTypes.shape(blockItemPropTypes).isRequired,
   state: PropTypes.string,
-  header: PropTypes.string.isRequired,
-  user: PropTypes.shape({
-    fullName: PropTypes.string.isRequired,
-    avatarBgColor: PropTypes.string.isRequired,
-  }).isRequired,
-  revisionId: PropTypes.number.isRequired,
 };
 
 CustomItem.defaultProps = {
-  html: null,
   state: null,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/RevisionLog.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/RevisionLog.jsx
@@ -10,15 +10,18 @@ import React from 'react';
 
 import CommentItem from './CommentItem';
 import CustomItem from './CustomItem';
+import {blockItemPropTypes} from './util';
 
-export default function RevisionLog({items, children, separator}) {
+export default function RevisionLog({items, state, children, separator}) {
   return (
     <div className="i-timeline">
       <div className="i-timeline with-line">
         <div className="i-timeline-connect-up" />
         {items.map(item => {
-          const Component = item.custom ? CustomItem : CommentItem;
-          return <Component key={item.id} {...item} />;
+          if (item.custom) {
+            return <CustomItem key={item.id} item={item} state={state} />;
+          }
+          return <CommentItem key={item.id} {...item} />;
         })}
         {children}
       </div>
@@ -35,7 +38,8 @@ export default function RevisionLog({items, children, separator}) {
 }
 
 RevisionLog.propTypes = {
-  items: PropTypes.array.isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape(blockItemPropTypes)).isRequired,
+  state: PropTypes.string,
   children: PropTypes.node,
   separator: PropTypes.bool,
 };
@@ -43,4 +47,5 @@ RevisionLog.propTypes = {
 RevisionLog.defaultProps = {
   children: null,
   separator: false,
+  state: null,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/RevisionLog.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/RevisionLog.jsx
@@ -8,6 +8,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import {FinalRevisionState} from '../../models';
+
 import CommentItem from './CommentItem';
 import CustomItem from './CustomItem';
 import {blockItemPropTypes} from './util';
@@ -39,7 +41,7 @@ export default function RevisionLog({items, state, children, separator}) {
 
 RevisionLog.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape(blockItemPropTypes)).isRequired,
-  state: PropTypes.string,
+  state: PropTypes.oneOf(Object.values(FinalRevisionState)),
   children: PropTypes.node,
   separator: PropTypes.bool,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -25,7 +25,7 @@ import {blockPropTypes} from './util';
 
 import './TimelineItem.module.scss';
 
-export default function TimelineItem({block}) {
+export default function TimelineItem({block, index}) {
   const {submitter, createdDt} = block;
   const lastBlock = useSelector(selectors.getLastTimelineBlock);
   const needsSubmitterConfirmation = useSelector(selectors.needsSubmitterConfirmation);
@@ -62,7 +62,7 @@ export default function TimelineItem({block}) {
                 ) : (
                   <Translate>
                     <Param name="submitterName" value={submitter.fullName} wrapper={<strong />} />{' '}
-                    submitted revision <Param name="revisionNumber" value={`#${block.number}`} />
+                    submitted revision <Param name="revisionNumber" value={`#${index + 1}`} />
                   </Translate>
                 )}{' '}
                 <time dateTime={serializeDate(createdDt, moment.HTML5_FMT.DATETIME_LOCAL)}>
@@ -118,4 +118,5 @@ export default function TimelineItem({block}) {
 
 TimelineItem.propTypes = {
   block: PropTypes.shape(blockPropTypes).isRequired,
+  index: PropTypes.number.isRequired,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -106,7 +106,7 @@ export default function TimelineItem({block, index}) {
         </div>
       </div>
       {visible && (
-        <RevisionLog items={block.items} separator={isLastBlock}>
+        <RevisionLog items={block.items} state={block.finalState.name} separator={isLastBlock}>
           {isLastBlock && !['accepted', 'rejected'].includes(editableState.name) && canComment && (
             <ReviewForm block={block} />
           )}

--- a/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
@@ -70,6 +70,7 @@ describe('timeline selectors', () => {
         finalState: {
           name: FinalRevisionState.needs_submitter_confirmation,
         },
+        commentHtml: 'hey',
       },
       {
         id: 2,
@@ -98,6 +99,7 @@ describe('timeline selectors', () => {
     expect(result[0].items).toStrictEqual([
       expect.objectContaining({
         header: revisionStates.any[FinalRevisionState.needs_submitter_confirmation](result[0]),
+        html: 'hey',
       }),
     ]);
     expect(result[1].id).toBe(2);
@@ -117,8 +119,8 @@ describe('timeline selectors', () => {
     const revisions = [
       {
         id: 1,
-        submitter: {
-          fullName: 'author',
+        editor: {
+          fullName: 'service',
         },
         comments: [
           {
@@ -138,8 +140,8 @@ describe('timeline selectors', () => {
       },
       {
         id: 2,
-        submitter: {
-          fullName: 'someone_else',
+        editor: {
+          fullName: 'john',
         },
         comments: [
           {
@@ -172,7 +174,7 @@ describe('timeline selectors', () => {
       expect.objectContaining({text: 'first comment'}),
       expect.objectContaining({
         header: revisionStates.any[FinalRevisionState.replaced],
-        user: result[1].submitter,
+        user: result[0].editor,
       }),
     ]);
     expect(result[1].id).toBe(2);
@@ -181,7 +183,7 @@ describe('timeline selectors', () => {
       expect.objectContaining({text: 'done'}),
       expect.objectContaining({
         header: revisionStates.any[FinalRevisionState.needs_submitter_changes],
-        user: result[1].submitter,
+        user: result[1].editor,
       }),
     ]);
   });

--- a/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
@@ -7,8 +7,7 @@
 
 import {FinalRevisionState, InitialRevisionState} from 'indico/modules/events/editing/models';
 
-import {processRevisions} from '../selectors';
-import {revisionStates} from '../util';
+import {processRevisions, revisionStates} from '../util';
 
 describe('timeline selectors', () => {
   it('should describe each revision transition', () => {

--- a/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
@@ -117,6 +117,9 @@ describe('timeline selectors', () => {
     const revisions = [
       {
         id: 1,
+        submitter: {
+          fullName: 'author',
+        },
         comments: [
           {
             id: 1,
@@ -135,6 +138,9 @@ describe('timeline selectors', () => {
       },
       {
         id: 2,
+        submitter: {
+          fullName: 'someone_else',
+        },
         comments: [
           {
             id: 1,
@@ -166,6 +172,7 @@ describe('timeline selectors', () => {
       expect.objectContaining({text: 'first comment'}),
       expect.objectContaining({
         header: revisionStates.any[FinalRevisionState.replaced],
+        user: result[1].submitter,
       }),
     ]);
     expect(result[1].id).toBe(2);
@@ -174,6 +181,7 @@ describe('timeline selectors', () => {
       expect.objectContaining({text: 'done'}),
       expect.objectContaining({
         header: revisionStates.any[FinalRevisionState.needs_submitter_changes],
+        user: result[1].submitter,
       }),
     ]);
   });

--- a/indico/modules/events/editing/client/js/editing/timeline/reducer.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/reducer.js
@@ -8,7 +8,7 @@
 import {camelizeKeys} from 'indico/utils/case';
 
 import {SET_LOADING, SET_DETAILS, SET_NEW_DETAILS} from './actions';
-import {processRevisions} from './selectors';
+import {processRevisions} from './util';
 
 export const initialState = {
   details: null,

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -39,13 +39,13 @@ export function processRevisions(revisions) {
   const newRevisions = [];
   let numberOfRevisions = 1;
   let items = [];
-  let currRevision = null;
+  let currBlockIdx = -1;
 
   for (const [index, _revision] of revisions.entries()) {
     const revision = {..._revision};
     const {initialState, finalState} = revision;
-    if (!currRevision) {
-      currRevision = revision;
+    if (currBlockIdx === -1) {
+      currBlockIdx = index;
       items = [...revision.comments];
     }
 
@@ -125,12 +125,14 @@ export function processRevisions(revisions) {
     }
 
     if (shouldCreateNewRevision(revision) || index === revisions.length - 1) {
+      // From here on, a new revision block will be created
       newRevisions.push({
-        ..._.omit(currRevision, 'comments'),
+        ..._.omit(revisions[currBlockIdx], 'comments'),
         number: numberOfRevisions++,
+        customActions: revision.customActions, // Use the actions from the latest revision in the block
         items,
       });
-      currRevision = null;
+      currBlockIdx = -1;
     }
   }
 

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -16,13 +16,14 @@ import {getRevisionTransition} from './util';
 // with a label referring to its previous state transition
 export function processRevisions(revisions) {
   let revisionState;
-  return revisions.map(revision => {
+  return revisions.map((revision, idx) => {
     const items = [...revision.comments];
     const header = revisionState;
     revisionState = getRevisionTransition(revision);
     // Generate the comment header
     if (revisionState) {
-      items.push(commentFromState(revision, revisionState));
+      const author = revisions[Math.min(idx + 1, revisions.length - 1)].submitter;
+      items.push(commentFromState(revision, revisionState, author));
     }
     return {
       ...revision,

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -35,17 +35,16 @@ export function processRevisions(revisions) {
   });
 }
 
-export function commentFromState(revision) {
-  const {initialState, finalState, id, createdDt, user, submitter} = revision;
+export function commentFromState(revision, user) {
+  const {initialState, finalState, id, createdDt, submitter} = revision;
   const headerStates = revisionStates[initialState.name] || revisionStates['any'];
   const header =
     typeof headerStates === 'function' ? headerStates(revision) : headerStates[finalState.name];
   return {
-    id: `custom-item-${id}-${createdDt}-${finalState}`,
+    id: `custom-item-${id}-${createdDt}-${finalState.name}`,
     revisionId: id,
     header,
     createdDt,
-    finalState,
     user: user || submitter,
     custom: true,
   };

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -10,43 +10,6 @@ import {createSelector} from 'reselect';
 
 import {FinalRevisionState, InitialRevisionState} from '../../models';
 
-import {getRevisionTransition} from './util';
-
-// This method defines each revision as a block
-// with a label referring to its previous state transition
-export function processRevisions(revisions) {
-  let revisionState;
-  return revisions.map(revision => {
-    const items = [...revision.comments];
-    const header = revisionState;
-    revisionState = getRevisionTransition(revision);
-    // Generate the comment header
-    if (revisionState) {
-      const author = revision.editor || revision.submitter;
-      items.push(commentFromState(revision, revisionState, author));
-    }
-    return {
-      ...revision,
-      // use the previous state transition as current block header
-      header: header || revision.header,
-      items,
-    };
-  });
-}
-
-export function commentFromState(revision, state, user) {
-  const {finalState, id, createdDt, submitter} = revision;
-  return {
-    id: `custom-item-${id}-${createdDt}-${finalState.name}`,
-    revisionId: id,
-    header: state,
-    createdDt,
-    user: user || submitter,
-    custom: true,
-    html: revision.commentHtml,
-  };
-}
-
 export const getDetails = state => (state.timeline ? state.timeline.details : null);
 export const getNewDetails = state => (state.timeline ? state.timeline.newDetails : null);
 export const isInitialEditableDetailsLoading = state =>

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -16,13 +16,13 @@ import {getRevisionTransition} from './util';
 // with a label referring to its previous state transition
 export function processRevisions(revisions) {
   let revisionState;
-  return revisions.map((revision, idx) => {
+  return revisions.map(revision => {
     const items = [...revision.comments];
     const header = revisionState;
     revisionState = getRevisionTransition(revision);
     // Generate the comment header
     if (revisionState) {
-      const author = revisions[Math.min(idx + 1, revisions.length - 1)].submitter;
+      const author = revision.editor || revision.submitter;
       items.push(commentFromState(revision, revisionState, author));
     }
     return {
@@ -43,6 +43,7 @@ export function commentFromState(revision, state, user) {
     createdDt,
     user: user || submitter,
     custom: true,
+    html: revision.commentHtml,
   };
 }
 
@@ -53,9 +54,7 @@ export const isInitialEditableDetailsLoading = state =>
 export const isTimelineOutdated = createSelector(
   getDetails,
   getNewDetails,
-  (details, newDetails) => {
-    return newDetails !== null && !_.isEqual(details, newDetails);
-  }
+  (details, newDetails) => newDetails !== null && !_.isEqual(details, newDetails)
 );
 export const getTimelineBlocks = state => state.timeline.timelineBlocks;
 export const getLastTimelineBlock = createSelector(

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -7,7 +7,32 @@
 
 import PropTypes from 'prop-types';
 
+import {FinalRevisionState, InitialRevisionState} from 'indico/modules/events/editing/models';
+import {Translate} from 'indico/react/i18n';
+
 import {filePropTypes} from './FileManager/util';
+
+export const revisionStates = {
+  [InitialRevisionState.needs_submitter_confirmation]: revision => {
+    if (revision.finalState.name === FinalRevisionState.accepted) {
+      return revision.editor !== null
+        ? Translate.string('Editor has accepted after making some changes')
+        : Translate.string('Submitter has accepted proposed changes');
+    }
+    if (revision.finalState.name === FinalRevisionState.needs_submitter_changes) {
+      return Translate.string('Submitter rejected proposed changes');
+    }
+  },
+  any: {
+    [FinalRevisionState.replaced]: Translate.string('Revision has been replaced'),
+    [FinalRevisionState.accepted]: Translate.string('Revision has been accepted'),
+    [FinalRevisionState.rejected]: Translate.string('Revision has been rejected'),
+    [FinalRevisionState.needs_submitter_changes]: Translate.string(
+      'Submitter has been asked to make some changes'
+    ),
+    [FinalRevisionState.needs_submitter_confirmation]: Translate.string('Editor made some changes'),
+  },
+};
 
 export const userPropTypes = {
   identifier: PropTypes.string.isRequired,

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -34,7 +34,7 @@ export const revisionStates = {
     ),
     [FinalRevisionState.needs_submitter_confirmation]: revision =>
       Translate.string('{editorName} (editor) has made some changes to the paper', {
-        editorName: revision.editor ? revision.editor.fullName : '',
+        editorName: revision.editor?.fullName || '',
       }),
   },
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -47,26 +47,37 @@ const statePropTypes = {
   title: PropTypes.string,
 };
 
+// Type that represents a revision comment block
+// (a simplified-ish version of the revision blocks below)
 export const blockItemPropTypes = {
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  revisionId: PropTypes.number.isRequired,
   createdDt: PropTypes.string.isRequired,
   modifiedDt: PropTypes.string,
+  canModify: PropTypes.bool,
   user: PropTypes.shape(userPropTypes),
+  header: PropTypes.string,
   text: PropTypes.string,
   html: PropTypes.string,
   internal: PropTypes.bool,
   system: PropTypes.bool,
+  custom: PropTypes.bool,
+  modifyCommentURL: PropTypes.string,
 };
 
+// Type that represents a revision block (with files)
 export const blockPropTypes = {
   id: PropTypes.number.isRequired,
-  files: PropTypes.arrayOf(PropTypes.shape(filePropTypes)).isRequired,
   submitter: PropTypes.shape(userPropTypes).isRequired,
   editor: PropTypes.shape(userPropTypes),
   createdDt: PropTypes.string.isRequired,
-  items: PropTypes.arrayOf(PropTypes.shape(blockItemPropTypes)).isRequired,
   initialState: PropTypes.shape(statePropTypes).isRequired,
   finalState: PropTypes.shape(statePropTypes).isRequired,
   comment: PropTypes.string.isRequired,
   commentHtml: PropTypes.string.isRequired,
+  files: PropTypes.arrayOf(PropTypes.shape(filePropTypes)).isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape(blockItemPropTypes)).isRequired,
+  customActions: PropTypes.array.isRequired,
+  customActionURL: PropTypes.string,
+  downloadFilesURL: PropTypes.string,
 };

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -172,7 +172,7 @@ def replace_revision(revision, user, comment, files, tags, initial_state=None):
     revision.tags = tags
     revision.final_state = FinalRevisionState.replaced
     revision.editor = user
-    new_revision = EditingRevision(submitter=user,
+    new_revision = EditingRevision(submitter=revision.submitter,
                                    initial_state=(initial_state or revision.initial_state),
                                    files=_make_editable_files(revision.editable, files))
     revision.editable.revisions.append(new_revision)

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -171,6 +171,7 @@ def replace_revision(revision, user, comment, files, tags, initial_state=None):
     revision.comment = comment
     revision.tags = tags
     revision.final_state = FinalRevisionState.replaced
+    revision.editor = user
     new_revision = EditingRevision(submitter=user,
                                    initial_state=(initial_state or revision.initial_state),
                                    files=_make_editable_files(revision.editable, files))


### PR DESCRIPTION
The `processRevisions` selector is becoming too complex mainly because it is describing all the possible combination of states in revisions, such as:

```
[InitialRevisionState.needs_submitter_confirmation, FinalRevisionState.needs_submitter_changes]
```
meaning **Submitter rejected proposed changes**.

The purpose of this is to refactor it, implementing a less verbose state machine.

---

Should also fix a bug causing custom revision actions not to show up.

This is a bug introduced in #4641 causing custom actions to disappear in a block with more than one revision. Caused because we may group multiple revisions in blocks, causing the client to use the actions for the first revision in the block, instead of the latest (the most recent one).

## How to reproduce

- Make sure the micro-service is connected with an action to replace the revision as soon as it is submitted
- Make sure the micro-service exposes custom actions
- Upload a paper for editing
- Accept the paper

The actions will no longer show up.