### PR TITLE
Fix ACL dropdown overflow in modals

### DIFF
--- a/indico/web/client/js/jquery/widgets/track_role_widget.js
+++ b/indico/web/client/js/jquery/widgets/track_role_widget.js
@@ -34,6 +34,7 @@ import {TrackACLField} from 'indico/react/components';
         eventId: this.options.eventId,
         eventRoles: this.options.eventRoles,
         categoryRoles: this.options.categoryRoles,
+        scrollOnOpen: true,
         onChange,
       });
       ReactDOM.render(component, element);

--- a/indico/web/client/js/react/components/principals/ACLField.jsx
+++ b/indico/web/client/js/react/components/principals/ACLField.jsx
@@ -167,7 +167,8 @@ const ACLField = props => {
             <Dropdown
               text={Translate.string('Event Role')}
               button
-              upward
+              defaultUpward
+              scrolling
               floating
               disabled={eventRoleOptions.length === 0}
               options={eventRoleOptions}
@@ -182,7 +183,8 @@ const ACLField = props => {
             <Dropdown
               text={Translate.string('Category Role')}
               button
-              upward
+              defaultUpward
+              scrolling
               floating
               disabled={categoryRoleOptions.length === 0}
               options={categoryRoleOptions}

--- a/indico/web/client/js/react/components/principals/ACLField.jsx
+++ b/indico/web/client/js/react/components/principals/ACLField.jsx
@@ -48,6 +48,7 @@ const ACLField = props => {
     favoriteUsersController,
     readAccessAllowed,
     fullAccessAllowed,
+    scrollOnOpen,
     permissionInfo,
     permissionManager,
   } = props;
@@ -99,6 +100,20 @@ const ACLField = props => {
       value: r.identifier,
       text: r.name,
     }));
+
+  const onDropdownOpen = event => {
+    // Fixes semantic dropdown cropping within constrained elements
+    // `defer` ensures the scroll is queued after all state updates
+    const target = event.currentTarget;
+    if (scrollOnOpen && target) {
+      _.defer(() =>
+        target.querySelector('.menu.visible')?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'end',
+        })
+      );
+    }
+  };
 
   return (
     <>
@@ -176,6 +191,7 @@ const ACLField = props => {
               openOnFocus={false}
               selectOnBlur={false}
               selectOnNavigation={false}
+              onOpen={onDropdownOpen}
               onChange={(e, data) => handleAddItems([{identifier: data.value}])}
             />
           )}
@@ -192,6 +208,7 @@ const ACLField = props => {
               openOnFocus={false}
               selectOnBlur={false}
               selectOnNavigation={false}
+              onOpen={onDropdownOpen}
               onChange={(e, data) => handleAddItems([{identifier: data.value}])}
             />
           )}
@@ -223,6 +240,8 @@ ACLField.propTypes = {
   /** Whether the 'full_access' permission is used/allowed */
   fullAccessAllowed: PropTypes.bool,
   /** The ID of the event used in case of event-scoped principals */
+  scrollOnOpen: PropTypes.bool,
+  /** Whether to adapt the scroll to the field dropdown positions */
   eventId: PropTypes.number,
   /** The event roles that are available for the specified eventId */
   eventRoles: PropTypes.array,
@@ -247,6 +266,7 @@ ACLField.defaultProps = {
   eventId: null,
   eventRoles: [],
   categoryRoles: [],
+  scrollOnOpen: false,
 };
 
 export default React.memo(ACLField);

--- a/indico/web/client/js/react/components/principals/TrackACLField.jsx
+++ b/indico/web/client/js/react/components/principals/TrackACLField.jsx
@@ -18,6 +18,7 @@ export default function TrackACLField({
   eventId,
   eventRoles,
   categoryRoles,
+  scrollOnOpen,
   onChange,
 }) {
   const [currentValue, setCurrentValue] = useState(value);
@@ -42,6 +43,7 @@ export default function TrackACLField({
       eventId={eventId}
       eventRoles={eventRoles}
       categoryRoles={categoryRoles}
+      scrollOnOpen={scrollOnOpen}
     />
   );
 }
@@ -58,5 +60,10 @@ TrackACLField.propTypes = {
   eventId: PropTypes.number.isRequired,
   eventRoles: PropTypes.array.isRequired,
   categoryRoles: PropTypes.array.isRequired,
+  scrollOnOpen: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
+};
+
+TrackACLField.defaultProps = {
+  scrollOnOpen: false,
 };


### PR DESCRIPTION
Fixes dropdown cropping in modals with hidden overflow. I've tried many different approaches resorting to CSS only and while the menu is `absolute` positioned, its parent - the buttons - are relative, making it very hard to ignore the modal overflow. In the original implementation, semantic doesn't expect any surrounding overflow.

For that reason, I'm removing the forced `upward` positioning, including scroll, which should cause it to play with the direction nicely.

![imagem](https://user-images.githubusercontent.com/12183954/120456097-34e28e80-c38d-11eb-852f-f5c57fd6167c.png)