### PR TITLE
Better listed/unlisted field for event creation form

### DIFF
--- a/indico/core/db/sqlalchemy/protection.py
+++ b/indico/core/db/sqlalchemy/protection.py
@@ -212,10 +212,10 @@ class ProtectionMixin:
                 # mixin or a legacy object with an AccessController
                 parent = self.protection_parent
                 if parent is None:
-                    # This should be the case for the top-level object,
-                    # i.e. the root category, which shouldn't allow
-                    # ProtectionMode.inheriting as it makes no sense.
-                    raise TypeError(f'protection_parent of {self} is None')
+                    # This is the case for unlisted events, which are inheriting
+                    # by default but have no parent category, so its parent
+                    # protection won't be checked.
+                    rv = False
                 elif hasattr(parent, 'can_access'):
                     rv = parent.can_access(user, allow_admin=allow_admin)
                 else:

--- a/indico/core/db/sqlalchemy/protection.py
+++ b/indico/core/db/sqlalchemy/protection.py
@@ -317,6 +317,9 @@ class ProtectionMixin:
             self.acl_entries.remove(entry)
 
     def get_inherited_acl(self):
+        if self.protection_parent is None:
+            return []
+
         own_acl = {entry.principal for entry in self.acl_entries}
         parent_acl = self.protection_parent.get_access_list(skip_managers=True)
         return [x for x in parent_acl if x not in own_acl]

--- a/indico/migrations/versions/20210707_1648_dc53d6e8c576_make_event_category_nullable.py
+++ b/indico/migrations/versions/20210707_1648_dc53d6e8c576_make_event_category_nullable.py
@@ -1,0 +1,23 @@
+"""Make event category nullable
+
+Revision ID: dc53d6e8c576
+Revises: 1cec32e42f65
+Create Date: 2021-07-07 16:48:03.719901
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'dc53d6e8c576'
+down_revision = '1cec32e42f65'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('ck_events_category_data_set', 'events', schema='events')
+
+
+def downgrade():
+    op.create_check_constraint('category_data_set', 'events', 'category_id IS NOT NULL OR is_deleted', schema='events')

--- a/indico/migrations/versions/20210813_1633_dc53d6e8c576_make_event_category_nullable.py
+++ b/indico/migrations/versions/20210813_1633_dc53d6e8c576_make_event_category_nullable.py
@@ -1,7 +1,7 @@
 """Make event category nullable
 
 Revision ID: dc53d6e8c576
-Revises: 1cec32e42f65
+Revises: 9d00917b2fa8
 Create Date: 2021-07-07 16:48:03.719901
 """
 
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'dc53d6e8c576'
-down_revision = '1cec32e42f65'
+down_revision = '9d00917b2fa8'
 branch_labels = None
 depends_on = None
 

--- a/indico/modules/admin/views.py
+++ b/indico/modules/admin/views.py
@@ -6,7 +6,7 @@
 # LICENSE file for more details.
 
 from indico.util.i18n import _
-from indico.web.breadcrumbs import render_breadcrumbs
+from indico.web.breadcrumbs import Breadcrumb, render_breadcrumbs
 from indico.web.flask.util import url_for
 from indico.web.menu import get_menu_item
 from indico.web.views import WPDecorated, WPJinjaMixin
@@ -21,7 +21,7 @@ class WPAdmin(WPJinjaMixin, WPDecorated):
 
     def _get_breadcrumbs(self):
         menu_item = get_menu_item('admin-sidemenu', self._kwargs['active_menu_item'])
-        items = [(_('Administration'), url_for('core.admin_dashboard'))]
+        items = [Breadcrumb(_('Administration'), url_for('core.admin_dashboard'))]
         if menu_item:
             items.append(menu_item.title)
         return render_breadcrumbs(*items)

--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -178,14 +178,13 @@ def get_visibility_options(category_or_event, allow_invisible=True):
 
     options = []
 
-    if category is not None:
-        options = [(n + 1, ('{} \N{RIGHTWARDS ARROW} "{}"'.format(_category_above_message(n).format(n), title)))
-                   for n, title in enumerate(category.chain_titles[::-1])]
-        if event is None:
-            options[0] = (1, _('From this category only'))
-        else:
-            options[0] = (1, '{} \N{RIGHTWARDS ARROW} "{}"'.format(_('From the current category only'), category.title))
-        options[-1] = ('', _('From everywhere'))
+    options = [(n + 1, ('{} \N{RIGHTWARDS ARROW} "{}"'.format(_category_above_message(n).format(n), title)))
+               for n, title in enumerate(category.chain_titles[::-1])]
+    if event is None:
+        options[0] = (1, _('From this category only'))
+    else:
+        options[0] = (1, '{} \N{RIGHTWARDS ARROW} "{}"'.format(_('From the current category only'), category.title))
+    options[-1] = ('', _('From everywhere'))
 
     if allow_invisible:
         options.insert(0, (0, _('Invisible')))

--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -176,8 +176,6 @@ def get_visibility_options(category_or_event, allow_invisible=True):
     def _category_above_message(number):
         return ngettext('From the category above', 'From {} categories above', number).format(number)
 
-    options = []
-
     options = [(n + 1, ('{} \N{RIGHTWARDS ARROW} "{}"'.format(_category_above_message(n).format(n), title)))
                for n, title in enumerate(category.chain_titles[::-1])]
     if event is None:

--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -176,13 +176,16 @@ def get_visibility_options(category_or_event, allow_invisible=True):
     def _category_above_message(number):
         return ngettext('From the category above', 'From {} categories above', number).format(number)
 
-    options = [(n + 1, ('{} \N{RIGHTWARDS ARROW} "{}"'.format(_category_above_message(n).format(n), title)))
-               for n, title in enumerate(category.chain_titles[::-1])]
-    if event is None:
-        options[0] = (1, _('From this category only'))
-    else:
-        options[0] = (1, '{} \N{RIGHTWARDS ARROW} "{}"'.format(_('From the current category only'), category.title))
-    options[-1] = ('', _('From everywhere'))
+    options = []
+
+    if category is not None:
+        options = [(n + 1, ('{} \N{RIGHTWARDS ARROW} "{}"'.format(_category_above_message(n).format(n), title)))
+                   for n, title in enumerate(category.chain_titles[::-1])]
+        if event is None:
+            options[0] = (1, _('From this category only'))
+        else:
+            options[0] = (1, '{} \N{RIGHTWARDS ARROW} "{}"'.format(_('From the current category only'), category.title))
+        options[-1] = ('', _('From everywhere'))
 
     if allow_invisible:
         options.insert(0, (0, _('Invisible')))

--- a/indico/modules/events/client/js/creation.js
+++ b/indico/modules/events/client/js/creation.js
@@ -20,6 +20,8 @@ import {camelizeKeys} from 'indico/utils/case';
     options = $.extend(
       {
         categoryField: null,
+        listingField: null,
+        listingValue: null,
         protectionModeFields: null,
         initialCategory: null,
         checkAvailability: false,
@@ -58,18 +60,37 @@ import {camelizeKeys} from 'indico/utils/case';
       if (mode === 'inheriting') {
         mode = currentCategory.is_protected ? 'inheriting-protected' : 'inheriting-public';
       }
-      const elem = messages.filter('.{0}-protection-message'.format(mode));
-      elem.find('.js-category-title').text(currentCategory.title);
+      const elem = messages.filter(`.${mode}-protection-message`);
+      elem.find('.js-category-title').text(currentCategory && currentCategory.title);
       protectionMessage.html(elem);
     }
 
     options.categoryField.on('indico:categorySelected', (evt, cat) => {
-      if (!currentCategory) {
+      if (!options.listingField.prop('checked')) {
+        options.protectionModeFields.filter('[value=inheriting]').prop('disabled', true);
+        options.protectionModeFields.filter('[value=public]').prop('checked', true);
+      } else if (!currentCategory) {
         options.protectionModeFields.prop('disabled', false);
         options.protectionModeFields.filter('[value=inheriting]').prop('checked', true);
       }
       currentCategory = cat;
       updateProtectionMessage();
+    });
+
+    options.listingField.on('change', evt => {
+      if (evt.target.checked) {
+        $('#form-group-event-creation-category').show();
+        options.categoryField.val(JSON.stringify(options.initialCategory));
+        options.categoryField.prop('disabled', false);
+        $('#category-title-event-creation-category').text(options.initialCategory.title);
+        options.categoryField.trigger('indico:categorySelected', [options.initialCategory]);
+      } else {
+        $('#form-group-event-creation-category').hide();
+        $('#event-creation-protection_mode-1').prop('disabled', true);
+        options.categoryField.val('');
+        options.categoryField.prop('disabled', true);
+        options.categoryField.trigger('indico:categorySelected', []);
+      }
     });
 
     options.protectionModeFields.on('change', function() {

--- a/indico/modules/events/client/js/creation.js
+++ b/indico/modules/events/client/js/creation.js
@@ -66,11 +66,7 @@ import {camelizeKeys} from 'indico/utils/case';
     }
 
     options.categoryField.on('indico:categorySelected', (evt, cat) => {
-      if (!options.listingField.prop('checked')) {
-        options.protectionModeFields.filter('[value=inheriting]').prop('disabled', true);
-        options.protectionModeFields.filter('[value=public]').prop('checked', true);
-      } else if (!currentCategory) {
-        options.protectionModeFields.prop('disabled', false);
+      if (!currentCategory) {
         options.protectionModeFields.filter('[value=inheriting]').prop('checked', true);
       }
       currentCategory = cat;
@@ -80,13 +76,14 @@ import {camelizeKeys} from 'indico/utils/case';
     options.listingField.on('change', evt => {
       if (evt.target.checked) {
         $('#form-group-event-creation-category').show();
+        $('#form-group-event-creation-protection_mode').show();
         options.categoryField.val(JSON.stringify(options.initialCategory));
         options.categoryField.prop('disabled', false);
         $('#category-title-event-creation-category').text(options.initialCategory.title);
         options.categoryField.trigger('indico:categorySelected', [options.initialCategory]);
       } else {
         $('#form-group-event-creation-category').hide();
-        $('#event-creation-protection_mode-1').prop('disabled', true);
+        $('#form-group-event-creation-protection_mode').hide();
         options.categoryField.val('');
         options.categoryField.prop('disabled', true);
         options.categoryField.trigger('indico:categorySelected', []);

--- a/indico/modules/events/client/js/creation.js
+++ b/indico/modules/events/client/js/creation.js
@@ -20,7 +20,6 @@ import {camelizeKeys} from 'indico/utils/case';
     options = $.extend(
       {
         categoryField: null,
-        listingField: null,
         listingValue: null,
         protectionModeFields: null,
         initialCategory: null,
@@ -33,6 +32,7 @@ import {camelizeKeys} from 'indico/utils/case';
 
     const messages = $($.parseHTML($('#event-creation-protection-messages').html()));
     const protectionMessage = $('<div>', {class: 'form-group', css: {marginTop: '5px'}});
+    const listingMessage = $($.parseHTML($('#event-listing-message').html()));
 
     const $createBooking = $('#event-creation-create_booking');
     const $availableMessage = $('#room-available');
@@ -48,14 +48,20 @@ import {camelizeKeys} from 'indico/utils/case';
     const $prebookingSwitch = $('#create-prebooking');
     const $bookingSwitchPrebooking = $('#create-booking-over-prebooking');
     const $prebookingSwitchPrebooking = $('#create-prebooking-over-prebooking');
+    const $listingField = $('#event-creation-listing-checkbox');
 
     let currentCategory = null;
     let previousRoomId, $currentMessage, startDt, endDt, category, roomData, timezone;
     let multipleOccurrences = false;
 
     protectionMessage.appendTo(options.protectionModeFields.closest('.form-field'));
+    listingMessage.appendTo($listingField.closest('.form-field'));
+    listingMessage.hide();
 
     function updateProtectionMessage() {
+      if (!currentCategory) {
+        return;
+      }
       let mode = options.protectionModeFields.filter(':checked').val();
       if (mode === 'inheriting') {
         mode = currentCategory.is_protected ? 'inheriting-protected' : 'inheriting-public';
@@ -63,6 +69,11 @@ import {camelizeKeys} from 'indico/utils/case';
       const elem = messages.filter(`.${mode}-protection-message`);
       elem.find('.js-category-title').text(currentCategory && currentCategory.title);
       protectionMessage.html(elem);
+    }
+
+    function updateListingMessage() {
+      const listingValue = JSON.parse($listingField.val());
+      listingMessage.toggle(!listingValue);
     }
 
     options.categoryField.on('indico:categorySelected', (evt, cat) => {
@@ -73,22 +84,21 @@ import {camelizeKeys} from 'indico/utils/case';
       updateProtectionMessage();
     });
 
-    options.listingField.on('change', evt => {
-      if (evt.target.checked) {
+    $listingField.on('change', evt => {
+      const value = JSON.parse(evt.target.value);
+      if (value) {
         $('#form-group-event-creation-category').show();
         $('#form-group-event-creation-protection_mode').show();
         options.categoryField.val(JSON.stringify(options.initialCategory));
-        options.categoryField.prop('disabled', false);
         $('#category-title-event-creation-category').text(options.initialCategory.title);
         options.categoryField.trigger('indico:categorySelected', [options.initialCategory]);
         $(`#category-warning-event-creation-category`).addClass('hidden');
       } else {
         $('#form-group-event-creation-category').hide();
         $('#form-group-event-creation-protection_mode').hide();
-        options.categoryField.val('');
-        options.categoryField.prop('disabled', true);
         options.categoryField.trigger('indico:categorySelected', []);
       }
+      updateListingMessage();
     });
 
     options.protectionModeFields.on('change', function() {

--- a/indico/modules/events/client/js/creation.js
+++ b/indico/modules/events/client/js/creation.js
@@ -81,6 +81,7 @@ import {camelizeKeys} from 'indico/utils/case';
         options.categoryField.prop('disabled', false);
         $('#category-title-event-creation-category').text(options.initialCategory.title);
         options.categoryField.trigger('indico:categorySelected', [options.initialCategory]);
+        $(`#category-warning-event-creation-category`).addClass('hidden');
       } else {
         $('#form-group-event-creation-category').hide();
         $('#form-group-event-creation-protection_mode').hide();

--- a/indico/modules/events/contributions/client/js/PublicationButton.jsx
+++ b/indico/modules/events/contributions/client/js/PublicationButton.jsx
@@ -32,7 +32,7 @@ export default function PublicationButton({eventId, onSuccess}) {
 
   const trigger = (
     <IButton onClick={() => setModalOpen(true)}>
-      <Translate>Publish now</Translate>
+      <Translate>Publish contributions</Translate>
     </IButton>
   );
 

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -9,7 +9,7 @@ from datetime import time
 
 from flask import session
 from wtforms.fields import StringField, TextAreaField
-from wtforms.fields.core import SelectField
+from wtforms.fields.core import BooleanField, SelectField
 from wtforms.fields.html5 import URLField
 from wtforms.validators import DataRequired, InputRequired, ValidationError
 
@@ -26,7 +26,7 @@ from indico.web.forms.colors import get_sui_colors
 from indico.web.forms.fields import (IndicoDateTimeField, IndicoEnumRadioField, IndicoLocationField,
                                      IndicoTimezoneSelectField, JSONField, OccurrencesField)
 from indico.web.forms.validators import LinkedDateTime
-from indico.web.forms.widgets import CKEditorWidget
+from indico.web.forms.widgets import CKEditorWidget, SwitchWidget
 
 
 class ReferenceTypeForm(IndicoForm):
@@ -69,7 +69,8 @@ class EventLabelForm(IndicoForm):
 
 
 class EventCreationFormBase(IndicoForm):
-    category = CategoryField(_('Category'), [DataRequired()], require_event_creation_rights=True)
+    listing = BooleanField(_('Listing'), default=True, widget=SwitchWidget())
+    category = CategoryField(_('Category'), require_event_creation_rights=True)
     title = StringField(_('Event title'), [DataRequired()])
     timezone = IndicoTimezoneSelectField(_('Timezone'), [DataRequired()])
     location_data = IndicoLocationField(_('Location'), allow_location_inheritance=False, edit_address=False)
@@ -77,7 +78,7 @@ class EventCreationFormBase(IndicoForm):
     create_booking = JSONField()
 
     def validate_category(self, field):
-        if not field.data.can_create_events(session.user):
+        if self._fields['listing'].data and not field.data.can_create_events(session.user):
             raise ValidationError(_('You are not allowed to create events in this category.'))
 
 

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -9,7 +9,7 @@ from datetime import time
 
 from flask import session
 from wtforms.fields import StringField, TextAreaField
-from wtforms.fields.core import BooleanField, SelectField
+from wtforms.fields.core import SelectField
 from wtforms.fields.html5 import URLField
 from wtforms.validators import DataRequired, InputRequired, ValidationError
 
@@ -25,8 +25,9 @@ from indico.web.forms.base import IndicoForm
 from indico.web.forms.colors import get_sui_colors
 from indico.web.forms.fields import (IndicoDateTimeField, IndicoEnumRadioField, IndicoLocationField,
                                      IndicoTimezoneSelectField, JSONField, OccurrencesField)
+from indico.web.forms.fields.simple import IndicoButtonsBooleanField
 from indico.web.forms.validators import LinkedDateTime
-from indico.web.forms.widgets import CKEditorWidget, SwitchWidget
+from indico.web.forms.widgets import CKEditorWidget
 
 
 class ReferenceTypeForm(IndicoForm):
@@ -69,7 +70,9 @@ class EventLabelForm(IndicoForm):
 
 
 class EventCreationFormBase(IndicoForm):
-    listing = BooleanField(_('Listing'), default=True, widget=SwitchWidget())
+    listing = IndicoButtonsBooleanField(_('Listing'), default=True,
+                                        true_caption=(_('List in a category'), 'eye'),
+                                        false_caption=(_('Keep unlisted'), 'eye-blocked'))
     category = CategoryField(_('Category'), require_event_creation_rights=True)
     title = StringField(_('Event title'), [DataRequired()])
     timezone = IndicoTimezoneSelectField(_('Timezone'), [DataRequired()])

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -78,7 +78,7 @@ class EventCreationFormBase(IndicoForm):
     create_booking = JSONField()
 
     def validate_category(self, field):
-        if self._fields['listing'].data and not field.data.can_create_events(session.user):
+        if self.listing.data and not field.data.can_create_events(session.user):
             raise ValidationError(_('You are not allowed to create events in this category.'))
 
 

--- a/indico/modules/events/layout/__init__.py
+++ b/indico/modules/events/layout/__init__.py
@@ -48,14 +48,14 @@ theme_settings = ThemeSettingsProxy()
 
 @signals.event.created.connect
 def _event_created(event, **kwargs):
-    defaults = event.category.default_event_themes
+    defaults = event.category.default_event_themes if event.category else None
     if not layout_settings.get(event, 'timetable_theme') and event.type_.name in defaults:
         layout_settings.set(event, 'timetable_theme', defaults[event.type_.name])
 
 
 @signals.event.type_changed.connect
 def _event_type_changed(event, **kwargs):
-    theme = event.category.default_event_themes.get(event.type_.name)
+    theme = event.category.default_event_themes.get(event.type_.name) if event.category else None
     if theme is None:
         layout_settings.delete(event, 'timetable_theme')
     else:

--- a/indico/modules/events/layout/__init__.py
+++ b/indico/modules/events/layout/__init__.py
@@ -49,7 +49,7 @@ theme_settings = ThemeSettingsProxy()
 @signals.event.created.connect
 def _event_created(event, **kwargs):
     defaults = event.category.default_event_themes if event.category else None
-    if not layout_settings.get(event, 'timetable_theme') and event.type_.name in defaults:
+    if not layout_settings.get(event, 'timetable_theme') and defaults and event.type_.name in defaults:
         layout_settings.set(event, 'timetable_theme', defaults[event.type_.name])
 
 

--- a/indico/modules/events/management/client/js/EventMove.jsx
+++ b/indico/modules/events/management/client/js/EventMove.jsx
@@ -88,7 +88,8 @@ function EventMove({currentCategoryId, submitMove, renderTrigger, getEventCount,
               <Modal.Content>
                 <Form onSubmit={fprops.handleSubmit} id="move-event-form">
                   {publish ? (
-                    <>You are about to publish this event to{' '}
+                    <>
+                      You are about to publish this event to{' '}
                       <Param
                         name="target"
                         value={targetCategory.path.join(' » ')}
@@ -149,21 +150,22 @@ function EventMove({currentCategoryId, submitMove, renderTrigger, getEventCount,
                             </Plural>
                           </PluralTranslate>
                         )}
-
                       </p>
                       <FinalTextArea
                         name="comment"
                         label={Translate.string('Comment')}
-                        description={publish ?
-                          <Translate>
-                            You can provide a comment to the category managers to help them decide
-                            whether to approve your publish request.
-                          </Translate>
-                        :
-                          <Translate>
-                            You can provide a comment to the category managers to help them decide
-                            whether to approve your move request.
-                          </Translate>
+                        description={
+                          publish ? (
+                            <Translate>
+                              You can provide a comment to the category managers to help them decide
+                              whether to approve your publish request.
+                            </Translate>
+                          ) : (
+                            <Translate>
+                              You can provide a comment to the category managers to help them decide
+                              whether to approve your move request.
+                            </Translate>
+                          )
                         }
                       />
                     </>
@@ -197,12 +199,14 @@ EventMove.propTypes = {
   renderTrigger: PropTypes.func.isRequired,
   getEventCount: PropTypes.func,
   currentCategoryId: PropTypes.number,
+  publish: PropTypes.bool,
 };
 
 EventMove.defaultProps = {
   bulk: false,
   currentCategoryId: null,
   getEventCount: null,
+  publish: false,
 };
 
 export function SingleEventMove({
@@ -284,9 +288,10 @@ export function EventPublish({eventId, hasPendingPublishRequest}) {
     <IButton
       highlight
       icon="play"
-      title={hasPendingPublishRequest
-        ? Translate.string('Event has a pending publish request')
-        : Translate.string('Publish event to a category')
+      title={
+        hasPendingPublishRequest
+          ? Translate.string('Event has a pending publish request')
+          : Translate.string('Publish event to a category')
       }
       disabled={hasPendingPublishRequest}
       onClick={fn}
@@ -295,13 +300,7 @@ export function EventPublish({eventId, hasPendingPublishRequest}) {
     </IButton>
   );
 
-  return (
-    <EventMove
-      submitMove={submitMove}
-      renderTrigger={renderTrigger}
-      publish
-    />
-  );
+  return <EventMove submitMove={submitMove} renderTrigger={renderTrigger} publish />;
 }
 
 EventPublish.propTypes = {

--- a/indico/modules/events/management/client/js/EventMove.jsx
+++ b/indico/modules/events/management/client/js/EventMove.jsx
@@ -25,8 +25,10 @@ function EventMove({currentCategoryId, submitMove, renderTrigger, getEventCount,
     let dialogTitle;
     if (publish) {
       dialogTitle = Translate.string('Publish event');
+    } else if (bulk) {
+      dialogTitle = Translate.string('Move events');
     } else {
-      dialogTitle = bulk ? Translate.string('Move events') : Translate.string('Move event');
+      dialogTitle = Translate.string('Move event');
     }
 
     $('<div>').categorynavigator({

--- a/indico/modules/events/management/client/js/EventMove.jsx
+++ b/indico/modules/events/management/client/js/EventMove.jsx
@@ -24,13 +24,13 @@ function EventMove({currentCategoryId, submitMove, renderTrigger, getEventCount,
   const selectCategoryForMove = initialCategoryId => {
     let dialogTitle;
     if (publish) {
-      dialogTitle = 'Publish event';
+      dialogTitle = Translate.string('Publish event');
     } else {
       dialogTitle = bulk ? Translate.string('Move events') : Translate.string('Move event');
     }
 
     $('<div>').categorynavigator({
-      category: initialCategoryId ? initialCategoryId : undefined,
+      category: initialCategoryId,
       openInDialog: true,
       dialogTitle,
       dialogSubtitle: bulk
@@ -88,7 +88,7 @@ function EventMove({currentCategoryId, submitMove, renderTrigger, getEventCount,
               <Modal.Content>
                 <Form onSubmit={fprops.handleSubmit} id="move-event-form">
                   {publish ? (
-                    <>
+                    <Translate>
                       You are about to publish this event to{' '}
                       <Param
                         name="target"
@@ -96,7 +96,7 @@ function EventMove({currentCategoryId, submitMove, renderTrigger, getEventCount,
                         wrapper={<strong />}
                       />
                       .
-                    </>
+                    </Translate>
                   ) : (
                     <PluralTranslate count={eventCount}>
                       <Singular>
@@ -155,17 +155,10 @@ function EventMove({currentCategoryId, submitMove, renderTrigger, getEventCount,
                         name="comment"
                         label={Translate.string('Comment')}
                         description={
-                          publish ? (
-                            <Translate>
-                              You can provide a comment to the category managers to help them decide
-                              whether to approve your publish request.
-                            </Translate>
-                          ) : (
-                            <Translate>
-                              You can provide a comment to the category managers to help them decide
-                              whether to approve your move request.
-                            </Translate>
-                          )
+                          <Translate>
+                            You can provide a comment to the category managers to help them decide
+                            whether to approve your request.
+                          </Translate>
                         }
                       />
                     </>
@@ -271,43 +264,6 @@ SingleEventMove.defaultProps = {
   inCategoryManagement: false,
 };
 
-export function EventPublish({eventId, hasPendingPublishRequest}) {
-  const submitMove = async (targetCategoryId, {comment}) => {
-    const data = {target_category_id: targetCategoryId, comment};
-    try {
-      await indicoAxios.post(eventMoveURL({event_id: eventId}), data);
-    } catch (e) {
-      return handleSubmitError(e);
-    }
-    location.reload();
-    // never finish submitting to avoid fields being re-enabled
-    await new Promise(() => {});
-  };
-
-  const renderTrigger = fn => (
-    <IButton
-      highlight
-      icon="play"
-      title={
-        hasPendingPublishRequest
-          ? Translate.string('Event has a pending publish request')
-          : Translate.string('Publish event to a category')
-      }
-      disabled={hasPendingPublishRequest}
-      onClick={fn}
-    >
-      <Translate>Publish</Translate>
-    </IButton>
-  );
-
-  return <EventMove submitMove={submitMove} renderTrigger={renderTrigger} publish />;
-}
-
-EventPublish.propTypes = {
-  eventId: PropTypes.number.isRequired,
-  hasPendingPublishRequest: PropTypes.bool.isRequired,
-};
-
 export function BulkEventMove({currentCategoryId, getEventData}) {
   const submitMove = async (targetCategoryId, {comment}) => {
     const selectedEventData = getEventData();
@@ -351,4 +307,41 @@ export function BulkEventMove({currentCategoryId, getEventData}) {
 BulkEventMove.propTypes = {
   currentCategoryId: PropTypes.number.isRequired,
   getEventData: PropTypes.func.isRequired,
+};
+
+export function EventPublish({eventId, hasPendingPublishRequest}) {
+  const submitMove = async (targetCategoryId, {comment}) => {
+    const data = {target_category_id: targetCategoryId, comment};
+    try {
+      await indicoAxios.post(eventMoveURL({event_id: eventId}), data);
+    } catch (e) {
+      return handleSubmitError(e);
+    }
+    location.reload();
+    // never finish submitting to avoid fields being re-enabled
+    await new Promise(() => {});
+  };
+
+  const renderTrigger = fn => (
+    <IButton
+      highlight
+      icon="play"
+      title={
+        hasPendingPublishRequest
+          ? Translate.string('Event has a pending publish request')
+          : Translate.string('Publish event to a category')
+      }
+      disabled={hasPendingPublishRequest}
+      onClick={fn}
+    >
+      <Translate>Publish</Translate>
+    </IButton>
+  );
+
+  return <EventMove submitMove={submitMove} renderTrigger={renderTrigger} publish />;
+}
+
+EventPublish.propTypes = {
+  eventId: PropTypes.number.isRequired,
+  hasPendingPublishRequest: PropTypes.bool.isRequired,
 };

--- a/indico/modules/events/management/client/js/index.js
+++ b/indico/modules/events/management/client/js/index.js
@@ -23,19 +23,32 @@ import './badges';
 
 import {$T} from 'indico/utils/i18n';
 
-import {SingleEventMove} from './EventMove';
+import {SingleEventMove, EventPublish} from './EventMove';
 
 (function(global) {
   global.setupEventManagementActionMenu = function setupEventManagementActionMenu() {
     const moveContainer = document.querySelector('#event-action-move-container');
-    ReactDOM.render(
-      React.createElement(SingleEventMove, {
-        eventId: +moveContainer.dataset.eventId,
-        currentCategoryId: +moveContainer.dataset.categoryId,
-        hasPendingMoveRequest: moveContainer.dataset.pendingRequest !== undefined,
-      }),
-      moveContainer
-    );
+    if (moveContainer) {
+      ReactDOM.render(
+        React.createElement(SingleEventMove, {
+          eventId: +moveContainer.dataset.eventId,
+          currentCategoryId: +moveContainer.dataset.categoryId,
+          hasPendingMoveRequest: moveContainer.dataset.pendingRequest !== undefined,
+        }),
+        moveContainer
+      );
+    }
+
+    const publishContainer = document.querySelector('#event-action-publish-container');
+    if (publishContainer) {
+      ReactDOM.render(
+        React.createElement(EventPublish, {
+          eventId: +publishContainer.dataset.eventId,
+          hasPendingPublishRequest: publishContainer.dataset.pendingRequest !== undefined,
+        }),
+        publishContainer
+      );
+    }
 
     $('#event-action-menu-clones-target').qbubble({
       content: {

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -31,9 +31,10 @@ class RHDeleteEvent(RHManageEventBase):
         self.event.delete('Deleted by user', session.user)
         flash(_('Event "{}" successfully deleted.').format(self.event.title), 'success')
         category = self.event.category
-        if category.can_manage(session.user):
+
+        if category and category.can_manage(session.user):
             redirect_url = url_for('categories.manage_content', category)
-        elif category.can_access(session.user):
+        elif category and category.can_access(session.user):
             redirect_url = url_for('categories.display', category)
         else:
             redirect_url = url_for_index()

--- a/indico/modules/events/management/controllers/cloning.py
+++ b/indico/modules/events/management/controllers/cloning.py
@@ -148,8 +148,8 @@ class RHCloneEvent(RHManageEventBase):
         elif step == 2:
             return CloneContentsForm(self.event, set_defaults=set_defaults)
         elif step == 3:
-            default_category = (self.event.category if self.event.category and
-                                self.event.category.can_create_events(session.user)
+            default_category = (self.event.category
+                                if self.event.category and self.event.category.can_create_events(session.user)
                                 else None)
             return CloneCategorySelectForm(self.event, category=default_category)
         elif step == 4:

--- a/indico/modules/events/management/controllers/cloning.py
+++ b/indico/modules/events/management/controllers/cloning.py
@@ -148,7 +148,8 @@ class RHCloneEvent(RHManageEventBase):
         elif step == 2:
             return CloneContentsForm(self.event, set_defaults=set_defaults)
         elif step == 3:
-            default_category = (self.event.category if self.event.category.can_create_events(session.user)
+            default_category = (self.event.category if self.event.category and
+                                self.event.category.can_create_events(session.user)
                                 else None)
             return CloneCategorySelectForm(self.event, category=default_category)
         elif step == 4:

--- a/indico/modules/events/management/controllers/protection.py
+++ b/indico/modules/events/management/controllers/protection.py
@@ -82,11 +82,13 @@ class RHEventProtection(RHManageEventBase):
         form.permissions.hidden_permissions = [(p.name, perms) for p, perms in hidden_permissions]
         if form.validate_on_submit():
             update_permissions(self.event, form)
-            update_event_protection(self.event, {'protection_mode': form.protection_mode.data,
-                                                 'own_no_access_contact': form.own_no_access_contact.data,
-                                                 'access_key': form.access_key.data,
-                                                 'visibility': form.visibility.data if form.visibility else None,
-                                                 'public_regform_access': form.public_regform_access.data})
+            data = {'protection_mode': form.protection_mode.data,
+                    'own_no_access_contact': form.own_no_access_contact.data,
+                    'access_key': form.access_key.data,
+                    'public_regform_access': form.public_regform_access.data}
+            if form.visibility:
+                data['visibility'] = form.visibility.data
+            update_event_protection(self.event, data)
             self._update_session_coordinator_privs(form)
             flash(_('Protection settings have been updated'), 'success')
             return redirect(url_for('.protection', self.event))

--- a/indico/modules/events/management/controllers/protection.py
+++ b/indico/modules/events/management/controllers/protection.py
@@ -85,7 +85,7 @@ class RHEventProtection(RHManageEventBase):
             update_event_protection(self.event, {'protection_mode': form.protection_mode.data,
                                                  'own_no_access_contact': form.own_no_access_contact.data,
                                                  'access_key': form.access_key.data,
-                                                 'visibility': form.visibility.data,
+                                                 'visibility': form.visibility.data if form.visibility else None,
                                                  'public_regform_access': form.public_regform_access.data})
             self._update_session_coordinator_privs(form)
             flash(_('Protection settings have been updated'), 'success')

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -259,7 +259,10 @@ class EventProtectionForm(IndicoForm):
     def __init__(self, *args, **kwargs):
         self.protected_object = self.event = kwargs.pop('event')
         super().__init__(*args, **kwargs)
-        self._init_visibility(self.event)
+        if not self.event.category:
+            del self.visibility
+        else:
+            self._init_visibility(self.event)
 
     def _get_event_own_visibility_horizon(self, event):
         if self.visibility.data is None:  # unlimited

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -273,8 +273,7 @@ class EventProtectionForm(IndicoForm):
             return event.category.nth_parent(self.visibility.data - 1)
 
     def _init_visibility(self, event):
-        if event.category is None:
-            return None
+        assert event.category
 
         self.visibility.choices = get_visibility_options(event, allow_invisible=True)
         # Check if event visibility would be affected by any of the categories

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -270,6 +270,9 @@ class EventProtectionForm(IndicoForm):
             return event.category.nth_parent(self.visibility.data - 1)
 
     def _init_visibility(self, event):
+        if event.category is None:
+            return None
+
         self.visibility.choices = get_visibility_options(event, allow_invisible=True)
         # Check if event visibility would be affected by any of the categories
         real_horizon = event.category.real_visibility_horizon

--- a/indico/modules/events/management/templates/_action_menu.html
+++ b/indico/modules/events/management/templates/_action_menu.html
@@ -74,10 +74,10 @@
 {% macro _render_move_event(event) %}
     {% if event.category %}
         <span class="hide-if-locked"
-            id="event-action-move-container"
-            data-event-id="{{ event.id }}"
-            data-category-id="{{ event.category.id }}"
-            {{ 'data-pending-request' if event.pending_move_request }}></span>
+              id="event-action-move-container"
+              data-event-id="{{ event.id }}"
+              data-category-id="{{ event.category.id }}"
+              {{ 'data-pending-request' if event.pending_move_request }}></span>
     {% endif %}
 {% endmacro %}
 
@@ -110,11 +110,11 @@
     <div class="action-menu">
         <div class="toolbar">
             {% if event.can_manage(session.user) %}
-                {% if event.category is none %}
+                {% if not event.category %}
                     <span class="hide-if-locked group"
-                        id="event-action-publish-container"
-                        data-event-id="{{ event.id }}"
-                        {{ 'data-pending-request' if event.pending_move_request }}></span>
+                          id="event-action-publish-container"
+                          data-event-id="{{ event.id }}"
+                          {{ 'data-pending-request' if event.pending_move_request }}></span>
                    </a>
                 {% endif %}
 

--- a/indico/modules/events/management/templates/_action_menu.html
+++ b/indico/modules/events/management/templates/_action_menu.html
@@ -111,7 +111,7 @@
         <div class="toolbar">
             {% if event.can_manage(session.user) %}
                 {% if event.category is none %}
-                    <span class="hide-if-locked"
+                    <span class="hide-if-locked group"
                         id="event-action-publish-container"
                         data-event-id="{{ event.id }}"
                         {{ 'data-pending-request' if event.pending_move_request }}></span>

--- a/indico/modules/events/management/templates/_action_menu.html
+++ b/indico/modules/events/management/templates/_action_menu.html
@@ -72,11 +72,13 @@
 
 
 {% macro _render_move_event(event) %}
-    <span class="hide-if-locked"
-          id="event-action-move-container"
-          data-event-id="{{ event.id }}"
-          data-category-id="{{ event.category.id }}"
-          {{ 'data-pending-request' if event.pending_move_request }}></span>
+    {% if event.category %}
+        <span class="hide-if-locked"
+            id="event-action-move-container"
+            data-event-id="{{ event.id }}"
+            data-category-id="{{ event.category.id }}"
+            {{ 'data-pending-request' if event.pending_move_request }}></span>
+    {% endif %}
 {% endmacro %}
 
 
@@ -108,6 +110,14 @@
     <div class="action-menu">
         <div class="toolbar">
             {% if event.can_manage(session.user) %}
+                {% if event.category is none %}
+                    <span class="hide-if-locked"
+                        id="event-action-publish-container"
+                        data-event-id="{{ event.id }}"
+                        {{ 'data-pending-request' if event.pending_move_request }}></span>
+                   </a>
+                {% endif %}
+
                 <div class="group">
                     <a class="i-button icon-copy" title="{% trans %}Clone event{% endtrans %}"
                        data-href="{{ url_for('event_management.clone', event) }}"

--- a/indico/modules/events/management/templates/event_protection.html
+++ b/indico/modules/events/management/templates/event_protection.html
@@ -6,7 +6,10 @@
 {% block content %}
     {{ form_header(form, id='event-protection-form') }}
     {{ form_row(form.permissions, skip_label=true) }}
-    {{ form_rows(form, skip=form.priv_fields.union(['permissions']),
+    {% if event.category %}
+        {{ form_row(form.protection_mode) }}
+    {% endif %}
+    {{ form_rows(form, skip=form.priv_fields.union(['permissions', 'protection_mode']),
                  widget_attrs={'own_no_access_contact': {'placeholder': event.no_access_contact}}) }}
     {% call form_fieldset(_("Session coordinator rights"), collapsible=true, initially_collapsed=true) %}
         <div class="action-box highlight">

--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -52,7 +52,7 @@
         </div>
     {%- endif -%}
     {%- if not event.category and event.can_manage(session.user) -%}
-        <div id="unlisted-event-info" class="action-box info">
+        <div class="action-box info">
             <div class="section">
                 <div class="icon icon-unlisted-event"></div>
                 <div class="text">
@@ -62,11 +62,6 @@
                     {% endtrans %}
                 </div>
             </div>
-
-            <script>
-                // Render PublicationModal into #draft-mode-warning-button
-                setupDraftModeWarning();
-            </script>
         </div>
     {%- endif -%}
     {%- if show_draft_warning -%}

--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -51,6 +51,24 @@
             </div>
         </div>
     {%- endif -%}
+    {%- if not event.category and event.can_manage(session.user) -%}
+        <div id="unlisted-event-info" class="action-box info">
+            <div class="section">
+                <div class="icon icon-unlisted-event"></div>
+                <div class="text">
+                    <div class="label">{% trans %}This event is currently unlisted{% endtrans %}</div>
+                    {% trans %}
+                        Unlisted events are not shown in any category and only the creator can see them.
+                    {% endtrans %}
+                </div>
+            </div>
+
+            <script>
+                // Render PublicationModal into #draft-mode-warning-button
+                setupDraftModeWarning();
+            </script>
+        </div>
+    {%- endif -%}
     {%- if show_draft_warning -%}
         {{ render_draft_mode_warning(event) }}
     {%- endif -%}

--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -58,7 +58,7 @@
                 <div class="text">
                     <div class="label">{% trans %}This event is currently unlisted{% endtrans %}</div>
                     {% trans %}
-                        Unlisted events are not shown in any category and only the creator can see them.
+                        Unlisted events are not shown in any category and only explicitly authorized users can see them.
                     {% endtrans %}
                 </div>
             </div>

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -936,7 +936,6 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
                          session.user, data={'From': old_path}, meta=log_meta)
         else:
             notify_event_creation(self)
-
             self.log(EventLogRealm.management, LogKind.change, 'Category', 'Event published', session.user,
                      data={'To': new_path}, meta=log_meta)
             category.log(CategoryLogRealm.events, LogKind.positive, 'Content', f'Event published here: "{self.title}"',

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -97,7 +97,6 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
                          cls.is_deleted, cls.category_id, cls.start_dt, cls.end_dt),
                 db.Index('ix_uq_events_url_shortcut', db.func.lower(cls.url_shortcut), unique=True,
                          postgresql_where=db.text('NOT is_deleted')),
-                db.CheckConstraint('category_id IS NOT NULL OR is_deleted', 'category_data_set'),
                 db.CheckConstraint("(logo IS NULL) = (logo_metadata::text = 'null')", 'valid_logo'),
                 db.CheckConstraint("(stylesheet IS NULL) = (stylesheet_metadata::text = 'null')",
                                    'valid_stylesheet'),

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -78,6 +78,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     __tablename__ = 'events'
     disallowed_protection_modes = frozenset()
     inheriting_have_acl = True
+    allow_none_protection_parent = True
     allow_access_key = True
     allow_no_access_contact = True
     location_backref_name = 'events'

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -706,7 +706,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
 
     def can_lock(self, user):
         """Check whether the user can lock/unlock the event."""
-        return user and (user.is_admin or user == self.creator or self.category.can_manage(user))
+        return user and (user.is_admin or user == self.creator or (self.category and self.category.can_manage(user)))
 
     def can_display(self, user):
         """Check whether the user can display the event in the category."""

--- a/indico/modules/events/notifications.py
+++ b/indico/modules/events/notifications.py
@@ -38,6 +38,9 @@ def notify_event_creation(event, occurrences=None):
                         and dates/times are only taken from the
                         events in this list.
     """
+    if not event.category:
+        return
+
     emails = set()
     query = (event.category.chain_query.
              filter(Category.notify_managers | (Category.event_creation_notification_emails != []))

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -395,14 +395,14 @@ def create_event_request(event, category, comment=''):
     db.session.flush()
     logger.info('Category move request %r to %r created by %r', req, category, session.user)
     sep = ' \N{RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK} '
-    event.log(EventLogRealm.event, LogKind.change, 'Category', f'Move to "{category.title}" requested',
+    verb = 'move' if event.category else 'publish'
+    event.log(EventLogRealm.event, LogKind.change, 'Category', f'{verb.capitalize()} to "{category.title}" requested',
               user=session.user, data={'Category ID': category.id, 'Category': sep.join(category.chain_titles),
                                        'Comment': comment},
               meta={'event_move_request_id': req.id})
-    category.log(CategoryLogRealm.events, LogKind.positive, 'Moderation', f'Event move requested: "{event.title}"',
-                 session.user, data={
-                     'Event ID': event.id,
-                     'From': sep.join(event.category.chain_titles if event.category else 'Unlisted')
-                 },
-                 meta={'event_move_request_id': req.id})
+    category_log_data = {'Event ID': event.id}
+    if event.category:
+        category_log_data['From'] = sep.join(event.category.chain_titles)
+    category.log(CategoryLogRealm.events, LogKind.positive, 'Moderation', f'Event {verb} requested: "{event.title}"',
+                 session.user, data=category_log_data, meta={'event_move_request_id': req.id})
     return req

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -400,7 +400,9 @@ def create_event_request(event, category, comment=''):
                                        'Comment': comment},
               meta={'event_move_request_id': req.id})
     category.log(CategoryLogRealm.events, LogKind.positive, 'Moderation', f'Event move requested: "{event.title}"',
-                 session.user, data={'Event ID': event.id, 'From': sep.join(event.category.chain_titles),
-                                     'Comment': comment},
+                 session.user, data={
+                     'Event ID': event.id,
+                     'From': sep.join(event.category.chain_titles if event.category else 'Unlisted')
+                 },
                  meta={'event_move_request_id': req.id})
     return req

--- a/indico/modules/events/templates/display/_event_header_message.html
+++ b/indico/modules/events/templates/display/_event_header_message.html
@@ -2,7 +2,7 @@
 
 {% macro render_event_header_msg(event, meeting=true) %}
     {% set category = event.category %}
-    {% if category.event_message_mode.name != 'disabled' and category.event_message %}
+    {% if category and category.event_message_mode.name != 'disabled' and category.event_message %}
         {%- call message_box(category.event_message_mode.name, classes=('event-message' if meeting)) -%}
             {{ category.event_message }}
         {%- endcall %}

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -14,11 +14,21 @@
     {% block header %}
         <div class="event-header event-header-lecture {%- if not has_subheader %} round-bottom-corners{% endif %}">
             {% if not g.static_site %}
-                <a class="lecture-category" href="{{ url_for('categories.display', event.category) }}">
-                    {{ category }}
-                </a>
+                {% if category %}
+                    <a class="lecture-category" href="{{ url_for('categories.display', event.category) }}">
+                        {{ category }}
+                    </a>
+                {% else %}
+                    <a class="lecture-category" href="{{ url_for('event_management.settings', event) }}">
+                        {% trans %}Unlisted event{% endtrans %}
+                    </a>
+                {% endif %}
             {% else %}
-                <div>{{ category }}</div>
+                {% if category %}
+                    <div>{{ category }}</div>
+                {% else %}
+                    <div>{% trans %}Unlisted event{% endtrans %}</div>
+                {% endif %}
             {% endif %}
             {% set show_button = not event.is_locked and event.can_manage_attachments(session.user) %}
             <div class="event-manage-button">

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -13,21 +13,13 @@
 <div class="event-wrapper">
     {% block header %}
         <div class="event-header event-header-lecture {%- if not has_subheader %} round-bottom-corners{% endif %}">
-            {% if not g.static_site %}
-                {% if category %}
+            {% if category %}
+                {% if not g.static_site %}
                     <a class="lecture-category" href="{{ url_for('categories.display', event.category) }}">
                         {{ category }}
                     </a>
                 {% else %}
-                    <a class="lecture-category" href="{{ url_for('event_management.settings', event) }}">
-                        {% trans %}Unlisted event{% endtrans %}
-                    </a>
-                {% endif %}
-            {% else %}
-                {% if category %}
                     <div>{{ category }}</div>
-                {% else %}
-                    <div>{% trans %}Unlisted event{% endtrans %}</div>
                 {% endif %}
             {% endif %}
             {% set show_button = not event.is_locked and event.can_manage_attachments(session.user) %}

--- a/indico/modules/events/templates/forms/event_creation_form.html
+++ b/indico/modules/events/templates/forms/event_creation_form.html
@@ -89,10 +89,29 @@ purely client-side and are worded for event creation instead of being generic.
     </div>
 </script>
 
+<script type="text/html" id="event-listing-message">
+    <div class="form-group">
+        <div class="action-box mid-form for-form listing-message unlisted-message info">
+            <div class="section">
+                <div class="icon icon-eye-blocked"></div>
+                <div class="text">
+                    <div class="label">
+                        {% trans %}Unlisted event{% endtrans %}
+                    </div>
+                    <div>
+                        {% trans -%}
+                            Users will not see this event yet. You can publish the event in a category once it is ready.
+                        {%- endtrans %}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</script>
+
 <script>
     setupEventCreationDialog({
         categoryField: $('#{{ form.category.id }}'),
-        listingField: $('#{{ form.listing.id }}'),
         protectionModeFields: $('input[name="{{ form.protection_mode.name }}"][id^="{{ form.protection_mode.id }}"]'),
         initialCategory: {{ category | tojson }},
         checkAvailability: {{ check_room_availability | tojson }},

--- a/indico/modules/events/templates/forms/event_creation_form.html
+++ b/indico/modules/events/templates/forms/event_creation_form.html
@@ -4,6 +4,7 @@
                    'title': form.category.data.title} if form.category.data else none %}
 
 {{ form_header(form, action=url_for('events.create', event_type=event_type)) }}
+{{ form_row(form.listing) }}
 {{ form_row(form.category, orientation=('hidden' if single_category else '')) }}
 {{ form_rows(form, fields=form._field_order) }}
 {% if form._advanced_field_order %}
@@ -91,6 +92,7 @@ purely client-side and are worded for event creation instead of being generic.
 <script>
     setupEventCreationDialog({
         categoryField: $('#{{ form.category.id }}'),
+        listingField: $('#{{ form.listing.id }}'),
         protectionModeFields: $('input[name="{{ form.protection_mode.name }}"][id^="{{ form.protection_mode.id }}"]'),
         initialCategory: {{ category | tojson }},
         checkAvailability: {{ check_room_availability | tojson }},

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -34,7 +34,7 @@
            title="{% trans %}Newest event{% endtrans %}"></a>
     {% endif %}
 
-    {% if event.category or ( (rel['first'], rel['prev'], rel['next'], rel['last'])|any ) %}
+    {% if event.category or rel.first or rel.prev or rel.next or rel.last %}
         <span class="separator"></span>
     {% endif %}
 {%- endmacro -%}

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -19,8 +19,10 @@
            title="{% trans %}Older event{% endtrans %}"></a>
     {% endif %}
 
-    <a class="i-button text-color subtle icon-collapse" href="{{ event.category.url }}"
-       title="{% trans %}Up to category{% endtrans %}"></a>
+    {% if event.category %}
+        <a class="i-button text-color subtle icon-collapse" href="{{ event.category.url }}"
+           title="{% trans %}Up to category{% endtrans %}"></a>
+    {% endif %}
 
     {% if rel.next is not none %}
         <a class="i-button text-color subtle icon-next" href="{{ url_for('events.display', event_id=rel.next) }}"
@@ -32,7 +34,9 @@
            title="{% trans %}Newest event{% endtrans %}"></a>
     {% endif %}
 
-    <span class="separator"></span>
+    {% if event.category or ( (rel['first'], rel['prev'], rel['next'], rel['last'])|any ) %}
+        <span class="separator"></span>
+    {% endif %}
 {%- endmacro -%}
 
 

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -214,7 +214,7 @@ class WPSimpleEventDisplay(WPSimpleEventDisplayBase):
 
         return render_template(tpl,
                                event=self.event,
-                               category=self.event.category.title,
+                               category=self.event.category.title if self.event.category else None,
                                timezone=self.event.display_tzinfo,
                                theme_settings=self.theme.get('settings', {}),
                                theme_user_settings=layout_settings.get(self.event, 'timetable_theme_settings'),

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -214,7 +214,7 @@ class WPSimpleEventDisplay(WPSimpleEventDisplayBase):
 
         return render_template(tpl,
                                event=self.event,
-                               category=self.event.category.title if self.event.category else None,
+                               category=(self.event.category.title if self.event.category else None),
                                timezone=self.event.display_tzinfo,
                                theme_settings=self.theme.get('settings', {}),
                                theme_user_settings=layout_settings.get(self.event, 'timetable_theme_settings'),

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -43,8 +43,8 @@ from indico.modules.users.models.users import ProfilePictureSource
 from indico.modules.users.operations import create_user
 from indico.modules.users.schemas import BasicCategorySchema
 from indico.modules.users.util import (get_avatar_url_from_name, get_gravatar_for_user, get_linked_events,
-                                       get_related_categories, get_suggested_categories, merge_users, search_users,
-                                       send_avatar, serialize_user, set_user_avatar)
+                                       get_related_categories, get_suggested_categories, get_unlisted_events,
+                                       merge_users, search_users, send_avatar, serialize_user, set_user_avatar)
 from indico.modules.users.views import WPUser, WPUserDashboard, WPUserFavorites, WPUserProfilePic, WPUsersAdmin
 from indico.util.date_time import now_utc
 from indico.util.i18n import _
@@ -142,7 +142,8 @@ class RHUserDashboard(RHUserBase):
                                                categories=categories,
                                                categories_events=categories_events,
                                                suggested_categories=get_suggested_categories(self.user),
-                                               linked_events=linked_events)
+                                               linked_events=linked_events,
+                                               unlisted_events=get_unlisted_events(self.user))
 
 
 @allow_signed_url

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -82,16 +82,10 @@
                         </a>
                     </div>
                 </div>
-                <div id="happeningCategories" class="dashboard-box">
-                    <h3>{% trans %}Your unlisted events{% endtrans %}</h3>
-                    <ol>
-                        {% if not unlisted_events %}
-                            <li class="no-event">
-                                <span class="event-title italic text-superfluous">
-                                    {% trans %}You have no unlisted events.{% endtrans %}
-                                </span>
-                            </li>
-                        {% else %}
+                {% if unlisted_events %}
+                    <div class="dashboard-box">
+                        <h3>{% trans %}Your unlisted events{% endtrans %}</h3>
+                        <ol>
                             {% for event in unlisted_events %}
                                 <li class="flexrow">
                                     <span class="event-date f-self-no-shrink"
@@ -109,9 +103,9 @@
                                     </a>
                                 </li>
                             {% endfor %}
-                        {% endif %}
-                    </ol>
-                </div>
+                        </ol>
+                    </div>
+                {% endif %}
                 <div class="dashboard-box">
                     <h3>
                         {% trans %}Your events at hand{% endtrans %}
@@ -174,7 +168,7 @@
                         {% endif %}
                     </ol>
                 </div>
-                <div id="happeningCategories" class="dashboard-box">
+                <div class="dashboard-box">
                     <h3>{% trans %}Happening in your categories{% endtrans %}</h3>
                     <ol>
                         {% if not categories %}

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -110,7 +110,7 @@
                     <h3>
                         {% trans %}Your events at hand{% endtrans %}
                     </h3>
-                    <ol>
+                    <ul>
                         {% for event, roles in linked_events %}
                             <li id="event-{{ event.id }}" class="flexrow">
                                 <span class="event-date" title="{{ _format_event_times(event) }}">
@@ -138,23 +138,23 @@
                                 </span>
                             </li>
                         {% endfor %}
-                    </ol>
+                    </ul>
                 </div>
                 {% if suggested_categories %}
                     <div id="suggestedCategories" class="dashboard-box suggestions">
                         <h3>{% trans %}You might be interested in the following categories...{% endtrans %}</h3>
-                        <ol>
+                        <ul>
                             {% for category in suggested_categories %}
                                 {{ suggested_category(category.categ, category.path) }}
                             {% endfor %}
-                        </ol>
+                        </ul>
                     </div>
                 {% endif %}
             </div>
             <div class="dashboard-col">
                 <div id="yourCategories" class="dashboard-box">
                     <h3>{% trans %}Your categories{% endtrans %}</h3>
-                    <ol>
+                    <ul>
                         {% if not categories %}
                             <li class="no-event">
                                 <span class="event-title italic text-superfluous">
@@ -166,11 +166,11 @@
                                 {{ user_category(category.categ, category.path, category.managed) }}
                             {% endfor %}
                         {% endif %}
-                    </ol>
+                    </ul>
                 </div>
                 <div class="dashboard-box">
                     <h3>{% trans %}Happening in your categories{% endtrans %}</h3>
-                    <ol>
+                    <ul>
                         {% if not categories %}
                             <li class="no-event">
                                 <span class="event-title italic text-superfluous">
@@ -204,7 +204,7 @@
                                 </li>
                             {% endfor %}
                         {% endif %}
-                    </ol>
+                    </ul>
                 </div>
             </div>
         </div>

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -85,7 +85,7 @@
                 {% if unlisted_events %}
                     <div class="dashboard-box">
                         <h3>{% trans %}Your unlisted events{% endtrans %}</h3>
-                        <ol>
+                        <ul>
                             {% for event in unlisted_events %}
                                 <li class="flexrow">
                                     <span class="event-date f-self-no-shrink"
@@ -103,7 +103,7 @@
                                     </a>
                                 </li>
                             {% endfor %}
-                        </ol>
+                        </ul>
                     </div>
                 {% endif %}
                 <div class="dashboard-box">

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -82,6 +82,36 @@
                         </a>
                     </div>
                 </div>
+                <div id="happeningCategories" class="dashboard-box">
+                    <h3>{% trans %}Your unlisted events{% endtrans %}</h3>
+                    <ol>
+                        {% if not unlisted_events %}
+                            <li class="no-event">
+                                <span class="event-title italic text-superfluous">
+                                    {% trans %}You have no unlisted events.{% endtrans %}
+                                </span>
+                            </li>
+                        {% else %}
+                            {% for event in unlisted_events %}
+                                <li class="flexrow">
+                                    <span class="event-date f-self-no-shrink"
+                                          title="{{ _format_event_times(event) }}">
+                                        {{ _format_event_time(event) }}
+                                    </span>
+                                    <span class="event-title ellipsis f-self-stretch">
+                                        <a href="{{ event.url }}">
+                                            {{ event.get_verbose_title(show_series_pos=true) }}
+                                        </a>
+                                        {{ event.get_label_markup('mini') }}
+                                    </span>
+                                    <a href="{{ url_for('event_management.settings', event) }}">
+                                        <span class="unlisted-events-action icon-edit active"></span>
+                                    </a>
+                                </li>
+                            {% endfor %}
+                        {% endif %}
+                    </ol>
+                </div>
                 <div class="dashboard-box">
                     <h3>
                         {% trans %}Your events at hand{% endtrans %}

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -165,16 +165,12 @@ def get_linked_events(user, dt, limit=None, load_also=()):
 
 
 def get_unlisted_events(user):
-    """Get the unlisted events for the given user.
-
-    :param user: A `User`
-    """
-    return (Event.query
+    return (user.created_events
             .filter(~Event.is_deleted,
-                    Event.creator_id == user.id,
                     Event.category_id.is_(None))
             .options(load_only('id', 'title', 'start_dt'))
-            .order_by(Event.start_dt)).all()
+            .order_by(Event.start_dt)
+            .all())
 
 
 def serialize_user(user):

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -164,6 +164,19 @@ def get_linked_events(user, dt, limit=None, load_also=()):
     return {event: links[event.id] for event in query}
 
 
+def get_unlisted_events(user):
+    """Get the unlisted events for the given user.
+
+    :param user: A `User`
+    """
+    return (Event.query
+            .filter(~Event.is_deleted,
+                    Event.creator_id == user.id,
+                    Event.category_id.is_(None))
+            .options(load_only('id', 'title', 'start_dt'))
+            .order_by(Event.start_dt)).all()
+
+
 def serialize_user(user):
     """Serialize user to JSON-like object."""
     return {

--- a/indico/web/breadcrumbs.py
+++ b/indico/web/breadcrumbs.py
@@ -5,6 +5,8 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from dataclasses import dataclass
+
 from flask import render_template, session
 
 from indico.util.i18n import _
@@ -12,11 +14,30 @@ from indico.web.flask.util import url_for
 from indico.web.util import url_for_index
 
 
+@dataclass()
+class Breadcrumb:
+    """A breadcrumb to be rendered by the template.
+
+    If `url` is present, the breadcrumb will be a link to it.
+
+    The `content` is typically string or Markup object, but in some special cases
+    it may also be a different object.
+
+    Typically this class does not need to be used when registering a template hook
+    unless you need the ability to specify priority or disable markup wrapping at
+    execution time, or yield multiple snippets with different settings.
+    """
+
+    title: str
+    url: str = None
+    icon: str = None
+
+
 def render_breadcrumbs(*titles, category=None, event=None, management=False, category_url_factory=None):
     """Render the breadcrumb navigation.
 
-    :param titles: A list of plain text titles.  If present, these will
-                   simply create a unlinked trail of breadcrumbs.
+    :param titles: A list of titles, either strings or Breadcrumb objects.
+                   If present, these will simply create a trail of breadcrumbs.
                    A 'Home' element is inserted automatically.
     :param event: Generate the event/category breadcrumb trail starting
                   at the specified event.
@@ -29,25 +50,28 @@ def render_breadcrumbs(*titles, category=None, event=None, management=False, cat
                        should link to management pages.
     """
     assert titles or event or category
+
     if not category and not event:
-        items = [(_('Home'), url_for_index())]
+        items = [Breadcrumb(_('Home'), url_for_index())]
     elif event and not event.category:
         assert category is None
         items = []
-        # TODO: add link to unlisted events view
-        items.append((_('My unlisted events'), None))
-        items.append((event.title, url_for('event_management.settings', event) if management else event.url))
+        items.append(Breadcrumb(_('My unlisted events'), url_for('users.user_dashboard')))
+        items.append(Breadcrumb(event.title, url_for('event_management.settings', event) if management else event.url,
+                                'icon-unlisted-event'))
     else:
         items = []
         if event:
-            items.append((event.title, url_for('event_management.settings', event) if management else event.url))
+            items.append(Breadcrumb(event.title,
+                                    url_for('event_management.settings', event) if management else event.url))
             category = event.category
         if category_url_factory is None:
             category_url_factory = lambda cat, management: (url_for('categories.manage_content', cat)
                                                             if management and cat.can_manage(session.user)
                                                             else cat.url)
         for cat in category.chain_query[::-1]:
-            items.append((cat.title, category_url_factory(cat, management=management)))
+            items.append(Breadcrumb(cat.title, category_url_factory(cat, management=management)))
         items.reverse()
-    items += [(x, None) if isinstance(x, str) else x for x in titles]
+
+    items += [Breadcrumb(title) if isinstance(title, str) else title for title in titles]
     return render_template('breadcrumbs.html', items=items, management=management)

--- a/indico/web/breadcrumbs.py
+++ b/indico/web/breadcrumbs.py
@@ -14,7 +14,7 @@ from indico.web.flask.util import url_for
 from indico.web.util import url_for_index
 
 
-@dataclass()
+@dataclass(frozen=True)
 class Breadcrumb:
     """A breadcrumb to be rendered by the template.
 

--- a/indico/web/breadcrumbs.py
+++ b/indico/web/breadcrumbs.py
@@ -31,6 +31,11 @@ def render_breadcrumbs(*titles, category=None, event=None, management=False, cat
     assert titles or event or category
     if not category and not event:
         items = [(_('Home'), url_for_index())]
+    elif event and not category and not event.category:
+        items = []
+        # TODO: add link to unlisted events view
+        items.append((_('My unlisted events'), None))
+        items.append((event.title, url_for('event_management.settings', event) if management else event.url))
     else:
         items = []
         if event:

--- a/indico/web/breadcrumbs.py
+++ b/indico/web/breadcrumbs.py
@@ -20,12 +20,8 @@ class Breadcrumb:
 
     If `url` is present, the breadcrumb will be a link to it.
 
-    The `content` is typically string or Markup object, but in some special cases
-    it may also be a different object.
-
-    Typically this class does not need to be used when registering a template hook
-    unless you need the ability to specify priority or disable markup wrapping at
-    execution time, or yield multiple snippets with different settings.
+    If `icon` is present, the breadcrumb will include the specified icon after the
+    title.
     """
 
     title: str

--- a/indico/web/breadcrumbs.py
+++ b/indico/web/breadcrumbs.py
@@ -31,7 +31,8 @@ def render_breadcrumbs(*titles, category=None, event=None, management=False, cat
     assert titles or event or category
     if not category and not event:
         items = [(_('Home'), url_for_index())]
-    elif event and not category and not event.category:
+    elif event and not event.category:
+        assert category is None
         items = []
         # TODO: add link to unlisted events view
         items.append((_('My unlisted events'), None))

--- a/indico/web/client/js/jquery/widgets/categorynavigator.js
+++ b/indico/web/client/js/jquery/widgets/categorynavigator.js
@@ -77,7 +77,7 @@ import Palette from '../../utils/palette';
         self._fillCache(self.options.category);
         self._categoryId = self.options.category.category.id;
       } else {
-        self._categoryId = self.options.category;
+        self._categoryId = self.options.category || 0;
       }
       if (self.options.openInDialog) {
         self._createInDialog();

--- a/indico/web/client/js/jquery/widgets/jinja/boolean_buttons_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/boolean_buttons_widget.js
@@ -1,0 +1,27 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2021 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {WTFButtonsBooleanField} from 'indico/react/components';
+
+window.setupBooleanButtonsWidget = function setupBooleanButtonsWidget({
+  fieldId,
+  trueCaption,
+  falseCaption,
+  disabled,
+}) {
+  ReactDOM.render(
+    <WTFButtonsBooleanField
+      checkboxId={`${fieldId}-checkbox`}
+      trueCaption={trueCaption}
+      falseCaption={falseCaption}
+      disabled={disabled}
+    />,
+    document.getElementById(fieldId)
+  );
+};

--- a/indico/web/client/js/jquery/widgets/jinja/index.js
+++ b/indico/web/client/js/jquery/widgets/jinja/index.js
@@ -5,6 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import './boolean_buttons_widget';
 import './category_picker_widget';
 import './ckeditor_widget';
 import './color_picker_widget';

--- a/indico/web/client/js/jquery/widgets/jinja/permissions_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/permissions_widget.js
@@ -21,6 +21,7 @@ import Palette from 'indico/utils/palette';
   $.widget('indico.permissionswidget', {
     options: {
       objectType: null,
+      isUnlistedEvent: null,
       permissionsInfo: null,
       hiddenPermissions: null,
       hiddenPermissionsInfo: null,
@@ -346,11 +347,13 @@ import Palette from 'indico/utils/palette';
         this.$permissionsWidgetList.append(this._renderItem(item));
       });
       // Add default entries
-      const anonymous = [
-        {_type: 'DefaultEntry', name: $T.gettext('Anonymous'), id: 'anonymous'},
-        [READ_ACCESS_PERMISSIONS],
-      ];
-      this.$permissionsWidgetList.append(this._renderItem(anonymous));
+      if (!this.options.isUnlistedEvent) {
+        const anonymous = [
+          {_type: 'DefaultEntry', name: $T.gettext('Anonymous'), id: 'anonymous'},
+          [READ_ACCESS_PERMISSIONS],
+        ];
+        this.$permissionsWidgetList.append(this._renderItem(anonymous));
+      }
 
       if (this.options.hiddenPermissions.length > 0) {
         const additionalPermissions = [
@@ -374,17 +377,19 @@ import Palette from 'indico/utils/palette';
         this.$permissionsWidgetList.append(this._renderHiddenPermissions(additionalPermissions));
       }
 
-      let managersTitle;
-      if (this.options.objectType === 'event') {
-        managersTitle = $T.gettext('Category Managers');
-      } else if (this.options.objectType === 'category') {
-        managersTitle = $T.gettext('Parent Category Managers');
-      } else {
-        managersTitle = $T.gettext('Event Managers');
+      if (!this.options.isUnlistedEvent) {
+        let managersTitle;
+        if (this.options.objectType === 'event') {
+          managersTitle = $T.gettext('Category Managers');
+        } else if (this.options.objectType === 'category') {
+          managersTitle = $T.gettext('Parent Category Managers');
+        } else {
+          managersTitle = $T.gettext('Event Managers');
+        }
+        const managers = [{_type: 'DefaultEntry', name: managersTitle}, [FULL_ACCESS_PERMISSIONS]];
+        this.$permissionsWidgetList.prepend(this._renderItem(managers));
+        this.$permissionsWidgetList.find('.anonymous').toggle(!this.isEventProtected);
       }
-      const managers = [{_type: 'DefaultEntry', name: managersTitle}, [FULL_ACCESS_PERMISSIONS]];
-      this.$permissionsWidgetList.prepend(this._renderItem(managers));
-      this.$permissionsWidgetList.find('.anonymous').toggle(!this.isEventProtected);
 
       if (this.$eventRoleDropdown.length) {
         this._renderDropdown(this.$eventRoleDropdown);

--- a/indico/web/client/js/react/components/WTFButtonsBooleanField.jsx
+++ b/indico/web/client/js/react/components/WTFButtonsBooleanField.jsx
@@ -1,0 +1,57 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2021 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import React, {useMemo, useState} from 'react';
+
+import {Translate} from '../i18n';
+
+import IButton from './IButton';
+
+export default function WTFButtonsBooleanField({checkboxId, trueCaption, falseCaption, disabled}) {
+  const checkboxField = useMemo(() => document.getElementById(checkboxId), [checkboxId]);
+  const [value, setValue] = useState(JSON.parse(checkboxField.value));
+  const [trueText, trueIcon] = trueCaption;
+  const [falseText, falseIcon] = falseCaption;
+
+  const handleSetTrue = () => {
+    setValue(true);
+    checkboxField.value = true;
+    checkboxField.dispatchEvent(new Event('change'));
+  };
+
+  const handleSetFalse = () => {
+    setValue(false);
+    checkboxField.value = false;
+    checkboxField.dispatchEvent(new Event('change'));
+  };
+
+  return (
+    <>
+      <IButton icon={trueIcon} highlight={value} onClick={handleSetTrue} disabled={disabled}>
+        <strong>{trueText}</strong>
+      </IButton>
+
+      <IButton icon={falseIcon} highlight={!value} onClick={handleSetFalse} disabled={disabled}>
+        <strong>{falseText}</strong>
+      </IButton>
+    </>
+  );
+}
+
+WTFButtonsBooleanField.propTypes = {
+  checkboxId: PropTypes.string.isRequired,
+  trueCaption: PropTypes.array,
+  falseCaption: PropTypes.array,
+  disabled: PropTypes.bool,
+};
+
+WTFButtonsBooleanField.defaultProps = {
+  trueCaption: [Translate.string('Yes')],
+  falseCaption: [Translate.string('No')],
+  disabled: false,
+};

--- a/indico/web/client/js/react/components/index.js
+++ b/indico/web/client/js/react/components/index.js
@@ -38,6 +38,7 @@ export {default as ReviewRating} from './ReviewRating';
 export {default as ManagementPageBackButton} from './ManagementPageBackButton';
 export {default as ManagementPageSubTitle} from './ManagementPageSubTitle';
 export {default as ManagementPageTitle} from './ManagementPageTitle';
+export {default as WTFButtonsBooleanField} from './WTFButtonsBooleanField';
 export {default as WTFDateField} from './WTFDateField';
 export {default as WTFDateTimeField} from './WTFDateTimeField';
 export {default as WTFTimeField} from './WTFTimeField';

--- a/indico/web/client/styles/modules/_dashboard.scss
+++ b/indico/web/client/styles/modules/_dashboard.scss
@@ -82,7 +82,6 @@
   background: #dcebf5;
 }
 
-.dashboard-box ol,
 .dashboard-box ul {
   list-style: none;
   margin: 0;
@@ -90,15 +89,13 @@
   border: none;
 }
 
-.dashboard-box ol li,
 .dashboard-box ul li {
   border-bottom: 1px solid #e5e5e5;
   padding: 10px 10px 5px 10px;
 }
 
-.dashboard-box ol li a,
-.dashboard-box ol li.no-event span,
-.dashboard-box ul li a {
+.dashboard-box ul li a,
+.dashboard-box ul li.no-event span {
   font-size: 1.2em;
   line-height: 18px;
   position: relative;
@@ -109,66 +106,62 @@
   -ms-user-select: none;
 }
 
-.dashboard-box.suggestions ol li > a {
+.dashboard-box.suggestions ul li > a {
   margin-right: 15px;
 }
 
-.dashboard-box ol li .actions {
+.dashboard-box ul li .actions {
   font-size: 10px;
   padding: 0 0 5px 10px;
 }
 
-.dashboard-box ol li .actions a:hover span {
+.dashboard-box ul li .actions a:hover span {
   text-decoration: underline;
 }
 
-.dashboard-box.suggestions ol .item-legend {
+.dashboard-box.suggestions ul .item-legend {
   display: none;
 }
 
-.dashboard-box ol li:last-child > a,
-.dashboard-box ol li.no-event:last-child span {
+.dashboard-box ul li:last-child > a,
+.dashboard-box ul li.no-event:last-child span {
   border-bottom: none;
 }
 
-.dashboard-box ol li > a:hover .event-title,
 .dashboard-box ul li > a:hover .event-title {
   text-decoration: underline;
 }
 
-.dashboard-box ol .event-title,
 .dashboard-box ul .event-title {
   vertical-align: middle;
 }
 
-.dashboard-box ol .event-date,
-.dashboard-box ol .event-category,
-.dashboard-box ul .event-date {
+.dashboard-box ul .event-date,
+.dashboard-box ul .event-category {
   color: $dark-gray;
   display: inline-block;
   font-weight: normal;
   vertical-align: middle;
 }
 
-.dashboard-box ol .event-date,
 .dashboard-box ul .event-date {
   display: inline-block;
   font-size: 12px;
-  width: 85px;
+  width: 95px;
 }
 
-.dashboard-box ol .event-category {
+.dashboard-box ul .event-category {
   display: block;
   font-size: 0.8em;
 }
 
-.dashboard-box ol .item-legend {
+.dashboard-box ul .item-legend {
   max-width: 150px;
   position: relative;
   float: right;
 }
 
-.dashboard-box ol li .close-box {
+.dashboard-box ul li .close-box {
   display: none;
   font-size: 18px;
   position: absolute;
@@ -177,7 +170,7 @@
   margin: 10px 10px 0 0;
 }
 
-.dashboard-box ol li:hover .close-box {
+.dashboard-box ul li:hover .close-box {
   display: inline-block;
 }
 

--- a/indico/web/client/styles/modules/_dashboard.scss
+++ b/indico/web/client/styles/modules/_dashboard.scss
@@ -82,20 +82,23 @@
   background: #dcebf5;
 }
 
-.dashboard-box ol {
+.dashboard-box ol,
+.dashboard-box ul {
   list-style: none;
   margin: 0;
   padding: 0;
   border: none;
 }
 
-.dashboard-box ol li {
+.dashboard-box ol li,
+.dashboard-box ul li {
   border-bottom: 1px solid #e5e5e5;
   padding: 10px 10px 5px 10px;
 }
 
 .dashboard-box ol li a,
-.dashboard-box ol li.no-event span {
+.dashboard-box ol li.no-event span,
+.dashboard-box ul li a {
   font-size: 1.2em;
   line-height: 18px;
   position: relative;
@@ -128,23 +131,27 @@
   border-bottom: none;
 }
 
-.dashboard-box ol li > a:hover .event-title {
+.dashboard-box ol li > a:hover .event-title,
+.dashboard-box ul li > a:hover .event-title {
   text-decoration: underline;
 }
 
-.dashboard-box ol .event-title {
+.dashboard-box ol .event-title,
+.dashboard-box ul .event-title {
   vertical-align: middle;
 }
 
 .dashboard-box ol .event-date,
-.dashboard-box ol .event-category {
+.dashboard-box ol .event-category,
+.dashboard-box ul .event-date {
   color: $dark-gray;
   display: inline-block;
   font-weight: normal;
   vertical-align: middle;
 }
 
-.dashboard-box ol .event-date {
+.dashboard-box ol .event-date,
+.dashboard-box ul .event-date {
   display: inline-block;
   font-size: 12px;
   width: 85px;

--- a/indico/web/client/styles/modules/_users.scss
+++ b/indico/web/client/styles/modules/_users.scss
@@ -318,3 +318,7 @@
     margin-top: 0.2rem;
   }
 }
+
+.unlisted-events-action {
+  font-size: 1.05em;
+}

--- a/indico/web/client/styles/partials/_actionboxes.scss
+++ b/indico/web/client/styles/partials/_actionboxes.scss
@@ -163,4 +163,9 @@
   .date {
     font-weight: bold;
   }
+
+  &.mid-form {
+    margin-top: 5px;
+    margin-bottom: 6px;
+  }
 }

--- a/indico/web/client/styles/partials/_icons.scss
+++ b/indico/web/client/styles/partials/_icons.scss
@@ -601,3 +601,8 @@ i[class^='icon-']::before {
   @extend .icon-lock;
   color: $red;
 }
+
+.icon-unlisted-event {
+  @extend .icon-eye-blocked;
+  color: $red;
+}

--- a/indico/web/forms/fields/simple.py
+++ b/indico/web/forms/fields/simple.py
@@ -9,6 +9,7 @@ import json
 
 from markupsafe import escape
 from wtforms.fields import Field, HiddenField, PasswordField, RadioField, SelectMultipleField, TextAreaField
+from wtforms.fields.core import BooleanField
 from wtforms.widgets import CheckboxInput
 
 from indico.util.i18n import _
@@ -32,6 +33,15 @@ class IndicoSelectMultipleCheckboxBooleanField(IndicoSelectMultipleCheckboxField
         for value, label in self.choices:
             selected = self.data is not None and self.data.get(self.coerce(value))
             yield (value, label, selected)
+
+
+class IndicoButtonsBooleanField(BooleanField):
+    widget = JinjaWidget('forms/buttons_boolean_widget.html', single_kwargs=True, single_line=True)
+
+    def __init__(self, *args, **kwargs):
+        self.true_caption = kwargs.pop('true_caption')
+        self.false_caption = kwargs.pop('false_caption')
+        super().__init__(*args, **kwargs)
 
 
 class IndicoRadioField(RadioField):

--- a/indico/web/templates/breadcrumbs.html
+++ b/indico/web/templates/breadcrumbs.html
@@ -1,20 +1,26 @@
 <div class="main-breadcrumb {{ 'management' if management }}"
      itemprop="breadcrumb" itemscope itemtype="http://schema.org/Breadcrumb">
     <span class="path" itemscope itemtype="http://schema.org/BreadcrumbList">
-        {% for (title, url) in items %}
+        {% for item in items %}
             {%- if not loop.first -%}
                 <span class="sep">»</span>
             {%- endif -%}
-            {%- if url -%}
+            {%- if item.url -%}
                 <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-                    <a href="{{ url }}" itemprop="item" class="item">
-                        <span itemprop="name">{{ title|truncate(40) }}</span>
+                    <a href="{{ item.url }}" itemprop="item" class="item">
+                        <span itemprop="name">{{ item.title|truncate(40) }}</span>
                     </a>
+                    {%- if item.icon -%}
+                        <i class="{{ item.icon }}"></i>
+                    {%- endif -%}
                     <meta itemprop="position" content="{{ loop.index }}" />
                 </span>
             {%- else -%}
                 <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
-                    <span class="item" itemprop="name">{{ title|truncate(40) }}</span>
+                    <span class="item" itemprop="name">{{ item.title|truncate(40) }}</span>
+                    {%- if item.icon -%}
+                        <i class="{{ item.icon }}"></i>
+                    {%- endif -%}
                     <meta itemprop="position" content="{{ loop.index }}" />
                 </span>
             {%- endif -%}

--- a/indico/web/templates/forms/buttons_boolean_widget.html
+++ b/indico/web/templates/forms/buttons_boolean_widget.html
@@ -1,0 +1,21 @@
+{% extends 'forms/base_widget.html' %}
+
+{% block html %}
+    <div class="i-form-field-fixed-width">
+        <input type="hidden" name="{{ field.name }}" id="{{ field.id }}-checkbox"
+               {% if field.data is not none %}value="{{ field.data | tojson }}"{% endif %}
+               {{ input_args | html_params }}>
+        <span id="{{ field.id }}"></span>
+    </div>
+{% endblock %}
+
+{% block javascript %}
+    <script>
+        setupBooleanButtonsWidget({
+            fieldId: {{ field.id | tojson }},
+            trueCaption: {{ field.true_caption | tojson }},
+            falseCaption: {{ field.false_caption | tojson }},
+            disabled: {{ input_args.disabled | default(false) | tojson }},
+        });
+    </script>
+{% endblock %}

--- a/indico/web/templates/forms/permissions_widget.html
+++ b/indico/web/templates/forms/permissions_widget.html
@@ -61,5 +61,10 @@
             hiddenPermissions: {{ field.hidden_permissions|default([])|tojson }},
             hiddenPermissionsInfo: {{ field.hidden_permissions_info|tojson }}
         });
+
+        // make sure permission widget updates even if protection widget is not there to trigger an update
+        {% if field.event.category is none %}
+            $('#permissions-widget-{{ field.id }}').trigger('indico:protectionModeChanged');
+        {% endif %}
     </script>
 {% endblock %}

--- a/indico/web/templates/forms/permissions_widget.html
+++ b/indico/web/templates/forms/permissions_widget.html
@@ -56,10 +56,11 @@
 {% block javascript %}
     <script>
         $('#permissions-widget-{{ field.id }}').permissionswidget({
-            objectType: {{ field.object_type|tojson }},
-            permissionsInfo: {{ field.permissions_info|tojson }},
-            hiddenPermissions: {{ field.hidden_permissions|default([])|tojson }},
-            hiddenPermissionsInfo: {{ field.hidden_permissions_info|tojson }}
+            objectType: {{ field.object_type | tojson }},
+            isUnlistedEvent: {{ (field.object_type == 'event' and field.event.category is none) | tojson }},
+            permissionsInfo: {{ field.permissions_info | tojson }},
+            hiddenPermissions: {{ field.hidden_permissions | default([]) | tojson }},
+            hiddenPermissionsInfo: {{ field.hidden_permissions_info | tojson }}
         });
 
         // make sure permission widget updates even if protection widget is not there to trigger an update

--- a/indico/web/templates/forms/permissions_widget.html
+++ b/indico/web/templates/forms/permissions_widget.html
@@ -63,7 +63,7 @@
         });
 
         // make sure permission widget updates even if protection widget is not there to trigger an update
-        {% if field.event.category is none %}
+        {% if field.object_type == 'event' and field.event.category is none %}
             $('#permissions-widget-{{ field.id }}').trigger('indico:protectionModeChanged');
         {% endif %}
     </script>


### PR DESCRIPTION
This PR adds a React form field for booleans which shows two captioned buttons. The field is then used to show the listed/unlisted selector similar to [this mock](https://user-images.githubusercontent.com/6058151/124724777-93f76e00-df0c-11eb-8b0f-4fee73a2a622.png).

![image](https://user-images.githubusercontent.com/6058151/130641046-0ea6ea10-0076-4364-ab8d-52f375dbf999.png)
![image](https://user-images.githubusercontent.com/6058151/130641118-cb034b98-d037-496a-9599-e711049d5c06.png)

