### PR TITLE
Fix registration pdf export trying to remove `tags_present` when hidden

### DIFF
--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -339,7 +339,8 @@ class RHRegistrationsExportPDFTable(RHRegistrationsExportBase):
 
     def _process_args(self):
         RHRegistrationsExportBase._process_args(self)
-        self.export_config['static_item_ids'].remove('tags_present')
+        if 'tags_present' in self.export_config['static_item_ids']:
+            self.export_config['static_item_ids'].remove('tags_present')
 
     def _process(self):
         pdf = RegistrantsListToPDF(self.event, reglist=self.registrations, display=self.export_config['regform_items'],


### PR DESCRIPTION
Fix unconditional removal of `tags_present` even when they were hidden in the filters.