### PR TITLE
Use StrictUndefined in templates

### DIFF
--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -256,7 +256,7 @@ Customization
         {% extends '~footer.html' %}
 
         {% block footer_logo %}
-            {%- set filename = 'cern_small_light.png' if dark else 'cern_small.png' -%}
+            {%- set filename = 'cern_small_light.png' if dark|default(false) else 'cern_small.png' -%}
             <a href="https://home.cern/" class="footer-logo">
                 <img src="{{ url_for('assets.custom', filename=filename) }}" alt="CERN">
             </a>

--- a/indico/modules/attachments/controllers/management/base.py
+++ b/indico/modules/attachments/controllers/management/base.py
@@ -98,7 +98,8 @@ class AddAttachmentFilesMixin:
             return jsonify_data(attachment_list=_render_attachment_list(self.object))
         return jsonify_template('attachments/upload.html', form=form, action=url_for('.upload', self.object),
                                 protection_message=_render_protection_message(self.object),
-                                folders_protection_info=_get_folders_protection_info(self.object))
+                                folders_protection_info=_get_folders_protection_info(self.object),
+                                existing_attachment=None)
 
 
 class AddAttachmentLinkMixin:

--- a/indico/modules/designer/templates/list.html
+++ b/indico/modules/designer/templates/list.html
@@ -1,4 +1,4 @@
-{% extends 'categories/management/base.html' if category else 'events/management/base.html' %}
+{% extends 'categories/management/base.html' if category|default(none) else 'events/management/base.html' %}
 {% from 'designer/_list.html' import render_template_list %}
 
 {% block title %}

--- a/indico/modules/designer/templates/template.html
+++ b/indico/modules/designer/templates/template.html
@@ -1,4 +1,4 @@
-{% extends 'categories/management/full_width_base.html' if category else 'events/management/full_width_base.html' %}
+{% extends 'categories/management/full_width_base.html' if category|default(none) else 'events/management/full_width_base.html' %}
 
 {% from 'message_box.html' import message_box %}
 

--- a/indico/modules/events/abstracts/templates/forms/track_role_widget.html
+++ b/indico/modules/events/abstracts/templates/forms/track_role_widget.html
@@ -7,7 +7,7 @@
             <span class="i-box-title">{{ title }}</span>
         </div>
         <div class="i-box-content">
-            {% if caller %}
+            {% if caller is defined %}
                 <p class="text-superfluous">
                     {{ caller() }}
                 </p>

--- a/indico/modules/events/contributions/templates/forms/contribution.html
+++ b/indico/modules/events/contributions/templates/forms/contribution.html
@@ -6,7 +6,7 @@
     {{ form_header(form) }}
     {{ form_row(form.title) }}
     {{ form_row(form.description, widget_attrs={'rows': 10}) }}
-    {{ form_rows(form, fields=fields or none, skip=skip_fields) }}
+    {{ form_rows(form, fields=fields|default(none), skip=skip_fields) }}
     {% call form_fieldset(_('Advanced'), collapsible=true) %}
         {{ form_rows(form, fields=form.custom_field_names + ('references', 'board_number', 'code')) }}
     {% endcall %}

--- a/indico/modules/events/notes/templates/edit_note.html
+++ b/indico/modules/events/notes/templates/edit_note.html
@@ -4,7 +4,7 @@
 {{ form_rows(form, skip_labels=true) }}
 {% call form_footer(form) %}
     <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}"
-           {% if not is_compilation %}data-disabled-until-change{% endif %}>
+           {% if not is_compilation|default(false) %}data-disabled-until-change{% endif %}>
     <a class="i-button big" data-button-back>{% trans %}Close{% endtrans %}</a>
 {% endcall %}
 

--- a/indico/modules/events/templates/display/common/_legacy.html
+++ b/indico/modules/events/templates/display/common/_legacy.html
@@ -19,7 +19,7 @@
     <span class="location-info">
         {#- -#}
         <span class="text">
-            {%- if item.venue_name and (not parent or parent.venue_name != item.venue_name) -%}
+            {%- if item.venue_name -%}
                 <strong>{{ item.venue_name }}</strong>
                 {%- if item.room_name  %}
                     ({{ item.get_room_name(full=false) }})

--- a/indico/modules/events/templates/display/indico/_common.html
+++ b/indico/modules/events/templates/display/indico/_common.html
@@ -73,7 +73,7 @@
 
 {% macro render_users(user_list, span_class='', title=true, italic_affiliation=false, separator=', ') -%}
     {%- for link in user_list -%}
-        {%- if caller -%}
+        {%- if caller is defined -%}
             {{- caller(link) -}}
         {%- else -%}
             <span class="{{ span_class }}">

--- a/indico/modules/events/timetable/templates/display/_weeks.html
+++ b/indico/modules/events/timetable/templates/display/_weeks.html
@@ -50,7 +50,7 @@
         {% if entry.type.name == 'CONTRIBUTION' and speakers %}
             <ul>
                 {% for link in speakers -%}
-                    <li>{{ render_user_data(link, show_title=false, italic_affiliation=italic_affiliation) }}</li>
+                    <li>{{ render_user_data(link, show_title=false) }}</li>
                 {% endfor %}
             </ul>
         {% endif %}
@@ -75,7 +75,7 @@
     <div class="{{ ' '.join(classes) }}" style="{{ '; '.join(extra_styles) }}" data-slot="{{ start_time }}">
         <span class="time">
             {{ start_time|format_time(timezone=timezone) if loop.first else '' }}
-            {% if hide_placeholders and show_end_times %}
+            {% if show_end_times %}
                 <span class="end-time">
                     {{ entry.end_dt | format_time(timezone=timezone) }}
                 </span>
@@ -118,7 +118,7 @@
         {% endif %}
     {% endif %}
     {% if height > 0 %}
-        <div class="row placeholder" data-slot="{{ start_time }}" style="height: {{ height }}px;">
+        <div class="row placeholder" data-slot="" style="height: {{ height }}px;">
         </div>
     {% endif %}
 {% endmacro %}
@@ -136,7 +136,10 @@
         {% endif %}
 
         {% set has_multi = false %}
+        {% set same_time = true %}
+        {% set extra_styles = [] %}
         {% if loop.first %}
+            {% set same_time = false %}
             {% set time_parts = (entry.duration.seconds/60) /5 %}
             {% set height = (time_parts * px_per_5_minutes) %}
             {% if to_subtract[-1] %}
@@ -174,8 +177,6 @@
                     {% set __ = extra_styles.append('background-color: #%s'|format(session.background_color)) %}
                 {% endif %}
             {% endif %}
-        {% else %}
-            {% set same_time = true %}
         {% endif %}
         {% if entry.type.name == 'CONTRIBUTION' or session %}
             {% if entry.type.name == 'CONTRIBUTION' %}

--- a/indico/web/flask/templating.py
+++ b/indico/web/flask/templating.py
@@ -14,11 +14,10 @@ from flask import current_app
 from flask_pluginengine.templating import PluginEnvironment
 from flask_pluginengine.util import get_state
 from jinja2 import environmentfilter
-from jinja2.exceptions import UndefinedError
 from jinja2.filters import _GroupTuple, make_attrgetter
 from jinja2.loaders import BaseLoader, FileSystemLoader, TemplateNotFound, split_template_path
 from jinja2.runtime import StrictUndefined, Undefined
-from jinja2.utils import internalcode, missing
+from jinja2.utils import internalcode
 from markupsafe import Markup
 
 from indico.core import signals
@@ -259,14 +258,6 @@ def _convert_undefined(new_cls, undefined):
         name=undefined._undefined_name,
         exc=undefined._undefined_exception,
     )
-
-
-class IndicoStrictUndefined(StrictUndefined):
-    def __new__(cls, hint=None, obj=missing, name=None, exc=UndefinedError):
-        # XXX should we just use `caller is undefined` in macros instead of this hack?
-        if hint == 'No caller defined' and name == 'caller':
-            return Undefined(hint, obj, name, exc)
-        return super().__new__(cls)
 
 
 class IndicoEnvironment(PluginEnvironment):

--- a/indico/web/flask/wrappers.py
+++ b/indico/web/flask/wrappers.py
@@ -18,13 +18,14 @@ from flask.wrappers import Request
 from flask_pluginengine import PluginFlaskMixin
 from flask_webpackext import current_webpack
 from jinja2 import FileSystemLoader, TemplateNotFound
+from jinja2.runtime import StrictUndefined
 from werkzeug.datastructures import ImmutableOrderedMultiDict
 from werkzeug.utils import cached_property
 
 from indico.core.config import config
 from indico.util.json import IndicoJSONEncoder
 from indico.web.flask.session import IndicoSessionInterface
-from indico.web.flask.templating import CustomizationLoader, IndicoEnvironment, IndicoStrictUndefined
+from indico.web.flask.templating import CustomizationLoader, IndicoEnvironment
 from indico.web.flask.util import make_view_func
 
 
@@ -83,7 +84,7 @@ class IndicoFlask(PluginFlaskMixin, Flask):
     session_interface = IndicoSessionInterface()
     test_client_class = IndicoFlaskClient
     jinja_environment = IndicoEnvironment
-    jinja_options = dict(Flask.jinja_options, undefined=IndicoStrictUndefined)
+    jinja_options = dict(Flask.jinja_options, undefined=StrictUndefined)
 
     @property
     def session_cookie_name(self):

--- a/indico/web/flask/wrappers.py
+++ b/indico/web/flask/wrappers.py
@@ -24,7 +24,7 @@ from werkzeug.utils import cached_property
 from indico.core.config import config
 from indico.util.json import IndicoJSONEncoder
 from indico.web.flask.session import IndicoSessionInterface
-from indico.web.flask.templating import CustomizationLoader
+from indico.web.flask.templating import CustomizationLoader, IndicoEnvironment, IndicoStrictUndefined
 from indico.web.flask.util import make_view_func
 
 
@@ -82,6 +82,8 @@ class IndicoFlask(PluginFlaskMixin, Flask):
     request_class = IndicoRequest
     session_interface = IndicoSessionInterface()
     test_client_class = IndicoFlaskClient
+    jinja_environment = IndicoEnvironment
+    jinja_options = dict(Flask.jinja_options, undefined=IndicoStrictUndefined)
 
     @property
     def session_cookie_name(self):

--- a/indico/web/templates/_sortable_list.html
+++ b/indico/web/templates/_sortable_list.html
@@ -14,7 +14,7 @@
             <div class="actions">
                 <div class="move-prev"></div>
                 <div class="move-next"></div>
-                {% if caller %}
+                {% if caller is defined %}
                     {{ caller(item) }}
                 {% endif %}
             </div>
@@ -24,7 +24,7 @@
 
 {% macro sortable_list(items, classes="", draggable=true, title=none, id=none, invisible_handle=false) -%}
     {# Caller is called with an item and must render the action buttons. #}
-    {% set _caller = caller %}
+    {% set _caller = caller|default(none) %}
     <div class="sortable-list js-sortable-list-widget {{ classes }}"
          {% if id %}id="{{ id }}"{% endif %}
          {% if not draggable %}data-disable-dragging{% endif %}>
@@ -44,7 +44,7 @@
 {% macro sortable_lists(enabled_title, enabled_items, disabled_title, disabled_items, classes="", draggable=true,
                         id=none, invisible_handle=false) -%}
     {# Caller is called with an item and must render the action buttons. #}
-    {% set _caller = caller %}
+    {% set _caller = caller|default(none) %}
     <div class="sortable-list js-sortable-list-widget {{ classes }}"
          {% if id %}id="{{ id }}"{% endif %}
          {% if not draggable %}data-disable-dragging{% endif %}>

--- a/indico/web/templates/error.html
+++ b/indico/web/templates/error.html
@@ -1,7 +1,7 @@
 <div class="error-box">
     <h1>{{ error_message }}</h1>
     <p>{{ error_description }}</p>
-    {% if g.saved_error_uuid and not standalone %}
+    {% if g.saved_error_uuid and not standalone|default(false) %}
         <button id="report-error" class="i-button big">
             {%- trans %}Report Error{% endtrans -%}
         </button>

--- a/indico/web/templates/footer.html
+++ b/indico/web/templates/footer.html
@@ -1,4 +1,4 @@
-<div class="footer {{ 'dark' if dark }}">
+<div class="footer {{ 'dark' if dark|default(false) }}">
     {% block footer -%}
         {%- set indico -%}
             <a href="https://getindico.io">Indico</a> <span class="version">{{ indico_version }}</span>
@@ -6,7 +6,7 @@
         <div class="flexrow f-j-space-between">
             <div class="flexrow f-a-center f-self-stretch">
                 {% block footer_logo %}
-                    {% set filename = 'indico_small_white.png' if dark else 'indico_small.png' %}
+                    {% set filename = 'indico_small_white.png' if dark|default(false) else 'indico_small.png' %}
                     <img src="{{ url_for('assets.image', filename=filename) }}" class="footer-logo" alt="Indico">
                 {% endblock %}
                 <div class="f-self-no-shrink" style="margin-left: 1em;">

--- a/indico/web/templates/forms/_form.html
+++ b/indico/web/templates/forms/_form.html
@@ -14,7 +14,7 @@
           class="{{ 'i-form' if i_form }} {{ 'disable-fields-if-locked' if disable_if_locked }} {{ orientation }} {{ classes }}"
           {% if id %}id="{{ id }}"{% endif %}
           {% if multipart %}enctype="multipart/form-data"{% endif %}
-          {% if caller %}{{ caller() }}{% endif %}
+          {% if caller is defined %}{{ caller() }}{% endif %}
           {% if no_ajax %}data-no-ajax{% endif %}
           {{ extra_attrs|html_params }}>
         {% if form.meta.csrf -%}
@@ -48,7 +48,7 @@
         {% if field.widget.input_type == 'checkbox' %}
             <div class="form-checkbox-label">{{ field.label() }}</div>
         {% endif %}
-        {%- if caller -%}
+        {%- if caller is defined -%}
             {{ caller() }}
         {%- endif -%}
         {% if not hide_description and field.description %}
@@ -81,7 +81,7 @@
             {% endif %}
             {% set widget_attrs = dict(widget_attrs, placeholder=(field.label.text if placeholder else widget_attrs.get('placeholder', ''))) %}
             {% set classes = 'form-field %s' | format(classes) %}
-            {%- if caller -%}
+            {%- if caller is defined -%}
                 {% set caller_ = caller %}
                 {% call form_field(field, classes, widget_attrs, disabled=disabled, hide_description=hide_description) -%}
                     {{ caller_() }}
@@ -102,7 +102,7 @@
 
 {# `form` and `i_form` args are there in case we need them in the future #}
 {% macro form_footer(form, i_form=true, skip_label=false, align_right=false, classes='') -%}
-    {% if caller %}
+    {% if caller is defined %}
         <div class="form-group form-group-footer {{ classes }}">
             {% if not skip_label -%}
                 <div class="form-label"></div>
@@ -160,7 +160,7 @@
     {% if message %}
         {{ message_box('warning', message=message, icon=true) }}
     {% endif %}
-    {% if caller %}
+    {% if caller is defined %}
         {{ caller() }}
     {% else %}
         {{ form_rows(form, fields=fields, disable=disabled_fields, skip_labels=skip_labels) }}

--- a/indico/web/templates/forms/radio_buttons_widget.html
+++ b/indico/web/templates/forms/radio_buttons_widget.html
@@ -4,9 +4,7 @@
 
 {% block html %}
     <div id="{{ field.id }}" class="{{ 'i-group' if vertical_alignment else 'group i-selection' }}">
-        {% if field.enum and field.enum.__css_classes__ %}
-            {% set options = field.enum | list %}
-        {% endif %}
+        {% set options = field.enum|list if field.enum and field.enum.__css_classes__ else none %}
         {% for subfield in field %}
             <div class="{{ 'i-radio' if vertical_alignment else 'inline-vcentered'}} radio-item-{{ loop.index0 }} {% if options %} {{ options[loop.index0].css_class }} {% endif %}">
                 {{ subfield(**input_args) }}

--- a/indico/web/templates/indico_base.html
+++ b/indico/web/templates/indico_base.html
@@ -54,7 +54,7 @@
 
     <script type="text/javascript" src="{{ url_for('assets.js_vars_user') }}"></script>
 
-    {{ head_content|safe }}
+    {{ head_content|default('')|safe }}
 
     {% for url in css_files -%}
         <link rel="stylesheet" type="text/css" href="{{ url }}">

--- a/indico/web/templates/overview/base.html
+++ b/indico/web/templates/overview/base.html
@@ -15,7 +15,7 @@
 {% block content %}
     <div class="i-box-group vert">
         <div class="i-box">
-            {{ form_header(form, method='get', action=action) }}
+            {{ form_header(form, method='get', action=action|default('')) }}
             {{ form_rows(form) }}
             {% call form_footer(form) %}
                 <input class="i-button big highlight" type="submit" value="{% trans %}Search{% endtrans %}">


### PR DESCRIPTION
In the end using `StrictUndefined` was fine, with one notable exception: Undefined attributes/item return a slightly more lenient Undefined object that allows boolean and equality checks.

closes #4678