### PR TITLE
Validate regform field data using schemas

### DIFF
--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -7,9 +7,20 @@
 
 from copy import deepcopy
 
+from marshmallow import fields, validate
 from wtforms.validators import DataRequired, Optional
 
+from indico.core.marshmallow import mm
 from indico.modules.events.registration.models.registrations import RegistrationData
+
+
+class BillableFieldDataSchema(mm.Schema):
+    is_billable = fields.Bool(missing=False)
+    price = fields.Float(missing=0)
+
+
+class LimitedPlacesBillableFieldDataSchema(BillableFieldDataSchema):
+    places_limit = fields.Integer(missing=0, validate=validate.Range(0))
 
 
 class RegistrationFormFieldBase:
@@ -27,6 +38,10 @@ class RegistrationFormFieldBase:
     not_required_validator = Optional
     #: the data fields that need to be versioned
     versioned_data_fields = frozenset({'is_billable', 'price'})
+    #: the marshmallow base schema for configuring the field
+    setup_schema_base_cls = mm.Schema
+    #: a dict with extra marshmallow fields to include in the setup schema
+    setup_schema_fields = {}
 
     def __init__(self, form_item):
         self.form_item = form_item
@@ -67,6 +82,11 @@ class RegistrationFormFieldBase:
         elif self.not_required_validator:
             validators.append(self.not_required_validator())
         return self.wtf_field_class(self.form_item.title, validators, **self.wtf_field_kwargs)
+
+    def create_setup_schema(self):
+        name = f'{type(self).__name__}SetupDataSchema'
+        schema = self.setup_schema_base_cls.from_dict(self.setup_schema_fields, name=name)
+        return schema()
 
     def has_data_changed(self, value, old_data):
         return value != old_data.data
@@ -135,6 +155,8 @@ class RegistrationFormFieldBase:
 
 
 class RegistrationFormBillableField(RegistrationFormFieldBase):
+    setup_schema_base_cls = BillableFieldDataSchema
+
     @classmethod
     def process_field_data(cls, data, old_data=None, old_versioned_data=None):
         data = deepcopy(data)
@@ -154,6 +176,8 @@ class RegistrationFormBillableField(RegistrationFormFieldBase):
 
 
 class RegistrationFormBillableItemsField(RegistrationFormBillableField):
+    setup_schema_base_cls = mm.Schema
+
     @classmethod
     def process_field_data(cls, data, old_data=None, old_versioned_data=None):
         unversioned_data, versioned_data = super().process_field_data(

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -10,10 +10,12 @@ from datetime import datetime
 from operator import itemgetter
 
 import wtforms
+from marshmallow import fields, validate
 from werkzeug.datastructures import FileStorage
 from wtforms.validators import InputRequired, NumberRange, ValidationError
 
-from indico.modules.events.registration.fields.base import RegistrationFormBillableField, RegistrationFormFieldBase
+from indico.modules.events.registration.fields.base import (LimitedPlacesBillableFieldDataSchema,
+                                                            RegistrationFormBillableField, RegistrationFormFieldBase)
 from indico.util.countries import get_countries, get_country
 from indico.util.date_time import strftime_all_years
 from indico.util.fs import secure_client_filename
@@ -26,12 +28,20 @@ from indico.web.forms.validators import IndicoEmail
 class TextField(RegistrationFormFieldBase):
     name = 'text'
     wtf_field_class = wtforms.StringField
+    setup_schema_fields = {
+        'length': fields.Integer(missing=None, validate=validate.Range(5, 60)),
+        'min_length': fields.Integer(missing=None, validate=validate.Range(1)),
+        'max_length': fields.Integer(missing=None, validate=validate.Range(1)),
+    }
 
 
 class NumberField(RegistrationFormBillableField):
     name = 'number'
     wtf_field_class = wtforms.IntegerField
     required_validator = InputRequired
+    setup_schema_fields = {
+        'min_value': fields.Integer(missing=0, validate=validate.Range(0)),
+    }
 
     @property
     def validators(self):
@@ -52,11 +62,16 @@ class NumberField(RegistrationFormBillableField):
 class TextAreaField(RegistrationFormFieldBase):
     name = 'textarea'
     wtf_field_class = wtforms.StringField
+    setup_schema_fields = {
+        'number_of_columns': fields.Integer(missing=None, validate=validate.Range(1, 60)),
+        'number_of_rows': fields.Integer(missing=None, validate=validate.Range(1, 20)),
+    }
 
 
 class CheckboxField(RegistrationFormBillableField):
     name = 'checkbox'
     wtf_field_class = wtforms.BooleanField
+    setup_schema_base_cls = LimitedPlacesBillableFieldDataSchema
     friendly_data_mapping = {None: '',
                              True: L_('Yes'),
                              False: L_('No')}
@@ -109,6 +124,25 @@ class CheckboxField(RegistrationFormBillableField):
 class DateField(RegistrationFormFieldBase):
     name = 'date'
     wtf_field_class = wtforms.StringField
+    setup_schema_fields = {
+        'date_format': fields.String(required=True, validate=validate.OneOf([
+            '%d/%m/%Y %H:%M',
+            '%d.%m.%Y %H:%M',
+            '%m/%d/%Y %H:%M',
+            '%m.%d.%Y %H:%M',
+            '%Y/%m/%d %H:%M',
+            '%Y.%m.%d %H:%M',
+            '%d/%m/%Y',
+            '%d.%m.%Y',
+            '%m/%d/%Y',
+            '%m.%d.%Y',
+            '%Y/%m/%d',
+            '%Y.%m.%d',
+            '%m/%Y',
+            '%m.%Y',
+            '%Y'
+        ])),
+    }
 
     def process_form_data(self, registration, value, old_data=None, billable_items_locked=False):
         if value:
@@ -135,6 +169,10 @@ class BooleanField(RegistrationFormBillableField):
     name = 'bool'
     wtf_field_class = IndicoRadioField
     required_validator = InputRequired
+    setup_schema_base_cls = LimitedPlacesBillableFieldDataSchema
+    setup_schema_fields = {
+        'default_value': fields.String(missing='', validate=validate.OneOf(['', 'yes', 'no'])),
+    }
     friendly_data_mapping = {None: '',
                              True: L_('Yes'),
                              False: L_('No')}


### PR DESCRIPTION
There are some cases where you can get validation errors due to bugs in the legacy angular code (some fields allowing both empty and 0, or simply not having a value depending on whether or not you touched them); but that's something to fix when moving the frontend to react.

closes #5112