### PR TITLE
Fix a bug preventing cloning invited abstract on customize

### DIFF
--- a/indico/modules/events/abstracts/lists.py
+++ b/indico/modules/events/abstracts/lists.py
@@ -14,6 +14,7 @@ from indico.core.db import db
 from indico.modules.events.abstracts.models.abstracts import Abstract, AbstractState
 from indico.modules.events.abstracts.models.fields import AbstractFieldValue
 from indico.modules.events.abstracts.models.reviews import AbstractReview
+from indico.modules.events.abstracts.util import can_create_invited_abstracts
 from indico.modules.events.contributions.models.fields import ContributionField
 from indico.modules.events.tracks.models.tracks import Track
 from indico.modules.events.util import ListGeneratorBase
@@ -213,7 +214,8 @@ class AbstractListGeneratorBase(ListGeneratorBase):
         filter_statistics = tpl_lists.render_displayed_entries_fragment(len(list_kwargs['abstracts']),
                                                                         list_kwargs['total_abstracts'])
         return {
-            'html': tpl.render_abstract_list(**list_kwargs),
+            'html': tpl.render_abstract_list(**list_kwargs,
+                                             can_create_invited_abstracts=can_create_invited_abstracts(self.event)),
             'filtering_enabled': filtering_enabled,
             'filter_statistics': filter_statistics,
             'hide_abstract': abstract not in list_kwargs['abstracts'] if abstract else None


### PR DESCRIPTION
Can be reproduced by customizing the list of abstracts and trying to clone them into an invited abstract. Even if an email template is set up, it will incorrectly prevent it.

Introduced in #5217