### PR TITLE
Add a new form to capture rejection reason for registration(s)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+Version 2.3.4
+-------------
+
+Improvements
+^^^^^^^^^^^^
+
+- Store a reason for rejection of registration(s) if stated by the moderator
+  through a form in a dialog box, can be sent to users along with notification,
+  Add a new 'rejection_reason' placeholder for an email template.
+  (:pr:`4740`, thanks :user:`vasantvohra`)
+
 
 Version 2.3.4
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,10 +7,11 @@ Version 2.3.4
 Improvements
 ^^^^^^^^^^^^
 
-- Store a reason for rejection of registration(s) if stated by the moderator
-  through a form in a dialog box, can be sent to users along with notification,
-  Add a new 'rejection_reason' placeholder for an email template.
-  (:pr:`4740`, thanks :user:`vasantvohra`)
+- When the moderator states the reason for the rejection of registrations in a form available in the popup window.
+  The reason is saved in the database as `registration.rejection_reason` and added to the event log.
+  A switch allows the reason to be attached to an email notification.
+  Also, add a new 'rejection_reason' placeholder/tag to use in email templates.
+  (:pr:`4769`, thanks :user:`vasantvohra`)
 
 
 Version 2.3.4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,22 +10,12 @@ Version 2.3.4
 Improvements
 ^^^^^^^^^^^^
 
-- Allow managers to specify a reason when rejecting registrants and add a new placeholder
-  for the rejection reason when emailing registrants (:pr:`4769`, thanks :user:`vasantvohra`)
-
-
-Version 2.3.4
--------------
-
-*Unreleased*
-
-Improvements
-^^^^^^^^^^^^
-
 - Fail more gracefully is a user has an invalid locale set and fall back to the default
   locale or English in case the default locale is invalid as well
 - Log an error if the configured default locale does not exist
 - Add ID-1 page size for badge printing (:pr:`4774`, thanks :user:`omegak`)
+- Allow managers to specify a reason when rejecting registrants and add a new placeholder
+  for the rejection reason when emailing registrants (:pr:`4769`, thanks :user:`vasantvohra`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,10 +10,8 @@ Version 2.3.4
 Improvements
 ^^^^^^^^^^^^
 
-- Add a new form to capture rejection reason for registration, store it in DB, and event log.
-  If enabled send the reason with notification email to registrant and event managers.
-  Add a new 'rejection_reason' placeholder to use in email templates.
-  (:pr:`4769`, thanks :user:`vasantvohra`)
+- Allow managers to specify a reason when rejecting registrants and add a new placeholder
+  for the rejection reason when emailing registrants (:pr:`4769`, thanks :user:`vasantvohra`)
 
 
 Version 2.3.4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,16 +1,18 @@
 Changelog
 =========
 
+
 Version 2.3.4
 -------------
+
+*Unreleased*
 
 Improvements
 ^^^^^^^^^^^^
 
-- When the moderator states the reason for the rejection of registrations in a form available in the popup window.
-  The reason is saved in the database as `registration.rejection_reason` and added to the event log.
-  A switch allows the reason to be attached to an email notification.
-  Also, add a new 'rejection_reason' placeholder/tag to use in email templates.
+- Add a new form to capture rejection reason for registration, store it in DB, and event log.
+  If enabled send the reason with notification email to registrant and event managers.
+  Add a new 'rejection_reason' placeholder to use in email templates.
   (:pr:`4769`, thanks :user:`vasantvohra`)
 
 

--- a/indico/migrations/versions/20210129_2232_e787389ca868_add_rejection_reason.py
+++ b/indico/migrations/versions/20210129_2232_e787389ca868_add_rejection_reason.py
@@ -17,7 +17,7 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('registrations', sa.Column('rejection_reason', sa.String(), nullable=True),
+    op.add_column('registrations', sa.Column('rejection_reason', sa.String(), server_default='', nullable=False),
                   schema='event_registration')
 
 

--- a/indico/migrations/versions/20210129_2232_e787389ca868_add_rejection_reason.py
+++ b/indico/migrations/versions/20210129_2232_e787389ca868_add_rejection_reason.py
@@ -1,0 +1,25 @@
+"""add 'rejection_reason' to registration.
+
+Revision ID: e787389ca868
+Revises: e4fb983dc64c
+Create Date: 2021-01-29 22:32:11.206740
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'e787389ca868'
+down_revision = 'e4fb983dc64c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('registrations', sa.Column('rejection_reason', sa.String(), nullable=True),
+                  schema='event_registration')
+
+
+def downgrade():
+    op.drop_column('registrations', 'rejection_reason', schema='event_registration')

--- a/indico/migrations/versions/20210129_2232_e787389ca868_add_rejection_reason.py
+++ b/indico/migrations/versions/20210129_2232_e787389ca868_add_rejection_reason.py
@@ -19,6 +19,7 @@ depends_on = None
 def upgrade():
     op.add_column('registrations', sa.Column('rejection_reason', sa.String(), server_default='', nullable=False),
                   schema='event_registration')
+    op.alter_column('registrations', 'rejection_reason', server_default=None, schema='event_registration')
 
 
 def downgrade():

--- a/indico/modules/events/registration/__init__.py
+++ b/indico/modules/events/registration/__init__.py
@@ -156,13 +156,15 @@ def _get_registration_placeholders(sender, regform, registration, **kwargs):
     from indico.modules.events.registration.placeholders.registrations import (IDPlaceholder, LastNamePlaceholder,
                                                                                FirstNamePlaceholder, LinkPlaceholder,
                                                                                EventTitlePlaceholder,
-                                                                               EventLinkPlaceholder, FieldPlaceholder)
+                                                                               EventLinkPlaceholder, FieldPlaceholder,
+                                                                               RejectionReasonPlaceholder)
     yield FirstNamePlaceholder
     yield LastNamePlaceholder
     yield EventTitlePlaceholder
     yield EventLinkPlaceholder
     yield IDPlaceholder
     yield LinkPlaceholder
+    yield RejectionReasonPlaceholder
     yield FieldPlaceholder
 
 

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -70,7 +70,7 @@ _bp.add_url_rule(
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/approve',
                  'approve_registration', reglists.RHRegistrationApprove, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/reject',
-                 'reject_registration', reglists.RHRegistrationReject, methods=('POST',))
+                 'reject_registration', reglists.RHRegistrationReject, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/reset',
                  'reset_registration', reglists.RHRegistrationReset, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/withdraw',
@@ -92,7 +92,7 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/registrat
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/registrations.xlsx',
                  'registrations_excel_export', reglists.RHRegistrationsExportExcel, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/modify-status', 'registrations_modify_status',
-                 reglists.RHRegistrationsModifyStatus, methods=('POST',))
+                 reglists.RHRegistrationsModifyStatus, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/check-in', 'registrations_check_in',
                  reglists.RHRegistrationBulkCheckIn, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/attachments', 'registrations_attachments_export',

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -91,8 +91,10 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/registrat
                  reglists.RHRegistrationsExportCSV, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/registrations.xlsx',
                  'registrations_excel_export', reglists.RHRegistrationsExportExcel, methods=('POST',))
-_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/modify-status', 'registrations_modify_status',
-                 reglists.RHRegistrationsModifyStatus, methods=('GET', 'POST'))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/approve', 'registrations_approve',
+                 reglists.RHRegistrationsApprove, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/reject', 'registrations_reject',
+                 reglists.RHRegistrationsReject, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/check-in', 'registrations_check_in',
                  reglists.RHRegistrationBulkCheckIn, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/attachments', 'registrations_attachments_export',

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -94,7 +94,7 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/registrat
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/approve', 'registrations_approve',
                  reglists.RHRegistrationsApprove, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/reject', 'registrations_reject',
-                 reglists.RHRegistrationsReject, methods=('GET', 'POST'))
+                 reglists.RHRegistrationsReject, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/check-in', 'registrations_check_in',
                  reglists.RHRegistrationBulkCheckIn, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/attachments', 'registrations_attachments_export',

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -569,11 +569,12 @@ class RHRegistrationReject(RHManageRegistrationBase):
 
     def _process(self):
         form = RejectRegistrantsForm()
+        message = _("Rejecting this registration will trigger a notification email.")
         if form.validate_on_submit():
             self.registration.rejection_reason = form.rejection_reason.data
             _modify_registration_status(self.registration, approve=False)
             return jsonify_data(html=_render_registration_details(self.registration))
-        return jsonify_form(form, disabled_until_change=False, submit='Reject')
+        return jsonify_form(form, disabled_until_change=False, submit='Reject', message=message)
 
 
 class RHRegistrationReset(RHManageRegistrationBase):
@@ -651,19 +652,19 @@ class RHRegistrationsModifyStatus(RHRegistrationsActionBase):
         if approve:
             for registration in self.registrations:
                 _modify_registration_status(registration, approve)
-            flash(_("The status of the selected registrations was successfully '{}'.").format('approved'), 'success')
+            flash(_("The selected registrations was successfully '{}'.").format('approved'), 'success')
             return jsonify_data(**self.list_generator.render_list())
         else:
             form = RejectRegistrantsForm(obj=FormDefaults(flag=request.args.get('flag'),
                                                           registration_id=request.args.getlist('registration_id')))
+            message = _("Rejecting the selected registrations will trigger a notification email for each registrant.")
             if form.validate_on_submit():
                 for registration in self.registrations:
                     registration.rejection_reason = form.rejection_reason.data
                     _modify_registration_status(registration, approve)
-                flash(_("The status of the selected registrations was successfully '{}'.").format('rejected'),
-                      'success')
+                flash(_("The selected registrations was successfully '{}'.").format('rejected'), 'success')
                 return jsonify_data(**self.list_generator.render_list())
-            return jsonify_form(form, disabled_until_change=False, submit='Reject')
+            return jsonify_form(form, disabled_until_change=False, submit='Reject', message=message)
 
 
 class RHRegistrationsExportAttachments(RHRegistrationsExportBase, ZipGeneratorMixin):

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -411,7 +411,7 @@ class ImportRegistrationsForm(IndicoForm):
 
 class RejectRegistrantsForm(IndicoForm):
     rejection_reason = TextAreaField(_('Reason'), description=_("Provide a reason for rejection of registration(s)."))
-    notify_reason = BooleanField(_('Attach reason'), [HiddenUnless('rejection_reason')], widget=SwitchWidget(),
+    attach_reason = BooleanField(_('Attach reason'), [HiddenUnless('rejection_reason')], widget=SwitchWidget(),
                                  description=_("Whether to attach reason with the reject notification"))
     flag = HiddenField()
     registration_id = HiddenFieldList()

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -407,3 +407,14 @@ class ImportRegistrationsForm(IndicoForm):
         super(ImportRegistrationsForm, self).__init__(*args, **kwargs)
         if not self.regform.moderation_enabled:
             del self.skip_moderation
+
+
+class RejectRegistrantsForm(IndicoForm):
+
+    rejection_reason = TextAreaField(_('Reason'), description=_("Provide a reason for rejection of registration."))
+
+    notify_reason = BooleanField(_('Attach reason'), default=False, widget=SwitchWidget(),
+                                 description=_("Whether to attach reason with the reject notification"))
+
+    flag = HiddenField()
+    registration_id = HiddenFieldList()

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -410,8 +410,7 @@ class ImportRegistrationsForm(IndicoForm):
 
 
 class RejectRegistrantsForm(IndicoForm):
-    rejection_reason = TextAreaField(_('Reason'), description=_("Provide a reason for rejection of registration(s)."))
+    rejection_reason = TextAreaField(_('Reason'), description=_("You can provide a reason for the rejection here."))
     attach_reason = BooleanField(_('Attach reason'), [HiddenUnless('rejection_reason')], widget=SwitchWidget(),
                                  description=_("Whether to attach reason with the reject notification"))
-    flag = HiddenField()
     registration_id = HiddenFieldList()

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -410,11 +410,8 @@ class ImportRegistrationsForm(IndicoForm):
 
 
 class RejectRegistrantsForm(IndicoForm):
-
-    rejection_reason = TextAreaField(_('Reason'), description=_("Provide a reason for rejection of registration."))
-
-    notify_reason = BooleanField(_('Attach reason'), default=False, widget=SwitchWidget(),
+    rejection_reason = TextAreaField(_('Reason'), description=_("Provide a reason for rejection of registration(s)."))
+    notify_reason = BooleanField(_('Attach reason'), [HiddenUnless('rejection_reason')], widget=SwitchWidget(),
                                  description=_("Whether to attach reason with the reject notification"))
-
     flag = HiddenField()
     registration_id = HiddenFieldList()

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -411,8 +411,7 @@ class ImportRegistrationsForm(IndicoForm):
 
 class RejectRegistrantsForm(IndicoForm):
     rejection_reason = TextAreaField(_('Reason'), description=_("You can provide a reason for the rejection here."))
-    attach_rejection_reason = BooleanField(_('Attach reason'), [HiddenUnless('rejection_reason')],
-                                           widget=SwitchWidget())
+    attach_rejection_reason = BooleanField(_('Attach reason'), widget=SwitchWidget())
     registration_id = HiddenFieldList()
     submitted = HiddenField()
 

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -411,6 +411,10 @@ class ImportRegistrationsForm(IndicoForm):
 
 class RejectRegistrantsForm(IndicoForm):
     rejection_reason = TextAreaField(_('Reason'), description=_("You can provide a reason for the rejection here."))
-    attach_reason = BooleanField(_('Attach reason'), [HiddenUnless('rejection_reason')], widget=SwitchWidget(),
-                                 description=_("Whether to attach reason with the reject notification"))
+    attach_rejection_reason = BooleanField(_('Attach reason'), [HiddenUnless('rejection_reason')],
+                                           widget=SwitchWidget())
     registration_id = HiddenFieldList()
+    submitted = HiddenField()
+
+    def is_submitted(self):
+        return super(RejectRegistrantsForm, self).is_submitted() and 'submitted' in request.form

--- a/indico/modules/events/registration/logging.py
+++ b/indico/modules/events/registration/logging.py
@@ -43,13 +43,13 @@ def log_registration_updated(registration, previous_state, **kwargs):
     elif previous_state == RegistrationState.pending and registration.state == RegistrationState.rejected:
         log_text = 'Registration for "{}" has been rejected'
         kind = EventLogKind.negative
+        data["Reason"] = registration.rejection_reason if registration.rejection_reason else None
     elif previous_state == RegistrationState.unpaid and registration.state == RegistrationState.complete:
         log_text = 'Registration for "{}" has been paid'
         kind = EventLogKind.positive
     elif previous_state == RegistrationState.complete and registration.state == RegistrationState.unpaid:
         log_text = 'Registration for "{}" has been marked as not paid'
         kind = EventLogKind.negative
-        data["Reason"] = registration.rejection_reason if registration.rejection_reason else None
     elif registration.state == RegistrationState.withdrawn:
         log_text = 'Registration for "{}" has been withdrawn'
         kind = EventLogKind.negative

--- a/indico/modules/events/registration/logging.py
+++ b/indico/modules/events/registration/logging.py
@@ -43,7 +43,8 @@ def log_registration_updated(registration, previous_state, **kwargs):
     elif previous_state == RegistrationState.pending and registration.state == RegistrationState.rejected:
         log_text = 'Registration for "{}" has been rejected'
         kind = EventLogKind.negative
-        data["Reason"] = registration.rejection_reason if registration.rejection_reason else None
+        if registration.rejection_reason:
+            data['Reason'] = registration.rejection_reason
     elif previous_state == RegistrationState.unpaid and registration.state == RegistrationState.complete:
         log_text = 'Registration for "{}" has been paid'
         kind = EventLogKind.positive

--- a/indico/modules/events/registration/logging.py
+++ b/indico/modules/events/registration/logging.py
@@ -35,6 +35,7 @@ def log_registration_updated(registration, previous_state, **kwargs):
     if not previous_state:
         return
     previous_state_title = orig_string(previous_state.title)
+    data = {'Previous state': previous_state_title}
     if (previous_state == RegistrationState.pending
             and registration.state in (RegistrationState.complete, RegistrationState.unpaid)):
         log_text = 'Registration for "{}" has been approved'
@@ -48,6 +49,7 @@ def log_registration_updated(registration, previous_state, **kwargs):
     elif previous_state == RegistrationState.complete and registration.state == RegistrationState.unpaid:
         log_text = 'Registration for "{}" has been marked as not paid'
         kind = EventLogKind.negative
+        data["Reason"] = registration.rejection_reason if registration.rejection_reason else None
     elif registration.state == RegistrationState.withdrawn:
         log_text = 'Registration for "{}" has been withdrawn'
         kind = EventLogKind.negative
@@ -57,4 +59,4 @@ def log_registration_updated(registration, previous_state, **kwargs):
                                                                                    state_title)
         kind = EventLogKind.change
     registration.log(EventLogRealm.participants, kind, 'Registration', log_text.format(registration.full_name),
-                     session.user, data={'Previous state': previous_state_title})
+                     session.user, data=data)

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -189,7 +189,8 @@ class Registration(db.Model):
     #: If given a reason for rejection
     rejection_reason = db.Column(
         db.String,
-        nullable=True
+        nullable=False,
+        default='',
     )
     #: The Event containing this registration
     event = db.relationship(

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -186,7 +186,11 @@ class Registration(db.Model):
         UTCDateTime,
         nullable=True
     )
-
+    #: If given a reason for rejection
+    rejection_reason = db.Column(
+        db.String,
+        nullable=True
+    )
     #: The Event containing this registration
     event = db.relationship(
         'Event',

--- a/indico/modules/events/registration/notifications.py
+++ b/indico/modules/events/registration/notifications.py
@@ -40,7 +40,7 @@ def _notify_registration(registration, template, to_managers=False):
         attachments = get_ticket_attachments(registration)
 
     template = get_template_module('events/registration/emails/{}'.format(template),
-                                   registration=registration, notify_reason=request.form.get('notify_reason') == 'y')
+                                   registration=registration, attach_reason=request.form.get('attach_reason') == 'y')
     to_list = registration.email if not to_managers else registration.registration_form.manager_notification_recipients
     from_address = registration.registration_form.sender_address if not to_managers else None
     mail = make_email(to_list=to_list, template=template, html=True, from_address=from_address, attachments=attachments)

--- a/indico/modules/events/registration/notifications.py
+++ b/indico/modules/events/registration/notifications.py
@@ -7,7 +7,7 @@
 
 from __future__ import unicode_literals
 
-from flask import session
+from flask import request, session
 
 from indico.core import signals
 from indico.core.notifications import make_email, send_email
@@ -39,7 +39,8 @@ def _notify_registration(registration, template, to_managers=False):
             registration.state == RegistrationState.complete):
         attachments = get_ticket_attachments(registration)
 
-    template = get_template_module('events/registration/emails/{}'.format(template), registration=registration)
+    template = get_template_module('events/registration/emails/{}'.format(template),
+                                   registration=registration, notify_reason=request.form.get('notify_reason') == 'y')
     to_list = registration.email if not to_managers else registration.registration_form.manager_notification_recipients
     from_address = registration.registration_form.sender_address if not to_managers else None
     mail = make_email(to_list=to_list, template=template, html=True, from_address=from_address, attachments=attachments)

--- a/indico/modules/events/registration/notifications.py
+++ b/indico/modules/events/registration/notifications.py
@@ -68,5 +68,4 @@ def notify_registration_state_update(registration):
     _notify_registration(registration, 'registration_state_update_to_registrant.html',
                          attach_rejection_reason=attach_rejection_reason)
     if registration.registration_form.manager_notifications_enabled:
-        _notify_registration(registration, 'registration_state_update_to_managers.html', to_managers=True,
-                             attach_rejection_reason=attach_rejection_reason)
+        _notify_registration(registration, 'registration_state_update_to_managers.html', to_managers=True)

--- a/indico/modules/events/registration/notifications.py
+++ b/indico/modules/events/registration/notifications.py
@@ -7,7 +7,7 @@
 
 from __future__ import unicode_literals
 
-from flask import request, session
+from flask import session
 
 from indico.core import signals
 from indico.core.notifications import make_email, send_email
@@ -63,8 +63,7 @@ def notify_registration_modification(registration, notify_user=True):
         _notify_registration(registration, 'registration_modification_to_managers.html', to_managers=True)
 
 
-def notify_registration_state_update(registration):
-    attach_rejection_reason = request.form.get('attach_rejection_reason') == 'y'
+def notify_registration_state_update(registration, attach_rejection_reason=False):
     _notify_registration(registration, 'registration_state_update_to_registrant.html',
                          attach_rejection_reason=attach_rejection_reason)
     if registration.registration_form.manager_notifications_enabled:

--- a/indico/modules/events/registration/placeholders/registrations.py
+++ b/indico/modules/events/registration/placeholders/registrations.py
@@ -72,6 +72,15 @@ class LinkPlaceholder(Placeholder):
         return Markup('<a href="{url}">{url}</a>').format(url=url)
 
 
+class RejectionReasonPlaceholder(Placeholder):
+    name = 'rejection_reason'
+    description = _("Reason stated while rejecting a participant by moderator")
+
+    @classmethod
+    def render(cls, regform, registration):
+        return registration.rejection_reason
+
+
 class FieldPlaceholder(ParametrizedPlaceholder):
     name = 'field'
     description = None

--- a/indico/modules/events/registration/placeholders/registrations.py
+++ b/indico/modules/events/registration/placeholders/registrations.py
@@ -74,7 +74,7 @@ class LinkPlaceholder(Placeholder):
 
 class RejectionReasonPlaceholder(Placeholder):
     name = 'rejection_reason'
-    description = _("Reason stated while rejecting a participant by moderator")
+    description = _("The reason why the registration was rejected")
 
     @classmethod
     def render(cls, regform, registration):

--- a/indico/modules/events/registration/templates/emails/registration_creation_to_managers.html
+++ b/indico/modules/events/registration/templates/emails/registration_creation_to_managers.html
@@ -31,6 +31,13 @@
 {%- endmacro %}
 
 
+{% macro render_rejection_reason() %}
+    {% if registration.state.name == 'rejected' and registration.rejection_reason %}
+    	<br>The reason stated for rejection: "{{ registration.rejection_reason }}".<br>
+    {% endif %}
+{% endmacro %}
+
+
 {% macro render_text_pending() %}
     {% if registration.state.name == 'pending' %}
         Please note that it's waiting for manual approval by a manager.

--- a/indico/modules/events/registration/templates/emails/registration_creation_to_managers.html
+++ b/indico/modules/events/registration/templates/emails/registration_creation_to_managers.html
@@ -33,7 +33,7 @@
 
 {% macro render_rejection_reason() %}
     {% if registration.state.name == 'rejected' and registration.rejection_reason %}
-    	<br>Rejection reason: {{ registration.rejection_reason }}.<br>
+        <br>Rejection reason: {{ registration.rejection_reason }}.<br>
     {% endif %}
 {% endmacro %}
 

--- a/indico/modules/events/registration/templates/emails/registration_creation_to_managers.html
+++ b/indico/modules/events/registration/templates/emails/registration_creation_to_managers.html
@@ -33,7 +33,7 @@
 
 {% macro render_rejection_reason() %}
     {% if registration.state.name == 'rejected' and registration.rejection_reason %}
-    	<br>The reason stated for rejection: "{{ registration.rejection_reason }}".<br>
+    	<br>Rejection reason: {{ registration.rejection_reason }}.<br>
     {% endif %}
 {% endmacro %}
 

--- a/indico/modules/events/registration/templates/emails/registration_creation_to_managers.html
+++ b/indico/modules/events/registration/templates/emails/registration_creation_to_managers.html
@@ -33,7 +33,7 @@
 
 {% macro render_rejection_reason() %}
     {% if registration.state.name == 'rejected' and registration.rejection_reason %}
-        <br>Rejection reason: {{ registration.rejection_reason }}.<br>
+        <br>Rejection reason: {{ registration.rejection_reason }}<br>
     {% endif %}
 {% endmacro %}
 

--- a/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
@@ -49,6 +49,13 @@
 {% endmacro %}
 
 
+{% macro render_rejection_reason() %}
+    {% if registration.state.name == 'rejected' and registration.rejection_reason %}
+    	<br>The reason stated for rejection: "{{ registration.rejection_reason }}".<br>
+    {% endif %}
+{% endmacro %}
+
+
 {% macro render_text_pending() %}
     {% if registration.state.name == 'pending' %}
         Please note that this event requires manual approval.

--- a/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
@@ -51,7 +51,7 @@
 
 {% macro render_rejection_reason() %}
     {% if registration.state.name == 'rejected' and registration.rejection_reason %}
-    	<br>The reason stated for rejection: "{{ registration.rejection_reason }}".<br>
+    	<br>Rejection reason: {{ registration.rejection_reason }}.<br>
     {% endif %}
 {% endmacro %}
 

--- a/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
@@ -51,7 +51,7 @@
 
 {% macro render_rejection_reason() %}
     {% if registration.state.name == 'rejected' and registration.rejection_reason %}
-        <br>Rejection reason: {{ registration.rejection_reason }}.<br>
+        <br>Rejection reason: {{ registration.rejection_reason }}<br>
     {% endif %}
 {% endmacro %}
 

--- a/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
@@ -51,7 +51,7 @@
 
 {% macro render_rejection_reason() %}
     {% if registration.state.name == 'rejected' and registration.rejection_reason %}
-    	<br>Rejection reason: {{ registration.rejection_reason }}.<br>
+        <br>Rejection reason: {{ registration.rejection_reason }}.<br>
     {% endif %}
 {% endmacro %}
 

--- a/indico/modules/events/registration/templates/emails/registration_state_update_to_managers.html
+++ b/indico/modules/events/registration/templates/emails/registration_state_update_to_managers.html
@@ -8,7 +8,7 @@
 {% block registration_header_text %}
     The registration {{ render_registration_info() }}
     is now <strong>{{ registration.state.title|lower }}</strong>.
-    {% if notify_reason %}
+    {% if attach_reason %}
     	{{ render_rejection_reason() }}
     {% endif %}
     {{ render_text_pending() }}

--- a/indico/modules/events/registration/templates/emails/registration_state_update_to_managers.html
+++ b/indico/modules/events/registration/templates/emails/registration_state_update_to_managers.html
@@ -8,6 +8,9 @@
 {% block registration_header_text %}
     The registration {{ render_registration_info() }}
     is now <strong>{{ registration.state.title|lower }}</strong>.
+    {% if notify_reason %}
+    	{{ render_rejection_reason() }}
+    {% endif %}
     {{ render_text_pending() }}
     {{ render_text_manage() }}
 {% endblock %}

--- a/indico/modules/events/registration/templates/emails/registration_state_update_to_managers.html
+++ b/indico/modules/events/registration/templates/emails/registration_state_update_to_managers.html
@@ -8,9 +8,7 @@
 {% block registration_header_text %}
     The registration {{ render_registration_info() }}
     is now <strong>{{ registration.state.title|lower }}</strong>.
-    {% if attach_reason %}
-    	{{ render_rejection_reason() }}
-    {% endif %}
+    {{ render_rejection_reason() }}
     {{ render_text_pending() }}
     {{ render_text_manage() }}
 {% endblock %}

--- a/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
@@ -8,9 +8,8 @@
 {% block registration_header_text -%}
     Your registration {{ render_registration_info() }}
     is now <strong>{{ registration.state.title|lower }}</strong>.
-    {% if notify_reason and registration.state == 3 and registration.rejection_reason %}
-    	<br>The reason stated for rejection as follows:<br>
-    		{{ registration.rejection_reason }}
+    {% if notify_reason %}
+    	{{ render_rejection_reason() }}
     {% endif %}
     {{ render_text_pending() }}
     {{ render_text_unpaid() }}

--- a/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
@@ -8,6 +8,10 @@
 {% block registration_header_text -%}
     Your registration {{ render_registration_info() }}
     is now <strong>{{ registration.state.title|lower }}</strong>.
+    {% if notify_reason and registration.state == 3 and registration.rejection_reason %}
+    	<br>The reason stated for rejection as follows:<br>
+    		{{ registration.rejection_reason }}
+    {% endif %}
     {{ render_text_pending() }}
     {{ render_text_unpaid() }}
 {%- endblock %}

--- a/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
@@ -8,7 +8,7 @@
 {% block registration_header_text -%}
     Your registration {{ render_registration_info() }}
     is now <strong>{{ registration.state.title|lower }}</strong>.
-    {% if notify_reason %}
+    {% if attach_reason %}
     	{{ render_rejection_reason() }}
     {% endif %}
     {{ render_text_pending() }}

--- a/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
@@ -8,9 +8,7 @@
 {% block registration_header_text -%}
     Your registration {{ render_registration_info() }}
     is now <strong>{{ registration.state.title|lower }}</strong>.
-    {% if attach_reason %}
-    	{{ render_rejection_reason() }}
-    {% endif %}
+    {{ render_rejection_reason() if attach_rejection_reason  }}
     {{ render_text_pending() }}
     {{ render_text_unpaid() }}
 {%- endblock %}

--- a/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
@@ -8,7 +8,7 @@
 {% block registration_header_text -%}
     Your registration {{ render_registration_info() }}
     is now <strong>{{ registration.state.title|lower }}</strong>.
-    {{ render_rejection_reason() if attach_rejection_reason  }}
+    {{ render_rejection_reason() if attach_rejection_reason }}
     {{ render_text_pending() }}
     {{ render_text_unpaid() }}
 {%- endblock %}

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -106,7 +106,6 @@
             <a class="i-button danger"
                data-update="#registration-details"
                data-href="{{ url_for('.reject_registration', registration) }}"
-               data-confirm="{% trans %}Are you sure you want to reject this registration? This will trigger a notification email.{% endtrans %}"
                data-title="{% trans %}Reject registration{% endtrans %}"
                data-ajax-dialog>
                 {%- trans %}Reject{% endtrans -%}

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -105,10 +105,10 @@
         <div class="group">
             <a class="i-button danger"
                data-update="#registration-details"
-               data-method="POST"
                data-href="{{ url_for('.reject_registration', registration) }}"
                data-confirm="{% trans %}Are you sure you want to reject this registration? This will trigger a notification email.{% endtrans %}"
-               data-title="{% trans %}Reject registration{% endtrans %}">
+               data-title="{% trans %}Reject registration{% endtrans %}"
+               data-ajax-dialog>
                 {%- trans %}Reject{% endtrans -%}
             </a>
         </div>

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -183,6 +183,9 @@
                 This registration is {{ state }}
             {%- endtrans %}
         </div>
+        {% if registration.state.name == 'rejected' and registration.rejection_reason %}
+            {% trans reason=registration.rejection_reason %}Reason: {{ reason }}{% endtrans %}
+        {% endif %}
     </div>
     <div class="toolbar hide-if-locked">
         {% set action = _('Reset rejection') if registration.state.name == 'rejected' else _('Reset withdrawal') %}

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -150,8 +150,7 @@
                         <ul class="i-dropdown">
                             <li>
                                 <a href="#" class="icon-checkmark js-requires-selected-row disabled js-modify-status"
-                                   data-href="{{ url_for('.registrations_modify_status', regform) }}"
-                                   data-flag="1"
+                                   data-href="{{ url_for('.registrations_approve', regform) }}"
                                    data-method="POST"
                                    data-confirm="{% trans %}Do you really want to approve the selected registrations? This will trigger a notification email for each registrant.{% endtrans %}">
                                     {%- trans %}Approve registrations{% endtrans -%}
@@ -159,8 +158,7 @@
                             </li>
                             <li>
                                 <a href="#" class="icon-close js-requires-selected-row disabled"
-                                   data-href="{{ url_for('.registrations_modify_status', regform) }}"
-                                   data-flag="0"
+                                   data-href="{{ url_for('.registrations_reject', regform) }}"
                                    data-params-selector="#registration-list tr input[type=checkbox]:checked"
                                    data-title="{% trans %}Reject registrations{% endtrans %}"
                                    data-update="#registration-list"

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -162,7 +162,6 @@
                                    data-href="{{ url_for('.registrations_modify_status', regform) }}"
                                    data-flag="0"
                                    data-params-selector="#registration-list tr input[type=checkbox]:checked"
-                                   data-confirm="{% trans %}Do you really want to reject the selected registrations? This will trigger a notification email for each registrant.{% endtrans %}"
                                    data-title="{% trans %}Reject registrations{% endtrans %}"
                                    data-update="#registration-list"
                                    data-ajax-dialog>

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -158,10 +158,13 @@
                                 </a>
                             </li>
                             <li>
-                                <a href="#" class="icon-close js-requires-selected-row disabled js-modify-status"
+                                <a href="#" class="icon-close js-requires-selected-row disabled"
                                    data-href="{{ url_for('.registrations_modify_status', regform) }}"
                                    data-flag="0"
+                                   data-params-selector="#registration-list tr input[type=checkbox]:checked"
                                    data-confirm="{% trans %}Do you really want to reject the selected registrations? This will trigger a notification email for each registrant.{% endtrans %}"
+                                   data-title="{% trans %}Reject registrations{% endtrans %}"
+                                   data-update="#registration-list"
                                    data-ajax-dialog>
                                     {%- trans %}Reject registrations{% endtrans -%}
                                 </a>

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -161,8 +161,8 @@
                                 <a href="#" class="icon-close js-requires-selected-row disabled js-modify-status"
                                    data-href="{{ url_for('.registrations_modify_status', regform) }}"
                                    data-flag="0"
-                                   data-method="POST"
-                                   data-confirm="{% trans %}Do you really want to reject the selected registrations? This will trigger a notification email for each registrant.{% endtrans %}">
+                                   data-confirm="{% trans %}Do you really want to reject the selected registrations? This will trigger a notification email for each registrant.{% endtrans %}"
+                                   data-ajax-dialog>
                                     {%- trans %}Reject registrations{% endtrans -%}
                                 </a>
                             </li>

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -160,6 +160,7 @@
                                 <a href="#" class="icon-close js-requires-selected-row disabled"
                                    data-href="{{ url_for('.registrations_reject', regform) }}"
                                    data-params-selector="#registration-list tr input[type=checkbox]:checked"
+                                   data-method="POST"
                                    data-title="{% trans %}Reject registrations{% endtrans %}"
                                    data-update="#registration-list"
                                    data-ajax-dialog>


### PR DESCRIPTION
Test Instructions
- Create an event with enabled moderation in the registration form.
- Register for the event
- Go to the registration display page, reject the participant, a form in the popup window will appear to enter a reason for rejection and a switch to enable or disable attaching the reason with the notification.
- The reason will be stored in the database as `registration.rejection_reason`, added as data into the event log,
- Also available to use in email templates as `rejection_reason` tag.
- Similarly, while rejecting multiple registrations from the registration list the same popup window would appear.

> Squash and Merge pl.

- Let me know if there are any changes required.