### PR TITLE
Correctly handle note imports in existing events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -83,6 +83,8 @@ Bugfixes
 - Fix error when exporting a conference timetable PDF with the option "Print abstract content of all
   contributions" and one of the abstracts is too big to fit in a page (:issue:`4881`, :pr:`4955`)
 - Emails sent via the Editing module are now logged to the event log (:pr:`4960`)
+- Fix error when importing event notes from another event while the target event already
+  has a deleted note (:pr:`4959`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/notes/clone.py
+++ b/indico/modules/events/notes/clone.py
@@ -67,5 +67,5 @@ class NoteCloner(EventCloner):
 
     def _clone_note(self, old_note, new_object):
         revision = old_note.current_revision
-        new_object.note = EventNote()
-        new_object.note.create_revision(render_mode=revision.render_mode, source=revision.source, user=revision.user)
+        note = EventNote.get_or_create(new_object)
+        note.create_revision(render_mode=revision.render_mode, source=revision.source, user=revision.user)


### PR DESCRIPTION
Fixes the case where importing notes into an event with a soft-deleted note resulted in a an error.

Instead of creating a new note, we check whether a note already exists in the event.