### PR TITLE
Set positions for personal data fields in regforms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ Bugfixes
 - Fix certain registration list filters (checkin status & state) being combined
   with OR instead of AND (:pr:`5101`)
 - Fix translations not being taken into account in some places (:issue:`5073`, :pr:`5105`)
+- Use correct/consistent field order for personal data fields in newly created
+  registration forms
 
 
 Version 3.0.2

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -73,19 +73,23 @@ class PersonalDataType(int, IndicoEnum):
         return [
             (cls.first_name, {
                 'title': cls.first_name.get_title(),
-                'input_type': 'text'
+                'input_type': 'text',
+                'position': 1
             }),
             (cls.last_name, {
                 'title': cls.last_name.get_title(),
-                'input_type': 'text'
+                'input_type': 'text',
+                'position': 2
             }),
             (cls.email, {
                 'title': cls.email.get_title(),
-                'input_type': 'email'
+                'input_type': 'email',
+                'position': 3
             }),
             (cls.affiliation, {
                 'title': cls.affiliation.get_title(),
-                'input_type': 'text'
+                'input_type': 'text',
+                'position': 4
             }),
             # Fields disabled by default start in position 1000 to avoid problems reordering
             (cls.address, {

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -188,8 +188,6 @@ def create_personal_data_fields(regform):
             continue
         field = RegistrationFormPersonalDataField(registration_form=regform, personal_data_type=pd_type,
                                                   is_required=pd_type.is_required)
-        if not data.get('is_enabled', True):
-            field.position = data['position']
         for key, value in data.items():
             setattr(field, key, value)
         field.data, versioned_data = field.field_impl.process_field_data(data.pop('data', {}))


### PR DESCRIPTION
Otherwise all personal data fields get created with position 1 since the automatic position assignment doesn't work as none of the previous fields have been flushed to the DB at that point.