### PR TITLE
Update event QR content for new OAuth features

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ Improvements
 - Allow adding groups/roles as "authorized abstract submitters" (:pr:`4834`)
 - Direct links to (sub-)contributions in meetings using the URLs usually meant for
   conferences now redirect to the meeting view page (:pr:`4847`)
+- New version of the event QR code that enables code-with-PKCE flow in the Check-in App
+  (:pr:`4844`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,8 +50,8 @@ Improvements
 - Allow adding groups/roles as "authorized abstract submitters" (:pr:`4834`)
 - Direct links to (sub-)contributions in meetings using the URLs usually meant for
   conferences now redirect to the meeting view page (:pr:`4847`)
-- New version of the event QR code that enables code-with-PKCE flow in the Check-in App
-  (:pr:`4844`)
+- Use a more compact setup QR code for the mobile *Indico check-in* app; the latest version of
+  the app is now required. (:pr:`4844`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/controllers/management/tickets.py
+++ b/indico/modules/events/registration/controllers/management/tickets.py
@@ -61,14 +61,14 @@ class RHTicketConfigQRCodeImage(RHManageRegFormBase):
 
         checkin_app = OAuthApplication.query.filter_by(system_app_type=SystemAppType.checkin).one()
         qr_data = {
-            "event_id": self.event.id,
-            "title": self.event.title,
-            "date": self.event.start_dt.isoformat(),
-            "version": 2,
-            "server": {
-                "base_url": config.BASE_URL,
-                "consumer_key": checkin_app.client_id,
-                "scope": "registrants",
+            'event_id': self.event.id,
+            'title': self.event.title,
+            'date': self.event.start_dt.isoformat(),
+            'version': 2,
+            'server': {
+                'base_url': config.BASE_URL,
+                'client_id': checkin_app.client_id,
+                'scope': 'registrants',
             }
         }
         json_qr_data = json.dumps(qr_data)

--- a/indico/modules/events/registration/controllers/management/tickets.py
+++ b/indico/modules/events/registration/controllers/management/tickets.py
@@ -16,7 +16,7 @@ from indico.core.oauth.models.applications import OAuthApplication, SystemAppTyp
 from indico.modules.designer import PageOrientation, PageSize
 from indico.modules.events.registration.controllers.management import RHManageRegFormBase
 from indico.modules.events.registration.forms import TicketsForm
-from indico.web.flask.util import send_file, url_for
+from indico.web.flask.util import send_file
 from indico.web.util import jsonify_data, jsonify_template
 
 
@@ -64,12 +64,11 @@ class RHTicketConfigQRCodeImage(RHManageRegFormBase):
             "event_id": self.event.id,
             "title": self.event.title,
             "date": self.event.start_dt.isoformat(),
-            "version": 1,
+            "version": 2,
             "server": {
                 "base_url": config.BASE_URL,
                 "consumer_key": checkin_app.client_id,
-                "auth_url": url_for('oauth.oauth_authorize', _external=True),
-                "token_url": url_for('oauth.oauth_token', _external=True)
+                "scope": "registrants",
             }
         }
         json_qr_data = json.dumps(qr_data)


### PR DESCRIPTION
This PR updates the QR generated at [RHTicketConfigQRCodeImage](https://github.com/indico/indico/blob/master/indico/modules/events/registration/controllers/management/tickets.py#L50) to enable the [Indico Check-in App](https://github.com/indico/indico-checkin) to make use of the new features brought in by https://github.com/indico/indico/pull/4798, namely PKCE flow and provider metadata endpoint.

Bumping the version number in the QR to 2 allows enabling the new behavior for up-to-date instances and maintain compatibility for legacy ones.

Also, querying the discovery endpoint (`/.well-known/oauth-authorization-server`) to get the URLs for authentication and token requests reduces the QR size a bit.

Related Issue in checkin-app: https://github.com/indico/indico-checkin/issues/9