### PR TITLE
Clone custom abstract fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Bugfixes
   for Editing (:pr:`4715`)
 - Fix filename pattern check in Editing when a filename contains dots (:pr:`4715`)
 - Require explicit admin override (or being whitelisted) to override blockings (:pr:`4706`)
+- Clone custom abstract/contribution fields when clonint abstract settings (:pr:`4724`,
+  thanks :user:`bpedersen2`)
 
 Version 2.3.1
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,7 +31,7 @@ Bugfixes
   for Editing (:pr:`4715`)
 - Fix filename pattern check in Editing when a filename contains dots (:pr:`4715`)
 - Require explicit admin override (or being whitelisted) to override blockings (:pr:`4706`)
-- Clone custom abstract/contribution fields when clonint abstract settings (:pr:`4724`,
+- Clone custom abstract/contribution fields when cloning abstract settings (:pr:`4724`,
   thanks :user:`bpedersen2`)
 
 Version 2.3.1

--- a/indico/modules/events/abstracts/clone.py
+++ b/indico/modules/events/abstracts/clone.py
@@ -21,7 +21,7 @@ from indico.util.i18n import _
 class AbstractSettingsCloner(EventCloner):
     name = 'abstracts_settings'
     friendly_name = _('Call for Abstracts (settings, email templates, review questions)')
-    requires = {'contribution_types', 'tracks'}
+    requires = {'contribution_fields', 'contribution_types', 'tracks'}
 
     @property
     def is_visible(self):


### PR DESCRIPTION
Enable cloning custom abstract fields, otherwise only the default
fields are available in cloned events.
