### PR TITLE
Add 'attach_rejection_reason' parameter to the 'before_notification_send' signal

### DIFF
--- a/indico/modules/events/registration/notifications.py
+++ b/indico/modules/events/registration/notifications.py
@@ -46,7 +46,8 @@ def _notify_registration(registration, template_name, to_managers=False, attach_
     mail = make_email(to_list=to_list, template=tpl, html=True, from_address=from_address, attachments=attachments)
     user = session.user if session else None
     signals.core.before_notification_send.send('notify-registration', email=mail, registration=registration,
-                                               template_name=template_name)
+                                               template_name=template_name,
+                                               attach_rejection_reason=attach_rejection_reason)
     send_email(mail, event=registration.registration_form.event, module='Registration', user=user,
                log_metadata={'registration_id': registration.id})
 


### PR DESCRIPTION
On the UN side, there are separate email templates coming from DB, therefore, we are using signal `before_notification_send` to get the name of the template and match it with the one in the database 👎, While adding the rejection reason PR, I wasn't well aware of the system.
Now, the `attach_rejection_reason` parameter is required to remove the placeholder when the switch is disabled in the interface.

Thanks
