### PR TITLE
Remove registration data after the retention period expires

### DIFF
--- a/indico/modules/events/registration/__init__.py
+++ b/indico/modules/events/registration/__init__.py
@@ -39,6 +39,11 @@ registration_settings = RegistrationSettingsProxy('registrations', {
 })
 
 
+@signals.core.import_tasks.connect
+def _import_tasks(sender, **kwargs):
+    import indico.modules.events.registration.tasks  # noqa: F401
+
+
 @signals.users.merged.connect
 def _merge_users(target, source, **kwargs):
     # registrations are unique per user, so we can only update the user

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -78,6 +78,24 @@ export default function FormItem({
   const inputProps = {title, description, isRequired, isEnabled, ...rest};
   const showPurged = !setupMode && isPurged;
   const disabled = !isEnabled || showPurged || (paidItemLocked && !isManagement);
+
+  let retentionPeriodIcon = null;
+  if (setupMode && retentionPeriod) {
+    retentionPeriodIcon = (
+      <Icon
+        name="clock outline"
+        color="red"
+        style={{marginLeft: '3px'}}
+        title={PluralTranslate.string(
+          'Field data will be purged {retentionPeriod} week after the event ended.',
+          'Field data will be purged {retentionPeriod} weeks after the event ended.',
+          retentionPeriod,
+          {retentionPeriod}
+        )}
+      />
+    );
+  }
+
   return (
     <div
       styleName={`form-item ${toClasses({
@@ -95,24 +113,13 @@ export default function FormItem({
               isRequired={isRequired || meta.alwaysRequired}
               disabled={disabled}
               isPurged={showPurged}
+              retentionPeriodIcon={retentionPeriodIcon}
               {...inputProps}
             />
           ) : (
             <Form.Field required={isRequired || meta.alwaysRequired} styleName="field">
               <label style={{opacity: disabled ? 0.8 : 1, display: 'inline-block'}}>{title}</label>
-              {setupMode && !!retentionPeriod && (
-                <Icon
-                  name="clock outline"
-                  color="red"
-                  style={{marginLeft: '3px'}}
-                  title={PluralTranslate.string(
-                    'Field data will be purged {retentionPeriod} week after the event ended.',
-                    'Field data will be purged {retentionPeriod} weeks after the event ended.',
-                    retentionPeriod,
-                    {retentionPeriod}
-                  )}
-                />
-              )}
+              {retentionPeriodIcon}
               <InputComponent
                 isRequired={isRequired || meta.alwaysRequired}
                 disabled={disabled}

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -93,6 +93,7 @@ export default function FormItem({
             <InputComponent
               isRequired={isRequired || meta.alwaysRequired}
               disabled={disabled}
+              isPurged={isPurged}
               {...inputProps}
             />
           ) : (
@@ -114,6 +115,7 @@ export default function FormItem({
               <InputComponent
                 isRequired={isRequired || meta.alwaysRequired}
                 disabled={disabled}
+                isPurged={isPurged}
                 {...inputProps}
               />
             </Form.Field>

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -76,13 +76,14 @@ export default function FormItem({
   const meta = fieldRegistry[inputType] || {};
   const InputComponent = meta.inputComponent;
   const inputProps = {title, description, isRequired, isEnabled, ...rest};
-  const disabled = !isEnabled || isPurged || (paidItemLocked && !isManagement);
+  const showPurged = !setupMode && isPurged;
+  const disabled = !isEnabled || showPurged || (paidItemLocked && !isManagement);
   return (
     <div
       styleName={`form-item ${toClasses({
         'disabled': !isEnabled || paidItemLocked,
-        'purged-disabled': isPurged,
-        'paid-disabled': !isPurged && paidItemLocked,
+        'purged-disabled': showPurged,
+        'paid-disabled': !showPurged && paidItemLocked,
         'editable': setupMode,
       })}`}
     >
@@ -93,7 +94,7 @@ export default function FormItem({
             <InputComponent
               isRequired={isRequired || meta.alwaysRequired}
               disabled={disabled}
-              isPurged={isPurged}
+              isPurged={showPurged}
               {...inputProps}
             />
           ) : (
@@ -115,7 +116,7 @@ export default function FormItem({
               <InputComponent
                 isRequired={isRequired || meta.alwaysRequired}
                 disabled={disabled}
-                isPurged={isPurged}
+                isPurged={showPurged}
                 {...inputProps}
               />
             </Form.Field>
@@ -130,8 +131,8 @@ export default function FormItem({
         )}
       </div>
       {setupActions && <div styleName="actions">{setupActions}</div>}
-      {isPurged && <PurgedItemLocked isUpdateMode={isUpdateMode} />}
-      {!isPurged && paidItemLocked && <PaidItemLocked management={isManagement} />}
+      {showPurged && <PurgedItemLocked isUpdateMode={isUpdateMode} />}
+      {!showPurged && paidItemLocked && <PaidItemLocked management={isManagement} />}
     </div>
   );
 }

--- a/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
@@ -32,6 +32,7 @@ function AccommodationInputComponent({
   value,
   onChange,
   disabled,
+  isPurged,
   choices,
   arrival,
   departure,
@@ -114,7 +115,7 @@ function AccommodationInputComponent({
                           (placesUsed[c.id] || 0) >= c.placesLimit &&
                           c.id !== existingValue.choice)
                       }
-                      checked={c.id === value.choice}
+                      checked={!isPurged && c.id === value.choice}
                       onChange={makeHandleChange(c)}
                     />
                   </td>
@@ -177,6 +178,7 @@ AccommodationInputComponent.propTypes = {
   value: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
+  isPurged: PropTypes.bool.isRequired,
   choices: PropTypes.arrayOf(PropTypes.shape(choiceShape)).isRequired,
   arrival: PropTypes.shape({
     startDate: PropTypes.string.isRequired,
@@ -195,6 +197,7 @@ export default function AccommodationInput({
   htmlName,
   disabled,
   isRequired,
+  isPurged,
   choices,
   arrival,
   departure,
@@ -208,6 +211,7 @@ export default function AccommodationInput({
       component={AccommodationInputComponent}
       required={isRequired}
       disabled={disabled}
+      isPurged={isPurged}
       choices={choices}
       arrival={arrival}
       departure={departure}
@@ -229,6 +233,7 @@ AccommodationInput.propTypes = {
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,
+  isPurged: PropTypes.bool.isRequired,
   choices: PropTypes.arrayOf(PropTypes.shape(choiceShape)).isRequired,
   arrival: PropTypes.shape({
     startDate: PropTypes.string.isRequired,

--- a/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
@@ -26,6 +26,7 @@ function BooleanInputComponent({
   onChange,
   disabled,
   required,
+  isPurged,
   price,
   placesLimit,
   placesUsed,
@@ -46,7 +47,7 @@ function BooleanInputComponent({
       <Button.Group>
         <Button
           type="button"
-          active={value === true}
+          active={!isPurged && value === true}
           disabled={disabled || (placesLimit > 0 && placesUsed >= placesLimit && !existingValue)}
           onClick={makeOnClick(true)}
         >
@@ -54,7 +55,7 @@ function BooleanInputComponent({
         </Button>
         <Button
           type="button"
-          active={value === false}
+          active={!isPurged && value === false}
           disabled={disabled}
           onClick={makeOnClick(false)}
         >
@@ -81,6 +82,7 @@ BooleanInputComponent.propTypes = {
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
   required: PropTypes.bool.isRequired,
+  isPurged: PropTypes.bool.isRequired,
   price: PropTypes.number.isRequired,
   placesLimit: PropTypes.number.isRequired,
   placesUsed: PropTypes.number.isRequired,
@@ -95,6 +97,7 @@ export default function BooleanInput({
   htmlName,
   disabled,
   isRequired,
+  isPurged,
   price,
   placesLimit,
   placesUsed,
@@ -106,6 +109,7 @@ export default function BooleanInput({
       component={BooleanInputComponent}
       required={isRequired}
       disabled={disabled}
+      isPurged={isPurged}
       allowNull
       price={price}
       placesLimit={placesLimit}
@@ -119,6 +123,7 @@ BooleanInput.propTypes = {
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,
+  isPurged: PropTypes.bool.isRequired,
   price: PropTypes.number,
   placesLimit: PropTypes.number,
   placesUsed: PropTypes.number,

--- a/indico/modules/events/registration/client/js/form/fields/CheckboxInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/CheckboxInput.jsx
@@ -30,6 +30,7 @@ export default function CheckboxInput({
   price,
   placesLimit,
   placesUsed,
+  retentionPeriodIcon,
 }) {
   const currency = useSelector(getCurrency);
   const existingValue = useSelector(state => getFieldValue(state, id));
@@ -42,6 +43,7 @@ export default function CheckboxInput({
       disabled={disabled || (placesLimit > 0 && placesUsed >= placesLimit && !existingValue)}
       required={isRequired}
     >
+      {retentionPeriodIcon}
       {!!price && (
         <Field name={htmlName} subscription={{value: true}}>
           {({input: {value: checked}}) => (
@@ -69,11 +71,13 @@ CheckboxInput.propTypes = {
   price: PropTypes.number,
   placesLimit: PropTypes.number.isRequired,
   placesUsed: PropTypes.number.isRequired,
+  retentionPeriodIcon: PropTypes.element,
 };
 
 CheckboxInput.defaultProps = {
   disabled: false,
   price: 0,
+  retentionPeriodIcon: null,
 };
 
 export function CheckboxSettings() {

--- a/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
@@ -32,6 +32,7 @@ function SingleChoiceDropdown({
   onChange,
   disabled,
   isRequired,
+  isPurged,
   choices,
   withExtraSlots,
   placesUsed,
@@ -111,7 +112,7 @@ function SingleChoiceDropdown({
           placeholder={Translate.string('Choose an option')}
           options={options}
           disabled={disabled}
-          value={selectedChoice.id || ''}
+          value={(!isPurged && selectedChoice.id) || ''}
           onChange={(e, data) => onChange(data.value ? {[data.value]: 1} : {})}
           clearable={!isRequired}
           search
@@ -137,6 +138,7 @@ SingleChoiceDropdown.propTypes = {
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
   isRequired: PropTypes.bool.isRequired,
+  isPurged: PropTypes.bool.isRequired,
   choices: PropTypes.arrayOf(PropTypes.shape(choiceShape)).isRequired,
   withExtraSlots: PropTypes.bool.isRequired,
   placesUsed: PropTypes.objectOf(PropTypes.number).isRequired,
@@ -149,6 +151,7 @@ function SingleChoiceRadioGroup({
   onChange,
   disabled,
   isRequired,
+  isPurged,
   choices,
   withExtraSlots,
   placesUsed,
@@ -200,7 +203,7 @@ function SingleChoiceRadioGroup({
                     (c.placesLimit > 0 &&
                       (placesUsed[c.id] || 0) - (existingValue[c.id] || 0) >= c.placesLimit)
                   }
-                  checked={isChecked(c, idx)}
+                  checked={!isPurged && isChecked(c, idx)}
                   onChange={() => handleChange(c.id)}
                 />
               </td>
@@ -274,6 +277,7 @@ SingleChoiceRadioGroup.propTypes = {
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
   isRequired: PropTypes.bool.isRequired,
+  isPurged: PropTypes.bool.isRequired,
   choices: PropTypes.arrayOf(PropTypes.shape(choiceShape)).isRequired,
   withExtraSlots: PropTypes.bool.isRequired,
   placesUsed: PropTypes.objectOf(PropTypes.number).isRequired,
@@ -286,6 +290,7 @@ function SingleChoiceInputComponent({
   onChange,
   disabled,
   isRequired,
+  isPurged,
   itemType,
   choices,
   withExtraSlots,
@@ -300,6 +305,7 @@ function SingleChoiceInputComponent({
         onChange={onChange}
         disabled={disabled}
         isRequired={isRequired}
+        isPurged={isPurged}
         choices={choices}
         withExtraSlots={withExtraSlots}
         placesUsed={placesUsed}
@@ -313,6 +319,7 @@ function SingleChoiceInputComponent({
         onChange={onChange}
         disabled={disabled}
         isRequired={isRequired}
+        isPurged={isPurged}
         choices={choices}
         withExtraSlots={withExtraSlots}
         placesUsed={placesUsed}
@@ -328,6 +335,7 @@ function SingleChoiceInputComponent({
 SingleChoiceInputComponent.propTypes = {
   disabled: PropTypes.bool.isRequired,
   isRequired: PropTypes.bool.isRequired,
+  isPurged: PropTypes.bool.isRequired,
   itemType: PropTypes.oneOf(['dropdown', 'radiogroup']).isRequired,
   choices: PropTypes.arrayOf(PropTypes.shape(choiceShape)).isRequired,
   withExtraSlots: PropTypes.bool.isRequired,
@@ -340,6 +348,7 @@ export default function SingleChoiceInput({
   htmlName,
   disabled,
   isRequired,
+  isPurged,
   itemType,
   choices,
   withExtraSlots,
@@ -354,6 +363,7 @@ export default function SingleChoiceInput({
       required={isRequired}
       isRequired={isRequired}
       disabled={disabled}
+      isPurged={isPurged}
       itemType={itemType}
       choices={choices}
       withExtraSlots={withExtraSlots}
@@ -369,6 +379,7 @@ SingleChoiceInput.propTypes = {
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,
+  isPurged: PropTypes.bool.isRequired,
   itemType: PropTypes.oneOf(['dropdown', 'radiogroup']).isRequired,
   choices: PropTypes.arrayOf(PropTypes.shape(choiceShape)).isRequired,
   withExtraSlots: PropTypes.bool,

--- a/indico/modules/events/registration/client/styles/regform.module.scss
+++ b/indico/modules/events/registration/client/styles/regform.module.scss
@@ -60,6 +60,16 @@
     );
   }
 
+  &.purged-disabled {
+    background: repeating-linear-gradient(
+      45deg,
+      rgba(255, 201, 184, 0.5),
+      rgba(255, 201, 184, 0.5) 10px,
+      #fff 10px,
+      #fff 20px
+    );
+  }
+
   > .content {
     flex-grow: 1;
 

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -138,7 +138,7 @@ class RegistrationFormFieldBase:
     @property
     def view_data(self):
         return (self.unprocess_field_data(self.form_item.versioned_data, self.form_item.data) |
-                {'default_value': self.default_value})
+                {'default_value': self.default_value, 'is_purged': self.form_item.is_purged})
 
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):
         """Return the data contained in the field.

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -373,11 +373,11 @@ class RegistrationForm(db.Model):
 
     @property
     def active_fields(self):
-        return [field
-                for field in self.form_items
-                if (field.is_field and
-                    field.is_enabled and not field.is_deleted and
-                    field.parent.is_enabled and not field.parent.is_deleted)]
+        return [field for field in self.form_items if field.is_field and field.is_active]
+
+    @property
+    def active_labels(self):
+        return [field for field in self.form_items if field.is_label and field.is_active]
 
     @property
     def sections(self):

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -337,6 +337,10 @@ class RegistrationFormItem(db.Model):
         """Return object with data that Angular can understand."""
         return dict(id=self.id, description=self.description, position=self.position)
 
+    @property
+    def is_active(self):
+        return self.is_enabled and not self.is_deleted and self.parent.is_enabled and not self.parent.is_deleted
+
     @hybrid_property
     def is_section(self):
         return self.type in {RegistrationFormItemType.section, RegistrationFormItemType.section_pd}
@@ -352,6 +356,14 @@ class RegistrationFormItem(db.Model):
     @is_field.expression
     def is_field(cls):
         return cls.type.in_([RegistrationFormItemType.field, RegistrationFormItemType.field_pd])
+
+    @hybrid_property
+    def is_label(self):
+        return self.type == RegistrationFormItemType.text
+
+    @is_label.expression
+    def is_label(cls):
+        return cls.type == RegistrationFormItemType.text
 
     @hybrid_property
     def is_visible(self):
@@ -431,5 +443,5 @@ class RegistrationFormText(RegistrationFormItem):
     @property
     def view_data(self):
         field_data = dict(super().view_data, section_id=self.parent_id, is_enabled=self.is_enabled, input_type='label',
-                          title=self.title)
+                          title=self.title, is_purged=self.is_purged)
         return camelize_keys(field_data)

--- a/indico/modules/events/registration/tasks.py
+++ b/indico/modules/events/registration/tasks.py
@@ -45,7 +45,12 @@ def delete_field_data():
         logger.info('Purging fields from registration %r: %r', regform, fields)
         for data in regform_data:
             logger.debug('Deleting registration field data: %r', data)
-            data.data = None
+            # Overwrite with the field's default value.
+            # This is cleaner than setting the data to 'None' since some fields
+            # expect structured data e.g. Accommodation & {Single,Multi}Choice.
+            # This makes the React code relatively simple and we can always distinguish
+            # purged fields since they have the 'is_purged' flag set to True
+            data.data = data.field_data.field.field_impl.default_value
             if data.field_data.field.field_impl.is_file_field:
                 logger.debug('Deleting file: %s', data.filename)
                 try:

--- a/indico/modules/events/registration/tasks.py
+++ b/indico/modules/events/registration/tasks.py
@@ -32,4 +32,6 @@ def delete_field_data():
     for data in registration_data:
         logger.info(f'Deleting registration field data: {data}')
         data.data = None
+        if data.field_data.field.field_impl.is_file_field:
+            data.file = None
     db.session.commit()

--- a/indico/modules/events/registration/tasks.py
+++ b/indico/modules/events/registration/tasks.py
@@ -1,0 +1,35 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from celery.schedules import crontab
+
+from indico.core.celery import celery
+from indico.core.db import db
+from indico.modules.events import Event
+from indico.modules.events.registration.models.form_fields import RegistrationFormField, RegistrationFormFieldData
+from indico.modules.events.registration.models.forms import RegistrationForm
+from indico.modules.events.registration.models.items import RegistrationFormItem
+from indico.modules.events.registration.models.registrations import RegistrationData
+from indico.modules.events.reminders import logger
+from indico.util.date_time import now_utc
+
+
+@celery.periodic_task(name='registration_fields_retention_period', run_every=crontab(hour='*/24'))
+def delete_field_data():
+    registration_data = (RegistrationData.query
+                         .join(RegistrationFormFieldData)
+                         .join(RegistrationFormField, RegistrationFormFieldData.field_id == RegistrationFormField.id)
+                         .join(RegistrationForm)
+                         .join(Event)
+                         .filter(RegistrationFormItem.retention_period.isnot(None),
+                                 Event.end_dt + RegistrationFormItem.retention_period <= now_utc())
+                         .all())
+
+    for data in registration_data:
+        logger.info(f'Deleting registration field data: {data}')
+        data.data = None
+    db.session.commit()

--- a/indico/modules/events/registration/tasks.py
+++ b/indico/modules/events/registration/tasks.py
@@ -15,7 +15,6 @@ from indico.modules.events import Event
 from indico.modules.events.registration import logger
 from indico.modules.events.registration.models.form_fields import RegistrationFormField, RegistrationFormFieldData
 from indico.modules.events.registration.models.forms import RegistrationForm
-from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import RegistrationData
 from indico.util.date_time import now_utc
 
@@ -34,9 +33,9 @@ def delete_field_data():
                          .join(RegistrationFormField, RegistrationFormFieldData.field_id == RegistrationFormField.id)
                          .join(RegistrationForm)
                          .join(Event)
-                         .filter(~RegistrationFormItem.is_purged,
-                                 RegistrationFormItem.retention_period.isnot(None),
-                                 Event.end_dt + RegistrationFormItem.retention_period <= now_utc())
+                         .filter(~RegistrationFormField.is_purged,
+                                 RegistrationFormField.retention_period.isnot(None),
+                                 Event.end_dt + RegistrationFormField.retention_period <= now_utc())
                          .all())
 
     data_by_regform = _group_by_regform(registration_data)

--- a/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
+++ b/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
@@ -14,6 +14,12 @@
                               title="{% trans %}This field no longer exists{% endtrans %}">
                         </span>
                     {% endif %}
+                    {% if field.is_purged -%}
+                        <span class="icon-warning purged-field-warning right"
+                              data-qtip-style="warning"
+                              title="{% trans %}The field data has been purged due to an expired retention period{% endtrans %}">
+                        </span>
+                    {% endif %}
                 </td>
             </tr>
         {%- endfor %}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -319,6 +319,11 @@ def create_registration(regform, data, invitation=None, management=False, notify
         value = data.get(form_item.html_field_name, default) if can_modify else default
         data_entry = RegistrationData()
         registration.data.append(data_entry)
+
+        if form_item.is_purged:
+            # Leave the registration data empty
+            continue
+
         for attr, value in form_item.field_impl.process_form_data(registration, value).items():
             setattr(data_entry, attr, value)
         if form_item.type == RegistrationFormItemType.field_pd and form_item.personal_data_type.column:
@@ -357,6 +362,9 @@ def modify_registration(registration, data, management=False, notify_user=True):
 
     billable_items_locked = not management and registration.is_paid
     for form_item in regform.active_fields:
+        if form_item.is_purged:
+            continue
+
         field_impl = form_item.field_impl
         has_data = form_item.html_field_name in data
         can_modify = management or not form_item.parent.is_manager_only

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -319,7 +319,6 @@ def create_registration(regform, data, invitation=None, management=False, notify
         value = data.get(form_item.html_field_name, default) if can_modify else default
         data_entry = RegistrationData()
         registration.data.append(data_entry)
-
         if form_item.is_purged:
             # Leave the registration data empty
             continue

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -140,6 +140,8 @@ def get_flat_section_submission_data(regform, *, management=False, registration=
         else:
             field_data = item.view_data
         item_data[item.id] = field_data
+    for item in regform.active_labels:
+        item_data[item.id] = item.view_data
     return {'sections': section_data, 'items': item_data}
 
 

--- a/indico/web/client/styles/modules/_registrationform.scss
+++ b/indico/web/client/styles/modules/_registrationform.scss
@@ -1296,6 +1296,14 @@ textarea.regFormDescriptionInputMgmt {
       }
     }
   }
+
+  tr {
+    td {
+      .purged-field-warning {
+        color: $yellow;
+      }
+    }
+  }
 }
 
 #registration-details {


### PR DESCRIPTION
Depends on #5283 

- [x]  Add a celery task to remove `RegistrationData` where the retention period of the associated field has expired when measured from the `event.end_dt`.
- [x] Signal in the frontend that the registration data have been deleted 
