### PR TITLE
Fixes Pre-populate of SelectizeWidget

### DIFF
--- a/indico/web/client/js/jquery/widgets/jinja/selectize_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/selectize_widget.js
@@ -18,7 +18,6 @@
         searchMethod: 'GET',
         searchPayload: null,
         selectizeOptions: null,
-        selectedItem: null,
         allowById: false,
         preload: false,
       },
@@ -42,6 +41,10 @@
     var params = {
       load: function(query, callback) {
         var self = this;
+        if (!options.searchUrl) {
+          self.settings.load = null;
+          return callback();
+        }
         var data = getSearchData(query);
         if (!data) {
           return callback();
@@ -65,9 +68,6 @@
               self.settings.load = null;
             }
             callback(res);
-            if (options.selectedItem !== null) {
-              $field[0].selectize.setValue(options.selectedItem.id);
-            }
           });
       },
       score: function(query) {

--- a/indico/web/templates/forms/selectize_widget.html
+++ b/indico/web/templates/forms/selectize_widget.html
@@ -4,7 +4,7 @@
 {% block html %}
     <div class="i-form-field-fixed-width" data-tooltip-anchor>
         <input id="{{ field.id }}" class="typeahead" type="text" name="{{ field.name }}"
-               {%- if field.data is not none -%}data-data="{{ field._value() | tojson | forceescape}}"{%- endif -%}
+               {%- if field.data is not none -%}data-data="{{ (field._value() or []) | tojson | forceescape}}"{%- endif -%}
                {{ input_args | html_params }} autocomplete="off">
         <span></span>
     </div>
@@ -15,7 +15,6 @@
     <script>
         setupSelectizeWidget({
             fieldId: {{ field.id | tojson }},
-            selectedItem: {{ field._value() | tojson }},
             minTriggerLength: {{ min_trigger_length | tojson }},
             searchUrl: {{ search_url | tojson }},
             searchMethod: {{ search_method | tojson }},


### PR DESCRIPTION
On Ajax call, the following lines re-populates the previously selected choice while the user continues typing. These lines are redundant because the 'data-data' attribute of the field and selectize.js take care of pre-populating the field.

```js
if (options.selectedItem !== null) {
  $field[0].selectize.setValue(options.selectedItem.id);
}
```

At UN Plugin, I'm working on creating two fields which could be used just like usual `SelectField`, and `SelectMultipleField(SelectField)`.

- SelectizeField(wtforms.Field)
- SelectizeMultipleField(SelectizeField)

You may review the code over [here](https://github.com/UNOG-Indico/indico-un/pull/681/files#): https://github.com/UNOG-Indico/indico-un/pull/681/files#
Filename: `un/util/wtform.py`, Let me know if it is worthy contribution upstream.

## Before
<img width="1280" alt="Screenshot 2021-12-26 at 6 28 21 PM" src="https://user-images.githubusercontent.com/20479333/147409112-e1a10100-3233-456f-b288-5e17bb85accb.png">

## After
<img width="1280" alt="Screenshot 2021-12-25 at 10 17 40 PM" src="https://user-images.githubusercontent.com/20479333/147409124-ac524952-daeb-4d5b-b563-6d12a50f73ed.png">
