### PR TITLE
Show `reviewed_dt` for paper reviews

### DIFF
--- a/indico/migrations/versions/20210707_1635_1cec32e42f65_add_reviewed_dt_to_paper_revisions.py
+++ b/indico/migrations/versions/20210707_1635_1cec32e42f65_add_reviewed_dt_to_paper_revisions.py
@@ -1,0 +1,33 @@
+"""Add reviewed_dt to paper revisions
+
+Revision ID: 1cec32e42f65
+Revises: cd3fef2095b4
+Create Date: 2021-07-05 16:35:54.667174
+"""
+import sqlalchemy as sa
+from alembic import op
+
+from indico.core.db.sqlalchemy import UTCDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = '1cec32e42f65'
+down_revision = 'cd3fef2095b4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('revisions', sa.Column('reviewed_dt', UTCDateTime(), nullable=True), schema='event_editing')
+    op.execute('UPDATE event_editing.revisions SET reviewed_dt = created_dt WHERE final_state != 0')
+    op.create_check_constraint(
+        'reviewed_dt_set_when_final_state',
+        'revisions',
+        '((final_state = 0) OR (reviewed_dt IS NOT NULL))',
+        schema='event_editing'
+    )
+
+
+def downgrade():
+    op.drop_constraint('ck_revisions_reviewed_dt_set_when_final_state', 'revisions', schema='event_editing')
+    op.drop_column('revisions', 'reviewed_dt', schema='event_editing')

--- a/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
@@ -18,7 +18,7 @@ import * as selectors from './selectors';
 import StateIndicator from './StateIndicator';
 import {blockItemPropTypes} from './util';
 
-export default function CustomItem({item: {header, user, createdDt, html, revisionId}, state}) {
+export default function CustomItem({item: {header, user, reviewedDt, html, revisionId}, state}) {
   const lastRevertableRevisionId = useSelector(selectors.getLastRevertableRevisionId);
 
   return (
@@ -32,8 +32,8 @@ export default function CustomItem({item: {header, user, createdDt, html, revisi
           >
             <div className="f-self-stretch">
               {header}{' '}
-              <time dateTime={serializeDate(createdDt, moment.HTML5_FMT.DATETIME_LOCAL)}>
-                {serializeDate(createdDt, 'LL')}
+              <time dateTime={serializeDate(reviewedDt, moment.HTML5_FMT.DATETIME_LOCAL)}>
+                {serializeDate(reviewedDt, 'LL')}
               </time>
             </div>
             {revisionId === lastRevertableRevisionId && <ResetReview revisionId={revisionId} />}

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -98,8 +98,9 @@ const statePropTypes = {
 export const blockItemPropTypes = {
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   revisionId: PropTypes.number.isRequired,
-  createdDt: PropTypes.string.isRequired,
+  createdDt: PropTypes.string,
   modifiedDt: PropTypes.string,
+  reviewedDt: PropTypes.string,
   canModify: PropTypes.bool,
   user: PropTypes.shape(userPropTypes),
   header: PropTypes.string,

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -35,12 +35,12 @@ export function processRevisions(revisions) {
 }
 
 export function commentFromState(revision, state, user) {
-  const {finalState, id, createdDt, submitter} = revision;
+  const {finalState, id, reviewedDt, submitter} = revision;
   return {
-    id: `custom-item-${id}-${createdDt}-${finalState.name}`,
+    id: `custom-item-${id}-${reviewedDt}-${finalState.name}`,
     revisionId: id,
     header: state,
-    createdDt,
+    reviewedDt,
     user: user || submitter,
     custom: true,
     html: revision.commentHtml,

--- a/indico/modules/events/editing/models/revisions.py
+++ b/indico/modules/events/editing/models/revisions.py
@@ -60,9 +60,14 @@ def _make_state_check():
                f_accepted=FinalRevisionState.accepted)).strip()
 
 
+def _make_reviewed_dt_check():
+    return f'((final_state = {FinalRevisionState.none}) OR (reviewed_dt IS NOT NULL))'
+
+
 class EditingRevision(RenderModeMixin, db.Model):
     __tablename__ = 'revisions'
     __table_args__ = (db.CheckConstraint(_make_state_check(), name='valid_state_combination'),
+                      db.CheckConstraint(_make_reviewed_dt_check(), name='reviewed_dt_set_when_final_state'),
                       {'schema': 'event_editing'})
 
     possible_render_modes = {RenderMode.markdown}
@@ -91,6 +96,10 @@ class EditingRevision(RenderModeMixin, db.Model):
         UTCDateTime,
         nullable=False,
         default=now_utc
+    )
+    reviewed_dt = db.Column(
+        UTCDateTime,
+        nullable=True
     )
     initial_state = db.Column(
         PyIntEnum(InitialRevisionState),

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -110,6 +110,7 @@ def review_editable_revision(revision, editor, action, comment, tags, files=None
     _ensure_state(revision, initial=InitialRevisionState.ready_for_review, final=FinalRevisionState.none)
     revision.editor = editor
     revision.comment = comment
+    revision.reviewed_dt = now_utc()
     revision.tags = tags
     revision.final_state = {
         EditingReviewAction.accept: FinalRevisionState.accepted,
@@ -153,6 +154,7 @@ def confirm_editable_changes(revision, submitter, action, comment):
     }[action]
     if comment:
         revision.comment = comment
+    revision.reviewed_dt = now_utc()
     db.session.flush()
     if action == EditingConfirmationAction.accept:
         _ensure_publishable_files(revision)
@@ -168,6 +170,7 @@ def replace_revision(revision, user, comment, files, tags, initial_state=None):
                   initial=(InitialRevisionState.new, InitialRevisionState.ready_for_review),
                   final=FinalRevisionState.none)
     revision.comment = comment
+    revision.reviewed_dt = now_utc()
     revision.tags = tags
     revision.final_state = FinalRevisionState.replaced
     revision.editor = user
@@ -222,6 +225,7 @@ def undo_review(revision):
     db.session.flush()
     revision.final_state = FinalRevisionState.none
     revision.comment = ''
+    revision.reviewed_dt = None
     db.session.flush()
     logger.info('Revision %r review undone', revision)
 

--- a/indico/modules/events/editing/operations_test.py
+++ b/indico/modules/events/editing/operations_test.py
@@ -56,10 +56,10 @@ def test_can_undo_review(db, dummy_contribution, dummy_user, is1, fs1, ok1, is2,
     from indico.modules.events.editing.operations import InvalidEditableState, undo_review
     editable = Editable(contribution=dummy_contribution, type=EditableType.paper)
     rev1 = EditingRevision(editable=editable, submitter=dummy_user, initial_state=is1,
-                           final_state=fs1, reviewed_dt=None if fs1 == FinalRevisionState.none else now_utc())
+                           final_state=fs1, reviewed_dt=(None if fs1 == FinalRevisionState.none else now_utc()))
     if is2 is not None:
         rev2 = EditingRevision(editable=editable, submitter=dummy_user, initial_state=is2,
-                               final_state=fs2, reviewed_dt=None if fs2 == FinalRevisionState.none else now_utc())
+                               final_state=fs2, reviewed_dt=(None if fs2 == FinalRevisionState.none else now_utc()))
     db.session.flush()
 
     if ok1:

--- a/indico/modules/events/editing/operations_test.py
+++ b/indico/modules/events/editing/operations_test.py
@@ -9,6 +9,7 @@ import pytest
 
 from indico.modules.events.editing.models.editable import Editable, EditableType
 from indico.modules.events.editing.models.revisions import EditingRevision, FinalRevisionState, InitialRevisionState
+from indico.util.date_time import now_utc
 
 
 def test_cannot_undo_review_old_rev(dummy_contribution, dummy_user):
@@ -16,10 +17,10 @@ def test_cannot_undo_review_old_rev(dummy_contribution, dummy_user):
     editable = Editable(contribution=dummy_contribution, type=EditableType.paper)
     rev1 = EditingRevision(editable=editable, submitter=dummy_user,
                            initial_state=InitialRevisionState.ready_for_review,
-                           final_state=FinalRevisionState.needs_submitter_confirmation)
+                           final_state=FinalRevisionState.needs_submitter_confirmation, reviewed_dt=now_utc())
     rev2 = EditingRevision(editable=editable, submitter=dummy_user,
                            initial_state=InitialRevisionState.needs_submitter_confirmation,
-                           final_state=FinalRevisionState.needs_submitter_changes)
+                           final_state=FinalRevisionState.needs_submitter_changes, reviewed_dt=now_utc())
     rev3 = EditingRevision(editable=editable, submitter=dummy_user,
                            initial_state=InitialRevisionState.ready_for_review)
     with pytest.raises(InvalidEditableState):
@@ -54,9 +55,11 @@ def test_cannot_undo_review_old_rev(dummy_contribution, dummy_user):
 def test_can_undo_review(db, dummy_contribution, dummy_user, is1, fs1, ok1, is2, fs2, ok2):
     from indico.modules.events.editing.operations import InvalidEditableState, undo_review
     editable = Editable(contribution=dummy_contribution, type=EditableType.paper)
-    rev1 = EditingRevision(editable=editable, submitter=dummy_user, initial_state=is1, final_state=fs1)
+    rev1 = EditingRevision(editable=editable, submitter=dummy_user, initial_state=is1,
+                           final_state=fs1, reviewed_dt=None if fs1 == FinalRevisionState.none else now_utc())
     if is2 is not None:
-        rev2 = EditingRevision(editable=editable, submitter=dummy_user, initial_state=is2, final_state=fs2)
+        rev2 = EditingRevision(editable=editable, submitter=dummy_user, initial_state=is2,
+                               final_state=fs2, reviewed_dt=None if fs2 == FinalRevisionState.none else now_utc())
     db.session.flush()
 
     if ok1:

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -150,8 +150,8 @@ class EditingRevisionCommentSchema(mm.SQLAlchemyAutoSchema):
 class EditingRevisionSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = EditingRevision
-        fields = ('id', 'created_dt', 'submitter', 'editor', 'files', 'comment', 'comment_html', 'comments',
-                  'initial_state', 'final_state', 'tags', 'create_comment_url', 'download_files_url',
+        fields = ('id', 'created_dt', 'reviewed_dt', 'submitter', 'editor', 'files', 'comment', 'comment_html',
+                  'comments', 'initial_state', 'final_state', 'tags', 'create_comment_url', 'download_files_url',
                   'review_url', 'confirm_url', 'custom_actions', 'custom_action_url')
 
     comment_html = fields.Function(lambda rev: escape(rev.comment))


### PR DESCRIPTION
Changes the date shown next to a paper review to the date
the paper was reviewed. Previously, the date shown was
the date when the revision was created, which lead to confusions.

This PR adds a new column `reviewed_dt` to  `EditingRevision`
to track the date when a review was made, which is exposed
to the API.

React then renders `reviewedDt` instead of `createdDt`.

![Screenshot from 2021-07-06 14-35-21](https://user-images.githubusercontent.com/8739637/124605673-75da3100-de6c-11eb-84fd-861414eb498d.png)
