### PR TITLE
Fix missing invitation data when user not logged in

### DIFF
--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -156,10 +156,10 @@ def get_initial_form_values(regform, *, management=False):
 
 def get_user_data(regform, user, invitation=None):
     if user is None:
-        return {}
-
-    user_data = {t.name: getattr(user, t.name, None) for t in PersonalDataType
-                 if t.name != 'title' and getattr(user, t.name, None)}
+        user_data = {}
+    else:
+        user_data = {t.name: getattr(user, t.name, None) for t in PersonalDataType
+                     if t.name != 'title' and getattr(user, t.name, None)}
     if invitation:
         user_data.update((attr, getattr(invitation, attr)) for attr in ('first_name', 'last_name', 'email'))
         if invitation.affiliation:

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -653,6 +653,11 @@ def test_get_user_data(monkeypatch, dummy_event, dummy_user, dummy_regform):
     assert user_data == {'email': 'awang@example.com', 'first_name': 'Amy', 'last_name': 'Wang',
                          'phone': '+1 22 50 14', 'address': 'Geneva', 'affiliation': 'ACME Inc.'}
 
+    # Check that data is taken from the invitation when user is missing
+    user_data = get_user_data(dummy_regform, None, invitation)
+    assert user_data == {'email': 'awang@example.com', 'first_name': 'Amy', 'last_name': 'Wang',
+                         'affiliation': 'ACME Inc.'}
+
     # Check that data from disabled/deleted fields is not used
     title_field = next(item for item in dummy_regform.active_fields
                        if item.type == RegistrationFormItemType.field_pd and item.personal_data_type.name == 'title')


### PR DESCRIPTION
Fixes a bug when the data from an invitation were not prefilled in
the registration if the user was not logged in.
