### PR TITLE
change signals.category.updated name to 'updated'

### DIFF
--- a/indico/core/signals/category.py
+++ b/indico/core/signals/category.py
@@ -21,7 +21,7 @@ created = _signals.signal('created', """
 Called when a new category is created. The `sender` is the new category.
 """)
 
-updated = _signals.signal('created', """
+updated = _signals.signal('updated', """
 Called when a category is modified. The `sender` is the updated category.
 """)
 


### PR DESCRIPTION
As per the discussion on https://talk.getindico.io/t/misleading-category-created-signal/2048
I propose to change the name of the `NamedSignal` to `updated` accordingly with the variable name.