### PR TITLE
Fix character count inconsistencies while dealing with line breaks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,7 @@ Bugfixes
 - Restore the ability to see who's inheriting access from a parent object (:pr:`4833`)
 - Fix misleading message when cancelling a booking that already started and has past
   occurrences that won't be cancelled (:issue:`4719`, :pr:`4861`)
+- Correctly count line breaks in length-limited abstracts (:pr:`4918`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -380,8 +380,12 @@ class SoftLength(Length):
     """
 
     def __call__(self, form, field):
+        orig_data = field.data
         field.data = re.sub(r'(\r\n|\r)', '\n', field.data)
-        super().__call__(form, field)
+        try:
+            super().__call__(form, field)
+        finally:
+            field.data = orig_data
 
 
 class SecurePassword:

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -379,6 +379,10 @@ class SoftLength(Length):
     where surrounding whitespace is stripped before validation.
     """
 
+    def __call__(self, form, field):
+        field.data = re.sub(r'(\r\n|\r)', '\n', field.data)
+        super().__call__(form, field)
+
 
 class SecurePassword:
     """Validate that a string is a secure password."""

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -381,7 +381,8 @@ class SoftLength(Length):
 
     def __call__(self, form, field):
         orig_data = field.data
-        field.data = re.sub(r'(\r\n|\r)', '\n', field.data)
+        if field.data is not None:
+            field.data = re.sub(r'(\r\n|\r)', '\n', field.data)
         try:
             super().__call__(form, field)
         finally:


### PR DESCRIPTION
![May-26-2021 16-13-57](https://user-images.githubusercontent.com/12183954/119685767-9068c580-be3d-11eb-806b-2e14ae0a6cb8.gif)

I first went for a client-sided approach (fix it before sending), but it's not that easy with multiple change listeners. Then I noticed on top of that we have a SoftLength validator which seemed like a good candidate to accept line-breaks as a single character.