### PR TITLE
Increase the usage of program codes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Improvements
   while not logged in (:pr:`5053`)
 - When searching external users, prefer results with a name in case of multiple matches
   with the same email address (:pr:`5066`)
+- Show program codes in additional places (:pr:`5075`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -49,12 +49,20 @@
 {% endmacro %}
 
 {% block title -%}
-    <span class="js-mathjax">{{ contribution.title }}</span>
+    <span class="js-mathjax">
+        {{ contribution.title }}
+    </span>
 {%- endblock %}
 
 {% block info -%}
     <div class="flexrow f-j-space-between">
         <div>
+            {% if contribution.code %}
+                <div class="generic-data">
+                    <i class="icon-tag header-data"></i>
+                    <span>{{ contribution.code }}</span>
+                </div>
+            {% endif %}
             <div class="time-data">
                 <i class="icon-calendar header-data"></i>
                 <span class="time-info">

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -63,7 +63,7 @@
                     <span>{{ contribution.code }}</span>
                 </div>
             {% endif %}
-            <div class="time-data">
+            <div class="generic-data">
                 <i class="icon-calendar header-data"></i>
                 <span class="time-info">
                     {%- if contribution.start_dt_display %}
@@ -74,7 +74,7 @@
                 </span>
             </div>
             {% if contribution.duration_display -%}
-                <div class="time-data">
+                <div class="generic-data">
                     <i class="icon-time header-data"></i>
                     <span class="time-info" title="{% trans %}Duration{% endtrans %}">
                         {{ contribution.duration_display|format_human_timedelta(narrow=true) }}
@@ -82,12 +82,12 @@
                 </div>
             {%- endif %}
             {% if contribution.has_location_info %}
-                <div class="location-data">
+                <div class="generic-data">
                     {{ render_location(contribution, class='contribution-location') }}
                 </div>
             {% endif %}
             {% if contribution.board_number -%}
-                <div class="board-data">
+                <div class="generic-data">
                     <i class="icon-price-tag header-data"></i>
                     <span class="board-info">
                         {% trans board_number=contribution.board_number %}Board: {{ board_number }}{% endtrans %}

--- a/indico/modules/events/contributions/templates/display/subcontribution_display.html
+++ b/indico/modules/events/contributions/templates/display/subcontribution_display.html
@@ -17,7 +17,7 @@
 {%- endblock %}
 
 {% block description %}
-    <div class="time-data">
+    <div class="generic-data">
         <i class="icon-time header-data"></i>
         <span class="time-info">
             {% if subcontrib.timetable_entry -%}

--- a/indico/modules/events/sessions/templates/display/session_display.html
+++ b/indico/modules/events/sessions/templates/display/session_display.html
@@ -16,6 +16,12 @@
 {% endblock %}
 
 {% block info %}
+    {% if sess.code %}
+        <div class="generic-data">
+            <i class="icon-tag header-data"></i>
+            {{ sess.code }}
+        </div>
+    {% endif %}
     <div class="generic-data">
         <i class="icon-time header-data"></i>
         <span class="time-info">

--- a/indico/modules/events/sessions/templates/display/session_display.html
+++ b/indico/modules/events/sessions/templates/display/session_display.html
@@ -16,7 +16,7 @@
 {% endblock %}
 
 {% block info %}
-    <div class="time-data">
+    <div class="generic-data">
         <i class="icon-time header-data"></i>
         <span class="time-info">
             {% if sess.start_dt -%}
@@ -27,7 +27,7 @@
         </span>
     </div>
     {% if sess.has_location_info %}
-        <div class="location-data">
+        <div class="generic-data">
             {{ render_location(sess, class='session-location') }}
         </div>
     {% endif %}

--- a/indico/modules/events/timetable/legacy.py
+++ b/indico/modules/events/timetable/legacy.py
@@ -163,6 +163,7 @@ class TimetableSerializer:
                                                    key=lambda x: (x.author_type != AuthorType.primary,
                                                                   x.author_type != AuthorType.secondary,
                                                                   x.display_order_key)))),
+                     'code': contribution.code,
                      'sessionCode': block.session.code if block else None,
                      'sessionId': block.session_id if block else None,
                      'sessionSlotId': block.id if block else None,

--- a/indico/modules/events/timetable/templates/balloons/block.html
+++ b/indico/modules/events/timetable/templates/balloons/block.html
@@ -4,10 +4,13 @@
 <div class="balloon {{ 'event-locked' if event_locked }}">
     <div class="title-container session-block">
         <div class="title">
-            {{- block.session.title }}
-            {%- if block.title %}
+            {{ block.session.title }}
+            {% if block.title %}
                 <span class="balloon-subtitle">({{ block.title }})</span>
-            {%- endif -%}
+            {% endif %}
+            {% if block.session.code %}
+                <span class="balloon-code">({{ block.session.code }})</span>
+            {% endif %}
         </div>
     </div>
     <div class="description" data-display-href="{{ url_for('sessions.display_session', block.session) }}">

--- a/indico/modules/events/timetable/templates/balloons/contribution.html
+++ b/indico/modules/events/timetable/templates/balloons/contribution.html
@@ -3,7 +3,12 @@
 
 <div class="balloon {{ 'event-locked' if event_locked }}">
     <div class="title-container">
-        <div class="title">{{ contrib.title }}</div>
+        <div class="title">
+            {{ contrib.title }}
+            {% if contrib.code %}
+                <span class="balloon-code">({{ contrib.code }})</span>
+            {% endif %}
+        </div>
         <div class="group right entry-action-buttons hide-if-locked">
             {% if editable %}
                 {% if can_manage_contributions %}

--- a/indico/web/client/js/legacy/libs/timetable/Draw.js
+++ b/indico/web/client/js/legacy/libs/timetable/Draw.js
@@ -147,6 +147,9 @@ type(
       if (this.eventData.slotTitle && this.eventData.slotTitle !== '') {
         title += ': ' + this.eventData.slotTitle;
       }
+      if (this.eventData.code) {
+        title += ` (${this.eventData.code})`;
+      }
       return title;
     },
 

--- a/indico/web/client/styles/modules/event_display/_conferences.scss
+++ b/indico/web/client/styles/modules/event_display/_conferences.scss
@@ -15,9 +15,6 @@
   }
 }
 
-.time-data,
-.location-data,
-.board-data,
 .generic-data {
   line-height: 1.6em;
   font-size: 1.2em;

--- a/indico/web/client/styles/modules/event_display/_conferences.scss
+++ b/indico/web/client/styles/modules/event_display/_conferences.scss
@@ -17,7 +17,8 @@
 
 .time-data,
 .location-data,
-.board-data {
+.board-data,
+.generic-data {
   line-height: 1.6em;
   font-size: 1.2em;
   color: $light-black;

--- a/indico/web/client/styles/partials/_timetable-balloons.scss
+++ b/indico/web/client/styles/partials/_timetable-balloons.scss
@@ -28,6 +28,11 @@
       color: $black;
     }
 
+    .balloon-code {
+      font-size: 0.8em;
+      color: $dark-gray;
+    }
+
     &.session-block {
       .title {
         width: 100%;


### PR DESCRIPTION
The current use of program codes is very limited, these changes increase its usage up to:
- The timetable blocks
- The timetable tips
![Screenshot from 2021-09-02 16-01-13](https://user-images.githubusercontent.com/12183954/131857509-99ca311a-1d9e-4629-b060-24039d3c51f2.png)
- The individual entry pages (session and contribution) (may be in the title instead?)
![Screenshot from 2021-09-02 16-00-40](https://user-images.githubusercontent.com/12183954/131857429-155758ce-2abb-4405-93a9-d02e97fa58c5.png)
