### PR TITLE
Use 3.9 for RTD build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,7 @@
 requirements_file: docs/requirements.txt
+build:
+  image: testing
 python:
-  version: 3.8
+  version: 3.9
   setup_py_install: false
   pip_install: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ project_urls =
 packages = find:
 zip_safe = false
 include_package_data = true
+python_requires = ~=3.9
 
 [options.packages.find]
 include = indico, indico.*

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,4 @@ if __name__ == '__main__':
         cmdclass=cmdclass,
         install_requires=get_requirements('requirements.txt'),
         extras_require={'dev': get_requirements('requirements.dev.txt')},
-        python_requires=('~=3.9' if 'READTHEDOCS' not in os.environ else None),
     )


### PR DESCRIPTION
Merge this once RTD supports Python 3.9: readthedocs/readthedocs-docker-images#140, readthedocs/readthedocs.org#7554