### PR TITLE
Scale ratings proportionally when the range is changed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,7 @@ Improvements
   plugin) (:issue:`4900`, :pr:`4899`)
 - Support cloning surveys when cloning events (:issue:`2045`, :pr:`4910`)
 - Show external contribution references in conferences (:issue:`4928`, :pr:`4933`)
+- Allow changing the rating scale in abstract/paper reviewing even after reviewing started (:pr:`4942`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/controllers/management.py
+++ b/indico/modules/events/abstracts/controllers/management.py
@@ -132,7 +132,7 @@ class RHManageAbstractReviewing(RHManageAbstractsBase):
         abstracts_reviewing_settings.set(self.event, 'scale_lower', scale_min)
         abstracts_reviewing_settings.set(self.event, 'scale_upper', scale_max)
         for rating in self.ratings:
-            if not rating.value:
+            if rating.value is None:
                 continue
             value = (rating.value - prev_min) / (prev_max - prev_min)
             rating.value = round(value * (scale_max - scale_min) + scale_min)

--- a/indico/modules/events/abstracts/controllers/management.py
+++ b/indico/modules/events/abstracts/controllers/management.py
@@ -113,24 +113,41 @@ class RHManageAbstractSubmission(RHManageAbstractsBase):
 class RHManageAbstractReviewing(RHManageAbstractsBase):
     """Configure abstract reviewing."""
 
+    @property
+    def ratings(self):
+        return (AbstractReviewRating.query
+                .join(AbstractReviewRating.review)
+                .join(AbstractReview.abstract)
+                .join(AbstractReviewRating.question)
+                .filter(~Abstract.is_deleted, Abstract.event == self.event,
+                        AbstractReviewQuestion.field_type == 'rating'))
+
+    def _scale_ratings(self, scale_min, scale_max):
+        prev_min = abstracts_reviewing_settings.get(self.event, 'scale_lower')
+        prev_max = abstracts_reviewing_settings.get(self.event, 'scale_upper')
+        if not (scale_min != prev_min or scale_max != prev_max):
+            return
+        assert scale_max > scale_min
+
+        abstracts_reviewing_settings.set(self.event, 'scale_lower', scale_min)
+        abstracts_reviewing_settings.set(self.event, 'scale_upper', scale_max)
+        for rating in self.ratings:
+            if not rating.value:
+                continue
+            value = (rating.value - prev_min) / (prev_max - prev_min)
+            rating.value = round(value * (scale_max - scale_min) + scale_min)
+
     def _process(self):
-        has_ratings = (AbstractReviewRating.query
-                       .join(AbstractReviewRating.review)
-                       .join(AbstractReview.abstract)
-                       .join(AbstractReviewRating.question)
-                       .filter(~Abstract.is_deleted, Abstract.event == self.event,
-                               AbstractReviewQuestion.field_type == 'rating')
-                       .has_rows())
         defaults = FormDefaults(**abstracts_reviewing_settings.get_all(self.event))
-        form = AbstractReviewingSettingsForm(event=self.event, obj=defaults, has_ratings=has_ratings)
+        form = AbstractReviewingSettingsForm(event=self.event, obj=defaults, has_ratings=self.ratings.has_rows())
         if form.validate_on_submit():
             data = form.data
+            self._scale_ratings(data['scale_lower'], data['scale_upper'])
             abstracts_reviewing_settings.set_multi(self.event, data)
             flash(_('Abstract reviewing settings have been saved'), 'success')
             return jsonify_data()
         self.commit = False
-        disabled_fields = form.RATING_FIELDS if has_ratings else ()
-        return jsonify_form(form, disabled_fields=disabled_fields)
+        return jsonify_form(form)
 
 
 class RHManageReviewingRoles(RHManageAbstractsBase):

--- a/indico/modules/events/abstracts/controllers/management.py
+++ b/indico/modules/events/abstracts/controllers/management.py
@@ -129,8 +129,10 @@ class RHManageAbstractReviewing(RHManageAbstractsBase):
             return
         assert scale_max > scale_min
 
-        abstracts_reviewing_settings.set(self.event, 'scale_lower', scale_min)
-        abstracts_reviewing_settings.set(self.event, 'scale_upper', scale_max)
+        abstracts_reviewing_settings.set_multi(self.event, {
+            'scale_lower': scale_min,
+            'scale_upper': scale_max,
+        })
         for rating in self.ratings_query:
             if rating.value is None:
                 continue

--- a/indico/modules/events/abstracts/controllers/management.py
+++ b/indico/modules/events/abstracts/controllers/management.py
@@ -125,7 +125,7 @@ class RHManageAbstractReviewing(RHManageAbstractsBase):
     def _scale_ratings(self, scale_min, scale_max):
         prev_min = abstracts_reviewing_settings.get(self.event, 'scale_lower')
         prev_max = abstracts_reviewing_settings.get(self.event, 'scale_upper')
-        if not (scale_min != prev_min or scale_max != prev_max):
+        if scale_min == prev_min and scale_max == prev_max:
             return
         assert scale_max > scale_min
 

--- a/indico/modules/events/abstracts/controllers/management.py
+++ b/indico/modules/events/abstracts/controllers/management.py
@@ -114,7 +114,7 @@ class RHManageAbstractReviewing(RHManageAbstractsBase):
     """Configure abstract reviewing."""
 
     @property
-    def ratings(self):
+    def ratings_query(self):
         return (AbstractReviewRating.query
                 .join(AbstractReviewRating.review)
                 .join(AbstractReview.abstract)
@@ -131,7 +131,7 @@ class RHManageAbstractReviewing(RHManageAbstractsBase):
 
         abstracts_reviewing_settings.set(self.event, 'scale_lower', scale_min)
         abstracts_reviewing_settings.set(self.event, 'scale_upper', scale_max)
-        for rating in self.ratings:
+        for rating in self.ratings_query:
             if rating.value is None:
                 continue
             value = (rating.value - prev_min) / (prev_max - prev_min)
@@ -139,7 +139,7 @@ class RHManageAbstractReviewing(RHManageAbstractsBase):
 
     def _process(self):
         defaults = FormDefaults(**abstracts_reviewing_settings.get_all(self.event))
-        form = AbstractReviewingSettingsForm(event=self.event, obj=defaults, has_ratings=self.ratings.has_rows())
+        form = AbstractReviewingSettingsForm(event=self.event, obj=defaults, has_ratings=self.ratings_query.has_rows())
         if form.validate_on_submit():
             data = form.data
             self._scale_ratings(data['scale_lower'], data['scale_upper'])

--- a/indico/modules/events/abstracts/controllers/management_test.py
+++ b/indico/modules/events/abstracts/controllers/management_test.py
@@ -41,6 +41,7 @@ def test_abstract_review_scale_ratings(db, dummy_abstract, dummy_event, dummy_us
     rating = AbstractReviewRating(question=question, value=value)
     review.ratings.append(rating)
     db.session.flush()
+
     rh = RHManageAbstractReviewing()
     rh.event = dummy_event
     rh._scale_ratings(scale_min, scale_max)

--- a/indico/modules/events/abstracts/controllers/management_test.py
+++ b/indico/modules/events/abstracts/controllers/management_test.py
@@ -1,0 +1,59 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+
+from indico.modules.events.abstracts.models.abstracts import Abstract
+from indico.modules.events.abstracts.models.review_questions import AbstractReviewQuestion
+from indico.modules.events.abstracts.models.review_ratings import AbstractReviewRating
+from indico.modules.events.abstracts.models.reviews import AbstractAction, AbstractReview
+from indico.modules.events.abstracts.settings import abstracts_reviewing_settings
+from indico.modules.events.tracks import Track
+
+
+@pytest.fixture
+def dummy_abstract(db, dummy_event, dummy_user):
+    abstract = Abstract(friendly_id=314,
+                        title="Broken Symmetry and the Mass of Gauge Vector Mesons",
+                        event=dummy_event,
+                        submitter=dummy_user,
+                        locator={'event_id': -314, 'abstract_id': 1234},
+                        judgment_comment='Vague but interesting!')
+
+    db.session.add(abstract)
+    db.session.flush()
+    return abstract
+
+
+@pytest.mark.parametrize(('value', 'scale_min', 'scale_max', 'expected'), (
+    (5, 1, 3, 3),
+    (5, 0, 10, 10),
+    (0, 0, 10, 0),
+    (2, 0, 10, 4),
+    (3, 5, 50, 32),
+    (5, 5, 50, 50),
+    (None, 0, 10, None)
+))
+def test_abstract_review_scale_ratings(db, dummy_abstract, dummy_event, dummy_user,
+                                       value, scale_min, scale_max, expected):
+    from indico.modules.events.abstracts.controllers.management import RHManageAbstractReviewing
+    abstracts_reviewing_settings.set(dummy_event, 'scale_lower', 0)
+    abstracts_reviewing_settings.set(dummy_event, 'scale_upper', 5)
+
+    question = AbstractReviewQuestion(field_type='rating', title='Rating')
+    dummy_event.abstract_review_questions.append(question)
+    review = AbstractReview(
+        abstract=dummy_abstract, track=Track(title='Dummy Track', event=dummy_event),
+        user=dummy_user, proposed_action=AbstractAction.accept
+    )
+    rating = AbstractReviewRating(question=question, value=value)
+    review.ratings.append(rating)
+    db.session.flush()
+    rh = RHManageAbstractReviewing()
+    rh.event = dummy_event
+    rh._scale_ratings(scale_min, scale_max)
+    assert rating.value == expected

--- a/indico/modules/events/abstracts/controllers/management_test.py
+++ b/indico/modules/events/abstracts/controllers/management_test.py
@@ -7,7 +7,6 @@
 
 import pytest
 
-from indico.modules.events.abstracts.models.abstracts import Abstract
 from indico.modules.events.abstracts.models.review_questions import AbstractReviewQuestion
 from indico.modules.events.abstracts.models.review_ratings import AbstractReviewRating
 from indico.modules.events.abstracts.models.reviews import AbstractAction, AbstractReview
@@ -15,18 +14,7 @@ from indico.modules.events.abstracts.settings import abstracts_reviewing_setting
 from indico.modules.events.tracks import Track
 
 
-@pytest.fixture
-def dummy_abstract(db, dummy_event, dummy_user):
-    abstract = Abstract(friendly_id=314,
-                        title="Broken Symmetry and the Mass of Gauge Vector Mesons",
-                        event=dummy_event,
-                        submitter=dummy_user,
-                        locator={'event_id': -314, 'abstract_id': 1234},
-                        judgment_comment='Vague but interesting!')
-
-    db.session.add(abstract)
-    db.session.flush()
-    return abstract
+pytest_plugins = 'indico.modules.events.abstracts.testing.fixtures'
 
 
 @pytest.mark.parametrize(('value', 'scale_min', 'scale_max', 'expected'), (

--- a/indico/modules/events/abstracts/notifications_test.py
+++ b/indico/modules/events/abstracts/notifications_test.py
@@ -10,31 +10,19 @@ import re
 import pytest
 
 from indico.modules.events.abstracts.models.abstracts import Abstract, AbstractState
-from indico.modules.events.abstracts.models.persons import AbstractPersonLink
 from indico.modules.events.abstracts.notifications import send_abstract_notifications
 from indico.modules.events.abstracts.util import build_default_email_template
-from indico.modules.events.contributions.models.persons import AuthorType
 from indico.modules.events.contributions.models.types import ContributionType
 from indico.modules.events.tracks.models.tracks import Track
-from indico.modules.users.models.users import UserTitle
 from indico.util.date_time import now_utc
+
+
+pytest_plugins = 'indico.modules.events.abstracts.testing.fixtures'
 
 
 def assert_text_equal(v1, v2):
     """Compare two strings, ignoring white space and line breaks."""
     assert re.sub(r'\s', '', v1) == re.sub(r'\s', '', v2)
-
-
-@pytest.fixture
-def create_dummy_person(db, create_event_person):
-    def _create(abstract, first_name, last_name, email, affiliation, title, is_speaker, author_type):
-        person = create_event_person(abstract.event, first_name=first_name, last_name=last_name, email=email,
-                                     affiliation=affiliation, title=title)
-        link = AbstractPersonLink(abstract=abstract, person=person, is_speaker=is_speaker, author_type=author_type)
-        db.session.add(person)
-        db.session.flush()
-        return link
-    return _create
 
 
 @pytest.fixture
@@ -55,28 +43,6 @@ def create_dummy_contrib_type(db):
         db.session.flush()
         return contrib_type
     return _create
-
-
-@pytest.fixture
-def dummy_abstract(db, dummy_event, dummy_user, create_dummy_person):
-    abstract = Abstract(friendly_id=314,
-                        title="Broken Symmetry and the Mass of Gauge Vector Mesons",
-                        event=dummy_event,
-                        submitter=dummy_user,
-                        locator={'event_id': -314, 'abstract_id': 1234},
-                        judgment_comment='Vague but interesting!')
-
-    author1 = create_dummy_person(abstract, 'John', 'Doe', 'doe@example.com', 'ACME', UserTitle.mr, True,
-                                  AuthorType.primary)
-    author2 = create_dummy_person(abstract, 'Pocahontas', 'Silva', 'pocahontas@example.com', 'ACME', UserTitle.prof,
-                                  False, AuthorType.primary)
-    coauthor1 = create_dummy_person(abstract, 'John', 'Smith', 'smith@example.com', 'ACME', UserTitle.dr, False,
-                                    AuthorType.primary)
-
-    abstract.person_links = [author1, author2, coauthor1]
-    db.session.add(abstract)
-    db.session.flush()
-    return abstract
 
 
 @pytest.fixture

--- a/indico/modules/events/abstracts/testing/fixtures.py
+++ b/indico/modules/events/abstracts/testing/fixtures.py
@@ -1,0 +1,47 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+
+from indico.modules.events.abstracts.models.abstracts import Abstract
+from indico.modules.events.abstracts.models.persons import AbstractPersonLink
+from indico.modules.events.contributions.models.persons import AuthorType
+from indico.modules.users.models.users import UserTitle
+
+
+@pytest.fixture
+def create_dummy_person(db, create_event_person):
+    def _create(abstract, first_name, last_name, email, affiliation, title, is_speaker, author_type):
+        person = create_event_person(abstract.event, first_name=first_name, last_name=last_name, email=email,
+                                     affiliation=affiliation, title=title)
+        link = AbstractPersonLink(abstract=abstract, person=person, is_speaker=is_speaker, author_type=author_type)
+        db.session.add(person)
+        db.session.flush()
+        return link
+    return _create
+
+
+@pytest.fixture
+def dummy_abstract(db, dummy_event, dummy_user, create_dummy_person):
+    abstract = Abstract(friendly_id=314,
+                        title="Broken Symmetry and the Mass of Gauge Vector Mesons",
+                        event=dummy_event,
+                        submitter=dummy_user,
+                        locator={'event_id': -314, 'abstract_id': 1234},
+                        judgment_comment='Vague but interesting!')
+
+    author1 = create_dummy_person(abstract, 'John', 'Doe', 'doe@example.com', 'ACME', UserTitle.mr, True,
+                                  AuthorType.primary)
+    author2 = create_dummy_person(abstract, 'Pocahontas', 'Silva', 'pocahontas@example.com', 'ACME', UserTitle.prof,
+                                  False, AuthorType.primary)
+    coauthor1 = create_dummy_person(abstract, 'John', 'Smith', 'smith@example.com', 'ACME', UserTitle.dr, False,
+                                    AuthorType.primary)
+
+    abstract.person_links = [author1, author2, coauthor1]
+    db.session.add(abstract)
+    db.session.flush()
+    return abstract

--- a/indico/modules/events/papers/controllers/management.py
+++ b/indico/modules/events/papers/controllers/management.py
@@ -190,8 +190,10 @@ class RHManageReviewingSettings(RHManagePapersBase):
             return
         assert scale_max > scale_min
 
-        paper_reviewing_settings.set(self.event, 'scale_lower', scale_min)
-        paper_reviewing_settings.set(self.event, 'scale_upper', scale_max)
+        paper_reviewing_settings.set_multi(self.event, {
+            'scale_lower': scale_min,
+            'scale_upper': scale_max,
+        })
         for rating in self.ratings_query:
             if rating.value is None:
                 continue

--- a/indico/modules/events/papers/controllers/management.py
+++ b/indico/modules/events/papers/controllers/management.py
@@ -173,7 +173,7 @@ class RHCloseCFP(RHManagePapersBase):
 
 class RHManageReviewingSettings(RHManagePapersBase):
     @property
-    def ratings(self):
+    def ratings_query(self):
         return (PaperReviewRating.query
                 .join(PaperReviewRating.review)
                 .join(PaperReview.revision)
@@ -192,7 +192,7 @@ class RHManageReviewingSettings(RHManagePapersBase):
 
         paper_reviewing_settings.set(self.event, 'scale_lower', scale_min)
         paper_reviewing_settings.set(self.event, 'scale_upper', scale_max)
-        for rating in self.ratings:
+        for rating in self.ratings_query:
             if rating.value is None:
                 continue
             value = (rating.value - prev_min) / (prev_max - prev_min)
@@ -202,7 +202,7 @@ class RHManageReviewingSettings(RHManagePapersBase):
         defaults = FormDefaults(content_review_questions=self.event.cfp.content_review_questions,
                                 layout_review_questions=self.event.cfp.layout_review_questions,
                                 **paper_reviewing_settings.get_all(self.event))
-        form = PaperReviewingSettingsForm(event=self.event, obj=defaults, has_ratings=self.ratings.has_rows())
+        form = PaperReviewingSettingsForm(event=self.event, obj=defaults, has_ratings=self.ratings_query.has_rows())
         if form.validate_on_submit():
             data = form.data
             data.update(data.pop('email_settings'))

--- a/indico/modules/events/papers/controllers/management_test.py
+++ b/indico/modules/events/papers/controllers/management_test.py
@@ -1,0 +1,50 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+
+from indico.modules.events.papers.models.papers import Paper
+from indico.modules.events.papers.models.review_questions import PaperReviewQuestion
+from indico.modules.events.papers.models.review_ratings import PaperReviewRating
+from indico.modules.events.papers.models.reviews import PaperAction, PaperReview, PaperReviewType
+from indico.modules.events.papers.models.revisions import PaperRevision
+from indico.modules.events.papers.settings import paper_reviewing_settings
+
+
+@pytest.fixture
+def dummy_paper(dummy_contribution):
+    return Paper(dummy_contribution)
+
+
+@pytest.mark.parametrize(('value', 'scale_min', 'scale_max', 'expected'), (
+    (3, 1, 3, 3),
+    (3, 0, 10, 10),
+    (-3, 0, 10, 0),
+    (0, 0, 10, 5),
+    (1, 5, 50, 35),
+    (3, 5, 50, 50),
+    (None, 0, 10, None)
+))
+def test_paper_review_scale_ratings(db, dummy_paper, dummy_event, dummy_user,
+                                    value, scale_min, scale_max, expected):
+    from indico.modules.events.papers.controllers.management import RHManageReviewingSettings
+    paper_reviewing_settings.set(dummy_event, 'scale_lower', -3)
+    paper_reviewing_settings.set(dummy_event, 'scale_upper', 3)
+
+    question = PaperReviewQuestion(type=PaperReviewType.content, field_type='rating', title='Rating')
+    dummy_event.paper_review_questions.append(question)
+    revision = PaperRevision(submitter=dummy_user, paper=dummy_paper)
+    review = PaperReview(type=PaperReviewType.content, user=dummy_user, proposed_action=PaperAction.accept)
+    revision.reviews.append(review)
+    rating = PaperReviewRating(question=question, value=value)
+    review.ratings.append(rating)
+    db.session.flush()
+
+    rh = RHManageReviewingSettings()
+    rh.event = dummy_event
+    rh._scale_ratings(scale_min, scale_max)
+    assert rating.value == expected

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -83,8 +83,6 @@ class BulkPaperJudgmentForm(IndicoForm):
 class PaperReviewingSettingsForm(IndicoForm):
     """Settings form for paper reviewing."""
 
-    RATING_FIELDS = ('scale_lower', 'scale_upper')
-
     announcement = IndicoMarkdownField(_('Announcement'), editor=True)
     scale_lower = IntegerField(_("Scale (from)"), [InputRequired()])
     scale_upper = IntegerField(_("Scale (to)"), [InputRequired()])

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -95,8 +95,7 @@ class PaperReviewingSettingsForm(IndicoForm):
         self.has_ratings = kwargs.pop('has_ratings', False)
         super().__init__(*args, **kwargs)
         if self.has_ratings:
-            self.scale_upper.warning = _("Some reviewers have already submitted ratings so the scale cannot be changed "
-                                         "anymore.")
+            self.scale_upper.warning = _("Changing the ratings scale will proportionally affect existing ratings.")
 
     def validate_scale_upper(self, field):
         lower = self.scale_lower.data

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -20,7 +20,7 @@ from indico.web.forms.fields import (EditableFileField, FileField, HiddenEnumFie
                                      IndicoDateTimeField, IndicoMarkdownField, IndicoTagListField)
 from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.util import inject_validators
-from indico.web.forms.validators import HiddenUnless, LinkedDateTime, UsedIf
+from indico.web.forms.validators import HiddenUnless, LinkedDateTime
 from indico.web.forms.widgets import SwitchWidget
 
 
@@ -86,8 +86,8 @@ class PaperReviewingSettingsForm(IndicoForm):
     RATING_FIELDS = ('scale_lower', 'scale_upper')
 
     announcement = IndicoMarkdownField(_('Announcement'), editor=True)
-    scale_lower = IntegerField(_("Scale (from)"), [UsedIf(lambda form, field: not form.has_ratings), InputRequired()])
-    scale_upper = IntegerField(_("Scale (to)"), [UsedIf(lambda form, field: not form.has_ratings), InputRequired()])
+    scale_lower = IntegerField(_("Scale (from)"), [InputRequired()])
+    scale_upper = IntegerField(_("Scale (to)"), [InputRequired()])
     email_settings = PaperEmailSettingsField(_("Email notifications"))
 
     def __init__(self, *args, **kwargs):
@@ -107,14 +107,6 @@ class PaperReviewingSettingsForm(IndicoForm):
             raise ValidationError(_("The scale's 'to' value must be greater than the 'from' value."))
         if upper - lower > 20:
             raise ValidationError(_("The difference between 'to' and' from' may not be greater than 20."))
-
-    @property
-    def data(self):
-        data = super().data
-        if self.has_ratings:
-            for key in self.RATING_FIELDS:
-                del data[key]
-        return data
 
 
 class PaperSubmissionForm(IndicoForm):


### PR DESCRIPTION
This is a proposal to loosen the abstract/paper rating scale restriction, that can't be changed after a review has been submitted.
These changes scale the existing scores proportionally to the new scale.