### PR TITLE
Redirect meeting elements to slug based URL

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,8 @@ Improvements
   are exported. (:issue:`4785`, :issue:`4586`, :issue:`4587`, :issue:`4791`,
   :pr:`4820`)
 - Allow adding groups/roles as "authorized abstract submitters" (:pr:`4834`)
+- Direct links to (sub-)contributions in meetings using the URLs usually meant for
+  conferences now redirect to the meeting view page (:pr:`4847`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/models/contributions.py
+++ b/indico/modules/events/contributions/models/contributions.py
@@ -29,7 +29,7 @@ from indico.modules.events.papers.models.papers import Paper
 from indico.modules.events.papers.models.revisions import PaperRevision, PaperRevisionState
 from indico.modules.events.sessions.util import session_coordinator_priv_enabled
 from indico.util.locators import locator_property
-from indico.util.string import format_repr
+from indico.util.string import format_repr, slugify
 
 
 def _get_next_friendly_id(context):
@@ -522,6 +522,10 @@ class Contribution(DescriptionMixin, ProtectionManagersMixin, LocationMixin, Att
     @property
     def has_published_editables(self):
         return any(e.published_revision_id is not None for e in self.enabled_editables)
+
+    @property
+    def slug(self):
+        return slugify(self.friendly_id, self.title, maxlen=30)
 
     def is_paper_reviewer(self, user):
         return user in self.paper_content_reviewers or user in self.paper_layout_reviewers

--- a/indico/modules/events/contributions/models/subcontributions.py
+++ b/indico/modules/events/contributions/models/subcontributions.py
@@ -11,7 +11,7 @@ from indico.core.db.sqlalchemy.descriptions import DescriptionMixin, RenderMode
 from indico.core.db.sqlalchemy.notes import AttachedNotesMixin
 from indico.core.db.sqlalchemy.util.queries import increment_and_get
 from indico.util.locators import locator_property
-from indico.util.string import format_repr
+from indico.util.string import format_repr, slugify
 
 
 def _get_next_friendly_id(context):
@@ -143,6 +143,10 @@ class SubContribution(DescriptionMixin, AttachedItemsMixin, AttachedNotesMixin, 
     @speakers.setter
     def speakers(self, value):
         self.person_links = list(value.keys())
+
+    @property
+    def slug(self):
+        return slugify('sc', self.contribution.friendly_id, self.friendly_id, self.title, maxlen=30)
 
     @property
     def location_parent(self):

--- a/indico/modules/events/timetable/templates/display/indico/_contribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_contribution.html
@@ -6,8 +6,7 @@
 
 {% macro render_contribution(contrib, event, theme_settings, theme_context, parent=none, nested=false, hide_end_time=false,
                              timezone=none, show_notes=false, show_location=false) -%}
-    {% set anchor = slugify(contrib.friendly_id, contrib.title, maxlen=30) %}
-    <li class="timetable-item timetable-contrib" id="{{ anchor }}">
+    <li class="timetable-item timetable-contrib" id="{{ contrib.slug }}">
         <span class="timetable-time {{ 'nested' if nested else 'top-level' }}">
             {% if theme_settings.number_contributions %}
                 <span class="start-time">
@@ -20,7 +19,7 @@
 
         <div class="timetable-item-body flexcol">
             <div class="timetable-item-header flexrow">
-                <span class="timetable-title {{ 'nested' if nested }}" data-anchor="{{ anchor }}">
+                <span class="timetable-title {{ 'nested' if nested }}" data-anchor="{{ contrib.slug }}">
                     {{- contrib.title -}}
                 </span>
                 {% if contrib.duration and not theme_settings.hide_duration -%}

--- a/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
@@ -4,12 +4,10 @@
 
 
 {% macro render_subcontribution(subcontrib, event, theme_settings, theme_context, show_notes=true) %}
-    {% set contrib = subcontrib.contribution %}
-    {% set anchor = slugify('sc', contrib.friendly_id, subcontrib.friendly_id, subcontrib.title, maxlen=30) %}
-    <li class="timetable-subcontrib timetable-item" id="{{ anchor }}">
+    <li class="timetable-subcontrib timetable-item" id="{{ subcontrib.slug }}">
         <div class="timetable-item-body flexcol">
             <div class="timetable-item-header flexrow">
-                <span class="timetable-title" data-anchor="{{ anchor }}">
+                <span class="timetable-title" data-anchor="{{ subcontrib.slug }}">
                     {% if theme_settings.number_contributions %}
                         {%- set n_scontrib = theme_context.num_subcontribution -%}
                         {{- 'abcdefghijklmnopqrstuvwxyz'[n_scontrib % 28 - 1] * (n_scontrib / 28 + 1)|int }})


### PR DESCRIPTION
Accessing a contribution URL currently leads to the contribution individual page. 

In meetings, that's not the ideal use-case since contributions are an abstract concept not exactly used in the same way as conferences. In most cases, the user is looking for the element anchor in the event display.

These changes redirect **contributions** and **sub contributions** to their respective event display slug-based URLs in the **meeting type**.

To be added:
- [x] ~~Sessions~~
- [x] ~~Event notes~~