### PR TITLE
Implement rendering of invites on Outlook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,7 @@ Improvements
 - Add option to export role members as CSV (:issue:`5147`, :pr:`5156`)
 - Include attachment checksums in API responses (:issue:`5084`, :pr:`5169`, thanks
   :user:`avivace`)
+- iCalendar invites now render nicely in Outlook (:pr:`5178`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/sessions/ical.py
+++ b/indico/modules/events/sessions/ical.py
@@ -5,20 +5,29 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import typing as t
+
 import icalendar
 from werkzeug.urls import url_parse
 
 from indico.core.config import config
 from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.ical import generate_basic_component
+from indico.modules.events.sessions.models.blocks import SessionBlock
+from indico.modules.events.sessions.models.sessions import Session
+from indico.modules.users.models.users import User
 from indico.web.flask.util import url_for
 
 
-def generate_session_component(session, related_to_uid=None):
+def generate_session_component(
+    session: Session,
+    related_to_uid: t.Optional[str] = None,
+    organizer: t.Optional[t.Tuple[str, str]] = None
+):
     """Generate an Event iCalendar component from an Indico Session."""
     uid = f'indico-session-{session.id}@{url_parse(config.BASE_URL).host}'
     url = url_for('sessions.display_session', session, _external=True)
-    component = generate_basic_component(session, uid, url)
+    component = generate_basic_component(session, uid, url, organizer=organizer)
 
     if related_to_uid:
         component.add('related-to', related_to_uid)
@@ -26,12 +35,16 @@ def generate_session_component(session, related_to_uid=None):
     return component
 
 
-def generate_session_block_component(block, related_to_uid=None):
+def generate_session_block_component(
+    block: SessionBlock,
+    related_to_uid: t.Optional[str] = None,
+    organizer: t.Optional[t.Tuple[str, str]] = None
+):
     """Generate an Event iCalendar component for a session block in an Indico Session."""
     uid = f'indico-session-block-{block.id}@{url_parse(config.BASE_URL).host}'
     url = url_for('sessions.display_session', block.session, _external=True)
     component = generate_basic_component(
-        block, uid, url, title=block.full_title, description=block.session.description
+        block, uid, url, title=block.full_title, description=block.session.description, organizer=organizer
     )
 
     if related_to_uid:
@@ -40,11 +53,17 @@ def generate_session_block_component(block, related_to_uid=None):
     return component
 
 
-def session_to_ical(session, user=None, detailed=False):
+def session_to_ical(
+    session: Session,
+    user: t.Optional[User] = None,
+    detailed: bool = False,
+    organizer: t.Optional[t.Tuple[str, str]] = None
+):
     """Serialize a session into an iCal.
 
     :param session: The session to serialize
     :param detailed: If True, iCal will include the session's contributions
+    :param organizer: ORGANIZER field of the iCalendar object
     """
     calendar = icalendar.Calendar()
     calendar.add('version', '2.0')
@@ -53,7 +72,7 @@ def session_to_ical(session, user=None, detailed=False):
     related_event_uid = f'indico-event-{session.event.id}@{url_parse(config.BASE_URL).host}'
 
     if not detailed and session.blocks:
-        component = generate_session_component(session, related_event_uid)
+        component = generate_session_component(session, related_event_uid, organizer=organizer)
         calendar.add_component(component)
     elif detailed:
         from indico.modules.events.contributions.ical import generate_contribution_component
@@ -61,7 +80,7 @@ def session_to_ical(session, user=None, detailed=False):
         contributions = (Contribution.query.with_parent(session)
                          .filter(Contribution.is_scheduled)
                          .all())
-        components = [generate_contribution_component(contribution, related_event_uid)
+        components = [generate_contribution_component(contribution, related_event_uid, organizer=organizer)
                       for contribution in contributions
                       if contribution.can_access(user)]
         for component in components:


### PR DESCRIPTION
While clients such as Thunderbird can understand the ICS files we are attaching to our invites and ask the user whether they'd like to add them to their calendars:

<img width="689" alt="image" src="https://user-images.githubusercontent.com/2699/143594350-ff51cc9a-279e-42e2-a4a9-9b67298dfbee.png">

... this doesn't seem to be the case with Outlook, which requires some additional metadata to do so. This PR solves that by providing the `method=REQUEST` field which is missing for that to happen.

Example:

![image](https://user-images.githubusercontent.com/2699/143594488-c69ac5d8-3cf5-4e25-bdb7-d509da72daee.png)
![image](https://user-images.githubusercontent.com/2699/143594573-575f2709-1a25-4c1f-b908-ae88ef517f31.png)

Also added some gratuitous type information, since you can always count on me to type-annotate Python code.