### PR TITLE
Restore logical order of registration items

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Bugfixes
 - Remove excessive padding around category titles (:pr:`5225`)
 - Fix error when exporting registrations to PDFs that contained certain invalid HTML-like
   sequences (:pr:`5233`)
+- Restore logical order of registration list columns (:pr:`5240`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -84,20 +84,14 @@ class RegistrationListGenerator(ListGeneratorBase):
 
         :return: a list of {'id': ..., 'caption': ...} dicts
         """
+        ids = set(ids)
         result = []
-        for item_id in ids:
-            if item_id in self.personal_items:
-                field = RegistrationFormItem.query.filter_by(registration_form=self.regform,
-                                                             personal_data_type=PersonalDataType[item_id]).one()
-                result.append({
-                    'id': field.id,
-                    'caption': field.title
-                })
-            elif item_id in self.static_items:
-                result.append({
-                    'id': item_id,
-                    'caption': self.static_items[item_id]['title']
-                })
+        for item_id in [x for x in self.personal_items if x in ids]:
+            field = RegistrationFormItem.query.filter_by(registration_form=self.regform,
+                                                         personal_data_type=PersonalDataType[item_id]).one()
+            result.append({'id': field.id, 'caption': field.title})
+        for item_id in [x for x in self.static_items if x in ids]:
+            result.append({'id': item_id, 'caption': self.static_items[item_id]['title']})
         return result
 
     def _column_ids_to_db(self, ids):


### PR DESCRIPTION
I recently received some feedback on the registration form columns, where their sorting order (which isn't customizable atm) changed to a less readable order. (probably revision 42a42039efcbb9260474929bc38b59bfcc1d7a0a)

![imagem](https://user-images.githubusercontent.com/12183954/152788250-1552b11e-b245-4fdf-bd79-b632cfde16bd.png)

With these changes, I intend to fall back to the default order provided in code by the columns set.
(e.g. `self.personal_items = ('title', 'first_name', 'last_name', 'email', ....)`)