### PR TITLE
Update flask etc. & enable gettext context support everywhere

### DIFF
--- a/indico/cli/devserver.py
+++ b/indico/cli/devserver.py
@@ -120,7 +120,7 @@ def _make_wsgi_app(info, url, evalex_whitelist, proxy):
         return info.load_app()
 
     url_data = url_parse(url)
-    app = DispatchingApp(_load_app)
+    app = DispatchingApp(_load_app, use_eager_loading=False)
     app = DebuggedIndico(app, evalex_whitelist)
     app = _make_indico_dispatcher(app, url_data.path)
     if proxy:

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -59,7 +59,7 @@ DEFAULT_OPTIONS = {
         'domain': 'messages-js'
     },
     'extract_messages_js': {
-        'keywords': ['$T', 'gettext', 'ngettext:1,2'],
+        'keywords': ['$T', 'gettext', 'ngettext:1,2', 'pgettext:1c,2', 'npgettext:1c,2,3'],
         'width': '120',
         'output_file': MESSAGES_JS_POT,
         'mapping_file': 'babel-js.cfg',

--- a/indico/cli/watchman.py
+++ b/indico/cli/watchman.py
@@ -13,7 +13,7 @@ import time
 
 import pywatchman
 from flask.helpers import get_root_path
-from werkzeug._reloader import _find_observable_paths
+from werkzeug._reloader import _find_watchdog_paths
 
 from indico.util.console import cformat
 
@@ -89,7 +89,7 @@ class Watchman:
         self._client = pywatchman.client(timeout=300)
         self._client.capabilityCheck(required=['wildmatch', 'cmd-watch-project'])
         indico_project_root = os.path.realpath(os.path.join(get_root_path('indico'), '..'))
-        paths = sorted({os.path.realpath(p) for p in _find_observable_paths() if os.path.exists(p)})
+        paths = sorted({os.path.realpath(p) for p in _find_watchdog_paths(set(), set()) if os.path.exists(p)})
         for path in paths:
             patterns = ['**/*.py', '**/entry_points.txt']
             if path == indico_project_root:

--- a/indico/web/flask/app.py
+++ b/indico/web/flask/app.py
@@ -41,7 +41,8 @@ from indico.core.webpack import IndicoManifestLoader, webpack
 from indico.modules.auth.providers import IndicoAuthProvider, IndicoIdentityProvider
 from indico.modules.auth.util import url_for_login, url_for_logout
 from indico.util import date_time as date_time_util
-from indico.util.i18n import _, babel, get_all_locales, get_current_locale, gettext_context, ngettext_context
+from indico.util.i18n import (_, babel, get_all_locales, get_current_locale, gettext_context, ngettext_context,
+                              npgettext_context, pgettext_context)
 from indico.util.mimetypes import icon_from_mimetype
 from indico.util.signals import values_from_signal
 from indico.util.string import RichMarkup, alpha_enum, crc32, html_to_plaintext, sanitize_html, slugify
@@ -248,7 +249,8 @@ def setup_jinja(app):
     app.add_template_test(subclassof)  # only use this test if you really have to!
     # i18n
     app.jinja_env.add_extension('jinja2.ext.i18n')
-    app.jinja_env.install_gettext_callables(gettext_context, ngettext_context, True)
+    app.jinja_env.install_gettext_callables(gettext_context, ngettext_context, True,
+                                            pgettext=pgettext_context, npgettext=npgettext_context)
 
 
 def setup_jinja_customization(app):

--- a/indico/web/flask/util.py
+++ b/indico/web/flask/util.py
@@ -271,7 +271,7 @@ def send_file(name, path_or_fd, mimetype, last_modified=None, no_cache=True, inl
     assert '/' in mimetype
     if inline is None:
         inline = mimetype not in ('text/csv', 'text/xml', 'application/xml')
-    if request.user_agent.platform == 'android':
+    if request.user_agent.platform == 'Android':
         # Android is just full of fail when it comes to inline content-disposition...
         inline = False
     if _is_office_mimetype(mimetype):

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -19,6 +19,6 @@ pywatchman
 sphinx-autobuild
 sphinx-issues
 sphinx-rtd-theme
-sphinx
+sphinx!=4.0.*  # not compatible with jinja 3 - https://github.com/sphinx-doc/sphinx/issues/9216
 sqlparse
 transifex-client

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -41,7 +41,7 @@ flake8-colors==0.1.9
     # via -r requirements.dev.in
 flake8-quotes==3.2.0
     # via -r requirements.dev.in
-flake8==3.9.1
+flake8==3.9.2
     # via
     #   -r requirements.dev.in
     #   flake8-colors
@@ -95,7 +95,7 @@ mccabe==0.6.1
     # via flake8
 migra==3.0.1616366383
     # via -r requirements.dev.in
-mirakuru==2.3.0
+mirakuru==2.3.1
     # via pytest-redis
 packaging==20.9
     # via
@@ -154,7 +154,7 @@ pytz==2021.1
     # via
     #   -c requirements.txt
     #   babel
-pyupgrade==2.14.0
+pyupgrade==2.15.0
     # via -r requirements.dev.in
 pywatchman==1.4.1
     # via -r requirements.dev.in
@@ -208,7 +208,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.4
     # via sphinx
-sqlalchemy==1.4.14
+sqlalchemy==1.4.15
     # via
     #   -c requirements.txt
     #   schemainspect

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -48,7 +48,7 @@ flake8==3.9.1
     #   flake8-quotes
 flask-url-map-serializer==0.0.1
     # via -r requirements.dev.in
-flask==1.1.2
+flask==2.0.0
     # via
     #   -c requirements.txt
     #   flask-url-map-serializer
@@ -76,18 +76,18 @@ iniconfig==1.1.1
     # via pytest
 isort==5.8.0
     # via -r requirements.dev.in
-itsdangerous==1.1.0
+itsdangerous==2.0.0
     # via
     #   -c requirements.txt
     #   flask
-jinja2==2.11.3
+jinja2==3.0.0
     # via
     #   -c requirements.txt
     #   flask
     #   sphinx
 livereload==2.6.3
     # via sphinx-autobuild
-markupsafe==1.1.1
+markupsafe==2.0.0
     # via
     #   -c requirements.txt
     #   jinja2
@@ -234,7 +234,7 @@ urllib3==1.26.4
     #   -c requirements.txt
     #   requests
     #   transifex-client
-werkzeug==1.0.1
+werkzeug==2.0.0
     # via
     #   -c requirements.txt
     #   flask

--- a/requirements.in
+++ b/requirements.in
@@ -58,6 +58,7 @@ sqlalchemy
 termcolor
 terminaltables
 translitcodec
+ua-parser
 webargs
 werkzeug
 wtforms[ipaddress,email]

--- a/requirements.txt
+++ b/requirements.txt
@@ -103,7 +103,7 @@ flask-webpackext==1.0.2
     # via -r requirements.in
 flask-wtf==0.14.3
     # via -r requirements.in
-flask==1.1.2
+flask==2.0.0
     # via
     #   -r requirements.in
     #   flask-babel
@@ -137,14 +137,14 @@ ipython-genutils==0.2.0
     # via traitlets
 ipython==7.23.1
     # via -r requirements.in
-itsdangerous==1.1.0
+itsdangerous==2.0.0
     # via
     #   -r requirements.in
     #   flask
     #   flask-wtf
 jedi==0.18.0
     # via ipython
-jinja2==2.11.3
+jinja2==3.0.0
     # via
     #   -r requirements.in
     #   flask
@@ -164,7 +164,7 @@ mako==1.1.4
     # via alembic
 markdown==3.3.4
     # via -r requirements.in
-markupsafe==1.1.1
+markupsafe==2.0.0
     # via
     #   -r requirements.in
     #   jinja2
@@ -312,7 +312,7 @@ webencodings==0.5.1
     # via
     #   bleach
     #   html5lib
-werkzeug==1.0.1
+werkzeug==2.0.0
     # via
     #   -r requirements.in
     #   flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -279,7 +279,7 @@ six==1.16.0
     #   qrcode
 speaklater==1.3
     # via -r requirements.in
-sqlalchemy==1.4.14
+sqlalchemy==1.4.15
     # via
     #   -r requirements.in
     #   alembic
@@ -294,7 +294,7 @@ traitlets==5.0.5
     # via
     #   ipython
     #   matplotlib-inline
-translitcodec==0.6.0
+translitcodec==0.7.0
     # via -r requirements.in
 ua-parser==0.10.0
     # via -r requirements.in
@@ -322,7 +322,7 @@ wtforms[email,ipaddress]==2.3.3
     # via
     #   -r requirements.in
     #   flask-wtf
-xlsxwriter==1.4.2
+xlsxwriter==1.4.3
     # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -296,6 +296,8 @@ traitlets==5.0.5
     #   matplotlib-inline
 translitcodec==0.6.0
     # via -r requirements.in
+ua-parser==0.10.0
+    # via -r requirements.in
 urllib3==1.26.4
     # via
     #   requests


### PR DESCRIPTION
The major version bumps of the pallets libs will most likely be released on May 11th, so once they're out we just need to remove the rc suffix in the requirements.

It also closes #4610