### PR TITLE
Icalendar export enhancements, new Ical serializers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,14 +43,16 @@ Improvements
   (:issue:`1550`, :pr:`4817`)
 - Allow filtering the "Participant Roles" page by users who have not registered for the event
   (:issue:`4763`, :pr:`4822`)
+- iCalendar exports now include contact data, event logo URL and, when exporting
+  sessions/contributions, the UID of the related event. Also, only non-empty fields
+  are exported. (:issue:`4785`, :issue:`4586`, :issue:`4587`, :issue:`4791`,
+  :pr:`4820`)
 
 Bugfixes
 ^^^^^^^^
 
 - Take registrations of users who are only members of a custom event role into account on the
   "Participant Roles" page (:pr:`4822`)
-- iCalendar exports include more information and use new serializers
-  (:issue:`4785`, :issue:`4586`, :issue:`4587`, :pr:`4820`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ Bugfixes
 
 - Take registrations of users who are only members of a custom event role into account on the
   "Participant Roles" page (:pr:`4822`)
+- iCalendar exports include more information and use new serializers
+  (:issue:`4785`, :issue:`4586`, :issue:`4587`, :pr:`4820`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/client/js/header.jsx
+++ b/indico/modules/events/client/js/header.jsx
@@ -19,6 +19,14 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   const eventId = calendarContainer.dataset.eventId;
+  const options = [{key: 'event', text: Translate.string('Event'), extraParams: {}}];
+  if (parseInt(calendarContainer.dataset.eventContribs, 10) > 0) {
+    options.push({
+      key: 'contribution',
+      text: Translate.string('Detailed timetable'),
+      extraParams: {detail: 'contributions'},
+    });
+  }
 
   ReactDOM.render(
     <ICSCalendarLink
@@ -33,14 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
       )}
       dropdownPosition="top left"
       popupPosition="bottom right"
-      options={[
-        {key: 'event', text: Translate.string('Event'), extraParams: {}},
-        {
-          key: 'contributions',
-          text: Translate.string('Detailed timetable'),
-          extraParams: {detail: 'contributions'},
-        },
-      ]}
+      options={options}
     />,
     calendarContainer
   );

--- a/indico/modules/events/client/js/header.jsx
+++ b/indico/modules/events/client/js/header.jsx
@@ -18,9 +18,9 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  const eventId = calendarContainer.dataset.eventId;
+  const {eventId, eventContribCount} = calendarContainer.dataset.eventId;
   const options = [{key: 'event', text: Translate.string('Event'), extraParams: {}}];
-  if (parseInt(calendarContainer.dataset.eventContribs, 10) > 0) {
+  if (parseInt(eventContribCount, 10) > 0) {
     options.push({
       key: 'contribution',
       text: Translate.string('Detailed timetable'),

--- a/indico/modules/events/client/js/header.jsx
+++ b/indico/modules/events/client/js/header.jsx
@@ -18,11 +18,11 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  const {eventId, eventContribCount} = calendarContainer.dataset.eventId;
+  const {eventId, eventContribCount} = calendarContainer.dataset;
   const options = [{key: 'event', text: Translate.string('Event'), extraParams: {}}];
   if (parseInt(eventContribCount, 10) > 0) {
     options.push({
-      key: 'contribution',
+      key: 'contributions',
       text: Translate.string('Detailed timetable'),
       extraParams: {detail: 'contributions'},
     });

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -5,6 +5,8 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from io import BytesIO
+
 from flask import jsonify, request, session
 from sqlalchemy.orm import joinedload, load_only
 from werkzeug.exceptions import Forbidden, NotFound
@@ -14,12 +16,12 @@ from indico.core.db import db
 from indico.legacy.pdfinterface.latex import ContribsToPDF, ContribToPDF
 from indico.modules.events.abstracts.util import filter_field_values
 from indico.modules.events.contributions import contribution_settings
+from indico.modules.events.contributions.ical import contribution_to_ical
 from indico.modules.events.contributions.lists import ContributionDisplayListGenerator
 from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.contributions.models.persons import AuthorType, ContributionPersonLink
 from indico.modules.events.contributions.models.subcontributions import SubContribution
-from indico.modules.events.contributions.util import (get_contribution_ical_file,
-                                                      get_contributions_with_user_as_submitter,
+from indico.modules.events.contributions.util import (get_contributions_with_user_as_submitter,
                                                       has_contributions_with_user_as_submitter)
 from indico.modules.events.contributions.views import WPAuthorList, WPContributions, WPMyContributions, WPSpeakerList
 from indico.modules.events.controllers.base import RHDisplayEventBase
@@ -213,7 +215,7 @@ class RHContributionExportToICAL(RHContributionDisplayBase):
     def _process(self):
         if not self.contrib.is_scheduled:
             raise NotFound('This contribution is not scheduled')
-        return send_file('contribution.ics', get_contribution_ical_file(self.contrib), 'text/calendar')
+        return send_file('contribution.ics', BytesIO(contribution_to_ical(self.contrib)), 'text/calendar')
 
 
 class RHContributionListFilter(RHContributionList):

--- a/indico/modules/events/contributions/ical.py
+++ b/indico/modules/events/contributions/ical.py
@@ -6,6 +6,7 @@
 # LICENSE file for more details.
 
 from icalendar import Event
+from icalendar.cal import Calendar
 from lxml import html
 from lxml.etree import ParserError
 from werkzeug.urls import url_parse
@@ -52,3 +53,21 @@ def generate_contribution_component(contribution):
     cal_contribution.add('description', '\n'.join(description))
 
     return cal_contribution
+
+
+def contribution_to_ical(contribution):
+    """Serialize a contribution into an ical.
+
+    :param contribution: The contribution to serialize
+    """
+
+    calendar = Calendar()
+    calendar.add('version', '2.0')
+    calendar.add('prodid', '-//CERN//INDICO//EN')
+
+    cal_contribution = generate_contribution_component(contribution)
+    calendar.add_component(cal_contribution)
+
+    data = calendar.to_ical()
+
+    return data

--- a/indico/modules/events/contributions/ical.py
+++ b/indico/modules/events/contributions/ical.py
@@ -39,7 +39,7 @@ def contribution_to_ical(contribution):
     calendar.add('version', '2.0')
     calendar.add('prodid', '-//CERN//INDICO//EN')
 
-    related_event_uid = 'indico-event-{contribution.event.id}@{url_parse(config.BASE_URL).host}'
+    related_event_uid = f'indico-event-{contribution.event.id}@{url_parse(config.BASE_URL).host}'
     component = generate_contribution_component(contribution, related_event_uid)
     calendar.add_component(component)
 

--- a/indico/modules/events/contributions/ical.py
+++ b/indico/modules/events/contributions/ical.py
@@ -1,0 +1,54 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from icalendar import Event
+from lxml import html
+from lxml.etree import ParserError
+from werkzeug.urls import url_parse
+
+from indico.core.config import config
+from indico.util.date_time import now_utc
+
+
+def generate_contribution_component(contribution):
+    """Generates an Event icalendar component from an Indico Contribution.
+
+    :param contribution: The Indico Contribution to use
+    :returns: an icalendar Event
+    """
+
+    cal_contribution = Event()
+
+    cal_contribution.add(
+        'uid', 'indico-contribution-{}@{}'.format(contribution.id, url_parse(config.BASE_URL).host)
+    )
+    cal_contribution.add('dtstamp', now_utc(False))
+    cal_contribution.add('dtstart', contribution.start_dt)
+    cal_contribution.add('dtend', contribution.end_dt)
+    cal_contribution.add('summary', contribution.title)
+
+    location = (f'{contribution.room_name} ({contribution.venue_name})'
+                if contribution.venue_name and contribution.room_name
+                else (contribution.venue_name or contribution.room_name))
+    if location:
+        cal_contribution.add('location', location)
+
+    description = []
+    if contribution.person_links:
+        speakers = [f'{x.full_name} ({x.affiliation})' if x.affiliation else x.full_name
+                    for x in contribution.person_links]
+        description.append('Speakers: {}'.format(', '.join(speakers)))
+    if contribution.description:
+        desc_text = str(contribution.description) or '<p/>'  # get rid of RichMarkup
+        try:
+            description.append(str(html.fromstring(desc_text).text_content()))
+        except ParserError:
+            # this happens if desc_text only contains a html comment
+            pass
+    cal_contribution.add('description', '\n'.join(description))
+
+    return cal_contribution

--- a/indico/modules/events/contributions/ical.py
+++ b/indico/modules/events/contributions/ical.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from icalendar.cal import Calendar
+import icalendar
 from werkzeug.urls import url_parse
 
 from indico.core.config import config
@@ -14,14 +14,13 @@ from indico.web.flask.util import url_for
 
 
 def generate_contribution_component(contribution, related_to_uid=None):
-    """Generates an Event icalendar component from an Indico Contribution.
+    """Generate an Event icalendar component from an Indico Contribution.
 
     :param contribution: The Indico Contribution to use
     :param related_to_uid: Indico uid used in related_to field
-    :returns: an icalendar Event
+    :return: an icalendar Event
     """
-
-    uid = 'indico-contribution-{}@{}'.format(contribution.id, url_parse(config.BASE_URL).host)
+    uid = f'indico-contribution-{contribution.id}@{url_parse(config.BASE_URL).host}'
     url = url_for('contributions.display_contribution', contribution, _external=True)
     component = generate_basic_component(contribution, uid, url)
 
@@ -36,15 +35,12 @@ def contribution_to_ical(contribution):
 
     :param contribution: The contribution to serialize
     """
-
-    calendar = Calendar()
+    calendar = icalendar.Calendar()
     calendar.add('version', '2.0')
     calendar.add('prodid', '-//CERN//INDICO//EN')
 
-    related_event_uid = 'indico-event-{}@{}'.format(contribution.event.id, url_parse(config.BASE_URL).host)
+    related_event_uid = 'indico-event-{contribution.event.id}@{url_parse(config.BASE_URL).host}'
     component = generate_contribution_component(contribution, related_event_uid)
     calendar.add_component(component)
 
-    data = calendar.to_ical()
-
-    return data
+    return calendar.to_ical()

--- a/indico/modules/events/contributions/ical.py
+++ b/indico/modules/events/contributions/ical.py
@@ -15,7 +15,7 @@ from indico.core.config import config
 from indico.util.date_time import now_utc
 
 
-def generate_contribution_component(contribution):
+def generate_contribution_component(contribution, event_uid):
     """Generates an Event icalendar component from an Indico Contribution.
 
     :param contribution: The Indico Contribution to use
@@ -31,6 +31,9 @@ def generate_contribution_component(contribution):
     cal_contribution.add('dtstart', contribution.start_dt)
     cal_contribution.add('dtend', contribution.end_dt)
     cal_contribution.add('summary', contribution.title)
+
+    if event_uid:
+        cal_contribution.add('related_to', event_uid)
 
     location = (f'{contribution.room_name} ({contribution.venue_name})'
                 if contribution.venue_name and contribution.room_name

--- a/indico/modules/events/contributions/util.py
+++ b/indico/modules/events/contributions/util.py
@@ -8,7 +8,6 @@
 import csv
 from collections import defaultdict
 from datetime import timedelta
-from io import BytesIO
 from operator import attrgetter
 
 import dateutil.parser
@@ -37,7 +36,6 @@ from indico.util.spreadsheets import csv_text_io_wrapper
 from indico.util.string import validate_email
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import send_file, url_for
-from indico.web.http_api.metadata.serializer import Serializer
 from indico.web.util import jsonify_data
 
 
@@ -256,12 +254,6 @@ def serialize_contribution_for_ical(contrib):
         'speakers': [serialize_person_link(x) for x in contrib.speakers],
         'description': contrib.description
     }
-
-
-def get_contribution_ical_file(contrib):
-    data = {'results': serialize_contribution_for_ical(contrib)}
-    serializer = Serializer.create('ics')
-    return BytesIO(serializer(data))
 
 
 def import_contributions_from_csv(event, f):

--- a/indico/modules/events/controllers/display.py
+++ b/indico/modules/events/controllers/display.py
@@ -24,8 +24,8 @@ from indico.web.rh import allow_signed_url
 @allow_signed_url
 class RHExportEventICAL(RHDisplayEventBase):
     def _process(self):
-        detail_level = request.args.get('detail', 'events')
-        event_ical = event_to_ical(self.event, session.user, detail_level)
+        detailed = request.args.get('detail', 'events') == 'contributions'
+        event_ical = event_to_ical(self.event, session.user, detailed)
         return send_file('event.ics', BytesIO(event_ical), 'text/calendar')
 
 

--- a/indico/modules/events/controllers/display.py
+++ b/indico/modules/events/controllers/display.py
@@ -9,17 +9,15 @@ from io import BytesIO
 
 from flask import jsonify, redirect, request, session
 
-from indico.core import signals
 from indico.legacy.common.output import outputGenerator
 from indico.legacy.common.xmlGen import XMLGen
 from indico.modules.events.controllers.base import RHDisplayEventBase, RHEventBase
+from indico.modules.events.ical import event_to_ical
 from indico.modules.events.layout.views import WPPage
 from indico.modules.events.models.events import EventType
-from indico.modules.events.util import get_theme, serialize_event_for_ical
+from indico.modules.events.util import get_theme
 from indico.modules.events.views import WPConferenceDisplay, WPSimpleEventDisplay
-from indico.util.signals import values_from_signal
 from indico.web.flask.util import send_file, url_for
-from indico.web.http_api.metadata import Serializer
 from indico.web.rh import allow_signed_url
 
 
@@ -27,18 +25,8 @@ from indico.web.rh import allow_signed_url
 class RHExportEventICAL(RHDisplayEventBase):
     def _process(self):
         detail_level = request.args.get('detail', 'events')
-        data = serialize_event_for_ical(self.event, detail_level)
-
-        # check whether the plugins want to add/override any data
-        for update in values_from_signal(
-            signals.event.metadata_postprocess.send('ical-export', event=self.event, data=data, user=session.user),
-            as_list=True
-        ):
-            data.update(update)
-
-        response = {'results': data}
-        serializer = Serializer.create('ics')
-        return send_file('event.ics', BytesIO(serializer(response)), 'text/calendar')
+        event_ical = event_to_ical(self.event, session.user, detail_level)
+        return send_file('event.ics', BytesIO(event_ical), 'text/calendar')
 
 
 class RHDisplayEvent(RHDisplayEventBase):

--- a/indico/modules/events/controllers/display.py
+++ b/indico/modules/events/controllers/display.py
@@ -24,7 +24,7 @@ from indico.web.rh import allow_signed_url
 @allow_signed_url
 class RHExportEventICAL(RHDisplayEventBase):
     def _process(self):
-        detailed = request.args.get('detail', 'events') == 'contributions'
+        detailed = request.args.get('detail') == 'contributions'
         event_ical = event_to_ical(self.event, session.user, detailed)
         return send_file('event.ics', BytesIO(event_ical), 'text/calendar')
 

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -17,7 +17,7 @@ from indico.util.date_time import now_utc
 from indico.util.signals import values_from_signal
 
 
-def generate_event_component(event):
+def generate_event_component(event, event_uid):
     """Generates an Event icalendar component from an Indico Event.
 
     :param event: The Indico Event to use
@@ -25,7 +25,7 @@ def generate_event_component(event):
     """
 
     cal_event = Event()
-    cal_event.add('uid', 'indico-event-{}@{}'.format(event.id, url_parse(config.BASE_URL).host))
+    cal_event.add('uid', event_uid)
     cal_event.add('dtstamp', now_utc(False))
     cal_event.add('dtstart', event.start_dt)
     cal_event.add('dtend', event.end_dt)
@@ -86,11 +86,14 @@ def events_to_ical(events, user=None, detail_level='events'):
     calendar.add('prodid', '-//CERN//INDICO//EN')
 
     for event in events:
+        event_uid = 'indico-event-{}@{}'.format(event.id, url_parse(config.BASE_URL).host)
         if detail_level == 'events':
-            cal_event = generate_event_component(event)
+            cal_event = generate_event_component(event, event_uid)
             calendar.add_component(cal_event)
         elif detail_level == 'contributions':
-            contributions = [generate_contribution_component(contribution) for contribution in event.contributions]
+            contributions = [
+                generate_contribution_component(contribution, event_uid) for contribution in event.contributions
+            ]
             for contribution in contributions:
                 calendar.add_component(contribution)
 

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -55,6 +55,17 @@ def events_to_ical(events, user=None):
         if location:
             cal_event.add('location', location)
 
+        if event.contact_title:
+            contact_info = f'{event.contact_title}'
+
+            if len(event.contact_emails):
+                contact_info += f'; {"; ".join(event.contact_emails)}'
+
+            if len(event.contact_phones):
+                contact_info += f'; {"; ".join(event.contact_phones)}'
+
+            cal_event.add('contact', contact_info)
+
         description = []
         if event.person_links:
             speakers = [f'{x.full_name} ({x.affiliation})' if x.affiliation else x.full_name

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -40,10 +40,6 @@ def events_to_ical(events, user=None):
     for event in events:
         cal_event = Event()
 
-        location = (f'{event.room_name} ({event.venue_name})'
-                    if event.venue_name and event.room_name
-                    else (event.venue_name or event.room_name))
-
         cal_event.add('uid', 'indico-event-{}@{}'.format(event.id, url_parse(config.BASE_URL).host))
 
         cal_event.add('dtstamp', now_utc(False))
@@ -51,7 +47,13 @@ def events_to_ical(events, user=None):
         cal_event.add('dtend', event.end_dt)
         cal_event.add('url', event.external_url)
         cal_event.add('summary', event.title)
-        cal_event.add('location', location)
+
+        location = (f'{event.room_name} ({event.venue_name})'
+                    if event.venue_name and event.room_name
+                    else (event.venue_name or event.room_name))
+
+        if location:
+            cal_event.add('location', location)
 
         description = []
         if event.person_links:

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -12,6 +12,7 @@ from werkzeug.urls import url_parse
 
 from indico.core import signals
 from indico.core.config import config
+from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.events.contributions.ical import generate_contribution_component
 from indico.util.date_time import now_utc
 from indico.util.signals import values_from_signal
@@ -45,6 +46,10 @@ def generate_event_component(event, event_uid):
         if len(event.contact_phones):
             contact_info += f'; {"; ".join(event.contact_phones)}'
         cal_event.add('contact', contact_info)
+
+    # logo url will be added only if event is public
+    if event.effective_protection_mode == ProtectionMode.public and event.has_logo:
+        cal_event.add('image', f"{config.BASE_URL}{event.logo_url}", {'VALUE': 'URI'})
 
     description = []
     if event.person_links:

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -71,11 +71,10 @@ def generate_event_component(event, user=None):
     uid = f'indico-event-{event.id}@{url_parse(config.BASE_URL).host}'
     component = generate_basic_component(event, uid)
 
-    # add contact title, phones and emails
-    contact_info = [event.contact_title]
-    contact_info += event.contact_emails
-    contact_info += event.contact_phones
-    component.add('contact', ';'.join(contact_info))
+    # add contact information
+    contact_info = event.contact_emails + event.contact_phones
+    if contact_info:
+        component.add('contact', ';'.join(contact_info))
 
     # add logo url if event is public
     if event.effective_protection_mode == ProtectionMode.public and event.has_logo:
@@ -121,7 +120,9 @@ def events_to_ical(events, user=None, detailed=False):
         else:
             from indico.modules.events.contributions.ical import generate_contribution_component
             components = [
-                generate_contribution_component(contribution) for contribution in event.contributions
+                generate_contribution_component(contrib)
+                for contrib in event.contributions
+                if contrib.start_dt
             ]
             for component in components:
                 calendar.add_component(component)

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -13,60 +13,90 @@ from werkzeug.urls import url_parse
 from indico.core import signals
 from indico.core.config import config
 from indico.core.db.sqlalchemy.protection import ProtectionMode
-from indico.modules.events.contributions.ical import generate_contribution_component
 from indico.util.date_time import now_utc
 from indico.util.signals import values_from_signal
 
 
-def generate_event_component(event, event_uid):
-    """Generates an Event icalendar component from an Indico Event.
+def generate_basic_component(entity, uid=None, url=None):
+    """Generates an icalendar component with basic common properties.
 
-    :param event: The Indico Event to use
+    :param entity: Event/session/contribution where properties come from
+    :param uid: UID for the component
+    :param url: URL for the component (defaults to `entity.external_url`)
+
+    :returns: icalendar event with basic properties
+    """
+
+    component = Event()
+
+    component.add('dtstamp', now_utc(False))
+    component.add('dtstart', entity.start_dt)
+    component.add('dtend', entity.end_dt)
+    component.add('summary', entity.title)
+
+    if uid:
+        component.add('uid', uid)
+
+    if url:
+        component.add('url', url)
+    elif hasattr(entity, 'external_url'):
+        component.add('url', entity.external_url)
+
+    location = (f'{entity.room_name} ({entity.venue_name})'
+                if entity.venue_name and entity.room_name
+                else (entity.venue_name or entity.room_name))
+    if location:
+        component.add('location', location)
+
+    # speakers are located in a different variable in contributions
+    speaker_list = None
+    if hasattr(entity, 'person_links'):
+        speaker_list = entity.person_links
+    elif hasattr(entity, 'speakers'):
+        speaker_list = entity.speakers
+
+    description = []
+    if speaker_list:
+        speakers = [f'{x.full_name} ({x.affiliation})' if x.affiliation else x.full_name
+                    for x in speaker_list]
+        description.append('Speakers: {}'.format(', '.join(speakers)))
+    if entity.description:
+        desc_text = str(entity.description) or '<p/>'  # get rid of RichMarkup
+        try:
+            description.append(str(html.fromstring(desc_text).text_content()))
+        except ParserError:
+            # this happens if desc_text only contains a html comment
+            pass
+    component.add('description', '\n'.join(description))
+
+    return component
+
+
+def generate_event_component(event):
+    """Generates an event icalendar component from an Indico event.
+
+    :param event: The Indico event to use
+
     :returns: an icalendar Event
     """
 
-    cal_event = Event()
-    cal_event.add('uid', event_uid)
-    cal_event.add('dtstamp', now_utc(False))
-    cal_event.add('dtstart', event.start_dt)
-    cal_event.add('dtend', event.end_dt)
-    cal_event.add('url', event.external_url)
-    cal_event.add('summary', event.title)
+    uid = 'indico-event-{}@{}'.format(event.id, url_parse(config.BASE_URL).host)
+    component = generate_basic_component(event, uid)
 
-    location = (f'{event.room_name} ({event.venue_name})'
-                if event.venue_name and event.room_name
-                else (event.venue_name or event.room_name))
-    if location:
-        cal_event.add('location', location)
-
+    # add contact title, phones and emails if present
     if event.contact_title:
         contact_info = f'{event.contact_title}'
         if len(event.contact_emails):
             contact_info += f'; {"; ".join(event.contact_emails)}'
         if len(event.contact_phones):
             contact_info += f'; {"; ".join(event.contact_phones)}'
-        cal_event.add('contact', contact_info)
+        component.add('contact', contact_info)
 
-    # logo url will be added only if event is public
+    # add logo url if event is public
     if event.effective_protection_mode == ProtectionMode.public and event.has_logo:
-        cal_event.add('image', f"{config.BASE_URL}{event.logo_url}", {'VALUE': 'URI'})
+        component.add('image', f"{config.BASE_URL}{event.logo_url}", {'VALUE': 'URI'})
 
-    description = []
-    if event.person_links:
-        speakers = [f'{x.full_name} ({x.affiliation})' if x.affiliation else x.full_name
-                    for x in event.person_links]
-        description.append('Speakers: {}'.format(', '.join(speakers)))
-    if event.description:
-        desc_text = str(event.description) or '<p/>'  # get rid of RichMarkup
-        try:
-            description.append(str(html.fromstring(desc_text).text_content()))
-        except ParserError:
-            # this happens if desc_text only contains a html comment
-            pass
-    description.append(event.external_url)
-    cal_event.add('description', '\n'.join(description))
-
-    return cal_event
+    return component
 
 
 def event_to_ical(event, user=None, detail_level='events'):
@@ -84,6 +114,8 @@ def events_to_ical(events, user=None, detail_level='events'):
 
     :param events: A list of events to serialize
     :param user: The user who needs to be able to access the events
+    :param detail_level: Determines the level of entities that will end up
+                         being exported. Either `events` or `contributions`.
     """
 
     calendar = Calendar()
@@ -91,16 +123,16 @@ def events_to_ical(events, user=None, detail_level='events'):
     calendar.add('prodid', '-//CERN//INDICO//EN')
 
     for event in events:
-        event_uid = 'indico-event-{}@{}'.format(event.id, url_parse(config.BASE_URL).host)
         if detail_level == 'events':
-            cal_event = generate_event_component(event, event_uid)
-            calendar.add_component(cal_event)
+            component = generate_event_component(event)
+            calendar.add_component(component)
         elif detail_level == 'contributions':
-            contributions = [
-                generate_contribution_component(contribution, event_uid) for contribution in event.contributions
+            from indico.modules.events.contributions.ical import generate_contribution_component
+            components = [
+                generate_contribution_component(contribution) for contribution in event.contributions
             ]
-            for contribution in contributions:
-                calendar.add_component(contribution)
+            for component in components:
+                calendar.add_component(component)
 
     data = calendar.to_ical()
 

--- a/indico/modules/events/sessions/client/js/session_display.jsx
+++ b/indico/modules/events/sessions/client/js/session_display.jsx
@@ -18,14 +18,22 @@ document.addEventListener('DOMContentLoaded', () => {
     return;
   }
 
-  const {eventId, sessionId} = calendarContainer.dataset;
+  const {eventId, sessionId, sessionContribCount} = calendarContainer.dataset;
+  const options = [{key: 'session', text: Translate.string('Session'), extraParams: {}}];
+  if (parseInt(sessionContribCount, 10) > 0) {
+    options.push({
+      key: 'contribution',
+      text: Translate.string('Detailed timetable'),
+      extraParams: {detail: 'contributions'},
+    });
+  }
 
   ReactDOM.render(
     <ICSCalendarLink
       endpoint="sessions.export_ics"
       params={{event_id: eventId, session_id: sessionId}}
       renderButton={onClick => <IButton icon="calendar" onClick={onClick} />}
-      options={[{key: 'session', text: Translate.string('Session'), extraParams: {}}]}
+      options={options}
     />,
     calendarContainer
   );

--- a/indico/modules/events/sessions/controllers/display.py
+++ b/indico/modules/events/sessions/controllers/display.py
@@ -73,9 +73,9 @@ class RHDisplaySession(RHDisplaySessionBase):
 @allow_signed_url
 class RHExportSessionToICAL(RHDisplaySessionBase):
     def _process(self):
-        detail_level = request.args.get('detail', 'sessions')
+        detailed = request.args.get('detail', 'sessions') == 'contributions'
 
-        return send_file('session.ics', BytesIO(session_to_ical(self.session, detail_level=detail_level)),
+        return send_file('session.ics', BytesIO(session_to_ical(self.session, detailed)),
                          'text/calendar')
 
 

--- a/indico/modules/events/sessions/controllers/display.py
+++ b/indico/modules/events/sessions/controllers/display.py
@@ -12,8 +12,9 @@ from sqlalchemy.orm import joinedload, subqueryload
 from werkzeug.exceptions import Forbidden
 
 from indico.modules.events.controllers.base import RHDisplayEventBase
+from indico.modules.events.sessions.ical import session_to_ical
 from indico.modules.events.sessions.models.sessions import Session
-from indico.modules.events.sessions.util import get_session_ical_file, get_session_timetable_pdf, get_sessions_for_user
+from indico.modules.events.sessions.util import get_session_timetable_pdf, get_sessions_for_user
 from indico.modules.events.sessions.views import WPDisplayMySessionsConference, WPDisplaySession
 from indico.web.flask.util import send_file
 from indico.web.rh import allow_signed_url
@@ -72,7 +73,10 @@ class RHDisplaySession(RHDisplaySessionBase):
 @allow_signed_url
 class RHExportSessionToICAL(RHDisplaySessionBase):
     def _process(self):
-        return send_file('session.ics', get_session_ical_file(self.session), 'text/calendar')
+        detail_level = request.args.get('detail', 'sessions')
+
+        return send_file('session.ics', BytesIO(session_to_ical(self.session, detail_level=detail_level)),
+                         'text/calendar')
 
 
 class RHExportSessionTimetableToPDF(RHDisplaySessionBase):

--- a/indico/modules/events/sessions/controllers/display.py
+++ b/indico/modules/events/sessions/controllers/display.py
@@ -73,7 +73,7 @@ class RHDisplaySession(RHDisplaySessionBase):
 @allow_signed_url
 class RHExportSessionToICAL(RHDisplaySessionBase):
     def _process(self):
-        detailed = request.args.get('detail', 'sessions') == 'contributions'
+        detailed = request.args.get('detail') == 'contributions'
 
         return send_file('session.ics', BytesIO(session_to_ical(self.session, detailed)),
                          'text/calendar')

--- a/indico/modules/events/sessions/ical.py
+++ b/indico/modules/events/sessions/ical.py
@@ -1,0 +1,58 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from icalendar.cal import Calendar
+from werkzeug.urls import url_parse
+
+from indico.core.config import config
+from indico.modules.events.ical import generate_basic_component
+from indico.web.flask.util import url_for
+
+
+def generate_session_component(session, related_to_uid=None):
+    """Generates an Event icalendar component from an Indico Session.
+
+    :param session: The Indico Session to use
+    :param related_to_uid: Indico uid used in related_to field
+    :returns: an icalendar Event
+    """
+
+    uid = 'indico-session-{}@{}'.format(session.id, url_parse(config.BASE_URL).host)
+    url = url_for('sessions.display_session', session, _external=True)
+    component = generate_basic_component(session, uid, url)
+
+    if related_to_uid:
+        component.add('related_to', related_to_uid)
+
+    return component
+
+
+def session_to_ical(session, detail_level='sessions'):
+    """Serialize a contribution into an ical.
+
+    :param event: The contribution to serialize
+    """
+
+    calendar = Calendar()
+    calendar.add('version', '2.0')
+    calendar.add('prodid', '-//CERN//INDICO//EN')
+
+    related_event_uid = 'indico-event-{}@{}'.format(session.event.id, url_parse(config.BASE_URL).host)
+
+    if detail_level == 'sessions':
+        component = generate_session_component(session, related_event_uid)
+        calendar.add_component(component)
+    elif detail_level == 'contributions':
+        from indico.modules.events.contributions.ical import generate_contribution_component
+        components = [generate_contribution_component(contribution, related_event_uid)
+                      for contribution in session.contributions]
+        for component in components:
+            calendar.add_component(component)
+
+    data = calendar.to_ical()
+
+    return data

--- a/indico/modules/events/sessions/ical.py
+++ b/indico/modules/events/sessions/ical.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from icalendar.cal import Calendar
+import icalendar
 from werkzeug.urls import url_parse
 
 from indico.core.config import config
@@ -14,8 +14,7 @@ from indico.web.flask.util import url_for
 
 
 def generate_session_component(session, related_to_uid=None):
-    """Generates an Event iCalendar component from an Indico Session."""
-
+    """Generate an Event iCalendar component from an Indico Session."""
     uid = f'indico-session-{session.id}@{url_parse(config.BASE_URL).host}'
     url = url_for('sessions.display_session', session, _external=True)
     component = generate_basic_component(session, uid, url)
@@ -32,8 +31,7 @@ def session_to_ical(session, detailed=False):
     :param session: The session to serialize
     :param detailed: If True, iCal will include the session's contributions
     """
-
-    calendar = Calendar()
+    calendar = icalendar.Calendar()
     calendar.add('version', '2.0')
     calendar.add('prodid', '-//CERN//INDICO//EN')
 

--- a/indico/modules/events/sessions/ical.py
+++ b/indico/modules/events/sessions/ical.py
@@ -14,14 +14,9 @@ from indico.web.flask.util import url_for
 
 
 def generate_session_component(session, related_to_uid=None):
-    """Generates an Event icalendar component from an Indico Session.
+    """Generates an Event iCalendar component from an Indico Session."""
 
-    :param session: The Indico Session to use
-    :param related_to_uid: Indico uid used in related_to field
-    :returns: an icalendar Event
-    """
-
-    uid = 'indico-session-{}@{}'.format(session.id, url_parse(config.BASE_URL).host)
+    uid = f'indico-session-{session.id}@{url_parse(config.BASE_URL).host}'
     url = url_for('sessions.display_session', session, _external=True)
     component = generate_basic_component(session, uid, url)
 
@@ -31,28 +26,27 @@ def generate_session_component(session, related_to_uid=None):
     return component
 
 
-def session_to_ical(session, detail_level='sessions'):
-    """Serialize a contribution into an ical.
+def session_to_ical(session, detailed=False):
+    """Serialize a session into an iCal.
 
-    :param event: The contribution to serialize
+    :param session: The session to serialize
+    :param detailed: If True, iCal will include the session's contributions
     """
 
     calendar = Calendar()
     calendar.add('version', '2.0')
     calendar.add('prodid', '-//CERN//INDICO//EN')
 
-    related_event_uid = 'indico-event-{}@{}'.format(session.event.id, url_parse(config.BASE_URL).host)
+    related_event_uid = f'indico-event-{session.event.id}@{url_parse(config.BASE_URL).host}'
 
-    if detail_level == 'sessions':
+    if not detailed:
         component = generate_session_component(session, related_event_uid)
         calendar.add_component(component)
-    elif detail_level == 'contributions':
+    else:
         from indico.modules.events.contributions.ical import generate_contribution_component
         components = [generate_contribution_component(contribution, related_event_uid)
                       for contribution in session.contributions]
         for component in components:
             calendar.add_component(component)
 
-    data = calendar.to_ical()
-
-    return data
+    return calendar.to_ical()

--- a/indico/modules/events/sessions/templates/display/session_display.html
+++ b/indico/modules/events/sessions/templates/display/session_display.html
@@ -59,14 +59,11 @@
                 {% if g.static_site %}
                     <a href="{{ url_for('sessions.export_ics', sess) }}" class="i-button icon-calendar"></a>
                 {% else %}
-                    <div id="session-calendar-link" data-session-id="{{ sess.id }}"
-                         data-event-id="{{ sess.event_id }}"></div>
+                    <div id="session-calendar-link" data-session-id="{{ sess.id }}" data-event-id="{{ sess.event_id }}"
+                         data-session-contrib-count="{{ sess.contributions|length }}"-></div>
                 {% endif %}
             {%- endif %}
         </div>
-        {% if sess.start_dt -%}
-            <div id="session-calendar-link" data-session-id="{{ sess.id }}" data-event-id="{{ sess.event_id }}"></div>
-        {%- endif %}
     </div>
 {%- endblock %}
 

--- a/indico/modules/events/sessions/templates/display/session_display.html
+++ b/indico/modules/events/sessions/templates/display/session_display.html
@@ -60,10 +60,13 @@
                     <a href="{{ url_for('sessions.export_ics', sess) }}" class="i-button icon-calendar"></a>
                 {% else %}
                     <div id="session-calendar-link" data-session-id="{{ sess.id }}" data-event-id="{{ sess.event_id }}"
-                         data-session-contrib-count="{{ sess.contributions|length }}"-></div>
+                         data-session-contrib-count="{{ sess.contributions|length }}"></div>
                 {% endif %}
             {%- endif %}
         </div>
+        {% if sess.start_dt -%}
+            <div id="session-calendar-link" data-session-id="{{ sess.id }}" data-event-id="{{ sess.event_id }}"></div>
+        {%- endif %}
     </div>
 {%- endblock %}
 

--- a/indico/modules/events/sessions/templates/display/session_display.html
+++ b/indico/modules/events/sessions/templates/display/session_display.html
@@ -64,9 +64,6 @@
                 {% endif %}
             {%- endif %}
         </div>
-        {% if sess.start_dt -%}
-            <div id="session-calendar-link" data-session-id="{{ sess.id }}" data-event-id="{{ sess.event_id }}"></div>
-        {%- endif %}
     </div>
 {%- endblock %}
 

--- a/indico/modules/events/sessions/util.py
+++ b/indico/modules/events/sessions/util.py
@@ -177,13 +177,6 @@ def serialize_session_for_ical(sess):
     }
 
 
-def get_session_ical_file(sess):
-    from indico.web.http_api.metadata.serializer import Serializer
-    data = {'results': serialize_session_for_ical(sess) if sess.start_dt and sess.end_dt else []}
-    serializer = Serializer.create('ics')
-    return BytesIO(serializer(data))
-
-
 def get_session_timetable_pdf(sess, **kwargs):
     from indico.legacy.pdfinterface.conference import TimetablePDFFormat, TimeTablePlain
     pdf_format = TimetablePDFFormat(params={'coverPage': False})

--- a/indico/modules/events/static/offline.py
+++ b/indico/modules/events/static/offline.py
@@ -32,13 +32,14 @@ from indico.modules.attachments.models.folders import AttachmentFolder
 from indico.modules.events.contributions.controllers.display import (RHAuthorList, RHContributionAuthor,
                                                                      RHContributionDisplay, RHContributionList,
                                                                      RHSpeakerList, RHSubcontributionDisplay)
-from indico.modules.events.contributions.util import get_contribution_ical_file
+from indico.modules.events.contributions.ical import contribution_to_ical
 from indico.modules.events.layout.models.menu import MenuEntryType
 from indico.modules.events.layout.util import menu_entries_for_event
 from indico.modules.events.models.events import EventType
 from indico.modules.events.registration.controllers.display import RHParticipantList
 from indico.modules.events.sessions.controllers.display import RHDisplaySession
-from indico.modules.events.sessions.util import get_session_ical_file, get_session_timetable_pdf
+from indico.modules.events.sessions.ical import session_to_ical
+from indico.modules.events.sessions.util import get_session_timetable_pdf
 from indico.modules.events.static.util import collect_static_files, override_request_endpoint, rewrite_css_urls
 from indico.modules.events.timetable.controllers.display import RHTimetable
 from indico.modules.events.timetable.util import get_timetable_offline_pdf_generator
@@ -343,7 +344,7 @@ class StaticConferenceCreator(StaticEventCreator):
             self._get_author(contrib, author)
 
         if contrib.timetable_entry:
-            self._add_file(get_contribution_ical_file(contrib), 'contributions.export_ics', contrib)
+            self._add_file(contribution_to_ical(contrib), 'contributions.export_ics', contrib)
 
     def _get_sub_contrib(self, subcontrib):
         self._add_from_rh(RHSubcontributionDisplay, WPStaticSubcontributionDisplay,
@@ -366,7 +367,7 @@ class StaticConferenceCreator(StaticEventCreator):
         pdf = get_session_timetable_pdf(session, tz=self._display_tz)
         self._add_pdf(session, 'sessions.export_session_timetable', pdf)
 
-        self._add_file(get_session_ical_file(session), 'sessions.export_ics', session)
+        self._add_file(session_to_ical(session), 'sessions.export_ics', session)
 
     def _add_pdf(self, target, uh_or_endpoint, generator_class_or_instance, **kwargs):
         if inspect.isclass(generator_class_or_instance):

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -202,7 +202,7 @@
                 {% endif %}
 
                 <div id="event-calendar-link" data-event-id="{{ event.id }}"
-                     data-event-contrib-count={{ event.contributions|length }}></div>
+                     data-event-contrib-count="{{ event.contributions|length }}"></div>
 
                 {% if event.type == 'meeting' %}
                     <a class="i-button text-color subtle icon-file-pdf" title="{% trans %}Export to PDF{% endtrans %}"

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -201,7 +201,8 @@
                     {{ _render_filters() }}
                 {% endif %}
 
-                <div id="event-calendar-link" data-event-id="{{ event.id }}"></div>
+                <div id="event-calendar-link" data-event-id="{{ event.id }}"
+                     data-event-contribs={{ event.contributions|length }}></div>
 
                 {% if event.type == 'meeting' %}
                     <a class="i-button text-color subtle icon-file-pdf" title="{% trans %}Export to PDF{% endtrans %}"

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -202,7 +202,7 @@
                 {% endif %}
 
                 <div id="event-calendar-link" data-event-id="{{ event.id }}"
-                     data-event-contribs={{ event.contributions|length }}></div>
+                     data-event-contrib-count={{ event.contributions|length }}></div>
 
                 {% if event.type == 'meeting' %}
                     <a class="i-button text-color subtle icon-file-pdf" title="{% trans %}Export to PDF{% endtrans %}"


### PR DESCRIPTION
Closes #4785, closes #4786, closes #4787, and closes #4791.

Also:
  * Includes options to download detailed timetable for Sessions, so UX is uniform with event ical download.
  * New serializer for Sessions and Contributions, similar to the one for Events, replacing the legacy ones.
