### PR TITLE
Fix broken permalinks with query string args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Bugfixes
 - Correctly handle relative URLs in PDF generation (:issue:`5042`, :pr:`5044`)
 - Render markdown in track descriptions in PDF generation (:issue:`5043`, :pr:`5044`)
 - Fix error when importing chairpersons from an existing event (:pr:`5047`)
+- Fix broken timetable entry permalinks when query string args are present (:pr:`5049`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/js/jquery/utils/declarative.js
+++ b/indico/web/client/js/jquery/utils/declarative.js
@@ -352,7 +352,8 @@ import {$T} from '../../utils/i18n';
       if (stripArg) {
         params.delete(stripArg);
       }
-      const url = window.location.pathname + params.toString();
+      const newQueryString = params.toString();
+      const url = window.location.pathname + (newQueryString ? `?${newQueryString}` : '');
 
       $('<a>', {
         class: 'anchor-link',


### PR DESCRIPTION
URLSearchParams toString does not include the `?` at the beginning, but the code using it expected it to do so.