### PR TITLE
Replace OrderedDict instances with dicts (#4703)

### DIFF
--- a/indico/core/plugins/controllers.py
+++ b/indico/core/plugins/controllers.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from operator import attrgetter
 
 from flask import flash, request
@@ -38,7 +38,7 @@ class RHPlugins(RHPluginsBase):
         # listed in the front
         for category in categories:
             categories[category].sort(key=attrgetter('configurable', 'title'))
-        ordered_categories = OrderedDict(sorted(categories.items()))
+        ordered_categories = dict(sorted(categories.items()))
         if other:
             ordered_categories[PluginCategory.other] = sorted(other, key=attrgetter('configurable', 'title'))
         return WPPlugins.render_template('index.html', categorized_plugins=ordered_categories)

--- a/indico/core/settings/converters.py
+++ b/indico/core/settings/converters.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
 from datetime import timedelta
 
 import dateutil.parser
@@ -143,13 +142,3 @@ class ModelListConverter(SettingConverter):
         if not value:
             return []
         return self.collection_class(self.model.query.filter(self.column.in_(value)))
-
-
-class OrderedDictConverter(SettingConverter):
-    @staticmethod
-    def from_python(value):
-        return list(value.items())
-
-    @staticmethod
-    def to_python(value):
-        return OrderedDict(value)

--- a/indico/modules/attachments/controllers/event_package.py
+++ b/indico/modules/attachments/controllers/event_package.py
@@ -6,7 +6,6 @@
 # LICENSE file for more details.
 
 import os
-from collections import OrderedDict
 
 from celery.exceptions import TimeoutError
 from flask import flash, jsonify, request, session
@@ -200,7 +199,7 @@ class AttachmentPackageMixin(AttachmentPackageGeneratorMixin):
     def _prepare_form(self):
         form = AttachmentPackageForm(obj=FormDefaults(filter_type='all'))
         form.dates.choices = list(self._iter_event_days())
-        filter_types = OrderedDict()
+        filter_types = {}
         filter_types['all'] = _('Everything')
         filter_types['sessions'] = _('Specific sessions')
         filter_types['contributions'] = _('Specific contributions')

--- a/indico/modules/attachments/controllers/event_package.py
+++ b/indico/modules/attachments/controllers/event_package.py
@@ -199,11 +199,12 @@ class AttachmentPackageMixin(AttachmentPackageGeneratorMixin):
     def _prepare_form(self):
         form = AttachmentPackageForm(obj=FormDefaults(filter_type='all'))
         form.dates.choices = list(self._iter_event_days())
-        filter_types = {}
-        filter_types['all'] = _('Everything')
-        filter_types['sessions'] = _('Specific sessions')
-        filter_types['contributions'] = _('Specific contributions')
-        filter_types['dates'] = _('Specific days')
+        filter_types = {
+            'all': _('Everything'),
+            'sessions': _('Specific sessions'),
+            'contributions': _('Specific contributions'),
+            'dates': _('Specific days'),
+        }
 
         form.sessions.choices = self._load_session_data()
         if not form.sessions.choices:

--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
 from datetime import date, timedelta
 
 from pytz import timezone
@@ -35,7 +34,7 @@ def get_events_by_year(category_id=None):
 
     :param category_id: The category ID to get statistics for. Events
                         from subcategories are also included.
-    :return: An `OrderedDict` mapping years to event counts.
+    :return: A dictionary mapping years to event counts.
     """
     category_filter = Event.category_chain_overlaps(category_id) if category_id else True
     query = (db.session
@@ -45,7 +44,7 @@ def get_events_by_year(category_id=None):
                      category_filter)
              .order_by('year')
              .group_by('year'))
-    return OrderedDict(query)
+    return dict(query)
 
 
 def get_contribs_by_year(category_id=None):
@@ -54,7 +53,7 @@ def get_contribs_by_year(category_id=None):
     :param category_id: The category ID to get statistics for.
                         Contributions from subcategories are also
                         included.
-    :return: An `OrderedDict` mapping years to contribution counts.
+    :return: A dictionary mapping years to contribution counts.
     """
     category_filter = Event.category_chain_overlaps(category_id) if category_id else True
     query = (db.session
@@ -66,7 +65,7 @@ def get_contribs_by_year(category_id=None):
                      category_filter)
              .order_by('year')
              .group_by('year'))
-    return OrderedDict(query)
+    return dict(query)
 
 
 def get_min_year(category_id=None):

--- a/indico/modules/events/abstracts/notifications.py
+++ b/indico/modules/events/abstracts/notifications.py
@@ -6,7 +6,6 @@
 # LICENSE file for more details.
 
 import itertools
-from collections import OrderedDict
 
 from flask import session
 
@@ -32,9 +31,9 @@ class EmailNotificationCondition(Condition):
     def get_available_values(cls, event=None, **kwargs):
         choices = cls._iter_available_values(event=event, **kwargs)
         if not cls.required:
-            return OrderedDict(itertools.chain([('*', cls.any_caption), ('', cls.none_caption)], choices))
+            return dict(itertools.chain([('*', cls.any_caption), ('', cls.none_caption)], choices))
         else:
-            return OrderedDict(choices)
+            return dict(choices)
 
     @classmethod
     def _iter_available_values(cls, event, **kwargs):

--- a/indico/modules/events/abstracts/util.py
+++ b/indico/modules/events/abstracts/util.py
@@ -8,7 +8,7 @@
 import errno
 import os
 import shutil
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 
 from sqlalchemy.orm import joinedload, load_only, noload
 
@@ -55,22 +55,22 @@ def generate_spreadsheet_from_abstracts(abstracts, static_item_ids, dynamic_item
     :param dynamic_items: Contribution fields as extra columns
     """
     field_names = ['Id', 'Title']
-    static_item_mapping = OrderedDict([
-        ('state', ('State', lambda x: x.state.title)),
-        ('submitter', ('Submitter', lambda x: x.submitter.full_name)),
-        ('authors', ('Primary authors', lambda x: [a.full_name for a in x.primary_authors])),
-        ('accepted_track', ('Accepted track', lambda x: x.accepted_track.short_title if x.accepted_track else None)),
-        ('submitted_for_tracks', ('Submitted for tracks',
-                                  lambda x: [t.short_title for t in x.submitted_for_tracks])),
-        ('reviewed_for_tracks', ('Reviewed for tracks', lambda x: [t.short_title for t in x.reviewed_for_tracks])),
-        ('accepted_contrib_type', ('Accepted type',
-                                   lambda x: x.accepted_contrib_type.name if x.accepted_contrib_type else None)),
-        ('submitted_contrib_type', ('Submitted type',
-                                    lambda x: x.submitted_contrib_type.name if x.submitted_contrib_type else None)),
-        ('score', ('Score', lambda x: round(x.score, 1) if x.score is not None else None)),
-        ('submitted_dt', ('Submission date', lambda x: x.submitted_dt)),
-        ('modified_dt', ('Modification date', lambda x: x.modified_dt if x.modified_dt else ''))
-    ])
+    static_item_mapping = {
+        'state': ('State', lambda x: x.state.title),
+        'submitter': ('Submitter', lambda x: x.submitter.full_name),
+        'authors': ('Primary authors', lambda x: [a.full_name for a in x.primary_authors]),
+        'accepted_track': ('Accepted track', lambda x: x.accepted_track.short_title if x.accepted_track else None),
+        'submitted_for_tracks': ('Submitted for tracks',
+                                 lambda x: [t.short_title for t in x.submitted_for_tracks]),
+        'reviewed_for_tracks': ('Reviewed for tracks', lambda x: [t.short_title for t in x.reviewed_for_tracks]),
+        'accepted_contrib_type': ('Accepted type',
+                                  lambda x: x.accepted_contrib_type.name if x.accepted_contrib_type else None),
+        'submitted_contrib_type': ('Submitted type',
+                                   lambda x: x.submitted_contrib_type.name if x.submitted_contrib_type else None),
+        'score': ('Score', lambda x: round(x.score, 1) if x.score is not None else None),
+        'submitted_dt': ('Submission date', lambda x: x.submitted_dt),
+        'modified_dt': ('Modification date', lambda x: x.modified_dt if x.modified_dt else ''),
+    }
     field_names.extend(unique_col(item.title, item.id) for item in dynamic_items)
     field_names.extend(title for name, (title, fn) in static_item_mapping.items() if name in static_item_ids)
     rows = []

--- a/indico/modules/events/contributions/lists.py
+++ b/indico/modules/events/contributions/lists.py
@@ -36,18 +36,16 @@ class ContributionListGenerator(ListGeneratorBase):
         session_empty = {None: _('No session')}
         track_empty = {None: _('No track')}
         type_empty = {None: _('No type')}
-        session_choices = {str(s.id): s.title for s in sorted(self.event.sessions,
-                                                              key=attrgetter('title'))}
+        session_choices = {str(s.id): s.title for s in sorted(self.event.sessions, key=attrgetter('title'))}
         track_choices = {str(t.id): t.title for t in sorted(self.event.tracks, key=attrgetter('title'))}
-        type_choices = {str(t.id): t.name for t in sorted(self.event.contribution_types,
-                                                          key=attrgetter('name'))}
+        type_choices = {str(t.id): t.name for t in sorted(self.event.contribution_types, key=attrgetter('name'))}
         self.static_items = {
             'session': {'title': _('Session'),
-                        'filter_choices': dict(session_empty | session_choices)},
+                        'filter_choices': session_empty | session_choices},
             'track': {'title': _('Track'),
-                      'filter_choices': dict(track_empty | track_choices)},
+                      'filter_choices': track_empty | track_choices},
             'type': {'title': _('Type'),
-                     'filter_choices': dict(type_empty | type_choices)},
+                     'filter_choices': type_empty | type_choices},
             'status': {'title': _('Status'), 'filter_choices': {'scheduled': _('Scheduled'),
                                                                 'unscheduled': _('Not scheduled')}},
             'speakers': {'title': _('Speakers'), 'filter_choices': {'registered': _('Registered'),

--- a/indico/modules/events/contributions/lists.py
+++ b/indico/modules/events/contributions/lists.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
 from datetime import timedelta
 from operator import attrgetter
 
@@ -37,23 +36,23 @@ class ContributionListGenerator(ListGeneratorBase):
         session_empty = {None: _('No session')}
         track_empty = {None: _('No track')}
         type_empty = {None: _('No type')}
-        session_choices = OrderedDict((str(s.id), s.title) for s in sorted(self.event.sessions,
-                                                                           key=attrgetter('title')))
-        track_choices = OrderedDict((str(t.id), t.title) for t in sorted(self.event.tracks, key=attrgetter('title')))
-        type_choices = OrderedDict((str(t.id), t.name) for t in sorted(self.event.contribution_types,
-                                                                       key=attrgetter('name')))
-        self.static_items = OrderedDict([
-            ('session', {'title': _('Session'),
-                         'filter_choices': OrderedDict(session_empty | session_choices)}),
-            ('track', {'title': _('Track'),
-                       'filter_choices': OrderedDict(track_empty | track_choices)}),
-            ('type', {'title': _('Type'),
-                      'filter_choices': OrderedDict(type_empty | type_choices)}),
-            ('status', {'title': _('Status'), 'filter_choices': {'scheduled': _('Scheduled'),
-                                                                 'unscheduled': _('Not scheduled')}}),
-            ('speakers', {'title': _('Speakers'), 'filter_choices': {'registered': _('Registered'),
-                                                                     'not_registered': _('Not registered')}})
-        ])
+        session_choices = {str(s.id): s.title for s in sorted(self.event.sessions,
+                                                              key=attrgetter('title'))}
+        track_choices = {str(t.id): t.title for t in sorted(self.event.tracks, key=attrgetter('title'))}
+        type_choices = {str(t.id): t.name for t in sorted(self.event.contribution_types,
+                                                          key=attrgetter('name'))}
+        self.static_items = {
+            'session': {'title': _('Session'),
+                        'filter_choices': dict(session_empty | session_choices)},
+            'track': {'title': _('Track'),
+                      'filter_choices': dict(track_empty | track_choices)},
+            'type': {'title': _('Type'),
+                     'filter_choices': dict(type_empty | type_choices)},
+            'status': {'title': _('Status'), 'filter_choices': {'scheduled': _('Scheduled'),
+                                                                'unscheduled': _('Not scheduled')}},
+            'speakers': {'title': _('Speakers'), 'filter_choices': {'registered': _('Registered'),
+                                                                    'not_registered': _('Not registered')}},
+        }
 
         self.list_config = self._get_config()
 

--- a/indico/modules/events/export.py
+++ b/indico/modules/events/export.py
@@ -9,7 +9,7 @@ import os
 import posixpath
 import re
 import tarfile
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from datetime import date, datetime
 from io import BytesIO
 from operator import itemgetter
@@ -175,14 +175,14 @@ class EventExporter:
             tablespec.setdefault('skipif', None)
             tablespec.setdefault('order', None)
             tablespec.setdefault('allow_duplicates', False)
-            fks = OrderedDict()
+            fks = {}
             for fk_name in tablespec['fks']:
                 col = _resolve_col(fk_name)
                 fk = _get_single_fk(col)
                 fks.setdefault(fk.column.name, []).append(col)
             tablespec['fks'] = fks
-            tablespec['fks_out'] = OrderedDict((fk, _get_single_fk(db.metadata.tables[tablename].c[fk]).column)
-                                               for fk in tablespec['fks_out'])
+            tablespec['fks_out'] = {fk: _get_single_fk(db.metadata.tables[tablename].c[fk]).column
+                                    for fk in tablespec['fks_out']}
             return tablespec
 
         with open(os.path.join(current_app.root_path, 'modules', 'events', 'export.yaml')) as f:

--- a/indico/modules/events/layout/util.py
+++ b/indico/modules/events/layout/util.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from itertools import chain, count
 
 from sqlalchemy.exc import IntegrityError
@@ -127,10 +127,10 @@ class MenuEntryData:
 def _get_split_signal_entries():
     """Get the top-level and child menu entry data."""
     signal_entries = get_menu_entries_from_signal()
-    top_data = OrderedDict((name, data)
-                           for name, data in sorted(signal_entries.items(),
-                                                    key=lambda name_data: _menu_entry_key(name_data[1]))
-                           if not data.parent)
+    top_data = {name: data
+                for name, data in sorted(signal_entries.items(),
+                                         key=lambda name_data: _menu_entry_key(name_data[1]))
+                if not data.parent}
     child_data = defaultdict(list)
     for name, data in signal_entries.items():
         if data.parent is not None:

--- a/indico/modules/events/management/controllers/cloning.py
+++ b/indico/modules/events/management/controllers/cloning.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
 from datetime import datetime, timedelta
 
 from dateutil import rrule
@@ -31,15 +30,15 @@ REPEAT_FORM_MAP = {
     'pattern': CloneRepeatPatternForm
 }
 
-RRULE_FREQ_MAP = OrderedDict([
-    ('years', rrule.YEARLY),
-    ('months', rrule.MONTHLY),
-    ('weeks', rrule.WEEKLY),
-    ('days', rrule.DAILY),
-    ('hours', rrule.HOURLY),
-    ('minutes', rrule.MINUTELY),
-    ('seconds', rrule.SECONDLY)
-])
+RRULE_FREQ_MAP = {
+    'years': rrule.YEARLY,
+    'months': rrule.MONTHLY,
+    'weeks': rrule.WEEKLY,
+    'days': rrule.DAILY,
+    'hours': rrule.HOURLY,
+    'minutes': rrule.MINUTELY,
+    'seconds': rrule.SECONDLY,
+}
 
 
 def relativedelta_to_rrule_interval(rdelta):

--- a/indico/modules/events/management/program_codes.py
+++ b/indico/modules/events/management/program_codes.py
@@ -5,8 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
-
 from indico.modules.events.management.settings import program_codes_settings
 from indico.util.date_time import format_datetime
 from indico.util.i18n import _
@@ -34,11 +32,11 @@ def generate_program_codes(event, object_type, objects):
         raise ValueError(f'Invalid object type: {object_type}')
 
     template = program_codes_settings.get(event, template_setting)
-    return OrderedDict(
-        (obj, (replace_placeholders(context, template, escape_html=False, **{kwarg: obj}),
-               get_empty_placeholders(context, template, **{kwarg: obj})))
+    return {
+        obj: (replace_placeholders(context, template, escape_html=False, **{kwarg: obj}),
+              get_empty_placeholders(context, template, **{kwarg: obj}))
         for obj in objects
-    )
+    }
 
 
 def _make_date_placeholder(class_name, name, render_kwarg, date_format, description, transform=None):

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
 from contextlib import contextmanager
 from datetime import timedelta
 from operator import attrgetter
@@ -802,7 +801,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
                                chairpersons (or lecture speakers)
         :param extra: An email address that is always included, even
                       if it is not in any of the included lists.
-        :return: An OrderedDict mapping emails to pretty names
+        :return: A dictionary mapping emails to pretty names
         """
         emails = {}
         # Contact/Support
@@ -831,7 +830,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
                   for email, name in emails.items()
                   if email and email.strip()}
         own_email = session.user.email if has_request_context() and session.user else None
-        return OrderedDict(sorted(list(emails.items()), key=lambda x: (x[0] != own_email, x[1].lower())))
+        return dict(sorted(list(emails.items()), key=lambda x: (x[0] != own_email, x[1].lower())))
 
     @memoize_request
     def has_feature(self, feature):

--- a/indico/modules/events/papers/lists.py
+++ b/indico/modules/events/papers/lists.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
 from operator import attrgetter
 
 from flask import request
@@ -35,26 +34,26 @@ class PaperListGeneratorBase(ListGeneratorBase):
         track_empty = {None: _('No track')}
         session_empty = {None: _('No session')}
         type_empty = {None: _('No type')}
-        state_choices = OrderedDict((state.value, state.title) for state in PaperRevisionState)
-        unassigned_choices = OrderedDict((role.value, role.title) for role in PaperReviewingRole)
-        track_choices = OrderedDict((str(t.id), t.title) for t in sorted(self.event.tracks, key=attrgetter('title')))
-        session_choices = OrderedDict((str(s.id), s.title) for s in sorted(self.event.sessions,
-                                                                           key=attrgetter('title')))
-        type_choices = OrderedDict((str(t.id), t.name) for t in sorted(self.event.contribution_types,
-                                                                       key=attrgetter('name')))
+        state_choices = {state.value: state.title for state in PaperRevisionState}
+        unassigned_choices = {role.value: role.title for role in PaperReviewingRole}
+        track_choices = {str(t.id): t.title for t in sorted(self.event.tracks, key=attrgetter('title'))}
+        session_choices = {str(s.id): s.title for s in sorted(self.event.sessions,
+                                                              key=attrgetter('title'))}
+        type_choices = {str(t.id): t.name for t in sorted(self.event.contribution_types,
+                                                          key=attrgetter('name'))}
 
         if not event.cfp.content_reviewing_enabled:
             del unassigned_choices[PaperReviewingRole.content_reviewer.value]
         if not event.cfp.layout_reviewing_enabled:
             del unassigned_choices[PaperReviewingRole.layout_reviewer.value]
 
-        self.static_items = OrderedDict([
-            ('state', {'title': _('State'), 'filter_choices': OrderedDict(state_not_submitted | state_choices)}),
-            ('track', {'title': _('Track'), 'filter_choices': OrderedDict(track_empty | track_choices)}),
-            ('session', {'title': _('Session'), 'filter_choices': OrderedDict(session_empty | session_choices)}),
-            ('type', {'title': _('Type'), 'filter_choices': OrderedDict(type_empty | type_choices)}),
-            ('unassigned', {'title': _('Unassigned'), 'filter_choices': unassigned_choices}),
-        ])
+        self.static_items = {
+            'state': {'title': _('State'), 'filter_choices': dict(state_not_submitted | state_choices)},
+            'track': {'title': _('Track'), 'filter_choices': dict(track_empty | track_choices)},
+            'session': {'title': _('Session'), 'filter_choices': dict(session_empty | session_choices)},
+            'type': {'title': _('Type'), 'filter_choices': dict(type_empty | type_choices)},
+            'unassigned': {'title': _('Unassigned'), 'filter_choices': unassigned_choices},
+        }
         self.list_config = self._get_config()
 
     def _get_static_columns(self, ids):
@@ -186,7 +185,7 @@ class PaperJudgingAreaListGeneratorDisplay(PaperListGeneratorBase):
         }
         judging_unassigned_choices = {role.value: role.title for role in PaperReviewingRole
                                       if role is not PaperReviewingRole.judge}
-        self.static_items['unassigned']['filter_choices'] = OrderedDict(sorted(judging_unassigned_choices.items()))
+        self.static_items['unassigned']['filter_choices'] = judging_unassigned_choices
 
     def _build_query(self):
         query = super()._build_query()

--- a/indico/modules/events/papers/lists.py
+++ b/indico/modules/events/papers/lists.py
@@ -37,10 +37,8 @@ class PaperListGeneratorBase(ListGeneratorBase):
         state_choices = {state.value: state.title for state in PaperRevisionState}
         unassigned_choices = {role.value: role.title for role in PaperReviewingRole}
         track_choices = {str(t.id): t.title for t in sorted(self.event.tracks, key=attrgetter('title'))}
-        session_choices = {str(s.id): s.title for s in sorted(self.event.sessions,
-                                                              key=attrgetter('title'))}
-        type_choices = {str(t.id): t.name for t in sorted(self.event.contribution_types,
-                                                          key=attrgetter('name'))}
+        session_choices = {str(s.id): s.title for s in sorted(self.event.sessions, key=attrgetter('title'))}
+        type_choices = {str(t.id): t.name for t in sorted(self.event.contribution_types, key=attrgetter('name'))}
 
         if not event.cfp.content_reviewing_enabled:
             del unassigned_choices[PaperReviewingRole.content_reviewer.value]
@@ -48,10 +46,10 @@ class PaperListGeneratorBase(ListGeneratorBase):
             del unassigned_choices[PaperReviewingRole.layout_reviewer.value]
 
         self.static_items = {
-            'state': {'title': _('State'), 'filter_choices': dict(state_not_submitted | state_choices)},
-            'track': {'title': _('Track'), 'filter_choices': dict(track_empty | track_choices)},
-            'session': {'title': _('Session'), 'filter_choices': dict(session_empty | session_choices)},
-            'type': {'title': _('Type'), 'filter_choices': dict(type_empty | type_choices)},
+            'state': {'title': _('State'), 'filter_choices': state_not_submitted | state_choices},
+            'track': {'title': _('Track'), 'filter_choices': track_empty | track_choices},
+            'session': {'title': _('Session'), 'filter_choices': session_empty | session_choices},
+            'type': {'title': _('Type'), 'filter_choices': type_empty | type_choices},
             'unassigned': {'title': _('Unassigned'), 'filter_choices': unassigned_choices},
         }
         self.list_config = self._get_config()
@@ -183,9 +181,11 @@ class PaperJudgingAreaListGeneratorDisplay(PaperListGeneratorBase):
             'items': ('state',),
             'filters': {'items': {}}
         }
-        judging_unassigned_choices = {role.value: role.title for role in PaperReviewingRole
-                                      if role is not PaperReviewingRole.judge}
-        self.static_items['unassigned']['filter_choices'] = judging_unassigned_choices
+        self.static_items['unassigned']['filter_choices'] = {
+            role.value: role.title
+            for role in sorted(PaperReviewingRole, key=attrgetter('title'))
+            if role is not PaperReviewingRole.judge
+        }
 
     def _build_query(self):
         query = super()._build_query()

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -162,8 +162,8 @@ class RHPersonsBase(RHManageEventBase):
             event_user_roles_data = {}
             for role in event_user_roles[event_person.user]:
                 event_user_roles_data[f'custom_{role.id}'] = {'name': role.name, 'code': role.code, 'css': role.css}
-            event_user_roles_data = dict(sorted(list(event_user_roles_data.items()), key=lambda t: t[1]['code']))
-            data['roles'] = dict(data['roles'] | event_user_roles_data)
+            event_user_roles_data = dict(sorted(event_user_roles_data.items(), key=lambda t: t[1]['code']))
+            data['roles'] = data['roles'] | event_user_roles_data
 
             event_person_users.add(event_person.user)
 

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -6,7 +6,7 @@
 # LICENSE file for more details.
 
 import itertools
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 from flask import flash, jsonify, redirect, request, session
 from marshmallow import fields
@@ -94,7 +94,7 @@ class RHPersonsBase(RHManageEventBase):
         event_strategy.joinedload('person').joinedload('user')
 
         chairpersons = {link.person for link in self.event.person_links}
-        persons = defaultdict(lambda: {'roles': OrderedDict(),
+        persons = defaultdict(lambda: {'roles': {},
                                        'registrations': [],
                                        'has_event_person': True,
                                        'id_field_name': 'person_id'})
@@ -162,12 +162,12 @@ class RHPersonsBase(RHManageEventBase):
             event_user_roles_data = {}
             for role in event_user_roles[event_person.user]:
                 event_user_roles_data[f'custom_{role.id}'] = {'name': role.name, 'code': role.code, 'css': role.css}
-            event_user_roles_data = OrderedDict(sorted(list(event_user_roles_data.items()), key=lambda t: t[1]['code']))
-            data['roles'] = OrderedDict(data['roles'] | event_user_roles_data)
+            event_user_roles_data = dict(sorted(list(event_user_roles_data.items()), key=lambda t: t[1]['code']))
+            data['roles'] = dict(data['roles'] | event_user_roles_data)
 
             event_person_users.add(event_person.user)
 
-        internal_role_users = defaultdict(lambda: {'roles': OrderedDict(),
+        internal_role_users = defaultdict(lambda: {'roles': {},
                                                    'person': [],
                                                    'has_event_person': False,
                                                    'id_field_name': 'user_id'})
@@ -178,7 +178,7 @@ class RHPersonsBase(RHManageEventBase):
                 user_metadata = internal_role_users[user.email]
                 user_metadata['person'] = user
                 user_metadata['roles'][f'custom_{role.id}'] = {'name': role.name, 'code': role.code, 'css': role.css}
-            user_metadata['roles'] = OrderedDict(sorted(user_metadata['roles'].items(), key=lambda x: x[1]['code']))
+            user_metadata['roles'] = dict(sorted(user_metadata['roles'].items(), key=lambda x: x[1]['code']))
 
         # Some EventPersons will have no roles since they were connected to deleted things
         persons = {email: data for email, data in persons.items() if any(data['roles'].values())}

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -211,7 +211,7 @@ class CountryField(RegistrationFormFieldBase):
 
     @property
     def filter_choices(self):
-        return self.wtf_field_kwargs['choices']
+        return dict(self.wtf_field_kwargs['choices'])
 
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):
         if registration_data.data == 'None':

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -6,7 +6,6 @@
 # LICENSE file for more details.
 
 import mimetypes
-from collections import OrderedDict
 from datetime import datetime
 from operator import itemgetter
 
@@ -212,7 +211,7 @@ class CountryField(RegistrationFormFieldBase):
 
     @property
     def filter_choices(self):
-        return OrderedDict(self.wtf_field_kwargs['choices'])
+        return self.wtf_field_kwargs['choices']
 
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):
         if registration_data.data == 'None':

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -5,8 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
-
 from flask import request
 from sqlalchemy.orm import joinedload
 
@@ -32,31 +30,31 @@ class RegistrationListGenerator(ListGeneratorBase):
             'items': ('title', 'email', 'affiliation', 'reg_date', 'state'),
             'filters': {'fields': {}, 'items': {}}
         }
-        self.static_items = OrderedDict([
-            ('reg_date', {
+        self.static_items = {
+            'reg_date': {
                 'title': _('Registration Date'),
-            }),
-            ('price', {
+            },
+            'price': {
                 'title': _('Price'),
-            }),
-            ('state', {
+            },
+            'state': {
                 'title': _('State'),
                 'filter_choices': {str(state.value): state.title for state in RegistrationState}
-            }),
-            ('checked_in', {
+            },
+            'checked_in': {
                 'title': _('Checked in'),
                 'filter_choices': {
                     '0': _('No'),
                     '1': _('Yes')
                 }
-            }),
-            ('checked_in_date', {
+            },
+            'checked_in_date': {
                 'title': _('Check-in date'),
-            }),
-            ('payment_date', {
+            },
+            'payment_date': {
                 'title': _('Payment date'),
-            })
-        ])
+            },
+        }
         self.personal_items = ('title', 'first_name', 'last_name', 'email', 'position', 'affiliation', 'address',
                                'phone', 'country')
         self.list_config = self._get_config()

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -7,7 +7,6 @@
 
 import posixpath
 import time
-from collections import OrderedDict
 from decimal import Decimal
 from uuid import uuid4
 
@@ -374,7 +373,7 @@ class Registration(db.Model):
             for section in self.registration_form.sections:
                 if not section.is_visible:
                     continue
-                summary[section] = OrderedDict()
+                summary[section] = {}
                 for field in section.fields:
                     if not field.is_visible:
                         continue
@@ -383,11 +382,11 @@ class Registration(db.Model):
         def _fill_from_registration():
             for field, data in field_summary.items():
                 section = field.parent
-                summary.setdefault(section, OrderedDict())
+                summary.setdefault(section, {})
                 if field not in summary[section]:
                     summary[section][field] = data
 
-        summary = OrderedDict()
+        summary = {}
         field_summary = {x.field_data.field: x for x in self.data}
         _fill_from_regform()
         _fill_from_registration()

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -7,7 +7,6 @@
 
 import csv
 import itertools
-from collections import OrderedDict
 from operator import attrgetter
 
 from flask import current_app, json, session
@@ -303,17 +302,17 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
     :param static_items: Registration form information as extra columns
     """
     field_names = ['ID', 'Name']
-    special_item_mapping = OrderedDict([
-        ('reg_date', ('Registration date', lambda x: x.submitted_dt)),
-        ('state', ('Registration state', lambda x: x.state.title)),
-        ('price', ('Price', lambda x: x.render_price())),
-        ('checked_in', ('Checked in', lambda x: x.checked_in)),
-        ('checked_in_date', ('Check-in date', lambda x: x.checked_in_dt if x.checked_in else '')),
-        ('payment_date', ('Payment date', lambda x: (x.transaction.timestamp
-                                                     if (x.transaction is not None and
-                                                         x.transaction.status == TransactionStatus.successful)
-                                                     else '')))
-    ])
+    special_item_mapping = {
+        'reg_date': ('Registration date', lambda x: x.submitted_dt),
+        'state': ('Registration state', lambda x: x.state.title),
+        'price': ('Price', lambda x: x.render_price()),
+        'checked_in': ('Checked in', lambda x: x.checked_in),
+        'checked_in_date': ('Check-in date', lambda x: x.checked_in_dt if x.checked_in else ''),
+        'payment_date': ('Payment date', lambda x: (x.transaction.timestamp
+                                                    if (x.transaction is not None and
+                                                        x.transaction.status == TransactionStatus.successful)
+                                                    else '')),
+    }
     for item in regform_items:
         field_names.append(unique_col(item.title, item.id))
         if item.input_type == 'accommodation':

--- a/indico/modules/events/surveys/fields/choices.py
+++ b/indico/modules/events/surveys/fields/choices.py
@@ -6,7 +6,7 @@
 # LICENSE file for more details.
 
 import uuid
-from collections import Counter, OrderedDict
+from collections import Counter
 from copy import deepcopy
 
 from indico.modules.events.surveys.fields.base import SurveyField
@@ -38,8 +38,8 @@ class SurveySingleChoiceField(_AddUUIDMixin, SingleChoiceField, SurveyField):
             options.append(no_option)
         return {'total': total,
                 'labels': [alpha_enum(val).upper() for val in range(len(options))],
-                'absolute': OrderedDict((opt['option'], counter[opt['id']]) for opt in options),
-                'relative': OrderedDict((opt['option'], counter[opt['id']] / total) for opt in options)}
+                'absolute': {opt['option']: counter[opt['id']] for opt in options},
+                'relative': {opt['option']: counter[opt['id']] / total for opt in options}}
 
 
 class SurveyMultiSelectField(_AddUUIDMixin, MultiSelectField, SurveyField):
@@ -51,5 +51,5 @@ class SurveyMultiSelectField(_AddUUIDMixin, MultiSelectField, SurveyField):
         options = self.object.field_data['options']
         return {'total': total,
                 'labels': [alpha_enum(val).upper() for val in range(len(options))],
-                'absolute': OrderedDict((opt['option'], counter[opt['id']]) for opt in options),
-                'relative': OrderedDict((opt['option'], counter[opt['id']] / total if total else 0) for opt in options)}
+                'absolute': {opt['option']: counter[opt['id']] for opt in options},
+                'relative': {opt['option']: counter[opt['id']] / total if total else 0 for opt in options}}

--- a/indico/modules/events/surveys/fields/simple.py
+++ b/indico/modules/events/surveys/fields/simple.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import Counter, OrderedDict
+from collections import Counter
 
 from indico.modules.events.surveys.fields.base import SurveyField
 from indico.util.i18n import _
@@ -30,8 +30,8 @@ class SurveyNumberField(NumberField, SurveyField):
         results = {'total': sum(counter.elements()),
                    'max': max(counter.elements()),
                    'min': min(counter.elements()),
-                   'absolute': OrderedDict(sorted(counter.items())),
-                   'relative': OrderedDict((k, v / total_answers) for k, v in sorted(counter.items()))}
+                   'absolute': dict(sorted(counter.items())),
+                   'relative': {k: v / total_answers for k, v in sorted(counter.items())}}
         results['average'] = results['total'] / len(list(counter.elements()))
         return results
 
@@ -45,5 +45,5 @@ class SurveyBoolField(BoolField, SurveyField):
             return
         total = sum(counter.values())
         return {'total': total,
-                'absolute': OrderedDict(((_('Yes'), counter[True]), (_('No'), counter[False]))),
-                'relative': OrderedDict(((_('Yes'), counter[True] / total), (_('No'), counter[False] / total)))}
+                'absolute': {_('Yes'): counter[True], _('No'): counter[False]},
+                'relative': {_('Yes'): counter[True] / total, _('No'): counter[False] / total}}

--- a/indico/modules/events/timetable/views/weeks.py
+++ b/indico/modules/events/timetable/views/weeks.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from datetime import timedelta
 from itertools import takewhile
 
@@ -72,7 +72,7 @@ def inject_week_timetable(event, days, tz_name, tpl='events/timetable/display/_w
             # We've got a dict with a {slot: [entry, entry, ...]} mapping (for a single day)
             # We'll run over it and make some additional calculations
             day_tmp_sorted = sorted(day_tmp.items())
-            day_entries = OrderedDict()
+            day_entries = {}
             for n, (slot, slot_entries) in enumerate(day_tmp_sorted):
                 tmp_slot_entries = []
                 for entry in slot_entries:

--- a/indico/modules/rb/models/reservations.py
+++ b/indico/modules/rb/models/reservations.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from datetime import datetime
 
 from sqlalchemy import Date, Time
@@ -386,7 +386,7 @@ class Reservation(Serializer, db.Model):
             if offset:
                 query = query.offset(offset)
 
-        result = OrderedDict((r.id, {'reservation': r}) for r in query)
+        result = {r.id: {'reservation': r} for r in query}
 
         if 'occurrences' in args:
             occurrence_data = OrderedMultiDict(db.session.query(ReservationOccurrence.reservation_id,

--- a/indico/modules/rb/operations/bookings.py
+++ b/indico/modules/rb/operations/bookings.py
@@ -224,13 +224,13 @@ def get_room_calendar(start_date, end_date, room_ids, include_inactive=False, **
                                                                          explicit=True))
     dates = [d.date() for d in iterdays(start_dt, end_dt)]
 
-    calendar = { room.id: {
+    calendar = {room.id: {
         'room_id': room.id,
         'nonbookable_periods': group_nonbookable_periods(nonbookable_periods.get(room.id, []), dates),
         'unbookable_hours': unbookable_hours.get(room.id, []),
         'blockings': group_blockings(nonoverridable_blocked_rooms.get(room.id, []), dates),
         'overridable_blockings': group_blockings(overridable_blocked_rooms.get(room.id, []), dates),
-    } for room in rooms }
+    } for room in rooms}
 
     for room_id, occurrences in occurrences_by_room:
         occurrences = list(occurrences)

--- a/indico/modules/rb/operations/bookings.py
+++ b/indico/modules/rb/operations/bookings.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from datetime import date, datetime, time
 from itertools import chain, groupby
 from operator import attrgetter, itemgetter
@@ -101,7 +101,7 @@ def get_existing_rooms_occurrences(rooms, start_dt, end_dt, repeat_frequency, re
 
 def get_rooms_availability(rooms, start_dt, end_dt, repeat_frequency, repeat_interval, skip_conflicts_with=None,
                            admin_override_enabled=False, skip_past_conflicts=False):
-    availability = OrderedDict()
+    availability = {}
     candidates = ReservationOccurrence.create_series(start_dt, end_dt, (repeat_frequency, repeat_interval))
     date_range = sorted({cand.start_dt.date() for cand in candidates})
     occurrences = get_existing_rooms_occurrences(rooms, start_dt.replace(hour=0, minute=0),
@@ -224,13 +224,13 @@ def get_room_calendar(start_date, end_date, room_ids, include_inactive=False, **
                                                                          explicit=True))
     dates = [d.date() for d in iterdays(start_dt, end_dt)]
 
-    calendar = OrderedDict((room.id, {
+    calendar = { room.id: {
         'room_id': room.id,
         'nonbookable_periods': group_nonbookable_periods(nonbookable_periods.get(room.id, []), dates),
         'unbookable_hours': unbookable_hours.get(room.id, []),
         'blockings': group_blockings(nonoverridable_blocked_rooms.get(room.id, []), dates),
         'overridable_blockings': group_blockings(overridable_blocked_rooms.get(room.id, []), dates),
-    }) for room in rooms)
+    } for room in rooms }
 
     for room_id, occurrences in occurrences_by_room:
         occurrences = list(occurrences)

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -76,7 +76,7 @@ def get_related_categories(user, detailed=True):
             'managed': categ in managed,
             'path': truncate_path(categ.chain_titles[:-1], chars=50)
         }
-    return dict(sorted(list(res.items()), key=itemgetter(0)))
+    return dict(sorted(res.items(), key=itemgetter(0)))
 
 
 def get_suggested_categories(user):

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -7,7 +7,6 @@
 
 import hashlib
 import os
-from collections import OrderedDict
 from datetime import datetime
 from io import BytesIO
 from operator import itemgetter
@@ -77,7 +76,7 @@ def get_related_categories(user, detailed=True):
             'managed': categ in managed,
             'path': truncate_path(categ.chain_titles[:-1], chars=50)
         }
-    return OrderedDict(sorted(list(res.items()), key=itemgetter(0)))
+    return dict(sorted(list(res.items()), key=itemgetter(0)))
 
 
 def get_suggested_categories(user):
@@ -124,7 +123,7 @@ def get_linked_events(user, dt, limit=None, load_also=()):
     from indico.modules.events.util import (get_events_created_by, get_events_managed_by,
                                             get_events_with_linked_event_persons)
 
-    links = OrderedDict()
+    links = {}
     for event_id in get_events_registered(user, dt):
         links.setdefault(event_id, set()).add('registration_registrant')
     for event_id in get_events_with_submitted_surveys(user, dt):
@@ -147,7 +146,7 @@ def get_linked_events(user, dt, limit=None, load_also=()):
         links.setdefault(event_id, set()).update(roles)
 
     if not links:
-        return OrderedDict()
+        return {}
 
     query = (Event.query
              .filter(~Event.is_deleted,
@@ -160,7 +159,7 @@ def get_linked_events(user, dt, limit=None, load_also=()):
              .order_by(Event.start_dt, Event.id))
     if limit is not None:
         query = query.limit(limit)
-    return OrderedDict((event, links[event.id]) for event in query)
+    return {event: links[event.id] for event in query}
 
 
 def serialize_user(user):

--- a/indico/modules/vc/controllers.py
+++ b/indico/modules/vc/controllers.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 from operator import itemgetter
 
 from flask import flash, jsonify, redirect, request, session
@@ -356,6 +356,6 @@ class RHVCRoomList(RHProtected):
                                  key=lambda r: r.event.start_dt.date(),
                                  sort_by=lambda r: r.event.start_dt,
                                  sort_reverse=reverse)
-            results = OrderedDict(sorted(results.items(), key=itemgetter(0), reverse=reverse))
+            results = dict(sorted(results.items(), key=itemgetter(0), reverse=reverse))
         return WPVCService.render_template('vc_room_list.html', form=form, results=results,
                                            action=url_for('.vc_room_list'))

--- a/indico/util/date_time.py
+++ b/indico/util/date_time.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
 from datetime import datetime
 from datetime import time as dt_time
 from datetime import timedelta
@@ -166,7 +165,7 @@ def format_human_timedelta(delta, granularity='seconds', narrow=False):
     }
     if narrow:
         long_names = short_names
-    values = OrderedDict((key, 0) for key in field_order)
+    values = {key: 0 for key in field_order}
     values['seconds'] = delta.total_seconds()
     values['days'], values['seconds'] = divmod(values['seconds'], 86400)
     values['hours'], values['seconds'] = divmod(values['seconds'], 3600)
@@ -182,7 +181,7 @@ def format_human_timedelta(delta, granularity='seconds', narrow=False):
         used_fields.add(available_fields.pop(0))
     for key in available_fields:
         values[key] = 0
-    nonzero = OrderedDict((k, v) for k, v in values.items() if v)
+    nonzero = {k: v for k, v in values.items() if v}
     if not nonzero:
         return long_names[granularity](0)
     elif len(nonzero) == 1:

--- a/indico/util/rules_test.py
+++ b/indico/util/rules_test.py
@@ -5,8 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
-
 import pytest
 
 from indico.core import signals
@@ -26,7 +24,7 @@ class ActionCondition(TestCondition):
 
     @classmethod
     def get_available_values(cls, **kwargs):
-        return OrderedDict([('add', 'added'), ('del', 'deleted')])
+        return {'add': 'added', 'del': 'deleted'}
 
     @classmethod
     def check(cls, values, action, **kwargs):
@@ -40,7 +38,7 @@ class FooCondition(TestCondition):
 
     @classmethod
     def get_available_values(cls, **kwargs):
-        return OrderedDict([(1, '1'), (2, '2'), (3, '3')])
+        return {1: '1', 2: '2', 3: '3'}
 
     @classmethod
     def check(cls, values, foo, **kwargs):

--- a/indico/web/forms/fields/datetime.py
+++ b/indico/web/forms/fields/datetime.py
@@ -6,7 +6,6 @@
 # LICENSE file for more details.
 
 import json
-from collections import OrderedDict
 from datetime import time, timedelta
 
 import dateutil.parser
@@ -46,12 +45,12 @@ class TimeDeltaField(Field):
         'hours': 'Hours',
         'days': 'Days'
     }
-    magnitudes = OrderedDict([
-        ('days', 86400),
-        ('hours', 3600),
-        ('minutes', 60),
-        ('seconds', 1)
-    ])
+    magnitudes = {
+        'days': 86400,
+        'hours': 3600,
+        'minutes': 60,
+        'seconds': 1,
+    }
 
     def __init__(self, *args, **kwargs):
         self.units = kwargs.pop('units', ('hours', 'days'))
@@ -123,15 +122,15 @@ class RelativeDeltaField(Field):
         'months': 'Months',
         'years': 'Years'
     }
-    magnitudes = OrderedDict([
-        ('years', relativedelta(years=1)),
-        ('months', relativedelta(months=1)),
-        ('weeks', relativedelta(weeks=1)),
-        ('days', relativedelta(days=1)),
-        ('hours', relativedelta(hours=1)),
-        ('minutes', relativedelta(minutes=1)),
-        ('seconds', relativedelta(seconds=1))
-    ])
+    magnitudes = {
+        'years': relativedelta(years=1),
+        'months': relativedelta(months=1),
+        'weeks': relativedelta(weeks=1),
+        'days': relativedelta(days=1),
+        'hours': relativedelta(hours=1),
+        'minutes': relativedelta(minutes=1),
+        'seconds': relativedelta(seconds=1)
+    }
 
     def __init__(self, *args, **kwargs):
         self.units = kwargs.pop('units', ('hours', 'days'))

--- a/indico/web/forms/util.py
+++ b/indico/web/forms/util.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import OrderedDict
 from copy import deepcopy
 
 from wtforms.fields.core import UnboundField
@@ -63,6 +62,6 @@ def inject_validators(form, field_name, validators, early=False):
         unbound.kwargs['validators'] = validators
     setattr(form, field_name, unbound)
     if form._unbound_fields is not None:
-        unbound_fields = OrderedDict(form._unbound_fields)
+        unbound_fields = dict(form._unbound_fields)
         unbound_fields[field_name] = unbound
         form._unbound_fields = list(unbound_fields.items())


### PR DESCRIPTION
Fixes #4703. Changes:
* Replace all `OrderedDict` instances with normal `dict`s.
* Remove the `OrderedDictConverter` class.

I have also removed the `OrderedDict` constructor calls where unnecessary, but I may have missed some spots (hopefully not).

`pytest` looks OK, but I haven't tested every single change on the locally deployed site.

I can also send a PR for `plugins-cern` if we need the same changes there too.