### PR TITLE
Add "invite-options" template hook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Internal Changes
   :user:`bpedersen2`)
 - Add ``event.registration.after_registration_form_clone`` signal (:pr:`5037`, thanks
   :user:`vasantvohra`)
+- Add ``registration-invite-options`` template hook (:pr:`5045`, thanks :user:`vasantvohra`)
 
 
 Version 3.0

--- a/indico/modules/events/registration/templates/management/regform_invitations.html
+++ b/indico/modules/events/registration/templates/management/regform_invitations.html
@@ -21,6 +21,7 @@
                     </div>
                 </div>
                 <div class="toolbar">
+                    {{ template_hook('registration-invite-options', event=event, regform=regform) }}
                     <a class="i-button icon-user arrow js-dropdown" data-toggle="dropdown">
                         {% trans %}Invite{% endtrans %}
                     </a>


### PR DESCRIPTION
Working on a new feature at the UN plugin side, which allows importing and sending invitations in bulk using excel. This requires the addition of buttons on the core template. Therefore, I'd like to add a template hook there.

Let me know if any changes are required on this PR.

Here are some screenshots for reference :)
<img width="1280" alt="Screenshot 2021-08-18 at 6 16 27 PM" src="https://user-images.githubusercontent.com/20479333/129902044-340e1ee1-c7e6-4aa4-a530-f75d16f734b3.png">

<img width="1280" alt="Screenshot 2021-08-18 at 6 17 16 PM" src="https://user-images.githubusercontent.com/20479333/129902058-b222c478-c70e-4f29-932f-9e7023532ca2.png">
