### PR TITLE
Deduplicate identities keeping the best one when searching external users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Improvements
 - Use more space-efficient QR code version in registration tickets (:pr:`5052`)
 - Improve user experience when accessing an event restricted to registered participants
   while not logged in (:pr:`5053`)
+- When searching external users, prefer results with a name in case of multiple matches
+  with the same email address (:pr:`5066`)
 
 Bugfixes
 ^^^^^^^^


### PR DESCRIPTION
Depending on where the external results are coming from, there might be multiple matches for the same email address. If not all of them have a name, we prefer using one that has a name instead of just whatever we get first.