### PR TITLE
Fixes in vCalendar attachment MIME header

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Bugfixes
 - Restore logical order of registration list columns (:pr:`5240`)
 - Fix a performance issue in the HTTP API when exporting events from a specific category
   while specifying a limit (only affected large databases) (:pr:`5260`)
+- Correctly specify charset in iCalendar files attached to emails (:issue:`5228`,
+  :pr:`5258`, thanks :user:`imranyusuff`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -32,7 +32,8 @@ class MIMECalendar(MIMEBase):
 
     def __init__(self, filename: str, payload: str):
         message.Message.__init__(self, policy=compat32)
-        self.add_header('Content-Type', 'text/calendar', filename=filename, charset='utf-8', method='REQUEST')
+        self.add_header('Content-Type', 'text/calendar', charset='utf-8', method='REQUEST')
+        self.add_header('Content-Disposition', 'attachment', filename=filename)
         self['MIME-Version'] = '1.0'
         self.set_payload(payload)
 

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -32,7 +32,7 @@ class MIMECalendar(MIMEBase):
 
     def __init__(self, filename: str, payload: str):
         message.Message.__init__(self, policy=compat32)
-        self.add_header('Content-Type', 'text/calendar', filename=filename, encoding='utf-8', method='REQUEST')
+        self.add_header('Content-Type', 'text/calendar', filename=filename, charset='utf-8', method='REQUEST')
         self['MIME-Version'] = '1.0'
         self.set_payload(payload)
 


### PR DESCRIPTION
This is a new pull request to replace PR #5250 which got messed up.

This change addressed issue #5228.

Also moved the `filename` parameter from `Content-Type` to `Content-Disposition` field. I can finally got this vCalendar attachment to work on MailDump now.