### PR TITLE
Add visibility duration to participant lists

### DIFF
--- a/indico/migrations/versions/20220329_1207_a61ce4bd7549_add_publish_registrations_duration_to_regforms.py
+++ b/indico/migrations/versions/20220329_1207_a61ce4bd7549_add_publish_registrations_duration_to_regforms.py
@@ -1,0 +1,26 @@
+"""Add publish registrations duration to registration forms
+
+Revision ID: a61ce4bd7549
+Revises: 57696d76f9b0
+Create Date: 2022-03-29 12:07:54.108451
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'a61ce4bd7549'
+down_revision = '57696d76f9b0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('forms',
+                  sa.Column('publish_registrations_duration', sa.Interval(), nullable=True),
+                  schema='event_registration')
+
+
+def downgrade():
+    op.drop_column('forms', 'publish_registrations_duration', schema='event_registration')

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -501,7 +501,7 @@ class RegistrationPrivacyForm(IndicoForm):
         super().__init__(*args, **kwargs)
 
     def validate_visibility(self, field):
-        participant_visibility, public_visibility = (PublishRegistrationsMode[v] for v in field.data)
+        participant_visibility, public_visibility = (PublishRegistrationsMode[v] for v in field.data[:-1])
         if participant_visibility.value < public_visibility.value:
             raise ValidationError(_('Participant visibility can not be more restrictive for other participants than '
                                     'for the public'))

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -142,6 +142,11 @@ class RegistrationForm(db.Model):
         nullable=False,
         default=PublishRegistrationsMode.show_with_consent
     )
+    #: For how long should the registrations be displayed after the event ends
+    publish_registrations_duration = db.Column(
+        db.Interval,
+        nullable=True
+    )
     #: Whether to display the number of registrations
     publish_registration_count = db.Column(
         db.Boolean,

--- a/indico/web/client/js/react/components/WTFParticipantVisibilityField.jsx
+++ b/indico/web/client/js/react/components/WTFParticipantVisibilityField.jsx
@@ -7,7 +7,7 @@
 
 import PropTypes from 'prop-types';
 import React, {useMemo, useState, useEffect} from 'react';
-import {Dropdown, Form, Icon, Message} from 'semantic-ui-react';
+import {Dropdown, Form, Icon, Input, Message} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 
@@ -15,6 +15,7 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
   const parentElement = useMemo(() => document.getElementById(wrapperId), [wrapperId]);
   const [participantVisibility, setParticipantVisibility] = useState(values[0]);
   const [publicVisibility, setPublicVisibility] = useState(values[1]);
+  const [visibilityDuration, setVisibilityDuration] = useState(values[2]);
 
   // Trigger change only after the DOM has changed
   useEffect(() => {
@@ -46,8 +47,8 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
 
   return (
     <div>
-      <div style={{display: 'flex', alignItems: 'center', gap: '0 10px'}}>
-        <Form.Field style={{flexBasis: '50%'}}>
+      <div style={{display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '10px'}}>
+        <Form.Field style={{flexBasis: '49%'}}>
           <label>
             <Translate>Visibility to participants</Translate>
           </label>
@@ -66,7 +67,7 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
             value={participantVisibility}
           />
         </Form.Field>
-        <Form.Field style={{flexBasis: '50%'}}>
+        <Form.Field style={{flexBasis: '49%'}}>
           <label>
             <Translate>Visibility to everyone</Translate>
           </label>
@@ -79,6 +80,21 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
             options={publicOptions}
             selection
             value={publicVisibility}
+          />
+        </Form.Field>
+        <Form.Field style={{flexGrow: 1}}>
+          <label>
+            <Translate>Visibility duration (months)</Translate>
+          </label>
+          <Input
+            type="number"
+            placeholder={Translate.string('Permanent')}
+            step="1"
+            min="0"
+            value={visibilityDuration}
+            onChange={(evt, {value}) => setVisibilityDuration(value)}
+            disabled={participantVisibility === 'hide_all'}
+            fluid
           />
         </Form.Field>
       </div>

--- a/indico/web/client/js/react/components/WTFParticipantVisibilityField.jsx
+++ b/indico/web/client/js/react/components/WTFParticipantVisibilityField.jsx
@@ -20,7 +20,7 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
   // Trigger change only after the DOM has changed
   useEffect(() => {
     parentElement.dispatchEvent(new Event('change', {bubbles: true}));
-  }, [participantVisibility, publicVisibility, parentElement]);
+  }, [participantVisibility, publicVisibility, visibilityDuration, parentElement]);
 
   const choiceMap = {
     hide_all: ['hide_all'],
@@ -48,7 +48,7 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
   return (
     <div>
       <div style={{display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: '10px'}}>
-        <Form.Field style={{flexBasis: '49%'}}>
+        <Form.Field style={{flex: '1 49%'}}>
           <label>
             <Translate>Visibility to participants</Translate>
           </label>
@@ -67,7 +67,7 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
             value={participantVisibility}
           />
         </Form.Field>
-        <Form.Field style={{flexBasis: '49%'}}>
+        <Form.Field style={{flex: '1 49%'}}>
           <label>
             <Translate>Visibility to everyone</Translate>
           </label>
@@ -91,8 +91,8 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
             placeholder={Translate.string('Permanent')}
             step="1"
             min="0"
-            value={visibilityDuration}
-            onChange={(evt, {value}) => setVisibilityDuration(value)}
+            value={visibilityDuration === null ? '' : visibilityDuration}
+            onChange={(evt, {value}) => setVisibilityDuration(value === '' ? null : +value)}
             disabled={participantVisibility === 'hide_all'}
             fluid
           />
@@ -116,7 +116,7 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
         type="hidden"
         id={fieldId}
         name={fieldId}
-        value={JSON.stringify([participantVisibility, publicVisibility])}
+        value={JSON.stringify([participantVisibility, publicVisibility, visibilityDuration])}
       />
     </div>
   );


### PR DESCRIPTION
Closes #5303
Depends on #5302

This PR adds a setting to indicate for how many months after the event the participant list should be displayed.

<img width="713" alt="image" src="https://user-images.githubusercontent.com/27357203/160836559-9f1f7569-6953-4f59-976f-93cb2a822dbe.png">

Progress:
- [x] Add visibility duration field to privacy widget
- [x] Add visibility duration column to the registration forms
- [x] Hide participant lists after the set duration expires
- [x] Add unit tests