### PR TITLE
Improve utils for service overview pages

### DIFF
--- a/indico/web/templates/overview/base.html
+++ b/indico/web/templates/overview/base.html
@@ -1,5 +1,6 @@
 {% extends 'layout/base.html' %}
 {% from 'forms/_form.html' import form_header, form_rows, form_footer  %}
+{% from 'message_box.html' import message_box %}
 
 {# Implement this macro in child templates
     {% macro result_group_entries(items) %}
@@ -12,7 +13,41 @@
 #}
 
 {% block page_class %}fixed-width-standalone-page{% endblock %}
+
+{% block page_actions -%}
+    {% if calendar_link_supported|default(false) -%}
+        <div class="toolbar">
+            <a href="#"
+               class="i-button icon-calendar"
+               title="{% trans %}Generate iCalendar link{% endtrans %}"
+               data-href="{{ url_for('.request_calendar_link') }}"
+               data-title="{% trans %}Generate iCalendar link{% endtrans %}"
+               data-ajax-dialog
+               data-reload-after></a>
+        </div>
+    {%- endif -%}
+{%- endblock %}
+
 {% block content %}
+    {% if calendar_link_supported|default(false) and calendar_link %}
+        {% call message_box('success') %}
+            {%- set link_start -%}
+                <a href="{{ calendar_link }}"
+                   class="js-copy-to-clipboard"
+                   title="{% trans %}Copy link to clipboard{% endtrans %}"
+                   data-clipboard-text="{{ calendar_link }}"
+                   data-clipboard-action="copy">
+            {%- endset -%}
+            {%- set link_end -%}
+                </a>
+            {%- endset -%}
+
+            {% trans %}
+                Your {{ link_start }}calendar link{{ link_end }} has been generated.
+            {% endtrans %}
+        {% endcall %}
+    {% endif %}
+
     <div class="i-box-group vert">
         <div class="i-box">
             {{ form_header(form, method='get', action=action|default('')) }}

--- a/indico/web/util.py
+++ b/indico/web/util.py
@@ -205,7 +205,7 @@ def is_legacy_signed_url_valid(user, url):
         '',
         '',
         parsed.path,
-        url_encode(sorted(params.items()), sort=True),
+        url_encode(params, sort=False),
         parsed.fragment
     ))
     signer = Signer(user.signing_secret, salt='url-signing')
@@ -269,7 +269,7 @@ def verify_signed_user_url(url, method):
         '',
         '',
         parsed.path,
-        url_encode(sorted(params.items()), sort=True),
+        url_encode(params, sort=False),
         parsed.fragment
     ))
 

--- a/indico/web/util_test.py
+++ b/indico/web/util_test.py
@@ -87,6 +87,13 @@ def test_verify_signed_user_url(dummy_user, url):
     assert 'The persistent link you used is invalid' in str(exc_info.value)
 
 
+@pytest.mark.parametrize('args', ([1, 2], [2, 1]))
+def test_verify_signed_user_url_lists(dummy_user, args):
+    dummy_user.signing_secret = 'sixtynine'
+    url = signed_url_for_user(dummy_user, 'core.contact', foo=args)
+    assert verify_signed_user_url(url, 'GET') == dummy_user
+
+
 def test_verify_signed_user_url_no_token():
     assert verify_signed_user_url('/contact', 'GET') is None
 


### PR DESCRIPTION
- fix error in signed url checking for urls containing multiple values for the same arg
- add marshmallow field to handle dates like `yesterday` or `-14d`
- add boilerplate to service overview page base template to generate/show calendar links

The template is actually only used in plugins, but for some reason (deduplication I guess?) we added it to the core at some point during the v2 development... Since there's no good place to put it w/o duplicating it I'm leaving it there.

The marshmallow field might be useful in the future for some newer API endpoints in case we want to allow those relative URLs (even though it might not be needed since without signed API URLs there's no reason for a client to not generate explicit start/end dates itself)