### PR TITLE
Fix performance problem in HTTP API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Bugfixes
 - Fix error when exporting registrations to PDFs that contained certain invalid HTML-like
   sequences (:pr:`5233`)
 - Restore logical order of registration list columns (:pr:`5240`)
+- Fix a performance issue in the HTTP API when exporting events from a specific category
+  while specifying a limit (only affected large databases) (:pr:`5260`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -467,8 +467,8 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         from indico.modules.categories import Category
         if not isinstance(category_ids, (list, tuple, set)):
             category_ids = [category_ids]
-        cte = Category.get_tree_cte()
-        return (cte.c.id == Event.category_id) & cte.c.path.overlap(category_ids)
+        cte = Category.get_subtree_ids_cte(category_ids)
+        return cte.c.id == Event.category_id
 
     @classmethod
     def is_visible_in(cls, category_id):


### PR DESCRIPTION
This happened because when applying a limit Postgres started using a very inefficient query plan. By using a CTE that's only including the category subtree instead of everything we care about we avoid this problem altogether.