### PR TITLE
Allow filtering abstracts by 'No selection'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Version 3.0.1
 
 *Unreleased*
 
+Improvements
+^^^^^^^^^^^^
+
+- Allow filtering abstracts by custom fields having no value (:issue:`5033`, :pr:`5034`)
+
 Bugfixes
 ^^^^^^^^
 

--- a/indico/modules/events/contributions/models/fields.py
+++ b/indico/modules/events/contributions/models/fields.py
@@ -131,9 +131,8 @@ class ContributionField(db.Model):
 
     @property
     def filter_choices(self):
-        choices = {x['id']: x['option'] for x in self.field_data.get('options', {})}
-        choices['_None'] = _('No selection')
-        return choices
+        no_value = {None: _('No value')}
+        return no_value | {x['id']: x['option'] for x in self.field_data.get('options', {})}
 
     def __repr__(self):
         return format_repr(self, 'id', 'field_type', is_required=False, is_active=True, _text=self.title)

--- a/indico/modules/events/contributions/models/fields.py
+++ b/indico/modules/events/contributions/models/fields.py
@@ -131,7 +131,9 @@ class ContributionField(db.Model):
 
     @property
     def filter_choices(self):
-        return {x['id']: x['option'] for x in self.field_data.get('options', {})}
+        choices = {x['id']: x['option'] for x in self.field_data.get('options', {})}
+        choices['_None'] = _('No selection')
+        return choices
 
     def __repr__(self):
         return format_repr(self, 'id', 'field_type', is_required=False, is_active=True, _text=self.title)


### PR DESCRIPTION
Closes #5033 

Adds an extra filter option 'No selection' to custom abstract fields in the abstract list filter view.
This can be used to filter abstracts where no value for the given field has been selected.

![image](https://user-images.githubusercontent.com/179599/129012862-9ec7c84d-14ed-409a-8573-35d84007506b.png)
