### PR TITLE
Add option to blacklist emails when registering users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,7 @@ Improvements
 - Support cloning surveys when cloning events (:issue:`2045`, :pr:`4910`)
 - Show external contribution references in conferences (:issue:`4928`, :pr:`4933`)
 - Allow changing the rating scale in abstract/paper reviewing even after reviewing started (:pr:`4942`)
+- Allow blacklisting email addresses for user registrations (:issue:`4644`, :pr:`4946`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/users/__init__.py
+++ b/indico/modules/users/__init__.py
@@ -40,7 +40,8 @@ user_settings = UserSettingsProxy('users', {
 })
 
 user_management_settings = SettingsProxy('user_management', {
-    'notify_account_creation': False
+    'notify_account_creation': False,
+    'email_blacklist': []
 })
 
 

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -111,9 +111,8 @@ class AdminUserSettingsForm(IndicoForm):
                                                          'registers a new local account.'))
     email_blacklist = MultiStringField(_('Email blacklist'), field=('email_blacklist', _('email')),
                                        unique=True, flat=True,
-                                       description=_('Disallow users from registering with these email addresses. '
-                                                     'Comma-separated list of addresses. '
-                                                     'Supports wildcards (*), e.g., *@gmail.com.'))
+                                       description=_('Prevent users from creating Indico accounts with these email '
+                                                     'addresses. Supports wildcards, e.g. *@gmail.com'))
 
 
 class AdminAccountRegistrationForm(LocalRegistrationForm):

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -20,7 +20,7 @@ from indico.modules.users.models.emails import UserEmail
 from indico.modules.users.models.users import NameFormat, UserTitle
 from indico.util.i18n import _, get_all_locales
 from indico.web.forms.base import IndicoForm, SyncedInputsMixin
-from indico.web.forms.fields import IndicoEnumSelectField, PrincipalField, PrincipalListField
+from indico.web.forms.fields import IndicoEnumSelectField, MultiStringField, PrincipalField, PrincipalListField
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless, used_if_not_synced
 from indico.web.forms.widgets import SwitchWidget, SyncedInputWidget
@@ -109,6 +109,11 @@ class AdminUserSettingsForm(IndicoForm):
     notify_account_creation = BooleanField(_('Registration notifications'), widget=SwitchWidget(),
                                            description=_('Send an email to all administrators whenever someone '
                                                          'registers a new local account.'))
+    email_blacklist = MultiStringField(_('Email blacklist'), field=('email_blacklist', _('email')),
+                                       unique=True, flat=True,
+                                       description=_('Disallow users from registering with these email addresses. '
+                                                     'Comma-separated list of addresses. '
+                                                     'Supports wildcards (*), e.g., *@gmail.com.'))
 
 
 class AdminAccountRegistrationForm(LocalRegistrationForm):


### PR DESCRIPTION
Closes #4644 

Adds a new field to the admin user settings cog menu where one can specify a
comma-separated list of blacklisted email addresses.

It is possible to use specific addresses or wildcard patterns using the symbol *, e.g., `*@gmail.com`,
which would blacklist all `@gmail.com` emails.

![image](https://user-images.githubusercontent.com/8739637/121909306-146fe800-cd2e-11eb-8bd7-cc3ed74f11ac.png)

![Screenshot from 2021-06-14 14-44-55](https://user-images.githubusercontent.com/8739637/121895529-9fe27c80-cd20-11eb-97d8-eb793a8a402d.png)
