### PR TITLE
Remove semi-broken persistent ical links for contributions

### DIFF
--- a/indico/modules/events/contributions/templates/display/contribution_ical_export.html
+++ b/indico/modules/events/contributions/templates/display/contribution_ical_export.html
@@ -1,15 +1,4 @@
 {% extends '_ical_export.html' %}
 
 {% block download_text %}{% trans %}Download current contribution:{% endtrans %}{% endblock %}
-{% block javascript %}
-    {{ super() }}
-
-    <script>
-        exportPopups["{{ item.id }}"] = new ExportIcalInterface(
-            {{ api_mode|tojson }}, {{ persistent_user_enabled|tojson }},
-            {{ persistent_allowed|tojson }}, {{ api_active|tojson }}, {{ user_logged|tojson }}, setURLs,
-            {{ url_for('api.build_urls')|tojson }}, {eventId: "{{ item.event.id }}", contribId: "{{ item.id }}"},
-            {{ request_urls|tojson }}, "{{ item.id }}", "{{ session.user.full_name if session.user else '' }}"
-        );
-    </script>
-{% endblock %}
+{% block persistent_ui %}{# left empty on purpose #}{% endblock %}

--- a/indico/web/client/js/legacy/libs/indico/Common/Export.js
+++ b/indico/web/client/js/legacy/libs/indico/Common/Export.js
@@ -5,12 +5,15 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+/* eslint-disable import/unambiguous */
+/* global type:false, handleAjaxError:false, any:false, progressIndicator:false, $T:false */
+
 type(
   'ExportIcalInterface',
   [],
   {
-    _getExportURLs: function(progressTarget) {
-      var self = this;
+    _getExportURLs() {
+      const self = this;
       $.ajax({
         url: self.getURLsMethod,
         type: 'POST',
@@ -19,51 +22,51 @@ type(
         contentType: 'application/json',
         error: handleAjaxError,
         complete: IndicoUI.Dialogs.Util.progress(),
-        success: function(data) {
+        success(data) {
           self.setURLsFunction(data.urls);
           switch (self.apiMode) {
             case 0:
               if (self.apiActive) {
-                self._postAcceptAgreements('#agreementApiKey' + self.id);
+                self._postAcceptAgreements(`#agreementApiKey${self.id}`);
               }
               break;
             case 1:
               if (self.apiActive) {
-                $('#publicLinkWrapper' + self.id)
-                  .append($('#publicLink' + self.id))
+                $(`#publicLinkWrapper${self.id}`)
+                  .append($(`#publicLink${self.id}`))
                   .show();
-                self._postAcceptAgreements('#agreementApiKey' + self.id);
+                self._postAcceptAgreements(`#agreementApiKey${self.id}`);
               }
               break;
             case 2:
               if (self.apiActive) {
-                $('#agreementApiKey' + self.id).hide();
+                $(`#agreementApiKey${self.id}`).hide();
                 if (self.persistentUserEnabled && self.persistentAllowed) {
-                  self._postAcceptAgreements('#agreementPersistentSignatures' + self.id);
+                  self._postAcceptAgreements(`#agreementPersistentSignatures${self.id}`);
                 }
               }
               break;
             case 3:
               if (self.apiActive) {
-                $('#publicLinkWrapper' + self.id)
-                  .append($('#publicLink' + self.id))
+                $(`#publicLinkWrapper${self.id}`)
+                  .append($(`#publicLink${self.id}`))
                   .show();
                 if (self.persistentUserEnabled && self.persistentAllowed) {
-                  self._postAcceptAgreements('#agreementPersistentSignatures' + self.id);
+                  self._postAcceptAgreements(`#agreementPersistentSignatures${self.id}`);
                 } else {
-                  $('#extraInformation' + self.id).insertAfter('#publicLinkWrapper' + self.id);
+                  $(`#extraInformation${self.id}`).insertAfter(`#publicLinkWrapper${self.id}`);
                 }
-                $('#agreementApiKey' + self.id).hide();
+                $(`#agreementApiKey${self.id}`).hide();
               }
               break;
             case 4:
               if (self.apiActive) {
-                $('#agreementApiKey' + self.id).hide();
+                $(`#agreementApiKey${self.id}`).hide();
                 if (self.persistentUserEnabled && self.persistentAllowed) {
-                  $('#publicLinkWrapper' + self.id)
-                    .append($('#publicLink' + self.id))
+                  $(`#publicLinkWrapper${self.id}`)
+                    .append($(`#publicLink${self.id}`))
                     .show();
-                  self._postAcceptAgreements('#agreementPersistentSignatures' + self.id);
+                  self._postAcceptAgreements(`#agreementPersistentSignatures${self.id}`);
                 }
               }
               break;
@@ -72,61 +75,61 @@ type(
       });
     },
 
-    _showPrivatePanel: function(question) {
-      var self = this;
+    _showPrivatePanel(question) {
+      const self = this;
       if (self.persistentAllowed) {
         if (self.persistentUserEnabled) {
           self._showAuthLink();
         } else {
           question =
             question || $T('Would you like to export private information to your calendar?');
-          var privateInfo = $("<span class='fake-link'>" + question + '</span>');
+          const privateInfo = $(`<span class='fake-link'>${question}</span>`);
 
-          $('#authLinkWrapper' + self.id)
+          $(`#authLinkWrapper${self.id}`)
             .append(privateInfo)
             .show();
 
           privateInfo.click(function() {
             privateInfo.hide();
-            $('#exportIcalHeader' + self.id).show();
-            $('#authLinkWrapper' + self.id)
-              .append($('#agreementPersistentSignatures' + self.id))
+            $(`#exportIcalHeader${self.id}`).show();
+            $(`#authLinkWrapper${self.id}`)
+              .append($(`#agreementPersistentSignatures${self.id}`))
               .show();
           });
         }
-        $('#iCalSeparator' + self.id).show();
+        $(`#iCalSeparator${self.id}`).show();
       }
     },
 
-    _postAcceptAgreements: function(targetAgreement) {
-      $('#authLinkWrapper' + this.id)
-        .append($('#authLink' + this.id))
+    _postAcceptAgreements(targetAgreement) {
+      $(`#authLinkWrapper${this.id}`)
+        .append($(`#authLink${this.id}`))
         .show();
-      $('#extraInformation' + this.id).insertAfter('#authLinkWrapper' + this.id);
+      $(`#extraInformation${this.id}`).insertAfter(`#authLinkWrapper${this.id}`);
       $(targetAgreement).hide();
     },
 
-    _showAuthLink: function() {
-      $('#exportIcalHeader' + this.id).show();
-      $('#authLinkWrapper' + this.id)
-        .append($('#authLink' + this.id))
+    _showAuthLink() {
+      $(`#exportIcalHeader${this.id}`).show();
+      $(`#authLinkWrapper${this.id}`)
+        .append($(`#authLink${this.id}`))
         .show();
-      $('#extraInformation' + this.id).insertAfter('#authLinkWrapper' + this.id);
+      $(`#extraInformation${this.id}`).insertAfter(`#authLinkWrapper${this.id}`);
     },
 
-    _showAgreement: function(agreementTarget) {
-      $('#extraInformation').insertAfter('#publicLinkWrapper' + this.id);
-      $('#authLinkWrapper' + this.id)
+    _showAgreement(agreementTarget) {
+      $('#extraInformation').insertAfter(`#publicLinkWrapper${this.id}`);
+      $(`#authLinkWrapper${this.id}`)
         .append($(agreementTarget))
         .show();
     },
 
-    getRequestURLs: function() {
+    getRequestURLs() {
       return this.requestURLs;
     },
 
-    createKey: function(enablePersistent, progressTarget) {
-      var self = this;
+    createKey(enablePersistent, progressTarget) {
+      const self = this;
       $(progressTarget).html($(progressIndicator(true, false).dom));
       $.ajax({
         url: Indico.Urls.APIKeyCreate,
@@ -136,11 +139,11 @@ type(
           quiet: '1',
           persistent: enablePersistent ? '1' : '0',
         },
-        error: function(xhr) {
+        error(xhr) {
           handleAjaxError(xhr);
           $(progressTarget).html('');
         },
-        success: function(data) {
+        success(data) {
           self.apiActive = true;
           self.persistentUserEnabled = data.is_persistent_allowed;
           self._getExportURLs(progressTarget);
@@ -148,8 +151,8 @@ type(
       });
     },
 
-    enablePersistentSignatures: function() {
-      var self = this;
+    enablePersistentSignatures() {
+      const self = this;
       if (self.apiActive) {
         $.ajax({
           url: Indico.Urls.APIKeyTogglePersistent,
@@ -159,11 +162,11 @@ type(
             enabled: '1',
             quiet: '1',
           },
-          error: function(xhr) {
+          error(xhr) {
             handleAjaxError(xhr);
             $('#progressPersistentSignatures').html('');
           },
-          success: function(data) {
+          success(data) {
             self.persistentUserEnabled = data.enabled;
             self._getExportURLs('progressPersistentSignatures');
           },
@@ -173,72 +176,72 @@ type(
       }
     },
 
-    showContent: function() {
-      var self = this;
+    showContent() {
+      const self = this;
       self.setURLsFunction(self.requestURLs);
       switch (self.apiMode) {
-        case 0: //Public:nothing; Private:API_KEY
-          $('#publicLinkWrapper' + self.id)
-            .append($('#publicLink' + self.id))
+        case 0: // Public:nothing; Private:API_KEY
+          $(`#publicLinkWrapper${self.id}`)
+            .append($(`#publicLink${self.id}`))
             .show();
           if (self.userLogged) {
             if (self.apiActive) {
               self._showAuthLink();
             } else {
-              $('#exportIcalHeader' + self.id).show();
-              self._showAgreement('#agreementApiKey' + self.id);
+              $(`#exportIcalHeader${self.id}`).show();
+              self._showAgreement(`#agreementApiKey${self.id}`);
             }
-            $('#iCalSeparator' + self.id).show();
+            $(`#iCalSeparator${self.id}`).show();
           }
           break;
-        case 1: //Public:API_KEY; Private:API_KEY
+        case 1: // Public:API_KEY; Private:API_KEY
           if (self.userLogged) {
             if (self.apiActive) {
-              $('#publicLinkWrapper' + self.id)
-                .append($('#publicLink' + self.id))
+              $(`#publicLinkWrapper${self.id}`)
+                .append($(`#publicLink${self.id}`))
                 .show();
               self._showAuthLink();
             } else {
-              $('#exportIcalHeader' + self.id).show();
-              $('#authLinkWrapper' + self.id)
-                .append($('#agreementApiKey' + self.id))
+              $(`#exportIcalHeader${self.id}`).show();
+              $(`#authLinkWrapper${self.id}`)
+                .append($(`#agreementApiKey${self.id}`))
                 .show();
             }
-            $('#iCalSeparator' + self.id).show();
+            $(`#iCalSeparator${self.id}`).show();
           }
           break;
-        case 2: //Public:nothing; Private:SIGNED
-          $('#publicLinkWrapper' + self.id)
-            .append($('#publicLink' + self.id))
+        case 2: // Public:nothing; Private:SIGNED
+          $(`#publicLinkWrapper${self.id}`)
+            .append($(`#publicLink${self.id}`))
             .show();
           if (self.userLogged) {
             self._showPrivatePanel();
           } else {
-            $('#extraInformation' + self.id).insertAfter('#publicLinkWrapper' + self.id);
+            $(`#extraInformation${self.id}`).insertAfter(`#publicLinkWrapper${self.id}`);
           }
-          $('#iCalSeparator' + self.id).show();
+          $(`#iCalSeparator${self.id}`).show();
           break;
-        case 3: //Public:API_KEY; Private:SIGNED
+        case 3: // Public:API_KEY; Private:SIGNED
           if (self.userLogged) {
             if (self.apiActive) {
-              $('#publicLinkWrapper' + self.id)
-                .append($('#publicLink' + self.id))
+              $(`#publicLinkWrapper${self.id}`)
+                .append($(`#publicLink${self.id}`))
                 .show();
             } else {
-              $('#publicLinkWrapper' + self.id)
-                .append($('#agreementApiKey' + self.id))
+              $(`#publicLinkWrapper${self.id}`)
+                .append($(`#agreementApiKey${self.id}`))
                 .show();
             }
             self._showPrivatePanel();
-            $('#iCalSeparator' + self.id).show();
+            $(`#iCalSeparator${self.id}`).show();
           }
           break;
-        case 4: //ALL_SIGNED
+        case 4: // ALL_SIGNED
           if (self.userLogged) {
             if (self.persistentAllowed) {
               if (self.persistentUserEnabled) {
-                $('#publicLinkWrapper' + self.id)
-                  .append($('#publicLink' + self.id))
+                $(`#publicLinkWrapper${self.id}`)
+                  .append($(`#publicLink${self.id}`))
                   .show();
               }
               self._showPrivatePanel(
@@ -281,11 +284,11 @@ type(
   }
 );
 
-var exportPopups = {};
+window.exportPopups = {};
 
 $(document).ready(function() {
   $('.js-export-ical').on('menu_select', function() {
-    var $button = $(this);
+    const $button = $(this);
 
     if ($button.hasClass('open')) {
       return;
@@ -307,17 +310,17 @@ $(document).ready(function() {
           at: 'bottom center',
           target: $button,
         },
-        content: function(api) {
-          return $('#icalExportPopup' + $button.data('id'));
+        content() {
+          return $(`#icalExportPopup${$button.data('id')}`);
         },
         show: {
           ready: true,
-          effect: function() {
+          effect() {
             $(this).fadeIn(300);
           },
         },
         events: {
-          hide: function() {
+          hide() {
             $(this).fadeOut(300);
             $button.removeClass('open');
           },
@@ -334,30 +337,30 @@ $(document).ready(function() {
   });
 
   $('body')
-    .delegate('.apiURL', 'click', function(e) {
+    .delegate('.apiURL', 'click', function() {
       $(this).select();
     })
-    .delegate('.agreementButtonPersistent', 'click', function(e) {
-      var id = $(this).data('id');
-      $('#progressPersistentSignatures' + id).html($(progressIndicator(true, false).dom));
-      exportPopups[id].enablePersistentSignatures();
+    .delegate('.agreementButtonPersistent', 'click', function() {
+      const id = $(this).data('id');
+      $(`#progressPersistentSignatures${id}`).html($(progressIndicator(true, false).dom));
+      window.exportPopups[id].enablePersistentSignatures();
     })
-    .delegate('.agreementButtonKey', 'click', function(e) {
-      var id = $(this).data('id');
-      exportPopups[id].createKey(false, '#progressPersistentKey' + id);
+    .delegate('.agreementButtonKey', 'click', function() {
+      const id = $(this).data('id');
+      window.exportPopups[id].createKey(false, `#progressPersistentKey${id}`);
     })
-    .delegate('.agreeCheckBoxKey', 'click', function(e) {
-      var id = $(this).data('id');
-      $('#agreementButtonKey' + id).prop('disabled', !this.checked);
+    .delegate('.agreeCheckBoxKey', 'click', function() {
+      const id = $(this).data('id');
+      $(`#agreementButtonKey${id}`).prop('disabled', !this.checked);
     })
-    .delegate('.agreeCheckBoxPersistent', 'click', function(e) {
-      var id = $(this).data('id');
-      $('#agreementButtonPersistent' + id).prop('disabled', !this.checked);
-      $('#agreeCheckBoxKey' + id)
+    .delegate('.agreeCheckBoxPersistent', 'click', function() {
+      const id = $(this).data('id');
+      $(`#agreementButtonPersistent${id}`).prop('disabled', !this.checked);
+      $(`#agreeCheckBoxKey${id}`)
         .prop('checked', this.checked)
         .prop('disabled', this.checked);
       if (this.checked) {
-        $('#agreementButtonKey' + id).prop('disabled', true);
+        $(`#agreementButtonKey${id}`).prop('disabled', true);
       }
     });
 });

--- a/indico/web/templates/_ical_export.html
+++ b/indico/web/templates/_ical_export.html
@@ -8,6 +8,7 @@
 
     {% block extra_download %}{% endblock %}
 
+    {% block persistent_ui %}
     <div id="iCalSeparator{{ item.id }}" class="icalSeparator" style="display: none;"></div>
     <div id="exportICalDialogs" style="display: none;">
         <div id="agreementApiKey{{ item.id }}">
@@ -62,6 +63,7 @@
             {% block extra_info %}{% endblock %}
         </div>
     </div>
+    {% endblock %}
 </div>
 
 {% block javascript %}


### PR DESCRIPTION
- They pointed to the event ical (without any contribution details)
- When enabling (persistent) API keys from that widget, the URLs generated pointed to a legacy contribution-only ical api which 503s since v1.9.x
- Persistent calendar links for a single contribution are not particularly useful

When we improve the ical links in all the other places (see #4776), we can consider doing the same for contributions for the sake if being consistent, i.e. having the option to generate a persistent link in any place where we also have a regular ical link.

Nothing changed in Export.js btw; I just thought it may need some changes so I ran eslint on it before, and didn't feel like reverting those in the end, even though I seriously hope this file goes away for good with #4776!

---

![image](https://user-images.githubusercontent.com/179599/107380287-085ceb00-6aee-11eb-9694-7adba406342b.png)

I did not bother removing the dropdown in favor of a direct link, since there's a very good chance that the issue mentioned above will land in 3.0 anyway, and I didn't feel like improving UI that won't make it into the final release of this version.