### PR TITLE
Update participant filter logic

### DIFF
--- a/indico/modules/events/management/client/js/index.js
+++ b/indico/modules/events/management/client/js/index.js
@@ -81,8 +81,9 @@ import {SingleEventMove, EventPublish} from './EventMove';
       })
       .get();
 
-    const visibleEntries = personRows.filter((idx, entry) =>
-      filters.find(filterName => $(entry).data('person-roles')[filterName])
+    const visibleEntries = personRows.filter(
+      (idx, entry) =>
+        !filters.length || filters.find(filterName => $(entry).data('person-roles')[filterName])
     );
 
     personRows.addClass('hidden');
@@ -91,10 +92,10 @@ import {SingleEventMove, EventPublish} from './EventMove';
   }
 
   function toggleResetBtn() {
-    const isInitialState =
-      $('#person-filters [data-filter]:checked').length ===
-      $('#person-filters [data-filter]:not(#filter-no-account,#filter-no-registration)').length;
-    $('.js-reset-role-filter').toggleClass('disabled', isInitialState);
+    $('.js-reset-role-filter').toggleClass(
+      'disabled',
+      $('#person-filters [data-filter]:checked').length === 0
+    );
   }
 
   function initTooltip() {
@@ -256,10 +257,8 @@ import {SingleEventMove, EventPublish} from './EventMove';
     $personFilters.find('.js-reset-role-filter').on('click', function() {
       $('.js-event-person-list [data-filter]').each(function() {
         const $this = $(this);
-        $this.prop('checked', !$this.is('#filter-no-account, #filter-no-registration'));
-        $this
-          .parent()
-          .toggleClass('enabled', !$this.is('#filter-no-account, #filter-no-registration'));
+        $this.prop('checked', false);
+        $this.parent().toggleClass('enabled', false);
       });
       refreshPersonFilters();
       applySearchFilters();

--- a/indico/modules/events/persons/templates/management/person_list.html
+++ b/indico/modules/events/persons/templates/management/person_list.html
@@ -125,7 +125,7 @@
                     <ul class="i-dropdown">
                         {% if event.type != 'lecture' %}
                             <li class="enabled">
-                                <input type="checkbox" id="filter-chairpersons" data-filter="chairperson" checked>
+                                <input type="checkbox" id="filter-chairpersons" data-filter="chairperson">
                                 <i class="icon-checkmark"></i>
                                 <i class="icon-stop colored-square" style="color: #{{ builtin_roles.chairperson.color }};"></i>
                                 <label for="filter-chairpersons">
@@ -133,20 +133,20 @@
                                 </label>
                             </li>
                             <li class="enabled">
-                                <input type="checkbox" id="filter-speakers" data-filter="speaker" checked>
+                                <input type="checkbox" id="filter-speakers" data-filter="speaker">
                                 <i class="icon-checkmark"></i>
                                 <i class="icon-stop colored-square" style="color: #{{ builtin_roles.speaker.color }};"></i>
                                 <label for="filter-speakers">{% trans %}Speakers{% endtrans %}</label>
                             </li>
                             <li class="enabled">
-                                <input type="checkbox" id="filter-conveners" data-filter="convener" checked>
+                                <input type="checkbox" id="filter-conveners" data-filter="convener">
                                 <i class="icon-checkmark"></i>
                                 <i class="icon-stop colored-square" style="color: #{{ builtin_roles.convener.color }};"></i>
                                 <label for="filter-conveners">{% trans %}Conveners{% endtrans %}</label>
                             </li>
                             {% if event.has_feature('abstracts') %}
                                 <li class="enabled">
-                                    <input type="checkbox" id="filter-abstract-author" data-filter="author" checked>
+                                    <input type="checkbox" id="filter-abstract-author" data-filter="author">
                                     <i class="icon-checkmark"></i>
                                     <i class="icon-stop colored-square" style="color: #{{ builtin_roles.author.color }};"></i>
                                     <label for="filter-abstract-author">
@@ -156,7 +156,7 @@
                             {% endif %}
                         {% else %}
                             <li class="enabled">
-                                <input type="checkbox" id="filter-lecture-speakers" data-filter="lecture_speaker" checked>
+                                <input type="checkbox" id="filter-lecture-speakers" data-filter="lecture_speaker">
                                 <i class="icon-checkmark"></i>
                                 <i class="icon-stop colored-square" style="color: #{{ builtin_roles.lecture_speaker.color }};"></i>
                                 <label for="filter-lecture-speakers">{% trans %}Speakers{% endtrans %}</label>
@@ -164,7 +164,7 @@
                         {% endif %}
                         {% for role_id, role_data in custom_roles.items() %}
                             <li class="enabled">
-                                <input type="checkbox" id="filter-{{ role_id }}" data-filter="{{ role_id }}" checked>
+                                <input type="checkbox" id="filter-{{ role_id }}" data-filter="{{ role_id }}">
                                 <i class="icon-checkmark"></i>
                                 <i class="icon-stop colored-square" style="color: #{{ role_data.color }};"></i>
                                 <label for="filter-{{ role_id }}" title="{{ role_data.code }}">{{ role_data.name }}</label>


### PR DESCRIPTION
Under "Participant Roles" there is a filter drop-down menu. By default, all roles are selected. If one wants to deselect all and then select only one or two, they have to manually go and click on all the others.

My proposal is to ease this behaviour and make the logic of none selected the same as all selected, updating the "X" for reset filters.

![imagem](https://user-images.githubusercontent.com/12183954/160416070-3ea4afa4-aeb7-4fb2-ba64-005d2fe84198.png)
![imagem](https://user-images.githubusercontent.com/12183954/160416100-5e4e249d-d0dc-4449-b950-cafdd05956e7.png)

The images above would become the same, having by default none selected.