### PR TITLE
Show placeholders in room-specific notification settings

### DIFF
--- a/indico/modules/rb/blueprint.py
+++ b/indico/modules/rb/blueprint.py
@@ -29,6 +29,7 @@ _bp.add_url_rule('/rooms/<int:room_id>.jpg', 'room_photo', rooms.RHRoomPhoto)
 # General backend
 _bp.add_url_rule('/api/<path:path>', '404', lambda path: (jsonify(), 404))
 _bp.add_url_rule('/api/config', 'config', misc.RHConfig)
+_bp.add_url_rule('/api/config/notifications', 'notification_settings', misc.RHNotificationSettings)
 _bp.add_url_rule('/api/stats', 'stats', misc.RHStats)
 _bp.add_url_rule('/api/map-areas', 'map_areas', misc.RHMapAreas)
 _bp.add_url_rule('/api/equipment', 'equipment_types', misc.RHEquipmentTypes)

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
@@ -13,6 +13,7 @@ import roomsURL from 'indico-url:rb.admin_rooms';
 import updateRoomAttributesURL from 'indico-url:rb.admin_update_room_attributes';
 import updateRoomAvailabilityURL from 'indico-url:rb.admin_update_room_availability';
 import updateRoomEquipmentURL from 'indico-url:rb.admin_update_room_equipment';
+import roomNotificationSettingsURL from 'indico-url:rb.notification_settings';
 
 import arrayMutators from 'final-form-arrays';
 import _ from 'lodash';
@@ -74,6 +75,7 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
     bookable_hours: [],
     nonbookable_periods: [],
   });
+  const [roomNotificationSettings, setRoomNotificationSettings] = useState({});
 
   const isNewRoom = roomId === undefined;
 
@@ -93,8 +95,11 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
       fetchData(roomURL({room_id: roomId})),
       fetchData(roomAttributesURL({room_id: roomId})),
       fetchData(roomAvailabilityURL({room_id: roomId})),
+      fetchData(roomNotificationSettingsURL()),
     ]);
-    [setRoomDetails, setRoomAttributes, setRoomAvailability].forEach((fn, i) => fn(resp[i]));
+    [setRoomDetails, setRoomAttributes, setRoomAvailability, setRoomNotificationSettings].forEach(
+      (fn, i) => fn(resp[i])
+    );
   }, [roomId]);
 
   const tabPanes = useMemo(
@@ -142,7 +147,12 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
         {
           key: 'notifications',
           menuItem: <Translate>Notifications</Translate>,
-          pane: <RoomEditNotifications key="notifications" />,
+          pane: (
+            <RoomEditNotifications
+              key="notifications"
+              roomNotificationSettings={roomNotificationSettings}
+            />
+          ),
           fields: [
             'notification_emails',
             'notifications_enabled',
@@ -191,6 +201,7 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
       permissionInfo,
       permissionManager,
       activeTab,
+      roomNotificationSettings,
     ]
   );
 

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
@@ -13,7 +13,7 @@ import roomsURL from 'indico-url:rb.admin_rooms';
 import updateRoomAttributesURL from 'indico-url:rb.admin_update_room_attributes';
 import updateRoomAvailabilityURL from 'indico-url:rb.admin_update_room_availability';
 import updateRoomEquipmentURL from 'indico-url:rb.admin_update_room_equipment';
-import roomNotificationSettingsURL from 'indico-url:rb.notification_settings';
+import roomNotificationDefaultsURL from 'indico-url:rb.notification_settings';
 
 import arrayMutators from 'final-form-arrays';
 import _ from 'lodash';
@@ -75,7 +75,7 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
     bookable_hours: [],
     nonbookable_periods: [],
   });
-  const [roomNotificationSettings, setRoomNotificationSettings] = useState({});
+  const [roomNotificationDefaults, setRoomNotificationDefaults] = useState({});
 
   const isNewRoom = roomId === undefined;
 
@@ -95,9 +95,9 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
       fetchData(roomURL({room_id: roomId})),
       fetchData(roomAttributesURL({room_id: roomId})),
       fetchData(roomAvailabilityURL({room_id: roomId})),
-      fetchData(roomNotificationSettingsURL()),
+      fetchData(roomNotificationDefaultsURL()),
     ]);
-    [setRoomDetails, setRoomAttributes, setRoomAvailability, setRoomNotificationSettings].forEach(
+    [setRoomDetails, setRoomAttributes, setRoomAvailability, setRoomNotificationDefaults].forEach(
       (fn, i) => fn(resp[i])
     );
   }, [roomId]);
@@ -147,12 +147,7 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
         {
           key: 'notifications',
           menuItem: <Translate>Notifications</Translate>,
-          pane: (
-            <RoomEditNotifications
-              key="notifications"
-              roomNotificationSettings={roomNotificationSettings}
-            />
-          ),
+          pane: <RoomEditNotifications key="notifications" defaults={roomNotificationDefaults} />,
           fields: [
             'notification_emails',
             'notifications_enabled',
@@ -201,7 +196,7 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
       permissionInfo,
       permissionManager,
       activeTab,
-      roomNotificationSettings,
+      roomNotificationDefaults,
     ]
   );
 

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditNotifications.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditNotifications.jsx
@@ -13,7 +13,7 @@ import {FinalEmailList} from 'indico/react/components';
 import {FieldCondition, FinalCheckbox, FinalInput, validators as v} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-export default function RoomEditNotifications({active}) {
+export default function RoomEditNotifications({active, roomNotificationSettings}) {
   return (
     <Tab.Pane active={active}>
       <Header>
@@ -35,6 +35,7 @@ export default function RoomEditNotifications({active}) {
           <FinalInput
             fluid
             name="notification_before_days"
+            placeholder={roomNotificationSettings.notification_before_days}
             label={Translate.string('Single/Daily')}
             type="number"
             min="1"
@@ -44,6 +45,7 @@ export default function RoomEditNotifications({active}) {
           <FinalInput
             fluid
             name="notification_before_days_weekly"
+            placeholder={roomNotificationSettings.notification_before_days_weekly}
             label={Translate.string('Weekly')}
             type="number"
             min="1"
@@ -53,6 +55,7 @@ export default function RoomEditNotifications({active}) {
           <FinalInput
             fluid
             name="notification_before_days_monthly"
+            placeholder={roomNotificationSettings.notification_before_days_monthly}
             label={Translate.string('Monthly')}
             type="number"
             min="1"
@@ -69,6 +72,7 @@ export default function RoomEditNotifications({active}) {
           <FinalInput
             fluid
             name="end_notification_daily"
+            placeholder={roomNotificationSettings.end_notification_daily}
             label={Translate.string('Daily')}
             type="number"
             min="1"
@@ -78,6 +82,7 @@ export default function RoomEditNotifications({active}) {
           <FinalInput
             fluid
             name="end_notification_weekly"
+            placeholder={roomNotificationSettings.end_notification_weekly}
             label={Translate.string('Weekly')}
             type="number"
             min="1"
@@ -87,6 +92,7 @@ export default function RoomEditNotifications({active}) {
           <FinalInput
             fluid
             name="end_notification_monthly"
+            placeholder={roomNotificationSettings.end_notification_monthly}
             label={Translate.string('Monthly')}
             type="number"
             min="1"
@@ -101,8 +107,24 @@ export default function RoomEditNotifications({active}) {
 
 RoomEditNotifications.propTypes = {
   active: PropTypes.bool,
+  roomNotificationSettings: PropTypes.shape({
+    notification_before_days: PropTypes.string,
+    notification_before_days_weekly: PropTypes.string,
+    notification_before_days_monthly: PropTypes.string,
+    end_notification_daily: PropTypes.string,
+    end_notification_weekly: PropTypes.string,
+    end_notification_monthly: PropTypes.string,
+  }),
 };
 
 RoomEditNotifications.defaultProps = {
   active: true,
+  roomNotificationSettings: PropTypes.shape({
+    notification_before_days: '',
+    notification_before_days_weekly: '',
+    notification_before_days_monthly: '',
+    end_notification_daily: '',
+    end_notification_weekly: '',
+    end_notification_monthly: '',
+  }),
 };

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditNotifications.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditNotifications.jsx
@@ -35,7 +35,11 @@ export default function RoomEditNotifications({active, defaults}) {
           <FinalInput
             fluid
             name="notification_before_days"
-            placeholder={defaults.notification_before_days}
+            placeholder={
+              defaults.notification_before_days === null
+                ? ''
+                : String(defaults.notification_before_days)
+            }
             label={Translate.string('Single/Daily')}
             type="number"
             min="1"
@@ -45,7 +49,11 @@ export default function RoomEditNotifications({active, defaults}) {
           <FinalInput
             fluid
             name="notification_before_days_weekly"
-            placeholder={defaults.notification_before_days_weekly}
+            placeholder={
+              defaults.notification_before_days_weekly === null
+                ? ''
+                : String(defaults.notification_before_days_weekly)
+            }
             label={Translate.string('Weekly')}
             type="number"
             min="1"
@@ -55,7 +63,11 @@ export default function RoomEditNotifications({active, defaults}) {
           <FinalInput
             fluid
             name="notification_before_days_monthly"
-            placeholder={defaults.notification_before_days_monthly}
+            placeholder={
+              defaults.notification_before_days_monthly === null
+                ? ''
+                : String(defaults.notification_before_days_monthly)
+            }
             label={Translate.string('Monthly')}
             type="number"
             min="1"
@@ -72,7 +84,11 @@ export default function RoomEditNotifications({active, defaults}) {
           <FinalInput
             fluid
             name="end_notification_daily"
-            placeholder={defaults.end_notification_daily}
+            placeholder={
+              defaults.end_notification_daily === null
+                ? ''
+                : String(defaults.end_notification_daily)
+            }
             label={Translate.string('Daily')}
             type="number"
             min="1"
@@ -82,7 +98,11 @@ export default function RoomEditNotifications({active, defaults}) {
           <FinalInput
             fluid
             name="end_notification_weekly"
-            placeholder={defaults.end_notification_weekly}
+            placeholder={
+              defaults.end_notification_weekly === null
+                ? ''
+                : String(defaults.end_notification_weekly)
+            }
             label={Translate.string('Weekly')}
             type="number"
             min="1"
@@ -92,7 +112,11 @@ export default function RoomEditNotifications({active, defaults}) {
           <FinalInput
             fluid
             name="end_notification_monthly"
-            placeholder={defaults.end_notification_monthly}
+            placeholder={
+              defaults.end_notification_monthly === null
+                ? ''
+                : String(defaults.end_notification_monthly)
+            }
             label={Translate.string('Monthly')}
             type="number"
             min="1"
@@ -108,23 +132,23 @@ export default function RoomEditNotifications({active, defaults}) {
 RoomEditNotifications.propTypes = {
   active: PropTypes.bool,
   defaults: PropTypes.shape({
-    notification_before_days: PropTypes.string,
-    notification_before_days_weekly: PropTypes.string,
-    notification_before_days_monthly: PropTypes.string,
-    end_notification_daily: PropTypes.string,
-    end_notification_weekly: PropTypes.string,
-    end_notification_monthly: PropTypes.string,
+    notification_before_days: PropTypes.number,
+    notification_before_days_weekly: PropTypes.number,
+    notification_before_days_monthly: PropTypes.number,
+    end_notification_daily: PropTypes.number,
+    end_notification_weekly: PropTypes.number,
+    end_notification_monthly: PropTypes.number,
   }),
 };
 
 RoomEditNotifications.defaultProps = {
   active: true,
   defaults: PropTypes.shape({
-    notification_before_days: '',
-    notification_before_days_weekly: '',
-    notification_before_days_monthly: '',
-    end_notification_daily: '',
-    end_notification_weekly: '',
-    end_notification_monthly: '',
+    notification_before_days: null,
+    notification_before_days_weekly: null,
+    notification_before_days_monthly: null,
+    end_notification_daily: null,
+    end_notification_weekly: null,
+    end_notification_monthly: null,
   }),
 };

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditNotifications.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditNotifications.jsx
@@ -13,7 +13,7 @@ import {FinalEmailList} from 'indico/react/components';
 import {FieldCondition, FinalCheckbox, FinalInput, validators as v} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-export default function RoomEditNotifications({active, roomNotificationSettings}) {
+export default function RoomEditNotifications({active, defaults}) {
   return (
     <Tab.Pane active={active}>
       <Header>
@@ -35,7 +35,7 @@ export default function RoomEditNotifications({active, roomNotificationSettings}
           <FinalInput
             fluid
             name="notification_before_days"
-            placeholder={roomNotificationSettings.notification_before_days}
+            placeholder={defaults.notification_before_days}
             label={Translate.string('Single/Daily')}
             type="number"
             min="1"
@@ -45,7 +45,7 @@ export default function RoomEditNotifications({active, roomNotificationSettings}
           <FinalInput
             fluid
             name="notification_before_days_weekly"
-            placeholder={roomNotificationSettings.notification_before_days_weekly}
+            placeholder={defaults.notification_before_days_weekly}
             label={Translate.string('Weekly')}
             type="number"
             min="1"
@@ -55,7 +55,7 @@ export default function RoomEditNotifications({active, roomNotificationSettings}
           <FinalInput
             fluid
             name="notification_before_days_monthly"
-            placeholder={roomNotificationSettings.notification_before_days_monthly}
+            placeholder={defaults.notification_before_days_monthly}
             label={Translate.string('Monthly')}
             type="number"
             min="1"
@@ -72,7 +72,7 @@ export default function RoomEditNotifications({active, roomNotificationSettings}
           <FinalInput
             fluid
             name="end_notification_daily"
-            placeholder={roomNotificationSettings.end_notification_daily}
+            placeholder={defaults.end_notification_daily}
             label={Translate.string('Daily')}
             type="number"
             min="1"
@@ -82,7 +82,7 @@ export default function RoomEditNotifications({active, roomNotificationSettings}
           <FinalInput
             fluid
             name="end_notification_weekly"
-            placeholder={roomNotificationSettings.end_notification_weekly}
+            placeholder={defaults.end_notification_weekly}
             label={Translate.string('Weekly')}
             type="number"
             min="1"
@@ -92,7 +92,7 @@ export default function RoomEditNotifications({active, roomNotificationSettings}
           <FinalInput
             fluid
             name="end_notification_monthly"
-            placeholder={roomNotificationSettings.end_notification_monthly}
+            placeholder={defaults.end_notification_monthly}
             label={Translate.string('Monthly')}
             type="number"
             min="1"
@@ -107,7 +107,7 @@ export default function RoomEditNotifications({active, roomNotificationSettings}
 
 RoomEditNotifications.propTypes = {
   active: PropTypes.bool,
-  roomNotificationSettings: PropTypes.shape({
+  defaults: PropTypes.shape({
     notification_before_days: PropTypes.string,
     notification_before_days_weekly: PropTypes.string,
     notification_before_days_monthly: PropTypes.string,
@@ -119,7 +119,7 @@ RoomEditNotifications.propTypes = {
 
 RoomEditNotifications.defaultProps = {
   active: true,
-  roomNotificationSettings: PropTypes.shape({
+  defaults: PropTypes.shape({
     notification_before_days: '',
     notification_before_days_weekly: '',
     notification_before_days_monthly: '',

--- a/indico/modules/rb/controllers/backend/misc.py
+++ b/indico/modules/rb/controllers/backend/misc.py
@@ -22,7 +22,7 @@ from indico.modules.rb.models.map_areas import MapArea
 from indico.modules.rb.models.reservation_occurrences import ReservationOccurrence
 from indico.modules.rb.models.reservations import Reservation
 from indico.modules.rb.models.rooms import Room
-from indico.modules.rb.schemas import EquipmentTypeSchema, map_areas_schema, rb_user_schema
+from indico.modules.rb.schemas import EquipmentTypeSchema, SettingsSchema, map_areas_schema, rb_user_schema
 from indico.modules.rb.util import build_rooms_spritesheet
 from indico.util.caching import memoize_redis
 from indico.util.i18n import get_all_locales
@@ -55,12 +55,14 @@ class RHConfig(RHRoomBookingBase):
 
 class RHNotificationSettings(RHRoomBookingBase):
     def _process(self):
-        return jsonify(notification_before_days=str(rb_settings.get('notification_before_days')),
-                       notification_before_days_weekly=str(rb_settings.get('notification_before_days_weekly')),
-                       notification_before_days_monthly=str(rb_settings.get('notification_before_days_monthly')),
-                       end_notification_daily=str(rb_settings.get('end_notification_daily')),
-                       end_notification_weekly=str(rb_settings.get('end_notification_weekly')),
-                       end_notification_monthly=str(rb_settings.get('end_notification_monthly')))
+        return SettingsSchema(only=[
+            'notification_before_days',
+            'notification_before_days_weekly',
+            'notification_before_days_monthly',
+            'end_notification_daily',
+            'end_notification_weekly',
+            'end_notification_monthly'
+        ]).jsonify(rb_settings.get_all())
 
 
 class RHUserInfo(RHRoomBookingBase):

--- a/indico/modules/rb/controllers/backend/misc.py
+++ b/indico/modules/rb/controllers/backend/misc.py
@@ -53,6 +53,16 @@ class RHConfig(RHRoomBookingBase):
                        privacy_policy_html=privacy_policy_html)
 
 
+class RHNotificationSettings(RHRoomBookingBase):
+    def _process(self):
+        return jsonify(notification_before_days=str(rb_settings.get('notification_before_days')),
+                       notification_before_days_weekly=str(rb_settings.get('notification_before_days_weekly')),
+                       notification_before_days_monthly=str(rb_settings.get('notification_before_days_monthly')),
+                       end_notification_daily=str(rb_settings.get('end_notification_daily')),
+                       end_notification_weekly=str(rb_settings.get('end_notification_weekly')),
+                       end_notification_monthly=str(rb_settings.get('end_notification_monthly')))
+
+
 class RHUserInfo(RHRoomBookingBase):
     def _process(self):
         data = rb_user_schema.dump(session.user)


### PR DESCRIPTION
Closes #4840 

Added notification placeholders in  the `Notifications` tab
of the `Edit Room Details` modal. The notification settings
were previously only available from the `api/admin/settings`
endpoint which is admin-protected.

This commit adds a new unprotected endpoint `api/config/notifications`
which exposes only the notification settings. This endpoint is
used to show the corresponding placeholder values in the input
elements.

![Screenshot from 2021-06-07 17-41-44](https://user-images.githubusercontent.com/8739637/121049085-aff5db80-c7b7-11eb-8b59-39689ae3e77c.png)

