### PR TITLE
Update deprecated set-env and add-path commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,8 @@ jobs:
 
       - name: Activate virtualenv for later steps
         run: |
-          echo "::set-env name=VIRTUAL_ENV::$(pwd)/.venv"
-          echo "::add-path::$(pwd)/.venv/bin"
+          echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
+          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
 
       - name: Install Indico
         run: pip install -e .
@@ -202,8 +202,8 @@ jobs:
 
       - name: Activate virtualenv for later steps
         run: |
-          echo "::set-env name=VIRTUAL_ENV::$(pwd)/.venv"
-          echo "::add-path::$(pwd)/.venv/bin"
+          echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
+          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
 
       - name: Install Indico
         run: pip install -e .
@@ -257,8 +257,8 @@ jobs:
 
       - name: Activate virtualenv for later steps
         run: |
-          echo "::set-env name=VIRTUAL_ENV::$(pwd)/.venv"
-          echo "::add-path::$(pwd)/.venv/bin"
+          echo "VIRTUAL_ENV=$(pwd)/.venv" >> $GITHUB_ENV
+          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
 
       - name: Install Indico
         run: pip install -e .


### PR DESCRIPTION
Update `set-env` and `add-path` commands that are being deprecated according to [changelog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/).