### PR TITLE
Add hard wrapping to map URL in event settings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Bugfixes
   while specifying a limit (only affected large databases) (:pr:`5260`)
 - Correctly specify charset in iCalendar files attached to emails (:issue:`5228`,
   :pr:`5258`, thanks :user:`imranyusuff`)
+- Fix very long map URLs breaking out of the event management settings box (:pr:`5275`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/management/templates/_settings.html
+++ b/indico/modules/events/management/templates/_settings.html
@@ -113,7 +113,7 @@
             <dd>{{ with_default(event.address|replace('\n', '<br>'|safe)) }}</dd>
 
             <dt>{% trans %}Map URL{% endtrans %}</dt>
-            <dd>{{ with_default(event.map_url) }}</dd>
+            <dd class="break-word">{{ with_default(event.map_url) }}</dd>
         </dl>
     {% endcall %}
 

--- a/indico/web/client/styles/modules/_event_management.scss
+++ b/indico/web/client/styles/modules/_event_management.scss
@@ -601,6 +601,10 @@ th.i-table {
       color: $dark-gray !important;
     }
 
+    .text {
+      width: 80%;
+    }
+
     .text,
     .toolbar {
       align-self: flex-start;
@@ -623,6 +627,10 @@ th.i-table {
       &:not(:last-of-type) {
         margin-bottom: 0.3em;
       }
+    }
+
+    .break-word {
+      word-wrap: break-word;
     }
 
     dd {


### PR DESCRIPTION
This PR fixes very long map URLs from breaking out of the settings box in event management.

Before:

![image](https://user-images.githubusercontent.com/6058151/157253803-9e3a0b42-d724-4e0e-b71e-41ae5ceb29fc.png)

After:

![image](https://user-images.githubusercontent.com/6058151/157253717-7a02e86f-9495-4504-8a58-281af2e39fe3.png)
