### PR TITLE
Exclude unlisted events in category suggestions

### DIFF
--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -577,6 +577,14 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         if old_type is not None and old_type != value:
             signals.event.type_changed.send(self, old_type=old_type)
 
+    @hybrid_property
+    def is_unlisted(self):
+        return self.category is None
+
+    @is_unlisted.expression
+    def is_unlisted(cls):
+        return cls.category_id.is_(None)
+
     @property
     def url(self):
         return url_for('events.display', self)
@@ -1036,10 +1044,6 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
                         ~Registration.is_deleted,
                         ~RegistrationForm.is_deleted)
                 .has_rows())
-
-    @property
-    def is_unlisted(self):
-        return self.category is None
 
 
 Event.register_location_events()

--- a/indico/util/suggestions.py
+++ b/indico/util/suggestions.py
@@ -114,7 +114,7 @@ def get_category_scores(user, debug=False):
     if not event_ids:
         return {}
     attended = (Event.query
-                .filter(Event.id.in_(event_ids), ~Event.is_deleted)
+                .filter(Event.id.in_(event_ids), ~Event.is_deleted, ~Event.is_unlisted)
                 .options(joinedload('category'))
                 .order_by(Event.start_dt, Event.id)
                 .all())


### PR DESCRIPTION
It's not possible to get a score for them and they aren't in a category so it makes no sense anyway.