### PR TITLE
Prevent durations containing seconds

### DIFF
--- a/indico/migrations/versions/20210527_1314_178d297eae7e_disallow_seconds_in_durations.py
+++ b/indico/migrations/versions/20210527_1314_178d297eae7e_disallow_seconds_in_durations.py
@@ -1,0 +1,67 @@
+"""Disallow seconds in durations
+
+Revision ID: 178d297eae7e
+Revises: cf9e1b4e2f5f
+Create Date: 2021-05-27 13:14:59.253773
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '178d297eae7e'
+down_revision = 'cf9e1b4e2f5f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('''
+        UPDATE events.contributions SET duration = date_trunc('minute', duration) WHERE date_trunc('minute', duration) != duration;
+        UPDATE events.subcontributions SET duration = date_trunc('minute', duration) WHERE date_trunc('minute', duration) != duration;
+        UPDATE events.breaks SET duration = date_trunc('minute', duration) WHERE date_trunc('minute', duration) != duration;
+        UPDATE events.session_blocks SET duration = date_trunc('minute', duration) WHERE date_trunc('minute', duration) != duration;
+        UPDATE events.sessions SET default_contribution_duration = date_trunc('minute', default_contribution_duration) WHERE date_trunc('minute', default_contribution_duration) != default_contribution_duration;
+    ''')
+
+    # force execution of trigger events
+    op.execute('SET CONSTRAINTS ALL IMMEDIATE')
+
+    op.create_check_constraint(
+        'duration_no_seconds',
+        'breaks',
+        "date_trunc('minute', duration) = duration",
+        schema='events'
+    )
+    op.create_check_constraint(
+        'duration_no_seconds',
+        'contributions',
+        "date_trunc('minute', duration) = duration",
+        schema='events'
+    )
+    op.create_check_constraint(
+        'duration_no_seconds',
+        'session_blocks',
+        "date_trunc('minute', duration) = duration",
+        schema='events'
+    )
+    op.create_check_constraint(
+        'duration_no_seconds',
+        'subcontributions',
+        "date_trunc('minute', duration) = duration",
+        schema='events'
+    )
+    op.create_check_constraint(
+        'default_contribution_duration_no_seconds',
+        'sessions',
+        "date_trunc('minute', default_contribution_duration) = default_contribution_duration",
+        schema='events'
+    )
+
+
+def downgrade():
+    op.drop_constraint('ck_breaks_duration_no_seconds', 'breaks', schema='events')
+    op.drop_constraint('ck_contributions_duration_no_seconds', 'contributions', schema='events')
+    op.drop_constraint('ck_session_blocks_duration_no_seconds', 'session_blocks', schema='events')
+    op.drop_constraint('ck_subcontributions_duration_no_seconds', 'subcontributions', schema='events')
+    op.drop_constraint('ck_sessions_default_contribution_duration_no_seconds', 'sessions', schema='events')

--- a/indico/modules/events/contributions/models/contributions.py
+++ b/indico/modules/events/contributions/models/contributions.py
@@ -79,6 +79,7 @@ class Contribution(DescriptionMixin, ProtectionManagersMixin, LocationMixin, Att
                          db.Index(None, 'abstract_id', unique=True, postgresql_where=db.text('NOT is_deleted')),
                          db.CheckConstraint("session_block_id IS NULL OR session_id IS NOT NULL",
                                             'session_block_if_session'),
+                         db.CheckConstraint("date_trunc('minute', duration) = duration", 'duration_no_seconds'),
                          db.ForeignKeyConstraint(['session_block_id', 'session_id'],
                                                  ['events.session_blocks.id', 'events.session_blocks.session_id']),
                          {'schema': 'events'})

--- a/indico/modules/events/contributions/models/subcontributions.py
+++ b/indico/modules/events/contributions/models/subcontributions.py
@@ -34,6 +34,7 @@ def _get_next_position(context):
 class SubContribution(DescriptionMixin, AttachedItemsMixin, AttachedNotesMixin, db.Model):
     __tablename__ = 'subcontributions'
     __table_args__ = (db.Index(None, 'friendly_id', 'contribution_id', unique=True),
+                      db.CheckConstraint("date_trunc('minute', duration) = duration", 'duration_no_seconds'),
                       {'schema': 'events'})
 
     PRELOAD_EVENT_ATTACHED_ITEMS = True

--- a/indico/modules/events/sessions/models/blocks.py
+++ b/indico/modules/events/sessions/models/blocks.py
@@ -20,6 +20,7 @@ from indico.util.string import format_repr
 class SessionBlock(LocationMixin, db.Model):
     __tablename__ = 'session_blocks'
     __auto_table_args = (db.UniqueConstraint('id', 'session_id'),  # useless but needed for the compound fkey
+                         db.CheckConstraint("date_trunc('minute', duration) = duration", 'duration_no_seconds'),
                          {'schema': 'events'})
     location_backref_name = 'session_blocks'
 

--- a/indico/modules/events/sessions/models/sessions.py
+++ b/indico/modules/events/sessions/models/sessions.py
@@ -39,6 +39,9 @@ class Session(DescriptionMixin, ColorMixin, ProtectionManagersMixin, LocationMix
     __tablename__ = 'sessions'
     __auto_table_args = (db.Index(None, 'friendly_id', 'event_id', unique=True,
                                   postgresql_where=db.text('NOT is_deleted')),
+                         db.CheckConstraint("date_trunc('minute', default_contribution_duration) = "
+                                            "default_contribution_duration",
+                                            'default_contribution_duration_no_seconds'),
                          {'schema': 'events'})
     location_backref_name = 'sessions'
     disallowed_protection_modes = frozenset()

--- a/indico/modules/events/timetable/models/breaks.py
+++ b/indico/modules/events/timetable/models/breaks.py
@@ -21,7 +21,8 @@ from indico.util.string import format_repr
 
 class Break(DescriptionMixin, ColorMixin, LocationMixin, db.Model):
     __tablename__ = 'breaks'
-    __auto_table_args = {'schema': 'events'}
+    __auto_table_args = (db.CheckConstraint("date_trunc('minute', duration) = duration", 'duration_no_seconds'),
+                         {'schema': 'events'})
     location_backref_name = 'breaks'
     default_colors = ColorTuple('#202020', '#90c0f0')
     possible_render_modes = {RenderMode.markdown}

--- a/indico/web/client/js/react/components/WTFDurationField.jsx
+++ b/indico/web/client/js/react/components/WTFDurationField.jsx
@@ -15,10 +15,7 @@ const timeToSeconds = time => {
     return null;
   }
 
-  // avoid counting seconds in a DST day.
-  const safeDate = time.date(1).month(0);
-
-  return safeDate.diff(safeDate.clone().startOf('day'), 'seconds');
+  return time.hours() * 3600 + time.minutes() * 60;
 };
 
 const secondsToTime = seconds =>

--- a/indico/web/forms/fields/datetime.py
+++ b/indico/web/forms/fields/datetime.py
@@ -189,6 +189,8 @@ class IndicoDurationField(Field):
     def process_formdata(self, valuelist):
         if valuelist:
             self.data = timedelta(seconds=int(valuelist[0]))
+            if self.data.total_seconds() % 60:
+                raise ValueError('Duration cannot contain seconds')
 
 
 class IndicoDateField(DateField):

--- a/indico/web/forms/fields/datetime.py
+++ b/indico/web/forms/fields/datetime.py
@@ -18,6 +18,7 @@ from wtforms.fields import TimeField
 from wtforms.validators import StopValidation
 
 from indico.core.config import config
+from indico.core.logger import Logger
 from indico.util.date_time import localize_as_utc, relativedelta
 from indico.util.i18n import _, get_current_locale
 from indico.web.forms.fields import JSONField
@@ -190,6 +191,7 @@ class IndicoDurationField(Field):
         if valuelist:
             self.data = timedelta(seconds=int(valuelist[0]))
             if self.data.total_seconds() % 60:
+                Logger.get('forms').warning('Duration with seconds submitted')
                 raise ValueError('Duration cannot contain seconds')
 
 


### PR DESCRIPTION
The warning log is just temporary so we can get something on sentry until we figure out why this happens...