### PR TITLE
Let event managers see timetable & contribs in draft mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Improvements
 - Allow importing registration invitations from a CSV file (:issue:`3673`, :pr:`5108`)
 - Show event label on category overviews and in iCal event titles (:issue:`5140`,
   :pr:`5143`)
+- Let event managers view the final timetable even while in draft mode (:issue:`5141`,
+  :pr:`5145`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/__init__.py
+++ b/indico/modules/events/contributions/__init__.py
@@ -109,7 +109,8 @@ def _extend_event_menu(sender, **kwargs):
 
     def _visible_list_of_contributions(event):
         published = contribution_settings.get(event, 'published')
-        return published and Contribution.query.filter(Contribution.event == event).has_rows()
+        can_manage = event.can_manage(session.user)
+        return (published or can_manage) and Contribution.query.filter(Contribution.event == event).has_rows()
 
     yield MenuEntryData(title=_('My Contributions'), name='my_contributions', visible=_visible_my_contributions,
                         endpoint='contributions.my_contributions', position=2, parent='my_conference')

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -78,7 +78,8 @@ class RHDisplayProtectionBase(RHDisplayEventBase):
     def _check_access(self):
         RHDisplayEventBase._check_access(self)
         published = contribution_settings.get(self.event, 'published')
-        if not published and not has_contributions_with_user_as_submitter(self.event, session.user):
+        can_manage = self.event.can_manage(session.user)
+        if not published and not can_manage and not has_contributions_with_user_as_submitter(self.event, session.user):
             raise NotFound(_('The contributions of this event have not been published yet.'))
 
         if not is_menu_entry_enabled(self.MENU_ENTRY_NAME, self.event):
@@ -114,6 +115,7 @@ class RHContributionList(RHDisplayProtectionBase):
     def _process(self):
         return self.view_class.render_template('display/contribution_list.html', self.event,
                                                timezone=self.event.display_tzinfo,
+                                               published=contribution_settings.get(self.event, 'published'),
                                                **self.list_generator.get_list_kwargs())
 
 

--- a/indico/modules/events/contributions/templates/display/contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/contribution_list.html
@@ -1,6 +1,7 @@
 {% extends 'events/display/conference/base.html' %}
 
 {% from 'events/contributions/display/_contribution_list.html' import render_contribution_list %}
+{% from 'events/contributions/management/_draft_mode_warning.html' import render_draft_mode_warning %}
 {% from 'events/management/_lists.html' import render_displayed_entries_fragment %}
 
 {% block title %}
@@ -8,6 +9,9 @@
 {% endblock %}
 
 {% block content -%}
+    {% if not published %}
+        {{ render_draft_mode_warning(event) }}
+    {% endif %}
     {% if total_entries %}
         <div class="toolbar f-j-end space-after">
             <div id="counter" class="group">

--- a/indico/modules/events/timetable/__init__.py
+++ b/indico/modules/events/timetable/__init__.py
@@ -26,7 +26,7 @@ def _extend_event_menu(sender, **kwargs):
     from indico.modules.events.layout.util import MenuEntryData
 
     def _visible_timetable(event):
-        return contribution_settings.get(event, 'published')
+        return contribution_settings.get(event, 'published') or event.can_manage(session.user)
 
     yield MenuEntryData(title=_('Timetable'), name='timetable', endpoint='timetable.timetable', position=3,
                         visible=_visible_timetable, static_site=True)

--- a/indico/modules/events/timetable/controllers/display.py
+++ b/indico/modules/events/timetable/controllers/display.py
@@ -30,7 +30,7 @@ class RHTimetableProtectionBase(RHDisplayEventBase):
     def _check_access(self):
         RHDisplayEventBase._check_access(self)
         published = contribution_settings.get(self.event, 'published')
-        if not published:
+        if not published and not self.event.can_manage(session.user):
             raise NotFound(_('The contributions of this event have not been published yet'))
 
 
@@ -51,7 +51,8 @@ class RHTimetable(RHTimetableProtectionBase):
             timetable_settings = layout_settings.get(self.event, 'timetable_theme_settings')
             return self.view_class.render_template('display.html', self.event, event_info=event_info,
                                                    timetable_data=timetable_data, timetable_settings=timetable_settings,
-                                                   timetable_layout=self.timetable_layout)
+                                                   timetable_layout=self.timetable_layout,
+                                                   published=contribution_settings.get(self.event, 'published'))
         else:
             return self.view_class_simple(self, self.event, self.theme, self.theme_override).display()
 

--- a/indico/modules/events/timetable/templates/display.html
+++ b/indico/modules/events/timetable/templates/display.html
@@ -1,4 +1,5 @@
 {% extends 'events/display/conference/base.html' %}
+{% from 'events/contributions/management/_draft_mode_warning.html' import render_draft_mode_warning %}
 {% from 'events/timetable/_timetable.html' import render_timetable %}
 
 {% block title %}
@@ -6,5 +7,8 @@
 {% endblock %}
 
 {% block content %}
+    {% if not published %}
+        {{ render_draft_mode_warning(event) }}
+    {% endif %}
     {{ render_timetable(timetable_data, event_info, timetable_layout) }}
 {% endblock %}


### PR DESCRIPTION
closes #5141 

With this change, the timetable and the contribution list become visible
to managers even in draft mode.

I decided to keep the boa hidden since that is just a PDF and
we have no way to inform people about the draft mode there.

I reused the same draft mode warning from the management pages:
![image](https://user-images.githubusercontent.com/8739637/140496092-4de6dd2d-b6b2-4443-aeb5-b8d4fcb9b4db.png)
