### PR TITLE
Use the same icon for `List` action

### DIFF
--- a/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
@@ -170,7 +170,7 @@ export default function EditableTypeDashboard() {
                 label={Translate.string('Allow editors to self-assign editables')}
               />
               <Link
-                className="i-button icon-settings"
+                className="i-button icon-list"
                 to={manageEditableTypeListURL({event_id: eventId, type})}
               >
                 <Translate>List</Translate>


### PR DESCRIPTION
Replaces `icon-settings` with `icon-list`.

I searched for `icon-settings` and `List` to try to find other occurrences but didn't find anything else
except for this one.

closes #4974