### PR TITLE
Fix issue causing overflow in principal list dropdown

### DIFF
--- a/indico/web/client/js/react/components/principals/PrincipalListField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalListField.jsx
@@ -207,6 +207,7 @@ function AddPrincipalDropdown({text, options, disabled, onChange}) {
       button
       upward
       floating
+      scrolling
       disabled={disabled || options.length === 0}
       options={options}
       openOnFocus={false}


### PR DESCRIPTION
The issue below is caused when there are too many roles to fit in the screen size.
A simple way to reproduce is to either use the Jacow testing event (in the respective instance) or create around 30 roles in an event.
![imagem](https://user-images.githubusercontent.com/12183954/145614808-3b75e52c-514f-469b-8fc1-26480280a6b5.png)
