### PR TITLE
Add {note,event}_restored signals

### DIFF
--- a/indico/cli/event.py
+++ b/indico/cli/event.py
@@ -10,8 +10,9 @@ import sys
 import click
 
 from indico.cli.core import cli_group
+from indico.core import signals
 from indico.core.db import db
-from indico.modules.events import Event, EventLogKind, EventLogRealm
+from indico.modules.events import Event
 from indico.modules.events.export import export_event, import_event
 from indico.modules.users.models.users import User
 
@@ -36,9 +37,8 @@ def restore(event_id, user_id, message):
     elif not event.is_deleted:
         click.secho('This event is not deleted', fg='yellow')
         sys.exit(1)
-    event.is_deleted = False
-    text = f'Event restored: {message}' if message else 'Event restored'
-    event.log(EventLogRealm.event, EventLogKind.positive, 'Event', text, user=user)
+    event.restore(message, user)
+    signals.after_process.send()
     db.session.commit()
     click.secho(f'Event undeleted: "{event.title}"', fg='green')
 

--- a/indico/core/signals/core.py
+++ b/indico/core/signals/core.py
@@ -23,8 +23,9 @@ only ``import`` these modules and do nothing else.
 """)
 
 after_process = _signals.signal('after-process', """
-Called after an Indico request has been processed.  This signal is
-executed for both RH classes and legacy JSON-RPC services.
+Called after an Indico request has been processed.  This signal should
+also be triggered by CLI utilities that result in other signals being
+triggered.
 """)
 
 after_commit = _signals.signal('after-commit', """

--- a/indico/core/signals/event/core.py
+++ b/indico/core/signals/event/core.py
@@ -18,6 +18,12 @@ Called when an event is deleted. The *sender* is the event object.
 The `user` kwarg contains the user performing the deletion if available.
 """)
 
+restored = _signals.signal('restored', """
+Called when a previously-deleted event is restored. The *sender* is the event
+object. The `user` kwarg contains the user restoring the event if available,
+and the `reason` kwarg the reason if available.
+""")
+
 updated = _signals.signal('updated', """
 Called when basic data of an event is updated. The *sender* is the event.
 A dict of changes is passed in the `changes` kwarg, with ``(old, new)``

--- a/indico/core/signals/event/notes.py
+++ b/indico/core/signals/event/notes.py
@@ -22,3 +22,10 @@ Called when a note is modified. The `sender` is the note.
 note_deleted = _signals.signal('note-deleted', """
 Called when a note is deleted. The `sender` is the note.
 """)
+
+note_restored = _signals.signal('note-restored', """
+Called when a previously-deleted note is restored.
+The `sender` is the note. This is triggered when a "new" note
+is created on an object that previously already had a note
+which got deleted.
+""")


### PR DESCRIPTION
Those are triggered when a note is recreated or an event is restored after deletion.

This is useful for plugins like LiveSync to distinguish between something that's been newly created and something that was there before, just soft-deleted.