### PR TITLE
Fix PDF timetable breaking when 'print abstracts' option is set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,8 @@ Bugfixes
 - Correctly count line breaks in length-limited abstracts (:pr:`4918`)
 - Fix error when trying to access subcontributions while event is in draft mode
 - Update the user link in registrations when merging two users (:pr:`4936`)
+- Fix error when exporting a conference timetable PDF with the option "Print abstract content of all
+  contributions" and one of the abstracts is too big to fit in a page (:issue:`4881`, :pr:`4955`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/legacy/pdfinterface/conference.py
+++ b/indico/legacy/pdfinterface/conference.py
@@ -343,12 +343,14 @@ class TimeTablePlain(PDFWithTOC):
         details_style.leftIndent = 10
         self._styles['details_style'] = details_style
 
-        color_tablestyle = TableStyle([('FONTNAME', (0, 0), (-1, -1), 'Sans'),
-                              ('LEFTPADDING', (0, 0), (-1, -1), 3),
-                              ('RIGHTPADDING', (0, 0), (-1, -1), 0),
-                              ('TOPPADDING', (0, 0), (-1, -1), 0),
-                              ('BOTTOMPADDING', (0, 0), (-1, -1), 0),
-                              ('GRID', (0, 0), (0, -1), 1, colors.lightgrey)])
+        color_tablestyle = TableStyle([
+            ('FONTNAME', (0, 0), (-1, -1), 'Sans'),
+            ('LEFTPADDING', (0, 0), (-1, -1), 3),
+            ('RIGHTPADDING', (0, 0), (-1, -1), 0),
+            ('TOPPADDING', (0, 0), (-1, -1), 0),
+            ('BOTTOMPADDING', (0, 0), (-1, -1), 0),
+            ('GRID', (0, 0), (0, -1), 1, colors.lightgrey)
+        ])
         self._styles['color_tablestyle'] = color_tablestyle
 
     def _getSessionColor(self, block):
@@ -662,19 +664,20 @@ class TimeTablePlain(PDFWithTOC):
         return res
 
     def _print_contribution_with_abstract(self, res, contribution, sess_block):
-        title_line = contribution.title
+        title_list = [contribution.title]
         if self._ttPDFFormat.showContribId():
-            title_line = f'[{contribution.friendly_id}] {title_line}'
+            title_list.insert(0, f'[{contribution.friendly_id}] ')
         if sess_block.session.is_poster and contribution.board_number:
-            title_line += f' (board {contribution.board_number})'
-        if hasattr(contribution, 'start_dt') and not sess_block.session.is_poster:
-            title_line += f' ({format_time(contribution.start_dt, timezone=self._tz)}'
+            title_list.append(f' (board {contribution.board_number})')
+        if hasattr(contribution, 'start_dt'):
+            title_list.append(f' ({format_time(contribution.start_dt, timezone=self._tz)}')
             if self._ttPDFFormat.showLengthContribs():
-                title_line += f', {format_human_timedelta(contribution.timetable_entry.duration)})'
+                title_list.append(f', {format_human_timedelta(contribution.timetable_entry.duration)})')
             else:
-                title_line += ')'
+                title_list.append(')')
 
-        title = Paragraph(title_line, self._styles['session_title'])
+
+        title = Paragraph(''.join(title_list), self._styles['session_title'])
         if self._useColors():
             ts = deepcopy(self._styles['color_tablestyle'])
             ts.add('BACKGROUND', (0, 0), (0, -1), self._getSessionColor(sess_block))
@@ -687,7 +690,7 @@ class TimeTablePlain(PDFWithTOC):
             speaker_content = speaker_title + ', '.join(speaker_list)
             speaker_content = f'<font name="Times-Italic"><i>{speaker_content}</i></font>'
         speakers = Paragraph(speaker_content, self._styles['details_style'])
-        
+
         abstract = Paragraph(escape(str(contribution.description)), self._styles['details_style'])
 
         res.append(title)

--- a/indico/legacy/pdfinterface/conference.py
+++ b/indico/legacy/pdfinterface/conference.py
@@ -374,12 +374,8 @@ class TimeTablePlain(PDFWithTOC):
         elif self._ttPDFFormat.showLengthContribs():
             caption = f'{caption} ({format_human_timedelta(contrib.timetable_entry.duration)})'
 
-        color_cell = ''
         caption = f'<font size="{str(modifiedFontSize(10, self._fontsize))}">{caption}</font>'
         lt.append([self._fontify(caption, 10)])
-
-        if self._useColors():
-            color_cell = ' '
 
         caption = Table(lt, colWidths=None, style=self._tsSpk)
         speaker_list = [[Paragraph(escape(self._get_speaker_name(spk)), self._styles['table_body'])]
@@ -387,8 +383,8 @@ class TimeTablePlain(PDFWithTOC):
         if not speaker_list:
             speaker_list = [['']]
         speakers = Table(speaker_list, style=self._tsSpk)
-        if color_cell:
-            l.append([color_cell, date, caption, speakers])
+        if self._useColors():
+            l.append([' ', date, caption, speakers])
         else:
             l.append([date, caption, speakers])
 
@@ -412,8 +408,8 @@ class TimeTablePlain(PDFWithTOC):
 
             caption = Table(lt, colWidths=None, style=self._tsSpk)
             speakers = Table(speaker_list, style=self._tsSpk)
-            if color_cell:
-                l.append([color_cell, '', caption, speakers])
+            if self._useColors():
+                l.append([' ', '', caption, speakers])
             else:
                 l.append(['', caption, speakers])
 

--- a/indico/legacy/pdfinterface/conference.py
+++ b/indico/legacy/pdfinterface/conference.py
@@ -563,7 +563,7 @@ class TimeTablePlain(PDFWithTOC):
                         if not self._ttPDFFormat.showContribId():
                             title = 'title'
                         row = self._fontifyRow([title, 'presenter', 'board'], 11)
-                        widths = [None, 5 * cm, 1 * cm]
+                        widths = [None, 5 * cm, 1.1 * cm]
                         if self._useColors():
                             row.insert(0, '')
                             widths.insert(0, 0.2 * cm)


### PR DESCRIPTION
Changes the layout of the timetable PDF when the advanced option 'Print abstract content of all contributions' is selected.

ReportLab is unable to split table rows when the content is bigger than the page it's placed upon, as described by [the discussion](https://groups.google.com/g/reportlab-users/c/wlIN3Fsg2VA?pli=1) linked in the bug report by @bcc.

To overcome this limitation, the timetable will not be contained in a table if the option to print the abstracts is set. The document is slightly different, but still provides the same information. If that option is unset, the previous layout persists.

Closes https://github.com/indico/indico/issues/4881.