### PR TITLE
Configure participant visibility when creating a new registration form

### DIFF
--- a/indico/modules/events/registration/controllers/management/regforms.py
+++ b/indico/modules/events/registration/controllers/management/regforms.py
@@ -18,8 +18,8 @@ from indico.modules.events.payment import payment_settings
 from indico.modules.events.registration import logger, registration_settings
 from indico.modules.events.registration.controllers.management import RHManageRegFormBase, RHManageRegFormsBase
 from indico.modules.events.registration.forms import (ParticipantsDisplayForm, ParticipantsDisplayFormColumnsForm,
-                                                      RegistrationFormForm, RegistrationFormScheduleForm,
-                                                      RegistrationManagersForm)
+                                                      RegistrationFormCreateForm, RegistrationFormEditForm,
+                                                      RegistrationFormScheduleForm, RegistrationManagersForm)
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.items import PersonalDataType
 from indico.modules.events.registration.models.registrations import PublishRegistrationsMode
@@ -127,28 +127,36 @@ class RHManageRegistrationFormDisplay(RHManageRegFormBase):
 class RHManageParticipants(RHManageRegFormsBase):
     """Show and enable the dummy registration form for participants."""
 
-    def _process_POST(self):
-        regform = self.event.participation_regform
-        set_feature_enabled(self.event, 'registration', True)
-        if not regform:
-            regform = RegistrationForm(event=self.event, title='Participants', is_participation=True,
-                                       currency=payment_settings.get('currency'),
-                                       publish_registrations_public=(PublishRegistrationsMode.hide_all
-                                                                     if self.event.type_ == EventType.conference
-                                                                     else PublishRegistrationsMode.show_with_consent))
-            create_personal_data_fields(regform)
-            db.session.add(regform)
-            db.session.flush()
-            signals.event.registration_form_created.send(regform)
-            self.event.log(EventLogRealm.management, LogKind.positive, 'Registration',
-                           f'Registration form "{regform.title}" has been created', session.user)
-        return redirect(url_for('event_registration.manage_regform', regform))
-
-    def _process_GET(self):
+    def _process(self):
         regform = self.event.participation_regform
         registration_enabled = self.event.has_feature('registration')
+        participant_visibility = (PublishRegistrationsMode.show_with_consent
+                                  if self.event.type_ == EventType.lecture
+                                  else PublishRegistrationsMode.show_all)
+        public_visibility = (PublishRegistrationsMode.show_with_consent
+                             if self.event.type_ == EventType.lecture
+                             else PublishRegistrationsMode.show_all)
+        form = RegistrationFormCreateForm(event=self.event, title='Participants',
+                                          currency=payment_settings.get('currency'),
+                                          visibility=[participant_visibility.name, public_visibility.name])
+        if form.validate_on_submit():
+            set_feature_enabled(self.event, 'registration', True)
+            if not regform:
+                regform = RegistrationForm(event=self.event, is_participation=True)
+                create_personal_data_fields(regform)
+                form.populate_obj(regform, skip=['visibility'])
+                participant_visibility, public_visibility = form.visibility.data
+                regform.publish_registrations_participants = PublishRegistrationsMode[participant_visibility]
+                regform.publish_registrations_public = PublishRegistrationsMode[public_visibility]
+                db.session.add(regform)
+                db.session.flush()
+                signals.event.registration_form_created.send(regform)
+                self.event.log(EventLogRealm.management, LogKind.positive, 'Registration',
+                               f'Registration form "{regform.title}" has been created', session.user)
+            return redirect(url_for('event_registration.manage_regform', regform))
+
         if not regform or not registration_enabled:
-            return WPManageParticipants.render_template('management/participants.html', self.event,
+            return WPManageParticipants.render_template('management/participants.html', self.event, form=form,
                                                         regform=regform, registration_enabled=registration_enabled)
         return redirect(url_for('event_registration.manage_regform', regform))
 
@@ -157,15 +165,19 @@ class RHRegistrationFormCreate(RHManageRegFormsBase):
     """Create a new registration form."""
 
     def _process(self):
-        publish_registrations_participants = (PublishRegistrationsMode.hide_all
-                                              if self.event.type_ == EventType.conference
-                                              else PublishRegistrationsMode.show_with_consent)
-        form = RegistrationFormForm(event=self.event, currency=payment_settings.get('currency'),
-                                    publish_registrations_participants=publish_registrations_participants)
+        participant_visibility = (PublishRegistrationsMode.hide_all
+                                  if self.event.type_ == EventType.conference
+                                  else PublishRegistrationsMode.show_all)
+        public_visibility = PublishRegistrationsMode.hide_all
+        form = RegistrationFormCreateForm(event=self.event, currency=payment_settings.get('currency'),
+                                          visibility=[participant_visibility.name, public_visibility.name])
         if form.validate_on_submit():
             regform = RegistrationForm(event=self.event)
             create_personal_data_fields(regform)
-            form.populate_obj(regform)
+            form.populate_obj(regform, skip=['visibility'])
+            participant_visibility, public_visibility = form.visibility.data
+            regform.publish_registrations_participants = PublishRegistrationsMode[participant_visibility]
+            regform.publish_registrations_public = PublishRegistrationsMode[public_visibility]
             db.session.add(regform)
             db.session.flush()
             signals.event.registration_form_created.send(regform)
@@ -173,7 +185,7 @@ class RHRegistrationFormCreate(RHManageRegFormsBase):
             self.event.log(EventLogRealm.management, LogKind.positive, 'Registration',
                            f'Registration form "{regform.title}" has been created', session.user)
             return redirect(url_for('.manage_regform', regform))
-        return WPManageRegistration.render_template('management/regform_edit.html', self.event,
+        return WPManageRegistration.render_template('management/regform_create.html', self.event,
                                                     form=form, regform=None)
 
 
@@ -191,7 +203,7 @@ class RHRegistrationFormEdit(RHManageRegFormBase):
         return FormDefaults(self.regform, limit_registrations=self.regform.registration_limit is not None)
 
     def _process(self):
-        form = RegistrationFormForm(obj=self._get_form_defaults(), event=self.event, regform=self.regform)
+        form = RegistrationFormEditForm(obj=self._get_form_defaults(), event=self.event, regform=self.regform)
         if form.validate_on_submit():
             form.populate_obj(self.regform)
             db.session.flush()

--- a/indico/modules/events/registration/controllers/management/regforms.py
+++ b/indico/modules/events/registration/controllers/management/regforms.py
@@ -136,13 +136,13 @@ class RHManageParticipants(RHManageRegFormsBase):
         public_visibility = (PublishRegistrationsMode.show_with_consent
                              if self.event.type_ == EventType.lecture
                              else PublishRegistrationsMode.show_all)
-        form = RegistrationFormCreateForm(event=self.event, title='Participants',
-                                          currency=payment_settings.get('currency'),
+        form = RegistrationFormCreateForm(title='Participants',
                                           visibility=[participant_visibility.name, public_visibility.name])
         if form.validate_on_submit():
             set_feature_enabled(self.event, 'registration', True)
             if not regform:
-                regform = RegistrationForm(event=self.event, is_participation=True)
+                regform = RegistrationForm(event=self.event, is_participation=True,
+                                           currency=payment_settings.get('currency'))
                 create_personal_data_fields(regform)
                 form.populate_obj(regform, skip=['visibility'])
                 participant_visibility, public_visibility = form.visibility.data
@@ -169,10 +169,10 @@ class RHRegistrationFormCreate(RHManageRegFormsBase):
                                   if self.event.type_ == EventType.conference
                                   else PublishRegistrationsMode.show_all)
         public_visibility = PublishRegistrationsMode.hide_all
-        form = RegistrationFormCreateForm(event=self.event, currency=payment_settings.get('currency'),
+        form = RegistrationFormCreateForm(event=self.event,
                                           visibility=[participant_visibility.name, public_visibility.name])
         if form.validate_on_submit():
-            regform = RegistrationForm(event=self.event)
+            regform = RegistrationForm(event=self.event, currency=payment_settings.get('currency'))
             create_personal_data_fields(regform)
             form.populate_obj(regform, skip=['visibility'])
             participant_visibility, public_visibility = form.visibility.data

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -128,16 +128,6 @@ class RegistrationFormCreateForm(IndicoForm):
                                                   description=_('Specify under which conditions the participant list '
                                                                 'will be visible to other participants and everyone '
                                                                 'else who can access the event'))
-    currency = SelectField(_('Currency'), [DataRequired()], description=_('The currency for new registrations'))
-
-    def __init__(self, *args, **kwargs):
-        self.event = kwargs.pop('event')
-        super().__init__(*args, **kwargs)
-        self._set_currencies()
-
-    def _set_currencies(self):
-        currencies = [(c['code'], '{0[code]} ({0[name]})'.format(c)) for c in payment_settings.get('currencies')]
-        self.currency.choices = sorted(currencies, key=lambda x: x[1].lower())
 
 
 class RegistrationFormScheduleForm(IndicoForm):

--- a/indico/modules/events/registration/templates/management/participants.html
+++ b/indico/modules/events/registration/templates/management/participants.html
@@ -16,7 +16,7 @@
         </div>
     </div>
     {% if not regform %}
-        {{ simple_form(form, fields=form._meeting_fields, submit='Create',
+        {{ simple_form(form, fields=form._meeting_fields, submit=_('Create'),
                        disabled_until_change=false, back_button=false) }}
     {% endif %}
 {% endblock %}

--- a/indico/modules/events/registration/templates/management/participants.html
+++ b/indico/modules/events/registration/templates/management/participants.html
@@ -1,4 +1,5 @@
 {% extends 'events/management/base.html' %}
+{% from 'forms/_form.html' import simple_form %}
 
 {% block title %}
     {%- trans %}Participants{% endtrans -%}
@@ -14,6 +15,10 @@
             {% endif %}
         </div>
     </div>
+    {% if not regform %}
+        {{ simple_form(form, fields=form._meeting_fields, submit='Create',
+                       disabled_until_change=false, back_button=false) }}
+    {% endif %}
 {% endblock %}
 
 
@@ -43,14 +48,8 @@
             {% trans %}There is no registration form for participants{% endtrans %}
         </div>
         {% trans -%}
-            Participants are now handled through a registration form.
+            To create a new registration form, specify the participant visibility settings below.
+            These settings can only be changed while there are no registrations.
         {%- endtrans %}
-    </div>
-    <div class="toolbar">
-        <a href="#" class="i-button highlight"
-           data-href="{{ url_for('.manage', event) }}"
-           data-method="POST">
-            {% trans %}Create{% endtrans %}
-        </a>
     </div>
 {% endmacro %}

--- a/indico/modules/events/registration/templates/management/regform.html
+++ b/indico/modules/events/registration/templates/management/regform.html
@@ -42,6 +42,21 @@
                     </a>
                 </div>
             </div>
+
+            <div class="section">
+                <div class="icon icon-lock-center"></div>
+                <div class="text">
+                    <div class="label">
+                        {% trans %}Privacy settings{% endtrans %}
+                    </div>
+                    {% trans %}Choose who can see the participants of this event.{% endtrans %}
+                </div>
+                <div class="toolbar">
+                    <a href="{{ url_for('.manage_registration_privacy_settings', regform) }}" class="i-button icon-settings">
+                        {% trans %}Configure{% endtrans %}
+                    </a>
+                </div>
+            </div>
         </div>
     {% endblock %}
 

--- a/indico/modules/events/registration/templates/management/regform_create.html
+++ b/indico/modules/events/registration/templates/management/regform_create.html
@@ -18,6 +18,6 @@
             </div>
         </div>
     </div>
-    {{ simple_form(form, fields=form._conference_fields, submit='Create',
+    {{ simple_form(form, fields=form._conference_fields, submit=_('Create'),
                    back_url=url_for('.manage_regform_list', event)) }}
 {% endblock %}

--- a/indico/modules/events/registration/templates/management/regform_create.html
+++ b/indico/modules/events/registration/templates/management/regform_create.html
@@ -1,0 +1,23 @@
+{% extends 'events/registration/management/_regform_base.html' %}
+{% from 'forms/_form.html' import simple_form %}
+
+{% block subtitle %}{% endblock %}
+
+{% block content %}
+    <div class="action-box highlight">
+        <div class="section">
+            <div class="icon icon-users"></div>
+            <div class="text">
+                <div class="label">
+                    {% trans %}Create a new registration form{% endtrans %}
+                </div>
+                {% trans -%}
+                    To create a new registration form, specify the title and participant visibility settings below.
+                    The visibility settings can only be changed while there are no registrations.
+                {%- endtrans %}
+            </div>
+        </div>
+    </div>
+    {{ simple_form(form, fields=form._conference_fields, submit='Create',
+                   back_url=url_for('.manage_regform_list', event)) }}
+{% endblock %}


### PR DESCRIPTION
Closes #5150 

Shows a simplified form when creating a new regform consisting of the title (for conferences)
and the participant visibility settings. All other settings are still normally accessible through the regform settings later.

Meetings:
![image](https://user-images.githubusercontent.com/8739637/155986642-a544fcb8-c2da-4589-96a6-d4f547857623.png)

Conferences:
![image](https://user-images.githubusercontent.com/8739637/155986584-ae527554-5472-40bd-859e-f37a5c54a4b8.png)

New `privacy` section in the regform main settings page:
![image](https://user-images.githubusercontent.com/8739637/155985847-f89c2ea9-0773-4a12-807f-58e3f425c0d9.png)



