### PR TITLE
Fix duplicate imports of the moment library

### DIFF
--- a/indico/web/client/js/jquery/index.js
+++ b/indico/web/client/js/jquery/index.js
@@ -12,6 +12,13 @@ import 'jquery-colorbox/example1/colorbox.css';
 
 import 'jquery-form';
 
+import moment from 'moment';
+// Make moment globally available.
+// Previously, we used the webpack `ProvidePlugin`, but instead of having
+// a single shared instance of moment, this resulted in duplicate instances,
+// which didn't have the correct locale as set in `indico_base.html`.
+window.moment = moment;
+
 // moment.js locales
 import 'moment/locale/tr';
 import 'moment/locale/mn';

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -145,7 +145,6 @@ export default env => {
       }),
       new webpack.ProvidePlugin({
         _: ['underscore', 'default'],
-        moment: 'moment',
       }),
     ],
     resolve: {


### PR DESCRIPTION
Closes #4538 

For a reason yet unknown the webpack `ProvidePlugin` does not import a library as a singleton but sometimes
duplicates it several times. This causes problems when we need to set global properties on the moment object
such as moment.locale().

This PR removes the ProvidePlugin in favour of importing the library manually and
making it globally available via window.moment.

Since the library is available as a global, it should not be necessary to change any code as
the usage is identical with that of `ProvidePlugin`.

