### PR TITLE
Fix location tracking involving predefined rooms

### DIFF
--- a/indico/modules/events/clone.py
+++ b/indico/modules/events/clone.py
@@ -40,6 +40,7 @@ class EventLocationCloner(EventCloner):
     def _clone_location(self, new_event):
         with track_location_changes():
             new_event.location_data = self.old_event.location_data
+            db.session.flush()
 
 
 class EventPersonCloner(EventCloner):

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -50,7 +50,7 @@ from indico.modules.events.sessions import Session
 from indico.modules.events.timetable.forms import ImportContributionsForm
 from indico.modules.events.timetable.operations import update_timetable_entry
 from indico.modules.events.tracks.models.tracks import Track
-from indico.modules.events.util import check_event_locked, get_field_values, track_time_changes
+from indico.modules.events.util import check_event_locked, get_field_values, track_location_changes, track_time_changes
 from indico.util.date_time import format_datetime, format_human_timedelta
 from indico.util.i18n import _, ngettext
 from indico.util.spreadsheets import send_csv, send_xlsx
@@ -198,7 +198,11 @@ class RHEditContribution(RHManageContributionBase):
                                                    **custom_field_values),
                                   event=self.event, contrib=self.contrib, session_block=parent_session_block)
         if form.validate_on_submit():
-            with track_time_changes(), flash_if_unregistered(self.event, lambda: self.contrib.person_links):
+            with (
+                track_time_changes(),
+                track_location_changes(),
+                flash_if_unregistered(self.event, lambda: self.contrib.person_links)
+            ):
                 update_contribution(self.contrib, *get_field_values(form.data))
             flash(_("Contribution '{}' successfully updated").format(self.contrib.title), 'success')
             tpl_components = self.list_generator.render_list(self.contrib)

--- a/indico/modules/events/contributions/operations.py
+++ b/indico/modules/events/contributions/operations.py
@@ -20,7 +20,7 @@ from indico.modules.events.contributions.models.subcontributions import SubContr
 from indico.modules.events.logs.models.entries import EventLogKind, EventLogRealm
 from indico.modules.events.timetable.operations import (delete_timetable_entry, schedule_contribution,
                                                         update_timetable_entry)
-from indico.modules.events.util import set_custom_fields, track_location_changes
+from indico.modules.events.util import set_custom_fields
 
 
 def _ensure_consistency(contrib):
@@ -88,8 +88,7 @@ def update_contribution(contrib, contrib_data, custom_fields_data=None):
     start_dt = contrib_data.pop('start_dt', None)
     if start_dt is not None:
         update_timetable_entry(contrib.timetable_entry, {'start_dt': start_dt})
-    with track_location_changes():
-        changes = contrib.populate_from_dict(contrib_data)
+    changes = contrib.populate_from_dict(contrib_data)
     if custom_fields_data:
         changes.update(set_custom_fields(contrib, custom_fields_data))
     if 'session' in contrib_data:

--- a/indico/modules/events/sessions/controllers/management/sessions.py
+++ b/indico/modules/events/sessions/controllers/management/sessions.py
@@ -29,7 +29,7 @@ from indico.modules.events.sessions.operations import (create_session, delete_se
 from indico.modules.events.sessions.util import (generate_pdf_from_sessions, generate_spreadsheet_from_sessions,
                                                  render_session_type_row)
 from indico.modules.events.sessions.views import WPManageSessions
-from indico.modules.events.util import get_random_color
+from indico.modules.events.util import get_random_color, track_location_changes
 from indico.util.spreadsheets import send_csv, send_xlsx
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import send_file
@@ -93,7 +93,8 @@ class RHModifySession(RHManageSessionBase):
     def _process(self):
         form = SessionForm(obj=self.session, event=self.event)
         if form.validate_on_submit():
-            update_session(self.session, form.data)
+            with track_location_changes():
+                update_session(self.session, form.data)
             return jsonify_data(html=_render_session_list(self.event))
         return jsonify_form(form)
 
@@ -237,7 +238,8 @@ class RHManageSessionBlock(RHManageSessionBase):
             session_data = {k[8:]: v for k, v in form.data.items() if k in form.session_fields}
             block_data = {k[6:]: v for k, v in form.data.items() if k in form.block_fields}
             update_session(self.session, session_data)
-            update_session_block(self.session_block, block_data)
+            with track_location_changes():
+                update_session_block(self.session_block, block_data)
             return jsonify_data(flash=False)
         self.commit = False
         return jsonify_template('events/forms/session_block_form.html', form=form, block=self.session_block)

--- a/indico/modules/events/sessions/operations.py
+++ b/indico/modules/events/sessions/operations.py
@@ -15,7 +15,6 @@ from indico.modules.events.models.events import EventType
 from indico.modules.events.sessions import COORDINATOR_PRIV_SETTINGS, COORDINATOR_PRIV_TITLES, logger, session_settings
 from indico.modules.events.sessions.models.blocks import SessionBlock
 from indico.modules.events.sessions.models.sessions import Session
-from indico.modules.events.util import track_location_changes
 from indico.util.i18n import orig_string
 
 
@@ -47,8 +46,7 @@ def create_session_block(session_, data):
 
 def update_session(event_session, data):
     """Update a session based on the information in the `data`."""
-    with track_location_changes():
-        event_session.populate_from_dict(data)
+    event_session.populate_from_dict(data)
     db.session.flush()
     signals.event.session_updated.send(event_session)
     event_session.event.log(EventLogRealm.management, EventLogKind.change, 'Sessions',
@@ -90,8 +88,7 @@ def update_session_block(session_block, data):
     if start_dt is not None:
         session_block.timetable_entry.move(start_dt)
         update_timetable_entry(session_block.timetable_entry, {'start_dt': start_dt})
-    with track_location_changes():
-        session_block.populate_from_dict(data)
+    session_block.populate_from_dict(data)
     db.session.flush()
     signals.event.session_block_updated.send(session_block)
     session_block.event.log(EventLogRealm.management, EventLogKind.change, 'Sessions',

--- a/indico/modules/events/timetable/operations.py
+++ b/indico/modules/events/timetable/operations.py
@@ -53,6 +53,7 @@ def update_break_entry(break_, data):
     if start_dt is not None:
         update_timetable_entry(break_.timetable_entry, {'start_dt': start_dt})
     break_.populate_from_dict(data)
+    db.session.flush()
 
 
 def create_session_block_entry(session_, data):


### PR DESCRIPTION
The events on the FK columns only trigger during a flush, so just wrapping the update of the objects in the tracking contextmanager wasn't enough.

Now the tracking isn't done inside the operation functions but rather in the RHs that may make changes to the location; similar to how it's already the case for time change tracking.