### PR TITLE
Let cloners know about multiple clones

### DIFF
--- a/indico/modules/events/cloning.py
+++ b/indico/modules/events/cloning.py
@@ -69,8 +69,8 @@ class EventCloner(object):
                       key=attrgetter('friendly_name'))
 
     @classmethod
-    def run_cloners(cls, old_event, new_event, cloners, event_exists=False):
-        all_cloners = OrderedDict((name, cloner_cls(old_event))
+    def run_cloners(cls, old_event, new_event, cloners, n_occurrence=0, event_exists=False):
+        all_cloners = OrderedDict((name, cloner_cls(old_event, n_occurrence))
                                   for name, cloner_cls in get_event_cloners().iteritems())
         if any(cloner.is_internal for name, cloner in all_cloners.iteritems() if name in cloners):
             raise Exception('An internal cloner was selected')
@@ -131,8 +131,9 @@ class EventCloner(object):
         # This is not very efficient, but it runs exactly once on a not-very-large set
         return {cloner.name for cloner in get_event_cloners().itervalues() if cls.name in cloner.requires_deep}
 
-    def __init__(self, old_event):
+    def __init__(self, old_event, n_occurrence=0):
         self.old_event = old_event
+        self.n_occurrence = n_occurrence
 
     def run(self, new_event, cloners, shared_data, event_exists=False):
         """Performs the cloning operation.

--- a/indico/modules/events/management/controllers/cloning.py
+++ b/indico/modules/events/management/controllers/cloning.py
@@ -179,16 +179,18 @@ class RHCloneEvent(RHManageEventBase):
 
             if form.validate_on_submit():
                 if form.repeatability.data == 'once':
-                    dates = [form.start_dt.data]
+                    # only one repetition
+                    clone = clone_event(
+                        self.event, None, form.start_dt.data, set(form.selected_items.data), form.category.data
+                    )
+                    flash(_('Welcome to your cloned event!'), 'success')
+                    return jsonify_data(redirect=url_for('event_management.settings', clone), flash=False)
                 else:
+                    # recurring event
                     clone_calculator = get_clone_calculator(form.repeatability.data, self.event)
                     dates = clone_calculator.calculate(request.form)[0]
-                clones = [clone_event(self.event, start_dt, set(form.selected_items.data), form.category.data)
-                          for start_dt in dates]
-                if len(clones) == 1:
-                    flash(_('Welcome to your cloned event!'), 'success')
-                    return jsonify_data(redirect=url_for('event_management.settings', clones[0]), flash=False)
-                else:
+                    for n, start_dt in enumerate(dates, 1):
+                        clone_event(self.event, n, start_dt, set(form.selected_items.data), form.category.data)
                     flash(_('{} new events created.').format(len(dates)), 'success')
                     return jsonify_data(redirect=form.category.data.url, flash=False)
             else:

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -153,11 +153,12 @@ def update_event(event, update_timetable=False, **data):
     _log_event_update(event, changes, visible_person_link_changes=visible_person_link_changes)
 
 
-def clone_event(event, start_dt, cloners, category=None):
+def clone_event(event, n_occurrence, start_dt, cloners, category=None):
     """Clone an event on a given date/time.
 
     Runs all required cloners.
 
+    :param n_occurrence: The 1-indexed number of the occurrence, if this is a "recurring" clone, otherwise `0`
     :param start_dt: The start datetime of the new event;
     :param cloners: A set containing the names of all enabled cloners;
     :param category: The `Category` the new event will be created in.
@@ -176,7 +177,7 @@ def clone_event(event, start_dt, cloners, category=None):
                              add_creator_as_manager=False, cloning=True)
 
     # Run the modular cloning system
-    EventCloner.run_cloners(event, new_event, cloners)
+    EventCloner.run_cloners(event, new_event, cloners, n_occurrence)
     signals.event.cloned.send(event, new_event=new_event)
 
     # Grant access to the event creator -- must be done after modular cloners

--- a/indico/modules/vc/clone.py
+++ b/indico/modules/vc/clone.py
@@ -27,6 +27,10 @@ class VCCloner(EventCloner):
 
     @property
     def is_available(self):
+        if self.n_occurrence > 1:
+            # if we're not on the first occurrence, we shouldn't do this check,
+            # since there's the possibility all rooms are gone in the meantime
+            return True
         return self._has_content(self.old_event)
 
     def has_conflicts(self, target_event):
@@ -60,4 +64,7 @@ class VCCloner(EventCloner):
             plugin = old_event_vc_room.vc_room.plugin
             if not plugin:
                 continue
-            old_event_vc_room.vc_room.events.append(plugin.clone_room(old_event_vc_room, link_object))
+            clone = plugin.clone_room(old_event_vc_room, link_object)
+            if clone:
+                # the plugin may decide to not clone the room
+                old_event_vc_room.vc_room.events.append(clone)


### PR DESCRIPTION
This is needed currently for Zoom, but will basically allow any cloner to know whether only one event is being cloned is supposed to be the only occurrence (`None`) or one of many (0-indexed).
We're now also allowing VC plugins to not clone a room (return `None`).