### PR TITLE
Fix incorrect date in meeting day picker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Bugfixes
 
 - Fix published editable files only being visible to users with access to the editing
   timeline (:pr:`5218`)
+- Fix incorrect date in multi-day meeting date selector dropdown in certain timezones
+  (:pr:`5223`)
 
 
 Version 3.1

--- a/indico/modules/events/timetable/templates/display/indico/meeting.html
+++ b/indico/modules/events/timetable/templates/display/indico/meeting.html
@@ -31,7 +31,7 @@
                                         {% for day, _ in days %}
                                             <li>
                                                 <a href="#day-{{ day.isoformat() }}">
-                                                    {{ day | format_skeleton('EEEdMMM', timezone=timezone) }}
+                                                    {{ day | format_skeleton('EEEdMMM') }}
                                                 </a>
                                             </li>
                                         {% endfor %}


### PR DESCRIPTION
The days are already localized to the event display timezone, so applying the timezone again during formatting was wrong.