### PR TITLE
Make get_placeholders interceptable

### DIFF
--- a/indico/modules/events/registration/badges.py
+++ b/indico/modules/events/registration/badges.py
@@ -81,7 +81,7 @@ class RegistrantsListToBadgesPDF(DesignerPDFBase):
             with template.background_image.open() as f:
                 self._draw_background(canvas, ImageReader(self._remove_transparency(f)), tpl_data, *badge_rect)
 
-        placeholders = get_placeholders('designer-fields')
+        placeholders = get_placeholders('designer-fields', registration=registration)
 
         # Print images first
         image_placeholders = {name for name, placeholder in placeholders.items() if placeholder.is_image}

--- a/indico/util/placeholders.py
+++ b/indico/util/placeholders.py
@@ -13,7 +13,7 @@ from markupsafe import Markup, escape
 
 from indico.core import signals
 from indico.util.decorators import classproperty
-from indico.util.signals import named_objects_from_signal
+from indico.util.signals import make_interceptable, named_objects_from_signal
 
 
 class Placeholder:
@@ -175,6 +175,7 @@ class ParametrizedPlaceholder(Placeholder):
         raise NotImplementedError
 
 
+@make_interceptable
 def get_placeholders(context, **kwargs):
     return named_objects_from_signal(signals.core.get_placeholders.send(context, **kwargs))
 


### PR DESCRIPTION
Hello, can we make the `get_placeholders` function interceptable so that we can change the value of the `context`