### PR TITLE
Remove wildcard import of signals.core into signals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,12 @@ Bugfixes
 
 - None so far :)
 
+Internal Changes
+^^^^^^^^^^^^^^^^
+
+- Signals previously exposed direcly via ``signals.foo`` now need to be accessed using their
+  explicit name, i.e. ``signals.core.foo`` (:pr:`5007`)
+
 Version 3.0rc2
 --------------
 

--- a/docs/source/plugins/signals.rst
+++ b/docs/source/plugins/signals.rst
@@ -44,7 +44,7 @@ indico.core.signals
                 # event.__init__.py always import its submodules directly so we
                 # don't recurse in those cases to avoid duplicate docs
                 elif (isinstance(attr, ModuleType) and
-                        name != 'core' and module.__name__ != 'indico.core.signals.event'):
+                        module.__name__ != 'indico.core.signals.event'):
                     print(attr.__name__)
                     print(separators[nesting] * len(attr.__name__))
                     generate_signal_doc(attr, nesting=(nesting + 1))

--- a/indico/cli/event.py
+++ b/indico/cli/event.py
@@ -39,7 +39,7 @@ def restore(event_id, user_id, message):
         click.secho('This event is not deleted', fg='yellow')
         sys.exit(1)
     event.restore(message, user)
-    signals.after_process.send()
+    signals.core.after_process.send()
     db.session.commit()
     click.secho(f'Event undeleted: "{event.title}"', fg='green')
 

--- a/indico/core/celery/__init__.py
+++ b/indico/core/celery/__init__.py
@@ -41,7 +41,7 @@ celery_settings = SettingsProxy('celery', {
 })
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _load_default_modules(app, **kwargs):
     celery.loader.import_default_modules()  # load all tasks
 
@@ -50,7 +50,7 @@ def _load_default_modules(app, **kwargs):
 def _import_modules(*args, **kwargs):
     import indico.core.emails  # noqa: F401
     import indico.util.tasks  # noqa: F401
-    signals.import_tasks.send()
+    signals.core.import_tasks.send()
 
 
 @beat_init.connect

--- a/indico/core/db/sqlalchemy/core.py
+++ b/indico/core/db/sqlalchemy/core.py
@@ -58,7 +58,7 @@ def handle_sqlalchemy_database_error():
 
 
 def _after_commit(*args, **kwargs):
-    signals.after_commit.send()
+    signals.core.after_commit.send()
     if hasattr(g, 'memoize_cache'):
         del g.memoize_cache
 
@@ -134,7 +134,7 @@ def _before_create(target, connection, **kw):
     for schema in schemas:
         if not _schema_exists(connection, schema):
             CreateSchema(schema).execute(connection)
-            signals.db_schema_created.send(str(schema), connection=connection)
+            signals.core.db_schema_created.send(str(schema), connection=connection)
     # Create our custom functions
     create_unaccent_function(connection)
     create_natsort_function(connection)

--- a/indico/core/oauth/__init__.py
+++ b/indico/core/oauth/__init__.py
@@ -17,7 +17,7 @@ from .oauth2 import require_oauth
 __all__ = ['require_oauth']
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _no_ssl_required_on_debug(app, **kwargs):
     if app.debug or app.testing:
         os.environ['AUTHLIB_INSECURE_TRANSPORT'] = '1'

--- a/indico/core/signals/__init__.py
+++ b/indico/core/signals/__init__.py
@@ -5,10 +5,9 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from indico.core.signals import (acl, agreements, attachments, category, event, event_management, menu, plugin, rb, rh,
-                                 users)
-from indico.core.signals.core import *
+from indico.core.signals import (acl, agreements, attachments, category, core, event, event_management, menu, plugin,
+                                 rb, rh, users)
 
 
-__all__ = ('acl', 'agreements', 'attachments', 'category', 'event', 'event_management', 'menu', 'plugin', 'rb', 'rh',
-           'users')
+__all__ = ('acl', 'agreements', 'attachments', 'category', 'core', 'event', 'event_management', 'menu', 'plugin', 'rb',
+           'rh', 'users')

--- a/indico/core/storage/backend.py
+++ b/indico/core/storage/backend.py
@@ -43,7 +43,7 @@ def get_storage(backend_name):
 
 
 def get_storage_backends():
-    return named_objects_from_signal(signals.get_storage_backends.send(), plugin_attr='plugin')
+    return named_objects_from_signal(signals.core.get_storage_backends.send(), plugin_attr='plugin')
 
 
 class StorageError(Exception):
@@ -280,13 +280,13 @@ class ReadOnlyFileSystemStorage(ReadOnlyStorageMixin, FileSystemStorage):
         return f'<ReadOnlyFileSystemStorage: {self.path}>'
 
 
-@signals.get_storage_backends.connect
+@signals.core.get_storage_backends.connect
 def _get_storage_backends(sender, **kwargs):
     yield FileSystemStorage
     yield ReadOnlyFileSystemStorage
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_storage_backends(app, **kwargs):
     # This will raise RuntimeError if the backend names are not unique
     get_storage_backends()

--- a/indico/modules/admin/__init__.py
+++ b/indico/modules/admin/__init__.py
@@ -32,6 +32,6 @@ def _topmenu_items(sender, **kwargs):
         yield TopMenuItem('admin', _('Administration'), url_for('core.admin_dashboard'), 70)
 
 
-@signals.import_tasks.connect
+@signals.core.import_tasks.connect
 def _import_tasks(sender, **kwargs):
     import indico.modules.admin.notices  # noqa: F401

--- a/indico/modules/attachments/__init__.py
+++ b/indico/modules/attachments/__init__.py
@@ -59,6 +59,6 @@ def _get_attachment_cloner(sender, **kwargs):
     return AttachmentCloner
 
 
-@signals.import_tasks.connect
+@signals.core.import_tasks.connect
 def _import_tasks(sender, **kwargs):
     import indico.modules.attachments.tasks  # noqa: F401

--- a/indico/modules/auth/__init__.py
+++ b/indico/modules/auth/__init__.py
@@ -116,7 +116,7 @@ def _delete_requests(user, **kwargs):
     db.session.flush()
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _handle_insecure_password_logins(app, **kwargs):
     @app.before_request
     def _redirect_if_insecure():

--- a/indico/modules/categories/__init__.py
+++ b/indico/modules/categories/__init__.py
@@ -25,7 +25,7 @@ upcoming_events_settings = SettingsProxy('upcoming_events', {
 })
 
 
-@signals.import_tasks.connect
+@signals.core.import_tasks.connect
 def _import_tasks(sender, **kwargs):
     import indico.modules.categories.tasks  # noqa: F401
 
@@ -55,7 +55,7 @@ def _extend_admin_menu(sender, **kwargs):
                            section='homepage')
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_permissions(app, **kwargs):
     check_permissions(Category)
 

--- a/indico/modules/categories/models/__init__.py
+++ b/indico/modules/categories/models/__init__.py
@@ -12,7 +12,7 @@ from sqlalchemy import DDL
 from indico.core import signals
 
 
-@signals.db_schema_created.connect_via('categories')
+@signals.core.db_schema_created.connect_via('categories')
 def _create_check_consistency_deleted(sender, connection, **kwargs):
     sql = textwrap.dedent('''
         CREATE FUNCTION categories.check_consistency_deleted() RETURNS trigger AS
@@ -71,7 +71,7 @@ def _create_check_consistency_deleted(sender, connection, **kwargs):
     DDL(sql).execute(connection)
 
 
-@signals.db_schema_created.connect_via('categories')
+@signals.core.db_schema_created.connect_via('categories')
 def _create_check_cycles(sender, connection, **kwargs):
     sql = textwrap.dedent('''
         CREATE FUNCTION categories.check_cycles() RETURNS trigger AS

--- a/indico/modules/designer/__init__.py
+++ b/indico/modules/designer/__init__.py
@@ -79,7 +79,7 @@ DEFAULT_CONFIG = {
 }
 
 
-@signals.get_placeholders.connect_via('designer-fields')
+@signals.core.get_placeholders.connect_via('designer-fields')
 def _get_notification_placeholders(sender, **kwargs):
     from indico.modules.designer import placeholders
     for name in placeholders.__all__:

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -130,7 +130,7 @@ def _log_acl_changes(sender, obj, principal, entry, is_new, old_data, quiet, **k
         obj.log(EventLogRealm.management, EventLogKind.change, 'Protection', 'ACL entry changed', user, data=data)
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _handle_legacy_ids(app, **kwargs):
     """
     Handle the redirect from broken legacy event ids such as a12345
@@ -171,7 +171,7 @@ def _handle_legacy_ids(app, **kwargs):
         return redirect(new_url, 302 if app.debug else 301)
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_permissions(app, **kwargs):
     check_permissions(Event)
 
@@ -221,7 +221,7 @@ def _extend_event_menu(sender, **kwargs):
     yield MenuEntryData(_('My Conference'), 'my_conference', position=7, visible=_my_conference_visible)
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_cloners(app, **kwargs):
     # This will raise RuntimeError if the cloner names are not unique
     get_event_cloners()

--- a/indico/modules/events/abstracts/__init__.py
+++ b/indico/modules/events/abstracts/__init__.py
@@ -77,7 +77,7 @@ def _merge_users(target, source, **kwargs):
     abstracts_settings.acls.merge_users(target, source)
 
 
-@signals.get_conditions.connect_via('abstract-notifications')
+@signals.core.get_conditions.connect_via('abstract-notifications')
 def _get_abstract_notification_rules(sender, **kwargs):
     yield StateCondition
     yield TrackCondition
@@ -127,7 +127,7 @@ class AbstractReviewerPermission(ManagementPermission):
     description = _('Grants abstract reviewing rights on an event.')
 
 
-@signals.get_placeholders.connect_via('abstract-notification-email')
+@signals.core.get_placeholders.connect_via('abstract-notification-email')
 def _get_notification_placeholders(sender, **kwargs):
     from indico.modules.events.abstracts import placeholders
     for name in placeholders.__all__:

--- a/indico/modules/events/agreements/__init__.py
+++ b/indico/modules/events/agreements/__init__.py
@@ -23,7 +23,7 @@ __all__ = ('AgreementPersonInfo', 'AgreementDefinitionBase')
 logger = Logger.get('agreements')
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_agreement_definitions(app, **kwargs):
     # This will raise RuntimeError if the agreement definition types are not unique
     get_agreement_definitions()
@@ -44,7 +44,7 @@ def _merge_users(target, source, **kwargs):
     Agreement.query.filter_by(user_id=source.id).update({Agreement.user_id: target.id})
 
 
-@signals.get_placeholders.connect_via('agreement-email')
+@signals.core.get_placeholders.connect_via('agreement-email')
 def _get_placeholders(sender, agreement, definition, **kwargs):
     yield PersonNamePlaceholder
     yield AgreementLinkPlaceholder

--- a/indico/modules/events/contributions/__init__.py
+++ b/indico/modules/events/contributions/__init__.py
@@ -53,14 +53,14 @@ def _convert_email_principals(user, **kwargs):
               'info')
 
 
-@signals.get_fields.connect_via(ContributionField)
+@signals.core.get_fields.connect_via(ContributionField)
 def _get_fields(sender, **kwargs):
     from . import contrib_fields
     yield contrib_fields.ContribTextField
     yield contrib_fields.ContribSingleChoiceField
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_field_definitions(app, **kwargs):
     # This will raise RuntimeError if the field names are not unique
     get_contrib_field_types()
@@ -80,7 +80,7 @@ def _get_contribution_cloner(sender, **kwargs):
     yield clone.ContributionCloner
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_permissions(app, **kwargs):
     check_permissions(Contribution)
 

--- a/indico/modules/events/features/__init__.py
+++ b/indico/modules/events/features/__init__.py
@@ -28,7 +28,7 @@ def _extend_event_management_menu(sender, event, **kwargs):
     return SideMenuItem('features', _('Features'), url_for('event_features.index', event), section='advanced')
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_feature_definitions(app, **kwargs):
     # This will raise RuntimeError if the feature names are not unique
     from indico.modules.events.features.util import get_feature_definitions

--- a/indico/modules/events/logs/__init__.py
+++ b/indico/modules/events/logs/__init__.py
@@ -37,7 +37,7 @@ def _get_log_renderers(sender, **kwargs):
     yield EmailRenderer
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_agreement_definitions(app, **kwargs):
     # This will raise RuntimeError if the log renderer types are not unique
     get_log_renderers()

--- a/indico/modules/events/management/__init__.py
+++ b/indico/modules/events/management/__init__.py
@@ -35,7 +35,7 @@ def _sidemenu_items(sender, event, **kwargs):
                                section='advanced')
 
 
-@signals.get_placeholders.connect_via('program-codes-contribution')
+@signals.core.get_placeholders.connect_via('program-codes-contribution')
 def _get_placeholders(sender, contribution, **kwargs):
     from . import program_codes as pc
     yield pc.ContributionIDPlaceholder
@@ -49,21 +49,21 @@ def _get_placeholders(sender, contribution, **kwargs):
     yield pc.ContributionWeekday3Placeholder
 
 
-@signals.get_placeholders.connect_via('program-codes-subcontribution')
+@signals.core.get_placeholders.connect_via('program-codes-subcontribution')
 def _get_subcontribution_program_codes_placeholders(sender, subcontribution, **kwargs):
     from . import program_codes as pc
     yield pc.SubContributionIDPlaceholder
     yield pc.SubContributionContributionCodePlaceholder
 
 
-@signals.get_placeholders.connect_via('program-codes-session')
+@signals.core.get_placeholders.connect_via('program-codes-session')
 def _get_program_codes_session_placeholders(sender, session, **kwargs):
     from . import program_codes as pc
     yield pc.SessionIDPlaceholder
     yield pc.SessionSessionTypeCodePlaceholder
 
 
-@signals.get_placeholders.connect_via('program-codes-session-block')
+@signals.core.get_placeholders.connect_via('program-codes-session-block')
 def _get_program_codes_session_block_placeholders(sender, session_block, **kwargs):
     from . import program_codes as pc
     yield pc.SessionBlockSessionCodePlaceholder

--- a/indico/modules/events/models/__init__.py
+++ b/indico/modules/events/models/__init__.py
@@ -12,7 +12,7 @@ from sqlalchemy import DDL
 from indico.core import signals
 
 
-@signals.db_schema_created.connect_via('events')
+@signals.core.db_schema_created.connect_via('events')
 def _create_check_timetable_consistency(sender, connection, **kwargs):
     sql = textwrap.dedent('''
         CREATE FUNCTION events.check_timetable_consistency() RETURNS trigger AS

--- a/indico/modules/events/persons/__init__.py
+++ b/indico/modules/events/persons/__init__.py
@@ -24,7 +24,7 @@ def _sidemenu_items(sender, event, **kwargs):
                             section='organization')
 
 
-@signals.get_placeholders.connect_via('event-persons-email')
+@signals.core.get_placeholders.connect_via('event-persons-email')
 def _get_placeholders(sender, person, event, register_link=False, **kwargs):
     from indico.modules.events.persons.placeholders import (ContributionsPlaceholder, EmailPlaceholder,
                                                             EventLinkPlaceholder, EventTitlePlaceholder,

--- a/indico/modules/events/registration/__init__.py
+++ b/indico/modules/events/registration/__init__.py
@@ -150,7 +150,7 @@ def _get_event_management_url(event, **kwargs):
         return url_for('event_registration.manage_regform_list', event)
 
 
-@signals.get_placeholders.connect_via('registration-invitation-email')
+@signals.core.get_placeholders.connect_via('registration-invitation-email')
 def _get_invitation_placeholders(sender, invitation, **kwargs):
     from indico.modules.events.registration.placeholders.invitations import (FirstNamePlaceholder,
                                                                              InvitationLinkPlaceholder,
@@ -160,7 +160,7 @@ def _get_invitation_placeholders(sender, invitation, **kwargs):
     yield InvitationLinkPlaceholder
 
 
-@signals.get_placeholders.connect_via('registration-email')
+@signals.core.get_placeholders.connect_via('registration-email')
 def _get_registration_placeholders(sender, regform, registration, **kwargs):
     from indico.modules.events.registration.placeholders.registrations import (EventLinkPlaceholder,
                                                                                EventTitlePlaceholder, FieldPlaceholder,

--- a/indico/modules/events/reminders/__init__.py
+++ b/indico/modules/events/reminders/__init__.py
@@ -22,7 +22,7 @@ from indico.web.menu import SideMenuItem
 logger = Logger.get('events.reminders')
 
 
-@signals.import_tasks.connect
+@signals.core.import_tasks.connect
 def _import_tasks(sender, **kwargs):
     import indico.modules.events.reminders.tasks  # noqa: F401
 

--- a/indico/modules/events/requests/__init__.py
+++ b/indico/modules/events/requests/__init__.py
@@ -18,7 +18,7 @@ from indico.web.menu import SideMenuItem
 __all__ = ('RequestDefinitionBase', 'RequestFormBase')
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_request_definitions(app, **kwargs):
     # This will raise RuntimeError if the request type names are not unique
     get_request_definitions()

--- a/indico/modules/events/sessions/__init__.py
+++ b/indico/modules/events/sessions/__init__.py
@@ -68,7 +68,7 @@ def _get_session_cloner(sender, **kwargs):
     return SessionCloner
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_permissions(app, **kwargs):
     check_permissions(Session)
 

--- a/indico/modules/events/surveys/__init__.py
+++ b/indico/modules/events/surveys/__init__.py
@@ -80,7 +80,7 @@ def _get_management_permissions(sender, **kwargs):
     return SurveysPermission
 
 
-@signals.import_tasks.connect
+@signals.core.import_tasks.connect
 def _import_tasks(sender, **kwargs):
     import indico.modules.events.surveys.tasks  # noqa: F401
 
@@ -102,7 +102,7 @@ class SurveysPermission(ManagementPermission):
     user_selectable = True
 
 
-@signals.get_placeholders.connect_via('survey-link-email')
+@signals.core.get_placeholders.connect_via('survey-link-email')
 def _get_placeholders(sender, event, survey, **kwargs):
     from indico.modules.events.surveys import placeholders
     yield placeholders.EventTitlePlaceholder

--- a/indico/modules/events/surveys/fields/__init__.py
+++ b/indico/modules/events/surveys/fields/__init__.py
@@ -15,7 +15,7 @@ def get_field_types():
     return get_field_definitions(SurveyField)
 
 
-@signals.get_fields.connect_via(SurveyField)
+@signals.core.get_fields.connect_via(SurveyField)
 def _get_fields(sender, **kwargs):
     from .choices import SurveyMultiSelectField, SurveySingleChoiceField
     from .simple import SurveyBoolField, SurveyNumberField, SurveyTextField
@@ -26,7 +26,7 @@ def _get_fields(sender, **kwargs):
     yield SurveyMultiSelectField
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_field_definitions(app, **kwargs):
     # This will raise RuntimeError if the field names are not unique
     get_field_types()

--- a/indico/modules/files/__init__.py
+++ b/indico/modules/files/__init__.py
@@ -12,6 +12,6 @@ from indico.core.logger import Logger
 logger = Logger.get('files')
 
 
-@signals.import_tasks.connect
+@signals.core.import_tasks.connect
 def _import_tasks(sender, **kwargs):
     import indico.modules.files.tasks  # noqa: F401

--- a/indico/modules/rb/__init__.py
+++ b/indico/modules/rb/__init__.py
@@ -47,7 +47,7 @@ rb_settings = SettingsProxy('roombooking', {
 })
 
 
-@signals.import_tasks.connect
+@signals.core.import_tasks.connect
 def _import_tasks(sender, **kwargs):
     import indico.modules.rb.tasks  # noqa: F401
 
@@ -146,6 +146,6 @@ def _get_management_permissions(sender, **kwargs):
     yield ModeratePermission
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_permissions(app, **kwargs):
     check_permissions(Room)

--- a/indico/modules/search/__init__.py
+++ b/indico/modules/search/__init__.py
@@ -11,7 +11,7 @@ from indico.core import signals
 from indico.web.flask.templating import template_hook
 
 
-@signals.app_created.connect
+@signals.core.app_created.connect
 def _check_search_provider(app, **kwargs):
     from .base import get_search_provider
     get_search_provider(only_active=False)

--- a/indico/modules/search/base.py
+++ b/indico/modules/search/base.py
@@ -21,7 +21,7 @@ def get_search_provider(only_active=True):
                         provider will be used.
     """
     from indico.modules.search.controllers import InternalSearch
-    providers = values_from_signal(signals.get_search_providers.send(), as_list=True)
+    providers = values_from_signal(signals.core.get_search_providers.send(), as_list=True)
 
     if not providers:
         return InternalSearch

--- a/indico/modules/users/__init__.py
+++ b/indico/modules/users/__init__.py
@@ -92,6 +92,6 @@ def _registered(user, identity, from_moderation, **kwargs):
     send_email(make_email(get_admin_emails(), template=tpl))
 
 
-@signals.import_tasks.connect
+@signals.core.import_tasks.connect
 def _import_tasks(sender, **kwargs):
     import indico.modules.users.tasks  # noqa: F401

--- a/indico/testing/fixtures/storage.py
+++ b/indico/testing/fixtures/storage.py
@@ -16,7 +16,7 @@ from indico.modules.attachments.models.attachments import Attachment, Attachment
 from indico.modules.attachments.models.folders import AttachmentFolder
 
 
-@signals.get_storage_backends.connect
+@signals.core.get_storage_backends.connect
 def _get_storage_backends(sender, **kwargs):
     return MemoryStorage
 

--- a/indico/util/passwords.py
+++ b/indico/util/passwords.py
@@ -178,7 +178,8 @@ def validate_secure_password(context, password, *, username='', fast=False):
     # there's a good chance that single dictionary words are already included in the pwned password
     # list.
 
-    if errors := values_from_signal(signals.check_password_secure.send(context, username=username, password=password),
+    if errors := values_from_signal(signals.core.check_password_secure.send(context, username=username,
+                                                                            password=password),
                                     as_list=True):
         return errors[0]
 

--- a/indico/util/passwords_test.py
+++ b/indico/util/passwords_test.py
@@ -150,7 +150,7 @@ def test_validate_secure_password(monkeypatch, password, username, expected):
             return 'signalfail'
 
     monkeypatch.setattr('indico.util.passwords.check_password_pwned', _mock_pwned)
-    with signals.check_password_secure.connected_to(_signal_fn):
+    with signals.core.check_password_secure.connected_to(_signal_fn):
         rv = validate_secure_password('test', password, username=username)
     assert signal_called
     if expected is None:

--- a/indico/util/placeholders.py
+++ b/indico/util/placeholders.py
@@ -176,7 +176,7 @@ class ParametrizedPlaceholder(Placeholder):
 
 
 def get_placeholders(context, **kwargs):
-    return named_objects_from_signal(signals.get_placeholders.send(context, **kwargs))
+    return named_objects_from_signal(signals.core.get_placeholders.send(context, **kwargs))
 
 
 def replace_placeholders(context, text, escape_html=True, **kwargs):

--- a/indico/util/rules.py
+++ b/indico/util/rules.py
@@ -88,7 +88,7 @@ def get_conditions(context, **kwargs):
     :param context: the context where the conditions are used
     :param kwargs: arguments specific to the context
     """
-    return named_objects_from_signal(signals.get_conditions.send(context, **kwargs))
+    return named_objects_from_signal(signals.core.get_conditions.send(context, **kwargs))
 
 
 def check_rule(context, rule, **kwargs):

--- a/indico/util/rules_test.py
+++ b/indico/util/rules_test.py
@@ -71,7 +71,7 @@ def _get_test_conditions(sender, **kwargs):
 
 @pytest.fixture(autouse=True)
 def _register_test_rules():
-    with signals.get_conditions.connected_to(_get_test_conditions, sender='test'):
+    with signals.core.get_conditions.connected_to(_get_test_conditions, sender='test'):
         yield
 
 

--- a/indico/web/fields/__init__.py
+++ b/indico/web/fields/__init__.py
@@ -19,4 +19,4 @@ def get_field_definitions(for_):
     :param for_: The identifier/object passed to the `get_fields`
                  signal to identify which fields to get.
     """
-    return named_objects_from_signal(signals.get_fields.send(for_), plugin_attr='plugin')
+    return named_objects_from_signal(signals.core.get_fields.send(for_), plugin_attr='plugin')

--- a/indico/web/flask/app.py
+++ b/indico/web/flask/app.py
@@ -422,7 +422,7 @@ def make_app(testing=False, config_override=None):
         # Below this points plugins are available, i.e. sending signals makes sense
         add_plugin_blueprints(app)
         # themes can be provided by plugins
-        signals.app_created.send(app)
+        signals.core.app_created.send(app)
         config.validate()
         check_db()
 

--- a/indico/web/forms/base.py
+++ b/indico/web/forms/base.py
@@ -54,7 +54,7 @@ class IndicoFormMeta(FormMeta):
         # if the signal receiver didn't specify a sender.
         if kwargs.pop('__extended', False):
             return super().__call__(*args, **kwargs)
-        extra_fields = values_from_signal(signals.add_form_fields.send(cls))
+        extra_fields = values_from_signal(signals.core.add_form_fields.send(cls))
         # If there are no extra fields, we don't need any custom logic
         # and simply create an instance of the original form.
         if not extra_fields:
@@ -143,7 +143,7 @@ class IndicoForm(FlaskForm, metaclass=IndicoFormMeta):
         valid = super().validate()
         if not valid:
             return False
-        if not all(values_from_signal(signals.form_validated.send(self), single_value=True)):
+        if not all(values_from_signal(signals.core.form_validated.send(self), single_value=True)):
             return False
         self.post_validate()
         return True

--- a/indico/web/http_api/hooks/base.py
+++ b/indico/web/http_api/hooks/base.py
@@ -188,7 +188,7 @@ class HTTPAPIHook:
             try:
                 init_email_queue()
                 is_response, resultList, complete, extra = self._perform(user, func, extra_func)
-                signals.after_process.send()
+                signals.core.after_process.send()
                 db.session.commit()
                 flush_email_queue()
             except Exception:

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -279,7 +279,7 @@ class RH:
             init_email_queue()
             self._check_csrf()
             res = self._do_process()
-            signals.after_process.send()
+            signals.core.after_process.send()
 
             if self.commit:
                 db.session.commit()


### PR DESCRIPTION
`signals.core` was the only module inside signals that did this, and wildcard imports are pretty messy to begin with...