### PR TITLE
Preserve multi-choice field order in registration emails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Bugfixes
 - Show correct placeholders in date picker fields (:pr:`5022`)
 - Correctly preselect the default currency when creating a registration form
 - Do not notify registrants when a payment transaction is created in "pending" state
+- Keep the order of multi-choice options in registration summary (:issue:`5020`, :pr:`5032`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Closes #5020 

The problem is that `RegistrationData` is juggled around in many
places and doesn't keep the order given by the `RegistrationFormField`.
This is a problem only when asked for `friendly_data`.

Since `RegistrationData` keeps a reference to the underlying form field,
we can restore the order when we get the friendly data.

