### PR TITLE
Add signals for rendering attachments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,7 +34,8 @@ Internal Changes
   sections (:pr:`5237`, thanks :user:`omegak`)
 - Add ``event.reminder.before_reminder_make_email`` signal (:pr:`5242`, thanks
   :user:`vasantvohra`)
-
+- Add ``attachments.render_attachment_list`` signal (:pr:`5255`, thanks :user:`vtran99`)
+- Add ``attachments.get_attached_items`` signal (:pr:`5255`, thanks :user:`vtran99`)
 
 Version 3.1
 -----------

--- a/indico/core/signals/attachments.py
+++ b/indico/core/signals/attachments.py
@@ -62,3 +62,13 @@ with `from_preview=False`).
 get_file_previewers = _signals.signal('get-file-previewers', '''
 Expected to return one or more `Previewer` subclasses.
 ''')
+
+render_attachment_list = _signals.signal('render-attachment-list', '''
+Called when attachment list is rendered.  The *sender* is the
+`linked object`.  Expected to return a couple (template, template context).
+''')
+
+get_attached_items = _signals.signal('get-attached-items', '''
+Called when getting attached items of a linked object.  The *sender* is the
+`linked object`.  Expected to return a couple (folders, files).
+''')

--- a/indico/modules/attachments/util.py
+++ b/indico/modules/attachments/util.py
@@ -7,7 +7,9 @@
 
 from flask import session
 
+from indico.core import signals
 from indico.core.db import db
+from indico.util.signals import values_from_signal
 
 
 def get_attached_folders(linked_object, include_empty=True, include_hidden=True, preload_event=False):
@@ -53,6 +55,12 @@ def get_attached_items(linked_object, include_empty=True, include_hidden=True, p
     files = folders.pop(0).attachments if folders[0].is_default else []
     if not files and not folders:
         return {}
+    signal_value = values_from_signal(signals.attachments.get_attached_items.send(linked_object,
+                                                                                  folders=folders,
+                                                                                  files=files),
+                                      as_list=True)
+    if signal_value:
+        folders, files = signal_value[0]
     return {
         'folders': folders,
         'files': files


### PR DESCRIPTION
Add signals to intercept the attachments retrieving and the rendering of the template.