### PR TITLE
Fix bug while downloading a file without a published revision

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Bugfixes
   :pr:`5258`, thanks :user:`imranyusuff`)
 - Fix very long map URLs breaking out of the event management settings box (:pr:`5275`)
 - Fix missing abstract withdrawal notification (:pr:`5281`)
+- Fix downloading files from editables without a published revision (:pr:`5290`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -406,8 +406,8 @@ class RHDownloadRevisionFile(RHContributionEditableRevisionBase):
                               .first_or_404())
 
     def _check_revision_access(self):
-        if (self.revision_file in self.editable.published_revision.files and
-                self.revision_file.file_type.publishable):
+        if (self.editable.published_revision and self.revision_file in self.editable.published_revision.files
+                and self.revision_file.file_type.publishable):
             return self.contrib.can_access(session.user)
         return self.editable.can_see_timeline(session.user)
 


### PR DESCRIPTION
**How to reproduce**
Download a file from any revision within editing without published files.

For reference: #5218 