### PR TITLE
Modify gettext to look through plural translations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Bugfixes
 
 - Fix certain registration list filters (checkin status & state) being combined
   with OR instead of AND (:pr:`5101`)
+- Fix translations not being taken into account in some places (:issue:`5073`, :pr:`5105`)
 
 
 Version 3.0.2

--- a/indico/modules/events/abstracts/templates/display/tracks.html
+++ b/indico/modules/events/abstracts/templates/display/tracks.html
@@ -58,7 +58,7 @@
                             {% endif %}
                             {% if track.can_convene(session.user) %}
                                 <div class="label i-tag">
-                                    {%- trans %}Convener{% endtrans -%}
+                                    {{- pgettext('track convener', 'Convener') -}}
                                 </div>
                             {% endif %}
                         </li>

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -50,12 +50,52 @@ def get_translation_domain(plugin_name=_use_context):
             return get_domain()
 
 
+def _gettext(tr, message):
+    """Look for a translation in both the standard and plural translations.
+
+    Same as gettext.GNUTranslations.gettext but when the translation is not found,
+    it looks for a translation in plurals to find the singular case.
+    When neither is found, the gettext fallback is used.
+
+    This is needed because by default, gettext() only looks through non-pluralized translations.
+    For example, the following cannot be translated with gettext:
+
+    # Polish
+    msgid "Convener"
+    msgid_plural "Conveners"
+    msgstr[0] "Lider"
+
+    To get a translation for 'Convener', we need ngettext('Convener', 'Conveners', 1).
+
+    See GNUTranslations.gettext & ngettext for more details.
+    """
+    translation = tr.gettext(message)
+    if message != translation:
+        return translation
+    return tr.ngettext(message, message, 1)
+
+
+def _pgettext(tr, context, message):
+    """pgettext variant of _gettext."""
+
+    translation = tr.pgettext(context, message)
+    if message != translation:
+        return translation
+    return tr.npgettext(context, message, message, 1)
+
+
 def _indico_gettext(*args, **kwargs):
     func_name = kwargs.pop('func_name', 'gettext')
     plugin_name = kwargs.pop('plugin_name', None)
 
     translations = get_translation_domain(plugin_name).get_translations()
-    return getattr(translations, func_name)(*args, **kwargs)
+
+    if func_name == 'gettext':
+        return _gettext(translations, *args, **kwargs)
+    elif func_name == 'pgettext':
+        return _pgettext(translations, *args, **kwargs)
+    else:
+        return getattr(translations, func_name)(*args, **kwargs)
 
 
 def lazy_gettext(string, plugin_name=None):

--- a/indico/util/i18n_test.py
+++ b/indico/util/i18n_test.py
@@ -17,7 +17,11 @@ from speaklater import _LazyString
 from werkzeug.datastructures import LanguageAccept
 
 from indico.core.plugins import IndicoPlugin, plugin_engine
-from indico.util.i18n import _, babel, gettext_context, make_bound_gettext, ngettext, session_language
+from indico.util.i18n import _, babel, gettext_context, make_bound_gettext, ngettext, pgettext, session_language
+
+
+def _to_msgid(context, message):
+    return f'{context}\x04{message}'
 
 
 DICTIONARIES = {
@@ -34,7 +38,14 @@ DICTIONARIES = {
 
     'en_PI': {
         'I need a drink.': "I be needin' a bottle of rhum!"
-    }
+    },
+
+    'pl_PL': {
+        ('Convener', 0): 'Lider',
+        ('Convener', 1): 'Liderzy',
+        (_to_msgid('Dummy context', 'Convener'), 0): 'Lider (Context)',
+        (_to_msgid('Dummy context', 'Convener'), 1): 'Liderzy (Context)',
+    },
 }
 
 
@@ -165,3 +176,19 @@ def test_translation_plugins(app, tmpdir):
         assert _('This is not a string') == french_core_str
         assert gettext_context('This is not a string') == french_plugin_str
         assert gettext_plugin('This is not a string') == french_plugin_str
+
+
+@pytest.mark.usefixtures('mock_translations')
+def test_gettext_plurals():
+    session.lang = 'pl_PL'  # Polish
+
+    assert _('Convener') == 'Lider'
+    assert _('User') == 'User'
+
+
+@pytest.mark.usefixtures('mock_translations')
+def test_pgettext_plurals():
+    session.lang = 'pl_PL'  # Polish
+
+    assert pgettext('Dummy context', 'Convener') == 'Lider (Context)'
+    assert pgettext('Dummy context', 'User') == 'User'


### PR DESCRIPTION
Closes #5073 

This is kind of a hacky solution so I'm open to suggestions..

Basically, the problem is that if there is a plural translation ,e.g.,

```
# Polish
msgid "Convener"
msgid_plural "Conveners"
msgstr[0] "Lider"
```
the only way to translate `Convener` to `Lider` is to use `ngettext(..., 1)`. `gettext` ignores
the plural translations when looking for a translation.
The solution is to use our own `gettext` with a fallback to `ngettext` if a translation is not found.

I don't know if this 100% foolproof as there might be some languages where a normal translation
differs from its singular translation when used with numbers.
