### PR TITLE
New duration field for durations under 24h

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@ Improvements
   conferences now redirect to the meeting view page (:pr:`4847`)
 - Use a more compact setup QR code for the mobile *Indico check-in* app; the latest version of
   the app is now required. (:pr:`4844`)
+- Duration fields in different forms throughout the application are now easier to use.
+  (:issue:`2462`, :pr:`4873`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,8 +52,8 @@ Improvements
   conferences now redirect to the meeting view page (:pr:`4847`)
 - Use a more compact setup QR code for the mobile *Indico check-in* app; the latest version of
   the app is now required. (:pr:`4844`)
-- Duration fields in different forms throughout the application are now easier to use.
-  (:issue:`2462`, :pr:`4873`)
+- Contribution duration fields now use a widget similar to the time picker that makes selecting
+  durations easier. (:issue:`2462`, :pr:`4873`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -27,6 +27,7 @@ from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm, generated_data
 from indico.web.forms.fields import (HiddenFieldList, IndicoDateTimeField, IndicoEnumSelectField, IndicoLocationField,
                                      IndicoProtectionField, IndicoTagListField, TimeDeltaField)
+from indico.web.forms.fields.datetime import IndicoDurationField
 from indico.web.forms.fields.principals import PermissionsField
 from indico.web.forms.validators import DateTimeRange, MaxDuration
 from indico.web.forms.widgets import SwitchWidget
@@ -179,8 +180,7 @@ class ContributionDurationForm(IndicoForm):
 
 
 class ContributionDefaultDurationForm(IndicoForm):
-    duration = TimeDeltaField(_('Duration'), [DataRequired(), MaxDuration(timedelta(days=1))],
-                              units=('minutes', 'hours'))
+    duration = IndicoDurationField(_('Duration'), [DataRequired()])
 
 
 class ContributionTypeForm(IndicoForm):

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -26,7 +26,7 @@ from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm, generated_data
 from indico.web.forms.fields import (HiddenFieldList, IndicoDateTimeField, IndicoEnumSelectField, IndicoLocationField,
-                                     IndicoProtectionField, IndicoTagListField, TimeDeltaField)
+                                     IndicoProtectionField, IndicoTagListField)
 from indico.web.forms.fields.datetime import IndicoDurationField
 from indico.web.forms.fields.principals import PermissionsField
 from indico.web.forms.validators import DateTimeRange, MaxDuration
@@ -42,8 +42,8 @@ class ContributionForm(IndicoForm):
                                                   latest=lambda form, field: form._get_latest_start_dt())],
                                    allow_clear=False,
                                    description=_("Start date of the contribution"))
-    duration = TimeDeltaField(_("Duration"), [DataRequired(), MaxDuration(timedelta(hours=24))],
-                              default=timedelta(minutes=20), units=('minutes', 'hours'))
+    duration = IndicoDurationField(_('Duration'), [DataRequired(), MaxDuration(timedelta(hours=24))],
+                                   default=timedelta(minutes=20))
     type = QuerySelectField(_("Type"), get_label='name', allow_blank=True, blank_text=_("No type selected"))
     person_link_data = ContributionPersonLinkListField(_("People"))
     location_data = IndicoLocationField(_("Location"))
@@ -112,8 +112,8 @@ class ContributionProtectionForm(IndicoForm):
 class SubContributionForm(IndicoForm):
     title = StringField(_('Title'), [DataRequired()])
     description = TextAreaField(_('Description'))
-    duration = TimeDeltaField(_('Duration'), [DataRequired(), MaxDuration(timedelta(hours=24))],
-                              default=timedelta(minutes=20), units=('minutes', 'hours'))
+    duration = IndicoDurationField(_('Duration'), [DataRequired(), MaxDuration(timedelta(hours=24))],
+                                   default=timedelta(minutes=20))
     speakers = SubContributionPersonLinkListField(_('Speakers'), allow_submitters=False, allow_authors=False,
                                                   description=_('The speakers of the subcontribution'))
     references = ReferencesField(_("External IDs"), reference_class=SubContributionReference,
@@ -156,8 +156,8 @@ class ContributionStartDateForm(IndicoForm):
 
 
 class ContributionDurationForm(IndicoForm):
-    duration = TimeDeltaField(_('Duration'), [DataRequired(), MaxDuration(timedelta(days=1))],
-                              default=timedelta(minutes=20), units=('minutes', 'hours'))
+    duration = IndicoDurationField(_('Duration'), [DataRequired(), MaxDuration(timedelta(hours=24))],
+                                   default=timedelta(minutes=20))
 
     def __init__(self, *args, **kwargs):
         self.contrib = kwargs.pop('contrib')
@@ -180,7 +180,8 @@ class ContributionDurationForm(IndicoForm):
 
 
 class ContributionDefaultDurationForm(IndicoForm):
-    duration = IndicoDurationField(_('Duration'), [DataRequired()])
+    duration = IndicoDurationField(_('Duration'), [DataRequired(), MaxDuration(timedelta(hours=24))],
+                                   default=timedelta(minutes=20))
 
 
 class ContributionTypeForm(IndicoForm):

--- a/indico/modules/events/sessions/forms.py
+++ b/indico/modules/events/sessions/forms.py
@@ -19,7 +19,8 @@ from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.colors import get_colors
-from indico.web.forms.fields import IndicoLocationField, IndicoPalettePickerField, IndicoProtectionField, TimeDeltaField
+from indico.web.forms.fields import IndicoLocationField, IndicoPalettePickerField, IndicoProtectionField
+from indico.web.forms.fields.datetime import IndicoDurationField
 from indico.web.forms.fields.principals import PermissionsField
 from indico.web.forms.widgets import SwitchWidget
 
@@ -29,10 +30,11 @@ class SessionForm(IndicoForm):
     code = StringField(_('Session code'), description=_('The code that will identify the session in the Book of '
                                                         'Abstracts.'))
     description = TextAreaField(_('Description'))
-    default_contribution_duration = TimeDeltaField(_('Default contribution duration'), units=('minutes', 'hours'),
-                                                   description=_('Duration that a contribution created within this '
-                                                                 'session will have by default.'),
-                                                   default=timedelta(minutes=20))
+    default_contribution_duration = IndicoDurationField(_('Default contribution duration'),
+                                                        description=_('Duration that a contribution created within '
+                                                                      'this session will have by default.'),
+                                                        default=timedelta(minutes=20))
+
     type = QuerySelectField(_("Type"), get_label='name', allow_blank=True, blank_text=_("No type selected"))
     location_data = IndicoLocationField(_("Default location"),
                                         description=_("Default location for blocks inside the session."))

--- a/indico/modules/events/timetable/forms.py
+++ b/indico/modules/events/timetable/forms.py
@@ -22,7 +22,8 @@ from indico.util.i18n import _
 from indico.web.forms.base import FormDefaults, IndicoForm, generated_data
 from indico.web.forms.colors import get_colors
 from indico.web.forms.fields import (FileField, IndicoLocationField, IndicoPalettePickerField,
-                                     IndicoSelectMultipleCheckboxBooleanField, IndicoTimeField, TimeDeltaField)
+                                     IndicoSelectMultipleCheckboxBooleanField, IndicoTimeField)
+from indico.web.forms.fields.datetime import IndicoDurationField
 from indico.web.forms.util import get_form_field_names
 from indico.web.forms.validators import HiddenUnless, MaxDuration
 from indico.web.forms.widgets import SwitchWidget
@@ -34,8 +35,8 @@ class EntryFormMixin:
     _display_fields = None
 
     time = IndicoTimeField(_("Start time"), [InputRequired()])
-    duration = TimeDeltaField(_("Duration"), [DataRequired(), MaxDuration(timedelta(hours=24))],
-                              units=('minutes', 'hours'))
+    duration = IndicoDurationField(_('Duration'), [DataRequired(), MaxDuration(timedelta(hours=24))],
+                                   default=timedelta(minutes=20))
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs['event']

--- a/indico/web/client/js/jquery/widgets/jinja/duration_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/duration_widget.js
@@ -1,0 +1,26 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2021 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {WTFDurationField} from 'indico/react/components';
+
+window.setupDurationWidget = function setupDurationWidget({fieldId, required, disabled}) {
+  // Make sure the results dropdown is displayed above the dialog.
+  const field = $(`#${fieldId}`);
+  field.closest('.ui-dialog-content').css('overflow', 'inherit');
+  field.closest('.exclusivePopup').css('overflow', 'inherit');
+
+  ReactDOM.render(
+    <WTFDurationField
+      timeId={`${fieldId}-timestorage`}
+      required={required}
+      disabled={disabled}
+    />,
+    document.getElementById(fieldId)
+  );
+};

--- a/indico/web/client/js/jquery/widgets/jinja/index.js
+++ b/indico/web/client/js/jquery/widgets/jinja/index.js
@@ -10,6 +10,7 @@ import './ckeditor_widget';
 import './color_picker_widget';
 import './date_widget';
 import './datetime_widget';
+import './duration_widget';
 import './time_widget';
 import './linking_widget';
 import './location_widget';

--- a/indico/web/client/js/react/components/WTFDateTimeField.jsx
+++ b/indico/web/client/js/react/components/WTFDateTimeField.jsx
@@ -185,6 +185,7 @@ export default function WTFDateTimeField({
       <TimePicker
         showSecond={false}
         value={time}
+        focusOnOpen
         format={format}
         onChange={updateTime}
         use12Hours={!uses24HourFormat}

--- a/indico/web/client/js/react/components/WTFDurationField.jsx
+++ b/indico/web/client/js/react/components/WTFDurationField.jsx
@@ -1,0 +1,65 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2021 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import TimePicker from 'rc-time-picker';
+import React, {useEffect, useMemo, useRef, useState, useCallback} from 'react';
+
+const timeToSeconds = time => (time ? time.diff(moment().startOf('day'), 'seconds') : null);
+const secondsToTime = seconds =>
+  moment()
+    .startOf('day')
+    .seconds(seconds);
+
+export default function WTFDurationField({timeId, required, disabled}) {
+  const timeField = useMemo(() => document.getElementById(timeId), [timeId]);
+  const [time, setTime] = useState(secondsToTime(timeField.value));
+  const timePickerRef = useRef(null);
+
+  const handleTimePickerChange = useCallback(
+    value => {
+      setTime(value || null);
+      timeField.value = timeToSeconds(value);
+      timeField.dispatchEvent(new Event('change', {bubbles: true}));
+    },
+    [timeField]
+  );
+
+  useEffect(() => {
+    timePickerRef.current.picker.required = required;
+  }, [required]);
+
+  return (
+    <TimePicker
+      showSecond={false}
+      value={time}
+      focusOnOpen
+      format="H:mm"
+      onChange={handleTimePickerChange}
+      allowEmpty={false}
+      placeholder="h:mm"
+      disabled={disabled}
+      ref={timePickerRef}
+      // keep the picker in the DOM tree of the surrounding element to avoid
+      // e.g. qbubbles from closing when a picker is used inside one and the
+      // user clicks something in the picker
+      getPopupContainer={node => node}
+    />
+  );
+}
+
+WTFDurationField.propTypes = {
+  timeId: PropTypes.string.isRequired,
+  required: PropTypes.bool,
+  disabled: PropTypes.bool,
+};
+
+WTFDurationField.defaultProps = {
+  required: false,
+  disabled: false,
+};

--- a/indico/web/client/js/react/components/WTFDurationField.jsx
+++ b/indico/web/client/js/react/components/WTFDurationField.jsx
@@ -33,6 +33,11 @@ export default function WTFDurationField({timeId, required, disabled}) {
 
   const handleTimePickerChange = useCallback(
     value => {
+      // zero duration can come from the user selecting 0 minutes then 0 hours,
+      // but disabling 0 hours when minutes are 0 is bad for usability
+      if (value && value.hour() === 0 && value.minute() === 0) {
+        value.minutes(1);
+      }
       setTime(value || null);
       timeField.value = timeToSeconds(value);
       timeField.dispatchEvent(new Event('change', {bubbles: true}));
@@ -54,6 +59,7 @@ export default function WTFDurationField({timeId, required, disabled}) {
       allowEmpty={false}
       placeholder="h:mm"
       disabled={disabled}
+      disabledMinutes={h => (h === 0 ? [0] : [])}
       ref={timePickerRef}
       // keep the picker in the DOM tree of the surrounding element to avoid
       // e.g. qbubbles from closing when a picker is used inside one and the

--- a/indico/web/client/js/react/components/WTFDurationField.jsx
+++ b/indico/web/client/js/react/components/WTFDurationField.jsx
@@ -10,7 +10,17 @@ import PropTypes from 'prop-types';
 import TimePicker from 'rc-time-picker';
 import React, {useEffect, useMemo, useRef, useState, useCallback} from 'react';
 
-const timeToSeconds = time => (time ? time.diff(moment().startOf('day'), 'seconds') : null);
+const timeToSeconds = time => {
+  if (!time) {
+    return null;
+  }
+
+  // avoid counting seconds in a DST day.
+  const safeDate = time.date(1).month(0);
+
+  return safeDate.diff(safeDate.clone().startOf('day'), 'seconds');
+};
+
 const secondsToTime = seconds =>
   moment()
     .startOf('day')

--- a/indico/web/client/js/react/components/WTFTimeField.jsx
+++ b/indico/web/client/js/react/components/WTFTimeField.jsx
@@ -34,6 +34,7 @@ export default function WTFTimeField({timeId, uses24HourFormat, required, disabl
     <TimePicker
       showSecond={false}
       value={time}
+      focusOnOpen
       format={format}
       onChange={updateTime}
       use12Hours={!uses24HourFormat}

--- a/indico/web/client/js/react/components/index.js
+++ b/indico/web/client/js/react/components/index.js
@@ -41,6 +41,7 @@ export {default as ManagementPageTitle} from './ManagementPageTitle';
 export {default as WTFDateField} from './WTFDateField';
 export {default as WTFDateTimeField} from './WTFDateTimeField';
 export {default as WTFTimeField} from './WTFTimeField';
+export {default as WTFDurationField} from './WTFDurationField';
 export {default as WTFOccurrencesField} from './WTFOccurrencesField';
 export {default as WTFPrincipalListField} from './WTFPrincipalListField';
 export {default as WTFPrincipalField} from './WTFPrincipalField';

--- a/indico/web/client/styles/modules/_contributions.scss
+++ b/indico/web/client/styles/modules/_contributions.scss
@@ -142,8 +142,8 @@
 .qbubble-contrib-duration {
   max-width: 420px !important;
 
-  div form {
-    height: 200px;
+  .qtip-content {
+    overflow: visible;
   }
 }
 

--- a/indico/web/client/styles/modules/_contributions.scss
+++ b/indico/web/client/styles/modules/_contributions.scss
@@ -142,7 +142,7 @@
 .qbubble-contrib-duration {
   max-width: 420px !important;
 
-  & div form {
+  div form {
     height: 200px;
   }
 }

--- a/indico/web/client/styles/modules/_contributions.scss
+++ b/indico/web/client/styles/modules/_contributions.scss
@@ -141,6 +141,10 @@
 
 .qbubble-contrib-duration {
   max-width: 420px !important;
+
+  & div form {
+    height: 200px;
+  }
 }
 
 #contributions-fixed-fields {

--- a/indico/web/client/styles/partials/_timetable-balloons.scss
+++ b/indico/web/client/styles/partials/_timetable-balloons.scss
@@ -166,6 +166,10 @@
       width: auto !important;
     }
   }
+
+  .qtip-content {
+    overflow: visible;
+  }
 }
 
 .push-back {

--- a/indico/web/forms/fields/datetime.py
+++ b/indico/web/forms/fields/datetime.py
@@ -187,7 +187,7 @@ class IndicoDurationField(TimeField):
             return int(self.data.total_seconds())
 
     def process_formdata(self, valuelist):
-        if valuelist and len(valuelist) == 1:
+        if valuelist:
             self.data = timedelta(seconds=int(valuelist[0]))
 
 

--- a/indico/web/forms/fields/datetime.py
+++ b/indico/web/forms/fields/datetime.py
@@ -177,7 +177,7 @@ class IndicoTimeField(TimeField):
     widget = JinjaWidget('forms/time_widget.html', single_line=True, single_kwargs=True)
 
 
-class IndicoDurationField(TimeField):
+class IndicoDurationField(Field):
     widget = JinjaWidget('forms/duration_widget.html', single_line=True, single_kwargs=True)
 
     def _value(self):

--- a/indico/web/forms/fields/datetime.py
+++ b/indico/web/forms/fields/datetime.py
@@ -177,6 +177,20 @@ class IndicoTimeField(TimeField):
     widget = JinjaWidget('forms/time_widget.html', single_line=True, single_kwargs=True)
 
 
+class IndicoDurationField(TimeField):
+    widget = JinjaWidget('forms/duration_widget.html', single_line=True, single_kwargs=True)
+
+    def _value(self):
+        if self.data is None:
+            return 0
+        else:
+            return int(self.data.total_seconds())
+
+    def process_formdata(self, valuelist):
+        if valuelist and len(valuelist) == 1:
+            self.data = timedelta(seconds=int(valuelist[0]))
+
+
 class IndicoDateField(DateField):
     widget = JinjaWidget('forms/date_widget.html', single_line=True, single_kwargs=True)
 

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -293,7 +293,7 @@ class UsedIfChecked(UsedIf):
 
 
 class MaxDuration:
-    """Validate if TimeDeltaField value doesn't exceed `max_duration`."""
+    """Validate the duration doesn't exceed `max_duration`."""
 
     def __init__(self, max_duration=None, **kwargs):
         assert max_duration or kwargs

--- a/indico/web/templates/forms/duration_widget.html
+++ b/indico/web/templates/forms/duration_widget.html
@@ -1,0 +1,21 @@
+{% extends 'forms/base_widget.html' %}
+
+{% block html %}
+    <div class="time-widget i-form-field-fixed-width">
+        {# the hidden field has autofocus on purpose to prevent our JS from focusing the time picker #}
+        <input type="hidden" name="{{ field.name }}" id="{{ field.id }}-timestorage" autofocus
+               {% if field.data is not none %}value="{{ field._value() }}"{% endif %}
+               {{ input_args | html_params }}>
+        <span id="{{ field.id }}"></span>
+    </div>
+{% endblock %}
+
+{% block javascript %}
+    <script>
+        setupDurationWidget({
+            fieldId: {{ field.id | tojson }},
+            required: {{ input_args.required | default(false) | tojson }},
+            disabled: {{ input_args.disabled | default(false) | tojson }},
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
This PR implements the same widget Newdle uses for time durations (https://github.com/indico/newdle/pull/213). The new `IndicoDurationField` replaces `TimedeltaField` in places where values lower than a day are used.

Closes https://github.com/indico/indico/issues/2462.

Also, the focus stays in the input element when clicking in the field, so no double click is needed anymore.