### PR TITLE
Auto-expand notes from meeting note permalinks

### DIFF
--- a/indico/modules/events/notes/blueprint.py
+++ b/indico/modules/events/notes/blueprint.py
@@ -6,7 +6,7 @@
 # LICENSE file for more details.
 
 from indico.modules.events import event_object_url_prefixes
-from indico.modules.events.notes.controllers import RHCompileNotes, RHDeleteNote, RHEditNote, RHViewNote
+from indico.modules.events.notes.controllers import RHCompileNotes, RHDeleteNote, RHEditNote, RHGotoNote, RHViewNote
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
@@ -23,3 +23,5 @@ for object_type, prefixes in event_object_url_prefixes.items():
                          defaults={'object_type': object_type})
         _bp.add_url_rule(prefix + '/note/delete', 'delete', RHDeleteNote, methods=('POST',),
                          defaults={'object_type': object_type})
+
+_bp.add_url_rule('/note/<int:note_id>', 'goto', RHGotoNote)

--- a/indico/modules/events/notes/templates/_note.html
+++ b/indico/modules/events/notes/templates/_note.html
@@ -1,13 +1,13 @@
-{% macro render_note(note, hidden=true, can_edit=false, for_event=none) %}
+{% macro render_note(note, hidden=true, can_edit=false, for_event=none, anchor=none) %}
     {% if note %}
         {% if for_event %}
             <div class="event-note-section">
-                {{ _render_note_box(note=note, event=for_event, hidden=hidden, can_edit=can_edit) }}
+                {{ _render_note_box(note=note, event=for_event, hidden=hidden, can_edit=can_edit, anchor=anchor) }}
             </div>
         {% else %}
             <div class="note-area-wrapper">
                 <div class="note-area {{ _togglable_classes(hidden) }}">
-                    {{ _render_note_box(note=note, can_edit=can_edit) }}
+                    {{ _render_note_box(note=note, can_edit=can_edit, anchor=anchor) }}
                 </div>
             </div>
         {% endif %}
@@ -15,7 +15,7 @@
 {% endmacro %}
 
 
-{% macro render_toggle_button(note, note_is_hidden) %}
+{% macro render_toggle_button(note, note_is_hidden, anchor=none) %}
     <div class="group i-selection note-visibility-toggle">
         {% set hash = uuid() %}
         <input type="checkbox" class="js-toggle-note-cb" id="toggle-note-{{ note.id }}-{{ hash }}" {% if not note_is_hidden %}checked{% endif %}>
@@ -25,11 +25,11 @@
 {% endmacro %}
 
 
-{% macro _render_note_box(note, event=none, hidden=false, can_edit=false) %}
+{% macro _render_note_box(note, event=none, hidden=false, can_edit=false, anchor=none) %}
     <div class="padded-box">
         <div class="padded-box-pad icon-file-text"></div>
         <div class="padded-box-content">
-            {{ _render_note_actions(note=note, event=event, hidden=hidden, can_edit=can_edit) }}
+            {{ _render_note_actions(note=note, event=event, hidden=hidden, can_edit=can_edit, anchor=anchor) }}
             <div class="note-text {% if event %}{{ _togglable_classes(hidden=hidden) }}{% endif %}">
                 {{ note.html|sanitize_html }}
             </div>
@@ -54,12 +54,12 @@
 {% endmacro %}
 
 
-{% macro _render_note_actions(note, event=none, hidden=true, can_edit=false) %}
+{% macro _render_note_actions(note, event=none, hidden=true, can_edit=false, anchor=none) %}
     <div class="note-actions {% if event %}{{ _togglable_classes(hidden) }}{% endif %}">
         {% if event %}
             <a href="#" class="js-show-note-toggle">{% trans %}Hide{% endtrans %}</a>
         {% endif %}
-        <a href="{{ url_for('event_notes.view', note) }}" target="_blank"
+        <a href="?note={{ note.id }}{% if anchor %}#{{ anchor }}{% endif %}" target="_blank"
            class="permalink icon-link" title="{% trans %}Permanent link{% endtrans %}"></a>
         {% if can_edit %}
             <a href="#" class="icon-edit js-note-editor hide-if-locked"

--- a/indico/modules/events/notes/templates/_note.html
+++ b/indico/modules/events/notes/templates/_note.html
@@ -54,12 +54,19 @@
 {% endmacro %}
 
 
+{% macro _note_link(note, anchor) -%}
+    {%- set url_kw = dict(request.view_args, **request.args.to_dict(false)) -%}
+    {%- set __ = url_kw.pop('note', none) -%}
+    {{- url_for(request.endpoint, note=note.id, _anchor=anchor, **url_kw) -}}
+{%- endmacro %}
+
+
 {% macro _render_note_actions(note, event=none, hidden=true, can_edit=false, anchor=none) %}
     <div class="note-actions {% if event %}{{ _togglable_classes(hidden) }}{% endif %}">
         {% if event %}
             <a href="#" class="js-show-note-toggle">{% trans %}Hide{% endtrans %}</a>
         {% endif %}
-        <a href="?note={{ note.id }}{% if anchor %}#{{ anchor }}{% endif %}" target="_blank"
+        <a href="{{ _note_link(note, anchor) }}" target="_blank"
            class="permalink icon-link" title="{% trans %}Permanent link{% endtrans %}"></a>
         {% if can_edit %}
             <a href="#" class="icon-edit js-note-editor hide-if-locked"

--- a/indico/modules/events/sessions/models/blocks.py
+++ b/indico/modules/events/sessions/models/blocks.py
@@ -14,7 +14,7 @@ from indico.core.db import db
 from indico.core.db.sqlalchemy.locations import LocationMixin
 from indico.core.db.sqlalchemy.util.models import auto_table_args
 from indico.util.locators import locator_property
-from indico.util.string import format_repr
+from indico.util.string import format_repr, slugify
 
 
 class SessionBlock(LocationMixin, db.Model):
@@ -131,6 +131,10 @@ class SessionBlock(LocationMixin, db.Model):
     @property
     def end_dt(self):
         return self.timetable_entry.start_dt + self.duration if self.timetable_entry else None
+
+    @property
+    def slug(self):
+        return slugify('b', self.id, self.session.title, self.title, maxlen=30)
 
     def __repr__(self):
         return format_repr(self, 'id', _text=self.title or None)

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -172,12 +172,7 @@
         {% if toggle_notes and item.has_note %}
             {% set req = request.args.get('note') %}
             {% set note_id = item.note.id|string %}
-
-            {% if req == note_id %}
-                {{ render_toggle_button(note=item.note, note_is_hidden=false, anchor=anchor) }}
-            {% else %}
-                {{ render_toggle_button(note=item.note, note_is_hidden=(not show_notes), anchor=anchor) }}
-            {% endif %}
+            {{ render_toggle_button(item.note, note_is_hidden=(req != note_id and not show_notes), anchor=anchor) }}
         {% endif %}
         {% if show_button %}
             <div class="group manage-button">

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -165,11 +165,19 @@
     </ul>
 {%- endmacro %}
 
-{% macro render_manage_button(item, item_type, show_notes=true, toggle_notes=true, show_note_operations=false,
-                              show_button=true) -%}
+{% macro render_manage_button(item, item_type, show_notes=true,
+                              toggle_notes=true, show_note_operations=false,
+                              show_button=true, anchor=none) -%}
     <div class="toolbar right thin">
         {% if toggle_notes and item.has_note %}
-            {{ render_toggle_button(note=item.note, note_is_hidden=not show_notes) }}
+            {% set req = request.args.get('note') %}
+            {% set note_id = item.note.id|string %}
+
+            {% if req == note_id %}
+                {{ render_toggle_button(note=item.note, note_is_hidden=false, anchor=anchor) }}
+            {% else %}
+                {{ render_toggle_button(note=item.note, note_is_hidden=(not show_notes), anchor=anchor) }}
+            {% endif %}
         {% endif %}
         {% if show_button %}
             <div class="group manage-button">

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -1,6 +1,7 @@
 {% from 'events/display/_event_header_message.html' import render_event_header_msg %}
 {% from 'events/display/common/_manage_button.html' import render_manage_button %}
 {% from 'events/display/indico/_common.html' import render_location, render_users, render_event_time %}
+{% from 'events/timetable/display/indico/_common.html' import render_notes %}
 {% from 'events/notes/_note.html' import render_note %}
 
 {{ render_event_header_msg(event) }}
@@ -60,10 +61,7 @@
             </div>
         {% endif %}
 
-        {% if event.has_note %}
-            {{ render_note(event.note, hidden=not theme_settings.show_notes, can_edit=event.can_manage(session.user),
-                           for_event=event) }}
-        {% endif %}
+        {{ render_notes(event, for_event=event) }}
 
         <div class="event-body {{ 'event-locked' if event.is_locked }}">
             {{ template_hook('meeting-body', event=event) }}

--- a/indico/modules/events/timetable/templates/display/indico/_common.html
+++ b/indico/modules/events/timetable/templates/display/indico/_common.html
@@ -54,8 +54,18 @@
     </div>
 {%- endmacro %}
 
-{% macro render_notes(item) -%}
+{% macro render_notes(item, for_event=none, anchor=none) -%}
     {% if item.has_note %}
-        {{ render_note(note=item.note, can_edit=item.can_edit_note(session.user)) }}
+        {# Check if url contains ?note=note_id and if so, expand the note #}
+        {% set req = request.args.get('note') %}
+        {% set note_id = item.note.id|string %}
+
+        {% if req == note_id %}
+            {{ render_note(note=item.note, hidden=false, can_edit=item.can_edit_note(session.user),
+                           for_event=for_event, anchor=anchor) }}
+        {% else %}
+            {{ render_note(note=item.note, can_edit=item.can_edit_note(session.user),
+                           for_event=for_event, anchor=anchor) }}
+        {% endif %}
     {% endif %}
 {%- endmacro %}

--- a/indico/modules/events/timetable/templates/display/indico/_common.html
+++ b/indico/modules/events/timetable/templates/display/indico/_common.html
@@ -56,16 +56,9 @@
 
 {% macro render_notes(item, for_event=none, anchor=none) -%}
     {% if item.has_note %}
-        {# Check if url contains ?note=note_id and if so, expand the note #}
         {% set req = request.args.get('note') %}
         {% set note_id = item.note.id|string %}
-
-        {% if req == note_id %}
-            {{ render_note(note=item.note, hidden=false, can_edit=item.can_edit_note(session.user),
-                           for_event=for_event, anchor=anchor) }}
-        {% else %}
-            {{ render_note(note=item.note, can_edit=item.can_edit_note(session.user),
-                           for_event=for_event, anchor=anchor) }}
-        {% endif %}
+        {{ render_note(item.note, hidden=(req != note_id), can_edit=item.can_edit_note(session.user),
+                       for_event=for_event, anchor=anchor) }}
     {% endif %}
 {%- endmacro %}

--- a/indico/modules/events/timetable/templates/display/indico/_contribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_contribution.html
@@ -19,7 +19,7 @@
 
         <div class="timetable-item-body flexcol">
             <div class="timetable-item-header flexrow">
-                <span class="timetable-title {{ 'nested' if nested }}" data-anchor="{{ contrib.slug }}">
+                <span class="timetable-title {{ 'nested' if nested }}" data-anchor="{{ contrib.slug }}" data-anchor-strip-arg="note">
                     {{- contrib.title -}}
                 </span>
                 {% if contrib.duration and not theme_settings.hide_duration -%}
@@ -52,7 +52,7 @@
             {%- endif %}
             {{ render_attachments(contrib) }}
 
-            {{ render_notes(contrib) }}
+            {{ render_notes(contrib, anchor=contrib.slug) }}
 
             {% if contrib.subcontributions %}
                 <ul class="subcontrib-list">

--- a/indico/modules/events/timetable/templates/display/indico/_session_block.html
+++ b/indico/modules/events/timetable/templates/display/indico/_session_block.html
@@ -11,9 +11,7 @@
     {% set session_ = block.session %}
     {% set entries = block.timetable_entry.children %}
 
-    {% set anchor = slugify('b', block.id, session_.title, block.title, maxlen=30) %}
-
-    <li class="timetable-item timetable-block" id="{{ anchor }}">
+    <li class="timetable-item timetable-block" id="{{ block.slug }}">
         <span class="timetable-time top-level">
             {% if not theme_settings.hide_session_block_time %}
                 {{ render_time(block, timezone=timezone) }}
@@ -21,7 +19,7 @@
         </span>
         <div class="timetable-item-body flexcol">
             <div class="timetable-item-header flexrow">
-                <span class="timetable-title top-level" data-anchor="{{ anchor }}">
+                <span class="timetable-title top-level" data-anchor="{{ block.slug }}" data-anchor-strip-arg="note">
                     {%- if block.title and block.title != session_.title -%}
                         {{- session_.title -}}: {{ block.title -}}
                     {%- else -%}
@@ -34,7 +32,7 @@
                 <div class="timetable-item-actions">
                     {{ render_manage_button(block, 'SESSION_BLOCK', show_notes=show_notes,
                                             show_button=(not event.is_locked and
-                                                         block.can_manage_attachments(session.user))) }}
+                                                         block.can_manage_attachments(session.user)), anchor=block.slug) }}
                     {{ template_hook('vc-actions', event=event, item=block) }}
                 </div>
             </div>
@@ -57,7 +55,7 @@
                 </tbody>
             </table>
 
-            {{ render_notes(session_) }}
+            {{ render_notes(session_, anchor=block.slug) }}
 
             {% if entries and not hide_contribs -%}
                 <ul class="meeting-sub-timetable">

--- a/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
@@ -7,7 +7,7 @@
     <li class="timetable-subcontrib timetable-item" id="{{ subcontrib.slug }}">
         <div class="timetable-item-body flexcol">
             <div class="timetable-item-header flexrow">
-                <span class="timetable-title" data-anchor="{{ subcontrib.slug }}">
+                <span class="timetable-title" data-anchor="{{ subcontrib.slug }}" data-anchor-strip-arg="note">
                     {% if theme_settings.number_contributions %}
                         {%- set n_scontrib = theme_context.num_subcontribution -%}
                         {{- 'abcdefghijklmnopqrstuvwxyz'[(n_scontrib - 1) % 26] * ((n_scontrib - 1) // 26 + 1) }})
@@ -44,7 +44,7 @@
                 </tbody>
             </table>
 
-            {{ render_notes(subcontrib) }}
+            {{ render_notes(subcontrib, anchor=subcontrib.slug) }}
         </div>
     </li>
 {% endmacro %}

--- a/indico/modules/events/timetable/templates/display/indico/meeting.html
+++ b/indico/modules/events/timetable/templates/display/indico/meeting.html
@@ -22,7 +22,7 @@
                     {% if multiple_days %}
                         {% block day_header scoped %}
                             <div class="day-header" style="width: 100%;">
-                                <div class="day-title" data-anchor="{{ anchor }}">
+                                <div class="day-title" data-anchor="{{ anchor }}" data-anchor-strip-arg="note">
                                     {{ item.start_dt | format_date(format='EEEE, d MMMM', timezone=timezone) }}
                                 </div>
                                 {% if days %}

--- a/indico/modules/search/result_schemas.py
+++ b/indico/modules/search/result_schemas.py
@@ -199,32 +199,7 @@ class EventNoteResultSchema(ResultSchemaBase):
     event_path = fields.Method('_get_event_path', dump_only=True)
 
     def _get_url(self, data):
-        note_id = data['note_id']
-        event_id = data['event_id']
-        note = EventNote.get(note_id)
-        event = Event.get(data['event_id'])
-
-        # Keep the fallback URL for conferences
-        if not event or event.type_ == EventType.conference:
-            return self._get_fallback_url(data)
-
-        # Notes attached to the meeting itself don't have fragments to anchor to
-        if event.note and event.note.id == note_id:
-            return url_for('events.display', event_id=event_id, note=note_id)
-
-        # Find the parent of the note
-        if note.session and (block := note.session.blocks[0]):
-            return url_for('events.display', event_id=event_id, note=note_id, _anchor=block.slug)
-        elif (contrib := note.contribution):
-            return url_for('events.display', event_id=event_id, note=note_id, _anchor=contrib.slug)
-        elif (subcontrib := note.subcontribution):
-            return url_for('events.display', event_id=event_id, note=note_id, _anchor=subcontrib.slug)
-        else:
-            return self._get_fallback_url(data)
-
-    def _get_fallback_url(self, data):
-        return url_for('event_notes.view', event_id=data['event_id'],
-                       contrib_id=data['contribution_id'], subcontrib_id=data['subcontribution_id'])
+        return url_for('event_notes.goto', event_id=data['event_id'], note_id=data['note_id'])
 
     def _get_event_path(self, data):
         if not (note := EventNote.get(data['note_id'])):

--- a/indico/web/client/js/jquery/utils/declarative.js
+++ b/indico/web/client/js/jquery/utils/declarative.js
@@ -345,9 +345,18 @@ import {$T} from '../../utils/i18n';
       const $elem = $(this);
       const fragment = $elem.data('anchor');
       const permalink = $elem.data('permalink');
+      const stripArg = $elem.data('anchor-strip-arg');
+
+      // remove the field `stripArg` from the query string
+      const params = new URLSearchParams(window.location.search);
+      if (stripArg) {
+        params.delete(stripArg);
+      }
+      const url = window.location.pathname + params.toString();
+
       $('<a>', {
         class: 'anchor-link',
-        href: permalink || `#${fragment}`,
+        href: permalink || `${url}#${fragment}`,
         title: $elem.data('anchor-text') || $T.gettext('Direct link to this item'),
       })
         .html('&para;')


### PR DESCRIPTION
Resolves #4947

Currently, the meeting notes permalinks lead to a plain HTML page with just the notes.

This commit changes the permalink to point to the contribution/block title fragment on the
event page (same link when clicking the direct link next to the title).

In addition, it also adds `?note=note_id` to the query string of the permalink.
This query field is used to automatically expand the relevant note when the event page is loaded.

This includes both the individual notes and the `main` note on the event itself.

To test this, go to a meeting which has minutes attached, expand the minutes and click on the permalink.
The link should lead to the event page with the block title highlighted and the minutes expanded.

Furthermore, the search results for notes now use the this new URL instead.

