### PR TITLE
Add revision numbers to each timeline block

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Improvements
 - Show program codes in contribution list (:pr:`4713`)
 - Display the target URL of link materials if the user can access them (:issue:`2599`,
   :pr:`4718`)
+- Show the revision number for all revisions in the Editing timeline (:pr:`4708`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -57,7 +57,7 @@ export default function TimelineItem({block, index}) {
           >
             <div className="i-box-header flexrow">
               <div className="f-self-stretch" styleName="header">
-                <span styleName="item-index">#{index + 1}</span>
+                <span styleName="item-index">#{index + 1}</span>{' '}
                 <span>
                   {block.header ? (
                     <strong>{block.header}</strong>
@@ -67,7 +67,7 @@ export default function TimelineItem({block, index}) {
                       submitted a revision
                     </Translate>
                   )}
-                </span>
+                </span>{' '}
                 <time dateTime={serializeDate(createdDt, moment.HTML5_FMT.DATETIME_LOCAL)}>
                   {serializeDate(createdDt, 'LL')}
                 </time>

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -56,17 +56,18 @@ export default function TimelineItem({block, index}) {
             id={`block-info-${block.id}`}
           >
             <div className="i-box-header flexrow">
-              <div className="f-self-stretch">
-                {block.header ? (
-                  <span>
-                    <strong>{block.header}</strong> {`#${index + 1}`}
-                  </span>
-                ) : (
-                  <Translate>
-                    <Param name="submitterName" value={submitter.fullName} wrapper={<strong />} />{' '}
-                    submitted revision <Param name="revisionNumber" value={`#${index + 1}`} />
-                  </Translate>
-                )}{' '}
+              <div className="f-self-stretch" styleName="header">
+                <span styleName="item-index">#{index + 1}</span>
+                <span>
+                  {block.header ? (
+                    <strong>{block.header}</strong>
+                  ) : (
+                    <Translate>
+                      <Param name="submitterName" value={submitter.fullName} wrapper={<strong />} />{' '}
+                      submitted a revision
+                    </Translate>
+                  )}
+                </span>
                 <time dateTime={serializeDate(createdDt, moment.HTML5_FMT.DATETIME_LOCAL)}>
                   {serializeDate(createdDt, 'LL')}
                 </time>

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -58,7 +58,9 @@ export default function TimelineItem({block, index}) {
             <div className="i-box-header flexrow">
               <div className="f-self-stretch">
                 {block.header ? (
-                  <strong>{block.header}</strong>
+                  <span>
+                    <strong>{block.header}</strong> {`#${index + 1}`}
+                  </span>
                 ) : (
                   <Translate>
                     <Param name="submitterName" value={submitter.fullName} wrapper={<strong />} />{' '}

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
@@ -17,6 +17,6 @@
 
 .header > :not(:first-child)::before {
   content: '\00B7' !important;
-  padding: 0 0.4em;
+  padding-right: 0.3em;
   color: $gray;
 }

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
@@ -5,6 +5,18 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@import 'base/palette';
+
 .state-indicator {
   margin-left: 5px;
+}
+
+.item-index {
+  color: $gray;
+}
+
+.header > :not(:first-child)::before {
+  content: '\00B7' !important;
+  padding: 0 0.4em;
+  color: $gray;
 }


### PR DESCRIPTION
Regarding revision blocks, we previously only appended the revision reference when a custom header wasn't set.

This change converts a revision title such as "Revision as been replaced" to "Revision has been replaced #\2".

Will depend on #4709.