### PR TITLE
Support prev/next pagination and use it in InternalSearch

### DIFF
--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -52,7 +52,7 @@ class SearchOptions:
 class IndicoSearchProvider:
     RESULTS_PER_PAGE = 10
 
-    def search(self, query, access, page=1, object_types=(), **params):
+    def search(self, query, access, page=None, object_types=(), **params):
         """Search using a custom service across multiple targets.
 
         :param query: Keyword based query string

--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -52,12 +52,12 @@ class SearchOptions:
 class IndicoSearchProvider:
     RESULTS_PER_PAGE = 10
 
-    def search(self, query, access, page=None, object_types=(), **params):
+    def search(self, query, user=None, page=None, object_types=(), **params):
         """Search using a custom service across multiple targets.
 
         :param query: Keyword based query string
-        :param access: The requester access control list
-        :param page: The target page
+        :param user: The user performing the search (for access checks)
+        :param page: The result page to show
         :param object_types: A filter for a specific `SearchTarget`
         :param params: Any additional search params such as filters
 

--- a/indico/modules/search/client/js/components/ResultList.jsx
+++ b/indico/modules/search/client/js/components/ResultList.jsx
@@ -8,8 +8,9 @@
 import {nanoid} from 'nanoid';
 import PropTypes from 'prop-types';
 import React from 'react';
-import {List, Pagination, Placeholder, Segment} from 'semantic-ui-react';
+import {List, Menu, Pagination, Placeholder, Segment} from 'semantic-ui-react';
 
+import {Translate} from 'indico/react/i18n';
 import {useResponsive} from 'indico/react/util';
 
 import './ResultList.module.scss';
@@ -18,6 +19,7 @@ export default function ResultList({
   component: Component,
   page,
   numPages,
+  pageNav,
   data,
   loading,
   onPageChange,
@@ -58,7 +60,18 @@ export default function ResultList({
           )}
         </List>
       </Segment>
-      {numPages > 1 && (
+      {pageNav && (pageNav.next !== null || pageNav.prev !== null) ? (
+        <div styleName="pagination">
+          <Menu pagination>
+            <Menu.Item disabled={pageNav.prev === null} onClick={() => onPageChange(pageNav.prev)}>
+              <Translate>⟨ Previous page</Translate>
+            </Menu.Item>
+            <Menu.Item disabled={pageNav.next === null} onClick={() => onPageChange(pageNav.next)}>
+              <Translate>Next page ⟩</Translate>
+            </Menu.Item>
+          </Menu>
+        </div>
+      ) : numPages > 1 ? (
         <div styleName="pagination">
           <Pagination
             activePage={page}
@@ -68,7 +81,7 @@ export default function ResultList({
             siblingRange={isWideScreen ? 2 : 1}
           />
         </div>
-      )}
+      ) : null}
     </>
   );
 }
@@ -77,8 +90,16 @@ ResultList.propTypes = {
   component: PropTypes.elementType.isRequired,
   page: PropTypes.number.isRequired,
   numPages: PropTypes.number.isRequired,
+  pageNav: PropTypes.shape({
+    prev: PropTypes.number,
+    next: PropTypes.number,
+  }),
   data: PropTypes.arrayOf(PropTypes.object).isRequired,
   loading: PropTypes.bool.isRequired,
   onPageChange: PropTypes.func.isRequired,
   showCategoryPath: PropTypes.bool.isRequired,
+};
+
+ResultList.defaultProps = {
+  pageNav: null,
 };

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -38,7 +38,7 @@ const camelizeValues = obj =>
   );
 
 function useSearch(url, query, type, scope = {}) {
-  const [page, setPage] = useState(1);
+  const [page, setPage] = useState(undefined);
 
   const {data, error, loading, lastData} = useIndicoAxios({
     url,
@@ -48,13 +48,14 @@ function useSearch(url, query, type, scope = {}) {
   });
 
   useEffect(() => {
-    setPage(1);
+    setPage(undefined);
   }, [query]);
 
   return [
     useMemo(
       () => ({
-        page,
+        page: page || 1,
+        pageNav: data?.pagenav,
         pages: data?.pages || 1,
         total: data?.total || 0,
         data: camelizeKeys(data?.results || []),
@@ -308,11 +309,12 @@ export default function SearchApp({category, eventId}) {
         {!isAnyLoading && (
           <ResultHeader query={q} hasResults={!!results.total} categoryTitle={category?.title} />
         )}
-        {q && (results.total || isAnyLoading) && (
+        {q && (results.total !== 0 || isAnyLoading) && (
           <ResultList
             component={Component}
             page={results.page}
             numPages={results.pages}
+            pageNav={results.pageNav}
             data={results.data}
             onPageChange={setPage}
             loading={results.loading}

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -62,7 +62,7 @@ class RHAPISearch(RH):
     """
 
     @use_kwargs({
-        'page': fields.Int(missing=1),
+        'page': fields.Int(missing=None),
         'q': fields.String(required=True),
         'type': fields.List(EnumField(SearchTarget), missing=None)
     }, location='query', unknown=INCLUDE)
@@ -84,7 +84,7 @@ class RHAPISearchOptions(RH):
 
 
 class InternalSearch(IndicoSearchProvider):
-    def search(self, query, access, page=1, object_types=(), **params):
+    def search(self, query, access, page=None, object_types=(), **params):
         if object_types == [SearchTarget.category]:
             total, results = InternalSearch.search_categories(page, query, params.get('category_id'))
         elif object_types == [SearchTarget.event]:

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -19,7 +19,7 @@ from indico.modules.events.controllers.base import RHDisplayEventBase
 from indico.modules.groups import GroupProxy
 from indico.modules.search.base import IndicoSearchProvider, SearchOptions, SearchTarget, get_search_provider
 from indico.modules.search.result_schemas import CategoryResultSchema, EventResultSchema, ResultSchema
-from indico.modules.search.schemas import DetailedCategorySchema, EventSchema
+from indico.modules.search.schemas import DetailedCategorySchema, HTMLStrippingEventSchema
 from indico.modules.search.views import WPCategorySearch, WPEventSearch, WPSearch
 from indico.util.caching import memoize_redis
 from indico.web.args import use_kwargs
@@ -155,5 +155,5 @@ class InternalSearch(IndicoSearchProvider):
                  .filter(*filters)
                  .options(subqueryload(Event.acl_entries), undefer(Event.effective_protection_mode)))
         objs, pagenav = self._paginate(query, page, Event.id, session.user)
-        res = EventSchema(many=True).dump(objs)
+        res = HTMLStrippingEventSchema(many=True).dump(objs)
         return pagenav, EventResultSchema(many=True).load(res)

--- a/indico/modules/search/result_schemas.py
+++ b/indico/modules/search/result_schemas.py
@@ -246,8 +246,14 @@ class ResultItemSchema(OneOfSchema):
         return rv
 
 
+class PageNavSchema(_ResultSchemaBase):
+    prev = fields.Int(required=True, allow_none=True)
+    next = fields.Int(required=True, allow_none=True)
+
+
 class ResultSchema(_ResultSchemaBase):
     total = fields.Int(required=True)
-    pages = fields.Int(required=True)
+    pages = fields.Int(missing=None)
+    pagenav = fields.Nested(PageNavSchema, missing=None)
     results = fields.List(fields.Nested(ResultItemSchema), required=True)
     aggregations = fields.Dict(fields.String(), fields.Nested(AggregationSchema), missing={})

--- a/indico/modules/search/schemas.py
+++ b/indico/modules/search/schemas.py
@@ -13,6 +13,7 @@ from indico.modules.events import Event
 from indico.modules.search.base import SearchTarget
 from indico.modules.users.models.users import User
 from indico.util.marshmallow import NoneRemovingList
+from indico.util.string import strip_tags
 from indico.web.flask.util import url_for
 
 
@@ -71,3 +72,10 @@ class EventSchema(mm.SQLAlchemyAutoSchema):
     persons = NoneRemovingList(fields.Nested(PersonSchema), attribute='person_links')
     category_id = fields.Int()
     category_path = fields.List(fields.Nested(CategorySchema), attribute='detailed_category_chain')
+
+
+class HTMLStrippingEventSchema(EventSchema):
+    @post_dump
+    def _strip_html(self, data, **kwargs):
+        data['description'] = strip_tags(data['description'])
+        return data


### PR DESCRIPTION
This allows us to perform `can_access()` checks in Indico without getting terrible performance.

![image](https://user-images.githubusercontent.com/179599/118521166-0cc32080-b73b-11eb-897c-2a0d1c141edb.png)

Event on an instance as big as our production one searching by event title takes less than 1.5 seconds - and instances that big aren't even expected to use the internal search.