### PR TITLE
Editing: Only show menu links the user can access

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Bugfixes
 ^^^^^^^^
 
 - Do not show soft-deleted long-lasting events in category calendar (:pr:`4824`)
+- Do not show management-related links in editing hybrid view unless the user has
+  access to them (:pr:`4830`)
 
 Version 2.3.4
 -------------

--- a/indico/modules/events/editing/client/js/editing/page_layout/EditingView.jsx
+++ b/indico/modules/events/editing/client/js/editing/page_layout/EditingView.jsx
@@ -25,16 +25,17 @@ export default function EditingView({eventTitle, children}) {
   const {data, lastData} = useIndicoAxios({
     url: menuEntriesURL({confId: eventId}),
     trigger: eventId,
+    camelize: true,
   });
 
-  const menuItems = data || lastData;
-  if (!menuItems) {
+  const menuData = data || lastData;
+  if (!menuData) {
     return null;
   }
 
   return (
     <div styleName="editing-view">
-      <MenuBar eventId={eventId} menuItems={menuItems} editableType={type} contribId={contribId} />
+      <MenuBar eventId={eventId} menuData={menuData} editableType={type} contribId={contribId} />
       <div styleName="contents">
         <div styleName="timeline">
           <Header as="h2" styleName="header">

--- a/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.jsx
+++ b/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.jsx
@@ -48,19 +48,22 @@ EditableListMenu.propTypes = {
   editableType: PropTypes.oneOf(Object.values(EditableType)).isRequired,
 };
 
-export default function MenuBar({eventId, menuItems, editableType, contribId}) {
+export default function MenuBar({eventId, menuData, editableType, contribId}) {
   const displayViewURL =
     contribId === null
       ? displayURL({confId: eventId})
       : contribDisplayURL({confId: eventId, contrib_id: contribId});
   const managementViewURL = manageEditableTypeURL({confId: eventId, type: editableType});
+  const {items: menuItems, showManagementLink, showEditableList} = menuData;
 
   return (
     <div styleName="menu-bar">
       <Header as="h2" styleName="header">
         {EditableEditingTitles[editableType]}
       </Header>
-      <EditableListMenu eventId={eventId} editableType={editableType} />
+      {showEditableList[editableType] && (
+        <EditableListMenu eventId={eventId} editableType={editableType} />
+      )}
       {!!menuItems.length && (
         <Menu vertical>
           <Menu.Item header>
@@ -89,11 +92,13 @@ export default function MenuBar({eventId, menuItems, editableType, contribId}) {
             <Icon name="tv" /> <Translate>Display</Translate>
           </span>
         </Menu.Item>
-        <Menu.Item name="management" as="a" href={managementViewURL}>
-          <span style={{color: Palette.blue}}>
-            <Icon name="pencil" /> <Translate>Management</Translate>
-          </span>
-        </Menu.Item>
+        {showManagementLink && (
+          <Menu.Item name="management" as="a" href={managementViewURL}>
+            <span style={{color: Palette.blue}}>
+              <Icon name="pencil" /> <Translate>Management</Translate>
+            </span>
+          </Menu.Item>
+        )}
       </Menu>
     </div>
   );
@@ -109,7 +114,15 @@ const menuEntryPropTypes = {
 MenuBar.propTypes = {
   eventId: PropTypes.number.isRequired,
   contribId: PropTypes.number,
-  menuItems: PropTypes.arrayOf(PropTypes.shape(menuEntryPropTypes)).isRequired,
+  menuData: PropTypes.shape({
+    items: PropTypes.arrayOf(PropTypes.shape(menuEntryPropTypes)).isRequired,
+    showManagementLink: PropTypes.bool.isRequired,
+    showEditableList: PropTypes.shape({
+      paper: PropTypes.bool.isRequired,
+      slides: PropTypes.bool.isRequired,
+      poster: PropTypes.bool.isRequired,
+    }).isRequired,
+  }).isRequired,
   editableType: PropTypes.oneOf(Object.values(EditableType)).isRequired,
 };
 


### PR DESCRIPTION
We were always showing the link back to the editable list, but as someone who just submitted an editable you don't have access to that. Same for the management view link.