### PR TITLE
Enable CodeQL scans and fix issues found there

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - master
+      - 2.3-maintenance
+  pull_request:
+    branches:
+      - master
+      - 2.3-maintenance
+  schedule:
+    - cron: '0 0 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - javascript
+          - python
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup Python
+        if: matrix.language == 'python'
+        uses: actions/setup-python@v2
+        with:
+          python-version: 2.7
+
+      - name: Install Python dependencies
+        if: matrix.language == 'python'
+        run: |
+          sudo apt-get install libpq-dev
+          pip install -U pip setuptools wheel
+          pip install -r requirements.dev.txt
+          pip install -r requirements.txt
+          echo "CODEQL_PYTHON=$(which python)" >> $GITHUB_ENV
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          setup-python-dependencies: false
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,15 @@ Version 2.3.5
 
 *Unreleased*
 
+Security fixes
+^^^^^^^^^^^^^^
+
+- Fix XSS vulnerabilities in the category picker (via category titles), location widget (via room and
+  venue names defined by an Indico administrator) and the "Indico Weeks View" timetable theme (via
+  contribution/break titles defined by an event organizer). As neither of these objects can be created
+  by untrusted users (on a properly configured instance) we consider the severity of this vulnerability
+  "minor" (:pr:`4897`)
+
 Internationalization
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/indico/core/celery/templates/celery_tasks.html
+++ b/indico/core/celery/templates/celery_tasks.html
@@ -11,7 +11,7 @@
             {%- call message_box('info', fixed_width=true) -%}
                 {%- trans flower_url=indico_config.FLOWER_URL -%}
                     Monitor Indico's Celery tasks with Flower
-                    <a class="bold" href="{{ flower_url }}" target="_blank">here</a>.
+                    <a class="bold" href="{{ flower_url }}" target="_blank" rel="noopener noreferrer">here</a>.
                 {%- endtrans -%}
             {%- endcall %}
         {%- endif -%}

--- a/indico/modules/attachments/templates/preview.html
+++ b/indico/modules/attachments/templates/preview.html
@@ -6,7 +6,8 @@
             <span class="{{ get_attachment_icon(attachment) }}">{{ attachment.title }}</span>
         </div>
         <div class="attachment-actions">
-            <a href="{{ attachment.download_url }}" target="_blank" title="{% trans %}Download{% endtrans %}"
+            <a href="{{ attachment.download_url }}" target="_blank" rel="noopener noreferrer"
+               title="{% trans %}Download{% endtrans %}"
                class="i-button icon icon-file-download attachment-download" download>
                 {%- trans %}Download{% endtrans -%}
             </a>

--- a/indico/modules/auth/templates/login_page.html
+++ b/indico/modules/auth/templates/login_page.html
@@ -65,7 +65,7 @@
         {% elif indico_config.EXTERNAL_REGISTRATION_URL %}
             <p class="register">
                 {% trans url=indico_config.EXTERNAL_REGISTRATION_URL -%}
-                    If you do not have an account yet, you can <a href="{{ url }}" target="_blank">create one here</a>.
+                    If you do not have an account yet, you can <a href="{{ url }}" target="_blank" rel="noopener noreferrer">create one here</a>.
                 {%- endtrans %}
             </p>
         {% endif %}

--- a/indico/modules/events/papers/templates/_contributions.html
+++ b/indico/modules/events/papers/templates/_contributions.html
@@ -178,7 +178,8 @@
                     {% set icon = icon_from_mimetype(file.content_type, 'icon-file-filled') %}
                     <tr>
                         <td class="revision-file-row">
-                            <a href="{{ download_url }}" class="attachment {{ icon }}" target="_blank">
+                            <a href="{{ download_url }}" class="attachment {{ icon }}" target="_blank"
+                               rel="noopener noreferrer">
                                 {{ file.filename }}
                             </a>
                         </td>

--- a/indico/modules/events/timetable/templates/display/_weeks.html
+++ b/indico/modules/events/timetable/templates/display/_weeks.html
@@ -291,7 +291,7 @@
             }
 
             while ($main.outerHeight() > $this.height() && ($main.outerHeight() - parseInt($main.css('line-height'), 10)) > 1) {
-                $title.html($title.text().slice(0, -5) + '&#8230;');
+                $title.text($title.text().slice(0, -5) + '…');
             }
         });
     });

--- a/indico/modules/events/timetable/templates/display/indico/_common.html
+++ b/indico/modules/events/timetable/templates/display/indico/_common.html
@@ -14,7 +14,7 @@
             <li title="{% trans title=reference.reference_type.name %}External reference ({{ title }}){% endtrans %}"
                 class="icon-link">
             {% if reference.url -%}
-                <a href="{{ reference.url }}" class="title" target="_blank">
+                <a href="{{ reference.url }}" class="title" target="_blank" rel="noopener noreferrer">
                     {{ reference.urn or reference.value }}
                 </a>
             {%- else -%}

--- a/indico/modules/rb/client/js/common/bookings/BookingObjectLink.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingObjectLink.jsx
@@ -56,14 +56,13 @@ export default class BookingObjectLink extends React.PureComponent {
             {pending ? pendingMessages[type] : linkedMessages[type]}
             <div styleName="object-link">
               {type === 'event' ? (
-                /* eslint-disable react/jsx-no-target-blank */
-                <a href={eventURL} target="_blank">
+                <a href={eventURL} target="_blank" rel="noopener noreferrer">
                   <em>{title}</em>
                 </a>
               ) : (
                 <span>
                   <em>{title}</em> (
-                  <a href={eventURL} target="_blank">
+                  <a href={eventURL} target="_blank" rel="noopener noreferrer">
                     {eventTitle}
                   </a>
                   )

--- a/indico/modules/rb/client/js/common/linking/LinkBar.jsx
+++ b/indico/modules/rb/client/js/common/linking/LinkBar.jsx
@@ -41,14 +41,13 @@ const LinkBar = ({visible, clear, data}) => {
       <span>
         {messages[type]}{' '}
         {type === 'event' ? (
-          /* eslint-disable react/jsx-no-target-blank */
-          <a href={eventURL} target="_blank">
+          <a href={eventURL} target="_blank" rel="noopener noreferrer">
             <em>{title}</em>
           </a>
         ) : (
           <span>
             <em>{title}</em> (
-            <a href={eventURL} target="_blank">
+            <a href={eventURL} target="_blank" rel="noopener noreferrer">
               {eventTitle}
             </a>
             )

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
@@ -389,8 +389,7 @@ class BookRoomModal extends React.Component {
     if (link) {
       return (
         <span styleName="link-active">
-          {/* eslint-disable-next-line react/jsx-no-target-blank */}
-          <a href={link} target="_blank">
+          <a href={link} target="_blank" rel="noopener noreferrer">
             <Icon name="external" link />
           </a>
         </span>

--- a/indico/web/client/js/jquery/utils/pagedown_mathjax.js
+++ b/indico/web/client/js/jquery/utils/pagedown_mathjax.js
@@ -67,9 +67,9 @@
       var block = blocks
         .slice(i, j + 1)
         .join('')
-        .replace(/&/g, '&') // use HTML entity for &
-        .replace(/</g, '<') // use HTML entity for <
-        .replace(/>/g, '>'); // use HTML entity for >
+        .replace(/&/g, '&amp;') // use HTML entity for &
+        .replace(/</g, '&lt;') // use HTML entity for <
+        .replace(/>/g, '&gt;'); // use HTML entity for >
       if (HUB.Browser.isMSIE) {
         block = block.replace(/(%[^\n]*)\n/g, '$1<br/>\n');
       }

--- a/indico/web/client/js/jquery/widgets/categorynavigator.js
+++ b/indico/web/client/js/jquery/widgets/categorynavigator.js
@@ -402,13 +402,11 @@ import Palette from '../../utils/palette';
       var indexStart = title.toLowerCase().search(query.toLowerCase());
       var indexEnd = indexStart + query.length;
 
-      $title.html(
-        title.substring(0, indexStart) +
-          '<strong>' +
-          title.substring(indexStart, indexEnd) +
-          '</strong>' +
-          title.substring(indexEnd)
-      );
+      const prefix = $('<span />').text(title.substring(0, indexStart));
+      const highlight = $('<strong />').text(title.substring(indexStart, indexEnd));
+      const suffix = $('<span />').text(title.substring(indexEnd));
+
+      $title.empty().append(prefix, highlight, suffix);
     },
 
     _renderCurrentCategory: function(category) {

--- a/indico/web/client/js/jquery/widgets/jinja/location_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/location_widget.js
@@ -223,7 +223,7 @@
 
     function highlightOption(inputField, value) {
       var highlighter = inputField.siblings('.keyword-highlighter');
-      highlighter.html(value).addClass('visible');
+      highlighter.text(value).addClass('visible');
     }
 
     function cleanQuery(query) {
@@ -327,6 +327,9 @@
       cancelButton: false,
       callback: {
         onInit: function(node) {
+          // XXX: setting this affects all instances of typeahead, but we want to be protected
+          // from XSS everywhere anyway
+          this.helper.cleanStringFromScript = v => $('<span />').text(v).html();
           this.query = this.rawQuery = node.val(); // Updates the results dropdown on init
           handleKeystrokes(node);
         },
@@ -407,6 +410,9 @@
       display: 'name',
       callback: {
         onInit: function(node) {
+          // XXX: setting this affects all instances of typeahead, but we want to be protected
+          // from XSS everywhere anyway
+          this.helper.cleanStringFromScript = v => $('<span />').text(v).html();
           this.query = this.rawQuery = node.val();
           handleKeystrokes(node);
         },


### PR DESCRIPTION
There were also two cases of catastrophic backtracking in regexps which I didn't fix as those are in client-side code where the user could only slow down their own browser, so it's not really worth touching that legacy code...