### PR TITLE
Allow submitters to edit their own contributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Improvements
 
 - Prompt before leaving the event protection page without saving changes (:pr:`5222`)
 - Add the ability to clone abstracts (:pr:`5217`)
-- Allow submitters to edit their own contributions (:pr:`5213`)
+- Add setting to allow submitters to edit their own contributions (:pr:`5213`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Improvements
 
 - Prompt before leaving the event protection page without saving changes (:pr:`5222`)
 - Add the ability to clone abstracts (:pr:`5217`)
+- Allow submitters to edit their own contributions (:pr:`5213`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/__init__.py
+++ b/indico/modules/events/contributions/__init__.py
@@ -130,6 +130,7 @@ def _event_created(event, **kwargs):
 
 contribution_settings = EventSettingsProxy('contributions', {
     'default_duration': timedelta(minutes=20),
+    'allow_submitters_edit_contributions': False,
     'published': True
 }, converters={
     'default_duration': TimedeltaConverter

--- a/indico/modules/events/contributions/__init__.py
+++ b/indico/modules/events/contributions/__init__.py
@@ -130,7 +130,7 @@ def _event_created(event, **kwargs):
 
 contribution_settings = EventSettingsProxy('contributions', {
     'default_duration': timedelta(minutes=20),
-    'allow_submitters_edit_contributions': False,
+    'submitters_can_edit': False,
     'published': True
 }, converters={
     'default_duration': TimedeltaConverter

--- a/indico/modules/events/contributions/blueprint.py
+++ b/indico/modules/events/contributions/blueprint.py
@@ -103,7 +103,7 @@ _bp.add_url_rule('/manage/contributions/duration', 'manage_default_duration',
                  management.RHManageDefaultContributionDuration, methods=('GET', 'POST'))
 
 # Allow editing by submitters
-_bp.add_url_rule('/manage/contributions/submitter_edits', 'manage_submitter_edits',
+_bp.add_url_rule('/manage/contributions/submitter-edits', 'manage_submitter_edits',
                  management.RHManageSubmitterEdits, methods=('GET', 'POST'))
 
 # Publish contribution

--- a/indico/modules/events/contributions/blueprint.py
+++ b/indico/modules/events/contributions/blueprint.py
@@ -102,6 +102,10 @@ _bp.add_url_rule('/manage/contributions/types/<int:contrib_type_id>/delete', 'de
 _bp.add_url_rule('/manage/contributions/duration', 'manage_default_duration',
                  management.RHManageDefaultContributionDuration, methods=('GET', 'POST'))
 
+# Allow editing by submitters
+_bp.add_url_rule('/manage/contributions/submitter_edits', 'manage_submitter_edits',
+                 management.RHManageSubmitterEdits, methods=('GET', 'POST'))
+
 # Publish contribution
 _bp.add_url_rule('/manage/contributions/published', 'manage_publication',
                  management.RHManageContributionPublicationREST, methods=('GET', 'PUT', 'DELETE'))

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -191,11 +191,10 @@ class RHCreateContribution(RHManageContributionsBase):
 
 
 class RHEditContribution(RHManageContributionBase):
-    """
-    Edit the contribution.
+    """Edit a contribution.
 
-    If configured in the contribution settings,
-    editing is also allowed to the submitters of the given contribution.
+    If configured in the contribution settings, editing is also
+    allowed for the submitters.
     """
 
     def _check_access(self):
@@ -355,9 +354,8 @@ class RHCreateSubContribution(RHManageContributionBase):
 class RHEditSubContribution(RHManageSubContributionBase):
     """Edit a subcontribution.
 
-    If configured in the contribution settings,
-    editing of the given subcontribution is also allowed to
-    the submitters of the parent contribution.
+    If configured in the contribution settings, editing is also
+    allowed for the submitters of the parent contribution.
     """
 
     def _check_access(self):
@@ -579,14 +577,13 @@ class RHManageDefaultContributionDuration(RHManageContributionsBase):
 
 
 class RHManageSubmitterEdits(RHManageContributionsBase):
-    """Dialog which sets whether to allow contribution edits by their submitters."""
+    """Dialog to configure submitter edit permissions."""
 
     def _process(self):
-        form = AllowSubmitterEditsForm(
-            allow=contribution_settings.get(self.event, 'submitters_can_edit'))
+        form = AllowSubmitterEditsForm(allow=contribution_settings.get(self.event, 'submitters_can_edit'))
         if form.validate_on_submit():
             contribution_settings.set(self.event, 'submitters_can_edit', form.allow.data)
-            flash(_('Submitter settings changed successfully'), 'success')
+            flash(_('Submitter edit settings changed successfully'), 'success')
             return jsonify_data()
         return jsonify_form(form)
 

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -187,7 +187,7 @@ class RHCreateContribution(RHManageContributionsBase):
             if tpl_components['hide_contrib']:
                 self.list_generator.flash_info_message(contrib)
             return jsonify_data(**tpl_components)
-        return jsonify_template('events/contributions/forms/contribution.html', form=form)
+        return jsonify_template('events/contributions/forms/contribution.html', form=form, can_manage=True)
 
 
 class RHEditContribution(RHManageContributionBase):
@@ -348,7 +348,7 @@ class RHCreateSubContribution(RHManageContributionBase):
             subcontrib = create_subcontribution(self.contrib, form.data)
             flash(_("Subcontribution '{}' created successfully").format(subcontrib.title), 'success')
             return jsonify_data(html=_render_subcontribution_list(self.contrib))
-        return jsonify_template('events/contributions/forms/subcontribution.html', form=form)
+        return jsonify_template('events/contributions/forms/subcontribution.html', form=form, can_manage=True)
 
 
 class RHEditSubContribution(RHManageSubContributionBase):

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -583,9 +583,9 @@ class RHManageSubmitterEdits(RHManageContributionsBase):
 
     def _process(self):
         form = AllowSubmitterEditsForm(
-            allow=contribution_settings.get(self.event, 'allow_submitters_edit_contributions'))
+            allow=contribution_settings.get(self.event, 'submitters_can_edit'))
         if form.validate_on_submit():
-            contribution_settings.set(self.event, 'allow_submitters_edit_contributions', form.allow.data)
+            contribution_settings.set(self.event, 'submitters_can_edit', form.allow.data)
             flash(_('Submitter settings changed successfully'), 'success')
             return jsonify_data()
         return jsonify_form(form)

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -225,8 +225,9 @@ class RHEditContribution(RHManageContributionBase):
             return jsonify_data(flash=(request.args.get('flash') == '1'), **tpl_components)
         elif not form.is_submitted():
             handle_legacy_description(form.description, self.contrib)
+        can_manage = self.contrib.can_manage(session.user)
         self.commit = False
-        return jsonify_template('events/contributions/forms/contribution.html', form=form)
+        return jsonify_template('events/contributions/forms/contribution.html', form=form, can_manage=can_manage)
 
 
 class RHDeleteContributions(RHManageContributionsActionsBase):
@@ -352,8 +353,7 @@ class RHCreateSubContribution(RHManageContributionBase):
 
 
 class RHEditSubContribution(RHManageSubContributionBase):
-    """
-    Edit the subcontribution.
+    """Edit a subcontribution.
 
     If configured in the contribution settings,
     editing of the given subcontribution is also allowed to
@@ -373,8 +373,9 @@ class RHEditSubContribution(RHManageSubContributionBase):
             return jsonify_data(html=_render_subcontribution_list(self.contrib))
         elif not form.is_submitted():
             handle_legacy_description(form.description, self.subcontrib)
+        can_manage = self.subcontrib.can_manage(session.user)
         self.commit = False
-        return jsonify_template('events/contributions/forms/subcontribution.html', form=form)
+        return jsonify_template('events/contributions/forms/subcontribution.html', form=form, can_manage=can_manage)
 
 
 class RHSubContributionREST(RHManageSubContributionBase):

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -184,6 +184,12 @@ class ContributionDefaultDurationForm(IndicoForm):
                                    default=timedelta(minutes=20))
 
 
+class AllowSubmitterEditsForm(IndicoForm):
+    allow = BooleanField(_('Allow submitters to edit contributions'), widget=SwitchWidget(),
+                         description=_('Allow submitters to edit their contributions '
+                                       'once an abstract has been accepted'))
+
+
 class ContributionTypeForm(IndicoForm):
     """Form to create or edit a ContributionType."""
 

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -34,6 +34,7 @@ from indico.web.forms.widgets import SwitchWidget
 
 
 class ContributionForm(IndicoForm):
+    _submitter_editable_fields = ('title', 'description', 'person_link_data')
     title = StringField(_('Title'), [DataRequired()])
     description = TextAreaField(_('Description'))
     start_dt = IndicoDateTimeField(_('Start date'),
@@ -110,6 +111,7 @@ class ContributionProtectionForm(IndicoForm):
 
 
 class SubContributionForm(IndicoForm):
+    _submitter_editable_fields = ('title', 'description', 'speakers')
     title = StringField(_('Title'), [DataRequired()])
     description = TextAreaField(_('Description'))
     duration = IndicoDurationField(_('Duration'), [DataRequired(), MaxDuration(timedelta(hours=24))],
@@ -185,9 +187,9 @@ class ContributionDefaultDurationForm(IndicoForm):
 
 
 class AllowSubmitterEditsForm(IndicoForm):
-    allow = BooleanField(_('Allow submitters to edit contributions'), widget=SwitchWidget(),
-                         description=_('Allow submitters to edit their contributions '
-                                       'once an abstract has been accepted'))
+    allow = BooleanField(_('Edit'), widget=SwitchWidget(),
+                         description=_('Allows submitters to edit basic information of '
+                                       'their contribution (title, description, speakers and authors)'))
 
 
 class ContributionTypeForm(IndicoForm):

--- a/indico/modules/events/contributions/models/contributions.py
+++ b/indico/modules/events/contributions/models/contributions.py
@@ -552,7 +552,7 @@ class Contribution(SearchableTitleMixin, SearchableDescriptionMixin, ProtectionM
     def can_edit(self, user):
         # Submitters can edit their own contributions if configured
         from indico.modules.events.contributions import contribution_settings
-        submitters_can_edit = contribution_settings.get(self.event, 'allow_submitters_edit_contributions')
+        submitters_can_edit = contribution_settings.get(self.event, 'submitters_can_edit')
         return self.can_manage(user, permission=('submit' if submitters_can_edit else None))
 
     def get_non_inheriting_objects(self):

--- a/indico/modules/events/contributions/models/contributions.py
+++ b/indico/modules/events/contributions/models/contributions.py
@@ -549,6 +549,12 @@ class Contribution(SearchableTitleMixin, SearchableDescriptionMixin, ProtectionM
             return True
         return False
 
+    def can_edit(self, user):
+        # Submitters can edit their own contributions if configured
+        from indico.modules.events.contributions import contribution_settings
+        submitters_can_edit = contribution_settings.get(self.event, 'allow_submitters_edit_contributions')
+        return self.can_manage(user, permission=('submit' if submitters_can_edit else None))
+
     def get_non_inheriting_objects(self):
         """Get a set of child objects that do not inherit protection."""
         return get_non_inheriting_objects(self)

--- a/indico/modules/events/contributions/models/subcontributions.py
+++ b/indico/modules/events/contributions/models/subcontributions.py
@@ -183,6 +183,9 @@ class SubContribution(SearchableTitleMixin, SearchableDescriptionMixin, Attached
     def can_manage(self, user, permission=None, **kwargs):
         return self.contribution.can_manage(user, permission=permission, **kwargs)
 
+    def can_edit(self, user):
+        return self.contribution.can_edit(user)
+
     def is_user_associated(self, user):
         if user is None:
             return False

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -119,7 +119,7 @@
 
 {% block page_actions -%}
     <div class="toolbar">
-        {% if contribution.can_manage(session.user) -%}
+        {% if contribution.can_edit(session.user) -%}
             <a href="#" class="i-button icon-edit"
                data-title="{% trans %}Edit contribution{% endtrans %}"
                data-href="{{ url_for('contributions.manage_update_contrib', contribution) }}"
@@ -254,7 +254,7 @@
                                         {{- subcontrib.title -}}
                                     </a>
                                 </span>
-                                {% if subcontrib.can_manage(session.user) -%}
+                                {% if subcontrib.can_edit(session.user) -%}
                                     <span>
                                         <a href="#" class="icon-edit"
                                            data-href="{{ url_for('contributions.manage_edit_subcontrib', subcontrib) }}"

--- a/indico/modules/events/contributions/templates/display/subcontribution_display.html
+++ b/indico/modules/events/contributions/templates/display/subcontribution_display.html
@@ -31,7 +31,7 @@
 
 {% block page_actions -%}
     <div class="toolbar">
-        {% if subcontrib.can_manage(session.user) -%}
+        {% if subcontrib.can_edit(session.user) -%}
             <a href="#" class="i-button icon-edit"
                data-title="{% trans title=subcontrib.title %}Edit subcontribution '{{ title }}'{% endtrans %}"
                data-href="{{ url_for('.manage_edit_subcontrib', subcontrib) }}"

--- a/indico/modules/events/contributions/templates/display/user_contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/user_contribution_list.html
@@ -17,7 +17,7 @@
                                 </a>
                             </span>
                             <div class="group">
-                                {% if contrib.can_manage(session.user) -%}
+                                {% if contrib.can_edit(session.user) -%}
                                     <a href="#" class="icon-edit js-edit-contribution"
                                        title="{% trans %}Edit this contribution{% endtrans %}"
                                        data-title="{% trans title=contrib.title %}Edit contribution '{{ title }}'{% endtrans %}"

--- a/indico/modules/events/contributions/templates/forms/contribution.html
+++ b/indico/modules/events/contributions/templates/forms/contribution.html
@@ -6,10 +6,14 @@
     {{ form_header(form) }}
     {{ form_row(form.title) }}
     {{ form_row(form.description, widget_attrs={'rows': 10}) }}
-    {{ form_rows(form, fields=fields|default(none), skip=skip_fields) }}
-    {% call form_fieldset(_('Advanced'), collapsible=true) %}
-        {{ form_rows(form, fields=form.custom_field_names + ('references', 'board_number', 'code')) }}
-    {% endcall %}
+    {% if can_manage %}
+        {{ form_rows(form, fields=fields|default(none), skip=skip_fields) }}
+        {% call form_fieldset(_('Advanced'), collapsible=true) %}
+            {{ form_rows(form, fields=form.custom_field_names + ('references', 'board_number', 'code')) }}
+        {% endcall %}
+    {% else %}
+        {{ form_rows(form, fields=form._submitter_editable_fields, skip=('title', 'description')) }}
+    {% endif %}
     {% call form_footer(form) %}
         <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}" data-disabled-until-change>
         <button type="button" class="i-button big" data-button-back>{% trans %}Cancel{% endtrans %}</button>

--- a/indico/modules/events/contributions/templates/forms/subcontribution.html
+++ b/indico/modules/events/contributions/templates/forms/subcontribution.html
@@ -2,10 +2,14 @@
 
 {%- block content %}
     {{ form_header(form) }}
-    {{ form_rows(form, skip=('references', 'code')) }}
-    {% call form_fieldset(_('Advanced'), collapsible=true) %}
-        {{ form_rows(form, fields=('references', 'code')) }}
-    {% endcall %}
+    {% if can_manage %}
+        {{ form_rows(form, skip=('references', 'code')) }}
+        {% call form_fieldset(_('Advanced'), collapsible=true) %}
+            {{ form_rows(form, fields=('references', 'code')) }}
+        {% endcall %}
+    {% else %}
+        {{ form_rows(form, fields=form._submitter_editable_fields) }}
+    {% endif %}
     {% call form_footer(form) %}
         <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}" data-disabled-until-change>
         <button type="button" class="i-button big" data-button-back>{% trans %}Cancel{% endtrans %}</button>

--- a/indico/modules/events/contributions/templates/management/contributions.html
+++ b/indico/modules/events/contributions/templates/management/contributions.html
@@ -41,6 +41,15 @@
                    data-qtip-position="right">
                     {% trans %}Custom fields{% endtrans %}</a>
             </li>
+            <li>
+                <a href="#"
+                   title="{% trans %}Submitter privileges{% endtrans %}"
+                   data-ajax-dialog
+                   data-title="{% trans %}Submitter privileges{% endtrans %}"
+                   data-href="{{ url_for('.manage_submitter_edits', event) }}"
+                   data-qtip-position="right">
+                    {% trans %}Submitter privileges{% endtrans %}</a>
+            </li>
         </ul>
     {%- endif -%}
     <div id="pub-switch" data-event-id="{{ event.id }}"></div>

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -104,7 +104,7 @@
                     {{ _render_note_editor(item) }}
                 {% endif %}
             {% endif %}
-            {% if item.can_manage(session.user) %}
+            {% if item.can_edit(session.user) %}
                 <li>
                     <a href="" class="contribution-edit"
                                data-href="{{ url_for('contributions.manage_update_contrib', item) }}"
@@ -112,6 +112,8 @@
                         {% trans %}Edit contribution{% endtrans %}
                     </a>
                 </li>
+            {% endif %}
+            {% if item.can_manage(session.user) %}
                 <li>
                     <a href=""
                        data-href="{{ url_for('contributions.manage_contrib_protection', item) }}"
@@ -128,7 +130,7 @@
                     {{ _render_note_editor(item) }}
                 {% endif %}
             {% endif %}
-            {% if item.can_manage(session.user) %}
+            {% if item.can_edit(session.user) %}
                 <li>
                     <a href=""
                        class="subcontribution-edit"

--- a/indico/modules/events/timetable/controllers/legacy.py
+++ b/indico/modules/events/timetable/controllers/legacy.py
@@ -111,7 +111,8 @@ class RHLegacyTimetableAddContribution(RHLegacyTimetableAddEntryBase):
             return jsonify_data(entries=[serialize_entry_update(entry, session_=self.session)],
                                 notifications=notifications)
         self.commit = False
-        return jsonify_template('events/contributions/forms/contribution.html', form=form, fields=form._display_fields)
+        return jsonify_template('events/contributions/forms/contribution.html', form=form, fields=form._display_fields,
+                                can_manage=True)
 
 
 class RHLegacyTimetableAddSessionBlock(RHLegacyTimetableAddEntryBase):
@@ -197,7 +198,7 @@ class RHLegacyTimetableEditEntry(RHManageTimetableEntryBase):
             elif not form.is_submitted():
                 handle_legacy_description(form.description, contrib)
             return jsonify_template('events/contributions/forms/contribution.html', form=form,
-                                    fields=form._display_fields)
+                                    fields=form._display_fields, can_manage=True)
         elif self.entry.break_:
             break_ = self.entry.break_
             tt_entry_dt = self.entry.start_dt.astimezone(self.event.tzinfo)


### PR DESCRIPTION
Closes #5187 

If configured in the Contribution settings -> Submitter privileges, this change allows
abstract submitters to edit their contributions once the abstracts are accepted.

![image](https://user-images.githubusercontent.com/8739637/150337986-ae1263a5-37ed-4472-a314-e295262f4832.png)
![image](https://user-images.githubusercontent.com/8739637/150338028-9813bc18-31a0-46ea-b0f3-d9cbfd4e5d01.png)
