### PR TITLE
Add meeting theme with numbered contribs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@ Improvements
   the app is now required. (:pr:`4844`)
 - Contribution duration fields now use a widget similar to the time picker that makes selecting
   durations easier. (:issue:`2462`, :pr:`4873`)
+- Add new meeting themes that show sequential numbers instead of start times for contributions
+  (:pr:`4899`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/themes.yaml
+++ b/indico/modules/events/themes.yaml
@@ -34,6 +34,25 @@ definitions:
     settings:
       show_notes: true
 
+  standard_numbered:
+    <<: *standard
+    title: Indico style - numbered
+    settings:
+      hide_duration: true
+      hide_session_block_time: true
+      hide_end_time: true
+      number_contributions: true
+
+  standard_numbered_inline_minutes:
+    <<: *standard
+    title: Indico style - numbered + minutes
+    settings:
+      hide_duration: true
+      hide_session_block_time: true
+      hide_end_time: true
+      number_contributions: true
+      show_notes: true
+
   nicecompact:
     event_types: [conference, meeting]
     stylesheet: compact.scss


### PR DESCRIPTION
We have this in the CERN theme for the council, but there are many meetings where contribution times/durations are meaningless.

We can probably just use these settings we already apply for the council theme, but let's check if each one of them is useful here.

```yaml
    settings:
      hide_duration: true
      hide_session_block_time: true
      number_contributions: true
      hide_end_time: true
```

We may also want to have two new themes for this, one with inline minutes and one without (especially since we use the one with inline minutes in our own meeting ;))