### PR TITLE
Add db_query signal and signal_query method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,9 @@ Internal Changes
 - Add :data:`EMAIL_BACKEND` configuration variable to support different email sending
   backends e.g. during development (:issue:`5375`, :pr:`5376`, thanks :user:`Moist-Cat`)
 - Make model attrs to clone interceptable by plugins (:pr:`5403`, thanks :user:`omegak`)
+- Add ``signal_query`` method in the ``IndicoBaseQuery`` class and the ``db_query``
+  signal, allowing to intercept and modify queries by signal handlers (:pr:`4981`,
+  thanks :user:`omegak`).
 
 
 ----

--- a/indico/core/signals/core.py
+++ b/indico/core/signals/core.py
@@ -88,6 +88,12 @@ Executed when a new database schema is created.  The *sender* is the
 name of the schema.
 ''')
 
+db_query = _signals.signal('db-query', '''
+Expected to return exactly one single `Query` object.  The *sender* is a string
+identifying the context.  The *query* kwarg contains the query object to be
+customized.  The additional kwargs passed to this signal depend on the context.
+''')
+
 check_password_secure = _signals.signal('check-password-secure', '''
 Check whether a password is secure. The *sender* is a string indicating
 the context where the password check happens, the plaintext password is


### PR DESCRIPTION
Add a `db_query` signal that allows a handler modify the query object. The `signal_query` method is expected to be used for sending the signal in order to guarantee that only one handler modifies the query.

An example of usage is the following:

```python
query = (Registration.query.with_parent(self.event)
         .filter(Registration.is_state_publishable, ~RegistrationForm.is_deleted)
         .join(Registration.registration_form)
         .options(subqueryload('data').joinedload('field_data'),
                  contains_eager('registration_form'))
         .signal_query('publishable-registrations-in-participant-list'))
```

On the signal handler side, the query can be intercepted like this:

```python
@signals.core.db_query.connect_via('publishable-registrations-in-participant-list')
def _intercept_publishable_registrations_in_participant_list(sender, query, **kwargs):
    return query.filter(...)
```