### PR TITLE
Timetable: add warning in case of draft mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Improvements
 - Users cannot submit multiple anonymous surveys anymore by logging out and in again
   (:issue:`4693`, :pr:`4970`)
 - Improve reviewing state display for paper reviewers (:issue:`4979`, :pr:`4984`)
+- Make it clearer if the contributions/timetable of a conference are still in draft mode
+  (:issue:`4977`, :pr:`4986`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/client/js/PublicationButton.jsx
+++ b/indico/modules/events/contributions/client/js/PublicationButton.jsx
@@ -9,32 +9,31 @@ import publicationURL from 'indico-url:contributions.manage_publication';
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Checkbox} from 'semantic-ui-react';
 
-import {useTogglableValue} from 'indico/react/hooks';
+import {IButton} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
+import {handleAxiosError, indicoAxios} from 'indico/utils/axios';
 
 import PublicationModal from './PublicationModal';
 
-export default function PublicationSwitch({eventId}) {
+export default function PublicationButton({eventId, onSuccess}) {
+  const url = publicationURL({event_id: eventId});
   const [modalOpen, setModalOpen] = useState(false);
 
-  const [published, togglePublished, loading, saving] = useTogglableValue(
-    publicationURL({event_id: eventId})
-  );
-
-  if (loading) {
-    return null;
-  }
+  const onClick = async () => {
+    try {
+      await indicoAxios.put(url);
+    } catch (error) {
+      return handleAxiosError(error);
+    }
+    onSuccess();
+    setModalOpen(false);
+  };
 
   const trigger = (
-    <Checkbox
-      label={published ? Translate.string('Published') : Translate.string('Draft')}
-      toggle
-      onClick={() => setModalOpen(true)}
-      checked={published}
-      disabled={saving}
-    />
+    <IButton onClick={() => setModalOpen(true)}>
+      <Translate>Publish now</Translate>
+    </IButton>
   );
 
   return (
@@ -42,15 +41,13 @@ export default function PublicationSwitch({eventId}) {
       open={modalOpen}
       setModalOpen={setModalOpen}
       trigger={trigger}
-      published={published}
-      onClick={() => {
-        togglePublished();
-        setModalOpen(false);
-      }}
+      published={false}
+      onClick={onClick}
     />
   );
 }
 
-PublicationSwitch.propTypes = {
+PublicationButton.propTypes = {
   eventId: PropTypes.string.isRequired,
+  onSuccess: PropTypes.func.isRequired,
 };

--- a/indico/modules/events/contributions/client/js/PublicationModal.jsx
+++ b/indico/modules/events/contributions/client/js/PublicationModal.jsx
@@ -1,0 +1,85 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2021 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Header, Modal, Button, List} from 'semantic-ui-react';
+
+import {Translate} from 'indico/react/i18n';
+
+export default function PublicationModal({open, setModalOpen, trigger, published, onClick}) {
+  return (
+    <Modal open={open} onClose={() => setModalOpen(false)} size="tiny" trigger={trigger} closeIcon>
+      <Header
+        content={
+          published
+            ? Translate.string('Set contribution list in draft mode')
+            : Translate.string('Publish contributions')
+        }
+      />
+      <Modal.Content>
+        {published ? (
+          <>
+            <p>
+              <Translate>
+                Are you sure you want to change the contribution list back to draft mode?
+              </Translate>
+            </p>
+            <p>
+              <Translate>By doing so the following menu items won't be accessible:</Translate>
+            </p>
+          </>
+        ) : (
+          <>
+            <p>
+              <Translate>Are you sure you want to publish the contribution list?</Translate>
+            </p>
+            <p>
+              <Translate>By doing so the following menu items will be accessible:</Translate>
+            </p>
+          </>
+        )}
+        <List bulleted>
+          <List.Item>
+            <Translate>Contribution List</Translate>
+          </List.Item>
+          <List.Item>
+            <Translate>My Contributions</Translate>
+          </List.Item>
+          <List.Item>
+            <Translate>Author List</Translate>
+          </List.Item>
+          <List.Item>
+            <Translate>Speaker List</Translate>
+          </List.Item>
+          <List.Item>
+            <Translate>Timetable</Translate>
+          </List.Item>
+          <List.Item>
+            <Translate>Book of Abstracts</Translate>
+          </List.Item>
+        </List>
+      </Modal.Content>
+      <Modal.Actions>
+        <Button onClick={() => setModalOpen(false)}>
+          <Translate>No</Translate>
+        </Button>
+        <Button primary onClick={onClick}>
+          <Translate>Yes</Translate>
+        </Button>
+      </Modal.Actions>
+    </Modal>
+  );
+}
+
+PublicationModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  setModalOpen: PropTypes.func.isRequired,
+  trigger: PropTypes.node.isRequired,
+  published: PropTypes.bool.isRequired,
+  onClick: PropTypes.func.isRequired,
+};

--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -25,6 +25,7 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
 import {$T} from 'indico/utils/i18n';
 
+import PublicationButton from './PublicationButton';
 import PublicationSwitch from './PublicationSwitch';
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -416,5 +417,19 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const applySearchFilters = setupSearchBox(filterConfig);
     applySearchFilters();
+  };
+
+  global.setupDraftModeWarning = function setupDraftModeWarning() {
+    const warning = document.querySelector('#draft-mode-warning');
+    const button = document.querySelector('#draft-mode-warning-button');
+    if (warning && button) {
+      ReactDOM.render(
+        <PublicationButton
+          eventId={button.dataset.eventId}
+          onSuccess={() => warning.classList.add('hidden')}
+        />,
+        button
+      );
+    }
   };
 })(window);

--- a/indico/modules/events/contributions/templates/management/_draft_mode_warning.html
+++ b/indico/modules/events/contributions/templates/management/_draft_mode_warning.html
@@ -1,0 +1,23 @@
+{% macro render_draft_mode_warning(event) %}
+    <div id="draft-mode-warning" class="action-box warning draft-mode">
+        <div class="section">
+            <div class="icon icon-edit"></div>
+            <div class="text">
+                <div class="label">{% trans %}Contributions are in draft mode{% endtrans %}</div>
+                {% trans %}
+                    While in draft mode, regular users cannot see the contributions and timetable.
+                {% endtrans %}
+            </div>
+            <div class="toolbar">
+                <div class="group">
+                    <span id="draft-mode-warning-button" data-event-id="{{ event.id }}"></span>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            // Render PublicationModal into #draft-mode-warning-button
+            setupDraftModeWarning();
+        </script>
+    </div>
+{% endmacro %}

--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -1,5 +1,6 @@
 {% extends 'events/management/base.html' %}
 {% from 'events/management/_settings.html' import render_event_settings %}
+{% from 'events/contributions/management/_draft_mode_warning.html' import render_draft_mode_warning %}
 
 {% block title %}{% trans %}Settings{% endtrans %}{% endblock %}
 
@@ -27,25 +28,7 @@
         </div>
     {%- endif -%}
     {%- if show_draft_warning -%}
-        <div class="action-box warning">
-            <div class="section">
-                <div class="icon icon-edit"></div>
-                <div class="text">
-                    <div class="label">{% trans %}Contributions are in draft mode{% endtrans %}</div>
-                    {% trans %}
-                        While in draft mode, regular users cannot see the contributions and timetable.
-                    {% endtrans %}
-                </div>
-                <div class="toolbar">
-                    <div class="group">
-                        <a class="i-button icon-settings"
-                           href="{{ url_for('contributions.manage_contributions', event) }}">
-                            {% trans %}Manage Contributions{% endtrans %}
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
+        {{ render_draft_mode_warning(event) }}
     {%- endif -%}
     <div class="action-box event-settings">
         {{ render_event_settings(event, has_reference_types, has_event_labels) }}

--- a/indico/modules/events/management/views.py
+++ b/indico/modules/events/management/views.py
@@ -61,6 +61,8 @@ class WPEventManagement(WPJinjaMixin, WPDecorated):
 
 class WPEventSettings(WPEventManagement):
     template_prefix = 'events/management/'
+    # PublicationButton React component for the draft mode warning
+    bundles = ('module_events.contributions.js',)
 
 
 class WPEventProtection(WPEventManagement):

--- a/indico/modules/events/timetable/controllers/manage.py
+++ b/indico/modules/events/timetable/controllers/manage.py
@@ -23,7 +23,7 @@ from indico.modules.events.timetable.operations import (create_timetable_entry, 
                                                         update_timetable_entry)
 from indico.modules.events.timetable.util import render_entry_info_balloon
 from indico.modules.events.timetable.views import WPManageTimetable
-from indico.modules.events.util import track_time_changes
+from indico.modules.events.util import should_show_draft_warning, track_time_changes
 from indico.web.forms.colors import get_colors
 from indico.web.util import jsonify_data
 
@@ -37,6 +37,7 @@ class RHManageTimetable(RHManageTimetableBase):
         event_info = serialize_event_info(self.event)
         timetable_data = TimetableSerializer(self.event, management=True).serialize_timetable()
         return WPManageTimetable.render_template('management.html', self.event, event_info=event_info,
+                                                 show_draft_warning=should_show_draft_warning(self.event),
                                                  timetable_data=timetable_data)
 
 

--- a/indico/modules/events/timetable/templates/management.html
+++ b/indico/modules/events/timetable/templates/management.html
@@ -1,10 +1,14 @@
 {% extends 'events/management/full_width_base.html' %}
 {% from 'events/timetable/_timetable.html' import render_timetable %}
+{% from 'events/contributions/management/_draft_mode_warning.html' import render_draft_mode_warning %}
 
 {% block title %}
     {%- trans %}Timetable{% endtrans -%}
 {% endblock %}
 
 {% block content %}
+    {% if show_draft_warning %}
+        {{ render_draft_mode_warning(event) }}
+    {% endif %}
     {{ render_timetable(timetable_data, event_info, management=true, custom_links=custom_links) }}
 {% endblock %}

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -29,6 +29,7 @@ from indico.core.errors import NoReportError, UserValueError
 from indico.core.permissions import FULL_ACCESS_PERMISSION, READ_ACCESS_PERMISSION
 from indico.modules.categories.models.roles import CategoryRole
 from indico.modules.events import Event
+from indico.modules.events.contributions import contribution_settings
 from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.layout import theme_settings
@@ -741,3 +742,10 @@ def get_all_user_roles(event, user):
         .filter(CategoryRole.members.any(User.id == user.id))
     )
     return event_roles, category_roles
+
+
+def should_show_draft_warning(event):
+    return (event.type_ == EventType.conference and
+            not contribution_settings.get(event, 'published') and
+            (TimetableEntry.query.with_parent(event).has_rows() or
+             Contribution.query.with_parent(event).has_rows()))

--- a/indico/web/client/styles/partials/_actionboxes.scss
+++ b/indico/web/client/styles/partials/_actionboxes.scss
@@ -149,6 +149,10 @@
     background-color: transparent;
   }
 
+  &.draft-mode {
+    max-width: 800px;
+  }
+
   ul:not(.i-dropdown) {
     margin: 0;
     padding-left: 1.5em;


### PR DESCRIPTION
Adds a warning to the manage/timetable page of
conferences in case the draft mode is enabled.
This is the same warning shown on the main settings
page.

Instead of showing the 'Manage contributions' button,
we change the warning to include a 'Publish now', which
turns off the draft mode. We show the same modal that
is shown on the contribution settings page
('manage/contributions') when the button is clicked.

![image](https://user-images.githubusercontent.com/8739637/124285454-38189800-db4e-11eb-98f7-e7bd6a4a9dbf.png)
![image](https://user-images.githubusercontent.com/8739637/124285504-42d32d00-db4e-11eb-80cc-c5d86c00dbe2.png)


closes #4977