### PR TITLE
Add validation for text input size values

### DIFF
--- a/indico/modules/events/registration/client/js/form/fields/NumberInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/NumberInput.jsx
@@ -88,7 +88,7 @@ NumberInput.defaultProps = {
   isRequired: false,
   price: 0,
   minValue: 0,
-  maxValue: null,
+  maxValue: 0,
 };
 
 export function NumberSettings() {
@@ -103,6 +103,7 @@ export function NumberSettings() {
         min="0"
         validate={v.optional(v.min(0))}
         format={val => val || ''}
+        parse={val => +val || 0}
         fluid
       />
       <FinalInput
@@ -111,8 +112,10 @@ export function NumberSettings() {
         label={Translate.string('Maximum')}
         placeholder={Translate.string('No maximum')}
         step="1"
-        min="1"
-        validate={v.optional(v.min(1))}
+        min="0"
+        validate={v.optional(v.min(0))}
+        format={val => val || ''}
+        parse={val => +val || 0}
         fluid
       />
     </Form.Group>

--- a/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
@@ -27,7 +27,6 @@ export default function TextInput({htmlName, disabled, title, isRequired, ...pro
       {...inputProps}
       required={isRequired}
       disabled={disabled}
-      parse={val => val || null}
     />
   );
 }
@@ -43,8 +42,8 @@ TextInput.propTypes = {
 
 TextInput.defaultProps = {
   disabled: false,
-  minLength: null,
-  maxLength: null,
+  minLength: 0,
+  maxLength: 0,
 };
 
 export function TextSettings() {
@@ -54,19 +53,24 @@ export function TextSettings() {
         name="minLength"
         type="number"
         label={Translate.string('Min. length')}
+        placeholder={String(TextInput.defaultProps.minLength)}
         step="1"
         min="0"
         validate={v.optional(v.min(0))}
         format={val => val || ''}
+        parse={val => +val || 0}
         fluid
       />
       <FinalInput
         name="maxLength"
         type="number"
         label={Translate.string('Max. length')}
+        placeholder={Translate.string('No maximum')}
         step="1"
-        min="1"
-        validate={v.optional(v.min(1))}
+        min="0"
+        validate={v.optional(v.min(0))}
+        format={val => val || ''}
+        parse={val => +val || 0}
         fluid
       />
     </Form.Group>

--- a/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
@@ -56,7 +56,7 @@ export function TextSettings() {
         placeholder={String(TextInput.defaultProps.minLength)}
         step="1"
         min="0"
-        validate={v.optional(v.min(0))}
+        validate={v.optional(v.or(v.chain(v.min(0), v.max(0)), v.min(2)))}
         format={val => val || ''}
         parse={val => +val || 0}
         fluid

--- a/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
@@ -56,7 +56,17 @@ export function TextSettings() {
         placeholder={String(TextInput.defaultProps.minLength)}
         step="1"
         min="0"
-        validate={v.optional(v.or(v.chain(v.min(0), v.max(0)), v.min(2)))}
+        validate={v.optional(
+          v.chain(val => {
+            if (val === 0) {
+              return v.STOP_VALIDATION;
+            } else if (val === 1) {
+              return Translate.string(
+                'If you want to make the field required, select the "Required field" checkbox. The minimum length only applies if the field is not empty.'
+              );
+            }
+          }, v.min(2))
+        )}
         format={val => val || ''}
         parse={val => +val || 0}
         fluid

--- a/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
@@ -27,6 +27,7 @@ export default function TextInput({htmlName, disabled, title, isRequired, ...pro
       {...inputProps}
       required={isRequired}
       disabled={disabled}
+      parse={val => val || null}
     />
   );
 }
@@ -54,8 +55,9 @@ export function TextSettings() {
         type="number"
         label={Translate.string('Min. length')}
         step="1"
-        min="1"
-        validate={v.optional(v.min(1))}
+        min="0"
+        validate={v.optional(v.min(0))}
+        format={val => val || ''}
         fluid
       />
       <FinalInput
@@ -69,4 +71,14 @@ export function TextSettings() {
       />
     </Form.Group>
   );
+}
+
+export function textSettingsFormValidator({minLength, maxLength}) {
+  if (minLength && maxLength && minLength > maxLength) {
+    const msg = Translate.string('The minimum length cannot be greater than the maximum length.');
+    return {
+      minLength: msg,
+      maxLength: msg,
+    };
+  }
 }

--- a/indico/modules/events/registration/client/js/form/fields/registry.js
+++ b/indico/modules/events/registration/client/js/form/fields/registry.js
@@ -37,7 +37,7 @@ import SingleChoiceInput, {
   singleChoiceSettingsInitialData,
 } from './SingleChoiceInput';
 import TextAreaInput, {TextAreaSettings} from './TextAreaInput';
-import TextInput, {TextSettings} from './TextInput';
+import TextInput, {TextSettings, textSettingsFormValidator} from './TextInput';
 
 /*
 Available keys:
@@ -74,6 +74,7 @@ const fieldRegistry = {
     title: Translate.string('Text'),
     inputComponent: TextInput,
     settingsComponent: TextSettings,
+    settingsFormValidator: textSettingsFormValidator,
     icon: 'textfield',
   },
   number: {

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -29,8 +29,8 @@ KEEP_EXISTING_FILE_UUID = '00000000-0000-0000-0000-000000000001'
 
 
 class TextFieldDataSchema(mm.Schema):
-    min_length = fields.Integer(load_default=0, validate=validate.Range(0), allow_none=True)
-    max_length = fields.Integer(validate=validate.Range(0), allow_none=True)
+    min_length = fields.Integer(load_default=0, validate=validate.Range(0))
+    max_length = fields.Integer(load_default=0, validate=validate.Range(0))
 
     @validates_schema(skip_on_field_errors=True)
     def validate_min_max(self, data, **kwargs):
@@ -56,8 +56,8 @@ class TextField(RegistrationFormFieldBase):
 
 
 class NumberFieldDataSchema(BillableFieldDataSchema):
-    min_value = fields.Integer(load_default=0, validate=validate.Range(0), allow_none=True)
-    max_value = fields.Integer(validate=validate.Range(0), allow_none=True)
+    min_value = fields.Integer(load_default=0, validate=validate.Range(0))
+    max_value = fields.Integer(load_default=0, validate=validate.Range(0))
 
     @validates_schema(skip_on_field_errors=True)
     def validate_min_max(self, data, **kwargs):
@@ -72,8 +72,8 @@ class NumberField(RegistrationFormBillableField):
     setup_schema_base_cls = NumberFieldDataSchema
 
     def get_validators(self, existing_registration):
-        return validate.Range(min=self.form_item.data.get('min_value', None) or 0,
-                              max=self.form_item.data.get('max_value', None))
+        return validate.Range(min=self.form_item.data.get('min_value') or 0,
+                              max=self.form_item.data.get('max_value') or None)
 
     def calculate_price(self, reg_data, versioned_data):
         return versioned_data.get('price', 0) * int(reg_data or 0)

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -29,7 +29,7 @@ KEEP_EXISTING_FILE_UUID = '00000000-0000-0000-0000-000000000001'
 
 
 class TextFieldDataSchema(mm.Schema):
-    min_length = fields.Integer(load_default=0, validate=validate.Range(0))
+    min_length = fields.Integer(load_default=0, validate=validate.And(validate.Range(0), validate.NoneOf((1,))))
     max_length = fields.Integer(load_default=0, validate=validate.Range(0))
 
     @validates_schema(skip_on_field_errors=True)

--- a/indico/web/client/js/react/forms/validators.js
+++ b/indico/web/client/js/react/forms/validators.js
@@ -126,4 +126,5 @@ export default {
   chain,
   or,
   dates,
+  STOP_VALIDATION,
 };


### PR DESCRIPTION
This PR includes:

- Validation to ensure minimum length is smaller than maximum length in regform text inputs;
- Validation to ensure the value of the text field is within the minimum and maximum lengths set in the settings;
- A fix to an error that occurred when setting only the minimum length/value in text and number inputs.