### PR TITLE
Ensure there is only one momentjs instance

### DIFF
--- a/indico/modules/categories/client/js/index.js
+++ b/indico/modules/categories/client/js/index.js
@@ -15,7 +15,6 @@ import './display';
 import './base';
 
 import SearchBox from 'indico/modules/search/components/SearchBox';
-import {setMomentLocale} from 'indico/utils/date';
 
 import CategoryStatistics from './components/CategoryStatistics';
 import {LocaleContext} from './context.js';
@@ -50,14 +49,13 @@ import {LocaleContext} from './context.js';
     }
   });
   global.setupCategoryStats = function setupCategoryStats() {
-    document.addEventListener('DOMContentLoaded', async () => {
+    document.addEventListener('DOMContentLoaded', () => {
       const rootElement = document.querySelector('#category-stats-root');
       if (!rootElement) {
         return;
       }
       const categoryId = parseInt(rootElement.dataset.categoryId, 10);
       const lang = rootElement.dataset.lang;
-      await setMomentLocale(lang);
       ReactDOM.render(
         <LocaleContext.Provider value={lang}>
           <CategoryStatistics categoryId={categoryId} />

--- a/indico/web/views.py
+++ b/indico/web/views.py
@@ -156,7 +156,7 @@ class WPJinjaMixin:
 
 
 class WPBundleMixin:
-    bundles = ('exports.js',)
+    bundles = ('exports.js', 'common-runtime.js')
     print_bundles = tuple()
 
     @classproperty

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -327,6 +327,7 @@ export function webpackDefaults(env, config, bundles, isPlugin = false) {
     },
     mode: currentEnv,
     optimization: {
+      runtimeChunk: {name: 'common-runtime'},
       splitChunks: {
         cacheGroups: isPlugin
           ? {}


### PR DESCRIPTION
By having the webpack runtime in a separate chunk momentjs correctly gets loaded as a singleton instead of once for each bundle that includes it, so setting the global moment locale always works as expected.

https://webpack.js.org/configuration/optimization/#optimizationruntimechunk

closes #4538
closes #5068 (this didn't fix it everywhere, especially not in react code)