### PR TITLE
Support local search for other result types

### DIFF
--- a/indico/core/db/sqlalchemy/util/queries.py
+++ b/indico/core/db/sqlalchemy/util/queries.py
@@ -137,7 +137,7 @@ def get_related_object(obj, relationship, criteria):
     return cls.query.with_parent(obj, relationship).filter_by(**criteria).first()
 
 
-def get_n_matching(query, n, predicate, *, prefetch_factor=5):
+def get_n_matching(query, n, predicate, *, prefetch_factor=5, preload_bulk=None):
     """Get N objects from a query that satisfy a condition.
 
     This queries for ``n * 5`` objects initially and then loads
@@ -148,6 +148,9 @@ def get_n_matching(query, n, predicate, *, prefetch_factor=5):
     :param n: The max number of objects to return
     :param predicate: A callable used to filter the found objects
     :param prefetch_factor: Prefetch ``n * factor`` objects in each query
+    :param preload_bulk: Function that's called with the full set of objects
+                         to allow for bulk-preloading of data neede in the
+                         predicate function
     """
     _offset = 0
 
@@ -163,6 +166,9 @@ def get_n_matching(query, n, predicate, *, prefetch_factor=5):
         objects = _get()
         if not objects:
             break
+
+        if preload_bulk:
+            preload_bulk(objects)
 
         for obj in objects:
             if not predicate(obj):

--- a/indico/migrations/versions/20210615_1612_fda76e047e87_make_sure_contributions_have_titles.py
+++ b/indico/migrations/versions/20210615_1612_fda76e047e87_make_sure_contributions_have_titles.py
@@ -1,0 +1,26 @@
+"""Make sure contributions have titles
+
+Revision ID: fda76e047e87
+Revises: 735dc4e8d2f3
+Create Date: 2021-06-15 16:12:55.960647
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'fda76e047e87'
+down_revision = '735dc4e8d2f3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('''
+        UPDATE events.contributions SET title = '(no title)' WHERE title = '';
+        UPDATE events.subcontributions SET title = '(no title)' WHERE title = '';
+    ''')
+
+
+def downgrade():
+    pass

--- a/indico/migrations/versions/20210615_1627_79e770865675_add_more_fts_indexes.py
+++ b/indico/migrations/versions/20210615_1627_79e770865675_add_more_fts_indexes.py
@@ -1,0 +1,46 @@
+"""Add more FTS indexes
+
+Revision ID: 79e770865675
+Revises: fda76e047e87
+Create Date: 2021-06-15 16:27:35.922384
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '79e770865675'
+down_revision = 'fda76e047e87'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_check_constraint('valid_title', 'contributions', "title != ''", schema='events')
+    op.create_check_constraint('valid_title', 'subcontributions', "title != ''", schema='events')
+    op.create_index('ix_contributions_title_fts', 'contributions', [sa.text("to_tsvector('simple', title)")],
+                    schema='events', postgresql_using='gin')
+    op.create_index('ix_subcontributions_title_fts', 'subcontributions', [sa.text("to_tsvector('simple', title)")],
+                    schema='events', postgresql_using='gin')
+    op.create_index('ix_attachments_title_fts', 'attachments', [sa.text("to_tsvector('simple', title)")],
+                    schema='attachments', postgresql_using='gin')
+    op.create_index('ix_contributions_description_fts', 'contributions',
+                    [sa.text("to_tsvector('simple', description)")],
+                    schema='events', postgresql_using='gin')
+    op.create_index('ix_subcontributions_description_fts', 'subcontributions',
+                    [sa.text("to_tsvector('simple', description)")],
+                    schema='events', postgresql_using='gin')
+    op.create_index('ix_notes_html_fts', 'notes', [sa.text("to_tsvector('simple', html)")],
+                    schema='events', postgresql_using='gin')
+
+
+def downgrade():
+    op.drop_constraint('ck_contributions_valid_title', 'contributions', schema='events')
+    op.drop_constraint('ck_subcontributions_valid_title', 'subcontributions', schema='events')
+    op.drop_index('ix_contributions_title_fts', table_name='contributions', schema='events')
+    op.drop_index('ix_subcontributions_title_fts', table_name='subcontributions', schema='events')
+    op.drop_index('ix_attachments_title_fts', table_name='attachments', schema='attachments')
+    op.drop_index('ix_contributions_description_fts', table_name='contributions', schema='events')
+    op.drop_index('ix_subcontributions_description_fts', table_name='subcontributions', schema='events')
+    op.drop_index('ix_notes_html_fts', table_name='notes', schema='events')

--- a/indico/modules/attachments/models/attachments.py
+++ b/indico/modules/attachments/models/attachments.py
@@ -254,7 +254,7 @@ class Attachment(SearchableTitleMixin, ProtectionMixin, VersionedResourceMixin, 
         or if the user can manage attachments for the linked object.
         """
         return (super().can_access(user, *args, **kwargs) or
-                can_manage_attachments(self.folder.object, user))
+                can_manage_attachments(self.folder.object, user, allow_admin=kwargs.get('allow_admin', True)))
 
     def __repr__(self):
         return '<Attachment({}, {}, {}{}, {}, {})>'.format(

--- a/indico/modules/attachments/models/folders.py
+++ b/indico/modules/attachments/models/folders.py
@@ -148,7 +148,7 @@ class AttachmentFolder(LinkMixin, ProtectionMixin, db.Model):
         user can manage attachments for the linked object.
         """
         return (super().can_access(user, *args, **kwargs) or
-                can_manage_attachments(self.object, user))
+                can_manage_attachments(self.object, user, allow_admin=kwargs.get('allow_admin', True)))
 
     def can_view(self, user):
         """Check if the user can see the folder.

--- a/indico/modules/attachments/util.py
+++ b/indico/modules/attachments/util.py
@@ -59,18 +59,18 @@ def get_attached_items(linked_object, include_empty=True, include_hidden=True, p
     }
 
 
-def can_manage_attachments(obj, user):
+def can_manage_attachments(obj, user, allow_admin=True):
     """Check if a user can manage attachments for the object."""
     if not user:
         return False
-    if obj.can_manage(user):
+    if obj.can_manage(user, allow_admin=allow_admin):
         return True
-    if isinstance(obj, db.m.Event) and obj.can_manage(user, 'submit'):
+    if isinstance(obj, db.m.Event) and obj.can_manage(user, 'submit', allow_admin=allow_admin):
         return True
-    if isinstance(obj, db.m.Contribution) and obj.can_manage(user, 'submit'):
+    if isinstance(obj, db.m.Contribution) and obj.can_manage(user, 'submit', allow_admin=allow_admin):
         return True
     if isinstance(obj, db.m.SubContribution):
-        return can_manage_attachments(obj.contribution, user)
+        return can_manage_attachments(obj.contribution, user, allow_admin=allow_admin)
     return False
 
 

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -63,6 +63,7 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
     possible_render_modes = {RenderMode.markdown}
     default_render_mode = RenderMode.markdown
     allow_no_access_contact = True
+    allow_relationship_preloading = True
     ATTACHMENT_FOLDER_ID_COLUMN = 'category_id'
 
     @strict_classproperty
@@ -572,6 +573,13 @@ def _mappers_configured():
     cte = Category.get_tree_cte('title')
     query = select([cte.c.path]).where(cte.c.id == Category.id).correlate_except(cte).scalar_subquery()
     Category.chain_titles = column_property(query, deferred=True)
+
+    # Category.chain_ids -- a list of the ids in the parent chain,
+    # starting with the root category down to the current category.
+    # This is equivalent to the `category_chain` in the Event model.
+    cte = Category.get_tree_cte()
+    query = select([cte.c.path]).where(cte.c.id == Category.id).correlate_except(cte).scalar_subquery()
+    Category.chain_ids = column_property(query, deferred=True)
 
     # Category.chain -- a list of the ids and titles in the parent
     # chain, starting with the root category down to the current

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -21,7 +21,7 @@ from indico.core.db.sqlalchemy import PyIntEnum
 from indico.core.db.sqlalchemy.attachments import AttachedItemsMixin
 from indico.core.db.sqlalchemy.descriptions import DescriptionMixin, RenderMode
 from indico.core.db.sqlalchemy.protection import ProtectionManagersMixin, ProtectionMode
-from indico.core.db.sqlalchemy.searchable_titles import SearchableTitleMixin
+from indico.core.db.sqlalchemy.searchable import SearchableTitleMixin
 from indico.core.db.sqlalchemy.util.models import auto_table_args
 from indico.util.date_time import get_display_tz
 from indico.util.decorators import strict_classproperty

--- a/indico/modules/events/contributions/models/contributions.py
+++ b/indico/modules/events/contributions/models/contributions.py
@@ -15,10 +15,11 @@ from sqlalchemy.orm.base import NEVER_SET, NO_VALUE
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy.attachments import AttachedItemsMixin
-from indico.core.db.sqlalchemy.descriptions import DescriptionMixin, RenderMode
+from indico.core.db.sqlalchemy.descriptions import RenderMode, SearchableDescriptionMixin
 from indico.core.db.sqlalchemy.locations import LocationMixin
 from indico.core.db.sqlalchemy.notes import AttachedNotesMixin
 from indico.core.db.sqlalchemy.protection import ProtectionManagersMixin
+from indico.core.db.sqlalchemy.searchable import SearchableTitleMixin
 from indico.core.db.sqlalchemy.util.models import auto_table_args
 from indico.core.db.sqlalchemy.util.queries import increment_and_get
 from indico.core.db.sqlalchemy.util.session import no_autoflush
@@ -69,8 +70,9 @@ class CustomFieldsMixin:
         return old_value
 
 
-class Contribution(DescriptionMixin, ProtectionManagersMixin, LocationMixin, AttachedItemsMixin, AttachedNotesMixin,
-                   PersonLinkDataMixin, AuthorsSpeakersMixin, CustomFieldsMixin, db.Model):
+class Contribution(SearchableTitleMixin, SearchableDescriptionMixin, ProtectionManagersMixin, LocationMixin,
+                   AttachedItemsMixin, AttachedNotesMixin, PersonLinkDataMixin, AuthorsSpeakersMixin, CustomFieldsMixin,
+                   db.Model):
     __tablename__ = 'contributions'
     __auto_table_args = (db.Index(None, 'friendly_id', 'event_id', unique=True,
                                   postgresql_where=db.text('NOT is_deleted')),
@@ -159,10 +161,6 @@ class Contribution(DescriptionMixin, ProtectionManagersMixin, LocationMixin, Att
         db.ForeignKey('events.contribution_types.id'),
         index=True,
         nullable=True
-    )
-    title = db.Column(
-        db.String,
-        nullable=False
     )
     code = db.Column(
         db.String,

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -1018,6 +1018,7 @@ def _mappers_configured():
     query = (select([db.case({ProtectionMode.inheriting.value: Category.effective_protection_mode},
                              else_=Event.protection_mode, value=Event.protection_mode)])
              .where(Category.id == Event.category_id)
+             .correlate(Event)
              .scalar_subquery())
     Event.effective_protection_mode = column_property(query, deferred=True)
 

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -29,7 +29,7 @@ from indico.core.db.sqlalchemy.locations import LocationMixin
 from indico.core.db.sqlalchemy.notes import AttachedNotesMixin
 from indico.core.db.sqlalchemy.principals import PrincipalType
 from indico.core.db.sqlalchemy.protection import ProtectionManagersMixin, ProtectionMode
-from indico.core.db.sqlalchemy.searchable_titles import SearchableTitleMixin
+from indico.core.db.sqlalchemy.searchable import SearchableTitleMixin
 from indico.core.db.sqlalchemy.util.models import auto_table_args
 from indico.core.db.sqlalchemy.util.queries import db_dates_overlap, get_related_object
 from indico.modules.categories import Category

--- a/indico/modules/search/internal.py
+++ b/indico/modules/search/internal.py
@@ -5,15 +5,59 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from sqlalchemy.orm import subqueryload, undefer
+import itertools
 
+from sqlalchemy.orm import contains_eager, joinedload, load_only, raiseload, selectinload, subqueryload, undefer
+
+from indico.core.db import db
+from indico.core.db.sqlalchemy.links import LinkType
 from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.core.db.sqlalchemy.util.queries import get_n_matching
+from indico.modules.attachments.models.attachments import Attachment
+from indico.modules.attachments.models.folders import AttachmentFolder
+from indico.modules.attachments.models.principals import AttachmentFolderPrincipal, AttachmentPrincipal
 from indico.modules.categories import Category
+from indico.modules.categories.models.principals import CategoryPrincipal
 from indico.modules.events import Event
+from indico.modules.events.contributions.models.contributions import Contribution
+from indico.modules.events.contributions.models.principals import ContributionPrincipal
+from indico.modules.events.contributions.models.subcontributions import SubContribution
+from indico.modules.events.models.principals import EventPrincipal
+from indico.modules.events.notes.models.notes import EventNote, EventNoteRevision
+from indico.modules.events.sessions.models.blocks import SessionBlock
+from indico.modules.events.sessions.models.principals import SessionPrincipal
+from indico.modules.events.sessions.models.sessions import Session
 from indico.modules.search.base import IndicoSearchProvider, SearchTarget
-from indico.modules.search.result_schemas import CategoryResultSchema, EventResultSchema
-from indico.modules.search.schemas import DetailedCategorySchema, HTMLStrippingEventSchema
+from indico.modules.search.result_schemas import (AttachmentResultSchema, CategoryResultSchema,
+                                                  ContributionResultSchema, EventNoteResultSchema, EventResultSchema)
+from indico.modules.search.schemas import (AttachmentSchema, DetailedCategorySchema, HTMLStrippingContributionSchema,
+                                           HTMLStrippingEventNoteSchema, HTMLStrippingEventSchema)
+
+
+def _apply_acl_entry_strategy(rel, principal):
+    user_strategy = rel.joinedload('user')
+    user_strategy.lazyload('*')
+    user_strategy.load_only('id')
+    rel.joinedload('local_group').load_only('id')
+    if principal.allow_networks:
+        rel.joinedload('ip_network_group').load_only('id')
+    if principal.allow_category_roles:
+        rel.joinedload('category_role').load_only('id')
+    if principal.allow_event_roles:
+        rel.joinedload('event_role').load_only('id')
+    if principal.allow_registration_forms:
+        rel.joinedload('registration_form').load_only('id')
+    return rel
+
+
+def _apply_event_access_strategy(rel):
+    rel.load_only('id', 'category_id', 'access_key', 'protection_mode')
+    return rel
+
+
+def _apply_contrib_access_strategy(rel):
+    rel.load_only('id', 'session_id', 'event_id', 'protection_mode', 'title')
+    return rel
 
 
 class InternalSearch(IndicoSearchProvider):
@@ -26,6 +70,15 @@ class InternalSearch(IndicoSearchProvider):
         elif object_types == [SearchTarget.event]:
             pagenav, results = self.search_events(query, user, page, category_id,
                                                   admin_override_enabled)
+        elif set(object_types) == {SearchTarget.contribution, SearchTarget.subcontribution}:
+            pagenav, results = self.search_contribs(query, user, page, category_id,
+                                                    admin_override_enabled)
+        elif object_types == [SearchTarget.attachment]:
+            pagenav, results = self.search_attachments(query, user, page, category_id,
+                                                       admin_override_enabled)
+        elif object_types == [SearchTarget.event_note]:
+            pagenav, results = self.search_notes(query, user, page, category_id,
+                                                 admin_override_enabled)
         else:
             pagenav, results = {}, []
         return {
@@ -49,11 +102,66 @@ class InternalSearch(IndicoSearchProvider):
             pagenav['next'] = -(page - 1)
             reverse = True
 
-        def _can_access(obj):
-            return (obj.effective_protection_mode == ProtectionMode.public or
+        preloaded_categories = set()
+
+        def _preload_categories(objs):
+            nonlocal preloaded_categories
+            obj_types = {type(o) for o in objs}
+            assert len(obj_types) == 1
+            obj_type = obj_types.pop()
+
+            if obj_type == Event:
+                chain_query = db.session.query(Event.category_chain).filter(Event.id.in_(o.id for o in objs))
+            elif obj_type == Category:
+                chain_query = db.session.query(Category.chain_ids).filter(Category.id.in_(o.id for o in objs))
+            elif obj_type == Contribution:
+                chain_query = (db.session.query(Event.category_chain)
+                               .join(Contribution.event)
+                               .filter(Contribution.id.in_(o.id for o in objs)))
+            elif obj_type == Attachment:
+                chain_query = (db.session.query(Event.category_chain)
+                               .join(Attachment.folder)
+                               .join(AttachmentFolder.event)
+                               .filter(Attachment.id.in_(o.id for o in objs)))
+            elif obj_type == EventNote:
+                chain_query = (db.session.query(Event.category_chain)
+                               .join(EventNote.event)
+                               .filter(EventNote.id.in_(o.id for o in objs)))
+            else:
+                raise Exception(f'Unhandled object type: {obj_type}')
+            category_ids = set(itertools.chain.from_iterable(id for id, in chain_query))
+            query = (
+                Category.query
+                .filter(Category.id.in_(category_ids))
+                .options(load_only('id', 'parent_id', 'protection_mode'))
+            )
+            Category.preload_relationships(query, 'acl_entries',
+                                           strategy=lambda rel: _apply_acl_entry_strategy(subqueryload(rel),
+                                                                                          CategoryPrincipal))
+            preloaded_categories |= set(query)
+
+        def _can_access(obj, allow_effective_protection_mode=True):
+            if isinstance(obj, (Category, Event, Contribution)):
+                # more efficient for events/categories/contribs since it avoids climbing up the chain
+                protection_mode = (obj.effective_protection_mode if allow_effective_protection_mode
+                                   else obj.protection_mode)
+            elif isinstance(obj, Attachment):
+                # attachments don't have it so we can only skip access checks if they
+                # are public themselves
+                protection_mode = obj.protection_mode
+            elif isinstance(obj, EventNote):
+                # notes inherit from their parent
+                return _can_access(obj.object, allow_effective_protection_mode=False)
+            elif isinstance(obj, SubContribution):
+                # subcontributions inherit from their contribution
+                return _can_access(obj.contribution, allow_effective_protection_mode=False)
+            else:
+                raise Exception(f'Unexpected object: {obj}')
+            return (protection_mode == ProtectionMode.public or
                     obj.can_access(user, allow_admin=admin_override_enabled))
 
-        res = get_n_matching(query, self.RESULTS_PER_PAGE + 1, _can_access, prefetch_factor=20)
+        res = get_n_matching(query, self.RESULTS_PER_PAGE + 1, _can_access, prefetch_factor=20,
+                             preload_bulk=_preload_categories)
 
         if len(res) > self.RESULTS_PER_PAGE:
             # we queried 1 more so we can see if there are more results available
@@ -91,9 +199,334 @@ class InternalSearch(IndicoSearchProvider):
         if category_id is not None:
             filters.append(Event.category_chain_overlaps(category_id))
 
-        query = (Event.query
-                 .filter(*filters)
-                 .options(subqueryload(Event.acl_entries), undefer(Event.effective_protection_mode)))
+        query = (
+            Event.query
+            .filter(*filters)
+            .options(
+                load_only('id', 'category_id', 'access_key', 'protection_mode'),
+                undefer(Event.effective_protection_mode),
+                _apply_acl_entry_strategy(selectinload(Event.acl_entries), EventPrincipal)
+            )
+        )
         objs, pagenav = self._paginate(query, page, Event.id, user, admin_override_enabled)
-        res = HTMLStrippingEventSchema(many=True).dump(objs)
+
+        query = (
+            Event.query
+            .filter(Event.id.in_(e.id for e in objs))
+            .options(
+                undefer(Event.detailed_category_chain),
+                selectinload(Event.person_links).joinedload('person').joinedload('user').load_only('is_system'),
+                joinedload(Event.own_venue),
+                joinedload(Event.own_room).options(raiseload('*'), joinedload('location')),
+            )
+        )
+        events_by_id = {e.id: e for e in query}
+        events = [events_by_id[e.id] for e in objs]
+
+        res = HTMLStrippingEventSchema(many=True).dump(events)
         return pagenav, EventResultSchema(many=True).load(res)
+
+    def search_contribs(self, q, user, page, category_id, admin_override_enabled):
+        # XXX: Ideally we would search in subcontributions as well, but our pagination
+        # does not really work when we do not have a single unique ID
+
+        contrib_filters = [
+            Contribution.title_matches(q) | Contribution.description_matches(q),
+            ~Contribution.is_deleted,
+            ~Event.is_deleted
+        ]
+
+        if category_id is not None:
+            contrib_filters.append(Event.category_chain_overlaps(category_id))
+
+        query = (
+            Contribution.query
+            .filter(*contrib_filters)
+            .join(Contribution.event)
+            .options(
+                load_only('id', 'session_id', 'event_id', 'protection_mode'),
+                undefer(Contribution.effective_protection_mode),
+                _apply_acl_entry_strategy(selectinload(Contribution.acl_entries), ContributionPrincipal),
+                joinedload(Contribution.session).options(
+                    load_only('id', 'protection_mode', 'event_id'),
+                    selectinload(Session.acl_entries)
+                ),
+                contains_eager('event').options(
+                    _apply_acl_entry_strategy(selectinload(Event.acl_entries), EventPrincipal)
+                )
+            )
+        )
+
+        objs, pagenav = self._paginate(query, page, Contribution.id, user, admin_override_enabled)
+
+        event_strategy = joinedload(Contribution.event)
+        event_strategy.joinedload(Event.own_venue)
+        event_strategy.joinedload(Event.own_room).options(raiseload('*'), joinedload('location'))
+        event_strategy.undefer(Event.detailed_category_chain)
+
+        session_strategy = joinedload(Contribution.session)
+        session_strategy.joinedload(Session.own_venue)
+        session_strategy.joinedload(Session.own_room).options(raiseload('*'), joinedload('location'))
+
+        session_block_strategy = joinedload(Contribution.session_block)
+        session_block_strategy.joinedload(SessionBlock.own_venue)
+        session_block_strategy.joinedload(SessionBlock.own_room).options(raiseload('*'), joinedload('location'))
+        session_block_session_strategy = session_block_strategy.joinedload(SessionBlock.session)
+        session_block_session_strategy.joinedload(Session.own_venue)
+        session_block_session_strategy.joinedload(Session.own_room).options(raiseload('*'), joinedload('location'))
+
+        query = (
+            Contribution.query
+            .filter(Contribution.id.in_(c.id for c in objs))
+            .options(
+                selectinload(Contribution.person_links).joinedload('person').joinedload('user').load_only('is_system'),
+                event_strategy,
+                session_strategy,
+                session_block_strategy,
+                joinedload(Contribution.type),
+                joinedload(Contribution.own_venue),
+                joinedload(Contribution.own_room).options(raiseload('*'), joinedload('location')),
+                joinedload(Contribution.timetable_entry),
+            )
+        )
+        contribs_by_id = {c.id: c for c in query}
+        contribs = [contribs_by_id[c.id] for c in objs]
+
+        res = HTMLStrippingContributionSchema(many=True).dump(contribs)
+        return pagenav, ContributionResultSchema(many=True).load(res)
+
+    def search_attachments(self, q, user, page, category_id, admin_override_enabled):
+        contrib_event = db.aliased(Event)
+        contrib_session = db.aliased(Session)
+        subcontrib_contrib = db.aliased(Contribution)
+        subcontrib_session = db.aliased(Session)
+        subcontrib_event = db.aliased(Event)
+        session_event = db.aliased(Event)
+
+        attachment_strategy = _apply_acl_entry_strategy(selectinload(Attachment.acl_entries), AttachmentPrincipal)
+        folder_strategy = contains_eager(Attachment.folder)
+        folder_strategy.load_only('id', 'protection_mode', 'link_type', 'category_id', 'event_id', 'linked_event_id',
+                                  'contribution_id', 'subcontribution_id', 'session_id')
+        _apply_acl_entry_strategy(folder_strategy.selectinload(AttachmentFolder.acl_entries), AttachmentFolderPrincipal)
+        # event
+        event_strategy = folder_strategy.contains_eager(AttachmentFolder.linked_event)
+        _apply_event_access_strategy(event_strategy)
+        _apply_acl_entry_strategy(event_strategy.selectinload(Event.acl_entries), EventPrincipal)
+        # contribution
+        contrib_strategy = folder_strategy.contains_eager(AttachmentFolder.contribution)
+        _apply_contrib_access_strategy(contrib_strategy)
+        _apply_acl_entry_strategy(contrib_strategy.selectinload(Contribution.acl_entries), ContributionPrincipal)
+        contrib_event_strategy = contrib_strategy.contains_eager(Contribution.event.of_type(contrib_event))
+        _apply_event_access_strategy(contrib_event_strategy)
+        _apply_acl_entry_strategy(contrib_event_strategy.selectinload(contrib_event.acl_entries), EventPrincipal)
+        contrib_session_strategy = contrib_strategy.contains_eager(Contribution.session.of_type(contrib_session))
+        contrib_session_strategy.load_only('id', 'event_id', 'protection_mode')
+        _apply_acl_entry_strategy(contrib_session_strategy.selectinload(contrib_session.acl_entries), SessionPrincipal)
+        # subcontribution
+        subcontrib_strategy = folder_strategy.contains_eager(AttachmentFolder.subcontribution)
+        subcontrib_strategy.load_only('id', 'contribution_id', 'title')
+        subcontrib_contrib_strategy = subcontrib_strategy.contains_eager(
+            SubContribution.contribution.of_type(subcontrib_contrib)
+        )
+        _apply_contrib_access_strategy(subcontrib_contrib_strategy)
+        _apply_acl_entry_strategy(subcontrib_contrib_strategy
+                                  .selectinload(subcontrib_contrib.acl_entries), ContributionPrincipal)
+        subcontrib_event_strategy = subcontrib_contrib_strategy.contains_eager(
+            subcontrib_contrib.event.of_type(subcontrib_event)
+        )
+        _apply_event_access_strategy(subcontrib_event_strategy)
+        _apply_acl_entry_strategy(subcontrib_event_strategy.selectinload(subcontrib_event.acl_entries), EventPrincipal)
+        subcontrib_session_strategy = subcontrib_contrib_strategy.contains_eager(
+            subcontrib_contrib.session.of_type(subcontrib_session)
+        )
+        subcontrib_session_strategy.load_only('id', 'event_id', 'protection_mode')
+        _apply_acl_entry_strategy(subcontrib_session_strategy.selectinload(subcontrib_session.acl_entries),
+                                  SessionPrincipal)
+        # session
+        session_strategy = folder_strategy.contains_eager(AttachmentFolder.session)
+        session_strategy.load_only('id', 'event_id', 'protection_mode')
+        session_event_strategy = session_strategy.contains_eager(Session.event.of_type(session_event))
+        _apply_event_access_strategy(session_event_strategy)
+        session_event_strategy.selectinload(session_event.acl_entries)
+        _apply_acl_entry_strategy(session_strategy.selectinload(Session.acl_entries), SessionPrincipal)
+
+        attachment_filters = [
+            Attachment.title_matches(q),
+            ~Attachment.is_deleted,
+            ~AttachmentFolder.is_deleted,
+            AttachmentFolder.link_type != LinkType.category,
+            db.or_(
+                AttachmentFolder.link_type != LinkType.event,
+                ~Event.is_deleted,
+            ),
+            db.or_(
+                AttachmentFolder.link_type != LinkType.contribution,
+                ~Contribution.is_deleted & ~contrib_event.is_deleted
+            ),
+            db.or_(
+                AttachmentFolder.link_type != LinkType.subcontribution,
+                db.and_(
+                    ~SubContribution.is_deleted,
+                    ~subcontrib_contrib.is_deleted,
+                    ~subcontrib_event.is_deleted,
+                )
+            ),
+            db.or_(
+                AttachmentFolder.link_type != LinkType.session,
+                ~Session.is_deleted & ~session_event.is_deleted
+            )
+        ]
+
+        if category_id is not None:
+            attachment_filters.append(AttachmentFolder.event.has(Event.category_chain_overlaps(category_id)))
+
+        query = (
+            Attachment.query
+            .join(Attachment.folder)
+            .filter(*attachment_filters)
+            .options(folder_strategy, attachment_strategy, joinedload(Attachment.user).joinedload('_affiliation'))
+            .outerjoin(AttachmentFolder.linked_event)
+            .outerjoin(AttachmentFolder.contribution)
+            .outerjoin(Contribution.event.of_type(contrib_event))
+            .outerjoin(Contribution.session.of_type(contrib_session))
+            .outerjoin(AttachmentFolder.subcontribution)
+            .outerjoin(SubContribution.contribution.of_type(subcontrib_contrib))
+            .outerjoin(subcontrib_contrib.event.of_type(subcontrib_event))
+            .outerjoin(subcontrib_contrib.session.of_type(subcontrib_session))
+            .outerjoin(AttachmentFolder.session)
+            .outerjoin(Session.event.of_type(session_event))
+        )
+
+        objs, pagenav = self._paginate(query, page, Attachment.id, user, admin_override_enabled)
+
+        query = (
+            Attachment.query
+            .filter(Attachment.id.in_(a.id for a in objs))
+            .options(
+                joinedload(Attachment.folder).options(
+                    joinedload(AttachmentFolder.subcontribution),
+                    joinedload(AttachmentFolder.event).options(
+                        undefer(Event.detailed_category_chain)
+                    )
+                )
+            )
+        )
+        attachments_by_id = {a.id: a for a in query}
+        attachments = [attachments_by_id[a.id] for a in objs]
+
+        res = AttachmentSchema(many=True).dump(attachments)
+        return pagenav, AttachmentResultSchema(many=True).load(res)
+
+    def search_notes(self, q, user, page, category_id, admin_override_enabled):
+        contrib_event = db.aliased(Event)
+        contrib_session = db.aliased(Session)
+        subcontrib_contrib = db.aliased(Contribution)
+        subcontrib_session = db.aliased(Session)
+        subcontrib_event = db.aliased(Event)
+        session_event = db.aliased(Event)
+
+        note_strategy = load_only('id', 'link_type', 'event_id', 'linked_event_id', 'contribution_id',
+                                  'subcontribution_id', 'session_id', 'html')
+        # event
+        event_strategy = note_strategy.contains_eager(EventNote.linked_event)
+        event_strategy.undefer(Event.effective_protection_mode)
+        _apply_event_access_strategy(event_strategy)
+        _apply_acl_entry_strategy(event_strategy.selectinload(Event.acl_entries), EventPrincipal)
+        # contribution
+        contrib_strategy = note_strategy.contains_eager(EventNote.contribution)
+        _apply_contrib_access_strategy(contrib_strategy)
+        _apply_acl_entry_strategy(contrib_strategy.selectinload(Contribution.acl_entries), ContributionPrincipal)
+        contrib_event_strategy = contrib_strategy.contains_eager(Contribution.event.of_type(contrib_event))
+        _apply_event_access_strategy(contrib_event_strategy)
+        _apply_acl_entry_strategy(contrib_event_strategy.selectinload(contrib_event.acl_entries), EventPrincipal)
+        contrib_session_strategy = contrib_strategy.contains_eager(Contribution.session.of_type(contrib_session))
+        contrib_session_strategy.load_only('id', 'event_id', 'protection_mode')
+        _apply_acl_entry_strategy(contrib_session_strategy.selectinload(contrib_session.acl_entries), SessionPrincipal)
+        # subcontribution
+        subcontrib_strategy = note_strategy.contains_eager(EventNote.subcontribution)
+        subcontrib_contrib_strategy = subcontrib_strategy.contains_eager(
+            SubContribution.contribution.of_type(subcontrib_contrib)
+        )
+        _apply_contrib_access_strategy(subcontrib_contrib_strategy)
+        _apply_acl_entry_strategy(subcontrib_contrib_strategy
+                                  .selectinload(subcontrib_contrib.acl_entries), ContributionPrincipal)
+        subcontrib_event_strategy = subcontrib_contrib_strategy.contains_eager(
+            subcontrib_contrib.event.of_type(subcontrib_event)
+        )
+        _apply_event_access_strategy(subcontrib_event_strategy)
+        _apply_acl_entry_strategy(subcontrib_event_strategy.selectinload(subcontrib_event.acl_entries), EventPrincipal)
+        subcontrib_session_strategy = subcontrib_contrib_strategy.contains_eager(
+            subcontrib_contrib.session.of_type(subcontrib_session)
+        )
+        subcontrib_session_strategy.load_only('id', 'event_id', 'protection_mode')
+        _apply_acl_entry_strategy(subcontrib_session_strategy.selectinload(subcontrib_session.acl_entries),
+                                  SessionPrincipal)
+        # session
+        session_strategy = note_strategy.contains_eager(EventNote.session)
+        session_strategy.load_only('id', 'event_id', 'protection_mode')
+        session_event_strategy = session_strategy.contains_eager(Session.event.of_type(session_event))
+        _apply_event_access_strategy(session_event_strategy)
+        session_event_strategy.selectinload(session_event.acl_entries)
+        _apply_acl_entry_strategy(session_strategy.selectinload(Session.acl_entries), SessionPrincipal)
+
+        note_filters = [
+            EventNote.html_matches(q),
+            ~EventNote.is_deleted,
+            db.or_(
+                EventNote.link_type != LinkType.event,
+                ~Event.is_deleted
+            ),
+            db.or_(
+                EventNote.link_type != LinkType.contribution,
+                ~Contribution.is_deleted & ~contrib_event.is_deleted
+            ),
+            db.or_(
+                EventNote.link_type != LinkType.subcontribution,
+                db.and_(
+                    ~SubContribution.is_deleted,
+                    ~subcontrib_contrib.is_deleted,
+                    ~subcontrib_event.is_deleted
+                )
+            ),
+            db.or_(
+                EventNote.link_type != LinkType.session,
+                ~Session.is_deleted & ~session_event.is_deleted
+            )
+        ]
+
+        if category_id is not None:
+            note_filters.append(EventNote.event.has(Event.category_chain_overlaps(category_id)))
+
+        query = (
+            EventNote.query
+            .filter(*note_filters)
+            .options(note_strategy)
+            .outerjoin(EventNote.linked_event)
+            .outerjoin(EventNote.contribution)
+            .outerjoin(Contribution.event.of_type(contrib_event))
+            .outerjoin(Contribution.session.of_type(contrib_session))
+            .outerjoin(EventNote.subcontribution)
+            .outerjoin(SubContribution.contribution.of_type(subcontrib_contrib))
+            .outerjoin(subcontrib_contrib.event.of_type(subcontrib_event))
+            .outerjoin(subcontrib_contrib.session.of_type(subcontrib_session))
+            .outerjoin(EventNote.session)
+            .outerjoin(Session.event.of_type(session_event))
+        )
+
+        objs, pagenav = self._paginate(query, page, EventNote.id, user, admin_override_enabled)
+
+        query = (
+            EventNote.query
+            .filter(EventNote.id.in_(n.id for n in objs))
+            .options(
+                joinedload(EventNote.contribution),
+                joinedload(EventNote.subcontribution).joinedload(SubContribution.contribution),
+                joinedload(EventNote.event).options(undefer(Event.detailed_category_chain)),
+                joinedload(EventNote.current_revision).joinedload(EventNoteRevision.user).joinedload('_affiliation'),
+            )
+        )
+        notes_by_id = {n.id: n for n in query}
+        notes = [notes_by_id[n.id] for n in objs]
+
+        res = HTMLStrippingEventNoteSchema(many=True).dump(notes)
+        return pagenav, EventNoteResultSchema(many=True).load(res)

--- a/indico/modules/search/schemas.py
+++ b/indico/modules/search/schemas.py
@@ -7,9 +7,13 @@
 
 from marshmallow import fields, post_dump
 
+from indico.core.db.sqlalchemy.links import LinkType
 from indico.core.marshmallow import mm
+from indico.modules.attachments.models.attachments import Attachment
 from indico.modules.categories import Category
 from indico.modules.events import Event
+from indico.modules.events.contributions.models.contributions import Contribution
+from indico.modules.events.notes.models.notes import EventNote
 from indico.modules.search.base import SearchTarget
 from indico.modules.users.models.users import User
 from indico.util.marshmallow import NoneRemovingList
@@ -74,8 +78,92 @@ class EventSchema(mm.SQLAlchemyAutoSchema):
     category_path = fields.List(fields.Nested(CategorySchema), attribute='detailed_category_chain')
 
 
+class ContributionSchema(mm.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Contribution
+        fields = ('contribution_id', 'type', 'contribution_type', 'event_id', 'title', 'description', 'location',
+                  'persons', 'url', 'category_id', 'category_path', 'start_dt', 'end_dt', 'duration')
+
+    contribution_id = fields.Int(attribute='id')
+    type = fields.Constant(SearchTarget.contribution.name)
+    contribution_type = fields.String(attribute='type.name')
+    location = fields.Function(lambda contrib: LocationSchema().dump(contrib))
+    persons = NoneRemovingList(fields.Nested(PersonSchema), attribute='person_links')
+    category_id = fields.Int(attribute='event.category_id')
+    category_path = fields.List(fields.Nested(CategorySchema), attribute='event.detailed_category_chain')
+    url = fields.Function(lambda contrib: url_for('contributions.display_contribution', contrib, _external=False))
+    duration = fields.TimeDelta(precision=fields.TimeDelta.MINUTES)
+
+
+class AttachmentSchema(mm.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Attachment
+        fields = ('attachment_id', 'folder_id', 'type', 'attachment_type', 'title', 'filename', 'event_id',
+                  'contribution_id', 'subcontribution_id', 'user', 'url', 'category_id', 'category_path',
+                  'modified_dt')
+
+    attachment_id = fields.Int(attribute='id')
+    folder_id = fields.Int(attribute='folder_id')
+    type = fields.Constant(SearchTarget.attachment.name)
+    attachment_type = fields.String(attribute='type.name')
+    filename = fields.String(attribute='file.filename')
+    event_id = fields.Int(attribute='folder.event.id')
+    contribution_id = fields.Method('_contribution_id')
+    subcontribution_id = fields.Int(attribute='folder.subcontribution_id')
+    user = fields.Nested(PersonSchema)
+    category_id = fields.Int(attribute='folder.event.category_id')
+    category_path = fields.List(fields.Nested(CategorySchema), attribute='folder.event.detailed_category_chain')
+    url = fields.String(attribute='download_url')
+
+    def _contribution_id(self, attachment):
+        if attachment.folder.link_type == LinkType.contribution:
+            return attachment.folder.contribution_id
+        elif attachment.folder.link_type == LinkType.subcontribution:
+            return attachment.folder.subcontribution.contribution_id
+        return None
+
+
+class EventNoteSchema(mm.SQLAlchemyAutoSchema):
+    class Meta:
+        model = EventNote
+        fields = ('note_id', 'type', 'content', 'event_id', 'contribution_id', 'subcontribution_id', 'url',
+                  'category_id', 'category_path', 'modified_dt', 'user', 'title')
+
+    note_id = fields.Int(attribute='id')
+    type = fields.Constant(SearchTarget.event_note.name)
+    content = fields.Str(attribute='current_revision.source')
+    title = fields.Str(attribute='object.title')
+    contribution_id = fields.Method('_contribution_id')
+    subcontribution_id = fields.Int()
+    category_id = fields.Int(attribute='event.category_id')
+    category_path = fields.List(fields.Nested(CategorySchema), attribute='event.detailed_category_chain')
+    url = fields.Function(lambda note: url_for('event_notes.view', note, _external=False))
+    modified_dt = fields.DateTime(attribute='current_revision.created_dt')
+    user = fields.Nested(PersonSchema, attribute='current_revision.user')
+
+    def _contribution_id(self, note):
+        if note.link_type == LinkType.contribution:
+            return note.contribution_id
+        elif note.link_type == LinkType.subcontribution:
+            return note.subcontribution.contribution_id
+
+
 class HTMLStrippingEventSchema(EventSchema):
     @post_dump
     def _strip_html(self, data, **kwargs):
         data['description'] = strip_tags(data['description'])
+        return data
+
+
+class HTMLStrippingContributionSchema(ContributionSchema):
+    @post_dump
+    def _strip_html(self, data, **kwargs):
+        data['description'] = strip_tags(data['description'])
+        return data
+
+
+class HTMLStrippingEventNoteSchema(EventNoteSchema):
+    @post_dump
+    def _strip_html(self, data, **kwargs):
+        data['content'] = strip_tags(data['content'])
         return data

--- a/indico/modules/search/schemas.py
+++ b/indico/modules/search/schemas.py
@@ -13,6 +13,7 @@ from indico.modules.attachments.models.attachments import Attachment
 from indico.modules.categories import Category
 from indico.modules.events import Event
 from indico.modules.events.contributions.models.contributions import Contribution
+from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.notes.models.notes import EventNote
 from indico.modules.search.base import SearchTarget
 from indico.modules.users.models.users import User
@@ -92,6 +93,25 @@ class ContributionSchema(mm.SQLAlchemyAutoSchema):
     category_id = fields.Int(attribute='event.category_id')
     category_path = fields.List(fields.Nested(CategorySchema), attribute='event.detailed_category_chain')
     url = fields.Function(lambda contrib: url_for('contributions.display_contribution', contrib, _external=False))
+    duration = fields.TimeDelta(precision=fields.TimeDelta.MINUTES)
+
+
+class SubContributionSchema(mm.SQLAlchemyAutoSchema):
+    class Meta:
+        model = SubContribution
+        fields = ('subcontribution_id', 'type', 'title', 'description', 'event_id', 'contribution_id', 'persons',
+                  'location', 'url', 'category_id', 'category_path', 'start_dt', 'end_dt', 'duration')
+
+    subcontribution_id = fields.Int(attribute='id')
+    type = fields.Constant(SearchTarget.subcontribution.name)
+    event_id = fields.Int(attribute='contribution.event_id')
+    persons = NoneRemovingList(fields.Nested(PersonSchema), attribute='person_links')
+    location = fields.Function(lambda subc: LocationSchema().dump(subc.contribution))
+    category_id = fields.Int(attribute='event.category_id')
+    category_path = fields.List(fields.Nested(CategorySchema), attribute='event.detailed_category_chain')
+    url = fields.Function(lambda subc: url_for('contributions.display_subcontribution', subc, _external=False))
+    start_dt = fields.DateTime(attribute='contribution.start_dt')
+    end_dt = fields.DateTime(attribute='contribution.end_dt')
     duration = fields.TimeDelta(precision=fields.TimeDelta.MINUTES)
 
 

--- a/indico/modules/search/schemas_test.py
+++ b/indico/modules/search/schemas_test.py
@@ -5,7 +5,21 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from datetime import datetime, timedelta
+from io import BytesIO
+
+import pytest
+from pytz import utc
+
+from indico.modules.attachments.models.attachments import Attachment, AttachmentFile, AttachmentType
+from indico.modules.attachments.models.folders import AttachmentFolder
+from indico.modules.events.contributions.models.persons import ContributionPersonLink, SubContributionPersonLink
+from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.models.persons import EventPerson, EventPersonLink
+from indico.modules.events.notes.models.notes import EventNote, RenderMode
+
+
+pytest_plugins = 'indico.modules.events.timetable.testing.fixtures'
 
 
 def test_dump_event(db, dummy_user, dummy_event):
@@ -37,4 +51,166 @@ def test_dump_event(db, dummy_user, dummy_event):
         'type': 'event',
         'event_type': 'meeting',
         'url': '/event/0/',
+    }
+
+
+@pytest.mark.parametrize('scheduled', (False, True))
+def test_dump_contribution(db, dummy_user, dummy_event, dummy_contribution, create_entry, scheduled):
+    from indico.modules.search.schemas import ContributionSchema
+
+    person = EventPerson.create_from_user(dummy_user, dummy_event)
+    dummy_contribution.person_links.append(ContributionPersonLink(person=person))
+    dummy_contribution.description = 'A dummy contribution'
+
+    extra = {'start_dt': None, 'end_dt': None}
+    if scheduled:
+        create_entry(dummy_contribution, utc.localize(datetime(2020, 4, 20, 4, 20)))
+        extra = {
+            'start_dt': dummy_contribution.start_dt.isoformat(),
+            'end_dt': dummy_contribution.end_dt.isoformat(),
+        }
+
+    db.session.flush()
+    category_id = dummy_contribution.event.category_id
+    schema = ContributionSchema()
+    assert schema.dump(dummy_contribution) == {
+        'description': 'A dummy contribution',
+        'location': {'address': '', 'room_name': '', 'venue_name': ''},
+        'persons': [{'affiliation': None, 'name': 'Guinea Pig'}],
+        'title': 'Dummy Contribution',
+        'category_id': category_id,
+        'category_path': [
+            {'id': 0, 'title': 'Home', 'url': '/'},
+            {'id': category_id, 'title': 'dummy', 'url': f'/category/{category_id}/'},
+        ],
+        'contribution_id': dummy_contribution.id,
+        'duration': 20,
+        'event_id': 0,
+        'type': 'contribution',
+        'url': f'/event/0/contributions/{dummy_contribution.id}/',
+        **extra
+    }
+
+
+@pytest.mark.parametrize('scheduled', (False, True))
+def test_dump_subcontribution(db, dummy_user, dummy_event, dummy_contribution, create_entry, scheduled):
+    from indico.modules.search.schemas import SubContributionSchema
+
+    extra = {'start_dt': None, 'end_dt': None}
+    if scheduled:
+        create_entry(dummy_contribution, utc.localize(datetime(2020, 4, 20, 4, 20)))
+        extra = {
+            'start_dt': dummy_contribution.start_dt.isoformat(),
+            'end_dt': dummy_contribution.end_dt.isoformat(),
+        }
+
+    subcontribution = SubContribution(contribution=dummy_contribution, title='Dummy Subcontribution',
+                                      description='A dummy subcontribution',
+                                      duration=timedelta(minutes=10))
+
+    person = EventPerson.create_from_user(dummy_user, dummy_event)
+    subcontribution.person_links.append(SubContributionPersonLink(person=person))
+
+    db.session.flush()
+    category_id = dummy_contribution.event.category_id
+    schema = SubContributionSchema()
+    assert schema.dump(subcontribution) == {
+        'description': 'A dummy subcontribution',
+        'location': {'address': '', 'room_name': '', 'venue_name': ''},
+        'persons': [{'affiliation': None, 'name': 'Guinea Pig'}],
+        'title': 'Dummy Subcontribution',
+        'category_id': category_id,
+        'category_path': [
+            {'id': 0, 'title': 'Home', 'url': '/'},
+            {'id': category_id, 'title': 'dummy', 'url': f'/category/{category_id}/'},
+        ],
+        'contribution_id': dummy_contribution.id,
+        'duration': 10,
+        'event_id': 0,
+        'subcontribution_id': subcontribution.id,
+        'type': 'subcontribution',
+        'url': f'/event/0/contributions/{dummy_contribution.id}/subcontributions/{subcontribution.id}',
+        **extra
+    }
+
+
+def test_dump_attachment(db, dummy_user, dummy_contribution):
+    from indico.modules.search.schemas import AttachmentSchema
+
+    folder = AttachmentFolder(title='Dummy Folder', description='a dummy folder')
+    file = AttachmentFile(user=dummy_user, filename='dummy_file.txt', content_type='text/plain')
+    attachment = Attachment(folder=folder, user=dummy_user, title='Dummy Attachment', type=AttachmentType.file,
+                            file=file)
+    attachment.folder.object = dummy_contribution
+    attachment.file.save(BytesIO(b'hello world'))
+    db.session.flush()
+
+    category_id = dummy_contribution.event.category_id
+    schema = AttachmentSchema()
+    assert schema.dump(attachment) == {
+        'filename': 'dummy_file.txt',
+        'title': 'Dummy Attachment',
+        'user': {'affiliation': None, 'name': 'Guinea Pig'},
+        'attachment_id': attachment.id,
+        'attachment_type': 'file',
+        'category_id': category_id,
+        'category_path': [
+            {'id': 0, 'title': 'Home', 'url': '/'},
+            {'id': category_id, 'title': 'dummy', 'url': f'/category/{category_id}/'},
+        ],
+        'contribution_id': dummy_contribution.id,
+        'subcontribution_id': None,
+        'event_id': 0,
+        'folder_id': folder.id,
+        'modified_dt': attachment.modified_dt.isoformat(),
+        'type': 'attachment',
+        'url': (
+            f'/event/0/contributions/'
+            f'{dummy_contribution.id}/attachments/{folder.id}/{attachment.id}/dummy_file.txt'
+        ),
+    }
+
+
+@pytest.mark.parametrize('link_type', ('event', 'contrib', 'subcontrib'))
+def test_dump_event_note(db, dummy_user, dummy_event, dummy_contribution, link_type):
+    from indico.modules.search.schemas import EventNoteSchema
+
+    if link_type == 'event':
+        ids = {'contribution_id': None, 'subcontribution_id': None}
+        note = EventNote(object=dummy_event)
+        url = '/event/0/note/'
+    elif link_type == 'contrib':
+        ids = {'contribution_id': dummy_contribution.id, 'subcontribution_id': None}
+        note = EventNote(object=dummy_contribution)
+        url = f'/event/0/contributions/{dummy_contribution.id}/note/'
+    elif link_type == 'subcontrib':
+        subcontribution = SubContribution(contribution=dummy_contribution, title='Dummy Subcontribution',
+                                          duration=timedelta(minutes=10))
+        db.session.flush()
+        ids = {
+            'contribution_id': subcontribution.contribution_id,
+            'subcontribution_id': subcontribution.id,
+        }
+        note = EventNote(object=subcontribution)
+        url = f'/event/0/contributions/{dummy_contribution.id}/subcontributions/{subcontribution.id}/note/'
+
+    note.create_revision(RenderMode.html, 'this is a dummy note', dummy_user)
+    db.session.flush()
+    category_id = dummy_event.category_id
+    schema = EventNoteSchema()
+    assert schema.dump(note) == {
+        'content': 'this is a dummy note',
+        'user': {'affiliation': None, 'name': 'Guinea Pig'},
+        'category_id': category_id,
+        'category_path': [
+            {'id': 0, 'title': 'Home', 'url': '/'},
+            {'id': category_id, 'title': 'dummy', 'url': f'/category/{category_id}/'},
+        ],
+        'modified_dt': note.current_revision.created_dt.isoformat(),
+        'event_id': 0,
+        'note_id': note.id,
+        'title': note.object.title,
+        'type': 'event_note',
+        'url': url,
+        **ids
     }


### PR DESCRIPTION
closes #4911

In the end I'm creating the indexes unconditionally, even on our large DB it's reasonable fast (and they can be created using CONCURRENTLY to avoid exclusive locks)

This PR also fixes a bug where `Attachment.can_access(..., allow_admin=False)` did not propagate this flag when checking whether the user can manage attachments on the parent object, so it always succeeded for admins (not relevant before, but in the search we do not honor admin permissions by default).