### PR TITLE
Add tooltips for `FileAction`

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
@@ -91,7 +91,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
             <FileAction
               iconName="exchange"
               styleName="exchange-icon"
-              popupContent={Translate.string('Replace')}
+              popupContent={Translate.string('Replace the existing file')}
               active={activeButton === 'replace'}
               onClick={open}
             />
@@ -104,7 +104,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
           <FileAction
             iconName="trash"
             styleName="delete-icon"
-            popupContent={Translate.string('Delete')}
+            popupContent={Translate.string('Delete the existing file')}
             active={activeButton === 'delete'}
             onClick={async () => {
               if (!claimed) {
@@ -121,7 +121,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
           <FileAction
             iconName="undo"
             styleName="undo-icon"
-            popupContent={Translate.string('Undo')}
+            popupContent={Translate.string('Revert to the existing file')}
             active={activeButton === 'undo'}
             onClick={async () => {
               if (!claimed) {

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
@@ -8,27 +8,34 @@
 import PropTypes from 'prop-types';
 import React, {useContext, useCallback, useState} from 'react';
 import {useDropzone} from 'react-dropzone';
-import {Icon} from 'semantic-ui-react';
+import {Icon, Popup} from 'semantic-ui-react';
 
 import {TooltipIfTruncated} from 'indico/react/components';
 import {uploadFile, deleteFile} from 'indico/react/components/files/util';
+import {Translate} from 'indico/react/i18n';
 
 import * as actions from './actions';
 import {FileManagerContext, filePropTypes, uploadFiles, fileTypePropTypes} from './util';
 
 import './FileManager.module.scss';
 
-function FileAction({onClick, active, icon, className}) {
+function FileAction({onClick, active, icon, className, popupContent}) {
   return (
-    <Icon
-      className={className}
-      name={active ? 'spinner' : icon}
-      loading={active}
-      onClick={() => {
-        if (!active) {
-          onClick();
-        }
-      }}
+    <Popup
+      position="bottom center"
+      content={<Translate>{popupContent}</Translate>}
+      trigger={
+        <Icon
+          className={className}
+          name={active ? 'spinner' : icon}
+          loading={active}
+          onClick={() => {
+            if (!active) {
+              onClick();
+            }
+          }}
+        />
+      }
     />
   );
 }
@@ -38,6 +45,7 @@ FileAction.propTypes = {
   active: PropTypes.bool.isRequired,
   icon: PropTypes.string.isRequired,
   className: PropTypes.string.isRequired,
+  popupContent: PropTypes.string.isRequired,
 };
 
 function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, downloadURL}}) {
@@ -86,8 +94,9 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
           <>
             <FileAction
               icon="exchange"
-              active={activeButton === 'replace'}
               styleName="exchange-icon"
+              popupContent="Replace"
+              active={activeButton === 'replace'}
               onClick={open}
             />
             <span {...getRootProps()}>
@@ -97,8 +106,9 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
         )}
         {state !== 'deleted' && state !== 'modified' ? (
           <FileAction
-            styleName="delete-icon"
             icon="trash"
+            styleName="delete-icon"
+            popupContent="Delete"
             active={activeButton === 'delete'}
             onClick={async () => {
               if (!claimed) {
@@ -114,8 +124,9 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
         ) : (
           <FileAction
             icon="undo"
-            active={activeButton === 'undo'}
             styleName="undo-icon"
+            popupContent="Undo"
+            active={activeButton === 'undo'}
             onClick={async () => {
               if (!claimed) {
                 setActiveButton('undo');

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
@@ -19,31 +19,27 @@ import {FileManagerContext, filePropTypes, uploadFiles, fileTypePropTypes} from 
 
 import './FileManager.module.scss';
 
-function FileAction({onClick, active, icon, className, popupContent}) {
-  return (
-    <Popup
-      position="bottom center"
-      content={popupContent}
-      trigger={
-        <Icon
-          className={className}
-          name={active ? 'spinner' : icon}
-          loading={active}
-          onClick={() => {
-            if (!active) {
-              onClick();
-            }
-          }}
-        />
-      }
+function FileAction({onClick, active, iconName, className, popupContent}) {
+  const icon = (
+    <Icon
+      className={className}
+      name={active ? 'spinner' : iconName}
+      loading={active}
+      onClick={() => {
+        if (!active) {
+          onClick();
+        }
+      }}
     />
   );
+
+  return <Popup position="bottom center" content={popupContent} trigger={icon} />;
 }
 
 FileAction.propTypes = {
   onClick: PropTypes.func.isRequired,
   active: PropTypes.bool.isRequired,
-  icon: PropTypes.string.isRequired,
+  iconName: PropTypes.string.isRequired,
   className: PropTypes.string.isRequired,
   popupContent: PropTypes.string.isRequired,
 };
@@ -93,7 +89,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
         {!state && fileType.allowMultipleFiles && (
           <>
             <FileAction
-              icon="exchange"
+              iconName="exchange"
               styleName="exchange-icon"
               popupContent={Translate.string('Replace')}
               active={activeButton === 'replace'}
@@ -106,7 +102,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
         )}
         {state !== 'deleted' && state !== 'modified' ? (
           <FileAction
-            icon="trash"
+            iconName="trash"
             styleName="delete-icon"
             popupContent={Translate.string('Delete')}
             active={activeButton === 'delete'}
@@ -123,7 +119,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
           />
         ) : (
           <FileAction
-            icon="undo"
+            iconName="undo"
             styleName="undo-icon"
             popupContent={Translate.string('Undo')}
             active={activeButton === 'undo'}

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
@@ -19,11 +19,11 @@ import {FileManagerContext, filePropTypes, uploadFiles, fileTypePropTypes} from 
 
 import './FileManager.module.scss';
 
-function FileAction({onClick, active, iconName, className, popupContent}) {
-  const icon = (
+function FileAction({onClick, active, icon, className, popupContent}) {
+  const trigger = (
     <Icon
       className={className}
-      name={active ? 'spinner' : iconName}
+      name={active ? 'spinner' : icon}
       loading={active}
       onClick={() => {
         if (!active) {
@@ -33,13 +33,13 @@ function FileAction({onClick, active, iconName, className, popupContent}) {
     />
   );
 
-  return <Popup position="bottom center" content={popupContent} trigger={icon} />;
+  return <Popup position="bottom center" content={popupContent} trigger={trigger} />;
 }
 
 FileAction.propTypes = {
   onClick: PropTypes.func.isRequired,
   active: PropTypes.bool.isRequired,
-  iconName: PropTypes.string.isRequired,
+  icon: PropTypes.string.isRequired,
   className: PropTypes.string.isRequired,
   popupContent: PropTypes.string.isRequired,
 };
@@ -89,7 +89,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
         {!state && fileType.allowMultipleFiles && (
           <>
             <FileAction
-              iconName="exchange"
+              icon="exchange"
               styleName="exchange-icon"
               popupContent={Translate.string('Replace the existing file')}
               active={activeButton === 'replace'}
@@ -102,7 +102,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
         )}
         {state !== 'deleted' && state !== 'modified' ? (
           <FileAction
-            iconName="trash"
+            icon="trash"
             styleName="delete-icon"
             popupContent={Translate.string('Delete the existing file')}
             active={activeButton === 'delete'}
@@ -119,7 +119,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
           />
         ) : (
           <FileAction
-            iconName="undo"
+            icon="undo"
             styleName="undo-icon"
             popupContent={Translate.string('Revert to the existing file')}
             active={activeButton === 'undo'}

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileList.jsx
@@ -23,7 +23,7 @@ function FileAction({onClick, active, icon, className, popupContent}) {
   return (
     <Popup
       position="bottom center"
-      content={<Translate>{popupContent}</Translate>}
+      content={popupContent}
       trigger={
         <Icon
           className={className}
@@ -95,7 +95,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
             <FileAction
               icon="exchange"
               styleName="exchange-icon"
-              popupContent="Replace"
+              popupContent={Translate.string('Replace')}
               active={activeButton === 'replace'}
               onClick={open}
             />
@@ -108,7 +108,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
           <FileAction
             icon="trash"
             styleName="delete-icon"
-            popupContent="Delete"
+            popupContent={Translate.string('Delete')}
             active={activeButton === 'delete'}
             onClick={async () => {
               if (!claimed) {
@@ -125,7 +125,7 @@ function FileEntry({uploadURL, fileType, file: {uuid, filename, state, claimed, 
           <FileAction
             icon="undo"
             styleName="undo-icon"
-            popupContent="Undo"
+            popupContent={Translate.string('Undo')}
             active={activeButton === 'undo'}
             onClick={async () => {
               if (!claimed) {


### PR DESCRIPTION
Closes #4941

Adds tooltips to file actions to make it more clear what they do.

![Screenshot from 2021-06-11 14-04-41](https://user-images.githubusercontent.com/8739637/121683663-0025b400-cabe-11eb-94c6-c3c6327732d2.png)
