### PR TITLE
Fix error when submitting invited abstract as guest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,7 @@ Bugfixes
 ^^^^^^^^
 
 - Fix :data:`CUSTOM_COUNTRIES` not overriding names of existing countries (:pr:`5183`)
+- Fix error dialog when submitting an invited abstract without being logger in (:pr:`5200`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/js/jquery/widgets/jinja/person_link_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/person_link_widget.js
@@ -535,7 +535,6 @@ import {$T} from 'indico/utils/i18n';
             );
             forceUpdateUserSearch();
           }}
-          disabled={options.disableUserSearch}
           withExternalUsers={options.allow.externalUsers}
           triggerFactory={searchTrigger}
           withEventPersons={options.eventId !== null}
@@ -544,9 +543,11 @@ import {$T} from 'indico/utils/i18n';
       );
     };
 
-    ReactDOM.render(
-      <UserSearchWrapper />,
-      document.getElementById(`principalField-${options.fieldId}`)
-    );
+    if (!options.disableUserSearch) {
+      ReactDOM.render(
+        <UserSearchWrapper />,
+        document.getElementById(`principalField-${options.fieldId}`)
+      );
+    }
   };
 })(window);


### PR DESCRIPTION
Loading the favorite users fails and shows an error report dialog, and the user search is disabled anyway so we now just hide it.