### PR TITLE
Fix reminder email ical on protected events

### DIFF
--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -105,22 +105,24 @@ def generate_event_component(event, user=None):
     return component
 
 
-def event_to_ical(event, user=None, scope=None):
+def event_to_ical(event, user=None, scope=None, *, skip_access_check=False):
     """Serialize an event into an ical.
 
     :param event: The event to serialize
     :param user: The user who needs to be able to access the events
     :param scope: If specified, use a more detailed timetable using the given scope
+    :param skip_access_check: Do not perform access checks. Defaults to False.
     """
-    return events_to_ical([event], user, scope)
+    return events_to_ical([event], user, scope, skip_access_check=skip_access_check)
 
 
-def events_to_ical(events, user=None, scope=None):
+def events_to_ical(events, user=None, scope=None, *, skip_access_check=False):
     """Serialize multiple events into an ical.
 
     :param events: A list of events to serialize
     :param user: The user who needs to be able to access the events
     :param scope: If specified, use a more detailed timetable using the given scope
+    :param skip_access_check: Do not perform access checks. Defaults to False.
     """
     from indico.modules.events.contributions.ical import generate_contribution_component
     from indico.modules.events.sessions.ical import generate_session_block_component
@@ -130,7 +132,7 @@ def events_to_ical(events, user=None, scope=None):
     calendar.add('prodid', '-//CERN//INDICO//EN')
 
     for event in events:
-        if not event.can_access(user):
+        if not skip_access_check and not event.can_access(user):
             continue
 
         if scope == CalendarScope.contribution:

--- a/indico/modules/events/reminders/models/reminders.py
+++ b/indico/modules/events/reminders/models/reminders.py
@@ -210,7 +210,7 @@ class EventReminder(db.Model):
         email_tpl = make_reminder_email(self.event, self.include_summary, self.include_description, self.message)
         attachments = []
         if self.attach_ical:
-            event_ical = event_to_ical(self.event)
+            event_ical = event_to_ical(self.event, skip_access_check=True)
             attachments.append(('event.ics', event_ical, 'text/calendar'))
         email = make_email(
             bcc_list=recipients, from_address=self.reply_to_address, template=email_tpl, attachments=attachments


### PR DESCRIPTION
Reminders in protected events are not generating the iCalendar file properly, as the access check is not passing without a user in the serializer function.

This PR adds a flag to skip the access check to the function. When creating a reminder email, the serializer is called with the flag set to `True`.