### PR TITLE
Unify handling of the current user of a request

### DIFF
--- a/indico/core/oauth/oauth2_test.py
+++ b/indico/core/oauth/oauth2_test.py
@@ -75,7 +75,7 @@ def test_oauth_flows(create_application, test_client, dummy_user, app, trusted, 
                                                             code_verifier=code_verifier)
 
     with test_client.session_transaction() as sess:
-        sess.user = dummy_user
+        sess.set_session_user(dummy_user)
 
     # get consent page
     resp = test_client.get(auth_url)
@@ -121,7 +121,7 @@ def test_pkce_disabled(dummy_application, test_client, dummy_user, pkce_enabled)
                                 redirect_uri=dummy_application.default_redirect_uri)
 
     with test_client.session_transaction() as sess:
-        sess.user = dummy_user
+        sess.set_session_user(dummy_user)
 
     code_verifier = generate_token(64)
     auth_endpoint = url_for('oauth.oauth_authorize', _external=True)
@@ -153,7 +153,7 @@ def test_no_implicit_flow(dummy_application, test_client, dummy_user):
     auth_url = oauth_client.create_authorization_url(url_for('oauth.oauth_authorize', _external=True))[0]
 
     with test_client.session_transaction() as sess:
-        sess.user = dummy_user
+        sess.set_session_user(dummy_user)
 
     resp = test_client.get(auth_url)
     assert b'unauthorized_client' in resp.data
@@ -179,7 +179,7 @@ def test_checkin_app_implicit_flow(test_client, dummy_user):
     auth_url = oauth_client.create_authorization_url(url_for('oauth.oauth_authorize', _external=True))[0]
 
     with test_client.session_transaction() as sess:
-        sess.user = dummy_user
+        sess.set_session_user(dummy_user)
 
     resp = test_client.get(auth_url)
     assert resp.status_code == 302
@@ -208,7 +208,7 @@ def test_oauth_scopes(create_application, test_client, dummy_user, app):
                                 redirect_uri=oauth_app.default_redirect_uri)
 
     with test_client.session_transaction() as sess:
-        sess.user = dummy_user
+        sess.set_session_user(dummy_user)
 
     auth_endpoint = url_for('oauth.oauth_authorize', _external=True)
     auth_url = oauth_client.create_authorization_url(auth_endpoint, scope='read:legacy_api')[0]

--- a/indico/core/oauth/scopes.py
+++ b/indico/core/oauth/scopes.py
@@ -12,5 +12,7 @@ SCOPES = {
     'read:user': _("User information (read only)"),
     'read:legacy_api': _('Legacy API (read only)'),
     'write:legacy_api': _('Legacy API (write only)'),
-    'registrants': _('Event registrants')
+    'registrants': _('Event registrants'),
+    'read:everything': _('Everything (only GET)'),
+    'full:everything': _('Everything (all methods)'),
 }

--- a/indico/modules/attachments/controllers/display/event_test.py
+++ b/indico/modules/attachments/controllers/display/event_test.py
@@ -33,7 +33,7 @@ def _make_attachment(user, obj):
 
 @pytest.fixture
 def attachment_access_test_env(request_context, dummy_user, dummy_event, dummy_session, create_contribution):
-    session.user = dummy_user
+    session.set_session_user(dummy_user)
     session_contrib = create_contribution(dummy_event, 'Session Contrib', session=dummy_session)
     standalone_contrib = create_contribution(dummy_event, 'Standalone Contrib')
     event_attachment = _make_attachment(dummy_user, dummy_event)

--- a/indico/modules/auth/__init__.py
+++ b/indico/modules/auth/__init__.py
@@ -89,7 +89,7 @@ def login_user(user, identity=None, admin_impersonation=False):
         session.timezone = user.settings.get('timezone', config.DEFAULT_TIMEZONE)
     else:
         session.timezone = 'LOCAL'
-    session.user = user
+    session.set_session_user(user)
     session.lang = user.settings.get('lang')
     if not admin_impersonation:
         if identity:

--- a/indico/modules/auth/util.py
+++ b/indico/modules/auth/util.py
@@ -87,7 +87,7 @@ def undo_impersonate_user():
         return
     user = User.get_or_404(entry['user_id'])
     logger.info('Admin %r stopped impersonating user %r', user, session.user)
-    session.user = user
+    session.set_session_user(user)
     session.update(entry['session_data'])
 
 

--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -39,7 +39,7 @@ from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults
 from indico.web.rh import RH, RHProtected
-from indico.web.util import signed_url_for
+from indico.web.util import signed_url_for, signed_url_for_user
 
 
 class RHContact(RH):
@@ -287,7 +287,12 @@ class RHSignURL(RHProtected):
         url_params = {k: v for k, v in url_params.items() if not k.startswith('_')}
         query_params = request.json.get('query_params', {})
         query_params = {k: v for k, v in query_params.items() if not k.startswith('_')}
-        url = signed_url_for(session.user, endpoint, url_params=url_params, _external=True, **query_params)
+        if 'user_id' in url_params:
+            # TODO: get rid of this
+            url = signed_url_for(session.user, endpoint, url_params=url_params, _external=True, **query_params)
+        else:
+            url = signed_url_for_user(session.user, endpoint, _external=True, **query_params)
+        # XXX should we really log the signed urls, token included?
         Logger.get('url_signing').info("%s signed URL for endpoint '%s' (%s)", session.user, endpoint, url)
         return jsonify(url=url)
 

--- a/indico/modules/events/controllers/base_test.py
+++ b/indico/modules/events/controllers/base_test.py
@@ -32,7 +32,7 @@ def test_event_protected_access(db, create_user, create_event):
     with pytest.raises(Forbidden):
         rh._check_access()
     user = create_user(1)
-    session.user = user
+    session.set_session_user(user)
     with pytest.raises(Forbidden):
         rh._check_access()
     rh.event.update_principal(user, read_access=True)
@@ -51,5 +51,5 @@ def test_event_key_access(create_user, create_event):
 
     user = create_user(1)
     rh.event.update_principal(user, read_access=True)
-    session.user = user
+    session.set_session_user(user)
     rh._check_access()

--- a/indico/modules/events/registration/api.py
+++ b/indico/modules/events/registration/api.py
@@ -5,28 +5,24 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from authlib.integrations.flask_oauth2 import current_token
-from flask import jsonify, request
+from flask import jsonify, request, session
 from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import BadRequest, Forbidden
 
 from indico.core import signals
-from indico.core.oauth import require_oauth
 from indico.modules.events.controllers.base import RHProtectedEventBase
 from indico.modules.events.models.events import Event
 from indico.modules.events.registration.models.registrations import RegistrationState
 from indico.modules.events.registration.util import build_registration_api_data, build_registrations_api_data
-from indico.web.rh import RH
+from indico.web.rh import RH, oauth_scope
 
 
+@oauth_scope('registrants')
 class RHAPIRegistrant(RH):
     """RESTful registrant API."""
 
-    CSRF_ENABLED = False
-
-    @require_oauth('registrants')
     def _check_access(self):
-        if not self.event.can_manage(current_token.user, permission='registration'):
+        if not self.event.can_manage(session.user, permission='registration'):
             raise Forbidden()
 
     def _process_args(self):
@@ -57,12 +53,12 @@ class RHAPIRegistrant(RH):
         return jsonify(build_registration_api_data(self._registration))
 
 
+@oauth_scope('registrants')
 class RHAPIRegistrants(RH):
     """RESTful registrants API."""
 
-    @require_oauth('registrants')
     def _check_access(self):
-        if not self.event.can_manage(current_token.user, permission='registration'):
+        if not self.event.can_manage(session.user, permission='registration'):
             raise Forbidden()
 
     def _process_args(self):

--- a/indico/modules/events/registration/controllers/display_test.py
+++ b/indico/modules/events/registration/controllers/display_test.py
@@ -31,13 +31,13 @@ def test_RHRegistrationForm_can_register(db, dummy_regform, dummy_reg, dummy_use
     assert not rh._can_register()  # not open
     dummy_regform.start_dt = now_utc(False)
     assert rh._can_register()
-    session.user = dummy_user  # registered in dummy_reg
+    session.set_session_user(dummy_user)  # registered in dummy_reg
     assert not rh._can_register()
     dummy_reg.state = RegistrationState.rejected
     assert not rh._can_register()  # being rejected does not allow registering again
     dummy_reg.state = RegistrationState.withdrawn
     assert not rh._can_register()  # being withdrawn does not allow registering again
-    session.user = create_user(123, email='user@example.com')
+    session.set_session_user(create_user(123, email='user@example.com'))
     assert rh._can_register()
     dummy_regform.registration_limit = 1
     assert rh._can_register()  # withdrawn/rejected do not count against limit

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -413,7 +413,7 @@ def _build_base_registration_info(registration):
         'registrant_id': str(registration.id),
         'checked_in': registration.checked_in,
         'checkin_secret': registration.ticket_uuid,
-        'full_name': '{} {}'.format(personal_data.get('title', ''), registration.full_name),
+        'full_name': '{} {}'.format(personal_data.get('title', ''), registration.full_name).strip(),
         'personal_data': personal_data
     }
 

--- a/indico/modules/users/api.py
+++ b/indico/modules/users/api.py
@@ -5,20 +5,22 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from authlib.integrations.flask_oauth2 import current_token
-from flask import jsonify
+from flask import jsonify, session
 
-from indico.core.oauth import require_oauth
 from indico.modules.users import User
 from indico.web.http_api.hooks.base import HTTPAPIHook
 from indico.web.http_api.responses import HTTPAPIError
+from indico.web.rh import RH, oauth_scope
 
 
-@require_oauth('read:user')
-def fetch_authenticated_user():
-    user = current_token.user
-    return jsonify(id=user.id, email=user.email, first_name=user.first_name, last_name=user.last_name,
-                   admin=user.is_admin)
+@oauth_scope('read:user')
+class RHUserAPI(RH):
+    def _process(self):
+        user = session.user
+        if not user:
+            return jsonify(None)
+        return jsonify(id=user.id, email=user.email, first_name=user.first_name, last_name=user.last_name,
+                       admin=user.is_admin)
 
 
 @HTTPAPIHook.register

--- a/indico/modules/users/blueprint.py
+++ b/indico/modules/users/blueprint.py
@@ -54,7 +54,6 @@ with _bp.add_prefixed_rules('/<int:user_id>'):
     _bp.add_url_rule('/profile/picture', 'save_profile_picture', RHSaveProfilePicture, methods=('POST',))
     _bp.add_url_rule('/profile/picture/preview/<any(standard,gravatar,identicon,custom):source>',
                      'profile_picture_preview', RHProfilePicturePreview)
-    _bp.add_url_rule('/picture-<slug>', 'user_profile_picture_display', RHProfilePictureDisplay)
     _bp.add_url_rule('/preferences/', 'user_preferences', RHUserPreferences, methods=('GET', 'POST'))
     _bp.add_url_rule('/favorites/', 'user_favorites', RHUserFavorites)
     _bp.add_url_rule('/api/favorites/users', 'favorites_api', RHUserFavoritesAPI)
@@ -71,6 +70,7 @@ with _bp.add_prefixed_rules('/<int:user_id>'):
 
 _bp.add_url_rule('/dashboard.ics', 'export_dashboard_ics', RHExportDashboardICS)
 _bp.add_url_rule('/<int:user_id>/dashboard.ics', 'export_dashboard_ics_legacy', RHExportDashboardICSLegacy)
+_bp.add_url_rule('/<int:user_id>/picture-<slug>', 'user_profile_picture_display', RHProfilePictureDisplay)
 
 # User search
 _bp.add_url_rule('/search/info', 'user_search_info', RHUserSearchInfo)

--- a/indico/modules/users/blueprint.py
+++ b/indico/modules/users/blueprint.py
@@ -7,7 +7,7 @@
 
 from flask import request
 
-from indico.modules.users.api import fetch_authenticated_user
+from indico.modules.users.api import RHUserAPI
 from indico.modules.users.controllers import (RHAcceptRegistrationRequest, RHAdmins, RHExportDashboardICS,
                                               RHExportDashboardICSLegacy, RHPersonalData, RHProfilePictureDisplay,
                                               RHProfilePicturePage, RHProfilePicturePreview, RHRegistrationRequestList,
@@ -77,7 +77,7 @@ _bp.add_url_rule('/search/info', 'user_search_info', RHUserSearchInfo)
 _bp.add_url_rule('/search/', 'user_search', RHUserSearch)
 
 # Users API
-_bp.add_url_rule('!/api/user/', 'authenticated_user', fetch_authenticated_user)
+_bp.add_url_rule('!/api/user/', 'authenticated_user', RHUserAPI)
 
 
 @_bp.url_defaults

--- a/indico/modules/users/blueprint.py
+++ b/indico/modules/users/blueprint.py
@@ -9,8 +9,8 @@ from flask import request
 
 from indico.modules.users.api import fetch_authenticated_user
 from indico.modules.users.controllers import (RHAcceptRegistrationRequest, RHAdmins, RHExportDashboardICS,
-                                              RHPersonalData, RHProfilePictureDisplay, RHProfilePicturePage,
-                                              RHProfilePicturePreview, RHRegistrationRequestList,
+                                              RHExportDashboardICSLegacy, RHPersonalData, RHProfilePictureDisplay,
+                                              RHProfilePicturePage, RHProfilePicturePreview, RHRegistrationRequestList,
                                               RHRejectRegistrationRequest, RHSaveProfilePicture, RHUserBlock,
                                               RHUserDashboard, RHUserEmails, RHUserEmailsDelete, RHUserEmailsSetPrimary,
                                               RHUserEmailsVerify, RHUserFavorites, RHUserFavoritesAPI,
@@ -69,7 +69,8 @@ with _bp.add_prefixed_rules('/<int:user_id>'):
     _bp.add_url_rule('/emails/make-primary', 'user_emails_set_primary', RHUserEmailsSetPrimary, methods=('POST',))
     _bp.add_url_rule('/blocked', 'user_block', RHUserBlock, methods=('PUT', 'DELETE'))
 
-_bp.add_url_rule('/<int:user_id>/dashboard.ics', 'export_dashboard_ics', RHExportDashboardICS)
+_bp.add_url_rule('/dashboard.ics', 'export_dashboard_ics', RHExportDashboardICS)
+_bp.add_url_rule('/<int:user_id>/dashboard.ics', 'export_dashboard_ics_legacy', RHExportDashboardICSLegacy)
 
 # User search
 _bp.add_url_rule('/search/info', 'user_search_info', RHUserSearchInfo)

--- a/indico/modules/users/client/js/ICSCalendarLink.jsx
+++ b/indico/modules/users/client/js/ICSCalendarLink.jsx
@@ -15,7 +15,7 @@ import {Translate} from 'indico/react/i18n';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {snakifyKeys} from 'indico/utils/case';
 
-export default function ICSCalendarLink({endpoint, urlParams, options, ...restProps}) {
+export default function ICSCalendarLink({endpoint, params, options, ...restProps}) {
   const [copied, setCopied] = useState(false);
   const [option, setOption] = useState(null);
   const [open, setOpen] = useState(false);
@@ -30,11 +30,14 @@ export default function ICSCalendarLink({endpoint, urlParams, options, ...restPr
     />
   );
 
-  const fetchURL = async queryParams => {
+  const fetchURL = async extraParams => {
     try {
       const {
         data: {url: signedURL},
-      } = await indicoAxios.post(signURL(), snakifyKeys({endpoint, urlParams, queryParams}));
+      } = await indicoAxios.post(
+        signURL(),
+        snakifyKeys({endpoint, params: {...params, ...extraParams}})
+      );
       return signedURL;
     } catch (error) {
       handleAxiosError(error);
@@ -58,14 +61,14 @@ export default function ICSCalendarLink({endpoint, urlParams, options, ...restPr
           <Translate>Synchronise with your calendar</Translate>
         </Dropdown.Header>
         <Dropdown.Divider />
-        {options.map(({key, text, queryParams}) => (
+        {options.map(({key, text, extraParams}) => (
           <Dropdown.Item
             key={key}
             text={text}
             onClick={async () => {
               setOption({
                 text,
-                url: await fetchURL(queryParams),
+                url: await fetchURL(extraParams),
               });
               setOpen(true);
             }}
@@ -126,17 +129,17 @@ export default function ICSCalendarLink({endpoint, urlParams, options, ...restPr
 
 ICSCalendarLink.propTypes = {
   endpoint: PropTypes.string.isRequired,
-  urlParams: PropTypes.objectOf(PropTypes.string),
+  params: PropTypes.objectOf(PropTypes.string),
   options: PropTypes.arrayOf(
     PropTypes.shape({
       key: PropTypes.string.isRequired,
       text: PropTypes.string.isRequired,
-      queryParams: PropTypes.objectOf(PropTypes.string),
+      extraParams: PropTypes.objectOf(PropTypes.string),
     })
   ),
 };
 
 ICSCalendarLink.defaultProps = {
-  urlParams: {},
+  params: {},
   options: [],
 };

--- a/indico/modules/users/client/js/dashboard.jsx
+++ b/indico/modules/users/client/js/dashboard.jsx
@@ -13,19 +13,17 @@ import {Translate} from 'indico/react/i18n';
 import ICSCalendarLink from './ICSCalendarLink';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const userId = document.querySelector('body').dataset.userId;
   ReactDOM.render(
     <ICSCalendarLink
       endpoint="users.export_dashboard_ics"
-      urlParams={{user_id: userId}}
       options={[
-        {key: 'events', text: Translate.string('Events at hand'), queryParams: {include: 'linked'}},
+        {key: 'events', text: Translate.string('Events at hand'), extraParams: {include: 'linked'}},
         {
           key: 'categories',
           text: Translate.string('Categories'),
-          queryParams: {include: 'categories'},
+          extraParams: {include: 'categories'},
         },
-        {key: 'everything', text: Translate.string('Everything'), queryParams: {}},
+        {key: 'everything', text: Translate.string('Everything'), extraParams: {}},
       ]}
     />,
     document.querySelector('#dashboard-calendar-link')

--- a/indico/testing/fixtures/app.py
+++ b/indico/testing/fixtures/app.py
@@ -47,9 +47,16 @@ def request_context(app_context):
 
 
 @pytest.fixture
-def test_client(app, mocker):
-    """Create a flask request context."""
+def make_test_client(app, mocker):
+    """Return a factory for test clients."""
     mocker.patch.object(_FlaskWebpackExtState, 'manifest')
     mocker.patch.object(IndicoFlask, 'manifest')
-    with app.test_client() as c:
+
+    return app.test_client
+
+
+@pytest.fixture
+def test_client(make_test_client):
+    """Create a flask test client."""
+    with make_test_client() as c:
         yield c

--- a/indico/web/flask/errors.py
+++ b/indico/web/flask/errors.py
@@ -8,7 +8,7 @@
 import os
 import traceback
 
-from flask import current_app, jsonify, request, session
+from flask import current_app, g, jsonify, request, session
 from itsdangerous import BadData
 from sqlalchemy.exc import DatabaseError
 from werkzeug.exceptions import BadRequestKeyError, Forbidden, HTTPException, UnprocessableEntity
@@ -29,7 +29,8 @@ errors_bp = IndicoBlueprint('errors', __name__)
 def handle_forbidden(exc):
     if exc.response:
         return exc
-    if session.user is None and not request.is_xhr and not request.is_json and request.blueprint != 'auth':
+    if (session.user is None and not request.is_xhr and not request.is_json and request.blueprint != 'auth' and
+            not g.get('get_request_user_failed')):
         return redirect_to_login(reason=_('Please log in to access this page.'))
     return render_error(exc, _('Access Denied'), get_error_description(exc), exc.code)
 

--- a/indico/web/flask/util.py
+++ b/indico/web/flask/util.py
@@ -154,6 +154,7 @@ def url_for(endpoint, *targets, **values):
             values[key] = int(value)
 
     values.setdefault('_external', False)
+    values = dict(sorted(values.items()))
     url = _url_for(endpoint, **values)
     if g.get('static_site') and 'custom_manifests' in g and not values.get('_external'):
         # for static sites we assume all relative urls need to be

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -30,7 +30,7 @@ from indico.util.i18n import _
 from indico.util.locators import get_locator
 from indico.util.signals import values_from_signal
 from indico.web.flask.util import url_for
-from indico.web.util import get_request_user, is_signed_url_valid
+from indico.web.util import get_request_user
 
 
 HTTP_VERBS = {'GET', 'PATCH', 'POST', 'PUT', 'DELETE'}
@@ -344,18 +344,6 @@ class RHProtected(RH):
 class RequireUserMixin:
     def _check_access(self):
         if session.user is None:
-            raise Forbidden
-
-
-class RHTokenProtected(RH):
-    """A request handler which is protected through a signature token parameter."""
-
-    def _process_args(self):
-        self.user = db.m.User.get_or_404(request.view_args['user_id'])
-
-    def _check_access(self):
-        token = request.args.get('token')
-        if not token or not is_signed_url_valid(self.user, request.full_path):
             raise Forbidden
 
 

--- a/indico/web/util.py
+++ b/indico/web/util.py
@@ -296,7 +296,7 @@ def get_oauth_user(scopes):
     try:
         oauth_token = require_oauth.acquire_token(scopes)
     except OAuth2Error as exc:
-        raise BadRequest(f'OAuth error: {exc}')
+        require_oauth.raise_error_response(exc)
     return oauth_token.user
 
 

--- a/indico/web/util.py
+++ b/indico/web/util.py
@@ -309,7 +309,7 @@ def _lookup_request_user(allow_signed_url=False, oauth_scope_hint=None):
 
     signed_url_user = verify_signed_user_url(request.full_path, request.method)
     oauth_user = get_oauth_user(oauth_scopes)
-    session_user = session._session_user
+    session_user = session.get_session_user()
 
     if oauth_user:
         if signed_url_user:

--- a/indico/web/util.py
+++ b/indico/web/util.py
@@ -184,25 +184,14 @@ def url_for_index(_external=False, _anchor=None):
     return url_for('categories.display', _external=_external, _anchor=_anchor)
 
 
-def signed_url_for(user, blueprint, url_params=None, *args, **kwargs):
-    """Get a URL from a blueprint, which is signed using a user's signing secret."""
-    from indico.web.flask.util import url_for
-    _external = kwargs.pop('_external', False)
-    base_url = url_for(blueprint, *args, **(url_params or {}))
-    qs = url_encode(sorted(kwargs.items()))
-    # this is the URL which is to be signed
-    url = f'{base_url}?{qs}' if qs else base_url
+def is_legacy_signed_url_valid(user, url):
+    """Check whether a legacy signed URL is valid for a user.
 
-    signer = Signer(user.signing_secret.encode(), salt='url-signing')
-    qs = url_encode(dict(kwargs, token=signer.get_signature(url)))
-    full_base_url = url_for(blueprint, *args, _external=_external, **(url_params or {}))
-
-    # this is the final URL including the signature ('token' parameter)
-    return f'{full_base_url}?{qs}' if qs else base_url
-
-
-def is_signed_url_valid(user, url):
-    """Check whether a signed URL is valid according to the user's signing secret."""
+    This util is deprecated and only exists because people may be actively
+    using URLs using the old style token. Any new code should use the new
+    :func:`signed_url_for_user` and :func:`verify_signed_user_url` utils
+    which encode the user id within the signature.
+    """
     parsed = url_parse(url)
     params = url_decode(parsed.query)
     try:

--- a/indico/web/util.py
+++ b/indico/web/util.py
@@ -331,8 +331,7 @@ def _lookup_request_user(allow_signed_url=False, oauth_scope_hint=None):
 
 
 def _request_likely_seen_by_user():
-    # TODO: exclude json requests as well
-    return not request.is_xhr and request.blueprint != 'assets'
+    return not request.is_xhr and not request.is_json and request.blueprint != 'assets'
 
 
 def _check_request_user(user, source):

--- a/indico/web/util.py
+++ b/indico/web/util.py
@@ -301,14 +301,6 @@ def get_oauth_user(scopes):
 
 
 def _lookup_request_user(allow_signed_url=False, oauth_scope_hint=None):
-    # explicitly-set user
-    # XXX we may not need this, and the legacy api won't need it either - but oauth
-    # APIs should probably use it!
-    try:
-        return g.current_user, g.current_user_source
-    except AttributeError:
-        pass
-
     oauth_scopes = [oauth_scope_hint] if oauth_scope_hint else []
     if request.method == 'GET':
         oauth_scopes += ['read:everything', 'full:everything']
@@ -386,8 +378,6 @@ def get_request_user():
 
     - an OAuth token
     - a signature for a persistent url
-    - an explicitly-set user (for legacy code that authenticates users
-      through other means such as the HTTPAPI)
     """
 
     if g.get('get_request_user_failed'):
@@ -420,21 +410,3 @@ def get_request_user():
         raise
 
     return user, source
-
-
-def override_request_user(user, source):
-    """Override the user associated with the request.
-
-    This is only meant for special usecases where the request should be
-    processed for a different user than the one which would be usually
-    used (regardless of where that one is coming from, usually it's the
-    session).
-
-    If the current user for the request has already been retrieved, setting
-    a different user through this function will fail.
-    """
-
-    if 'current_user' in g:
-        raise RuntimeError(f'Cannot set request user to {user}; already set to {g.current_user}')
-    g.current_user = user
-    g.current_user_source = source

--- a/indico/web/util.py
+++ b/indico/web/util.py
@@ -286,7 +286,12 @@ def verify_signed_user_url(url, method):
 
 def get_oauth_user(scopes):
     from indico.core.oauth import require_oauth
-    if not request.headers.get('Authorization', '').lower().startswith('bearer '):
+    if (
+        not request.headers.get('Authorization', '').lower().startswith('bearer ') and
+        # TODO: remove the check below once indico-checkin no longer sends tokens in
+        # the query string!
+        'access_token' not in request.args
+    ):
         return None
     try:
         oauth_token = require_oauth.acquire_token(scopes)

--- a/indico/web/util_test.py
+++ b/indico/web/util_test.py
@@ -153,7 +153,7 @@ def test_get_oauth_user_oauth(mocker, dummy_user):
 @pytest.mark.usefixtures('request_context')
 def test_lookup_request_user_session(dummy_user):
     assert _lookup_request_user() == (None, None)
-    session.user = dummy_user
+    session.set_session_user(dummy_user)
     assert _lookup_request_user() == (dummy_user, 'session')
 
 
@@ -161,7 +161,7 @@ def test_lookup_request_user_session(dummy_user):
 def test_lookup_request_user_signed_url(create_user, dummy_user, mocker):
     assert _lookup_request_user(True) == (None, None)
     mocker.patch('indico.web.util.verify_signed_user_url').return_value = dummy_user
-    session.user = create_user(123)  # should be ignored
+    session.set_session_user(create_user(123))  # should be ignored
     assert _lookup_request_user(True) == (dummy_user, 'signed_url')
 
 
@@ -202,7 +202,7 @@ def test_lookup_request_user_signed_url_oauth(dummy_user, mocker):
 @pytest.mark.usefixtures('request_context')
 def test_lookup_request_user_session_oauth(dummy_user, mocker):
     assert _lookup_request_user() == (None, None)
-    session.user = dummy_user
+    session.set_session_user(dummy_user)
     mocker.patch('indico.web.util.get_oauth_user').return_value = dummy_user
     with pytest.raises(BadRequest) as exc_info:
         _lookup_request_user()
@@ -468,9 +468,9 @@ def test_get_request_user_complete(dummy_user, app, test_client, dummy_token, cr
     assert resp.status_code == 400
     assert b'OAuth tokens and signed URLs cannot be mixed' in resp.data
 
-    # request with a user being set in the actual session ( session cookies in the browser)
+    # request with a user being set in the actual session (session cookies in the browser)
     with test_client.session_transaction() as sess:
-        sess.user = create_user(123)
+        sess.set_session_user(create_user(123))
 
     assert test_client.get('/test/default').data == b'123|session'
     assert test_client.get('/test/signed').data == b'123|session'

--- a/indico/web/util_test.py
+++ b/indico/web/util_test.py
@@ -210,15 +210,20 @@ def test_lookup_request_user_session_oauth(dummy_user, mocker):
 
 
 @pytest.mark.usefixtures('request_context')
-@pytest.mark.parametrize(('xhr', 'blueprint', 'expected'), (
-    (False, 'assets', False),
-    (True, 'assets', False),
-    (False, 'foo', True),
-    (True, 'foo', False),
+@pytest.mark.parametrize(('xhr', 'json', 'blueprint', 'expected'), (
+    (False, False, 'assets', False),
+    (True, False, 'assets', False),
+    (False, True, 'assets', False),
+    (True, True, 'assets', False),
+    (False, False, 'foo', True),
+    (True, False, 'foo', False),
+    (False, True, 'foo', False),
+    (True, True, 'foo', False),
 ))
-def test_request_likely_seen_by_user(mocker, xhr, blueprint, expected):
+def test_request_likely_seen_by_user(mocker, xhr, json, blueprint, expected):
     request = mocker.patch('indico.web.util.request')
     request.is_xhr = xhr
+    request.is_json = json
     request.blueprint = blueprint
     assert _request_likely_seen_by_user() == expected
 

--- a/indico/web/util_test.py
+++ b/indico/web/util_test.py
@@ -37,10 +37,12 @@ def test_is_legacy_signed_url_valid(dummy_user, url, valid):
 
 
 @pytest.mark.parametrize(('endpoint', 'kwargs', 'expected'), (
-    ('core.contact', {}, '/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk'),
-    ('core.contact', {'_external': True}, 'http://localhost/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk'),  # noqa: E501
-    ('core.contact', {'foo': 'bar'}, '/contact?foo=bar&user_token=1337_WzEzMzcsIi9jb250YWN0P2Zvbz1iYXIiLCJHRVQiXQ.u_CUMB7nI_W7oa7v-CDndBEGUHc'),  # noqa: E501
-    ('events.display', {'event_id': 123, 'a': 'b'}, '/event/123/?a=b&user_token=1337_WzEzMzcsIi9ldmVudC8xMjMvP2E9YiIsIkdFVCJd.ZeWu1aXxTQ9Xfbv1q3zUhUrqKUc'),  # noqa: E501
+    ('core.contact', {}, '/contact?user_token=1337_F6kvmhWXsecSPOCqxfvlTCjO0A_Lvp-46SqnI6-LL_4'),
+    ('core.contact', {'_external': True},
+     'http://localhost/contact?user_token=1337_F6kvmhWXsecSPOCqxfvlTCjO0A_Lvp-46SqnI6-LL_4'),
+    ('core.contact', {'foo': 'bar'}, '/contact?foo=bar&user_token=1337_4UAW4-UXy8TbQl_UjAGU3CYj7QQGy2ywybeuoiV5-os'),
+    ('events.display', {'event_id': 123, 'a': 'b'},
+     '/event/123/?a=b&user_token=1337_oBedsl3f2qDtfHShn7MS8F_Mz58GTtnvHoqP3WzVnBY'),
 ))
 def test_signed_url_for_user(dummy_user, endpoint, kwargs, expected):
     dummy_user.signing_secret = 'sixtynine'
@@ -56,12 +58,12 @@ def test_signed_url_for_user_sorted(dummy_user):
 
 
 @pytest.mark.parametrize('url', (
-    '/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk',
-    'http://localhost/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk',
-    'http://localhost:8080/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk',
-    'https://indico.host/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk',
-    '/contact?foo=bar&user_token=1337_WzEzMzcsIi9jb250YWN0P2Zvbz1iYXIiLCJHRVQiXQ.u_CUMB7nI_W7oa7v-CDndBEGUHc',
-    '/event/123/?a=b&user_token=1337_WzEzMzcsIi9ldmVudC8xMjMvP2E9YiIsIkdFVCJd.ZeWu1aXxTQ9Xfbv1q3zUhUrqKUc',
+    '/contact?user_token=1337_F6kvmhWXsecSPOCqxfvlTCjO0A_Lvp-46SqnI6-LL_4',
+    'http://localhost/contact?user_token=1337_F6kvmhWXsecSPOCqxfvlTCjO0A_Lvp-46SqnI6-LL_4',
+    'http://localhost:8080/contact?user_token=1337_F6kvmhWXsecSPOCqxfvlTCjO0A_Lvp-46SqnI6-LL_4',
+    'https://indico.host/contact?user_token=1337_F6kvmhWXsecSPOCqxfvlTCjO0A_Lvp-46SqnI6-LL_4',
+    '/contact?foo=bar&user_token=1337_4UAW4-UXy8TbQl_UjAGU3CYj7QQGy2ywybeuoiV5-os',
+    '/event/123/?a=b&user_token=1337_oBedsl3f2qDtfHShn7MS8F_Mz58GTtnvHoqP3WzVnBY',
 ))
 def test_verify_signed_user_url(dummy_user, url):
     # valid signature
@@ -96,10 +98,9 @@ def test_verify_signed_user_url_bad_userid():
 
 
 def test_verify_signed_user_url_wrong_userid(dummy_user, create_user):
-    # this test is a bit stupid, because the only way we can fail the
-    # `signed_user_id != user.id` check is if two users have the same
-    # signing_secret AND someone changing the user id at the beginning
-    # of the token
+    # this test is a bit stupid, because the only way we can fail this
+    # check is if two users have the same signing_secret AND someone
+    # changes the user id at the beginning of the token
     user = create_user(123)
     user.signing_secret = dummy_user.signing_secret
     url = signed_url_for_user(dummy_user, 'core.contact')

--- a/indico/web/util_test.py
+++ b/indico/web/util_test.py
@@ -6,8 +6,18 @@
 # LICENSE file for more details.
 
 import pytest
+from authlib.oauth2 import OAuth2Error
+from flask import session
+from werkzeug.exceptions import BadRequest, Forbidden
 
-from indico.web.util import is_signed_url_valid, signed_url_for
+from indico.web.flask.util import make_view_func
+from indico.web.rh import RH, allow_signed_url, oauth_scope
+from indico.web.util import (_check_request_user, _lookup_request_user, _request_likely_seen_by_user, get_oauth_user,
+                             get_request_user, is_signed_url_valid, override_request_user, signed_url_for,
+                             signed_url_for_user, verify_signed_user_url)
+
+
+pytest_plugins = 'indico.core.oauth.testing.fixtures'
 
 
 @pytest.mark.usefixtures('request_context')
@@ -36,3 +46,471 @@ def test_full_urls(dummy_user):
     assert is_signed_url_valid(dummy_user, url)
     # the hostname part, etc... shouldn't be included in the signature
     assert is_signed_url_valid(dummy_user, 'http://indico.test/user/71/dashboard/?token=OsONJbxTpPzUYtSxgykZP7NZUHg')
+
+
+@pytest.mark.parametrize(('endpoint', 'kwargs', 'expected'), (
+    ('core.contact', {}, '/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk'),
+    ('core.contact', {'_external': True}, 'http://localhost/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk'),  # noqa: E501
+    ('core.contact', {'foo': 'bar'}, '/contact?foo=bar&user_token=1337_WzEzMzcsIi9jb250YWN0P2Zvbz1iYXIiLCJHRVQiXQ.u_CUMB7nI_W7oa7v-CDndBEGUHc'),  # noqa: E501
+    ('events.display', {'event_id': 123, 'a': 'b'}, '/event/123/?a=b&user_token=1337_WzEzMzcsIi9ldmVudC8xMjMvP2E9YiIsIkdFVCJd.ZeWu1aXxTQ9Xfbv1q3zUhUrqKUc'),  # noqa: E501
+))
+def test_signed_url_for_user(dummy_user, endpoint, kwargs, expected):
+    dummy_user.signing_secret = 'sixtynine'
+    url = signed_url_for_user(dummy_user, endpoint, **kwargs)
+    assert url == expected
+
+
+def test_signed_url_for_user_sorted(dummy_user):
+    dummy_user.signing_secret = 'fourtytwo'
+    url = signed_url_for_user(dummy_user, 'core.contact', a=1, b=2)
+    url2 = signed_url_for_user(dummy_user, 'core.contact', b=2, a=1)
+    assert url == url2
+
+
+@pytest.mark.parametrize('url', (
+    '/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk',
+    'http://localhost/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk',
+    'http://indico.host/contact?user_token=1337_WzEzMzcsIi9jb250YWN0IiwiR0VUIl0.S9N3hl_vZdJCqiWueeiJCFaCGyk',
+    '/contact?foo=bar&user_token=1337_WzEzMzcsIi9jb250YWN0P2Zvbz1iYXIiLCJHRVQiXQ.u_CUMB7nI_W7oa7v-CDndBEGUHc',
+    '/event/123/?a=b&user_token=1337_WzEzMzcsIi9ldmVudC8xMjMvP2E9YiIsIkdFVCJd.ZeWu1aXxTQ9Xfbv1q3zUhUrqKUc',
+))
+def test_verify_signed_user_url(dummy_user, url):
+    # valid signature
+    dummy_user.signing_secret = 'sixtynine'
+    assert verify_signed_user_url(url, 'GET') == dummy_user
+
+    # invalid method
+    with pytest.raises(BadRequest) as exc_info:
+        verify_signed_user_url(url, 'POST')
+    assert 'The persistent link you used is invalid' in str(exc_info.value)
+
+    # invalid url
+    with pytest.raises(BadRequest) as exc_info:
+        verify_signed_user_url(url.replace('?', '?x=y&'), 'GET')
+    assert 'The persistent link you used is invalid' in str(exc_info.value)
+
+    # invalid signature
+    dummy_user.signing_secret = 'somethingelse'
+    with pytest.raises(BadRequest) as exc_info:
+        verify_signed_user_url(url, 'GET')
+    assert 'The persistent link you used is invalid' in str(exc_info.value)
+
+
+def test_verify_signed_user_url_no_token():
+    assert verify_signed_user_url('/contact', 'GET') is None
+
+
+def test_verify_signed_user_url_bad_userid():
+    with pytest.raises(BadRequest) as exc_info:
+        verify_signed_user_url('/contact?user_token=x', 'GET')
+    assert 'The persistent link you used is invalid' in str(exc_info.value)
+
+
+def test_verify_signed_user_url_wrong_userid(dummy_user, create_user):
+    # this test is a bit stupid, because the only way we can fail the
+    # `signed_user_id != user.id` check is if two users have the same
+    # signing_secret AND someone changing the user id at the beginning
+    # of the token
+    user = create_user(123)
+    user.signing_secret = dummy_user.signing_secret
+    url = signed_url_for_user(dummy_user, 'core.contact')
+    url = url.replace(f'user_token={dummy_user.id}', f'user_token={user.id}')
+    with pytest.raises(BadRequest) as exc_info:
+        verify_signed_user_url(url, 'GET')
+    assert 'The persistent link you used is invalid' in str(exc_info.value)
+
+
+def test_verify_signed_user_url_invalid_user(dummy_user):
+    url = signed_url_for_user(dummy_user, 'core.contact')
+    url = url.replace('user_token=', 'user_token=111')
+    with pytest.raises(BadRequest) as exc_info:
+        verify_signed_user_url(url, 'GET')
+    assert 'The persistent link you used is invalid' in str(exc_info.value)
+
+
+@pytest.mark.usefixtures('request_context')
+@pytest.mark.parametrize('headers', ({}, {'Authorization': 'Basic foo'}))
+def test_get_oauth_user_no_token(mocker, headers):
+    request = mocker.patch('indico.web.util.request')
+    request.headers = headers
+    require_oauth = mocker.patch('indico.core.oauth.require_oauth')
+    assert get_oauth_user('whatever') is None
+    require_oauth.acquire_token.assert_not_called()
+
+
+@pytest.mark.usefixtures('request_context')
+def test_get_oauth_user_oauth_error(mocker):
+    request = mocker.patch('indico.web.util.request')
+    request.headers = {'Authorization': 'Bearer foo'}
+    require_oauth = mocker.patch('indico.core.oauth.require_oauth')
+    require_oauth.acquire_token.side_effect = OAuth2Error('nope')
+    with pytest.raises(BadRequest) as exc_info:
+        get_oauth_user('whatever')
+    assert 'nope' in str(exc_info.value)
+    require_oauth.acquire_token.assert_called_with('whatever')
+
+
+@pytest.mark.usefixtures('request_context')
+def test_get_oauth_user_oauth(mocker, dummy_user):
+    request = mocker.patch('indico.web.util.request')
+    request.headers = {'Authorization': 'Bearer foo'}
+    require_oauth = mocker.patch('indico.core.oauth.require_oauth')
+    require_oauth.acquire_token.return_value.user = dummy_user
+    assert get_oauth_user('whatever') == dummy_user
+    require_oauth.acquire_token.assert_called_with('whatever')
+
+
+@pytest.mark.usefixtures('request_context')
+def test_lookup_request_user_session(dummy_user):
+    assert _lookup_request_user() == (None, None)
+    session.user = dummy_user
+    assert _lookup_request_user() == (dummy_user, 'session')
+
+
+@pytest.mark.usefixtures('request_context')
+def test_lookup_request_user_explicit(create_user, dummy_user):
+    assert _lookup_request_user() == (None, None)
+    session.user = create_user(123)  # should be ignored
+    override_request_user(dummy_user, 'test')
+    assert _lookup_request_user() == (dummy_user, 'test')
+
+    # ensure we cannot override twice, regardless if it's the same user or not
+    with pytest.raises(RuntimeError) as exc_info:
+        override_request_user(dummy_user, 'test')
+    assert 'Cannot set request user to' in str(exc_info.value)
+    assert _lookup_request_user() == (dummy_user, 'test')
+
+    with pytest.raises(RuntimeError) as exc_info:
+        override_request_user(session.user, 'test')
+    assert 'Cannot set request user to' in str(exc_info.value)
+    assert _lookup_request_user() == (dummy_user, 'test')
+
+
+@pytest.mark.usefixtures('request_context')
+def test_lookup_request_user_signed_url(create_user, dummy_user, mocker):
+    assert _lookup_request_user(True) == (None, None)
+    mocker.patch('indico.web.util.verify_signed_user_url').return_value = dummy_user
+    session.user = create_user(123)  # should be ignored
+    assert _lookup_request_user(True) == (dummy_user, 'signed_url')
+
+
+@pytest.mark.usefixtures('request_context')
+def test_lookup_request_user_signed_url_not_allowed(create_user, dummy_user, mocker):
+    assert _lookup_request_user(False) == (None, None)
+    mocker.patch('indico.web.util.verify_signed_user_url').return_value = dummy_user
+    with pytest.raises(BadRequest) as exc_info:
+        _lookup_request_user(False)
+    assert 'Signature auth is not allowed for this URL' in str(exc_info.value)
+
+
+@pytest.mark.usefixtures('request_context')
+@pytest.mark.parametrize('method', ('GET', 'POST'))
+def test_lookup_request_user_oauth(dummy_user, mocker, method):
+    request = mocker.patch('indico.web.util.request')
+    request.method = method
+    request.full_path = '/test'
+    request.headers = {}
+    assert _lookup_request_user() == (None, None)
+    get_oauth_user = mocker.patch('indico.web.util.get_oauth_user')
+    get_oauth_user.return_value = dummy_user
+    assert _lookup_request_user() == (dummy_user, 'oauth')
+    scopes = ['read:everything', 'full:everything'] if method == 'GET' else ['full:everything']
+    get_oauth_user.assert_called_with(scopes)
+
+
+@pytest.mark.usefixtures('request_context')
+def test_lookup_request_user_signed_url_oauth(dummy_user, mocker):
+    assert _lookup_request_user() == (None, None)
+    mocker.patch('indico.web.util.verify_signed_user_url').return_value = dummy_user
+    mocker.patch('indico.web.util.get_oauth_user').return_value = dummy_user
+    with pytest.raises(BadRequest) as exc_info:
+        _lookup_request_user()
+    assert 'OAuth tokens and signed URLs cannot be mixed' in str(exc_info.value)
+
+
+@pytest.mark.usefixtures('request_context')
+def test_lookup_request_user_session_oauth(dummy_user, mocker):
+    assert _lookup_request_user() == (None, None)
+    session.user = dummy_user
+    mocker.patch('indico.web.util.get_oauth_user').return_value = dummy_user
+    with pytest.raises(BadRequest) as exc_info:
+        _lookup_request_user()
+    assert 'OAuth tokens and session cookies cannot be mixed' in str(exc_info.value)
+
+
+@pytest.mark.usefixtures('request_context')
+@pytest.mark.parametrize(('xhr', 'blueprint', 'expected'), (
+    (False, 'assets', False),
+    (True, 'assets', False),
+    (False, 'foo', True),
+    (True, 'foo', False),
+))
+def test_request_likely_seen_by_user(mocker, xhr, blueprint, expected):
+    request = mocker.patch('indico.web.util.request')
+    request.is_xhr = xhr
+    request.blueprint = blueprint
+    assert _request_likely_seen_by_user() == expected
+
+
+def test_check_request_user_no_user():
+    assert _check_request_user(None, None) == (None, None)
+    assert _check_request_user(None, 'foo') == (None, None)
+
+
+@pytest.mark.parametrize('source', ('session', 'foo'))
+def test_check_request_user(dummy_user, source):
+    assert _check_request_user(dummy_user, source) == (dummy_user, source)
+
+
+def test_check_request_user_blocked(mocker, dummy_user):
+    _request_likely_seen_by_user = mocker.patch('indico.web.util._request_likely_seen_by_user', return_value=False)
+    dummy_user.is_blocked = True
+    with pytest.raises(Forbidden) as exc_info:
+        _check_request_user(dummy_user, 'foo')
+    assert 'User has been blocked' in str(exc_info.value)
+    _request_likely_seen_by_user.assert_not_called()
+
+
+@pytest.mark.usefixtures('request_context')
+def test_check_request_user_blocked_session(mocker, dummy_user):
+    session = mocker.patch('indico.web.util.session')
+    flash = mocker.patch('indico.web.util.flash')
+    _request_likely_seen_by_user = mocker.patch('indico.web.util._request_likely_seen_by_user')
+    dummy_user.is_blocked = True
+
+    # request not likely seen by the end user
+    _request_likely_seen_by_user.return_value = False
+    assert _check_request_user(dummy_user, 'session') == (None, None)
+    session.clear.assert_not_called()
+    flash.assert_not_called()
+
+    # request likely seen by the user
+    _request_likely_seen_by_user.return_value = True
+    assert _check_request_user(dummy_user, 'session') == (None, None)
+    session.clear.assert_called()
+    flash.assert_called()
+    assert 'Your profile has been blocked' in flash.call_args.args[0]
+
+
+def test_check_request_user_deleted(mocker, dummy_user, create_user):
+    _request_likely_seen_by_user = mocker.patch('indico.web.util._request_likely_seen_by_user', return_value=False)
+    dummy_user.is_deleted = True
+
+    # just deleted
+    with pytest.raises(Forbidden) as exc_info:
+        _check_request_user(dummy_user, 'foo')
+    assert 'User has been deleted' in str(exc_info.value)
+    _request_likely_seen_by_user.assert_not_called()
+
+    # merged into another user
+    dummy_user.merged_into_user = create_user(123)
+    with pytest.raises(Forbidden) as exc_info:
+        _check_request_user(dummy_user, 'foo')
+    assert 'User has been merged into another user' in str(exc_info.value)
+    _request_likely_seen_by_user.assert_not_called()
+
+
+@pytest.mark.usefixtures('request_context')
+def test_check_request_user_deleted_session(mocker, dummy_user):
+    session = mocker.patch('indico.web.util.session')
+    flash = mocker.patch('indico.web.util.flash')
+    _request_likely_seen_by_user = mocker.patch('indico.web.util._request_likely_seen_by_user')
+    dummy_user.is_deleted = True
+
+    # request not likely seen by the end user
+    _request_likely_seen_by_user.return_value = False
+    assert _check_request_user(dummy_user, 'session') == (None, None)
+    session.clear.assert_not_called()
+    flash.assert_not_called()
+
+    # request likely seen by the user
+    _request_likely_seen_by_user.return_value = True
+    assert _check_request_user(dummy_user, 'session') == (None, None)
+    session.clear.assert_called()
+    flash.assert_called()
+    assert 'Your profile has been deleted' in flash.call_args.args[0]
+
+
+@pytest.mark.usefixtures('request_context')
+def test_check_request_user_deleted_merged_session(mocker, dummy_user, create_user):
+    session = mocker.patch('indico.web.util.session')
+    flash = mocker.patch('indico.web.util.flash')
+    _request_likely_seen_by_user = mocker.patch('indico.web.util._request_likely_seen_by_user')
+    dummy_user.is_deleted = True
+    dummy_user.merged_into_user = create_user(123)
+
+    # request not likely seen by the end user
+    _request_likely_seen_by_user.return_value = False
+    assert _check_request_user(dummy_user, 'session') == (None, None)
+    session.clear.assert_not_called()
+    flash.assert_not_called()
+
+    # request likely seen by the user
+    _request_likely_seen_by_user.return_value = True
+    assert _check_request_user(dummy_user, 'session') == (None, None)
+    session.clear.assert_called()
+    flash.assert_called()
+    assert 'Your profile has been merged into' in flash.call_args.args[0]
+
+
+def test_get_request_user(dummy_user, mocker, monkeypatch):
+    _lookup_request_user = mocker.patch('indico.web.util._lookup_request_user', return_value=(dummy_user, 'whatever'))
+    monkeypatch.setattr('indico.web.util._check_request_user', lambda user, source: (user, source))
+    assert get_request_user() == (dummy_user, 'whatever')
+    _lookup_request_user.assert_called_once()
+    assert get_request_user() == (dummy_user, 'whatever')
+    assert _lookup_request_user.call_count == 2
+
+
+def test_get_request_user_lookup_failure(mocker, monkeypatch):
+    _lookup_request_user = mocker.patch('indico.web.util._lookup_request_user', side_effect=Exception('kaboom'))
+    monkeypatch.setattr('indico.web.util._check_request_user', lambda user, source: (user, source))
+    with pytest.raises(Exception) as exc_info:
+        get_request_user()
+    assert str(exc_info.value) == 'kaboom'
+    _lookup_request_user.assert_called_once()
+    # after a failure, we always return None
+    assert get_request_user() == (None, None)
+    # the lookup should not be done again once a failure is cached
+    _lookup_request_user.assert_called_once()
+
+
+def test_get_request_user_check_failure(dummy_user, mocker):
+    _lookup_request_user = mocker.patch('indico.web.util._lookup_request_user', return_value=(dummy_user, 'whatever'))
+    _check_request_user = mocker.patch('indico.web.util._check_request_user', side_effect=Exception('kaboom'))
+    with pytest.raises(Exception) as exc_info:
+        get_request_user()
+    assert str(exc_info.value) == 'kaboom'
+    _lookup_request_user.assert_called_once()
+    _check_request_user.assert_called_once()
+    # after a failure, we always return None
+    assert get_request_user() == (None, None)
+    # the lookup/check should not be done again once a failure is cached
+    _lookup_request_user.assert_called_once()
+    _check_request_user.assert_called_once()
+
+
+def test_get_request_user_complete(dummy_user, app, test_client, dummy_token, create_user):
+    class RHTest(RH):
+        def _process(self):
+            user, source = get_request_user()
+            assert session.user == user
+            if not user:
+                return 'none'
+            return f'{user.id}|{source}'
+
+    @allow_signed_url
+    class RHTestSigned(RHTest):
+        pass
+
+    @oauth_scope('read:user')
+    class RHTestScope(RHTest):
+        pass
+
+    app.add_url_rule('/test/default', 'test_default', make_view_func(RHTest), methods=('GET', 'POST'))
+    app.add_url_rule('/test/signed', 'test_signed', make_view_func(RHTestSigned))
+    app.add_url_rule('/test/scope', 'test_scope', make_view_func(RHTestScope), methods=('GET', 'POST'))
+
+    # no auth
+    assert test_client.get('/test/default').data == b'none'
+    assert test_client.get('/test/signed').data == b'none'
+    assert test_client.get('/test/scope').data == b'none'
+
+    # signature auth
+    resp = test_client.get(signed_url_for_user(dummy_user, 'test_default'))
+    assert resp.status_code == 400
+    assert b'Signature auth is not allowed for this URL' in resp.data
+
+    resp = test_client.get(signed_url_for_user(dummy_user, 'test_signed'))
+    assert resp.status_code == 200
+    assert resp.data == b'1337|signed_url'
+
+    resp = test_client.get(signed_url_for_user(dummy_user, 'test_scope'))
+    assert resp.status_code == 400
+    assert b'Signature auth is not allowed for this URL' in resp.data
+
+    # oauth - token with read:user scope
+    oauth_headers = {'Authorization': f'Bearer {dummy_token._plaintext_token}'}
+    resp = test_client.get('/test/default', headers=oauth_headers)
+    assert resp.status_code == 400
+    assert b'insufficient_scope' in resp.data
+
+    resp = test_client.post('/test/default', headers=oauth_headers)
+    assert resp.status_code == 400
+    assert b'insufficient_scope' in resp.data
+
+    resp = test_client.get('/test/signed', headers=oauth_headers)
+    assert resp.status_code == 400
+    assert b'insufficient_scope' in resp.data
+
+    resp = test_client.get('/test/scope', headers=oauth_headers)
+    assert resp.status_code == 200
+    assert resp.data == b'1337|oauth'
+
+    resp = test_client.post('/test/scope', headers=oauth_headers)
+    assert resp.status_code == 200
+    assert resp.data == b'1337|oauth'
+
+    # oauth - token with read:everything scope
+    dummy_token._scopes.append('read:everything')
+    dummy_token.app_user_link.scopes.append('read:everything')
+    dummy_token.app_user_link.application.allowed_scopes.append('read:everything')
+
+    resp = test_client.get('/test/default', headers=oauth_headers)
+    assert resp.status_code == 200
+    assert resp.data == b'1337|oauth'
+
+    # default post requires full:everything
+    resp = test_client.post('/test/default', headers=oauth_headers)
+    assert resp.status_code == 400
+    assert b'insufficient_scope' in resp.data
+
+    resp = test_client.get('/test/signed', headers=oauth_headers)
+    assert resp.status_code == 200
+    assert resp.data == b'1337|oauth'
+
+    resp = test_client.get('/test/scope', headers=oauth_headers)
+    assert resp.status_code == 200
+    assert resp.data == b'1337|oauth'
+
+    # custom scopes are not method-specific
+    resp = test_client.post('/test/scope', headers=oauth_headers)
+    assert resp.status_code == 200
+    assert resp.data == b'1337|oauth'
+
+    # full:everything should allow posting to any endpoint
+    dummy_token._scopes.append('full:everything')
+    dummy_token.app_user_link.scopes.append('full:everything')
+    dummy_token.app_user_link.application.allowed_scopes.append('full:everything')
+
+    resp = test_client.post('/test/default', headers=oauth_headers)
+    assert resp.status_code == 200
+    assert resp.data == b'1337|oauth'
+
+    # oauth + signature is not allowed
+    resp = test_client.get(signed_url_for_user(dummy_user, 'test_signed'), headers=oauth_headers)
+    assert resp.status_code == 400
+    assert b'OAuth tokens and signed URLs cannot be mixed' in resp.data
+
+    # request with a user being set in the actual session ( session cookies in the browser)
+    with test_client.session_transaction() as sess:
+        sess.user = create_user(123)
+
+    assert test_client.get('/test/default').data == b'123|session'
+    assert test_client.get('/test/signed').data == b'123|session'
+    assert test_client.get('/test/scope').data == b'123|session'
+
+    # oauth + session is not allowed
+    resp = test_client.get('/test/default', headers=oauth_headers)
+    assert resp.status_code == 400
+    assert b'OAuth tokens and session cookies cannot be mixed' in resp.data
+
+    # regular requests still need a CSRF token
+    resp = test_client.post('/test/default')
+    assert resp.status_code == 400
+    assert b'problem with your current session' in resp.data
+
+    # signed links override the session user
+    resp = test_client.get(signed_url_for_user(dummy_user, 'test_signed'))
+    assert resp.status_code == 200
+    assert resp.data == b'1337|signed_url'

--- a/indico/web/util_test.py
+++ b/indico/web/util_test.py
@@ -13,8 +13,7 @@ from werkzeug.exceptions import BadRequest, Forbidden
 from indico.web.flask.util import make_view_func
 from indico.web.rh import RH, allow_signed_url, oauth_scope
 from indico.web.util import (_check_request_user, _lookup_request_user, _request_likely_seen_by_user, get_oauth_user,
-                             get_request_user, is_legacy_signed_url_valid, override_request_user, signed_url_for_user,
-                             verify_signed_user_url)
+                             get_request_user, is_legacy_signed_url_valid, signed_url_for_user, verify_signed_user_url)
 
 
 pytest_plugins = 'indico.core.oauth.testing.fixtures'
@@ -155,25 +154,6 @@ def test_lookup_request_user_session(dummy_user):
     assert _lookup_request_user() == (None, None)
     session.user = dummy_user
     assert _lookup_request_user() == (dummy_user, 'session')
-
-
-@pytest.mark.usefixtures('request_context')
-def test_lookup_request_user_explicit(create_user, dummy_user):
-    assert _lookup_request_user() == (None, None)
-    session.user = create_user(123)  # should be ignored
-    override_request_user(dummy_user, 'test')
-    assert _lookup_request_user() == (dummy_user, 'test')
-
-    # ensure we cannot override twice, regardless if it's the same user or not
-    with pytest.raises(RuntimeError) as exc_info:
-        override_request_user(dummy_user, 'test')
-    assert 'Cannot set request user to' in str(exc_info.value)
-    assert _lookup_request_user() == (dummy_user, 'test')
-
-    with pytest.raises(RuntimeError) as exc_info:
-        override_request_user(session.user, 'test')
-    assert 'Cannot set request user to' in str(exc_info.value)
-    assert _lookup_request_user() == (dummy_user, 'test')
 
 
 @pytest.mark.usefixtures('request_context')


### PR DESCRIPTION
My approach is to first use the slightly ugly solution where `session.user` returns the current user, and then later (in a separate PR) replace `session.user` with something else.