### PR TITLE
Show data controller information

### DIFF
--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -15,6 +15,7 @@ from indico.core.db.sqlalchemy.protection import make_acl_log_fn
 from indico.core.logger import Logger
 from indico.core.permissions import ManagementPermission, check_permissions
 from indico.modules.events.cloning import get_event_cloners
+from indico.modules.events.management.settings import privacy_settings
 from indico.modules.events.models.events import Event
 from indico.modules.events.models.legacy_mapping import LegacyEventMapping
 from indico.modules.logs import EventLogRealm
@@ -168,8 +169,13 @@ def _extend_event_menu(sender, **kwargs):
         return session.user and (get_menu_entry_by_name('my_contributions', event).is_visible or
                                  get_menu_entry_by_name('my_sessions', event).is_visible)
 
+    def _visible_privacy_information(event):
+        return any(privacy_settings.get_all(event).values())
+
     yield MenuEntryData(_('Overview'), 'overview', 'events.display_overview', position=0, static_site=True)
     yield MenuEntryData(_('My Conference'), 'my_conference', position=7, visible=_my_conference_visible)
+    yield MenuEntryData(_('Privacy Information'), 'privacy', 'events.display_privacy', position=13,
+                        visible=_visible_privacy_information, static_site=True, hide_if_restricted=False)
 
 
 @signals.core.app_created.connect

--- a/indico/modules/events/controllers/display.py
+++ b/indico/modules/events/controllers/display.py
@@ -17,8 +17,7 @@ from indico.modules.events.layout.views import WPPage
 from indico.modules.events.management.settings import privacy_settings
 from indico.modules.events.models.events import EventType
 from indico.modules.events.util import get_theme
-from indico.modules.events.views import WPConferenceDisplay, WPSimpleEventDisplay
-from indico.modules.legal.views import WPDisplayPrivacyPolicy
+from indico.modules.events.views import WPConferenceDisplay, WPConferencePrivacyDisplay, WPSimpleEventDisplay
 from indico.web.args import use_kwargs
 from indico.web.flask.util import send_file, url_for
 from indico.web.rh import allow_signed_url
@@ -83,9 +82,11 @@ class RHEventAccessKey(RHEventBase):
 class RHDisplayPrivacyPolicy(RHEventBase):
     """Display event privacy policy."""
 
+    view_class = WPConferencePrivacyDisplay
+
     def _process(self):
-        if urls := privacy_settings.get(self.event, 'privacy_policy_urls'):
-            # There could be multiple urls, redirect to the first one.
-            return redirect(urls[0]['url'])
-        return WPDisplayPrivacyPolicy.render_template('privacy.html',
-                                                      content=privacy_settings.get(self.event, 'privacy_policy'))
+        return self.view_class.render_template(
+            'privacy_policy.html' if request.is_xhr else 'privacy.html',
+            self.event,
+            privacy_info=privacy_settings.get_all(self.event)
+        )

--- a/indico/modules/events/templates/display/common/_privacy_info_button.html
+++ b/indico/modules/events/templates/display/common/_privacy_info_button.html
@@ -1,0 +1,71 @@
+{% macro render_privacy_info_button(event, privacy_info) -%}
+    {% set data_controller_exists = privacy_info.data_controller_name or privacy_info.data_controller_email %}
+    {% if data_controller_exists or privacy_info.privacy_policy_urls|length > 1 %}
+        <div class="privacy-dropdown">
+            <a href="#"
+               onclick="return false;"
+               title="{% trans %}Event privacy information{% endtrans %}">
+                <i class="info icon small"></i>
+            </a>
+            <div class="menu">
+                {% if data_controller_exists %}
+                    <div class="header">{% trans %}Data controller{% endtrans %}</div>
+                    {% if privacy_info.data_controller_name %}
+                        <div class="item">{{ privacy_info.data_controller_name }}</div>
+                    {% endif %}
+                    {% if privacy_info.data_controller_email %}
+                        <a class="item" href="mailto:{{ privacy_info.data_controller_email }}">{{ privacy_info.data_controller_email }}</a>
+                    {% endif %}
+                    {% if privacy_info.privacy_policy or privacy_info.privacy_policy_urls %}
+                        <div class="divider"></div>
+                    {% endif %}
+                {% endif %}
+                {% if privacy_info.privacy_policy %}
+                    <a class="item"
+                       href="{{ url_for('events.display_privacy', event) }}"
+                       data-title="{% trans %}Event privacy notice{% endtrans %}"
+                       data-href="{{ url_for('events.display_privacy', event) }}"
+                       data-ajax-dialog
+                       data-hide-page-header
+                       data-close-button>
+                        {% trans %}Privacy notice{% endtrans %}
+                    </a>
+                {% elif privacy_info.privacy_policy_urls|length == 1 %}
+                    <a class="item"
+                       href="{{ privacy_info.privacy_policy_urls[0].url }}"
+                       target="_blank"
+                       rel="noopener noreferrer">
+                        {% trans %}Privacy notice{% endtrans %}
+                    </a>
+                {% elif privacy_info.privacy_policy_urls %}
+                    <div class="header">{% trans %}Privacy notices{% endtrans %}</div>
+                    {% for privacy_url in privacy_info.privacy_policy_urls %}
+                        <a class="item"
+                           href="{{ privacy_url.url }}"
+                           target="_blank"
+                           rel="noopener noreferrer">
+                            {{ privacy_url.title }}
+                        </a>
+                    {% endfor %}
+                {% endif %}
+            </div>
+        </div>
+    {% elif privacy_info.privacy_policy %}
+        <a href="{{ url_for('events.display_privacy', event) }}"
+           title="{% trans %}Event privacy notice{% endtrans %}"
+           data-title="{% trans %}Event privacy notice{% endtrans %}"
+           data-href="{{ url_for('events.display_privacy', event) }}"
+           data-ajax-dialog
+           data-hide-page-header
+           data-close-button>
+            <i class="info icon small"></i>
+        </a>
+    {% elif privacy_info.privacy_policy_urls %}
+        <a href="{{ privacy_info.privacy_policy_urls[0].url }}"
+           target="_blank"
+           rel="noopener noreferrer"
+           title="{% trans %}Event privacy notice{% endtrans %}">
+            <i class="info icon small"></i>
+        </a>
+    {% endif %}
+{%- endmacro %}

--- a/indico/modules/events/templates/display/common/_privacy_info_button.html
+++ b/indico/modules/events/templates/display/common/_privacy_info_button.html
@@ -14,7 +14,9 @@
                         <div class="item">{{ privacy_info.data_controller_name }}</div>
                     {% endif %}
                     {% if privacy_info.data_controller_email %}
-                        <a class="item" href="mailto:{{ privacy_info.data_controller_email }}">{{ privacy_info.data_controller_email }}</a>
+                        <a class="item" href="mailto:{{ privacy_info.data_controller_email }}">
+                            {{ privacy_info.data_controller_email }}
+                        </a>
                     {% endif %}
                     {% if privacy_info.privacy_policy or privacy_info.privacy_policy_urls %}
                         <div class="divider"></div>

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -1,5 +1,6 @@
 {% from 'events/display/_event_header_message.html' import render_event_header_msg %}
 {% from 'events/display/common/_manage_button.html' import render_manage_button %}
+{% from 'events/display/common/_privacy_info_button.html' import render_privacy_info_button %}
 {% from 'events/display/indico/_common.html' import render_location, render_users, render_event_time %}
 {% from 'events/notes/_note.html' import render_note %}
 
@@ -13,6 +14,9 @@
 <div class="event-wrapper">
     {% block header %}
         <div class="event-header event-header-lecture {%- if not has_subheader %} round-bottom-corners{% endif %}">
+            <div class="event-privacy-info-button">
+                {{ render_privacy_info_button(event, privacy_info) }}
+            </div>
             {% if category %}
                 {% if not g.static_site %}
                     <a class="lecture-category" href="{{ url_for('categories.display', event.category) }}">

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -1,5 +1,6 @@
 {% from 'events/display/_event_header_message.html' import render_event_header_msg %}
 {% from 'events/display/common/_manage_button.html' import render_manage_button %}
+{% from 'events/display/common/_privacy_info_button.html' import render_privacy_info_button %}
 {% from 'events/display/indico/_common.html' import render_location, render_users, render_event_time %}
 {% from 'events/timetable/display/indico/_common.html' import render_notes %}
 {% from 'events/notes/_note.html' import render_note %}
@@ -14,6 +15,9 @@
 <div class="event-wrapper">
     {% block header %}
         <div class="event-header {%- if not has_subheader %} round-bottom-corners{% endif %}">
+            <div class="event-privacy-info-button">
+                {{ render_privacy_info_button(event, privacy_info) }}
+            </div>
             {% set show_button = not event.is_locked and event.can_manage_attachments(session.user) %}
             <div class="event-manage-button">
                 {{ render_manage_button(event, 'EVENT', show_button=show_button, toggle_notes=false) }}

--- a/indico/modules/events/templates/display/privacy.html
+++ b/indico/modules/events/templates/display/privacy.html
@@ -1,0 +1,81 @@
+{% if event.type == 'conference' %}
+    {% extends 'events/display/conference/base.html' %}
+{% else %}
+    {% extends 'layout/meeting_page_base.html' %}
+{% endif %}
+
+{% from 'message_box.html' import message_box %}
+
+{% block title %}
+    {% trans %}Privacy Information{% endtrans %}
+{% endblock %}
+
+{% block content %}
+    {% set data_controller_exists = privacy_info.data_controller_name or privacy_info.data_controller_email %}
+    {% set privacy_policy_exists = privacy_info.privacy_policy or privacy_info.privacy_policy_urls %}
+    {% if not data_controller_exists and not privacy_policy_exists %}
+        {% call message_box('info', fixed_width=true) %}
+            {% trans %}There is no privacy information for this event.{% endtrans %}
+        {% endcall %}
+    {% endif %}
+    {% if data_controller_exists %}
+        <div class="infogrid">
+            <div class="infoline date">
+                <span class="icon icon-user-chairperson"></span>
+                <div class="text">
+                    <div>
+                        <span class="label">{% trans %}Data controller{% endtrans %}</span>
+                    </div>
+                    {% if privacy_info.data_controller_name %}
+                        <div>
+                            {{ privacy_info.data_controller_name }}
+                        </div>
+                    {% endif %}
+                    {% if privacy_info.data_controller_email %}
+                        <div>
+                            <a href="mailto:{{ privacy_info.data_controller_email }}">{{ privacy_info.data_controller_email }}</a>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+    {% if privacy_info.privacy_policy %}
+        <section>
+            <div class="header">
+                <div class="header-row">
+                    <h3>{% trans %}Privacy notice{% endtrans %}</h3>
+                </div>
+            </div>
+            {{ privacy_info.privacy_policy|sanitize_html }}
+        </section>
+    {% elif privacy_info.privacy_policy_urls|length == 1 %}
+        <a href="{{ privacy_info.privacy_policy_urls[0].url }}" target="_blank" rel="noopener noreferrer">
+            {% trans %}Privacy notice{% endtrans %}
+        </a>
+    {% elif privacy_info.privacy_policy_urls %}
+        <section>
+            <div class="header">
+                <div class="header-row">
+                    <h3>{% trans %}Privacy notices{% endtrans %}</h3>
+                </div>
+            </div>
+            <table class="i-table">
+                <tbody>
+                    {% for privacy_url in privacy_info.privacy_policy_urls %}
+                        <tr class="i-table" role="row">
+                            <td class="i-table">
+                                <a class="item"
+                                   href="{{ privacy_url.url }}"
+                                   target="_blank"
+                                   rel="noopener noreferrer">
+                                    {{ privacy_url.title }}
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </section>
+    {% endif %}
+{% endblock %}

--- a/indico/modules/events/templates/display/privacy_policy.html
+++ b/indico/modules/events/templates/display/privacy_policy.html
@@ -1,0 +1,10 @@
+{% extends 'layout/base.html' %}
+{% block page_class %}fixed-width-standalone-text-page{% endblock %}
+
+{% block title %}
+    {% trans %}Privacy Notice{% endtrans %}
+{% endblock %}
+
+{% block content %}
+    {{ privacy_info.privacy_policy|sanitize_html }}
+{% endblock %}

--- a/indico/modules/events/templates/footer.html
+++ b/indico/modules/events/templates/footer.html
@@ -1,35 +1,5 @@
 {% extends 'footer.html' %}
 
-{% block footer_links_extra %}
-    {% if privacy_urls|length == 1 %}
-        <li>
-            <a href="{{ privacy_urls[0].url }}">{% trans %}Event privacy notice{% endtrans %}</a>
-        </li>
-    {% elif privacy_urls %}
-        <li>
-            <div class="privacy-dropdown">
-                <a href="#" onclick="return false;">{% trans %}Event privacy notices{% endtrans %}</a>
-                <div class="menu">
-                    {% for privacy_url in privacy_urls  %}
-                        <a class="item" href="{{ privacy_url.url }}">{{ privacy_url.title }}</a>
-                    {% endfor %}
-                </div>
-            </div>
-        </li>
-    {% elif privacy_text %}
-        <li>
-            <a href="{{ url_for('events.display_privacy', event) }}"
-               data-title="{% trans %}Event privacy notice{% endtrans %}"
-               data-href="{{ url_for('events.display_privacy', event) }}"
-               data-ajax-dialog
-               data-hide-page-header
-               data-close-button>
-                {% trans %}Event privacy notice{% endtrans %}
-            </a>
-        </li>
-    {% endif %}
-{% endblock %}
-
 {% block footer_extra %}
     {%- set url = event.short_external_url -%}
 

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -306,6 +306,12 @@ class WPConferenceDisplay(WPConferenceDisplayBase):
         return render_template('events/display/conference.html', **self._kwargs)
 
 
+class WPConferencePrivacyDisplay(WPConferenceDisplayBase):
+    template_prefix = 'events/display/'
+    sidemenu_option = 'privacy'
+    ALLOW_JSON = True
+
+
 class WPAccessKey(WPJinjaMixin, WPDecorated):
     template_prefix = 'events/'
 

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -74,16 +74,12 @@ def render_event_footer(event, dark=False):
 
     social_settings_data = social_settings.get_all()
     show_social = social_settings_data['enabled'] and layout_settings.get(event, 'show_social_badges')
-    privacy_text = privacy_settings.get(event, 'privacy_policy')
-    privacy_urls = privacy_settings.get(event, 'privacy_policy_urls')
     return render_template('events/footer.html',
                            event=event,
                            dark=dark,
                            social_settings=social_settings_data,
                            show_social=show_social,
-                           google_calendar_params=google_calendar_params,
-                           privacy_text=privacy_text,
-                           privacy_urls=privacy_urls)
+                           google_calendar_params=google_calendar_params)
 
 
 class WPEventAdmin(WPAdmin):

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -202,6 +202,7 @@ class WPSimpleEventDisplay(WPSimpleEventDisplayBase):
         attached_items = self.event.attached_items
         folders = [folder for folder in attached_items.get('folders', []) if folder.title != 'Internal Page Files']
         files = attached_items.get('files', [])
+        privacy_info = privacy_settings.get_all(self.event)
 
         lectures = []
         if self.event.series is not None and self.event.series.show_links:
@@ -225,6 +226,7 @@ class WPSimpleEventDisplay(WPSimpleEventDisplayBase):
                                theme_user_settings=layout_settings.get(self.event, 'timetable_theme_settings'),
                                files=files,
                                folders=folders,
+                               privacy_info=privacy_info,
                                lectures=lectures)
 
 

--- a/indico/web/client/styles/partials/_footer.scss
+++ b/indico/web/client/styles/partials/_footer.scss
@@ -50,32 +50,6 @@
   &.dark .version {
     color: $dark-gray;
   }
-
-  .privacy-dropdown {
-    display: inline-block;
-    position: relative;
-
-    .menu {
-      display: none;
-      position: absolute;
-      z-index: 1;
-      bottom: 2.5em;
-      min-width: 10em;
-      border-radius: 2px;
-      background-color: $light-gray;
-      box-shadow: 0 2px 10px 1px rgba(50, 50, 50, 0.4);
-
-      a {
-        display: block;
-        line-height: 30px;
-        padding: 0 0.5em;
-      }
-    }
-
-    &:focus-within .menu {
-      display: block;
-    }
-  }
 }
 
 .social-share {

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -377,6 +377,61 @@ ul.day-list {
   font-size: 10pt;
 }
 
+.event-privacy-info-button {
+  @extend %font-family-body;
+
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  font-size: 12pt;
+
+  .privacy-dropdown {
+    display: inline-block;
+    position: relative;
+
+    .menu {
+      display: none;
+      position: absolute;
+      z-index: 1;
+      top: 1.5em;
+      right: 0;
+      min-width: 10em;
+      border-radius: 2px;
+      background-color: $light-gray;
+      box-shadow: 0 2px 10px 1px rgba(50, 50, 50, 0.4);
+      padding-top: 0.2em;
+
+      .item,
+      .header {
+        display: block;
+        padding: 0 0.5em 0.4em;
+        font-size: 0.9em;
+
+        &:not(a) {
+          color: $black;
+        }
+
+        &.header {
+          padding-bottom: 0.2em;
+          font-weight: bold;
+          text-transform: uppercase;
+          font-size: 0.8em;
+        }
+      }
+
+      .divider {
+        border-top: 1px dotted $dark-gray;
+        height: 0;
+        margin-bottom: 0.2em;
+      }
+    }
+
+    &:focus-within .menu {
+      display: block;
+    }
+  }
+}
+
 .meeting-sub-timetable {
   margin-top: 1em;
 }

--- a/indico/web/client/styles/themes/print/indico.scss
+++ b/indico/web/client/styles/themes/print/indico.scss
@@ -34,6 +34,8 @@ body {
 
 .manage-button,
 .event-manage-button,
+.event-privacy-info-button,
+.privacy-dropdown .item,
 #session-bar,
 .eventHeaderButtonBar,
 .js-go-to-day,

--- a/indico/web/forms/fields/simple.py
+++ b/indico/web/forms/fields/simple.py
@@ -182,7 +182,10 @@ class IndicoLinkListField(JSONField):
         super().process_formdata(valuelist)
         self.data = [link for link in self.data if link.get('title') or link.get('url')]
         if len(self.data) == 1:
-            self.data[0]['title'] = ''
+            if self.data[0]['url']:
+                self.data[0]['title'] = ''
+            else:
+                self.data = []
 
     def pre_validate(self, form):
         if not all(x.get('url') for x in self.data):

--- a/indico/web/templates/footer.html
+++ b/indico/web/templates/footer.html
@@ -34,7 +34,6 @@
                         {{ item }}
                     </li>
                 {% endfor %}
-                {% block footer_links_extra %}{% endblock %}
             </ul>
             <div class="footer-extra f-self-stretch">
                 {% block footer_extra %}


### PR DESCRIPTION
Closes #5307

This PR adds a new privacy information menu with the data controller information to meetings and lectures, as well as a privacy information page in conferences.

![screenshot](https://user-images.githubusercontent.com/27357203/161561079-a7fa841d-0424-47e6-860f-2ce4d9a77aa0.png)

![screenshot](https://user-images.githubusercontent.com/27357203/162407797-b0773266-2900-4ae2-96e1-8ec34c914636.png)
