### PR TITLE
reminder: add send to speaker option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Improvements
 - Improve reviewing state display for paper reviewers (:issue:`4979`, :pr:`4984`)
 - Make it clearer if the contributions/timetable of a conference are still in draft mode
   (:issue:`4977`, :pr:`4986`)
+- Add "send to speakers" option in Reminders. (:issue:`4958`, :pr:`4966`, thanks :user:`Naveenaidu`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,7 +28,8 @@ Improvements
 - Improve reviewing state display for paper reviewers (:issue:`4979`, :pr:`4984`)
 - Make it clearer if the contributions/timetable of a conference are still in draft mode
   (:issue:`4977`, :pr:`4986`)
-- Add "send to speakers" option in Reminders. (:issue:`4958`, :pr:`4966`, thanks :user:`Naveenaidu`)
+- Add "send to speakers" option in event reminders (:issue:`4958`, :pr:`4966`, thanks
+  :user:`Naveenaidu`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20210627_2317_420195768776_add_reminder_send_to_speakers_column.py
+++ b/indico/migrations/versions/20210627_2317_420195768776_add_reminder_send_to_speakers_column.py
@@ -1,0 +1,27 @@
+"""Add reminder send_to_speakers column
+
+Revision ID: 420195768776
+Revises: 90384b9b3d22
+Create Date: 2021-06-27 23:17:44.458327
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '420195768776'
+down_revision = '90384b9b3d22'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('reminders',
+                  sa.Column('send_to_speakers', sa.Boolean(), nullable=False, server_default='false'),
+                  schema='events')
+    op.alter_column('reminders', 'send_to_speakers', server_default=None, schema='events')
+
+
+def downgrade():
+    op.drop_column('reminders', 'send_to_speakers', schema='events')

--- a/indico/migrations/versions/20210705_1337_420195768776_add_reminder_send_to_speakers_column.py
+++ b/indico/migrations/versions/20210705_1337_420195768776_add_reminder_send_to_speakers_column.py
@@ -1,7 +1,7 @@
 """Add reminder send_to_speakers column
 
 Revision ID: 420195768776
-Revises: 90384b9b3d22
+Revises: 5cbb0eb12eb3
 Create Date: 2021-06-27 23:17:44.458327
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '420195768776'
-down_revision = '90384b9b3d22'
+down_revision = '5cbb0eb12eb3'
 branch_labels = None
 depends_on = None
 

--- a/indico/modules/events/reminders/forms.py
+++ b/indico/modules/events/reminders/forms.py
@@ -17,7 +17,7 @@ from indico.web.forms.validators import DateTimeRange, HiddenUnless
 
 
 class ReminderForm(IndicoForm):
-    recipient_fields = {'recipients', 'send_to_participants'}
+    recipient_fields = {'recipients', 'send_to_participants', 'send_to_speakers'}
     schedule_fields = {'schedule_type', 'absolute_dt', 'relative_delta'}
     schedule_recipient_fields = recipient_fields | schedule_fields
 
@@ -34,6 +34,8 @@ class ReminderForm(IndicoForm):
     send_to_participants = BooleanField(_('Participants'),
                                         description=_('Send the reminder to all participants/registrants '
                                                       'of the event.'))
+    send_to_speakers = BooleanField(_('Speakers'),
+                                    description=_('Send the reminder to all speakers/chairpersons of the event.'))
     # Misc
     reply_to_address = SelectField(_('Sender'), [DataRequired()],
                                    description=_('The email address that will show up as the sender.'))
@@ -55,12 +57,16 @@ class ReminderForm(IndicoForm):
             del self.include_summary
 
     def validate_recipients(self, field):
-        if not field.data and not self.send_to_participants.data:
-            raise ValidationError(_('If participants are not included you need to specify recipients.'))
+        if not field.data and not self.send_to_participants.data and not self.send_to_speakers.data:
+            raise ValidationError(_('If participants or speakers are not included you need to specify recipients.'))
 
     def validate_send_to_participants(self, field):
-        if not field.data and not self.recipients.data:
-            raise ValidationError(_('If no recipients are specified you need to include participants.'))
+        if not field.data and not self.recipients.data and not self.send_to_speakers.data:
+            raise ValidationError(_('If no recipients or speakers are specified you need to include participants.'))
+
+    def validate_send_to_speakers(self, field):
+        if not field.data and not self.recipients.data and not self.send_to_participants.data:
+            raise ValidationError(_('If no participants or recipients are specified you need to include speakers.'))
 
     def validate_schedule_type(self, field):
         # Be graceful and allow a reminder that's in the past but on the same day.

--- a/indico/modules/events/reminders/forms.py
+++ b/indico/modules/events/reminders/forms.py
@@ -17,9 +17,9 @@ from indico.web.forms.validators import DateTimeRange, HiddenUnless
 
 
 class ReminderForm(IndicoForm):
-    recipient_fields = {'recipients', 'send_to_participants', 'send_to_speakers'}
-    schedule_fields = {'schedule_type', 'absolute_dt', 'relative_delta'}
-    schedule_recipient_fields = recipient_fields | schedule_fields
+    recipient_fields = ['recipients', 'send_to_participants', 'send_to_speakers']
+    schedule_fields = ['schedule_type', 'absolute_dt', 'relative_delta']
+    schedule_recipient_fields = recipient_fields + schedule_fields
 
     # Schedule
     schedule_type = IndicoRadioField(_('Type'), [DataRequired()],

--- a/indico/modules/events/reminders/models/reminders.py
+++ b/indico/modules/events/reminders/models/reminders.py
@@ -83,7 +83,7 @@ class EventReminder(db.Model):
         nullable=False,
         default=False
     )
-    #: If the notification should also be sent to all event speaker
+    #: If the notification should also be sent to all event speakers
     send_to_speakers = db.Column(
         db.Boolean,
         nullable=False,
@@ -147,7 +147,7 @@ class EventReminder(db.Model):
         """Return all recipients of the notifications.
 
         This includes both explicit recipients and, if enabled,
-        participants of the event.
+        participants/speakers of the event.
         """
         recipients = set(self.recipients)
         if self.send_to_participants:


### PR DESCRIPTION
closes #4958

Screenshot of the option:
![2021-06-29_22-47](https://user-images.githubusercontent.com/30195193/123841178-dfb68000-d92c-11eb-9885-9056493f6d51.png)



TODO:
- [x] Apply migrations
- [x] Add Changelog entry
- [x] Fetch the speakers and add them to `all_recepients`
- [x] Format the code and apply the suggestion from pylint