### PR TITLE
Extract badge format logic into util

### DIFF
--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -40,8 +40,9 @@ from indico.modules.events.registration.models.items import PersonalDataType, Re
 from indico.modules.events.registration.models.registrations import Registration, RegistrationData, RegistrationState
 from indico.modules.events.registration.notifications import notify_registration_state_update
 from indico.modules.events.registration.settings import event_badge_settings
-from indico.modules.events.registration.util import (create_registration, generate_spreadsheet_from_registrations,
-                                                     get_event_section_data, get_ticket_attachments, get_title_uuid,
+from indico.modules.events.registration.util import (BadgeFormatMixin, create_registration,
+                                                     generate_spreadsheet_from_registrations, get_event_section_data,
+                                                     get_ticket_attachments, get_title_uuid,
                                                      import_registrations_from_csv, make_registration_form)
 from indico.modules.events.registration.views import WPManageRegistration
 from indico.modules.events.util import ZipGeneratorMixin
@@ -427,25 +428,11 @@ class RHRegistrationsPrintBadges(RHRegistrationsActionBase):
         return send_file(f'Badges-{self.event.id}.pdf', pdf.get_pdf(), 'application/pdf')
 
 
-class RHRegistrationsConfigBadges(RHRegistrationsActionBase):
+class RHRegistrationsConfigBadges(BadgeFormatMixin, RHRegistrationsActionBase):
     """Print badges for the selected registrations."""
 
     ALLOW_LOCKED = True
     TICKET_BADGES = False
-
-    format_map_portrait = {
-        'A0': (84.1, 118.9),
-        'A1': (59.4, 84.1),
-        'A2': (42.0, 59.4),
-        'A3': (29.7, 42.0),
-        'A4': (21.0, 29.7),
-        'A5': (14.8, 21.0),
-        'A6': (10.5, 14.8),
-        'A7': (7.4, 10.5),
-        'A8': (5.2, 7.4),
-    }
-
-    format_map_landscape = {name: (h, w) for name, (w, h) in format_map_portrait.items()}
 
     def _process_args(self):
         RHManageRegFormBase._process_args(self)
@@ -456,13 +443,6 @@ class RHRegistrationsConfigBadges(RHRegistrationsActionBase):
                               .order_by(*Registration.order_by_name)
                               .all()) if ids else []
         self.template_id = request.args.get('template_id', self._default_template_id)
-
-    def _get_format(self, tpl):
-        from indico.modules.designer.pdf import PIXELS_CM
-        format_map = self.format_map_landscape if tpl.data['width'] > tpl.data['height'] else self.format_map_portrait
-        return next((frm for frm, frm_size in format_map.items()
-                     if (frm_size[0] == float(tpl.data['width']) / PIXELS_CM and
-                         frm_size[1] == float(tpl.data['height']) / PIXELS_CM)), 'custom')
 
     @property
     def _default_template_id(self):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -22,7 +22,7 @@ from indico.core.notifications import make_email, send_email
 from indico.legacy.pdfinterface.conference import RegistrantsListToBookPDF, RegistrantsListToPDF
 from indico.modules.designer import PageLayout, TemplateType
 from indico.modules.designer.models.templates import DesignerTemplate
-from indico.modules.designer.util import get_inherited_templates
+from indico.modules.designer.util import get_badge_format, get_inherited_templates
 from indico.modules.events import EventLogKind, EventLogRealm
 from indico.modules.events.payment.models.transactions import TransactionAction
 from indico.modules.events.payment.util import register_transaction
@@ -40,9 +40,8 @@ from indico.modules.events.registration.models.items import PersonalDataType, Re
 from indico.modules.events.registration.models.registrations import Registration, RegistrationData, RegistrationState
 from indico.modules.events.registration.notifications import notify_registration_state_update
 from indico.modules.events.registration.settings import event_badge_settings
-from indico.modules.events.registration.util import (BadgeFormatMixin, create_registration,
-                                                     generate_spreadsheet_from_registrations, get_event_section_data,
-                                                     get_ticket_attachments, get_title_uuid,
+from indico.modules.events.registration.util import (create_registration, generate_spreadsheet_from_registrations,
+                                                     get_event_section_data, get_ticket_attachments, get_title_uuid,
                                                      import_registrations_from_csv, make_registration_form)
 from indico.modules.events.registration.views import WPManageRegistration
 from indico.modules.events.util import ZipGeneratorMixin
@@ -428,7 +427,7 @@ class RHRegistrationsPrintBadges(RHRegistrationsActionBase):
         return send_file(f'Badges-{self.event.id}.pdf', pdf.get_pdf(), 'application/pdf')
 
 
-class RHRegistrationsConfigBadges(BadgeFormatMixin, RHRegistrationsActionBase):
+class RHRegistrationsConfigBadges(RHRegistrationsActionBase):
     """Print badges for the selected registrations."""
 
     ALLOW_LOCKED = True
@@ -457,7 +456,7 @@ class RHRegistrationsConfigBadges(BadgeFormatMixin, RHRegistrationsActionBase):
             'data': tpl.data,
             'backside_tpl_id': tpl.backside_template_id,
             'orientation': 'landscape' if tpl.data['width'] > tpl.data['height'] else 'portrait',
-            'format': self._get_format(tpl)
+            'format': get_badge_format(tpl)
         } for tpl in all_templates if tpl.type.name == 'badge'}
         settings = event_badge_settings.get_all(self.event.id)
         form = BadgeSettingsForm(self.event, template=self.template_id, tickets=self.TICKET_BADGES, **settings)

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -630,3 +630,28 @@ def serialize_registration_form(regform):
         'identifier': f'RegistrationForm:{regform.id}',
         '_type': 'RegistrationForm'
     }
+
+
+class BadgeFormatMixin(object):
+    """Mixin for RHs that generate badge PDF files."""
+
+    format_map_portrait = {
+        'A0': (84.1, 118.9),
+        'A1': (59.4, 84.1),
+        'A2': (42.0, 59.4),
+        'A3': (29.7, 42.0),
+        'A4': (21.0, 29.7),
+        'A5': (14.8, 21.0),
+        'A6': (10.5, 14.8),
+        'A7': (7.4, 10.5),
+        'A8': (5.2, 7.4),
+    }
+
+    format_map_landscape = {name: (h, w) for name, (w, h) in format_map_portrait.items()}
+
+    def _get_format(self, tpl):
+        from indico.modules.designer.pdf import PIXELS_CM
+        format_map = self.format_map_landscape if tpl.data['width'] > tpl.data['height'] else self.format_map_portrait
+        return next((frm for frm, frm_size in format_map.items()
+                     if (frm_size[0] == float(tpl.data['width']) / PIXELS_CM and
+                         frm_size[1] == float(tpl.data['height']) / PIXELS_CM)), 'custom')

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -630,28 +630,3 @@ def serialize_registration_form(regform):
         'identifier': f'RegistrationForm:{regform.id}',
         '_type': 'RegistrationForm'
     }
-
-
-class BadgeFormatMixin(object):
-    """Mixin for RHs that generate badge PDF files."""
-
-    format_map_portrait = {
-        'A0': (84.1, 118.9),
-        'A1': (59.4, 84.1),
-        'A2': (42.0, 59.4),
-        'A3': (29.7, 42.0),
-        'A4': (21.0, 29.7),
-        'A5': (14.8, 21.0),
-        'A6': (10.5, 14.8),
-        'A7': (7.4, 10.5),
-        'A8': (5.2, 7.4),
-    }
-
-    format_map_landscape = {name: (h, w) for name, (w, h) in format_map_portrait.items()}
-
-    def _get_format(self, tpl):
-        from indico.modules.designer.pdf import PIXELS_CM
-        format_map = self.format_map_landscape if tpl.data['width'] > tpl.data['height'] else self.format_map_portrait
-        return next((frm for frm, frm_size in format_map.items()
-                     if (frm_size[0] == float(tpl.data['width']) / PIXELS_CM and
-                         frm_size[1] == float(tpl.data['height']) / PIXELS_CM)), 'custom')


### PR DESCRIPTION
 - We have a new module called `Accreditation` which is connected to a `Category` for badge printing purposes.
 - The RH to print badge which generates pdf has some duplicated code to avoid it may we have a Mixin upstream?
 - This would close [this code review suggestion](https://github.com/UNOG-Indico/indico-un/pull/505#discussion_r681896699)
 
 
![image](https://user-images.githubusercontent.com/20479333/128181394-5bbd48f4-8113-4e8c-9db4-2ed649716da8.png)
