### PR TITLE
Make lecture roles more uniform

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Bugfixes
 
 - Fix formatting and datetime localization in various PDF exports and timetable tab headers
   (:pr:`5009`)
+- Show lecture speakers as speakers instead of chairpersons on the participant roles page
+  (:pr:`5008`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -126,7 +126,10 @@ class RHPersonsBase(RHManageEventBase):
                 data['registrations'].append(registration)
             data['person'] = event_person
             if event_person in chairpersons:
-                data['roles']['chairperson'] = BUILTIN_ROLES['chairperson'].copy()
+                if self.event.type != 'lecture':
+                    data['roles']['chairperson'] = BUILTIN_ROLES['chairperson'].copy()
+                else:
+                    data['roles']['speaker'] = BUILTIN_ROLES['speaker'].copy()
 
             if self.event.type == 'lecture':
                 continue

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -49,14 +49,16 @@ from indico.web.forms.base import FormDefaults
 from indico.web.util import jsonify_form
 
 
-BUILTIN_ROLES = {'chairperson': {'name': 'Chairperson', 'code': 'CHR', 'color': 'f7b076',
+BUILTIN_ROLES = {'chairperson': {'name': _('Chairperson'), 'code': 'CHR', 'color': 'f7b076',
                                  'css': 'background-color: #f7b076 !important; border-color: #f7b076 !important'},
-                 'author': {'name': 'Author', 'code': 'AUT', 'color': '6582e8',
+                 'author': {'name': _('Author'), 'code': 'AUT', 'color': '6582e8',
                             'css': 'background-color: #6582e8 !important; border-color: #6582e8 !important'},
-                 'convener': {'name': 'Convener', 'code': 'CON', 'color': 'ce69e0',
+                 'convener': {'name': _('Convener'), 'code': 'CON', 'color': 'ce69e0',
                               'css': 'background-color: #ce69e0 !important; border-color: #ce69e0 !important'},
-                 'speaker': {'name': 'Speaker', 'code': 'SPK', 'color': '53c7ad',
-                             'css': 'background-color: #53c7ad !important; border-color: #53c7ad !important'}}
+                 'speaker': {'name': _('Speaker'), 'code': 'SPK', 'color': '53c7ad',
+                             'css': 'background-color: #53c7ad !important; border-color: #53c7ad !important'},
+                 'lecture_speaker': {'name': _('Speaker'), 'code': 'SPK', 'color': '53c7ad',
+                                     'css': 'background-color: #53c7ad !important; border-color: #53c7ad !important'}}
 
 
 class RHPersonsBase(RHManageEventBase):
@@ -129,7 +131,7 @@ class RHPersonsBase(RHManageEventBase):
                 if self.event.type != 'lecture':
                     data['roles']['chairperson'] = BUILTIN_ROLES['chairperson'].copy()
                 else:
-                    data['roles']['speaker'] = BUILTIN_ROLES['speaker'].copy()
+                    data['roles']['lecture_speaker'] = BUILTIN_ROLES['lecture_speaker'].copy()
 
             if self.event.type == 'lecture':
                 continue

--- a/indico/modules/events/persons/templates/management/person_list.html
+++ b/indico/modules/events/persons/templates/management/person_list.html
@@ -123,19 +123,15 @@
                 <div id="person-filters" class="group list-filter">
                     <a class="i-button arrow highlight js-dropdown" data-toggle="dropdown">Filter role</a>
                     <ul class="i-dropdown">
-                        <li class="enabled">
-                            <input type="checkbox" id="filter-chairpersons" data-filter="chairperson" checked>
-                            <i class="icon-checkmark"></i>
-                            <i class="icon-stop colored-square" style="color: #{{ builtin_roles.chairperson.color }};"></i>
-                            <label for="filter-chairpersons">
-                                {%- if event.type == 'lecture' -%}
-                                    {%- trans %}Speakers{% endtrans -%}
-                                {%- else -%}
-                                    {%- trans %}Chairpersons{% endtrans -%}
-                                {%- endif -%}
-                            </label>
-                        </li>
                         {% if event.type != 'lecture' %}
+                            <li class="enabled">
+                                <input type="checkbox" id="filter-chairpersons" data-filter="chairperson" checked>
+                                <i class="icon-checkmark"></i>
+                                <i class="icon-stop colored-square" style="color: #{{ builtin_roles.chairperson.color }};"></i>
+                                <label for="filter-chairpersons">
+                                    {%- trans %}Chairpersons{% endtrans -%}
+                                </label>
+                            </li>
                             <li class="enabled">
                                 <input type="checkbox" id="filter-speakers" data-filter="speaker" checked>
                                 <i class="icon-checkmark"></i>
@@ -158,6 +154,13 @@
                                     </label>
                                 </li>
                             {% endif %}
+                        {% else %}
+                            <li class="enabled">
+                                <input type="checkbox" id="filter-lecture-speakers" data-filter="lecture_speaker" checked>
+                                <i class="icon-checkmark"></i>
+                                <i class="icon-stop colored-square" style="color: #{{ builtin_roles.lecture_speaker.color }};"></i>
+                                <label for="filter-lecture-speakers">{% trans %}Speakers{% endtrans %}</label>
+                            </li>
                         {% endif %}
                         {% for role_id, role_data in custom_roles.items() %}
                             <li class="enabled">


### PR DESCRIPTION
This PR makes the lecture roles uniform across the management settings and the participant roles views.

Previously the person showing as speaker in the management settings view:
![image](https://user-images.githubusercontent.com/6058151/125453951-611566b3-4f88-4a42-aa85-1404afaaafb0.png)

Was being labelled as chairperson in the participant roles table:
![image](https://user-images.githubusercontent.com/6058151/125454232-99940ccc-a157-4e15-ab85-780079976165.png)

It will be shown as speaker in that table too.