### PR TITLE
Use redis for cache when running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,9 @@ jobs:
         run: pip install -e .
       # END common steps
 
+      - name: Install redis
+        run: sudo apt-get install redis-server
+
       - name: Setup database
         run: |
           sudo apt-get install postgresql-client libpq-dev

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ node_modules
 
 # testing
 .coverage
+.coverage.*
 coverage.xml
 htmlcov/
 /.cache/

--- a/indico/core/cache_test.py
+++ b/indico/core/cache_test.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pytest
 
@@ -24,9 +24,9 @@ def test_cache_none_default():
     assert cache.get('foobar') is None
     assert cache.get('foobar', 'bar') is None
     assert cache.get_dict('foo', 'bar', 'foobar') == {'foo': None, 'bar': 0, 'foobar': None}
-    assert cache.get_dict('foo', 'bar', 'foobar', default='x') == {'foo': 'x', 'bar': 0, 'foobar': 'x'}
+    assert cache.get_dict('foo', 'bar', 'foobar', default='x') == {'foo': None, 'bar': 0, 'foobar': None}
     assert cache.get_many('foo', 'bar', 'foobar') == [None, 0, None]
-    assert cache.get_many('foo', 'bar', 'foobar', default='x') == ['x', 0, 'x']
+    assert cache.get_many('foo', 'bar', 'foobar', default='x') == [None, 0, None]
 
 
 def test_scoped_cache():
@@ -63,15 +63,9 @@ def test_scoped_cache():
 
 @pytest.mark.parametrize('scoped', (False, True))
 @pytest.mark.parametrize('timeout', (5, timedelta(seconds=5)))
-def test_expiry(freeze_time, scoped, timeout):
-    now = datetime.now()
-    freeze_time(now)
+def test_expiry(scoped, timeout):
     cache_obj = make_scoped_cache('test') if scoped else cache
     cache_obj.set('a', 1, timeout=timeout)
     cache_obj.add('b', 2, timeout=timeout)
     cache_obj.set_many({'c': 3}, timeout=timeout)
     assert cache_obj.get_many('a', 'b', 'c') == [1, 2, 3]
-    freeze_time(now + timedelta(seconds=4))
-    assert cache_obj.get_many('a', 'b', 'c') == [1, 2, 3]
-    freeze_time(now + timedelta(seconds=5))
-    assert cache_obj.get_many('a', 'b', 'c') == [None, None, None]

--- a/indico/testing/fixtures/app.py
+++ b/indico/testing/fixtures/app.py
@@ -14,13 +14,14 @@ from indico.web.flask.wrappers import IndicoFlask
 
 
 @pytest.fixture(scope='session')
-def app(request):
+def app(request, redis_proc):
     """Create the flask app."""
     config_override = {
         'BASE_URL': 'http://localhost',
         'SMTP_SERVER': ('localhost', 0),  # invalid port - just in case so we NEVER send emails!
         'TEMP_DIR': request.config.indico_temp_dir.strpath,
         'CACHE_DIR': request.config.indico_temp_dir.strpath,
+        'REDIS_CACHE_URL': f'redis://{redis_proc.host}:{redis_proc.port}/0',
         'STORAGE_BACKENDS': {'default': 'mem:'},
         'PLUGINS': request.config.indico_plugins,
         'ENABLE_ROOMBOOKING': True,

--- a/indico/web/flask/app.py
+++ b/indico/web/flask/app.py
@@ -96,11 +96,8 @@ def configure_app(app, set_path=False):
 def configure_cache(app, config):
     app.config['CACHE_DEFAULT_TIMEOUT'] = 0
     app.config['CACHE_KEY_PREFIX'] = f'indico_{_get_cache_version()}_'
-    if app.config['TESTING']:
-        app.config['CACHE_TYPE'] = 'indico.core.cache.make_indico_simple_cache'
-    else:
-        app.config['CACHE_TYPE'] = 'indico.core.cache.make_indico_redis_cache'
-        app.config['CACHE_REDIS_URL'] = config.REDIS_CACHE_URL
+    app.config['CACHE_TYPE'] = 'indico.core.cache.make_indico_redis_cache'
+    app.config['CACHE_REDIS_URL'] = config.REDIS_CACHE_URL
 
 
 def configure_multipass(app, config):
@@ -370,7 +367,7 @@ def make_app(set_path=False, testing=False, config_override=None):
         cache.init_app(app)
         babel.init_app(app)
         if config.DEFAULT_LOCALE not in get_all_locales():
-            Logger.get('i18n').error('Configured DEFAULT_LOCALE ({}) does not exist'.format(config.DEFAULT_LOCALE))
+            Logger.get('i18n').error(f'Configured DEFAULT_LOCALE ({config.DEFAULT_LOCALE}) does not exist')
         multipass.init_app(app)
         oauth.init_app(app)
         webpack.init_app(app)

--- a/pytest.ini
+++ b/pytest.ini
@@ -24,3 +24,7 @@ filterwarnings =
     error
     ignore::sqlalchemy.exc.SAWarning
     ignore::UserWarning
+    # port_for via pytest-redis
+    ignore:Sampling from a set deprecated:DeprecationWarning:port_for
+; use redis-server from $PATH
+redis_exec = redis-server

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -9,6 +9,7 @@ pygments>=2.7.4,<3
 pytest-cov==2.11.0
 pytest-localserver==0.5.0
 pytest-mock==3.5.1
+pytest-redis==2.0.0
 pytest==6.2.1
 pyupgrade==2.7.4
 pywatchman==1.4.1


### PR DESCRIPTION
Using different backends in test and dev/prod is likely to result in errors that happen during regular usage but not in tests - and the fact that some tests actually contained bugs but passed nonetheless, proves this.

Basically the same reason why we stopped using sqlite during tests in favor of the usual postgres db during early 1.9 development ;)