### PR TITLE
Show external contribution references in conferences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,7 @@ Improvements
 - Remove the very outdated "Compact style" theme (it's still available via the ``themes_legacy``
   plugin) (:issue:`4900`, :pr:`4899`)
 - Support cloning surveys when cloning events (:issue:`2045`, :pr:`4910`)
+- Show external contribution references in conferences (:issue:`4928`, :pr:`4933`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -4,6 +4,7 @@
 {% from 'events/display/indico/_common.html' import render_location, render_users, render_speakers %}
 {% from 'events/papers/_contributions.html' import render_paper_section, render_editables_section, render_proceedings_section %}
 {% from 'message_box.html' import message_box %}
+{% from 'events/timetable/display/indico/_common.html' import render_references %}
 
 {% block page_class %}conference-page item-summary{% endblock %}
 
@@ -215,6 +216,17 @@
     {% endif %}
 
     {{ render_attachments(contribution) }}
+
+    {% if contribution.references -%}
+        <section>
+            <div class="header">
+                <div class="header-row">
+                    <h3>{% trans %}External References{% endtrans %}</h3>
+                </div>
+            </div>
+            {{ render_references(contribution, 'reference-list-conference') }}
+        </section>
+    {%- endif %}
 
     {% if contribution.subcontributions -%}
         <section>

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -3,8 +3,8 @@
 {% from 'events/display/common/_conferences.html' import render_attachments %}
 {% from 'events/display/indico/_common.html' import render_location, render_users, render_speakers %}
 {% from 'events/papers/_contributions.html' import render_paper_section, render_editables_section, render_proceedings_section %}
-{% from 'message_box.html' import message_box %}
 {% from 'events/timetable/display/indico/_common.html' import render_references %}
+{% from 'message_box.html' import message_box %}
 
 {% block page_class %}conference-page item-summary{% endblock %}
 
@@ -221,7 +221,7 @@
         <section>
             <div class="header">
                 <div class="header-row">
-                    <h3>{% trans %}External References{% endtrans %}</h3>
+                    <h3>{% trans %}External references{% endtrans %}</h3>
                 </div>
             </div>
             {{ render_references(contribution, 'reference-list-conference') }}

--- a/indico/modules/events/contributions/templates/display/subcontribution_display.html
+++ b/indico/modules/events/contributions/templates/display/subcontribution_display.html
@@ -49,7 +49,7 @@
         <section>
             <div class="header">
                 <div class="header-row">
-                    <h3>{% trans %}External References{% endtrans %}</h3>
+                    <h3>{% trans %}External references{% endtrans %}</h3>
                 </div>
             </div>
             {{ render_references(subcontrib, 'reference-list-conference') }}

--- a/indico/modules/events/contributions/templates/display/subcontribution_display.html
+++ b/indico/modules/events/contributions/templates/display/subcontribution_display.html
@@ -2,6 +2,7 @@
 
 {% from 'events/display/common/_conferences.html' import render_attachments %}
 {% from 'events/display/indico/_common.html' import render_location, render_speakers %}
+{% from 'events/timetable/display/indico/_common.html' import render_references %}
 
 {% block page_class %}conference-page item-summary{% endblock %}
 
@@ -43,6 +44,17 @@
 {% block content -%}
     {{ render_speakers(subcontrib) }}
     {{ render_attachments(subcontrib) }}
+
+    {% if subcontrib.references -%}
+        <section>
+            <div class="header">
+                <div class="header-row">
+                    <h3>{% trans %}External References{% endtrans %}</h3>
+                </div>
+            </div>
+            {{ render_references(subcontrib, 'reference-list-conference') }}
+        </section>
+    {%- endif %}
 
     <script>
         setupAttachmentTreeView();

--- a/indico/modules/events/templates/display/common/_conferences.html
+++ b/indico/modules/events/templates/display/common/_conferences.html
@@ -5,7 +5,7 @@
         <div class="header">
             <div class="header-row">
                 <h3 class="icon-attachment">
-                    {%- trans %}Presentation Materials{% endtrans -%}
+                    {%- trans %}Presentation materials{% endtrans -%}
                 </h3>
                 {% if item.can_manage_attachments(session.user) -%}
                     <div class="toolbar">

--- a/indico/modules/events/timetable/templates/display/indico/_common.html
+++ b/indico/modules/events/timetable/templates/display/indico/_common.html
@@ -8,8 +8,8 @@
     </div>
 {% endmacro %}
 
-{% macro render_references(item) -%}
-    <ul class="reference-list">
+{% macro render_references(item, class='reference-list-meeting') -%}
+    <ul class="reference-list {{ class }}">
         {%- for reference in item.references -%}
             <li title="{% trans title=reference.reference_type.name %}External reference ({{ title }}){% endtrans %}"
                 class="icon-link">

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -130,3 +130,46 @@
     }
   }
 }
+
+.reference-list {
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  display: block;
+
+  li {
+    display: inline-block;
+    margin: 0.2em 0.2em;
+    border-radius: 2px;
+
+    .type-name {
+      color: $light-black;
+    }
+  }
+}
+
+.reference-list-meeting {
+  li {
+    &::before {
+      color: $yellow;
+    }
+
+    padding: 0.2em 0.5em;
+    background-color: lighten($light-yellow, 5%);
+
+    &:first-child {
+      margin-left: 0;
+    }
+  }
+}
+
+.reference-list-conference {
+  li {
+    &::before {
+      content: '';
+    }
+
+    padding: 0.2em 1em 0.2em 0;
+    background-color: $white;
+  }
+}

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -165,10 +165,6 @@
 
 .reference-list-conference {
   li {
-    &::before {
-      content: '';
-    }
-
     padding: 0.2em 1em 0.2em 0;
     background-color: $white;
   }

--- a/indico/web/client/styles/modules/event_display/_meetings.scss
+++ b/indico/web/client/styles/modules/event_display/_meetings.scss
@@ -172,33 +172,6 @@ li > table + .note-area-wrapper {
   }
 }
 
-.reference-list {
-  list-style-type: none;
-  margin: 0;
-  padding: 0;
-  display: block;
-
-  li {
-    &::before {
-      color: $yellow;
-    }
-
-    display: inline-block;
-    margin: 0.2em 0.2em;
-    border-radius: 2px;
-    padding: 0.2em 0.5em;
-    background-color: lighten($light-yellow, 5%);
-
-    &:first-child {
-      margin-left: 0;
-    }
-
-    .type-name {
-      color: $light-black;
-    }
-  }
-}
-
 .session-block-form {
   width: 840px !important;
 }


### PR DESCRIPTION
Shows external references on contribution and subcontribution pages.

Contribution detail:
![Screenshot from 2021-06-04 13-59-58](https://user-images.githubusercontent.com/8739637/120801447-77e56300-c541-11eb-9a8a-c29bd262c62e.png)
Subcontribution detail:
![Screenshot from 2021-06-04 14-02-28](https://user-images.githubusercontent.com/8739637/120801463-7ae05380-c541-11eb-8a57-71290c098051.png)

The function `render_references()` now shows the references differently based on whether the references are in a meeting or a conference. The function takes an extra parameter `class` which specifies additional styles to be applied. The default value applies the meeting styles so other code does not need to be modified. For (sub)contributions, the function is used as `render_references(contrib, 'reference-list-conference')`. 

The related `css` classes are moved from `_meetings.scss` to `_common.scss`.

closes #4928
