### PR TITLE
Registration CSV import: Check for unique users as well

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,8 @@ Bugfixes
 
 - Take registrations of users who are only members of a custom event role into account on the
   "Participant Roles" page (:pr:`4822`)
+- Fail gracefully during registration import when two rows have different emails that belong
+  to the same user (:pr:`4823`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
We check for [unique emails](https://github.com/indico/indico/blob/aeee94f34f07d745802c5ae1c6f422f1eed4adbd/indico/modules/events/registration/util.py#L576-L577) but if two emails belong to the same user the import still fails with an ugly database error.