### PR TITLE
Protect auth endpoints against CSRF login attacks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,12 @@ Version 3.0.3
 
 *Unreleased*
 
+Security fixes
+^^^^^^^^^^^^^^
+
+- Protect authentication endpoints against CSRF login attacks (:pr:`5099`,
+  thanks :user:`omegak`)
+
 Bugfixes
 ^^^^^^^^
 

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -105,7 +105,8 @@ class IndicoSession(BaseSession):
 
     @property
     def csrf_protected(self):
-        return self.user is not None
+        # Protect auth endpoints to prevent CSRF login attacks
+        return self.user is not None or request.blueprint == 'auth'
 
     @property
     def timezone(self):


### PR DESCRIPTION
Indico seems to be vulnerable to CSRF login attacks per [OWASP Cross Site Request Forgery article](https://owasp.org/www-community/attacks/csrf): 

> An attacker can use CSRF to obtain the victim’s private data via a special form of the attack, known as login CSRF. The attacker forces a non-authenticated user to log in to an account the attacker controls.

This PR protects authentication endpoints against CSRF.