### PR TITLE
Unlisted events: Global settings / ACL

### DIFF
--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -233,5 +233,9 @@ def serialize_category_role(role, legacy=True):
 
 
 def can_create_unlisted_events(user):
-    return (user.is_admin or unlisted_events_settings.get('enabled') and (not unlisted_events_settings.get('restricted')
-            or unlisted_events_settings.acls.contains_user('authorized_creators', user)))
+    if not user or not unlisted_events_settings.get('enabled'):
+        return False
+    elif user.is_admin or not unlisted_events_settings.get('restricted'):
+        return True
+    else:
+        return unlisted_events_settings.acls.contains_user('authorized_creators', user)

--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -22,6 +22,7 @@ from indico.modules.events import Event
 from indico.modules.events.contributions import Contribution
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.sessions import Session
+from indico.modules.events.settings import unlisted_events_settings
 from indico.modules.events.timetable.models.entries import TimetableEntry, TimetableEntryType
 from indico.util.caching import memoize_redis
 from indico.util.date_time import now_utc
@@ -229,3 +230,8 @@ def serialize_category_role(role, legacy=True):
             'name': role.name,
             'identifier': f'CategoryRole:{role.id}',
         }
+
+
+def can_create_unlisted_events(user):
+    return (user.is_admin or unlisted_events_settings.get('enabled') and (not unlisted_events_settings.get('restricted')
+            or unlisted_events_settings.acls.contains_user('authorized_creators', user)))

--- a/indico/modules/categories/util_test.py
+++ b/indico/modules/categories/util_test.py
@@ -1,0 +1,28 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2021 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+
+from indico.modules.categories.util import can_create_unlisted_events
+from indico.modules.events.settings import unlisted_events_settings
+
+
+@pytest.mark.usefixtures('db')
+def test_can_create_unlisted_events(dummy_user, create_user):
+    admin_user = create_user(123, admin=True)
+    assert not can_create_unlisted_events(None)
+    unlisted_events_settings.set('enabled', False)
+    unlisted_events_settings.set('restricted', False)
+    assert not can_create_unlisted_events(dummy_user)
+    assert not can_create_unlisted_events(admin_user)
+    unlisted_events_settings.set('enabled', True)
+    assert can_create_unlisted_events(dummy_user)
+    unlisted_events_settings.set('restricted', True)
+    assert not can_create_unlisted_events(dummy_user)
+    unlisted_events_settings.acls.set('authorized_creators', {dummy_user})
+    assert can_create_unlisted_events(dummy_user)
+    assert can_create_unlisted_events(admin_user)

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -144,6 +144,8 @@ def _sidemenu_items(sender, **kwargs):
                            section='customization')
         yield SideMenuItem('event_labels', _('Event Labels'), url_for('events.event_labels'),
                            section='customization')
+        yield SideMenuItem('unlisted_events', _('Unlisted events'), url_for('events.unlisted_events'),
+                           section='customization')
 
 
 @signals.menu.sections.connect_via('top-menu')

--- a/indico/modules/events/blueprint.py
+++ b/indico/modules/events/blueprint.py
@@ -7,7 +7,7 @@
 
 from indico.modules.events.controllers.admin import (RHCreateEventLabel, RHCreateReferenceType, RHDeleteEventLabel,
                                                      RHDeleteReferenceType, RHEditEventLabel, RHEditReferenceType,
-                                                     RHEventLabels, RHReferenceTypes)
+                                                     RHEventLabels, RHReferenceTypes, RHUnlistedEvents)
 from indico.modules.events.controllers.creation import RHCreateEvent, RHPrepareEvent
 from indico.modules.events.controllers.display import RHEventAccessKey, RHExportEventICAL
 from indico.modules.events.controllers.entry import event_or_shorturl
@@ -23,6 +23,7 @@ _bp.add_url_rule('/admin/external-id-types/create', 'create_reference_type', RHC
                  methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/event-labels/', 'event_labels', RHEventLabels, methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/event-labels/create', 'create_event_label', RHCreateEventLabel, methods=('GET', 'POST'))
+_bp.add_url_rule('/admin/unlisted-events/', 'unlisted_events', RHUnlistedEvents, methods=('GET', 'POST'))
 
 # Single reference type
 _bp.add_url_rule('/admin/external-id-types/<int:reference_type_id>/edit', 'update_reference_type', RHEditReferenceType,

--- a/indico/modules/events/client/js/creation.js
+++ b/indico/modules/events/client/js/creation.js
@@ -56,7 +56,6 @@ import {camelizeKeys} from 'indico/utils/case';
 
     protectionMessage.appendTo(options.protectionModeFields.closest('.form-field'));
     listingMessage.appendTo($listingField.closest('.form-field'));
-    listingMessage.hide();
 
     function updateProtectionMessage() {
       if (!currentCategory) {
@@ -110,7 +109,7 @@ import {camelizeKeys} from 'indico/utils/case';
       }
 
       // update listing and warning message boxes
-      listingMessage.toggleClass('hidden', !JSON.parse($listingField.val()));
+      listingMessage.toggleClass('hidden', JSON.parse($listingField.val()));
       updateWarningMessage();
     });
 

--- a/indico/modules/events/controllers/creation.py
+++ b/indico/modules/events/controllers/creation.py
@@ -141,8 +141,7 @@ class RHCreateEvent(RHProtected):
         if form.validate_on_submit():
             data = form.data
             listing = data.pop('listing')
-            # TODO: this should be done in the frontend
-            if not listing:
+            if not listing and can_create_unlisted_events(session.user):
                 del data['category']
 
             if self.event_type == EventType.lecture:

--- a/indico/modules/events/controllers/creation.py
+++ b/indico/modules/events/controllers/creation.py
@@ -19,6 +19,7 @@ from indico.core.cache import make_scoped_cache
 from indico.core.config import config
 from indico.core.db.sqlalchemy.util.models import get_simple_column_attrs
 from indico.modules.categories import Category
+from indico.modules.categories.util import can_create_unlisted_events
 from indico.modules.events.forms import EventCreationForm, LectureCreationForm
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.persons import EventPerson, EventPersonLink
@@ -159,7 +160,8 @@ class RHCreateEvent(RHProtected):
         return jsonify_template('events/forms/event_creation_form.html', form=form, fields=form._field_order,
                                 event_type=self.event_type.name, single_category=(not self.root_category.has_children),
                                 check_room_availability=check_room_availability,
-                                rb_excluded_categories=rb_excluded_categories)
+                                rb_excluded_categories=rb_excluded_categories,
+                                can_create_unlisted_events=can_create_unlisted_events(session.user))
 
 
 class RHPrepareEvent(RH):

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -107,8 +107,9 @@ class LectureCreationForm(EventCreationFormBase):
 
 class UnlistedEventsForm(IndicoForm):
     enabled = BooleanField(_('Enabled'), widget=SwitchWidget(), default=False)
-    restricted = BooleanField(_('Require permission'), [HiddenUnless('enabled', preserve_data=True)],
-                              widget=SwitchWidget())
-    authorized_creators = PrincipalListField(_('Permissions'), [HiddenUnless('enabled', preserve_data=True)],
+    restricted = BooleanField(_('Restrict creation'), [HiddenUnless('enabled', preserve_data=True)],
+                              widget=SwitchWidget(),
+                              description=_('Restrict creation of unlisted events to the authorized users below.'))
+    authorized_creators = PrincipalListField(_('Authorized users'), [HiddenUnless('enabled', preserve_data=True)],
                                              allow_external_users=True, allow_groups=True,
                                              description=_('These users may create unlisted events.'))

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -9,7 +9,7 @@ from datetime import time
 
 from flask import session
 from wtforms.fields import StringField, TextAreaField
-from wtforms.fields.core import SelectField
+from wtforms.fields.core import BooleanField, SelectField
 from wtforms.fields.html5 import URLField
 from wtforms.validators import DataRequired, InputRequired, ValidationError
 
@@ -25,9 +25,10 @@ from indico.web.forms.base import IndicoForm
 from indico.web.forms.colors import get_sui_colors
 from indico.web.forms.fields import (IndicoDateTimeField, IndicoEnumRadioField, IndicoLocationField,
                                      IndicoTimezoneSelectField, JSONField, OccurrencesField)
+from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.fields.simple import IndicoButtonsBooleanField
-from indico.web.forms.validators import LinkedDateTime, UsedIf
-from indico.web.forms.widgets import CKEditorWidget
+from indico.web.forms.validators import HiddenUnless, LinkedDateTime, UsedIf
+from indico.web.forms.widgets import CKEditorWidget, SwitchWidget
 
 
 class ReferenceTypeForm(IndicoForm):
@@ -102,3 +103,12 @@ class LectureCreationForm(EventCreationFormBase):
     person_link_data = EventPersonLinkListField(_('Speakers'))
     description = TextAreaField(_('Description'), widget=CKEditorWidget())
     theme = IndicoThemeSelectField(_('Theme'), event_type=EventType.lecture, allow_default=True)
+
+
+class UnlistedEventsForm(IndicoForm):
+    enabled = BooleanField(_('Enabled'), widget=SwitchWidget(), default=False)
+    restricted = BooleanField(_('Require permission'), [HiddenUnless('enabled', preserve_data=True)],
+                              widget=SwitchWidget())
+    authorized_creators = PrincipalListField(_('Permissions'), [HiddenUnless('enabled', preserve_data=True)],
+                                             allow_external_users=True, allow_groups=True,
+                                             description=_('These users may create unlisted events.'))

--- a/indico/modules/events/settings.py
+++ b/indico/modules/events/settings.py
@@ -15,6 +15,7 @@ from flask.helpers import get_root_path
 from indico.core import signals
 from indico.core.settings import ACLProxyBase, SettingProperty, SettingsProxyBase
 from indico.core.settings.converters import DatetimeConverter
+from indico.core.settings.proxy import SettingsProxy
 from indico.core.settings.util import get_all_settings, get_setting, get_setting_acl
 from indico.modules.events.models.settings import EventSetting, EventSettingPrincipal
 from indico.util.caching import memoize
@@ -250,4 +251,11 @@ event_contact_settings = EventSettingsProxy('contact', {
     'title': 'Contact',
     'emails': [],
     'phones': []
+})
+
+unlisted_events_settings = SettingsProxy('unlisted_events', {
+    'enabled': False,
+    'restricted': False,
+}, acls={
+    'authorized_creators'
 })

--- a/indico/modules/events/templates/admin/unlisted_events.html
+++ b/indico/modules/events/templates/admin/unlisted_events.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block description %}
-    {% trans %}Unlisted events enable users to set up and customise events before publishing them into a category.{% endtrans %}
+    {% trans %}Unlisted events enable users to set up and customize events before publishing them into a category.{% endtrans %}
 {% endblock %}
 
 {% block content %}

--- a/indico/modules/events/templates/admin/unlisted_events.html
+++ b/indico/modules/events/templates/admin/unlisted_events.html
@@ -1,0 +1,14 @@
+{% extends 'layout/admin_page.html' %}
+{% from 'forms/_form.html' import simple_form %}
+
+{% block title %}
+    {% trans %}Unlisted events{% endtrans %}
+{% endblock %}
+
+{% block description %}
+    {% trans %}Unlisted events enable users to set up and customise events before publishing them into a category.{% endtrans %}
+{% endblock %}
+
+{% block content %}
+    {{ simple_form(form, back_button=false) }}
+{% endblock %}

--- a/indico/modules/events/templates/forms/event_creation_form.html
+++ b/indico/modules/events/templates/forms/event_creation_form.html
@@ -93,19 +93,17 @@ purely client-side and are worded for event creation instead of being generic.
 </script>
 
 <script type="text/html" id="event-listing-message">
-    <div class="form-group">
-        <div class="action-box mid-form for-form listing-message unlisted-message info">
-            <div class="section">
-                <div class="icon icon-eye-blocked"></div>
-                <div class="text">
-                    <div class="label">
-                        {% trans %}Unlisted event{% endtrans %}
-                    </div>
-                    <div>
-                        {% trans -%}
-                            Users will not see this event yet. You can publish the event in a category once it is ready.
-                        {%- endtrans %}
-                    </div>
+    <div class="action-box mid-form for-form listing-message unlisted-message info hidden">
+        <div class="section">
+            <div class="icon icon-eye-blocked"></div>
+            <div class="text">
+                <div class="label">
+                    {% trans %}Unlisted event{% endtrans %}
+                </div>
+                <div>
+                    {% trans -%}
+                        Users will not see this event yet. You can publish the event in a category once it is ready.
+                    {%- endtrans %}
                 </div>
             </div>
         </div>

--- a/indico/modules/events/templates/forms/event_creation_form.html
+++ b/indico/modules/events/templates/forms/event_creation_form.html
@@ -5,7 +5,9 @@
                    'has_events': form.category.data.has_events} if form.category.data else none %}
 
 {{ form_header(form, action=url_for('events.create', event_type=event_type)) }}
-{{ form_row(form.listing) }}
+{% if can_create_unlisted_events %}
+    {{ form_row(form.listing) }}
+{% endif %}
 {{ form_row(form.category, orientation=('hidden' if single_category else '')) }}
 {{ form_rows(form, fields=form._field_order) }}
 {% if form._advanced_field_order %}


### PR DESCRIPTION
This PR closes https://github.com/indico/indico/issues/5055.

Adds a settings page in the customization tree (I thought the general settings are too global to include this in there) to add permissions to create unlisted events:

![image](https://user-images.githubusercontent.com/6058151/133802384-293c53e0-79cc-4a47-b2e9-63e8de7e5609.png)
