### PR TITLE
Fix timetable details with explicit session access

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Bugfixes
   access to them (:pr:`4830`)
 - Fix error when assigning paper reviewer roles with notifications enabled and one
   of the reviewing types disabled (:pr:`4838`)
+- Fix viewing timetable entries if you cannot access the event but a specific session
+  inside it (:pr:`4857`)
 
 Version 2.3.4
 -------------

--- a/indico/modules/events/timetable/controllers/display.py
+++ b/indico/modules/events/timetable/controllers/display.py
@@ -66,7 +66,6 @@ class RHTimetableEntryInfo(RHTimetableProtectionBase):
         self.entry = self.event.timetable_entries.filter_by(id=request.view_args['entry_id']).first_or_404()
 
     def _check_access(self):
-        RHTimetableProtectionBase._check_access(self)
         if not self.entry.can_view(session.user):
             raise Forbidden
 

--- a/indico/modules/events/timetable/controllers/display_test.py
+++ b/indico/modules/events/timetable/controllers/display_test.py
@@ -1,0 +1,32 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+from mock import MagicMock
+from werkzeug.exceptions import Forbidden
+
+from indico.core.db.sqlalchemy.protection import ProtectionMode
+from indico.modules.events.timetable.controllers.display import RHTimetableEntryInfo
+
+
+@pytest.mark.usefixtures('request_context')
+@pytest.mark.parametrize('event_allowed', (False, True))
+@pytest.mark.parametrize('allowed', (False, True))
+def test_timetable_entry_info_access(dummy_event, dummy_user, allowed, event_allowed):
+    dummy_event.protection_mode = ProtectionMode.public if event_allowed else ProtectionMode.protected
+    rh = RHTimetableEntryInfo()
+    rh.event = dummy_event
+    rh.entry = MagicMock()
+    rh.entry.can_view.return_value = allowed
+    # event access should not matter for the RH access check as having access e.g.
+    # to a specific session lets users view the timetabel for that session
+    assert dummy_event.can_access(dummy_user) == event_allowed
+    if allowed:
+        rh._check_access()
+    else:
+        with pytest.raises(Forbidden):
+            rh._check_access()


### PR DESCRIPTION
When a user has no access to the event but to a session, they should be able to view the timetable entry details for the contributions within that session.