### PR TITLE
Update abstract review visibility to match can_view

### DIFF
--- a/indico/modules/events/abstracts/models/reviews.py
+++ b/indico/modules/events/abstracts/models/reviews.py
@@ -168,7 +168,7 @@ class AbstractReview(ProposalReviewMixin, RenderModeMixin, db.Model):
 
     @property
     def visibility(self):
-        return AbstractCommentVisibility.reviewers
+        return AbstractCommentVisibility.conveners
 
     @property
     def score(self):


### PR DESCRIPTION
Reviews are deemed to only be visible to conveners and judges, even though we currently show an incorrect message.