### PR TITLE
Allow unstaging users in the principal search dialog

### DIFF
--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -341,7 +341,11 @@ const searchFactory = config => {
             <>
               {' '}
               <Popup
-                trigger={<Label circular>{staged.length}</Label>}
+                trigger={
+                  <Label circular styleName="staged-label">
+                    {staged.length}
+                  </Label>
+                }
                 position="bottom left"
                 hoverable
               >
@@ -361,7 +365,7 @@ const searchFactory = config => {
           {single && alwaysConfirm && !!staged.length && (
             <>
               {' '}
-              <Label circular>
+              <Label circular styleName="staged-label">
                 {staged[0].name}
                 <Icon name="delete" onClick={() => handleRemove(staged[0])} />
               </Label>

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -340,10 +340,19 @@ const searchFactory = config => {
           {!single && !!staged.length && (
             <>
               {' '}
-              <Popup trigger={<Label circular>{staged.length}</Label>} position="bottom left">
+              <Popup
+                trigger={<Label circular>{staged.length}</Label>}
+                position="bottom left"
+                hoverable
+              >
                 <List>
                   {_.sortBy(staged, 'name').map(x => (
-                    <List.Item key={x.identifier}>{x.name}</List.Item>
+                    <List.Item key={x.identifier}>
+                      <div styleName="staged-list-item">
+                        {x.name}
+                        <Icon styleName="button" name="delete" onClick={() => handleRemove(x)} />
+                      </div>
+                    </List.Item>
                   ))}
                 </List>
               </Popup>
@@ -352,7 +361,10 @@ const searchFactory = config => {
           {single && alwaysConfirm && !!staged.length && (
             <>
               {' '}
-              <Label circular>{staged[0].name}</Label>
+              <Label circular>
+                {staged[0].name}
+                <Icon name="delete" onClick={() => handleRemove(staged[0])} />
+              </Label>
             </>
           )}
         </Modal.Header>

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -58,14 +58,18 @@ const searchFactory = config => {
   } = config;
 
   /* eslint-disable react/prop-types */
-  const FavoriteItem = ({name, detail, added, onAdd}) => (
+  const FavoriteItem = ({name, detail, added, onAdd, onRemove}) => (
     <Dropdown.Item
       disabled={added}
       styleName="favorite"
       style={{pointerEvents: 'all'}}
       onClick={e => {
         e.stopPropagation();
-        onAdd();
+        if (added) {
+          onRemove();
+        } else {
+          onAdd();
+        }
       }}
     >
       <div styleName="item">
@@ -87,7 +91,7 @@ const searchFactory = config => {
     </Dropdown.Item>
   );
 
-  const SearchForm = ({onSearch, favorites, isAdded, onAdd, single}) => {
+  const SearchForm = ({onSearch, favorites, isAdded, onAdd, onRemove, single}) => {
     const initialFormValues = useContext(InitialFormValuesContext);
     const [dropdownOpen, setDropdownOpen] = useState(false);
     return (
@@ -133,6 +137,9 @@ const searchFactory = config => {
                             setDropdownOpen(false);
                           }
                         }}
+                        onRemove={() => {
+                          onRemove(x);
+                        }}
                       />
                     ))}
                   </Dropdown.Menu>
@@ -145,7 +152,7 @@ const searchFactory = config => {
     );
   };
 
-  const ResultItem = ({name, detail, added, favorite, onAdd, existsInEvent}) => (
+  const ResultItem = ({name, detail, added, favorite, onAdd, onRemove, existsInEvent}) => (
     <List.Item>
       <div styleName="item">
         <div styleName="icon">
@@ -172,7 +179,7 @@ const searchFactory = config => {
         </div>
         <div styleName="actions">
           {added ? (
-            <Icon name="checkmark" size="large" color="green" />
+            <Icon name="checkmark" size="large" color="green" onClick={onRemove} />
           ) : (
             <Icon styleName="button" name="add" size="large" onClick={onAdd} />
           )}
@@ -181,7 +188,7 @@ const searchFactory = config => {
     </List.Item>
   );
 
-  const SearchResults = ({results, total, onAdd, isAdded, favorites}) =>
+  const SearchResults = ({results, total, onAdd, onRemove, isAdded, favorites}) =>
     total !== 0 ? (
       <>
         <Divider horizontal>{getResultsText(total)}</Divider>
@@ -194,6 +201,7 @@ const searchFactory = config => {
               added={isAdded(r)}
               favorite={favorites && favoriteKey ? r[favoriteKey] in favorites : false}
               onAdd={() => onAdd(r)}
+              onRemove={() => onRemove(r)}
               existsInEvent={r.existsInEvent}
             />
           ))}
@@ -204,7 +212,15 @@ const searchFactory = config => {
       <Divider horizontal>{noResultsText}</Divider>
     );
 
-  const SearchContent = ({onAdd, isAdded, favorites, single, withEventPersons, eventId}) => {
+  const SearchContent = ({
+    onAdd,
+    onRemove,
+    isAdded,
+    favorites,
+    single,
+    withEventPersons,
+    eventId,
+  }) => {
     const [result, setResult] = useState(null);
 
     const handleSearch = data => runSearch(data, setResult, withEventPersons, eventId);
@@ -213,6 +229,7 @@ const searchFactory = config => {
         <SearchForm
           onSearch={handleSearch}
           onAdd={onAdd}
+          onRemove={onRemove}
           isAdded={isAdded}
           favorites={favorites}
           single={single}
@@ -223,6 +240,7 @@ const searchFactory = config => {
             total={result.total}
             favorites={favorites}
             onAdd={onAdd}
+            onRemove={onRemove}
             isAdded={isAdded}
           />
         )}
@@ -259,6 +277,10 @@ const searchFactory = config => {
       } else if (!isAdded(item)) {
         setStaged(prev => (single ? [item] : [...prev, item]));
       }
+    };
+
+    const handleRemove = item => {
+      setStaged(prev => prev.filter(it => it.identifier !== item.identifier));
     };
 
     const handleAddButtonClick = () => {
@@ -338,6 +360,7 @@ const searchFactory = config => {
           <SearchContent
             favorites={favorites}
             onAdd={handleAdd}
+            onRemove={handleRemove}
             isAdded={isAdded}
             single={single}
             withEventPersons={withEventPersons}

--- a/indico/web/client/js/react/components/principals/Search.module.scss
+++ b/indico/web/client/js/react/components/principals/Search.module.scss
@@ -14,3 +14,12 @@
 :global(.icon).event-person {
   color: $blue;
 }
+
+.staged-list-item {
+  display: flex;
+  justify-content: space-between;
+
+  > :global(.icon) {
+    margin-left: 0.5em;
+  }
+}

--- a/indico/web/client/js/react/components/principals/Search.module.scss
+++ b/indico/web/client/js/react/components/principals/Search.module.scss
@@ -15,6 +15,10 @@
   color: $blue;
 }
 
+.staged-label :global {
+  animation: highlight 0.5s ease-out;
+}
+
 .staged-list-item {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/179599/111469170-aadc3f80-8726-11eb-924c-7f8ebf89b92f.png)

Clicking the entry of a favorite user or the checkmark of a user in the results again will also unstage them.


closes #4707