### PR TITLE
Signal for more generic function call interceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Internal Changes
   sections (:pr:`5237`, thanks :user:`omegak`)
 - Add ``event.reminder.before_reminder_make_email`` signal (:pr:`5242`, thanks
   :user:`vasantvohra`)
+- Add ``plugin.interceptable_function`` signal to intercept selected function
+  calls (:pr:`5254`)
 
 
 Version 3.1

--- a/indico/core/signals/plugin.py
+++ b/indico/core/signals/plugin.py
@@ -109,3 +109,30 @@ the following arguments:
 If a plugin wants to modify the resulting data, it may do so by modifying the contents of
 ``data``.
 ''')
+
+interceptable_function = _signals.signal('interceptable-function', '''
+This signal provides a generic way to let plugins intercept function calls and
+inspect or modify their call arguments. The sender should always be taken from the
+:func:`~indico.util.signals.interceptable_sender` util and not be used directly.
+
+The signal handler also receives the original function in the ``func`` kwarg and the
+:class:`~inspect.BoundArguments` for the original function call in the ``args`` kwarg.
+Additional context may be preovided in the ``ctx`` kwargs.
+
+The args object is mutable; its `arguments` attribute is a dict containing all the arguments
+of the original function call; if necessary its `apply_defaults` method can be called to
+fill in any default values the function provides.
+
+The signal handler may also return a value; if it does so, the original function will NOT
+be called but rather the returned value used. Note that using the signal in this way should
+only be done if you are very sure that no other signal handler does so, as the function call
+will fail with an error in case more than one return value override is specified.
+
+Due to how Python works, returning an explicit ``None`` in order to override the return value
+with ``None`` won't work; but you can use the special ``RETURN_NONE`` kwarg for this purpose.
+
+Note that this signal does NOT let you intercept arbitrary functions; only those which are
+either decorated or where the caller explicitly wrapped the function using
+:func:`~indico.util.signals.make_interceptable` can be intercepted. If you believe a certain
+function should allow this, you're welcome to send a Pull Request.
+''')

--- a/indico/util/signals_test.py
+++ b/indico/util/signals_test.py
@@ -9,7 +9,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from indico.util.signals import named_objects_from_signal, values_from_signal
+from indico.core import signals
+from indico.util.signals import interceptable_sender, make_interceptable, named_objects_from_signal, values_from_signal
 
 
 def _make_signal_response(objects):
@@ -90,3 +91,128 @@ def test_named_objects_from_signal_duplicate():
     with pytest.raises(RuntimeError) as exc_info:
         named_objects_from_signal(signal_response)
     assert str(exc_info.value) == 'Non-unique object names: a, c'
+
+
+def test_interceptable():
+    def foo(a, /, b, c=1, *, d=123, **kw):
+        return f'{a=} {b=} {c=} {d=} {kw=}'
+
+    def _handler(sender, func, args, ctx, **kwargs):
+        args.apply_defaults()
+        args.arguments['c'] = 'ccc'
+        args.arguments['kw'].setdefault('lol', 'funny')
+        if ctx:
+            return {'return': 'value', 'orig': func(*args.args, **args.kwargs)}
+
+    foo = make_interceptable(foo)
+    foo2 = make_interceptable(foo, ctx=True)
+    with signals.plugin.interceptable_function.connected_to(_handler, interceptable_sender(foo)):
+        assert foo(1, 2) == "a=1 b=2 c='ccc' d=123 kw={'lol': 'funny'}"
+        assert foo(1, 2, lol='test') == "a=1 b=2 c='ccc' d=123 kw={'lol': 'test'}"
+        assert foo2(3, 4) == {'return': 'value', 'orig': "a=3 b=4 c='ccc' d=123 kw={'lol': 'funny'}"}
+
+
+def test_interceptable_method():
+    class Foo:
+        def __init__(self, x):
+            self.x = x
+
+        def bar(self, a):
+            return f'{self.x=} {a=}'
+
+    def _handler(sender, func, args, ctx, **kwargs):
+        args.arguments['a'] = 'x'
+
+    foo = Foo(1)
+    bar = make_interceptable(foo.bar)
+    with signals.plugin.interceptable_function.connected_to(_handler, interceptable_sender(Foo.bar)):
+        assert bar(2) == "self.x=1 a='x'"
+
+
+def test_interceptable_method_decorated():
+    class Foo:
+        def __init__(self, x):
+            self.x = x
+
+        @make_interceptable
+        def bar(self, a):
+            return f'{self.x=} {a=}'
+
+    def _handler(sender, func, args, ctx, **kwargs):
+        args.arguments['a'] = 'x'
+
+    with signals.plugin.interceptable_function.connected_to(_handler, interceptable_sender(Foo.bar)):
+        assert Foo(1).bar(2) == "self.x=1 a='x'"
+
+
+def test_interceptable_starargs():
+    def foo(a, *va, **kw):
+        return f'{a=} {va=} {kw=}'
+
+    def _handler(sender, func, args, **kwargs):
+        args.apply_defaults()
+        assert args.arguments == {'a': 1, 'va': (2, 3), 'kw': {'x': 4}}
+        args.arguments['va'] = (*args.arguments['va'], 33)
+        args.arguments['kw'] = {**args.arguments['kw'], 'y': 5}
+
+    foo = make_interceptable(foo, 'test')
+    with signals.plugin.interceptable_function.connected_to(_handler, interceptable_sender(foo, 'test')):
+        assert foo(1, 2, 3, x=4) == "a=1 va=(2, 3, 33) kw={'x': 4, 'y': 5}"
+
+
+@pytest.mark.parametrize(('caller_key', 'receiver_key'), (
+    (None, None),
+    (None, 'test'),
+    ('test', None),
+    ('test', 'test'),
+    ('foo', 'bar'),
+))
+def test_interceptable_key(caller_key, receiver_key):
+    called = False
+
+    def _handler(sender, func, args, **kwargs):
+        nonlocal called
+        called = True
+
+    foo = make_interceptable(lambda a: f'{a=}', caller_key)
+    with signals.plugin.interceptable_function.connected_to(_handler, interceptable_sender(foo, receiver_key)):
+        assert foo(1) == 'a=1'
+    assert called == (caller_key == receiver_key)
+
+
+def test_interceptable_override_multi():
+    foo = make_interceptable(lambda a: f'{a=}')
+    with (
+        signals.plugin.interceptable_function.connected_to(lambda *a, **kw: 'x', interceptable_sender(foo)),
+        signals.plugin.interceptable_function.connected_to(lambda *a, **kw: 'y', interceptable_sender(foo)),
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            foo(1)
+        assert str(exc_info.value) == f'Multiple results returned for interceptable {interceptable_sender(foo)}'
+
+
+def test_interceptable_override_none():
+    foo = make_interceptable(lambda: 'nope')
+    with signals.plugin.interceptable_function.connected_to(lambda *a, **kw: None, interceptable_sender(foo)):
+        # simply returning None won't work
+        assert foo() == 'nope'
+    with signals.plugin.interceptable_function.connected_to(lambda *a, RETURN_NONE, **kw: RETURN_NONE,
+                                                            interceptable_sender(foo)):
+        assert foo() is None
+
+
+def test_interceptable_multi():
+    def _handler(sender, func, args, **kwargs):
+        args.arguments['a'] *= 2
+
+    def _handler2(sender, func, args, **kwargs):
+        args.arguments['a'] *= 3
+
+    foo = make_interceptable(lambda a: a)
+    with signals.plugin.interceptable_function.connected_to(_handler, interceptable_sender(foo)):
+        assert foo(1) == 2
+    with (
+        signals.plugin.interceptable_function.connected_to(_handler, interceptable_sender(foo)),
+        signals.plugin.interceptable_function.connected_to(_handler2, interceptable_sender(foo)),
+    ):
+        assert foo(1) == 6


### PR DESCRIPTION
Recently we've got a bunch of PRs adding signals that are pretty much just providing a way to tamper with the arguments of certain function calls. And while we're open to accepting such PRs, I had the feeling that this was getting a bit messy, so I thought about providing a more standard way to handle this. While it would still require PRs to adjust a function call in order to provide this type of hook, it'd be much simpler than building a dict and updating it based on the signal return values...

Feedback welcome!

---

Also, for our UN colleagues @OmeGak @vasantvohra @SegiNyn, maybe you can have a look as well and see if you'd find this useful? Here's an example on how I'd use this instead of the recently-added `draw_item_on_badge` signal:

```patch
diff --git a/indico/modules/events/registration/badges.py b/indico/modules/events/registration/badges.py
index 918edd21fa..baec526e3a 100644
--- a/indico/modules/events/registration/badges.py
+++ b/indico/modules/events/registration/badges.py
@@ -13,12 +13,11 @@ from reportlab.lib.units import cm
 from reportlab.lib.utils import ImageReader
 from werkzeug.exceptions import BadRequest

-from indico.core import signals
 from indico.modules.designer.pdf import DesignerPDFBase
 from indico.modules.events.registration.settings import DEFAULT_BADGE_SETTINGS
 from indico.util.i18n import _
 from indico.util.placeholders import get_placeholders
-from indico.util.signals import values_from_signal
+from indico.util.signals import make_interceptable


 FONT_SIZE_RE = re.compile(r'(\d+)(pt)?')
@@ -101,15 +100,9 @@ class RegistrantsListToBadgesPDF(DesignerPDFBase):
             else:
                 continue

-            item_data = {'item': item, 'text': text, 'pos_x': pos_x, 'pos_y': pos_y}
-            for update in values_from_signal(
-                signals.event.designer.draw_item_on_badge.send(registration, items=items, height=self.height,
-                                                               width=self.width, data=item_data),
-                as_list=True
-            ):
-                item_data.update(update)
-            self._draw_item(canvas, item_data['item'], tpl_data, item_data['text'], item_data['pos_x'],
-                            item_data['pos_y'])
+            draw_item = make_interceptable(self._draw_item, ctx={'registration': registration, 'items': items,
+                                                                 'height': self.height, 'width': self.width})
+            draw_item(canvas, item, tpl_data, text, pos_x, pos_y)
```

and the plugin could be doing something like this then:

```python
    def init(self):
        super().init()
        from indico.modules.events.registration.badges import RegistrantsListToBadgesPDF
        from indico.util.signals import interceptable_sender
        self.connect(signals.plugin.interceptable_function, self._intercept_draw_item,
                     sender=interceptable_sender(RegistrantsListToBadgesPDF._draw_item))

    def _intercept_draw_item(self, sender, args, ctx, RETURN_NONE, **kwargs):
        if args.arguments['content'] == 'CERN':
            # this skips the item - if we force a return value, the original function won't get called
            return RETURN_NONE
        elif args.arguments['content']:
            args.arguments['content'] = f"[{args.arguments['content'].strip()}]"
        args.arguments['item']['color'] = '#ff00cc'
        args.arguments['item']['background_color'] = '#000000'
```