### PR TITLE
Restore "show inherited ACL" functionality

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,7 @@ Bugfixes
   "Participant Roles" page (:pr:`4822`)
 - Fail gracefully during registration import when two rows have different emails that belong
   to the same user (:pr:`4823`)
+- Restore the ability to see who's inheriting access from a parent object (:pr:`4833`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/core/db/sqlalchemy/principals.py
+++ b/indico/core/db/sqlalchemy/principals.py
@@ -68,12 +68,6 @@ class EmailPrincipal:
     """
 
     principal_type = PrincipalType.email
-    is_network = False
-    is_group = False
-    is_single_person = True
-    is_event_role = False
-    is_category_role = False
-    is_registration_form = False
     principal_order = 0
 
     def __init__(self, email):

--- a/indico/modules/attachments/forms.py
+++ b/indico/modules/attachments/forms.py
@@ -33,7 +33,6 @@ class AttachmentFormBase(IndicoForm):
                                  allow_groups=True, allow_external_users=True, allow_event_roles=True,
                                  allow_category_roles=True, allow_registration_forms=True,
                                  event=lambda form: form.event,
-                                 default_text=_('Restrict access to this material'),
                                  description=_("The list of users and groups allowed to access the material"))
 
     def __init__(self, *args, **kwargs):
@@ -95,7 +94,6 @@ class AttachmentFolderForm(IndicoForm):
                                  allow_groups=True, allow_external_users=True, allow_event_roles=True,
                                  allow_category_roles=True, allow_registration_forms=True,
                                  event=lambda form: form.event,
-                                 default_text=_('Restrict access to this folder'),
                                  description=_("The list of users and groups allowed to access the folder"))
     is_always_visible = BooleanField(_("Always Visible"),
                                      [HiddenUnless('is_hidden', value=False)],

--- a/indico/modules/categories/models/roles.py
+++ b/indico/modules/categories/models/roles.py
@@ -21,7 +21,7 @@ class CategoryRole(db.Model):
     is_event_role = False
     is_registration_form = False
     is_category_role = True
-    is_single_person = True
+    is_single_person = False
     is_network = False
     principal_order = 2
     principal_type = PrincipalType.category_role

--- a/indico/modules/categories/models/roles.py
+++ b/indico/modules/categories/models/roles.py
@@ -17,12 +17,6 @@ class CategoryRole(db.Model):
                       db.Index(None, 'category_id', 'code', unique=True),
                       {'schema': 'categories'})
 
-    is_group = False
-    is_event_role = False
-    is_registration_form = False
-    is_category_role = True
-    is_single_person = False
-    is_network = False
     principal_order = 2
     principal_type = PrincipalType.category_role
 

--- a/indico/modules/categories/templates/display/sidebar.html
+++ b/indico/modules/categories/templates/display/sidebar.html
@@ -27,7 +27,7 @@
         </div>
         <ul id="manager-list">
             {% for manager in managers %}
-                <li class="{{ 'icon-user' if manager.is_single_person else 'icon-users' }}">
+                <li class="{{ 'icon-user' if manager.principal_type.name in ('user', 'email') else 'icon-users' }}">
                     {{ manager.name }}
                 </li>
             {% endfor %}

--- a/indico/modules/events/models/roles.py
+++ b/indico/modules/events/models/roles.py
@@ -20,7 +20,7 @@ class EventRole(db.Model):
     is_group = False
     is_event_role = True
     is_category_role = False
-    is_single_person = True
+    is_single_person = False
     is_network = False
     is_registration_form = False
     principal_order = 2

--- a/indico/modules/events/models/roles.py
+++ b/indico/modules/events/models/roles.py
@@ -17,12 +17,6 @@ class EventRole(db.Model):
                       db.Index(None, 'event_id', 'code', unique=True),
                       {'schema': 'events'})
 
-    is_group = False
-    is_event_role = True
-    is_category_role = False
-    is_single_person = False
-    is_network = False
-    is_registration_form = False
     principal_order = 2
     principal_type = PrincipalType.event_role
 

--- a/indico/modules/events/notifications.py
+++ b/indico/modules/events/notifications.py
@@ -7,6 +7,7 @@
 
 from sqlalchemy.orm import joinedload
 
+from indico.core.db.sqlalchemy.principals import PrincipalType
 from indico.core.notifications import make_email, send_email
 from indico.modules.categories.models.categories import Category
 from indico.web.flask.templating import get_template_module
@@ -29,9 +30,9 @@ def notify_event_creation(event, occurrences=None):
         emails.update(cat.event_creation_notification_emails)
         if cat.notify_managers:
             for manager in cat.get_manager_list():
-                if manager.is_single_person:
+                if manager.principal_type in (PrincipalType.user, PrincipalType.email):
                     emails.add(manager.email)
-                elif manager.is_group:
+                elif manager.principal_type in (PrincipalType.local_group, PrincipalType.multipass_group):
                     emails.update(x.email for x in manager.get_members())
 
     if emails:

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -314,6 +314,11 @@ class RegistrationForm(db.Model):
                 .has_rows())
 
     @property
+    def name(self):
+        # needed when sorting acl entries by name
+        return self.title
+
+    @property
     def identifier(self):
         return f'RegistrationForm:{self.id}'
 

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -42,12 +42,6 @@ class RegistrationForm(db.Model):
     __tablename__ = 'forms'
     principal_type = PrincipalType.registration_form
     principal_order = 2
-    is_group = False
-    is_network = False
-    is_single_person = False
-    is_event_role = False
-    is_category_role = False
-    is_registration_form = True
 
     __table_args__ = (db.Index('ix_uq_forms_participation', 'event_id', unique=True,
                                postgresql_where=db.text('is_participation AND NOT is_deleted')),

--- a/indico/modules/groups/core.py
+++ b/indico/modules/groups/core.py
@@ -35,13 +35,6 @@ class GroupProxy:
     :param provider: The provider of a multipass group
     """
 
-    # Useful when dealing with both users and groups in the same code
-    is_group = True
-    is_network = False
-    is_single_person = False
-    is_event_role = False
-    is_category_role = False
-    is_registration_form = False
     principal_order = 3
 
     def __new__(cls, name_or_id, provider=None, _group=None):

--- a/indico/modules/networks/models/networks.py
+++ b/indico/modules/networks/models/networks.py
@@ -21,12 +21,6 @@ class IPNetworkGroup(db.Model):
     __tablename__ = 'ip_network_groups'
     principal_type = PrincipalType.network
     principal_order = 1
-    is_group = False
-    is_network = True
-    is_single_person = False
-    is_event_role = False
-    is_category_role = False
-    is_registration_form = False
 
     @declared_attr
     def __table_args__(cls):

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -163,13 +163,6 @@ def format_display_full_name(user, obj):
 class User(PersonMixin, db.Model):
     """Indico users."""
 
-    # Useful when dealing with both users and groups in the same code
-    is_group = False
-    is_single_person = True
-    is_event_role = False
-    is_category_role = False
-    is_registration_form = False
-    is_network = False
     principal_order = 0
     principal_type = PrincipalType.user
 

--- a/indico/web/client/js/jquery/widgets/jinja/protection_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/protection_widget.js
@@ -5,9 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-(function(global) {
-  'use strict';
+/* global handleAjaxError:true */
 
+import _ from 'lodash';
+
+(function(global) {
   global.setupProtectionWidget = function setupProtectionWidget(options) {
     options = $.extend(
       true,
@@ -22,13 +24,11 @@
       options
     );
 
-    var inputs = $('input[name=' + options.fieldName + '][id^=' + options.fieldId + ']');
-    var $enableAclLink = $('.enable-acl-link');
-    var $aclListField = $('.acl-list-field');
+    const inputs = $(`input[name=${options.fieldName}][id^=${options.fieldId}]`);
 
     inputs.on('change', function() {
-      var $this = $(this);
-      var isProtected =
+      const $this = $(this);
+      const isProtected =
         $this.val() === 'protected' || ($this.val() === 'inheriting' && options.parentProtected);
 
       if (this.checked) {
@@ -42,7 +42,7 @@
             url: options.aclMessageUrl,
             data: {mode: $this.val()},
             error: handleAjaxError,
-            success: function(data) {
+            success(data) {
               $this
                 .closest('form')
                 .find('.inheriting-acl-message')
@@ -50,8 +50,6 @@
             },
           });
         }
-        $aclListField.toggleClass('hidden', !isProtected);
-        $enableAclLink.toggleClass('hidden', isProtected);
         if (options.permissionsFieldId) {
           $('#permissions-widget-{0}'.format(options.permissionsFieldId)).trigger(
             'indico:protectionModeChanged',
@@ -59,11 +57,6 @@
           );
         }
       }
-    });
-
-    $enableAclLink.on('click', function(evt) {
-      evt.preventDefault();
-      $('input[name=' + options.fieldName + '][value="protected"]').trigger('click');
     });
 
     _.defer(function() {

--- a/indico/web/forms/fields/principals.py
+++ b/indico/web/forms/fields/principals.py
@@ -105,8 +105,6 @@ class PrincipalListField(HiddenField):
 
 class AccessControlListField(PrincipalListField):
     def __init__(self, *args, **kwargs):
-        # The text of the link that changes the protection mode of the object to protected
-        self.default_text = kwargs.pop('default_text')
         # Hardcoded value of the protected field for legacy compatibility
         self.protected_field_id = 'protected'
         super().__init__(*args, **kwargs)

--- a/indico/web/forms/fields/principals.py
+++ b/indico/web/forms/fields/principals.py
@@ -40,7 +40,7 @@ def serialize_principal(principal):
         return serialize_category_role(principal)
     elif principal.principal_type == PrincipalType.registration_form:
         return serialize_registration_form(principal)
-    elif principal.is_group:
+    elif principal.principal_type in (PrincipalType.local_group, PrincipalType.multipass_group):
         return serialize_group(principal)
     else:
         raise ValueError(f'Invalid principal: {principal} ({principal.principal_type})')

--- a/indico/web/templates/_access_list.html
+++ b/indico/web/templates/_access_list.html
@@ -3,14 +3,21 @@
         <div class="i-box just-group-list">
             <div class="i-box-content">
                 <ul class="group-list">
-                    {% for user in acl | selectattr('is_single_person') | sort(attribute='name') %}
-                        <li class="icon-user">{{ user.name }}</li>
-                    {% endfor %}
-                    {% for group in acl | selectattr('is_group') | sort(attribute='name') %}
-                        <li class="icon-users">{{ group.name }}</li>
-                    {% endfor %}
-                    {% for network in acl | selectattr('is_network') | sort(attribute='name') %}
-                        <li class="icon-lan">{{ network.name }}</li>
+                    {% for item in acl|sort(attribute='name')|sort(attribute='principal_type') %}
+                        {% if item.principal_type.name in ['user', 'email'] %}
+                            <li class="icon-user">{{ item.name }}</li>
+                        {% elif item.principal_type.name in ['local_group', 'multipass_group'] %}
+                            <li class="icon-users">{{ item.name }}</li>
+                        {% elif item.principal_type.name == 'network' %}
+                            <li class="icon-lan">{{ item.name }}</li>
+                        {% elif item.principal_type.name in ['event_role', 'category_role'] %}
+                            <li class="icon-medal">{{ item.name }}</li>
+                        {% elif item.principal_type.name == 'registration_form' %}
+                            <li class="icon-ticket">{{ item.name }}</li>
+                        {% else %}
+                            {# just in case someone forgets to add a new principal type here... #}
+                            <li class="icon-users">{{ item.name }}</li>
+                        {% endif %}
                     {% endfor %}
                 </ul>
             </div>

--- a/indico/web/templates/_protection_messages.html
+++ b/indico/web/templates/_protection_messages.html
@@ -61,6 +61,7 @@
             </div>
         </div>
     </div>
+    <div class="inheriting-acl-message"></div>
 {%- endmacro %}
 
 {%- macro render_non_inheriting_children_message(protected_object, non_inheriting_objects) -%}

--- a/indico/web/templates/_session_bar.html
+++ b/indico/web/templates/_session_bar.html
@@ -2,7 +2,7 @@
     {% if not obj.is_protected %}
         {% set mode = 'public' %}
     {% else %}
-        {% set networks = obj.get_access_list()|selectattr('is_network')|map(attribute='name')|sort %}
+        {% set networks = obj.get_access_list()|selectattr('principal_type.name', 'equalto', 'network')|map(attribute='name')|sort %}
         {% set mode = 'network' if networks else 'restricted' %}
     {% endif %}
 

--- a/indico/web/templates/forms/principal_list_widget.html
+++ b/indico/web/templates/forms/principal_list_widget.html
@@ -2,17 +2,8 @@
 
 
 {% block html %}
-    {% if acl %}
-        <a href="#" class="enable-acl-link hidden"
-           title='{% trans %}This will change the protection mode to "Protected"{% endtrans %}'>
-            {{- field.default_text -}}
-        </a>
-    {% endif %}
     {% set value_json = field._value() | tojson %}
-    <div class="i-form-field-fixed-width {{ 'acl-list-field' if acl }}" data-tooltip-anchor>
-        {% if acl %}
-            <div class="inheriting-acl-message"></div>
-        {% endif %}
+    <div class="i-form-field-fixed-width" data-tooltip-anchor>
         <div id="userGroupList-{{ field.id }}" style="margin-bottom: 10px;"></div>
         <input type="hidden" id="{{ field.id }}" name="{{ field.name }}" value="{{ value_json | forceescape }}"
                {{ input_args | html_params }}>


### PR DESCRIPTION
This got lost at some point, probably when we switched to the fancy "permissions widget" in v2.1. Apparently nobody missed it but I spotted it when removing some unused code and thus fixed it.

For those who don't remember it, it's this:

![image](https://user-images.githubusercontent.com/179599/111669031-abec9a00-8816-11eb-9435-909227fe59cd.png)

![image](https://user-images.githubusercontent.com/179599/111669052-b0b14e00-8816-11eb-90b2-d6a7c90338bf.png)
