### PR TITLE
Allow imagemaps in advanced RichText editors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 
 - Add ``event.before_check_registration_email`` signal (:pr:`5021`, thanks :user:`omegak`)
+- Do not strip image maps in places where HTML is allowed (:pr:`5026`, thanks
+  :user:`bpedersen2`)
 
 
 Version 3.0

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -49,7 +49,7 @@ BLEACH_ALLOWED_ATTRIBUTES_HTML = BLEACH_ALLOWED_ATTRIBUTES | {'*': [
     'id', 'ismap', 'lang', 'name', 'noshade', 'nowrap', 'rel', 'rev', 'rowspan', 'rules', 'size', 'scope', 'shape',
     'span', 'src', 'start', 'style', 'summary', 'tabindex', 'target', 'title', 'type', 'valign', 'value', 'vspace',
     'width', 'wrap'
-]}
+], 'img': [*BLEACH_ALLOWED_ATTRIBUTES['img'], 'usemap'], 'area': ['coords']}
 BLEACH_ALLOWED_STYLES_HTML = [
     'background-color', 'border-top-color', 'border-top-style', 'border-top-width', 'border-top', 'border-right-color',
     'border-right-style', 'border-right-width', 'border-right', 'border-bottom-color', 'border-bottom-style',

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -11,8 +11,8 @@ from itertools import count
 import pytest
 
 from indico.util.string import (camelize, camelize_keys, crc32, format_repr, html_to_plaintext, make_unique_token,
-                                normalize_phone_number, render_markdown, sanitize_email, seems_html, slugify, snakify,
-                                snakify_keys, strip_tags, text_to_repr)
+                                normalize_phone_number, render_markdown, sanitize_email, sanitize_html, seems_html,
+                                slugify, snakify, snakify_keys, strip_tags, text_to_repr)
 
 
 def test_seems_html():
@@ -209,3 +209,13 @@ def test_html_to_plaintext(input, output):
 ))
 def test_markdown(input, output):
     assert render_markdown(input,  extensions=('tables',)) == output
+
+
+def test_sanitize_html_imagemaps():
+    html = '''
+        <img src="example.jpg" usemap="#image-map">
+        <map name="image-map">
+            <area alt="test" coords="1,2,3,4" href="//example.com" shape="rect" target="_blank" title="test">
+        </map>
+    '''
+    assert sanitize_html(html) == html

--- a/indico/web/client/js/legacy/libs/indico/Core/Widgets/RichText.js
+++ b/indico/web/client/js/legacy/libs/indico/Core/Widgets/RichText.js
@@ -278,7 +278,7 @@ function initializeEditor(
       format_tags: 'p;h1;h2;h3;pre',
       removeDialogTabs: 'image:advanced;link:advanced',
       // Note: *(*) => allow additional classes on any allowed element
-      extraAllowedContent: 'dl dt dd div span pre; *(*)',
+      extraAllowedContent: 'dl dt dd div span pre; *(*); img[usemap]; area[*]; map[*]',
     };
 
     if (simple) {


### PR DESCRIPTION
 - enable area and map elements for ckeditor
 - enable usemap on img tags in ckeditor
 - enable the coords and usemap attributes in bleach

Note: map and area where already enabled in the bleach filters.