### PR TITLE
Add support for abstract cloning

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Bugfixes
   timeline (:pr:`5218`)
 - Fix incorrect date in multi-day meeting date selector dropdown in certain timezones
   (:pr:`5223`)
+- Add support for abstract cloning (:pr:`5217`)
 
 
 Version 3.1
@@ -68,7 +69,6 @@ Improvements
 - Add background color option and layer order to badge/poster designer items (:pr:`5139`,
   thanks :user:`SegiNyn`)
 - Allow external users in event/category ACLs (:pr:`5146`)
-- Add support for abstract cloning (:pr:`5217`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Improvements
 ^^^^^^^^^^^^
 
 - Prompt before leaving the event protection page without saving changes (:pr:`5222`)
+- Add the ability to clone abstracts (:pr:`5217`)
 
 Bugfixes
 ^^^^^^^^
@@ -19,7 +20,6 @@ Bugfixes
   timeline (:pr:`5218`)
 - Fix incorrect date in multi-day meeting date selector dropdown in certain timezones
   (:pr:`5223`)
-- Add support for abstract cloning (:pr:`5217`)
 
 
 Version 3.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,7 @@ Improvements
 - Add background color option and layer order to badge/poster designer items (:pr:`5139`,
   thanks :user:`SegiNyn`)
 - Allow external users in event/category ACLs (:pr:`5146`)
+- Add support for abstract cloning (:pr:`5217`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/controllers/abstract_list.py
+++ b/indico/modules/events/abstracts/controllers/abstract_list.py
@@ -137,9 +137,7 @@ class RHCreateAbstract(RHAbstractListBase):
         is_invited = request.args.get('invited') == '1'
         abstract_form_class = make_abstract_form(self.event, session.user, notification_option=True,
                                                  management=self.management, invited=is_invited)
-        cloned_fields = {}
-        if self.abstract:
-            cloned_fields = self.clone_fields(self.abstract)
+        cloned_fields = self.clone_fields(self.abstract) if self.abstract else {}
         form = abstract_form_class(event=self.event, management=self.management, invited=is_invited, **cloned_fields)
         if is_invited:
             del form.submitted_contrib_type

--- a/indico/modules/events/abstracts/controllers/abstract_list.py
+++ b/indico/modules/events/abstracts/controllers/abstract_list.py
@@ -163,7 +163,8 @@ class RHCreateAbstract(RHAbstractListBase):
             if tpl_components.get('hide_abstract'):
                 self.list_generator.flash_info_message(abstract)
             return jsonify_data(**tpl_components)
-        return jsonify_form(form, back=_('Cancel'), form_header_kwargs={'action': request.relative_url})
+        return jsonify_form(form, back=_('Cancel'), disabled_until_change=not abstract,
+                            form_header_kwargs={'action': request.relative_url})
 
 
 class RHDeleteAbstracts(RHManageAbstractsActionsBase):

--- a/indico/modules/events/abstracts/controllers/abstract_list.py
+++ b/indico/modules/events/abstracts/controllers/abstract_list.py
@@ -126,8 +126,10 @@ class RHCreateAbstract(RHAbstractListBase):
             field_data[f'custom_{f.contribution_field_id}'] = f.data
         return field_data
 
-    @use_kwargs({'abstract_id': fields.Int()}, location='query')
-    def _process_args(self, abstract_id=None):
+    @use_kwargs({
+        'abstract_id': fields.Int(load_default=None)
+    }, location='query')
+    def _process_args(self, abstract_id):
         RHAbstractListBase._process_args(self)
         self.abstract = None
         if abstract_id:
@@ -171,7 +173,7 @@ class RHCreateAbstract(RHAbstractListBase):
             if tpl_components.get('hide_abstract'):
                 self.list_generator.flash_info_message(abstract)
             return jsonify_data(**tpl_components)
-        return jsonify_form(form, back=_('Cancel'), disabled_until_change=not self.abstract,
+        return jsonify_form(form, back=_('Cancel'), disabled_until_change=(not self.abstract or is_invited),
                             form_header_kwargs={'action': request.relative_url})
 
 

--- a/indico/modules/events/abstracts/templates/management/_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/_abstract_list.html
@@ -61,7 +61,7 @@
     {% endfor -%}
 {% endmacro %}
 
-{% macro render_abstract_list(abstracts, dynamic_columns, static_columns, total_abstracts, context_track=none, reviewed_abstracts=none) %}
+{% macro render_abstract_list(abstracts, dynamic_columns, static_columns, total_abstracts, context_track=none, reviewed_abstracts=none, can_create_invited_abstracts=false) %}
     {% if abstracts %}
         <form method="POST">
             <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
@@ -93,7 +93,7 @@
                                     {%- trans %}Reviewed{% endtrans -%}
                                 </th>
                             {% endif %}
-                            <th class="i-table thin-column" data-sorter="false"></th>
+                            <th class="i-table actions-column" data-sorter="false"></th>
                         </tr>
                     </thead>
                     <tbody>
@@ -228,12 +228,50 @@
                                         {% endif %}
                                     </td>
                                 {% endif %}
-                                <td class="i-table">
-                                    {% if abstract.state.name == 'accepted' and abstract.contribution %}
+                                <td class="i-table actions-column">
+                                    <div class="group right">
+                                        {% if abstract.state.name == 'accepted' and abstract.contribution %}
                                         <a class="icon-arrow-right-sparse"
                                            href="{{ url_for('contributions.display_contribution', abstract.contribution) }}"
                                            title="{% trans %}Go to contribution{% endtrans %}"></a>
-                                    {% endif %}
+                                        {% endif %}
+                                        <div class="group hide-if-locked">
+                                            <a class="icon-copy hide-if-locked"
+                                               data-toggle="dropdown"
+                                               title="{% trans %}Clone{% endtrans %}"></a>
+                                            <ul class="i-dropdown">
+                                                <li>
+                                                    <a class="js-dialog-action"
+                                                       title="{% trans %}Add new abstract{% endtrans %}"
+                                                       data-title="{% trans %}Add new abstract{% endtrans %}"
+                                                       data-href="{{ url_for('.manage_create_abstract', abstract) }}"
+                                                       data-params-selector="#abstract-list input[name=abstract_id]:checked"
+                                                       data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
+                                                       data-confirm-close-unsaved
+                                                       data-ajax-dialog>
+                                                        {% trans %}Abstract{% endtrans %}
+                                                    </a>
+                                                </li>
+                                                <li>
+                                                    {%- if can_create_invited_abstracts -%}
+                                                        {%- set message = _("Add new invited abstract") %}
+                                                    {%- else -%}
+                                                        {%- set message = _("You first need to create a notification template for invited abstracts") %}
+                                                    {%- endif -%}
+                                                    <a class="js-dialog-action {{ 'disabled' if not can_create_invited_abstracts }}"
+                                                       title="{{ message }}"
+                                                       data-title="{% trans %}Add new invited abstract{% endtrans %}"
+                                                       data-href="{{ url_for('.manage_create_abstract', abstract, invited=true) }}"
+                                                       data-params-selector="#abstract-list input[name=abstract_id]:checked"
+                                                       data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
+                                                       data-confirm-close-unsaved
+                                                       data-ajax-dialog>
+                                                        {% trans %}Invited abstract{% endtrans %}
+                                                    </a>
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    </div>
                                 </td>
                             </tr>
                             {% for item in static_columns if item.id == 'description' %}
@@ -260,4 +298,8 @@
             {%- endif %}
         {%- endcall %}
     {%- endif %}
+
+    <script>
+        $('.abstract-row').dropdown({selector: "a[data-toggle='dropdown']"});
+    </script>
 {% endmacro %}

--- a/indico/modules/events/abstracts/templates/management/abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/abstract_list.html
@@ -50,7 +50,6 @@
                                title="{% trans %}Add new abstract{% endtrans %}"
                                data-title="{% trans %}Add new abstract{% endtrans %}"
                                data-href="{{ url_for('.manage_create_abstract', event) }}"
-                               data-params-selector="#abstract-list input[name=abstract_id]:checked"
                                data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
                                data-confirm-close-unsaved
                                data-ajax-dialog>
@@ -67,7 +66,6 @@
                                title="{{ message }}"
                                data-title="{% trans %}Add new invited abstract{% endtrans %}"
                                data-href="{{ url_for('.manage_create_abstract', event, invited=true) }}"
-                               data-params-selector="#abstract-list input[name=abstract_id]:checked"
                                data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
                                data-confirm-close-unsaved
                                data-ajax-dialog>
@@ -206,6 +204,43 @@
                             <a href="#"
                                class="icon-file-css js-requires-selected-row disabled js-submit-list-form"
                                data-href="{{ url_for('.abstracts_json_export', event) }}">JSON</a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="group">
+                    <a class="i-button arrow icon-copy js-requires-selected-row single-row
+                        hide-if-locked" data-toggle="dropdown">
+                        {% trans %}Clone{% endtrans %}
+                    </a>
+                    <ul class="i-dropdown">
+                        <li>
+                            <a class="js-dialog-action"
+                               title="{% trans %}Add new abstract{% endtrans %}"
+                               data-title="{% trans %}Add new abstract{% endtrans %}"
+                               data-href="{{ url_for('.manage_create_abstract', event) }}"
+                               data-params-selector="#abstract-list input[name=abstract_id]:checked"
+                               data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
+                               data-confirm-close-unsaved
+                               data-ajax-dialog>
+                                {% trans %}Abstract{% endtrans %}
+                            </a>
+                        </li>
+                        <li>
+                            {%- if can_create_invited_abstracts -%}
+                                {%- set message = _("Add new invited abstract") %}
+                            {%- else -%}
+                                {%- set message = _("You first need to create a notification template for invited abstracts") %}
+                            {%- endif -%}
+                            <a class="js-dialog-action {{ 'disabled' if not can_create_invited_abstracts }}"
+                               title="{{ message }}"
+                               data-title="{% trans %}Add new invited abstract{% endtrans %}"
+                               data-href="{{ url_for('.manage_create_abstract', event, invited=true) }}"
+                               data-params-selector="#abstract-list input[name=abstract_id]:checked"
+                               data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
+                               data-confirm-close-unsaved
+                               data-ajax-dialog>
+                                {% trans %}Invited abstract{% endtrans %}
+                            </a>
                         </li>
                     </ul>
                 </div>

--- a/indico/modules/events/abstracts/templates/management/abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/abstract_list.html
@@ -208,8 +208,7 @@
                     </ul>
                 </div>
                 <div class="group">
-                    <a class="i-button arrow icon-copy js-requires-selected-row single-row
-                        hide-if-locked" data-toggle="dropdown">
+                    <a class="i-button arrow icon-copy js-requires-selected-row single-row hide-if-locked" data-toggle="dropdown">
                         {% trans %}Clone{% endtrans %}
                     </a>
                     <ul class="i-dropdown">

--- a/indico/modules/events/abstracts/templates/management/abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/abstract_list.html
@@ -50,6 +50,7 @@
                                title="{% trans %}Add new abstract{% endtrans %}"
                                data-title="{% trans %}Add new abstract{% endtrans %}"
                                data-href="{{ url_for('.manage_create_abstract', event) }}"
+                               data-params-selector="#abstract-list input[name=abstract_id]:checked"
                                data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
                                data-confirm-close-unsaved
                                data-ajax-dialog>
@@ -66,6 +67,7 @@
                                title="{{ message }}"
                                data-title="{% trans %}Add new invited abstract{% endtrans %}"
                                data-href="{{ url_for('.manage_create_abstract', event, invited=true) }}"
+                               data-params-selector="#abstract-list input[name=abstract_id]:checked"
                                data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
                                data-confirm-close-unsaved
                                data-ajax-dialog>

--- a/indico/modules/events/abstracts/templates/management/abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/abstract_list.html
@@ -208,42 +208,6 @@
                     </ul>
                 </div>
                 <div class="group">
-                    <a class="i-button arrow icon-copy js-requires-selected-row single-row hide-if-locked" data-toggle="dropdown">
-                        {% trans %}Clone{% endtrans %}
-                    </a>
-                    <ul class="i-dropdown">
-                        <li>
-                            <a class="js-dialog-action"
-                               title="{% trans %}Add new abstract{% endtrans %}"
-                               data-title="{% trans %}Add new abstract{% endtrans %}"
-                               data-href="{{ url_for('.manage_create_abstract', event) }}"
-                               data-params-selector="#abstract-list input[name=abstract_id]:checked"
-                               data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
-                               data-confirm-close-unsaved
-                               data-ajax-dialog>
-                                {% trans %}Abstract{% endtrans %}
-                            </a>
-                        </li>
-                        <li>
-                            {%- if can_create_invited_abstracts -%}
-                                {%- set message = _("Add new invited abstract") %}
-                            {%- else -%}
-                                {%- set message = _("You first need to create a notification template for invited abstracts") %}
-                            {%- endif -%}
-                            <a class="js-dialog-action {{ 'disabled' if not can_create_invited_abstracts }}"
-                               title="{{ message }}"
-                               data-title="{% trans %}Add new invited abstract{% endtrans %}"
-                               data-href="{{ url_for('.manage_create_abstract', event, invited=true) }}"
-                               data-params-selector="#abstract-list input[name=abstract_id]:checked"
-                               data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
-                               data-confirm-close-unsaved
-                               data-ajax-dialog>
-                                {% trans %}Invited abstract{% endtrans %}
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                <div class="group">
                     <a class="i-button button change-columns-width" title="{% trans %}Adapt columns width{% endtrans %}"></a>
                 </div>
             </div>
@@ -265,7 +229,7 @@
             </div>
         </div>
         <div class="list-content" id="abstract-list">
-            {{ render_abstract_list(abstracts, dynamic_columns, static_columns, total_abstracts) }}
+            {{ render_abstract_list(abstracts, dynamic_columns, static_columns, total_abstracts, can_create_invited_abstracts=can_create_invited_abstracts) }}
         </div>
         <div id="filter-placeholder"></div>
     </div>

--- a/indico/modules/events/client/js/util/list_generator.js
+++ b/indico/modules/events/client/js/util/list_generator.js
@@ -39,10 +39,11 @@
       $(this)
         .closest('tr')
         .toggleClass('selected', this.checked);
-      $('.js-requires-selected-row').toggleClass(
-        'disabled',
-        !$('.list input:checkbox:checked').length
-      );
+      const rows = $('.list input:checkbox:checked').length;
+      $('.js-requires-selected-row').toggleClass('disabled', !rows);
+      if (rows > 1) {
+        $('.js-requires-selected-row.single-row').toggleClass('disabled', true);
+      }
     });
 
     if (trigger) {

--- a/indico/modules/events/client/js/util/list_generator.js
+++ b/indico/modules/events/client/js/util/list_generator.js
@@ -41,9 +41,7 @@
         .toggleClass('selected', this.checked);
       const rows = $('.list input:checkbox:checked').length;
       $('.js-requires-selected-row').toggleClass('disabled', !rows);
-      if (rows > 1) {
-        $('.js-requires-selected-row.single-row').toggleClass('disabled', true);
-      }
+      $('.js-requires-selected-row.single-row').toggleClass('disabled', rows !== 1);
     });
 
     if (trigger) {

--- a/indico/modules/events/client/js/util/list_generator.js
+++ b/indico/modules/events/client/js/util/list_generator.js
@@ -39,9 +39,10 @@
       $(this)
         .closest('tr')
         .toggleClass('selected', this.checked);
-      const rows = $('.list input:checkbox:checked').length;
-      $('.js-requires-selected-row').toggleClass('disabled', !rows);
-      $('.js-requires-selected-row.single-row').toggleClass('disabled', rows !== 1);
+      $('.js-requires-selected-row').toggleClass(
+        'disabled',
+        !$('.list input:checkbox:checked').length
+      );
     });
 
     if (trigger) {

--- a/indico/web/client/styles/modules/abstracts/_abstract_list.scss
+++ b/indico/web/client/styles/modules/abstracts/_abstract_list.scss
@@ -9,6 +9,14 @@
   text-align: center;
 }
 
+.actions-column {
+  width: 4em;
+}
+
+.actions-column .group {
+  display: inline;
+}
+
 .accepted-on-other-track {
   td,
   a {


### PR DESCRIPTION
Adds support for a new cloning handle, that generates a new abstract form with pre-filled information.
Also ensures a single row is selected/cloned at a time.

For the sake of simplicity, I'm re-using the existing `RHCreateAbstract`.