### PR TITLE
Make update_event  interceptable

### DIFF
--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -24,6 +24,7 @@ from indico.modules.events.models.references import ReferenceType
 from indico.modules.logs.models.entries import CategoryLogRealm, LogKind
 from indico.modules.logs.util import make_diff_log
 from indico.util.i18n import orig_string
+from indico.util.signals import make_interceptable
 
 
 def create_reference_type(data):
@@ -136,6 +137,7 @@ def create_event(category, event_type, data, add_creator_as_manager=True, featur
     return event
 
 
+@make_interceptable
 def update_event(event, update_timetable=False, **data):
     assert set(data.keys()) <= {'title', 'description', 'url_shortcut', 'location_data', 'keywords',
                                 'person_link_data', 'start_dt', 'end_dt', 'timezone', 'keywords', 'references',


### PR DESCRIPTION
We have introduced two fields arrangement_type enum (virtual, hybrid, in-person), and virtual_details fields. 
We would like to pop, save and update logs before it goes to update_events and gives an assertion error.