### PR TITLE
Fix evaluation of available page width & height

### DIFF
--- a/indico/modules/events/registration/badges.py
+++ b/indico/modules/events/registration/badges.py
@@ -50,9 +50,9 @@ class RegistrantsListToBadgesPDF(DesignerPDFBase):
     def _build_pdf(self, canvas):
         config = self.config
 
-        available_width = self.width - (config.left_margin - config.right_margin + config.margin_columns) * cm
+        available_width = self.width - (config.left_margin + config.right_margin + config.margin_columns) * cm
         n_horizontal = int(available_width / ((self.tpl_data.width_cm + config.margin_columns) * cm))
-        available_height = self.height - (config.top_margin - config.bottom_margin + config.margin_rows) * cm
+        available_height = self.height - (config.top_margin + config.bottom_margin + config.margin_rows) * cm
         n_vertical = int(available_height / ((self.tpl_data.height_cm + config.margin_rows) * cm))
 
         if not n_horizontal or not n_vertical:

--- a/indico/modules/events/registration/badges.py
+++ b/indico/modules/events/registration/badges.py
@@ -144,9 +144,9 @@ class RegistrantsListToBadgesPDFDoubleSided(RegistrantsListToBadgesPDF):
     def _build_pdf(self, canvas):
         config = self.config
 
-        available_width = self.width - (config.left_margin - config.right_margin + config.margin_columns) * cm
+        available_width = self.width - (config.left_margin + config.right_margin + config.margin_columns) * cm
         n_horizontal = int(available_width / ((self.tpl_data.width_cm + config.margin_columns) * cm))
-        available_height = self.height - (config.top_margin - config.bottom_margin + config.margin_rows) * cm
+        available_height = self.height - (config.top_margin + config.bottom_margin + config.margin_rows) * cm
         n_vertical = int(available_height / ((self.tpl_data.height_cm + config.margin_rows) * cm))
 
         if not n_horizontal or not n_vertical:

--- a/indico/modules/events/registration/settings.py
+++ b/indico/modules/events/registration/settings.py
@@ -15,7 +15,7 @@ DEFAULT_BADGE_SETTINGS = {
     'top_margin': 1.6,
     'bottom_margin': 1.1,
     'left_margin': 1.6,
-    'right_margin': 1.4,
+    'right_margin': 0.4,
     'margin_columns': 1.0,
     'margin_rows': 0.0,
     'page_size': PageSize.A4,


### PR DESCRIPTION
This is for a bug found when calculating the available height and width when printing a badge. The calculations do not take into account the `right_margin` and `bottom_margin`. 

e.g.
`available_width = self.width - (config.left_margin - config.right_margin + config.margin_columns) * cm`
but if the right_margin is taken into account, then should be:
`available_width = self.width - (config.left_margin + config.right_margin + config.margin_columns) * cm`

So for example if you have the following settings in your badge printing configurations page: 
<img width="683" alt="Screenshot 2022-03-09 at 17 12 00" src="https://user-images.githubusercontent.com/54508387/157483013-321e2538-a0ad-4113-8400-745fc5de7c4d.png">

'top_margin': 22.42,
'bottom_margin': 0.26,
'left_margin': 6.4,
'right_margin': 6.0,
'margin_columns': 0.0,
'margin_rows': 0.0,
The right_margin is not taken into account and instead prints the badge side by side. 

<img width="651" alt="Screenshot 2022-03-09 at 17 12 28" src="https://user-images.githubusercontent.com/54508387/157482962-d350ccd1-5f31-4879-8ba8-8b3136a3a806.png">

After changing the expression then it takes the right_margin into account and prints the badge one per page:
<img width="423" alt="Screenshot 2022-03-09 at 17 11 36" src="https://user-images.githubusercontent.com/54508387/157483191-9d08fc0c-1cad-43d6-9faa-bd906c4b3c77.png">

