### PR TITLE
Allow uploading revisions when an editor hasn't been assigned

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Improvements
 - Update the editing state color scheme (:pr:`5236`)
 - Include program codes in export API (:pr:`5246`)
 - Add abstract rating scores grouped by track (:pr:`5298`)
+- Allow uploading revisions when an editor hasn't been assigned (:pr:`5289`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -91,7 +91,7 @@ document.addEventListener('DOMContentLoaded', () => {
         eventId={+eventId}
         contributionId={+contributionId}
         contributionCode={contributionCode}
-        uploadableFiles={lastRevFiles}
+        uploadableFiles={lastRevFiles.map(({id, ...rest}) => ({...rest, paperId: id}))}
       />,
       editableSubmissionButton
     );

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -101,8 +101,8 @@ _bp.add_url_rule(contrib_api_prefix + '/editor/me', 'api_assign_editable_self', 
 _bp.add_url_rule(contrib_api_prefix, 'api_editable', timeline.RHEditable)
 _bp.add_url_rule(contrib_api_prefix, 'api_create_editable', timeline.RHCreateEditable, methods=('PUT',))
 _bp.add_url_rule(contrib_api_prefix + '/upload', 'api_upload', timeline.RHEditingUploadFile, methods=('POST',))
-_bp.add_url_rule(contrib_api_prefix + '/add-paper-file', 'api_add_paper_file',
-                 timeline.RHEditingUploadPaperLastRevision, methods=('POST',))
+_bp.add_url_rule(contrib_api_prefix + '/add-paper-file', 'api_add_contribution_file',
+                 timeline.RHEditingUploadContributionFile, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/review', 'api_review_editable',
                  timeline.RHReviewEditable, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/confirm', 'api_confirm_changes',

--- a/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
@@ -33,14 +33,15 @@ export default function EditableSubmissionButton({
   fileTypes,
   uploadableFiles,
   text,
+  submitURL,
 }) {
   const [currentType, setCurrentType] = useState(null);
   const submitRevision = async formData => {
     try {
-      await indicoAxios.put(
-        submitRevisionURL({event_id: eventId, contrib_id: contributionId, type: currentType}),
-        formData
-      );
+      const url =
+        submitURL ||
+        submitRevisionURL({event_id: eventId, contrib_id: contributionId, type: currentType});
+      await indicoAxios.post(url, formData);
     } catch (e) {
       return handleSubmitError(e);
     }
@@ -136,9 +137,11 @@ EditableSubmissionButton.propTypes = {
   contributionId: PropTypes.number.isRequired,
   contributionCode: PropTypes.string.isRequired,
   uploadableFiles: PropTypes.arrayOf(PropTypes.shape(uploadablePropTypes)),
+  submitURL: PropTypes.string,
 };
 
 EditableSubmissionButton.defaultProps = {
   text: undefined,
   uploadableFiles: [],
+  submitURL: undefined,
 };

--- a/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import apiUploadExistingURL from 'indico-url:event_editing.api_add_paper_file';
+import apiUploadExistingURL from 'indico-url:event_editing.api_add_contribution_file';
 import submitRevisionURL from 'indico-url:event_editing.api_create_editable';
 import apiUploadURL from 'indico-url:event_editing.api_upload';
 import editableURL from 'indico-url:event_editing.editable';

--- a/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
@@ -33,15 +33,19 @@ export default function EditableSubmissionButton({
   fileTypes,
   uploadableFiles,
   text,
-  submitURL,
+  onSubmit,
 }) {
   const [currentType, setCurrentType] = useState(null);
   const submitRevision = async formData => {
     try {
-      const url =
-        submitURL ||
-        submitRevisionURL({event_id: eventId, contrib_id: contributionId, type: currentType});
-      await indicoAxios.post(url, formData);
+      if (onSubmit) {
+        await onSubmit(currentType, formData);
+      } else {
+        await indicoAxios.put(
+          submitRevisionURL({event_id: eventId, contrib_id: contributionId, type: currentType}),
+          formData
+        );
+      }
     } catch (e) {
       return handleSubmitError(e);
     }
@@ -137,11 +141,11 @@ EditableSubmissionButton.propTypes = {
   contributionId: PropTypes.number.isRequired,
   contributionCode: PropTypes.string.isRequired,
   uploadableFiles: PropTypes.arrayOf(PropTypes.shape(uploadablePropTypes)),
-  submitURL: PropTypes.string,
+  onSubmit: PropTypes.func,
 };
 
 EditableSubmissionButton.defaultProps = {
   text: undefined,
   uploadableFiles: [],
-  submitURL: undefined,
+  onSubmit: undefined,
 };

--- a/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
+++ b/indico/modules/events/editing/client/js/editing/EditableSubmissionButton.jsx
@@ -96,7 +96,7 @@ export default function EditableSubmissionButton({
                       contrib_id: contributionId,
                       type: currentType,
                     })}
-                    uploadableFiles={uploadableFiles}
+                    files={uploadableFiles}
                     mustChange
                   />
                 </Form>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -23,7 +23,13 @@ import {createRevisionComment} from './actions';
 import CommentForm from './CommentForm';
 import JudgmentBox from './judgment/JudgmentBox';
 import JudgmentDropdownItems from './judgment/JudgmentDropdownItems';
-import {getLastRevision, canJudgeLastRevision, getDetails, getStaticData} from './selectors';
+import {
+  getLastRevision,
+  canJudgeLastRevision,
+  getDetails,
+  getStaticData,
+  canReviewLastRevision,
+} from './selectors';
 import {blockPropTypes} from './util';
 
 import './ReviewForm.module.scss';
@@ -55,7 +61,8 @@ export default function ReviewForm({block}) {
   const dispatch = useDispatch();
   const lastRevision = useSelector(getLastRevision);
   const canJudge = useSelector(canJudgeLastRevision);
-  const {canPerformSubmitterActions, contribution} = useSelector(getDetails);
+  const canReview = useSelector(canReviewLastRevision);
+  const {canPerformSubmitterActions, contribution, editor} = useSelector(getDetails);
   const {eventId, editableType, fileTypes} = useSelector(getStaticData);
   const currentUser = {
     fullName: Indico.User.fullName,
@@ -87,7 +94,7 @@ export default function ReviewForm({block}) {
   const judgmentForm = (
     <div className="flexrow f-a-center" styleName="judgment-form">
       <CommentForm onSubmit={createComment} onToggleExpand={setCommentFormVisible} />
-      {canPerformSubmitterActions && (
+      {canPerformSubmitterActions && canReview && !editor && (
         <>
           <span className="comment-or-review">
             <Translate>or</Translate>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -15,6 +15,7 @@ import {Dropdown} from 'semantic-ui-react';
 import EditableSubmissionButton from 'indico/modules/events/editing/editing/EditableSubmissionButton';
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {Translate} from 'indico/react/i18n';
+import {indicoAxios} from 'indico/utils/axios';
 
 import {EditingReviewAction} from '../../models';
 
@@ -69,9 +70,19 @@ export default function ReviewForm({block}) {
     if (rv.error) {
       return rv.error;
     }
-
     setTimeout(() => form.reset(), 0);
   };
+
+  const onSubmit = (type, formData) =>
+    indicoAxios.post(
+      submitRevisionURL({
+        event_id: eventId,
+        contrib_id: contribution.id,
+        type,
+        revision_id: lastRevision.id,
+      }),
+      formData
+    );
 
   const judgmentForm = (
     <div className="flexrow" styleName="judgment-form">
@@ -88,12 +99,7 @@ export default function ReviewForm({block}) {
             fileTypes={{[editableType]: fileTypes}}
             uploadableFiles={lastRevision.files}
             text={Translate.string('Submit files')}
-            submitURL={submitRevisionURL({
-              event_id: eventId,
-              contrib_id: contribution.id,
-              type: editableType,
-              revision_id: lastRevision.id,
-            })}
+            onSubmit={onSubmit}
           />
         </>
       )}

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -55,7 +55,7 @@ export default function ReviewForm({block}) {
   const dispatch = useDispatch();
   const lastRevision = useSelector(getLastRevision);
   const canJudge = useSelector(canJudgeLastRevision);
-  const {editor, contribution} = useSelector(getDetails);
+  const {canPerformSubmitterActions, contribution} = useSelector(getDetails);
   const {eventId, editableType, fileTypes} = useSelector(getStaticData);
   const currentUser = {
     fullName: Indico.User.fullName,
@@ -87,7 +87,7 @@ export default function ReviewForm({block}) {
   const judgmentForm = (
     <div className="flexrow" styleName="judgment-form">
       <CommentForm onSubmit={createComment} onToggleExpand={setCommentFormVisible} />
-      {!editor && (
+      {canPerformSubmitterActions && (
         <>
           <span className="comment-or-review">
             <Translate>or</Translate>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -85,7 +85,7 @@ export default function ReviewForm({block}) {
     );
 
   const judgmentForm = (
-    <div className="flexrow" styleName="judgment-form">
+    <div className="flexrow f-a-center" styleName="judgment-form">
       <CommentForm onSubmit={createComment} onToggleExpand={setCommentFormVisible} />
       {canPerformSubmitterActions && (
         <>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -5,11 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import submitRevisionURL from 'indico-url:event_editing.api_create_submitter_revision';
+
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Dropdown} from 'semantic-ui-react';
 
+import EditableSubmissionButton from 'indico/modules/events/editing/editing/EditableSubmissionButton';
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {Translate} from 'indico/react/i18n';
 
@@ -19,7 +22,7 @@ import {createRevisionComment} from './actions';
 import CommentForm from './CommentForm';
 import JudgmentBox from './judgment/JudgmentBox';
 import JudgmentDropdownItems from './judgment/JudgmentDropdownItems';
-import {getLastRevision, canJudgeLastRevision} from './selectors';
+import {getLastRevision, canJudgeLastRevision, getDetails, getStaticData} from './selectors';
 import {blockPropTypes} from './util';
 
 import './ReviewForm.module.scss';
@@ -51,6 +54,8 @@ export default function ReviewForm({block}) {
   const dispatch = useDispatch();
   const lastRevision = useSelector(getLastRevision);
   const canJudge = useSelector(canJudgeLastRevision);
+  const {editor, contribution} = useSelector(getDetails);
+  const {eventId, editableType, fileTypes} = useSelector(getStaticData);
   const currentUser = {
     fullName: Indico.User.fullName,
     avatarURL: Indico.User.avatarURL,
@@ -71,6 +76,27 @@ export default function ReviewForm({block}) {
   const judgmentForm = (
     <div className="flexrow" styleName="judgment-form">
       <CommentForm onSubmit={createComment} onToggleExpand={setCommentFormVisible} />
+      {!editor && (
+        <>
+          <span className="comment-or-review">
+            <Translate>or</Translate>
+          </span>
+          <EditableSubmissionButton
+            eventId={eventId}
+            contributionId={contribution.id}
+            contributionCode={contribution.code}
+            fileTypes={{[editableType]: fileTypes}}
+            // uploadableFiles={lastRevision.files}
+            text={Translate.string('Submit files')}
+            submitURL={submitRevisionURL({
+              event_id: eventId,
+              contrib_id: contribution.id,
+              type: editableType,
+              revision_id: lastRevision.id,
+            })}
+          />
+        </>
+      )}
       {!commentFormVisible && canJudge && (
         <div className="review-trigger flexrow">
           <span className="comment-or-review">

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -86,7 +86,7 @@ export default function ReviewForm({block}) {
             contributionId={contribution.id}
             contributionCode={contribution.code}
             fileTypes={{[editableType]: fileTypes}}
-            // uploadableFiles={lastRevision.files}
+            uploadableFiles={lastRevision.files}
             text={Translate.string('Submit files')}
             submitURL={submitRevisionURL({
               event_id: eventId,

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -34,7 +34,6 @@ export default function TimelineItem({block, index}) {
   const {fileTypes} = useSelector(selectors.getStaticData);
   const isLastBlock = lastBlock.id === block.id;
   const [visible, setVisible] = useState(isLastBlock);
-  const headerOnly = !visible || (!isLastBlock && block.items.length === 0 && !block.comment);
 
   useEffect(() => {
     // when undoing a judgment deletes the last revision this revision may become the
@@ -50,9 +49,7 @@ export default function TimelineItem({block, index}) {
         <div className="i-timeline-item">
           <UserAvatar user={block.submitter} />
           <div
-            className={`i-timeline-item-box header-indicator-left ${
-              headerOnly ? 'header-only' : ''
-            }`}
+            className={`i-timeline-item-box header-indicator-left ${!visible ? 'header-only' : ''}`}
             id={`block-info-${block.id}`}
           >
             <div className="i-box-header flexrow">

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -28,6 +28,13 @@ export const getLastRevision = createSelector(
   getDetails,
   details => details && details.revisions[details.revisions.length - 1]
 );
+export const canReviewLastRevision = createSelector(
+  getLastRevision,
+  lastRevision =>
+    lastRevision &&
+    lastRevision.initialState.name === InitialRevisionState.ready_for_review &&
+    lastRevision.finalState.name === FinalRevisionState.none
+);
 export const needsSubmitterChanges = createSelector(
   getLastRevision,
   lastRevision =>

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -57,9 +57,10 @@ class RHEditingUploadContributionFile(RHEditingUploadFile):
     def _process(self, id):
         files = []
         if self.contrib.editables:
-            files = [file.file for e in self.contrib.editables for file in e.revisions[-1].files]
+            files = [file.file for e in self.contrib.editables
+                     if e.type == self.editable.type for file in e.revisions[-1].files]
         if self.contrib.paper and (last_rev := self.contrib.paper.get_last_revision()):
-            files += [f for f in last_rev.files]
+            files.extend(last_rev.files)
         if found := next((f for f in files if f.id == id), None):
             with found.open() as stream:
                 return self._save_file(found, stream)

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -63,7 +63,7 @@ class RHEditingUploadContributionFile(RHEditingUploadFile):
             files = [file.file for e in self.contrib.editables
                      if e.type == self.editable.type for file in e.revisions[-1].files]
         if paper_id and self.contrib.paper and (last_rev := self.contrib.paper.get_last_revision()):
-            files.extend(last_rev.files)
+            files = last_rev.files
         if found := next((f for f in files if f.id == (id or paper_id)), None):
             with found.open() as stream:
                 return self._save_file(found, stream)

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -52,14 +52,14 @@ class RHEditingUploadFile(UploadFileMixin, RHContributionEditableBase):
 
 class RHEditingUploadContributionFile(RHEditingUploadFile):
     @use_kwargs({
-        'file_id': fields.Int(),
-        'paper_id': fields.Int()
+        'id': fields.Int(load_default=None),
+        'paper_id': fields.Int(load_default=None)
     })
-    def _process(self, file_id, paper_id):
-        if file_id and paper_id:
+    def _process(self, id, paper_id):
+        if id and paper_id:
             raise BadRequest
         files = []
-        if file_id and self.contrib.editables:
+        if id and self.contrib.editables:
             files = [file.file for e in self.contrib.editables
                      if e.type == self.editable.type for file in e.revisions[-1].files]
         if paper_id and self.contrib.paper and (last_rev := self.contrib.paper.get_last_revision()):

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -56,7 +56,7 @@ class RHEditingUploadContributionFile(RHEditingUploadFile):
         'paper_id': fields.Int(load_default=None)
     })
     def _process(self, id, paper_id):
-        if id and paper_id:
+        if bool(id) == bool(paper_id):
             raise BadRequest
         files = []
         if id and self.contrib.editables:

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -64,7 +64,7 @@ class RHEditingUploadContributionFile(RHEditingUploadFile):
                      if e.type == self.editable.type for file in e.revisions[-1].files]
         if paper_id and self.contrib.paper and (last_rev := self.contrib.paper.get_last_revision()):
             files.extend(last_rev.files)
-        if found := next((f for f in files if f.id == id), None):
+        if found := next((f for f in files if f.id == (id or paper_id)), None):
             with found.open() as stream:
                 return self._save_file(found, stream)
         raise UserValueError(_('No such file was found within the paper'))

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -185,7 +185,12 @@ def replace_revision(revision, user, comment, files, tags, initial_state=None):
 @no_autoflush
 def create_submitter_revision(prev_revision, user, files):
     ensure_latest_revision(prev_revision)
-    _ensure_state(prev_revision, final=FinalRevisionState.needs_submitter_changes)
+    try:
+        _ensure_state(prev_revision, initial=InitialRevisionState.ready_for_review, final=FinalRevisionState.none)
+        if prev_revision.editable.editor:
+            raise InvalidEditableState
+    except InvalidEditableState:
+        _ensure_state(prev_revision, final=FinalRevisionState.needs_submitter_changes)
     new_revision = EditingRevision(submitter=user,
                                    initial_state=InitialRevisionState.ready_for_review,
                                    files=_make_editable_files(prev_revision.editable, files),

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -110,8 +110,10 @@ class EditingTagSchema(mm.SQLAlchemyAutoSchema):
 class EditingRevisionFileSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = EditingRevisionFile
-        fields = ('uuid', 'filename', 'size', 'content_type', 'file_type', 'download_url', 'external_download_url')
+        fields = ('id', 'uuid', 'filename', 'size', 'content_type', 'file_type', 'download_url',
+                  'external_download_url')
 
+    id = fields.Int(attribute='file.id')
     uuid = fields.String(attribute='file.uuid')
     filename = fields.String(attribute='file.filename')
     size = fields.Int(attribute='file.size')

--- a/indico/modules/events/papers/client/js/components/Paper.jsx
+++ b/indico/modules/events/papers/client/js/components/Paper.jsx
@@ -152,7 +152,7 @@ function PaperSteps({
                 contributionId={contribution.id}
                 contributionCode={contribution.code}
                 fileTypes={{[EditableType.paper]: fileTypes}}
-                uploadableFiles={uploadableFiles}
+                uploadableFiles={uploadableFiles.map(({id, ...rest}) => ({...rest, paperId: id}))}
                 text={Translate.string('Submit for editing')}
               />
             )}


### PR DESCRIPTION
Once an editable has been submitted, it is currently impossible to upload a new version of it. The improvement would allow a new revision to be made at any time (but disallowed when an editor has been assigned - to prevent him from seeing an old version).