### PR TITLE
Expose links the user can access

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Improvements
 - Add gender-neutral "Mx" title (:issue:`4688`, :pr:`4692`)
 - Add contributions placeholder for emails (:pr:`4716`, thanks :user:`bpedersen2`)
 - Show program codes in contribution list (:pr:`4713`)
+- Display the target URL of link materials if the user can access them (:issue:`2599`,
+  :pr:`4718`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/attachments/templates/_attachments.html
+++ b/indico/modules/attachments/templates/_attachments.html
@@ -8,8 +8,7 @@
 
 {% macro render_attachment(attachment, has_label=false, classes='') %}
     {% set previewable = (attachment.file.is_previewable and not g.static_site) or false %}
-    {% set restricted = attachment.is_self_protected and not attachment.can_access(session.user) %}
-    {% set visible_link = attachment.type.name == 'link' and not restricted %}
+    {% set visible_link = attachment.type.name == 'link' and (not attachment.is_self_protected or attachment.can_access(session.user)) %}
     <a class="attachment {{ get_attachment_icon(attachment) }} {% if attachment.is_self_protected %}is-protected{% endif %} {% if has_label %}has-label{% endif %} {%- if previewable %} js-preview-dialog{% endif %} {{ classes }}"
        data-previewable="{{ previewable|tojson }}"
        data-attachment-id="{{ attachment.id }}"
@@ -17,9 +16,7 @@
        title="{{ attachment.description or attachment.title }}
               {%- if attachment.is_self_protected %} ({% trans %}Protected{% endtrans %}){% endif %}">
         {%- if not has_label -%}
-            <span class="title">
-                {{ attachment.link_url if visible_link else attachment.title }}
-            </span>
+            <span class="title">{{ attachment.title }}</span>
         {%- endif -%}
     </a>
 {% endmacro %}

--- a/indico/modules/attachments/templates/_attachments.html
+++ b/indico/modules/attachments/templates/_attachments.html
@@ -8,14 +8,18 @@
 
 {% macro render_attachment(attachment, has_label=false, classes='') %}
     {% set previewable = (attachment.file.is_previewable and not g.static_site) or false %}
+    {% set restricted = attachment.is_self_protected and not attachment.can_access(session.user) %}
+    {% set visible_link = attachment.type.name == 'link' and not restricted %}
     <a class="attachment {{ get_attachment_icon(attachment) }} {% if attachment.is_self_protected %}is-protected{% endif %} {% if has_label %}has-label{% endif %} {%- if previewable %} js-preview-dialog{% endif %} {{ classes }}"
        data-previewable="{{ previewable|tojson }}"
        data-attachment-id="{{ attachment.id }}"
-       href="{{ attachment.download_url }}" target="_blank"
+       href="{{ attachment.link_url if visible_link else attachment.download_url }}" target="_blank"
        title="{{ attachment.description or attachment.title }}
               {%- if attachment.is_self_protected %} ({% trans %}Protected{% endtrans %}){% endif %}">
         {%- if not has_label -%}
-            <span class="title">{{ attachment.title }}</span>
+            <span class="title">
+                {{ attachment.link_url if visible_link else attachment.title }}
+            </span>
         {%- endif -%}
     </a>
 {% endmacro %}

--- a/indico/modules/attachments/templates/_attachments.html
+++ b/indico/modules/attachments/templates/_attachments.html
@@ -8,11 +8,12 @@
 
 {% macro render_attachment(attachment, has_label=false, classes='') %}
     {% set previewable = (attachment.file.is_previewable and not g.static_site) or false %}
-    {% set visible_link = attachment.type.name == 'link' and (not attachment.is_self_protected or attachment.can_access(session.user)) %}
+    {% set visible_link = attachment.type.name == 'link' and (not attachment.is_protected or attachment.can_access(session.user)) %}
     <a class="attachment {{ get_attachment_icon(attachment) }} {% if attachment.is_self_protected %}is-protected{% endif %} {% if has_label %}has-label{% endif %} {%- if previewable %} js-preview-dialog{% endif %} {{ classes }}"
        data-previewable="{{ previewable|tojson }}"
        data-attachment-id="{{ attachment.id }}"
        href="{{ attachment.link_url if visible_link else attachment.download_url }}" target="_blank"
+       rel="noopener noreferrer"
        title="{{ attachment.description or attachment.title }}
               {%- if attachment.is_self_protected %} ({% trans %}Protected{% endtrans %}){% endif %}">
         {%- if not has_label -%}

--- a/indico/modules/attachments/templates/_display.html
+++ b/indico/modules/attachments/templates/_display.html
@@ -14,10 +14,12 @@
                 <ul class="i-dropdown">
                     {%- for attachment in folder.attachments -%}
                         {% set previewable = (attachment.file and attachment.file.is_previewable and not g.static_site) or false %}
+                        {% set visible_link = attachment.type.name == 'link' and (not attachment.is_protected or attachment.can_access(session.user)) %}
                         <li>
                             <a data-previewable="{{ previewable | tojson }}"
                                data-attachment-id="{{ attachment.id }}"
-                               href="{{ attachment.download_url }}" target="_blank"
+                               href="{{ attachment.link_url if visible_link else attachment.download_url }}" target="_blank"
+                               rel="noopener noreferrer"
                                class="attachment {{ get_attachment_icon(attachment) }}
                                       {%- if attachment.is_self_protected %} is-protected{% endif %}
                                       {%- if previewable %} js-preview-dialog{% endif %}">
@@ -48,24 +50,4 @@
             {{ render_folder(folder) }}
         {%- endfor %}
     </div>
-{% endmacro %}
-
-
-{% macro render_attachments_button(files, folders) %}
-    <span class="attachments-tooltip-button"></span>
-    <ul class="material_list weak-hidden">
-        {% for attachment in files %}
-            <li><a href="{{ attachment.download_url }}">{{ attachment.title }}</a></li>
-        {% endfor %}
-        {% for folder in folders %}
-            <li>
-                <h3>{{ folder.title }}</h3>
-                <ul class="resource_list">
-                    {% for attachment in folder.attachments %}
-                        <li><a href="{{ attachment.download_url }}">{{ attachment.title }}</a></li>
-                    {% endfor %}
-                </ul>
-            </li>
-        {% endfor %}
-    </ul>
 {% endmacro %}


### PR DESCRIPTION
Closes #2599

Uses the simplistic approach where links are visible if the user has permissions on them. It causes an access check on our side for every button, but realistically I'm assuming no impact while doing that.

We also considered creating an Indico redirector (could even contain a signature to avoid malicious access) but concluded it could become a burden for a simple use-case.

View with permissions (the redirection is immediate):
![imagem](https://user-images.githubusercontent.com/12183954/99827599-c0af6e80-2b51-11eb-9042-f4696ef86d13.png)

View without permission (the redirection goes through the server):
![imagem](https://user-images.githubusercontent.com/12183954/99827673-d9b81f80-2b51-11eb-94ba-97600f05e0fa.png)