### PR TITLE
Allow injecting extra events in a category

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Internal Changes
 
 - Signals previously exposed direcly via ``signals.foo`` now need to be accessed using their
   explicit name, i.e. ``signals.core.foo`` (:pr:`5007`)
+- Add ``category.extra_events`` signal (:pr:`5005`, thanks :user:`omegak`)
 
 Version 3.0rc2
 --------------

--- a/indico/core/signals/category.py
+++ b/indico/core/signals/category.py
@@ -28,3 +28,9 @@ Called when a category is modified. The `sender` is the updated category.
 deleted = _signals.signal('deleted', '''
 Called when a category is deleted. The `sender` is the category.
 ''')
+
+extra_events = _signals.signal('extra-events', '''
+Called when a category is displayed.  The `sender` is the category.  `is_flat`
+is passed as kwarg with the same name.  The additional kwargs passed to this
+signal depend on the context.
+''')


### PR DESCRIPTION
The UN plugin still needs to be able to display hidden events in the category flat view. This signal allows us to inject them.