### PR TITLE
Add option to delete unused 'EventPerson's

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Improvements
   :user:`PerilousApricot`)
 - Show affiliations of submitters and authors in abstract/contribution lists and
   add an extra column with this information to Excel/CSV exports (:pr:`5330`)
+- Add option to delete persons from the event if they have no roles or other ties
+  to the event anymore (:issue:`5294`, :pr:`5313`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/management/client/js/index.js
+++ b/indico/modules/events/management/client/js/index.js
@@ -117,6 +117,7 @@ import {SingleEventMove, EventPublish} from './EventMove';
       {
         hasNoAccountFilter: false,
         hasNoRegistrationFilter: false,
+        hasNoRolesFilter: false,
       },
       options
     );
@@ -235,6 +236,24 @@ import {SingleEventMove, EventPublish} from './EventMove';
       $('#filter-no-registration').on('change', function() {
         if (this.checked) {
           $('.js-event-person-list [data-filter]:checked:not(#filter-no-registration)').prop(
+            'checked',
+            false
+          );
+        }
+        refreshPersonFilters();
+        applySearchFilters();
+      });
+    }
+
+    if (options.hasNoRolesFilter) {
+      $('.js-event-person-list [data-filter]:not(#filter-no-roles)').on('change', function() {
+        $('#filter-no-roles').prop('checked', false);
+        refreshPersonFilters();
+        applySearchFilters();
+      });
+      $('#filter-no-roles').on('change', function() {
+        if (this.checked) {
+          $('.js-event-person-list [data-filter]:checked:not(#filter-no-roles)').prop(
             'checked',
             false
           );

--- a/indico/modules/events/management/client/js/index.js
+++ b/indico/modules/events/management/client/js/index.js
@@ -117,7 +117,7 @@ import {SingleEventMove, EventPublish} from './EventMove';
       {
         hasNoAccountFilter: false,
         hasNoRegistrationFilter: false,
-        hasNoRolesFilter: false,
+        hasNoBuiltinRolesFilter: false,
       },
       options
     );
@@ -245,15 +245,18 @@ import {SingleEventMove, EventPublish} from './EventMove';
       });
     }
 
-    if (options.hasNoRolesFilter) {
-      $('.js-event-person-list [data-filter]:not(#filter-no-roles)').on('change', function() {
-        $('#filter-no-roles').prop('checked', false);
-        refreshPersonFilters();
-        applySearchFilters();
-      });
-      $('#filter-no-roles').on('change', function() {
+    if (options.hasNoBuiltinRolesFilter) {
+      $('.js-event-person-list [data-filter]:not(#filter-no-builtin-roles)').on(
+        'change',
+        function() {
+          $('#filter-no-builtin-roles').prop('checked', false);
+          refreshPersonFilters();
+          applySearchFilters();
+        }
+      );
+      $('#filter-no-builtin-roles').on('change', function() {
         if (this.checked) {
-          $('.js-event-person-list [data-filter]:checked:not(#filter-no-roles)').prop(
+          $('.js-event-person-list [data-filter]:checked:not(#filter-no-builtin-roles)').prop(
             'checked',
             false
           );

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -350,19 +350,14 @@ class EventPerson(PersonMixin, db.Model):
     def has_links(self):
         """Whether the person is an author, speaker, etc., in the event."""
         chairpersons = {link.person for link in self.event.person_links}
-        if self in chairpersons:
-            return True
-        if (
-            self.event.has_feature('abstracts') and
-            {link for link in self.abstract_links if not link.abstract.is_deleted}
-        ):
-            return True
-        if {link for link in self.session_block_links if not link.session_block.session.is_deleted}:
-            return True
-        if {link for link in self.contribution_links if not link.contribution.is_deleted}:
-            return True
-        if {link for link in self.subcontribution_links if not link.subcontribution.contribution.is_deleted}:
-            return True
+        return (
+            self in chairpersons or
+            # Check regardless of the abstract feature being enabled
+            any(link for link in self.abstract_links if not link.abstract.is_deleted) or
+            any(link for link in self.session_block_links if not link.session_block.session.is_deleted) or
+            any(link for link in self.contribution_links if not link.contribution.is_deleted) or
+            any(link for link in self.subcontribution_links if not link.subcontribution.contribution.is_deleted)
+        )
 
 
 class PersonLinkBase(PersonMixin, db.Model):

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -346,6 +346,24 @@ class EventPerson(PersonMixin, db.Model):
                    if ((self.user_id is not None and self.user_id == x.user_id) or
                        (self.email is not None and self.email == x.email)))
 
+    @property
+    def has_links(self):
+        """Whether the person is an author, speaker, etc., in the event."""
+        chairpersons = {link.person for link in self.event.person_links}
+        if self in chairpersons:
+            return True
+        if (
+            self.event.has_feature('abstracts') and
+            {link for link in self.abstract_links if not link.abstract.is_deleted}
+        ):
+            return True
+        if {link for link in self.session_block_links if not link.session_block.session.is_deleted}:
+            return True
+        if {link for link in self.contribution_links if not link.contribution.is_deleted}:
+            return True
+        if {link for link in self.subcontribution_links if not link.subcontribution.contribution.is_deleted}:
+            return True
+
 
 class PersonLinkBase(PersonMixin, db.Model):
     """Base class for EventPerson associations."""

--- a/indico/modules/events/models/persons_test.py
+++ b/indico/modules/events/models/persons_test.py
@@ -1,0 +1,54 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from indico.modules.events.abstracts.models.persons import AbstractPersonLink
+from indico.modules.events.contributions.models.persons import (AuthorType, ContributionPersonLink,
+                                                                SubContributionPersonLink)
+from indico.modules.events.features.util import set_feature_enabled
+from indico.modules.events.models.persons import EventPerson, EventPersonLink
+
+
+def test_unused_event_person(db, dummy_user, dummy_event, create_contribution, create_subcontribution, create_abstract):
+    person = EventPerson.create_from_user(dummy_user, event=dummy_event)
+    assert not person.has_links
+
+    dummy_event.person_links.append(EventPersonLink(person=person))
+    db.session.flush()
+    assert person.has_links
+
+    dummy_event.person_links.clear()
+    db.session.flush()
+    assert not person.has_links
+
+    set_feature_enabled(dummy_event, 'abstracts', True)
+    abstract = create_abstract(dummy_event, 'Dummy abstract', submitter=dummy_user, person_links=[
+        AbstractPersonLink(person=person, is_speaker=True, author_type=AuthorType.primary)
+    ])
+    assert person.has_links
+    abstract.is_deleted = True
+    assert not person.has_links
+
+    contrib = create_contribution(dummy_event, 'Dummy contribution', person_links=[
+        ContributionPersonLink(person=person, is_speaker=True)
+    ])
+    assert person.has_links
+    contrib.is_deleted = True
+    assert not person.has_links
+    db.session.delete(contrib)
+
+    contrib = create_contribution(dummy_event, 'Dummy contribution', person_links=[])
+    assert not person.has_links
+    create_subcontribution(contrib, 'Dummy subcontribution', person_links=[
+        SubContributionPersonLink(person=person, is_speaker=True)
+    ])
+    assert person.has_links
+
+    contrib.is_deleted = True
+    assert not person.has_links
+
+    db.session.delete(contrib)
+    assert not person.has_links

--- a/indico/modules/events/persons/blueprint.py
+++ b/indico/modules/events/persons/blueprint.py
@@ -5,7 +5,8 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from indico.modules.events.persons.controllers import (RHEditEventPerson, RHEmailEventPersons, RHEventPersonSearch,
+from indico.modules.events.persons.controllers import (RHDeleteUnusedEventPerson, RHEditEventPerson,
+                                                       RHEmailEventPersons, RHEventPersonSearch,
                                                        RHGrantModificationRights, RHGrantSubmissionRights,
                                                        RHPersonsList, RHRevokeSubmissionRights)
 from indico.web.flask.wrappers import IndicoBlueprint
@@ -25,4 +26,6 @@ _bp.add_url_rule('/persons/revoke-submission', 'revoke_submission_rights', RHRev
 
 # EventPerson operations
 _bp.add_url_rule('/persons/<int:person_id>/edit', 'edit_person', RHEditEventPerson, methods=('GET', 'POST'))
+_bp.add_url_rule('/persons/<int:person_id>', 'delete_unused_person', RHDeleteUnusedEventPerson,
+                 methods=('DELETE',))
 _bp.add_url_rule('/api/persons/search', 'event_person_search', RHEventPersonSearch)

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -198,11 +198,15 @@ class RHPersonsBase(RHManageEventBase):
         for reg in regs:
             internal_role_users[reg.user.email]['registrations'].append(reg)
 
-        # Some EventPersons will have no roles since they were connected to deleted things
-        for person in persons:
-            if not any(persons[person]['roles'].values()):
-                persons[person]['roles']['no_roles'] = True
         persons = persons | internal_role_users
+        # Some EventPersons will have no built-in roles since they were connected to deleted things
+        builtin_roles = set(BUILTIN_ROLES)
+        for person in persons:
+            roles = set(persons[person]['roles'].keys())
+            if not roles:
+                persons[person]['roles']['no_roles'] = True
+            if not roles & builtin_roles:
+                persons[person]['roles']['no_builtin_roles'] = True
         return persons
 
 

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -391,14 +391,9 @@ class RHDeleteUnusedEventPerson(RHPersonsBase):
         RHPersonsBase._process_args(self)
         self.person = EventPerson.query.with_parent(self.event).filter_by(id=request.view_args['person_id']).one()
 
-    def _is_unused(self):
-        persons = self.get_persons()
-        person = persons.get(self.person.email or self.person.id)
-        return not person or person['roles'].get('no_roles', False)
-
     def _process(self):
-        if not self._is_unused():
-            raise Forbidden(_('Only users with no roles can be deleted.'))
+        if self.person.has_links:
+            raise Forbidden(_('Only users with no ties to the event can be deleted.'))
         db.session.delete(self.person)
         logger.info('EventPerson deleted from event %r: %r', self.event, self.person)
         return jsonify_data()

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -13,6 +13,7 @@ from marshmallow import fields
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import contains_eager, joinedload
 from webargs import validate
+from werkzeug.exceptions import Forbidden
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy.custom.unaccent import unaccent_match
@@ -30,6 +31,7 @@ from indico.modules.events.management.controllers import RHManageEventBase
 from indico.modules.events.models.persons import EventPerson
 from indico.modules.events.models.principals import EventPrincipal
 from indico.modules.events.models.roles import EventRole
+from indico.modules.events.persons import logger
 from indico.modules.events.persons.forms import EmailEventPersonsForm, EventPersonForm
 from indico.modules.events.persons.operations import update_person
 from indico.modules.events.persons.schemas import EventPersonSchema
@@ -197,7 +199,9 @@ class RHPersonsBase(RHManageEventBase):
             internal_role_users[reg.user.email]['registrations'].append(reg)
 
         # Some EventPersons will have no roles since they were connected to deleted things
-        persons = {email: data for email, data in persons.items() if any(data['roles'].values())}
+        for person in persons:
+            if not any(persons[person]['roles'].values()):
+                persons[person]['roles']['no_roles'] = True
         persons = persons | internal_role_users
         return persons
 
@@ -380,6 +384,24 @@ class RHEditEventPerson(RHPersonsBase):
             tpl = get_template_module('events/persons/management/_person_list_row.html')
             return jsonify_data(html=tpl.render_person_row(person_data, bool(self.event.registration_forms)))
         return jsonify_form(form)
+
+
+class RHDeleteUnusedEventPerson(RHPersonsBase):
+    def _process_args(self):
+        RHPersonsBase._process_args(self)
+        self.person = EventPerson.query.with_parent(self.event).filter_by(id=request.view_args['person_id']).one()
+
+    def _is_unused(self):
+        persons = self.get_persons()
+        person = persons.get(self.person.email or self.person.id)
+        return not person or person['roles'].get('no_roles', False)
+
+    def _process(self):
+        if not self._is_unused():
+            raise Forbidden(_('Only users with no roles can be deleted.'))
+        db.session.delete(self.person)
+        logger.info('EventPerson deleted from event %r: %r', self.event, self.person)
+        return jsonify_data()
 
 
 class RHEventPersonSearch(RHAuthenticatedEventBase):

--- a/indico/modules/events/persons/templates/management/_person_list_row.html
+++ b/indico/modules/events/persons/templates/management/_person_list_row.html
@@ -26,7 +26,7 @@
     {% endif %}
     <td class="i-table name-column" data-searchable="{{ person.display_full_name|lower }}">
         {{ person.display_full_name }}
-        {% if 'no_roles' in person_data.roles %}
+        {% if person_data.roles.no_roles %}
             <span class="icon-question"
                   title="{%- trans %}This person currently has no ties to the event.{% endtrans -%}"></span>
         {% elif person.is_untrusted %}
@@ -47,7 +47,7 @@
     </td>
     <td class="i-table roles-column">
         {% for role, role_data in person_data.roles.items() %}
-            {%- if role not in ('no_account', 'no_registration', 'no_roles') %}
+            {%- if role not in ('no_account', 'no_registration', 'no_roles', 'no_builtin_roles') %}
                 {%- if role_data.elements -%}
                     <span class="i-tag outline contrast js-count-label" style="{{ role_data.css }};"
                           data-role-name="{{ role_data.name }}"
@@ -95,7 +95,7 @@
             <a class="i-link icon-edit disabled"
                title="{%- trans %}This user does not play any public role{% endtrans -%}"></a>
         {% endif %}
-        {% if person_data.roles['no_roles'] %}
+        {% if person_data.has_event_person and person_data.roles.no_builtin_roles %}
             <a class="i-link icon-remove"
                title="{%- trans %}Delete person{% endtrans -%}"
                data-href="{{ url_for('persons.delete_unused_person', person) }}"

--- a/indico/modules/events/persons/templates/management/_person_list_row.html
+++ b/indico/modules/events/persons/templates/management/_person_list_row.html
@@ -26,7 +26,10 @@
     {% endif %}
     <td class="i-table name-column" data-searchable="{{ person.display_full_name|lower }}">
         {{ person.display_full_name }}
-        {% if person.is_untrusted %}
+        {% if 'no_roles' in person_data.roles %}
+            <span class="icon-question"
+                  title="{%- trans %}This person currently has no ties to the event.{% endtrans -%}"></span>
+        {% elif person.is_untrusted %}
             {% set untrusted_tooltip -%}
                 {%- trans -%}
                     This person is currently just an author of an abstract with no other ties to the event.
@@ -44,7 +47,7 @@
     </td>
     <td class="i-table roles-column">
         {% for role, role_data in person_data.roles.items() %}
-            {%- if role not in ('no_account', 'no_registration') %}
+            {%- if role not in ('no_account', 'no_registration', 'no_roles') %}
                 {%- if role_data.elements -%}
                     <span class="i-tag outline contrast js-count-label" style="{{ role_data.css }};"
                           data-role-name="{{ role_data.name }}"
@@ -91,6 +94,15 @@
         {% else %}
             <a class="i-link icon-edit disabled"
                title="{%- trans %}This user does not play any public role{% endtrans -%}"></a>
+        {% endif %}
+        {% if person_data.roles['no_roles'] %}
+            <a class="i-link icon-remove"
+               title="{%- trans %}Delete person{% endtrans -%}"
+               data-href="{{ url_for('persons.delete_unused_person', person) }}"
+               data-title="{%- trans %}Delete person{% endtrans -%}"
+               data-method="DELETE"
+               data-update="#person-{{ person.id }}"
+               data-confirm="{% trans %}Do you really want to delete this person from the event?{% endtrans %}"></a>
         {% endif %}
     </td>
 {% endmacro %}

--- a/indico/modules/events/persons/templates/management/person_list.html
+++ b/indico/modules/events/persons/templates/management/person_list.html
@@ -188,6 +188,15 @@
                             <i class="icon-stop colored-square no-registration"></i>
                             <label for="filter-no-registration">{% trans %}Unregistered users{% endtrans %}</label>
                         </li>
+                        <li class="separator">
+                            <span class="titled-rule">{% trans %}or{% endtrans %}</span>
+                        </li>
+                        <li for="filter-no-roles">
+                            <input type="checkbox" id="filter-no-roles" data-filter="no_roles">
+                            <i class="icon-checkmark"></i>
+                            <i class="icon-stop colored-square no-roles"></i>
+                            <label for="filter-no-roles">{% trans %}Users with no roles{% endtrans %}</label>
+                        </li>
                     </ul>
                     <a class="i-button highlight icon-close disabled js-reset-role-filter"
                        title="{% trans %}Reset role filters{% endtrans %}"></a>
@@ -250,7 +259,8 @@
     <script>
         setupEventPersonsList({
             hasNoAccountFilter: true,
-            hasNoRegistrationFilter: true
+            hasNoRegistrationFilter: true,
+            hasNoRolesFilter: true,
         });
     </script>
 {% endblock %}

--- a/indico/modules/events/persons/templates/management/person_list.html
+++ b/indico/modules/events/persons/templates/management/person_list.html
@@ -191,11 +191,11 @@
                         <li class="separator">
                             <span class="titled-rule">{% trans %}or{% endtrans %}</span>
                         </li>
-                        <li for="filter-no-roles">
-                            <input type="checkbox" id="filter-no-roles" data-filter="no_roles">
+                        <li for="filter-no-builtin-roles">
+                            <input type="checkbox" id="filter-no-builtin-roles" data-filter="no_builtin_roles">
                             <i class="icon-checkmark"></i>
-                            <i class="icon-stop colored-square no-roles"></i>
-                            <label for="filter-no-roles">{% trans %}Users with no roles{% endtrans %}</label>
+                            <i class="icon-stop colored-square no-builtin-roles"></i>
+                            <label for="filter-no-builtin-roles">{% trans %}Users with no public roles{% endtrans %}</label>
                         </li>
                     </ul>
                     <a class="i-button highlight icon-close disabled js-reset-role-filter"
@@ -239,7 +239,7 @@
                 <tbody>
                     {% for person_data in persons -%}
                         <tr id="person-{{ person_data.person.id }}"
-                            class="i-table {{ 'untrusted' if person_data.person.is_untrusted }}"
+                            class="i-table {{ 'untrusted' if person_data.person.is_untrusted }} {{ 'no-roles' if person_data.roles.no_roles }}"
                             data-person-roles="{{ person_data.roles | tojson | forceescape }}"
                             {{ 'data-no-account' if person_data.roles.no_account }}>
                             {{ render_person_row(person_data, event_has_registration_forms) }}
@@ -260,7 +260,7 @@
         setupEventPersonsList({
             hasNoAccountFilter: true,
             hasNoRegistrationFilter: true,
-            hasNoRolesFilter: true,
+            hasNoBuiltinRolesFilter: true,
         });
     </script>
 {% endblock %}

--- a/indico/testing/fixtures/abstract.py
+++ b/indico/testing/fixtures/abstract.py
@@ -1,0 +1,23 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+
+from indico.modules.events.abstracts.models.abstracts import Abstract
+
+
+@pytest.fixture
+def create_abstract(db):
+    """Return a callable that lets you create an abstract."""
+
+    def _create_abstract(event, title, **kwargs):
+        abstract = Abstract(event=event, title=title, **kwargs)
+        db.session.add(abstract)
+        db.session.flush()
+        return abstract
+
+    return _create_abstract

--- a/indico/testing/fixtures/contribution.py
+++ b/indico/testing/fixtures/contribution.py
@@ -10,6 +10,7 @@ from datetime import timedelta
 import pytest
 
 from indico.modules.events.contributions.models.contributions import Contribution
+from indico.modules.events.contributions.models.subcontributions import SubContribution
 
 
 @pytest.fixture
@@ -28,3 +29,16 @@ def create_contribution(db):
 @pytest.fixture
 def dummy_contribution(create_contribution, dummy_event):
     return create_contribution(dummy_event, 'Dummy Contribution')
+
+
+@pytest.fixture
+def create_subcontribution(db):
+    """Return a callable that lets you create a subcontribution."""
+
+    def _create_subcontribution(contribution, title, duration=timedelta(minutes=10), **kwargs):
+        entry = SubContribution(contribution=contribution, title=title, duration=duration, **kwargs)
+        db.session.add(entry)
+        db.session.flush()
+        return entry
+
+    return _create_subcontribution

--- a/indico/testing/pytest_plugin.py
+++ b/indico/testing/pytest_plugin.py
@@ -17,11 +17,12 @@ import py
 # Ignore config file in case there is one
 os.environ['INDICO_CONFIG'] = os.devnull
 
-pytest_plugins = ('indico.testing.fixtures.app', 'indico.testing.fixtures.cache', 'indico.testing.fixtures.category',
-                  'indico.testing.fixtures.contribution', 'indico.testing.fixtures.database',
-                  'indico.testing.fixtures.disallow', 'indico.testing.fixtures.person', 'indico.testing.fixtures.user',
-                  'indico.testing.fixtures.event', 'indico.testing.fixtures.smtp', 'indico.testing.fixtures.storage',
-                  'indico.testing.fixtures.util', 'indico.testing.fixtures.session')
+pytest_plugins = ('indico.testing.fixtures.abstract', 'indico.testing.fixtures.app', 'indico.testing.fixtures.cache',
+                  'indico.testing.fixtures.category', 'indico.testing.fixtures.contribution',
+                  'indico.testing.fixtures.database', 'indico.testing.fixtures.disallow',
+                  'indico.testing.fixtures.person', 'indico.testing.fixtures.user', 'indico.testing.fixtures.event',
+                  'indico.testing.fixtures.smtp', 'indico.testing.fixtures.storage', 'indico.testing.fixtures.util',
+                  'indico.testing.fixtures.session')
 
 
 def pytest_configure(config):

--- a/indico/web/client/styles/modules/_event_management.scss
+++ b/indico/web/client/styles/modules/_event_management.scss
@@ -440,7 +440,8 @@ th.i-table {
     min-width: 20em;
   }
 
-  .untrusted {
+  .untrusted,
+  .no-roles {
     background-color: $light-gray;
 
     td {

--- a/indico/web/client/styles/modules/abstracts/_roles.scss
+++ b/indico/web/client/styles/modules/abstracts/_roles.scss
@@ -125,6 +125,10 @@
         color: $orange;
       }
 
+      .icon-stop.no-roles {
+        color: $red;
+      }
+
       span.titled-rule {
         width: 100%;
       }

--- a/indico/web/client/styles/modules/abstracts/_roles.scss
+++ b/indico/web/client/styles/modules/abstracts/_roles.scss
@@ -125,7 +125,7 @@
         color: $orange;
       }
 
-      .icon-stop.no-roles {
+      .icon-stop.no-builtin-roles {
         color: $red;
       }
 


### PR DESCRIPTION
Closes #5294 

Adds a new filter and an option to delete unused `EventPerson`s on the
_participant roles_ page

![image](https://user-images.githubusercontent.com/8739637/161987667-c805f7a7-d6d9-40a0-9d60-1ce3216fb59c.png)
