### PR TITLE
Fix constrained i-dropdown height

### DIFF
--- a/indico/web/client/styles/partials/_dropdowns.scss
+++ b/indico/web/client/styles/partials/_dropdowns.scss
@@ -21,7 +21,6 @@
     cursor: pointer;
     display: block;
     list-style-type: none;
-    height: 1.7rem;
     min-width: 1em;
     padding: 0.1em 1em;
 


### PR DESCRIPTION
Removes the fixed height on an `i-dropdown > li` since it incorrectly places most of the lists that do not fit in a single line.
I couldn't find any occurrences where this was useful, as the current dropdowns seem to play fine with it.

![imagem](https://user-images.githubusercontent.com/12183954/124768637-be5b2280-df30-11eb-9310-62d919ad80a8.png)

![imagem](https://user-images.githubusercontent.com/12183954/124769157-2578d700-df31-11eb-84bc-0d50abdbafa6.png)

