### PR TITLE
Add redis server start for macOS

### DIFF
--- a/docs/source/installation/development.rst
+++ b/docs/source/installation/development.rst
@@ -58,6 +58,7 @@ We recommend that you use `Homebrew <https://brew.sh/>`_::
 
     brew install redis libjpeg libffi pcre libyaml postgresql
     brew services start postgresql
+    brew services start redis
 
 
 Creating the directory structure


### PR DESCRIPTION
When development environment is being installed on macOS via brew, both postgresql and redis should be started. This add the respective line into the installation guide.