### PR TITLE
Display avatars in user search

### DIFF
--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -31,7 +31,6 @@ from indico.modules.core.settings import core_settings, social_settings
 from indico.modules.core.views import WPContact, WPSettings
 from indico.modules.legal import legal_settings
 from indico.modules.users.controllers import RHUserBase
-from indico.modules.users.util import get_avatar_from_name
 from indico.util.i18n import _, get_all_locales
 from indico.util.marshmallow import PrincipalDict, validate_with_message
 from indico.util.string import sanitize_html
@@ -200,8 +199,7 @@ class PrincipalsMixin:
                     'last_name': principal.last_name,
                     'email': principal.email,
                     'affiliation': principal.affiliation,
-                    'avatar_url': (principal.avatar_url
-                                   if principal.avatar_url else get_avatar_from_name(principal.first_name)),
+                    'avatar_url': principal.avatar_url,
                     'detail': (f'{principal.email} ({principal.affiliation})'
                                if principal.affiliation else principal.email)}
         elif principal.principal_type == PrincipalType.local_group:

--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -31,6 +31,7 @@ from indico.modules.core.settings import core_settings, social_settings
 from indico.modules.core.views import WPContact, WPSettings
 from indico.modules.legal import legal_settings
 from indico.modules.users.controllers import RHUserBase
+from indico.modules.users.util import get_avatar_from_name
 from indico.util.i18n import _, get_all_locales
 from indico.util.marshmallow import PrincipalDict, validate_with_message
 from indico.util.string import sanitize_html
@@ -199,6 +200,8 @@ class PrincipalsMixin:
                     'last_name': principal.last_name,
                     'email': principal.email,
                     'affiliation': principal.affiliation,
+                    'avatar_url': (principal.avatar_url
+                                   if principal.avatar_url else get_avatar_from_name(principal.first_name)),
                     'detail': (f'{principal.email} ({principal.affiliation})'
                                if principal.affiliation else principal.email)}
         elif principal.principal_type == PrincipalType.local_group:

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -42,9 +42,9 @@ from indico.modules.users.models.emails import UserEmail
 from indico.modules.users.models.users import ProfilePictureSource
 from indico.modules.users.operations import create_user
 from indico.modules.users.schemas import BasicCategorySchema
-from indico.modules.users.util import (get_gravatar_for_user, get_linked_events, get_related_categories,
-                                       get_suggested_categories, merge_users, search_users, send_avatar, serialize_user,
-                                       set_user_avatar)
+from indico.modules.users.util import (get_avatar_from_name, get_gravatar_for_user, get_linked_events,
+                                       get_related_categories, get_suggested_categories, merge_users, search_users,
+                                       send_avatar, serialize_user, set_user_avatar)
 from indico.modules.users.views import WPUser, WPUserDashboard, WPUserFavorites, WPUserProfilePic, WPUsersAdmin
 from indico.util.date_time import now_utc
 from indico.util.i18n import _
@@ -680,7 +680,7 @@ class RHRejectRegistrationRequest(RHRegistrationRequestBase):
 class UserSearchResultSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = User
-        fields = ('id', 'identifier', 'email', 'affiliation', 'full_name', 'first_name', 'last_name')
+        fields = ('id', 'identifier', 'email', 'affiliation', 'full_name', 'first_name', 'last_name', 'avatar_url')
 
 
 search_result_schema = UserSearchResultSchema()
@@ -696,6 +696,8 @@ class RHUserSearch(RHProtected):
         affiliation = entry.data.get('affiliation') or ''
         email = entry.data['email'].lower()
         ext_id = f'{entry.provider.name}:{entry.identifier}'
+        avatar_url = entry.data.get('avatar_url') or get_avatar_from_name(first_name)
+
         # detailed data to put in redis to create a pending user if needed
         self.externals[ext_id] = {
             'first_name': first_name,
@@ -715,6 +717,7 @@ class RHUserSearch(RHProtected):
             'full_name': full_name,
             'first_name': first_name,
             'last_name': last_name,
+            'avatar_url': avatar_url
         }
 
     def _serialize_entry(self, entry):

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -42,7 +42,7 @@ from indico.modules.users.models.emails import UserEmail
 from indico.modules.users.models.users import ProfilePictureSource
 from indico.modules.users.operations import create_user
 from indico.modules.users.schemas import BasicCategorySchema
-from indico.modules.users.util import (get_avatar_from_name, get_gravatar_for_user, get_linked_events,
+from indico.modules.users.util import (get_avatar_url_from_name, get_gravatar_for_user, get_linked_events,
                                        get_related_categories, get_suggested_categories, merge_users, search_users,
                                        send_avatar, serialize_user, set_user_avatar)
 from indico.modules.users.views import WPUser, WPUserDashboard, WPUserFavorites, WPUserProfilePic, WPUsersAdmin
@@ -696,7 +696,8 @@ class RHUserSearch(RHProtected):
         affiliation = entry.data.get('affiliation') or ''
         email = entry.data['email'].lower()
         ext_id = f'{entry.provider.name}:{entry.identifier}'
-        avatar_url = entry.data.get('avatar_url') or get_avatar_from_name(first_name)
+        # IdentityInfo from flask-multipass does not have `avatar_url`
+        avatar_url = get_avatar_url_from_name(first_name)
 
         # detailed data to put in redis to create a pending user if needed
         self.externals[ext_id] = {

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -38,7 +38,7 @@ from indico.util.event import truncate_path
 from indico.util.fs import secure_filename
 from indico.util.i18n import _
 from indico.util.string import crc32, remove_accents
-from indico.web.flask.util import send_file
+from indico.web.flask.util import send_file, url_for
 
 
 # colors for user-specific avatar bubbles
@@ -441,3 +441,8 @@ def send_avatar(user):
     return send_file('avatar.png', BytesIO(user.picture), mimetype=metadata['content_type'],
                      inline=True, conditional=True, last_modified=parse_date(metadata['lastmod']),
                      cache_timeout=(86400*7))
+
+
+def get_avatar_from_name(first_name):
+    first_char = first_name[0] if first_name else None
+    return url_for('assets.avatar', name=first_char)

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -443,6 +443,6 @@ def send_avatar(user):
                      cache_timeout=(86400*7))
 
 
-def get_avatar_from_name(first_name):
+def get_avatar_url_from_name(first_name):
     first_char = first_name[0] if first_name else None
     return url_for('assets.avatar', name=first_char)

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -27,6 +27,7 @@ import {
   Message,
   Modal,
   Popup,
+  Image,
 } from 'semantic-ui-react';
 
 import {FinalCheckbox, FinalInput, handleSubmitError} from 'indico/react/forms';
@@ -58,38 +59,48 @@ const searchFactory = config => {
   } = config;
 
   /* eslint-disable react/prop-types */
-  const FavoriteItem = ({name, detail, added, onAdd, onRemove}) => (
-    <Dropdown.Item
-      disabled={added}
-      styleName="favorite"
-      style={{pointerEvents: 'all'}}
-      onClick={e => {
-        e.stopPropagation();
-        if (added) {
-          onRemove();
-        } else {
-          onAdd();
-        }
-      }}
-    >
-      <div styleName="item">
-        <div styleName="icon">
-          <Icon.Group size="large">
-            <Icon name={resultIcon} />
-            {added && <Icon name="check" color="green" corner />}
-          </Icon.Group>
+  const FavoriteItem = ({name, detail, added, onAdd, onRemove, avatarURL}) => {
+    const avatar = avatarURL ? (
+      <Image src={avatarURL} size="mini" avatar />
+    ) : (
+      <Icon name={resultIcon} />
+    );
+
+    const marginLeft = avatarURL ? 'margin-left' : '';
+
+    return (
+      <Dropdown.Item
+        disabled={added}
+        styleName="favorite"
+        style={{pointerEvents: 'all'}}
+        onClick={e => {
+          e.stopPropagation();
+          if (added) {
+            onRemove();
+          } else {
+            onAdd();
+          }
+        }}
+      >
+        <div styleName="item">
+          <div styleName="icon">
+            <Icon.Group size="large">
+              {avatar}
+              {added && <Icon name="check" color="green" corner />}
+            </Icon.Group>
+          </div>
+          <div styleName={`content ${marginLeft}`}>
+            <List.Content>{name}</List.Content>
+            {detail && (
+              <List.Description>
+                <small>{detail}</small>
+              </List.Description>
+            )}
+          </div>
         </div>
-        <div styleName="content">
-          <List.Content>{name}</List.Content>
-          {detail && (
-            <List.Description>
-              <small>{detail}</small>
-            </List.Description>
-          )}
-        </div>
-      </div>
-    </Dropdown.Item>
-  );
+      </Dropdown.Item>
+    );
+  };
 
   const SearchForm = ({onSearch, favorites, isAdded, onAdd, onRemove, single}) => {
     const initialFormValues = useContext(InitialFormValuesContext);
@@ -141,6 +152,7 @@ const searchFactory = config => {
                         onRemove={() => {
                           onRemove(x);
                         }}
+                        avatarURL={x.avatarURL}
                       />
                     ))}
                   </Dropdown.Menu>
@@ -153,41 +165,60 @@ const searchFactory = config => {
     );
   };
 
-  const ResultItem = ({name, detail, added, favorite, onAdd, onRemove, existsInEvent}) => (
-    <List.Item>
-      <div styleName="item">
-        <div styleName="icon">
-          <Icon.Group size="large">
-            <Icon name={resultIcon} />
-            {favorite && <Icon name="star" color="yellow" corner="bottom right" />}
-            {existsInEvent && (
-              <Popup
-                content={Translate.string('Person exists in event')}
-                trigger={<Icon name="ticket" styleName="event-person" corner="top right" />}
-                offset={[-15, 0]}
-                position="top left"
-              />
+  const ResultItem = ({
+    name,
+    detail,
+    added,
+    favorite,
+    onAdd,
+    onRemove,
+    existsInEvent,
+    avatarURL,
+  }) => {
+    const avatar = avatarURL ? (
+      <Image src={avatarURL} size="mini" avatar />
+    ) : (
+      <Icon name={resultIcon} />
+    );
+
+    const marginLeft = avatarURL ? 'margin-left' : '';
+
+    return (
+      <List.Item>
+        <div styleName="item">
+          <div styleName="icon">
+            <Icon.Group size="large">
+              {avatar}
+              {favorite && <Icon name="star" color="yellow" corner="bottom right" />}
+              {existsInEvent && (
+                <Popup
+                  content={Translate.string('Person exists in event')}
+                  trigger={<Icon name="ticket" styleName="event-person" corner="top right" />}
+                  offset={[-15, 0]}
+                  position="top left"
+                />
+              )}
+            </Icon.Group>
+          </div>
+          <div styleName={`content ${marginLeft}`}>
+            <List.Content>{name}</List.Content>
+            {detail && (
+              <List.Description>
+                <small>{detail}</small>
+              </List.Description>
             )}
-          </Icon.Group>
+          </div>
+          <div styleName="actions">
+            {added ? (
+              <Icon name="checkmark" size="large" color="green" onClick={onRemove} />
+            ) : (
+              <Icon styleName="button" name="add" size="large" onClick={onAdd} />
+            )}
+          </div>
         </div>
-        <div styleName="content">
-          <List.Content>{name}</List.Content>
-          {detail && (
-            <List.Description>
-              <small>{detail}</small>
-            </List.Description>
-          )}
-        </div>
-        <div styleName="actions">
-          {added ? (
-            <Icon name="checkmark" size="large" color="green" onClick={onRemove} />
-          ) : (
-            <Icon styleName="button" name="add" size="large" onClick={onAdd} />
-          )}
-        </div>
-      </div>
-    </List.Item>
-  );
+      </List.Item>
+    );
+  };
 
   const SearchResults = ({
     results,
@@ -216,6 +247,7 @@ const searchFactory = config => {
                 onAdd={() => onAdd(r)}
                 onRemove={() => onRemove(r)}
                 existsInEvent={r.existsInEvent}
+                avatarURL={r.avatarURL}
               />
             ))}
           </List>
@@ -546,7 +578,7 @@ const InnerUserSearch = searchFactory({
     }
     const resultData = camelizeKeys(response.data);
     resultData.results = resultData.users.map(
-      ({identifier, id, fullName, email, affiliation, firstName, lastName}) => ({
+      ({identifier, id, fullName, email, affiliation, firstName, lastName, avatarURL}) => ({
         identifier,
         type: PrincipalType.user,
         userId: id,
@@ -558,6 +590,7 @@ const InnerUserSearch = searchFactory({
         existsInEvent: false,
         email,
         affiliation,
+        avatarURL,
       })
     );
     delete resultData.users;

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -66,7 +66,7 @@ const searchFactory = config => {
       <Icon name={resultIcon} />
     );
 
-    const hasAvatar = avatarURL ? 'has-avatar' : '';
+    const hasAvatarClass = avatarURL ? 'has-avatar' : '';
 
     return (
       <Dropdown.Item
@@ -89,7 +89,7 @@ const searchFactory = config => {
               {added && <Icon name="check" color="green" corner />}
             </Icon.Group>
           </div>
-          <div styleName={`content ${hasAvatar}`}>
+          <div styleName={`content ${hasAvatarClass}`}>
             <List.Content>{name}</List.Content>
             {detail && (
               <List.Description>
@@ -181,7 +181,7 @@ const searchFactory = config => {
       <Icon name={resultIcon} />
     );
 
-    const hasAvatar = avatarURL ? 'has-avatar' : '';
+    const hasAvatarClass = avatarURL ? 'has-avatar' : '';
 
     return (
       <List.Item>
@@ -200,7 +200,7 @@ const searchFactory = config => {
               )}
             </Icon.Group>
           </div>
-          <div styleName={`content ${hasAvatar}`}>
+          <div styleName={`content ${hasAvatarClass}`}>
             <List.Content>{name}</List.Content>
             {detail && (
               <List.Description>

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -66,7 +66,7 @@ const searchFactory = config => {
       <Icon name={resultIcon} />
     );
 
-    const marginLeft = avatarURL ? 'margin-left' : '';
+    const hasAvatar = avatarURL ? 'has-avatar' : '';
 
     return (
       <Dropdown.Item
@@ -89,7 +89,7 @@ const searchFactory = config => {
               {added && <Icon name="check" color="green" corner />}
             </Icon.Group>
           </div>
-          <div styleName={`content ${marginLeft}`}>
+          <div styleName={`content ${hasAvatar}`}>
             <List.Content>{name}</List.Content>
             {detail && (
               <List.Description>
@@ -143,6 +143,7 @@ const searchFactory = config => {
                         name={x.name}
                         detail={x.detail}
                         added={isAdded(x)}
+                        avatarURL={x.avatarURL}
                         onAdd={() => {
                           onAdd(x);
                           if (single) {
@@ -152,7 +153,6 @@ const searchFactory = config => {
                         onRemove={() => {
                           onRemove(x);
                         }}
-                        avatarURL={x.avatarURL}
                       />
                     ))}
                   </Dropdown.Menu>
@@ -181,7 +181,7 @@ const searchFactory = config => {
       <Icon name={resultIcon} />
     );
 
-    const marginLeft = avatarURL ? 'margin-left' : '';
+    const hasAvatar = avatarURL ? 'has-avatar' : '';
 
     return (
       <List.Item>
@@ -200,7 +200,7 @@ const searchFactory = config => {
               )}
             </Icon.Group>
           </div>
-          <div styleName={`content ${marginLeft}`}>
+          <div styleName={`content ${hasAvatar}`}>
             <List.Content>{name}</List.Content>
             {detail && (
               <List.Description>

--- a/indico/web/client/js/react/components/principals/Search.module.scss
+++ b/indico/web/client/js/react/components/principals/Search.module.scss
@@ -54,6 +54,6 @@
   overflow-y: auto;
 }
 
-.margin-left {
+.has-avatar {
   margin-left: 8px;
 }

--- a/indico/web/client/js/react/components/principals/Search.module.scss
+++ b/indico/web/client/js/react/components/principals/Search.module.scss
@@ -53,3 +53,7 @@
   max-height: 490px;
   overflow-y: auto;
 }
+
+.margin-left {
+  margin-left: 8px;
+}


### PR DESCRIPTION
When searching users, instead of the default icon, avatars are displayed.
If the user does not have an avatar, the default avatar with the first letter of
the first name is used.

The group search still displays the default result icon.

Before:
![Screenshot from 2021-06-08 16-41-21](https://user-images.githubusercontent.com/8739637/121331371-19d8c700-c917-11eb-8fde-48219af77bf6.png)
After:
![Screenshot from 2021-06-08 18-07-55](https://user-images.githubusercontent.com/8739637/121331403-1fcea800-c917-11eb-87a5-fb26d6da7960.png)
![Screenshot from 2021-06-09 10-47-43](https://user-images.githubusercontent.com/8739637/121331415-23fac580-c917-11eb-8552-07e5f33e799e.png)

