### PR TITLE
contributions in mails: Add missing external flag

### DIFF
--- a/indico/modules/events/persons/templates/emails/_contributions.html
+++ b/indico/modules/events/persons/templates/emails/_contributions.html
@@ -2,7 +2,7 @@
     <ul>
         {% for contribution in contributions %}
             <li>
-                <a href="{{ url_for('contributions.display_contribution', contribution) }}">{{ contribution.title }}</a>
+                <a href="{{ url_for('contributions.display_contribution', contribution, _external=true) }}">{{ contribution.title }}</a>
                 (
                 {%- if contribution.timetable_entry -%}
                     {{ contribution.timetable_entry.start_dt | format_datetime(format='EEEE', timezone=timezone) }}


### PR DESCRIPTION
The external flag was missing on url_for, so the links where relative.