### PR TITLE
Fix weird libpq errors in uWSGI

### DIFF
--- a/indico/modules/search/__init__.py
+++ b/indico/modules/search/__init__.py
@@ -14,7 +14,7 @@ from indico.web.flask.templating import template_hook
 @signals.app_created.connect
 def _check_search_provider(app, **kwargs):
     from .base import get_search_provider
-    get_search_provider()
+    get_search_provider(only_active=False)
 
 
 @template_hook('conference-header-right-column')


### PR DESCRIPTION
If something triggered database queries during startup, we have connections in the pool and when using uwsgi which preforks workers after initializing the WSGI app (ie `make_app` runs only once for all workers), this passes a pool containing unusable connections to the workers, which results in VERY strange databases errors such as "error with status PGRES_TUPLES_OK and no message from the libpq".

Since we do not expect any queries during startup, and it's a bad idea, we fail hard when in debug mode. For the unlikely case that existing code is doing this (it shouldn't!), we just dispose the engine which creates a fresh pool (with no connections in it) to avoid the errors.