### PR TITLE
Update the search API to support multiple types 

### DIFF
--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -28,12 +28,12 @@ class IndicoSearchProvider:
     RESULTS_PER_PAGE = 10
 
     def search(self, query, access, page=1, object_types=(), **params):
-        """Search using a custom service across multiple targets
+        """Search using a custom service across multiple targets.
 
-        :param query Keyword based query string
-        :param access The requester access control list
-        :param page The target page
-        :param object_types A filter for a specific `SearchTarget`
-        :param params Any additional search params such as filters
+        :param query: Keyword based query string
+        :param access: The requester access control list
+        :param page: The target page
+        :param object_types: A filter for a specific `SearchTarget`
+        :param params: Any additional search params such as filters
         """
         raise NotImplementedError()

--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -27,5 +27,6 @@ class SearchTarget(int, IndicoEnum):
 class IndicoSearchProvider:
     RESULTS_PER_PAGE = 10
 
-    def search(self, query, access, object_type=SearchTarget.event, page=1, params=None):
+    def search(self, query, access, page=1, object_types=(), params=None):
+        # TODO: docs
         raise NotImplementedError()

--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -27,6 +27,13 @@ class SearchTarget(int, IndicoEnum):
 class IndicoSearchProvider:
     RESULTS_PER_PAGE = 10
 
-    def search(self, query, access, page=1, object_types=(), params=None):
-        # TODO: docs
+    def search(self, query, access, page=1, object_types=(), **params):
+        """Search using a custom service across multiple targets
+
+        :param query Keyword based query string
+        :param access The requester access control list
+        :param page The target page
+        :param object_types A filter for a specific `SearchTarget`
+        :param params Any additional search params such as filters
+        """
         raise NotImplementedError()

--- a/indico/modules/search/blueprint.py
+++ b/indico/modules/search/blueprint.py
@@ -15,5 +15,4 @@ _bp = IndicoBlueprint('search', __name__, template_folder='templates', virtual_t
 _bp.add_url_rule('/search/', 'search', RHSearchDisplay)
 
 # Search APIs
-_bp.add_url_rule('/search/api/<any(event,category,contribution,attachment,event_note):type>',
-                 'api_search', RHAPISearch)
+_bp.add_url_rule('/search/api', 'api_search', RHAPISearch)

--- a/indico/modules/search/blueprint.py
+++ b/indico/modules/search/blueprint.py
@@ -15,4 +15,4 @@ _bp = IndicoBlueprint('search', __name__, template_folder='templates', virtual_t
 _bp.add_url_rule('/search/', 'search', RHSearchDisplay)
 
 # Search APIs
-_bp.add_url_rule('/search/api', 'api_search', RHAPISearch)
+_bp.add_url_rule('/search/api/search', 'api_search', RHAPISearch)

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -35,12 +35,12 @@ const camelizeValues = obj =>
     {}
   );
 
-function useSearch(url, query) {
+function useSearch(url, query, type = undefined) {
   const [page, setPage] = useState(1);
 
   const {data, loading, lastData} = useIndicoAxios({
     url,
-    options: {params: {...query, page}},
+    options: {params: {...query, type, page, internal: type === 'category'}},
     forceDispatchEffect: () => query?.q,
     trigger: [url, query, page],
   });
@@ -123,14 +123,14 @@ export default function SearchApp() {
   const [query, setQuery] = useQueryParams();
   const [activeMenuItem, setActiveMenuItem] = useState(undefined);
   const {q, ...filters} = query;
-  const [categoryResults, setCategoryPage] = useSearch(searchURL({type: 'category'}), query);
-  const [eventResults, setEventPage] = useSearch(searchURL({type: 'event'}), query);
-  const [contributionResults, setContributionPage] = useSearch(
-    searchURL({type: 'contribution'}),
-    query
-  );
-  const [fileResults, setFilePage] = useSearch(searchURL({type: 'attachment'}), query);
-  const [noteResults, setNotePage] = useSearch(searchURL({type: 'event_note'}), query);
+  const [categoryResults, setCategoryPage] = useSearch(searchURL(), query, 'category');
+  const [eventResults, setEventPage] = useSearch(searchURL(), query, 'event');
+  const [contributionResults, setContributionPage] = useSearch(searchURL(), query, [
+    'contribution',
+    'subcontribution',
+  ]);
+  const [fileResults, setFilePage] = useSearch(searchURL(), query, 'attachment');
+  const [noteResults, setNotePage] = useSearch(searchURL(), query, 'event_note');
   const searchMap = [
     [Translate.string('Categories'), categoryResults, setCategoryPage, Category],
     [Translate.string('Events'), eventResults, setEventPage, Event],

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -40,7 +40,7 @@ function useSearch(url, query, type = undefined) {
 
   const {data, loading, lastData} = useIndicoAxios({
     url,
-    options: {params: {...query, type, page, internal: type === 'category'}},
+    options: {params: {...query, type, page}},
     forceDispatchEffect: () => query?.q,
     trigger: [url, query, page],
   });

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -56,7 +56,7 @@ class RHAPISearch(RH):
         if not search_provider or SearchTarget.category in type:
             search_provider = InternalSearch
         access = get_groups(session.user) if session.user else []
-        total, pages, results, aggs = search_provider().search(q, access, page, type, params)
+        total, pages, results, aggs = search_provider().search(q, access, page, type, **params)
         return {
             'total': total,
             'pages': pages,
@@ -66,7 +66,7 @@ class RHAPISearch(RH):
 
 
 class InternalSearch(IndicoSearchProvider):
-    def search(self, query, access, page=1, object_types=(), params=None):
+    def search(self, query, access, page=1, object_types=(), **params):
         if SearchTarget.category in object_types:
             total, results = InternalSearch.search_categories(page, query)
         elif SearchTarget.event in object_types:

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -54,7 +54,7 @@ class RHAPISearch(RH):
     }, location='query', unknown=INCLUDE)
     def _process(self, page, q, type, **params):
         search_provider = get_search_provider()
-        if not search_provider or SearchTarget.category in type:
+        if not search_provider or type == [SearchTarget.category]:
             search_provider = InternalSearch
         access = get_groups(session.user) if session.user else []
         total, pages, results, aggs = search_provider().search(q, access, page, type, **params)

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -40,12 +40,13 @@ class RHSearchDisplay(RH):
 
 
 class RHAPISearch(RH):
-    """API for searching across all records with the current search provider
+    """API for searching across all records with the current search provider.
 
     Besides pagination, filters or placeholders may be passed as query parameters.
     Since `type` may be a list, the results from the search provider are not mixed with
     the InternalSearch.
     """
+
     @use_kwargs({
         'page': fields.Int(missing=1),
         'q': fields.String(required=True),

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -43,19 +43,17 @@ class RHAPISearch(RH):
     """API for searching across all records with the current search provider
 
     Besides pagination, filters or placeholders may be passed as query parameters.
-    A boolean flag `internal` can be used to override the service to an internal lookup.
     Since `type` may be a list, the results from the search provider are not mixed with
     the InternalSearch.
     """
     @use_kwargs({
         'page': fields.Int(missing=1),
         'q': fields.String(required=True),
-        'type': fields.List(EnumField(SearchTarget), missing=None),
-        'internal': fields.Boolean(missing=False)
+        'type': fields.List(EnumField(SearchTarget), missing=None)
     }, location='query', unknown=INCLUDE)
-    def _process(self, page, q, type, internal, **params):
+    def _process(self, page, q, type, **params):
         search_provider = get_search_provider()
-        if not search_provider or internal:
+        if not search_provider or SearchTarget.category in type:
             search_provider = InternalSearch
         access = get_groups(session.user) if session.user else []
         total, pages, results, aggs = search_provider().search(q, access, page, type, params)

--- a/indico/web/client/js/react/hooks.js
+++ b/indico/web/client/js/react/hooks.js
@@ -244,12 +244,17 @@ export function useQueryParams() {
   const history = useHistory();
 
   const setQuery = useCallback(
-    (type, name, reset) => {
+    (key, value, reset) => {
       const params = new URLSearchParams(reset ? undefined : query);
-      if (name !== undefined) {
-        params.set(type, name);
+      if (value !== undefined) {
+        if (Array.isArray(value)) {
+          params.delete(key);
+          value.forEach(v => params.append(key, v));
+        } else {
+          params.set(key, value);
+        }
       } else {
-        params.delete(type);
+        params.delete(key);
       }
       const _query = params.toString();
       history.push({


### PR DESCRIPTION
This PR finally lifts the restriction of a single type per search. 
This brings up some considerations about the current API such as receiving a `category` together with an `event` object type. Since the former should be queried directly from the InternalSearch (categories are not initially designed to be indexed by any elastic search service), we don't really have any simple means of merging results from two different sources (InternalSearch and the currently used search provider).

My approach keeps these are two different sources apart by ignoring any `object_types` and return only categories if that target is provided as a type. 
This should prevent us from running into the previous situation while preserving the possibility of querying categories directly from the `InternalSearch`.

In other news, the `InternalSearch` was kept as originally, only supporting a single `SearchTarget`.

In addition, merges contributions with sub-contributions.