### PR TITLE
Add category moderation through event move requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,11 @@ Major Features
   category log (similar to the event log). This log includes information about
   all events being created, deleted or moved in the category (:issue:`2809`,
   :pr:`5029`)
+- Besides letting everyone create events in a category or restricting it to
+  specific users, categories now also support a moderation workflow which allows
+  event managers to request moving an event to a category. Only once a category
+  manager approves this request, the event is actually moved (:issue:`2057`, :pr:`5013`)
 - TODO write something about unlisted events
-- TODO write something about moderated categories
 
 Internationalization
 ^^^^^^^^^^^^^^^^^^^^

--- a/indico/migrations/versions/20210715_1211_9d00917b2fa8_add_event_category_request.py
+++ b/indico/migrations/versions/20210715_1211_9d00917b2fa8_add_event_category_request.py
@@ -1,0 +1,59 @@
+"""Add event category request
+
+Revision ID: 9d00917b2fa8
+Revises: 1cec32e42f65
+Create Date: 2021-07-15 12:11:28.157824
+"""
+from enum import Enum
+
+import sqlalchemy as sa
+from alembic import op
+
+from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = '9d00917b2fa8'
+down_revision = '1cec32e42f65'
+branch_labels = None
+depends_on = None
+
+
+class _MoveRequestState(int, Enum):
+    pending = 0
+    accepted = 1
+    rejected = 2
+    withdrawn = 3
+
+
+def upgrade():
+    op.create_table(
+        'event_move_requests',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('event_id', sa.Integer(), nullable=False, index=True),
+        sa.Column('category_id', sa.Integer(), nullable=True, index=True),
+        sa.Column('submitter_id', sa.Integer(), nullable=True, index=True),
+        sa.Column('state', PyIntEnum(_MoveRequestState), nullable=False),
+        sa.Column('moderator_id', sa.Integer(), nullable=True),
+        sa.Column('submitted_dt', UTCDateTime, nullable=False),
+        sa.CheckConstraint('state in (1, 2) AND moderator_id IS NOT NULL OR moderator_id IS NULL',
+                           name=op.f('moderator_state')),
+        sa.ForeignKeyConstraint(['category_id'], ['categories.categories.id']),
+        sa.ForeignKeyConstraint(['event_id'], ['events.events.id']),
+        sa.ForeignKeyConstraint(['moderator_id'], ['users.users.id']),
+        sa.ForeignKeyConstraint(['submitter_id'], ['users.users.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='categories'
+    )
+    op.create_index(op.f('ix_uq_event_move_requests_event_id'), 'event_move_requests', ['event_id'], unique=True,
+                    schema='categories', postgresql_where=sa.text('state = 0'))
+    op.add_column('categories',
+                  sa.Column('event_requires_approval', sa.Boolean(), nullable=False, server_default='false'),
+                  schema='categories')
+
+
+def downgrade():
+    op.drop_column('categories', 'event_requires_approval', schema='categories')
+    op.drop_index(op.f('ix_uq_event_move_requests_event_id'), table_name='event_move_requests', schema='categories',
+                  postgresql_where=sa.text('state = 0'))
+    op.drop_table('event_move_requests', schema='categories')

--- a/indico/migrations/versions/20210715_1211_9d00917b2fa8_add_event_category_request.py
+++ b/indico/migrations/versions/20210715_1211_9d00917b2fa8_add_event_category_request.py
@@ -34,6 +34,7 @@ def upgrade():
         sa.Column('category_id', sa.Integer(), nullable=True, index=True),
         sa.Column('submitter_id', sa.Integer(), nullable=True, index=True),
         sa.Column('state', PyIntEnum(_MoveRequestState), nullable=False),
+        sa.Column('state_reason', sa.String(), nullable=True),
         sa.Column('moderator_id', sa.Integer(), nullable=True),
         sa.Column('submitted_dt', UTCDateTime, nullable=False),
         sa.CheckConstraint('state in (1, 2) AND moderator_id IS NOT NULL OR moderator_id IS NULL',

--- a/indico/migrations/versions/20210804_1211_9d00917b2fa8_add_event_category_request.py
+++ b/indico/migrations/versions/20210804_1211_9d00917b2fa8_add_event_category_request.py
@@ -1,7 +1,7 @@
 """Add event category request
 
 Revision ID: 9d00917b2fa8
-Revises: 1cec32e42f65
+Revises: 4b097412a8d9
 Create Date: 2021-07-15 12:11:28.157824
 """
 from enum import Enum
@@ -14,7 +14,7 @@ from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
 
 # revision identifiers, used by Alembic.
 revision = '9d00917b2fa8'
-down_revision = '1cec32e42f65'
+down_revision = '4b097412a8d9'
 branch_labels = None
 depends_on = None
 

--- a/indico/migrations/versions/20210804_1211_9d00917b2fa8_add_event_category_request.py
+++ b/indico/migrations/versions/20210804_1211_9d00917b2fa8_add_event_category_request.py
@@ -31,30 +31,29 @@ def upgrade():
         'event_move_requests',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('event_id', sa.Integer(), nullable=False, index=True),
-        sa.Column('category_id', sa.Integer(), nullable=True, index=True),
-        sa.Column('submitter_id', sa.Integer(), nullable=True, index=True),
+        sa.Column('category_id', sa.Integer(), nullable=False, index=True),
+        sa.Column('requestor_id', sa.Integer(), nullable=False, index=True),
         sa.Column('state', PyIntEnum(_MoveRequestState), nullable=False),
         sa.Column('moderator_comment', sa.String(), nullable=False, default=''),
         sa.Column('moderator_id', sa.Integer(), nullable=True),
-        sa.Column('submitted_dt', UTCDateTime, nullable=False),
-        sa.CheckConstraint('state in (1, 2) AND moderator_id IS NOT NULL OR moderator_id IS NULL',
-                           name=op.f('moderator_state')),
+        sa.Column('requested_dt', UTCDateTime, nullable=False),
+        sa.CheckConstraint('(state in (1, 2) AND moderator_id IS NOT NULL) OR moderator_id IS NULL',
+                           name='moderator_state'),
         sa.ForeignKeyConstraint(['category_id'], ['categories.categories.id']),
         sa.ForeignKeyConstraint(['event_id'], ['events.events.id']),
         sa.ForeignKeyConstraint(['moderator_id'], ['users.users.id']),
-        sa.ForeignKeyConstraint(['submitter_id'], ['users.users.id']),
+        sa.ForeignKeyConstraint(['requestor_id'], ['users.users.id']),
         sa.PrimaryKeyConstraint('id'),
         schema='categories'
     )
-    op.create_index(op.f('ix_uq_event_move_requests_event_id'), 'event_move_requests', ['event_id'], unique=True,
+    op.create_index(None, 'event_move_requests', ['event_id'], unique=True,
                     schema='categories', postgresql_where=sa.text('state = 0'))
     op.add_column('categories',
                   sa.Column('event_requires_approval', sa.Boolean(), nullable=False, server_default='false'),
                   schema='categories')
+    op.alter_column('categories', 'event_requires_approval', server_default=None, schema='categories')
 
 
 def downgrade():
     op.drop_column('categories', 'event_requires_approval', schema='categories')
-    op.drop_index(op.f('ix_uq_event_move_requests_event_id'), table_name='event_move_requests', schema='categories',
-                  postgresql_where=sa.text('state = 0'))
     op.drop_table('event_move_requests', schema='categories')

--- a/indico/migrations/versions/20210804_1211_9d00917b2fa8_add_event_category_request.py
+++ b/indico/migrations/versions/20210804_1211_9d00917b2fa8_add_event_category_request.py
@@ -34,7 +34,7 @@ def upgrade():
         sa.Column('category_id', sa.Integer(), nullable=True, index=True),
         sa.Column('submitter_id', sa.Integer(), nullable=True, index=True),
         sa.Column('state', PyIntEnum(_MoveRequestState), nullable=False),
-        sa.Column('state_reason', sa.String(), nullable=True),
+        sa.Column('moderator_comment', sa.String(), nullable=False, default=''),
         sa.Column('moderator_id', sa.Integer(), nullable=True),
         sa.Column('submitted_dt', UTCDateTime, nullable=False),
         sa.CheckConstraint('state in (1, 2) AND moderator_id IS NOT NULL OR moderator_id IS NULL',

--- a/indico/modules/categories/__init__.py
+++ b/indico/modules/categories/__init__.py
@@ -53,6 +53,8 @@ def _sidemenu_items(sender, category, **kwargs):
                        50, icon='users')
     yield SideMenuItem('logs', _('Logs'), url_for('logs.category', category),
                        0, icon='stack')
+    yield SideMenuItem('moderation', _('Moderation'), url_for('categories.manage_moderation', category),
+                       50, icon='users')
 
 
 @signals.menu.items.connect_via('admin-sidemenu')

--- a/indico/modules/categories/__init__.py
+++ b/indico/modules/categories/__init__.py
@@ -43,8 +43,9 @@ def _merge_users(target, source, **kwargs):
 
 
 def _is_moderation_visible(category):
-    return category.event_requires_approval and category.event_move_requests.filter(
-        EventMoveRequest.state == MoveRequestState.pending)
+    return category.event_requires_approval or category.event_move_requests.filter(
+        EventMoveRequest.state == MoveRequestState.pending).first() or any(
+        ['event_move_request' in e.permissions for e in category.acl_entries])
 
 
 @signals.menu.items.connect_via('category-management-sidemenu')

--- a/indico/modules/categories/__init__.py
+++ b/indico/modules/categories/__init__.py
@@ -12,7 +12,7 @@ from indico.core.db.sqlalchemy.protection import make_acl_log_fn
 from indico.core.logger import Logger
 from indico.core.permissions import ManagementPermission, check_permissions
 from indico.core.settings import SettingsProxy
-from indico.modules.categories.models.categories import Category
+from indico.modules.categories.models.categories import Category, EventCreationMode
 from indico.modules.categories.models.event_move_request import MoveRequestState
 from indico.modules.logs.models.entries import CategoryLogRealm
 from indico.util.i18n import _
@@ -44,7 +44,7 @@ def _merge_users(target, source, **kwargs):
 
 def _is_moderation_visible(category):
     return (
-        category.event_requires_approval or
+        category.event_creation_mode == EventCreationMode.moderated or
         category.event_move_requests.filter_by(state=MoveRequestState.pending).has_rows() or
         any('event_move_request' in entry.permissions for entry in category.acl_entries)
     )

--- a/indico/modules/categories/__init__.py
+++ b/indico/modules/categories/__init__.py
@@ -13,8 +13,8 @@ from indico.core.logger import Logger
 from indico.core.permissions import ManagementPermission, check_permissions
 from indico.core.settings import SettingsProxy
 from indico.modules.categories.models.categories import Category
-from indico.modules.logs.models.entries import CategoryLogRealm
 from indico.modules.categories.models.event_move_request import EventMoveRequest, MoveRequestState
+from indico.modules.logs.models.entries import CategoryLogRealm
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.menu import SideMenuItem

--- a/indico/modules/categories/__init__.py
+++ b/indico/modules/categories/__init__.py
@@ -71,11 +71,19 @@ def _check_permissions(app, **kwargs):
 
 @signals.acl.get_management_permissions.connect_via(Category)
 def _get_management_permissions(sender, **kwargs):
-    return CreatorPermission
+    yield CreatorPermission
+    yield EventMoveRequestPermission
 
 
 class CreatorPermission(ManagementPermission):
     name = 'create'
     friendly_name = _('Event creation')
     description = _('Allows creating events in the category')
+    user_selectable = True
+
+
+class EventMoveRequestPermission(ManagementPermission):
+    name = 'event_move_request'
+    friendly_name = _('Request event move')
+    description = _('Allows requesting for an event to be moved to this category')
     user_selectable = True

--- a/indico/modules/categories/__init__.py
+++ b/indico/modules/categories/__init__.py
@@ -58,13 +58,13 @@ def _sidemenu_items(sender, category, **kwargs):
                        90, icon='settings')
     yield SideMenuItem('protection', _('Protection'), url_for('categories.manage_protection', category),
                        70, icon='shield')
+    if _is_moderation_visible(category):
+        yield SideMenuItem('moderation', _('Moderation'), url_for('categories.manage_moderation', category),
+                           60, icon='user-reading')
     yield SideMenuItem('roles', _('Roles'), url_for('categories.manage_roles', category),
                        50, icon='users')
     yield SideMenuItem('logs', _('Logs'), url_for('logs.category', category),
                        0, icon='stack')
-    if _is_moderation_visible(category):
-        yield SideMenuItem('moderation', _('Moderation'), url_for('categories.manage_moderation', category),
-                           50, icon='users')
 
 
 @signals.menu.items.connect_via('admin-sidemenu')

--- a/indico/modules/categories/__init__.py
+++ b/indico/modules/categories/__init__.py
@@ -13,7 +13,7 @@ from indico.core.logger import Logger
 from indico.core.permissions import ManagementPermission, check_permissions
 from indico.core.settings import SettingsProxy
 from indico.modules.categories.models.categories import Category
-from indico.modules.categories.models.event_move_request import EventMoveRequest, MoveRequestState
+from indico.modules.categories.models.event_move_request import MoveRequestState
 from indico.modules.logs.models.entries import CategoryLogRealm
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
@@ -43,9 +43,11 @@ def _merge_users(target, source, **kwargs):
 
 
 def _is_moderation_visible(category):
-    return category.event_requires_approval or category.event_move_requests.filter(
-        EventMoveRequest.state == MoveRequestState.pending).first() or any(
-        ['event_move_request' in e.permissions for e in category.acl_entries])
+    return (
+        category.event_requires_approval or
+        category.event_move_requests.filter_by(state=MoveRequestState.pending).has_rows() or
+        any('event_move_request' in entry.permissions for entry in category.acl_entries)
+    )
 
 
 @signals.menu.items.connect_via('category-management-sidemenu')

--- a/indico/modules/categories/blueprint.py
+++ b/indico/modules/categories/blueprint.py
@@ -17,14 +17,16 @@ from indico.modules.categories.controllers.display import (RHCategoryCalendarVie
                                                            RHReachableCategoriesInfo, RHShowFutureEventsInCategory,
                                                            RHShowPastEventsInCategory, RHSubcatInfo)
 from indico.modules.categories.controllers.management import (RHAddCategoryRole, RHAddCategoryRoleMembers,
-                                                              RHCategoryRoleMembersImportCSV, RHCategoryRoles,
-                                                              RHCreateCategory, RHDeleteCategory, RHDeleteCategoryRole,
-                                                              RHDeleteEvents, RHDeleteSubcategories, RHEditCategoryRole,
+                                                              RHAPIEventMoveRequests, RHCategoryRoleMembersImportCSV,
+                                                              RHCategoryRoles, RHCreateCategory, RHDeleteCategory,
+                                                              RHDeleteCategoryRole, RHDeleteEvents,
+                                                              RHDeleteSubcategories, RHEditCategoryRole,
                                                               RHManageCategoryContent, RHManageCategoryIcon,
-                                                              RHManageCategoryLogo, RHManageCategoryProtection,
-                                                              RHManageCategorySettings, RHMoveCategory, RHMoveEvents,
-                                                              RHMoveSubcategories, RHRemoveCategoryRoleMember,
-                                                              RHSortSubcategories, RHSplitCategory)
+                                                              RHManageCategoryLogo, RHManageCategoryModeration,
+                                                              RHManageCategoryProtection, RHManageCategorySettings,
+                                                              RHMoveCategory, RHMoveEvents, RHMoveSubcategories,
+                                                              RHRemoveCategoryRoleMember, RHSortSubcategories,
+                                                              RHSplitCategory)
 from indico.modules.users import User
 from indico.web.flask.util import make_compat_redirect_func, redirect_view, url_for
 from indico.web.flask.wrappers import IndicoBlueprint
@@ -46,6 +48,7 @@ _bp.add_url_rule('/manage/logo', 'manage_logo', RHManageCategoryLogo, methods=('
 _bp.add_url_rule('/manage/move', 'move', RHMoveCategory, methods=('POST',))
 _bp.add_url_rule('/manage/protection', 'manage_protection', RHManageCategoryProtection, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/settings', 'manage_settings', RHManageCategorySettings, methods=('POST', 'GET'))
+_bp.add_url_rule('/manage/moderation', 'manage_moderation', RHManageCategoryModeration, methods=('POST', 'GET'))
 
 # Role management
 _bp.add_url_rule('/manage/roles', 'manage_roles', RHCategoryRoles, methods=('POST', 'GET'))
@@ -98,6 +101,7 @@ _bp.add_url_rule('!/c/<int:category_id>', view_func=redirect_view('.display'), s
 
 # Internal API
 _bp.add_url_rule('!/category/search', 'search', RHCategorySearch)
+_bp.add_url_rule('/api/event-move-requests', 'api_event_move_requests', RHAPIEventMoveRequests, methods=('GET', 'POST'))
 
 # Administration
 _bp.add_url_rule('!/admin/upcoming-events', 'manage_upcoming', RHManageUpcomingEvents, methods=('GET', 'POST'))

--- a/indico/modules/categories/blueprint.py
+++ b/indico/modules/categories/blueprint.py
@@ -48,7 +48,7 @@ _bp.add_url_rule('/manage/logo', 'manage_logo', RHManageCategoryLogo, methods=('
 _bp.add_url_rule('/manage/move', 'move', RHMoveCategory, methods=('POST',))
 _bp.add_url_rule('/manage/protection', 'manage_protection', RHManageCategoryProtection, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/settings', 'manage_settings', RHManageCategorySettings, methods=('POST', 'GET'))
-_bp.add_url_rule('/manage/moderation', 'manage_moderation', RHManageCategoryModeration, methods=('POST', 'GET'))
+_bp.add_url_rule('/manage/moderation', 'manage_moderation', RHManageCategoryModeration)
 
 # Role management
 _bp.add_url_rule('/manage/roles', 'manage_roles', RHCategoryRoles, methods=('POST', 'GET'))

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -1,3 +1,10 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2021 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
 import eventRequestsURL from 'indico-url:categories.api_event_move_requests';
 import eventURL from 'indico-url:events.display';
 

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -42,65 +42,62 @@ function EventRequestList({requests, onApprove, onReject}) {
   }
 
   return (
-    <>
-      {/* TODO: check if module is enabled */}
-      <Table celled>
-        <Table.Header>
-          <Table.Row>
-            <Table.HeaderCell />
-            <Translate as={Table.HeaderCell}>User</Translate>
-            <Translate as={Table.HeaderCell}>Event</Translate>
-            <Translate as={Table.HeaderCell}>State</Translate>
-            <Translate as={Table.HeaderCell}>Submitted Date</Translate>
+    <Table celled>
+      <Table.Header>
+        <Table.Row>
+          <Table.HeaderCell />
+          <Translate as={Table.HeaderCell}>User</Translate>
+          <Translate as={Table.HeaderCell}>Event</Translate>
+          <Translate as={Table.HeaderCell}>State</Translate>
+          <Translate as={Table.HeaderCell}>Submitted Date</Translate>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {requests.map(({id, submitter, event, state, submittedDt}) => (
+          <Table.Row key={id}>
+            <Table.Cell collapsing>
+              <Checkbox
+                checked={selected.has(id)}
+                onChange={() => select(id)}
+                disabled={state !== 'pending'}
+              />
+            </Table.Cell>
+            <Table.Cell styleName="user">
+              <Image styleName="avatar" src={submitter.avatarURL} size="mini" avatar />
+              {submitter.fullName} {submitter.affiliation && `(${submitter.affiliation})`}
+            </Table.Cell>
+            <Table.Cell>
+              <a href={eventURL({event_id: event.id})}>{event.title}</a>
+            </Table.Cell>
+            <Table.Cell>{state}</Table.Cell>
+            <Table.Cell>{serializeDate(submittedDt)}</Table.Cell>
           </Table.Row>
-        </Table.Header>
-        <Table.Body>
-          {requests.map(({id, submitter, event, state, submittedDt}) => (
-            <Table.Row key={id}>
-              <Table.Cell collapsing>
-                <Checkbox
-                  checked={selected.has(id)}
-                  onChange={() => select(id)}
-                  disabled={state !== 'pending'}
-                />
-              </Table.Cell>
-              <Table.Cell styleName="user">
-                <Image styleName="avatar" src={submitter.avatarURL} size="mini" avatar />
-                {submitter.name} {submitter.affiliation && `(${submitter.affiliation})`}
-              </Table.Cell>
-              <Table.Cell>
-                <a href={eventURL({event_id: event.id})}>{event.title}</a>
-              </Table.Cell>
-              <Table.Cell>{state}</Table.Cell>
-              <Table.Cell>{serializeDate(submittedDt)}</Table.Cell>
-            </Table.Row>
-          ))}
-        </Table.Body>
-        <Table.Footer fullWidth>
-          <Table.Row>
-            <Table.HeaderCell />
-            <Table.HeaderCell colSpan="4">
-              <Translate
-                as={Button}
-                size="small"
-                onClick={() => submit(onApprove)}
-                disabled={!isAnySelected}
-              >
-                Approve
-              </Translate>
-              <Translate
-                as={Button}
-                size="small"
-                onClick={() => submit(onReject)}
-                disabled={!isAnySelected}
-              >
-                Reject
-              </Translate>
-            </Table.HeaderCell>
-          </Table.Row>
-        </Table.Footer>
-      </Table>
-    </>
+        ))}
+      </Table.Body>
+      <Table.Footer fullWidth>
+        <Table.Row>
+          <Table.HeaderCell />
+          <Table.HeaderCell colSpan="4">
+            <Translate
+              as={Button}
+              size="small"
+              onClick={() => submit(onApprove)}
+              disabled={!isAnySelected}
+            >
+              Approve
+            </Translate>
+            <Translate
+              as={Button}
+              size="small"
+              onClick={() => submit(onReject)}
+              disabled={!isAnySelected}
+            >
+              Reject
+            </Translate>
+          </Table.HeaderCell>
+        </Table.Row>
+      </Table.Footer>
+    </Table>
   );
 }
 

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -87,12 +87,13 @@ const judgmentOptions = [
 function RequestList({requests, onSubmit, loading}) {
   const [selected, _setSelected] = useState(new Set());
   const [judgeValue, setJudgeValue] = useState(judgmentOptions[0].value);
+  const [reason, setReason] = useState(undefined);
   const isAnySelected = selected.size > 0;
   const judgeOption = judgmentOptions.find(x => x.value === judgeValue);
 
   const submit = accept => {
     _setSelected(new Set());
-    onSubmit(Array.from(selected), accept);
+    onSubmit(Array.from(selected), accept, reason);
   };
 
   const select = id =>
@@ -159,6 +160,8 @@ function RequestList({requests, onSubmit, loading}) {
                   <Input
                     size="small"
                     placeholder={Translate.string('Provide the rejection reason')}
+                    value={reason}
+                    onChange={(_, {value}) => setReason(value)}
                   />
                 </>
               )}
@@ -187,10 +190,10 @@ export default function CategoryModeration({categoryId}) {
     camelize: true,
   });
 
-  const setRequestsState = async (requests, accept) => {
+  const setRequestsState = async (requests, accept, reason) => {
     const url = eventRequestsURL({category_id: categoryId});
     try {
-      await indicoAxios.post(url, {requests, accept});
+      await indicoAxios.post(url, {requests, accept, reason});
       reFetch();
     } catch (e) {
       return handleSubmitError(e);

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -64,7 +64,9 @@ function EventRequestList({requests, onApprove, onReject}) {
             </Table.Cell>
             <Table.Cell styleName="user">
               <Image styleName="avatar" src={submitter.avatarURL} size="mini" avatar />
-              {submitter.fullName} {submitter.affiliation && `(${submitter.affiliation})`}
+              <span>
+                {submitter.fullName} {submitter.affiliation && `(${submitter.affiliation})`}
+              </span>
             </Table.Cell>
             <Table.Cell>
               <a href={eventURL({event_id: event.id})}>{event.title}</a>

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -81,7 +81,7 @@ RequestTableRow.defaultProps = {
 
 function RequestList({requests, onSubmit, loading}) {
   const [selected, _setSelected] = useState(new Set());
-  const [reason, setReason] = useState(undefined);
+  const [reason, setReason] = useState('');
   const isAnySelected = selected.size > 0;
 
   const submit = accept => {

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -48,10 +48,10 @@ function EventRequestList({requests, onApprove, onReject}) {
         <Table.Header>
           <Table.Row>
             <Table.HeaderCell />
-            <Table.HeaderCell>User</Table.HeaderCell>
-            <Table.HeaderCell>Event</Table.HeaderCell>
-            <Table.HeaderCell>State</Table.HeaderCell>
-            <Table.HeaderCell>Submitted Date</Table.HeaderCell>
+            <Translate as={Table.HeaderCell}>User</Translate>
+            <Translate as={Table.HeaderCell}>Event</Translate>
+            <Translate as={Table.HeaderCell}>State</Translate>
+            <Translate as={Table.HeaderCell}>Submitted Date</Translate>
           </Table.Row>
         </Table.Header>
         <Table.Body>
@@ -80,12 +80,22 @@ function EventRequestList({requests, onApprove, onReject}) {
           <Table.Row>
             <Table.HeaderCell />
             <Table.HeaderCell colSpan="4">
-              <Button size="small" onClick={() => submit(onApprove)} disabled={!isAnySelected}>
+              <Translate
+                as={Button}
+                size="small"
+                onClick={() => submit(onApprove)}
+                disabled={!isAnySelected}
+              >
                 Approve
-              </Button>
-              <Button size="small" onClick={() => submit(onReject)} disabled={!isAnySelected}>
+              </Translate>
+              <Translate
+                as={Button}
+                size="small"
+                onClick={() => submit(onReject)}
+                disabled={!isAnySelected}
+              >
                 Reject
-              </Button>
+              </Translate>
             </Table.HeaderCell>
           </Table.Row>
         </Table.Footer>

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -10,7 +10,7 @@ import eventURL from 'indico-url:events.display';
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Button, Checkbox, Image, Table} from 'semantic-ui-react';
+import {Button, Checkbox, Image, Placeholder, Table} from 'semantic-ui-react';
 
 import {handleSubmitError} from 'indico/react/forms';
 import {useIndicoAxios} from 'indico/react/hooks';
@@ -19,7 +19,65 @@ import {indicoAxios} from 'indico/utils/axios';
 import {serializeDate} from 'indico/utils/date';
 import './CategoryModeration.module.scss';
 
-function EventRequestList({requests, onSubmit}) {
+function PlaceholderTableRow() {
+  return (
+    <Table.Row>
+      <Table.Cell collapsing>
+        <Checkbox />
+      </Table.Cell>
+      <Table.Cell colSpan="4">
+        <Placeholder fluid>
+          <Placeholder.Header image>
+            <Placeholder.Line />
+            <Placeholder.Line />
+          </Placeholder.Header>
+        </Placeholder>
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+function RequestTableRow({submitter, event, submittedDt, selected, onSelect}) {
+  const {fullName, avatarURL, affiliation} = submitter;
+  return (
+    <Table.Row>
+      <Table.Cell collapsing>
+        <Checkbox checked={selected} onChange={onSelect} />
+      </Table.Cell>
+      <Table.Cell styleName="user">
+        <Image styleName="avatar" src={avatarURL} size="mini" avatar />
+        <span>
+          {fullName} {affiliation && `(${affiliation})`}
+        </span>
+      </Table.Cell>
+      <Table.Cell>
+        <a href={eventURL({event_id: event.id})}>{event.title}</a>
+      </Table.Cell>
+      <Table.Cell>{serializeDate(submittedDt)}</Table.Cell>
+    </Table.Row>
+  );
+}
+
+RequestTableRow.propTypes = {
+  submitter: PropTypes.shape({
+    fullName: PropTypes.string,
+    avatarURL: PropTypes.string,
+    affiliation: PropTypes.string,
+  }).isRequired,
+  event: PropTypes.shape({
+    id: PropTypes.number,
+    title: PropTypes.string,
+  }).isRequired,
+  submittedDt: PropTypes.string.isRequired,
+  selected: PropTypes.bool,
+  onSelect: PropTypes.func.isRequired,
+};
+
+RequestTableRow.defaultProps = {
+  selected: false,
+};
+
+function RequestList({requests, onSubmit, loading}) {
   const [selected, _setSelected] = useState(new Set());
   const isAnySelected = selected.size > 0;
 
@@ -37,8 +95,8 @@ function EventRequestList({requests, onSubmit}) {
       return set;
     });
 
-  if (requests.length === 0) {
-    return <Translate as="p">There are no event move requests</Translate>;
+  if (requests.length === 0 && !loading) {
+    return <Translate as="p">There are no event move requests.</Translate>;
   }
 
   return (
@@ -48,33 +106,25 @@ function EventRequestList({requests, onSubmit}) {
           <Table.HeaderCell />
           <Translate as={Table.HeaderCell}>User</Translate>
           <Translate as={Table.HeaderCell}>Event</Translate>
-          <Translate as={Table.HeaderCell}>State</Translate>
           <Translate as={Table.HeaderCell}>Submitted Date</Translate>
         </Table.Row>
       </Table.Header>
       <Table.Body>
-        {requests.map(({id, submitter, event, state, submittedDt}) => (
-          <Table.Row key={id}>
-            <Table.Cell collapsing>
-              <Checkbox
-                checked={selected.has(id)}
-                onChange={() => select(id)}
-                disabled={state !== 'pending'}
-              />
-            </Table.Cell>
-            <Table.Cell styleName="user">
-              <Image styleName="avatar" src={submitter.avatarURL} size="mini" avatar />
-              <span>
-                {submitter.fullName} {submitter.affiliation && `(${submitter.affiliation})`}
-              </span>
-            </Table.Cell>
-            <Table.Cell>
-              <a href={eventURL({event_id: event.id})}>{event.title}</a>
-            </Table.Cell>
-            <Table.Cell>{state}</Table.Cell>
-            <Table.Cell>{serializeDate(submittedDt)}</Table.Cell>
-          </Table.Row>
-        ))}
+        {loading ? (
+          <PlaceholderTableRow />
+        ) : (
+          requests.map(({id, submitter, event, submittedDt}) => (
+            <RequestTableRow
+              key={id}
+              id={id}
+              event={event}
+              submitter={submitter}
+              submittedDt={submittedDt}
+              selected={selected.has(id)}
+              onSelect={() => select(id)}
+            />
+          ))
+        )}
       </Table.Body>
       <Table.Footer fullWidth>
         <Table.Row>
@@ -103,13 +153,18 @@ function EventRequestList({requests, onSubmit}) {
   );
 }
 
-EventRequestList.propTypes = {
+RequestList.propTypes = {
   requests: PropTypes.array.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  loading: PropTypes.bool,
+};
+
+RequestList.defaultProps = {
+  loading: false,
 };
 
 export default function CategoryModeration({categoryId}) {
-  const {data, reFetch} = useIndicoAxios({
+  const {data, loading, reFetch} = useIndicoAxios({
     url: eventRequestsURL({category_id: categoryId}),
     trigger: categoryId,
     camelize: true,
@@ -125,7 +180,9 @@ export default function CategoryModeration({categoryId}) {
     }
   };
 
-  return <EventRequestList requests={data || []} onSubmit={setRequestsState} />;
+  return (
+    <RequestList requests={data || []} onSubmit={setRequestsState} loading={!data || loading} />
+  );
 }
 
 CategoryModeration.propTypes = {

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -19,13 +19,13 @@ import {indicoAxios} from 'indico/utils/axios';
 import {serializeDate} from 'indico/utils/date';
 import './CategoryModeration.module.scss';
 
-function EventRequestList({requests, onApprove, onReject}) {
+function EventRequestList({requests, onSubmit}) {
   const [selected, _setSelected] = useState(new Set());
   const isAnySelected = selected.size > 0;
 
-  const submit = event => {
+  const submit = accept => {
     _setSelected(new Set());
-    event(Array.from(selected));
+    onSubmit(Array.from(selected), accept);
   };
 
   const select = id =>
@@ -83,7 +83,7 @@ function EventRequestList({requests, onApprove, onReject}) {
             <Translate
               as={Button}
               size="small"
-              onClick={() => submit(onApprove)}
+              onClick={() => submit(true)}
               disabled={!isAnySelected}
             >
               Approve
@@ -91,7 +91,7 @@ function EventRequestList({requests, onApprove, onReject}) {
             <Translate
               as={Button}
               size="small"
-              onClick={() => submit(onReject)}
+              onClick={() => submit(false)}
               disabled={!isAnySelected}
             >
               Reject
@@ -105,8 +105,7 @@ function EventRequestList({requests, onApprove, onReject}) {
 
 EventRequestList.propTypes = {
   requests: PropTypes.array.isRequired,
-  onApprove: PropTypes.func.isRequired,
-  onReject: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
 };
 
 export default function CategoryModeration({categoryId}) {
@@ -116,23 +115,17 @@ export default function CategoryModeration({categoryId}) {
     camelize: true,
   });
 
-  const setRequestsState = async (requests, state) => {
+  const setRequestsState = async (requests, accept) => {
     const url = eventRequestsURL({category_id: categoryId});
     try {
-      await indicoAxios.post(url, {requests, state});
+      await indicoAxios.post(url, {requests, accept});
       reFetch();
     } catch (e) {
       return handleSubmitError(e);
     }
   };
 
-  return (
-    <EventRequestList
-      requests={data || []}
-      onApprove={ids => setRequestsState(ids, 'accepted')}
-      onReject={ids => setRequestsState(ids, 'rejected')}
-    />
-  );
+  return <EventRequestList requests={data || []} onSubmit={setRequestsState} />;
 }
 
 CategoryModeration.propTypes = {

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -169,7 +169,7 @@ RequestList.defaultProps = {
 };
 
 export default function CategoryModeration({categoryId}) {
-  const {data, loading, reFetch} = useIndicoAxios({
+  const {data, lastData, loading, reFetch} = useIndicoAxios({
     url: eventRequestsURL({category_id: categoryId}),
     trigger: categoryId,
     camelize: true,
@@ -184,6 +184,10 @@ export default function CategoryModeration({categoryId}) {
       return handleSubmitError(e);
     }
   };
+
+  if (!lastData) {
+    return null;
+  }
 
   return (
     <RequestList requests={data || []} onSubmit={setRequestsState} loading={!data || loading} />

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -10,7 +10,7 @@ import eventURL from 'indico-url:events.display';
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Button, Checkbox, Image, Placeholder, Table} from 'semantic-ui-react';
+import {Button, Checkbox, Dropdown, Image, Input, Placeholder, Table} from 'semantic-ui-react';
 
 import {handleSubmitError} from 'indico/react/forms';
 import {useIndicoAxios} from 'indico/react/hooks';
@@ -18,6 +18,8 @@ import {Translate} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
 import {serializeDate} from 'indico/utils/date';
 import './CategoryModeration.module.scss';
+
+/* eslint-disable react/jsx-no-useless-fragment */
 
 function PlaceholderTableRow() {
   return (
@@ -77,9 +79,16 @@ RequestTableRow.defaultProps = {
   selected: false,
 };
 
+const judgmentOptions = [
+  {icon: 'checkmark', text: Translate.string('Approve'), value: true},
+  {icon: 'close', text: Translate.string('Reject'), value: false},
+];
+
 function RequestList({requests, onSubmit, loading}) {
   const [selected, _setSelected] = useState(new Set());
+  const [judgeValue, setJudgeValue] = useState(judgmentOptions[0].value);
   const isAnySelected = selected.size > 0;
+  const judgeOption = judgmentOptions.find(x => x.value === judgeValue);
 
   const submit = accept => {
     _setSelected(new Set());
@@ -130,22 +139,30 @@ function RequestList({requests, onSubmit, loading}) {
         <Table.Row>
           <Table.HeaderCell />
           <Table.HeaderCell colSpan="4">
-            <Translate
-              as={Button}
-              size="small"
-              onClick={() => submit(true)}
-              disabled={!isAnySelected}
-            >
-              Approve
-            </Translate>
-            <Translate
-              as={Button}
-              size="small"
-              onClick={() => submit(false)}
-              disabled={!isAnySelected}
-            >
-              Reject
-            </Translate>
+            <div styleName={`table-footer ${!isAnySelected ? 'disabled' : ''}`}>
+              <Button.Group className="small" color={judgeValue ? 'teal' : 'red'}>
+                <Button onClick={() => submit(judgeValue)}>{judgeOption.text}</Button>
+                <Dropdown
+                  className="button icon small"
+                  floating
+                  value={judgeValue}
+                  options={judgmentOptions}
+                  trigger={<></>}
+                  onChange={(_, {value}) => setJudgeValue(value)}
+                />
+              </Button.Group>
+              {!judgeValue && (
+                <>
+                  <Translate as="span" styleName="text-separator">
+                    and
+                  </Translate>
+                  <Input
+                    size="small"
+                    placeholder={Translate.string('Provide the rejection reason')}
+                  />
+                </>
+              )}
+            </div>
           </Table.HeaderCell>
         </Table.Row>
       </Table.Footer>

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -19,8 +19,6 @@ import {indicoAxios} from 'indico/utils/axios';
 import {serializeDate} from 'indico/utils/date';
 import './CategoryModeration.module.scss';
 
-/* eslint-disable react/jsx-no-useless-fragment */
-
 function PlaceholderTableRow() {
   return (
     <Table.Row>

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -39,8 +39,8 @@ function PlaceholderTableRow() {
   );
 }
 
-function RequestTableRow({submitter, event, submittedDt, selected, onSelect}) {
-  const {fullName, avatarURL, affiliation} = submitter;
+function RequestTableRow({requestor, event, requestedDt, selected, onSelect}) {
+  const {fullName, avatarURL, affiliation} = requestor;
   return (
     <Table.Row>
       <Table.Cell collapsing>
@@ -55,13 +55,13 @@ function RequestTableRow({submitter, event, submittedDt, selected, onSelect}) {
       <Table.Cell>
         <a href={eventURL({event_id: event.id})}>{event.title}</a>
       </Table.Cell>
-      <Table.Cell>{serializeDate(submittedDt)}</Table.Cell>
+      <Table.Cell>{serializeDate(requestedDt)}</Table.Cell>
     </Table.Row>
   );
 }
 
 RequestTableRow.propTypes = {
-  submitter: PropTypes.shape({
+  requestor: PropTypes.shape({
     fullName: PropTypes.string,
     avatarURL: PropTypes.string,
     affiliation: PropTypes.string,
@@ -70,7 +70,7 @@ RequestTableRow.propTypes = {
     id: PropTypes.number,
     title: PropTypes.string,
   }).isRequired,
-  submittedDt: PropTypes.string.isRequired,
+  requestedDt: PropTypes.string.isRequired,
   selected: PropTypes.bool,
   onSelect: PropTypes.func.isRequired,
 };
@@ -109,20 +109,20 @@ function RequestList({requests, onSubmit, loading}) {
           <Table.HeaderCell />
           <Translate as={Table.HeaderCell}>User</Translate>
           <Translate as={Table.HeaderCell}>Event</Translate>
-          <Translate as={Table.HeaderCell}>Submitted Date</Translate>
+          <Translate as={Table.HeaderCell}>Requested Date</Translate>
         </Table.Row>
       </Table.Header>
       <Table.Body>
         {loading ? (
           <PlaceholderTableRow />
         ) : (
-          requests.map(({id, submitter, event, submittedDt}) => (
+          requests.map(({id, requestor, event, requestedDt}) => (
             <RequestTableRow
               key={id}
               id={id}
               event={event}
-              submitter={submitter}
-              submittedDt={submittedDt}
+              requestor={requestor}
+              requestedDt={requestedDt}
               selected={selected.has(id)}
               onSelect={() => select(id)}
             />

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -1,0 +1,124 @@
+import eventRequestsURL from 'indico-url:categories.api_event_move_requests';
+import eventURL from 'indico-url:events.display';
+
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+import {Button, Checkbox, Image, Table} from 'semantic-ui-react';
+
+import {handleSubmitError} from 'indico/react/forms';
+import {useIndicoAxios} from 'indico/react/hooks';
+import {Translate} from 'indico/react/i18n';
+import {indicoAxios} from 'indico/utils/axios';
+import {serializeDate} from 'indico/utils/date';
+import './CategoryModeration.module.scss';
+
+function EventRequestList({requests, onApprove, onReject}) {
+  const [selected, _setSelected] = useState(new Set());
+  const isAnySelected = selected.size > 0;
+
+  const submit = event => {
+    _setSelected(new Set());
+    event(Array.from(selected));
+  };
+
+  const select = id =>
+    _setSelected(state => {
+      const set = new Set([...state, id]);
+      if (state.has(id)) {
+        set.delete(id);
+      }
+      return set;
+    });
+
+  if (requests.length === 0) {
+    return <Translate as="p">There are no event move requests</Translate>;
+  }
+
+  return (
+    <>
+      {/* TODO: check if module is enabled */}
+      <Table celled>
+        <Table.Header>
+          <Table.Row>
+            <Table.HeaderCell />
+            <Table.HeaderCell>User</Table.HeaderCell>
+            <Table.HeaderCell>Event</Table.HeaderCell>
+            <Table.HeaderCell>State</Table.HeaderCell>
+            <Table.HeaderCell>Submitted Date</Table.HeaderCell>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {requests.map(({id, submitter, event, state, submittedDt}) => (
+            <Table.Row key={id}>
+              <Table.Cell collapsing>
+                <Checkbox
+                  checked={selected.has(id)}
+                  onChange={() => select(id)}
+                  disabled={state !== 'pending'}
+                />
+              </Table.Cell>
+              <Table.Cell styleName="user">
+                <Image styleName="avatar" src={submitter.avatarURL} size="mini" avatar />
+                {submitter.name} {submitter.affiliation && `(${submitter.affiliation})`}
+              </Table.Cell>
+              <Table.Cell>
+                <a href={eventURL({event_id: event.id})}>{event.title}</a>
+              </Table.Cell>
+              <Table.Cell>{state}</Table.Cell>
+              <Table.Cell>{serializeDate(submittedDt)}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+        <Table.Footer fullWidth>
+          <Table.Row>
+            <Table.HeaderCell />
+            <Table.HeaderCell colSpan="4">
+              <Button size="small" onClick={() => submit(onApprove)} disabled={!isAnySelected}>
+                Approve
+              </Button>
+              <Button size="small" onClick={() => submit(onReject)} disabled={!isAnySelected}>
+                Reject
+              </Button>
+            </Table.HeaderCell>
+          </Table.Row>
+        </Table.Footer>
+      </Table>
+    </>
+  );
+}
+
+EventRequestList.propTypes = {
+  requests: PropTypes.array.isRequired,
+  onApprove: PropTypes.func.isRequired,
+  onReject: PropTypes.func.isRequired,
+};
+
+export default function CategoryModeration({categoryId}) {
+  const {data, reFetch} = useIndicoAxios({
+    url: eventRequestsURL({category_id: categoryId}),
+    trigger: categoryId,
+    camelize: true,
+  });
+
+  const setRequestsState = async (requests, state) => {
+    const url = eventRequestsURL({category_id: categoryId});
+    try {
+      await indicoAxios.post(url, {requests, state});
+      reFetch();
+    } catch (e) {
+      return handleSubmitError(e);
+    }
+  };
+
+  return (
+    <EventRequestList
+      requests={data || []}
+      onApprove={ids => setRequestsState(ids, 'accepted')}
+      onReject={ids => setRequestsState(ids, 'rejected')}
+    />
+  );
+}
+
+CategoryModeration.propTypes = {
+  categoryId: PropTypes.number.isRequired,
+};

--- a/indico/modules/categories/client/js/components/CategoryModeration.jsx
+++ b/indico/modules/categories/client/js/components/CategoryModeration.jsx
@@ -10,7 +10,7 @@ import eventURL from 'indico-url:events.display';
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Button, Checkbox, Dropdown, Image, Input, Placeholder, Table} from 'semantic-ui-react';
+import {Button, Checkbox, Image, Input, Placeholder, Table} from 'semantic-ui-react';
 
 import {handleSubmitError} from 'indico/react/forms';
 import {useIndicoAxios} from 'indico/react/hooks';
@@ -79,17 +79,10 @@ RequestTableRow.defaultProps = {
   selected: false,
 };
 
-const judgmentOptions = [
-  {icon: 'checkmark', text: Translate.string('Approve'), value: true},
-  {icon: 'close', text: Translate.string('Reject'), value: false},
-];
-
 function RequestList({requests, onSubmit, loading}) {
   const [selected, _setSelected] = useState(new Set());
-  const [judgeValue, setJudgeValue] = useState(judgmentOptions[0].value);
   const [reason, setReason] = useState(undefined);
   const isAnySelected = selected.size > 0;
-  const judgeOption = judgmentOptions.find(x => x.value === judgeValue);
 
   const submit = accept => {
     _setSelected(new Set());
@@ -141,30 +134,24 @@ function RequestList({requests, onSubmit, loading}) {
           <Table.HeaderCell />
           <Table.HeaderCell colSpan="4">
             <div styleName={`table-footer ${!isAnySelected ? 'disabled' : ''}`}>
-              <Button.Group className="small" color={judgeValue ? 'teal' : 'red'}>
-                <Button onClick={() => submit(judgeValue)}>{judgeOption.text}</Button>
-                <Dropdown
-                  className="button icon small"
-                  floating
-                  value={judgeValue}
-                  options={judgmentOptions}
-                  trigger={<></>}
-                  onChange={(_, {value}) => setJudgeValue(value)}
-                />
-              </Button.Group>
-              {!judgeValue && (
-                <>
-                  <Translate as="span" styleName="text-separator">
-                    and
-                  </Translate>
-                  <Input
-                    size="small"
-                    placeholder={Translate.string('Provide the rejection reason')}
-                    value={reason}
-                    onChange={(_, {value}) => setReason(value)}
-                  />
-                </>
-              )}
+              <Translate as={Button} onClick={() => submit(true)} color="teal">
+                Approve
+              </Translate>
+              <Translate as="span" styleName="text-separator">
+                or
+              </Translate>
+              <Input
+                size="small"
+                placeholder={Translate.string('Provide the rejection reason')}
+                value={reason}
+                onChange={(_, {value}) => setReason(value)}
+              />
+              <Translate as="span" styleName="text-separator">
+                and
+              </Translate>
+              <Translate as={Button} onClick={() => submit(false, reason)} color="red">
+                Reject
+              </Translate>
             </div>
           </Table.HeaderCell>
         </Table.Row>

--- a/indico/modules/categories/client/js/components/CategoryModeration.module.scss
+++ b/indico/modules/categories/client/js/components/CategoryModeration.module.scss
@@ -1,3 +1,10 @@
-.user img:global(.ui.avatar) {
+// This file is part of Indico.
+// Copyright (C) 2002 - 2021 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+.user .avatar:global(.ui.avatar) {
   margin-right: 1em;
 }

--- a/indico/modules/categories/client/js/components/CategoryModeration.module.scss
+++ b/indico/modules/categories/client/js/components/CategoryModeration.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@import 'base/palette';
+
 .user {
   display: flex;
   align-items: center;
@@ -12,4 +14,26 @@
 
 .user .avatar:global(.ui.avatar) {
   margin-right: 1em;
+}
+
+.table-footer {
+  display: flex;
+  align-items: center;
+}
+
+.table-footer.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.table-footer :global(.ui.input) {
+  width: 100%;
+}
+
+.text-separator {
+  color: $gray;
+  font-size: 1.1em;
+  font-weight: bold;
+  padding-left: 1em;
+  padding-right: 1em;
 }

--- a/indico/modules/categories/client/js/components/CategoryModeration.module.scss
+++ b/indico/modules/categories/client/js/components/CategoryModeration.module.scss
@@ -1,0 +1,3 @@
+.user img:global(.ui.avatar) {
+  margin-right: 1em;
+}

--- a/indico/modules/categories/client/js/components/CategoryModeration.module.scss
+++ b/indico/modules/categories/client/js/components/CategoryModeration.module.scss
@@ -5,6 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+.user {
+  display: flex;
+  align-items: center;
+}
+
 .user .avatar:global(.ui.avatar) {
   margin-right: 1em;
 }

--- a/indico/modules/categories/client/js/index.js
+++ b/indico/modules/categories/client/js/index.js
@@ -17,6 +17,7 @@ import './base';
 import SearchBox from 'indico/modules/search/components/SearchBox';
 import {setMomentLocale} from 'indico/utils/date';
 
+import CategoryModeration from './components/CategoryModeration';
 import CategoryStatistics from './components/CategoryStatistics';
 import {LocaleContext} from './context.js';
 
@@ -47,6 +48,13 @@ import {LocaleContext} from './context.js';
         }),
         domContainer
       );
+    }
+  });
+  document.addEventListener('DOMContentLoaded', () => {
+    const rootElement = document.querySelector('#category-moderation');
+    if (rootElement) {
+      const categoryId = parseInt(rootElement.dataset.categoryId, 10);
+      ReactDOM.render(<CategoryModeration categoryId={categoryId} />, rootElement);
     }
   });
   global.setupCategoryStats = function setupCategoryStats() {

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -123,7 +123,7 @@ class RHCategoryInfo(RHDisplayCategoryBase):
     @classmethod
     def _category_query_options(cls):
         children_strategy = subqueryload('children')
-        children_strategy.load_only('id', 'parent_id', 'title', 'protection_mode', 'event_creation_restricted')
+        children_strategy.load_only('id', 'parent_id', 'title', 'protection_mode', 'event_creation_mode')
         children_strategy.subqueryload('acl_entries')
         children_strategy.undefer('deep_children_count')
         children_strategy.undefer('deep_events_count')

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -129,15 +129,16 @@ class RHAPIEventMoveRequests(RHManageCategoryBase):
         return EventMoveRequestSchema(many=True).jsonify(move_requests)
 
     @use_kwargs({
-        'accept': fields.Bool(required=True)
+        'accept': fields.Bool(required=True),
+        'reason': fields.String()
     })
-    def _process_POST(self, accept):
+    def _process_POST(self, accept, reason):
         move_requests = parser.parse({
             'requests': EventRequestList(required=True, category=self.category, validate=not_empty)
         }, unknown=EXCLUDE)['requests']
 
         for rq in move_requests:
-            update_event_move_request(rq, accept)
+            update_event_move_request(rq, accept, reason)
         return '', 204
 
 

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -25,6 +25,7 @@ from indico.modules.categories.forms import (CategoryIconForm, CategoryLogoForm,
                                              CategoryRoleForm, CategorySettingsForm, CreateCategoryForm,
                                              SplitCategoryForm)
 from indico.modules.categories.models.categories import Category
+from indico.modules.categories.models.event_move_request import EventMoveRequest, MoveRequestState
 from indico.modules.categories.models.roles import CategoryRole
 from indico.modules.categories.operations import create_category, delete_category, move_category, update_category, update_category_protection, update_event_move_request
 from indico.modules.categories.schemas import EventMoveRequestSchema
@@ -124,7 +125,8 @@ class RHManageCategorySettings(RHManageCategoryBase):
 
 class RHAPIEventMoveRequests(RHManageCategoryBase):
     def _process_GET(self):
-        return EventMoveRequestSchema(many=True).jsonify(self.category.event_move_requests)
+        move_requests = self.category.event_move_requests.filter(EventMoveRequest.state == MoveRequestState.pending)
+        return EventMoveRequestSchema(many=True).jsonify(move_requests)
 
     @use_kwargs({
         'accept': fields.Bool(required=True)

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -27,7 +27,8 @@ from indico.modules.categories.forms import (CategoryIconForm, CategoryLogoForm,
 from indico.modules.categories.models.categories import Category
 from indico.modules.categories.models.event_move_request import EventMoveRequest, MoveRequestState
 from indico.modules.categories.models.roles import CategoryRole
-from indico.modules.categories.operations import create_category, delete_category, move_category, update_category, update_category_protection, update_event_move_request
+from indico.modules.categories.operations import (create_category, delete_category, move_category, update_category,
+                                                  update_category_protection, update_event_move_request)
 from indico.modules.categories.schemas import EventMoveRequestSchema
 from indico.modules.categories.util import get_image_data, serialize_category_role
 from indico.modules.categories.views import WPCategoryManagement

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -11,9 +11,9 @@ from io import BytesIO
 
 from flask import flash, redirect, request, session
 from marshmallow import EXCLUDE
-from marshmallow_enum import EnumField
 from PIL import Image
 from sqlalchemy.orm import joinedload, load_only, undefer_group
+from webargs import fields
 from werkzeug.exceptions import BadRequest, Forbidden
 
 from indico.core.db import db
@@ -128,21 +128,21 @@ class RHAPIEventMoveRequests(RHManageCategoryBase):
         return EventMoveRequestSchema(many=True).jsonify(self.category.event_move_requests)
 
     @use_kwargs({
-        'state': EnumField(MoveRequestState, required=True)
+        'accept': fields.Bool(required=True)
     })
-    def _process_POST(self, state):
+    def _process_POST(self, accept):
         move_requests = parser.parse({
             'requests': EventRequestList(required=True, category=self.category, validate=not_empty)
         }, unknown=EXCLUDE)['requests']
 
-        if state not in (MoveRequestState.accepted, MoveRequestState.rejected):
-            raise Forbidden
         for rq in move_requests:
-            rq.state = state
+            rq.state = MoveRequestState.rejected
             rq.moderator = session.user
-            if state == MoveRequestState.accepted:
+            if accept:
+                rq.state = MoveRequestState.accepted
                 rq.event.move(rq.category)
         db.session.flush()
+        return '', 204
 
 
 class RHManageCategoryModeration(RHManageCategoryBase):

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -10,6 +10,8 @@ import random
 from io import BytesIO
 
 from flask import flash, redirect, request, session
+from marshmallow import EXCLUDE
+from marshmallow_enum import EnumField
 from PIL import Image
 from sqlalchemy.orm import joinedload, load_only, undefer_group
 from werkzeug.exceptions import BadRequest, Forbidden
@@ -18,13 +20,15 @@ from indico.core.db import db
 from indico.core.permissions import get_principal_permissions, update_permissions
 from indico.modules.categories import logger
 from indico.modules.categories.controllers.base import RHManageCategoryBase
+from indico.modules.categories.fields import EventRequestList
 from indico.modules.categories.forms import (CategoryIconForm, CategoryLogoForm, CategoryProtectionForm,
                                              CategoryRoleForm, CategorySettingsForm, CreateCategoryForm,
                                              SplitCategoryForm)
 from indico.modules.categories.models.categories import Category
+from indico.modules.categories.models.event_move_request import MoveRequestState
 from indico.modules.categories.models.roles import CategoryRole
-from indico.modules.categories.operations import (create_category, delete_category, move_category, update_category,
-                                                  update_category_protection)
+from indico.modules.categories.operations import create_category, delete_category, move_category, update_category, update_category_protection
+from indico.modules.categories.schemas import EventMoveRequestSchema
 from indico.modules.categories.util import get_image_data, serialize_category_role
 from indico.modules.categories.views import WPCategoryManagement
 from indico.modules.events import Event
@@ -33,10 +37,10 @@ from indico.modules.rb.models.reservations import Reservation, ReservationLink
 from indico.modules.users import User
 from indico.util.fs import secure_filename
 from indico.util.i18n import _, ngettext
-from indico.util.marshmallow import PrincipalList
+from indico.util.marshmallow import PrincipalList, not_empty
 from indico.util.roles import ImportRoleMembersMixin
 from indico.util.string import crc32
-from indico.web.args import use_kwargs
+from indico.web.args import parser, use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults
@@ -117,6 +121,36 @@ class RHManageCategorySettings(RHManageCategoryBase):
                 logo_form.logo.data = self.category
         return WPCategoryManagement.render_template('management/settings.html', self.category, 'settings', form=form,
                                                     icon_form=icon_form, logo_form=logo_form)
+
+
+class RHAPIEventMoveRequests(RHManageCategoryBase):
+    def _process_args(self):
+        RHManageCategoryBase._process_args(self)
+        if request.method != 'GET':
+            self.move_requests = parser.parse({
+                'requests': EventRequestList(required=True, category=self.category, validate=not_empty)
+            }, unknown=EXCLUDE)['requests']
+
+    def _process_GET(self):
+        return EventMoveRequestSchema(many=True).jsonify(self.category.event_move_requests)
+
+    @use_kwargs({
+        'state': EnumField(MoveRequestState, required=True)
+    })
+    def _process_POST(self, state):
+        if state not in (MoveRequestState.accepted, MoveRequestState.rejected):
+            raise Forbidden
+        for rq in self.move_requests:
+            rq.state = state
+            rq.moderator = session.user
+            if state == MoveRequestState.accepted:
+                rq.event.move(rq.category)
+        db.session.flush()
+
+
+class RHManageCategoryModeration(RHManageCategoryBase):
+    def _process(self):
+        return WPCategoryManagement.render_template('management/moderation.html', self.category, 'moderation')
 
 
 class RHCategoryImageUploadBase(RHManageCategoryBase):
@@ -216,7 +250,8 @@ class RHManageCategoryProtection(RHManageCategoryBase):
                                        {'protection_mode': form.protection_mode.data,
                                         'own_no_access_contact': form.own_no_access_contact.data,
                                         'event_creation_restricted': form.event_creation_restricted.data,
-                                        'visibility': form.visibility.data})
+                                        'visibility': form.visibility.data,
+                                        'event_requires_approval': form.event_requires_approval.data})
             flash(_('Protection settings of the category have been updated'), 'success')
             return redirect(url_for('.manage_protection', self.category))
         return WPCategoryManagement.render_template('management/category_protection.html', self.category, 'protection',

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -244,9 +244,8 @@ class RHManageCategoryProtection(RHManageCategoryBase):
             update_category_protection(self.category,
                                        {'protection_mode': form.protection_mode.data,
                                         'own_no_access_contact': form.own_no_access_contact.data,
-                                        'event_creation_restricted': form.event_creation_restricted.data,
-                                        'visibility': form.visibility.data,
-                                        'event_requires_approval': form.event_requires_approval.data})
+                                        'event_creation_mode': form.event_creation_mode.data,
+                                        'visibility': form.visibility.data})
             flash(_('Protection settings of the category have been updated'), 'success')
             return redirect(url_for('.manage_protection', self.category))
         return WPCategoryManagement.render_template('management/category_protection.html', self.category, 'protection',

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -131,7 +131,7 @@ class RHAPIEventMoveRequests(RHManageCategoryBase):
 
     @use_kwargs({
         'accept': fields.Bool(required=True),
-        'reason': fields.String()
+        'reason': fields.String(missing=None)
     })
     def _process_POST(self, accept, reason):
         move_requests = parser.parse({

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -25,9 +25,8 @@ from indico.modules.categories.forms import (CategoryIconForm, CategoryLogoForm,
                                              CategoryRoleForm, CategorySettingsForm, CreateCategoryForm,
                                              SplitCategoryForm)
 from indico.modules.categories.models.categories import Category
-from indico.modules.categories.models.event_move_request import MoveRequestState
 from indico.modules.categories.models.roles import CategoryRole
-from indico.modules.categories.operations import create_category, delete_category, move_category, update_category, update_category_protection
+from indico.modules.categories.operations import create_category, delete_category, move_category, update_category, update_category_protection, update_event_move_request
 from indico.modules.categories.schemas import EventMoveRequestSchema
 from indico.modules.categories.util import get_image_data, serialize_category_role
 from indico.modules.categories.views import WPCategoryManagement
@@ -136,12 +135,7 @@ class RHAPIEventMoveRequests(RHManageCategoryBase):
         }, unknown=EXCLUDE)['requests']
 
         for rq in move_requests:
-            rq.state = MoveRequestState.rejected
-            rq.moderator = session.user
-            if accept:
-                rq.state = MoveRequestState.accepted
-                rq.event.move(rq.category)
-        db.session.flush()
+            update_event_move_request(rq, accept)
         return '', 204
 
 

--- a/indico/modules/categories/fields.py
+++ b/indico/modules/categories/fields.py
@@ -9,6 +9,8 @@ import json
 
 from wtforms.fields.simple import HiddenField
 
+from indico.modules.categories.models.event_move_request import EventMoveRequest, MoveRequestState
+from indico.util.marshmallow import ModelList
 from indico.web.forms.widgets import JinjaWidget
 
 
@@ -49,3 +51,13 @@ class CategoryField(HiddenField):
 
     def _get_data(self):
         return self.data
+
+
+class EventRequestList(ModelList):
+    def __init__(self, category, **kwargs):
+        def _get_query(m):
+            return m.query.filter(
+                EventMoveRequest.category == category,
+                EventMoveRequest.state == MoveRequestState.pending
+            )
+        super().__init__(model=EventMoveRequest, get_query=_get_query, collection_class=set, **kwargs)

--- a/indico/modules/categories/forms.py
+++ b/indico/modules/categories/forms.py
@@ -84,7 +84,8 @@ class CategoryLogoForm(IndicoForm):
 
 
 class CategoryProtectionForm(IndicoForm):
-    _event_creation_fields = ('event_creation_restricted', 'event_creation_notification_emails')
+    _event_creation_fields = ('event_creation_restricted', 'event_creation_notification_emails',
+                              'event_requires_approval')
     permissions = PermissionsField(_('Permissions'), object_type='category')
     protection_mode = IndicoProtectionField(_('Protection mode'), protected_object=lambda form: form.protected_object)
     own_no_access_contact = StringField(_('No access contact'),
@@ -97,6 +98,9 @@ class CategoryProtectionForm(IndicoForm):
     event_creation_restricted = BooleanField(_('Restricted event creation'), widget=SwitchWidget(),
                                              description=_('Whether the event creation should be restricted '
                                                            'to a list of specific persons'))
+    event_requires_approval = BooleanField(_('Moderated event move'), widget=SwitchWidget(),
+                                           description=_('Whether moving an event to this category should be subject '
+                                                         'to a prior approval'))
 
     def __init__(self, *args, **kwargs):
         self.protected_object = self.category = kwargs.pop('category')

--- a/indico/modules/categories/forms.py
+++ b/indico/modules/categories/forms.py
@@ -12,7 +12,7 @@ from wtforms.fields import BooleanField, HiddenField, IntegerField, SelectField,
 from wtforms.validators import DataRequired, InputRequired, Length, NumberRange, Optional, ValidationError
 
 from indico.core.permissions import FULL_ACCESS_PERMISSION, READ_ACCESS_PERMISSION
-from indico.modules.categories.models.categories import Category, EventMessageMode
+from indico.modules.categories.models.categories import Category, EventCreationMode, EventMessageMode
 from indico.modules.categories.models.roles import CategoryRole
 from indico.modules.categories.util import get_image_data, get_visibility_options
 from indico.modules.events import Event
@@ -84,8 +84,7 @@ class CategoryLogoForm(IndicoForm):
 
 
 class CategoryProtectionForm(IndicoForm):
-    _event_creation_fields = ('event_creation_restricted', 'event_creation_notification_emails',
-                              'event_requires_approval')
+    _event_creation_fields = ('event_creation_mode', 'event_creation_notification_emails')
     permissions = PermissionsField(_('Permissions'), object_type='category')
     protection_mode = IndicoProtectionField(_('Protection mode'), protected_object=lambda form: form.protected_object)
     own_no_access_contact = StringField(_('No access contact'),
@@ -95,12 +94,12 @@ class CategoryProtectionForm(IndicoForm):
                              description=_('''From which point in the category tree contents will be visible from '''
                                            '''(number of categories upwards). Applies to "Today's events" and '''
                                            '''Calendar. If the category is moved, this number will be preserved.'''))
-    event_creation_restricted = BooleanField(_('Restricted event creation'), widget=SwitchWidget(),
-                                             description=_('Whether the event creation should be restricted '
-                                                           'to a list of specific persons'))
-    event_requires_approval = BooleanField(_('Moderated event move'), widget=SwitchWidget(),
-                                           description=_('Whether moving an event to this category should be subject '
-                                                         'to a prior approval'))
+    event_creation_mode = IndicoEnumSelectField(_('Event creation mode'), enum=EventCreationMode,
+                                                default=EventCreationMode.restricted,
+                                                description=_('Specify who can create events in the category and '
+                                                              'whether they need to be approved. Regardless of this '
+                                                              'setting, users cannot create/propose events unless they '
+                                                              'have at least read access to the category.'))
 
     def __init__(self, *args, **kwargs):
         self.protected_object = self.category = kwargs.pop('category')

--- a/indico/modules/categories/forms.py
+++ b/indico/modules/categories/forms.py
@@ -84,7 +84,6 @@ class CategoryLogoForm(IndicoForm):
 
 
 class CategoryProtectionForm(IndicoForm):
-    _event_creation_fields = ('event_creation_mode', 'event_creation_notification_emails')
     permissions = PermissionsField(_('Permissions'), object_type='category')
     protection_mode = IndicoProtectionField(_('Protection mode'), protected_object=lambda form: form.protected_object)
     own_no_access_contact = StringField(_('No access contact'),

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -330,8 +330,8 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
 
     def can_propose_events(self, user):
         """Check whether the user can propose move requests to the category."""
-        return self.event_requires_approval or (
-            user and self.can_manage(user, permission='event_move_request')) or self.can_create_events(user)
+        return user and (self.can_manage(user, permission='event_move_request')
+                         or self.event_requires_approval) and not self.can_create_events(user)
 
     def can_create_events(self, user):
         """Check whether the user can create events in the category."""

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -225,6 +225,7 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
     # relationship backrefs:
     # - attachment_folders (AttachmentFolder.category)
     # - designer_templates (DesignerTemplate.category)
+    # - event_move_requests (EventMoveRequest.category)
     # - events (Event.category)
     # - favorite_of (User.favorite_categories)
     # - legacy_mapping (LegacyCategoryMapping.category)
@@ -233,7 +234,6 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
     # - roles (CategoryRole.category)
     # - settings (CategorySetting.category)
     # - suggestions (SuggestedCategory.category)
-    # - event_move_requests (EventMoveRequest.category)
 
     @hybrid_property
     def event_message(self):

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -183,6 +183,11 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
         nullable=True,
         index=True
     )
+    event_requires_approval = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
 
     children = db.relationship(
         'Category',
@@ -228,6 +233,7 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
     # - roles (CategoryRole.category)
     # - settings (CategorySetting.category)
     # - suggestions (SuggestedCategory.category)
+    # - event_move_requests (EventMoveRequest.category)
 
     @hybrid_property
     def event_message(self):
@@ -321,6 +327,11 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
                                  data=(data or {}), meta=(meta or {}))
         self.log_entries.append(entry)
         return entry
+
+    def can_propose_events(self, user):
+        """Check whether the user can propose move requests to the category."""
+        return self.event_requires_approval or (
+            user and self.can_manage(user, permission='event_move_request')) or self.can_create_events(user)
 
     def can_create_events(self, user):
         """Check whether the user can create events in the category."""

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -330,8 +330,7 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
 
     def can_propose_events(self, user):
         """Check whether the user can propose move requests to the category."""
-        return user and (self.can_manage(user, permission='event_move_request')
-                         or self.event_requires_approval) and not self.can_create_events(user)
+        return user and (self.can_manage(user, permission='event_move_request') or self.event_requires_approval)
 
     def can_create_events(self, user):
         """Check whether the user can create events in the category."""

--- a/indico/modules/categories/models/categories_test.py
+++ b/indico/modules/categories/models/categories_test.py
@@ -10,24 +10,25 @@ from sqlalchemy.orm import undefer
 
 from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.categories import Category
+from indico.modules.categories.models.categories import EventCreationMode
 
 
-@pytest.mark.parametrize(('protection_mode', 'creation_restricted', 'acl', 'allowed'), (
+@pytest.mark.parametrize(('protection_mode', 'creation_mode', 'acl', 'allowed'), (
     # not restricted
-    (ProtectionMode.public, False, None, True),
-    (ProtectionMode.protected, False, None, False),
-    (ProtectionMode.protected, False, {'read_access': True}, True),
+    (ProtectionMode.public, EventCreationMode.open, None, True),
+    (ProtectionMode.protected, EventCreationMode.open, None, False),
+    (ProtectionMode.protected, EventCreationMode.open, {'read_access': True}, True),
     # restricted - authorized
-    (ProtectionMode.protected, True, {'full_access': True}, True),
-    (ProtectionMode.protected, True, {'permissions': {'create'}}, True),
+    (ProtectionMode.protected, EventCreationMode.restricted, {'full_access': True}, True),
+    (ProtectionMode.protected, EventCreationMode.restricted, {'permissions': {'create'}}, True),
     # restricted - not authorized
-    (ProtectionMode.public, True, None, False),
-    (ProtectionMode.protected, True, None, False),
-    (ProtectionMode.protected, True, {'read_access': True}, False)
+    (ProtectionMode.public, EventCreationMode.restricted, None, False),
+    (ProtectionMode.protected, EventCreationMode.restricted, None, False),
+    (ProtectionMode.protected, EventCreationMode.restricted, {'read_access': True}, False)
 ))
-def test_can_create_events(dummy_category, dummy_user, protection_mode, creation_restricted, acl, allowed):
+def test_can_create_events(dummy_category, dummy_user, protection_mode, creation_mode, acl, allowed):
     dummy_category.protection_mode = protection_mode
-    dummy_category.event_creation_restricted = creation_restricted
+    dummy_category.event_creation_mode = creation_mode
     if acl:
         dummy_category.update_principal(dummy_user, **acl)
     assert dummy_category.can_create_events(dummy_user) == allowed

--- a/indico/modules/categories/models/event_move_request.py
+++ b/indico/modules/categories/models/event_move_request.py
@@ -7,7 +7,6 @@
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
-from indico.modules.events import EventLogKind, EventLogRealm
 from indico.util.date_time import now_utc
 from indico.util.enum import RichIntEnum
 from indico.util.locators import locator_property
@@ -107,6 +106,7 @@ class EventMoveRequest(db.Model):
         return dict(self.event.locator, request_id=self.id)
 
     def withdraw(self, user=None):
+        from indico.modules.events import EventLogKind, EventLogRealm
         assert self.state == MoveRequestState.pending
         self.state = MoveRequestState.withdrawn
         db.session.flush()

--- a/indico/modules/categories/models/event_move_request.py
+++ b/indico/modules/categories/models/event_move_request.py
@@ -1,3 +1,10 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
 from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
 from indico.modules.events import EventLogKind, EventLogRealm

--- a/indico/modules/categories/models/event_move_request.py
+++ b/indico/modules/categories/models/event_move_request.py
@@ -7,6 +7,7 @@
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+from indico.modules.logs.models.entries import CategoryLogRealm
 from indico.util.date_time import now_utc
 from indico.util.enum import RichIntEnum
 from indico.util.locators import locator_property
@@ -116,4 +117,8 @@ class EventMoveRequest(db.Model):
         assert self.state == MoveRequestState.pending
         self.state = MoveRequestState.withdrawn
         db.session.flush()
-        self.event.log(EventLogRealm.event, LogKind.change, 'Event', 'Move request withdrawn', user=user)
+        self.event.log(EventLogRealm.event, LogKind.change, 'Category', 'Move request withdrawn', user=user,
+                       meta={'event_move_request_id': self.id})
+        self.category.log(CategoryLogRealm.events, LogKind.change, 'Moderation',
+                          f'Event move request withdrawn: "{self.event.title}"', user,
+                          data={'Event ID': self.event.id}, meta={'event_move_request_id': self.id})

--- a/indico/modules/categories/models/event_move_request.py
+++ b/indico/modules/categories/models/event_move_request.py
@@ -54,6 +54,10 @@ class EventMoveRequest(db.Model):
         default=MoveRequestState.pending,
         nullable=False
     )
+    state_reason = db.Column(
+        db.String,
+        nullable=True
+    )
     moderator_id = db.Column(
         db.ForeignKey('users.users.id'),
         nullable=True

--- a/indico/modules/categories/models/event_move_request.py
+++ b/indico/modules/categories/models/event_move_request.py
@@ -89,14 +89,17 @@ class EventMoveRequest(db.Model):
         foreign_keys=submitter_id,
         backref=db.backref(
             'event_move_requests',
-            cascade_backrefs=False,
             lazy='dynamic'
         )
     )
     moderator = db.relationship(
         'User',
+        lazy=False,
         foreign_keys=moderator_id,
-        lazy=False
+        backref=db.backref(
+            'moderated_event_move_requests',
+            lazy='dynamic'
+        )
     )
 
     @locator_property

--- a/indico/modules/categories/models/event_move_request.py
+++ b/indico/modules/categories/models/event_move_request.py
@@ -25,8 +25,8 @@ class EventMoveRequest(db.Model):
     __tablename__ = 'event_move_requests'
     __table_args__ = (db.Index(None, 'event_id', unique=True,
                                postgresql_where=db.text(f'state = {MoveRequestState.pending}')),
-                      db.CheckConstraint(f'state in ({MoveRequestState.accepted}, {MoveRequestState.rejected}) '
-                                         f'AND moderator_id IS NOT NULL OR moderator_id IS NULL',
+                      db.CheckConstraint(f'(state in ({MoveRequestState.accepted}, {MoveRequestState.rejected}) '
+                                         f'AND moderator_id IS NOT NULL) OR moderator_id IS NULL',
                                          'moderator_state'),
                       {'schema': 'categories'})
 
@@ -41,12 +41,12 @@ class EventMoveRequest(db.Model):
     )
     category_id = db.Column(
         db.ForeignKey('categories.categories.id'),
-        nullable=True,
+        nullable=False,
         index=True
     )
-    submitter_id = db.Column(
+    requestor_id = db.Column(
         db.ForeignKey('users.users.id'),
-        nullable=True,
+        nullable=False,
         index=True
     )
     state = db.Column(
@@ -63,7 +63,7 @@ class EventMoveRequest(db.Model):
         db.ForeignKey('users.users.id'),
         nullable=True
     )
-    submitted_dt = db.Column(
+    requested_dt = db.Column(
         UTCDateTime,
         nullable=False,
         default=now_utc
@@ -87,10 +87,10 @@ class EventMoveRequest(db.Model):
             lazy='dynamic'
         )
     )
-    submitter = db.relationship(
+    requestor = db.relationship(
         'User',
         lazy=True,
-        foreign_keys=submitter_id,
+        foreign_keys=requestor_id,
         backref=db.backref(
             'event_move_requests',
             lazy='dynamic'

--- a/indico/modules/categories/models/event_move_request.py
+++ b/indico/modules/categories/models/event_move_request.py
@@ -54,9 +54,10 @@ class EventMoveRequest(db.Model):
         default=MoveRequestState.pending,
         nullable=False
     )
-    state_reason = db.Column(
+    moderator_comment = db.Column(
         db.String,
-        nullable=True
+        nullable=False,
+        default=''
     )
     moderator_id = db.Column(
         db.ForeignKey('users.users.id'),

--- a/indico/modules/categories/models/event_move_request.py
+++ b/indico/modules/categories/models/event_move_request.py
@@ -110,8 +110,9 @@ class EventMoveRequest(db.Model):
         return dict(self.event.locator, request_id=self.id)
 
     def withdraw(self, user=None):
-        from indico.modules.events import EventLogKind, EventLogRealm
+        from indico.modules.events import EventLogRealm
+        from indico.modules.logs import LogKind
         assert self.state == MoveRequestState.pending
         self.state = MoveRequestState.withdrawn
         db.session.flush()
-        self.event.log(EventLogRealm.event, EventLogKind.change, 'Event', 'Move request withdrawn', user=user)
+        self.event.log(EventLogRealm.event, LogKind.change, 'Event', 'Move request withdrawn', user=user)

--- a/indico/modules/categories/models/event_move_request.py
+++ b/indico/modules/categories/models/event_move_request.py
@@ -1,0 +1,103 @@
+from indico.core.db import db
+from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+from indico.modules.events import EventLogKind, EventLogRealm
+from indico.util.date_time import now_utc
+from indico.util.enum import RichIntEnum
+from indico.util.locators import locator_property
+
+
+class MoveRequestState(RichIntEnum):
+    pending = 0
+    accepted = 1
+    rejected = 2
+    withdrawn = 3
+
+
+class EventMoveRequest(db.Model):
+    """A request that represents a proposed event move."""
+
+    __tablename__ = 'event_move_requests'
+    __table_args__ = (db.Index(None, 'event_id', unique=True,
+                               postgresql_where=db.text(f'state = {MoveRequestState.pending}')),
+                      db.CheckConstraint(f'state in ({MoveRequestState.accepted}, {MoveRequestState.rejected}) '
+                                         f'AND moderator_id IS NOT NULL OR moderator_id IS NULL',
+                                         'moderator_state'),
+                      {'schema': 'categories'})
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+    event_id = db.Column(
+        db.ForeignKey('events.events.id'),
+        nullable=False,
+        index=True
+    )
+    category_id = db.Column(
+        db.ForeignKey('categories.categories.id'),
+        nullable=True,
+        index=True
+    )
+    submitter_id = db.Column(
+        db.ForeignKey('users.users.id'),
+        nullable=True,
+        index=True
+    )
+    state = db.Column(
+        PyIntEnum(MoveRequestState),
+        default=MoveRequestState.pending,
+        nullable=False
+    )
+    moderator_id = db.Column(
+        db.ForeignKey('users.users.id'),
+        nullable=True
+    )
+    submitted_dt = db.Column(
+        UTCDateTime,
+        nullable=False,
+        default=now_utc
+    )
+
+    event = db.relationship(
+        'Event',
+        lazy=True,
+        backref=db.backref(
+            'move_requests',
+            cascade='all, delete-orphan',
+            lazy='dynamic'
+        )
+    )
+    category = db.relationship(
+        'Category',
+        lazy=True,
+        backref=db.backref(
+            'event_move_requests',
+            cascade='all, delete-orphan',
+            lazy='dynamic'
+        )
+    )
+    submitter = db.relationship(
+        'User',
+        lazy=True,
+        foreign_keys=submitter_id,
+        backref=db.backref(
+            'event_move_requests',
+            cascade_backrefs=False,
+            lazy='dynamic'
+        )
+    )
+    moderator = db.relationship(
+        'User',
+        foreign_keys=moderator_id,
+        lazy=False
+    )
+
+    @locator_property
+    def locator(self):
+        return dict(self.event.locator, request_id=self.id)
+
+    def withdraw(self, user=None):
+        assert self.state == MoveRequestState.pending
+        self.state = MoveRequestState.withdrawn
+        db.session.flush()
+        self.event.log(EventLogRealm.event, EventLogKind.change, 'Event', 'Move request withdrawn', user=user)

--- a/indico/modules/categories/operations.py
+++ b/indico/modules/categories/operations.py
@@ -11,10 +11,10 @@ from indico.core import signals
 from indico.core.db import db
 from indico.modules.categories import logger
 from indico.modules.categories.models.categories import Category
+from indico.modules.categories.models.event_move_request import MoveRequestState
 from indico.modules.categories.util import format_visibility
 from indico.modules.logs.models.entries import CategoryLogRealm, LogKind
 from indico.modules.logs.util import make_diff_log
-from indico.modules.categories.models.event_move_request import MoveRequestState
 
 
 def create_category(parent, data):
@@ -63,7 +63,10 @@ def update_category(category, data, skip=()):
 
 
 def update_category_protection(category, data):
-    assert set(data) <= {'protection_mode', 'own_no_access_contact', 'event_creation_restricted', 'visibility', 'event_requires_approval'}
+    assert set(data) <= {
+        'protection_mode', 'own_no_access_contact', 'event_creation_restricted',
+        'visibility', 'event_requires_approval'
+    }
     changes = category.populate_from_dict(data)
     db.session.flush()
     signals.category.updated.send(category, changes=changes)

--- a/indico/modules/categories/operations.py
+++ b/indico/modules/categories/operations.py
@@ -63,10 +63,7 @@ def update_category(category, data, skip=()):
 
 
 def update_category_protection(category, data):
-    assert set(data) <= {
-        'protection_mode', 'own_no_access_contact', 'event_creation_restricted',
-        'visibility', 'event_requires_approval'
-    }
+    assert set(data) <= {'protection_mode', 'own_no_access_contact', 'event_creation_mode', 'visibility'}
     changes = category.populate_from_dict(data)
     db.session.flush()
     signals.category.updated.send(category, changes=changes)
@@ -76,8 +73,7 @@ def update_category_protection(category, data):
                       'own_no_access_contact': 'No access contact',
                       'visibility': {'title': 'Visibility', 'type': 'string',
                                      'convert': lambda changes: [format_visibility(category, x) for x in changes]},
-                      'event_creation_restricted': 'Event creation restricted',
-                      'event_requires_approval': 'Event requires approval'}
+                      'event_creation_mode': 'Event creation mode'}
         category.log(CategoryLogRealm.category, LogKind.change, 'Category', 'Protection updated', session.user,
                      data={'Changes': make_diff_log(changes, log_fields)})
 

--- a/indico/modules/categories/operations.py
+++ b/indico/modules/categories/operations.py
@@ -62,7 +62,7 @@ def update_category(category, data, skip=()):
 
 
 def update_category_protection(category, data):
-    assert set(data) <= {'protection_mode', 'own_no_access_contact', 'event_creation_restricted', 'visibility'}
+    assert set(data) <= {'protection_mode', 'own_no_access_contact', 'event_creation_restricted', 'visibility', 'event_requires_approval'}
     changes = category.populate_from_dict(data)
     db.session.flush()
     signals.category.updated.send(category, changes=changes)
@@ -72,7 +72,8 @@ def update_category_protection(category, data):
                       'own_no_access_contact': 'No access contact',
                       'visibility': {'title': 'Visibility', 'type': 'string',
                                      'convert': lambda changes: [format_visibility(category, x) for x in changes]},
-                      'event_creation_restricted': 'Event creation restricted'}
+                      'event_creation_restricted': 'Event creation restricted',
+                      'event_requires_approval': 'Event requires approval'}
         category.log(CategoryLogRealm.category, LogKind.change, 'Category', 'Protection updated', session.user,
                      data={'Changes': make_diff_log(changes, log_fields)})
 

--- a/indico/modules/categories/operations.py
+++ b/indico/modules/categories/operations.py
@@ -102,10 +102,12 @@ def _log_category_update(category, changes):
     logger.info('Category %s updated by %s', category, session.user)
 
 
-def update_event_move_request(request, accept):
+def update_event_move_request(request, accept, reason=None):
     request.state = MoveRequestState.rejected
+    request.state_reason = reason
     request.moderator = session.user
     if accept:
         request.state = MoveRequestState.accepted
+        request.state_reason = None
         request.event.move(request.category)
     db.session.flush()

--- a/indico/modules/categories/operations.py
+++ b/indico/modules/categories/operations.py
@@ -107,10 +107,9 @@ def _log_category_update(category, changes):
 
 def update_event_move_request(request, accept, reason=None):
     request.state = MoveRequestState.rejected
-    request.state_reason = reason
+    request.moderator_comment = reason
     request.moderator = session.user
     if accept:
         request.state = MoveRequestState.accepted
-        request.state_reason = None
         request.event.move(request.category)
     db.session.flush()

--- a/indico/modules/categories/operations.py
+++ b/indico/modules/categories/operations.py
@@ -112,4 +112,9 @@ def update_event_move_request(request, accept, reason=None):
     if accept:
         request.state = MoveRequestState.accepted
         request.event.move(request.category)
+    else:
+        category = request.category
+        sep = ' \N{RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK} '
+        category.log(CategoryLogRealm.category, LogKind.negative, 'Category', 'Move request rejected', session.user,
+                     data={'Location': sep.join(category.chain_titles), 'Reason': reason})
     db.session.flush()

--- a/indico/modules/categories/operations.py
+++ b/indico/modules/categories/operations.py
@@ -105,7 +105,7 @@ def _log_category_update(category, changes):
     logger.info('Category %s updated by %s', category, session.user)
 
 
-def update_event_move_request(request, accept, reason=None):
+def update_event_move_request(request, accept, reason=''):
     request.state = MoveRequestState.rejected
     request.moderator_comment = reason
     request.moderator = session.user

--- a/indico/modules/categories/schemas.py
+++ b/indico/modules/categories/schemas.py
@@ -1,0 +1,34 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from indico.core.marshmallow import fields, mm
+from indico.modules.categories.models.event_move_request import EventMoveRequest
+from indico.modules.events import Event
+from indico.modules.users import User
+
+
+class CategoryEventSchema(mm.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Event
+        fields = ('title', 'id')
+
+
+class CategoryUserSchema(mm.SQLAlchemyAutoSchema):
+    class Meta:
+        model = User
+        fields = ('id', 'name', 'first_name', 'last_name', 'title', 'affiliation', 'avatar_url')
+
+    name = fields.Function(lambda p: p.get_full_name(abbrev_first_name=False))
+
+
+class EventMoveRequestSchema(mm.SQLAlchemyAutoSchema):
+    class Meta:
+        model = EventMoveRequest
+        fields = ('id', 'event', 'category_id', 'submitter', 'state', 'submitted_dt')
+
+    event = fields.Nested(CategoryEventSchema)
+    submitter = fields.Nested(CategoryUserSchema)

--- a/indico/modules/categories/schemas.py
+++ b/indico/modules/categories/schemas.py
@@ -14,7 +14,7 @@ from indico.modules.users import User
 class CategoryEventSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Event
-        fields = ('title', 'id')
+        fields = ('id', 'title')
 
 
 class CategoryUserSchema(mm.SQLAlchemyAutoSchema):

--- a/indico/modules/categories/schemas.py
+++ b/indico/modules/categories/schemas.py
@@ -20,9 +20,7 @@ class CategoryEventSchema(mm.SQLAlchemyAutoSchema):
 class CategoryUserSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = User
-        fields = ('id', 'name', 'first_name', 'last_name', 'title', 'affiliation', 'avatar_url')
-
-    name = fields.Function(lambda p: p.get_full_name(abbrev_first_name=False))
+        fields = ('id', 'full_name', 'first_name', 'last_name', 'title', 'affiliation', 'avatar_url')
 
 
 class EventMoveRequestSchema(mm.SQLAlchemyAutoSchema):

--- a/indico/modules/categories/schemas.py
+++ b/indico/modules/categories/schemas.py
@@ -26,7 +26,7 @@ class CategoryUserSchema(mm.SQLAlchemyAutoSchema):
 class EventMoveRequestSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = EventMoveRequest
-        fields = ('id', 'event', 'category_id', 'submitter', 'state', 'submitted_dt')
+        fields = ('id', 'event', 'category_id', 'requestor', 'state', 'requested_dt')
 
     event = fields.Nested(CategoryEventSchema)
-    submitter = fields.Nested(CategoryUserSchema)
+    requestor = fields.Nested(CategoryUserSchema)

--- a/indico/modules/categories/serialize.py
+++ b/indico/modules/categories/serialize.py
@@ -106,6 +106,7 @@ def serialize_category(category, with_favorite=False, with_path=False, parent_pa
         'deep_event_count': category.deep_events_count,
         'can_access': category.can_access(session.user),
         'can_create_events': category.can_create_events(session.user),
+        'can_propose_events': category.can_propose_events(session.user),
     }
     if with_path:
         if child_path:

--- a/indico/modules/categories/templates/management/category_protection.html
+++ b/indico/modules/categories/templates/management/category_protection.html
@@ -9,11 +9,8 @@
 {% block content %}
     {{ form_header(form) }}
     {{ form_row(form.permissions, skip_label=true) }}
-    {{ form_rows(form, skip=(form._event_creation_fields + ('permissions',)),
+    {{ form_rows(form, skip=('permissions',),
                  widget_attrs={'own_no_access_contact': {'placeholder': category.no_access_contact}}) }}
-    {% call form_fieldset(_('Event creation settings')) %}
-        {{ form_rows(form, fields=form._event_creation_fields) }}
-    {% endcall %}
     {% call form_footer(form) %}
         <input class="i-button big highlight"
                type="submit"

--- a/indico/modules/categories/templates/management/category_protection.html
+++ b/indico/modules/categories/templates/management/category_protection.html
@@ -11,7 +11,7 @@
     {{ form_row(form.permissions, skip_label=true) }}
     {{ form_rows(form, skip=(form._event_creation_fields + ('permissions',)),
                  widget_attrs={'own_no_access_contact': {'placeholder': category.no_access_contact}}) }}
-    {% call form_fieldset(_('Event settings')) %}
+    {% call form_fieldset(_('Event creation settings')) %}
         {{ form_rows(form, fields=form._event_creation_fields) }}
     {% endcall %}
     {% call form_footer(form) %}

--- a/indico/modules/categories/templates/management/category_protection.html
+++ b/indico/modules/categories/templates/management/category_protection.html
@@ -11,7 +11,7 @@
     {{ form_row(form.permissions, skip_label=true) }}
     {{ form_rows(form, skip=(form._event_creation_fields + ('permissions',)),
                  widget_attrs={'own_no_access_contact': {'placeholder': category.no_access_contact}}) }}
-    {% call form_fieldset(_('Event creation settings')) %}
+    {% call form_fieldset(_('Event settings')) %}
         {{ form_rows(form, fields=form._event_creation_fields) }}
     {% endcall %}
     {% call form_footer(form) %}

--- a/indico/modules/categories/templates/management/moderation.html
+++ b/indico/modules/categories/templates/management/moderation.html
@@ -1,0 +1,9 @@
+{% extends 'categories/management/content.html' %}
+
+{% block title %}
+    {% trans %}Category moderation{% endtrans %}
+{% endblock %}
+
+{% block content %}
+    <div id="category-moderation" data-category-id="{{ category.id }}"></div>
+{% endblock %}

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -194,3 +194,9 @@ def _event_cloned(old_event, new_event, **kwargs):
     new_event.contact_title = old_event.contact_title
     new_event.contact_emails = old_event.contact_emails
     new_event.contact_phones = old_event.contact_phones
+
+
+@signals.event.moved.connect
+def _event_request_moved(event, old_parent):
+    if event.pending_move_request and event.pending_move_request.category == event.category:
+        event.pending_move_request.withdraw()

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -194,9 +194,3 @@ def _event_cloned(old_event, new_event, **kwargs):
     new_event.contact_title = old_event.contact_title
     new_event.contact_emails = old_event.contact_emails
     new_event.contact_phones = old_event.contact_phones
-
-
-@signals.event.moved.connect
-def _event_request_moved(event, old_parent):
-    if event.pending_move_request and event.pending_move_request.category == event.category:
-        event.pending_move_request.withdraw()

--- a/indico/modules/events/management/blueprint.py
+++ b/indico/modules/events/management/blueprint.py
@@ -31,6 +31,7 @@ _bp.add_url_rule('/change-type', 'change_type', actions.RHChangeEventType, metho
 _bp.add_url_rule('/lock', 'lock', actions.RHLockEvent, methods=('GET', 'POST'))
 _bp.add_url_rule('/unlock', 'unlock', actions.RHUnlockEvent, methods=('POST',))
 _bp.add_url_rule('/move', 'move', actions.RHMoveEvent, methods=('POST',))
+_bp.add_url_rule('/withdraw-move-request', 'withdraw_move_request', actions.RHWithdrawMoveRequest, methods=('POST',))
 # Protection
 _bp.add_url_rule('/api/principals', 'api_principals', protection.RHEventPrincipals, methods=('POST',))
 _bp.add_url_rule('/api/event-roles', 'api_event_roles', protection.RHEventRolesJSON)

--- a/indico/modules/events/management/client/js/index.js
+++ b/indico/modules/events/management/client/js/index.js
@@ -20,8 +20,10 @@ import './badges';
   global.setupEventManagementActionMenu = function setupEventManagementActionMenu() {
     $('#event-action-move-to-category').on('click', function(evt) {
       evt.preventDefault();
-
       const $this = $(this);
+      if ($this.hasClass('disabled')) {
+        return;
+      }
       $('<div>').categorynavigator({
         openInDialog: true,
         actionOn: {

--- a/indico/modules/events/management/client/js/index.js
+++ b/indico/modules/events/management/client/js/index.js
@@ -27,7 +27,7 @@ import './badges';
       $('<div>').categorynavigator({
         openInDialog: true,
         actionOn: {
-          categoriesWithoutEventCreationRights: {
+          categoriesWithoutEventProposalRights: {
             disabled: true,
           },
           categories: {

--- a/indico/modules/events/management/client/js/index.js
+++ b/indico/modules/events/management/client/js/index.js
@@ -27,7 +27,7 @@ import './badges';
       $('<div>').categorynavigator({
         openInDialog: true,
         actionOn: {
-          categoriesWithoutEventProposalRights: {
+          categoriesWithoutEventProposalOrCreationRights: {
             disabled: true,
           },
           categories: {

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -84,6 +84,7 @@ class RHMoveEvent(RHManageEventBase):
         self.target_category = Category.get_or_404(int(request.form['target_category_id']), is_deleted=False)
 
     def _check_access(self):
+        RHManageEventBase._check_access(self)
         if (not self.target_category.can_create_events(session.user)
                 and not self.target_category.can_propose_events(session.user)):
             raise Forbidden(_('You may not move events to this category.'))

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -6,7 +6,7 @@
 # LICENSE file for more details.
 
 from flask import flash, request, session
-from werkzeug.exceptions import BadRequest, Forbidden, NotFound
+from werkzeug.exceptions import Forbidden, NotFound
 
 from indico.modules.categories.models.categories import Category
 from indico.modules.events.management.controllers.base import RHManageEventBase
@@ -87,8 +87,6 @@ class RHMoveEvent(RHManageEventBase):
         if (not self.target_category.can_create_events(session.user)
                 and not self.target_category.can_propose_events(session.user)):
             raise Forbidden(_('You may not move events to this category.'))
-        if self.event.pending_move_request:
-            raise BadRequest(_('There is already a move request pending review.'))
 
     def _process(self):
         if self.target_category.can_create_events(session.user):

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -82,19 +82,19 @@ class RHMoveEvent(RHManageEventBase):
     def _process_args(self):
         RHManageEventBase._process_args(self)
         self.target_category = Category.get_or_404(int(request.form['target_category_id']), is_deleted=False)
-        if not self.target_category.can_create_events(session.user):
-            raise Forbidden(_('You may only move events to categories where you are allowed to create events.'))
-        if self.target_category.requires_approval and self.event.pending_move_request:
+        if not self.target_category.can_propose_events(session.user):
+            raise Forbidden(_('You may only move events to categories where you are allowed to propose events.'))
+        if self.event.pending_move_request:
             raise BadRequest(_('There is already a move request pending review.'))
 
     def _process(self):
-        if self.target_category.requires_approval:
-            create_event_request(self.event, self.target_category)
-            flash(_('A request to move "{}" to "{}" has been submitted')
-                  .format(self.event.title, self.target_category.title), 'success')
-        else:
+        if self.target_category.can_create_events(session.user):
             self.event.move(self.target_category)
             flash(_('Event "{}" has been moved to category "{}"')
+                  .format(self.event.title, self.target_category.title), 'success')
+        else:
+            create_event_request(self.event, self.target_category)
+            flash(_('A request to move "{}" to "{}" has been submitted')
                   .format(self.event.title, self.target_category.title), 'success')
         return jsonify_data(flash=False)
 

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -84,8 +84,9 @@ class RHMoveEvent(RHManageEventBase):
         self.target_category = Category.get_or_404(int(request.form['target_category_id']), is_deleted=False)
 
     def _check_access(self):
-        if not self.target_category.can_propose_events(session.user):
-            raise Forbidden(_('You may only move events to categories where you are allowed to propose events.'))
+        if (not self.target_category.can_create_events(session.user)
+                and not self.target_category.can_propose_events(session.user)):
+            raise Forbidden(_('You may only move events to categories you are allowed to.'))
         if self.event.pending_move_request:
             raise BadRequest(_('There is already a move request pending review.'))
 

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -96,7 +96,7 @@ class RHMoveEvent(RHManageEventBase):
                   .format(self.event.title, self.target_category.title), 'success')
         else:
             create_event_request(self.event, self.target_category)
-            flash(_('A request to move "{}" to "{}" has been submitted')
+            flash(_('Moving the event "{}" to "{}" has been requested and is pending approval')
                   .format(self.event.title, self.target_category.title), 'success')
         return jsonify_data(flash=False)
 

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -89,7 +89,7 @@ class RHMoveEvent(RHManageEventBase):
 
     def _process(self):
         if self.target_category.requires_approval:
-            create_event_request(self.target_category, self.event, session.user)
+            create_event_request(self.event, self.target_category)
             flash(_('A request to move "{}" to "{}" has been submitted')
                   .format(self.event.title, self.target_category.title), 'success')
         else:

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -86,7 +86,7 @@ class RHMoveEvent(RHManageEventBase):
     def _check_access(self):
         if (not self.target_category.can_create_events(session.user)
                 and not self.target_category.can_propose_events(session.user)):
-            raise Forbidden(_('You may only move events to categories you are allowed to.'))
+            raise Forbidden(_('You may not move events to this category.'))
         if self.event.pending_move_request:
             raise BadRequest(_('There is already a move request pending review.'))
 

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -82,6 +82,8 @@ class RHMoveEvent(RHManageEventBase):
     def _process_args(self):
         RHManageEventBase._process_args(self)
         self.target_category = Category.get_or_404(int(request.form['target_category_id']), is_deleted=False)
+
+    def _check_access(self):
         if not self.target_category.can_propose_events(session.user):
             raise Forbidden(_('You may only move events to categories where you are allowed to propose events.'))
         if self.event.pending_move_request:

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -92,12 +92,14 @@ class RHMoveEvent(RHManageEventBase):
     def _process(self):
         if self.target_category.can_create_events(session.user):
             self.event.move(self.target_category)
-            flash(_('Event "{}" has been moved to category "{}"')
-                  .format(self.event.title, self.target_category.title), 'success')
+            flash(_('Event "{event}" has been moved to category "{category}"')
+                  .format(event=self.event.title, category=self.target_category.title),
+                  'success')
         else:
             create_event_request(self.event, self.target_category)
-            flash(_('Moving the event "{}" to "{}" has been requested and is pending approval')
-                  .format(self.event.title, self.target_category.title), 'success')
+            flash(_('Moving the event "{event}" to "{category}" has been requested and is pending approval')
+                  .format(event=self.event.title, category=self.target_category.title),
+                  'success')
         return jsonify_data(flash=False)
 
 

--- a/indico/modules/events/management/controllers/actions_test.py
+++ b/indico/modules/events/management/controllers/actions_test.py
@@ -17,7 +17,7 @@ def target_category(create_category):
 
 
 @pytest.mark.parametrize(('requires_approval', 'permissions'), ((True, {}), (False, {'event_move_request'})))
-def test_move_event_request(app, requires_approval, permissions, dummy_user, dummy_event,
+def test_move_event_request(db, app, requires_approval, permissions, dummy_user, dummy_event,
                             dummy_category, target_category):
     dummy_event.category = dummy_category
     target_category.event_requires_approval = requires_approval
@@ -30,6 +30,7 @@ def test_move_event_request(app, requires_approval, permissions, dummy_user, dum
         session.set_session_user(dummy_user)
         rh._check_access()
         rh._process()
+        db.session.expire(dummy_event, ['pending_move_request'])
         assert dummy_event.category == dummy_category
         assert dummy_event.pending_move_request is not None
         assert dummy_event.pending_move_request.category == target_category

--- a/indico/modules/events/management/controllers/actions_test.py
+++ b/indico/modules/events/management/controllers/actions_test.py
@@ -6,6 +6,7 @@
 # LICENSE file for more details.
 
 import pytest
+from flask import session
 
 from indico.modules.events.management.controllers.actions import RHMoveEvent
 
@@ -15,28 +16,36 @@ def target_category(create_category):
     return create_category(25, title='Target')
 
 
-def test_move_event_request(app, dummy_event, dummy_category, target_category):
+@pytest.mark.parametrize(('requires_approval', 'permissions'), ((True, {}), (False, {'event_move_request'})))
+def test_move_event_request(app, requires_approval, permissions, dummy_user, dummy_event,
+                            dummy_category, target_category):
     dummy_event.category = dummy_category
-    target_category.event_requires_approval = True
+    target_category.event_requires_approval = requires_approval
+    target_category.update_principal(dummy_user, read_access=True, permissions=permissions)
     assert dummy_event.pending_move_request is None
     rh = RHMoveEvent()
     rh.event = dummy_event
     rh.target_category = target_category
     with app.test_request_context():
+        session.set_session_user(dummy_user)
+        rh._check_access()
         rh._process()
         assert dummy_event.category == dummy_category
         assert dummy_event.pending_move_request is not None
         assert dummy_event.pending_move_request.category == target_category
 
 
-def test_move_event(app, dummy_event, dummy_category, target_category):
+def test_move_event(app, dummy_event, dummy_user, dummy_category, target_category):
     dummy_event.category = dummy_category
     target_category.event_requires_approval = False
+    target_category.update_principal(dummy_user, read_access=True, permissions={'create'})
     assert dummy_event.pending_move_request is None
     rh = RHMoveEvent()
     rh.event = dummy_event
     rh.target_category = target_category
     with app.test_request_context():
+        session.set_session_user(dummy_user)
+        rh._check_access()
         rh._process()
         assert dummy_event.category == target_category
         assert dummy_event.pending_move_request is None

--- a/indico/modules/events/management/controllers/actions_test.py
+++ b/indico/modules/events/management/controllers/actions_test.py
@@ -24,6 +24,7 @@ def target_category(create_category):
 def test_move_event_request(db, app, creation_mode, permissions, dummy_user, dummy_event,
                             dummy_category, target_category):
     dummy_event.category = dummy_category
+    dummy_event.update_principal(dummy_user, full_access=True)
     target_category.event_creation_mode = creation_mode
     target_category.update_principal(dummy_user, read_access=True, permissions=permissions)
     assert dummy_event.pending_move_request is None
@@ -42,6 +43,7 @@ def test_move_event_request(db, app, creation_mode, permissions, dummy_user, dum
 
 def test_move_event(app, dummy_event, dummy_user, dummy_category, target_category):
     dummy_event.category = dummy_category
+    dummy_event.update_principal(dummy_user, full_access=True)
     target_category.event_creation_mode = EventCreationMode.open
     target_category.update_principal(dummy_user, read_access=True, permissions={'create'})
     assert dummy_event.pending_move_request is None

--- a/indico/modules/events/management/controllers/actions_test.py
+++ b/indico/modules/events/management/controllers/actions_test.py
@@ -1,3 +1,10 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
 import pytest
 
 from indico.modules.events.management.controllers.actions import RHMoveEvent

--- a/indico/modules/events/management/controllers/actions_test.py
+++ b/indico/modules/events/management/controllers/actions_test.py
@@ -1,0 +1,35 @@
+import pytest
+
+from indico.modules.events.management.controllers.actions import RHMoveEvent
+
+
+@pytest.fixture
+def target_category(create_category):
+    return create_category(25, title='Target')
+
+
+def test_move_event_request(app, dummy_event, dummy_category, target_category):
+    dummy_event.category = dummy_category
+    target_category.event_requires_approval = True
+    assert dummy_event.pending_move_request is None
+    rh = RHMoveEvent()
+    rh.event = dummy_event
+    rh.target_category = target_category
+    with app.test_request_context():
+        rh._process()
+        assert dummy_event.category == dummy_category
+        assert dummy_event.pending_move_request is not None
+        assert dummy_event.pending_move_request.category == target_category
+
+
+def test_move_event(app, dummy_event, dummy_category, target_category):
+    dummy_event.category = dummy_category
+    target_category.event_requires_approval = False
+    assert dummy_event.pending_move_request is None
+    rh = RHMoveEvent()
+    rh.event = dummy_event
+    rh.target_category = target_category
+    with app.test_request_context():
+        rh._process()
+        assert dummy_event.category == target_category
+        assert dummy_event.pending_move_request is None

--- a/indico/modules/events/management/templates/_action_menu.html
+++ b/indico/modules/events/management/templates/_action_menu.html
@@ -72,15 +72,13 @@
 
 
 {% macro _render_move_event(event) %}
-    {% if event.pending_event_request is none %}
-        <button class="i-button borderless icon-transmission hide-if-locked"
-                id="event-action-move-to-category"
-                title="{% trans %}Move event to another category{% endtrans %}"
-                data-href="{{ url_for('event_management.move', event) }}"
-                data-category-id="{{ event.category.id }}">
-            {% trans %}Move{% endtrans %}
-        </button>
-    {% endif %}
+    <button class="i-button borderless icon-transmission hide-if-locked {{ 'disabled' if event.pending_move_request is not none }}"
+            id="event-action-move-to-category"
+            title="{% trans %}Move event to another category{% endtrans %}"
+            data-href="{{ url_for('event_management.move', event) }}"
+            data-category-id="{{ event.category.id }}">
+        {% trans %}Move{% endtrans %}
+    </button>
 {% endmacro %}
 
 

--- a/indico/modules/events/management/templates/_action_menu.html
+++ b/indico/modules/events/management/templates/_action_menu.html
@@ -72,13 +72,15 @@
 
 
 {% macro _render_move_event(event) %}
-    <button class="i-button borderless icon-transmission hide-if-locked"
-            id="event-action-move-to-category"
-            title="{% trans %}Move event to another category{% endtrans %}"
-            data-href="{{ url_for('event_management.move', event) }}"
-            data-category-id="{{ event.category.id }}">
-        {% trans %}Move{% endtrans %}
-    </button>
+    {% if event.pending_event_request is none %}
+        <button class="i-button borderless icon-transmission hide-if-locked"
+                id="event-action-move-to-category"
+                title="{% trans %}Move event to another category{% endtrans %}"
+                data-href="{{ url_for('event_management.move', event) }}"
+                data-category-id="{{ event.category.id }}">
+            {% trans %}Move{% endtrans %}
+        </button>
+    {% endif %}
 {% endmacro %}
 
 

--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -6,14 +6,16 @@
 
 {% block content %}
     {{ template_hook('event-actions', event=event) }}
-    {%- if event.pending_move_request -%}
+    {% set move_request = event.pending_move_request %}
+    {%- if move_request -%}
         <div class="action-box highlight">
             <div class="section">
                 <div class="icon icon-bookmark"></div>
                 <div class="text">
                     <div class="label">{% trans %}Pending event moderation{% endtrans %}</div>
-                    {% trans %}
-                        There is an on-going request to move this event to another category.
+                    {% trans url=move_request.category, category=move_request.category.title %}
+                        There is an ongoing request to move this event to
+                        <a href="{{ url }}">{{ category }}</a>.
                     {% endtrans %}
                 </div>
                 <div class="toolbar">

--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -6,6 +6,29 @@
 
 {% block content %}
     {{ template_hook('event-actions', event=event) }}
+    {%- if event.pending_move_request -%}
+        <div class="action-box highlight">
+            <div class="section">
+                <div class="icon icon-bookmark"></div>
+                <div class="text">
+                    <div class="label">{% trans %}Pending event moderation{% endtrans %}</div>
+                    {% trans %}
+                        There is an on-going request to move this event to another category.
+                    {% endtrans %}
+                </div>
+                <div class="toolbar">
+                    <div class="group">
+                        <button class="i-button icon-arrow-left hide-if-locked"
+                                data-href="{{ url_for('event_management.withdraw_move_request', event) }}"
+                                data-method="POST"
+                                data-reload-after>
+                            {% trans %}Withdraw{% endtrans %}
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    {%- endif -%}
     {%- if show_booking_warning -%}
         <div class="action-box warning">
             <div class="section">

--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -12,10 +12,9 @@
             <div class="section">
                 <div class="icon icon-bookmark"></div>
                 <div class="text">
-                    <div class="label">{% trans %}Pending event moderation{% endtrans %}</div>
+                    <div class="label">{% trans %}Awaiting moderation{% endtrans %}</div>
                     {% trans url=move_request.category.url, category=move_request.category.title %}
-                        There is an ongoing request to move this event to
-                        <a href="{{ url }}">{{ category }}</a>.
+                        There is a pending request to move this event to <a href="{{ url }}">{{ category }}</a>.
                     {% endtrans %}
                 </div>
                 <div class="toolbar">

--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -13,7 +13,7 @@
                 <div class="icon icon-bookmark"></div>
                 <div class="text">
                     <div class="label">{% trans %}Pending event moderation{% endtrans %}</div>
-                    {% trans url=move_request.category, category=move_request.category.title %}
+                    {% trans url=move_request.category.url, category=move_request.category.title %}
                         There is an ongoing request to move this event to
                         <a href="{{ url }}">{{ category }}</a>.
                     {% endtrans %}

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -915,7 +915,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         db.m.Contribution.preload_acl_entries(self)
         db.m.Session.preload_acl_entries(self)
 
-    def move(self, category):
+    def move(self, category, *, log_meta=None):
         from indico.modules.events import EventLogRealm
         from indico.modules.logs import LogKind
         old_category = self.category
@@ -926,11 +926,11 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         db.session.flush()
         signals.event.moved.send(self, old_parent=old_category)
         self.log(EventLogRealm.management, LogKind.change, 'Category', 'Event moved', session.user,
-                 data={'From': old_path, 'To': new_path})
+                 data={'From': old_path, 'To': new_path}, meta=log_meta)
         old_category.log(CategoryLogRealm.events, LogKind.negative, 'Content', f'Event moved out: "{self.title}"',
-                         session.user, data={'ID': self.id, 'To': new_path})
+                         session.user, data={'ID': self.id, 'To': new_path}, meta=log_meta)
         category.log(CategoryLogRealm.events, LogKind.positive, 'Content', f'Event moved in: "{self.title}"',
-                     session.user, data={'From': old_path})
+                     session.user, data={'From': old_path}, meta=log_meta)
 
     def delete(self, reason, user=None):
         from indico.modules.events import EventLogRealm, logger

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -918,6 +918,8 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     def move(self, category, *, log_meta=None):
         from indico.modules.events import EventLogRealm
         from indico.modules.logs import LogKind
+        if self.pending_move_request:
+            self.pending_move_request.withdraw(user=session.user)
         old_category = self.category
         self.category = category
         sep = ' \N{RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK} '

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -407,6 +407,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     # - legacy_subcontribution_mappings (LegacySubContributionMapping.event)
     # - log_entries (EventLogEntry.event)
     # - menu_entries (MenuEntry.event)
+    # - move_requests (EventMoveRequest.event)
     # - note (EventNote.linked_event)
     # - paper_competences (PaperCompetence.event)
     # - paper_review_questions (PaperReviewQuestion.event)
@@ -429,7 +430,6 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     # - track_groups (TrackGroup.event)
     # - tracks (Track.event)
     # - vc_room_associations (VCRoomEventAssociation.linked_event)
-    # - move_requests (EventMoveRequest.event)
 
     start_dt_override = _EventSettingProperty(event_core_settings, 'start_dt_override')
     end_dt_override = _EventSettingProperty(event_core_settings, 'end_dt_override')

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -377,6 +377,15 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
             lazy=True
         )
     )
+    #: The current pending move request
+    pending_move_request = db.relationship(
+        'EventMoveRequest',
+        lazy=True,
+        viewonly=True,
+        uselist=False,
+        primaryjoin=lambda: (EventMoveRequest.event_id == Event.id) &
+                            (EventMoveRequest.state == MoveRequestState.pending)
+    )
 
     # relationship backrefs:
     # - abstract_email_templates (AbstractEmailTemplate.event)
@@ -615,10 +624,6 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     @property
     def has_custom_boa(self):
         return self.custom_boa_id is not None
-
-    @property
-    def pending_move_request(self):
-        return self.move_requests.filter(EventMoveRequest.state == MoveRequestState.pending).first()
 
     @property
     @contextmanager

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -383,8 +383,8 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         lazy=True,
         viewonly=True,
         uselist=False,
-        primaryjoin=lambda: (EventMoveRequest.event_id == Event.id) &
-                            (EventMoveRequest.state == MoveRequestState.pending)
+        primaryjoin=lambda: db.and_(EventMoveRequest.event_id == Event.id,
+                                    EventMoveRequest.state == MoveRequestState.pending)
     )
 
     # relationship backrefs:

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -33,6 +33,7 @@ from indico.core.db.sqlalchemy.searchable import SearchableTitleMixin
 from indico.core.db.sqlalchemy.util.models import auto_table_args
 from indico.core.db.sqlalchemy.util.queries import db_dates_overlap, get_related_object
 from indico.modules.categories import Category
+from indico.modules.categories.models.event_move_request import EventMoveRequest, MoveRequestState
 from indico.modules.events.management.util import get_non_inheriting_objects
 from indico.modules.events.models.persons import EventPerson, PersonLinkDataMixin
 from indico.modules.events.settings import EventSettingProperty, event_contact_settings, event_core_settings
@@ -428,6 +429,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     # - track_groups (TrackGroup.event)
     # - tracks (Track.event)
     # - vc_room_associations (VCRoomEventAssociation.linked_event)
+    # - move_requests (EventMoveRequest.event)
 
     start_dt_override = _EventSettingProperty(event_core_settings, 'start_dt_override')
     end_dt_override = _EventSettingProperty(event_core_settings, 'end_dt_override')
@@ -613,6 +615,10 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     @property
     def has_custom_boa(self):
         return self.custom_boa_id is not None
+
+    @property
+    def pending_move_request(self):
+        return self.move_requests.filter(EventMoveRequest.state == MoveRequestState.pending).first()
 
     @property
     @contextmanager

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -392,6 +392,7 @@ def create_event_request(event, category):
     rq = EventMoveRequest(event=event, category=category, requestor=session.user)
     db.session.flush()
     logger.info('Category move request %s to %s created by %s', rq, category, session.user)
+    sep = ' \N{RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK} '
     event.log(EventLogRealm.event, LogKind.change, 'Event', f'Move request to {category.title} created',
-              user=session.user)
+              user=session.user, data={'Category ID': category.id, 'Category': sep.join(category.chain_titles)})
     return rq

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -388,9 +388,8 @@ def sort_reviewing_questions(questions, new_positions):
 
 
 def create_event_request(event, category):
-    assert event.id != category.id
+    assert event.category != category
     rq = EventMoveRequest(event=event, category=category, submitter=session.user)
-    db.session.add(rq)
     db.session.flush()
     logger.info('Category move request %s to %s created by %s', rq, category, session.user)
     event.log(EventLogRealm.event, EventLogKind.change, 'Event', f'Move request to {category.title} created',

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -389,7 +389,7 @@ def sort_reviewing_questions(questions, new_positions):
 
 def create_event_request(event, category):
     assert event.category != category
-    rq = EventMoveRequest(event=event, category=category, submitter=session.user)
+    rq = EventMoveRequest(event=event, category=category, requestor=session.user)
     db.session.flush()
     logger.info('Category move request %s to %s created by %s', rq, category, session.user)
     event.log(EventLogRealm.event, LogKind.change, 'Event', f'Move request to {category.title} created',

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -387,10 +387,12 @@ def sort_reviewing_questions(questions, new_positions):
     logger.info('Reviewing questions of %r reordered by %r', questions[0].event, session.user)
 
 
-def create_event_request(category, event, user):
-    rq = EventMoveRequest(event=event, category=category, submitter=user)
+def create_event_request(event, category):
+    assert event.id != category.id
+    rq = EventMoveRequest(event=event, category=category, submitter=session.user)
     db.session.add(rq)
     db.session.flush()
     logger.info('Category move request %s to %s created by %s', rq, category, session.user)
-    event.log(EventLogRealm.event, EventLogKind.change, 'Event', f'Move request to {category.title} created', user=user)
+    event.log(EventLogRealm.event, EventLogKind.change, 'Event', f'Move request to {category.title} created',
+              user=session.user)
     return rq

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -14,7 +14,7 @@ from indico.core.db import db
 from indico.core.db.sqlalchemy.util.session import no_autoflush
 from indico.modules.categories.models.event_move_request import EventMoveRequest
 from indico.modules.categories.util import format_visibility
-from indico.modules.events import Event, EventLogKind, EventLogRealm, logger
+from indico.modules.events import Event, EventLogRealm, logger
 from indico.modules.events.cloning import EventCloner, get_event_cloners
 from indico.modules.events.features import features_event_settings
 from indico.modules.events.layout import layout_settings
@@ -392,6 +392,6 @@ def create_event_request(event, category):
     rq = EventMoveRequest(event=event, category=category, submitter=session.user)
     db.session.flush()
     logger.info('Category move request %s to %s created by %s', rq, category, session.user)
-    event.log(EventLogRealm.event, EventLogKind.change, 'Event', f'Move request to {category.title} created',
+    event.log(EventLogRealm.event, LogKind.change, 'Event', f'Move request to {category.title} created',
               user=session.user)
     return rq

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -443,6 +443,7 @@ class User(PersonMixin, db.Model):
     # - static_sites (StaticSite.creator)
     # - survey_submissions (SurveySubmission.user)
     # - vc_rooms (VCRoom.created_by_user)
+    # - event_move_requests (EventMoveRequest.user)
 
     @staticmethod
     def get_system_user():

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -402,6 +402,7 @@ class User(PersonMixin, db.Model):
     # - editor_for_editables (Editable.editor)
     # - editor_for_revisions (EditingRevision.editor)
     # - event_log_entries (EventLogEntry.user)
+    # - event_move_requests (EventMoveRequest.submitter)
     # - event_notes_revisions (EventNoteRevision.user)
     # - event_persons (EventPerson.user)
     # - event_reminders (EventReminder.creator)
@@ -443,7 +444,6 @@ class User(PersonMixin, db.Model):
     # - static_sites (StaticSite.creator)
     # - survey_submissions (SurveySubmission.user)
     # - vc_rooms (VCRoom.created_by_user)
-    # - event_move_requests (EventMoveRequest.user)
 
     @staticmethod
     def get_system_user():

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -402,7 +402,7 @@ class User(PersonMixin, db.Model):
     # - editor_for_editables (Editable.editor)
     # - editor_for_revisions (EditingRevision.editor)
     # - event_log_entries (EventLogEntry.user)
-    # - event_move_requests (EventMoveRequest.submitter)
+    # - event_move_requests (EventMoveRequest.requestor)
     # - event_notes_revisions (EventNoteRevision.user)
     # - event_persons (EventPerson.user)
     # - event_reminders (EventReminder.creator)

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -426,6 +426,7 @@ class User(PersonMixin, db.Model):
     # - layout_reviewer_for_contributions (Contribution.paper_layout_reviewers)
     # - local_groups (LocalGroup.members)
     # - merged_from_users (User.merged_into_user)
+    # - moderated_event_move_requests (EventMoveRequest.moderator)
     # - modified_abstract_comments (AbstractComment.modified_by)
     # - modified_abstracts (Abstract.modified_by)
     # - modified_review_comments (PaperReviewComment.modified_by)

--- a/indico/web/client/js/jquery/widgets/categorynavigator.js
+++ b/indico/web/client/js/jquery/widgets/categorynavigator.js
@@ -30,6 +30,10 @@ import Palette from '../../utils/palette';
       dialogSubtitle: null,
       // Disallow action on specific categories
       actionOn: {
+        categoriesWithoutEventProposalRights: {
+          disabled: false,
+          message: $T.gettext('Not possible for categories where you cannot propose events'),
+        },
         categoriesWithoutEventCreationRights: {
           disabled: false,
           message: $T.gettext('Not possible for categories where you cannot create events'),
@@ -711,6 +715,10 @@ import Palette from '../../utils/palette';
         category,
         true
       );
+      const canActOnCategoriesWithoutEventProposalRights = self._canActOnCategoriesWithoutEventProposalRights(
+        category,
+        true
+      );
 
       if (!canActOnCategories.allowed) {
         result = canActOnCategories;
@@ -718,6 +726,8 @@ import Palette from '../../utils/palette';
         result = canActOnCategoriesDescendingFrom;
       } else if (!canActOnCategoriesWithoutEventCreationRights.allowed) {
         result = canActOnCategoriesWithoutEventCreationRights;
+      } else if (!canActOnCategoriesWithoutEventProposalRights.allowed) {
+        result = canActOnCategoriesWithoutEventProposalRights;
       }
 
       return withMessage ? result : result.allowed;
@@ -731,6 +741,18 @@ import Palette from '../../utils/palette';
       if (categoriesWithoutEventCreationRights.disabled && !category.can_create_events) {
         result.allowed = false;
         result.message = categoriesWithoutEventCreationRights.message;
+      }
+      return withMessage ? result : result.allowed;
+    },
+
+    _canActOnCategoriesWithoutEventProposalRights(category, withMessage) {
+      const self = this;
+      const result = {allowed: true, message: ''};
+      const categoriesWithoutEventProposalRights =
+        self.options.actionOn.categoriesWithoutEventProposalRights;
+      if (categoriesWithoutEventProposalRights.disabled && !category.can_propose_events) {
+        result.allowed = false;
+        result.message = categoriesWithoutEventProposalRights.message;
       }
       return withMessage ? result : result.allowed;
     },

--- a/indico/web/client/js/jquery/widgets/categorynavigator.js
+++ b/indico/web/client/js/jquery/widgets/categorynavigator.js
@@ -34,6 +34,10 @@ import Palette from '../../utils/palette';
           disabled: false,
           message: $T.gettext('Not possible for categories where you cannot propose events'),
         },
+        categoriesWithoutEventProposalOrCreationRights: {
+          disabled: false,
+          message: $T.gettext('Not possible for categories where you cannot propose/create events'),
+        },
         categoriesWithoutEventCreationRights: {
           disabled: false,
           message: $T.gettext('Not possible for categories where you cannot create events'),
@@ -719,6 +723,10 @@ import Palette from '../../utils/palette';
         category,
         true
       );
+      const canActOnCategoriesWithoutEventProposalOrCreationRights = self._canActOnCategoriesWithoutEventProposalOrCreationRights(
+        category,
+        true
+      );
 
       if (!canActOnCategories.allowed) {
         result = canActOnCategories;
@@ -728,6 +736,8 @@ import Palette from '../../utils/palette';
         result = canActOnCategoriesWithoutEventCreationRights;
       } else if (!canActOnCategoriesWithoutEventProposalRights.allowed) {
         result = canActOnCategoriesWithoutEventProposalRights;
+      } else if (!canActOnCategoriesWithoutEventProposalOrCreationRights.allowed) {
+        result = canActOnCategoriesWithoutEventProposalOrCreationRights;
       }
 
       return withMessage ? result : result.allowed;
@@ -753,6 +763,22 @@ import Palette from '../../utils/palette';
       if (categoriesWithoutEventProposalRights.disabled && !category.can_propose_events) {
         result.allowed = false;
         result.message = categoriesWithoutEventProposalRights.message;
+      }
+      return withMessage ? result : result.allowed;
+    },
+
+    _canActOnCategoriesWithoutEventProposalOrCreationRights(category, withMessage) {
+      const self = this;
+      const result = {allowed: true, message: ''};
+      const categoriesWithoutEventProposalOrCreationRights =
+        self.options.actionOn.categoriesWithoutEventProposalOrCreationRights;
+      if (
+        categoriesWithoutEventProposalOrCreationRights.disabled &&
+        !category.can_propose_events &&
+        !category.can_create_events
+      ) {
+        result.allowed = false;
+        result.message = categoriesWithoutEventProposalOrCreationRights.message;
       }
       return withMessage ? result : result.allowed;
     },


### PR DESCRIPTION
An embryonic version of the event moderation is described in #2057. Still working to address:

- [x] Withdraw a request if an event is forcibly moved to the target category
- [x] ACL permission to allow requesting to publish an event
- [x] Allow reasons in moderation judgments #5025 
- [x] Enhance event logs #5025 
- [ ] Allow comments while opening a new request

The current proposal flow is the following:

- User can create events in the target category? The event is immediately moved
- User has permission to propose event moves? A proposal to move is created
- Target category setting requires approval for moves? A proposal to move is created
- Otherwise normal conditions apply

![imagem](https://user-images.githubusercontent.com/12183954/125785373-73d08665-58e6-45cb-8e1d-1b6a60c77f8d.png)
![imagem](https://user-images.githubusercontent.com/12183954/125788873-a14f89c3-5264-472a-9f56-3feb381a3477.png)

closes #2057