### PR TITLE
Fix a key error when getting registration summary

### DIFF
--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -473,7 +473,8 @@ class Registration(db.Model):
                 for field in section.fields:
                     if not field.is_visible:
                         continue
-                    summary[section][field] = field_summary[field]
+                    if field in field_summary:
+                        summary[section][field] = field_summary[field]
 
         def _fill_from_registration():
             for field, data in field_summary.items():


### PR DESCRIPTION
This error happens when a new field is added to a regform. When we modify an existing registration,
it does not yet contain the RegistrationData for the new field which causes the error.
Since the data does not exist, we can just skip this field.
