### PR TITLE
Skip access checks option for admin search

### DIFF
--- a/indico/modules/categories/client/js/index.js
+++ b/indico/modules/categories/client/js/index.js
@@ -26,7 +26,7 @@ import {LocaleContext} from './context.js';
 
     if (domContainer) {
       const category = JSON.parse(domContainer.dataset.category);
-      const isAdmin = JSON.parse(domContainer.dataset.isAdmin);
+      const isAdmin = domContainer.dataset.isAdmin !== undefined;
 
       ReactDOM.render(
         React.createElement(SearchBox, {

--- a/indico/modules/categories/client/js/index.js
+++ b/indico/modules/categories/client/js/index.js
@@ -30,10 +30,10 @@ import {LocaleContext} from './context.js';
 
       ReactDOM.render(
         React.createElement(SearchBox, {
-          onSearch: (keyword, isGlobal, allowAdmin) => {
+          onSearch: (keyword, isGlobal, adminOverrideEnabled) => {
             const params = {q: keyword};
-            if (isAdmin && allowAdmin) {
-              params.allow_admin = true;
+            if (isAdmin && adminOverrideEnabled) {
+              params.admin_override_enabled = true;
             }
             if (isGlobal) {
               window.location = searchUrl(params);

--- a/indico/modules/categories/client/js/index.js
+++ b/indico/modules/categories/client/js/index.js
@@ -26,17 +26,24 @@ import {LocaleContext} from './context.js';
 
     if (domContainer) {
       const category = JSON.parse(domContainer.dataset.category);
+      const isAdmin = JSON.parse(domContainer.dataset.isAdmin);
 
       ReactDOM.render(
         React.createElement(SearchBox, {
-          onSearch: (keyword, isGlobal) => {
+          onSearch: (keyword, isGlobal, allowAdmin) => {
+            const params = {q: keyword};
+            if (isAdmin && allowAdmin) {
+              params.allow_admin = true;
+            }
             if (isGlobal) {
-              window.location = searchUrl({q: keyword});
+              window.location = searchUrl(params);
             } else {
-              window.location = categorySearchUrl({category_id: category.id, q: keyword});
+              params.category_id = category.id;
+              window.location = categorySearchUrl(params);
             }
           },
           category,
+          isAdmin,
         }),
         domContainer
       );

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -25,7 +25,7 @@
                 <div class="group">
                     <div id="search-box" class="search-box"
                          data-category="{{ {'id': category.id, 'isRoot': category.is_root, 'title': category.title} | tojson | forceescape }}"
-                         data-is-admin="{{ session.user.is_admin | tojson }}"
+                         {% if session.user.is_admin %}data-is-admin{% endif %}
                     ></div>
                 </div>
                 <div class="group">

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -25,7 +25,7 @@
                 <div class="group">
                     <div id="search-box" class="search-box"
                          data-category="{{ {'id': category.id, 'isRoot': category.is_root, 'title': category.title} | tojson | forceescape }}"
-                         {% if session.user.is_admin %}data-is-admin{% endif %}
+                         {% if session.user and session.user.is_admin %}data-is-admin{% endif %}
                     ></div>
                 </div>
                 <div class="group">

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -25,6 +25,7 @@
                 <div class="group">
                     <div id="search-box" class="search-box"
                          data-category="{{ {'id': category.id, 'isRoot': category.is_root, 'title': category.title} | tojson | forceescape }}"
+                         data-is-admin="{{ session.user.is_admin | tojson }}"
                     ></div>
                 </div>
                 <div class="group">

--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -72,13 +72,15 @@ class IndicoSearchProvider:
         """
         return True
 
-    def search(self, query, user=None, page=None, object_types=(), **params):
+    def search(self, query, user=None, page=None, object_types=(), *, admin_override_enabled=False,
+               **params):
         """Search using a custom service across multiple targets.
 
         :param query: Keyword based query string
         :param user: The user performing the search (for access checks)
         :param page: The result page to show
         :param object_types: A filter for a specific `SearchTarget`
+        :param admin_override_enabled: Whether to ignore access restrictions
         :param params: Any additional search params such as filters
 
         :return: a dict with the `ResultSchema` structure

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -218,8 +218,8 @@ export default function SearchApp({category, eventId, isAdmin}) {
   const eventSearch = eventId !== null;
   const [query, setQuery] = useQueryParams();
   const [activeMenuItem, setActiveMenuItem] = useState(undefined);
-  const {q, sort, allow_admin: allowAdminStr = false, ...filters} = query;
-  const allowAdmin = JSON.parse(allowAdminStr);
+  const {q, sort, admin_override_enabled: adminOverrideEnabledStr = false, ...filters} = query;
+  const adminOverrideEnabled = JSON.parse(adminOverrideEnabledStr);
   const {data: options} = useIndicoAxios({
     url: searchOptionsURL(),
     trigger: 'once',
@@ -294,13 +294,9 @@ export default function SearchApp({category, eventId, isAdmin}) {
             <Label content={Translate.string('ADMIN')} size="small" color="red" />
             <Checkbox
               label={Translate.string('Skip access checks')}
-              checked={allowAdmin}
+              checked={adminOverrideEnabled}
               onChange={(__, {checked}) => {
-                if (checked) {
-                  handleQuery(true, 'allow_admin');
-                } else {
-                  handleQuery(undefined, 'allow_admin');
-                }
+                handleQuery(checked ? true : undefined, 'admin_override_enabled');
               }}
               styleName="admin-search-checkbox"
             />

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -218,7 +218,7 @@ export default function SearchApp({category, eventId, isAdmin}) {
   const eventSearch = eventId !== null;
   const [query, setQuery] = useQueryParams();
   const [activeMenuItem, setActiveMenuItem] = useState(undefined);
-  const {q, sort, admin_override_enabled: adminOverrideEnabledStr = false, ...filters} = query;
+  const {q, sort, admin_override_enabled: adminOverrideEnabledStr = 'false', ...filters} = query;
   const adminOverrideEnabled = JSON.parse(adminOverrideEnabledStr);
   const {data: options} = useIndicoAxios({
     url: searchOptionsURL(),

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -299,7 +299,7 @@ export default function SearchApp({category, eventId, isAdmin}) {
                 if (checked) {
                   handleQuery(true, 'allow_admin');
                 } else {
-                  handleQuery(query.q);
+                  handleQuery(undefined, 'allow_admin');
                 }
               }}
               styleName="admin-search-checkbox"

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -219,7 +219,10 @@ export default function SearchApp({category, eventId, isAdmin}) {
   const [query, setQuery] = useQueryParams();
   const [activeMenuItem, setActiveMenuItem] = useState(undefined);
   const {q, sort, admin_override_enabled: adminOverrideEnabledStr = 'false', ...filters} = query;
-  const adminOverrideEnabled = JSON.parse(adminOverrideEnabledStr);
+  const adminOverrideEnabled = isAdmin && JSON.parse(adminOverrideEnabledStr);
+  if (!adminOverrideEnabled) {
+    delete query.admin_override_enabled;
+  }
   const {data: options} = useIndicoAxios({
     url: searchOptionsURL(),
     trigger: 'once',

--- a/indico/modules/search/client/js/components/SearchApp.module.scss
+++ b/indico/modules/search/client/js/components/SearchApp.module.scss
@@ -18,3 +18,14 @@
   display: flex;
   justify-content: flex-end;
 }
+
+.admin-search-checkbox:global(.ui.checkbox) {
+  margin-left: 1rem;
+}
+
+.admin-search-container {
+  margin-top: 0.5rem;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}

--- a/indico/modules/search/client/js/components/SearchBox.jsx
+++ b/indico/modules/search/client/js/components/SearchBox.jsx
@@ -25,7 +25,7 @@ const renderResult = ({label}, keyword) => (
 
 export default function SearchBox({onSearch, category, isAdmin}) {
   const [keyword, setKeyword] = useState('');
-  const [allowAdmin, setAllowAdmin] = useState(false);
+  const [adminOverrideEnabled, setAdminOverrideEnabled] = useState(false);
   const options =
     category && !category.isRoot
       ? [
@@ -46,20 +46,20 @@ export default function SearchBox({onSearch, category, isAdmin}) {
   if (isAdmin) {
     options.push({
       value: 'global',
-      title: 'allowAdmin',
+      title: 'enableAdminOverride',
       className: 'cursor-default',
       onClick: () => {},
-      // eslint-disable-next-line
+      // eslint-disable-next-line react/display-name
       renderer: () => (
         <div styleName="option">
           <Label content={Translate.string('ADMIN')} size="small" color="red" />
           <Checkbox
             styleName="checkbox-admin-search"
             label={Translate.string('Skip access checks')}
-            checked={allowAdmin}
+            checked={adminOverrideEnabled}
             onChange={e => {
               e.stopPropagation();
-              setAllowAdmin(!allowAdmin);
+              setAdminOverrideEnabled(!adminOverrideEnabled);
             }}
           />
         </div>
@@ -73,15 +73,15 @@ export default function SearchBox({onSearch, category, isAdmin}) {
 
   const handleSubmit = () => {
     if (keyword.trim()) {
-      onSearch(keyword.trim(), category ? category.isRoot : true, allowAdmin);
+      onSearch(keyword.trim(), category ? category.isRoot : true, adminOverrideEnabled);
     }
   };
 
   const handleResultSelect = (e, data) => {
-    if (data.result.title === 'allowAdmin') {
-      setAllowAdmin(!allowAdmin);
+    if (data.result.title === 'enableAdminOverride') {
+      setAdminOverrideEnabled(!adminOverrideEnabled);
     } else if (keyword.trim()) {
-      onSearch(keyword.trim(), data.result.value === 'global', allowAdmin);
+      onSearch(keyword.trim(), data.result.value === 'global', adminOverrideEnabled);
     }
   };
 
@@ -93,7 +93,7 @@ export default function SearchBox({onSearch, category, isAdmin}) {
         results={options}
         value={keyword}
         showNoResults={false}
-        open={!!keyword.length}
+        open={!!keyword}
         onResultSelect={handleResultSelect}
         onSearchChange={handleSearchChange}
         fluid

--- a/indico/modules/search/client/js/components/SearchBox.jsx
+++ b/indico/modules/search/client/js/components/SearchBox.jsx
@@ -59,7 +59,7 @@ export default function SearchBox({onSearch, category, isAdmin}) {
             checked={allowAdmin}
             onChange={e => {
               e.stopPropagation();
-              setAllowAdmin(curAllowAdmin => !curAllowAdmin);
+              setAllowAdmin(!allowAdmin);
             }}
           />
         </div>
@@ -79,7 +79,7 @@ export default function SearchBox({onSearch, category, isAdmin}) {
 
   const handleResultSelect = (e, data) => {
     if (data.result.title === 'allowAdmin') {
-      setAllowAdmin(curAllowAdmin => !curAllowAdmin);
+      setAllowAdmin(!allowAdmin);
     } else if (keyword.trim()) {
       onSearch(keyword.trim(), data.result.value === 'global', allowAdmin);
     }

--- a/indico/modules/search/client/js/components/SearchBox.jsx
+++ b/indico/modules/search/client/js/components/SearchBox.jsx
@@ -7,7 +7,7 @@
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Form, Icon, Label, Search} from 'semantic-ui-react';
+import {Checkbox, Form, Icon, Label, Search} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 
@@ -23,33 +23,66 @@ const renderResult = ({label}, keyword) => (
   </div>
 );
 
-export default function SearchBox({onSearch, category}) {
+export default function SearchBox({onSearch, category, isAdmin}) {
   const [keyword, setKeyword] = useState('');
+  const [allowAdmin, setAllowAdmin] = useState(false);
   const options =
     category && !category.isRoot
       ? [
           {
             value: 'category',
-            title: category.title,
             label: Translate.string('In this category ↵'),
+            title: category.title,
+            renderer: props => renderResult(props, keyword),
           },
-          {value: 'global', title: 'Global', label: Translate.string('All Indico ↵')},
+          {
+            value: 'global',
+            label: Translate.string('All Indico ↵'),
+            title: 'Global',
+            renderer: props => renderResult(props, keyword),
+          },
         ]
       : [];
+  if (isAdmin) {
+    options.push({
+      value: 'global',
+      title: 'allowAdmin',
+      className: 'cursor-default',
+      onClick: () => {},
+      // eslint-disable-next-line
+      renderer: () => (
+        <div styleName="option">
+          <Label content={Translate.string('ADMIN')} size="small" color="red" />
+          <Checkbox
+            styleName="checkbox-admin-search"
+            label={Translate.string('Skip access checks')}
+            checked={allowAdmin}
+            onChange={e => {
+              e.stopPropagation();
+              setAllowAdmin(curAllowAdmin => !curAllowAdmin);
+            }}
+          />
+        </div>
+      ),
+    });
+  }
 
   const handleSearchChange = event => {
     setKeyword(event.target.value);
   };
 
-  // form submit happens when no option is selected in search (eg. in home category)
   const handleSubmit = () => {
     if (keyword.trim()) {
-      onSearch(keyword.trim(), category ? category.isRoot : true);
+      onSearch(keyword.trim(), category ? category.isRoot : true, allowAdmin);
     }
   };
 
   const handleResultSelect = (e, data) => {
-    onSearch(keyword.trim(), data.result.value === 'global');
+    if (data.result.title === 'allowAdmin') {
+      setAllowAdmin(curAllowAdmin => !curAllowAdmin);
+    } else if (keyword.trim()) {
+      onSearch(keyword.trim(), data.result.value === 'global', allowAdmin);
+    }
   };
 
   return (
@@ -60,11 +93,12 @@ export default function SearchBox({onSearch, category}) {
         results={options}
         value={keyword}
         showNoResults={false}
+        open={!!keyword.length}
         onResultSelect={handleResultSelect}
         onSearchChange={handleSearchChange}
-        resultRenderer={results => renderResult(results, keyword)}
         fluid
-        selectFirstResult
+        // only select the first result if there is more than 1 (means we are in a category)
+        selectFirstResult={options.length > 1}
       />
     </Form>
   );
@@ -77,6 +111,7 @@ SearchBox.propTypes = {
     title: PropTypes.string.isRequired,
     isRoot: PropTypes.bool.isRequired,
   }),
+  isAdmin: PropTypes.bool.isRequired,
 };
 
 SearchBox.defaultProps = {

--- a/indico/modules/search/client/js/components/SearchBox.jsx
+++ b/indico/modules/search/client/js/components/SearchBox.jsx
@@ -45,8 +45,8 @@ export default function SearchBox({onSearch, category, isAdmin}) {
       : [];
   if (isAdmin) {
     options.push({
-      value: 'global',
-      title: 'enableAdminOverride',
+      value: 'enableAdminOverride',
+      title: 'Enable admin override',
       className: 'cursor-default',
       onClick: () => {},
       // eslint-disable-next-line react/display-name
@@ -78,7 +78,7 @@ export default function SearchBox({onSearch, category, isAdmin}) {
   };
 
   const handleResultSelect = (e, data) => {
-    if (data.result.title === 'enableAdminOverride') {
+    if (data.result.value === 'enableAdminOverride') {
       setAdminOverrideEnabled(!adminOverrideEnabled);
     } else if (keyword.trim()) {
       onSearch(keyword.trim(), data.result.value === 'global', adminOverrideEnabled);

--- a/indico/modules/search/client/js/components/SearchBox.module.scss
+++ b/indico/modules/search/client/js/components/SearchBox.module.scss
@@ -20,3 +20,18 @@
     width: 50%;
   }
 }
+
+.checkbox-admin-search:global(.ui.checkbox) {
+  display: flex;
+  justify-content: space-between;
+
+  label {
+    font-size: 0.8rem;
+    font-weight: bold;
+    color: $dark-gray;
+  }
+}
+
+:global(.ui.search > .results > .result.cursor-default) {
+  cursor: default;
+}

--- a/indico/modules/search/client/js/index.jsx
+++ b/indico/modules/search/client/js/index.jsx
@@ -17,10 +17,11 @@ document.addEventListener('DOMContentLoaded', () => {
   if (root) {
     const category = root.dataset.category ? JSON.parse(root.dataset.category) : null;
     const eventId = root.dataset.eventId !== undefined ? parseInt(root.dataset.eventId, 10) : null;
+    const isAdmin = root.dataset.isAdmin ? JSON.parse(root.dataset.isAdmin) : null;
 
     ReactDOM.render(
       <Router>
-        <SearchApp category={category} eventId={eventId} />
+        <SearchApp category={category} eventId={eventId} isAdmin={isAdmin} />
       </Router>,
       root
     );

--- a/indico/modules/search/client/js/index.jsx
+++ b/indico/modules/search/client/js/index.jsx
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (root) {
     const category = root.dataset.category ? JSON.parse(root.dataset.category) : null;
     const eventId = root.dataset.eventId !== undefined ? parseInt(root.dataset.eventId, 10) : null;
-    const isAdmin = root.dataset.isAdmin ? JSON.parse(root.dataset.isAdmin) : null;
+    const isAdmin = root.dataset.isAdmin !== undefined;
 
     ReactDOM.render(
       <Router>

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -45,13 +45,14 @@ class RHAPISearch(RH):
     @use_kwargs({
         'page': fields.Int(missing=None),
         'q': fields.String(required=True),
-        'type': fields.List(EnumField(SearchTarget), missing=None)
+        'type': fields.List(EnumField(SearchTarget), missing=None),
+        'allow_admin': fields.Bool(missing=False),
     }, location='query', unknown=INCLUDE)
-    def _process(self, page, q, type, **params):
+    def _process(self, page, q, type, allow_admin, **params):
         search_provider = get_search_provider()
         if type == [SearchTarget.category]:
             search_provider = InternalSearch
-        result = search_provider().search(q, session.user, page, type, **params)
+        result = search_provider().search(q, session.user, page, type, allow_admin, **params)
         return ResultSchema().dump(result)
 
 

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -15,6 +15,7 @@ from indico.modules.search.base import SearchOptions, SearchTarget, get_search_p
 from indico.modules.search.internal import InternalSearch
 from indico.modules.search.result_schemas import ResultSchema
 from indico.modules.search.views import WPCategorySearch, WPEventSearch, WPSearch
+from indico.util.marshmallow import validate_with_message
 from indico.web.args import use_kwargs
 from indico.web.rh import RH
 
@@ -46,7 +47,11 @@ class RHAPISearch(RH):
         'page': fields.Int(missing=None),
         'q': fields.String(required=True),
         'type': fields.List(EnumField(SearchTarget), missing=None),
-        'allow_admin': fields.Bool(missing=False),
+        'allow_admin': fields.Bool(missing=False,
+                                   validate=validate_with_message(
+                                       lambda value: session.user and session.user.is_admin,
+                                       'Restricted to admins'
+                                   )),
     }, location='query', unknown=INCLUDE)
     def _process(self, page, q, type, allow_admin, **params):
         search_provider = get_search_provider()

--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -47,17 +47,17 @@ class RHAPISearch(RH):
         'page': fields.Int(missing=None),
         'q': fields.String(required=True),
         'type': fields.List(EnumField(SearchTarget), missing=None),
-        'allow_admin': fields.Bool(missing=False,
-                                   validate=validate_with_message(
-                                       lambda value: session.user and session.user.is_admin,
-                                       'Restricted to admins'
-                                   )),
+        'admin_override_enabled': fields.Bool(
+            missing=False,
+            validate=validate_with_message(lambda value: session.user and session.user.is_admin,
+                                           'Restricted to admins')
+        ),
     }, location='query', unknown=INCLUDE)
-    def _process(self, page, q, type, allow_admin, **params):
+    def _process(self, page, q, type, **params):
         search_provider = get_search_provider()
         if type == [SearchTarget.category]:
             search_provider = InternalSearch
-        result = search_provider().search(q, session.user, page, type, allow_admin, **params)
+        result = search_provider().search(q, session.user, page, type, **params)
         return ResultSchema().dump(result)
 
 

--- a/indico/modules/search/internal.py
+++ b/indico/modules/search/internal.py
@@ -17,11 +17,11 @@ from indico.modules.search.schemas import DetailedCategorySchema, HTMLStrippingE
 
 
 class InternalSearch(IndicoSearchProvider):
-    def search(self, query, user=None, page=None, object_types=(), **params):
+    def search(self, query, user=None, page=None, object_types=(), allow_admin=False, **params):
         if object_types == [SearchTarget.category]:
-            pagenav, results = self.search_categories(query, user, page, params.get('category_id'))
+            pagenav, results = self.search_categories(query, user, page, params.get('category_id'), allow_admin)
         elif object_types == [SearchTarget.event]:
-            pagenav, results = self.search_events(query, user, page, params.get('category_id'))
+            pagenav, results = self.search_events(query, user, page, params.get('category_id'), allow_admin)
         else:
             pagenav, results = {}, []
         return {
@@ -30,7 +30,7 @@ class InternalSearch(IndicoSearchProvider):
             'results': results,
         }
 
-    def _paginate(self, query, page, column, user):
+    def _paginate(self, query, page, column, user, allow_admin):
         reverse = False
         pagenav = {'prev': None, 'next': None}
         if not page:
@@ -46,7 +46,8 @@ class InternalSearch(IndicoSearchProvider):
             reverse = True
 
         def _can_access(obj):
-            return obj.effective_protection_mode == ProtectionMode.public or obj.can_access(user, allow_admin=False)
+            return (obj.effective_protection_mode == ProtectionMode.public or
+                    obj.can_access(user, allow_admin=allow_admin))
 
         res = get_n_matching(query, self.RESULTS_PER_PAGE + 1, _can_access, prefetch_factor=20)
 
@@ -63,7 +64,7 @@ class InternalSearch(IndicoSearchProvider):
 
         return res, pagenav
 
-    def search_categories(self, q, user, page, category_id):
+    def search_categories(self, q, user, page, category_id, allow_admin):
         query = Category.query if not category_id else Category.get(category_id).deep_children_query
 
         query = (query
@@ -73,11 +74,11 @@ class InternalSearch(IndicoSearchProvider):
                           undefer(Category.effective_protection_mode),
                           subqueryload(Category.acl_entries)))
 
-        objs, pagenav = self._paginate(query, page, Category.id, user)
+        objs, pagenav = self._paginate(query, page, Category.id, user, allow_admin)
         res = DetailedCategorySchema(many=True).dump(objs)
         return pagenav, CategoryResultSchema(many=True).load(res)
 
-    def search_events(self, q, user, page, category_id):
+    def search_events(self, q, user, page, category_id, allow_admin):
         filters = [
             Event.title_matches(q),
             ~Event.is_deleted
@@ -89,6 +90,6 @@ class InternalSearch(IndicoSearchProvider):
         query = (Event.query
                  .filter(*filters)
                  .options(subqueryload(Event.acl_entries), undefer(Event.effective_protection_mode)))
-        objs, pagenav = self._paginate(query, page, Event.id, user)
+        objs, pagenav = self._paginate(query, page, Event.id, user, allow_admin)
         res = HTMLStrippingEventSchema(many=True).dump(objs)
         return pagenav, EventResultSchema(many=True).load(res)

--- a/indico/modules/search/templates/category_search.html
+++ b/indico/modules/search/templates/category_search.html
@@ -9,6 +9,6 @@
 {% block content %}
     <div id="search-root"
          data-category="{{ {'id': category.id, 'title': category.title} | tojson | forceescape }}"
-         data-is-admin="{{ session.user.is_admin | tojson }}"
+         {% if session.user.is_admin %}data-is-admin{% endif %}
     ></div>
 {% endblock %}

--- a/indico/modules/search/templates/category_search.html
+++ b/indico/modules/search/templates/category_search.html
@@ -9,5 +9,6 @@
 {% block content %}
     <div id="search-root"
          data-category="{{ {'id': category.id, 'title': category.title} | tojson | forceescape }}"
+         data-is-admin="{{ session.user.is_admin | tojson }}"
     ></div>
 {% endblock %}

--- a/indico/modules/search/templates/category_search.html
+++ b/indico/modules/search/templates/category_search.html
@@ -9,6 +9,6 @@
 {% block content %}
     <div id="search-root"
          data-category="{{ {'id': category.id, 'title': category.title} | tojson | forceescape }}"
-         {% if session.user.is_admin %}data-is-admin{% endif %}
+         {% if session.user and session.user.is_admin %}data-is-admin{% endif %}
     ></div>
 {% endblock %}

--- a/indico/modules/search/templates/search.html
+++ b/indico/modules/search/templates/search.html
@@ -7,5 +7,5 @@
 {% endblock %}
 
 {% block content %}
-    <div id="search-root"></div>
+    <div id="search-root" data-is-admin="{{ session.user.is_admin | tojson }}"></div>
 {% endblock %}

--- a/indico/modules/search/templates/search.html
+++ b/indico/modules/search/templates/search.html
@@ -7,5 +7,7 @@
 {% endblock %}
 
 {% block content %}
-    <div id="search-root" {% if session.user.is_admin %}data-is-admin{% endif %}></div>
+    <div id="search-root"
+         {% if session.user and session.user.is_admin %}data-is-admin{% endif %}
+    ></div>
 {% endblock %}

--- a/indico/modules/search/templates/search.html
+++ b/indico/modules/search/templates/search.html
@@ -7,5 +7,5 @@
 {% endblock %}
 
 {% block content %}
-    <div id="search-root" data-is-admin="{{ session.user.is_admin | tojson }}"></div>
+    <div id="search-root" {% if session.user.is_admin %}data-is-admin{% endif %}></div>
 {% endblock %}


### PR DESCRIPTION
Enables administrators to include protected entries in their search.

Provisionally includes two changes in the UI:

* A checkbox in the search page:
![image](https://user-images.githubusercontent.com/6058151/120453935-be955a80-c393-11eb-95f8-26006cb91c72.png)

* A new option with a checkbox in the search box popup (not sure yet if we are keeping this one):
![image](https://user-images.githubusercontent.com/6058151/120454176-f0a6bc80-c393-11eb-98f9-f3dc9abdefcd.png)


Closes https://github.com/indico/indico/issues/4912.
