### PR TITLE
API: Return file attachments checksum on the export endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,8 @@ Improvements
 - Let event managers view the final timetable even while in draft mode (:issue:`5141`,
   :pr:`5145`)
 - Add option to export role members as CSV (:issue:`5147`, :pr:`5156`)
+- Include attachment checksums in API responses (:issue:`5084`, :pr:`5169`, thanks
+  :user:`avivace`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/attachments/api/util.py
+++ b/indico/modules/attachments/api/util.py
@@ -118,6 +118,7 @@ def _build_attachment_api_data(attachment):
         data['filename'] = attachment.file.filename
         data['content_type'] = attachment.file.content_type
         data['size'] = attachment.file.size
+        data['checksum'] = attachment.file.md5
 
     elif attachment.type == AttachmentType.link:
         data['link_url'] = attachment.link_url


### PR DESCRIPTION
Replaces https://github.com/indico/indico/pull/5167 since I can't change the PR source branch and something funny happened on the GitHub UI on that PR

Solves #5084

If the attachment is a file, returns a "checksum" value exposing its the md5 checksum (`/export/event/` API endpoint)