### PR TITLE
Fix: Class RHRegistrationDisplayEdit check_access exception

### DIFF
--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -325,7 +325,7 @@ class RHRegistrationDisplayEdit(RegistrationEditMixin, RHRegistrationFormRegistr
 
     def _check_access(self):
         RHRegistrationFormRegistrationBase._check_access(self)
-        if not self.registration.can_be_modified:
+        if self.registration and not self.registration.can_be_modified:
             raise Forbidden
 
     def _process_args(self):


### PR DESCRIPTION
Traceback --
```sh
2021-02-19 09:26:38,349  7e640969791d42b4  -       indico.flask - ERROR errors.py:99 -- 'NoneType' object has no attribute 'is_active'

Traceback (most recent call last):
  File "/nas/indico.un/v2/env2/lib/python2.7/site-packages/flask/app.py", line 1950, in full_dispatch_request
    rv = self.dispatch_request()
  File "/nas/indico.un/v2/env2/lib/python2.7/site-packages/flask/app.py", line 1936, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/nas/indico.un/v2/indico-un/indico/indico/web/flask/util.py", line 83, in wrapper
    return obj().process()
  File "./un/util/permissions/patches.py", line 260, in process
    ret = super(_RH, self).process()
  File "/nas/indico.un/v2/indico-un/indico/indico/web/rh.py", line 275, in process
    res = self._do_process()
  File "/nas/indico.un/v2/indico-un/indico/indico/modules/events/controllers/base.py", line 88, in _do_process
    return RHEventBase._do_process(self)
  File "./un/util/permissions/patches.py", line 208, in _do_process
    self._check_access()
  File "/nas/indico.un/v2/indico-un/indico/indico/modules/events/registration/controllers/display.py", line 329, in _check_access
    if not self.registration.is_active:
AttributeError: 'NoneType' object has no attribute 'is_active'

{u'data': {u'get': {},
           u'headers': {'Accept': u'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
                        'Accept-Encoding': u'gzip, deflate, br',
                        'Accept-Language': u'it-IT,it;q=0.9,en-US;q=0.8,en;q=0.7',
                        'Connection': u'close',
                        'Cookie': u'_ga=',
                        'Host': u'indico.un.org',
                        'Referer': u'https://indico.un.org/event/xx/registrations/xx/edit',
                        'Sec-Fetch-Dest': u'document',
                        'Sec-Fetch-Mode': u'navigate',
                        'Sec-Fetch-Site': u'same-origin',
                        'Sec-Fetch-User': u'?1',
                        'Upgrade-Insecure-Requests': u'1',
                        'User-Agent': u'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36',
                        'X-Forwarded-For': u'',
                        'X-Forwarded-Host': u'indico.un.org',
                        'X-Forwarded-Proto': u'https',
                        'X-Forwarded-Ssl': u'on',
                        'X-Real-Ip': u''},
           u'json': None,
           u'post': {},
           u'url': {'confId': u'xx', 'reg_form_id': xx}},
 u'endpoint': u'event_registration.edit_registration_display',
 u'id': '7e640969791d42b4',
 u'ip': '10.130.3.7',
 u'method': 'GET',
 u'referrer': 'https://indico.un.org/event/xx/registrations/xx/edit',
 u'rh': 'RHRegistrationDisplayEdit',
 u'time': '2021-02-19T09:26:38.375152',
 u'url': u'https://indico.un.org/event/xx/registrations/xx/edit',
 u'user': None,
 u'user_agent': u'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36'}
```