### PR TITLE
Make the unlisted event notice stronger

### DIFF
--- a/indico/modules/events/management/templates/settings.html
+++ b/indico/modules/events/management/templates/settings.html
@@ -52,13 +52,14 @@
         </div>
     {%- endif -%}
     {%- if event.is_unlisted and event.can_manage(session.user) -%}
-        <div class="action-box info">
+        <div class="action-box warning">
             <div class="section">
                 <div class="icon icon-unlisted-event"></div>
                 <div class="text">
                     <div class="label">{% trans %}This event is currently unlisted{% endtrans %}</div>
                     {% trans %}
-                        Unlisted events are not shown in any category and only explicitly authorized users can see them.
+                        Unlisted events are not shown in any category and only explicitly authorized users can see them.<br>
+                        <strong>Please note:</strong> If you want to preserve events long-term, you should consider publishing them to a category.
                     {% endtrans %}
                 </div>
             </div>


### PR DESCRIPTION
This PR changes the unlisted event notice so it encourages user to publish their events.

![image](https://user-images.githubusercontent.com/6058151/136944918-20e053f2-de7b-42fa-b4f0-2d6d951d66f7.png)
