### PR TITLE
Remove padding on category title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Bugfixes
   timeline (:pr:`5218`)
 - Fix incorrect date in multi-day meeting date selector dropdown in certain timezones
   (:pr:`5223`)
+- Remove excessive padding around category titles (:pr:`5225`)
 
 
 Version 3.1

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -2,12 +2,7 @@
 
 <div class="category-container">
     <div class="category-header flexrow">
-        {% if category.is_root or category.attachment_count or category.can_manage(session.user) %}
-            {% set category_title_classes = 'sidebar-padding' %}
-        {% else %}
-            {% set category_title_classes = '' %}
-        {% endif %}
-        <h1 class="category-title {{ category_title_classes }}">
+        <h1 class="category-title">
             {% block title %}
                 {% if category.title == 'Home' and category.is_root %}
                     {% if category.children %}

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -49,10 +49,6 @@
   margin-left: 0;
   text-align: left;
 
-  &.sidebar-padding {
-    padding-right: 340px;
-  }
-
   .subtitle {
     font-style: italic;
     font-size: 0.8em;


### PR DESCRIPTION
This PR removes the padding from the category title. It was wrapping in small screens.

![image](https://user-images.githubusercontent.com/6058151/151395154-64f096cf-3519-4ef2-9b1e-d618395e17f9.png)

Becomes:

![image](https://user-images.githubusercontent.com/6058151/151395246-584f2142-bf4a-4fb7-bb39-80969fef1a32.png)
