### PR TITLE
Switch master to 3.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,42 @@ Changelog
 =========
 
 
+Version 3.1
+-----------
+
+*Unreleased*
+
+Major Features
+^^^^^^^^^^^^^^
+
+- TODO write something about unlisted events
+- TODO write something about moderated categories
+- TODO write something about the category log
+
+Internationalization
+^^^^^^^^^^^^^^^^^^^^
+
+- Nothing so far
+
+Improvements
+^^^^^^^^^^^^
+
+- Nothing so far
+
+Bugfixes
+^^^^^^^^
+
+- Nothing so far
+
+Internal Changes
+^^^^^^^^^^^^^^^^
+
+- Nothing so far
+
+
+----
+
+
 Version 3.0.1
 -------------
 

--- a/indico/__init__.py
+++ b/indico/__init__.py
@@ -8,7 +8,7 @@
 from indico.util.mimetypes import register_custom_mimetypes
 
 
-__version__ = '3.0.1-dev'
+__version__ = '3.1-dev'
 PREFERRED_PYTHON_VERSION_SPEC = '~=3.9.0'
 
 register_custom_mimetypes()


### PR DESCRIPTION
To be merged only before we merge one of the 3.1 PRs so until then we can keep fast-forwarding-merging 3.0.x into master for any 3.0-related changes.