### PR TITLE
Update calendar session exports to block level

### DIFF
--- a/indico/modules/events/sessions/ical.py
+++ b/indico/modules/events/sessions/ical.py
@@ -31,7 +31,7 @@ def generate_session_block_component(block, related_to_uid=None):
     uid = f'indico-session-block-{block.id}@{url_parse(config.BASE_URL).host}'
     url = url_for('sessions.display_session', block.session, _external=True)
     component = generate_basic_component(
-        block, uid, url, title=block.title or block.session.title, description=block.session.description
+        block, uid, url, title=block.full_title, description=block.session.description
     )
 
     if related_to_uid:

--- a/indico/modules/events/sessions/ical.py
+++ b/indico/modules/events/sessions/ical.py
@@ -26,6 +26,20 @@ def generate_session_component(session, related_to_uid=None):
     return component
 
 
+def generate_session_block_component(block, related_to_uid=None):
+    """Generate an Event iCalendar component for a session block in an Indico Session."""
+    uid = f'indico-session-block-{block.id}@{url_parse(config.BASE_URL).host}'
+    url = url_for('sessions.display_session', block.session, _external=True)
+    component = generate_basic_component(
+        block, uid, url, title=block.title or block.session.title, description=block.session.description
+    )
+
+    if related_to_uid:
+        component.add('related-to', related_to_uid)
+
+    return component
+
+
 def session_to_ical(session, user=None, detailed=False):
     """Serialize a session into an iCal.
 


### PR DESCRIPTION
Sessions can span over multiple details while exporting a calendar compact timetable. These changes ensure session blocks are exported instead, resulting in a better layout.