### PR TITLE
Contribution list: Filter speakers correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- Correctly filter 'non-registered' speakers in the admin contribution list  (thanks :user:`bpedersen2`)
+- Correctly filter 'non-registered' speakers in the admin contribution list  (:pr:`4712`, thanks :user:`bpedersen2`)
 
 Version 2.3.1
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- None so far :)
+- Correctly filter 'non-registered' speakers in the admin contribution list  (thanks :user:`bpedersen2`)
 
 Version 2.3.1
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,8 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- Correctly filter 'non-registered' speakers in the admin contribution list  (:pr:`4712`, thanks :user:`bpedersen2`)
+- Only considered actual speakers in the "has registered speakers" contribution list filter
+  (:pr:`4712`, thanks :user:`bpedersen2`)
 
 Version 2.3.1
 -------------

--- a/indico/modules/events/contributions/lists.py
+++ b/indico/modules/events/contributions/lists.py
@@ -90,6 +90,7 @@ class ContributionListGenerator(ListGeneratorBase):
             registration_join_criteria = db.and_(
                 Registration.event_id == Contribution.event_id,
                 Registration.is_active,
+                ContributionPersonLink.is_speaker,
                 (Registration.user_id == EventPerson.user_id) | (Registration.email == EventPerson.email)
             )
             contrib_query = (db.session.query(Contribution.id)


### PR DESCRIPTION
Do not attempt to match on all ContributionPersonLinks, only on
'speakers'.

Otherwise a contribution with a second, non-speaker author that has
registered will not show up if searching for non-registered speakers.
