### PR TITLE
Allow disabling public search of Indico users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,9 @@ Improvements
   with the same email address (:pr:`5066`)
 - Show program codes in additional places (:pr:`5075`)
 - Display localized country names (:issue:`5070`, :pr:`5076`)
+- Searching existing Indico users can be restricted to managers by setting
+  :data:`ALLOW_PUBLIC_USER_SEARCH` to ``False``. This also limits the verbosity of email
+  status checks while registering for events. (:pr:`5024`, thanks :user:`omegak`)
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -590,6 +590,24 @@ Logging
 Security
 --------
 
+.. data:: ALLOW_PUBLIC_USER_SEARCH
+
+    If disabled, users without management permissions cannot search for
+    existing Indico users. This affects places such as abstract submission,
+    material ACLs and the verbosity of the email status check (whether the
+    registration will be linked to an Indico account) while registering for
+    an event.
+
+    It is recommended to disable this setting in case you run a public instance
+    with strong privacy requirements that weigh heavier than the convenience
+    of being able to search Indico users.
+
+    Note that this setting is only effective if event creation is properly
+    restricted since otherwise any user can just create an event where they
+    then have management permissions and thus the ability to serach for users.
+
+    Default: ``True``
+
 .. data:: SECRET_KEY
 
     The secret key used to sign tokens in URLs.  It must be kept secret

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -27,6 +27,7 @@ from indico.util.string import crc32, snakify
 
 
 DEFAULTS = {
+    'ALLOW_PUBLIC_USER_SEARCH': True,
     'ATTACHMENT_STORAGE': 'default',
     'AUTH_PROVIDERS': {},
     'BASE_URL': None,

--- a/indico/modules/attachments/templates/_protection_message.html
+++ b/indico/modules/attachments/templates/_protection_message.html
@@ -3,7 +3,7 @@
 <div class="form-group">
     <div class="form-label"></div>
     <div class="form-field">
-        {{ render_protected_protection_message() }}
+        {{ render_protected_protection_message(users_allowed=users_allowed) }}
         {{ render_inherited_protection_message(parent, parent.type) }}
 
         <div class="action-box for-form folder-protection-message warning">

--- a/indico/modules/attachments/templates/add_link.html
+++ b/indico/modules/attachments/templates/add_link.html
@@ -18,7 +18,7 @@
             var form = $('#attachment-link-form');
             aclIfProtected(
                 $('#{{ form.protected.id }}'),
-                $('#{{ form.acl.id }}'),
+                {% if form.acl %}$('#{{ form.acl.id }}'){% else %}undefined{% endif %},
                 form.find('.protected-protection-message'),
                 form.find('.inheriting-protection-message'),
                 $('#{{ form.folder.id }}')

--- a/indico/modules/attachments/templates/create_folder.html
+++ b/indico/modules/attachments/templates/create_folder.html
@@ -17,7 +17,7 @@
             var form = $('#attachment-folder-form');
             aclIfProtected(
                 $('#{{ form.protected.id }}'),
-                $('#{{ form.acl.id }}'),
+                {% if form.acl %}$('#{{ form.acl.id }}'){% else %}undefined{% endif %},
                 form.find('.protected-protection-message'),
                 form.find('.inheriting-protection-message'),
                 null,

--- a/indico/modules/attachments/templates/upload.html
+++ b/indico/modules/attachments/templates/upload.html
@@ -33,7 +33,7 @@
             var form = $('#attachment-upload-form');
             aclIfProtected(
                 $('#{{ form.protected.id }}'),
-                $('#{{ form.acl.id }}'),
+                {% if form.acl %}$('#{{ form.acl.id }}'){% else %}undefined{% endif %},
                 form.find('.protected-protection-message'),
                 form.find('.inheriting-protection-message'),
                 $('#{{ form.folder.id }}')

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -127,7 +127,7 @@ class AbstractSubmissionSettingsForm(IndicoForm):
                                                     enum=SubmissionRightsType, sorted=True,
                                                     description=_('Specify who will get contribution submission rights '
                                                                   'once an abstract has been accepted'))
-    authorized_submitters = PrincipalListField(_('Authorized submitters'), event=lambda form: form.event,
+    authorized_submitters = PrincipalListField(_('Authorized submitters'),
                                                allow_external_users=True, allow_groups=True,
                                                allow_event_roles=True, allow_category_roles=True,
                                                description=_('These users may always submit abstracts, '
@@ -498,7 +498,9 @@ class AbstractForm(IndicoForm):
         if not is_invited:
             self.person_links.require_speaker_author = abstracts_settings.get(self.event, 'speakers_required')
             self.person_links.allow_speakers = abstracts_settings.get(self.event, 'allow_speakers')
-            self.person_links.disable_user_search = session.user is None
+            self.person_links.disable_user_search = ((not config.ALLOW_PUBLIC_USER_SEARCH and
+                                                      not self.event.can_manage(session.user)) or
+                                                     session.user is None)
         else:
             self.person_links.require_primary_author = False
 

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -13,6 +13,7 @@ from wtforms.fields.core import SelectField
 from wtforms.fields.html5 import URLField
 from wtforms.validators import DataRequired, InputRequired, ValidationError
 
+from indico.core.config import config
 from indico.core.db import db
 from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.categories.fields import CategoryField
@@ -97,3 +98,7 @@ class LectureCreationForm(EventCreationFormBase):
     person_link_data = EventPersonLinkListField(_('Speakers'))
     description = TextAreaField(_('Description'), widget=CKEditorWidget())
     theme = IndicoThemeSelectField(_('Theme'), event_type=EventType.lecture, allow_default=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.person_link_data.disable_user_search = not config.ALLOW_PUBLIC_USER_SEARCH and not session.user.is_admin

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -13,7 +13,9 @@ from marshmallow import fields
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import contains_eager, joinedload
 from webargs import validate
+from werkzeug.exceptions import Forbidden
 
+from indico.core.config import config
 from indico.core.db import db
 from indico.core.db.sqlalchemy.custom.unaccent import unaccent_match
 from indico.core.db.sqlalchemy.principals import PrincipalType
@@ -381,6 +383,11 @@ class RHEditEventPerson(RHPersonsBase):
 
 
 class RHEventPersonSearch(RHAuthenticatedEventBase):
+    def _check_access(self):
+        RHAuthenticatedEventBase._check_access(self)
+        if not config.ALLOW_PUBLIC_USER_SEARCH and not self.event.can_manage(session.user):
+            raise Forbidden
+
     def _search_event_persons(self, exact=False, **criteria):
         criteria = {key: v for key, value in criteria.items() if (v := value.strip())}
 

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -331,8 +331,7 @@ class RegistrationManagersForm(IndicoForm):
 
     managers = PrincipalListField(_('Registration managers'), allow_groups=True, allow_emails=True,
                                   allow_external_users=True,
-                                  description=_('List of users allowed to modify registrations'),
-                                  event=lambda form: form.event)
+                                  description=_('List of users allowed to modify registrations'))
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -105,6 +105,9 @@ def check_registration_email(regform, email, registration=None, management=False
     user = get_user_by_email(email)
     email_registration = regform.get_registration(email=email)
     user_registration = regform.get_registration(user=user) if user else None
+    if not registration or registration.email != email:
+        if email_err := validate_email_verbose(email):
+            return dict(status='error', conflict='email-invalid', email_error=email_err)
     extra_checks = values_from_signal(
         signals.event.before_check_registration_email.send(
             regform,
@@ -126,9 +129,6 @@ def check_registration_email(regform, email, registration=None, management=False
         elif user:
             return dict(status='ok', user=user.full_name, self=(not management and user == session.user),
                         same=(user == registration.user))
-        email_err = validate_email_verbose(email)
-        if email_err:
-            return dict(status='error', conflict='email-invalid', email_error=email_err)
         if regform.require_user and (management or email != registration.email):
             return dict(status='warning' if management else 'error', conflict='no-user')
         else:
@@ -140,9 +140,6 @@ def check_registration_email(regform, email, registration=None, management=False
             return dict(status='error', conflict='user-already-registered')
         elif user:
             return dict(status='ok', user=user.full_name, self=(not management and user == session.user), same=False)
-        email_err = validate_email_verbose(email)
-        if email_err:
-            return dict(status='error', conflict='email-invalid', email_error=email_err)
         if regform.require_user:
             return dict(status='warning' if management else 'error', conflict='no-user')
         else:

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -116,6 +116,8 @@ def check_registration_email(regform, email, registration=None, management=False
         as_list=True)
     if extra_checks:
         return sorted(extra_checks, key=lambda x: ['error', 'warning', 'ok'].index(x['status']))[0]
+    if user != session.user and not management and not config.ALLOW_PUBLIC_USER_SEARCH:
+        return dict(status='error', conflict='email-other-user')
     if registration is not None:
         if email_registration and email_registration != registration:
             return dict(status='error', conflict='email-already-registered')

--- a/indico/modules/users/client/js/Favorites.jsx
+++ b/indico/modules/users/client/js/Favorites.jsx
@@ -21,14 +21,17 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 import './Favorites.module.scss';
 
-window.setupFavoriteSelection = function setupFavoriteSelection(userId) {
-  ReactDOM.render(<FavoriteManager userId={userId} />, document.getElementById('user-favorites'));
+window.setupFavoriteSelection = function setupFavoriteSelection(userId, userSearchDisabled) {
+  ReactDOM.render(
+    <FavoriteManager userId={userId} userSearchDisabled={userSearchDisabled} />,
+    document.getElementById('user-favorites')
+  );
 };
 
-function FavoriteManager({userId}) {
+function FavoriteManager({userId, userSearchDisabled}) {
   return (
     <>
-      <FavoriteUserManager userId={userId} />
+      <FavoriteUserManager userId={userId} userSearchDisabled={userSearchDisabled} />
       <FavoriteCatManager userId={userId} />
     </>
   );
@@ -36,10 +39,12 @@ function FavoriteManager({userId}) {
 
 FavoriteManager.propTypes = {
   userId: PropTypes.number,
+  userSearchDisabled: PropTypes.bool,
 };
 
 FavoriteManager.defaultProps = {
   userId: null,
+  userSearchDisabled: false,
 };
 
 function FavoriteCatManager({userId}) {
@@ -135,7 +140,7 @@ FavoriteCatManager.defaultProps = {
   userId: null,
 };
 
-function FavoriteUserManager({userId}) {
+function FavoriteUserManager({userId, userSearchDisabled}) {
   const [favoriteUsers, [addFavoriteUser, deleteFavoriteUser], loading] = useFavoriteUsers(userId);
 
   const searchTrigger = triggerProps => (
@@ -189,19 +194,23 @@ function FavoriteUserManager({userId}) {
           )}
         </div>
       </div>
-      <UserSearch
-        existing={Object.values(favoriteUsers).map(u => u.identifier)}
-        onAddItems={e => e.forEach(u => addFavoriteUser(u.userId))}
-        triggerFactory={searchTrigger}
-      />
+      {!userSearchDisabled && (
+        <UserSearch
+          existing={Object.values(favoriteUsers).map(u => u.identifier)}
+          onAddItems={e => e.forEach(u => addFavoriteUser(u.userId))}
+          triggerFactory={searchTrigger}
+        />
+      )}
     </div>
   );
 }
 
 FavoriteUserManager.propTypes = {
   userId: PropTypes.number,
+  userSearchDisabled: PropTypes.bool,
 };
 
 FavoriteUserManager.defaultProps = {
   userId: null,
+  userSearchDisabled: false,
 };

--- a/indico/modules/users/templates/favorites.html
+++ b/indico/modules/users/templates/favorites.html
@@ -7,7 +7,10 @@
         </div>
     </div>
     <script>
-        setupFavoriteSelection({{ (user.id if user != session.user else none) | tojson }});
+        setupFavoriteSelection(
+            {{ (user.id if user != session.user else none) | tojson }},
+            {{ user_search_disabled | tojson }}
+        );
         (function() {
             $('.js-delete-category').on('click', function(e){
                 e.preventDefault();

--- a/indico/web/client/js/jquery/utils/forms.js
+++ b/indico/web/client/js/jquery/utils/forms.js
@@ -282,7 +282,9 @@
     folderProtection
   ) {
     protectionField.on('change', function() {
-      toggleAclField(aclField, !this.checked);
+      if (aclField) {
+        toggleAclField(aclField, !this.checked);
+      }
 
       if (selfProtection && inheritedProtection) {
         selfProtection.toggle(this.checked);

--- a/indico/web/client/js/jquery/widgets/jinja/permissions_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/permissions_widget.js
@@ -24,6 +24,8 @@ import Palette from 'indico/utils/palette';
       permissionsInfo: null,
       hiddenPermissions: null,
       hiddenPermissionsInfo: null,
+      eventId: null,
+      categoryId: null,
     },
 
     _update() {
@@ -494,6 +496,8 @@ import Palette from 'indico/utils/palette';
                   this._addItems(items, [READ_ACCESS_PERMISSIONS]);
                 }}
                 triggerFactory={userSearchTrigger}
+                eventId={this.options.eventId}
+                categoryId={this.options.categoryId}
               />
               <GroupSearch
                 existing={existing.filter(e => e.startsWith('Group'))}

--- a/indico/web/client/js/jquery/widgets/jinja/person_link_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/person_link_widget.js
@@ -24,6 +24,7 @@ import {$T} from 'indico/utils/i18n';
         fieldId: null,
         disableUserSearch: false,
         eventId: null,
+        categoryId: null,
         authorTypes: null,
         showEmptyCoauthors: true,
         sort: true,
@@ -535,18 +536,20 @@ import {$T} from 'indico/utils/i18n';
             );
             forceUpdateUserSearch();
           }}
-          disabled={options.disableUserSearch}
           withExternalUsers={options.allow.externalUsers}
           triggerFactory={searchTrigger}
           withEventPersons={options.eventId !== null}
           eventId={options.eventId}
+          categoryId={options.categoryId}
         />
       );
     };
 
-    ReactDOM.render(
-      <UserSearchWrapper />,
-      document.getElementById(`principalField-${options.fieldId}`)
-    );
+    if (!options.disableUserSearch) {
+      ReactDOM.render(
+        <UserSearchWrapper />,
+        document.getElementById(`principalField-${options.fieldId}`)
+      );
+    }
   };
 })(window);

--- a/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
@@ -9,10 +9,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {WTFPrincipalListField} from 'indico/react/components';
 
-window.setupPrincipalListWidget = function setupPrincipalListWidget({fieldId, ...options}) {
+window.setupPrincipalListWidget = function setupPrincipalListWidget({fieldId, eventId, ...options}) {
   options = {
     ...{
-      eventId: null,
       withGroups: false,
       withExternalUsers: false,
       withEventRoles: false,
@@ -26,7 +25,11 @@ window.setupPrincipalListWidget = function setupPrincipalListWidget({fieldId, ..
   const principals = JSON.parse(field.value);
 
   ReactDOM.render(
-    <WTFPrincipalListField fieldId={fieldId} defaultValue={principals} {...options} />,
+    <WTFPrincipalListField
+      fieldId={fieldId}
+      defaultValue={principals}
+      eventId={eventId}
+      {...options} />,
     document.getElementById(`userGroupList-${fieldId}`)
   );
 };

--- a/indico/web/client/js/jquery/widgets/jinja/principal_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_widget.js
@@ -14,6 +14,8 @@ window.setupPrincipalWidget = function setupPrincipalWidget({
   required,
   withExternalUsers,
   disabled,
+  eventId,
+  categoryId
 }) {
   const field = document.getElementById(fieldId);
 
@@ -24,6 +26,8 @@ window.setupPrincipalWidget = function setupPrincipalWidget({
       required={required}
       withExternalUsers={withExternalUsers}
       disabled={disabled}
+      eventId={eventId}
+      categoryId={categoryId}
     />,
     document.getElementById(`principalField-${fieldId}`)
   );

--- a/indico/web/client/js/react/components/WTFPrincipalField.jsx
+++ b/indico/web/client/js/react/components/WTFPrincipalField.jsx
@@ -19,6 +19,8 @@ export default function WTFPrincipalField({
   required,
   disabled,
   withExternalUsers,
+  eventId,
+  categoryId,
 }) {
   const favoriteUsersController = useFavoriteUsers();
   const inputField = useMemo(() => document.getElementById(fieldId), [fieldId]);
@@ -44,6 +46,8 @@ export default function WTFPrincipalField({
       onBlur={() => {}}
       value={value}
       styleName="fixed-width"
+      eventId={eventId}
+      categoryId={categoryId}
     />
   );
 }
@@ -54,6 +58,8 @@ WTFPrincipalField.propTypes = {
   withExternalUsers: PropTypes.bool,
   required: PropTypes.bool,
   disabled: PropTypes.bool,
+  eventId: PropTypes.number,
+  categoryId: PropTypes.number,
 };
 
 WTFPrincipalField.defaultProps = {
@@ -61,4 +67,6 @@ WTFPrincipalField.defaultProps = {
   withExternalUsers: false,
   required: false,
   disabled: false,
+  eventId: null,
+  categoryId: null,
 };

--- a/indico/web/client/js/react/components/principals/PrincipalField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalField.jsx
@@ -35,6 +35,8 @@ const PrincipalField = props => {
     favoriteUsersController,
     withExternalUsers,
     className,
+    eventId,
+    categoryId,
   } = props;
   const [favoriteUsers, [handleAddFavorite, handleDelFavorite]] = favoriteUsersController;
 
@@ -100,6 +102,8 @@ const PrincipalField = props => {
       favorites={favoriteUsers}
       disabled={disabled}
       withExternalUsers={withExternalUsers}
+      eventId={eventId}
+      categoryId={categoryId}
       single
     />
   );
@@ -143,6 +147,8 @@ PrincipalField.propTypes = {
   favoriteUsersController: PropTypes.array.isRequired,
   withExternalUsers: PropTypes.bool,
   className: PropTypes.string,
+  eventId: PropTypes.number,
+  categoryId: PropTypes.number,
 };
 
 PrincipalField.defaultProps = {
@@ -150,6 +156,8 @@ PrincipalField.defaultProps = {
   required: false,
   withExternalUsers: false,
   className: '',
+  eventId: null,
+  categoryId: null,
 };
 
 export default React.memo(PrincipalField);

--- a/indico/web/client/js/react/components/principals/PrincipalListField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalListField.jsx
@@ -126,6 +126,7 @@ const PrincipalListField = props => {
                 withExternalUsers={withExternalUsers}
                 onOpen={onFocus}
                 onClose={onBlur}
+                eventId={eventId}
               />
               {withGroups && (
                 <GroupSearch

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -267,6 +267,7 @@ const searchFactory = config => {
     single,
     withEventPersons,
     eventId,
+    categoryId,
   }) => {
     const [loading, setLoading] = useState(false);
     const [result, _setResult] = useState(null);
@@ -281,7 +282,7 @@ const searchFactory = config => {
     const handleSearch = async data => {
       setLoading(true);
       try {
-        await runSearch(data, setResult, withEventPersons, eventId);
+        await runSearch(data, setResult, withEventPersons, eventId, categoryId);
       } finally {
         setLoading(false);
       }
@@ -377,6 +378,7 @@ const searchFactory = config => {
     onClose,
     withEventPersons,
     eventId,
+    categoryId,
   }) => {
     const [open, setOpen] = useState(defaultOpen);
     const [staged, setStaged] = useState([]);
@@ -469,6 +471,7 @@ const searchFactory = config => {
             single={single}
             withEventPersons={withEventPersons}
             eventId={eventId}
+            categoryId={categoryId}
           />
         </Modal.Content>
         <Modal.Actions>
@@ -498,6 +501,7 @@ const searchFactory = config => {
     onClose: PropTypes.func,
     withEventPersons: PropTypes.bool,
     eventId: PropTypes.number,
+    categoryId: PropTypes.number,
   };
 
   Search.defaultProps = {
@@ -511,6 +515,7 @@ const searchFactory = config => {
     onClose: () => {},
     withEventPersons: false,
     eventId: null,
+    categoryId: null,
   };
 
   const component = React.memo(Search);
@@ -566,13 +571,17 @@ const InnerUserSearch = searchFactory({
       return {[FORM_ERROR]: 'No criteria specified'};
     }
   },
-  runSearch: async (data, setResult, withEventPersons, eventId) => {
+  runSearch: async (data, setResult, withEventPersons, eventId, categoryId) => {
     setResult(null);
     const values = _.fromPairs(Object.entries(data).filter(([, val]) => !!val));
     values.favorites_first = true;
+    const objectIds = {
+      event_id: eventId !== null ? eventId : '',
+      category_id: categoryId !== null ? categoryId : '',
+    };
     let response;
     try {
-      response = await indicoAxios.get(userSearchURL(values));
+      response = await indicoAxios.get(userSearchURL({...values, ...objectIds}));
     } catch (error) {
       return handleSubmitError(error);
     }

--- a/indico/web/forms/fields/principals.py
+++ b/indico/web/forms/fields/principals.py
@@ -76,8 +76,11 @@ class PrincipalListField(HiddenField):
         self.allow_category_roles = kwargs.pop('allow_category_roles', False)
         self.allow_registration_forms = kwargs.pop('allow_registration_forms', False)
         self.allow_emails = kwargs.pop('allow_emails', False)
-        self._event = kwargs.pop('event')(kwargs['_form']) if 'event' in kwargs else None
         super().__init__(*args, **kwargs)
+
+    @property
+    def event(self):
+        return self.get_form().event
 
     def _convert_principal(self, principal):
         event_id = self._event.id if self._event else None
@@ -125,6 +128,10 @@ class PrincipalField(HiddenField):
     def __init__(self, *args, **kwargs):
         self.allow_external_users = kwargs.pop('allow_external_users', False)
         super().__init__(*args, **kwargs)
+
+    @property
+    def event(self):
+        return self.get_form().event
 
     def process_formdata(self, valuelist):
         if valuelist:

--- a/indico/web/templates/_protection_messages.html
+++ b/indico/web/templates/_protection_messages.html
@@ -16,7 +16,7 @@
     </div>
 {%- endmacro %}
 
-{% macro render_protected_protection_message() -%}
+{% macro render_protected_protection_message(users_allowed=true) -%}
     <div class="action-box for-form protection-message protected-protection-message danger">
         <div class="section">
             <div class="icon icon-lock"></div>
@@ -25,9 +25,17 @@
                     {% trans %}Protected{% endtrans %}
                 </div>
                 <div>
-                    {% trans -%}
-                        This object is <strong>only</strong> accessible by the <strong>users specified</strong> above and the <strong>managers</strong> of <strong>parent resources</strong>.
-                    {%- endtrans %}
+                    {% if users_allowed %}
+                        {% trans -%}
+                            This object is <strong>only</strong> accessible by you, the <strong>users specified</strong>
+                            above and the <strong>managers</strong> of <strong>parent resources</strong>.
+                        {%- endtrans %}
+                    {% else %}
+                        {% trans -%}
+                            This object is <strong>only</strong> accessible by you and the <strong>managers</strong> of
+                            <strong>parent resources</strong>.
+                        {%- endtrans %}
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/indico/web/templates/forms/_person_link_widget_base.html
+++ b/indico/web/templates/forms/_person_link_widget_base.html
@@ -51,6 +51,7 @@
         setupPersonLinkWidget({
             fieldId: {{ field.id | tojson }},
             eventId: {{ (field.event.id if field.event else none) | tojson }},
+            categoryId: {{ (field.category.id if field.category else none) | tojson }},
             disableUserSearch: {{ field.disable_user_search | default(false) | tojson }},
             authorTypes: {{ (field.author_types or none) | tojson }},
             showEmptyCoauthors: {{ field.show_empty_coauthors | default(true) | tojson }},

--- a/indico/web/templates/forms/permissions_widget.html
+++ b/indico/web/templates/forms/permissions_widget.html
@@ -59,7 +59,9 @@
             objectType: {{ field.object_type|tojson }},
             permissionsInfo: {{ field.permissions_info|tojson }},
             hiddenPermissions: {{ field.hidden_permissions|default([])|tojson }},
-            hiddenPermissionsInfo: {{ field.hidden_permissions_info|tojson }}
+            hiddenPermissionsInfo: {{ field.hidden_permissions_info|tojson }},
+            eventId: {{ (field.event.id if field.event else none)|tojson }},
+            categoryId: {{ (field.category.id if field.category else none)|tojson }},
         });
     </script>
 {% endblock %}

--- a/indico/web/templates/forms/principal_list_widget.html
+++ b/indico/web/templates/forms/principal_list_widget.html
@@ -16,7 +16,7 @@
     <script>
         setupPrincipalListWidget({
             fieldId: {{ field.id | tojson }},
-            eventId: {{ (field._event.id if field._event else none) | tojson }},
+            eventId: {{ (field.event.id if field.event else none) | tojson }},
             withGroups: {{  field.allow_groups | tojson }},
             withExternalUsers: {{ field.allow_external_users | tojson }},
             withEventRoles: {{ field.allow_event_roles | tojson }},

--- a/indico/web/templates/forms/principal_widget.html
+++ b/indico/web/templates/forms/principal_widget.html
@@ -14,7 +14,9 @@
             fieldId: {{ field.id | tojson }},
             required: {{ input_args.required | default(false) | tojson }},
             withExternalUsers: {{ field.allow_external_users | tojson }},
-            disabled: {{ (field.render_kw.disabled if field.render_kw else false) | tojson }}
+            disabled: {{ (field.render_kw.disabled if field.render_kw else false) | tojson }},
+            eventId: {{ (field.event.id if field.event else none) | tojson }},
+            categoryId: {{ (field.category.id if field.category else none) | tojson }}
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
This PR makes it possible for Indico instances to limit searching users by email to only managers. This includes:
- Disabling registering to events as a different user than the one logged in.
- Disabling speakers to give access to specific users/groups in protected uploaded material.
- Disabling users to add other users as author/co-author in abstract submissions (details must be added manually).