### PR TITLE
Add new signal 'before_registration_email_send' to RHRegistrationEmai…

### DIFF
--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -221,6 +221,8 @@ class RHRegistrationEmailRegistrants(RHRegistrationsActionBase):
             email = make_email(to_list=registration.email, cc_list=form.cc_addresses.data, bcc_list=bcc,
                                from_address=form.from_address.data, template=template, html=True,
                                attachments=attachments)
+            signals.core.before_notification_send.send('registration-custom-email', email=email,
+                                                       registration=registration, form=form)
             send_email(email, self.event, 'Registration', log_metadata={'registration_id': registration.id})
 
     def _process(self):


### PR DESCRIPTION
…lRegistrants.

Request new signal before sending mail to registrants in order to attach PDF to the mail generated.
The contents of PDF is taken from the form.
