### PR TITLE
Fix pytest:date_time_test.py failing when timezone is east of UTC+1

### DIFF
--- a/indico/util/date_time_test.py
+++ b/indico/util/date_time_test.py
@@ -75,5 +75,5 @@ def test_iterdays(from_, to, skip_weekends, day_whitelist, day_blacklist, expect
     ('EEEdMMM', 'Mon, 8 Feb'),
 ))
 def test_format_skeleton(skeleton, expected):
-    dt = datetime(2021, 2, 8).astimezone(timezone('Europe/Zurich'))
+    dt = as_utc(datetime(2021, 2, 8)).astimezone(timezone('Europe/Zurich'))
     assert format_skeleton(dt, skeleton, 'en_GB', 'Europe/Zurich') == expected


### PR DESCRIPTION
`pytest` fails on `date_time_test.py` when time zone settings is east of Zurich (UTC+1).

This is because the function `datetime` will always return time at the current time zone, and converting this `datetime` time to Zurich time zone via `datetime.astimezone` will result in time to move back to previous day if the current time zone is anywhere to the east.

Fixed this by enclosing `datetime` with `as_utc` to make sure the time is in UTC before calling `datetime.astimezone`.

Futher `pytest` with this finally passed all tests.