### PR TITLE
New search interface

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -28,6 +28,7 @@ settings:
         - ['indico/modules/core', './indico/modules/core/client/js']
         - ['indico/modules/rb', './indico/modules/rb/client/js']
         - ['indico/modules/users', './indico/modules/users/client/js']
+        - ['indico/modules/search', './indico/modules/search/client/js']
         - ['indico/modules/events/reviewing', './indico/modules/events/client/js/reviewing']
         - ['indico/modules/events/editing', './indico/modules/events/editing/client/js']
         - ['indico/modules/events', './indico/modules/events/client/js']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
              indico/modules/events/papers/client/js/
              indico/web/client/js/react/
              indico/modules/users/
+             indico/modules/search/
 
       - name: Run stylelint for all files
         if: github.event_name == 'push' && (success() || failure())

--- a/indico/core/signals/core.py
+++ b/indico/core/signals/core.py
@@ -94,3 +94,8 @@ sent in the *password* kwarg. To fail the security check for a password,
 the signal handler should return a string describing why the password is
 not secure.
 """)
+
+# TODO write the docstring for this signal..
+get_search_providers = _signals.signal('get-search-providers', """
+Expected to return...
+""")

--- a/indico/modules/categories/client/js/index.js
+++ b/indico/modules/categories/client/js/index.js
@@ -5,18 +5,32 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import searchUrl from 'indico-url:search.search';
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 
 import './display';
 import './base';
 
+import SearchBox from 'indico/modules/search/components/SearchBox';
 import {setMomentLocale} from 'indico/utils/date';
 
 import CategoryStatistics from './components/CategoryStatistics';
 import {LocaleContext} from './context.js';
 
 (function(global) {
+  document.addEventListener('DOMContentLoaded', () => {
+    const domContainer = document.querySelector('#search-box');
+    ReactDOM.render(
+      React.createElement(SearchBox, {
+        onSearch: keyword => {
+          window.location = searchUrl({q: keyword});
+        },
+      }),
+      domContainer
+    );
+  });
   global.setupCategoryStats = function setupCategoryStats() {
     document.addEventListener('DOMContentLoaded', async () => {
       const rootElement = document.querySelector('#category-stats-root');

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -21,6 +21,9 @@
         {% block cat_toolbar %}
             <div id="category-toolbar" class="toolbar">
                 <div class="group">
+                    <div id="search-box"></div>
+                </div>
+                <div class="group">
                     {% block cat_create_event %}
                         {{ create_event_button(category, classes="highlight", text=_("Create event"), with_tooltip=false) }}
                     {% endblock %}

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -985,6 +985,12 @@ def _mappers_configured():
     query = select([cte.c.path]).where(cte.c.id == Event.category_id).correlate_except(cte)
     Event.category_chain = column_property(query, deferred=True)
 
+    # Event.detailed_category_chain -- the category chain of the event, starting
+    # with the root category down to the event's immediate parent.
+    cte = Category.get_tree_cte(lambda cat: db.func.json_build_object('id', cat.id, 'title', cat.title))
+    query = select([cte.c.path]).where(cte.c.id == Event.category_id).correlate_except(cte)
+    Event.detailed_category_chain = column_property(query, deferred=True)
+
     # Event.effective_protection_mode -- the effective protection mode
     # (public/protected) of the event, even if it's inheriting it from its
     # parent category

--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -15,7 +15,7 @@ class SearchTarget(int, IndicoEnum):
     attachment = 4
 
 
-class IndicoSearchProvider(object):
+class IndicoSearchProvider:
     RESULTS_PER_PAGE = 10
 
     @classmethod

--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -1,6 +1,6 @@
 from indico.core import signals
+from indico.util.enum import IndicoEnum
 from indico.util.signals import values_from_signal
-from indico.util.struct.enum import IndicoEnum
 
 
 def get_search_provider():

--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -1,0 +1,23 @@
+from indico.core import signals
+from indico.util.signals import values_from_signal
+from indico.util.struct.enum import IndicoEnum
+
+
+def get_search_provider():
+    providers = signals.get_search_providers.send()
+    return values_from_signal(providers, as_list=True)[0] if len(providers) else None
+
+
+class SearchTarget(int, IndicoEnum):
+    category = 1
+    event = 2
+    contribution = 3
+    attachment = 4
+
+
+class IndicoSearchProvider(object):
+    RESULTS_PER_PAGE = 10
+
+    @classmethod
+    def search(cls, query, access, object_type=SearchTarget.event, page=1):
+        raise NotImplementedError()

--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -18,6 +18,5 @@ class SearchTarget(int, IndicoEnum):
 class IndicoSearchProvider:
     RESULTS_PER_PAGE = 10
 
-    @classmethod
-    def search(cls, query, access, object_type=SearchTarget.event, page=1):
+    def search(self, query, access, object_type=SearchTarget.event, page=1):
         raise NotImplementedError()

--- a/indico/modules/search/blueprint.py
+++ b/indico/modules/search/blueprint.py
@@ -1,0 +1,24 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2020 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from indico.modules.search.controllers import (RHSearch, RHSearchCategories, RHSearchContributions, RHSearchEvents,
+                                               RHSearchFiles)
+from indico.web.flask.wrappers import IndicoBlueprint
+
+
+_bp = IndicoBlueprint('search', __name__, template_folder='templates', virtual_template_folder='search')
+
+# Frontend
+_bp.add_url_rule('/search/', 'search', RHSearch)
+
+# Search APIs
+_bp.add_url_rule('/search/api/categories', 'search_categories', RHSearchCategories)
+_bp.add_url_rule('/search/api/events', 'search_events', RHSearchEvents)
+_bp.add_url_rule('/search/api/contributions', 'search_contributions', RHSearchContributions)
+_bp.add_url_rule('/search/api/files', 'search_files', RHSearchFiles)

--- a/indico/modules/search/blueprint.py
+++ b/indico/modules/search/blueprint.py
@@ -5,8 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from __future__ import unicode_literals
-
 from indico.modules.search.controllers import (RHAPISearchAttachment, RHAPISearchCategory, RHAPISearchContribution,
                                                RHAPISearchEvent, RHSearchDisplay)
 from indico.web.flask.wrappers import IndicoBlueprint

--- a/indico/modules/search/blueprint.py
+++ b/indico/modules/search/blueprint.py
@@ -7,18 +7,18 @@
 
 from __future__ import unicode_literals
 
-from indico.modules.search.controllers import (RHSearch, RHSearchCategories, RHSearchContributions, RHSearchEvents,
-                                               RHSearchFiles)
+from indico.modules.search.controllers import (RHAPISearchAttachment, RHAPISearchCategory, RHAPISearchContribution,
+                                               RHAPISearchEvent, RHSearchDisplay)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('search', __name__, template_folder='templates', virtual_template_folder='search')
 
 # Frontend
-_bp.add_url_rule('/search/', 'search', RHSearch)
+_bp.add_url_rule('/search/', 'search', RHSearchDisplay)
 
 # Search APIs
-_bp.add_url_rule('/search/api/categories', 'search_categories', RHSearchCategories)
-_bp.add_url_rule('/search/api/events', 'search_events', RHSearchEvents)
-_bp.add_url_rule('/search/api/contributions', 'search_contributions', RHSearchContributions)
-_bp.add_url_rule('/search/api/files', 'search_files', RHSearchFiles)
+_bp.add_url_rule('/search/api/category', 'api_search_category', RHAPISearchCategory)
+_bp.add_url_rule('/search/api/event', 'api_search_event', RHAPISearchEvent)
+_bp.add_url_rule('/search/api/contribution', 'api_search_contribution', RHAPISearchContribution)
+_bp.add_url_rule('/search/api/attachment', 'api_search_attachment', RHAPISearchAttachment)

--- a/indico/modules/search/blueprint.py
+++ b/indico/modules/search/blueprint.py
@@ -1,5 +1,5 @@
 # This file is part of Indico.
-# Copyright (C) 2002 - 2020 CERN
+# Copyright (C) 2002 - 2021 CERN
 #
 # Indico is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/ResultList.jsx
+++ b/indico/modules/search/client/js/components/ResultList.jsx
@@ -1,0 +1,69 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import {List, Placeholder, Segment} from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import './ResultList.module.scss';
+import SearchPagination from './SearchPagination';
+
+export default function ResultList({
+  component: Component,
+  page,
+  numPages,
+  data,
+  loading,
+  onPageChange,
+}) {
+  return (
+    <>
+      <Segment>
+        <List divided relaxed stylename="space">
+          {loading ? (
+            <Placeholder>
+              <Placeholder.Paragraph>
+                <Placeholder.Line />
+                <Placeholder.Line />
+                <Placeholder.Line />
+              </Placeholder.Paragraph>
+              <Placeholder.Paragraph>
+                <Placeholder.Line />
+                <Placeholder.Line />
+                <Placeholder.Line />
+              </Placeholder.Paragraph>
+              <Placeholder.Paragraph>
+                <Placeholder.Line />
+                <Placeholder.Line />
+                <Placeholder.Line />
+              </Placeholder.Paragraph>
+            </Placeholder>
+          ) : (
+            data.map(item => (
+              <List.Item key={item.id}>
+                <List.Content styleName="list">
+                  <Component {...item} />
+                </List.Content>
+              </List.Item>
+            ))
+          )}
+        </List>
+      </Segment>
+      {numPages > 1 && (
+        <SearchPagination activePage={page} numOfPages={numPages} onPageChange={onPageChange} />
+      )}
+    </>
+  );
+}
+
+ResultList.propTypes = {
+  component: PropTypes.elementType.isRequired,
+  page: PropTypes.number.isRequired,
+  numPages: PropTypes.number.isRequired,
+  data: PropTypes.arrayOf(PropTypes.object).isRequired,
+  loading: PropTypes.bool.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+};

--- a/indico/modules/search/client/js/components/ResultList.jsx
+++ b/indico/modules/search/client/js/components/ResultList.jsx
@@ -5,11 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {List, Placeholder, Segment} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
-import './ResultList.module.scss';
+
 import SearchPagination from './SearchPagination';
+import './ResultList.module.scss';
 
 export default function ResultList({
   component: Component,

--- a/indico/modules/search/client/js/components/ResultList.jsx
+++ b/indico/modules/search/client/js/components/ResultList.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/ResultList.module.scss
+++ b/indico/modules/search/client/js/components/ResultList.module.scss
@@ -1,0 +1,16 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+.list {
+  a {
+    font-size: 18px;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}

--- a/indico/modules/search/client/js/components/ResultList.module.scss
+++ b/indico/modules/search/client/js/components/ResultList.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -1,0 +1,249 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import searchCategoriesURL from 'indico-url:search.search_categories';
+import searchEventsURL from 'indico-url:search.search_events';
+import searchContributionsURL from 'indico-url:search.search_contributions';
+import searchFilesURL from 'indico-url:search.search_files';
+
+import React, {useEffect, useReducer, useState} from 'react';
+import {Loader, Menu, Grid} from 'semantic-ui-react';
+import {useQueryParam, StringParam} from 'use-query-params';
+import {useIndicoAxios} from 'indico/react/hooks';
+import {Translate} from 'indico/react/i18n';
+import ResultList from './ResultList';
+import SearchBar from './SearchBar';
+import Category from './results/Category';
+import Event from './results/Event';
+import Contribution from './results/Contribution';
+import File from './results/File';
+import NoResults from './results/NoResults';
+import SideBar from './SideBar';
+
+const searchReducer = (state, action) => {
+  switch (action.type) {
+    case 'SET_QUERY':
+      return {...state, query: action.query, page: 1};
+    case 'SET_PAGE':
+      return {...state, page: action.page};
+    default:
+      throw new Error(`invalid action: ${action.type}`);
+  }
+};
+
+function useSearch(url, outerQuery) {
+  const [{query, page}, dispatch] = useReducer(searchReducer, {query: '', page: 1});
+  useEffect(() => {
+    // we have to dispatch an action that sets the query and resets the page.
+    // since the axios hook only monitors `query` the request won't be sent
+    // until the reducer ran and updated both query and page
+    dispatch({type: 'SET_QUERY', query: outerQuery});
+  }, [outerQuery]);
+
+  const {data, loading} = useIndicoAxios({
+    url,
+    camelize: true,
+    options: {params: {q: query, page}},
+    forceDispatchEffect: () => !!query,
+    trigger: [url, query, page],
+  });
+
+  const setPage = newPage => {
+    dispatch({type: 'SET_PAGE', page: newPage});
+  };
+
+  return [
+    {
+      page: data ? data.page : 1,
+      pages: data ? data.pages : 1,
+      total: data ? data.total : -1,
+      data: data ? data.results : [],
+      loading,
+    },
+    setPage,
+  ];
+}
+
+// eslint-disable-next-line react/prop-types
+function SearchTypeMenuItem({name, active, title, total, loading, onClick}) {
+  let indicator = null;
+  if (loading) {
+    indicator = <Loader active inline size="tiny" />;
+  } else if (total !== -1) {
+    indicator = ` (${total})`;
+  }
+  return (
+    <Menu.Item name={name} active={active} onClick={onClick} disabled={loading || !total}>
+      {title}
+      {indicator}
+    </Menu.Item>
+  );
+}
+
+export default function SearchApp() {
+  const [query, setQuery] = useQueryParam('q', StringParam);
+  const [activeMenuItem, setActiveMenuItem] = useState('categories');
+  const handleClick = (e, {name}) => {
+    setActiveMenuItem(name);
+  };
+
+  const [categoryResults, setCategoryPage] = useSearch(searchCategoriesURL(), query);
+  const [eventResults, setEventPage] = useSearch(searchEventsURL(), query);
+  const [contributionResults, setContributionPage] = useSearch(searchContributionsURL(), query);
+  const [fileResults, setFilePage] = useSearch(searchFilesURL(), query);
+  const [results, setResults] = useState('initial state');
+  const resultMap = {
+    categories: categoryResults,
+    events: eventResults,
+    contributions: contributionResults,
+    files: fileResults,
+  };
+  const resultTypes = ['categories', 'events', 'contributions', 'files'];
+
+  useEffect(() => {
+    if (resultMap[activeMenuItem].total !== 0) {
+      // don't switch if the currently active type has results
+      return;
+    }
+
+    const firstTypeWithResults = resultTypes.find(x => resultMap[x].total > 0);
+    if (firstTypeWithResults) {
+      setActiveMenuItem(firstTypeWithResults);
+      return;
+    }
+
+    const firstTypeStillSearching = resultTypes.find(x => resultMap[x].loading);
+    if (firstTypeStillSearching) {
+      setActiveMenuItem(firstTypeStillSearching);
+      return;
+    }
+  }, [
+    activeMenuItem,
+    categoryResults,
+    eventResults,
+    contributionResults,
+    fileResults,
+    resultMap,
+    resultTypes,
+  ]);
+
+  // handle the correct rendering of NoResults Placeholder
+  useEffect(() => {
+    if (Object.values(resultMap).some(x => x.total === -1)) {
+      setResults('initial state');
+      return;
+    }
+    // if (Object.values(resultMap).some(x => x.loading)) {
+    //   setResults('loading');
+    //   return;
+    // }
+    const firstTypeWithResults = resultTypes.find(x => resultMap[x].total !== 0);
+    if (firstTypeWithResults) {
+      setResults('loaded');
+      return;
+    }
+    setResults('empty');
+  }, [resultMap, resultTypes]);
+
+  const handleQuery = value => setQuery(value, 'pushIn');
+
+  return (
+    <Grid>
+      <Grid.Column width={5}>
+        <SideBar filterType="Contributions" />
+      </Grid.Column>
+      <Grid.Column width={6}>
+        <SearchBar onSearch={handleQuery} searchTerm={query || ''} />
+        {query && (
+          <>
+            <Menu pointing secondary>
+              <SearchTypeMenuItem
+                name="categories"
+                active={activeMenuItem === 'categories' && results !== 'empty'}
+                title={Translate.string('Categories')}
+                total={categoryResults.total}
+                loading={categoryResults.loading}
+                onClick={handleClick}
+              />
+              <SearchTypeMenuItem
+                name="events"
+                active={activeMenuItem === 'events' && results !== 'empty'}
+                title={Translate.string('Events')}
+                total={eventResults.total}
+                loading={eventResults.loading}
+                onClick={handleClick}
+              />
+              <SearchTypeMenuItem
+                name="contributions"
+                active={activeMenuItem === 'contributions' && results !== 'empty'}
+                title={Translate.string('Contributions')}
+                total={contributionResults.total}
+                loading={contributionResults.loading}
+                onClick={handleClick}
+              />
+              <SearchTypeMenuItem
+                name="files"
+                active={activeMenuItem === 'files' && results !== 'empty'}
+                title={Translate.string('Materials')}
+                total={fileResults.total}
+                loading={fileResults.loading}
+                onClick={handleClick}
+              />
+            </Menu>
+            {results !== 'empty' ? (
+              <>
+                {activeMenuItem === 'categories' && (
+                  <ResultList
+                    component={Category}
+                    page={categoryResults.page}
+                    numPages={categoryResults.pages}
+                    data={categoryResults.data}
+                    onPageChange={setCategoryPage}
+                    loading={categoryResults.loading}
+                  />
+                )}
+                {activeMenuItem === 'events' && (
+                  <ResultList
+                    component={Event}
+                    page={eventResults.page}
+                    numPages={eventResults.pages}
+                    data={eventResults.data}
+                    onPageChange={setEventPage}
+                    loading={eventResults.loading}
+                  />
+                )}
+                {activeMenuItem === 'contributions' && (
+                  <ResultList
+                    component={Contribution}
+                    page={contributionResults.page}
+                    numPages={contributionResults.pages}
+                    data={contributionResults.data}
+                    onPageChange={setContributionPage}
+                    loading={contributionResults.loading}
+                  />
+                )}
+                {activeMenuItem === 'files' && (
+                  <ResultList
+                    component={File}
+                    page={fileResults.page}
+                    numPages={fileResults.pages}
+                    data={fileResults.data}
+                    onPageChange={setFilePage}
+                    loading={fileResults.loading}
+                  />
+                )}
+              </>
+            ) : (
+              <NoResults query={query} />
+            )}
+          </>
+        )}
+      </Grid.Column>
+      <Grid.Column width={5} />
+    </Grid>
+  );
+}

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -6,22 +6,24 @@
 // LICENSE file for more details.
 
 import searchCategoriesURL from 'indico-url:search.search_categories';
-import searchEventsURL from 'indico-url:search.search_events';
 import searchContributionsURL from 'indico-url:search.search_contributions';
+import searchEventsURL from 'indico-url:search.search_events';
 import searchFilesURL from 'indico-url:search.search_files';
 
 import React, {useEffect, useReducer, useState} from 'react';
 import {Loader, Menu, Grid} from 'semantic-ui-react';
 import {useQueryParam, StringParam} from 'use-query-params';
+
 import {useIndicoAxios} from 'indico/react/hooks';
 import {Translate} from 'indico/react/i18n';
+
 import ResultList from './ResultList';
-import SearchBar from './SearchBar';
 import Category from './results/Category';
-import Event from './results/Event';
 import Contribution from './results/Contribution';
+import Event from './results/Event';
 import File from './results/File';
 import NoResults from './results/NoResults';
+import SearchBar from './SearchBar';
 import SideBar from './SideBar';
 
 const searchReducer = (state, action) => {

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -5,10 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import searchCategoriesURL from 'indico-url:search.search_categories';
-import searchContributionsURL from 'indico-url:search.search_contributions';
-import searchEventsURL from 'indico-url:search.search_events';
-import searchFilesURL from 'indico-url:search.search_files';
+import searchAttachmentURL from 'indico-url:search.api_search_attachment';
+import searchCategoryURL from 'indico-url:search.api_search_category';
+import searchContributionURL from 'indico-url:search.api_search_contribution';
+import searchEventURL from 'indico-url:search.api_search_event';
 
 import PropTypes from 'prop-types';
 import React, {useEffect, useReducer, useState, useMemo} from 'react';
@@ -113,10 +113,10 @@ export default function SearchApp() {
     setActiveMenuItem(index);
   };
 
-  const [categoryResults, setCategoryPage] = useSearch(searchCategoriesURL(), query);
-  const [eventResults, setEventPage] = useSearch(searchEventsURL(), query);
-  const [contributionResults, setContributionPage] = useSearch(searchContributionsURL(), query);
-  const [fileResults, setFilePage] = useSearch(searchFilesURL(), query);
+  const [categoryResults, setCategoryPage] = useSearch(searchCategoryURL(), query);
+  const [eventResults, setEventPage] = useSearch(searchEventURL(), query);
+  const [contributionResults, setContributionPage] = useSearch(searchContributionURL(), query);
+  const [fileResults, setFilePage] = useSearch(searchAttachmentURL(), query);
   const searchMap = [
     ['Categories', categoryResults, setCategoryPage, Category],
     ['Events', eventResults, setEventPage, Event],

--- a/indico/modules/search/client/js/components/SearchBar.jsx
+++ b/indico/modules/search/client/js/components/SearchBar.jsx
@@ -1,0 +1,44 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React, {useState, useEffect} from 'react';
+import PropTypes from 'prop-types';
+import {Form} from 'semantic-ui-react';
+import {Translate} from 'indico/react/i18n';
+
+export default function SearchBar({onSearch, searchTerm}) {
+  const [keyword, setKeyword] = useState(searchTerm);
+
+  const handleChange = event => {
+    setKeyword(event.target.value);
+  };
+
+  const handleSubmit = event => {
+    event.preventDefault();
+    onSearch(keyword);
+  };
+
+  useEffect(() => {
+    setKeyword(searchTerm);
+  }, [searchTerm]);
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Form.Input
+        action={Translate.string('Search')}
+        placeholder={Translate.string('Enter your search term')}
+        value={keyword}
+        onChange={handleChange}
+      />
+    </Form>
+  );
+}
+
+SearchBar.propTypes = {
+  onSearch: PropTypes.func.isRequired,
+  searchTerm: PropTypes.string.isRequired,
+};

--- a/indico/modules/search/client/js/components/SearchBar.jsx
+++ b/indico/modules/search/client/js/components/SearchBar.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useState, useEffect} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState, useEffect} from 'react';
 import {Form} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 
 export default function SearchBar({onSearch, searchTerm}) {

--- a/indico/modules/search/client/js/components/SearchBar.jsx
+++ b/indico/modules/search/client/js/components/SearchBar.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/SearchBox.jsx
+++ b/indico/modules/search/client/js/components/SearchBox.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Form} from 'semantic-ui-react';
+
 import {Translate} from 'indico/react/i18n';
 
 export default function SearchBox({onSearch}) {

--- a/indico/modules/search/client/js/components/SearchBox.jsx
+++ b/indico/modules/search/client/js/components/SearchBox.jsx
@@ -1,0 +1,35 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React, {useState} from 'react';
+import PropTypes from 'prop-types';
+import {Form} from 'semantic-ui-react';
+import {Translate} from 'indico/react/i18n';
+
+export default function SearchBox({onSearch}) {
+  const [keyword, setKeyword] = useState('');
+  const handleChange = event => {
+    setKeyword(event.target.value);
+  };
+  const handleSubmit = () => {
+    onSearch(keyword);
+  };
+  return (
+    <Form onSubmit={handleSubmit}>
+      <Form.Input
+        action={{icon: 'search', size: 'tiny', disabled: !keyword}}
+        placeholder={Translate.string('Enter your search term')}
+        onChange={handleChange}
+        value={keyword}
+      />
+    </Form>
+  );
+}
+
+SearchBox.propTypes = {
+  onSearch: PropTypes.func.isRequired,
+};

--- a/indico/modules/search/client/js/components/SearchBox.jsx
+++ b/indico/modules/search/client/js/components/SearchBox.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/SearchPagination.jsx
+++ b/indico/modules/search/client/js/components/SearchPagination.jsx
@@ -1,0 +1,39 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Pagination} from 'semantic-ui-react';
+import './SearchPagination.module.scss';
+
+export default function SearchPagination({activePage, numOfPages, onPageChange}) {
+  const handlePageChange = (e, {activePage: active}) => {
+    e.preventDefault();
+    onPageChange(active);
+  };
+
+  return (
+    <div styleName="pagination">
+      <Pagination
+        activePage={activePage}
+        onPageChange={handlePageChange}
+        totalPages={numOfPages}
+        boundaryRange={1}
+        ellipsisItem={null}
+        siblingRange={2}
+        firstItem={null}
+        lastItem={null}
+      />
+    </div>
+  );
+}
+
+SearchPagination.propTypes = {
+  activePage: PropTypes.number.isRequired,
+  numOfPages: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+};

--- a/indico/modules/search/client/js/components/SearchPagination.jsx
+++ b/indico/modules/search/client/js/components/SearchPagination.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Pagination} from 'semantic-ui-react';
 import './SearchPagination.module.scss';
 

--- a/indico/modules/search/client/js/components/SearchPagination.jsx
+++ b/indico/modules/search/client/js/components/SearchPagination.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/SearchPagination.module.scss
+++ b/indico/modules/search/client/js/components/SearchPagination.module.scss
@@ -1,0 +1,12 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}

--- a/indico/modules/search/client/js/components/SearchPagination.module.scss
+++ b/indico/modules/search/client/js/components/SearchPagination.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/SideBar.jsx
+++ b/indico/modules/search/client/js/components/SideBar.jsx
@@ -1,0 +1,135 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+import {Table, Checkbox} from 'semantic-ui-react';
+import {useQueryParam, StringParam} from 'use-query-params';
+
+import './SideBar.module.scss';
+
+export default function SideBar({filterType}) {
+  const [speakerValue, setSpeakerValue] = useState('');
+  const [affiliationValue, setAffiliationValue] = useState('');
+
+  const [speakerFilter, setSpeakerFilter] = useQueryParam('speaker', StringParam);
+  const [affiliationFilter, setAffiliationFilter] = useQueryParam('affiliation', StringParam);
+
+  const addSearchFilter = (value, type) => {
+    if (type === 'speaker') {
+      setSpeakerFilter(speakerValue === value ? '' : value, 'pushIn');
+      setSpeakerValue(speakerValue === value ? '' : value);
+    } else if (type === 'affiliation') {
+      setAffiliationFilter(affiliationValue === value ? '' : value, 'pushIn');
+      setAffiliationValue(affiliationValue === value ? '' : value);
+    }
+  };
+
+  const handleChange = (e, {value}) => {
+    addSearchFilter(value.name, value.type);
+  };
+
+  // it's going to change soon
+  if (filterType !== 'Contributions') {
+    return;
+  }
+  return (
+    <div styleName="sidebar">
+      <Table celled padded>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Speakers</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <Checkbox
+                label="Aristofanis (45)"
+                name="Aristofanis"
+                value={{name: 'Aristofanis', type: 'speaker'}}
+                checked={speakerValue === 'Aristofanis'}
+                onChange={handleChange}
+              />
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Checkbox
+                label="Pedro (4555)"
+                name="Pedro"
+                value={{name: 'Pedro', type: 'speaker'}}
+                checked={speakerValue === 'Pedro'}
+                onChange={handleChange}
+              />
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Checkbox
+                label="Adrian (455)"
+                name="Adrian"
+                value={{name: 'Adrian', type: 'speaker'}}
+                checked={speakerValue === 'Adrian'}
+                onChange={handleChange}
+              />
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+
+      <Table celled padded>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell>Affiliations</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell>
+              <Checkbox
+                label="Natalia's (123)"
+                name="Natalia"
+                value={{name: 'Natalia', type: 'affiliation'}}
+                checked={affiliationValue === 'Natalia'}
+                onChange={handleChange}
+              />
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Checkbox
+                label="Marco's (321)"
+                name="Marco"
+                value={{name: 'Marco', type: 'affiliation'}}
+                checked={affiliationValue === 'Marco'}
+                onChange={handleChange}
+              />
+            </Table.Cell>
+          </Table.Row>
+          <Table.Row>
+            <Table.Cell>
+              <Checkbox
+                label="Giota's (333)"
+                name="Giota"
+                value={{name: 'Giota', type: 'affiliation'}}
+                checked={affiliationValue === 'Giota'}
+                onChange={handleChange}
+              />
+            </Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </div>
+  );
+}
+
+SideBar.propTypes = {
+  filterType: PropTypes.string.isRequired,
+};

--- a/indico/modules/search/client/js/components/SideBar.jsx
+++ b/indico/modules/search/client/js/components/SideBar.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/SideBar.module.scss
+++ b/indico/modules/search/client/js/components/SideBar.module.scss
@@ -1,0 +1,11 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+.sidebar {
+  float: right;
+  margin-top: 8.25em;
+}

--- a/indico/modules/search/client/js/components/SideBar.module.scss
+++ b/indico/modules/search/client/js/components/SideBar.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/Category.jsx
+++ b/indico/modules/search/client/js/components/results/Category.jsx
@@ -1,0 +1,41 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import {List} from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import CategoryPath from './CategoryPath';
+import './Category.module.scss';
+
+export default function Category({title, path, url}) {
+  return (
+    <div styleName="category">
+      <List.Header>
+        <a href={url}>{title}</a>
+      </List.Header>
+      {path.length !== 0 && (
+        <div styleName="description">
+          <List.Description>
+            <CategoryPath path={path} />
+          </List.Description>
+        </div>
+      )}
+    </div>
+  );
+}
+
+Category.propTypes = {
+  title: PropTypes.string.isRequired,
+  path: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      title: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  url: PropTypes.string.isRequired,
+};

--- a/indico/modules/search/client/js/components/results/Category.jsx
+++ b/indico/modules/search/client/js/components/results/Category.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {List} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
+
 import CategoryPath from './CategoryPath';
 import './Category.module.scss';
 

--- a/indico/modules/search/client/js/components/results/Category.jsx
+++ b/indico/modules/search/client/js/components/results/Category.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/Category.module.scss
+++ b/indico/modules/search/client/js/components/results/Category.module.scss
@@ -1,0 +1,16 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@import 'base/palette';
+
+.category {
+  padding: 1em 0;
+
+  .description {
+    padding: 0.5em 0;
+  }
+}

--- a/indico/modules/search/client/js/components/results/Category.module.scss
+++ b/indico/modules/search/client/js/components/results/Category.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/CategoryPath.jsx
+++ b/indico/modules/search/client/js/components/results/CategoryPath.jsx
@@ -1,0 +1,37 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Breadcrumb, Icon} from 'semantic-ui-react';
+
+import './CategoryPath.module.scss';
+
+export default function CategoryPath({path}) {
+  const sections = path.map(item => ({
+    key: item.id,
+    href: item.url,
+    content: item.title,
+  }));
+
+  return (
+    <>
+      <Icon name="sitemap" />
+      <Breadcrumb styleName="path" divider="»" sections={sections} />
+    </>
+  );
+}
+
+CategoryPath.propTypes = {
+  path: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      title: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+};

--- a/indico/modules/search/client/js/components/results/CategoryPath.jsx
+++ b/indico/modules/search/client/js/components/results/CategoryPath.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/CategoryPath.jsx
+++ b/indico/modules/search/client/js/components/results/CategoryPath.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Breadcrumb, Icon} from 'semantic-ui-react';
 
 import './CategoryPath.module.scss';

--- a/indico/modules/search/client/js/components/results/CategoryPath.module.scss
+++ b/indico/modules/search/client/js/components/results/CategoryPath.module.scss
@@ -1,0 +1,21 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@import 'base/palette';
+
+.path:global(.ui.breadcrumb) {
+  :global(a.section),
+  :global(a.section:hover) {
+    font-size: 13px;
+    font-style: italic;
+    color: $dark-gray;
+  }
+
+  :global(.divider) {
+    color: $dark-gray;
+  }
+}

--- a/indico/modules/search/client/js/components/results/CategoryPath.module.scss
+++ b/indico/modules/search/client/js/components/results/CategoryPath.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/Contribution.jsx
+++ b/indico/modules/search/client/js/components/results/Contribution.jsx
@@ -1,0 +1,60 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import {List, Icon} from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import {toMoment, serializeDate} from 'indico/utils/date';
+
+import './Contribution.module.scss';
+
+const Contribution = ({title, url, startDt, eventURL, eventTitle, persons}) => (
+  <div styleName="contribution">
+    <List.Header>
+      <a href={url}>{title}</a>
+    </List.Header>
+    <List.Description styleName="description">
+      <List.Item styleName="high-priority">
+        {/* change to something that reminds an event */}
+        <Icon name="calendar check outline" />
+        <a href={eventURL}>{eventTitle}</a>
+      </List.Item>
+      <List.Item>
+        {persons.length !== 0 && (
+          <ul styleName="high-priority">
+            {persons.length > 1 ? <Icon name="users" /> : <Icon name="user" />}
+            {persons.map(person => (
+              <li key={person.id}>
+                {person.title ? `${person.title} ${person.name}` : person.name}
+              </li>
+            ))}
+          </ul>
+        )}
+      </List.Item>
+      <List.Item styleName="med-priority">
+        <Icon name="calendar alternate outline" />
+        {serializeDate(toMoment(startDt), 'DD MMMM YYYY HH:mm')}
+      </List.Item>
+    </List.Description>
+  </div>
+);
+
+Contribution.propTypes = {
+  title: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  startDt: PropTypes.string.isRequired,
+  eventURL: PropTypes.string.isRequired,
+  eventTitle: PropTypes.string.isRequired,
+  persons: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      title: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+};
+export default Contribution;

--- a/indico/modules/search/client/js/components/results/Contribution.jsx
+++ b/indico/modules/search/client/js/components/results/Contribution.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/Contribution.jsx
+++ b/indico/modules/search/client/js/components/results/Contribution.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {List, Icon} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
+
 import {toMoment, serializeDate} from 'indico/utils/date';
 
 import './Contribution.module.scss';

--- a/indico/modules/search/client/js/components/results/Contribution.module.scss
+++ b/indico/modules/search/client/js/components/results/Contribution.module.scss
@@ -1,0 +1,58 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+@import 'base/palette';
+
+.contribution {
+  padding: 1em 0;
+  color: $dark-gray;
+
+  .description {
+    padding: 0.4em 0;
+
+    a,
+    a:hover {
+      font-size: 15px;
+      color: $dark-gray;
+    }
+
+    .high-priority {
+      font-size: 15px;
+      padding: 0;
+      margin-top: 0.2em;
+      margin-bottom: 0.2em;
+      color: $dark-gray;
+
+      a,
+      a:hover {
+        color: $dark-gray;
+      }
+
+      li {
+        display: inline;
+        color: $dark-gray;
+
+        &::after {
+          content: ', ';
+        }
+
+        &:last-child::after {
+          content: '';
+        }
+      }
+    }
+
+    .med-priority {
+      font-size: 13px;
+      color: $dark-gray;
+      font-style: italic;
+
+      i {
+        color: $dark-gray;
+      }
+    }
+  }
+}

--- a/indico/modules/search/client/js/components/results/Contribution.module.scss
+++ b/indico/modules/search/client/js/components/results/Contribution.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/Event.jsx
+++ b/indico/modules/search/client/js/components/results/Event.jsx
@@ -1,0 +1,94 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import {List, Icon} from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import './Event.module.scss';
+import moment from 'moment';
+import {toMoment, serializeDate} from 'indico/utils/date';
+import CategoryPath from './CategoryPath';
+
+/* if end date == start date only show start date */
+const renderDates = (startDt, endDt) => (
+  <>
+    {moment(startDt).isSame(moment(endDt), 'day') ? (
+      <List.Item styleName="med-priority">
+        <Icon name="calendar alternate outline" />
+        {serializeDate(toMoment(startDt), 'DD MMMM YYYY HH:mm')}
+      </List.Item>
+    ) : (
+      <List.Item styleName="med-priority">
+        <Icon name="calendar alternate outline" />
+        {`${serializeDate(toMoment(startDt), 'DD MMMM YYYY')} -
+         ${serializeDate(toMoment(endDt), 'DD MMMM YYYY')}`}
+      </List.Item>
+    )}
+  </>
+);
+
+const Event = ({type, title, url, categoryPath, startDt, endDt, speakers}) => {
+  return (
+    <div styleName="event">
+      <List.Header>
+        <a href={url}>{title}</a>
+      </List.Header>
+      <List.Description styleName="description">
+        {/* if it's a lecture print the list of speakers */}
+        {type === 'lecture' && speakers.length !== 0 && (
+          <List.Item styleName="high-priority">
+            {speakers.map(i => (
+              <div key={i.name}>
+                {i.title
+                  ? `${i.title} ${i.name} (${i.affiliation})`
+                  : `${i.name} (${i.affiliation})`}
+              </div>
+            ))}
+          </List.Item>
+        )}
+
+        {renderDates(startDt, endDt)}
+        {/* Render the path */}
+        {categoryPath.length !== 0 && (
+          <List.Item>
+            <List.Description styleName="low-priority">
+              <CategoryPath path={categoryPath} />
+            </List.Description>
+          </List.Item>
+        )}
+      </List.Description>
+    </div>
+  );
+};
+
+Event.defaultProps = {
+  speakers: [],
+};
+
+const personShape = PropTypes.shape({
+  title: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  affiliation: PropTypes.string.isRequired,
+});
+
+Event.propTypes = {
+  title: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(['lecture', 'meeting', 'conference']).isRequired,
+  startDt: PropTypes.string.isRequired,
+  endDt: PropTypes.string.isRequired,
+  categoryPath: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      title: PropTypes.string.isRequired,
+      url: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  speakers: PropTypes.arrayOf(personShape),
+};
+
+export default Event;

--- a/indico/modules/search/client/js/components/results/Event.jsx
+++ b/indico/modules/search/client/js/components/results/Event.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/Event.jsx
+++ b/indico/modules/search/client/js/components/results/Event.jsx
@@ -5,33 +5,32 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import moment from 'moment';
+import PropTypes from 'prop-types';
 import React from 'react';
 import {List, Icon} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
 import './Event.module.scss';
-import moment from 'moment';
+
 import {toMoment, serializeDate} from 'indico/utils/date';
+
 import CategoryPath from './CategoryPath';
 
 /* if end date == start date only show start date */
-const renderDates = (startDt, endDt) => (
-  <>
-    {moment(startDt).isSame(moment(endDt), 'day') ? (
-      <List.Item styleName="med-priority">
-        <Icon name="calendar alternate outline" />
-        {serializeDate(toMoment(startDt), 'DD MMMM YYYY HH:mm')}
-      </List.Item>
-    ) : (
-      <List.Item styleName="med-priority">
-        <Icon name="calendar alternate outline" />
-        {`${serializeDate(toMoment(startDt), 'DD MMMM YYYY')} -
+const renderDates = (startDt, endDt) =>
+  moment(startDt).isSame(moment(endDt), 'day') ? (
+    <List.Item styleName="med-priority">
+      <Icon name="calendar alternate outline" />
+      {serializeDate(toMoment(startDt), 'DD MMMM YYYY HH:mm')}
+    </List.Item>
+  ) : (
+    <List.Item styleName="med-priority">
+      <Icon name="calendar alternate outline" />
+      {`${serializeDate(toMoment(startDt), 'DD MMMM YYYY')} -
          ${serializeDate(toMoment(endDt), 'DD MMMM YYYY')}`}
-      </List.Item>
-    )}
-  </>
-);
+    </List.Item>
+  );
 
-const Event = ({type, title, url, categoryPath, startDt, endDt, speakers}) => {
+const Event = ({type, title, url, categoryPath, startDt, endDt, chairPersons}) => {
   return (
     <div styleName="event">
       <List.Header>
@@ -39,9 +38,9 @@ const Event = ({type, title, url, categoryPath, startDt, endDt, speakers}) => {
       </List.Header>
       <List.Description styleName="description">
         {/* if it's a lecture print the list of speakers */}
-        {type === 'lecture' && speakers.length !== 0 && (
+        {type === 'lecture' && chairPersons.length !== 0 && (
           <List.Item styleName="high-priority">
-            {speakers.map(i => (
+            {chairPersons.map(i => (
               <div key={i.name}>
                 {i.title
                   ? `${i.title} ${i.name} (${i.affiliation})`
@@ -66,11 +65,11 @@ const Event = ({type, title, url, categoryPath, startDt, endDt, speakers}) => {
 };
 
 Event.defaultProps = {
-  speakers: [],
+  chairPersons: [],
 };
 
 const personShape = PropTypes.shape({
-  title: PropTypes.string.isRequired,
+  id: PropTypes.number,
   name: PropTypes.string.isRequired,
   affiliation: PropTypes.string.isRequired,
 });
@@ -88,7 +87,7 @@ Event.propTypes = {
       url: PropTypes.string.isRequired,
     })
   ).isRequired,
-  speakers: PropTypes.arrayOf(personShape),
+  chairPersons: PropTypes.arrayOf(personShape),
 };
 
 export default Event;

--- a/indico/modules/search/client/js/components/results/Event.module.scss
+++ b/indico/modules/search/client/js/components/results/Event.module.scss
@@ -1,0 +1,46 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+@import 'base/palette';
+
+.event {
+  padding: 1em 0;
+  color: $dark-gray;
+
+  .description {
+    padding: 0.5em 0;
+
+    i {
+      color: $dark-gray;
+    }
+
+    .high-priority {
+      font-size: 15px;
+    }
+
+    .med-priority {
+      font-size: 13px;
+      color: $dark-gray;
+      font-style: italic;
+    }
+
+    .low-priority {
+      font-size: 11px;
+      font-style: italic;
+
+      a,
+      a:hover {
+        font-size: 11px;
+        color: $dark-gray;
+      }
+
+      i {
+        padding-right: 1.4em;
+        padding-left: 0.1em;
+      }
+    }
+  }
+}

--- a/indico/modules/search/client/js/components/results/Event.module.scss
+++ b/indico/modules/search/client/js/components/results/Event.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/File.jsx
+++ b/indico/modules/search/client/js/components/results/File.jsx
@@ -1,0 +1,78 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import {List, Icon} from 'semantic-ui-react';
+import PropTypes from 'prop-types';
+import './File.module.scss';
+import {toMoment, serializeDate} from 'indico/utils/date';
+
+const iconSelector = type => {
+  const otherAttributes = {size: 'large'};
+  switch (type) {
+    case 'file-word':
+      return {color: 'blue', name: 'file word outline', ...otherAttributes};
+    case 'file-zip':
+      return {color: 'yellow', name: 'file archive outline', ...otherAttributes};
+    case 'file-presentation':
+      return {color: 'red', name: 'file powerpoint outline', ...otherAttributes};
+    case 'file-excel':
+      return {color: 'green', name: 'file excel outline', ...otherAttributes};
+    case 'file-pdf':
+      return {color: 'red', name: 'file pdf outline', ...otherAttributes};
+    case 'file-spreadsheet':
+      return {color: 'green', name: 'file excel outline', ...otherAttributes};
+    default:
+      return {name: 'file outline', ...otherAttributes};
+  }
+};
+
+const File = ({title, url, type, contributionTitle, date, contribURL, persons}) => (
+  <div styleName="file">
+    <List.Header>
+      <Icon {...iconSelector(type)} />
+      <a href={url}>{title}</a>
+    </List.Header>
+    <List.Description styleName="description">
+      <List.Item styleName="high-priority">
+        <Icon rotated="clockwise" name="level up alternate" />
+        <a href={contribURL}>{contributionTitle}</a>
+      </List.Item>
+      <List.Item>
+        {persons.length !== 0 && (
+          <ul styleName="high-priority">
+            {persons.length > 1 ? <Icon name="users" /> : <Icon name="user" />}
+            {persons.map(item => (
+              <li key={item.id}>{item.title ? `${item.title} ${item.name}` : `${item.name}`}</li>
+            ))}
+          </ul>
+        )}
+      </List.Item>
+      <List.Item styleName="med-priority">
+        <Icon name="calendar alternate outline" />
+        {serializeDate(toMoment(date), 'DD MMMM YYYY HH:mm')}
+      </List.Item>
+    </List.Description>
+  </div>
+);
+
+File.propTypes = {
+  title: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  contributionTitle: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+  contribURL: PropTypes.string.isRequired,
+  persons: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      title: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+};
+export default File;

--- a/indico/modules/search/client/js/components/results/File.jsx
+++ b/indico/modules/search/client/js/components/results/File.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import PropTypes from 'prop-types';
 import React from 'react';
 import {List, Icon} from 'semantic-ui-react';
-import PropTypes from 'prop-types';
+
 import './File.module.scss';
 import {toMoment, serializeDate} from 'indico/utils/date';
 
@@ -31,30 +32,26 @@ const iconSelector = type => {
   }
 };
 
-const File = ({title, url, type, contributionTitle, date, contribURL, persons}) => (
+const File = ({title, url, type, /* contributionTitle, contribURL,*/ modifiedDt, user}) => (
   <div styleName="file">
     <List.Header>
       <Icon {...iconSelector(type)} />
       <a href={url}>{title}</a>
     </List.Header>
     <List.Description styleName="description">
-      <List.Item styleName="high-priority">
-        <Icon rotated="clockwise" name="level up alternate" />
-        <a href={contribURL}>{contributionTitle}</a>
-      </List.Item>
+      {/* <List.Item styleName="high-priority">*/}
+      {/*  <Icon rotated="clockwise" name="level up alternate" />*/}
+      {/*  <a href={contribURL}>{contributionTitle}</a>*/}
+      {/* </List.Item>*/}
       <List.Item>
-        {persons.length !== 0 && (
-          <ul styleName="high-priority">
-            {persons.length > 1 ? <Icon name="users" /> : <Icon name="user" />}
-            {persons.map(item => (
-              <li key={item.id}>{item.title ? `${item.title} ${item.name}` : `${item.name}`}</li>
-            ))}
-          </ul>
-        )}
+        <ul styleName="high-priority">
+          <Icon name="user" />
+          <li key={user.id}>{user.name}</li>
+        </ul>
       </List.Item>
       <List.Item styleName="med-priority">
         <Icon name="calendar alternate outline" />
-        {serializeDate(toMoment(date), 'DD MMMM YYYY HH:mm')}
+        {serializeDate(toMoment(modifiedDt), 'DD MMMM YYYY HH:mm')}
       </List.Item>
     </List.Description>
   </div>
@@ -64,15 +61,13 @@ File.propTypes = {
   title: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  contributionTitle: PropTypes.string.isRequired,
-  date: PropTypes.string.isRequired,
-  contribURL: PropTypes.string.isRequired,
-  persons: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      title: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-    })
-  ).isRequired,
+  // contributionTitle: PropTypes.string,
+  modifiedDt: PropTypes.string.isRequired,
+  // contribURL: PropTypes.string,
+  user: PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+  }).isRequired,
 };
 export default File;

--- a/indico/modules/search/client/js/components/results/File.jsx
+++ b/indico/modules/search/client/js/components/results/File.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/File.module.scss
+++ b/indico/modules/search/client/js/components/results/File.module.scss
@@ -1,0 +1,59 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+@import 'base/palette';
+
+.file {
+  padding: 1em 0;
+  color: $dark-gray;
+
+  .description {
+    padding: 0.4em 0;
+    padding-left: 2em;
+
+    a,
+    a:hover {
+      font-size: 16px;
+      color: $dark-gray;
+    }
+
+    .high-priority {
+      font-size: 15px;
+      padding: 0;
+      margin-top: 0.2em;
+      margin-bottom: 0.2em;
+      color: $dark-gray;
+
+      a,
+      a:hover {
+        color: $dark-gray;
+      }
+
+      li {
+        display: inline;
+        color: $dark-gray;
+
+        &::after {
+          content: ', ';
+        }
+
+        &:last-child::after {
+          content: '';
+        }
+      }
+    }
+
+    .med-priority {
+      font-size: 13px;
+      color: $dark-gray;
+      font-style: italic;
+
+      i {
+        color: $dark-gray;
+      }
+    }
+  }
+}

--- a/indico/modules/search/client/js/components/results/File.module.scss
+++ b/indico/modules/search/client/js/components/results/File.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/NoResults.jsx
+++ b/indico/modules/search/client/js/components/results/NoResults.jsx
@@ -1,0 +1,25 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Message} from 'semantic-ui-react';
+import {Translate, Param} from 'indico/react/i18n';
+
+const NoResults = ({query}) => (
+  <Message warning>
+    <Message.Header>{Translate.string('No Results')}</Message.Header>
+    <Translate>
+      Your search - <Param name="query" value={query} /> - did not match any results
+    </Translate>
+  </Message>
+);
+
+NoResults.propTypes = {
+  query: PropTypes.string.isRequired,
+};
+export default NoResults;

--- a/indico/modules/search/client/js/components/results/NoResults.jsx
+++ b/indico/modules/search/client/js/components/results/NoResults.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/components/results/NoResults.jsx
+++ b/indico/modules/search/client/js/components/results/NoResults.jsx
@@ -5,9 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
 import PropTypes from 'prop-types';
+import React from 'react';
 import {Message} from 'semantic-ui-react';
+
 import {Translate, Param} from 'indico/react/i18n';
 
 const NoResults = ({query}) => (

--- a/indico/modules/search/client/js/index.jsx
+++ b/indico/modules/search/client/js/index.jsx
@@ -1,0 +1,24 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2020 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {BrowserRouter as Router, Route} from 'react-router-dom';
+import {QueryParamProvider} from 'use-query-params';
+import SearchApp from './components/SearchApp';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const root = document.querySelector('#search-root');
+  ReactDOM.render(
+    <Router>
+      <QueryParamProvider ReactRouterRoute={Route}>
+        <SearchApp />
+      </QueryParamProvider>
+    </Router>,
+    root
+  );
+});

--- a/indico/modules/search/client/js/index.jsx
+++ b/indico/modules/search/client/js/index.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2020 CERN
+// Copyright (C) 2002 - 2021 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/search/client/js/index.jsx
+++ b/indico/modules/search/client/js/index.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {BrowserRouter as Router, Route} from 'react-router-dom';
 import {QueryParamProvider} from 'use-query-params';
+
 import SearchApp from './components/SearchApp';
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -1,0 +1,461 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2020 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import division, unicode_literals
+
+from datetime import datetime
+from math import ceil
+
+import pytz
+from marshmallow import fields
+from sqlalchemy.orm import undefer
+
+from indico.core.db import db
+from indico.core.db.sqlalchemy.protection import ProtectionMode
+from indico.modules.categories import Category
+from indico.modules.events import Event
+from indico.modules.search.schemas import (CategoryResultSchema, ContributionResultSchema, EventResultSchema,
+                                           FileResultSchema)
+from indico.modules.search.views import WPSearch
+from indico.web.args import use_kwargs
+from indico.web.rh import RH
+
+
+RESULTS_PER_PAGE = 10
+
+
+class RHSearch(RH):
+    def _process(self):
+        return WPSearch.render_template('search.html')
+
+
+class RHSearchCategories(RH):
+    @use_kwargs({
+        'page': fields.Int(missing=1),
+        'q': fields.String(required=True),
+    })
+    def _process(self, page, q):
+        results = (Category.query
+                   .filter(Category.title_matches(q),
+                           ~Category.is_deleted)
+                   .options(undefer('chain'))
+                   .order_by(db.func.lower(Category.title))
+                   .paginate(page, RESULTS_PER_PAGE))
+        # XXX should we only show categories the user can access?
+        # this would be nicer but then we can't easily paginate...
+        return {'results': CategoryResultSchema(many=True).dump(results.items),
+                'page': results.page,
+                'pages': results.pages,
+                'total': results.total}
+
+
+class RHSearchEvents(RH):
+    @use_kwargs({
+        'page': fields.Int(missing=1),
+        'q': fields.String(required=True),
+    })
+    def _process(self, page, q):
+        results = (Event.query
+                   .filter(Event.title_matches(q),
+                           Event.effective_protection_mode == ProtectionMode.public,
+                           ~Event.is_deleted)
+                   .order_by(db.func.lower(Event.title))
+                   .paginate(page, RESULTS_PER_PAGE))
+        # XXX should we only show categories the user can access?
+        # this would be nicer but then we can't easily paginate...
+        return {'results': EventResultSchema(many=True).dump(results.items),
+                'page': results.page,
+                'pages': results.pages,
+                'total': results.total}
+
+
+class RHSearchContributions(RH):
+    @use_kwargs({
+        'page': fields.Int(missing=1),
+        'q': fields.String(required=True),
+    })
+    def _process(self, page, q):
+        data = [x for x in CONTRIB_DATA if q.lower() in x['title'].lower()]
+        total = len(data)
+        offset = (page - 1) * RESULTS_PER_PAGE
+        items = data[offset:offset + RESULTS_PER_PAGE]
+        pages = int(ceil(total / RESULTS_PER_PAGE))
+        return {'results': ContributionResultSchema(many=True).dump(items),
+                'page': page,
+                'pages': pages,
+                'total': total}
+
+
+class RHSearchFiles(RH):
+    @use_kwargs({
+        'page': fields.Int(missing=1),
+        'q': fields.String(required=True),
+    })
+    def _process(self, page, q):
+        data = [x for x in FILE_DATA if q.lower() in x['title'].lower()]
+        total = len(data)
+        offset = (page - 1) * RESULTS_PER_PAGE
+        items = data[offset:offset + RESULTS_PER_PAGE]
+        pages = int(ceil(total / RESULTS_PER_PAGE))
+        return {'results': FileResultSchema(many=True).dump(items),
+                'page': page,
+                'pages': pages,
+                'total': total}
+
+
+# dummy data
+CONTRIB_DATA = [
+    {'id': 2703412,
+     'persons': [{'id': 3319533, 'name': u'Michal Kolodziejski', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 13, 0)),
+     'title': u'Enterprise Authentication with Indico'},
+    {'id': 2703405,
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'persons': [{'id': 3336048, 'name': u'Dirk Hoffmann', 'title': u'Dr'}],
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 19, 9, 0)),
+     'title': u'Internationalization - tips and tricks'},
+    {'id': 2703418,
+     'persons': [{'id': 3319501, 'name': u'Pedro Ferreira', 'title': u''},
+                 {'id': 3361462, 'name': u'Thomas Baron', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 7, 50)),
+     'title': u"What's new in the Indicoverse?"},
+    {'id': 2703408,
+     'persons': [{'id': 3319509, 'name': u'Natalia Karina Juszka', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 19, 7, 0)),
+     'title': u'Any colour you like - customising Indico'},
+    {'id': 2703430,
+     'persons': [{'id': 3319550, 'name': u'Adrian M\xf6nnich', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 7, 15)),
+     'title': u'Maintaining an Indico instance - tips and tricks'},
+    {'id': 2703409,
+     'persons': [{'id': 3319523, 'name': u'Adrian M\xf6nnich', 'title': u''},
+                 {'id': 3319524, 'name': u'Natalia Karina Juszka', 'title': u''},
+                 {'id': 3319525, 'name': u'Pedro Ferreira', 'title': u''},
+                 {'id': 3319526, 'name': u'Marco Vidal', 'title': u''},
+                 {'id': 3319527, 'name': u'Michal Kolodziejski', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 14, 0)),
+     'title': u'Indico Development Bootcamp'},
+    {'id': 2703410,
+     'persons': [{'id': 3319506, 'name': u'Natalia Karina Juszka', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 9, 0)),
+     'title': u'Walkthrough - Developing a Plugin'},
+    {'id': 2703425,
+     'persons': [{'id': 3377568, 'name': u'Pedro Ferreira', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 12, 30)),
+     'title': u'The Future'},
+    {'id': 2703398,
+     'persons': [{'id': 3368725, 'name': u'Adrian M\xf6nnich', 'title': u''},
+                 {'id': 3368726, 'name': u'Pedro Ferreira', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 8, 50)),
+     'title': u"Version 2.0 - What's new?"},
+    {'id': 2703400,
+     'persons': [{'id': 3319499, 'name': u'Adrian M\xf6nnich', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 9, 50)),
+     'title': u'Version 2.0 - Under the hood'},
+    {'id': 2703414,
+     'persons': [{'id': 3328200, 'name': u'Stefan Hesselbach', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 12, 0)),
+     'title': u'Indico @ GSI'},
+    {'id': 2703415,
+     'persons': [{'id': 3328767, 'name': u'Giorgio Pieretti', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 19, 9, 30)),
+     'title': u'Indico @ UNOG'},
+    {'id': 2703413,
+     'persons': [{'id': 3319503, 'name': u'Marco Vidal', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 19, 7, 30)),
+     'title': u'Walkthrough: Container Deployment'},
+    {'id': 2703416,
+     'persons': [{'id': 3362150, 'name': u'Akihiro Shibata', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 8, 15)),
+     'title': u'Indico @ KEK'},
+    {'id': 2703417,
+     'persons': [{'id': 3367992, 'name': u'Thomas Baron', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 7, 30)),
+     'title': u'Welcome to CERN'},
+    {'id': 2703402,
+     'persons': [{'id': 3319515, 'name': u'Pedro Ferreira', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 12, 15)),
+     'title': u'Walkthrough - Migrating to 2.0'},
+    {'id': 2703681,
+     'persons': [{'id': 3319528, 'name': u'Pedro Ferreira', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 7, 0)),
+     'title': u'The Big Migration: An overview of three years of development'},
+    {'id': 2703772,
+     'persons': [{'id': 3328765, 'name': u'Penelope Constanta', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 19, 8, 45)),
+     'title': u'Indico @ Fermilab'},
+    {'id': 2703808,
+     'persons': [{'id': 3377569, 'name': u'Thomas Baron', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 13, 0)),
+     'title': u'Wrap-up'},
+    {'id': 2703807,
+     'persons': [{'id': 3379616, 'name': u'Natalia Karina Juszka', 'title': u''},
+                 {'id': 3379617, 'name': u'Pedro Ferreira', 'title': u''},
+                 {'id': 3379618, 'name': u'Michal Kolodziejski', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 11, 30)),
+     'title': u'Brainstorming: Event-based collaboration'},
+    {'id': 2704040,
+     'persons': [{'id': 3319540, 'name': u'Marco Vidal', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 7, 45)),
+     'title': u'Indico Community - Bringing everyone together'},
+    {'id': 2754586,
+     'persons': [{'id': 3367991, 'name': u'Tim Smith', 'title': u''}],
+     'url': '/category/1',
+     'eventURL': '/event/741230/',
+     'eventTitle': '"This is the event Title"',
+     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 7, 40)),
+     'title': u'CERN and Indico'}
+]
+
+FILE_DATA = [
+    {'id': 2703412,
+     'persons': [],
+     'url': '/category/1',
+     'type': 'file-word',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 18, 13, 0)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Enterprise Authentication with Indico'},
+    {'id': 2703405,
+     'url': '/category/1',
+     'type': 'file-presentation',
+     'contributionTitle': '"A contribution title goes here"',
+     'persons': [{'id': 3336048, 'name': u'Dirk Hoffmann', 'title': u'Dr'}],
+     'date': pytz.utc.localize(datetime(2017, 10, 19, 9, 0)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Internationalization - tips and tricks'},
+    {'id': 2703418,
+     'persons': [{'id': 3319501, 'name': u'Pedro Ferreira', 'title': u''},
+                 {'id': 3361462, 'name': u'Thomas Baron', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-excel',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 18, 7, 50)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u"What's new in the Indicoverse?"},
+    {'id': 2703408,
+     'persons': [{'id': 3319509, 'name': u'Natalia Karina Juszka', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-zip',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 19, 7, 0)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Any colour you like - customising Indico'},
+    {'id': 2703430,
+     'persons': [{'id': 3319550, 'name': u'Adrian M\xf6nnich', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-xml',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 20, 7, 15)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Maintaining an Indico instance - tips and tricks'},
+    {'id': 2703409,
+     'persons': [{'id': 3319523, 'name': u'Adrian M\xf6nnich', 'title': u''},
+                 {'id': 3319524, 'name': u'Natalia Karina Juszka', 'title': u''},
+                 {'id': 3319525, 'name': u'Pedro Ferreira', 'title': u''},
+                 {'id': 3319526, 'name': u'Marco Vidal', 'title': u''},
+                 {'id': 3319527, 'name': u'Michal Kolodziejski', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-spreadsheet',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 18, 14, 0)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Indico Development Bootcamp'},
+    {'id': 2703410,
+     'persons': [{'id': 3319506, 'name': u'Natalia Karina Juszka', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 20, 9, 0)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Walkthrough - Developing a Plugin'},
+    {'id': 2703425,
+     'persons': [{'id': 3377568, 'name': u'Pedro Ferreira', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 20, 12, 30)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'The Future'},
+    {'id': 2703398,
+     'persons': [{'id': 3368725, 'name': u'Adrian M\xf6nnich', 'title': u''},
+                 {'id': 3368726, 'name': u'Pedro Ferreira', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 18, 8, 50)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u"Version 2.0 - What's new?"},
+    {'id': 2703400,
+     'persons': [{'id': 3319499, 'name': u'Adrian M\xf6nnich', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 18, 9, 50)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Version 2.0 - Under the hood'},
+    {'id': 2703414,
+     'persons': [{'id': 3328200, 'name': u'Stefan Hesselbach', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 18, 12, 0)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Indico @ GSI'},
+    {'id': 2703415,
+     'persons': [{'id': 3328767, 'name': u'Giorgio Pieretti', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 19, 9, 30)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Indico @ UNOG'},
+    {'id': 2703413,
+     'persons': [{'id': 3319503, 'name': u'Marco Vidal', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 19, 7, 30)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Walkthrough: Container Deployment'},
+    {'id': 2703416,
+     'persons': [{'id': 3362150, 'name': u'Akihiro Shibata', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 20, 8, 15)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Indico @ KEK'},
+    {'id': 2703417,
+     'persons': [{'id': 3367992, 'name': u'Thomas Baron', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 18, 7, 30)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Welcome to CERN'},
+    {'id': 2703402,
+     'persons': [{'id': 3319515, 'name': u'Pedro Ferreira', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 18, 12, 15)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Walkthrough - Migrating to 2.0'},
+    {'id': 2703681,
+     'persons': [{'id': 3319528, 'name': u'Pedro Ferreira', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 20, 7, 0)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'The Big Migration: An overview of three years of development'},
+    {'id': 2703772,
+     'persons': [{'id': 3328765, 'name': u'Penelope Constanta', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 19, 8, 45)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Indico @ Fermilab'},
+    {'id': 2703808,
+     'persons': [{'id': 3377569, 'name': u'Thomas Baron', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 20, 13, 0)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Wrap-up'},
+    {'id': 2703807,
+     'persons': [{'id': 3379616, 'name': u'Natalia Karina Juszka', 'title': u''},
+                 {'id': 3379617, 'name': u'Pedro Ferreira', 'title': u''},
+                 {'id': 3379618, 'name': u'Michal Kolodziejski', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 20, 11, 30)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Brainstorming: Event-based collaboration'},
+    {'id': 2704040,
+     'persons': [{'id': 3319540, 'name': u'Marco Vidal', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 20, 7, 45)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'Indico Community - Bringing everyone together'},
+    {'id': 2754586,
+     'persons': [{'id': 3367991, 'name': u'Tim Smith', 'title': u''}],
+     'url': '/category/1',
+     'type': 'file-pdf',
+     'contributionTitle': '"A contribution title goes here"',
+     'date': pytz.utc.localize(datetime(2017, 10, 18, 7, 40)),
+     'contribURL': '/event/136179/contributions/6/',
+     'title': u'CERN and Indico'}
+]

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -5,8 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from __future__ import division, unicode_literals
-
 from marshmallow import fields
 from sqlalchemy.orm import undefer
 
@@ -37,7 +35,7 @@ class RHAPISearch(RH):
     @use_kwargs({
         'page': fields.Int(missing=1),
         'q': fields.String(required=True),
-    })
+    }, location='query')
     def _process(self, page, q):
         search_provider = get_search_provider()
         if search_provider and self.USE_PROVIDER:

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -7,10 +7,6 @@
 
 from __future__ import division, unicode_literals
 
-from datetime import datetime
-from math import ceil
-
-import pytz
 from marshmallow import fields
 from sqlalchemy.orm import undefer
 
@@ -18,444 +14,74 @@ from indico.core.db import db
 from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.categories import Category
 from indico.modules.events import Event
-from indico.modules.search.schemas import (CategoryResultSchema, ContributionResultSchema, EventResultSchema,
-                                           FileResultSchema)
+from indico.modules.search.base import IndicoSearchProvider, SearchTarget, get_search_provider
+from indico.modules.search.schemas import CategoryResultSchema, EventResultSchema
 from indico.modules.search.views import WPSearch
 from indico.web.args import use_kwargs
 from indico.web.rh import RH
 
 
-RESULTS_PER_PAGE = 10
-
-
-class RHSearch(RH):
+class RHSearchDisplay(RH):
     def _process(self):
         return WPSearch.render_template('search.html')
 
 
-class RHSearchCategories(RH):
+# TODO: plugin disabled
+class RHAPISearch(RH):
+    TARGET = None
+    USE_PROVIDER = True
+
+    def search(self, page, q):
+        return {'page': 0, 'pages': 0, 'total': 0, 'results': []}
+
     @use_kwargs({
         'page': fields.Int(missing=1),
         'q': fields.String(required=True),
     })
     def _process(self, page, q):
+        search_provider = get_search_provider()
+        if search_provider and self.USE_PROVIDER:
+            results = search_provider.search(q, None, self.TARGET)
+        else:
+            results = self.search(page, q)
+
+        return results
+
+
+class RHAPISearchCategory(RHAPISearch):
+    TARGET = SearchTarget.category
+    USE_PROVIDER = False
+
+    def search(self, page, q):
         results = (Category.query
                    .filter(Category.title_matches(q),
                            ~Category.is_deleted)
                    .options(undefer('chain'))
                    .order_by(db.func.lower(Category.title))
-                   .paginate(page, RESULTS_PER_PAGE))
+                   .paginate(page, IndicoSearchProvider.RESULTS_PER_PAGE))
         # XXX should we only show categories the user can access?
         # this would be nicer but then we can't easily paginate...
-        return {'results': CategoryResultSchema(many=True).dump(results.items),
-                'page': results.page,
-                'pages': results.pages,
-                'total': results.total}
+        return CategoryResultSchema().dump(results)
 
 
-class RHSearchEvents(RH):
-    @use_kwargs({
-        'page': fields.Int(missing=1),
-        'q': fields.String(required=True),
-    })
-    def _process(self, page, q):
+class RHAPISearchEvent(RHAPISearch):
+    TARGET = SearchTarget.event
+
+    def search(self, page, q):
         results = (Event.query
                    .filter(Event.title_matches(q),
                            Event.effective_protection_mode == ProtectionMode.public,
                            ~Event.is_deleted)
                    .order_by(db.func.lower(Event.title))
-                   .paginate(page, RESULTS_PER_PAGE))
+                   .paginate(page, IndicoSearchProvider.RESULTS_PER_PAGE))
         # XXX should we only show categories the user can access?
         # this would be nicer but then we can't easily paginate...
-        return {'results': EventResultSchema(many=True).dump(results.items),
-                'page': results.page,
-                'pages': results.pages,
-                'total': results.total}
+        return EventResultSchema().dump(results)
 
 
-class RHSearchContributions(RH):
-    @use_kwargs({
-        'page': fields.Int(missing=1),
-        'q': fields.String(required=True),
-    })
-    def _process(self, page, q):
-        data = [x for x in CONTRIB_DATA if q.lower() in x['title'].lower()]
-        total = len(data)
-        offset = (page - 1) * RESULTS_PER_PAGE
-        items = data[offset:offset + RESULTS_PER_PAGE]
-        pages = int(ceil(total / RESULTS_PER_PAGE))
-        return {'results': ContributionResultSchema(many=True).dump(items),
-                'page': page,
-                'pages': pages,
-                'total': total}
+class RHAPISearchContribution(RHAPISearch):
+    TARGET = SearchTarget.contribution
 
 
-class RHSearchFiles(RH):
-    @use_kwargs({
-        'page': fields.Int(missing=1),
-        'q': fields.String(required=True),
-    })
-    def _process(self, page, q):
-        data = [x for x in FILE_DATA if q.lower() in x['title'].lower()]
-        total = len(data)
-        offset = (page - 1) * RESULTS_PER_PAGE
-        items = data[offset:offset + RESULTS_PER_PAGE]
-        pages = int(ceil(total / RESULTS_PER_PAGE))
-        return {'results': FileResultSchema(many=True).dump(items),
-                'page': page,
-                'pages': pages,
-                'total': total}
-
-
-# dummy data
-CONTRIB_DATA = [
-    {'id': 2703412,
-     'persons': [{'id': 3319533, 'name': u'Michal Kolodziejski', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 13, 0)),
-     'title': u'Enterprise Authentication with Indico'},
-    {'id': 2703405,
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'persons': [{'id': 3336048, 'name': u'Dirk Hoffmann', 'title': u'Dr'}],
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 19, 9, 0)),
-     'title': u'Internationalization - tips and tricks'},
-    {'id': 2703418,
-     'persons': [{'id': 3319501, 'name': u'Pedro Ferreira', 'title': u''},
-                 {'id': 3361462, 'name': u'Thomas Baron', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 7, 50)),
-     'title': u"What's new in the Indicoverse?"},
-    {'id': 2703408,
-     'persons': [{'id': 3319509, 'name': u'Natalia Karina Juszka', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 19, 7, 0)),
-     'title': u'Any colour you like - customising Indico'},
-    {'id': 2703430,
-     'persons': [{'id': 3319550, 'name': u'Adrian M\xf6nnich', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 7, 15)),
-     'title': u'Maintaining an Indico instance - tips and tricks'},
-    {'id': 2703409,
-     'persons': [{'id': 3319523, 'name': u'Adrian M\xf6nnich', 'title': u''},
-                 {'id': 3319524, 'name': u'Natalia Karina Juszka', 'title': u''},
-                 {'id': 3319525, 'name': u'Pedro Ferreira', 'title': u''},
-                 {'id': 3319526, 'name': u'Marco Vidal', 'title': u''},
-                 {'id': 3319527, 'name': u'Michal Kolodziejski', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 14, 0)),
-     'title': u'Indico Development Bootcamp'},
-    {'id': 2703410,
-     'persons': [{'id': 3319506, 'name': u'Natalia Karina Juszka', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 9, 0)),
-     'title': u'Walkthrough - Developing a Plugin'},
-    {'id': 2703425,
-     'persons': [{'id': 3377568, 'name': u'Pedro Ferreira', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 12, 30)),
-     'title': u'The Future'},
-    {'id': 2703398,
-     'persons': [{'id': 3368725, 'name': u'Adrian M\xf6nnich', 'title': u''},
-                 {'id': 3368726, 'name': u'Pedro Ferreira', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 8, 50)),
-     'title': u"Version 2.0 - What's new?"},
-    {'id': 2703400,
-     'persons': [{'id': 3319499, 'name': u'Adrian M\xf6nnich', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 9, 50)),
-     'title': u'Version 2.0 - Under the hood'},
-    {'id': 2703414,
-     'persons': [{'id': 3328200, 'name': u'Stefan Hesselbach', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 12, 0)),
-     'title': u'Indico @ GSI'},
-    {'id': 2703415,
-     'persons': [{'id': 3328767, 'name': u'Giorgio Pieretti', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 19, 9, 30)),
-     'title': u'Indico @ UNOG'},
-    {'id': 2703413,
-     'persons': [{'id': 3319503, 'name': u'Marco Vidal', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 19, 7, 30)),
-     'title': u'Walkthrough: Container Deployment'},
-    {'id': 2703416,
-     'persons': [{'id': 3362150, 'name': u'Akihiro Shibata', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 8, 15)),
-     'title': u'Indico @ KEK'},
-    {'id': 2703417,
-     'persons': [{'id': 3367992, 'name': u'Thomas Baron', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 7, 30)),
-     'title': u'Welcome to CERN'},
-    {'id': 2703402,
-     'persons': [{'id': 3319515, 'name': u'Pedro Ferreira', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 12, 15)),
-     'title': u'Walkthrough - Migrating to 2.0'},
-    {'id': 2703681,
-     'persons': [{'id': 3319528, 'name': u'Pedro Ferreira', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 7, 0)),
-     'title': u'The Big Migration: An overview of three years of development'},
-    {'id': 2703772,
-     'persons': [{'id': 3328765, 'name': u'Penelope Constanta', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 19, 8, 45)),
-     'title': u'Indico @ Fermilab'},
-    {'id': 2703808,
-     'persons': [{'id': 3377569, 'name': u'Thomas Baron', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 13, 0)),
-     'title': u'Wrap-up'},
-    {'id': 2703807,
-     'persons': [{'id': 3379616, 'name': u'Natalia Karina Juszka', 'title': u''},
-                 {'id': 3379617, 'name': u'Pedro Ferreira', 'title': u''},
-                 {'id': 3379618, 'name': u'Michal Kolodziejski', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 11, 30)),
-     'title': u'Brainstorming: Event-based collaboration'},
-    {'id': 2704040,
-     'persons': [{'id': 3319540, 'name': u'Marco Vidal', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 20, 7, 45)),
-     'title': u'Indico Community - Bringing everyone together'},
-    {'id': 2754586,
-     'persons': [{'id': 3367991, 'name': u'Tim Smith', 'title': u''}],
-     'url': '/category/1',
-     'eventURL': '/event/741230/',
-     'eventTitle': '"This is the event Title"',
-     'start_dt': pytz.utc.localize(datetime(2017, 10, 18, 7, 40)),
-     'title': u'CERN and Indico'}
-]
-
-FILE_DATA = [
-    {'id': 2703412,
-     'persons': [],
-     'url': '/category/1',
-     'type': 'file-word',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 18, 13, 0)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Enterprise Authentication with Indico'},
-    {'id': 2703405,
-     'url': '/category/1',
-     'type': 'file-presentation',
-     'contributionTitle': '"A contribution title goes here"',
-     'persons': [{'id': 3336048, 'name': u'Dirk Hoffmann', 'title': u'Dr'}],
-     'date': pytz.utc.localize(datetime(2017, 10, 19, 9, 0)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Internationalization - tips and tricks'},
-    {'id': 2703418,
-     'persons': [{'id': 3319501, 'name': u'Pedro Ferreira', 'title': u''},
-                 {'id': 3361462, 'name': u'Thomas Baron', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-excel',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 18, 7, 50)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u"What's new in the Indicoverse?"},
-    {'id': 2703408,
-     'persons': [{'id': 3319509, 'name': u'Natalia Karina Juszka', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-zip',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 19, 7, 0)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Any colour you like - customising Indico'},
-    {'id': 2703430,
-     'persons': [{'id': 3319550, 'name': u'Adrian M\xf6nnich', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-xml',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 20, 7, 15)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Maintaining an Indico instance - tips and tricks'},
-    {'id': 2703409,
-     'persons': [{'id': 3319523, 'name': u'Adrian M\xf6nnich', 'title': u''},
-                 {'id': 3319524, 'name': u'Natalia Karina Juszka', 'title': u''},
-                 {'id': 3319525, 'name': u'Pedro Ferreira', 'title': u''},
-                 {'id': 3319526, 'name': u'Marco Vidal', 'title': u''},
-                 {'id': 3319527, 'name': u'Michal Kolodziejski', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-spreadsheet',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 18, 14, 0)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Indico Development Bootcamp'},
-    {'id': 2703410,
-     'persons': [{'id': 3319506, 'name': u'Natalia Karina Juszka', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 20, 9, 0)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Walkthrough - Developing a Plugin'},
-    {'id': 2703425,
-     'persons': [{'id': 3377568, 'name': u'Pedro Ferreira', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 20, 12, 30)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'The Future'},
-    {'id': 2703398,
-     'persons': [{'id': 3368725, 'name': u'Adrian M\xf6nnich', 'title': u''},
-                 {'id': 3368726, 'name': u'Pedro Ferreira', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 18, 8, 50)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u"Version 2.0 - What's new?"},
-    {'id': 2703400,
-     'persons': [{'id': 3319499, 'name': u'Adrian M\xf6nnich', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 18, 9, 50)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Version 2.0 - Under the hood'},
-    {'id': 2703414,
-     'persons': [{'id': 3328200, 'name': u'Stefan Hesselbach', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 18, 12, 0)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Indico @ GSI'},
-    {'id': 2703415,
-     'persons': [{'id': 3328767, 'name': u'Giorgio Pieretti', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 19, 9, 30)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Indico @ UNOG'},
-    {'id': 2703413,
-     'persons': [{'id': 3319503, 'name': u'Marco Vidal', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 19, 7, 30)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Walkthrough: Container Deployment'},
-    {'id': 2703416,
-     'persons': [{'id': 3362150, 'name': u'Akihiro Shibata', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 20, 8, 15)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Indico @ KEK'},
-    {'id': 2703417,
-     'persons': [{'id': 3367992, 'name': u'Thomas Baron', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 18, 7, 30)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Welcome to CERN'},
-    {'id': 2703402,
-     'persons': [{'id': 3319515, 'name': u'Pedro Ferreira', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 18, 12, 15)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Walkthrough - Migrating to 2.0'},
-    {'id': 2703681,
-     'persons': [{'id': 3319528, 'name': u'Pedro Ferreira', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 20, 7, 0)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'The Big Migration: An overview of three years of development'},
-    {'id': 2703772,
-     'persons': [{'id': 3328765, 'name': u'Penelope Constanta', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 19, 8, 45)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Indico @ Fermilab'},
-    {'id': 2703808,
-     'persons': [{'id': 3377569, 'name': u'Thomas Baron', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 20, 13, 0)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Wrap-up'},
-    {'id': 2703807,
-     'persons': [{'id': 3379616, 'name': u'Natalia Karina Juszka', 'title': u''},
-                 {'id': 3379617, 'name': u'Pedro Ferreira', 'title': u''},
-                 {'id': 3379618, 'name': u'Michal Kolodziejski', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 20, 11, 30)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Brainstorming: Event-based collaboration'},
-    {'id': 2704040,
-     'persons': [{'id': 3319540, 'name': u'Marco Vidal', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 20, 7, 45)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'Indico Community - Bringing everyone together'},
-    {'id': 2754586,
-     'persons': [{'id': 3367991, 'name': u'Tim Smith', 'title': u''}],
-     'url': '/category/1',
-     'type': 'file-pdf',
-     'contributionTitle': '"A contribution title goes here"',
-     'date': pytz.utc.localize(datetime(2017, 10, 18, 7, 40)),
-     'contribURL': '/event/136179/contributions/6/',
-     'title': u'CERN and Indico'}
-]
+class RHAPISearchAttachment(RHAPISearch):
+    TARGET = SearchTarget.attachment

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -1,5 +1,5 @@
 # This file is part of Indico.
-# Copyright (C) 2002 - 2020 CERN
+# Copyright (C) 2002 - 2021 CERN
 #
 # Indico is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see the

--- a/indico/modules/search/module.json
+++ b/indico/modules/search/module.json
@@ -1,0 +1,3 @@
+{
+    "name": "search"
+}

--- a/indico/modules/search/schemas.py
+++ b/indico/modules/search/schemas.py
@@ -1,0 +1,64 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2020 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from indico.core.marshmallow import mm
+from indico.modules.categories import Category
+from indico.modules.events import Event
+from indico.web.flask.util import url_for
+
+
+def _get_category_path(chain):
+    chain = chain[1:-1]  # strip root/self
+    return [
+        dict(c, url=url_for('categories.display', category_id=c['id']))
+        for c in chain
+    ]
+
+
+class CategoryResultSchema(mm.ModelSchema):
+    class Meta:
+        model = Category
+        fields = ('id', 'title', 'url', 'path')
+
+    path = mm.Function(lambda cat: _get_category_path(cat.chain))
+
+
+class EventResultSchema(mm.ModelSchema):
+    class Meta:
+        model = Event
+        fields = ('id', 'title', 'url', 'type', 'start_dt', 'end_dt', 'category_path', 'speakers')
+
+    category_path = mm.Function(lambda event: _get_category_path(event.detailed_category_chain))
+
+
+class PersonSchema(mm.Schema):
+    id = mm.Int()
+    title = mm.String()
+    name = mm.String()
+
+
+class ContributionResultSchema(mm.Schema):
+    id = mm.Int()
+    title = mm.String()
+    url = mm.String()
+    start_dt = mm.String()
+    eventURL = mm.String()
+    eventTitle = mm.String()
+    persons = mm.Nested(PersonSchema, many=True)
+
+
+class FileResultSchema(mm.Schema):
+    id = mm.Int()
+    title = mm.String()
+    url = mm.String()
+    type = mm.String()
+    contributionTitle = mm.String()
+    date = mm.String()
+    contribURL = mm.String()
+    persons = mm.Nested(PersonSchema, many=True)

--- a/indico/modules/search/schemas.py
+++ b/indico/modules/search/schemas.py
@@ -21,7 +21,7 @@ def _get_category_path(chain):
     ]
 
 
-class CategoryResultSchema(mm.ModelSchema):
+class CategorySchema(mm.ModelSchema):
     class Meta:
         model = Category
         fields = ('id', 'title', 'url', 'path')
@@ -29,7 +29,7 @@ class CategoryResultSchema(mm.ModelSchema):
     path = mm.Function(lambda cat: _get_category_path(cat.chain))
 
 
-class EventResultSchema(mm.ModelSchema):
+class EventSchema(mm.ModelSchema):
     class Meta:
         model = Event
         fields = ('id', 'title', 'url', 'type', 'start_dt', 'end_dt', 'category_path', 'speakers')
@@ -43,22 +43,35 @@ class PersonSchema(mm.Schema):
     name = mm.String()
 
 
-class ContributionResultSchema(mm.Schema):
+class BaseSchema(mm.Schema):
     id = mm.Int()
     title = mm.String()
     url = mm.String()
-    start_dt = mm.String()
-    eventURL = mm.String()
-    eventTitle = mm.String()
     persons = mm.Nested(PersonSchema, many=True)
 
 
-class FileResultSchema(mm.Schema):
-    id = mm.Int()
-    title = mm.String()
-    url = mm.String()
+class ContributionSchema(BaseSchema):
+    start_dt = mm.String()
+    eventURL = mm.String()
+    eventTitle = mm.String()
+
+
+class AttachmentSchema(BaseSchema):
     type = mm.String()
     contributionTitle = mm.String()
     date = mm.String()
     contribURL = mm.String()
-    persons = mm.Nested(PersonSchema, many=True)
+
+
+class ResultSchema(mm.Schema):
+    page = mm.Int(required=True)
+    pages = mm.Int(required=True)
+    total = mm.Int(required=True)
+
+
+class CategoryResultSchema(ResultSchema):
+    results = mm.Nested(CategorySchema, required=True, many=True, attribute='items')
+
+
+class EventResultSchema(ResultSchema):
+    results = mm.Nested(EventSchema, required=True, many=True, attribute='items')

--- a/indico/modules/search/schemas.py
+++ b/indico/modules/search/schemas.py
@@ -5,8 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from __future__ import unicode_literals
-
 from indico.core.marshmallow import mm
 from indico.modules.categories import Category
 from indico.modules.events import Event
@@ -21,7 +19,7 @@ def _get_category_path(chain):
     ]
 
 
-class CategorySchema(mm.ModelSchema):
+class CategorySchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Category
         fields = ('id', 'title', 'url', 'path')
@@ -29,7 +27,7 @@ class CategorySchema(mm.ModelSchema):
     path = mm.Function(lambda cat: _get_category_path(cat.chain))
 
 
-class EventSchema(mm.ModelSchema):
+class EventSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Event
         fields = ('id', 'title', 'url', 'type', 'start_dt', 'end_dt', 'category_path', 'speakers')

--- a/indico/modules/search/schemas.py
+++ b/indico/modules/search/schemas.py
@@ -1,5 +1,5 @@
 # This file is part of Indico.
-# Copyright (C) 2002 - 2020 CERN
+# Copyright (C) 2002 - 2021 CERN
 #
 # Indico is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see the

--- a/indico/modules/search/templates/search.html
+++ b/indico/modules/search/templates/search.html
@@ -1,0 +1,11 @@
+{% extends 'layout/base.html' %}
+
+{% block page_class %}search-page{% endblock %}
+
+{% block title %}
+    {% trans %}Search{% endtrans %}
+{% endblock %}
+
+{% block content %}
+    <div id="search-root"></div>
+{% endblock %}

--- a/indico/modules/search/views.py
+++ b/indico/modules/search/views.py
@@ -1,0 +1,23 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2020 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from __future__ import unicode_literals
+
+from indico.util.i18n import _
+from indico.web.breadcrumbs import render_breadcrumbs
+from indico.web.views import WPDecorated, WPJinjaMixin
+
+
+class WPSearch(WPJinjaMixin, WPDecorated):
+    template_prefix = 'search/'
+    bundles = ('module_search.js', 'module_search.css')
+
+    def _get_breadcrumbs(self):
+        return render_breadcrumbs(_('Search'))
+
+    def _get_body(self, params):
+        return self._get_page_content(params)

--- a/indico/modules/search/views.py
+++ b/indico/modules/search/views.py
@@ -1,5 +1,5 @@
 # This file is part of Indico.
-# Copyright (C) 2002 - 2020 CERN
+# Copyright (C) 2002 - 2021 CERN
 #
 # Indico is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see the

--- a/indico/modules/search/views.py
+++ b/indico/modules/search/views.py
@@ -5,8 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from __future__ import unicode_literals
-
 from indico.util.i18n import _
 from indico.web.breadcrumbs import render_breadcrumbs
 from indico.web.views import WPDecorated, WPJinjaMixin

--- a/indico/web/client/styles/base/_pages.scss
+++ b/indico/web/client/styles/base/_pages.scss
@@ -240,3 +240,12 @@
   background: transparent;
   color: white;
 }
+
+.search-page {
+  @extend %indico-page-standalone;
+
+  .title {
+    text-align: center;
+    margin-left: -65em;
+  }
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -10,6 +10,7 @@
       "indico/modules/core/*": ["./indico/modules/core/client/js/*"],
       "indico/modules/rb/*": ["./indico/modules/rb/client/js/*"],
       "indico/modules/users/*": ["./indico/modules/users/client/js/*"],
+      "indico/modules/search/*": ["./indico/modules/search/client/js/*"],
       "indico/modules/events/reviewing/*": ["./indico/modules/events/client/js/reviewing/*"],
       "indico/modules/events/editing/*": ["./indico/modules/events/editing/client/js/*"],
       "indico/modules/events/*": ["./indico/modules/events/client/js/*"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -6744,8 +6744,7 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -24902,6 +24901,26 @@
         "randombytes": "^2.1.0"
       }
     },
+    "serialize-query-params": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-0.1.4.tgz",
+      "integrity": "sha512-d3GHKPAOBULhCMg+jM687vRIMnTXMo8M0lHUOVeFxSGYvfmNlksiOpLyb0orhXPhhFCvZvt+SwC2iPRVIhKS/g==",
+      "requires": {
+        "query-string": "^5.0.0"
+      },
+      "dependencies": {
+        "query-string": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+          "requires": {
+            "decode-uri-component": "^0.2.0",
+            "object-assign": "^4.1.0",
+            "strict-uri-encode": "^1.0.0"
+          }
+        }
+      }
+    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -25391,6 +25410,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
     "string-hash": {
       "version": "1.1.3",
@@ -27147,6 +27171,14 @@
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
+    },
+    "use-query-params": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/use-query-params/-/use-query-params-0.3.4.tgz",
+      "integrity": "sha512-WHIM4SeitYAcu6eHQ93P5Qo7WgY8/ZVroUkv3VsdVSSYH9KdroZOQ93sYj80tV3L+8jFbWtHnEBo3uidaqyU8w==",
+      "requires": {
+        "serialize-query-params": "^0.1.3"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23484,6 +23484,16 @@
         "jquery": ">=1.6.0"
       }
     },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
     "quick-lru": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -24907,18 +24917,6 @@
       "integrity": "sha512-d3GHKPAOBULhCMg+jM687vRIMnTXMo8M0lHUOVeFxSGYvfmNlksiOpLyb0orhXPhhFCvZvt+SwC2iPRVIhKS/g==",
       "requires": {
         "query-string": "^5.0.0"
-      },
-      "dependencies": {
-        "query-string": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
-          }
-        }
       }
     },
     "set-blocking": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "taggle": "^1.15.0",
     "ua-parser-js": "^0.7.23",
     "underscore": "^1.12.0",
-    "use-query-params": "^0.3.3",
+    "use-query-params": "^0.3.4",
     "vanderlee-colorpicker": "^1.2.16"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "taggle": "^1.15.0",
     "ua-parser-js": "^0.7.23",
     "underscore": "^1.12.0",
+    "use-query-params": "^0.3.3",
     "vanderlee-colorpicker": "^1.2.16"
   },
   "devDependencies": {


### PR DESCRIPTION
For now this draft PR just contains a squashed commit of all the changes in #4067 since that PR got massive over time.

Things to do (most likely this list is non-exhaustive):

- [ ] Define a new search API to integrate with plugins (especially citadel - the livesync part is in indico/indico-plugins#86)
- [ ] Address the comments in the original PR.
- [ ] Possibly polish the UI (for later, since functionality is more important)

(please add new things up there as they come up)

Let's use this branch as a starting point for additional development regarding the new search in the core, so we have one PR/branch where everything gets consolidated.

Some ideas for the plugin API:

- Let's not create a new plugin class mixin unless we realize there's a strong need for this.
- No need to strongly enforce a single search engine - that way we can most likely just use a signal to trigger get a list of search implementations (like we do with other things like placeholders being provided by a plugin). And if we do want to keep enforcing a single active engine, we can simply fail when the signal call returns more than one search implementation.
- For the API we can look at the `search()` util in Michal's PR. This still needs tweaking of course, but should be a good start. We surely need to pass the user (and possibly a list of all their (multipass-based) groups) as well.
- For the search counterpart to `livesync_citadel` we could either put it in the same plugin (maybe easier, and allows reusing utils if needed) or create a separate `search_citadel` plugin. I'm more inclined to keep both parts (livesync + search) in a single plugin, and rename it to `search_citadel` in the end. It's very uncommon to use only one part, and in case of e.g. dev/staging instances we'd simply disable the livesync agent and only use the search part.
- It may be a good idea to create a `search_dummy` plugin that simply implements the new search API so we have something basic to test with, without depending on Citadel being fully functional. That also allows us to move out the demo data that's currently hardcoded in `indico/modules/search/controllers.py` out of the core. Ideally we can do this 
- The search UI supports applying extra filters to the current search results (by speaker affiliation / name) which are based on the data in those results, and not subject to the usual pagination. I think at the beginning we can ignore this to keep things easier, but eventually this need to be handled in the API between core and plugin as well 