### PR TITLE
Fix a bug causing system user checks for group membership

### DIFF
--- a/indico/core/db/sqlalchemy/protection.py
+++ b/indico/core/db/sqlalchemy/protection.py
@@ -365,10 +365,13 @@ class ProtectionManagersMixin(ProtectionMixin):
         if permission is not None and permission != 'ANY' and permission not in get_available_permissions(type(self)):
             raise ValueError("permission '{}' is not valid for '{}' objects".format(permission, type(self).__name__))
 
-        if user is None or user.is_system:
+        if user is None:
             # An unauthorized user is never allowed to perform management operations.
             # Not even signals may override this since management code generally
             # expects session.user to be not None.
+            return False
+        if user.is_system:
+            # A system user has no email and thus access checks (against groups) may fail
             return False
 
         # Trigger signals for protection overrides

--- a/indico/core/db/sqlalchemy/protection.py
+++ b/indico/core/db/sqlalchemy/protection.py
@@ -365,7 +365,7 @@ class ProtectionManagersMixin(ProtectionMixin):
         if permission is not None and permission != 'ANY' and permission not in get_available_permissions(type(self)):
             raise ValueError("permission '{}' is not valid for '{}' objects".format(permission, type(self).__name__))
 
-        if user is None:
+        if user is None or user.is_system:
             # An unauthorized user is never allowed to perform management operations.
             # Not even signals may override this since management code generally
             # expects session.user to be not None.


### PR DESCRIPTION
Fixes a bug causing the system user to be checked for group membership.

Introduced by #4657 

Can be reproduced by (within editing) accepting a revision where the previous revision was made by a system user. For example, when connected to the openreferee service.