### PR TITLE
Fixes to iCalendar exports

### DIFF
--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -61,7 +61,7 @@ def generate_basic_component(entity, uid=None, url=None):
             # this happens if desc_text only contains a html comment
             pass
     if url:
-        description.append(f'Agenda: {url}')
+        description.append(url)
     if description:
         component.add('description', '\n'.join(description))
 

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -36,10 +36,10 @@ def generate_basic_component(entity, uid=None, url=None):
     if uid:
         component.add('uid', uid)
 
+    if not url and hasattr(entity, 'external_url'):
+        url = entity.external_url
     if url:
         component.add('url', url)
-    elif hasattr(entity, 'external_url'):
-        component.add('url', entity.external_url)
 
     location = (f'{entity.room_name} ({entity.venue_name})'
                 if entity.venue_name and entity.room_name
@@ -60,6 +60,8 @@ def generate_basic_component(entity, uid=None, url=None):
         except ParserError:
             # this happens if desc_text only contains a html comment
             pass
+    if url:
+        description.append(f'Agenda: {url}')
     if description:
         component.add('description', '\n'.join(description))
 
@@ -87,7 +89,8 @@ def generate_event_component(event, user=None):
         as_list=True
     ):
         data.update(update)
-    component.add('description', data['description'])
+    if data['description']:
+        component['description'] = data['description']
 
     return component
 

--- a/indico/modules/events/sessions/ical.py
+++ b/indico/modules/events/sessions/ical.py
@@ -45,7 +45,8 @@ def session_to_ical(session, detailed=False):
         from indico.modules.events.contributions.ical import generate_contribution_component
 
         contributions = (Contribution.query.with_parent(session)
-                         .filter(Contribution.is_scheduled).all())
+                         .filter(Contribution.is_scheduled)
+                         .all())
         components = [generate_contribution_component(contribution, related_event_uid)
                       for contribution in contributions]
         for component in components:

--- a/indico/modules/events/sessions/ical.py
+++ b/indico/modules/events/sessions/ical.py
@@ -9,6 +9,7 @@ import icalendar
 from werkzeug.urls import url_parse
 
 from indico.core.config import config
+from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.ical import generate_basic_component
 from indico.web.flask.util import url_for
 
@@ -42,8 +43,11 @@ def session_to_ical(session, detailed=False):
         calendar.add_component(component)
     else:
         from indico.modules.events.contributions.ical import generate_contribution_component
+
+        contributions = (Contribution.query.with_parent(session)
+                         .filter(Contribution.is_scheduled).all())
         components = [generate_contribution_component(contribution, related_event_uid)
-                      for contribution in session.contributions]
+                      for contribution in contributions]
         for component in components:
             calendar.add_component(component)
 


### PR DESCRIPTION
* Show agenda link back in description, as Exchange does not parse `URL` field
* Remove duplicate `DESCRIPTION` field in some entities
* Do not export unscheduled contributions in sessions