### PR TITLE
Display more details when cloners are unavailable

### DIFF
--- a/indico/modules/attachments/clone.py
+++ b/indico/modules/attachments/clone.py
@@ -27,8 +27,9 @@ class AttachmentCloner(EventCloner):
     def is_available(self):
         return self._has_content(self.old_event)
 
-    def has_conflicts(self, target_event):
-        return self._has_content(target_event)
+    def get_conflicts(self, target_event):
+        if self._has_content(target_event):
+            return [_('The target event already has materials')]
 
     def run(self, new_event, cloners, shared_data, event_exists=False):
         self._clone_nested_attachments = False

--- a/indico/modules/events/abstracts/clone.py
+++ b/indico/modules/events/abstracts/clone.py
@@ -25,8 +25,16 @@ class AbstractSettingsCloner(EventCloner):
     def is_visible(self):
         return self.old_event.type_ == EventType.conference
 
-    def has_conflicts(self, target_event):
-        return bool(target_event.abstract_review_questions) or bool(target_event.abstract_email_templates)
+    def get_conflicts(self, target_event):
+        conflicts = []
+
+        if target_event.abstract_review_questions:
+            conflicts.append(_('The target event already has review questions'))
+
+        if target_event.abstract_email_templates:
+            conflicts.append(_('The target event already has email templates'))
+
+        return conflicts
 
     @no_autoflush
     def run(self, new_event, cloners, shared_data, event_exists=False):

--- a/indico/modules/events/cloning.py
+++ b/indico/modules/events/cloning.py
@@ -10,6 +10,7 @@ from operator import attrgetter
 from indico.core import signals
 from indico.util.caching import memoize_request
 from indico.util.decorators import cached_classproperty
+from indico.util.i18n import _
 from indico.util.signals import named_objects_from_signal
 
 
@@ -75,7 +76,7 @@ class EventCloner:
         if event_exists:
             if any(cloner.new_event_only for name, cloner in all_cloners.items() if name in cloners):
                 raise Exception('A new event only cloner was selected')
-            if any(cloner.has_conflicts(new_event) for name, cloner in all_cloners.items() if name in cloners):
+            if any(cloner.get_conflicts(new_event) for name, cloner in all_cloners.items() if name in cloners):
                 raise Exception('Cloner target is not empty')
 
         # enable internal cloners that are enabled by default or required by another cloner
@@ -173,13 +174,16 @@ class EventCloner:
         """
         return True
 
-    def has_conflicts(self, target_event):
-        """Check for conflicts between source event and target event.
+    def get_conflicts(self, target_event):
+        """Return conflicts between source event and target event.
 
         Use this when cloning into an existing event to disable options
         where ``target_event`` data would conflict with cloned data.
+
+        Returns a dummy conflict it not overridden as cloners
+        do not support importing by default.
         """
-        return True
+        return [_('Importing data is not supported')]
 
     def _prepare_shared_data(self, shared_data):
         linked = self.uses | self.requires

--- a/indico/modules/events/contributions/clone.py
+++ b/indico/modules/events/contributions/clone.py
@@ -37,8 +37,9 @@ class ContributionTypeCloner(EventCloner):
     # We do not override `is_available` as we have cloners depending
     # on this internal cloner even if it won't clone anything.
 
-    def has_conflicts(self, target_event):
-        return target_event.contribution_types.has_rows()
+    def get_conflicts(self, target_event):
+        if target_event.contribution_types.has_rows():
+            return [_('The target event already has contribution types')]
 
     def run(self, new_event, cloners, shared_data, event_exists=False):
         self._contrib_type_map = {}
@@ -63,8 +64,9 @@ class ContributionFieldCloner(EventCloner):
     # We do not override `is_available` as we have cloners depending
     # on this internal cloner even if it won't clone anything.
 
-    def has_conflicts(self, target_event):
-        return target_event.contribution_fields.has_rows()
+    def get_conflicts(self, target_event):
+        if target_event.contribution_fields.has_rows():
+            return [_('The target event already has contribution fields')]
 
     def run(self, new_event, cloners, shared_data, event_exists=False):
         self._contrib_field_map = {}
@@ -92,8 +94,9 @@ class ContributionCloner(EventCloner):
     # We do not override `is_available` as we have cloners depending
     # on this internal cloner even if it won't clone anything.
 
-    def has_conflicts(self, target_event):
-        return bool(target_event.contributions)
+    def get_conflicts(self, target_event):
+        if target_event.contributions:
+            return [_('The target event already has contributions')]
 
     @classmethod
     @no_autoflush

--- a/indico/modules/events/layout/clone.py
+++ b/indico/modules/events/layout/clone.py
@@ -27,8 +27,9 @@ class ImageCloner(EventCloner):
     def is_available(self):
         return self._find_images(self.old_event).has_rows()
 
-    def has_conflicts(self, target_event):
-        return self._find_images(target_event).has_rows()
+    def get_conflicts(self, target_event):
+        if self._find_images(target_event).has_rows():
+            return [_('The target event already has images')]
 
     def _find_images(self, event):
         return event.layout_images

--- a/indico/modules/events/management/templates/import_event.html
+++ b/indico/modules/events/management/templates/import_event.html
@@ -57,13 +57,6 @@
 
             {% elif step == 2 %}
                 {% call form_fieldset(_("What should be imported?")) %}
-                    {% call message_box('info') %}
-                        {% trans %}Some options might not be available because:{% endtrans %}
-                        <ul>
-                            <li>{% trans %}target event already has data in the module{% endtrans %}</li>
-                            <li>{% trans %}source event does not have any data in the module{% endtrans %}</li>
-                        </ul>
-                    {% endcall %}
                     {{ form_rows(form, skip=('source_event_url',), skip_labels=true) }}
                     {{ invisible_field(form.source_event_url) }}
                 {% endcall %}

--- a/indico/modules/events/notes/clone.py
+++ b/indico/modules/events/notes/clone.py
@@ -23,8 +23,9 @@ class NoteCloner(EventCloner):
     def is_available(self):
         return self._has_content(self.old_event)
 
-    def has_conflicts(self, target_event):
-        return self._has_content(target_event)
+    def get_conflicts(self, target_event):
+        if self._has_content(target_event):
+            return [_('The target event already has minutes')]
 
     def run(self, new_event, cloners, shared_data, event_exists=False):
         self._clone_nested_notes = False

--- a/indico/modules/events/registration/clone.py
+++ b/indico/modules/events/registration/clone.py
@@ -31,8 +31,9 @@ class RegistrationFormCloner(EventCloner):
     def is_available(self):
         return self._has_content(self.old_event)
 
-    def has_conflicts(self, target_event):
-        return self._has_content(target_event)
+    def get_conflicts(self, target_event):
+        if self._has_content(target_event):
+            return [_('The target event already has registration forms')]
 
     @no_autoflush
     def run(self, new_event, cloners, shared_data, event_exists=False):
@@ -100,8 +101,9 @@ class RegistrationCloner(EventCloner):
     def is_default(self):
         return self.old_event.type_ == EventType.meeting
 
-    def has_conflicts(self, target_event):
-        return self._has_content(target_event)
+    def get_conflicts(self, target_event):
+        if self._has_content(target_event):
+            return [_('The target event already has registrations')]
 
     def run(self, new_event, cloners, shared_data, event_exists=False):
         form_map = shared_data['registration_forms']['form_map']

--- a/indico/modules/events/reminders/__init__.py
+++ b/indico/modules/events/reminders/__init__.py
@@ -65,8 +65,9 @@ class ReminderCloner(EventCloner):
     def is_available(self):
         return self._find_reminders(self.old_event).has_rows()
 
-    def has_conflicts(self, target_event):
-        return self._find_reminders(target_event).has_rows()
+    def get_conflicts(self, target_event):
+        if self._find_reminders(target_event).has_rows():
+            return [_('The target event already has reminders')]
 
     def _find_reminders(self, event):
         return event.reminders.filter(db.m.EventReminder.is_relative)

--- a/indico/modules/events/roles/clone.py
+++ b/indico/modules/events/roles/clone.py
@@ -27,8 +27,9 @@ class EventRoleCloner(EventCloner):
     def is_available(self):
         return self._has_content(self.old_event)
 
-    def has_conflicts(self, target_event):
-        return self._has_content(target_event)
+    def get_conflicts(self, target_event):
+        if self._has_content(target_event):
+            return [_('The target event already has event roles')]
 
     def run(self, new_event, cloners, shared_data, event_exists):
         self._event_role_map = {}

--- a/indico/modules/events/sessions/clone.py
+++ b/indico/modules/events/sessions/clone.py
@@ -28,8 +28,9 @@ class SessionCloner(EventCloner):
     # We do not override `is_available` as we have cloners depending
     # on this internal cloner even if it won't clone anything.
 
-    def has_conflicts(self, target_event):
-        return bool(target_event.sessions)
+    def get_conflicts(self, target_event):
+        if target_event.sessions:
+            return [_('The target event already has sessions')]
 
     def run(self, new_event, cloners, shared_data, event_exists=False):
         self._event_role_map = shared_data['event_roles']['event_role_map'] if 'event_roles' in cloners else None

--- a/indico/modules/events/surveys/clone.py
+++ b/indico/modules/events/surveys/clone.py
@@ -21,8 +21,9 @@ class EventSurveyCloner(EventCloner):
     def is_available(self):
         return self._has_content(self.old_event)
 
-    def has_conflicts(self, target_event):
-        return self._has_content(target_event)
+    def get_conflicts(self, target_event):
+        if self._has_content(target_event):
+            return [_('The target event already has surveys')]
 
     def run(self, new_event, cloners, shared_data, event_exists=False):
         with db.session.no_autoflush:

--- a/indico/modules/events/timetable/clone.py
+++ b/indico/modules/events/timetable/clone.py
@@ -33,8 +33,15 @@ class TimetableCloner(EventCloner):
     def is_visible(self):
         return self.old_event.type_ in {EventType.meeting, EventType.conference}
 
-    def has_conflicts(self, target_event):
-        return self._has_content(target_event) or self.old_event.duration > target_event.duration
+    def get_conflicts(self, target_event):
+        conflicts = []
+        if self._has_content(target_event):
+            conflicts.append(_('The target event already has a timetable'))
+
+        if self.old_event.duration > target_event.duration:
+            conflicts.append(_('The source event is longer than the target event'))
+
+        return conflicts
 
     def run(self, new_event, cloners, shared_data, event_exists=False):
         self._session_block_map = shared_data['sessions']['session_block_map']

--- a/indico/modules/events/tracks/clone.py
+++ b/indico/modules/events/tracks/clone.py
@@ -30,8 +30,9 @@ class TrackCloner(EventCloner):
     def is_available(self):
         return self._has_content(self.old_event)
 
-    def has_conflicts(self, target_event):
-        return self._has_content(target_event)
+    def get_conflicts(self, target_event):
+        if self._has_content(target_event):
+            return [_('The target event already has tracks')]
 
     @no_autoflush
     def run(self, new_event, cloners, shared_data, event_exists=False):

--- a/indico/modules/vc/clone.py
+++ b/indico/modules/vc/clone.py
@@ -31,8 +31,9 @@ class VCCloner(EventCloner):
             return True
         return self._has_content(self.old_event)
 
-    def has_conflicts(self, target_event):
-        return self._has_content(target_event)
+    def get_conflicts(self, target_event):
+        if self._has_content(target_event):
+            return [_('The target event already has videoconference rooms')]
 
     def _has_content(self, event):
         return VCRoomEventAssociation.find_for_event(event, include_hidden=True).has_rows()

--- a/indico/web/client/styles/partials/_inputs.scss
+++ b/indico/web/client/styles/partials/_inputs.scss
@@ -382,6 +382,14 @@ $dropdown-transition: $dropdown-transition-step ease-out;
     display: inline-block;
     margin-left: 0.5em;
   }
+
+  i.icon-padding {
+    padding-left: 5px;
+  }
+
+  span.checkbox-label {
+    white-space: nowrap;
+  }
 }
 
 %tilted-strips-bg {

--- a/indico/web/templates/forms/checkbox_group_widget.html
+++ b/indico/web/templates/forms/checkbox_group_widget.html
@@ -4,11 +4,18 @@
 {% block html %}
     {% set input_args = dict(input_args) %}
     {% set field_disabled = input_args.pop('disabled', false) %}
+    {% set reasons = field.disabled_choices_reasons|default({}) %}
     {% for subfield in field %}
         {% set disabled = field_disabled or subfield.data in field.disabled_choices|default([]) %}
-        <div class="i-checkbox {{ 'checkbox-disabled' if disabled}}">
-            {{ subfield(disabled=disabled, **input_args) }}
-            {{ subfield.label }}
+        {% set reason = reasons.get(subfield.data) %}
+        <div class="i-checkbox">
+            <span class="checkbox-label {{ 'checkbox-disabled' if disabled }}">
+                {{ subfield(disabled=disabled, **input_args) }}
+                {{ subfield.label }}
+            </span>
+            {% if disabled and reason %}
+                <i class="icon-warning icon-padding" title="{{ reason }}"></i>
+            {% endif %}
         </div>
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
Closes #4913

Adds a little warning icon to disabled options in the clone and import forms.
When hovered over, these icons provide a description of why the given option is disabled.

![image](https://user-images.githubusercontent.com/8739637/123771128-19ef3580-d8cb-11eb-9457-2e23f20d9c53.png)
![image](https://user-images.githubusercontent.com/8739637/123771414-4b680100-d8cb-11eb-8ac9-b6265897f724.png)
![image](https://user-images.githubusercontent.com/8739637/123923607-757ff880-d989-11eb-92fc-2bf38e631d5b.png)
![image](https://user-images.githubusercontent.com/8739637/124122231-2794ee80-da76-11eb-890b-c8b68870ef00.png)


In order to report a reason when a cloner has conflicts, this commit replaces `Cloner.has_conflicts()` with
`Cloner.get_conflicts()` which returns a list of conflicts for the given cloner.