### PR TITLE
Fix registration tag manager after checkin etc

### DIFF
--- a/indico/modules/events/registration/client/js/index.js
+++ b/indico/modules/events/registration/client/js/index.js
@@ -84,7 +84,7 @@ import RegistrationTagsEditableList from './components/RegistrationTagsEditableL
     });
   };
 
-  document.addEventListener('DOMContentLoaded', () => {
+  function setupRegistrationTags() {
     const rootElement = document.getElementById('registration-detail-registration-tags-assign');
 
     if (rootElement) {
@@ -103,5 +103,12 @@ import RegistrationTagsEditableList from './components/RegistrationTagsEditableL
         rootElement
       );
     }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    setupRegistrationTags();
+    $('#registration-details')
+      .parent()
+      .on('indico:htmlUpdated', setupRegistrationTags);
   });
 })(window);


### PR DESCRIPTION
We replace most of the page content so the react tag editor needs to be re-initialized as well