### PR TITLE
Update Python deps once again

### DIFF
--- a/indico/modules/categories/util.py
+++ b/indico/modules/categories/util.py
@@ -177,7 +177,7 @@ def get_visibility_options(category_or_event, allow_invisible=True):
     def _category_above_message(number):
         return ngettext('From the category above', 'From {} categories above', number).format(number)
 
-    options = [(n + 1, ('{} \N{RIGHTWARDS ARROW} "{}"'.format(_category_above_message(n).format(n), title)))
+    options = [(n + 1, (f'{_category_above_message(n).format(n)} \N{RIGHTWARDS ARROW} "{title}"'))
                for n, title in enumerate(category.chain_titles[::-1])]
     if event is None:
         options[0] = (1, _('From this category only'))

--- a/indico/modules/logs/util.py
+++ b/indico/modules/logs/util.py
@@ -90,7 +90,7 @@ def render_changes(a, b, type_):
             a = '\N{EMPTY SET}'
         if b in (None, ''):
             b = '\N{EMPTY SET}'
-        return '{} \N{RIGHTWARDS ARROW} {}'.format(a, b)
+        return f'{a} \N{RIGHTWARDS ARROW} {b}'
     elif type_ == 'string':
         return '{} \N{RIGHTWARDS ARROW} {}'.format(a or '\N{EMPTY SET}', b or '\N{EMPTY SET}')
     elif type_ == 'list':

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -31,7 +31,7 @@ click==8.0.3
     #   pyquotes
 colorama==0.4.4
     # via sphinx-autobuild
-coverage[toml]==6.1.1
+coverage[toml]==6.1.2
     # via pytest-cov
 docutils==0.17.1
     # via
@@ -98,7 +98,7 @@ migra==3.0.1621480950
     # via -r requirements.dev.in
 mirakuru==2.4.1
     # via pytest-redis
-packaging==21.2
+packaging==21.3
     # via
     #   -c requirements.txt
     #   pytest
@@ -131,7 +131,7 @@ pygments==2.10.0
     #   -c requirements.txt
     #   -r requirements.dev.in
     #   sphinx
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via
     #   -c requirements.txt
     #   packaging
@@ -146,7 +146,7 @@ pytest==6.2.5
     #   pytest-snapshot
 pytest-cov==3.0.0
     # via -r requirements.dev.in
-pytest-localserver==0.5.0
+pytest-localserver==0.5.1
     # via -r requirements.dev.in
 pytest-mock==3.6.1
     # via -r requirements.dev.in
@@ -164,7 +164,7 @@ pytz==2021.3
     # via
     #   -c requirements.txt
     #   babel
-pyupgrade==2.29.0
+pyupgrade==2.29.1
     # via -r requirements.dev.in
 pywatchman==1.4.1
     # via -r requirements.dev.in
@@ -192,9 +192,9 @@ six==1.16.0
     #   transifex-client
 smmap==5.0.0
     # via gitdb
-snowballstemmer==2.1.0
+snowballstemmer==2.2.0
     # via sphinx
-sphinx==4.2.0
+sphinx==4.3.0
     # via
     #   -r requirements.dev.in
     #   sphinx-autobuild
@@ -218,7 +218,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlalchemy==1.4.26
+sqlalchemy==1.4.27
     # via
     #   -c requirements.txt
     #   schemainspect
@@ -241,7 +241,7 @@ tornado==6.1
     # via livereload
 transifex-client==0.14.3
     # via -r requirements.dev.in
-typing-extensions==3.10.0.2
+typing-extensions==4.0.0
     # via
     #   -c requirements.txt
     #   gitpython

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ babel
 bcrypt
 bleach
 blinker
-celery
+celery[redis]
 certifi
 click
 distro

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-alembic==1.7.4
+alembic==1.7.5
     # via
     #   -r requirements.in
     #   flask-migrate
@@ -34,7 +34,7 @@ blinker==1.4
     #   flask-multipass
     #   flask-pluginengine
     #   sentry-sdk
-celery==5.2.0
+celery[redis]==5.2.1
     # via
     #   -r requirements.in
     #   sentry-sdk
@@ -63,7 +63,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-cryptography==35.0.0
+cryptography==36.0.0
     # via authlib
 decorator==5.1.0
     # via ipython
@@ -129,6 +129,8 @@ idna==3.3
     # via
     #   email-validator
     #   requests
+importlib-metadata==4.8.2
+    # via markdown
 indico-fonts==1.1
     # via -r requirements.in
 ipython==7.29.0
@@ -138,7 +140,7 @@ itsdangerous==2.0.1
     #   -r requirements.in
     #   flask
     #   flask-wtf
-jedi==0.18.0
+jedi==0.18.1
     # via ipython
 jinja2==3.0.3
     # via
@@ -148,7 +150,7 @@ jinja2==3.0.3
     #   flask-pluginengine
 jsonschema==4.2.1
     # via -r requirements.in
-kombu==5.2.1
+kombu==5.2.2
     # via celery
 limits==1.5.1
     # via flask-limiter
@@ -156,9 +158,9 @@ lxml[html5]==4.6.4
     # via
     #   -r requirements.in
     #   feedgen
-mako==1.1.5
+mako==1.1.6
     # via alembic
-markdown==3.3.4
+markdown==3.3.6
     # via -r requirements.in
 markupsafe==2.0.1
     # via
@@ -166,7 +168,7 @@ markupsafe==2.0.1
     #   jinja2
     #   mako
     #   wtforms
-marshmallow==3.14.0
+marshmallow==3.14.1
     # via
     #   -r requirements.in
     #   flask-marshmallow
@@ -191,7 +193,7 @@ mypy-extensions==0.4.3
     # via typing-inspect
 node-semver==0.8.1
     # via pywebpack
-packaging==21.2
+packaging==21.3
     # via
     #   -r requirements.in
     #   bleach
@@ -210,7 +212,7 @@ prompt-toolkit==3.0.22
     #   -r requirements.in
     #   click-repl
     #   ipython
-psycopg2==2.9.1
+psycopg2==2.9.2
     # via -r requirements.in
 ptyprocess==0.7.0
     # via pexpect
@@ -228,7 +230,7 @@ pynpm==0.1.2
     # via
     #   flask-webpackext
     #   pywebpack
-pyparsing==2.4.7
+pyparsing==3.0.6
     # via packaging
 pypdf2==1.26.0
     # via -r requirements.in
@@ -256,14 +258,16 @@ pyyaml==6.0
 qrcode==7.3.1
     # via -r requirements.in
 redis[hiredis]==3.5.3
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   celery
 reportlab==3.6.2
     # via -r requirements.in
 requests==2.26.0
     # via -r requirements.in
-sentry-sdk[celery,flask,pure_eval,sqlalchemy]==1.4.3
+sentry-sdk[celery,flask,pure_eval,sqlalchemy]==1.5.0
     # via -r requirements.in
-simplejson==3.17.5
+simplejson==3.17.6
     # via -r requirements.in
 six==1.16.0
     # via
@@ -278,7 +282,7 @@ six==1.16.0
     #   python-dateutil
 speaklater==1.3
     # via -r requirements.in
-sqlalchemy==1.4.26
+sqlalchemy==1.4.27
     # via
     #   -r requirements.in
     #   alembic
@@ -294,7 +298,7 @@ traitlets==5.1.1
     #   matplotlib-inline
 translitcodec==0.7.0
     # via -r requirements.in
-typing-extensions==3.10.0.2
+typing-extensions==4.0.0
     # via typing-inspect
 typing-inspect==0.7.1
     # via marshmallow-dataclass
@@ -333,6 +337,8 @@ wtforms-sqlalchemy==0.3
     # via -r requirements.in
 xlsxwriter==3.0.2
     # via -r requirements.in
+zipp==3.6.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools


### PR DESCRIPTION
- properly specify celery dependency on redis (this ensures we get the current redis<4 pin from celery)
- celery update gets rid of the LegacyVersion deprecation warning from one of its requirements
- apply latest changes from pyupgrade (stronger f-string usage)