### PR TITLE
Decouple submitter permissions from person_link_data

### DIFF
--- a/indico/modules/events/abstracts/fields.py
+++ b/indico/modules/events/abstracts/fields.py
@@ -118,9 +118,6 @@ class AbstractPersonLinkListField(PersonLinkListFieldBase):
         self.empty_message = _('There are no authors')
         super().__init__(*args, **kwargs)
 
-    def _convert_data(self, data):
-        return list({self._get_person_link(x) for x in data})
-
     @no_autoflush
     def _get_person_link(self, data):
         person_link = super()._get_person_link(data)

--- a/indico/modules/events/contributions/fields.py
+++ b/indico/modules/events/contributions/fields.py
@@ -42,8 +42,8 @@ class ContributionPersonLinkListField(PersonLinkListFieldBase):
         self.empty_message = _('There are no authors')
         super().__init__(*args, **kwargs)
 
-    def _convert_data(self, data):
-        return {self._get_person_link(x): 'submitter' in x.get('roles', []) for x in data}
+    # def _convert_data(self, data):
+        # return {self._get_person_link(x): 'submitter' in x.get('roles', []) for x in data}
 
     @no_autoflush
     def _get_person_link(self, data):

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -45,7 +45,7 @@ class ContributionForm(IndicoForm):
     duration = IndicoDurationField(_('Duration'), [DataRequired(), MaxDuration(timedelta(hours=24))],
                                    default=timedelta(minutes=20))
     type = QuerySelectField(_('Type'), get_label='name', allow_blank=True, blank_text=_('No type selected'))
-    person_link_data = ContributionPersonLinkListField(_('People'))
+    person_links = ContributionPersonLinkListField(_('People'))
     location_data = IndicoLocationField(_('Location'))
     keywords = IndicoTagListField(_('Keywords'))
     references = ReferencesField(_('External IDs'), reference_class=ContributionReference,
@@ -66,7 +66,7 @@ class ContributionForm(IndicoForm):
         super().__init__(*args, **kwargs)
         self.type.query = self.event.contribution_types
         if self.event.type != 'conference':
-            self.person_link_data.label.text = _('Speakers')
+            self.person_links.label.text = _('Speakers')
         if not self.type.query.count():
             del self.type
         if not to_schedule and (self.contrib is None or not self.contrib.is_scheduled):

--- a/indico/modules/events/contributions/models/contributions.py
+++ b/indico/modules/events/contributions/models/contributions.py
@@ -27,7 +27,7 @@ from indico.core.db.sqlalchemy.util.session import no_autoflush
 from indico.modules.events.editing.models.editable import EditableType
 from indico.modules.events.management.util import get_non_inheriting_objects
 from indico.modules.events.models.events import Event
-from indico.modules.events.models.persons import AuthorsSpeakersMixin, PersonLinkDataMixin
+from indico.modules.events.models.persons import AuthorsSpeakersMixin
 from indico.modules.events.papers.models.papers import Paper
 from indico.modules.events.papers.models.revisions import PaperRevision, PaperRevisionState
 from indico.modules.events.sessions.models.sessions import Session
@@ -74,7 +74,7 @@ class CustomFieldsMixin:
 
 
 class Contribution(SearchableTitleMixin, SearchableDescriptionMixin, ProtectionManagersMixin, LocationMixin,
-                   AttachedItemsMixin, AttachedNotesMixin, PersonLinkDataMixin, AuthorsSpeakersMixin, CustomFieldsMixin,
+                   AttachedItemsMixin, AttachedNotesMixin, AuthorsSpeakersMixin, CustomFieldsMixin,
                    db.Model):
     __tablename__ = 'contributions'
     __auto_table_args = (db.Index(None, 'friendly_id', 'event_id', unique=True,

--- a/indico/modules/events/contributions/operations.py
+++ b/indico/modules/events/contributions/operations.py
@@ -180,8 +180,8 @@ def create_contribution_from_abstract(abstract, contrib_session=None):
                                           'type': abstract.accepted_contrib_type,
                                           'track': abstract.accepted_track,
                                           'session': contrib_session,
-                                          'person_link_data': {link: (author_submission_rights or link.is_speaker)
-                                                               for link in contrib_person_links}},
+                                          'person_links': {link: (author_submission_rights or link.is_speaker)
+                                                           for link in contrib_person_links}},
                                   custom_fields_data=custom_fields_data)
     if abstracts_settings.get(event, 'copy_attachments') and abstract.files:
         folder = AttachmentFolder.get_or_create_default(contrib)

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -97,11 +97,11 @@ class EventCreationForm(EventCreationFormBase):
 
 
 class LectureCreationForm(EventCreationFormBase):
-    _field_order = ('title', 'occurrences', 'timezone', 'location_data', 'person_link_data',
+    _field_order = ('title', 'occurrences', 'timezone', 'location_data', 'person_links',
                     'protection_mode')
     _advanced_field_order = ('description', 'theme')
     occurrences = OccurrencesField(_('Dates'), [DataRequired()])
-    person_link_data = EventPersonLinkListField(_('Speakers'), event_type=EventType.lecture)
+    person_links = EventPersonLinkListField(_('Speakers'), event_type=EventType.lecture)
     description = TextAreaField(_('Description'), widget=CKEditorWidget())
     theme = IndicoThemeSelectField(_('Theme'), event_type=EventType.lecture, allow_default=True)
 

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -176,13 +176,13 @@ class EventLocationForm(IndicoForm):
 
 
 class EventPersonsForm(IndicoForm):
-    person_link_data = EventPersonLinkListField(_('Chairpersons'))
+    person_links = EventPersonLinkListField(_('Chairpersons'))
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')
         super().__init__(*args, **kwargs)
         if self.event.type_ == EventType.lecture:
-            self.person_link_data.label.text = _('Speakers')
+            self.person_links.label.text = _('Speakers')
 
 
 class EventContactInfoForm(IndicoForm):

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -35,7 +35,7 @@ from indico.core.db.sqlalchemy.util.queries import db_dates_overlap, get_related
 from indico.modules.categories import Category
 from indico.modules.categories.models.event_move_request import EventMoveRequest, MoveRequestState
 from indico.modules.events.management.util import get_non_inheriting_objects
-from indico.modules.events.models.persons import EventPerson, PersonLinkDataMixin
+from indico.modules.events.models.persons import EventPerson
 from indico.modules.events.notifications import notify_event_creation
 from indico.modules.events.settings import EventSettingProperty, event_contact_settings, event_core_settings
 from indico.modules.events.timetable.models.entries import TimetableEntry
@@ -67,7 +67,7 @@ class _EventSettingProperty(EventSettingProperty):
 
 
 class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionManagersMixin, AttachedItemsMixin,
-            AttachedNotesMixin, PersonLinkDataMixin, db.Model):
+            AttachedNotesMixin, db.Model):
     """An Indico event.
 
     This model contains the most basic information related to an event.

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -139,7 +139,7 @@ def create_event(category, event_type, data, add_creator_as_manager=True, featur
 
 def update_event(event, update_timetable=False, **data):
     assert set(data.keys()) <= {'title', 'description', 'url_shortcut', 'location_data', 'keywords',
-                                'person_link_data', 'start_dt', 'end_dt', 'timezone', 'keywords', 'references',
+                                'person_links', 'start_dt', 'end_dt', 'timezone', 'keywords', 'references',
                                 'organizer_info', 'additional_info', 'contact_title', 'contact_emails',
                                 'contact_phones', 'start_dt_override', 'end_dt_override', 'label', 'label_message',
                                 'own_map_url'}
@@ -155,9 +155,9 @@ def update_event(event, update_timetable=False, **data):
     changes.update(event.populate_from_dict(data))
     # Person links are partially updated when the WTForms field is processed,
     # we we don't have proper change tracking there in some cases
-    changes.pop('person_link_data', None)
+    changes.pop('person_links', None)
     visible_person_link_changes = event.person_links != old_person_links
-    if visible_person_link_changes or 'person_link_data' in data:
+    if visible_person_link_changes or 'person_links' in data:
         changes['person_links'] = (old_person_links, event.person_links)
     db.session.flush()
     signals.event.updated.send(event, changes=changes)

--- a/indico/modules/events/persons/schemas.py
+++ b/indico/modules/events/persons/schemas.py
@@ -28,7 +28,7 @@ class PersonLinkSchema(mm.Schema):
     phone = fields.String(load_default='')
     address = fields.String(load_default='')
     email = fields.String(required=True)
-    display_order = fields.Int(load_default=0, dump_default=0)
+    display_order = fields.Int(load_default=0)
     avatar_url = fields.Function(lambda o: o.person.user.avatar_url if o.person.user else None)
 
     @pre_load

--- a/indico/modules/events/persons/util_test.py
+++ b/indico/modules/events/persons/util_test.py
@@ -113,7 +113,7 @@ def test_get_event_person_edit(db, dummy_event, dummy_user):
     person_2 = get_event_person(dummy_event, dict(data, _type='EventPerson', id=person_1.id))
     assert person_2 == person_1
 
-    person_3 = get_event_person(dummy_event, dict(data, _type='PersonLink', personId=person_1.id))
+    person_3 = get_event_person(dummy_event, dict(data, _type='PersonLink', person_id=person_1.id))
     assert person_3 == person_1
 
     with pytest.raises(ValueError):

--- a/indico/modules/events/sessions/fields.py
+++ b/indico/modules/events/sessions/fields.py
@@ -18,6 +18,3 @@ class SessionBlockPersonLinkListField(PersonLinkListFieldBase):
     def _serialize_person_link(self, principal):
         from indico.modules.events.persons.schemas import PersonLinkSchema
         return PersonLinkSchema().dump(principal)
-
-    def _convert_data(self, data):
-        return list({self._get_person_link(x) for x in data})

--- a/indico/modules/events/timetable/forms.py
+++ b/indico/modules/events/timetable/forms.py
@@ -100,7 +100,7 @@ class BreakEntryForm(EntryFormMixin, IndicoForm):
 
 class ContributionEntryForm(EntryFormMixin, ContributionForm):
     _entry_type = TimetableEntryType.CONTRIBUTION
-    _display_fields = ('title', 'description', 'type', 'time', 'duration', 'person_link_data', 'location_data',
+    _display_fields = ('title', 'description', 'type', 'time', 'duration', 'person_links', 'location_data',
                        'keywords', 'references')
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Previously, a new set of person_links could only be added by providing a list composed of {PersonLink: Bool} where the boolean represented if that link should have submitter permissions. As our uses broaden, it doesn't make sense to update permissions seamlessly while adding new links.

These changes update the `person_link_data` object form to a list of person_links.
In addition, introduces a method called `update_submitter_permissions` to restore the previous behaviour.