### PR TITLE
Add new abstract permission

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,8 @@ Internationalization
 Improvements
 ^^^^^^^^^^^^
 
-- Nothing so far
+- Add a new event management permission that grants access only to the abstracts
+  module (:pr:`5212`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/controllers/base.py
+++ b/indico/modules/events/abstracts/controllers/base.py
@@ -68,8 +68,8 @@ class RHAbstractsBase(RHDisplayEventBase):
 
     def _check_access(self):
         RHDisplayEventBase._check_access(self)
-        # Only let event managers access the management versions.
-        if self.management and not self.event.can_manage(session.user):
+        # Only let abstract managers access the management versions.
+        if self.management and not self.event.can_manage(session.user, permission='abstracts'):
             raise Forbidden
         check_event_locked(self, self.event)
 
@@ -86,6 +86,7 @@ class RHManageAbstractsBase(ManageEventMixin, RHAbstractsBase):
     """
 
     DENY_FRAMES = True
+    PERMISSION = 'abstracts'
 
     @property
     def management(self):

--- a/indico/modules/events/abstracts/controllers/boa.py
+++ b/indico/modules/events/abstracts/controllers/boa.py
@@ -87,7 +87,11 @@ class RHExportBOA(RHAbstractsBase):
             raise NotFound(_('The contributions of this event have not been published yet'))
 
     def _process(self):
-        if request.args.get('latex') == '1' and config.LATEX_ENABLED and self.event.can_manage(session.user):
+        if (
+            request.args.get('latex') == '1' and
+            config.LATEX_ENABLED and
+            self.event.can_manage(session.user, permission='abstracts')
+        ):
             return send_file('book-of-abstracts.pdf', create_boa(self.event), 'application/pdf')
         if self.event.has_custom_boa:
             return self.event.custom_boa.send()

--- a/indico/modules/events/abstracts/controllers/reviewing.py
+++ b/indico/modules/events/abstracts/controllers/reviewing.py
@@ -84,8 +84,8 @@ class RHResetAbstractState(RHAbstractBase):
     def _check_abstract_protection(self):
         if self.abstract.state == AbstractState.submitted:
             return False
-        # manages can always reset
-        if self.event.can_manage(session.user):
+        # abstract managers can always reset
+        if self.event.can_manage(session.user, permission='abstracts'):
             return True
         # judges can reset if the abstract has not been withdrawn
         return self.abstract.can_judge(session.user) and self.abstract.state != AbstractState.withdrawn

--- a/indico/modules/events/abstracts/models/abstracts.py
+++ b/indico/modules/events/abstracts/models/abstracts.py
@@ -503,7 +503,7 @@ class Abstract(ProposalMixin, ProposalRevisionMixin, DescriptionMixin, CustomFie
             return False
         if self.submitter == user:
             return True
-        if self.event.can_manage(user):
+        if self.event.can_manage(user, permission='abstracts'):
             return True
         if any(x.person.user == user for x in self.person_links):
             return True
@@ -551,7 +551,7 @@ class Abstract(ProposalMixin, ProposalRevisionMixin, DescriptionMixin, CustomFie
             return False
         elif check_state and self.state != AbstractState.submitted:
             return False
-        elif self.event.can_manage(user):
+        elif self.event.can_manage(user, permission='abstracts'):
             return True
         elif self.event.cfa.allow_convener_judgment and self.can_convene(user):
             return True
@@ -575,7 +575,7 @@ class Abstract(ProposalMixin, ProposalRevisionMixin, DescriptionMixin, CustomFie
             AbstractPublicState.awaiting,
             AbstractPublicState.invited,
         )
-        if self.public_state in manager_edit_states and self.event.can_manage(user):
+        if self.public_state in manager_edit_states and self.event.can_manage(user, permission='abstracts'):
             return True
         elif self.public_state not in (AbstractPublicState.awaiting, AbstractPublicState.invited):
             return False
@@ -599,7 +599,10 @@ class Abstract(ProposalMixin, ProposalRevisionMixin, DescriptionMixin, CustomFie
     def can_withdraw(self, user, check_state=False):
         if not user:
             return False
-        elif self.event.can_manage(user) and (not check_state or self.state != AbstractState.withdrawn):
+        elif (
+            self.event.can_manage(user, permission='abstracts') and
+            (not check_state or self.state != AbstractState.withdrawn)
+        ):
             return True
         elif user == self.submitter and (not check_state or self.state == AbstractState.submitted):
             return True

--- a/indico/modules/events/abstracts/models/comments.py
+++ b/indico/modules/events/abstracts/models/comments.py
@@ -64,7 +64,7 @@ class AbstractComment(ProposalCommentMixin, ReviewCommentMixin, db.Model):
     def can_edit(self, user):
         if user is None:
             return False
-        return self.user == user or self.abstract.event.can_manage(user)
+        return self.user == user or self.abstract.event.can_manage(user, permission='abstracts')
 
     def can_view(self, user):
         if user is None:

--- a/indico/modules/events/abstracts/templates/management/overview.html
+++ b/indico/modules/events/abstracts/templates/management/overview.html
@@ -34,29 +34,32 @@
             </div>
         </div>
 
-        <div class="section">
-            <div class="icon icon-wrench"></div>
-            <div class="text">
-                <div class="label">
-                    {%- trans %}Fields and types{% endtrans -%}
+        {# Only show contribution settings if user can manage them #}
+        {% if event.can_manage(session.user) %}
+            <div class="section">
+                <div class="icon icon-wrench"></div>
+                <div class="text">
+                    <div class="label">
+                        {%- trans %}Fields and types{% endtrans -%}
+                    </div>
+                    {%- trans %}Configure the contribution types and abstract fields.{% endtrans -%}
                 </div>
-                {%- trans %}Configure the contribution types and abstract fields.{% endtrans -%}
+                <div class="toolbar">
+                    <a href="#" class="i-button"
+                    data-href="{{ url_for('contributions.manage_types', event) }}"
+                    data-title="{% trans %}Manage contribution types{% endtrans %}"
+                    data-ajax-dialog>
+                        {%- trans %}Contribution types{% endtrans -%}
+                    </a>
+                    <a href="#" class="i-button js-dialog-action"
+                    data-title="{% trans %}Manage fields{% endtrans %}"
+                    data-href="{{ url_for('contributions.manage_fields', event) }}"
+                    data-ajax-dialog>
+                        {%- trans %}Abstract fields{% endtrans -%}
+                    </a>
+                </div>
             </div>
-            <div class="toolbar">
-                <a href="#" class="i-button"
-                   data-href="{{ url_for('contributions.manage_types', event) }}"
-                   data-title="{% trans %}Manage contribution types{% endtrans %}"
-                   data-ajax-dialog>
-                    {%- trans %}Contribution types{% endtrans -%}
-                </a>
-                <a href="#" class="i-button js-dialog-action"
-                   data-title="{% trans %}Manage fields{% endtrans %}"
-                   data-href="{{ url_for('contributions.manage_fields', event) }}"
-                   data-ajax-dialog>
-                    {%- trans %}Abstract fields{% endtrans -%}
-                </a>
-            </div>
-        </div>
+        {% endif %}
 
         <div class="section">
             <div class="icon icon-file-check"></div>

--- a/indico/modules/events/abstracts/templates/reviewing/public.html
+++ b/indico/modules/events/abstracts/templates/reviewing/public.html
@@ -11,7 +11,7 @@
             </span>
         </h3>
         <div class="toolbar thin">
-            {% set can_manage = abstract.event.can_manage(session.user) %}
+            {% set can_manage = abstract.event.can_manage(session.user, permission='abstracts') %}
             {% if abstract.submitter == session.user or can_manage %}
                 <div class="group">
                     {% if abstract.can_withdraw(session.user, check_state=true) %}
@@ -198,7 +198,7 @@
                         {{- abstract.judgment_dt|format_human_date -}}
                     </time>
                 </div>
-                {% if abstract.event.can_manage(session.user) %}
+                {% if abstract.event.can_manage(session.user, permission='abstracts') %}
                     <div class="hide-if-locked">
                         <a class="i-link icon-remove"
                            title="{% trans %}Reset judgment{% endtrans %}"

--- a/indico/modules/events/abstracts/util.py
+++ b/indico/modules/events/abstracts/util.py
@@ -202,7 +202,7 @@ def make_abstract_form(event, user, notification_option=False, management=False,
         if field_impl is None:
             # field definition is not available anymore
             continue
-        if custom_field.is_active and (custom_field.is_user_editable or event.can_manage(user)):
+        if custom_field.is_active and (custom_field.is_user_editable or event.can_manage(user, permission='abstracts')):
             name = f'custom_{custom_field.id}'
             setattr(form_class, name, field_impl.create_wtf_field())
     return form_class

--- a/indico/modules/events/abstracts/views.py
+++ b/indico/modules/events/abstracts/views.py
@@ -51,7 +51,7 @@ def render_abstract_page(abstract, view_class=None, management=False):
     judgment_form = AbstractJudgmentForm(abstract=abstract, formdata=None)
     review_track_list_form = AbstractReviewedForTracksForm(event=abstract.event, obj=abstract, formdata=None)
     track_session_map = {track.id: track.default_session_id for track in abstract.event.tracks}
-    can_manage = abstract.event.can_manage(session.user)
+    can_manage = abstract.event.can_manage(session.user, permission='abstracts')
     field_values = filter_field_values(abstract.field_values, can_manage, abstract.user_owns(session.user))
     params = {'abstract': abstract,
               'comment_form': comment_form,

--- a/indico/web/client/styles/widgets/_permissions.scss
+++ b/indico/web/client/styles/widgets/_permissions.scss
@@ -129,6 +129,10 @@
           }
 
           // Permission label palette
+          &.permission-event-abstracts {
+            @include permission-label($olive);
+          }
+
           &.permission-event-submit {
             @include permission-label($yellow);
           }


### PR DESCRIPTION
Adds a new `abstracts` permission for managing event abstracts

For users who only have this permission and are not event managers,
the `Fields and types` section on the abstract management page is hidden,
since those settings require full event permissions.

![image](https://user-images.githubusercontent.com/8739637/148965772-eed16875-9ed7-4061-b2c9-dbb468032ef7.png)