### PR TITLE
Add CLI to update to the latest Python version and update the virtualenv in-place

### DIFF
--- a/docs/source/installation/production/debian/apache.rst
+++ b/docs/source/installation/production/debian/apache.rst
@@ -8,7 +8,7 @@ PostgreSQL is installed from its upstream repos to get a much more recent versio
 
 .. code-block:: shell
 
-    apt install -y lsb-release wget gnupg
+    apt install -y lsb-release wget curl gnupg
     echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
     apt update

--- a/docs/source/installation/production/debian/nginx.rst
+++ b/docs/source/installation/production/debian/nginx.rst
@@ -11,7 +11,7 @@ much more recent versions.
 
 .. code-block:: shell
 
-    apt install -y lsb-release wget gnupg
+    apt install -y lsb-release wget curl gnupg
     echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
     echo "deb http://nginx.org/packages/$(lsb_release -is | tr '[:upper:]' '[:lower:]')/ $(lsb_release -cs) nginx" > /etc/apt/sources.list.d/nginx.list
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -

--- a/docs/source/installation/upgrade.rst
+++ b/docs/source/installation/upgrade.rst
@@ -46,6 +46,12 @@ If you installed the official plugins, update them too:
 
     pip install -U indico-plugins
 
+It is a good idea to ensure you are using the latest recommended Python version:
+
+.. code-block:: shell
+
+    indico setup upgrade-python
+
 Some versions may include database schema upgrades.  Make sure to
 perform them immediately after upgrading.  If there are no schema
 changes, the command will simply do nothing.

--- a/indico/__init__.py
+++ b/indico/__init__.py
@@ -9,6 +9,6 @@ from indico.util.mimetypes import register_custom_mimetypes
 
 
 __version__ = '3.0rc1'
-PREFERRED_PYTHON_VERSION_SPEC = '~=3.9.6'
+PREFERRED_PYTHON_VERSION_SPEC = '~=3.9.0'
 
 register_custom_mimetypes()

--- a/indico/__init__.py
+++ b/indico/__init__.py
@@ -9,5 +9,6 @@ from indico.util.mimetypes import register_custom_mimetypes
 
 
 __version__ = '3.0rc1'
+PREFERRED_PYTHON_VERSION_SPEC = '~=3.9.6'
 
 register_custom_mimetypes()

--- a/indico/cli/python_upgrader.py
+++ b/indico/cli/python_upgrader.py
@@ -1,0 +1,140 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+# XXX: This script will be executed standalone, outside the indico virtualenv.
+# It must not use anything that's not part of the standard library of Python
+# 3.9.6 (since that's the lowest version from which it may get executed).
+
+import itertools
+import os
+import subprocess
+import sys
+from pathlib import Path
+from venv import EnvBuilder
+
+
+class PythonUpgrader:
+    def __init__(self, venv_path: Path):
+        self.venv_path = venv_path
+        self.has_uwsgi = (self.venv_path / 'bin' / 'uwsgi').exists()
+
+    def check(self):
+        clear, upgrade = self._prepare()
+        print(f'check mode - not performing actions ({clear=}, {upgrade=})')
+        sys.exit(0)
+
+    def upgrade(self):
+        clear, upgrade = self._prepare()
+
+        if upgrade:
+            self._update_symlinks(sys.executable)
+
+        builder = EnvBuilder(
+            system_site_packages=False,
+            clear=clear,
+            symlinks=True,
+            upgrade=upgrade,
+            with_pip=True,
+            upgrade_deps=True
+        )
+        builder.create(self.venv_path)
+        subprocess.run([str(self.venv_path / 'bin' / 'pip'), 'install', '-U', 'wheel'], check=True)
+
+    def reinstall_uwsgi(self):
+        if not self.has_uwsgi:
+            print('No uWSGI installed; reinstall not needed')
+            return
+        print('Rebuilding uWSGI for the current python version')
+        subprocess.run([str(self.venv_path / 'bin' / 'pip'), 'install', '--force-reinstall', '--no-cache', 'uwsgi'],
+                       check=True)
+
+    def _prepare(self):
+        pyenv_root = Path('~/.pyenv/').expanduser()
+        pyenv_shim = pyenv_root / 'shims/python'
+
+        if not sys.executable.startswith(str(pyenv_root)):
+            # we can't run inside a virtualenv as this would result in some of the
+            # symlinks pointing there instead of the actual pyenv python binaries
+            if os.environ.get('_PYTHON_UPGRADER_REEXEC'):
+                print(f'Still not executed via venv ({sys.executable}); aborting')
+                sys.exit(1)
+            print(f'Not executed via pyenv (probably inside virtualenv); re-executing with {pyenv_shim}')
+            os.environ['_PYTHON_UPGRADER_REEXEC'] = '1'
+            os.execl(pyenv_shim, pyenv_shim, *sys.argv)
+
+        pyenv_global_python_version = Path('~/.pyenv/version').expanduser().read_text().strip()
+        pyenv_local_python_version = subprocess.run(['pyenv', 'version-name'], capture_output=True,
+                                                    encoding='utf-8').stdout.strip()
+        if pyenv_global_python_version != pyenv_local_python_version:
+            print(f'Warning: global pyenv version: {pyenv_global_python_version}; '
+                  f'local version: {pyenv_local_python_version}')
+        print(f'Python version: {".".join(map(str, sys.version_info[:3]))}; wanted: {pyenv_local_python_version}')
+        print(f'Venv path: {self.venv_path}')
+        config_file = self.venv_path / 'pyvenv.cfg'
+        if not self.venv_path.exists() or not config_file.exists():
+            print('Venv not found, creating new one')
+            upgrade = False
+            clear = True
+        else:
+            config = self._parse_venv_config(config_file)
+            print(f'Venv found; python version {config["version"]} from {config["home"]}')
+            if config['version'] == pyenv_local_python_version:
+                print('Venv is up to date; not doing anything')
+                sys.exit(0)
+            if tuple(map(int, config['version'].split('.')[:2])) != sys.version_info[:2]:
+                print('Venv is using a different Python 3.x version; recreating')
+                clear = True
+                upgrade = False
+            else:
+                clear = False
+                upgrade = True
+
+        return clear, upgrade
+
+    def _parse_venv_config(self, file: Path):
+        data = {}
+        for line in file.read_text().splitlines():
+            if '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            key = key.strip().lower()
+            value = value.strip()
+            data[key] = value
+        return data
+
+    def _update_symlinks(self, python_executable):
+        for file in itertools.chain([self.venv_path / 'bin' / 'python'], (self.venv_path / 'bin').glob('python3*')):
+            assert file.is_symlink()
+            target = file.readlink()
+            if not target.is_absolute():
+                # python3 and python3.x are usually symlinks to python
+                continue
+            print(f'Updating symlink {file} -> {python_executable}')
+            file.unlink()
+            file.symlink_to(python_executable)
+
+
+def main():
+    try:
+        venv_path = Path(sys.argv[1])
+        check = False
+        if len(sys.argv) > 2:
+            check = sys.argv[2] == '--check'
+    except IndexError:
+        print(f'Usage: {sys.argv[0]} VENV_PATH [--check]')
+        sys.exit(1)
+
+    upgrader = PythonUpgrader(venv_path)
+    if check:
+        upgrader.check()
+    else:
+        upgrader.upgrade()
+        upgrader.reinstall_uwsgi()
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ project_urls =
 packages = find:
 zip_safe = false
 include_package_data = true
-python_requires = ~=3.9
+python_requires = ~=3.9.0
 
 [options.packages.find]
 include = indico, indico.*


### PR DESCRIPTION
This is similar to the script we already use in production to avoid reinstalling all the packages after every minor Python version update (e.g. 3.9.5 to 3.9.6).

I also added a switch to force a version upgrade, so if a future Indico version requires 3.10, we can add a step to that version's upgrade asking people to run the script once to make sure they have the new Python version (even though this type of major upgrade requires a full recreation of the venv, and thus reinstalling of the indico-related packages)