### PR TITLE
Fix revision file access check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,18 @@ Changelog
 =========
 
 
+Version 3.1.1
+-------------
+
+*Unreleased*
+
+Bugfixes
+^^^^^^^^
+
+- Fix published editable files only being visible to users with access to the editing
+  timeline (:pr:`5218`)
+
+
 Version 3.1
 -----------
 

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -406,6 +406,9 @@ class RHDownloadRevisionFile(RHContributionEditableRevisionBase):
                               .first_or_404())
 
     def _check_revision_access(self):
+        if (self.revision_file in self.editable.published_revision.files and
+                self.revision_file.file_type.publishable):
+            return self.contrib.can_access(session.user)
         return self.editable.can_see_timeline(session.user)
 
     def _process(self):


### PR DESCRIPTION
This PR contains a fix for a bug relating to a contribution's published revision files only being accessible to users with access to the editing timeline, instead of all users with access to the contribution.