### PR TITLE
Add plugin extension points to new react registration form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,7 +38,9 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 
 - Add new ``regform-container-attrs`` template hook to pass additional (data-)attributes
-  to the React registration form containers
+  to the React registration form containers (:pr:`5271`)
+- Add support for JavaScript plugin hooks to register objects or react components for use
+  by JS code that's in the core (:pr:`5271`)
 
 
 ----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,7 +37,8 @@ Bugfixes
 Internal Changes
 ^^^^^^^^^^^^^^^^
 
-- Nothing so far
+- Add new ``regform-container-attrs`` template hook to pass additional (data-)attributes
+  to the React registration form containers
 
 
 ----

--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -20,6 +20,7 @@ import {
 } from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
+import {getPluginObjects, renderPluginComponents} from 'indico/utils/plugins';
 
 import ConsentToPublishDropdown from '../components/ConsentToPublishDropdown';
 import FormSection from '../form/FormSection';
@@ -111,8 +112,9 @@ export default function RegistrationFormSubmission() {
 
   const onSubmit = async (data, form) => {
     let resp;
+    const formData = isUpdateMode ? getChangedValues(data, form) : data;
     try {
-      resp = await indicoAxios.post(submitUrl, isUpdateMode ? getChangedValues(data, form) : data);
+      resp = await indicoAxios.post(submitUrl, formData);
     } catch (err) {
       return handleSubmitError(err);
     }
@@ -128,12 +130,14 @@ export default function RegistrationFormSubmission() {
       initialValues={isUpdateMode ? registrationData : initialValues}
       initialValuesEqual={_.isEqual}
       subscription={{}}
+      decorators={getPluginObjects('regformFormDecorators')}
     >
       {fprops => (
         <form onSubmit={fprops.handleSubmit}>
           {sections.map(section => (
             <FormSection key={section.id} {...section} />
           ))}
+          {renderPluginComponents('regformAfterSections')}
           <div>
             {isManagement && <EmailNotification />}
             {showConsentToPublish && (

--- a/indico/modules/events/registration/client/js/form_submission/index.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/index.jsx
@@ -32,6 +32,7 @@ export default function setupRegformSubmission(root) {
     publishToParticipants,
     publishToPublic,
     consentToPublish = null,
+    ...extraData
   } = root.dataset;
 
   const initialData = {
@@ -51,6 +52,10 @@ export default function setupRegformSubmission(root) {
       currency,
       publishToParticipants,
       publishToPublic,
+      // XXX: do NOT use extraData for anything in the core; this is solely meant as a way to
+      // pass data to plugins injecting custom stuff in the registration form. if you add
+      // something in the core, handle it properly above!
+      extraData,
     },
   };
   const store = createReduxStore('regform-submission', reducers, initialData);

--- a/indico/modules/events/registration/templates/_template_hooks.html
+++ b/indico/modules/events/registration/templates/_template_hooks.html
@@ -1,0 +1,6 @@
+{%- macro regform_attrs_template_hook(event, regform, management, registration=none) -%}
+    {% for attrs in template_hook('regform-container-attrs', as_list=true, event=event, regform=regform,
+                                  management=management, registration=registration) %}
+        {{ attrs | html_params }}
+    {% endfor %}
+{%- endmacro -%}

--- a/indico/modules/events/registration/templates/display/regform_display.html
+++ b/indico/modules/events/registration/templates/display/regform_display.html
@@ -6,6 +6,7 @@
     {% extends 'events/registration/display/_meeting_registration_base.html' %}
 {% endif %}
 
+{% from 'events/registration/_template_hooks.html' import regform_attrs_template_hook %}
 {% from 'events/registration/display/_regform_invitation_info.html' import render_invitation_info %}
 {% from 'events/registration/display/_regform_info.html' import render_regform_info %}
 {% from 'message_box.html' import message_box %}
@@ -120,7 +121,9 @@
              data-moderated="{{ moderated | tojson | forceescape }}"
              data-publish-to-participants="{{ regform.publish_registrations_participants.name }}"
              data-publish-to-public="{{ regform.publish_registrations_public.name }}"
-             {% if registration %}data-consent-to-publish="{{ registration.consent_to_publish.name }}"{% endif %}></div>
+             {% if registration %}data-consent-to-publish="{{ registration.consent_to_publish.name }}"{% endif %}
+             {{ regform_attrs_template_hook(event, regform, management) }}
+        ></div>
 
         <hr>
         <h1>Warning, angular 💩 below</h1>

--- a/indico/modules/events/registration/templates/display/registration_modify.html
+++ b/indico/modules/events/registration/templates/display/registration_modify.html
@@ -4,6 +4,7 @@
     {% extends 'events/registration/display/_meeting_registration_base.html' %}
 {% endif %}
 
+{% from 'events/registration/_template_hooks.html' import regform_attrs_template_hook %}
 {% from 'message_box.html' import message_box %}
 
 {% block title %}
@@ -28,7 +29,9 @@
          data-paid="{{ paid | tojson | forceescape }}"
          data-publish-to-participants="{{ regform.publish_registrations_participants.name }}"
          data-publish-to-public="{{ regform.publish_registrations_public.name }}"
-         data-consent-to-publish="{{ registration.consent_to_publish.name }}"></div>
+         data-consent-to-publish="{{ registration.consent_to_publish.name }}"
+         {{ regform_attrs_template_hook(event, registration.registration_form, false, registration) }}
+    ></div>
 
     <hr>
     <h1>Warning, angular 💩 below</h1>
@@ -65,6 +68,7 @@
         {{ template_hook('after-regform', event=event, regform=registration.registration_form,
                          registration=registration, management=false) }}
     {% else %}
+        {# TODO remove this - the endpoint rendering this template no longer allows access unless editing is allowed #}
         {% call message_box('error') %}
             {% if not registration.registration_form.is_modification_open -%}
                 {% trans %}The modification period is over{% endtrans %}

--- a/indico/modules/events/registration/templates/management/registration_modify.html
+++ b/indico/modules/events/registration/templates/management/registration_modify.html
@@ -1,5 +1,7 @@
 {% extends 'events/registration/management/_regform_base.html' %}
 
+{% from 'events/registration/_template_hooks.html' import regform_attrs_template_hook %}
+
 {% block subtitle %}
     {% trans id=registration.friendly_id, name=registration.full_name, regform_title=registration.registration_form.title -%}
         Modify #{{ id }}: {{ name }} in "{{ regform_title }}"
@@ -20,7 +22,9 @@
          data-paid="{{ paid | tojson | forceescape }}"
          data-publish-to-participants="{{ regform.publish_registrations_participants.name }}"
          data-publish-to-public="{{ regform.publish_registrations_public.name }}"
-         data-consent-to-publish="{{ registration.consent_to_publish.name }}"></div>
+         data-consent-to-publish="{{ registration.consent_to_publish.name }}"
+         {{ regform_attrs_template_hook(event, regform, true, registration) }}
+    ></div>
 
     <hr>
     <h1>Warning, angular 💩 below</h1>

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -275,12 +275,16 @@ def check_registration_email(regform, email, registration=None, management=False
             return dict(status='ok', user=None)
 
 
+class RegistrationSchemaBase(IndicoSchema):
+    # note: this schema is kept outside `make_registration_schema` so plugins can use it in
+    # subclass checks when using signals such as `schema_post_load`
+    class Meta:
+        unknown = RAISE
+
+
 def make_registration_schema(regform, management=False, registration=None):
     """Dynamically create a Marshmallow schema based on the registration form fields."""
-    class RegistrationSchema(IndicoSchema):
-        class Meta:
-            unknown = RAISE
-
+    class RegistrationSchema(RegistrationSchemaBase):
         @validates('email')
         def validate_email(self, email, **kwargs):
             status = check_registration_email(regform, email, registration, management=management)
@@ -303,7 +307,7 @@ def make_registration_schema(regform, management=False, registration=None):
 
     # TODO: what to do with signal -> signals.event.registration_form_wtform_created
 
-    return RegistrationSchema.from_dict(schema)
+    return RegistrationSchema.from_dict(schema, name='RegistrationSchema')
 
 
 def create_personal_data_fields(regform):

--- a/indico/util/marshmallow.py
+++ b/indico/util/marshmallow.py
@@ -37,7 +37,9 @@ def validate_with_message(fn, reason):
 
     def validate(args):
         if not fn(args):
-            raise ValidationError(reason)
+            # cast to str since ValidationError only wraps the message in a list
+            # if it's a string, but the babel lazy i18n string isn't a string
+            raise ValidationError(str(reason))
 
     return validate
 

--- a/indico/web/client/js/exports.js
+++ b/indico/web/client/js/exports.js
@@ -5,12 +5,17 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import * as FinalForm from 'final-form';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import * as ReactDom from 'react-dom';
+import * as ReactFinalForm from 'react-final-form';
 import * as ReactRedux from 'react-redux';
 import * as Redux from 'redux';
 import * as SUIR from 'semantic-ui-react';
+
+import * as IndicoReactComponents from 'indico/react/components';
+import * as IndicoUtilsDate from 'indico/utils/date';
 
 // exports for plugins
 window._IndicoCoreReact = React;
@@ -19,3 +24,7 @@ window._IndicoCorePropTypes = PropTypes;
 window._IndicoCoreReactRedux = ReactRedux;
 window._IndicoCoreRedux = Redux;
 window._IndicoCoreSUIR = SUIR;
+window._IndicoCoreReactFinalForm = ReactFinalForm;
+window._IndicoCoreFinalForm = FinalForm;
+window._IndicoReactComponents = IndicoReactComponents;
+window._IndicoUtilsDate = IndicoUtilsDate;

--- a/indico/web/client/js/exports.js
+++ b/indico/web/client/js/exports.js
@@ -16,6 +16,7 @@ import * as SUIR from 'semantic-ui-react';
 
 import * as IndicoReactComponents from 'indico/react/components';
 import * as IndicoUtilsDate from 'indico/utils/date';
+import * as IndicoUtilsPlugins from 'indico/utils/plugins';
 
 // exports for plugins
 window._IndicoCoreReact = React;
@@ -28,3 +29,4 @@ window._IndicoCoreReactFinalForm = ReactFinalForm;
 window._IndicoCoreFinalForm = FinalForm;
 window._IndicoReactComponents = IndicoReactComponents;
 window._IndicoUtilsDate = IndicoUtilsDate;
+window._IndicoUtilsPlugins = IndicoUtilsPlugins;

--- a/indico/web/client/js/utils/__tests__/plugins.spec.jsx
+++ b/indico/web/client/js/utils/__tests__/plugins.spec.jsx
@@ -1,0 +1,96 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2022 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import {mount} from 'enzyme';
+import React from 'react';
+
+import {
+  registerPluginObject,
+  getPluginObjects,
+  registerPluginComponent,
+  renderPluginComponents,
+  registries,
+} from '../plugins';
+
+afterEach(() => {
+  registries.clear();
+});
+
+describe('Plugin object registry', () => {
+  it('works with nothing registered', () => {
+    expect(getPluginObjects('foo')).toEqual([]);
+    expect(getPluginObjects('foo', true)).toEqual([]);
+  });
+
+  it('registers an object and retrieves it', () => {
+    const plugin = 'bar';
+    const object = {hello: 'world'};
+    registerPluginObject(plugin, 'foo', object);
+    expect(getPluginObjects('foo')).toEqual([object]);
+    expect(getPluginObjects('foo', true)).toEqual([{plugin, object}]);
+  });
+
+  it('returns multiple objects', () => {
+    const plugin = 'bar';
+    registerPluginObject(plugin, 'foo', 1);
+    registerPluginObject(plugin, 'foo', 2);
+    expect(getPluginObjects('foo')).toEqual([1, 2]);
+    expect(getPluginObjects('foo', true)).toEqual([{plugin, object: 1}, {plugin, object: 2}]);
+  });
+});
+
+describe('Plugin component registry', () => {
+  it('works with nothing registered', () => {
+    expect(renderPluginComponents('foo')).toEqual([]);
+    expect(renderPluginComponents('foo', true)).toEqual([]);
+  });
+
+  it('register a component and renders it', () => {
+    const plugin = 'bar';
+    const MyComponent = () => `test`;
+    const MyOtherComponent = () => `asdf`;
+    registerPluginComponent(plugin, 'foo', MyComponent);
+    // single component
+    let mounted = mount(<div>{renderPluginComponents('foo')}</div>);
+    expect(mounted.children().props()).toEqual({});
+    // same component twice
+    registerPluginComponent(plugin, 'foo', MyComponent);
+    mounted = mount(<div>{renderPluginComponents('foo')}</div>);
+    expect(mounted.children().map(c => c.props())).toEqual([{}, {}]);
+    // another component
+    registerPluginComponent(plugin, 'foo', MyOtherComponent);
+    mounted = mount(<div>{renderPluginComponents('foo')}</div>);
+    expect(mounted.children().map(c => c.name())).toEqual([
+      'MyComponent',
+      'MyComponent',
+      'MyOtherComponent',
+    ]);
+    expect(mounted.children().map(c => c.props())).toEqual([{}, {}, {}]);
+    expect(mounted.children().map(c => c.text())).toEqual(['test', 'test', 'asdf']);
+  });
+
+  it('passes props provided during registration and execution time', () => {
+    const plugin = 'bar';
+    const MyComponent = () => `test`;
+    const MyOtherComponent = () => `asdf`;
+    registerPluginComponent(plugin, 'foo', MyComponent);
+    // single component
+    let mounted = mount(<div>{renderPluginComponents('foo')}</div>);
+    expect(mounted.children().props()).toEqual({});
+    // another component
+    registerPluginComponent(plugin, 'foo', MyOtherComponent, {reg: 'foo', other: 'bar'});
+    mounted = mount(<div>{renderPluginComponents('foo')}</div>);
+    expect(mounted.children().map(c => c.props())).toEqual([{}, {reg: 'foo', other: 'bar'}]);
+    // same prop in both places -> the one during registration wins
+    mounted = mount(<div>{renderPluginComponents('foo', {other: 'test'})}</div>);
+    expect(mounted.children().map(c => c.props())).toEqual([
+      {other: 'test'},
+      {reg: 'foo', other: 'bar'},
+    ]);
+    expect(mounted.children().map(c => c.text())).toEqual(['test', 'asdf']);
+  });
+});

--- a/indico/web/client/js/utils/plugins.jsx
+++ b/indico/web/client/js/utils/plugins.jsx
@@ -1,0 +1,66 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2022 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import React from 'react';
+
+const registries = new Map();
+
+function getRegistry(name, create = false) {
+  let registry = registries.get(name);
+  if (registry === undefined) {
+    registry = [];
+    if (create) {
+      registries.set(name, registry);
+    }
+  }
+  return registry;
+}
+
+/**
+ * Register an object for an entry point.
+ * @param {string} plugin - the name of the plugin
+ * @param {string} entryPoint - the name of the entry point
+ * @param object - the object to register; can be whatever the entry point expects
+ */
+export function registerPluginObject(plugin, entryPoint, object) {
+  const registry = getRegistry(entryPoint, true);
+  registry.push({plugin, object});
+}
+
+/**
+ * Return the list of objects registered for an entry point.
+ * @param {string} entryPoint - the name of the entry point
+ * @param {boolean} verbose - whether to return the entries with all metadata or just the objects
+ */
+export function getPluginObjects(entryPoint, verbose = false) {
+  const registry = getRegistry(entryPoint);
+  return verbose ? registry : registry.map(entry => entry.object);
+}
+
+/**
+ * Register a react component for an entry point.
+ * @param {string} plugin - the name of the plugin
+ * @param {string} entryPoint - the name of the entry point
+ * @param component - the react component
+ * @param props - props that will be passed to the component when rendering it
+ */
+export function registerPluginComponent(plugin, entryPoint, component, props = {}) {
+  registerPluginObject(plugin, entryPoint, {component, props});
+}
+
+/**
+ * Render react components for an entry point.
+ * @param {string} entryPoint - the name of the entry point
+ * @param props - props that will be passed to the component when rendering it
+ */
+export function renderPluginComponents(entryPoint, props) {
+  const entries = getPluginObjects(entryPoint, true);
+  return entries.map(({plugin, object: {component: Component, props: pluginProps}}, i) => (
+    // eslint-disable-next-line react/no-array-index-key
+    <Component key={`${entryPoint}-${plugin}-${i}`} {...props} {...pluginProps} />
+  ));
+}

--- a/indico/web/client/js/utils/plugins.jsx
+++ b/indico/web/client/js/utils/plugins.jsx
@@ -7,7 +7,7 @@
 
 import React from 'react';
 
-const registries = new Map();
+export const registries = new Map();
 
 function getRegistry(name, create = false) {
   let registry = registries.get(name);

--- a/plugin.webpack.config.js
+++ b/plugin.webpack.config.js
@@ -48,12 +48,16 @@ module.exports = env => {
     entry,
     externals: {
       'jquery': 'jQuery',
+      'moment': 'moment',
       'react': '_IndicoCoreReact',
       'react-dom': '_IndicoCoreReactDom',
       'react-redux': '_IndicoCoreReactRedux',
       'prop-types': '_IndicoCorePropTypes',
       'redux': '_IndicoCoreRedux',
       'semantic-ui-react': '_IndicoCoreSUIR',
+      'react-final-form': '_IndicoCoreReactFinalForm',
+      'indico/react/components': '_IndicoReactComponents',
+      'indico/utils/date': '_IndicoUtilsDate',
     },
     module: {
       rules: [

--- a/plugin.webpack.config.js
+++ b/plugin.webpack.config.js
@@ -58,6 +58,7 @@ module.exports = env => {
       'react-final-form': '_IndicoCoreReactFinalForm',
       'indico/react/components': '_IndicoReactComponents',
       'indico/utils/date': '_IndicoUtilsDate',
+      'indico/utils/plugins': '_IndicoUtilsPlugins',
     },
     module: {
       rules: [


### PR DESCRIPTION
Still need to come up with a nicer API to register plugin components; the global variable was just a dirty way to test things.