### PR TITLE
Replace Flask-BabelEx with Flask-Babel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,11 @@ jobs:
           flake8 --format '%(path)s:%(row)d:%(col)d: %(code)s %(text)s'
           echo "::remove-matcher owner=flake8::"
 
-      - name: Try extracting i18n strings
+      - name: Try extracting i18n strings (Python)
+        if: success() || failure()
+        run: indico i18n extract-messages
+
+      - name: Try extracting i18n strings (JS)
         if: success() || failure()
         run: |
           echo "::add-matcher::.github/matchers/react-jsx-i18n-problem-matcher.json"

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 babel
 flask
-Flask-BabelEx
+Flask-Babel
 sphinx-issues
 plantweb

--- a/indico/core/plugins/__init__.py
+++ b/indico/core/plugins/__init__.py
@@ -10,7 +10,7 @@ import json
 import os
 
 from flask import g, session
-from flask_babelex import Domain
+from flask_babel import Domain
 from flask_pluginengine import (Plugin, PluginBlueprintMixin, PluginBlueprintSetupStateMixin, PluginEngine,
                                 current_plugin, render_plugin_template, wrap_in_plugin_context)
 from werkzeug.utils import cached_property

--- a/indico/modules/events/surveys/forms.py
+++ b/indico/modules/events/surveys/forms.py
@@ -65,7 +65,7 @@ class SurveyForm(IndicoForm):
                          Survey.title != field.object_data,
                          ~Survey.is_deleted))
         if query.count():
-            raise ValidationError(_(f'There is already a survey named "{escape(field.data)}" on this event'))
+            raise ValidationError(_('There is already a survey named "{}" on this event').format(escape(field.data)))
 
     def post_validate(self):
         if not self.anonymous.data:

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -14,7 +14,7 @@ from babel.core import LOCALE_ALIASES, Locale
 from babel.messages.pofile import read_po
 from babel.support import NullTranslations
 from flask import current_app, g, has_app_context, has_request_context, request, session
-from flask_babelex import Babel, Domain, get_domain
+from flask_babel import Babel, Domain, get_domain
 from flask_pluginengine import current_plugin
 from speaklater import is_lazy_string, make_lazy_string
 from werkzeug.utils import cached_property

--- a/indico/util/i18n_test.py
+++ b/indico/util/i18n_test.py
@@ -12,7 +12,7 @@ from babel.messages import Catalog
 from babel.messages.mofile import write_mo
 from babel.support import Translations
 from flask import has_request_context, request, session
-from flask_babelex import get_domain
+from flask_babel import get_domain
 from speaklater import _LazyString
 from werkzeug.datastructures import LanguageAccept
 

--- a/requirements.in
+++ b/requirements.in
@@ -11,7 +11,7 @@ colorclass
 distro
 email-validator
 feedgen
-flask-babelex
+flask-babel
 flask-caching
 flask-limiter
 flask-marshmallow
@@ -51,6 +51,7 @@ reportlab
 requests
 sentry-sdk[flask,celery,sqlalchemy,pure_eval]
 simplejson
+speaklater
 sqlalchemy
 termcolor
 terminaltables

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ authlib==1.0.0a1
 babel==2.9.0
     # via
     #   -r requirements.in
-    #   flask-babelex
+    #   flask-babel
 backcall==0.2.0
     # via ipython
 bcrypt==3.2.0
@@ -81,7 +81,7 @@ executing==0.6.0
     # via sentry-sdk
 feedgen==0.9.0
     # via -r requirements.in
-flask-babelex==0.9.4
+flask-babel==2.0.0
     # via -r requirements.in
 flask-caching==1.10.1
     # via -r requirements.in
@@ -106,7 +106,7 @@ flask-wtf==0.14.3
 flask==1.1.2
     # via
     #   -r requirements.in
-    #   flask-babelex
+    #   flask-babel
     #   flask-caching
     #   flask-limiter
     #   flask-marshmallow
@@ -148,7 +148,7 @@ jinja2==2.11.3
     # via
     #   -r requirements.in
     #   flask
-    #   flask-babelex
+    #   flask-babel
     #   flask-pluginengine
 jsonschema==3.2.0
     # via -r requirements.in
@@ -237,6 +237,7 @@ pytz==2021.1
     #   -r requirements.in
     #   babel
     #   celery
+    #   flask-babel
     #   icalendar
 pywebpack==1.2.0
     # via
@@ -270,7 +271,7 @@ six==1.15.0
     #   python-dateutil
     #   qrcode
 speaklater==1.3
-    # via flask-babelex
+    # via -r requirements.in
 sqlalchemy==1.4.9
     # via
     #   -r requirements.in


### PR DESCRIPTION
It's been a while since python-babel/flask-babel#163 has been merged and released (flask-babel 2.0)...

Also fixed an incorrectly formatted i18n string and added message extraction to the CI to spot such problems early (babel's error message is completely useless and the only way to find out what's causing the problem is to patch babel to print the code it choked on)