### PR TITLE
Improve scopes documentation

### DIFF
--- a/docs/source/http-api/access.rst
+++ b/docs/source/http-api/access.rst
@@ -70,7 +70,7 @@ OAuth flow have the ``indo_`` prefix instead.
 Scopes
 ~~~~~~
 
-API tokens can have one of these scopes:
+API tokens can have one or more of these scopes:
 
 .. exec::
     def main():


### PR DESCRIPTION
I'm trying to clarify why it's needed to have at least the scopes "Everything (Only GET)" and "Classic API (Read Only)" to have access to a restricted event.

I started by specifying than one or *more* scopes can be selected for a single token, but I'm still a bit confused about why it is expected to select those two.

I guess "everything" is needed for sending the get request (?) and the Classic API one is to grant the token to get access to the restricted event (because /export/ is legacy)?
