### PR TITLE
Force login before showing regform list in 'public registration' events where registering requires a login

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Improvements
 - Add support for syncing email addresses when logging in using external accounts
   (:pr:`5035`)
 - Use more space-efficient QR code version in registration tickets (:pr:`5052`)
+- Improve user experience when accessing an event restricted to registered participants
+  while not logged in (:pr:`5053`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/controllers/base.py
+++ b/indico/modules/events/controllers/base.py
@@ -77,6 +77,10 @@ class RHDisplayEventBase(RHProtectedEventBase):
 
     def _show_registration_form(self):
         displayed_regforms, user_registrations = get_event_regforms_registrations(self.event, session.user)
+        if displayed_regforms and all(r.require_login for r in displayed_regforms) and not session.user:
+            # force the user to log in first. like this they will go back to the page they tried to
+            # originally access in case they are already registered for the event
+            raise Forbidden
         if len(displayed_regforms) == 1:
             return redirect(url_for('event_registration.display_regform', displayed_regforms[0]))
         return redirect(url_for('event_registration.display_regform_list', self.event))


### PR DESCRIPTION
In case a user is registered in an event that's restricted to registered participants and accesses a deep link to an event page (e.g. timetable) while not logged in, we now force them to login befor redirecting them to the registration form(s). Like this the user will end up on the intended page after logging in if they are already registered.