### PR TITLE
Include content in abstract listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Version 3.0rc2
 
 *Unreleased*
 
+Improvements
+^^^^^^^^^^^^
+
+- Add abstract content to the abstract list customization options (:pr:`4968`)
+
 Bugfixes
 ^^^^^^^^
 
@@ -50,7 +55,6 @@ Internationalization
 Improvements
 ^^^^^^^^^^^^
 
-- Add abstract content to the abstract list customization options (:pr:`4968`)
 - Use a more modern search dialog when searching for users (:issue:`4674`, :pr:`4743`)
 - Add an option to refresh event person data from the underlying user when cloning an
   event (:issue:`4750`, :pr:`4760`)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,7 @@ Internationalization
 Improvements
 ^^^^^^^^^^^^
 
+- Add abstract content to the abstract list customization options (:pr:`4968`)
 - Use a more modern search dialog when searching for users (:issue:`4674`, :pr:`4743`)
 - Add an option to refresh event person data from the underlying user when cloning an
   event (:issue:`4750`, :pr:`4760`)

--- a/indico/modules/events/abstracts/lists.py
+++ b/indico/modules/events/abstracts/lists.py
@@ -48,7 +48,8 @@ class AbstractListGeneratorBase(ListGeneratorBase):
             'submitted_contrib_type': {'title': _('Submitted type'), 'filter_choices': type_empty | type_choices},
             'score': {'title': _('Score')},
             'submitted_dt': {'title': _('Submission date')},
-            'modified_dt': {'title': _('Modification date')}
+            'modified_dt': {'title': _('Modification date')},
+            'description': {'title': _('Content')}
         }
         self.extra_filters = {}
         self.list_config = self._get_config()

--- a/indico/modules/events/abstracts/templates/management/_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/_abstract_list.html
@@ -82,7 +82,7 @@
                             <th class="i-table thin-column" data-sorter="false"></th>
                             <th class="i-table id-column">{% trans %}ID{% endtrans %}</th>
                             <th class="i-table">{% trans %}Title{% endtrans %}</th>
-                            {% for item in static_columns %}
+                            {% for item in static_columns if item.id != 'description' %}
                                 <th class="i-table" data-sorter="text">{{ item.caption }}</th>
                             {% endfor %}
                             {% for item in dynamic_columns %}
@@ -237,9 +237,9 @@
                                 </td>
                             </tr>
                             {% for item in static_columns if item.id == 'description' %}
-                                <tr class="i-table-inner i-table-bottom">
+                                <tr class="details-row">
                                     <td></td>
-                                    <td colspan="{{ 3 + static_columns|length + dynamic_columns|length }}">
+                                    <td colspan="{{ 3 + static_columns|length + dynamic_columns|length - 1 }}">
                                         {{ abstract.description }}
                                     </td>
                                 </tr>

--- a/indico/modules/events/abstracts/templates/management/_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/_abstract_list.html
@@ -236,6 +236,16 @@
                                     {% endif %}
                                 </td>
                             </tr>
+                            {% for item in static_columns %}
+                                {% if item.id == 'description' %}
+                                    <tr class="i-table-inner i-table-bottom">
+                                        <td></td>
+                                        <td colspan="{{ 3 + static_columns|length + dynamic_columns|length }}">
+                                            {{ abstract.description }}
+                                        </td>
+                                    </tr>
+                                {% endif %}
+                            {% endfor %}
                         {% endfor %}
                     </tbody>
                 </table>

--- a/indico/modules/events/abstracts/templates/management/_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/_abstract_list.html
@@ -236,15 +236,13 @@
                                     {% endif %}
                                 </td>
                             </tr>
-                            {% for item in static_columns %}
-                                {% if item.id == 'description' %}
-                                    <tr class="i-table-inner i-table-bottom">
-                                        <td></td>
-                                        <td colspan="{{ 3 + static_columns|length + dynamic_columns|length }}">
-                                            {{ abstract.description }}
-                                        </td>
-                                    </tr>
-                                {% endif %}
+                            {% for item in static_columns if item.id == 'description' %}
+                                <tr class="i-table-inner i-table-bottom">
+                                    <td></td>
+                                    <td colspan="{{ 3 + static_columns|length + dynamic_columns|length }}">
+                                        {{ abstract.description }}
+                                    </td>
+                                </tr>
                             {% endfor %}
                         {% endfor %}
                     </tbody>

--- a/indico/modules/events/client/js/util/list_generator.js
+++ b/indico/modules/events/client/js/util/list_generator.js
@@ -58,6 +58,7 @@
       headers: {
         0: {sorter: false},
       },
+      cssChildRow: 'details-row',
     });
   };
 

--- a/indico/modules/events/client/js/util/static_filters.js
+++ b/indico/modules/events/client/js/util/static_filters.js
@@ -67,6 +67,7 @@
 
     $items.hide();
     $visibleEntries.show();
+    $visibleEntries.next(searchBoxConfig.childHandle || '.details-row').show();
 
     // Needed because $(window).scroll() is not called when hiding elements
     // causing scrolling elements to be out of place.

--- a/indico/modules/events/client/js/util/static_filters.js
+++ b/indico/modules/events/client/js/util/static_filters.js
@@ -59,8 +59,11 @@
         .text($T.gettext('There are no entries that match your search criteria.'))
         .show();
       $state.addClass('active');
-    } else if ($visibleEntries.length !== $items.length) {
-      $state.addClass('active');
+    } else {
+      $filterPlaceholder.hide();
+      if ($visibleEntries.length !== $items.length) {
+        $state.addClass('active');
+      }
     }
 
     setState($state, $visibleEntries, $items);

--- a/indico/web/client/styles/partials/_tables.scss
+++ b/indico/web/client/styles/partials/_tables.scss
@@ -90,7 +90,8 @@ tr.i-table {
   }
 }
 
-tr.i-table:last-child {
+tr.i-table:last-child,
+tr.details-row:last-child {
   border-bottom: 1px solid $pastel-gray;
 }
 

--- a/indico/web/client/styles/partials/_tables.scss
+++ b/indico/web/client/styles/partials/_tables.scss
@@ -77,7 +77,6 @@ table.i-table {
 }
 
 tr.i-table {
-  border-bottom: 1px solid $pastel-gray;
   border-top: 1px solid $pastel-gray;
 
   &.selected {
@@ -88,6 +87,15 @@ tr.i-table {
     @include transition(background-color 0.2s);
     background-color: $light-blue;
   }
+}
+
+tr.i-table:last-child,
+tr.i-table-bottom {
+  border-bottom: 1px solid $pastel-gray;
+}
+
+tr.i-table-inner {
+  background: $light-gray;
 }
 
 td.i-table,

--- a/indico/web/client/styles/partials/_tables.scss
+++ b/indico/web/client/styles/partials/_tables.scss
@@ -79,7 +79,8 @@ table.i-table {
 tr.i-table {
   border-top: 1px solid $pastel-gray;
 
-  &.selected {
+  &.selected,
+  &.selected + tr.details-row {
     background-color: $pastel-blue !important;
   }
 
@@ -89,12 +90,11 @@ tr.i-table {
   }
 }
 
-tr.i-table:last-child,
-tr.i-table-bottom {
+tr.i-table:last-child {
   border-bottom: 1px solid $pastel-gray;
 }
 
-tr.i-table-inner {
+tr.details-row {
   background: $light-gray;
 }
 


### PR DESCRIPTION
A simple proposal for the inclusion of content/description in the abstract listing, making use of another table row that simulates being part of its sibling.

This does not include collapsible rows as it didn't seem useful in a dynamic row, but suggestions are welcome.

![imagem](https://user-images.githubusercontent.com/12183954/123643778-a5f65400-d81c-11eb-8b5b-c8da56f8e22a.png)
