### PR TITLE
Be more forgiving with invalid locales

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,13 @@ Version 2.3.4
 
 *Unreleased*
 
+Improvements
+^^^^^^^^^^^^
+
+- Fail more gracefully is a user has an invalid locale set and fall back to the default
+  locale or English in case the default locale is invalid as well
+- Log an error if the configured default locale does not exist
+
 Bugfixes
 ^^^^^^^^
 

--- a/indico/web/assets/vars_js.py
+++ b/indico/web/assets/vars_js.py
@@ -41,8 +41,10 @@ def get_locale_data(path, name, domain, react=False):
 
 
 def generate_i18n_file(locale_name, react=False):
-    if locale_name not in get_all_locales():
-        return None
+    all_locales = get_all_locales()
+    if locale_name not in all_locales:
+        locale_name = config.DEFAULT_LOCALE if config.DEFAULT_LOCALE in all_locales else 'en_GB'
+
     root_path = os.path.join(current_app.root_path, 'translations')
     i18n_data = get_locale_data(root_path, locale_name, 'indico', react=react)
     if not i18n_data:

--- a/indico/web/flask/app.py
+++ b/indico/web/flask/app.py
@@ -41,7 +41,7 @@ from indico.modules.auth.providers import IndicoAuthProvider, IndicoIdentityProv
 from indico.modules.auth.util import url_for_login, url_for_logout
 from indico.modules.oauth import oauth
 from indico.util import date_time as date_time_util
-from indico.util.i18n import _, babel, get_current_locale, gettext_context, ngettext_context
+from indico.util.i18n import _, babel, get_all_locales, get_current_locale, gettext_context, ngettext_context
 from indico.util.mimetypes import icon_from_mimetype
 from indico.util.signals import values_from_signal
 from indico.util.string import RichMarkup, alpha_enum, crc32, html_to_plaintext, sanitize_html, slugify
@@ -362,6 +362,8 @@ def make_app(set_path=False, testing=False, config_override=None):
         celery.init_app(app)
         cache.init_app(app)
         babel.init_app(app)
+        if config.DEFAULT_LOCALE not in get_all_locales():
+            Logger.get('i18n').error('Configured DEFAULT_LOCALE ({}) does not exist'.format(config.DEFAULT_LOCALE))
         multipass.init_app(app)
         oauth.init_app(app)
         webpack.init_app(app)


### PR DESCRIPTION
See this forum thread for some more details: https://talk.getindico.io/t/localization-en-us-issue-in-2-3-3/2104

Basically having an invalid locale stored in the session/user currently results in a 404 error (instead of silently falling back to a minimal valid file) when trying to retrieve the locale information for JS. However, not having the locale data completely breaks our i18n JS, which in turns breaks pretty much all JS we have.

With this change we now simply redirect to the default locale (if it's valid, otherwise to the known-valid `en_GB` locale) instead of failing with a 404.