### PR TITLE
Fix contribution page access with explicit ACL entry and no event access

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Bugfixes
   inside it (:pr:`4857`)
 - Fix viewing contributions if you cannot access the event but have explicit access to
   the contribution (:pr:`4860`)
+- Hide registration menu item if you cannot access the event and registrations are not
+  exempt from event access checks (:pr:`4860`)
 
 Version 2.3.4
 -------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Bugfixes
   of the reviewing types disabled (:pr:`4838`)
 - Fix viewing timetable entries if you cannot access the event but a specific session
   inside it (:pr:`4857`)
+- Fix viewing contributions if you cannot access the event but have explicit access to
+  the contribution (:pr:`4860`)
 
 Version 2.3.4
 -------------

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -61,8 +61,9 @@ class RHContributionDisplayBase(RHDisplayEventBase):
         return self.event.can_manage(session.user) or self.contrib.is_user_associated(session.user)
 
     def _check_access(self):
-        RHDisplayEventBase._check_access(self)
         if not self.contrib.can_access(session.user):
+            # perform event access check since it may send the user to the access key or registration page
+            RHDisplayEventBase._check_access(self)
             raise Forbidden
         published = contribution_settings.get(self.event, 'published')
         if not published and not self._can_view_unpublished():
@@ -251,8 +252,9 @@ class RHSubcontributionDisplay(RHDisplayEventBase):
     view_class = WPContributions
 
     def _check_access(self):
-        RHDisplayEventBase._check_access(self)
         if not self.subcontrib.can_access(session.user):
+            # perform event access check since it may send the user to the access key or registration page
+            RHDisplayEventBase._check_access(self)
             raise Forbidden
         published = contribution_settings.get(self.event, 'published')
         if (not published and not self.event.can_manage(session.user)

--- a/indico/modules/events/contributions/controllers/display_test.py
+++ b/indico/modules/events/contributions/controllers/display_test.py
@@ -1,0 +1,51 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+from mock import MagicMock
+from werkzeug.exceptions import Forbidden
+
+from indico.core.db.sqlalchemy.protection import ProtectionMode
+from indico.modules.events.contributions.controllers.display import RHContributionDisplayBase, RHSubcontributionDisplay
+
+
+@pytest.mark.usefixtures('request_context')
+@pytest.mark.parametrize('event_allowed', (False, True))
+@pytest.mark.parametrize('allowed', (False, True))
+def test_contrib_explicit_access(dummy_event, dummy_user, allowed, event_allowed):
+    dummy_event.protection_mode = ProtectionMode.public if event_allowed else ProtectionMode.protected
+    rh = RHContributionDisplayBase()
+    rh.event = dummy_event
+    rh.contrib = MagicMock()
+    rh.contrib.can_access.return_value = allowed
+    # event access should not matter for the RH access check as having access e.g.
+    # to a specific contribution lets users view the details for that contribution
+    assert dummy_event.can_access(dummy_user) == event_allowed
+    if allowed:
+        rh._check_access()
+    else:
+        with pytest.raises(Forbidden):
+            rh._check_access()
+
+
+@pytest.mark.usefixtures('request_context')
+@pytest.mark.parametrize('event_allowed', (False, True))
+@pytest.mark.parametrize('allowed', (False, True))
+def test_subcontrib_explicit_access(dummy_event, dummy_user, allowed, event_allowed):
+    dummy_event.protection_mode = ProtectionMode.public if event_allowed else ProtectionMode.protected
+    rh = RHSubcontributionDisplay()
+    rh.event = dummy_event
+    rh.subcontrib = MagicMock()
+    rh.subcontrib.can_access.return_value = allowed
+    # event access should not matter for the RH access check as having access e.g.
+    # to a specific contribution lets users view the details for that subcontribution
+    assert dummy_event.can_access(dummy_user) == event_allowed
+    if allowed:
+        rh._check_access()
+    else:
+        with pytest.raises(Forbidden):
+            rh._check_access()

--- a/indico/modules/events/registration/__init__.py
+++ b/indico/modules/events/registration/__init__.py
@@ -87,6 +87,8 @@ def _extend_event_menu(sender, **kwargs):
     def _visible_registration(event):
         if not event.has_feature('registration'):
             return False
+        if not event.can_access(session.user) and not (event.has_regform_in_acl and event.public_regform_access):
+            return False
         if any(form.is_scheduled for form in event.registration_forms):
             return True
         if not session.user:

--- a/indico/modules/events/templates/display/conference/base.html
+++ b/indico/modules/events/templates/display/conference/base.html
@@ -55,12 +55,15 @@
         <div id="confSectionsBox" class="clearfix">
             {% include 'flashed_messages.html' %}
             {{ render_event_header_msg(event, meeting=false) }}
+            {% set visible_menu_entries = conf_layout_params.menu | selectattr('is_visible') | list %}
             <div class="conf_leftMenu">
-                <ul id="outer">
-                    {%- for entry in conf_layout_params.menu if entry.is_visible %}
-                        {{ menu_entry_display(entry, active_entry_id=conf_layout_params.active_menu_item) }}
-                    {% endfor -%}
-                </ul>
+                {% if visible_menu_entries %}
+                    <ul id="outer">
+                        {%- for entry in visible_menu_entries %}
+                            {{ menu_entry_display(entry, active_entry_id=conf_layout_params.active_menu_item) }}
+                        {% endfor -%}
+                    </ul>
+                {% endif %}
 
                 {% if event.contact_emails or event.contact_phones -%}
                     <div class="support_box">

--- a/indico/modules/events/timetable/controllers/display_test.py
+++ b/indico/modules/events/timetable/controllers/display_test.py
@@ -23,7 +23,7 @@ def test_timetable_entry_info_access(dummy_event, dummy_user, allowed, event_all
     rh.entry = MagicMock()
     rh.entry.can_view.return_value = allowed
     # event access should not matter for the RH access check as having access e.g.
-    # to a specific session lets users view the timetabel for that session
+    # to a specific session lets users view the timetable for that session
     assert dummy_event.can_access(dummy_user) == event_allowed
     if allowed:
         rh._check_access()


### PR DESCRIPTION
#4857 fixed the problem for the timetable bubble, but the (sub)contribution detail pages had the same issue.

also, I noticed that the registration menu item was always visible even if you could not access it, so that's fixed now as well.