### PR TITLE
Import Selectize.js globally

### DIFF
--- a/indico/modules/events/abstracts/client/js/index.js
+++ b/indico/modules/events/abstracts/client/js/index.js
@@ -9,10 +9,6 @@
 
 import _ from 'lodash';
 
-import 'selectize';
-import 'selectize/dist/css/selectize.css';
-import 'selectize/dist/css/selectize.default.css';
-
 import {$T} from 'indico/utils/i18n';
 
 import 'indico/modules/events/reviews';

--- a/indico/modules/events/management/client/js/index.js
+++ b/indico/modules/events/management/client/js/index.js
@@ -12,10 +12,6 @@ import _ from 'lodash';
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import 'selectize';
-import 'selectize/dist/css/selectize.css';
-import 'selectize/dist/css/selectize.default.css';
-
 import 'indico/modules/events/util/list_generator';
 import 'indico/modules/events/util/static_filters';
 

--- a/indico/web/client/js/jquery/index.js
+++ b/indico/web/client/js/jquery/index.js
@@ -31,6 +31,10 @@ import 'qtip2/dist/jquery.qtip.css';
 import 'vanderlee-colorpicker';
 import 'vanderlee-colorpicker/jquery.colorpicker.css';
 
+import 'selectize';
+import 'selectize/dist/css/selectize.css';
+import 'selectize/dist/css/selectize.default.css';
+
 import './widgets';
 
 // i18n (Jed)


### PR DESCRIPTION
Importing selectize widget here to be used globally by plugin and other files.
Let me know If I have to remove any legacy local imports.