### PR TITLE
Improve category breadcrumbs

### DIFF
--- a/indico/modules/categories/views.py
+++ b/indico/modules/categories/views.py
@@ -5,12 +5,14 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from flask import request
 from markupsafe import escape
 
 from indico.modules.admin.views import WPAdmin
 from indico.util.i18n import _
 from indico.util.mathjax import MathjaxMixin
 from indico.web.breadcrumbs import render_breadcrumbs
+from indico.web.flask.util import url_for
 from indico.web.views import WPDecorated, WPJinjaMixin, render_header
 
 
@@ -78,10 +80,18 @@ class WPCategoryManagement(WPCategory):
         return render_header(category=self.category, protected_object=self.category,
                              local_tz=self.category.timezone, force_local_tz=True)
 
+    def _get_parent_category_breadcrumb_url(self, category, management=False):
+        if not management:
+            return category.url
+        params = dict(request.view_args, **request.args.to_dict(False))
+        del params['category_id']
+        return url_for(request.endpoint, category, **params)
+
     def _get_breadcrumbs(self):
         if self.category.is_root:
             return ''
-        return render_breadcrumbs(category=self.category, management=True)
+        return render_breadcrumbs(category=self.category, management=True,
+                                  category_url_factory=self._get_parent_category_breadcrumb_url)
 
 
 class WPCategoryStatistics(WPCategory):

--- a/indico/modules/designer/views.py
+++ b/indico/modules/designer/views.py
@@ -7,6 +7,7 @@
 
 from indico.modules.categories.views import WPCategoryManagement
 from indico.modules.events.management.views import WPEventManagement
+from indico.web.flask.util import url_for
 
 
 class WPEventManagementDesigner(WPEventManagement):
@@ -17,3 +18,10 @@ class WPEventManagementDesigner(WPEventManagement):
 class WPCategoryManagementDesigner(WPCategoryManagement):
     template_prefix = 'designer/'
     bundles = ('module_designer.js',)
+
+    def _get_parent_category_breadcrumb_url(self, category, management=False):
+        if not management:
+            return category.url
+        # we don't want template-specific urls since those may be tied
+        # to the previous category
+        return url_for('designer.template_list', category)

--- a/indico/web/breadcrumbs.py
+++ b/indico/web/breadcrumbs.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from flask import render_template
+from flask import render_template, session
 
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
@@ -38,7 +38,7 @@ def render_breadcrumbs(*titles, category=None, event=None, management=False, cat
             category = event.category
         if category_url_factory is None:
             category_url_factory = lambda cat, management: (url_for('categories.manage_content', cat)
-                                                            if management
+                                                            if management and cat.can_manage(session.user)
                                                             else cat.url)
         for cat in category.chain_query[::-1]:
             items.append((cat.title, category_url_factory(cat, management=management)))

--- a/indico/web/breadcrumbs.py
+++ b/indico/web/breadcrumbs.py
@@ -12,8 +12,8 @@ from indico.web.flask.util import url_for
 from indico.web.util import url_for_index
 
 
-def render_breadcrumbs(*titles, **kwargs):
-    """Render the breadcrumb navigation
+def render_breadcrumbs(*titles, category=None, event=None, management=False, category_url_factory=None):
+    """Render the breadcrumb navigation.
 
     :param titles: A list of plain text titles.  If present, these will
                    simply create a unlinked trail of breadcrumbs.
@@ -22,13 +22,13 @@ def render_breadcrumbs(*titles, **kwargs):
                   at the specified event.
     :param category: Generate the category breadcrumb trail starting at
                      the specified category.
+    :param category_url_factory: Function to get the URL for a category
+                                 breadcrumb. If missing, the standard
+                                 category url will be used.
     :param management: Whether the event/category breadcrumb trail
                        should link to management pages.
     """
-    category = kwargs.get('category', None)
-    event = kwargs.get('event', None)
-    management = kwargs.get('management', False)
-    assert bool(titles) or bool(event) or bool(category)
+    assert titles or event or category
     if not category and not event:
         items = [(_('Home'), url_for_index())]
     else:
@@ -36,8 +36,12 @@ def render_breadcrumbs(*titles, **kwargs):
         if event:
             items.append((event.title, url_for('event_management.settings', event) if management else event.url))
             category = event.category
+        if category_url_factory is None:
+            category_url_factory = lambda cat, management: (url_for('categories.manage_content', cat)
+                                                            if management
+                                                            else cat.url)
         for cat in category.chain_query[::-1]:
-            items.append((cat.title, url_for('categories.manage_content', cat) if management else cat.url))
+            items.append((cat.title, category_url_factory(cat, management=management)))
         items.reverse()
     items += [(x, None) if isinstance(x, str) else x for x in titles]
     return render_template('breadcrumbs.html', items=items, management=management)

--- a/indico/web/breadcrumbs.py
+++ b/indico/web/breadcrumbs.py
@@ -28,10 +28,9 @@ def render_breadcrumbs(*titles, **kwargs):
     category = kwargs.get('category', None)
     event = kwargs.get('event', None)
     management = kwargs.get('management', False)
-    assert bool(titles) + bool(event) + bool(category) == 1
+    assert bool(titles) or bool(event) or bool(category)
     if not category and not event:
         items = [(_('Home'), url_for_index())]
-        items += [(x, None) if isinstance(x, str) else x for x in titles]
     else:
         items = []
         if event:
@@ -40,4 +39,5 @@ def render_breadcrumbs(*titles, **kwargs):
         for cat in category.chain_query[::-1]:
             items.append((cat.title, url_for('categories.manage_content', cat) if management else cat.url))
         items.reverse()
+    items += [(x, None) if isinstance(x, str) else x for x in titles]
     return render_template('breadcrumbs.html', items=items, management=management)


### PR DESCRIPTION
When staying inside category management, link to the current page in the other category.

When coming from event management, only link to category management if authorized to manage that particular category.