### PR TITLE
Add an option to send notifications of new abstract comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Improvements
   :pr:`5268`)
 - Highlight changed fields in notification emails about modified registrations
   (:issue:`5265`, :pr:`5269`)
+- Add an option to send notifications of new abstract comments (:issue:`5266`, :pr:`5284`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -171,6 +171,10 @@ class AbstractReviewingSettingsForm(IndicoForm):
                                                   widget=SwitchWidget(),
                                                   description=_('Enabling this allows submitters, authors, and '
                                                                 'speakers to also participate in the comments.'))
+    notify_on_new_comments = BooleanField(_('Comment notifications'),
+                                          [HiddenUnless('allow_comments', preserve_data=True)],
+                                          widget=SwitchWidget(),
+                                          description=_('Send email notifications when new comments are posted.'))
     reviewing_instructions = IndicoMarkdownField(_('Reviewing Instructions'), editor=True,
                                                  description=_('These instructions will be displayed right before the '
                                                                'reviewing form.'))

--- a/indico/modules/events/abstracts/settings.py
+++ b/indico/modules/events/abstracts/settings.py
@@ -131,6 +131,7 @@ abstracts_reviewing_settings = EventSettingsProxy('abstracts_reviewing', {
     'allow_convener_judgment': False,  # whether track conveners can make a judgment (e.g. accept/reject)
     'allow_convener_track_change': False,
     'allow_contributors_in_comments': False,
+    'notify_on_new_comments': False,
     'reviewing_instructions': '',
     'judgment_instructions': ''
 })

--- a/indico/modules/events/abstracts/templates/emails/base.html
+++ b/indico/modules/events/abstracts/templates/emails/base.html
@@ -1,0 +1,40 @@
+{% extends 'emails/base.html' %}
+
+{% block header %}{% endblock %}
+
+{% block footer %}{% endblock %}
+
+{% block subject -%}
+    {% block subject_message %}Call for Abstracts{% endblock %}
+    {%- block subject_name %}{% endblock %}
+{%- endblock %}
+
+{% block body %}
+    <div class="mail" style="width: 600px; font-family: Arial, sans-serif; border: 1px solid #dfdfdf; background-color: #fcfcfc; margin: auto auto 40px auto;">
+        <div class="header" style="background-color: #5d95ea; color: #eee; padding: 10px 20px;">
+            <h1 style="margin: 0;">
+                {% block header_title %}{{ event.title }}{% endblock %}
+            </h1>
+            <h3 style="margin: 0; margin-top: 10px; padding-top: 10px; border-top: 1px solid #eee;">
+                {% block header_subtitle %}{% endblock %}
+                <span style="float: right; font-style: italic;">
+                    {% block header_subtitle_ref %}{% endblock %}
+                </span>
+            </h3>
+        </div>
+        <div class="content" style="padding: 10px 20px; color: #555;">
+            {% block content %}
+                <div style="border-bottom: 1px solid #ebebeb;">
+                    {% block content_header %}{% endblock %}
+                </div>
+                {% block content_body %}{% endblock %}
+                <div>
+                    {% block content_footer %}{% endblock %}
+                </div>
+            {% endblock %}
+        </div>
+        <div style="text-align: center; padding: 10px; background: #ebebeb; font-size: small; color: #999;">
+            Indico :: Call for Abstracts
+        </div>
+    </div>
+{% endblock %}

--- a/indico/modules/events/abstracts/templates/emails/comment.html
+++ b/indico/modules/events/abstracts/templates/emails/comment.html
@@ -1,0 +1,24 @@
+{% extends 'events/abstracts/emails/base.html' %}
+
+{% block subject_message %}New abstract comment{% endblock %}
+
+{% block header_subtitle %}New abstract comment{% endblock %}
+
+{% block header_subtitle_ref %}ref #{{ abstract.friendly_id }}{% endblock %}
+
+{% block content_header %}
+    <p>Dear {{ recipient.first_name }},</p>
+    <p>{{ submitter.full_name }} commented on the abstract <strong>{{ abstract.title }}</strong>:</p>
+    <blockquote style="border-left: 5px solid #dfdfdf; padding-left: 10px; font-style: italic; color: #999;">
+        {{ comment }}
+    </blockquote>
+{% endblock %}
+
+{% block content_body %}
+    <p>You can view this comment on the abstract page:</p>
+    <p>
+        <a href="{{ url_for('abstracts.display_abstract', abstract, management=false, _external=true) }}">
+            {{- url_for('abstracts.display_abstract', abstract, management=false, _external=true) -}}
+        </a>
+    </p>
+{% endblock %}


### PR DESCRIPTION
Closes #5266 

Add a new setting which enables to send email notifications
to abstract judges, conveners and reviewers when a new comment is added.

![image](https://user-images.githubusercontent.com/8739637/157849411-b36201b3-9170-41a7-ab4c-5012fee48620.png)

I used the same email template we use for paper notifications:

![image](https://user-images.githubusercontent.com/8739637/157849566-98d5b5d6-b386-4874-b814-f998081bc031.png)


