### PR TITLE
Fix FileManager reset during re-render of "make change" editing action

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,9 @@ Bugfixes
   the contribution (:pr:`4860`)
 - Hide registration menu item if you cannot access the event and registrations are not
   exempt from event access checks (:pr:`4860`)
+- Fix inadvertently deleting a file uploaded during the "make changes" Editing action,
+  resulting in the revision sometimes still referencing the file even though it has been
+  deleted from storage (:pr:`4866`)
 
 Version 2.3.4
 -------------

--- a/indico/core/storage/models.py
+++ b/indico/core/storage/models.py
@@ -224,12 +224,15 @@ class StoredFileMixin(object):
         """Delete the file from storage."""
         if self.storage_file_id is None:
             raise Exception('There is no file to delete')
-        self.storage.delete(self.storage_file_id)
+        storage = self.storage
+        storage_file_id = self.storage_file_id
         if delete_from_db:
             db.session.delete(self)
+            db.session.flush()
         else:
             self.storage_backend = None
             self.storage_file_id = None
             self.size = None
             self.content_type = None
             self.filename = None
+        storage.delete(storage_file_id)

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/AcceptRejectForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/AcceptRejectForm.jsx
@@ -31,7 +31,10 @@ export default function AcceptRejectForm({action, setLoading}) {
     <FinalForm
       initialValues={{
         comment: '',
-        tags: lastRevision.tags.filter(t => !t.system).map(t => t.id),
+        tags: lastRevision.tags
+          .filter(t => !t.system)
+          .map(t => t.id)
+          .sort(),
       }}
       initialValuesEqual={_.isEqual}
       onSubmit={async formData => {

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/RequestChangesForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/RequestChangesForm.jsx
@@ -49,7 +49,10 @@ export default function RequestChangesForm({setLoading, onSuccess}) {
       subscription={{}}
       initialValues={{
         comment: '',
-        tags: lastRevision.tags.filter(t => !t.system).map(t => t.id),
+        tags: lastRevision.tags
+          .filter(t => !t.system)
+          .map(t => t.id)
+          .sort(),
       }}
       initialValuesEqual={_.isEqual}
     >

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesForm.jsx
@@ -71,7 +71,10 @@ export default function UpdateFilesForm({setLoading}) {
     <FinalForm
       initialValues={{
         comment: '',
-        tags: lastRevision.tags.filter(t => !t.system).map(t => t.id),
+        tags: lastRevision.tags
+          .filter(t => !t.system)
+          .map(t => t.id)
+          .sort(),
         files,
       }}
       initialValuesEqual={_.isEqual}


### PR DESCRIPTION
The tags are not guaranteed to be sorted in a stable way, so sometimes the re-render caused by `setLoading(true)` resulted in the final-form's `initialValues` changing and thus reinitializing the form, triggering the file manager's logic to reset it as well and delete any pending files.

Since this happened in parallel with the submission of the reviewing action, it at least resulted in the deleting request failing, but often also in a race between the deletion request and it checking whether the file has been claimed and the review claiming it, which resulted in the file being deleted from storage but not the database.