### PR TITLE
Allow speaker-only menu entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Improvements
   customization page (:issue:`5239`, :pr:`5259`)
 - Add more powerful filters to "get next editable" and the list of editables
   (:issue:`5188`, :pr:`5224`, :pr:`5241`)
+- Add the ability to create speaker-only menu entries for conferences (:issue:`5261`,
+  :pr:`5268`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20220225_1335_ef7a8b2e6737_add_access_column_to_menu_entries.py
+++ b/indico/migrations/versions/20220225_1335_ef7a8b2e6737_add_access_column_to_menu_entries.py
@@ -1,4 +1,4 @@
-"""Add visibility options to menu entries
+"""Add access column to menu entries
 
 Revision ID: ef7a8b2e6737
 Revises: 3dafee32ba7d

--- a/indico/migrations/versions/20220225_1335_ef7a8b2e6737_add_visibility_options_to_menu_entries.py
+++ b/indico/migrations/versions/20220225_1335_ef7a8b2e6737_add_visibility_options_to_menu_entries.py
@@ -1,0 +1,44 @@
+"""Add visibility options to menu entries
+
+Revision ID: ef7a8b2e6737
+Revises: 3dafee32ba7d
+Create Date: 2022-02-25 13:35:15.089546
+"""
+
+from enum import Enum
+
+import sqlalchemy as sa
+from alembic import op
+
+from indico.core.db.sqlalchemy import PyIntEnum
+
+
+# revision identifiers, used by Alembic.
+revision = 'ef7a8b2e6737'
+down_revision = '82fb6c6ac6db'
+branch_labels = None
+depends_on = None
+
+
+class _MenuEntryAccess(int, Enum):
+    everyone = 1
+    registered_participants = 2
+    speakers = 3
+
+
+def upgrade():
+    op.add_column('menu_entries',
+                  sa.Column('access', PyIntEnum(_MenuEntryAccess), server_default='1', nullable=False),
+                  schema='events')
+    op.alter_column('menu_entries', 'access', server_default=None, schema='events')
+    op.execute('UPDATE events.menu_entries SET access = 2 WHERE registered_only')
+    op.drop_column('menu_entries', 'registered_only', schema='events')
+
+
+def downgrade():
+    op.add_column('menu_entries',
+                  sa.Column('registered_only', sa.Boolean(), server_default='false', nullable=False),
+                  schema='events')
+    op.alter_column('menu_entries', 'registered_only', server_default=None, schema='events')
+    op.execute('UPDATE events.menu_entries SET registered_only = true WHERE access > 1')
+    op.drop_column('menu_entries', 'access', schema='events')

--- a/indico/modules/events/layout/controllers/menu.py
+++ b/indico/modules/events/layout/controllers/menu.py
@@ -242,8 +242,7 @@ class RHPageDisplay(RHDisplayEventBase):
 
     def _check_access(self):
         RHDisplayEventBase._check_access(self)
-        if (self.page.menu_entry.registered_only and not self.event.is_user_registered(session.user)
-                and not self.event.can_manage(session.user)):
+        if not self.page.menu_entry.can_access(session.user):
             raise Forbidden
 
     def _process_args(self):

--- a/indico/modules/events/layout/forms.py
+++ b/indico/modules/events/layout/forms.py
@@ -11,11 +11,13 @@ from wtforms.validators import DataRequired, Optional, ValidationError
 
 from indico.core.config import config
 from indico.modules.events.layout import theme_settings
+from indico.modules.events.layout.models.menu import MenuEntryAccess
 from indico.modules.events.layout.util import get_css_file_data, get_logo_data, get_plugin_conference_themes
 from indico.modules.users import NameFormat
 from indico.util.i18n import _, orig_string
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.fields import EditableFileField, FileField, IndicoEnumSelectField
+from indico.web.forms.fields.enums import IndicoEnumRadioField
 from indico.web.forms.validators import HiddenUnless, UsedIf
 from indico.web.forms.widgets import CKEditorWidget, ColorPickerWidget, SwitchWidget
 
@@ -160,8 +162,8 @@ class MenuUserEntryFormBase(IndicoForm):
     title = StringField(_('Title'), [DataRequired()])
     is_enabled = BooleanField(_('Show'), widget=SwitchWidget())
     new_tab = BooleanField(_('Open in a new tab'), widget=SwitchWidget())
-    registered_only = BooleanField(_('Restricted'), widget=SwitchWidget(),
-                                   description=_('Visible to registered users only.'))
+    access = IndicoEnumRadioField(_('Visibility'), enum=MenuEntryAccess,
+                                  description=_('Select which group of people can see this entry.'))
 
 
 class MenuLinkForm(MenuUserEntryFormBase):

--- a/indico/modules/events/layout/forms.py
+++ b/indico/modules/events/layout/forms.py
@@ -163,7 +163,7 @@ class MenuUserEntryFormBase(IndicoForm):
     is_enabled = BooleanField(_('Show'), widget=SwitchWidget())
     new_tab = BooleanField(_('Open in a new tab'), widget=SwitchWidget())
     access = IndicoEnumRadioField(_('Visibility'), enum=MenuEntryAccess,
-                                  description=_('Select which group of people can see this entry.'))
+                                  description=_('Specify who can see this menu item.'))
 
 
 class MenuLinkForm(MenuUserEntryFormBase):

--- a/indico/modules/events/layout/models/menu.py
+++ b/indico/modules/events/layout/models/menu.py
@@ -176,15 +176,15 @@ class MenuEntryMixin:
         )
 
     def can_access(self, user):
-        if self.event_ref.can_manage(user):
-            return True
         if self.access == MenuEntryAccess.everyone:
             return True
-        if self.access == MenuEntryAccess.registered_participants:
+        elif self.event_ref.can_manage(user):
+            return True
+        elif self.access == MenuEntryAccess.registered_participants:
             return self.event_ref.is_user_registered(user)
-        if self.access == MenuEntryAccess.speakers:
+        elif self.access == MenuEntryAccess.speakers:
             return self.event_ref.is_user_speaker(user)
-        return True
+        assert False, 'should not happen'
 
 
 class TransientMenuEntry(MenuEntryMixin):

--- a/indico/modules/events/layout/models/menu_test.py
+++ b/indico/modules/events/layout/models/menu_test.py
@@ -1,0 +1,86 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from datetime import timedelta
+
+import pytest
+
+from indico.modules.events.contributions.models.persons import ContributionPersonLink, SubContributionPersonLink
+from indico.modules.events.contributions.models.subcontributions import SubContribution
+from indico.modules.events.features.util import set_feature_enabled
+from indico.modules.events.layout.models.menu import MenuEntry, MenuEntryAccess, MenuEntryType
+from indico.modules.events.models.persons import EventPerson
+
+
+pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
+
+
+def test_access_everyone(dummy_contribution, dummy_user, dummy_event):
+    menu_entry = MenuEntry(event=dummy_event, type=MenuEntryType.page, access=MenuEntryAccess.everyone)
+    person = EventPerson.create_from_user(dummy_user, dummy_event)
+    assert menu_entry.can_access(dummy_user)
+    contrib_person_link = ContributionPersonLink(person=person)
+    dummy_contribution.person_links.append(contrib_person_link)
+    assert menu_entry.can_access(dummy_user)
+    contrib_person_link.is_speaker = True
+    assert menu_entry.can_access(dummy_user)
+
+
+def test_access_participants_not_registered(dummy_contribution, dummy_user, dummy_event):
+    menu_entry = MenuEntry(event=dummy_event, type=MenuEntryType.page, access=MenuEntryAccess.registered_participants)
+    person = EventPerson.create_from_user(dummy_user, dummy_event)
+    assert not menu_entry.can_access(dummy_user)
+    contrib_person_link = ContributionPersonLink(person=person)
+    dummy_contribution.person_links.append(contrib_person_link)
+    assert not menu_entry.can_access(dummy_user)
+    contrib_person_link.is_speaker = True
+    assert not menu_entry.can_access(dummy_user)
+
+
+@pytest.mark.usefixtures('dummy_reg')
+def test_access_participants_registered(dummy_contribution, dummy_user, dummy_event):
+    set_feature_enabled(dummy_event, 'registration', True)
+    menu_entry = MenuEntry(event=dummy_event, type=MenuEntryType.page, access=MenuEntryAccess.registered_participants)
+    person = EventPerson.create_from_user(dummy_user, dummy_event)
+    assert menu_entry.can_access(dummy_user)
+    contrib_person_link = ContributionPersonLink(person=person)
+    dummy_contribution.person_links.append(contrib_person_link)
+    assert menu_entry.can_access(dummy_user)
+    contrib_person_link.is_speaker = True
+    assert menu_entry.can_access(dummy_user)
+
+
+@pytest.mark.usefixtures('dummy_reg')
+def test_access_speakers_contrib(dummy_contribution, dummy_user, dummy_event):
+    set_feature_enabled(dummy_event, 'registration', True)
+    menu_entry = MenuEntry(event=dummy_event, type=MenuEntryType.page, access=MenuEntryAccess.speakers)
+    person = EventPerson.create_from_user(dummy_user, dummy_event)
+    assert not menu_entry.can_access(dummy_user)
+    contrib_person_link = ContributionPersonLink(person=person)
+    dummy_contribution.person_links.append(contrib_person_link)
+    assert not menu_entry.can_access(dummy_user)
+    contrib_person_link.is_speaker = True
+    assert menu_entry.can_access(dummy_user)
+    dummy_contribution.is_deleted = True
+    assert not menu_entry.can_access(dummy_user)
+
+
+@pytest.mark.usefixtures('dummy_reg')
+def test_access_speakers_subcontrib(dummy_contribution, dummy_user, dummy_event):
+    set_feature_enabled(dummy_event, 'registration', True)
+    menu_entry = MenuEntry(event=dummy_event, type=MenuEntryType.page, access=MenuEntryAccess.speakers)
+    person = EventPerson.create_from_user(dummy_user, dummy_event)
+    assert not menu_entry.can_access(dummy_user)
+    subcontrib = SubContribution(contribution=dummy_contribution, title='sc', duration=timedelta(minutes=10))
+    subcontrib_person_link = SubContributionPersonLink(person=person)
+    subcontrib.person_links.append(subcontrib_person_link)
+    assert menu_entry.can_access(dummy_user)
+    dummy_contribution.is_deleted = True
+    assert not menu_entry.can_access(dummy_user)
+    dummy_contribution.is_deleted = False
+    subcontrib.is_deleted = True
+    assert not menu_entry.can_access(dummy_user)


### PR DESCRIPTION
Closes #5261

This PR adds the ability to create speaker-only menu entries for conferences.

![image](https://user-images.githubusercontent.com/27357203/155996549-96603816-ed37-43f5-872d-009e3369ea38.png)
