### PR TITLE
Do not hardcode QR code version in tickets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Improvements
 - Allow filtering abstracts by custom fields having no value (:issue:`5033`, :pr:`5034`)
 - Add support for syncing email addresses when logging in using external accounts
   (:pr:`5035`)
+- Use more space-efficient QR code version in registration tickets (:pr:`5052`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/controllers/management/tickets.py
+++ b/indico/modules/events/registration/controllers/management/tickets.py
@@ -53,7 +53,7 @@ class RHTicketConfigQRCodeImage(RHManageRegFormBase):
     def _process(self):
         # QRCode (Version 6 with error correction L can contain up to 106 bytes)
         qr = qrcode.QRCode(
-            version=6,
+            version=None,
             error_correction=qrcode.constants.ERROR_CORRECT_M,
             box_size=4,
             border=1

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -454,8 +454,8 @@ def generate_ticket_qr_code(registration):
     :param registration: corresponding `Registration` object
     """
     qr = QRCode(
-        version=17,
-        error_correction=constants.ERROR_CORRECT_Q,
+        version=None,
+        error_correction=constants.ERROR_CORRECT_M,
         box_size=3,
         border=1
     )


### PR DESCRIPTION
QR version 17 is very dense and not easily scannable. By not specifying a version the library uses the lowest version that can be used to fit the data, which results in a much more easily scannable QR code (since it's using a bigger grid).

In case someone is curious, https://www.nayuki.io/page/qr-code-generator-library works nicely to play around with the different versions to see how they look like.