### PR TITLE
Add registration visibility override

### DIFF
--- a/indico/migrations/versions/20220318_1614_57696d76f9b0_add_registration_visibility_override.py
+++ b/indico/migrations/versions/20220318_1614_57696d76f9b0_add_registration_visibility_override.py
@@ -1,0 +1,27 @@
+"""Add registration visibility override
+
+Revision ID: 57696d76f9b0
+Revises: 5123f24eb41e
+Create Date: 2022-03-18 16:14:04.837722
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '57696d76f9b0'
+down_revision = '5123f24eb41e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('registrations',
+                  sa.Column('participant_hidden', sa.Boolean(), server_default='false', nullable=False),
+                  schema='event_registration')
+    op.alter_column('registrations', 'participant_hidden', server_default=None, schema='event_registration')
+
+
+def downgrade():
+    op.drop_column('registrations', 'participant_hidden', schema='event_registration')

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -71,6 +71,8 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:regi
                  'reject_registration', reglists.RHRegistrationReject, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/reset',
                  'reset_registration', reglists.RHRegistrationReset, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/hide',
+                 'hide_registration', reglists.RHRegistrationHide, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/withdraw',
                  'manage_withdraw_registration', reglists.RHRegistrationManageWithdraw, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/check-in',

--- a/indico/modules/events/registration/client/js/components/ConsentToPublishDropdown.jsx
+++ b/indico/modules/events/registration/client/js/components/ConsentToPublishDropdown.jsx
@@ -18,7 +18,6 @@ export default function ConsentToPublishDropdown({
   publishToParticipants,
   publishToPublic,
   value,
-  maximumConsentToPublish,
   useFinalForms,
   ...extraProps
 }) {
@@ -48,17 +47,12 @@ export default function ConsentToPublishDropdown({
         disabled: publishToParticipants !== 'show_with_consent',
       });
     }
-    if (maximumConsentToPublish !== 'nobody') {
-      options.push({
-        key: 'participants',
-        value: 'participants',
-        text: Translate.string('Display my participation only to other participants of this event'),
-      });
-    }
-    if (
-      maximumConsentToPublish === 'all' &&
-      (publishToPublic === 'show_with_consent' || value === 'all')
-    ) {
+    options.push({
+      key: 'participants',
+      value: 'participants',
+      text: Translate.string('Display my participation only to other participants of this event'),
+    });
+    if (publishToPublic === 'show_with_consent' || value === 'all') {
       options.push({
         key: 'all',
         value: 'all',
@@ -78,12 +72,10 @@ ConsentToPublishDropdown.propTypes = {
   publishToParticipants: publishModePropType.isRequired,
   publishToPublic: publishModePropType.isRequired,
   value: PropTypes.oneOf(['nobody', 'participants', 'all']),
-  maximumConsentToPublish: PropTypes.oneOf(['nobody', 'participants', 'all']),
   useFinalForms: PropTypes.bool,
 };
 
 ConsentToPublishDropdown.defaultProps = {
   value: null,
-  maximumConsentToPublish: 'all',
   useFinalForms: false,
 };

--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -53,14 +53,8 @@ function EmailNotification() {
   );
 }
 
-function ConsentToPublish({
-  publishToParticipants,
-  publishToPublic,
-  maximumConsentToPublish,
-  management,
-}) {
+function ConsentToPublish({publishToParticipants, publishToPublic}) {
   const isWarning = publishToParticipants === 'show_all' && publishToPublic === 'show_all';
-
   return (
     <Message info={!isWarning} warning={isWarning} style={{marginTop: 25}}>
       <Message.Header>
@@ -69,20 +63,15 @@ function ConsentToPublish({
       {(publishToParticipants === 'show_with_consent' ||
         publishToPublic === 'show_with_consent') && (
         <p>
-          {management
-            ? Translate.string(
-                "Modify the user's consent to being included in the event's list of participants"
-              )
-            : Translate.string(
-                "Specify whether you consent to being included in the event's list of participants"
-              )}
+          <Translate>
+            Specify whether you consent to being included in the event's list of participants
+          </Translate>
         </p>
       )}
       <ConsentToPublishDropdown
         name="consent_to_publish"
         publishToParticipants={publishToParticipants}
         publishToPublic={publishToPublic}
-        maximumConsentToPublish={maximumConsentToPublish}
         useFinalForms
       />
     </Message>
@@ -92,8 +81,6 @@ function ConsentToPublish({
 ConsentToPublish.propTypes = {
   publishToParticipants: PropTypes.oneOf(['hide_all', 'show_with_consent', 'show_all']).isRequired,
   publishToPublic: PropTypes.oneOf(['hide_all', 'show_with_consent', 'show_all']).isRequired,
-  maximumConsentToPublish: PropTypes.oneOf(['nobody', 'participants', 'all']).isRequired,
-  management: PropTypes.bool.isRequired,
 };
 
 export default function RegistrationFormSubmission() {
@@ -104,11 +91,7 @@ export default function RegistrationFormSubmission() {
   const isManagement = useSelector(getManagement);
   const publishToParticipants = useSelector(getPublishToParticipants);
   const publishToPublic = useSelector(getPublishToPublic);
-  const showConsentToPublish = isManagement
-    ? isUpdateMode &&
-      registrationData.consent_to_publish !== 'nobody' &&
-      (publishToParticipants === 'show_with_consent' || publishToPublic === 'show_with_consent')
-    : publishToParticipants !== 'hide_all';
+  const showConsentToPublish = !isManagement && publishToParticipants !== 'hide_all';
 
   const onSubmit = async (data, form) => {
     let resp;
@@ -144,8 +127,6 @@ export default function RegistrationFormSubmission() {
               <ConsentToPublish
                 publishToParticipants={publishToParticipants}
                 publishToPublic={publishToPublic}
-                maximumConsentToPublish={isManagement ? registrationData.consent_to_publish : 'all'}
-                management={isManagement}
               />
             )}
             <FinalSubmitButton

--- a/indico/modules/events/registration/client/js/form_submission/index.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/index.jsx
@@ -45,10 +45,7 @@ export default function setupRegformSubmission(root) {
       initialValues: JSON.parse(initialValues),
       submitUrl,
       registrationData: registrationData
-        ? {
-            ...JSON.parse(registrationData),
-            consent_to_publish: consentToPublish,
-          }
+        ? {...JSON.parse(registrationData), consent_to_publish: consentToPublish}
         : {},
       registrationUuid,
       fileData: fileData ? JSON.parse(fileData) : {},

--- a/indico/modules/events/registration/client/js/form_submission/index.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/index.jsx
@@ -45,7 +45,10 @@ export default function setupRegformSubmission(root) {
       initialValues: JSON.parse(initialValues),
       submitUrl,
       registrationData: registrationData
-        ? {...JSON.parse(registrationData), consent_to_publish: consentToPublish}
+        ? {
+            ...JSON.parse(registrationData),
+            consent_to_publish: consentToPublish,
+          }
         : {},
       registrationUuid,
       fileData: fileData ? JSON.parse(fileData) : {},

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -22,8 +22,7 @@ from indico.modules.events.registration.controllers import RegistrationEditMixin
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.invitations import InvitationState, RegistrationInvitation
 from indico.modules.events.registration.models.items import PersonalDataType
-from indico.modules.events.registration.models.registrations import (PublishRegistrationsMode, Registration,
-                                                                     RegistrationState)
+from indico.modules.events.registration.models.registrations import Registration, RegistrationState
 from indico.modules.events.registration.util import (check_registration_email, create_registration, generate_ticket,
                                                      get_event_regforms_registrations, get_event_section_data,
                                                      get_flat_section_submission_data, get_initial_form_values,
@@ -216,8 +215,9 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
             # There might be forms that have not been sorted by the user yet
             tables.extend(map(self._participant_list_table, regforms_dict.values()))
 
+        is_participant = self.event.is_user_registered(session.user)
         published = (RegistrationForm.query.with_parent(self.event)
-                     .filter(RegistrationForm.publish_registrations_public != PublishRegistrationsMode.hide_all)
+                     .filter(RegistrationForm.registrations.any(Registration.is_publishable(is_participant)))
                      .has_rows())
         num_participants = sum(table['num_participants'] for table in tables)
 

--- a/indico/modules/events/registration/controllers/management/privacy.py
+++ b/indico/modules/events/registration/controllers/management/privacy.py
@@ -13,7 +13,7 @@ from indico.core.db import db
 from indico.modules.events.registration.controllers.display import RHRegistrationFormRegistrationBase
 from indico.modules.events.registration.controllers.management import RHManageRegFormBase
 from indico.modules.events.registration.forms import RegistrationPrivacyForm
-from indico.modules.events.registration.models.registrations import PublishConsentType, PublishRegistrationsMode
+from indico.modules.events.registration.models.registrations import PublishRegistrationsMode, RegistrationVisibility
 from indico.modules.events.registration.views import WPManageRegistration
 from indico.util.i18n import _
 from indico.web.args import use_kwargs
@@ -43,7 +43,7 @@ class RHRegistrationPrivacy(RHManageRegFormBase):
 class RHAPIRegistrationChangeConsent(RHRegistrationFormRegistrationBase):
     """Internal API to change registration consent to publish."""
 
-    @use_kwargs({'consent_to_publish': EnumField(PublishConsentType)})
+    @use_kwargs({'consent_to_publish': EnumField(RegistrationVisibility)})
     def _process_POST(self, consent_to_publish):
         self.registration.consent_to_publish = consent_to_publish
         return '', 204

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -593,6 +593,14 @@ class RHRegistrationReset(RHManageRegistrationBase):
         return jsonify_data(html=_render_registration_details(self.registration))
 
 
+class RHRegistrationHide(RHManageRegistrationBase):
+    """Hide a registration from the participants lists."""
+
+    def _process(self):
+        self.registration.participant_hidden = not self.registration.participant_hidden
+        return jsonify_data(html=_render_registration_details(self.registration))
+
+
 class RHRegistrationManageWithdraw(RHManageRegistrationBase):
     """Let a manager withdraw a registration."""
 

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -60,7 +60,6 @@ class RegistrationListGenerator(ListGeneratorBase):
             },
             'visibility': {
                 'title': _('Visibility'),
-                'filter_choices': {str(visibility.value): visibility.title for visibility in RegistrationVisibility}
             },
             'consent_to_publish': {
                 'title': _('Consent to publish'),
@@ -179,10 +178,6 @@ class RegistrationListGenerator(ListGeneratorBase):
         if 'state' in filters['items']:
             states = [RegistrationState(int(state)) for state in filters['items']['state']]
             items_criteria.append(Registration.state.in_(states))
-
-        if 'visibility' in filters['items']:
-            states = [RegistrationVisibility(int(visibility)) for visibility in filters['items']['visibility']]
-            items_criteria.append(Registration.visibility.in_(states))
 
         if 'consent_to_publish' in filters['items']:
             states = [RegistrationVisibility(int(visibility)) for visibility in filters['items']['consent_to_publish']]

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -11,7 +11,8 @@ from sqlalchemy.orm import joinedload
 from indico.core.db import db
 from indico.modules.events.registration.models.form_fields import RegistrationFormFieldData
 from indico.modules.events.registration.models.items import PersonalDataType, RegistrationFormItem
-from indico.modules.events.registration.models.registrations import Registration, RegistrationData, RegistrationState
+from indico.modules.events.registration.models.registrations import (Registration, RegistrationData, RegistrationState,
+                                                                     RegistrationVisibility)
 from indico.modules.events.registration.models.tags import RegistrationTag
 from indico.modules.events.util import ListGeneratorBase
 from indico.util.i18n import _
@@ -59,6 +60,18 @@ class RegistrationListGenerator(ListGeneratorBase):
             },
             'visibility': {
                 'title': _('Visibility'),
+                'filter_choices': {str(visibility.value): visibility.title for visibility in RegistrationVisibility}
+            },
+            'consent_to_publish': {
+                'title': _('Consent to publish'),
+                'filter_choices': {str(visibility.value): visibility.title for visibility in RegistrationVisibility}
+            },
+            'participant_hidden': {
+                'title': _('Participant hidden'),
+                'filter_choices': {
+                    '0': _('No'),
+                    '1': _('Yes')
+                }
             },
             'tags_present': {
                 'title': _('Tags'),
@@ -166,6 +179,20 @@ class RegistrationListGenerator(ListGeneratorBase):
         if 'state' in filters['items']:
             states = [RegistrationState(int(state)) for state in filters['items']['state']]
             items_criteria.append(Registration.state.in_(states))
+
+        if 'visibility' in filters['items']:
+            states = [RegistrationVisibility(int(visibility)) for visibility in filters['items']['visibility']]
+            items_criteria.append(Registration.visibility.in_(states))
+
+        if 'consent_to_publish' in filters['items']:
+            states = [RegistrationVisibility(int(visibility)) for visibility in filters['items']['consent_to_publish']]
+            items_criteria.append(Registration.consent_to_publish.in_(states))
+
+        if 'participant_hidden' in filters['items']:
+            participant_hidden_values = filters['items']['participant_hidden']
+            # If both values 'true' and 'false' are selected, there's no point in filtering
+            if len(participant_hidden_values) == 1:
+                items_criteria.append(Registration.participant_hidden == bool(int(participant_hidden_values[0])))
 
         if 'tags_present' in filters['items']:
             tag_ids = [int(tag_id) for tag_id in filters['items']['tags_present']]

--- a/indico/modules/events/registration/privacy_test.py
+++ b/indico/modules/events/registration/privacy_test.py
@@ -21,7 +21,6 @@ def assert_visibility(reg, visibility, test_visibility_prop=True):
 
     if test_visibility_prop:
         assert reg.visibility == visibility
-        assert Registration.query.with_parent(reg.event).filter(Registration.visibility == visibility).has_rows()
     if visibility == RegistrationVisibility.nobody:
         assert not reg.is_publishable(True)
         assert not reg.is_publishable(False)

--- a/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
+++ b/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
@@ -25,7 +25,32 @@
         <th class="regform-done-caption">{% trans %}Visibility{% endtrans %}</th>
         <td class="regform-done-data">
             {% if from_management %}
-                {{ registration.visibility.title }}
+                <div class="regform-participant-visibility">
+                    {% if registration.visibility == registration.visibility_before_override %}
+                        <div>{{ registration.visibility_before_override.title }}</div>
+                    {% else %}
+                        <div class="old-visibility">{{ registration.visibility_before_override.title }}</div>
+                        <div>{{ registration.visibility.title }}</div>
+                    {% endif %}
+                    {% set tooltip_text -%}
+                        {%- if registration.participant_hidden -%}
+                            {% trans %}This will restore this participant's visibility based on the form's settings{% endtrans %}
+                        {%- else -%}
+                            {% trans %}This will hide this participant from the list of participants regardless of other settings{% endtrans %}
+                        {%- endif -%}
+                    {%- endset %}
+                    <a class="i-button {% if registration.participant_hidden %}icon-eye{% else %}icon-eye-blocked{% endif %}"
+                       data-update="#registration-details"
+                       data-method="POST"
+                       data-href="{{ url_for('.hide_registration', registration) }}"
+                       title="{{ tooltip_text }}">
+                        {%- if registration.participant_hidden -%}
+                            {% trans %}Show participant{% endtrans %}
+                        {%- else -%}
+                            {% trans %}Hide participant{% endtrans %}
+                        {%- endif -%}
+                    </a>
+                </div>
             {% else %}
                 <div id="registration-summary-consent-to-publish"
                      data-locator="{{ registration.locator.registrant|tojson|forceescape }}"

--- a/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
+++ b/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
@@ -25,7 +25,7 @@
         <th class="regform-done-caption">{% trans %}Visibility{% endtrans %}</th>
         <td class="regform-done-data">
             {% if from_management %}
-                {{ registration.consent_to_publish.title }}
+                {{ registration.visibility.title }}
             {% else %}
                 <div id="registration-summary-consent-to-publish"
                      data-locator="{{ registration.locator.registrant|tojson|forceescape }}"

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -86,8 +86,20 @@
                                             {% endfor %}
                                         </td>
                                     {% elif item.id == 'visibility' %}
+                                        <td class="i-table" data-text="{{ registration.visibility }}">
+                                            {{ registration.visibility.title }}
+                                        </td>
+                                    {% elif item.id == 'consent_to_publish' %}
                                         <td class="i-table" data-text="{{ registration.consent_to_publish }}">
                                             {{ registration.consent_to_publish.title }}
+                                        </td>
+                                    {% elif item.id == 'participant_hidden' %}
+                                        <td class="i-table" data-text="{{ registration.participant_hidden }}">
+                                            {% if registration.participant_hidden %}
+                                                {%- trans %}Yes{% endtrans -%}
+                                            {% else %}
+                                                {%- trans %}No{% endtrans -%}
+                                            {% endif %}
                                         </td>
                                     {% else %}
                                         <td class="i-table">{{ data[item.id].friendly_data if item.id in data }}</td>

--- a/indico/web/client/styles/modules/_registrationform.scss
+++ b/indico/web/client/styles/modules/_registrationform.scss
@@ -255,6 +255,22 @@
   .regform-done-data {
     padding: 0 0 0 5px;
     vertical-align: top;
+
+    .regform-participant-visibility {
+      display: flex;
+      align-items: center;
+      gap: 0.5em;
+      margin: 2px 0;
+
+      .old-visibility {
+        color: $light-black;
+        text-decoration: line-through;
+      }
+
+      .i-button {
+        margin-left: auto;
+      }
+    }
   }
 
   .regform-done-table-title {


### PR DESCRIPTION
This PR adds a manual override for the visibility of each registration, set by the event's manager.

This PR includes:
- A new visibility override attribute on registrations.
- Unit tests for the new attribute.
- Hide participant button on registration summary: 
![screenshot](https://user-images.githubusercontent.com/27357203/158421454-6e7507fb-c6d5-4716-993d-8a7874360f06.png)


