### PR TITLE
Add codes in the contribution list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Improvements
 - Disable title field by default in new registration forms (:issue:`4688`, :pr:`4692`)
 - Add gender-neutral "Mx" title (:issue:`4688`, :pr:`4692`)
 - Add contributions placeholder for emails (:pr:`4716`, thanks :user:`bpedersen2`)
+- Show program codes in contribution list (:pr:`4713`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/templates/display/_contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/_contribution_list.html
@@ -30,6 +30,11 @@
                 <a class="js-mathjax" href="{{ url_for('contributions.display_contribution', contrib) }}">
                     <span class="contrib-id">{{ contrib.friendly_id }}.</span>
                     {{ contrib.title }}
+                    {% if contrib.code -%}
+                        <span class="contrib-code" data-searchable="{{ contrib.code|lower }}">
+                            ({{ contrib.code }})
+                        </span>
+                    {%- endif %}
                 </a>
             </span>
         </div>

--- a/indico/web/client/styles/modules/event_display/_conferences.scss
+++ b/indico/web/client/styles/modules/event_display/_conferences.scss
@@ -195,6 +195,11 @@
       font-size: 1.2em;
     }
 
+    .contrib-code {
+      color: $dark-gray;
+      font-size: 0.8em;
+    }
+
     .description {
       position: relative;
       color: $dark-gray;


### PR DESCRIPTION
Includes the codes in the contribution lists and a `data-searchable` tag.
I've decided not to opt for a label (like we have in the editing view) since this one looks simpler. However, depending on the feedback we can change it either way.
![imagem](https://user-images.githubusercontent.com/12183954/99555487-4ac3cf80-29b8-11eb-844b-a6b792ba97ed.png)
