### PR TITLE
Raise ValidationError in wtforms validators

### DIFF
--- a/indico/modules/events/contributions/fields.py
+++ b/indico/modules/events/contributions/fields.py
@@ -5,6 +5,8 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from wtforms import ValidationError
+
 from indico.core.db.sqlalchemy.util.session import no_autoflush
 from indico.modules.events.contributions.models.persons import (AuthorType, ContributionPersonLink,
                                                                 SubContributionPersonLink)
@@ -51,7 +53,7 @@ class ContributionPersonLinkListField(PersonLinkListFieldBase):
                 if not self.object_data or person_link not in self.object_data:
                     person_link.author_type = AuthorType.none
             if person_link.author_type == AuthorType.none and not person_link.is_speaker:
-                raise ValueError(_('{} has no role').format(person_link.full_name))
+                raise ValidationError(_('{} has no role').format(person_link.full_name))
 
 
 class SubContributionPersonLinkListField(ContributionPersonLinkListField):

--- a/indico/web/forms/fields/colors.py
+++ b/indico/web/forms/fields/colors.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from wtforms import ValidationError
 from wtforms.fields import SelectField
 
 from indico.core.db.sqlalchemy.colors import ColorTuple
@@ -26,7 +27,7 @@ class IndicoPalettePickerField(JSONField):
 
     def pre_validate(self, form):
         if self.data not in self.color_list:
-            raise ValueError(_('Invalid colors selected'))
+            raise ValidationError(_('Invalid colors selected'))
 
     def process_formdata(self, valuelist):
         super().process_formdata(valuelist)
@@ -55,7 +56,7 @@ class IndicoSinglePalettePickerField(IndicoPalettePickerField):
 
     def pre_validate(self, form):
         if not any(self.data == color.background for color in self.color_list):
-            raise ValueError(_('Invalid color selected'))
+            raise ValidationError(_('Invalid color selected'))
 
     def _value(self):
         return ColorTuple(self.text_color, self.data)._asdict()

--- a/indico/web/forms/fields/datetime.py
+++ b/indico/web/forms/fields/datetime.py
@@ -12,7 +12,7 @@ import dateutil.parser
 import pytz
 from flask import session
 from markupsafe import escape
-from wtforms import Field, SelectField
+from wtforms import Field, SelectField, ValidationError
 from wtforms.fields import TimeField
 from wtforms.validators import StopValidation
 from wtforms_dateutil import DateField, DateTimeField
@@ -89,9 +89,9 @@ class TimeDeltaField(Field):
         if self.best_unit in self.units:
             return
         if self.object_data is None:
-            raise ValueError(_('Please choose a valid unit.'))
+            raise ValidationError(_('Please choose a valid unit.'))
         if self.object_data != self.data:
-            raise ValueError(_('Please choose a different unit or keep the previous value.'))
+            raise ValidationError(_('Please choose a different unit or keep the previous value.'))
 
     def _value(self):
         if self.data is None:
@@ -166,7 +166,7 @@ class RelativeDeltaField(Field):
 
     def pre_validate(self, form):
         if self.object_data is None:
-            raise ValueError(_('Please choose a valid unit.'))
+            raise ValidationError(_('Please choose a valid unit.'))
 
     def _value(self):
         if self.data is None:

--- a/indico/web/forms/fields/simple.py
+++ b/indico/web/forms/fields/simple.py
@@ -8,6 +8,7 @@
 import json
 
 from markupsafe import escape
+from wtforms import ValidationError
 from wtforms.fields import (BooleanField, Field, HiddenField, PasswordField, RadioField, SelectMultipleField,
                             TextAreaField)
 from wtforms.widgets import CheckboxInput
@@ -117,7 +118,7 @@ class EmailListField(TextListField):
 
     def _validate_item(self, line):
         if not validate_email(line):
-            raise ValueError(_('Invalid email address: {}').format(escape(line)))
+            raise ValidationError(_('Invalid email address: {}').format(escape(line)))
 
 
 class IndicoPasswordField(PasswordField):


### PR DESCRIPTION
WTForms 3 doesn't catch plain ValueErrors anymore:

https://wtforms.readthedocs.io/en/3.0.x/changes/#version-3-0-0

> `ValueError` raised by a validator are handled like regular exceptions. Validators need to raise `ValidationError` or `StopValidation` to make a validation fail.