### PR TITLE
Category moderation  - Move request email notifications

### DIFF
--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -33,7 +33,7 @@ from indico.modules.categories.schemas import EventMoveRequestSchema
 from indico.modules.categories.util import get_image_data, serialize_category_role
 from indico.modules.categories.views import WPCategoryManagement
 from indico.modules.events import Event
-from indico.modules.events.notifications import notify_move_request
+from indico.modules.events.notifications import notify_move_request_closure, notify_move_request_creation
 from indico.modules.events.operations import create_event_request
 from indico.modules.logs.models.entries import CategoryLogRealm, LogKind
 from indico.modules.rb.models.reservations import Reservation, ReservationLink
@@ -142,8 +142,7 @@ class RHAPIEventMoveRequests(RHManageCategoryBase):
 
         for rq in move_requests:
             update_event_move_request(rq, accept, reason)
-
-        notify_move_request(move_requests, accept, reason)
+        notify_move_request_closure(move_requests, accept, reason)
 
         return '', 204
 
@@ -472,6 +471,7 @@ class RHMoveEvents(RHManageCategorySelectedEventsBase):
         else:
             for event in self.events:
                 create_event_request(event, self.target_category, self.comment)
+            notify_move_request_creation(self.events, self.target_category, self.comment)
             flash(ngettext('You have requested the move of {count} event to the category "{cat}"',
                            'You have requested the move of {count} events to the category "{cat}"', len(self.events))
                   .format(count=len(self.events), cat=self.target_category.title), 'success')

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -33,6 +33,7 @@ from indico.modules.categories.schemas import EventMoveRequestSchema
 from indico.modules.categories.util import get_image_data, serialize_category_role
 from indico.modules.categories.views import WPCategoryManagement
 from indico.modules.events import Event
+from indico.modules.events.notifications import notify_move_request
 from indico.modules.events.operations import create_event_request
 from indico.modules.logs.models.entries import CategoryLogRealm, LogKind
 from indico.modules.rb.models.reservations import Reservation, ReservationLink
@@ -141,6 +142,9 @@ class RHAPIEventMoveRequests(RHManageCategoryBase):
 
         for rq in move_requests:
             update_event_move_request(rq, accept, reason)
+
+        notify_move_request(move_requests, accept, reason)
+
         return '', 204
 
 

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -12,6 +12,7 @@ from werkzeug.exceptions import Forbidden, NotFound
 from indico.modules.categories.models.categories import Category
 from indico.modules.events.management.controllers.base import RHManageEventBase
 from indico.modules.events.models.events import EventType
+from indico.modules.events.notifications import notify_move_request_creation
 from indico.modules.events.operations import create_event_request, lock_event, unlock_event, update_event_type
 from indico.util.i18n import _
 from indico.util.marshmallow import ModelField
@@ -105,6 +106,7 @@ class RHMoveEvent(RHManageEventBase):
                   'success')
         else:
             create_event_request(self.event, self.target_category, self.comment)
+            notify_move_request_creation([self.event], self.target_category, self.comment)
             flash(_('Moving the event "{event}" to "{category}" has been requested and is pending approval')
                   .format(event=self.event.title, category=self.target_category.title),
                   'success')

--- a/indico/modules/events/management/controllers/actions.py
+++ b/indico/modules/events/management/controllers/actions.py
@@ -112,7 +112,7 @@ class RHMoveEvent(RHManageEventBase):
 
 
 class RHWithdrawMoveRequest(RHManageEventBase):
-    """Move event to a different category."""
+    """Withdraw a move request."""
 
     def _process_args(self):
         RHManageEventBase._process_args(self)

--- a/indico/modules/events/notifications.py
+++ b/indico/modules/events/notifications.py
@@ -4,6 +4,7 @@
 # Indico is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
+
 import itertools
 
 from sqlalchemy.orm import joinedload
@@ -84,4 +85,4 @@ def notify_move_request_closure(move_requests, accept, reason=''):
         events = [rq.event for rq in requests]
         template = get_template_module('events/emails/move_request_closure.txt',
                                        events=events, accept=accept, reason=reason)
-        send_email(make_email(bcc_list=requestor.email, template=template))
+        send_email(make_email(to_list=requestor.email, template=template))

--- a/indico/modules/events/notifications.py
+++ b/indico/modules/events/notifications.py
@@ -14,6 +14,19 @@ from indico.modules.categories.models.categories import Category
 from indico.web.flask.templating import get_template_module
 
 
+def _get_emails_from_category(category, ignore_notify_managers=False):
+    emails = set(category.event_creation_notification_emails)
+
+    if category.notify_managers or ignore_notify_managers:
+        for manager in category.get_manager_list():
+            if manager.principal_type in (PrincipalType.user, PrincipalType.email):
+                emails.add(manager.email)
+            elif manager.principal_type in (PrincipalType.local_group, PrincipalType.multipass_group):
+                emails.update(x.email for x in manager.get_members())
+
+    return emails
+
+
 def notify_event_creation(event, occurrences=None):
     """Send email notifications when a new Event is created.
 
@@ -28,20 +41,37 @@ def notify_event_creation(event, occurrences=None):
              filter(Category.notify_managers | (Category.event_creation_notification_emails != []))
              .options(joinedload('acl_entries')))
     for cat in query:
-        emails.update(cat.event_creation_notification_emails)
-        if cat.notify_managers:
-            for manager in cat.get_manager_list():
-                if manager.principal_type in (PrincipalType.user, PrincipalType.email):
-                    emails.add(manager.email)
-                elif manager.principal_type in (PrincipalType.local_group, PrincipalType.multipass_group):
-                    emails.update(x.email for x in manager.get_members())
+        emails.update(_get_emails_from_category(cat))
 
     if emails:
         template = get_template_module('events/emails/event_creation.txt', event=event, occurrences=occurrences)
         send_email(make_email(bcc_list=emails, template=template))
 
 
-def notify_move_request(move_requests, accept, reason=''):
+def notify_move_request_creation(events, target_category, comment=''):
+    """Send email notifications when a move request is created.
+
+    :param events: List of events requested to move.
+    :param target_category: The category to move the events into.
+    :param comment: Optional requestor's comment.
+    """
+    emails = set()
+    query = (target_category.chain_query
+             .filter(Category.notify_managers | (Category.event_creation_notification_emails != []))
+             .options(joinedload('acl_entries')))
+
+    # Walk up the category chain
+    for cat in reversed(query.all()):
+        emails.update(_get_emails_from_category(cat, ignore_notify_managers=True))
+
+        if emails:
+            template = get_template_module('events/emails/move_request_creation.txt',
+                                           events=events, target_category=target_category, comment=comment)
+            send_email(make_email(bcc_list=emails, template=template))
+            break
+
+
+def notify_move_request_closure(move_requests, accept, reason=''):
     """Send email notifications when a move request is accepted/rejected.
 
     :param move_requests: List of `EventMoveRequest` that were accepted/rejected.

--- a/indico/modules/events/notifications_test.py
+++ b/indico/modules/events/notifications_test.py
@@ -20,7 +20,7 @@ from indico.web.flask.templating import get_template_module
 ))
 def test_move_request_creation_email_plaintext(snapshot, create_category, create_event, num_events, comment,
                                                snapshot_name):
-    cat = create_category(title='target')
+    cat = create_category(id_=314, title='target')
     events = [create_event(id_=n, title=f'test {n}') for n in range(1, num_events + 1)]
     template = get_template_module('events/emails/move_request_creation.txt',
                                    events=events, target_category=cat, comment=comment)
@@ -38,7 +38,7 @@ def test_move_request_creation_email_plaintext(snapshot, create_category, create
 ))
 def test_move_request_closed_email_plaintext(snapshot, create_category, create_event, accept, num_events, reason,
                                              snapshot_name):
-    cat = create_category(title='target')
+    cat = create_category(id_=314, title='target')
     events = [create_event(id_=n, title=f'test {n}') for n in range(1, num_events + 1)]
     template = get_template_module('events/emails/move_request_closure.txt',
                                    events=events, target_category=cat, accept=accept, reason=reason)

--- a/indico/modules/events/notifications_test.py
+++ b/indico/modules/events/notifications_test.py
@@ -1,0 +1,46 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from pathlib import Path
+
+import pytest
+
+from indico.web.flask.templating import get_template_module
+
+
+@pytest.mark.parametrize(('num_events', 'comment', 'snapshot_name'), (
+    (1, '', 'move-request-new-single-nocomment.txt'),
+    (2, '', 'move-request-new-multi-nocomment.txt'),
+    (1, 'Please move this.\nThanks!', 'move-request-new-single-comment.txt'),
+    (2, 'Please move this.\nThanks!', 'move-request-new-multi-comment.txt'),
+))
+def test_move_request_creation_email_plaintext(snapshot, create_category, create_event, num_events, comment,
+                                               snapshot_name):
+    cat = create_category(title='target')
+    events = [create_event(id_=n, title=f'test {n}') for n in range(1, num_events + 1)]
+    template = get_template_module('events/emails/move_request_creation.txt',
+                                   events=events, target_category=cat, comment=comment)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), snapshot_name)
+
+
+@pytest.mark.parametrize(('accept', 'num_events', 'reason', 'snapshot_name'), (
+    (False, 1, '', 'move-request-rejected-single-noreason.txt'),
+    (False, 2, '', 'move-request-rejected-multi-noreason.txt'),
+    (False, 1, 'We do not want your event.\nSorry not sorry.', 'move-request-rejected-single-reason.txt'),
+    (False, 2, 'We do not want your event.\nSorry not sorry.', 'move-request-rejected-multi-reason.txt'),
+    (True, 1, '', 'move-request-accepted-single.txt'),
+    (True, 2, '', 'move-request-accepted-multi.txt'),
+))
+def test_move_request_closed_email_plaintext(snapshot, create_category, create_event, accept, num_events, reason,
+                                             snapshot_name):
+    cat = create_category(title='target')
+    events = [create_event(id_=n, title=f'test {n}') for n in range(1, num_events + 1)]
+    template = get_template_module('events/emails/move_request_closure.txt',
+                                   events=events, target_category=cat, accept=accept, reason=reason)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), snapshot_name)

--- a/indico/modules/events/templates/emails/move_request_closure.txt
+++ b/indico/modules/events/templates/emails/move_request_closure.txt
@@ -1,0 +1,33 @@
+{% extends 'emails/base.txt' %}
+
+{% block subject -%}
+    Event move request update
+{%- endblock %}
+
+{% block header -%}{%- endblock %}
+
+{% block body -%}
+    {%- filter dedent -%}
+        {% if accept %}
+            The following events have been moved:
+        {% else %}
+            Move requests of the following events have been rejected:
+        {% endif %}
+
+        {% filter underline %}Events{% endfilter %}
+        {%- for evt in events %}
+            {{ evt.title }} ({{ evt.external_url }}) {# -#}
+        {% endfor %}
+
+        {% if not accept %}
+            {% filter underline %}Rejection reason{% endfilter %}
+            {{ reason }}
+        {%- endif -%}
+    {%- endfilter -%}
+{%- endblock %}
+
+{% block footer_title -%}
+    Event notifications
+{%- endblock %}
+
+{% block footer_url %}{% endblock %}

--- a/indico/modules/events/templates/emails/move_request_closure.txt
+++ b/indico/modules/events/templates/emails/move_request_closure.txt
@@ -1,25 +1,40 @@
 {% extends 'emails/base.txt' %}
 
 {% block subject -%}
-    Event move request update
+    {%- if accept -%}
+        Event move request accepted
+    {%- else -%}
+        Event move request rejected
+    {%- endif -%}
 {%- endblock %}
 
 {% block header -%}{%- endblock %}
 
 {% block body -%}
     {%- filter dedent -%}
-        {% if accept %}
-            The following events have been moved:
-        {% else %}
-            Move requests of the following events have been rejected:
-        {% endif %}
+        {%- if accept -%}
+            {% if events|length == 1 %}
+                Event moved:
+            {% else %}
+                The following events have been moved:
+            {% endif %}
+        {%- else -%}
+            {% if events|length == 1 %}
+                Request to move event rejected:
+            {% else %}
+                Move requests of the following events have been rejected:
+            {% endif %}
+        {%- endif %}
 
-        {% filter underline %}Events{% endfilter %}
         {%- for evt in events %}
-            {{ evt.title }} ({{ evt.external_url }}) {# -#}
-        {% endfor %}
+            - {{ evt.title }} ({{ evt.external_url }})
+        {%- endfor %}
 
-        {% if not accept %}
+        {% filter underline %}{{ 'New' if accept else 'Requested' }} category{% endfilter %}
+        {{ target_category.chain_titles|join(' » ') -}}
+
+        {% if not accept and reason %}
+
             {% filter underline %}Rejection reason{% endfilter %}
             {{ reason }}
         {%- endif -%}

--- a/indico/modules/events/templates/emails/move_request_creation.txt
+++ b/indico/modules/events/templates/emails/move_request_creation.txt
@@ -8,16 +8,26 @@
 
 {% block body -%}
     {%- filter dedent -%}
-        There are new move requests for the category:
+        {%- if events|length == 1 -%}
+            There is a new move request for the category:
+        {%- else -%}
+            There are new move requests for the category:
+        {%- endif %}
         {{ target_category.chain_titles|join(' » ') }}
 
         {% filter underline %}Requested events{% endfilter %}
         {%- for evt in events %}
             {{ evt.title }} ({{ evt.external_url }})
-        {% endfor %}
+        {%- endfor -%}
 
-        {% filter underline %}Comment{% endfilter %}
-        {{ comment }}
+        {% if comment %}
+
+            {% filter underline %}Comment{% endfilter %}
+            {{ comment }}
+        {%- endif %}
+
+        View all move requests here:
+        {{ url_for('categories.manage_moderation', target_category, _external=true) }}
     {%- endfilter -%}
 {%- endblock %}
 

--- a/indico/modules/events/templates/emails/move_request_creation.txt
+++ b/indico/modules/events/templates/emails/move_request_creation.txt
@@ -1,0 +1,28 @@
+{% extends 'emails/base.txt' %}
+
+{% block subject -%}
+    Event move request created
+{%- endblock %}
+
+{% block header -%}{%- endblock %}
+
+{% block body -%}
+    {%- filter dedent -%}
+        There are new move requests for the category:
+        {{ target_category.chain_titles|join(' » ') }}
+
+        {% filter underline %}Requested events{% endfilter %}
+        {%- for evt in events %}
+            {{ evt.title }} ({{ evt.external_url }})
+        {% endfor %}
+
+        {% filter underline %}Comment{% endfilter %}
+        {{ comment }}
+    {%- endfilter -%}
+{%- endblock %}
+
+{% block footer_title -%}
+    Event notifications
+{%- endblock %}
+
+{% block footer_url %}{% endblock %}

--- a/indico/modules/events/templates/emails/tests/move-request-accepted-multi.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-accepted-multi.txt
@@ -1,13 +1,12 @@
 
 The following events have been moved:
 
+- test 1 (http://localhost/event/1/)
+- test 2 (http://localhost/event/2/)
 
-Events
-------
-test 1 (http://localhost/event/1/) 
-test 2 (http://localhost/event/2/) 
-
-
+New category
+------------
+Home » target
 
 --
 Indico :: Event notifications

--- a/indico/modules/events/templates/emails/tests/move-request-accepted-multi.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-accepted-multi.txt
@@ -1,0 +1,14 @@
+
+The following events have been moved:
+
+
+Events
+------
+test 1 (http://localhost/event/1/) 
+test 2 (http://localhost/event/2/) 
+
+
+
+--
+Indico :: Event notifications
+

--- a/indico/modules/events/templates/emails/tests/move-request-accepted-single.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-accepted-single.txt
@@ -1,12 +1,11 @@
 
-The following events have been moved:
+Event moved:
 
+- test 1 (http://localhost/event/1/)
 
-Events
-------
-test 1 (http://localhost/event/1/) 
-
-
+New category
+------------
+Home » target
 
 --
 Indico :: Event notifications

--- a/indico/modules/events/templates/emails/tests/move-request-accepted-single.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-accepted-single.txt
@@ -1,0 +1,13 @@
+
+The following events have been moved:
+
+
+Events
+------
+test 1 (http://localhost/event/1/) 
+
+
+
+--
+Indico :: Event notifications
+

--- a/indico/modules/events/templates/emails/tests/move-request-new-multi-comment.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-new-multi-comment.txt
@@ -1,0 +1,18 @@
+There are new move requests for the category:
+Home » target
+
+Requested events
+----------------
+test 1 (http://localhost/event/1/)
+
+test 2 (http://localhost/event/2/)
+
+
+Comment
+-------
+Please move this.
+Thanks!
+
+--
+Indico :: Event notifications
+

--- a/indico/modules/events/templates/emails/tests/move-request-new-multi-comment.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-new-multi-comment.txt
@@ -4,14 +4,15 @@ Home » target
 Requested events
 ----------------
 test 1 (http://localhost/event/1/)
-
 test 2 (http://localhost/event/2/)
-
 
 Comment
 -------
 Please move this.
 Thanks!
+
+View all move requests here:
+http://localhost/category/314/manage/moderation
 
 --
 Indico :: Event notifications

--- a/indico/modules/events/templates/emails/tests/move-request-new-multi-nocomment.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-new-multi-nocomment.txt
@@ -4,13 +4,10 @@ Home » target
 Requested events
 ----------------
 test 1 (http://localhost/event/1/)
-
 test 2 (http://localhost/event/2/)
 
-
-Comment
--------
-
+View all move requests here:
+http://localhost/category/314/manage/moderation
 
 --
 Indico :: Event notifications

--- a/indico/modules/events/templates/emails/tests/move-request-new-multi-nocomment.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-new-multi-nocomment.txt
@@ -1,0 +1,17 @@
+There are new move requests for the category:
+Home » target
+
+Requested events
+----------------
+test 1 (http://localhost/event/1/)
+
+test 2 (http://localhost/event/2/)
+
+
+Comment
+-------
+
+
+--
+Indico :: Event notifications
+

--- a/indico/modules/events/templates/emails/tests/move-request-new-single-comment.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-new-single-comment.txt
@@ -1,15 +1,17 @@
-There are new move requests for the category:
+There is a new move request for the category:
 Home » target
 
 Requested events
 ----------------
 test 1 (http://localhost/event/1/)
 
-
 Comment
 -------
 Please move this.
 Thanks!
+
+View all move requests here:
+http://localhost/category/314/manage/moderation
 
 --
 Indico :: Event notifications

--- a/indico/modules/events/templates/emails/tests/move-request-new-single-comment.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-new-single-comment.txt
@@ -1,0 +1,16 @@
+There are new move requests for the category:
+Home » target
+
+Requested events
+----------------
+test 1 (http://localhost/event/1/)
+
+
+Comment
+-------
+Please move this.
+Thanks!
+
+--
+Indico :: Event notifications
+

--- a/indico/modules/events/templates/emails/tests/move-request-new-single-nocomment.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-new-single-nocomment.txt
@@ -1,14 +1,12 @@
-There are new move requests for the category:
+There is a new move request for the category:
 Home » target
 
 Requested events
 ----------------
 test 1 (http://localhost/event/1/)
 
-
-Comment
--------
-
+View all move requests here:
+http://localhost/category/314/manage/moderation
 
 --
 Indico :: Event notifications

--- a/indico/modules/events/templates/emails/tests/move-request-new-single-nocomment.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-new-single-nocomment.txt
@@ -1,0 +1,15 @@
+There are new move requests for the category:
+Home » target
+
+Requested events
+----------------
+test 1 (http://localhost/event/1/)
+
+
+Comment
+-------
+
+
+--
+Indico :: Event notifications
+

--- a/indico/modules/events/templates/emails/tests/move-request-rejected-multi-noreason.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-rejected-multi-noreason.txt
@@ -1,16 +1,12 @@
 
 Move requests of the following events have been rejected:
 
+- test 1 (http://localhost/event/1/)
+- test 2 (http://localhost/event/2/)
 
-Events
-------
-test 1 (http://localhost/event/1/) 
-test 2 (http://localhost/event/2/) 
-
-
-Rejection reason
-----------------
-
+Requested category
+------------------
+Home » target
 
 --
 Indico :: Event notifications

--- a/indico/modules/events/templates/emails/tests/move-request-rejected-multi-noreason.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-rejected-multi-noreason.txt
@@ -1,0 +1,17 @@
+
+Move requests of the following events have been rejected:
+
+
+Events
+------
+test 1 (http://localhost/event/1/) 
+test 2 (http://localhost/event/2/) 
+
+
+Rejection reason
+----------------
+
+
+--
+Indico :: Event notifications
+

--- a/indico/modules/events/templates/emails/tests/move-request-rejected-multi-reason.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-rejected-multi-reason.txt
@@ -1,12 +1,12 @@
 
 Move requests of the following events have been rejected:
 
+- test 1 (http://localhost/event/1/)
+- test 2 (http://localhost/event/2/)
 
-Events
-------
-test 1 (http://localhost/event/1/) 
-test 2 (http://localhost/event/2/) 
-
+Requested category
+------------------
+Home » target
 
 Rejection reason
 ----------------

--- a/indico/modules/events/templates/emails/tests/move-request-rejected-multi-reason.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-rejected-multi-reason.txt
@@ -1,0 +1,18 @@
+
+Move requests of the following events have been rejected:
+
+
+Events
+------
+test 1 (http://localhost/event/1/) 
+test 2 (http://localhost/event/2/) 
+
+
+Rejection reason
+----------------
+We do not want your event.
+Sorry not sorry.
+
+--
+Indico :: Event notifications
+

--- a/indico/modules/events/templates/emails/tests/move-request-rejected-single-noreason.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-rejected-single-noreason.txt
@@ -1,0 +1,16 @@
+
+Move requests of the following events have been rejected:
+
+
+Events
+------
+test 1 (http://localhost/event/1/) 
+
+
+Rejection reason
+----------------
+
+
+--
+Indico :: Event notifications
+

--- a/indico/modules/events/templates/emails/tests/move-request-rejected-single-noreason.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-rejected-single-noreason.txt
@@ -1,15 +1,11 @@
 
-Move requests of the following events have been rejected:
+Request to move event rejected:
 
+- test 1 (http://localhost/event/1/)
 
-Events
-------
-test 1 (http://localhost/event/1/) 
-
-
-Rejection reason
-----------------
-
+Requested category
+------------------
+Home » target
 
 --
 Indico :: Event notifications

--- a/indico/modules/events/templates/emails/tests/move-request-rejected-single-reason.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-rejected-single-reason.txt
@@ -1,0 +1,17 @@
+
+Move requests of the following events have been rejected:
+
+
+Events
+------
+test 1 (http://localhost/event/1/) 
+
+
+Rejection reason
+----------------
+We do not want your event.
+Sorry not sorry.
+
+--
+Indico :: Event notifications
+

--- a/indico/modules/events/templates/emails/tests/move-request-rejected-single-reason.txt
+++ b/indico/modules/events/templates/emails/tests/move-request-rejected-single-reason.txt
@@ -1,11 +1,11 @@
 
-Move requests of the following events have been rejected:
+Request to move event rejected:
 
+- test 1 (http://localhost/event/1/)
 
-Events
-------
-test 1 (http://localhost/event/1/) 
-
+Requested category
+------------------
+Home » target
 
 Rejection reason
 ----------------

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -13,6 +13,7 @@ pytest-cov
 pytest-localserver
 pytest-mock
 pytest-redis
+pytest-snapshot
 pytest
 pyquotes
 pyupgrade

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -102,6 +102,7 @@ packaging==21.0
     # via
     #   -c requirements.txt
     #   pytest
+    #   pytest-snapshot
     #   sphinx
     #   sqlbag
 parso==0.8.2
@@ -143,6 +144,7 @@ pytest==6.2.4
     #   pytest-cov
     #   pytest-mock
     #   pytest-redis
+    #   pytest-snapshot
 pytest-cov==2.12.1
     # via -r requirements.dev.in
 pytest-localserver==0.5.0
@@ -150,6 +152,8 @@ pytest-localserver==0.5.0
 pytest-mock==3.6.1
     # via -r requirements.dev.in
 pytest-redis==2.1.1
+    # via -r requirements.dev.in
+pytest-snapshot==0.6.1
     # via -r requirements.dev.in
 python-dateutil==2.8.2
     # via


### PR DESCRIPTION
Closes #5038
Closes #5039 

Sends an email notification to the requestor when a move request is accepted or rejected and
sends an email notification to category managers when a move request is created.