### PR TITLE
Show hidden participants in participant list

### DIFF
--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -517,6 +517,12 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         is_participant = self.is_user_registered(user)
         return get_published_registrations(self, is_participant)
 
+    @memoize_request
+    def count_hidden_registrations(self, user):
+        from indico.modules.events.registration.util import count_hidden_registrations
+        is_participant = self.is_user_registered(user)
+        return count_hidden_registrations(self, is_participant)
+
     @property
     def protection_parent(self):
         return self.category

--- a/indico/modules/events/registration/__init__.py
+++ b/indico/modules/events/registration/__init__.py
@@ -16,6 +16,7 @@ from indico.modules.events.features.base import EventFeature
 from indico.modules.events.layout.util import MenuEntryData
 from indico.modules.events.models.events import EventType
 from indico.modules.events.registration.logging import connect_log_signals
+from indico.modules.events.registration.models.registrations import PublishRegistrationsMode
 from indico.modules.events.registration.settings import RegistrationSettingsProxy
 from indico.util.i18n import _, ngettext
 from indico.util.signals import values_from_signal
@@ -113,6 +114,12 @@ def _extend_event_menu(sender, **kwargs):
 
     def _visible_participant_list(event):
         if not event.has_feature('registration'):
+            return False
+        if not (RegistrationForm.query.with_parent(event)
+                .filter(RegistrationForm.publish_registrations_participants > PublishRegistrationsMode.hide_all
+                        if event.is_user_registered(session.user)
+                        else RegistrationForm.publish_registrations_public > PublishRegistrationsMode.hide_all)
+                .has_rows()):
             return False
         return not any(values_from_signal(signals.event.hide_participant_list.send(event)))
 

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from operator import attrgetter
 from uuid import UUID
 
 from flask import flash, jsonify, redirect, request, session
@@ -13,6 +12,7 @@ from sqlalchemy.orm import contains_eager, joinedload, lazyload, load_only, subq
 from webargs import fields
 from werkzeug.exceptions import Forbidden, NotFound
 
+from indico.core.db import db
 from indico.modules.auth.util import redirect_to_login
 from indico.modules.events.controllers.base import RegistrationRequired, RHDisplayEventBase
 from indico.modules.events.models.events import EventType
@@ -22,8 +22,7 @@ from indico.modules.events.registration.controllers import RegistrationEditMixin
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.invitations import InvitationState, RegistrationInvitation
 from indico.modules.events.registration.models.items import PersonalDataType
-from indico.modules.events.registration.models.registrations import (PublishRegistrationsMode, Registration,
-                                                                     RegistrationState)
+from indico.modules.events.registration.models.registrations import Registration, RegistrationState
 from indico.modules.events.registration.util import (check_registration_email, create_registration, generate_ticket,
                                                      get_event_regforms_registrations, get_flat_section_submission_data,
                                                      get_initial_form_values, get_user_data, make_registration_schema)
@@ -140,7 +139,7 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
         headers = [PersonalDataType[column_name].get_title() for column_name in column_names]
 
         query = (Registration.query.with_parent(self.event)
-                 .filter(~RegistrationForm.is_deleted, ~Registration.is_deleted)
+                 .filter(Registration.is_state_publishable, ~RegistrationForm.is_deleted)
                  .join(Registration.registration_form)
                  .options(subqueryload('data').joinedload('field_data'),
                           contains_eager('registration_form')))
@@ -184,19 +183,24 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
                       for column_id in registration_settings.get_participant_list_columns(self.event, regform)
                       if column_id in active_fields]
         headers = [active_fields[column_id].title.title() for column_id in column_ids]
-        active_registrations = sorted(regform.active_registrations, key=attrgetter('last_name', 'first_name', 'id'))
+        query = (Registration.query.with_parent(regform)
+                 .filter(Registration.is_state_publishable)
+                 .options(subqueryload('data'))
+                 .order_by(db.func.lower(Registration.first_name),
+                           db.func.lower(Registration.last_name),
+                           Registration.friendly_id))
         is_participant = self.event.is_user_registered(session.user)
-        registrations = [_process_registration(reg, column_ids, active_fields) for reg in active_registrations
+        registrations = [_process_registration(reg, column_ids, active_fields) for reg in query
                          if reg.is_publishable(is_participant)]
         return {'headers': headers,
                 'rows': registrations,
                 'title': regform.title,
                 'show_checkin': any(registration['checked_in'] for registration in registrations),
-                'num_participants': len(active_registrations)}
+                'num_participants': query.count()}
 
     def _process(self):
         regforms = (RegistrationForm.query.with_parent(self.event)
-                    .filter(~RegistrationForm.is_deleted)
+                    .filter(RegistrationForm.is_participant_list_visible(self.event.is_user_registered(session.user)))
                     .options(subqueryload('registrations').subqueryload('data').joinedload('field_data'))
                     .all())
         if registration_settings.get(self.event, 'merge_registration_forms'):
@@ -215,19 +219,13 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
             # There might be forms that have not been sorted by the user yet
             tables.extend(map(self._participant_list_table, regforms_dict.values()))
 
-        published = (RegistrationForm.query.with_parent(self.event)
-                     .filter(RegistrationForm.publish_registrations_participants > PublishRegistrationsMode.hide_all
-                             if self.event.is_user_registered(session.user)
-                             else RegistrationForm.publish_registrations_public > PublishRegistrationsMode.hide_all)
-                     .has_rows())
         num_participants = sum(table['num_participants'] for table in tables)
 
         return self.view_class.render_template(
             'display/participant_list.html',
             self.event,
-            regforms=regforms,
             tables=tables,
-            published=published,
+            published=bool(regforms),
             num_participants=num_participants
         )
 

--- a/indico/modules/events/registration/templates/display/event_header.html
+++ b/indico/modules/events/registration/templates/display/event_header.html
@@ -76,13 +76,13 @@
     </div>
 {% endif %}
 
-{% if event.get_published_registrations(session.user) %}
+{% if published_registrations %}
     <div class="event-details-row">
         <div class="event-details-label">{% trans %}Participants{% endtrans %}</div>
         <div class="event-details-content">
             <div class="participant-list-wrapper">
                 <ul class="participant-list">
-                    {%- for participant in event.get_published_registrations(session.user)|sort(attribute='display_full_name') -%}
+                    {%- for participant in published_registrations|sort(attribute='display_full_name') -%}
                         <li class="ui image label meeting-participant {% if participant.checked_in and participant.registration_form.publish_checkin_enabled %} checked-in {% endif %}">
                             {%- if not g.static_site -%}
                                 <img src="{{ participant.avatar_url }}" alt="">
@@ -90,9 +90,21 @@
                             {{ participant.display_full_name }}
                         </li>
                     {%- endfor -%}
+                    {%- if num_hidden_registrations -%}
+                        <li class="ui circular label" title="{% trans num=num_hidden_registrations %}{{ num }} more participant{% pluralize %}{{ num }} more participants{% endtrans %}">
+                            +{{ num_hidden_registrations }}
+                        </li>
+                    {%- endif -%}
                 </ul>
                 <a class="trigger icon-expand" title="{% trans %}See the full list{% endtrans %}"></a>
             </div>
+        </div>
+    </div>
+{% elif num_hidden_registrations %}
+    <div class="event-details-row">
+        <div class="event-details-label">{% trans %}Participants{% endtrans %}</div>
+        <div class="event-details-content">
+            {{ num_hidden_registrations }}
         </div>
     </div>
 {% endif %}

--- a/indico/modules/events/registration/templates/display/event_header.html
+++ b/indico/modules/events/registration/templates/display/event_header.html
@@ -104,7 +104,9 @@
     <div class="event-details-row">
         <div class="event-details-label">{% trans %}Participants{% endtrans %}</div>
         <div class="event-details-content">
-            {{ num_hidden_registrations }}
+            <span class="ui circular label">
+                {{ num_hidden_registrations }}
+            </span>
         </div>
     </div>
 {% endif %}

--- a/indico/modules/events/registration/templates/display/participant_list.html
+++ b/indico/modules/events/registration/templates/display/participant_list.html
@@ -55,6 +55,7 @@
 
 {% macro participant_table(table) %}
     <section>
+        {% set hidden_participants = table.num_participants - table.rows|length %}
         {% if table.title %}
             <div class="header">
                 <div class="header-row">
@@ -69,11 +70,18 @@
                     {% for row in table.rows %}
                         {{ table_row(row, table.show_checkin) }}
                     {% endfor %}
+                    {% if hidden_participants %}
+                        <tr class="i-table">
+                            <td class="i-table empty" colspan="{{ table.headers|length+1 if table.show_checkin else table.headers|length }}">
+                                {% trans num=hidden_participants %}{{ num }} more participant{% pluralize %}{{ num }} more participants{% endtrans %}
+                            </td>
+                        </tr>
+                    {% endif %}
                 </tbody>
             </table>
         {% elif table.num_participants %}
             {% call message_box('info', fixed_width=true) %}
-                {% trans %}There are no published registrations.{% endtrans %}
+                {% trans num=hidden_participants %}There is {{ num }} hidden participant{% pluralize %}There are {{ num }} hidden participants{% endtrans %}
             {% endcall %}
         {% else %}
             {% call message_box('info', fixed_width=true) %}
@@ -90,7 +98,7 @@
         {% endcall %}
     {% elif not num_participants %}
         {% call message_box('info', fixed_width=true) %}
-            {% trans %}There are no participants yet.{% endtrans %}
+            {% trans %}There are no registrations yet.{% endtrans %}
         {% endcall %}
     {% else %}
         <div class="registrations list">

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -510,7 +510,7 @@ def count_hidden_registrations(event, is_participant):
     query = (Registration.query.with_parent(event)
              .filter(Registration.is_state_publishable,
                      ~Registration.is_publishable(is_participant),
-                     ~RegistrationForm.is_deleted)
+                     RegistrationForm.is_participant_list_visible(is_participant))
              .join(Registration.registration_form))
 
     return query.count()

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -500,6 +500,22 @@ def get_published_registrations(event, is_participant):
     return query.all()
 
 
+def count_hidden_registrations(event, is_participant):
+    """Get the number of hidden registrations for an event.
+
+    :param event: the `Event` to get registrations for
+    :param is_participant: whether the user accessing the registrations is a participant of the event
+    :return: number of registrations
+    """
+    query = (Registration.query.with_parent(event)
+             .filter(Registration.is_state_publishable,
+                     ~Registration.is_publishable(is_participant),
+                     ~RegistrationForm.is_deleted)
+             .join(Registration.registration_form))
+
+    return query.count()
+
+
 def get_events_registered(user, dt=None):
     """Get the IDs of events where the user is registered.
 


### PR DESCRIPTION
Closes #5301

This PR adds a "X more participants" row to participants lists to indicate that there are unpublished participants, as well as a "+X" badge on meeting/lecture-type events.

![screenshot](https://user-images.githubusercontent.com/27357203/160399836-a6e25fdf-75ea-41ec-8326-acde52ae2516.png)

![screenshot](https://user-images.githubusercontent.com/27357203/160400359-e528db27-87bf-4bdc-9e2d-5402a6b8df9e.png)
