### PR TITLE
Make it less likely to accidentally create mixed categories

### DIFF
--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -125,8 +125,8 @@ class RHCategoryInfo(RHDisplayCategoryBase):
         children_strategy.subqueryload('acl_entries')
         children_strategy.undefer('deep_children_count')
         children_strategy.undefer('deep_events_count')
-        children_strategy.undefer('has_events'),
-        children_strategy.undefer('has_children'),
+        children_strategy.undefer('has_events')
+        children_strategy.undefer('has_children')
         return (children_strategy,
                 load_only('id', 'parent_id', 'title', 'protection_mode'),
                 subqueryload('acl_entries'),

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -125,13 +125,15 @@ class RHCategoryInfo(RHDisplayCategoryBase):
         children_strategy.subqueryload('acl_entries')
         children_strategy.undefer('deep_children_count')
         children_strategy.undefer('deep_events_count')
-        children_strategy.undefer('has_events')
+        children_strategy.undefer('has_events'),
+        children_strategy.undefer('has_children'),
         return (children_strategy,
                 load_only('id', 'parent_id', 'title', 'protection_mode'),
                 subqueryload('acl_entries'),
                 undefer('deep_children_count'),
                 undefer('deep_events_count'),
                 undefer('has_events'),
+                undefer('has_children'),
                 undefer('chain'))
 
     def _process(self):
@@ -163,7 +165,7 @@ class RHCategorySearch(RH):
         query = (Category.query
                  .filter(Category.title_matches(q))
                  .options(undefer('deep_children_count'), undefer('deep_events_count'), undefer('has_events'),
-                          joinedload('acl_entries')))
+                          undefer('has_children'), joinedload('acl_entries')))
         if session.user:
             # Prefer favorite categories
             query = query.order_by(Category.favorite_of.any(favorite_category_table.c.user_id == session.user.id)

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -568,6 +568,14 @@ def _mappers_configured():
              .correlate_except(Event))
     Category.has_events = column_property(query, deferred=True)
 
+    # Category.has_children -- whether the category contains any
+    # non-deleted subcategories
+    cat_alias = db.aliased(Category)
+    query = (exists([1])
+             .where((cat_alias.parent_id == Category.id) & ~cat_alias.is_deleted)
+             .correlate_except(cat_alias))
+    Category.has_children = column_property(query, deferred=True)
+
     # Category.chain_titles -- a list of the titles in the parent chain,
     # starting with the root category down to the current category.
     cte = Category.get_tree_cte('title')

--- a/indico/modules/categories/serialize.py
+++ b/indico/modules/categories/serialize.py
@@ -101,6 +101,7 @@ def serialize_category(category, with_favorite=False, with_path=False, parent_pa
         'title': category.title,
         'is_protected': category.is_protected,
         'has_events': category.has_events,
+        'has_children': category.has_children,
         'deep_category_count': category.deep_children_count,
         'deep_event_count': category.deep_events_count,
         'can_access': category.can_access(session.user),

--- a/indico/modules/events/controllers/creation.py
+++ b/indico/modules/events/controllers/creation.py
@@ -46,16 +46,24 @@ class RHCreateEvent(RHProtected):
     def _process_args(self):
         self.event_type = EventType[request.view_args['event_type']]
         self.root_category = Category.get_root()
-        self.single_category = not self.root_category.children
+        self.single_category = not self.root_category.has_children
+
+    def _has_only_subcategories(self, category):
+        return category.has_children and not category.has_events
 
     @cached_property
     def _default_category(self):
         try:
             category_id = int(request.args['category_id'])
         except (ValueError, KeyError):
-            return self.root_category if self.single_category else None
+            return None if self._has_only_subcategories(self.root_category) else self.root_category
+
+        category = Category.get(category_id, is_deleted=False)
+        if (category and self._has_only_subcategories(category) and
+                (category.is_root or category.can_create_events(session.user))):
+            return None
         else:
-            return Category.get(category_id, is_deleted=False)
+            return category
 
     def _get_prepared_data(self):
         try:

--- a/indico/modules/events/controllers/creation.py
+++ b/indico/modules/events/controllers/creation.py
@@ -46,7 +46,6 @@ class RHCreateEvent(RHProtected):
     def _process_args(self):
         self.event_type = EventType[request.view_args['event_type']]
         self.root_category = Category.get_root()
-        self.single_category = not self.root_category.has_children
 
     def _has_only_subcategories(self, category):
         return category.has_children and not category.has_events
@@ -59,8 +58,7 @@ class RHCreateEvent(RHProtected):
             return None if self._has_only_subcategories(self.root_category) else self.root_category
 
         category = Category.get(category_id, is_deleted=False)
-        if (category and self._has_only_subcategories(category) and
-                (category.is_root or category.can_create_events(session.user))):
+        if category and category.is_root and self._has_only_subcategories(category):
             return None
         else:
             return category
@@ -152,7 +150,7 @@ class RHCreateEvent(RHProtected):
         check_room_availability = rb_check_user_access(session.user) and config.ENABLE_ROOMBOOKING
         rb_excluded_categories = [c.id for c in rb_settings.get('excluded_categories')]
         return jsonify_template('events/forms/event_creation_form.html', form=form, fields=form._field_order,
-                                event_type=self.event_type.name, single_category=self.single_category,
+                                event_type=self.event_type.name, single_category=(not self.root_category.has_children),
                                 check_room_availability=check_room_availability,
                                 rb_excluded_categories=rb_excluded_categories)
 

--- a/indico/web/client/js/jquery/widgets/jinja/category_picker_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/category_picker_widget.js
@@ -21,6 +21,7 @@
 
     const $field = $(`#${options.fieldId}`);
     const $categoryTitle = $(`#category-title-${options.fieldId}`);
+    const $categoryWarning = $(`#category-warning-${options.fieldId}`);
     const $dialogTrigger = $(`#categorynav-button-${options.fieldId}`);
     let hiddenData = $field.val() ? JSON.parse($field.val()) : {};
     let navigatorCategory = options.navigatorCategoryId;
@@ -51,6 +52,8 @@
         openInDialog: true,
         actionOn,
         onAction(category) {
+          $categoryWarning.toggleClass('hidden', !category.has_children || category.has_events);
+
           const event = $.Event('indico:categorySelected');
           const dfd = $.Deferred();
           $categoryTitle.text(category.title);

--- a/indico/web/client/js/jquery/widgets/jinja/category_picker_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/category_picker_widget.js
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 /* eslint-disable import/unambiguous */
+/* global build_url:false, handleAjaxError:false */
 
 (function(global) {
   global.setupCategoryPickerWidget = function setupCategoryPickerWidget(options) {
@@ -42,6 +43,8 @@
       error: handleAjaxError,
       success(data) {
         navigatorCategory = data;
+        const {category} = navigatorCategory;
+        $categoryWarning.toggleClass('hidden', !category.has_children || category.has_events);
       },
     });
 
@@ -52,10 +55,9 @@
         openInDialog: true,
         actionOn,
         onAction(category) {
-          $categoryWarning.toggleClass('hidden', !category.has_children || category.has_events);
-
           const event = $.Event('indico:categorySelected');
           const dfd = $.Deferred();
+          $categoryWarning.toggleClass('hidden', !category.has_children || category.has_events);
           $categoryTitle.text(category.title);
           hiddenData = {id: category.id, title: category.title};
           navigatorCategory = category.id;

--- a/indico/web/templates/forms/category_picker_widget.html
+++ b/indico/web/templates/forms/category_picker_widget.html
@@ -1,9 +1,18 @@
 {% extends 'forms/base_widget.html' %}
+{% from 'message_box.html' import message_box %}
 
 
 {% block html %}
     <div class="i-form-field-fixed-width">
         <div id="category-title-{{ field.id }}" class="text-holder-box flexrow f-a-center" data-tooltip-anchor></div>
+        <div id="category-warning-{{ field.id }}" class="hidden">
+            {% call message_box('warning') %}
+                {% trans %}
+                    The selected category does not contain any events, only subcategories.
+                    Please make sure that you really want to create an event there.
+                {% endtrans %}
+            {% endcall %}
+        </div>
         <a class="i-button" id="categorynav-button-{{ field.id }}"
            data-title='{% trans %}Choose category{% endtrans %}'>
             {%- trans %}Choose category{% endtrans -%}


### PR DESCRIPTION
Closes #4971

![image](https://user-images.githubusercontent.com/8739637/124120134-adfc0100-da73-11eb-9b89-155ac777c6c4.png)

Currently, the category field in the event creation form gets prefilled with the current category. This can lead
to creating events in categories which should only contain other subcategories, if one is not careful. This could be
especially problematic in the case of root category.

This commit changes the behavior such that it does not prefill categories which only contain other categories
and no events. In the case of non-root categories, we also require that the user has create access
to the category in order to stop the prefilling.

This is to maintain the user friendliness of the category picker for non-admin users as the picker
starts at the root category if no category is prefilled.
