### PR TITLE
Various fixes for Room Booking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ Bugfixes
 - Fail gracefully during registration import when two rows have different emails that belong
   to the same user (:pr:`4823`)
 - Restore the ability to see who's inheriting access from a parent object (:pr:`4833`)
+- Fix misleading message when cancelling a booking that already started and has past
+  occurrences that won't be cancelled (:issue:`4719`, :pr:`4861`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
@@ -571,7 +571,13 @@ class BookingDetails extends React.Component {
     return transformToLegendLabels(occurrenceTypes, inactiveTypes);
   };
 
-  renderActionButtons = (canCancel, canReject, showAccept, occurrenceCount, isAccepted) => {
+  renderActionButtons = (
+    canCancel,
+    canReject,
+    showAccept,
+    cancellableOccurrenceCount,
+    isAccepted
+  ) => {
     const {bookingStateChangeInProgress} = this.props;
     const {actionInProgress, activeConfirmation, acceptanceFormVisible} = this.state;
     const rejectButton = (
@@ -611,7 +617,7 @@ class BookingDetails extends React.Component {
             rows={2}
             required
           />
-          {isAccepted && occurrenceCount > 1 && (
+          {isAccepted && cancellableOccurrenceCount > 1 && (
             <FinalCheckbox
               name="_confirm"
               label={Translate.string(
@@ -688,26 +694,26 @@ class BookingDetails extends React.Component {
               </Modal.Header>
               <Modal.Content>
                 <p>
-                  <PluralTranslate count={occurrenceCount}>
+                  <PluralTranslate count={cancellableOccurrenceCount}>
                     <Singular>Are you sure you want to cancel this booking?</Singular>
                     <Plural>
-                      Are you sure you want to cancel this booking? This will cancel all{' '}
-                      <Param name="count" value={occurrenceCount} wrapper={<strong />} />{' '}
-                      occurrences.
+                      Are you sure you want to cancel this booking? This will cancel{' '}
+                      <Param name="count" value={cancellableOccurrenceCount} wrapper={<strong />} />{' '}
+                      upcoming occurrences.
                     </Plural>
                   </PluralTranslate>
                 </p>
-                <p>
-                  {occurrenceCount > 1 && (
+                {cancellableOccurrenceCount > 1 && (
+                  <p>
                     <Translate>
                       Single occurrences can be cancelled via the timeline view.
                     </Translate>
-                  )}
-                </p>
+                  </p>
+                )}
               </Modal.Content>
               <Modal.Actions>
                 <Button onClick={this.hideConfirm} content={Translate.string('Close')} />
-                {occurrenceCount > 1 && (
+                {cancellableOccurrenceCount > 1 && (
                   <Button
                     icon="calendar outline"
                     onClick={() => {
@@ -725,7 +731,7 @@ class BookingDetails extends React.Component {
                   content={PluralTranslate.string(
                     'Cancel booking',
                     'Cancel all occurrences',
-                    occurrenceCount
+                    cancellableOccurrenceCount
                   )}
                   negative
                 />
@@ -825,6 +831,9 @@ class BookingDetails extends React.Component {
     const showActionButtons = !isCancelled && !isRejected && (canCancel || canReject || showAccept);
     const activeBookings = _.omitBy(occurrences.bookings, value => _.isEmpty(value));
     const occurrenceCount = Object.keys(activeBookings).length;
+    const cancellableOccurrenceCount = Object.keys(activeBookings).filter(date =>
+      activeBookings[date].some(occurrence => occurrence.canCancel)
+    ).length;
 
     return (
       <>
@@ -872,7 +881,13 @@ class BookingDetails extends React.Component {
             </Grid>
           </Modal.Content>
           {showActionButtons &&
-            this.renderActionButtons(canCancel, canReject, showAccept, occurrenceCount, isAccepted)}
+            this.renderActionButtons(
+              canCancel,
+              canReject,
+              showAccept,
+              cancellableOccurrenceCount,
+              isAccepted
+            )}
         </Modal>
         <Modal open={occurrencesVisible} onClose={this.hideOccurrences} size="large" closeIcon>
           <Modal.Header className="legend-header">

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
@@ -831,8 +831,8 @@ class BookingDetails extends React.Component {
     const showActionButtons = !isCancelled && !isRejected && (canCancel || canReject || showAccept);
     const activeBookings = _.omitBy(occurrences.bookings, value => _.isEmpty(value));
     const occurrenceCount = Object.keys(activeBookings).length;
-    const cancellableOccurrenceCount = Object.keys(activeBookings).filter(date =>
-      activeBookings[date].some(occurrence => occurrence.canCancel)
+    const cancellableOccurrenceCount = Object.values(activeBookings).filter(date =>
+      date.some(occurrence => occurrence.canCancel)
     ).length;
 
     return (

--- a/indico/modules/rb/client/js/common/timeline/EditableTimelineItem.jsx
+++ b/indico/modules/rb/client/js/common/timeline/EditableTimelineItem.jsx
@@ -295,7 +295,7 @@ export default class EditableTimelineItem extends React.Component {
               header={`${hintPosition.hours}:${hintPosition.minutes.toString().padStart(2, '0')}`}
               content={tip}
               position="top left"
-              offset={hintPosition.pixels}
+              offset={[hintPosition.pixels, 0]}
               context={canvasRef}
               size="mini"
               styleName="editable-timeline-time-popup"

--- a/indico/modules/rb/client/js/modules/calendar/actions.js
+++ b/indico/modules/rb/client/js/modules/calendar/actions.js
@@ -135,10 +135,10 @@ export function fetchActiveBookings(limit, fetchRooms = true) {
 
     if (Object.keys(data).length) {
       const lastDt = Object.keys(data).reverse()[0];
-      body.start_dt = _.maxBy(data[lastDt], rv =>
+      params.start_dt = _.maxBy(data[lastDt], rv =>
         moment(rv.startDt, 'YYYY-MM-DD HH:mm').unix()
       ).startDt;
-      body.last_reservation_id = data[lastDt][data[lastDt].length - 1].reservation.id;
+      params.last_reservation_id = data[lastDt][data[lastDt].length - 1].reservation.id;
     }
 
     return await ajaxAction(

--- a/indico/modules/rb/models/reservation_occurrences_test.py
+++ b/indico/modules/rb/models/reservation_occurrences_test.py
@@ -395,7 +395,7 @@ def test_can_cancel(create_reservation, dummy_user, freeze_time):
     assert reservation.occurrences[-1].can_cancel(dummy_user)
 
 
-def test_cannot_cancel_archived_reservation(create_reservation, dummy_user, freeze_time):
+def test_cannot_cancel_archived_or_ongoing_reservation(create_reservation, dummy_user, freeze_time):
     reservation = create_reservation(start_dt=datetime.combine(date.today(), time(11)),
                                      end_dt=datetime.combine(date.today(), time(17)),
                                      repeat_frequency=RepeatFrequency.NEVER)
@@ -403,10 +403,10 @@ def test_cannot_cancel_archived_reservation(create_reservation, dummy_user, free
     assert reservation.can_cancel(dummy_user)
 
     freeze_time(datetime.combine(date.today(), time(13)))
-    assert reservation.can_cancel(dummy_user)
+    assert not reservation.can_cancel(dummy_user)
 
     freeze_time(datetime.combine(date.today(), time(17)))
-    assert reservation.can_cancel(dummy_user)
+    assert not reservation.can_cancel(dummy_user)
 
     freeze_time(datetime.combine(date.today(), time(17, 1)))
     assert not reservation.can_cancel(dummy_user)

--- a/indico/modules/rb/models/reservations.py
+++ b/indico/modules/rb/models/reservations.py
@@ -473,6 +473,8 @@ class Reservation(Serializer, db.Model):
             return False
         if self.is_rejected or self.is_cancelled or self.is_archived:
             return False
+        if not self.occurrences.filter(ReservationOccurrence.is_within_cancel_grace_period).count():
+            return False
 
         is_booked_or_owned_by_user = self.is_owned_by(user) or self.is_booked_for(user)
         return is_booked_or_owned_by_user or (allow_admin and rb_is_admin(user))

--- a/indico/modules/rb/models/reservations.py
+++ b/indico/modules/rb/models/reservations.py
@@ -473,7 +473,7 @@ class Reservation(Serializer, db.Model):
             return False
         if self.is_rejected or self.is_cancelled or self.is_archived:
             return False
-        if not self.occurrences.filter(ReservationOccurrence.is_within_cancel_grace_period).count():
+        if not self.occurrences.filter(ReservationOccurrence.is_within_cancel_grace_period).has_rows():
             return False
 
         is_booked_or_owned_by_user = self.is_owned_by(user) or self.is_booked_for(user)


### PR DESCRIPTION
This PR closes https://github.com/indico/indico/issues/4719, by showing the correct number  of booking occurrences that will be cancelled with a cancel action.

Also:
* Fixes an incorrect parameter passed to Popper's offset modifier which was causing the popup for the time on the click-and-drag ui for the day calendar not to follow the mouse pointer.
* Fixes the fetching of bookings so it doesn't get the same bookings infinitely.