### PR TITLE
Add support for multiple privacy notice URLs

### DIFF
--- a/indico/modules/events/controllers/display.py
+++ b/indico/modules/events/controllers/display.py
@@ -84,7 +84,8 @@ class RHDisplayPrivacyPolicy(RHEventBase):
     """Display event privacy policy."""
 
     def _process(self):
-        if url := privacy_settings.get(self.event, 'privacy_policy_url'):
-            return redirect(url)
+        if urls := privacy_settings.get(self.event, 'privacy_policy_urls'):
+            # There could be multiple urls, redirect to the first one.
+            return redirect(urls[0]['url'])
         return WPDisplayPrivacyPolicy.render_template('privacy.html',
                                                       content=privacy_settings.get(self.event, 'privacy_policy'))

--- a/indico/modules/events/management/settings.py
+++ b/indico/modules/events/management/settings.py
@@ -19,6 +19,6 @@ program_codes_settings = EventSettingsProxy('program_codes', {
 privacy_settings = EventSettingsProxy('privacy', {
     'data_controller_name': '',
     'data_controller_email': '',
-    'privacy_policy_url': '',
+    'privacy_policy_urls': [],
     'privacy_policy': '',
 })

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -414,10 +414,16 @@ def create_event_request(event, category, comment=''):
 
 
 def update_event_privacy(event, data):
-    log_fields = {'data_controller_name': {'title': 'Data controller name', 'type': 'string'},
-                  'data_controller_email': {'title': 'Data controller e-mail', 'type': 'string'},
-                  'privacy_policy_url': {'title': 'Privacy policy URL', 'type': 'string'},
-                  'privacy_policy': {'title': 'Privacy policy', 'type': 'text'}}
+    log_fields = {
+        'data_controller_name': {'title': 'Data controller name', 'type': 'string'},
+        'data_controller_email': {'title': 'Data controller e-mail', 'type': 'string'},
+        'privacy_policy_urls': {
+            'title': 'Privacy policy URLs',
+            'type': 'struct_list',
+            'convert': lambda changes: [[dict(sorted(rec.items())) for rec in chg] for chg in changes]
+        },
+        'privacy_policy': {'title': 'Privacy policy', 'type': 'text'}
+    }
     assert set(data.keys()) <= log_fields.keys()
     changes = {}
     for key, value in data.items():

--- a/indico/modules/events/templates/footer.html
+++ b/indico/modules/events/templates/footer.html
@@ -1,11 +1,12 @@
 {% extends 'footer.html' %}
 
 {% block footer_links_extra %}
-    {% if privacy_url %}
+    {% for privacy_url in privacy_urls  %}
         <li>
-            <a href="{{ privacy_url }}">{% trans %}Event privacy notice{% endtrans %}</a>
+            <a href="{{ privacy_url.url }}">{{ privacy_url.title }}</a>
         </li>
-    {% elif privacy_text %}
+    {% endfor %}
+    {% if privacy_text %}
         <li>
             <a href="{{ url_for('events.display_privacy', event) }}"
                data-title="{% trans %}Event privacy notice{% endtrans %}"

--- a/indico/modules/events/templates/footer.html
+++ b/indico/modules/events/templates/footer.html
@@ -8,8 +8,7 @@
     {% elif privacy_urls %}
         <li>
             <div class="privacy-dropdown">
-                <span>{% trans %}Event privacy notices{% endtrans %}</span>
-                <i class="triangle up icon"></i>
+                <a href="#">{% trans %}Event privacy notices{% endtrans %}</a>
                 <div class="menu">
                     {% for privacy_url in privacy_urls  %}
                         <a class="item" href="{{ privacy_url.url }}">{{ privacy_url.title }}</a>

--- a/indico/modules/events/templates/footer.html
+++ b/indico/modules/events/templates/footer.html
@@ -8,7 +8,7 @@
     {% elif privacy_urls %}
         <li>
             <div class="privacy-dropdown">
-                <a href="#">{% trans %}Event privacy notices{% endtrans %}</a>
+                <a href="#" onclick="return false;">{% trans %}Event privacy notices{% endtrans %}</a>
                 <div class="menu">
                     {% for privacy_url in privacy_urls  %}
                         <a class="item" href="{{ privacy_url.url }}">{{ privacy_url.title }}</a>

--- a/indico/modules/events/templates/footer.html
+++ b/indico/modules/events/templates/footer.html
@@ -1,12 +1,23 @@
 {% extends 'footer.html' %}
 
 {% block footer_links_extra %}
-    {% for privacy_url in privacy_urls  %}
+    {% if privacy_urls|length == 1 %}
         <li>
-            <a href="{{ privacy_url.url }}">{{ privacy_url.title }}</a>
+            <a href="{{ privacy_urls[0].url }}">{% trans %}Event privacy notice{% endtrans %}</a>
         </li>
-    {% endfor %}
-    {% if privacy_text %}
+    {% elif privacy_urls %}
+        <li>
+            <div class="privacy-dropdown">
+                <span>{% trans %}Event privacy notices{% endtrans %}</span>
+                <i class="triangle up icon"></i>
+                <div class="menu">
+                    {% for privacy_url in privacy_urls  %}
+                        <a class="item" href="{{ privacy_url.url }}">{{ privacy_url.title }}</a>
+                    {% endfor %}
+                </div>
+            </div>
+        </li>
+    {% elif privacy_text %}
         <li>
             <a href="{{ url_for('events.display_privacy', event) }}"
                data-title="{% trans %}Event privacy notice{% endtrans %}"

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -75,7 +75,7 @@ def render_event_footer(event, dark=False):
     social_settings_data = social_settings.get_all()
     show_social = social_settings_data['enabled'] and layout_settings.get(event, 'show_social_badges')
     privacy_text = privacy_settings.get(event, 'privacy_policy')
-    privacy_url = privacy_settings.get(event, 'privacy_policy_url')
+    privacy_urls = privacy_settings.get(event, 'privacy_policy_urls')
     return render_template('events/footer.html',
                            event=event,
                            dark=dark,
@@ -83,7 +83,7 @@ def render_event_footer(event, dark=False):
                            show_social=show_social,
                            google_calendar_params=google_calendar_params,
                            privacy_text=privacy_text,
-                           privacy_url=privacy_url)
+                           privacy_urls=privacy_urls)
 
 
 class WPEventAdmin(WPAdmin):

--- a/indico/web/client/styles/partials/_footer.scss
+++ b/indico/web/client/styles/partials/_footer.scss
@@ -72,7 +72,7 @@
       }
     }
 
-    &:hover .menu {
+    &:focus-within .menu {
       display: block;
     }
   }

--- a/indico/web/client/styles/partials/_footer.scss
+++ b/indico/web/client/styles/partials/_footer.scss
@@ -50,6 +50,32 @@
   &.dark .version {
     color: $dark-gray;
   }
+
+  .privacy-dropdown {
+    display: inline-block;
+    position: relative;
+
+    .menu {
+      display: none;
+      position: absolute;
+      z-index: 1;
+      bottom: 2.5em;
+      min-width: 10em;
+      border-radius: 2px;
+      background-color: $light-gray;
+      box-shadow: 0 2px 10px 1px rgba(50, 50, 50, 0.4);
+
+      a {
+        display: block;
+        line-height: 30px;
+        padding: 0 0.5em;
+      }
+    }
+
+    &:hover .menu {
+      display: block;
+    }
+  }
 }
 
 .social-share {


### PR DESCRIPTION
Depends on #5128

Adds support for multiple URLs:

![image](https://user-images.githubusercontent.com/8739637/145197506-f4fce70c-3bf6-45fa-862a-a1aebb972738.png)
