### PR TITLE
Replace confId with event_id

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 
 - Require Python 3.9 - older Python versions (especially Python 2.7) are **no longer supported**
+- ``confId`` has been changed to ``event_id`` and the corresponding URL path segments
+  now enforce numeric data (and thus pass the id as a number instead of string)
 
 
 ----

--- a/indico/modules/api/controllers.py
+++ b/indico/modules/api/controllers.py
@@ -155,8 +155,8 @@ class RHAPIBuildURLs(RH):
             self.object = Contribution.get_or_404(data['contribId'])
         elif 'sessionId' in data:
             self.object = Session.get_or_404(data['sessionId'])
-        elif 'confId' in data:
-            self.object = Event.get_or_404(data['confId'])
+        elif 'eventId' in data:
+            self.object = Event.get_or_404(data['eventId'])
 
         if self.object is None:
             raise BadRequest

--- a/indico/modules/attachments/blueprint.py
+++ b/indico/modules/attachments/blueprint.py
@@ -55,7 +55,7 @@ for object_type, prefixes in items:
         if object_type == 'category':
             prefix = '/category/<int:category_id>' + prefix
         else:
-            prefix = '/event/<int:confId>' + prefix
+            prefix = '/event/<int:event_id>' + prefix
         _bp.add_url_rule(prefix + '/attachments/', 'management',
                          _dispatch(RHManageEventAttachments, RHManageCategoryAttachments),
                          defaults={'object_type': object_type})
@@ -91,7 +91,7 @@ for object_type, prefixes in items:
         if object_type == 'category':
             prefix = '/category/<category_id>' + prefix
         else:
-            prefix = '/event/<confId>' + prefix
+            prefix = '/event/<int:event_id>' + prefix
         _bp.add_url_rule(prefix + '/attachments/<int:folder_id>/<int:attachment_id>/<filename>', 'download',
                          _dispatch(RHDownloadEventAttachment, RHDownloadCategoryAttachment),
                          defaults={'object_type': object_type})
@@ -104,16 +104,16 @@ for object_type, prefixes in items:
 
 
 # Package
-_bp.add_url_rule('/event/<confId>/attachments/package', 'package',
+_bp.add_url_rule('/event/<int:event_id>/attachments/package', 'package',
                  RHPackageEventAttachmentsDisplay, methods=('GET', 'POST'))
-_bp.add_url_rule('/event/<confId>/manage/attachments/package', 'package_management',
+_bp.add_url_rule('/event/<int:event_id>/manage/attachments/package', 'package_management',
                  RHPackageEventAttachmentsManagement, methods=('GET', 'POST'))
-_bp.add_url_rule('/event/<confId>/attachments/package/status/<task_id>', 'package_status',
+_bp.add_url_rule('/event/<int:event_id>/attachments/package/status/<task_id>', 'package_status',
                  RHPackageEventAttachmentsStatus)
 
 
 # Legacy redirects for the old URLs
-_compat_bp = IndicoBlueprint('compat_attachments', __name__, url_prefix='/event/<event_id>')
+_compat_bp = IndicoBlueprint('compat_attachments', __name__, url_prefix='/event/<int:event_id>')
 compat_folder_rules = [
     '/material/<material_id>/',
     '/session/<session_id>/contribution/<contrib_id>/material/<material_id>/',
@@ -134,11 +134,11 @@ compat_attachment_rules = [
     '/contribution/<contrib_id>/<subcontrib_id>/material/<material_id>/<resource_id>.<ext>'
 ]
 old_obj_prefix_rules = {
-    'session': ['!/event/<confId>/session/<sessionId>'],
-    'contribution': ['!/event/<confId>/session/<sessionId>/contribution/<contribId>',
-                     '!/event/<confId>/contribution/<contribId>'],
-    'subcontribution': ['!/event/<confId>/session/<sessionId>/contribution/<contribId>/<subContId>',
-                        '!/event/<confId>/contribution/<contribId>/<subContId>']
+    'session': ['!/event/<int:event_id>/session/<sessionId>'],
+    'contribution': ['!/event/<int:event_id>/session/<sessionId>/contribution/<contribId>',
+                     '!/event/<int:event_id>/contribution/<contribId>'],
+    'subcontribution': ['!/event/<int:event_id>/session/<sessionId>/contribution/<contribId>/<subContId>',
+                        '!/event/<int:event_id>/contribution/<contribId>/<subContId>']
 }
 for rule in compat_folder_rules:
     _compat_bp.add_url_rule(rule, 'folder', compat_folder)

--- a/indico/modules/attachments/client/js/package.js
+++ b/indico/modules/attachments/client/js/package.js
@@ -8,6 +8,7 @@
 /* global handleFlashes:false, handleAjaxError:false */
 
 import packageStatusURL from 'indico-url:attachments.package_status';
+
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {$T} from 'indico/utils/i18n';
 
@@ -25,7 +26,7 @@ window.setupGeneratePackage = function setupGeneratePackage(eventId) {
   async function poll(taskId) {
     let res;
     try {
-      res = await indicoAxios.get(packageStatusURL({confId: eventId, task_id: taskId}));
+      res = await indicoAxios.get(packageStatusURL({event_id: eventId, task_id: taskId}));
     } catch (error) {
       handleAxiosError(error);
       closeLoader();

--- a/indico/modules/attachments/controllers/compat.py
+++ b/indico/modules/attachments/controllers/compat.py
@@ -55,7 +55,6 @@ def compat_folder_old():
 def _redirect_to_note(**kwargs):
     del kwargs['material_id']
     del kwargs['resource_id']
-    kwargs['confId'] = kwargs.pop('event_id')
     return redirect(url_for('event_notes.view', **kwargs), 302 if current_app.debug else 301)
 
 

--- a/indico/modules/designer/blueprint.py
+++ b/indico/modules/designer/blueprint.py
@@ -40,7 +40,7 @@ for object_type in ('event', 'category'):
     if object_type == 'category':
         prefix = '/category/<int:category_id>'
     else:
-        prefix = '/event/<int:confId>'
+        prefix = '/event/<int:event_id>'
     prefix += '/manage/designer'
     _bp.add_url_rule(prefix + '/', 'template_list', _dispatch(RHListEventTemplates, RHListCategoryTemplates),
                      defaults={'object_type': object_type})

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -29,7 +29,7 @@ __all__ = ('Event', 'logger', 'event_management_object_url_prefixes', 'event_obj
 logger = Logger.get('events')
 
 #: URL prefixes for the various event objects (public area)
-#: All prefixes are expected to be used inside the '/event/<confId>'
+#: All prefixes are expected to be used inside the '/event/<int:event_id>'
 #: url space.
 event_object_url_prefixes = {
     'event': [''],
@@ -39,7 +39,7 @@ event_object_url_prefixes = {
 }
 
 #: URL prefixes for the various event objects (management area)
-#: All prefixes are expected to be used inside the '/event/<confId>'
+#: All prefixes are expected to be used inside the '/event/<int:event_id>'
 #: url space.
 event_management_object_url_prefixes = {
     'event': ['/manage'],

--- a/indico/modules/events/abstracts/blueprint.py
+++ b/indico/modules/events/abstracts/blueprint.py
@@ -16,7 +16,7 @@ from indico.web.flask.util import make_compat_redirect_func
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
-_bp = IndicoBlueprint('abstracts', __name__, url_prefix='/event/<confId>', template_folder='templates',
+_bp = IndicoBlueprint('abstracts', __name__, url_prefix='/event/<int:event_id>', template_folder='templates',
                       virtual_template_folder='events/abstracts')
 
 # Display pages (not related to any specific abstract)
@@ -169,7 +169,7 @@ def _add_management_flag(endpoint, values):
 
 
 # Legacy URLs - display
-_compat_bp = IndicoBlueprint('compat_abstracts', __name__, url_prefix='/event/<int:confId>')
+_compat_bp = IndicoBlueprint('compat_abstracts', __name__, url_prefix='/event/<int:event_id>')
 _compat_bp.add_url_rule('/call-for-abstracts/', 'cfa', make_compat_redirect_func(_bp, 'call_for_abstracts'))
 _compat_bp.add_url_rule('/call-for-abstracts/my-abstracts', 'mine',
                         make_compat_redirect_func(_bp, 'call_for_abstracts'))

--- a/indico/modules/events/abstracts/client/js/boa.jsx
+++ b/indico/modules/events/abstracts/client/js/boa.jsx
@@ -5,20 +5,20 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import uploadBOAFileURL from 'indico-url:abstracts.upload_boa_file';
 import customBOAURL from 'indico-url:abstracts.manage_custom_boa';
+import uploadBOAFileURL from 'indico-url:abstracts.upload_boa_file';
 
+import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
-
 import {Form as FinalForm} from 'react-final-form';
 import {Form, Modal, Button} from 'semantic-ui-react';
+
+import {FinalSingleFileManager} from 'indico/react/components';
+import {fileDetailsShape} from 'indico/react/components/files/props';
 import {FinalSubmitButton, handleSubmitError} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
-import {FinalSingleFileManager} from 'indico/react/components';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
-import {fileDetailsShape} from 'indico/react/components/files/props';
 
 export default function CustomBOAModal({eventId, initialFile, hasLatex}) {
   const [modalOpen, setModalOpen] = useState(false);
@@ -28,7 +28,7 @@ export default function CustomBOAModal({eventId, initialFile, hasLatex}) {
   const deleteExistingBOA = async () => {
     setDeleting(true);
     try {
-      await indicoAxios.delete(customBOAURL({confId: eventId}));
+      await indicoAxios.delete(customBOAURL({event_id: eventId}));
     } catch (e) {
       handleAxiosError(e);
       setDeleting(false);
@@ -39,7 +39,7 @@ export default function CustomBOAModal({eventId, initialFile, hasLatex}) {
 
   const handleSubmit = async ({file}) => {
     try {
-      await indicoAxios.post(customBOAURL({confId: eventId}), {file});
+      await indicoAxios.post(customBOAURL({event_id: eventId}), {file});
     } catch (e) {
       return handleSubmitError(e);
     }
@@ -95,7 +95,7 @@ export default function CustomBOAModal({eventId, initialFile, hasLatex}) {
                       name="file"
                       validExtensions={['pdf']}
                       initialFileDetails={initialFile}
-                      uploadURL={uploadBOAFileURL({confId: eventId})}
+                      uploadURL={uploadBOAFileURL({event_id: eventId})}
                       required
                       hideValidationError
                     />

--- a/indico/modules/events/abstracts/compat.py
+++ b/indico/modules/events/abstracts/compat.py
@@ -13,6 +13,6 @@ from indico.web.rh import RHSimple
 
 
 @RHSimple.wrap_function
-def compat_abstract(endpoint, confId, friendly_id, track_id=None, management=False):
-    abstract = Abstract.query.filter_by(event_id=confId, friendly_id=friendly_id).first_or_404()
+def compat_abstract(endpoint, event_id, friendly_id, track_id=None, management=False):
+    abstract = Abstract.query.filter_by(event_id=event_id, friendly_id=friendly_id).first_or_404()
     return redirect(url_for('abstracts.' + endpoint, abstract, management=management))

--- a/indico/modules/events/abstracts/notifications_test.py
+++ b/indico/modules/events/abstracts/notifications_test.py
@@ -63,7 +63,7 @@ def dummy_abstract(db, dummy_event, dummy_user, create_dummy_person):
                         title="Broken Symmetry and the Mass of Gauge Vector Mesons",
                         event=dummy_event,
                         submitter=dummy_user,
-                        locator={'confId': -314, 'abstract_id': 1234},
+                        locator={'event_id': -314, 'abstract_id': 1234},
                         judgment_comment='Vague but interesting!')
 
     author1 = create_dummy_person(abstract, 'John', 'Doe', 'doe@example.com', 'ACME', UserTitle.mr, True,

--- a/indico/modules/events/abstracts/util.py
+++ b/indico/modules/events/abstracts/util.py
@@ -132,7 +132,7 @@ def create_mock_abstract(event):
                                 track=track,
                                 session=session,
                                 type=contribution_type,
-                                locator={'confId': -314, 'contrib_id': 1234})
+                                locator={'event_id': -314, 'contrib_id': 1234})
 
     target_abstract = Abstract(friendly_id=315,
                                title="Broken Symmetry",
@@ -144,8 +144,8 @@ def create_mock_abstract(event):
                                contribution=contribution,
                                primary_authors=[englert, brout],
                                secondary_authors=[guralnik, hagen, kibble, higgs],
-                               locator=_MockLocator({'confId': -314, 'abstract_id': 1235},
-                                                    token={'confId': -314,
+                               locator=_MockLocator({'event_id': -314, 'abstract_id': 1235},
+                                                    token={'event_id': -314,
                                                            'uuid': '12345678-9abc-def0-1234-56789abcdef0'}),
                                judgment_comment='Vague but interesting!',
                                merged_into=None)
@@ -160,8 +160,8 @@ def create_mock_abstract(event):
                         contribution=contribution,
                         primary_authors=[englert, brout],
                         secondary_authors=[guralnik, hagen, kibble, higgs],
-                        locator=_MockLocator({'confId': -314, 'abstract_id': 1234},
-                                             token={'confId': -314, 'uuid': '12345678-9abc-def0-1234-56789abcdef0'}),
+                        locator=_MockLocator({'event_id': -314, 'abstract_id': 1234},
+                                             token={'event_id': -314, 'uuid': '12345678-9abc-def0-1234-56789abcdef0'}),
                         judgment_comment='Vague but interesting!',
                         merged_into=target_abstract)
 

--- a/indico/modules/events/agreements/blueprint.py
+++ b/indico/modules/events/agreements/blueprint.py
@@ -18,7 +18,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('agreements', __name__, template_folder='templates', virtual_template_folder='events/agreements',
-                      url_prefix='/event/<confId>')
+                      url_prefix='/event/<int:event_id>')
 
 # Event management
 _bp.add_url_rule('/manage/agreements/', 'event_agreements', RHAgreementManager)

--- a/indico/modules/events/agreements/models/agreements.py
+++ b/indico/modules/events/agreements/models/agreements.py
@@ -170,7 +170,7 @@ class Agreement(db.Model):
 
     @property
     def locator(self):
-        return {'confId': self.event_id,
+        return {'event_id': self.event_id,
                 'id': self.id}
 
     def __repr__(self):

--- a/indico/modules/events/agreements/models/agreements_test.py
+++ b/indico/modules/events/agreements/models/agreements_test.py
@@ -84,7 +84,7 @@ def test_locator():
     event_id = 9000
     agreement = Agreement(id=id_, event_id=event_id)
     assert agreement.locator == {'id': id_,
-                                 'confId': event_id}
+                                 'event_id': event_id}
 
 
 @pytest.mark.parametrize('person_with_user', (True, False))

--- a/indico/modules/events/blueprint.py
+++ b/indico/modules/events/blueprint.py
@@ -36,7 +36,7 @@ _bp.add_url_rule('/admin/event-labels/<int:event_label_id>/edit', 'update_event_
 _bp.add_url_rule('/admin/event-labels/<int:event_label_id>', 'delete_event_label', RHDeleteEventLabel,
                  methods=('DELETE',))
 
-_bp.add_url_rule('/event/<confId>/event.ics', 'export_event_ical', RHExportEventICAL)
+_bp.add_url_rule('/event/<int:event_id>/event.ics', 'export_event_ical', RHExportEventICAL)
 
 # Creation
 _bp.add_url_rule('/event/create/<any(lecture,meeting,conference):event_type>', 'create', RHCreateEvent,
@@ -45,15 +45,18 @@ _bp.add_url_rule('/event/create/<any(lecture,meeting,conference):event_type>', '
 # Main entry points supporting shortcut URLs
 # /e/ accepts slashes, /event/ doesn't - this is intended. We do not want to support slashes in the old namespace
 # since it's a major pain in the ass to do so (and its route would eat anything that's usually a 404)
-_bp.add_url_rule('/e/<path:confId>', 'shorturl', event_or_shorturl, strict_slashes=False,
+_bp.add_url_rule('/e/<path:event_id>', 'shorturl', event_or_shorturl, strict_slashes=False,
                  defaults={'shorturl_namespace': True})
-_bp.add_url_rule('/event/<confId>/', 'display', event_or_shorturl)
-_bp.add_url_rule('/event/<confId>/overview', 'display_overview', event_or_shorturl, defaults={'force_overview': True})
-_bp.add_url_rule('/event/<confId>/other-view', 'display_other', redirect_view('timetable.timetable'))
+# XXX: these two entries below use a string event_id on purpose, since they need to handle shortcuts
+# and possibly legacy ids as well
+_bp.add_url_rule('/event/<event_id>/', 'display', event_or_shorturl)
+_bp.add_url_rule('/event/<event_id>/overview', 'display_overview', event_or_shorturl,
+                 defaults={'force_overview': True})
+_bp.add_url_rule('/event/<int:event_id>/other-view', 'display_other', redirect_view('timetable.timetable'))
 
 # Misc
-_bp.add_url_rule('/event/<confId>/key-access', 'key_access', RHEventAccessKey, methods=('POST',))
-_bp.add_url_rule('/event/<confId>/event.marc.xml', 'marcxml', RHEventMarcXML)
+_bp.add_url_rule('/event/<int:event_id>/key-access', 'key_access', RHEventAccessKey, methods=('POST',))
+_bp.add_url_rule('/event/<int:event_id>/event.marc.xml', 'marcxml', RHEventMarcXML)
 
 
 # Legacy URLs
@@ -63,5 +66,6 @@ _compat_bp.add_url_rule('/conferenceOtherViews.py', 'display_other_modpython',
                         make_compat_redirect_func(_bp, 'display_other'))
 _compat_bp.add_url_rule('/conferenceDisplay.py/overview', 'display_overview_modpython',
                         make_compat_redirect_func(_bp, 'display_overview'))
-_compat_bp.add_url_rule('/event/<confId>/my-conference/', 'display_mystuff', make_compat_redirect_func(_bp, 'display'))
+_compat_bp.add_url_rule('/event/<int:event_id>/my-conference/', 'display_mystuff',
+                        make_compat_redirect_func(_bp, 'display'))
 _compat_bp.add_url_rule('/myconference.py', 'display_mystuff_modpython', make_compat_redirect_func(_bp, 'display'))

--- a/indico/modules/events/contributions/blueprint.py
+++ b/indico/modules/events/contributions/blueprint.py
@@ -14,7 +14,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('contributions', __name__, template_folder='templates',
-                      virtual_template_folder='events/contributions', url_prefix='/event/<confId>')
+                      virtual_template_folder='events/contributions', url_prefix='/event/<int:event_id>')
 
 _bp.add_url_rule('/manage/contributions/', 'manage_contributions', management.RHContributions)
 _bp.add_url_rule('/manage/contributions/customize', 'customize_contrib_list',
@@ -138,7 +138,7 @@ _bp.add_url_rule('/contributions/<int:contrib_id>/subcontributions/<int:subcontr
                  display.RHSubcontributionDisplay)
 
 # Legacy URLs
-_compat_bp = IndicoBlueprint('compat_contributions', __name__, url_prefix='/event/<event_id>')
+_compat_bp = IndicoBlueprint('compat_contributions', __name__, url_prefix='/event/<int:event_id>')
 
 with _compat_bp.add_prefixed_rules('/session/<legacy_session_id>'):
     _compat_bp.add_url_rule('/contribution/<legacy_contribution_id>', 'contribution',
@@ -151,7 +151,7 @@ with _compat_bp.add_prefixed_rules('/session/<legacy_session_id>'):
                             'subcontribution', compat_subcontribution)
 
 _compat_bp.add_url_rule('/my-conference/contributions', 'my_contributions',
-                        make_compat_redirect_func(_bp, 'my_contributions', view_args_conv={'event_id': 'confId'}))
+                        make_compat_redirect_func(_bp, 'my_contributions'))
 
 _compat_bp.add_url_rule('!/contributionDisplay.py', 'contribution_modpython',
                         make_compat_redirect_func(_compat_bp, 'contribution',

--- a/indico/modules/events/contributions/client/js/PublicationSwitch.jsx
+++ b/indico/modules/events/contributions/client/js/PublicationSwitch.jsx
@@ -7,17 +7,18 @@
 
 import publicationURL from 'indico-url:contributions.manage_publication';
 
-import React, {useState} from 'react';
 import PropTypes from 'prop-types';
+import React, {useState} from 'react';
 import {Header, Modal, Button, Checkbox, List} from 'semantic-ui-react';
-import {Translate} from 'indico/react/i18n';
+
 import {useTogglableValue} from 'indico/react/hooks';
+import {Translate} from 'indico/react/i18n';
 
 export default function PublicationSwitch({eventId}) {
   const [modalOpen, setModalOpen] = useState(false);
 
   const [published, togglePublished, loading, saving] = useTogglableValue(
-    publicationURL({confId: eventId})
+    publicationURL({event_id: eventId})
   );
 
   if (loading) {

--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -19,9 +19,10 @@ import ReactDOM from 'react-dom';
 
 import 'indico/modules/events/util/types_dialog';
 import EditableSubmissionButton from 'indico/modules/events/editing/editing/EditableSubmissionButton';
-import {$T} from 'indico/utils/i18n';
-import {camelizeKeys} from 'indico/utils/case';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+import {camelizeKeys} from 'indico/utils/case';
+import {$T} from 'indico/utils/i18n';
+
 import PublicationSwitch from './PublicationSwitch';
 
 (function(global) {
@@ -37,9 +38,9 @@ import PublicationSwitch from './PublicationSwitch';
     try {
       [fileTypeResponses, paperInfoResponse] = await Promise.all([
         Promise.all(
-          availableTypes.map(type => indicoAxios.get(fileTypesURL({confId: eventId, type})))
+          availableTypes.map(type => indicoAxios.get(fileTypesURL({event_id: eventId, type})))
         ),
-        indicoAxios.get(paperInfoURL({confId: eventId, contrib_id: contributionId}), {
+        indicoAxios.get(paperInfoURL({event_id: eventId, contrib_id: contributionId}), {
           validateStatus: status => (status >= 200 && status < 300) || status === 404,
         }),
       ]);

--- a/indico/modules/events/contributions/templates/display/contribution_ical_export.html
+++ b/indico/modules/events/contributions/templates/display/contribution_ical_export.html
@@ -8,7 +8,7 @@
         exportPopups["{{ item.id }}"] = new ExportIcalInterface(
             {{ api_mode|tojson }}, {{ persistent_user_enabled|tojson }},
             {{ persistent_allowed|tojson }}, {{ api_active|tojson }}, {{ user_logged|tojson }}, setURLs,
-            {{ url_for('api.build_urls')|tojson }}, {confId: "{{ item.event.id }}", contribId: "{{ item.id }}"},
+            {{ url_for('api.build_urls')|tojson }}, {eventId: "{{ item.event.id }}", contribId: "{{ item.id }}"},
             {{ request_urls|tojson }}, "{{ item.id }}", "{{ session.user.full_name if session.user else '' }}"
         );
     </script>

--- a/indico/modules/events/controllers/base.py
+++ b/indico/modules/events/controllers/base.py
@@ -18,7 +18,7 @@ from indico.web.rh import RH
 
 class RHEventBase(RH):
     def _process_args(self):
-        self.event = Event.get(int(request.view_args['confId']))
+        self.event = Event.get(request.view_args['event_id'])
         if self.event is None:
             raise NotFound(_('An event with this ID does not exist.'))
         elif self.event.is_deleted:

--- a/indico/modules/events/controllers/entry.py
+++ b/indico/modules/events/controllers/entry.py
@@ -19,7 +19,7 @@ from indico.util.string import is_legacy_id
 
 def event_or_shorturl(confId, shorturl_namespace=False, force_overview=False):
     func = None
-    event_ = Event.get(int(confId)) if confId.isdigit() else None
+    event_ = Event.get(int(confId)) if confId.isdigit() and (confId[0] != '0' or confId == '0') else None
     if event_ and event_.is_deleted:
         raise NotFound(_('This event has been deleted.'))
     elif event_:

--- a/indico/modules/events/controllers/entry.py
+++ b/indico/modules/events/controllers/entry.py
@@ -17,38 +17,36 @@ from indico.util.i18n import _
 from indico.util.string import is_legacy_id
 
 
-def event_or_shorturl(confId, shorturl_namespace=False, force_overview=False):
-    func = None
-    event_ = Event.get(int(confId)) if confId.isdigit() and (confId[0] != '0' or confId == '0') else None
-    if event_ and event_.is_deleted:
+# XXX: force_overview is not used by passed by flask, so it needs to remain here
+def event_or_shorturl(event_id, shorturl_namespace=False, force_overview=False):
+    event = Event.get(int(event_id)) if event_id.isdigit() and (event_id[0] != '0' or event_id == '0') else None
+    if event and event.is_deleted:
         raise NotFound(_('This event has been deleted.'))
-    elif event_:
+    elif event:
         # For obvious reasons an event id always comes first.
         # If it's used within the short url namespace we redirect to the event namespace, otherwise
         # we call the RH to display the event
         if shorturl_namespace:
-            func = lambda: redirect(event_.url)
+            return redirect(event.url)
         else:
-            request.view_args['confId'] = int(request.view_args['confId'])
-            func = lambda: RHDisplayEvent().process()
+            request.view_args['event_id'] = int(event_id)
+            return RHDisplayEvent().process()
     else:
         shorturl_event = (Event.query
-                          .filter(db.func.lower(Event.url_shortcut) == confId.lower(),
+                          .filter(db.func.lower(Event.url_shortcut) == event_id.lower(),
                                   ~Event.is_deleted)
                           .one_or_none())
         if (shorturl_namespace or config.ROUTE_OLD_URLS) and shorturl_event:
             if shorturl_namespace:
                 # Correct namespace => redirect to the event
-                func = lambda: redirect(shorturl_event.url)
+                return redirect(shorturl_event.url)
             else:
                 # Old event namespace => 301-redirect to the new shorturl first to get Google etc. to update it
-                func = lambda: redirect(shorturl_event.short_url, 301)
-        elif is_legacy_id(confId):
-            mapping = LegacyEventMapping.query.filter_by(legacy_event_id=confId).first()
+                return redirect(shorturl_event.short_url, 301)
+        elif is_legacy_id(event_id):
+            mapping = LegacyEventMapping.query.filter_by(legacy_event_id=event_id).first()
             if mapping is not None:
-                url = url_for('events.display', confId=mapping.event_id)
-                func = lambda: redirect(url, 301)
+                url = url_for('events.display', event_id=mapping.event_id)
+                return redirect(url, 301)
 
-    if func is None:
-        raise NotFound(_('An event with this ID/shortcut does not exist.'))
-    return func()
+    raise NotFound(_('An event with this ID/shortcut does not exist.'))

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -10,7 +10,7 @@ from indico.modules.events.editing.controllers.backend import common, editable_l
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
-_bp = IndicoBlueprint('event_editing', __name__, url_prefix='/event/<confId>', template_folder='templates',
+_bp = IndicoBlueprint('event_editing', __name__, url_prefix='/event/<int:event_id>', template_folder='templates',
                       virtual_template_folder='events/editing')
 
 # Frontend (management)

--- a/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
@@ -38,13 +38,13 @@ export default function EditableSubmissionButton({
   const submitRevision = async formData => {
     try {
       await indicoAxios.put(
-        submitRevisionURL({confId: eventId, contrib_id: contributionId, type: currentType}),
+        submitRevisionURL({event_id: eventId, contrib_id: contributionId, type: currentType}),
         formData
       );
     } catch (e) {
       return handleSubmitError(e);
     }
-    location.href = editableURL({confId: eventId, contrib_id: contributionId, type: currentType});
+    location.href = editableURL({event_id: eventId, contrib_id: contributionId, type: currentType});
   };
   const editableTypes = Object.keys(fileTypes);
   const textByType = {
@@ -82,12 +82,12 @@ export default function EditableSubmissionButton({
                       },
                     })}
                     uploadURL={apiUploadURL({
-                      confId: eventId,
+                      event_id: eventId,
                       contrib_id: contributionId,
                       type: currentType,
                     })}
                     uploadExistingURL={apiUploadExistingURL({
-                      confId: eventId,
+                      event_id: eventId,
                       contrib_id: contributionId,
                       type: currentType,
                     })}

--- a/indico/modules/events/editing/client/js/editing/ReduxTimeline.jsx
+++ b/indico/modules/events/editing/client/js/editing/ReduxTimeline.jsx
@@ -22,18 +22,18 @@ import Timeline from './timeline';
 import reducer from './timeline/reducer';
 
 export default function ReduxTimeline() {
-  const eventId = useNumericParam('confId');
+  const eventId = useNumericParam('event_id');
   const contributionId = useNumericParam('contrib_id');
   const {type: editableType} = useParams();
 
   const {data: fileTypes, loading: isLoadingFileTypes} = useIndicoAxios({
-    url: fileTypesURL({confId: eventId, type: editableType}),
+    url: fileTypesURL({event_id: eventId, type: editableType}),
     camelize: true,
     trigger: [eventId, editableType],
   });
 
   const {data: tags, loading: isLoadingTags} = useIndicoAxios({
-    url: tagsURL({confId: eventId}),
+    url: tagsURL({event_id: eventId}),
     camelize: true,
     trigger: [eventId],
   });
@@ -55,7 +55,7 @@ export default function ReduxTimeline() {
         fileTypes,
         tags,
         editableDetailsURL: editableDetailsURL({
-          confId: eventId,
+          event_id: eventId,
           contrib_id: contributionId,
           type: editableType,
         }),

--- a/indico/modules/events/editing/client/js/editing/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/index.jsx
@@ -37,18 +37,18 @@ document.addEventListener('DOMContentLoaded', async () => {
     <Router>
       <Route
         path={[
-          routerPathFromFlask(timelineURL, ['confId', 'contrib_id', 'type']),
-          routerPathFromFlask(editableTypeListURL, ['confId', 'type']),
+          routerPathFromFlask(timelineURL, ['event_id', 'contrib_id', 'type']),
+          routerPathFromFlask(editableTypeListURL, ['event_id', 'type']),
         ]}
       >
         <EditingView eventTitle={eventTitle}>
           <Switch>
             <Route
               exact
-              path={routerPathFromFlask(timelineURL, ['confId', 'contrib_id', 'type'])}
+              path={routerPathFromFlask(timelineURL, ['event_id', 'contrib_id', 'type'])}
               component={ReduxTimeline}
             />
-            <Route exact path={routerPathFromFlask(editableTypeListURL, ['confId', 'type'])}>
+            <Route exact path={routerPathFromFlask(editableTypeListURL, ['event_id', 'type'])}>
               <EditableList management={false} />
             </Route>
           </Switch>

--- a/indico/modules/events/editing/client/js/editing/page_layout/EditingView.jsx
+++ b/indico/modules/events/editing/client/js/editing/page_layout/EditingView.jsx
@@ -19,11 +19,11 @@ import MenuBar from './MenuBar';
 import './EditingView.module.scss';
 
 export default function EditingView({eventTitle, children}) {
-  const eventId = useNumericParam('confId');
+  const eventId = useNumericParam('event_id');
   const contribId = useNumericParam('contrib_id');
   const {type} = useParams();
   const {data, lastData} = useIndicoAxios({
-    url: menuEntriesURL({confId: eventId}),
+    url: menuEntriesURL({event_id: eventId}),
     trigger: eventId,
   });
 

--- a/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.jsx
+++ b/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.jsx
@@ -23,7 +23,7 @@ import {EditableType, EditableEditingTitles} from '../../models';
 import './MenuBar.module.scss';
 
 function EditableListMenu({eventId, editableType}) {
-  if (location.pathname === editableTypeListURL({confId: eventId, type: editableType})) {
+  if (location.pathname === editableTypeListURL({event_id: eventId, type: editableType})) {
     return (
       <Menu vertical>
         <Menu.Item active>
@@ -34,7 +34,7 @@ function EditableListMenu({eventId, editableType}) {
   }
   return (
     <Menu vertical>
-      <Menu.Item as={Link} to={editableTypeListURL({confId: eventId, type: editableType})}>
+      <Menu.Item as={Link} to={editableTypeListURL({event_id: eventId, type: editableType})}>
         <span style={{color: Palette.blue}}>
           <Translate>Editable list</Translate>
         </span>
@@ -51,9 +51,9 @@ EditableListMenu.propTypes = {
 export default function MenuBar({eventId, menuItems, editableType, contribId}) {
   const displayViewURL =
     contribId === null
-      ? displayURL({confId: eventId})
-      : contribDisplayURL({confId: eventId, contrib_id: contribId});
-  const managementViewURL = manageEditableTypeURL({confId: eventId, type: editableType});
+      ? displayURL({event_id: eventId})
+      : contribDisplayURL({event_id: eventId, contrib_id: contribId});
+  const managementViewURL = manageEditableTypeURL({event_id: eventId, type: editableType});
 
   return (
     <div styleName="menu-bar">

--- a/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
@@ -36,7 +36,7 @@ export default function ResetReview({revisionId}) {
     await dispatch(
       resetReviews(
         resetReviewsURL({
-          confId: eventId,
+          event_id: eventId,
           contrib_id: contributionId,
           type: editableType,
           revision_id: revisionId,

--- a/indico/modules/events/editing/client/js/editing/timeline/SubmitRevision.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/SubmitRevision.jsx
@@ -38,7 +38,7 @@ export default function SubmitRevision() {
     const rv = await dispatch(
       createRevision(
         createSubmitterRevisionURL({
-          confId: eventId,
+          event_id: eventId,
           contrib_id: contributionId,
           type: editableType,
           revision_id: lastRevision.id,
@@ -73,7 +73,7 @@ export default function SubmitRevision() {
                     fileTypes={fileTypes}
                     files={lastRevision.files}
                     uploadURL={uploadURL({
-                      confId: eventId,
+                      event_id: eventId,
                       contrib_id: contributionId,
                       type: editableType,
                     })}

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
@@ -36,7 +36,7 @@ export default function TimelineHeader({children, contribution, state, submitter
   const unassignEditor = async () => {
     try {
       await indicoAxios.delete(
-        unassignEditorURL({confId: eventId, contrib_id: contribution.id, type})
+        unassignEditorURL({event_id: eventId, contrib_id: contribution.id, type})
       );
     } catch (error) {
       return handleAxiosError(error);
@@ -46,7 +46,9 @@ export default function TimelineHeader({children, contribution, state, submitter
 
   const assignMyself = async () => {
     try {
-      await indicoAxios.put(assignMyselfURL({confId: eventId, contrib_id: contribution.id, type}));
+      await indicoAxios.put(
+        assignMyselfURL({event_id: eventId, contrib_id: contribution.id, type})
+      );
     } catch (error) {
       return handleAxiosError(error);
     }
@@ -84,7 +86,10 @@ export default function TimelineHeader({children, contribution, state, submitter
                   value={contribution.title}
                   wrapper={
                     <a
-                      href={contributionDisplayURL({contrib_id: contribution.id, confId: eventId})}
+                      href={contributionDisplayURL({
+                        event_id: eventId,
+                        contrib_id: contribution.id,
+                      })}
                     />
                   }
                 />

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesForm.jsx
@@ -86,7 +86,7 @@ export default function UpdateFilesForm({setLoading}) {
               fileTypes={fileTypes}
               files={lastRevision.files}
               uploadURL={uploadURL({
-                confId: eventId,
+                event_id: eventId,
                 contrib_id: contributionId,
                 type: editableType,
               })}

--- a/indico/modules/events/editing/client/js/management/EditableTypeList.jsx
+++ b/indico/modules/events/editing/client/js/management/EditableTypeList.jsx
@@ -31,7 +31,7 @@ export default function EditableTypeList({eventId}) {
     loading: isLoadingEnabledEditableTypes,
     reFetch,
   } = useIndicoAxios({
-    url: enabledEditableTypesURL({confId: eventId}),
+    url: enabledEditableTypesURL({event_id: eventId}),
     camelize: true,
     trigger: eventId,
   });
@@ -43,7 +43,7 @@ export default function EditableTypeList({eventId}) {
   }
 
   const handleSubmit = async formData => {
-    const url = enabledEditableTypesURL({confId: eventId});
+    const url = enabledEditableTypesURL({event_id: eventId});
     const enabledTypes = Object.keys(formData).filter(name => formData[name]);
     try {
       await indicoAxios.post(url, {editable_types: enabledTypes});
@@ -110,13 +110,13 @@ export default function EditableTypeList({eventId}) {
             <div className="toolbar">
               <Link
                 className="i-button icon-list"
-                to={manageEditableTypeListURL({confId: eventId, type})}
+                to={manageEditableTypeListURL({event_id: eventId, type})}
               >
                 <Translate>List</Translate>
               </Link>
               <Link
                 className="i-button icon-settings"
-                to={manageEditableTypeURL({confId: eventId, type})}
+                to={manageEditableTypeURL({event_id: eventId, type})}
               >
                 <Translate>Manage</Translate>
               </Link>

--- a/indico/modules/events/editing/client/js/management/EditingManagement.jsx
+++ b/indico/modules/events/editing/client/js/management/EditingManagement.jsx
@@ -32,32 +32,32 @@ export default function EditingManagement() {
       <Switch>
         <Route
           exact
-          path={routerPathFromFlask(dashboardURL, ['confId'])}
+          path={routerPathFromFlask(dashboardURL, ['event_id'])}
           component={EditingManagementDashboard}
         />
         <Route
           exact
-          path={routerPathFromFlask(manageTagsURL, ['confId'])}
+          path={routerPathFromFlask(manageTagsURL, ['event_id'])}
           component={EditingTagManagement}
         />
         <Route
           exact
-          path={routerPathFromFlask(editableTypeURL, ['confId', 'type'])}
+          path={routerPathFromFlask(editableTypeURL, ['event_id', 'type'])}
           component={EditableTypeDashboard}
         />
         <Route
           exact
-          path={routerPathFromFlask(manageFileTypesURL, ['confId', 'type'])}
+          path={routerPathFromFlask(manageFileTypesURL, ['event_id', 'type'])}
           component={FileTypeManagement}
         />
         <Route
           exact
-          path={routerPathFromFlask(manageReviewConditionsURL, ['confId', 'type'])}
+          path={routerPathFromFlask(manageReviewConditionsURL, ['event_id', 'type'])}
           component={ReviewConditionsManagement}
         />
         <Route
           exact
-          path={routerPathFromFlask(editableListURL, ['confId', 'type'])}
+          path={routerPathFromFlask(editableListURL, ['event_id', 'type'])}
           component={EditableList}
         />
       </Switch>

--- a/indico/modules/events/editing/client/js/management/EditingManagementDashboard.jsx
+++ b/indico/modules/events/editing/client/js/management/EditingManagementDashboard.jsx
@@ -18,7 +18,7 @@ import ManageService from './ManageService';
 import Section from './Section';
 
 export default function EditingManagementDashboard() {
-  const eventId = useNumericParam('confId');
+  const eventId = useNumericParam('event_id');
   return (
     <>
       <div className="action-box">
@@ -27,7 +27,7 @@ export default function EditingManagementDashboard() {
           label={Translate.string('Tags')}
           description={Translate.string('Configure the tags that can be assigned to revisions')}
         >
-          <Link to={manageTagsURL({confId: eventId})} className="i-button icon-settings">
+          <Link to={manageTagsURL({event_id: eventId})} className="i-button icon-settings">
             <Translate>Configure</Translate>
           </Link>
         </Section>

--- a/indico/modules/events/editing/client/js/management/ManageService.jsx
+++ b/indico/modules/events/editing/client/js/management/ManageService.jsx
@@ -36,7 +36,7 @@ export default function ManageService({eventId}) {
   const [connectOpen, setConnectOpen] = useState(false);
   const [disconnectOpen, setDisconnectOpen] = useState(false);
   const {data, error, loading, reFetch} = useIndicoAxios({
-    url: checkServiceStatusURL({confId: eventId}),
+    url: checkServiceStatusURL({event_id: eventId}),
     trigger: eventId,
     camelize: true,
   });
@@ -92,7 +92,7 @@ export default function ManageService({eventId}) {
 
   const connect = async ({url}) => {
     try {
-      await indicoAxios.post(connectServiceURL({confId: eventId}), {url});
+      await indicoAxios.post(connectServiceURL({event_id: eventId}), {url});
     } catch (err) {
       return handleSubmitError(err);
     }
@@ -102,7 +102,7 @@ export default function ManageService({eventId}) {
 
   const disconnect = async () => {
     try {
-      await indicoAxios.post(disconnectServiceURL({confId: eventId}), {force: forceDisconnect});
+      await indicoAxios.post(disconnectServiceURL({event_id: eventId}), {force: forceDisconnect});
     } catch (err) {
       handleAxiosError(err);
       return;
@@ -185,7 +185,7 @@ export default function ManageService({eventId}) {
                         // this does send a request on each keypress, but in this particular case
                         // it's VERY likely that people paste a url, so it shouldn't be an issue
                         resp = await debounce(() =>
-                          indicoAxios.get(checkServiceURL({confId: eventId}), {
+                          indicoAxios.get(checkServiceURL({event_id: eventId}), {
                             params: {url: value},
                           })
                         );

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -42,21 +42,21 @@ import NextEditable from './NextEditable';
 import './EditableList.module.scss';
 
 export default function EditableList({management}) {
-  const eventId = useNumericParam('confId');
+  const eventId = useNumericParam('event_id');
   const {type} = useParams();
   const {data: contribList, loading: isLoadingContribList} = useIndicoAxios({
-    url: editableListURL({confId: eventId, type}),
+    url: editableListURL({event_id: eventId, type}),
     camelize: true,
     trigger: [eventId, type],
   });
   const {data: editors, loading: isLoadingEditors} = useIndicoAxios({
-    url: editorsURL({confId: eventId, type}),
+    url: editorsURL({event_id: eventId, type}),
     camelize: true,
     trigger: [eventId, type],
     forceDispatchEffect: () => management,
   });
   const {data: canAssignSelf, loading: isLoadingCanAssignSelf} = useIndicoAxios({
-    url: canAssignSelfURL({confId: eventId, type}),
+    url: canAssignSelfURL({event_id: eventId, type}),
     trigger: [eventId, type],
     forceDispatchEffect: () => !management,
   });
@@ -301,7 +301,7 @@ function EditableListDisplay({
   const checkedEditablesRequest = async (urlFunc, data = {}) => {
     let response;
     try {
-      response = await indicoAxios.post(urlFunc({confId: eventId, type: editableType}), {
+      response = await indicoAxios.post(urlFunc({event_id: eventId, type: editableType}), {
         editables: checked,
         ...data,
       });
@@ -347,7 +347,7 @@ function EditableListDisplay({
     <>
       {management && <ManagementPageSubTitle title={title} />}
       {management && (
-        <ManagementPageBackButton url={editableTypeURL({confId: eventId, type: editableType})} />
+        <ManagementPageBackButton url={editableTypeURL({event_id: eventId, type: editableType})} />
       )}
       <div styleName="editable-topbar">
         <div>

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
@@ -33,7 +33,7 @@ import TeamManager from './TeamManager';
 import './EditableTypeDashboard.module.scss';
 
 export default function EditableTypeDashboard() {
-  const eventId = useNumericParam('confId');
+  const eventId = useNumericParam('event_id');
   const {type} = useParams();
   const [editorManagerVisible, setEditorManagerVisible] = useState(false);
   const [selfAssignModalVisible, setSelfAssignModalVisible] = useState(false);
@@ -43,19 +43,19 @@ export default function EditableTypeDashboard() {
     toggleSelfAssign,
     selfAssignLoading,
     selfAssignSaving,
-  ] = useTogglableValue(selfAssignURL({confId: eventId, type}));
+  ] = useTogglableValue(selfAssignURL({event_id: eventId, type}));
 
   const [submissionEnabled, toggleSubmission, submissionLoading] = useTogglableValue(
-    enableSubmissionURL({confId: eventId, type})
+    enableSubmissionURL({event_id: eventId, type})
   );
 
   const [editingEnabled, toggleEditing, editingLoading] = useTogglableValue(
-    enableEditingURL({confId: eventId, type})
+    enableEditingURL({event_id: eventId, type})
   );
 
   const contactEditingTeam = () => {
     ajaxDialog({
-      url: contactEditingTeamURL({confId: eventId, type}),
+      url: contactEditingTeamURL({event_id: eventId, type}),
       title: Translate.string('Send emails to the editing team'),
     });
   };
@@ -69,7 +69,7 @@ export default function EditableTypeDashboard() {
   return (
     <>
       <ManagementPageSubTitle title={EditableTypeTitles[type]} />
-      <ManagementPageBackButton url={dashboardURL({confId: eventId})} />
+      <ManagementPageBackButton url={dashboardURL({event_id: eventId})} />
       {selfAssignLoading || submissionLoading || editingLoading ? (
         <Loader active />
       ) : (
@@ -110,7 +110,7 @@ export default function EditableTypeDashboard() {
             >
               <Link
                 className="i-button icon-settings"
-                to={manageFileTypesURL({confId: eventId, type})}
+                to={manageFileTypesURL({event_id: eventId, type})}
               >
                 <Translate>Configure</Translate>
               </Link>
@@ -122,7 +122,7 @@ export default function EditableTypeDashboard() {
             >
               <Link
                 className="i-button icon-settings"
-                to={manageReviewConditionsURL({confId: eventId, type})}
+                to={manageReviewConditionsURL({event_id: eventId, type})}
               >
                 <Translate>Configure</Translate>
               </Link>
@@ -156,7 +156,7 @@ export default function EditableTypeDashboard() {
               />
               <Link
                 className="i-button icon-settings"
-                to={manageEditableTypeListURL({confId: eventId, type})}
+                to={manageEditableTypeListURL({event_id: eventId, type})}
               >
                 <Translate>List</Translate>
               </Link>

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableTypeSubPageNav.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableTypeSubPageNav.jsx
@@ -22,7 +22,7 @@ import {useNumericParam} from 'indico/react/util/routing';
 import {EditableTypeTitles} from '../../models';
 
 export default function EditableTypeSubPageNav({title}) {
-  const eventId = useNumericParam('confId');
+  const eventId = useNumericParam('event_id');
   const {type} = useParams();
   return (
     <>
@@ -30,7 +30,7 @@ export default function EditableTypeSubPageNav({title}) {
         title={Translate.string('Editing ({type})', {type: EditableTypeTitles[type]})}
       />
       <ManagementPageSubTitle title={title} />
-      <ManagementPageBackButton url={editableTypeURL({confId: eventId, type})} />
+      <ManagementPageBackButton url={editableTypeURL({event_id: eventId, type})} />
     </>
   );
 }

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -27,7 +27,7 @@ import './NextEditable.module.scss';
 
 export default function NextEditable({eventId, editableType, onClose, management}) {
   const {data: fileTypes, loading: isLoadingFileTypes} = useIndicoAxios({
-    url: fileTypesURL({confId: eventId, type: editableType}),
+    url: fileTypesURL({event_id: eventId, type: editableType}),
     camelize: true,
     trigger: [eventId, editableType],
   });
@@ -69,10 +69,13 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
       setLoading(true);
       let response;
       try {
-        response = await indicoAxios.post(editableListURL({confId: eventId, type: editableType}), {
-          extensions: _.pickBy(filters, x => Array.isArray(x)),
-          has_files: _.pickBy(filters, x => !Array.isArray(x)),
-        });
+        response = await indicoAxios.post(
+          editableListURL({event_id: eventId, type: editableType}),
+          {
+            extensions: _.pickBy(filters, x => Array.isArray(x)),
+            has_files: _.pickBy(filters, x => !Array.isArray(x)),
+          }
+        );
       } catch (e) {
         handleAxiosError(e);
         setLoading(false);
@@ -112,7 +115,7 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
     try {
       await indicoAxios.put(
         assignMyselfURL({
-          confId: eventId,
+          event_id: eventId,
           contrib_id: selectedEditable.contributionId,
           type: editableType,
         })

--- a/indico/modules/events/editing/client/js/management/editable_type/TeamManager.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/TeamManager.jsx
@@ -26,18 +26,18 @@ import {useNumericParam} from 'indico/react/util/routing';
 import {indicoAxios} from 'indico/utils/axios';
 
 export default function TeamManager({editableType, onClose}) {
-  const eventId = useNumericParam('confId');
+  const eventId = useNumericParam('event_id');
   const favoriteUsersController = useFavoriteUsers();
 
   const {data: principals, loading: isLoadingPrincipals} = useIndicoAxios({
-    url: principalsURL({confId: eventId, type: editableType}),
+    url: principalsURL({event_id: eventId, type: editableType}),
     trigger: [eventId, editableType],
   });
 
   const handleSubmit = async (data, form) => {
     const changedValues = getChangedValues(data, form);
     try {
-      await indicoAxios.post(principalsURL({confId: eventId, type: editableType}), changedValues);
+      await indicoAxios.post(principalsURL({event_id: eventId, type: editableType}), changedValues);
     } catch (error) {
       return handleSubmitError(error);
     }

--- a/indico/modules/events/editing/client/js/management/editable_type/file_types/FileTypeManager.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/file_types/FileTypeManager.jsx
@@ -60,14 +60,14 @@ StatusIcon.propTypes = {
 export default function FileTypeManager({eventId, editableType}) {
   const [state, dispatch] = useReducer(fileTypesReducer, initialState);
   const {data, loading: isLoadingFileTypes, reFetch, lastData} = useIndicoAxios({
-    url: fileTypesURL({confId: eventId, type: editableType}),
+    url: fileTypesURL({event_id: eventId, type: editableType}),
     camelize: true,
     trigger: eventId,
   });
 
   const createFileType = async formData => {
     try {
-      await indicoAxios.post(createFileTypeURL({confId: eventId, type: editableType}), formData);
+      await indicoAxios.post(createFileTypeURL({event_id: eventId, type: editableType}), formData);
       reFetch();
     } catch (e) {
       return handleSubmitError(e);
@@ -75,7 +75,7 @@ export default function FileTypeManager({eventId, editableType}) {
   };
 
   const editFileType = async (fileTypeId, fileTypeData) => {
-    const url = editFileTypeURL({confId: eventId, file_type_id: fileTypeId, type: editableType});
+    const url = editFileTypeURL({event_id: eventId, file_type_id: fileTypeId, type: editableType});
 
     try {
       await indicoAxios.patch(url, fileTypeData);
@@ -86,7 +86,7 @@ export default function FileTypeManager({eventId, editableType}) {
   };
 
   const deleteFileType = async fileTypeId => {
-    const url = editFileTypeURL({confId: eventId, file_type_id: fileTypeId, type: editableType});
+    const url = editFileTypeURL({event_id: eventId, file_type_id: fileTypeId, type: editableType});
 
     try {
       await indicoAxios.delete(url);

--- a/indico/modules/events/editing/client/js/management/editable_type/file_types/index.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/file_types/index.jsx
@@ -16,7 +16,7 @@ import EditableTypeSubPageNav from '../EditableTypeSubPageNav';
 import FileTypeManager from './FileTypeManager';
 
 export default function FileTypeManagement() {
-  const eventId = useNumericParam('confId');
+  const eventId = useNumericParam('event_id');
   const {type} = useParams();
 
   return (

--- a/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ConditionInfo.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ConditionInfo.jsx
@@ -27,7 +27,7 @@ export default function ConditionInfo({fileTypes, condId, editableType, onUpdate
   const [isEditing, setIsEditing] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const {eventId} = useContext(ReviewConditionsContext);
-  const url = editReviewConditionURL({confId: eventId, condition_id: condId, type: editableType});
+  const url = editReviewConditionURL({event_id: eventId, condition_id: condId, type: editableType});
 
   const deleteCondition = async () => {
     try {

--- a/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ReviewConditionsManager.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ReviewConditionsManager.jsx
@@ -25,7 +25,7 @@ export default function ReviewConditionsManager() {
   const {eventId, fileTypes, editableType} = useContext(ReviewConditionsContext);
   const [isAdding, setIsAdding] = useState(false);
   const {loading, reFetch, data: eventConditionsSetting, lastData} = useIndicoAxios({
-    url: reviewConditionsURL({confId: eventId, type: editableType}),
+    url: reviewConditionsURL({event_id: eventId, type: editableType}),
     trigger: eventId,
   });
 
@@ -43,7 +43,10 @@ export default function ReviewConditionsManager() {
   ]);
   const createNewCondition = async formData => {
     try {
-      await indicoAxios.post(reviewConditionsURL({confId: eventId, type: editableType}), formData);
+      await indicoAxios.post(
+        reviewConditionsURL({event_id: eventId, type: editableType}),
+        formData
+      );
       setIsAdding(false);
       reFetch();
     } catch (e) {

--- a/indico/modules/events/editing/client/js/management/editable_type/review_conditions/index.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/review_conditions/index.jsx
@@ -20,11 +20,11 @@ import ReviewConditionsContext from './context';
 import ReviewConditionsManager from './ReviewConditionsManager';
 
 export default function ReviewConditionManagement() {
-  const eventId = useNumericParam('confId');
+  const eventId = useNumericParam('event_id');
   const {type} = useParams();
 
   const {data: fileTypes} = useIndicoAxios({
-    url: fileTypesURL({confId: eventId, type}),
+    url: fileTypesURL({event_id: eventId, type}),
     camelize: true,
     trigger: [eventId, type],
   });

--- a/indico/modules/events/editing/client/js/management/tags/TagManager.jsx
+++ b/indico/modules/events/editing/client/js/management/tags/TagManager.jsx
@@ -46,14 +46,14 @@ function tagsReducer(state, action) {
 export default function TagManager({eventId}) {
   const [state, dispatch] = useReducer(tagsReducer, initialState);
   const {data, loading: isLoadingTags, reFetch, lastData} = useIndicoAxios({
-    url: tagsURL({confId: eventId}),
+    url: tagsURL({event_id: eventId}),
     camelize: true,
     trigger: eventId,
   });
 
   const createTag = async formData => {
     try {
-      await indicoAxios.post(createTagURL({confId: eventId}), formData);
+      await indicoAxios.post(createTagURL({event_id: eventId}), formData);
       reFetch();
     } catch (e) {
       return handleSubmitError(e);
@@ -61,7 +61,7 @@ export default function TagManager({eventId}) {
   };
 
   const editTag = async (tagId, tagData) => {
-    const url = editTagURL({confId: eventId, tag_id: tagId});
+    const url = editTagURL({event_id: eventId, tag_id: tagId});
 
     try {
       await indicoAxios.patch(url, tagData);
@@ -72,7 +72,7 @@ export default function TagManager({eventId}) {
   };
 
   const deleteTag = async tagId => {
-    const url = editTagURL({confId: eventId, tag_id: tagId});
+    const url = editTagURL({event_id: eventId, tag_id: tagId});
 
     try {
       await indicoAxios.delete(url);

--- a/indico/modules/events/editing/client/js/management/tags/index.js
+++ b/indico/modules/events/editing/client/js/management/tags/index.js
@@ -16,10 +16,10 @@ import {useNumericParam} from 'indico/react/util/routing';
 import TagManager from './TagManager';
 
 export default function EditingTagManagement() {
-  const eventId = useNumericParam('confId');
+  const eventId = useNumericParam('event_id');
   return (
     <>
-      <ManagementPageBackButton url={dashboardURL({confId: eventId})} />
+      <ManagementPageBackButton url={dashboardURL({event_id: eventId})} />
       <ManagementPageSubTitle title={Translate.string('Tags')} />
       <TagManager eventId={eventId} />
     </>

--- a/indico/modules/events/editing/controllers/base.py
+++ b/indico/modules/events/editing/controllers/base.py
@@ -27,7 +27,7 @@ class TokenAccessMixin:
     def _token_can_access(self):
         # we need to "fish" the event here because at this point _check_params
         # hasn't run yet
-        event = Event.get_or_404(int(request.view_args['confId']), is_deleted=False)
+        event = Event.get_or_404(request.view_args['event_id'], is_deleted=False)
         if not self.SERVICE_ALLOWED or not request.bearer_token:
             return False
 

--- a/indico/modules/events/features/blueprint.py
+++ b/indico/modules/events/features/blueprint.py
@@ -10,7 +10,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('event_features', __name__, template_folder='templates',
-                      virtual_template_folder='events/features', url_prefix='/event/<confId>/manage/features')
+                      virtual_template_folder='events/features', url_prefix='/event/<int:event_id>/manage/features')
 
 _bp.add_url_rule('/', 'index', RHFeatures)
 _bp.add_url_rule('/<feature>', 'switch', RHSwitchFeature, methods=('PUT', 'DELETE'))

--- a/indico/modules/events/features/templates/features.html
+++ b/indico/modules/events/features/templates/features.html
@@ -32,7 +32,7 @@
                 },
                 href: function() {
                     return build_url(urlTemplate, {
-                        confId: {{ event.id }},
+                        event_id: {{ event.id }},
                         feature: this.name
                     });
                 }

--- a/indico/modules/events/layout/blueprint.py
+++ b/indico/modules/events/layout/blueprint.py
@@ -20,7 +20,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('event_layout', __name__, template_folder='templates',
-                      virtual_template_folder='events/layout', url_prefix='/event/<confId>/manage/layout')
+                      virtual_template_folder='events/layout', url_prefix='/event/<int:event_id>/manage/layout')
 
 _bp.add_url_rule('/', 'index', RHLayoutEdit, methods=('GET', 'POST'))
 _bp.add_url_rule('/timetable-theme-form', 'timetable_theme_form', RHLayoutTimetableThemeForm)
@@ -43,21 +43,21 @@ _bp.add_url_rule('/logo', 'delete_logo', RHLayoutLogoDelete, methods=('DELETE',)
 _bp.add_url_rule('/images/', 'images', RHImages)
 _bp.add_url_rule('/images/upload', 'images_upload', RHImageUpload, methods=('POST',))
 _bp.add_url_rule('/images/<int:image_id>-<filename>', 'image_delete', RHImageDelete, methods=('DELETE',))
-_bp.add_url_rule('!/event/<confId>/<slug>.css', 'css_display', RHLayoutCSSDisplay)
+_bp.add_url_rule('!/event/<int:event_id>/<slug>.css', 'css_display', RHLayoutCSSDisplay)
 
 
 _bp_images = IndicoBlueprint('event_images', __name__, template_folder='templates',
-                             virtual_template_folder='events/layout', url_prefix='/event/<confId>')
+                             virtual_template_folder='events/layout', url_prefix='/event/<int:event_id>')
 _bp_images.add_url_rule('/logo-<slug>.png', 'logo_display', RHLogoDisplay)
 _bp_images.add_url_rule('/images/<int:image_id>-<filename>', 'image_display', RHImageDisplay)
 
 
 _bp_pages = IndicoBlueprint('event_pages', __name__, template_folder='templates',
-                            virtual_template_folder='events/layout', url_prefix='/event/<confId>')
+                            virtual_template_folder='events/layout', url_prefix='/event/<int:event_id>')
 _bp_pages.add_url_rule('/page/<int:page_id>', 'page_display', RHPageDisplay)
 _bp_pages.add_url_rule('/page/<int:page_id>-<slug>', 'page_display', RHPageDisplay)
 
-_compat_bp = IndicoBlueprint('compat_layout', __name__, url_prefix='/event/<event_id>')
+_compat_bp = IndicoBlueprint('compat_layout', __name__, url_prefix='/event/<int:event_id>')
 _compat_bp.add_url_rule('!/internalPage.py', 'page_modpython',
                         make_compat_redirect_func(_compat_bp, 'page', view_args_conv={'confId': 'event_id',
                                                                                       'pageId': 'legacy_page_id'}))

--- a/indico/modules/events/legacy_ids_test.py
+++ b/indico/modules/events/legacy_ids_test.py
@@ -1,0 +1,50 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+
+from indico.modules.events.models.legacy_mapping import LegacyEventMapping
+
+
+@pytest.mark.parametrize('url', ('/event/{}/timetable/', '/event/{}/'))
+def test_not_legacy(create_event, test_client, url):
+    event = create_event()
+    event.title = f'dummy#{event.id}'
+    assert event.id != 0
+    rv = test_client.get(url.format(event.id))
+    assert f'dummy#{event.id}'.encode() in rv.data
+    assert rv.status_code == 200
+
+
+@pytest.mark.parametrize('url', ('/event/0/timetable/', '/event/0/'))
+def test_not_legacy_id_0(dummy_event, test_client, url):
+    # `0` could look legacy ("leading zero") but it's not
+    assert dummy_event.id == 0
+    rv = test_client.get(url)
+    assert b'dummy#0' in rv.data
+    assert rv.status_code == 200
+
+
+@pytest.mark.usefixtures('db')
+def test_legacy_id_not_mapped(test_client):
+    # legacy id but not in the mapping table
+    rv = test_client.get('event/0999/timetable/')
+    assert b'Legacy event 0999 does not exist' in rv.data
+    assert rv.status_code == 404
+
+    rv = test_client.get('event/0999/')
+    assert b'An event with this ID/shortcut does not exist.' in rv.data
+    assert rv.status_code == 404
+
+
+@pytest.mark.parametrize('url', ('/event/{}/timetable', '/event/{}/timetable/', '/event/{}/'))
+@pytest.mark.parametrize('legacy_id', ('0123', 'a123', 'a0', 'asdf', '123x', '0xff'))
+def test_legacy_ids(db, dummy_event, test_client, url, legacy_id):
+    db.session.add(LegacyEventMapping(legacy_event_id=legacy_id, event=dummy_event))
+    rv = test_client.get(url.format(legacy_id))
+    assert rv.status_code == 301
+    assert rv.headers['Location'] == 'http://localhost' + url.format(dummy_event.id)

--- a/indico/modules/events/logs/blueprint.py
+++ b/indico/modules/events/logs/blueprint.py
@@ -10,7 +10,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('event_logs', __name__, template_folder='templates', virtual_template_folder='events/logs',
-                      url_prefix='/event/<confId>/manage/logs')
+                      url_prefix='/event/<int:event_id>/manage/logs')
 
 _bp.add_url_rule('/', 'index', RHEventLogs)
 _bp.add_url_rule('/api/logs', 'logs', RHEventLogsJSON)

--- a/indico/modules/events/management/blueprint.py
+++ b/indico/modules/events/management/blueprint.py
@@ -13,7 +13,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 _bp = IndicoBlueprint('event_management', __name__, template_folder='templates',
                       virtual_template_folder='events/management',
-                      url_prefix='/event/<confId>/manage')
+                      url_prefix='/event/<int:event_id>/manage')
 
 # Settings
 _bp.add_url_rule('/', 'settings', settings.RHEventSettings)
@@ -66,10 +66,10 @@ for object_type, prefixes in event_management_object_url_prefixes.items():
     if object_type == 'subcontribution':
         continue
     for prefix in prefixes:
-        prefix = '!/event/<confId>' + prefix
+        prefix = '!/event/<int:event_id>' + prefix
         _bp.add_url_rule(prefix + '/show-non-inheriting', 'show_non_inheriting', protection.RHShowNonInheriting,
                          defaults={'object_type': object_type})
 
 
-_compat_bp = IndicoBlueprint('compat_event_management', __name__, url_prefix='/event/<confId>/manage')
+_compat_bp = IndicoBlueprint('compat_event_management', __name__, url_prefix='/event/<int:event_id>/manage')
 _compat_bp.add_url_rule('/general/', 'settings', make_compat_redirect_func(_bp, 'settings'))

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -488,7 +488,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
 
     @property
     def locator(self):
-        return {'confId': self.id}
+        return {'event_id': self.id}
 
     @property
     def logo_url(self):
@@ -571,12 +571,12 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     @property
     def short_url(self):
         id_ = self.url_shortcut or self.id
-        return url_for('events.shorturl', confId=id_)
+        return url_for('events.shorturl', event_id=id_)
 
     @property
     def short_external_url(self):
         id_ = self.url_shortcut or self.id
-        return url_for('events.shorturl', confId=id_, _external=True)
+        return url_for('events.shorturl', event_id=id_, _external=True)
 
     @property
     def map_url(self):

--- a/indico/modules/events/notes/blueprint.py
+++ b/indico/modules/events/notes/blueprint.py
@@ -11,7 +11,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('event_notes', __name__, template_folder='templates', virtual_template_folder='events/notes',
-                      url_prefix='/event/<confId>')
+                      url_prefix='/event/<int:event_id>')
 
 _bp.add_url_rule('/note/compile', 'compile', RHCompileNotes, methods=('GET', 'POST'), defaults={'object_type': 'event'})
 

--- a/indico/modules/events/papers/blueprint.py
+++ b/indico/modules/events/papers/blueprint.py
@@ -11,7 +11,7 @@ from indico.modules.events.papers.controllers import api, display, management, p
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
-_bp = IndicoBlueprint('papers', __name__, url_prefix='/event/<confId>', template_folder='templates',
+_bp = IndicoBlueprint('papers', __name__, url_prefix='/event/<int:event_id>', template_folder='templates',
                       virtual_template_folder='events/papers')
 
 # API
@@ -104,8 +104,3 @@ def _add_management_flag(endpoint, values):
         # XXX: using getattr because the conference menu builds the url from an
         # RH without the management attribute
         values['management'] = getattr(g.rh, 'management', False)
-
-
-# Legacy URLs
-_compat_bp = IndicoBlueprint('compat_papers', __name__, url_prefix='/event/<int:confId>')
-# TODO...

--- a/indico/modules/events/papers/client/js/actions.js
+++ b/indico/modules/events/papers/client/js/actions.js
@@ -30,7 +30,7 @@ export const DELETE_COMMENT_ERROR = 'papers/DELETE_COMMENT_ERROR';
 
 export function fetchPaperDetails(eventId, contributionId) {
   return ajaxAction(
-    () => indicoAxios.get(paperInfoURL({confId: eventId, contrib_id: contributionId})),
+    () => indicoAxios.get(paperInfoURL({event_id: eventId, contrib_id: contributionId})),
     FETCH_PAPER_DETAILS_REQUEST,
     FETCH_PAPER_DETAILS_SUCCESS,
     FETCH_PAPER_DETAILS_ERROR
@@ -39,7 +39,7 @@ export function fetchPaperDetails(eventId, contributionId) {
 
 export function resetPaperJudgment(eventId, contributionId) {
   return ajaxAction(
-    () => indicoAxios.delete(resetPaperStateURL({confId: eventId, contrib_id: contributionId})),
+    () => indicoAxios.delete(resetPaperStateURL({event_id: eventId, contrib_id: contributionId})),
     RESET_PAPER_JUDGMENT_REQUEST,
     [RESET_PAPER_JUDGMENT_SUCCESS, () => fetchPaperDetails(eventId, contributionId)],
     RESET_PAPER_JUDGMENT_ERROR
@@ -48,7 +48,7 @@ export function resetPaperJudgment(eventId, contributionId) {
 
 export function createComment(eventId, contributionId, commentData) {
   const params = {
-    confId: eventId,
+    event_id: eventId,
     contrib_id: contributionId,
   };
 
@@ -62,7 +62,7 @@ export function createComment(eventId, contributionId, commentData) {
 
 export function updateComment(eventId, contributionId, revisionId, commentId, commentData) {
   const params = {
-    confId: eventId,
+    event_id: eventId,
     contrib_id: contributionId,
     revision_id: revisionId,
     comment_id: commentId,
@@ -78,7 +78,7 @@ export function updateComment(eventId, contributionId, revisionId, commentId, co
 
 export function deleteComment(eventId, contributionId, revisionId, commentId) {
   const params = {
-    confId: eventId,
+    event_id: eventId,
     contrib_id: contributionId,
     revision_id: revisionId,
     comment_id: commentId,
@@ -95,7 +95,10 @@ export function deleteComment(eventId, contributionId, revisionId, commentId) {
 export function judgePaper(eventId, contributionId, judgmentData) {
   return submitFormAction(
     () =>
-      indicoAxios.post(judgePaperURL({confId: eventId, contrib_id: contributionId}), judgmentData),
+      indicoAxios.post(
+        judgePaperURL({event_id: eventId, contrib_id: contributionId}),
+        judgmentData
+      ),
     null,
     () => fetchPaperDetails(eventId, contributionId),
     null
@@ -106,7 +109,7 @@ export function createReview(eventId, contributionId, group, reviewData) {
   return submitFormAction(
     () =>
       indicoAxios.post(
-        createReviewURL({confId: eventId, contrib_id: contributionId, review_type: group}),
+        createReviewURL({event_id: eventId, contrib_id: contributionId, review_type: group}),
         reviewData
       ),
     null,
@@ -120,7 +123,7 @@ export function updateReview(eventId, contributionId, revisionId, reviewId, revi
     () =>
       indicoAxios.post(
         updateReviewURL({
-          confId: eventId,
+          event_id: eventId,
           contrib_id: contributionId,
           revision_id: revisionId,
           review_id: reviewId,

--- a/indico/modules/events/papers/client/js/components/Paper.jsx
+++ b/indico/modules/events/papers/client/js/components/Paper.jsx
@@ -38,14 +38,14 @@ export default function Paper({eventId, contributionId}) {
   const paper = useSelector(getPaperDetails);
   const isInitialPaperDetailsLoading = useSelector(isFetchingInitialPaperDetails);
   const {data: fileTypes, loading: isFileTypesLoading} = useIndicoAxios({
-    url: fileTypesURL({confId: eventId, type: EditableType.paper}),
+    url: fileTypesURL({event_id: eventId, type: EditableType.paper}),
     trigger: eventId,
     unhandledErrors: [404], // if editing module is disabled
     camelize: true,
   });
   const {data: editable, loading: isEditableLoading} = useIndicoAxios({
     url: editableDetailsURL({
-      confId: eventId,
+      event_id: eventId,
       contrib_id: contributionId,
       type: EditableType.paper,
     }),
@@ -95,7 +95,7 @@ export default function Paper({eventId, contributionId}) {
           fileTypes={fileTypes}
           uploadableFiles={files}
           editableURL={editableURL({
-            confId: eventId,
+            event_id: eventId,
             contrib_id: contributionId,
             type: EditableType.paper,
           })}

--- a/indico/modules/events/papers/client/js/components/SubmitRevision.jsx
+++ b/indico/modules/events/papers/client/js/components/SubmitRevision.jsx
@@ -47,7 +47,7 @@ export default function SubmitRevision() {
 
     try {
       await indicoAxios.post(
-        submitRevisionURL({confId: eventId, contrib_id: contributionId}),
+        submitRevisionURL({event_id: eventId, contrib_id: contributionId}),
         formData,
         {headers}
       );

--- a/indico/modules/events/papers/client/js/components/TimelineHeader.jsx
+++ b/indico/modules/events/papers/client/js/components/TimelineHeader.jsx
@@ -39,7 +39,10 @@ export default function TimelineHeader({children, contribution, state, submitter
                   value={contribution.title}
                   wrapper={
                     <a
-                      href={contributionDisplayURL({contrib_id: contribution.id, confId: eventId})}
+                      href={contributionDisplayURL({
+                        event_id: eventId,
+                        contrib_id: contribution.id,
+                      })}
                     />
                   }
                 />

--- a/indico/modules/events/payment/blueprint.py
+++ b/indico/modules/events/payment/blueprint.py
@@ -19,15 +19,15 @@ _bp.add_url_rule('/admin/payment/<plugin>/', 'admin_plugin_settings', RHPaymentA
                  methods=('GET', 'POST'))
 
 # Event management
-_bp.add_url_rule('/event/<confId>/manage/payments/', 'event_settings', RHPaymentSettings)
-_bp.add_url_rule('/event/<confId>/manage/payments/settings',
+_bp.add_url_rule('/event/<int:event_id>/manage/payments/', 'event_settings', RHPaymentSettings)
+_bp.add_url_rule('/event/<int:event_id>/manage/payments/settings',
                  'event_settings_edit', RHPaymentSettingsEdit, methods=('GET', 'POST'))
-_bp.add_url_rule('/event/<confId>/manage/payments/method/<method>',
+_bp.add_url_rule('/event/<int:event_id>/manage/payments/method/<method>',
                  'event_plugin_edit', RHPaymentPluginEdit, methods=('GET', 'POST'))
 
 # Event
-_bp.add_url_rule('/event/<confId>/registrations/<int:reg_form_id>/checkout/',
+_bp.add_url_rule('/event/<int:event_id>/registrations/<int:reg_form_id>/checkout/',
                  'event_payment', RHPaymentCheckout, methods=('GET', 'POST'))
-_bp.add_url_rule('/event/<confId>/registrations/<int:reg_form_id>/checkout/form',
+_bp.add_url_rule('/event/<int:event_id>/registrations/<int:reg_form_id>/checkout/form',
                  'event_payment_form', RHPaymentForm)
-_bp.add_url_rule('/event/<confId>/payment/conditions', 'event_payment_conditions', RHPaymentConditions)
+_bp.add_url_rule('/event/<int:event_id>/payment/conditions', 'event_payment_conditions', RHPaymentConditions)

--- a/indico/modules/events/persons/blueprint.py
+++ b/indico/modules/events/persons/blueprint.py
@@ -12,7 +12,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('persons', __name__, template_folder='templates', virtual_template_folder='events/persons',
-                      url_prefix='/event/<confId>/manage')
+                      url_prefix='/event/<int:event_id>/manage')
 
 _bp.add_url_rule('/persons/', 'person_list', RHPersonsList)
 _bp.add_url_rule('/persons/email', 'email_event_persons', RHEmailEventPersons, methods=('POST',))

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -14,7 +14,7 @@ from indico.web.flask.util import make_compat_redirect_func
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
-_bp = IndicoBlueprint('event_registration', __name__, url_prefix='/event/<confId>', template_folder='templates',
+_bp = IndicoBlueprint('event_registration', __name__, url_prefix='/event/<int:event_id>', template_folder='templates',
                       virtual_template_folder='events/registration', event_feature='registration')
 
 # Management
@@ -180,7 +180,7 @@ _bp.add_url_rule('/api/registration-forms', 'api_registration_forms', api.RHAPIR
 
 
 # Participants
-_bp_participation = IndicoBlueprint('event_participation', __name__, url_prefix='/event/<confId>',
+_bp_participation = IndicoBlueprint('event_participation', __name__, url_prefix='/event/<int:event_id>',
                                     template_folder='templates', virtual_template_folder='events/registration')
 _bp_participation.add_url_rule('/manage/participants/', 'manage', regforms.RHManageParticipants,
                                methods=('GET', 'POST'))
@@ -190,7 +190,6 @@ _bp_participation.add_url_rule('/manage/participants/', 'manage', regforms.RHMan
 _compat_bp = IndicoBlueprint('compat_event_registration', __name__, url_prefix='/event/<int:event_id>')
 _compat_bp.add_url_rule('/registration/', 'registration', compat_registration)
 _compat_bp.add_url_rule('/registration/<path:path>', 'registration', compat_registration)
-_compat_bp.add_url_rule('/registration/registrants', 'registrants',
-                        make_compat_redirect_func(_bp, 'participant_list', view_args_conv={'event_id': 'confId'}))
+_compat_bp.add_url_rule('/registration/registrants', 'registrants', make_compat_redirect_func(_bp, 'participant_list'))
 _compat_bp.add_url_rule('!/confRegistrantsDisplay.py/list', 'registrants_modpython',
                         make_compat_redirect_func(_bp, 'participant_list'))

--- a/indico/modules/events/registration/client/js/form/field.js
+++ b/indico/modules/events/registration/client/js/form/field.js
@@ -13,7 +13,7 @@ ndRegForm.controller('FieldCtrl', function($scope, regFormFactory) {
 
   var getRequestParams = function(field) {
     return {
-      confId: $scope.confId,
+      eventId: $scope.eventId,
       sectionId: $scope.section.id,
       fieldId: field.id,
       confFormId: $scope.confFormId,

--- a/indico/modules/events/registration/client/js/form/form.js
+++ b/indico/modules/events/registration/client/js/form/form.js
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+/* eslint-disable import/unambiguous */
+
 window.ndRegForm = angular.module('nd.regform', ['ui.sortable', 'ngResource', 'ngSanitize']);
 
 // ============================================================================
@@ -13,12 +15,12 @@ window.ndRegForm = angular.module('nd.regform', ['ui.sortable', 'ngResource', 'n
 
 ndRegForm.value(
   'editionURL',
-  Indico.Urls.Base + '/event/:confId/manage/registration/:confFormId/form/'
+  Indico.Urls.Base + '/event/:eventId/manage/registration/:confFormId/form/'
 );
 
 ndRegForm.value(
   'displayurl',
-  Indico.Urls.Base + '/event/:confId/registration/:confFormId/sections'
+  Indico.Urls.Base + '/event/:eventId/registration/:confFormId/sections'
 );
 
 ndRegForm.value('sortableoptions', {
@@ -84,7 +86,7 @@ ndRegForm.factory('regFormFactory', function(
     },
     Sections: $resource(
       urls.section.add,
-      {confId: '@confId', sectionId: '@sectionId', confFormId: '@confFormId'},
+      {eventId: '@eventId', sectionId: '@sectionId', confFormId: '@confFormId'},
       {
         remove: {method: 'DELETE', url: urls.section.modify, isArray: true},
         enable: {method: 'POST', url: urls.section.toggle, params: {enable: true}},
@@ -95,7 +97,7 @@ ndRegForm.factory('regFormFactory', function(
     ),
     Fields: $resource(
       urls.field.add,
-      {confId: '@confId', sectionId: '@sectionId', fieldId: '@fieldId', confFormId: '@confFormId'},
+      {eventId: '@eventId', sectionId: '@sectionId', fieldId: '@fieldId', confFormId: '@confFormId'},
       {
         remove: {method: 'DELETE', url: urls.field.modify},
         enable: {method: 'POST', url: urls.field.toggle, params: {enable: true}},
@@ -106,7 +108,7 @@ ndRegForm.factory('regFormFactory', function(
     ),
     Labels: $resource(
       urls.text.add,
-      {confId: '@confId', sectionId: '@sectionId', fieldId: '@fieldId', confFormId: '@confFormId'},
+      {eventId: '@eventId', sectionId: '@sectionId', fieldId: '@fieldId', confFormId: '@confFormId'},
       {
         remove: {method: 'DELETE', url: urls.text.modify},
         enable: {method: 'POST', url: urls.text.toggle, params: {enable: true}},
@@ -128,7 +130,7 @@ ndRegForm.directive('ndRegForm', function($rootScope, url, sortableoptions, regF
     templateUrl: url.tpl('registrationform.tpl.html'),
 
     scope: {
-      confId: '@',
+      eventId: '@',
       confFormId: '@',
       confCurrency: '@',
       confSections: '@',
@@ -154,7 +156,7 @@ ndRegForm.directive('ndRegForm', function($rootScope, url, sortableoptions, regF
       $scope.registrationData = angular.fromJson($scope.registrationData);
       $scope.registrationMetaData = angular.fromJson($scope.registrationMetaData);
 
-      $rootScope.confId = $scope.confId;
+      $rootScope.eventId = $scope.eventId;
       $rootScope.confFormId = $scope.confFormId;
       $rootScope.eventStartDate = $scope.eventStartDate;
       $rootScope.eventEndDate = $scope.eventEndDate;
@@ -192,7 +194,7 @@ ndRegForm.directive('ndRegForm', function($rootScope, url, sortableoptions, regF
 
           regFormFactory.Sections.save(
             {
-              confId: $scope.confId,
+              eventId: $scope.eventId,
               title: data.newsection.title,
               description: data.newsection.description,
               is_manager_only: managerOnly,
@@ -216,7 +218,7 @@ ndRegForm.directive('ndRegForm', function($rootScope, url, sortableoptions, regF
         moveSection: function(section, position) {
           regFormFactory.Sections.move(
             {
-              confId: $scope.confId,
+              eventId: $scope.eventId,
               sectionId: section.id,
               endPos: position,
               confFormId: $scope.confFormId,
@@ -234,7 +236,7 @@ ndRegForm.directive('ndRegForm', function($rootScope, url, sortableoptions, regF
         restoreSection: function(section) {
           regFormFactory.Sections.enable(
             {
-              confId: $rootScope.confId,
+              eventId: $rootScope.eventId,
               sectionId: section.id,
               confFormId: $rootScope.confFormId,
             },
@@ -258,7 +260,7 @@ ndRegForm.directive('ndRegForm', function($rootScope, url, sortableoptions, regF
         removeSection: function(section) {
           regFormFactory.Sections.remove(
             {
-              confId: $rootScope.confId,
+              eventId: $rootScope.eventId,
               sectionId: section.id,
               confFormId: $rootScope.confFormId,
             },

--- a/indico/modules/events/registration/client/js/form/section.js
+++ b/indico/modules/events/registration/client/js/form/section.js
@@ -11,7 +11,7 @@ ndRegForm.controller('SectionCtrl', function($scope, $rootScope, regFormFactory)
 
   var getRequestParams = function(section) {
     return {
-      confId: $rootScope.confId,
+      eventId: $rootScope.eventId,
       sectionId: section.id,
       confFormId: $rootScope.confFormId,
     };

--- a/indico/modules/events/registration/client/js/form/tpls/registrationform.tpl.html
+++ b/indico/modules/events/registration/client/js/form/tpls/registrationform.tpl.html
@@ -67,7 +67,7 @@
         </div>
     </div>
 
-    <input type="hidden" value="{{ confId }}" id="conf_id">
+    <input type="hidden" value="{{ eventId }}" id="event_id">
 
     <nd-dialog nd-add-section-dialog
                ng-if="editMode"

--- a/indico/modules/events/registration/controllers/compat.py
+++ b/indico/modules/events/registration/controllers/compat.py
@@ -14,7 +14,7 @@ from indico.web.rh import RHSimple
 
 @RHSimple.wrap_function
 def compat_registration(event_id, path=None):
-    url = url_for('event_registration.display_regform_list', confId=event_id)
+    url = url_for('event_registration.display_regform_list', event_id=event_id)
     try:
         registrant_id = int(request.args['registrantId'])
         authkey = request.args['authkey']

--- a/indico/modules/events/registration/controllers/display_test.py
+++ b/indico/modules/events/registration/controllers/display_test.py
@@ -22,7 +22,7 @@ def test_RHRegistrationForm_can_register(db, dummy_regform, dummy_reg, dummy_use
     invitation = RegistrationInvitation(registration_form=dummy_regform, email='foo@bar.com', first_name='foo',
                                         last_name='bar', affiliation='test')
     db.session.flush()
-    request.view_args = {'reg_form_id': dummy_regform.id, 'confId': dummy_regform.event_id}
+    request.view_args = {'reg_form_id': dummy_regform.id, 'event_id': dummy_regform.event_id}
     request.args = {'invitation': invitation.uuid}
     rh = RHRegistrationForm()
     rh._process_args()

--- a/indico/modules/events/reminders/blueprint.py
+++ b/indico/modules/events/reminders/blueprint.py
@@ -11,7 +11,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('event_reminders', __name__, template_folder='templates',
-                      virtual_template_folder='events/reminders', url_prefix='/event/<confId>/manage/reminders')
+                      virtual_template_folder='events/reminders', url_prefix='/event/<int:event_id>/manage/reminders')
 
 _bp.add_url_rule('/', 'list', RHListReminders)
 _bp.add_url_rule('/add', 'add', RHAddReminder, methods=('GET', 'POST'))

--- a/indico/modules/events/requests/blueprint.py
+++ b/indico/modules/events/requests/blueprint.py
@@ -11,7 +11,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('requests', __name__, template_folder='templates', virtual_template_folder='events/requests',
-                      url_prefix='/event/<confId>/manage/requests')
+                      url_prefix='/event/<int:event_id>/manage/requests')
 
 # Event management
 _bp.add_url_rule('/', 'event_requests', RHRequestsEventRequests)

--- a/indico/modules/events/requests/models/requests.py
+++ b/indico/modules/events/requests/models/requests.py
@@ -135,7 +135,7 @@ class Request(db.Model):
 
     @property
     def locator(self):
-        return {'confId': self.event_id, 'type': self.type}
+        return {'event_id': self.event_id, 'type': self.type}
 
     def __repr__(self):
         state = self.state.name if self.state is not None else None

--- a/indico/modules/events/roles/blueprint.py
+++ b/indico/modules/events/roles/blueprint.py
@@ -12,7 +12,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('event_roles', __name__, template_folder='templates', virtual_template_folder='events/roles',
-                      url_prefix='/event/<confId>/manage/roles')
+                      url_prefix='/event/<int:event_id>/manage/roles')
 
 _bp.add_url_rule('/', 'manage', RHEventRoles)
 _bp.add_url_rule('/create', 'add_role', RHAddEventRole, methods=('GET', 'POST'))

--- a/indico/modules/events/sessions/blueprint.py
+++ b/indico/modules/events/sessions/blueprint.py
@@ -24,7 +24,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('sessions', __name__, template_folder='templates', virtual_template_folder='events/sessions',
-                      url_prefix='/event/<confId>')
+                      url_prefix='/event/<int:event_id>')
 
 _bp.add_url_rule('/manage/sessions/', 'session_list', RHSessionsList)
 _bp.add_url_rule('/manage/sessions/create', 'create_session', RHCreateSession, methods=('GET', 'POST'))
@@ -60,14 +60,13 @@ _bp.add_url_rule('/sessions/<int:session_id>/session-timetable.pdf', 'export_ses
                  RHExportSessionTimetableToPDF)
 
 # Legacy URLs
-_compat_bp = IndicoBlueprint('compat_sessions', __name__, url_prefix='/event/<event_id>')
+_compat_bp = IndicoBlueprint('compat_sessions', __name__, url_prefix='/event/<int:event_id>')
 
 _compat_bp.add_url_rule('/session/<legacy_session_id>/', 'session',
                         partial(compat_session, 'display_session'))
 _compat_bp.add_url_rule('/session/<legacy_session_id>/session.ics', 'session_ics',
                         partial(compat_session, 'export_ics'))
-_compat_bp.add_url_rule('/my-conference/sessions', 'my_sessions',
-                        make_compat_redirect_func(_bp, 'my_sessions', view_args_conv={'event_id': 'confId'}))
+_compat_bp.add_url_rule('/my-conference/sessions', 'my_sessions', make_compat_redirect_func(_bp, 'my_sessions'))
 
 _compat_bp.add_url_rule('!/sessionDisplay.py', 'session_modpython',
                         make_compat_redirect_func(_compat_bp, 'session',

--- a/indico/modules/events/sessions/templates/display/session_ical_export.html
+++ b/indico/modules/events/sessions/templates/display/session_ical_export.html
@@ -8,7 +8,7 @@
         exportPopups["{{ item.id }}"] = new ExportIcalInterface(
             {{ api_mode|tojson }}, {{ persistent_user_enabled|tojson }},
             {{ persistent_allowed|tojson }}, {{ api_active|tojson }}, {{ user_logged|tojson }}, setURLs,
-            {{ url_for('api.build_urls')|tojson }}, {confId: "{{ item.event.id }}", sessionId: "{{ item.id }}"},
+            {{ url_for('api.build_urls')|tojson }}, {eventId: "{{ item.event.id }}", sessionId: "{{ item.id }}"},
             {{ request_urls|tojson }}, "{{ item.id }}", "{{ session.user.full_name if session.user else '' }}"
         );
     </script>

--- a/indico/modules/events/static/blueprint.py
+++ b/indico/modules/events/static/blueprint.py
@@ -10,7 +10,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('static_site', __name__, template_folder='templates', virtual_template_folder='events/static',
-                      url_prefix='/event/<confId>/manage/offline-copy')
+                      url_prefix='/event/<int:event_id>/manage/offline-copy')
 
 # Event management
 _bp.add_url_rule('/', 'list', RHStaticSiteList)

--- a/indico/modules/events/static/models/static.py
+++ b/indico/modules/events/static/models/static.py
@@ -89,7 +89,7 @@ class StaticSite(StoredFileMixin, db.Model):
 
     @property
     def locator(self):
-        return {'confId': self.event_id, 'id': self.id}
+        return {'event_id': self.event_id, 'id': self.id}
 
     def _build_storage_path(self):
         path_segments = ['event', strict_str(self.event.id), 'static']

--- a/indico/modules/events/static/offline.py
+++ b/indico/modules/events/static/offline.py
@@ -297,7 +297,7 @@ class StaticConferenceCreator(StaticEventCreator):
     def _get_builtin_page(self, entry):
         obj = self._menu_offline_items.get(entry.name)
         if isinstance(obj, RH):
-            request.view_args = {'confId': self.event.id}
+            request.view_args = {'event_id': self.event.id}
             with override_request_endpoint(obj.view_class.endpoint):
                 obj._process_args()
                 self._add_page(obj._process(), obj.view_class.endpoint, self.event)
@@ -332,7 +332,7 @@ class StaticConferenceCreator(StaticEventCreator):
 
     def _get_contrib(self, contrib):
         self._add_from_rh(RHContributionDisplay, WPStaticContributionDisplay,
-                          {'confId': self.event.id, 'contrib_id': contrib.id},
+                          {'event_id': self.event.id, 'contrib_id': contrib.id},
                           contrib)
         if config.LATEX_ENABLED:
             self._add_pdf(contrib, 'contributions.export_pdf', ContribToPDF, contrib=contrib)
@@ -347,12 +347,12 @@ class StaticConferenceCreator(StaticEventCreator):
 
     def _get_sub_contrib(self, subcontrib):
         self._add_from_rh(RHSubcontributionDisplay, WPStaticSubcontributionDisplay,
-                          {'confId': self.event.id, 'contrib_id': subcontrib.contribution.id,
+                          {'event_id': self.event.id, 'contrib_id': subcontrib.contribution.id,
                            'subcontrib_id': subcontrib.id}, subcontrib)
 
     def _get_author(self, contrib, author):
         rh = RHContributionAuthor()
-        params = {'confId': self.event.id, 'contrib_id': contrib.id, 'person_id': author.id}
+        params = {'event_id': self.event.id, 'contrib_id': contrib.id, 'person_id': author.id}
         request.view_args = params
         with override_request_endpoint('contributions.display_author'):
             rh._process_args()
@@ -361,7 +361,7 @@ class StaticConferenceCreator(StaticEventCreator):
 
     def _get_session(self, session):
         self._add_from_rh(RHDisplaySession, WPStaticSessionDisplay,
-                          {'confId': self.event.id, 'session_id': session.id}, session)
+                          {'event_id': self.event.id, 'session_id': session.id}, session)
 
         pdf = get_session_timetable_pdf(session, tz=self._display_tz)
         self._add_pdf(session, 'sessions.export_session_timetable', pdf)

--- a/indico/modules/events/static/util.py
+++ b/indico/modules/events/static/util.py
@@ -71,7 +71,7 @@ def _rewrite_event_asset_url(event, url):
         endpoint_info = endpoint_for_url(path)
         if endpoint_info:
             endpoint, data = endpoint_info
-            if endpoint == 'event_images.image_display' and int(data['confId']) == event.id:
+            if endpoint == 'event_images.image_display' and data['event_id'] == event.id:
                 image_file = ImageFile.get(data['image_id'])
                 if image_file and image_file.event == event:
                     return f'images/{image_file.id}-{image_file.filename}', image_file

--- a/indico/modules/events/surveys/blueprint.py
+++ b/indico/modules/events/surveys/blueprint.py
@@ -27,7 +27,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('surveys', __name__, template_folder='templates', virtual_template_folder='events/surveys',
-                      url_prefix='/event/<confId>', event_feature='surveys')
+                      url_prefix='/event/<int:event_id>', event_feature='surveys')
 
 # survey display/submission
 _bp.add_url_rule('/surveys/', 'display_survey_list', RHSurveyList)

--- a/indico/modules/events/surveys/models/surveys.py
+++ b/indico/modules/events/surveys/models/surveys.py
@@ -213,7 +213,7 @@ class Survey(db.Model):
 
     @locator_property
     def locator(self):
-        return {'confId': self.event_id,
+        return {'event_id': self.event_id,
                 'survey_id': self.id}
 
     @locator.token

--- a/indico/modules/events/templates/display/event_ical_export.html
+++ b/indico/modules/events/templates/display/event_ical_export.html
@@ -27,7 +27,7 @@
         exportPopups["{{ item.id }}"] = new ExportIcalInterface(
             {{ api_mode|tojson }}, {{ persistent_user_enabled|tojson }}, {{ persistent_allowed|tojson }},
             {{ api_active|tojson }}, {{ user_logged|tojson }}, setURLs, {{ url_for('api.build_urls')|tojson }},
-            {confId: "{{ item.id }}"}, {{ request_urls|tojson  }}, "{{ item.id }}",
+            {eventId: "{{ item.id }}"}, {{ request_urls|tojson  }}, "{{ item.id }}",
             "{{ session.user.id if session.user else '' }}"
         );
 

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -10,12 +10,12 @@
     <span class="separator"></span>
 
     {% if rel.first is not none %}
-        <a class="i-button text-color subtle icon-first" href="{{ url_for('events.display', confId=rel.first) }}"
+        <a class="i-button text-color subtle icon-first" href="{{ url_for('events.display', event_id=rel.first) }}"
            title="{% trans %}Oldest event{% endtrans %}"></a>
     {% endif %}
 
     {% if rel.prev is not none %}
-        <a class="i-button text-color subtle icon-prev" href="{{ url_for('events.display', confId=rel.prev) }}"
+        <a class="i-button text-color subtle icon-prev" href="{{ url_for('events.display', event_id=rel.prev) }}"
            title="{% trans %}Older event{% endtrans %}"></a>
     {% endif %}
 
@@ -23,12 +23,12 @@
        title="{% trans %}Up to category{% endtrans %}"></a>
 
     {% if rel.next is not none %}
-        <a class="i-button text-color subtle icon-next" href="{{ url_for('events.display', confId=rel.next) }}"
+        <a class="i-button text-color subtle icon-next" href="{{ url_for('events.display', event_id=rel.next) }}"
            title="{% trans %}Newer event{% endtrans %}"></a>
     {% endif %}
 
     {% if rel.last is not none %}
-        <a class="i-button text-color subtle icon-last" href="{{ url_for('events.display', confId=rel.last) }}"
+        <a class="i-button text-color subtle icon-last" href="{{ url_for('events.display', event_id=rel.last) }}"
            title="{% trans %}Newest event{% endtrans %}"></a>
     {% endif %}
 

--- a/indico/modules/events/timetable/blueprint.py
+++ b/indico/modules/events/timetable/blueprint.py
@@ -30,7 +30,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('timetable', __name__, template_folder='templates', virtual_template_folder='events/timetable',
-                      url_prefix='/event/<confId>')
+                      url_prefix='/event/<int:event_id>')
 
 # Management
 _bp.add_url_rule('/manage/timetable/', 'management', RHManageTimetable)

--- a/indico/modules/events/tracks/blueprint.py
+++ b/indico/modules/events/tracks/blueprint.py
@@ -13,7 +13,7 @@ from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('tracks', __name__, template_folder='templates', virtual_template_folder='events/tracks',
-                      url_prefix='/event/<confId>')
+                      url_prefix='/event/<int:event_id>')
 
 _bp.add_url_rule('/manage/tracks/', 'manage', RHManageTracks)
 _bp.add_url_rule('/manage/tracks/program', 'edit_program', RHEditProgram, methods=('GET', 'POST'))
@@ -32,7 +32,7 @@ _bp.add_url_rule('/program', 'program', RHDisplayTracks)
 _bp.add_url_rule('/program.pdf', 'program_pdf', RHTracksPDF)
 
 
-_compat_bp = IndicoBlueprint('compat_tracks', __name__, url_prefix='/event/<int:confId>')
+_compat_bp = IndicoBlueprint('compat_tracks', __name__, url_prefix='/event/<int:event_id>')
 _compat_bp.add_url_rule('/manage/program/tracks/<int:track_id>/contributions/', 'track_contribs',
                         make_compat_redirect_func('contributions', 'contribution_list',
                                                   view_args_conv={'track_id': None}))

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -77,7 +77,7 @@ def get_object_from_args(args=None):
     if args is None:
         args = request.view_args
     object_type = args['object_type']
-    event = Event.query.filter_by(id=args['confId'], is_deleted=False).first()
+    event = Event.get(args['event_id'], is_deleted=False)
     if event is None:
         obj = None
     elif object_type == 'event':

--- a/indico/modules/rb/blueprint.py
+++ b/indico/modules/rb/blueprint.py
@@ -119,10 +119,10 @@ _bp.add_url_rule('/api/admin/rooms/<int:room_id>/photo', 'admin_room_photo', adm
 _bp.add_url_rule('/api/admin/map-areas', 'admin_map_areas', admin.RHMapAreas, methods=('POST', 'PATCH', 'DELETE'))
 
 # Event linking
-_bp.add_url_rule('!/event/<confId>/manage/rooms/', 'event_booking_list', event.RHEventBookingList)
-_bp.add_url_rule('!/event/<confId>/manage/rooms/linking/contributions', 'event_linkable_contributions',
+_bp.add_url_rule('!/event/<int:event_id>/manage/rooms/', 'event_booking_list', event.RHEventBookingList)
+_bp.add_url_rule('!/event/<int:event_id>/manage/rooms/linking/contributions', 'event_linkable_contributions',
                  event.RHListLinkableContributions)
-_bp.add_url_rule('!/event/<confId>/manage/rooms/linking/session-blocks', 'event_linkable_session_blocks',
+_bp.add_url_rule('!/event/<int:event_id>/manage/rooms/linking/session-blocks', 'event_linkable_session_blocks',
                  event.RHListLinkableSessionBlocks)
 
 

--- a/indico/modules/vc/blueprint.py
+++ b/indico/modules/vc/blueprint.py
@@ -19,29 +19,29 @@ _bp.add_url_rule('/service/videoconference', 'vc_room_list', RHVCRoomList)
 
 
 # Event management
-_bp.add_url_rule('/event/<confId>/manage/videoconference/', 'manage_vc_rooms', RHVCManageEvent)
-_bp.add_url_rule('/event/<confId>/manage/videoconference/select', 'manage_vc_rooms_select',
+_bp.add_url_rule('/event/<int:event_id>/manage/videoconference/', 'manage_vc_rooms', RHVCManageEvent)
+_bp.add_url_rule('/event/<int:event_id>/manage/videoconference/select', 'manage_vc_rooms_select',
                  RHVCManageEventSelectService, methods=('GET', 'POST'))
-_bp.add_url_rule('/event/<confId>/manage/videoconference/<service>/create', 'manage_vc_rooms_create',
+_bp.add_url_rule('/event/<int:event_id>/manage/videoconference/<service>/create', 'manage_vc_rooms_create',
                  RHVCManageEventCreate, methods=('GET', 'POST'))
-_bp.add_url_rule('/event/<confId>/manage/videoconference/<service>/<int:event_vc_room_id>/',
+_bp.add_url_rule('/event/<int:event_id>/manage/videoconference/<service>/<int:event_vc_room_id>/',
                  'manage_vc_rooms_modify', RHVCManageEventModify, methods=('GET', 'POST'))
-_bp.add_url_rule('/event/<confId>/manage/videoconference/<service>/<int:event_vc_room_id>/remove',
+_bp.add_url_rule('/event/<int:event_id>/manage/videoconference/<service>/<int:event_vc_room_id>/remove',
                  'manage_vc_rooms_remove', RHVCManageEventRemove, methods=('POST',))
-_bp.add_url_rule('/event/<confId>/manage/videoconference/<service>/<int:event_vc_room_id>/refresh',
+_bp.add_url_rule('/event/<int:event_id>/manage/videoconference/<service>/<int:event_vc_room_id>/refresh',
                  'manage_vc_rooms_refresh', RHVCManageEventRefresh, methods=('POST',))
-_bp.add_url_rule('/event/<confId>/manage/videoconference/<service>/attach/',
+_bp.add_url_rule('/event/<int:event_id>/manage/videoconference/<service>/attach/',
                  'manage_vc_rooms_search_form', RHVCManageAttach, methods=('GET', 'POST'))
-_bp.add_url_rule('/event/<confId>/manage/videoconference/<service>/search/',
+_bp.add_url_rule('/event/<int:event_id>/manage/videoconference/<service>/search/',
                  'manage_vc_rooms_search', RHVCManageSearch)
 
 # Event page
-_bp.add_url_rule('/event/<confId>/videoconference/', 'event_videoconference', RHVCEventPage)
+_bp.add_url_rule('/event/<int:event_id>/videoconference/', 'event_videoconference', RHVCEventPage)
 
 
 # Legacy URLs
 vc_compat_blueprint = _compat_bp = IndicoBlueprint('compat_vc', __name__)
-vc_compat_blueprint.add_url_rule('/event/<confId>/collaboration', 'collaboration',
+vc_compat_blueprint.add_url_rule('/event/<int:event_id>/collaboration', 'collaboration',
                                  make_compat_redirect_func(_bp, 'event_videoconference'))
 vc_compat_blueprint.add_url_rule('/collaborationDisplay.py', 'collaborationpy',
                                  make_compat_redirect_func(_bp, 'event_videoconference'))

--- a/indico/testing/fixtures/app.py
+++ b/indico/testing/fixtures/app.py
@@ -10,6 +10,7 @@ import os
 import pytest
 
 from indico.web.flask.app import make_app
+from indico.web.flask.wrappers import IndicoFlask
 
 
 @pytest.fixture(scope='session')
@@ -42,3 +43,11 @@ def request_context(app_context):
     """Create a flask request context."""
     with app_context.test_request_context():
         yield
+
+
+@pytest.fixture
+def test_client(app, mocker):
+    """Create a flask request context."""
+    mocker.patch.object(IndicoFlask, 'manifest')
+    with app.test_client() as c:
+        yield c

--- a/indico/web/client/js/legacy/libs/timetable/Actions.js
+++ b/indico/web/client/js/legacy/libs/timetable/Actions.js
@@ -18,7 +18,7 @@ type(
       info.set('sessionTimetable', self.isSessionTimetable);
 
       var urlArgs = {
-        confId: eventData.conferenceId,
+        event_id: eventData.conferenceId,
         entry_id: eventData.scheduleEntryId,
       };
       if (self.timetable.isSessionTimetable) {
@@ -50,7 +50,7 @@ type(
     editEntryStartEndDate: function(startDate, endDate, eventData, shift, undo) {
       var self = this;
       var urlArgs = {
-        confId: eventData.conferenceId,
+        event_id: eventData.conferenceId,
         entry_id: eventData.scheduleEntryId,
       };
 
@@ -91,7 +91,7 @@ type(
       }
 
       var urlArgs = {
-        confId: eventData.conferenceId,
+        event_id: eventData.conferenceId,
         entry_id: eventData.scheduleEntryId,
       };
       if (self.isSessionTimetable) {
@@ -210,7 +210,7 @@ type(
       var self = this;
       var params = self._addParams();
       var urlArgs = {
-        confId: self.eventInfo.id,
+        event_id: self.eventInfo.id,
         day: params.selectedDay,
       };
       if (self.session !== null) {
@@ -237,7 +237,7 @@ type(
       var params = this._addParams('Session');
       ajaxDialog({
         trigger: this,
-        url: build_url(Indico.Urls.Timetable.sessions.add, {confId: params.conference}),
+        url: build_url(Indico.Urls.Timetable.sessions.add, {event_id: params.conference}),
         title: $T.gettext('Add session'),
         onClose: function(data) {
           if (data) {
@@ -256,7 +256,7 @@ type(
       var self = this;
       var params = this._addToSessionParams(session, 'SessionSlot');
       var urlArgs = {
-        confId: params.conference,
+        event_id: params.conference,
         day: params.selectedDay,
         parent_session_id: params.session,
       };
@@ -305,7 +305,7 @@ type(
       }
 
       var urlArgs = {
-        confId: eventData.conferenceId,
+        event_id: eventData.conferenceId,
         entry_id: eventData.scheduleEntryId,
       };
 

--- a/indico/web/client/js/legacy/libs/timetable/Base.js
+++ b/indico/web/client/js/legacy/libs/timetable/Base.js
@@ -265,10 +265,10 @@ type(
 
     pdf: function() {
       if ($('html').data('static-site')) {
-        window.location = build_url(Indico.Urls.Timetable.default_pdf, {confId: this.eventInfo.id});
+        window.location = build_url(Indico.Urls.Timetable.default_pdf, {event_id: this.eventInfo.id});
       } else {
         ajaxDialog({
-          url: build_url(Indico.Urls.Timetable.pdf, {confId: this.eventInfo.id}),
+          url: build_url(Indico.Urls.Timetable.pdf, {event_id: this.eventInfo.id}),
           title: $T.gettext('Export to PDF'),
         });
       }
@@ -1563,7 +1563,7 @@ type(
       if (this.isSessionTimetable && this.canManageEvent) {
         var goBackLink = $('<a>', {
           class: 'icon-arrow-up i-button',
-          href: build_url(Indico.Urls.Timetable.management, {confId: this.eventInfo.id}),
+          href: build_url(Indico.Urls.Timetable.management, {event_id: this.eventInfo.id}),
         }).text($T.gettext('Go to event timetable'));
         return $('<div>', {class: 'group right'}).append(goBackLink);
       } else {

--- a/indico/web/client/js/legacy/libs/timetable/Draw.js
+++ b/indico/web/client/js/legacy/libs/timetable/Draw.js
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+/* eslint-disable import/unambiguous */
+
 type(
   'TimetableBlockBase',
   [],
@@ -490,7 +492,7 @@ function loadBalloonContent(self, api, editable) {
     ? Indico.Urls.Timetable.entries.info.manage
     : Indico.Urls.Timetable.entries.info.display;
   var urlParams = {
-    confId: self.eventData.conferenceId,
+    event_id: self.eventData.conferenceId,
     entry_id: entryId,
   };
   if (self.timetable.isSessionTimetable) {
@@ -608,7 +610,7 @@ function loadBalloonContent(self, api, editable) {
 
         $content.find('.js-move').on('click', function() {
           var urlArgs = {
-            confId: self.eventData.conferenceId,
+            event_id: self.eventData.conferenceId,
             entry_id: self.eventData.scheduleEntryId,
           };
           if (self.timetable.isSessionTimetable) {
@@ -692,12 +694,12 @@ function drawBalloon(self, evt, editable) {
     var url;
     if (self.eventData.entryType == 'Session') {
       url = build_url(Indico.Urls.Sessions.display_session, {
-        confId: self.eventData.conferenceId,
+        event_id: self.eventData.conferenceId,
         session_id: self.eventData.sessionId,
       });
     } else if (self.eventData.entryType == 'Contribution') {
       url = build_url(Indico.Urls.Contributions.display_contribution, {
-        confId: self.eventData.conferenceId,
+        event_id: self.eventData.conferenceId,
         contrib_id: self.eventData.contributionId,
       });
     } else {
@@ -1474,13 +1476,13 @@ type(
             title: $T.gettext('Edit'),
             data: {
               title: $T.gettext('Edit poster'),
-              confId: blockData.conferenceId,
+              eventId: blockData.conferenceId,
               timetableEntryId: blockData.scheduleEntryId,
             },
           }).on('click', function(evt, params) {
             var $this = $(this);
             var urlArgs = {
-              confId: $this.data('confId'),
+              event_id: $this.data('eventId'),
               entry_id: $this.data('timetableEntryId'),
             };
             if (self.timetable.isSessionTimetable) {
@@ -1508,13 +1510,13 @@ type(
             title: $T.gettext('Manage protection'),
             data: {
               title: $T.gettext('Manage poster protection'),
-              confId: blockData.conferenceId,
+              eventId: blockData.conferenceId,
               contribId: blockData.contributionId,
             },
           }).on('click', function(evt) {
             var $this = $(this);
             var urlArgs = {
-              confId: $this.data('confId'),
+              event_id: $this.data('eventId'),
               contrib_id: $this.data('contribId'),
             };
             ajaxDialog({

--- a/indico/web/client/js/legacy/libs/timetable/Management.js
+++ b/indico/web/client/js/legacy/libs/timetable/Management.js
@@ -157,7 +157,7 @@ type(
     _preload: [
       function(hook) {
         var self = this;
-        var args = {confId: self.args.get('conference')};
+        var args = {event_id: self.args.get('conference')};
         if (self.timetable.contextInfo.sessionSlotId) {
           args.session_block_id = self.timetable.contextInfo.sessionSlotId;
         }
@@ -193,7 +193,7 @@ type(
 
     addExisting: function(contributionIds, date) {
       var self = this;
-      var urlArgs = {confId: self.args.get('conference')};
+      var urlArgs = {event_id: self.args.get('conference')};
       if (self.args.get('slot')) {
         urlArgs.block_id = self.args.get('slot');
       }
@@ -320,7 +320,7 @@ type(
     draw: function() {
       var self = this;
       var urlArgs = {
-        confId: self.args.get('conference'),
+        event_id: self.args.get('conference'),
         day: self.args.get('selectedDay'),
       };
       if (self.args.get('slot')) {
@@ -696,7 +696,7 @@ type(
           if (!confirm) {
             return;
           }
-          var urlArgs = {confId: self.tt.eventInfo.id};
+          var urlArgs = {event_id: self.tt.eventInfo.id};
           var data = {
             mode: self.rescheduleAction,
             gap: +self.minuteInput.get(),
@@ -864,7 +864,7 @@ type(
         return;
       }
       var urlArgs = {
-        confId: self.tt.contextInfo.conferenceId,
+        event_id: self.tt.contextInfo.conferenceId,
         block_id: self.tt.contextInfo.sessionSlotId,
       };
       if (self.tt.isSessionTimetable) {

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -469,7 +469,7 @@ const InnerUserSearch = searchFactory({
     if (withEventPersons) {
       let epResponse;
       try {
-        epResponse = await indicoAxios.get(eventPersonSearchURL({...values, confId: eventId}));
+        epResponse = await indicoAxios.get(eventPersonSearchURL({...values, event_id: eventId}));
       } catch (error) {
         return handleSubmitError(error);
       }

--- a/indico/web/client/js/react/components/principals/hooks.js
+++ b/indico/web/client/js/react/components/principals/hooks.js
@@ -29,7 +29,7 @@ export const useFetchPrincipals = (principalIds, eventId = null) => {
   const missingPrincipalIds = _.difference(principalIds, Object.keys(informationMap));
 
   const {data} = useIndicoAxios({
-    url: eventId === null ? principalsURL() : eventPrincipalsURL({confId: eventId}),
+    url: eventId === null ? principalsURL() : eventPrincipalsURL({event_id: eventId}),
     forceDispatchEffect: () => !!missingPrincipalIds.length,
     trigger: principalIds,
     camelize: true,
@@ -75,7 +75,7 @@ export const usePermissionInfo = () => {
 
 const _useFetchPrincipalList = (eventId, enabled, urlFunc, options = {}) => {
   const {data, loading} = useIndicoAxios({
-    url: urlFunc({confId: eventId}),
+    url: urlFunc({event_id: eventId}),
     trigger: enabled ? eventId : null,
     forceDispatchEffect: () => enabled && eventId !== null,
     camelize: true,

--- a/indico/web/flask/wrappers.py
+++ b/indico/web/flask/wrappers.py
@@ -133,8 +133,8 @@ class IndicoBlueprint(Blueprint):
 
     :param event_feature: If set, this blueprint will raise `NotFound`
                           for all its endpoints unless the event referenced
-                          by the `confId` or `event_id` URL argument has
-                          the specified feature.
+                          by the `event_id` URL argument has the specified
+                          feature.
     """
 
     def __init__(self, *args, **kwargs):
@@ -148,7 +148,7 @@ class IndicoBlueprint(Blueprint):
             @self.before_request
             def _check_event_feature():
                 from indico.modules.events.features.util import require_feature
-                event_id = request.view_args.get('confId') or request.view_args.get('event_id')
+                event_id = request.view_args.get('event_id')
                 if event_id is not None:
                     require_feature(event_id, event_feature)
 

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -151,7 +151,10 @@ class RH:
 
         def _convert(v):
             # some legacy code has numeric ids in the locator data, but still takes
-            # string ids in the url rule (usually for confId)
+            # string ids in the url rule (usually for `confId` which is now numeric and
+            # called `event_id`, but just in case there's any other code that also has
+            # this ugly string/int mix we'll leave this here - there is no harm in
+            # passing strings to `url_for` even for int segments)
             return str(v) if isinstance(v, int) else v
 
         provided = {k: _convert(v) for k, v in request.view_args.items() if k not in defaults}
@@ -206,7 +209,7 @@ class RH:
 
     def _check_event_feature(self):
         from indico.modules.events.features.util import require_feature
-        event_id = request.view_args.get('confId') or request.view_args.get('event_id')
+        event_id = request.view_args.get('event_id')
         if event_id is not None:
             require_feature(event_id, self.EVENT_FEATURE)
 


### PR DESCRIPTION
For legacy reasons we still use confId in the flask url rules. Let's finally replace this with `event_id`!