### PR TITLE
Add translations for countries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Improvements
 - When searching external users, prefer results with a name in case of multiple matches
   with the same email address (:pr:`5066`)
 - Show program codes in additional places (:pr:`5075`)
+- Display localized country names (:issue:`5070`, :pr:`5076`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/util/countries.py
+++ b/indico/util/countries.py
@@ -10,19 +10,33 @@ from werkzeug.datastructures import ImmutableDict
 
 from indico.core.config import config
 from indico.util.caching import memoize
+from indico.util.i18n import get_current_locale
+
+
+def get_countries(locale=None):
+    if locale is None:
+        locale = get_current_locale()
+    return _get_countries(locale)
 
 
 @memoize
-def get_countries():
+def _get_countries(locale):
     _countries = {country.alpha_2: getattr(country, 'common_name', country.name) for country in pycountry.countries}
     _countries.update(config.CUSTOM_COUNTRIES)
+    _countries = {code: locale.territories.get(code, name) for code, name in _countries.items()}
     return ImmutableDict(_countries)
 
 
+def get_country(code, locale=None):
+    if locale is None:
+        locale = get_current_locale()
+    return _get_country(code, locale)
+
+
 @memoize
-def get_country(code):
+def _get_country(code, locale):
     try:
-        return get_countries()[code]
+        return _get_countries(locale)[code]
     except KeyError:
         country = pycountry.historic_countries.get(alpha_2=code)
         return country.name if country else None


### PR DESCRIPTION
Closes #5070 

Extends `get_country/ies` to accept a `locale` parameter which defaults to the current locale.