### PR TITLE
Truncate long filenames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,12 @@ Bugfixes
 - Remove deleted registration forms from ACLs (:issue:`5130`, :pr:`5131`, thanks
   :user:`jbtwist`)
 
+Internal Changes
+^^^^^^^^^^^^^^^^
+
+- Truncate file names to 150 characters to avoid hitting file system path limits
+  (:pr:`5116`, thanks :user:`vasantvohra`)
+
 
 Version 3.0.2
 -------------

--- a/indico/util/fs.py
+++ b/indico/util/fs.py
@@ -47,7 +47,10 @@ def secure_filename(filename, fallback):
     """
     if not filename:
         return fallback
-    return _secure_filename(str_to_ascii(filename)) or fallback
+    filename = _secure_filename(str_to_ascii(filename))
+    filename, ext = os.path.splitext(filename)
+    filename = f'{filename[:150]}{ext}'
+    return filename or fallback
 
 
 def secure_client_filename(filename, fallback='file'):

--- a/indico/util/fs_test.py
+++ b/indico/util/fs_test.py
@@ -35,6 +35,14 @@ def test_secure_client_filename(filename, expected):
     ('m\xf6p.txt', 'moep.txt'),
     ('/m\xf6p.txt', 'moep.txt'),
     (r'spacy   \filename', 'spacy_filename'),
+    ('.filename', 'filename'),
+    ('filename', 'filename'),
+    ('file.name', 'file.name'),
+    ('   ', 'fallback')
 ))
 def test_secure_filename(filename, expected):
     assert secure_filename(filename, 'fallback') == expected
+
+
+def test_secure_filename_max_length():
+    assert secure_filename(f'{"x" * 500}.pdf', 'fallback') == f'{"x" * 150}.pdf'


### PR DESCRIPTION
Users occasionally upload a file with a very lengthy name (>250) in the file field of the registration form; Mac and most OS allow up to 255 characters, but our servers return the error `[Errno 36] File name too long.`

Traceback:
```sh
File "/nas/indico.un/v2/indico-un/indico/indico/core/storage/models.py", line 208, in save
    self.storage_file_id, self.md5 = self.storage.save(path, self.content_type, self.filename, data)
  File "/nas/indico.un/v2/indico-un/indico/indico/core/storage/backend.py", line 252, in save
    with open(filepath, 'wb') as f:
StorageError: Could not save "event/1000135/registrations/5552/614104/102009-1633527965-AREMDCAM_AND_AUAG-CAMEROON-LETTER_OF_NOMINATIONS_ASSIGNMENT__RECOMMENDATION_FOR_ACCREDITATION_TO_THE7th_SESSION_OF_THE_MOP_TO_THE_AARHUS_CONVENTION_4TH_SESSION_OF_THE_MOPP_ON_PRTRs_THEIR_JHLS_AND_ASSOCIATED_MEETINGS_18-22_OCTOBER_IN_SWITZERLAN.pdf": 

[Errno 36] File name too long: u'/indico.un/v2/data/archive/event/1000135/registrations/5552/614104/102009-1633527965-AREMDCAM_AND_AUAG-CAMEROON-LETTER_OF_NOMINATIONS_ASSIGNMENT__RECOMMENDATION_FOR_ACCREDITATION_TO_THE7th_SESSION_OF_THE_MOP_TO_THE_AARHUS_CONVENTION_4TH_SESSION_OF_THE_MOPP_ON_PRTRs_THEIR_JHLS_AND_ASSOCIATED_MEETINGS_18-22_OCTOBER_IN_SWITZERLAN.pdf'
```