### PR TITLE
Vertically align affiliation with a person's name

### DIFF
--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -33,7 +33,7 @@
 
         display: inline-block;
         max-width: 10em;
-        vertical-align: text-bottom;
+        vertical-align: bottom;
       }
     }
   }


### PR DESCRIPTION
Vertically aligns the affiliation next a person's name. 

Before:
![Screenshot from 2021-06-04 15-38-50](https://user-images.githubusercontent.com/8739637/120811109-ed563100-c54b-11eb-814e-f2b7ad41e2f6.png)
After:
![Screenshot from 2021-06-04 15-38-23](https://user-images.githubusercontent.com/8739637/120811121-f0512180-c54b-11eb-8834-cd39fb5b06d3.png)

The fix is based on this SO thread: https://stackoverflow.com/q/20566710

Basically, `inline-block` together with `overflow: hidden` moves the element up which is fixed by adding `vertical-align: bottom`.


