### PR TITLE
Refactor RequestConfirm & add RequestConfirmDelete

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
@@ -63,17 +63,14 @@ export default function ResetReview({revisionId}) {
       />
       <RequestConfirm
         header={Translate.string('Reset review')}
-        confirmText={Translate.string('Yes')}
-        cancelText={Translate.string('No')}
+        confirmText={Translate.string('Reset')}
         onClose={() => setIsOpen(false)}
-        content={
-          <div className="content">
-            <Translate>Are you sure you want to reset the review?</Translate>
-          </div>
-        }
         requestFunc={resetRevisions}
         open={isOpen}
-      />
+        negative
+      >
+        <Translate>Are you sure you want to reset the review?</Translate>
+      </RequestConfirm>
     </>
   );
 }

--- a/indico/modules/events/editing/client/js/management/editable_type/file_types/FileTypeManager.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/file_types/FileTypeManager.jsx
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import React, {useReducer} from 'react';
 import {Button, Icon, Loader, Message, Segment, Popup, Label} from 'semantic-ui-react';
 
-import {RequestConfirm, TooltipIfTruncated} from 'indico/react/components';
+import {RequestConfirmDelete, TooltipIfTruncated} from 'indico/react/components';
 import {getChangedValues, handleSubmitError} from 'indico/react/forms';
 import {useIndicoAxios} from 'indico/react/hooks';
 import {Param, Translate} from 'indico/react/i18n';
@@ -212,24 +212,18 @@ export default function FileTypeManager({eventId, editableType}) {
           onClose={() => dispatch({type: 'CLEAR'})}
         />
       )}
-      <RequestConfirm
-        header={Translate.string('Delete file type')}
-        confirmText={Translate.string('Yes')}
-        cancelText={Translate.string('No')}
+      <RequestConfirmDelete
         onClose={() => dispatch({type: 'CLEAR'})}
-        content={
-          currentFileType ? (
-            <div className="content">
-              <Translate>
-                Are you sure you want to delete the file type{' '}
-                <Param name="fileType" value={currentFileType.name} wrapper={<strong />} />?
-              </Translate>
-            </div>
-          ) : null
-        }
         requestFunc={() => deleteFileType(currentFileType.id)}
         open={operation === 'delete'}
-      />
+      >
+        {currentFileType && (
+          <Translate>
+            Are you sure you want to delete the file type{' '}
+            <Param name="fileType" value={currentFileType.name} wrapper={<strong />} />?
+          </Translate>
+        )}
+      </RequestConfirmDelete>
     </div>
   );
 }

--- a/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ConditionInfo.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ConditionInfo.jsx
@@ -11,7 +11,7 @@ import PropTypes from 'prop-types';
 import React, {useState, useContext} from 'react';
 import {Icon, Label} from 'semantic-ui-react';
 
-import {RequestConfirm, TooltipIfTruncated} from 'indico/react/components';
+import {RequestConfirmDelete, TooltipIfTruncated} from 'indico/react/components';
 import {handleSubmitError} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 import {handleAxiosError, indicoAxios} from 'indico/utils/axios';
@@ -89,19 +89,13 @@ export default function ConditionInfo({fileTypes, condId, editableType, onUpdate
           disabled={disableActions}
         />
       </div>
-      <RequestConfirm
-        header={Translate.string('Delete review condition')}
-        confirmText={Translate.string('Yes')}
-        cancelText={Translate.string('No')}
+      <RequestConfirmDelete
         onClose={() => setIsDeleting(false)}
-        content={
-          <div className="content">
-            <Translate>Are you sure you want to delete this condition?</Translate>
-          </div>
-        }
         requestFunc={deleteCondition}
         open={isDeleting}
-      />
+      >
+        <Translate>Are you sure you want to delete this condition?</Translate>
+      </RequestConfirmDelete>
     </>
   );
 }

--- a/indico/modules/events/editing/client/js/management/tags/TagManager.jsx
+++ b/indico/modules/events/editing/client/js/management/tags/TagManager.jsx
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import React, {useReducer} from 'react';
 import {Button, Icon, Label, Loader, Message, Segment, Popup} from 'semantic-ui-react';
 
-import {RequestConfirm} from 'indico/react/components';
+import {RequestConfirmDelete} from 'indico/react/components';
 import {getChangedValues, handleSubmitError} from 'indico/react/forms';
 import {useIndicoAxios} from 'indico/react/hooks';
 import {Param, Translate} from 'indico/react/i18n';
@@ -163,24 +163,18 @@ export default function TagManager({eventId}) {
           onClose={() => dispatch({type: 'CLEAR'})}
         />
       )}
-      <RequestConfirm
-        header={Translate.string('Delete tag')}
-        confirmText={Translate.string('Yes')}
-        cancelText={Translate.string('No')}
+      <RequestConfirmDelete
         onClose={() => dispatch({type: 'CLEAR'})}
-        content={
-          currentTag ? (
-            <div className="content">
-              <Translate>
-                Are you sure you want to delete the tag{' '}
-                <Param name="tag" value={currentTag.verboseTitle} wrapper={<strong />} />?
-              </Translate>
-            </div>
-          ) : null
-        }
         requestFunc={() => deleteTag(currentTag.id)}
         open={operation === 'delete'}
-      />
+      >
+        {currentTag && (
+          <Translate>
+            Are you sure you want to delete the tag{' '}
+            <Param name="tag" value={currentTag.verboseTitle} wrapper={<strong />} />?
+          </Translate>
+        )}
+      </RequestConfirmDelete>
     </div>
   );
 }

--- a/indico/web/client/js/react/components/RequestConfirm.jsx
+++ b/indico/web/client/js/react/components/RequestConfirm.jsx
@@ -7,58 +7,108 @@
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Button, Confirm} from 'semantic-ui-react';
+import {Button, Modal} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 
 export default function RequestConfirm({
+  header,
+  children,
   requestFunc,
   confirmText,
   cancelText,
   onClose,
-  ...confirmProps
+  open,
+  persistent,
+  size,
+  negative,
 }) {
   const [requestInProgress, setRequestInProgress] = useState(false);
-  const confirmButton = (
-    <Button disabled={requestInProgress} loading={requestInProgress}>
-      {confirmText}
-    </Button>
-  );
+  const handleConfirmClick = async () => {
+    setRequestInProgress(true);
+    const keepOpen = await requestFunc();
+    if (persistent && keepOpen) {
+      // probably the request failed, so we clear the progress indicator
+      setRequestInProgress(false);
+    } else if (!persistent) {
+      setRequestInProgress(false);
+
+      if (onClose && !keepOpen) {
+        onClose();
+      }
+    }
+  };
 
   return (
-    <Confirm
-      {...confirmProps}
+    <Modal
       onClose={onClose}
-      onCancel={onClose}
-      confirmButton={confirmButton}
-      cancelButton={<Button disabled={requestInProgress}>{cancelText}</Button>}
-      onConfirm={async () => {
-        setRequestInProgress(true);
-        const keepOpen = await requestFunc();
-        setRequestInProgress(false);
-
-        if (onClose && !keepOpen) {
-          onClose();
-        }
-      }}
-      closeIcon={!requestInProgress}
+      size={size}
+      closeIcon={false}
       closeOnDimmerClick={!requestInProgress}
       closeOnEscape={!requestInProgress}
-    />
+      open={open}
+    >
+      <Modal.Header>{header}</Modal.Header>
+      <Modal.Content>{children}</Modal.Content>
+      <Modal.Actions>
+        <Button
+          onClick={handleConfirmClick}
+          disabled={requestInProgress}
+          loading={requestInProgress}
+          negative={negative}
+          primary={!negative}
+        >
+          {confirmText}
+        </Button>
+        <Button onClick={onClose} disabled={requestInProgress}>
+          {cancelText}
+        </Button>
+      </Modal.Actions>
+    </Modal>
   );
 }
 
 RequestConfirm.propTypes = {
+  header: PropTypes.node.isRequired,
   requestFunc: PropTypes.func.isRequired,
+  children: PropTypes.node,
+  open: PropTypes.bool.isRequired,
   confirmText: PropTypes.string,
   cancelText: PropTypes.string,
   onClose: PropTypes.func,
   size: PropTypes.oneOf(['mini', 'tiny', 'small', 'large', 'fullscreen']),
+  /**
+   * If the confirmation prompt is persistent, it will not close nor clear its "in progress"
+   * state after
+   */
+  persistent: PropTypes.bool,
+  /** Whether the confirmation is for a negative/dangerous action. */
+  negative: PropTypes.bool,
 };
 
 RequestConfirm.defaultProps = {
+  children: null,
   confirmText: Translate.string('Confirm'),
   cancelText: Translate.string('Cancel'),
   onClose: null,
   size: 'tiny',
+  persistent: false,
+  negative: false,
+};
+
+export function RequestConfirmDelete(props) {
+  return (
+    <RequestConfirm
+      header={Translate.string('Confirm deletion')}
+      confirmText={Translate.string('Delete')}
+      negative
+      {...props}
+    />
+  );
+}
+
+RequestConfirmDelete.propTypes = {
+  ...RequestConfirm.propTypes,
+  // eslint-disable-next-line react/require-default-props
+  header: PropTypes.node,
 };

--- a/indico/web/client/js/react/components/index.js
+++ b/indico/web/client/js/react/components/index.js
@@ -33,7 +33,7 @@ export {default as MathJax} from './MathJax';
 export {default as FileSubmission} from './files/FileSubmission';
 export {default as FinalSingleFileManager} from './files/SingleFileManager';
 export {default as ClipboardButton} from './ClipboardButton';
-export {default as RequestConfirm} from './RequestConfirm';
+export {default as RequestConfirm, RequestConfirmDelete} from './RequestConfirm';
 export {default as ReviewRating} from './ReviewRating';
 export {default as ManagementPageBackButton} from './ManagementPageBackButton';
 export {default as ManagementPageSubTitle} from './ManagementPageSubTitle';


### PR DESCRIPTION
- Use Modal instead of Confirm (to use default button order)
- Use children instead of content prop for message body
- Do not require wrapping the content in a Modal.Content div
- Add persistent mode which performs no state updates after successful request to avoid state updates if a deletion unmounts the confirmation
- Add RequestConfirmDelete component with a default title & label
- Update places using the original ConfirmDelete component