### PR TITLE
Add link to current stylesheet in layout management

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,8 @@ Improvements
 
 - Add a new event management permission that grants access only to the abstracts
   module (:pr:`5212`)
+- Add a link to quickly view the current stylesheet on the conference layout
+  customization page (:issue:`5239`, :pr:`5259`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/layout/blueprint.py
+++ b/indico/modules/events/layout/blueprint.py
@@ -10,7 +10,8 @@ from indico.modules.events.layout.controllers.images import RHImageDelete, RHIma
 from indico.modules.events.layout.controllers.layout import (RHLayoutCSSDelete, RHLayoutCSSDisplay, RHLayoutCSSPreview,
                                                              RHLayoutCSSSaveTheme, RHLayoutCSSUpload, RHLayoutEdit,
                                                              RHLayoutLogoDelete, RHLayoutLogoUpload,
-                                                             RHLayoutTimetableThemeForm, RHLogoDisplay)
+                                                             RHLayoutTimetableThemeForm, RHLayoutViewStylesheet,
+                                                             RHLogoDisplay)
 from indico.modules.events.layout.controllers.menu import (RHMenuAddEntry, RHMenuDeleteEntry, RHMenuEdit,
                                                            RHMenuEntryEdit, RHMenuEntryPosition,
                                                            RHMenuEntryToggleDefault, RHMenuEntryToggleEnabled,
@@ -36,6 +37,7 @@ _bp.add_url_rule('/menu/<int:menu_entry_id>/delete', 'menu_delete_entry', RHMenu
 _bp.add_url_rule('/menu/add', 'menu_add_entry', RHMenuAddEntry, methods=('GET', 'POST'))
 _bp.add_url_rule('/theme/save', 'css_save_theme', RHLayoutCSSSaveTheme, methods=('POST',))
 _bp.add_url_rule('/theme/preview', 'css_preview', RHLayoutCSSPreview)
+_bp.add_url_rule('/theme/stylesheet', 'view_stylesheet', RHLayoutViewStylesheet)
 _bp.add_url_rule('/css', 'upload_css', RHLayoutCSSUpload, methods=('POST',))
 _bp.add_url_rule('/css', 'delete_css', RHLayoutCSSDelete, methods=('DELETE',))
 _bp.add_url_rule('/logo', 'upload_logo', RHLayoutLogoUpload, methods=('POST',))

--- a/indico/modules/events/layout/controllers/layout.py
+++ b/indico/modules/events/layout/controllers/layout.py
@@ -220,6 +220,14 @@ class RHLayoutCSSPreview(RHLayoutBase):
         return WPConferenceDisplay(self, self.event, css_override_form=form, css_url_override=css_url).display()
 
 
+class RHLayoutViewStylesheet(RHLayoutBase):
+    def _process(self):
+        form = CSSSelectionForm(event=self.event, formdata=request.args, csrf_enabled=False)
+        if not form.validate() or not form.theme.data:
+            raise NotFound
+        return redirect(get_css_url(self.event, force_theme=form.theme.data))
+
+
 class RHLayoutCSSSaveTheme(RHLayoutBase):
     def _process(self):
         form = CSSSelectionForm(event=self.event)

--- a/indico/modules/events/layout/templates/layout_conference.html
+++ b/indico/modules/events/layout/templates/layout_conference.html
@@ -32,6 +32,14 @@
                     {%- trans %}Preview{% endtrans -%}
                 </a>
             {% endcall %}
+            <div class="form-group">
+                <div class="form-label"></div>
+                <div class="form-field">
+                    <a href="{{ url_for('event_layout.view_stylesheet', event) }}" target="_blank" class="js-view-stylesheet-btn">
+                        {%- trans %}View current stylesheet{% endtrans -%}
+                    </a>
+                </div>
+            </div>
         {% endcall %}
     {% endcall %}
 
@@ -75,12 +83,31 @@
         $(document).ready(function() {
             'use strict';
 
+            function updateViewStylesheet(theme) {
+                if (theme !== '') {
+                    const stylesheetURL = build_url(
+                        {{ url_for('event_layout.view_stylesheet', event) | tojson }},
+                        {theme}
+                    );
+                    $('.js-view-stylesheet-btn').attr('href', stylesheetURL).show();
+                } else {
+                    $('.js-view-stylesheet-btn').hide();
+                }
+            }
+
             $('#theme').nullableselector({nullvalue: ''}).on('change', function() {
-                var previewURL = build_url({{ url_for('event_layout.css_preview', event) | tojson }}, {
-                    theme: $(this).val()
+                const $this = $(this);
+                const previewURL = build_url({{ url_for('event_layout.css_preview', event) | tojson }}, {
+                    theme: $this.val()
                 });
-                $(this).nextAll('.js-theme-preview-btn').attr('href', previewURL);
+                $this.nextAll('.js-theme-preview-btn').attr('href', previewURL);
+                updateViewStylesheet($this.val());
             }).trigger('change');
+
+            $('#use_custom_css').on('change', function () {
+                const useCustomCSS = $(this).prop('checked');
+                updateViewStylesheet(useCustomCSS ? '_custom' : $('#theme').val())
+            });
 
             function updateCustomCSS(hasFile) {
                 var useCustomCSS = $('#use_custom_css');


### PR DESCRIPTION
Closes #5239

This PR adds a link to the source CSS of the currently selected theme on the layout management form.

![image](https://user-images.githubusercontent.com/27357203/155115006-3c536fd8-8bd8-4740-9e78-ddd1fef086aa.png)
