### PR TITLE
Validate unknown placeholders in room_name_format & map_url_template

### DIFF
--- a/indico/modules/rb/client/js/modules/admin/LocationPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/LocationPage.jsx
@@ -153,7 +153,30 @@ class LocationPage extends React.PureComponent {
             readOnly={selectedTemplate !== 'custom'}
             style={selectedTemplate === 'none' ? {display: 'none'} : {}}
             nullIfEmpty
-            validate={v.optional(v.url)}
+            validate={val => {
+              const rv = v.optional(v.url)(val);
+              if (rv) {
+                return rv;
+              }
+              const validPlaceholders = [
+                '{id}',
+                '{building}',
+                '{floor}',
+                '{number}',
+                '{lat}',
+                '{lng}',
+              ];
+              const placeholders = [...val.matchAll(/\{.*?\}/g)].map(match => match[0]);
+              const invalid = placeholders.filter(ph => !validPlaceholders.includes(ph));
+              if (invalid.length) {
+                return PluralTranslate.string(
+                  'Invalid placeholder: {placeholders}',
+                  'Invalid placeholders: {placeholders}',
+                  invalid.length,
+                  {placeholders: invalid.join(', ')}
+                );
+              }
+            }}
             description={
               selectedTemplate === 'custom' && (
                 <Translate>

--- a/indico/modules/rb/client/js/modules/admin/LocationPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/LocationPage.jsx
@@ -112,13 +112,24 @@ class LocationPage extends React.PureComponent {
           if (rv) {
             return rv;
           }
-          const missing = ['{building}', '{floor}', '{number}'].filter(x => !val.includes(x));
+          const validPlaceholders = ['{building}', '{floor}', '{number}'];
+          const missing = validPlaceholders.filter(x => !val.includes(x));
           if (missing.length) {
             return PluralTranslate.string(
               'Missing placeholder: {placeholders}',
               'Missing placeholders: {placeholders}',
               missing.length,
               {placeholders: missing.join(', ')}
+            );
+          }
+          const placeholders = [...val.matchAll(/\{.*?\}/g)].map(match => match[0]);
+          const invalid = placeholders.filter(ph => !validPlaceholders.includes(ph));
+          if (invalid.length) {
+            return PluralTranslate.string(
+              'Invalid placeholder: {placeholders}',
+              'Invalid placeholders: {placeholders}',
+              invalid.length,
+              {placeholders: invalid.join(', ')}
             );
           }
         }}

--- a/indico/modules/rb/schemas.py
+++ b/indico/modules/rb/schemas.py
@@ -400,22 +400,18 @@ class LocationArgs(mm.Schema):
         if missing:
             # validated client-side, no i18n needed
             raise ValidationError('Missing placeholders: {}'.format(', '.join(missing)))
-
-        try:
-            placeholders = get_format_placeholders(room_name_format)
-        except ValueError:
-            raise ValidationError(_('Invalid placeholder format'))
-        if invalid := set(placeholders) - {'building', 'floor', 'number'}:
-            # validated client-side, no i18n needed
-            raise ValidationError('Invalid placeholders: {}'.format(', '.join(invalid)))
+        self._validate_placeholders(room_name_format, {'building', 'floor', 'number'})
 
     @validates('map_url_template')
     def _check_map_url_template_placeholders(self, map_url_template, **kwargs):
+        self._validate_placeholders(map_url_template, {'id', 'building', 'floor', 'number', 'lat', 'lng'})
+
+    def _validate_placeholders(self, format_string, valid_placeholders):
         try:
-            placeholders = get_format_placeholders(map_url_template)
+            placeholders = get_format_placeholders(format_string)
         except ValueError:
             raise ValidationError(_('Invalid placeholder format'))
-        if invalid := set(placeholders) - {'id', 'building', 'floor', 'number', 'lat', 'lng'}:
+        if invalid := set(placeholders) - valid_placeholders:
             # validated client-side, no i18n needed
             raise ValidationError('Invalid placeholders: {}'.format(', '.join(invalid)))
 

--- a/indico/modules/rb/schemas.py
+++ b/indico/modules/rb/schemas.py
@@ -401,7 +401,10 @@ class LocationArgs(mm.Schema):
             # validated client-side, no i18n needed
             raise ValidationError('Missing placeholders: {}'.format(', '.join(missing)))
 
-        placeholders = get_format_placeholders(room_name_format)
+        try:
+            placeholders = get_format_placeholders(room_name_format)
+        except ValueError:
+            raise ValidationError(_('Invalid placeholder format'))
         if invalid := set(placeholders) - {'building', 'floor', 'number'}:
             raise ValidationError(_('Invalid placeholders: {}').format(', '.join(invalid)))
 

--- a/indico/modules/rb/schemas.py
+++ b/indico/modules/rb/schemas.py
@@ -34,7 +34,7 @@ from indico.modules.rb.models.room_bookable_hours import BookableHours
 from indico.modules.rb.models.room_features import RoomFeature
 from indico.modules.rb.models.room_nonbookable_periods import NonBookablePeriod
 from indico.modules.rb.models.rooms import Room
-from indico.modules.rb.util import rb_is_admin
+from indico.modules.rb.util import get_format_placeholders, rb_is_admin
 from indico.modules.users.schemas import UserSchema
 from indico.util.i18n import _
 from indico.util.marshmallow import (ModelList, NaiveDateTime, Principal, PrincipalList, PrincipalPermissionList,
@@ -400,6 +400,10 @@ class LocationArgs(mm.Schema):
         if missing:
             # validated client-side, no i18n needed
             raise ValidationError('Missing placeholders: {}'.format(', '.join(missing)))
+
+        placeholders = get_format_placeholders(room_name_format)
+        if invalid := set(placeholders) - {'building', 'floor', 'number'}:
+            raise ValidationError(_('Invalid placeholders: {}').format(', '.join(invalid)))
 
 
 class FeatureArgs(mm.Schema):

--- a/indico/modules/rb/schemas.py
+++ b/indico/modules/rb/schemas.py
@@ -406,7 +406,18 @@ class LocationArgs(mm.Schema):
         except ValueError:
             raise ValidationError(_('Invalid placeholder format'))
         if invalid := set(placeholders) - {'building', 'floor', 'number'}:
-            raise ValidationError(_('Invalid placeholders: {}').format(', '.join(invalid)))
+            # validated client-side, no i18n needed
+            raise ValidationError('Invalid placeholders: {}'.format(', '.join(invalid)))
+
+    @validates('map_url_template')
+    def _check_map_url_template_placeholders(self, map_url_template, **kwargs):
+        try:
+            placeholders = get_format_placeholders(map_url_template)
+        except ValueError:
+            raise ValidationError(_('Invalid placeholder format'))
+        if invalid := set(placeholders) - {'id', 'building', 'floor', 'number', 'lat', 'lng'}:
+            # validated client-side, no i18n needed
+            raise ValidationError('Invalid placeholders: {}'.format(', '.join(invalid)))
 
 
 class FeatureArgs(mm.Schema):

--- a/indico/modules/rb/util.py
+++ b/indico/modules/rb/util.py
@@ -6,6 +6,7 @@
 # LICENSE file for more details.
 
 import os
+import string
 from collections import namedtuple
 from datetime import datetime, time, timedelta
 from io import BytesIO
@@ -329,3 +330,7 @@ def get_prebooking_collisions(reservation):
     from indico.modules.rb.models.reservation_occurrences import ReservationOccurrence
     valid_occurrences = reservation.occurrences.filter(ReservationOccurrence.is_valid).all()
     return ReservationOccurrence.find_overlapping_with(reservation.room, valid_occurrences, reservation.id).all()
+
+
+def get_format_placeholders(format_str):
+    return [name for text, name, spec, conv in string.Formatter().parse(format_str) if name is not None]


### PR DESCRIPTION
Rejects unsupported placeholders, which prevents a 500 error
caused by directly calling .format() on the room_name_format