### PR TITLE
Add download option to calendar export popups

### DIFF
--- a/indico/modules/categories/client/js/base.jsx
+++ b/indico/modules/categories/client/js/base.jsx
@@ -24,7 +24,9 @@ document.addEventListener('DOMContentLoaded', () => {
     <ICSCalendarLink
       endpoint="categories.export_ical"
       params={{category_id: categoryId}}
-      renderButton={onClick => <IButton icon="calendar" onClick={onClick} />}
+      renderButton={(onClick, classes) => (
+        <IButton icon="calendar" onClick={onClick} classes={classes} />
+      )}
       options={[{key: 'category', text: Translate.string('Category'), extraParams: {}}]}
     />,
     calendarContainer

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -19,7 +19,7 @@
             {% endblock %}
         </h1>
         {% block cat_toolbar %}
-            <div id="category-toolbar" class="toolbar">
+            <div id="category-toolbar" class="toolbar fixed-height">
                 <div class="group">
                     {% block cat_create_event %}
                         {{ create_event_button(category, classes="highlight", text=_("Create event"), with_tooltip=false) }}

--- a/indico/modules/events/client/js/header.jsx
+++ b/indico/modules/events/client/js/header.jsx
@@ -32,11 +32,13 @@ document.addEventListener('DOMContentLoaded', () => {
     <ICSCalendarLink
       endpoint="events.export_event_ical"
       params={{event_id: eventId}}
-      renderButton={onClick => (
+      renderButton={(onClick, classes) => (
         <IButton
           icon="calendar"
-          classes={{'height-full': true, 'text-color': true, 'subtle': true}}
+          dropdown
+          classes={{'height-full': true, 'text-color': true, 'subtle': true, ...classes}}
           onClick={onClick}
+          title="Export"
         />
       )}
       dropdownPosition="top left"

--- a/indico/modules/events/client/js/header.jsx
+++ b/indico/modules/events/client/js/header.jsx
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
           dropdown
           classes={{'height-full': true, 'text-color': true, 'subtle': true, ...classes}}
           onClick={onClick}
-          title="Export"
+          title={Translate.string('Export')}
         />
       )}
       dropdownPosition="top left"

--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -40,7 +40,9 @@ document.addEventListener('DOMContentLoaded', () => {
     <ICSCalendarLink
       endpoint="contributions.export_ics"
       params={{event_id: eventId, contrib_id: contributionId}}
-      renderButton={onClick => <IButton icon="calendar" onClick={onClick} />}
+      renderButton={(onClick, classes) => (
+        <IButton icon="calendar" onClick={onClick} classes={classes} />
+      )}
       options={[{key: 'contribution', text: Translate.string('Contribution'), extraParams: {}}]}
     />,
     calendarContainer

--- a/indico/modules/events/sessions/client/js/session_display.jsx
+++ b/indico/modules/events/sessions/client/js/session_display.jsx
@@ -32,7 +32,9 @@ document.addEventListener('DOMContentLoaded', () => {
     <ICSCalendarLink
       endpoint="sessions.export_ics"
       params={{event_id: eventId, session_id: sessionId}}
-      renderButton={onClick => <IButton icon="calendar" onClick={onClick} />}
+      renderButton={(onClick, classes) => (
+        <IButton icon="calendar" onClick={onClick} classes={classes} />
+      )}
       options={options}
     />,
     calendarContainer

--- a/indico/web/client/js/react/components/ICSCalendarLink.jsx
+++ b/indico/web/client/js/react/components/ICSCalendarLink.jsx
@@ -84,7 +84,7 @@ export default function ICSCalendarLink({
       >
         <Dropdown.Menu>
           <Dropdown.Header>
-            <Translate>Synchronise with your calendar</Translate>
+            <Translate>Export</Translate>
           </Dropdown.Header>
           <Dropdown.Divider />
           {options.map(({key, text, extraParams}) => (
@@ -125,11 +125,12 @@ export default function ICSCalendarLink({
       wide
     >
       <Header
-        styleName="centered"
-        content={Translate.string('Sync with your calendar')}
+        styleName="export-header"
+        content={Translate.string('Export')}
         subheader={option && <Label color="blue">{option.text}</Label>}
       />
       <Popup.Content>
+        <strong styleName="export-option">Synchronise with your calendar</strong>
         <p>
           <Translate>
             You may copy-paste the following URL into your scheduling application. Contents will be
@@ -154,6 +155,20 @@ export default function ICSCalendarLink({
             </Grid.Row>
           </Grid>
         )}
+        <strong styleName="export-option">Download</strong>
+        <div styleName="download-option">
+          <span>
+            <Translate>
+              Download an iCalendar file that you can use in calendaring applications.
+            </Translate>
+          </span>
+          <Button
+            styleName="download-button"
+            as="a"
+            href={option ? option.url : ''}
+            icon="download"
+          />
+        </div>
       </Popup.Content>
     </Popup>
   );

--- a/indico/web/client/js/react/components/ICSCalendarLink.jsx
+++ b/indico/web/client/js/react/components/ICSCalendarLink.jsx
@@ -29,6 +29,7 @@ export default function ICSCalendarLink({
   const [copied, setCopied] = useState(false);
   const [option, setOption] = useState(null);
   const [open, setOpen] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   const copyButton = (
     <Button
@@ -59,7 +60,7 @@ export default function ICSCalendarLink({
       text,
       url: await fetchURL(extraParams),
     });
-    setOpen(true);
+    setOpen(!open);
   };
 
   let trigger;
@@ -71,7 +72,7 @@ export default function ICSCalendarLink({
         icon={null}
         trigger={
           renderButton ? (
-            renderButton(() => {})
+            renderButton(() => {}, {open: dropdownOpen || open})
           ) : (
             <Button icon size="small">
               <Icon name="calendar alternate outline" />
@@ -80,6 +81,12 @@ export default function ICSCalendarLink({
           )
         }
         pointing={dropdownPosition}
+        onOpen={() => {
+          setDropdownOpen(true);
+        }}
+        onClose={() => {
+          setDropdownOpen(false);
+        }}
         {...restProps}
       >
         <Dropdown.Menu>
@@ -100,7 +107,7 @@ export default function ICSCalendarLink({
   } else {
     const {text, extraParams} = options[0];
     trigger = renderButton ? (
-      renderButton(() => handleSetOption(text, extraParams))
+      renderButton(() => handleSetOption(text, extraParams), {open})
     ) : (
       <Button icon size="small" onClick={() => handleSetOption(text, extraParams)}>
         <Icon name="calendar alternate outline" />

--- a/indico/web/client/js/react/components/ICSCalendarLink.jsx
+++ b/indico/web/client/js/react/components/ICSCalendarLink.jsx
@@ -27,7 +27,7 @@ export default function ICSCalendarLink({
   ...restProps
 }) {
   const [copied, setCopied] = useState(false);
-  const [option, setOption] = useState(null);
+  const [option, setOption] = useState({url: null, text: null});
   const [open, setOpen] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
@@ -56,11 +56,14 @@ export default function ICSCalendarLink({
   };
 
   const handleSetOption = async (text, extraParams) => {
-    setOpen(!open);
-    setOption({
-      text,
-      url: await fetchURL(extraParams),
-    });
+    if (open) {
+      setOpen(false);
+    } else {
+      setOption({text, url: null});
+      setOpen(true);
+      const url = await fetchURL(extraParams);
+      setOption({text, url});
+    }
   };
 
   let trigger;
@@ -134,7 +137,7 @@ export default function ICSCalendarLink({
       <Header
         styleName="export-header"
         content={Translate.string('Export')}
-        subheader={option && <Label color="blue">{option.text}</Label>}
+        subheader={<Label color="blue">{option.text}</Label>}
       />
       <Popup.Content>
         <strong styleName="export-option">Synchronise with your calendar</strong>
@@ -147,11 +150,11 @@ export default function ICSCalendarLink({
         <Input
           placeholder={Translate.string('Loading…')}
           readOnly
-          loading={!option}
+          loading={!option.url}
           size="mini"
           fluid
-          value={option ? option.url : ''}
-          action={option && navigator.clipboard && copyButton}
+          value={option.url || ''}
+          action={option.url && navigator.clipboard ? copyButton : null}
         />
         {copied && (
           <Grid centered>
@@ -174,7 +177,8 @@ export default function ICSCalendarLink({
             as="a"
             href={option ? option.url : ''}
             icon="download"
-            disabled={!option}
+            loading={!option.url}
+            disabled={!option.url}
           />
         </div>
       </Popup.Content>

--- a/indico/web/client/js/react/components/ICSCalendarLink.jsx
+++ b/indico/web/client/js/react/components/ICSCalendarLink.jsx
@@ -56,11 +56,11 @@ export default function ICSCalendarLink({
   };
 
   const handleSetOption = async (text, extraParams) => {
+    setOpen(!open);
     setOption({
       text,
       url: await fetchURL(extraParams),
     });
-    setOpen(!open);
   };
 
   let trigger;
@@ -174,6 +174,7 @@ export default function ICSCalendarLink({
             as="a"
             href={option ? option.url : ''}
             icon="download"
+            disabled={!option}
           />
         </div>
       </Popup.Content>

--- a/indico/web/client/js/react/components/ICSCalendarLink.module.scss
+++ b/indico/web/client/js/react/components/ICSCalendarLink.module.scss
@@ -9,7 +9,39 @@
   height: 100%;
 }
 
-.centered {
+.export-header:global(.ui.header) {
   display: flex;
   justify-content: center;
+  margin-bottom: 0;
+}
+
+.export-option {
+  display: block;
+  text-align: center;
+  margin: 1rem 0 0.5rem 0;
+}
+
+.export-option::before,
+.export-option::after {
+  box-shadow: 1px 1px 1px #f9f9f9;
+  background-color: #dfdfdf;
+  content: '';
+  display: inline-block;
+  height: 1px;
+  position: relative;
+  vertical-align: middle;
+  width: 10%;
+  margin: 0 0.5rem;
+}
+
+.download-button:global(.ui.icon.button) {
+  display: flex;
+  align-items: center;
+  margin: 0;
+  height: 2.125rem;
+}
+
+.download-option {
+  display: flex;
+  align-items: center;
 }

--- a/indico/web/client/js/react/components/ICSCalendarLink.module.scss
+++ b/indico/web/client/js/react/components/ICSCalendarLink.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@import 'base/palette';
+
 .height-full {
   height: 100%;
 }
@@ -23,8 +25,8 @@
 
 .export-option::before,
 .export-option::after {
-  box-shadow: 1px 1px 1px #f9f9f9;
-  background-color: #dfdfdf;
+  box-shadow: 1px 1px 1px $light-gray;
+  background-color: $pastel-gray;
   content: '';
   display: inline-block;
   height: 1px;

--- a/indico/web/client/styles/partials/_toolbars.scss
+++ b/indico/web/client/styles/partials/_toolbars.scss
@@ -21,6 +21,10 @@ $i-button-spacing: 0.3rem;
   flex-shrink: 0;
   min-height: $toolbar-height;
 
+  &.fixed-height {
+    max-height: 1.75rem;
+  }
+
   &.space-before {
     margin-top: $toolbar-spacing;
   }


### PR DESCRIPTION
This PR remodels the popup shown when clicking on the different 'export calendar' buttons.

After https://github.com/indico/indico/pull/4801, the option to download the ICS file was lost, as we started using the dashboard popup everywhere. With the new layout, it is back; and the popup is uniform across the whole application:

![image](https://user-images.githubusercontent.com/6058151/113286433-7d79bf00-92ec-11eb-9b6d-23e5c00951ea.png)

Also, the different buttons that open the popup will now shade/sink properly when clicked.

Closes #4827.

