### PR TITLE
Set page title on profile and search pages

### DIFF
--- a/indico/modules/search/views.py
+++ b/indico/modules/search/views.py
@@ -18,6 +18,8 @@ class WPSearchMixin:
 
 
 class WPSearch(WPSearchMixin, WPJinjaMixin, WPDecorated):
+    title = _('Search')
+
     def _get_breadcrumbs(self):
         return render_breadcrumbs(_('Search'))
 
@@ -28,6 +30,10 @@ class WPSearch(WPSearchMixin, WPJinjaMixin, WPDecorated):
 class WPCategorySearch(WPSearchMixin, WPCategory):
     """WP for category-scoped search."""
 
+    @property
+    def _extra_title_parts(self):
+        return [_('Search')]
+
     def _get_breadcrumbs(self):
         if not self.category or self.category.is_root:
             return ''
@@ -35,4 +41,6 @@ class WPCategorySearch(WPSearchMixin, WPCategory):
 
 
 class WPEventSearch(WPSearchMixin, WPConferenceDisplayBase):
-    pass
+    @property
+    def _extra_title_parts(self):
+        return [_('Search')]

--- a/indico/modules/users/views.py
+++ b/indico/modules/users/views.py
@@ -29,13 +29,19 @@ class WPUser(WPJinjaMixin, WPDecorated):
         kwargs['active_menu_item'] = active_menu_item
         WPDecorated.__init__(self, rh, **kwargs)
 
-    def _get_breadcrumbs(self):
+    def _get_user_page_title(self):
         if 'user_id' in request.view_args:
             user = User.get(request.view_args['user_id'])
-            profile_breadcrumb = _('Profile of {name}').format(name=user.full_name)
+            return _('Profile of {name}').format(name=user.full_name)
         else:
-            profile_breadcrumb = _('My Profile')
-        return render_breadcrumbs(profile_breadcrumb)
+            return _('My Profile')
+
+    @property
+    def _extra_title_parts(self):
+        return [self._get_user_page_title()]
+
+    def _get_breadcrumbs(self):
+        return render_breadcrumbs(self._get_user_page_title())
 
     def _get_body(self, params):
         return self._get_page_content(params)

--- a/indico/web/views.py
+++ b/indico/web/views.py
@@ -241,11 +241,15 @@ class WPBase(WPBundleMixin):
     def _display(self, params):
         raise NotImplementedError
 
+    @property
+    def _extra_title_parts(self):
+        return ()
+
     def display(self, **params):
         from indico.modules.admin import RHAdminBase
         from indico.modules.core.settings import core_settings, social_settings
 
-        title_parts = [self.title]
+        title_parts = [*self._extra_title_parts, self.title]
         if self.MANAGEMENT:
             title_parts.insert(0, _('Management'))
         elif isinstance(self._rh, RHAdminBase):


### PR DESCRIPTION
These two places are just the most obvious ones I noticed while testing something...

At some point (future version) we should refactor this stuff and set useful titles everywhere... We have a page title in the breadcrumb in many places, so maybe that'd be worth bringing closer together.