### PR TITLE
Let plugins define custom regform field types

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,7 @@ Internal Changes
   to the React registration form containers (:pr:`5271`)
 - Add support for JavaScript plugin hooks to register objects or react components for use
   by JS code that's in the core (:pr:`5271`)
+- Plugins can now define custom registration form fields (:pr:`5282`)
 
 
 ----

--- a/indico/core/signals/core.py
+++ b/indico/core/signals/core.py
@@ -77,7 +77,7 @@ the context.
 ''')
 
 get_fields = _signals.signal('get-fields', '''
-Expected to return `BaseField` subclasses.  The *sender* is an object
+Expected to return field classes.  The *sender* is an object
 (or just a string) identifying for what to get fields.  This signal
 should never be registered without restricting the sender to ensure
 only the correct field types are returned.

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -15,7 +15,7 @@ import {Markdown, toClasses} from 'indico/react/util';
 
 import {getManagement, isPaidItemLocked} from '../form_submission/selectors';
 
-import {fieldRegistry} from './fields/registry';
+import {getFieldRegistry} from './fields/registry';
 
 import '../../styles/regform.module.scss';
 
@@ -53,6 +53,7 @@ export default function FormItem({
   const paidItemLocked = useSelector(state => isPaidItemLocked(state, rest.id));
   const isManagement = useSelector(getManagement);
 
+  const fieldRegistry = getFieldRegistry();
   const meta = fieldRegistry[inputType] || {};
   const InputComponent = meta.inputComponent;
   const inputProps = {title, description, isRequired, isEnabled, ...rest};

--- a/indico/modules/events/registration/client/js/form/fields/registry.js
+++ b/indico/modules/events/registration/client/js/form/fields/registry.js
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 import {Translate} from 'indico/react/i18n';
+import {getPluginObjects} from 'indico/utils/plugins';
 
 import AccommodationInput, {
   AccommodationSettings,
@@ -57,7 +58,7 @@ Available keys:
 - hasPrice: optional; show price field if the whole field can have a price attached
 */
 
-export const fieldRegistry = {
+const fieldRegistry = {
   label: {
     title: Translate.string('Static label'),
     inputComponent: LabelInput,
@@ -159,3 +160,13 @@ export const fieldRegistry = {
     icon: 'home',
   },
 };
+
+export function getFieldRegistry() {
+  const pluginFields = Object.fromEntries(
+    getPluginObjects('regformCustomFields').map(({name, ...rest}) => [name, rest])
+  );
+  if (Object.keys(pluginFields).some(x => !x.startsWith('ext__'))) {
+    throw new Error('Field names from plugins must begin with `ext__`');
+  }
+  return {...fieldRegistry, ...pluginFields};
+}

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -23,7 +23,7 @@ import {
 import {FinalModalForm} from 'indico/react/forms/final-form';
 import {Translate, Param} from 'indico/react/i18n';
 
-import {fieldRegistry} from '../form/fields/registry';
+import {getFieldRegistry} from '../form/fields/registry';
 import {getStaticData, getItemById} from '../form/selectors';
 
 import * as actions from './actions';
@@ -38,6 +38,7 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
     editing ? getItemById(state, id) : {}
   );
   const inputType = editing ? existingInputType : newItemType;
+  const fieldRegistry = getFieldRegistry();
   const isUnsupportedField = !(inputType in fieldRegistry); // TODO remove once no longer needed
   const meta = fieldRegistry[inputType] || {};
   const SettingsComponent = meta.settingsComponent;

--- a/indico/modules/events/registration/client/js/form_setup/ItemTypeDropdown.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemTypeDropdown.jsx
@@ -11,21 +11,12 @@ import {Dropdown} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 
-import {fieldRegistry} from '../form/fields/registry';
+import {getFieldRegistry} from '../form/fields/registry';
 
 import '../../styles/regform.module.scss';
 
-const staticLabel = fieldRegistry.label;
-const newItemTypeOptions = Object.entries(fieldRegistry)
-  .filter(([name]) => name !== 'label')
-  .map(([name, {title, icon}]) => ({
-    key: name,
-    value: name,
-    text: title,
-    icon,
-  }));
-
 export default function ItemTypeDropdown({newItemType, inModal, onClick}) {
+  const fieldRegistry = getFieldRegistry();
   const dropdownText = newItemType
     ? fieldRegistry[newItemType].title
     : Translate.string('Choose type');
@@ -44,6 +35,14 @@ export default function ItemTypeDropdown({newItemType, inModal, onClick}) {
     };
   }
 
+  const newItemTypeOptions = Object.entries(fieldRegistry)
+    .filter(([name]) => name !== 'label')
+    .map(([name, {title, icon}]) => ({
+      key: name,
+      value: name,
+      text: title,
+      icon,
+    }));
   const middle = Math.ceil(newItemTypeOptions.length / 2);
 
   return (
@@ -51,8 +50,8 @@ export default function ItemTypeDropdown({newItemType, inModal, onClick}) {
       <Dropdown.Menu>
         <DropdownItem
           value="label"
-          text={staticLabel.title}
-          icon={staticLabel.icon}
+          text={fieldRegistry.label.title}
+          icon={fieldRegistry.label.icon}
           centered
           onClick={onClick}
         />

--- a/indico/modules/events/registration/fields/__init__.py
+++ b/indico/modules/events/registration/fields/__init__.py
@@ -5,11 +5,37 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from indico.core import signals
+from indico.modules.events.registration.fields.base import RegistrationFormFieldBase
+from indico.web.fields import get_field_definitions
+
+
 def get_field_types():
     """Get a dict with all registration field types."""
+    return get_field_definitions(RegistrationFormFieldBase)
+
+
+@signals.core.get_fields.connect_via(RegistrationFormFieldBase)
+def _get_fields(sender, **kwargs):
     from .choices import AccommodationField, MultiChoiceField, SingleChoiceField
     from .simple import (BooleanField, CheckboxField, CountryField, DateField, EmailField, FileField, NumberField,
                          PhoneField, TextAreaField, TextField)
-    return {field.name: field for field in (TextField, NumberField, TextAreaField, SingleChoiceField, CheckboxField,
-                                            DateField, BooleanField, PhoneField, CountryField, FileField, EmailField,
-                                            AccommodationField, MultiChoiceField)}
+    yield AccommodationField
+    yield MultiChoiceField
+    yield SingleChoiceField
+    yield BooleanField
+    yield CheckboxField
+    yield CountryField
+    yield DateField
+    yield EmailField
+    yield FileField
+    yield NumberField
+    yield PhoneField
+    yield TextAreaField
+    yield TextField
+
+
+@signals.core.app_created.connect
+def _check_field_definitions(app, **kwargs):
+    # This will raise RuntimeError if the field names are not unique
+    get_field_types()

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -38,6 +38,8 @@ class RegistrationFormFieldBase:
     setup_schema_fields = {}
     #: whether this field is assocated with a file instead of normal data
     is_file_field = False
+    #: whether this field is invalid and cannot be used
+    is_invalid_field = False
 
     def __init__(self, form_item):
         self.form_item = form_item
@@ -197,3 +199,12 @@ class RegistrationFormBillableItemsField(RegistrationFormBillableField):
     def calculate_price(self, reg_data, versioned_data):
         # billable items need custom logic
         raise NotImplementedError
+
+
+class InvalidRegistrationFormField(RegistrationFormFieldBase):
+    """A field implementation for missing plugin fields."""
+
+    is_invalid_field = True
+
+    def create_mm_field(self, registration=None):
+        return None

--- a/indico/modules/events/registration/models/form_fields.py
+++ b/indico/modules/events/registration/models/form_fields.py
@@ -11,6 +11,7 @@ from werkzeug.datastructures import ImmutableDict
 
 from indico.core.db import db
 from indico.modules.events.registration.fields import get_field_types
+from indico.modules.events.registration.fields.base import InvalidRegistrationFormField
 from indico.modules.events.registration.models.items import RegistrationFormItem, RegistrationFormItemType
 from indico.util.string import camelize_keys
 
@@ -64,13 +65,7 @@ class RegistrationFormField(RegistrationFormItem):
 
         :return: An instance of a `RegistrationFormFieldBase` subclass
         """
-        try:
-            field_cls = get_field_types()[self.input_type]
-        except KeyError:
-            # XXX It'd be nicer to gracefully fail in all places where a missing field is used,
-            # but only few people will use custom fields from plugins, and they are unlikely to
-            # remove the plugin at some point...
-            raise Exception(f'Form field missing: {self.input_type} (plugin not loaded?)')
+        field_cls = get_field_types().get(self.input_type, InvalidRegistrationFormField)
         return field_cls(self)
 
     @property

--- a/indico/modules/events/registration/models/form_fields.py
+++ b/indico/modules/events/registration/models/form_fields.py
@@ -64,7 +64,14 @@ class RegistrationFormField(RegistrationFormItem):
 
         :return: An instance of a `RegistrationFormFieldBase` subclass
         """
-        return get_field_types()[self.input_type](self)
+        try:
+            field_cls = get_field_types()[self.input_type]
+        except KeyError:
+            # XXX It'd be nicer to gracefully fail in all places where a missing field is used,
+            # but only few people will use custom fields from plugins, and they are unlikely to
+            # remove the plugin at some point...
+            raise Exception(f'Form field missing: {self.input_type} (plugin not loaded?)')
+        return field_cls(self)
 
     @property
     def versioned_data(self):

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -150,7 +150,9 @@ def get_initial_form_values(regform, *, management=False):
     for item in regform.active_fields:
         can_modify = management or not item.parent.is_manager_only
         if can_modify:
-            initial_values[item.html_field_name] = camelize_keys(item.field_impl.default_value)
+            impl = item.field_impl
+            if not impl.is_invalid_field:
+                initial_values[item.html_field_name] = camelize_keys(impl.default_value)
     return initial_values
 
 
@@ -302,8 +304,8 @@ def make_registration_schema(regform, management=False, registration=None):
         if not management and form_item.parent.is_manager_only:
             continue
 
-        field_impl = form_item.field_impl
-        schema[form_item.html_field_name] = field_impl.create_mm_field(registration=registration)
+        if mm_field := form_item.field_impl.create_mm_field(registration=registration):
+            schema[form_item.html_field_name] = mm_field
 
     # TODO: what to do with signal -> signals.event.registration_form_wtform_created
 


### PR DESCRIPTION
Considering that this will most likely be a niche feature, I didn't spend a lot of time gracefully failing cases where a registration form contains a field but doesn't have the corresponding plugin; accessing such a form will simply fail with an error.

~~There's no special handling for fields containing files right now, I hope that someone who adds e.g. a passport photo field will eventually see how well this is possible and if there's a need for additional signals or calling methods of the field class instead of hardcoded logic...~~ Nevermind, found an easy solution to cover this.

In case someone who sees this PR wants to see how a custom field would be defined, here's the diff of what I used to test (yes, I was lazy and just added it to the one plugin that already uses regform-related extension points ;)): [pluginfield.diff.txt](https://github.com/indico/indico/files/8224230/pluginfield.diff.txt)
