### PR TITLE
Hide horizontal scrollbar in roles filter dropdown in Firefox

### DIFF
--- a/indico/web/client/styles/modules/abstracts/_roles.scss
+++ b/indico/web/client/styles/modules/abstracts/_roles.scss
@@ -89,7 +89,8 @@
     padding: 0;
 
     li {
-      padding: 0.1em 0.7em !important;
+      padding: 0.1em 0.7em;
+      -moz-padding-end: 2rem;
 
       & > ::before {
         cursor: pointer;

--- a/indico/web/client/styles/partials/_dropdowns.scss
+++ b/indico/web/client/styles/partials/_dropdowns.scss
@@ -23,7 +23,7 @@
     list-style-type: none;
     height: 1.7rem;
     min-width: 1em;
-    padding: 0.1em 1em !important;
+    padding: 0.1em 1em;
 
     a {
       display: block;

--- a/indico/web/client/styles/partials/_object-lists.scss
+++ b/indico/web/client/styles/partials/_object-lists.scss
@@ -204,7 +204,6 @@
   }
 
   ul.i-dropdown {
-    line-height: auto;
     height: auto;
     z-index: 1;
     max-height: 12em;


### PR DESCRIPTION
This PR should solve the remaining issue in https://github.com/indico/indico/issues/4821#issue-831823489 (Participant roles: Horizontal scrollbar as soon as there's a vertical scroll bar).

Also removes some unneeded/invalid properties in the CSS.

Closes #4821.