### PR TITLE
Fix undefined id in abstract fields sortable list

### DIFF
--- a/indico/modules/events/contributions/templates/management/fields_dialog.html
+++ b/indico/modules/events/contributions/templates/management/fields_dialog.html
@@ -19,7 +19,7 @@
         </ul>
     </div>
 
-    {% set abstract_content_item = {'title': _("Abstracts content")} %}
+    {% set abstract_content_item = {'id': 'content', 'title': _("Abstracts content")} %}
     {% call(item) sortable_list([abstract_content_item], draggable=false, invisible_handle=true,
                                 id='contributions-fixed-fields', classes='tiles') %}
         <a class="icon-edit js-action-button hide-if-locked" data-ajax-dialog

--- a/indico/web/templates/forms/form_common_fields_first.html
+++ b/indico/web/templates/forms/form_common_fields_first.html
@@ -1,12 +1,12 @@
 {% from 'forms/_form.html' import form_header, form_footer, form_rows %}
 
+{% set common_fields = form._common_fields|default([]) %}
 {{ form_header(form) }}
-{{ form_rows(form, fields=form._common_fields) }}
-{{ form_rows(form, skip=form._common_fields) }}
+{{ form_rows(form, fields=common_fields) }}
+{{ form_rows(form, skip=common_fields) }}
 {% call form_footer(form) %}
     <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}"
-           {% if disabled_until_change|default(true) %}data-disabled-until-change{% endif %}>
-
+           data-disabled-until-change>
     <button type="button" class="i-button big" data-button-back>{% trans %}Cancel{% endtrans %}</button>
 {% endcall %}
 {% block javascript %}{% endblock %}

--- a/indico/web/templates/forms/form_common_fields_first.html
+++ b/indico/web/templates/forms/form_common_fields_first.html
@@ -5,7 +5,7 @@
 {{ form_rows(form, skip=form._common_fields) }}
 {% call form_footer(form) %}
     <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}"
-           {% if disabled_until_change %}data-disabled-until-change{% endif %}>
+           {% if disabled_until_change|default(true) %}data-disabled-until-change{% endif %}>
 
     <button type="button" class="i-button big" data-button-back>{% trans %}Cancel{% endtrans %}</button>
 {% endcall %}


### PR DESCRIPTION
You can reproduce this error by clicking "Abstract fields" in "Cal for Abstracts" management, let alone add any fields (as `disabled_until_change` was undefined as well).

I believe this was triggered when #4678 was introduced as `id` was previously being incorrectly sent as undefined as part of the sortable list.