### PR TITLE
Allow adding external users to ACLs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,11 @@ Version 3.0.4
 
 *Unreleased*
 
+Improvements
+^^^^^^^^^^^^
+
+- Allow external users in event/category ACLs (:pr:`5146`)
+
 Bugfixes
 ^^^^^^^^
 

--- a/indico/core/permissions.py
+++ b/indico/core/permissions.py
@@ -195,6 +195,7 @@ def update_permissions(obj, form):
     new_principal_permissions = {
         principal_from_identifier(
             fossil['identifier'],
+            allow_external_users=True,
             allow_groups=True,
             allow_networks=True,
             allow_emails=True,

--- a/indico/modules/categories/forms.py
+++ b/indico/modules/categories/forms.py
@@ -115,6 +115,7 @@ class CategoryProtectionForm(IndicoForm):
     def validate_permissions(self, field):
         for principal_fossil, permissions in field.data:
             principal = principal_from_identifier(principal_fossil['identifier'],
+                                                  allow_external_users=True,
                                                   allow_groups=True,
                                                   allow_networks=True,
                                                   allow_category_roles=True,

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -641,6 +641,7 @@ def set_custom_fields(obj, custom_fields_data):
 def check_permissions(event, field, allow_networks=False):
     for principal_fossil, permissions in field.data:
         principal = principal_from_identifier(principal_fossil['identifier'],
+                                              allow_external_users=True,
                                               allow_groups=True,
                                               allow_category_roles=True,
                                               allow_event_roles=True,

--- a/indico/web/client/js/jquery/widgets/jinja/permissions_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/permissions_widget.js
@@ -480,6 +480,7 @@ import Palette from 'indico/utils/palette';
           {([favorites]) => (
             <>
               <UserSearch
+                withExternalUsers
                 favorites={favorites}
                 existing={existing.filter(e => e.startsWith('User'))}
                 onAddItems={e => {


### PR DESCRIPTION
There's no good reason against doing this, especially since we already allow adding them to event/category roles and those can be added to the ACL.

There are some valid usecases for adding those users, e.g. when setting up an invite-only event including users that exist externally but have never logged in to Indico.