### PR TITLE
Trigger signals when cloning into an existing event

### DIFF
--- a/indico/modules/attachments/logging.py
+++ b/indico/modules/attachments/logging.py
@@ -7,6 +7,7 @@
 
 from functools import wraps
 
+from flask import g
 from jinja2.filters import do_filesizeformat
 
 from indico.core import signals
@@ -82,6 +83,8 @@ def _log_folder_updated(folder, user, **kwargs):
 
 @_ignore_non_loggable
 def _log_attachment_created(attachment, user, **kwargs):
+    if g.get('importing_event'):
+        return
     event = attachment.folder.object.event
     _log(event, EventLogKind.positive, f'Added material "{attachment.title}"', user,
          _get_attachment_data(attachment))

--- a/indico/modules/events/clone.py
+++ b/indico/modules/events/clone.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from indico.core import signals
 from indico.core.db import db
 from indico.core.db.sqlalchemy.principals import clone_principals
 from indico.core.db.sqlalchemy.util.models import get_simple_column_attrs
@@ -141,6 +142,9 @@ class EventProtectionCloner(EventCloner):
             self._clone_acl(new_event, event_exists)
             self._clone_visibility(new_event)
         db.session.flush()
+        if event_exists:
+            signals.acl.protection_changed.send(type(new_event), obj=new_event, mode=new_event.protection_mode,
+                                                old_mode=None)
 
     def _clone_protection(self, new_event):
         new_event.protection_mode = self.old_event.protection_mode

--- a/indico/modules/events/contributions/clone.py
+++ b/indico/modules/events/contributions/clone.py
@@ -153,6 +153,11 @@ class ContributionCloner(EventCloner):
         with db.session.no_autoflush:
             self._clone_contribs(new_event, event_exists=event_exists)
         self._synchronize_friendly_id(new_event)
+        if event_exists:
+            for contrib in self._contrib_map.values():
+                signals.event.contribution_created.send(contrib)
+            for subcontrib in self._subcontrib_map.values():
+                signals.event.subcontribution_created.send(subcontrib)
         db.session.flush()
         return {'contrib_map': self._contrib_map, 'subcontrib_map': self._subcontrib_map}
 

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -7,7 +7,7 @@
 
 from operator import attrgetter
 
-from flask import session
+from flask import g, session
 
 from indico.core import signals
 from indico.core.db import db
@@ -202,7 +202,9 @@ def clone_into_event(source_event, target_event, cloners):
     """
 
     # Run the modular cloning system
+    g.importing_event = True
     EventCloner.run_cloners(source_event, target_event, cloners, event_exists=True)
+    del g.importing_event
     signals.event.imported.send(target_event, source_event=source_event)
 
     return target_event


### PR DESCRIPTION
Otherwise livesync won't send the newly added objects since we don't have the event creation in the queue..