### PR TITLE
Fix editable access for editors in case of unpublished contributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Bugfixes
   no longer installed
 - Do not auto-redirect to SSO when an MS office user agent is detected (:issue:`4720`,
   :pr:`4731`)
+- Allow Editing team to view editables of unpublished contributions (:issue:`4811`, :pr:`4812`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -57,13 +57,15 @@ class RHContributionDisplayBase(RHDisplayEventBase):
         }
     }
 
+    def _can_view_unpublished(self):
+        return self.event.can_manage(session.user) or self.contrib.is_user_associated(session.user)
+
     def _check_access(self):
         RHDisplayEventBase._check_access(self)
         if not self.contrib.can_access(session.user):
             raise Forbidden
         published = contribution_settings.get(self.event, 'published')
-        if (not published and not self.event.can_manage(session.user)
-                and not self.contrib.is_user_associated(session.user)):
+        if not published and not self._can_view_unpublished():
             raise NotFound(_("The contributions of this event have not been published yet."))
 
     def _process_args(self):

--- a/indico/modules/events/editing/controllers/base.py
+++ b/indico/modules/events/editing/controllers/base.py
@@ -106,6 +106,11 @@ class RHContributionEditableBase(TokenAccessMixin, RequireUserMixin, RHContribut
             RequireUserMixin._check_access(self)
             RHContributionDisplayBase._check_access(self)
 
+    def _can_view_unpublished(self):
+        if super(RHContributionEditableBase, self)._can_view_unpublished():
+            return True
+        return self.editable is not None and self.editable.can_see_timeline(session.user)
+
     def _process_args(self):
         RHContributionDisplayBase._process_args(self)
         self.editable_type = EditableType[request.view_args['type']]


### PR DESCRIPTION
fixes #4811

I did not enable access to the full contribution itself, since that shouldn't be needed when someone is just an Editor. In any case, this is pretty much an edge case, since Editing usually happens *after* an event, when everything is published.