### PR TITLE
Downgrade celery to 5.2.2

### DIFF
--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -33,10 +33,6 @@ colorama==0.4.4
     # via sphinx-autobuild
 coverage[toml]==6.2
     # via pytest-cov
-deprecated==1.2.13
-    # via
-    #   -c requirements.txt
-    #   redis
 docutils==0.17.1
     # via
     #   plantweb
@@ -106,7 +102,6 @@ packaging==21.3
     # via
     #   -c requirements.txt
     #   pytest
-    #   redis
     #   sphinx
     #   sqlbag
 parso==0.8.3
@@ -173,7 +168,7 @@ pyupgrade==2.31.0
     # via -r requirements.dev.in
 pywatchman==1.4.1
     # via -r requirements.dev.in
-redis[hiredis]==4.1.0
+redis[hiredis]==3.5.3
     # via
     #   -c requirements.txt
     #   pytest-redis
@@ -262,10 +257,6 @@ werkzeug==2.0.2
     #   pytest-localserver
 wheel==0.37.1
     # via pip-tools
-wrapt==1.13.3
-    # via
-    #   -c requirements.txt
-    #   deprecated
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ babel
 bcrypt
 bleach
 blinker
-celery[redis]
+celery[redis]!=5.2.3  # 5.2.3 pins setuptools which is a mess
 certifi
 click
 distro

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ blinker==1.4
     #   flask-multipass
     #   flask-pluginengine
     #   sentry-sdk
-celery[redis]==5.2.3
+celery[redis]==5.2.2
     # via
     #   -r requirements.in
     #   sentry-sdk
@@ -67,8 +67,6 @@ cryptography==36.0.1
     # via authlib
 decorator==5.1.0
     # via ipython
-deprecated==1.2.13
-    # via redis
 distro==1.6.0
     # via -r requirements.in
 dnspython==2.1.0
@@ -199,7 +197,6 @@ packaging==21.3
     # via
     #   -r requirements.in
     #   bleach
-    #   redis
 parso==0.8.3
     # via jedi
 pexpect==4.8.0
@@ -260,7 +257,7 @@ pyyaml==6.0
     # via -r requirements.in
 qrcode==7.3.1
     # via -r requirements.in
-redis[hiredis]==4.1.0
+redis[hiredis]==3.5.3
     # via
     #   -r requirements.in
     #   celery
@@ -326,8 +323,6 @@ werkzeug==2.0.2
     # via
     #   -r requirements.in
     #   flask
-wrapt==1.13.3
-    # via deprecated
 wtforms[email]==3.0.1
     # via
     #   -r requirements.in


### PR DESCRIPTION
The latest versions pins setuptools (see https://github.com/celery/celery/discussions/7202) which is a mess and really not something I want included in the 3.1 release... it'll be fixed in the next celery release but until that happens I'd rather stick with the previous version even if that blocks redis 4 (which pretty much just dropped Python 2 support anyway).