### PR TITLE
Remove search descriptions without content

### DIFF
--- a/indico/modules/search/client/js/components/results/Contribution.jsx
+++ b/indico/modules/search/client/js/components/results/Contribution.jsx
@@ -37,7 +37,7 @@ export default function Contribution({
         <a href={url}>{title}</a>
       </List.Header>
       <List.Description styleName="description">
-        <Highlight text={description} highlight={highlight.description} />
+        {description && <Highlight text={description} highlight={highlight.description} />}
         {persons.length !== 0 && (
           <List.Item>
             <PersonList persons={persons} />

--- a/indico/modules/search/client/js/components/results/Event.jsx
+++ b/indico/modules/search/client/js/components/results/Event.jsx
@@ -52,7 +52,7 @@ export default function Event({
         <a href={url}>{title}</a>
       </List.Header>
       <List.Description styleName="description">
-        <Highlight text={description} highlight={highlight.description} />
+        {description && <Highlight text={description} highlight={highlight.description} />}
         {['lecture', 'meeting'].includes(eventType) && persons.length !== 0 && (
           <List.Item>
             <PersonList persons={persons} />

--- a/indico/modules/search/client/js/components/results/EventNote.jsx
+++ b/indico/modules/search/client/js/components/results/EventNote.jsx
@@ -25,7 +25,7 @@ const EventNote = ({title, url, content, modifiedDt, highlight, categoryPath, ev
       </a>
     </List.Header>
     <List.Description styleName="description">
-      <Highlight text={content} highlight={highlight.content} />
+      {content && <Highlight text={content} highlight={highlight.content} />}
       <List.Item>
         <Icon name="calendar alternate outline" />
         {serializeDate(toMoment(modifiedDt), 'DD MMMM YYYY HH:mm')}


### PR DESCRIPTION
Highlight's div class summary applies a margin-bottom, when we render it empty, it causes a double margin.

![imagem](https://user-images.githubusercontent.com/12183954/118850356-9b18dd00-b8c8-11eb-9f43-061e60d836cb.png)

![imagem](https://user-images.githubusercontent.com/12183954/118851059-4b86e100-b8c9-11eb-85c2-8265fd507bc0.png)

Up for discussion, but I went for keeping this responsibility on the parent, i.e. decide whether or not highlighted descriptions should render.