### PR TITLE
Convert the search aggregations to an object

### DIFF
--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -47,7 +47,7 @@ function useSearch(url, query) {
         pages: data?.pages || 1,
         total: data?.total || 0,
         data: data?.results || [],
-        aggregations: data?.aggregations || lastData?.aggregations || [],
+        aggregations: data?.aggregations || lastData?.aggregations || {},
         loading,
       }),
       [page, data, lastData, loading]
@@ -140,7 +140,7 @@ export default function SearchApp() {
 
   return (
     <Grid columns={2} doubling padded styleName="grid">
-      {results.aggregations.length > 0 && (
+      {Object.keys(results.aggregations).length > 0 && (
         <Grid.Column width={3} only="large screen">
           <SideBar query={filters} aggregations={results.aggregations} onChange={handleQuery} />
         </Grid.Column>

--- a/indico/modules/search/client/js/components/SideBar.jsx
+++ b/indico/modules/search/client/js/components/SideBar.jsx
@@ -15,9 +15,9 @@ export default function SideBar({query, aggregations, onChange}) {
   const handleChange = (type, value) =>
     onChange && onChange(query[type] === value ? undefined : value, type);
 
-  return aggregations
-    .filter(({buckets}) => buckets && buckets.length)
-    .map(({key, label, buckets}) => (
+  return Object.entries(aggregations)
+    .filter(([, {buckets}]) => buckets && buckets.length)
+    .map(([key, {label, buckets}]) => (
       <AggregationList
         key={key}
         name={key}
@@ -77,12 +77,12 @@ AggregationList.propTypes = {
 
 SideBar.propTypes = {
   query: PropTypes.object,
-  aggregations: PropTypes.array,
+  aggregations: PropTypes.object,
   onChange: PropTypes.func,
 };
 
 SideBar.defaultProps = {
   query: {},
-  aggregations: [],
+  aggregations: {},
   onChange: undefined,
 };

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -67,7 +67,7 @@ class InternalSearch(IndicoSearchProvider):
         elif object_type == SearchTarget.event:
             total, results = InternalSearch.search_events(page, query)
         else:
-            return 0, [], []
+            return 0, {}, []
         return total, math.ceil(total / self.RESULTS_PER_PAGE), results, []
 
     @staticmethod


### PR DESCRIPTION
ES returns the aggregations as an object. Initially, we thought about returning a list to simplify the front-end handling.

However, the trade-off in having an object results in checking if a key is present being `aggregations.key` instead of `aggregations.find(x => x.key === key)`. As there are no advantages right now in using a list, and we should deal with aggregation keys a lot more often, I'm restoring the original behaviour.