### PR TITLE
Fix paper submission for managers

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -30,7 +30,7 @@ settings:
         - ['indico/modules/users', './indico/modules/users/client/js']
         - ['indico/modules/events/reviewing', './indico/modules/events/client/js/reviewing']
         - ['indico/modules/events/editing', './indico/modules/events/editing/client/js']
-        - ['indico/modules/events/util', './indico/modules/events/client/js/util']
+        - ['indico/modules/events', './indico/modules/events/client/js']
         - ['indico', './indico/web/client/js']
       extensions: [.js, .jsx, .json]
   import/internal-regex: ^indico/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,8 @@ jobs:
              indico/modules/rb/
              indico/modules/events/logs/
              indico/modules/events/editing/
+             indico/modules/events/client/js/reviewing/
+             indico/modules/events/papers/client/js/
              indico/web/client/js/react/
              indico/modules/users/
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Bugfixes
 - Fix OAuth access to HTTP API (:pr:`4663`)
 - Fix ICS export of events with draft timetable and contribution detail level
   (:pr:`4666`)
+- Fix paper revision submission field being displayed for judges/reviewers (:pr:`4667`)
+- Fix managers not being able to submit paper revisions on behalf of the user (:pr:`4667`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/papers/client/js/components/TimelineItem.jsx
+++ b/indico/modules/events/papers/client/js/components/TimelineItem.jsx
@@ -16,7 +16,7 @@ import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {Param, Translate} from 'indico/react/i18n';
 import {serializeDate} from 'indico/utils/date';
 
-import {canCommentPaper, canReviewPaper, getPaperDetails} from '../selectors';
+import {canCommentPaper, canReviewPaper, canSubmitNewRevision, getPaperDetails} from '../selectors';
 
 import PaperReviewForm from './PaperReviewForm';
 import RevisionJudgment from './RevisionJudgment';
@@ -28,6 +28,7 @@ export default function TimelineItem({block}) {
   const submitterName = submitter.isSystem ? Translate.string('A user') : submitter.fullName;
   const canComment = useSelector(canCommentPaper);
   const canReview = useSelector(canReviewPaper);
+  const canSubmitRevision = useSelector(canSubmitNewRevision);
   const paper = useSelector(getPaperDetails);
   const [visible, setVisible] = useState(isLastRevision);
 
@@ -92,7 +93,7 @@ export default function TimelineItem({block}) {
                 <div className="i-timeline-connect-down to-separator" />
               </div>
               <div className="i-timeline-separator" />
-              <SubmitRevision />
+              {canSubmitRevision && <SubmitRevision />}
               {paper.isInFinalState && <RevisionJudgment revision={block} />}
             </>
           )}

--- a/indico/modules/events/papers/client/js/index.js
+++ b/indico/modules/events/papers/client/js/index.js
@@ -114,7 +114,7 @@ import setupReactPaperTimeline from './setup';
           html.append(title);
           if ($this.is('.js-count-label')) {
             const list = $('<ul>', {class: 'qbubble-item-list'});
-            const items = _.values($this.data('items'));
+            const items = Object.values($this.data('items'));
             $.each(items, function(i, val) {
               const item = $('<li>');
               item.append(

--- a/indico/modules/events/papers/client/js/selectors.js
+++ b/indico/modules/events/papers/client/js/selectors.js
@@ -9,6 +9,8 @@ import {createSelector} from 'reselect';
 
 import {RequestState} from 'indico/utils/redux';
 
+import {PaperState} from './models';
+
 export const isFetchingInitialPaperDetails = state =>
   state.paper.requests.details.state === RequestState.STARTED && !state.paper.details;
 export const isPaperStateResetInProgress = state =>
@@ -38,6 +40,12 @@ export const canReviewPaper = createSelector(
   getPaperDetails,
   getPaperEvent,
   ({isInFinalState, canReview}, {isLocked}) => !isLocked && !isInFinalState && canReview
+);
+export const canSubmitNewRevision = createSelector(
+  getPaperDetails,
+  getPaperEvent,
+  ({canSubmitProceedings, canManage, state: {name: stateName}}, {isLocked}) =>
+    !isLocked && stateName === PaperState.to_be_corrected && (canManage || canSubmitProceedings)
 );
 export const canCommentPaper = createSelector(
   getPaperDetails,

--- a/indico/modules/events/papers/controllers/api.py
+++ b/indico/modules/events/papers/controllers/api.py
@@ -109,7 +109,7 @@ class RHSubmitNewRevision(RHPaperBase):
     def _check_paper_protection(self):
         if not RHPaperBase._check_paper_protection(self):
             return False
-        if not self.contribution.can_submit_proceedings(session.user):
+        if not self.contribution.can_submit_proceedings(session.user) and not self.event.cfp.is_manager(session.user):
             return False
         return self.contribution.paper.state == PaperRevisionState.to_be_corrected
 

--- a/indico/modules/events/papers/schemas.py
+++ b/indico/modules/events/papers/schemas.py
@@ -191,6 +191,7 @@ class PaperSchema(mm.Schema):
     revisions = List(Nested(PaperRevisionSchema))
     last_revision = Nested(PaperRevisionSchema)
     state = Nested(PaperRevisionStateSchema)
+    can_manage = Function(lambda paper, ctx: paper.cfp.is_manager(ctx.get('user')))
     can_judge = Function(lambda paper, ctx: paper.can_judge(ctx.get('user')))
     can_comment = Function(lambda paper, ctx: paper.can_comment(ctx.get('user'), check_state=True))
     can_review = Function(lambda paper, ctx: paper.can_review(ctx.get('user')))

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -12,7 +12,7 @@
       "indico/modules/users/*": ["./indico/modules/users/client/js/*"],
       "indico/modules/events/reviewing/*": ["./indico/modules/events/client/js/reviewing/*"],
       "indico/modules/events/editing/*": ["./indico/modules/events/editing/client/js/*"],
-      "indico/modules/events/util/*": ["./indico/modules/events/client/js/util/*"],
+      "indico/modules/events/*": ["./indico/modules/events/client/js/*"],
       "indico/*": ["./indico/web/client/js/*"]
     }
   },


### PR DESCRIPTION
- Allow managers to submit new paper revisions on behalf of the user like we did in previous versions.
- Hide the UI for judges/reviewers who cannot submit on behalf of the paper's author since it'd fail when submitting anyway

Also added some missing folders with modern JS to our ESLint CI (and fixed the warning in there).