### PR TITLE
Add CLI option to create a series

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Improvements
 ^^^^^^^^^^^^
 
 - Add abstract content to the abstract list customization options (:pr:`4968`)
+- Add CLI option to create a series (:pr:`4969`)
 
 Bugfixes
 ^^^^^^^^


### PR DESCRIPTION
![Screenshot from 2021-06-29 17-29-57](https://user-images.githubusercontent.com/8739637/123827546-ffd04a00-d900-11eb-8b85-3ba59b9f5524.png)

![image](https://user-images.githubusercontent.com/8739637/123929901-86cc0380-d98f-11eb-835e-7c347b62655f.png)


#### Usage:
indico event create-series [--no-title-sequence] [--no-links] 12 34 56

This command adds the events specified by event Ids to a new series provided the
events are not assigned to a series already.

Includes an option to hide the series sequence from the event titles. Also includes an option to hide
the links to other events in the series in the event page.
