### PR TITLE
Disable registrations for purged regforms

### DIFF
--- a/indico/migrations/versions/20220407_1306_a707753d16e2_add_registration_is_purged.py
+++ b/indico/migrations/versions/20220407_1306_a707753d16e2_add_registration_is_purged.py
@@ -1,0 +1,27 @@
+"""Add 'is_purged' flag to registration forms
+
+Revision ID: a707753d16e2
+Revises: 88eb87ee0d3e
+Create Date: 2022-04-07 13:06:45.650413
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'a707753d16e2'
+down_revision = '88eb87ee0d3e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('forms',
+                  sa.Column('is_purged', sa.Boolean(), nullable=False, server_default='false'),
+                  schema='event_registration')
+    op.alter_column('forms', 'is_purged', server_default=None, schema='event_registration')
+
+
+def downgrade():
+    op.drop_column('forms', 'is_purged', schema='event_registration')

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -305,6 +305,8 @@ class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
     def _can_register(self):
         if self.regform.limit_reached:
             return False
+        elif self.regform.is_purged:
+            return False
         elif not self.regform.is_active and self.invitation is None:
             return False
         elif session.user and self.regform.get_registration(user=session.user):

--- a/indico/modules/events/registration/controllers/management/regforms.py
+++ b/indico/modules/events/registration/controllers/management/regforms.py
@@ -25,7 +25,8 @@ from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.items import PersonalDataType
 from indico.modules.events.registration.models.registrations import PublishRegistrationsMode
 from indico.modules.events.registration.stats import AccommodationStats, OverviewStats
-from indico.modules.events.registration.util import create_personal_data_fields, get_flat_section_setup_data
+from indico.modules.events.registration.util import (close_registration, create_personal_data_fields,
+                                                     get_flat_section_setup_data)
 from indico.modules.events.registration.views import (WPManageParticipants, WPManageRegistration,
                                                       WPManageRegistrationStats)
 from indico.modules.events.util import update_object_principals
@@ -258,9 +259,7 @@ class RHRegistrationFormClose(RHManageRegFormBase):
     """Close registrations for a registration form."""
 
     def _process(self):
-        self.regform.end_dt = now_utc()
-        if not self.regform.has_started:
-            self.regform.start_dt = self.regform.end_dt
+        close_registration(self.regform)
         flash(_('Registrations for {} are now closed').format(self.regform.title), 'success')
         logger.info('Registrations for %s closed by %s', self.regform, session.user)
         log_text = f'Registration form "{self.regform.title}" was closed'

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -253,6 +253,12 @@ class RegistrationForm(db.Model):
         db.Interval,
         nullable=True
     )
+    #: Whether the registrations have been deleted due to an expired retention period
+    is_purged = db.Column(
+        db.Boolean,
+        default=False,
+        nullable=False
+    )
 
     #: The Event containing this registration form
     event = db.relationship(
@@ -407,7 +413,7 @@ class RegistrationForm(db.Model):
 
     @property
     def is_active(self):
-        return self.is_open and not self.limit_reached
+        return self.is_open and not self.limit_reached and not self.is_purged
 
     @property
     @memoize_request

--- a/indico/modules/events/registration/tasks.py
+++ b/indico/modules/events/registration/tasks.py
@@ -16,6 +16,7 @@ from indico.modules.events.registration import logger
 from indico.modules.events.registration.models.form_fields import RegistrationFormField, RegistrationFormFieldData
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.registrations import Registration, RegistrationData
+from indico.modules.events.registration.util import close_registration
 from indico.util.date_time import now_utc
 
 
@@ -84,6 +85,7 @@ def delete_registrations():
         db.session.delete(reg)
 
     for regform in regforms:
+        close_registration(regform)
         regform.is_purged = True
 
     db.session.commit()

--- a/indico/modules/events/registration/templates/display/regform_display.html
+++ b/indico/modules/events/registration/templates/display/regform_display.html
@@ -27,7 +27,20 @@
 
 
 {% block content %}
-    {% if is_restricted_access %}
+    {% if regform.is_purged %}
+        {% call message_box('error', fixed_width=true, large_icon=true) %}
+            <div class="label">
+                {% trans %}Registration is disabled due to an expired retention period.{% endtrans %}
+            </div>
+        {% endcall %}
+    {% else %}
+        {{ render_regform() }}
+    {% endif %}
+{% endblock %}
+
+
+{% macro render_regform() %}
+      {% if is_restricted_access %}
         {% call message_box('warning') %}
             {% trans -%}
                 Access to the rest of this event is restricted to registered participants.
@@ -125,4 +138,4 @@
              {{ regform_attrs_template_hook(event, regform, management) }}
         ></div>
     {% endif %}
-{% endblock %}
+{% endmacro %}

--- a/indico/modules/events/registration/templates/display/regform_list.html
+++ b/indico/modules/events/registration/templates/display/regform_list.html
@@ -69,6 +69,11 @@
                                title="{% trans %}You have already registered{% endtrans %}">
                                 {% trans %}Check details{% endtrans %}
                             </a>
+                        {% elif regform.is_purged %}
+                            <a class="i-button highlight disabled"
+                               title="{% trans %}Registration is disabled due to an expired retention period{% endtrans %}">
+                                {{ button_text }}
+                            </a>
                         {% elif not regform.is_open %}
                             <a class="i-button highlight disabled"
                                title="{% trans %}Registration is closed{% endtrans %}">

--- a/indico/modules/events/registration/templates/management/regform.html
+++ b/indico/modules/events/registration/templates/management/regform.html
@@ -1,7 +1,11 @@
 {% extends 'events/registration/management/_regform_base.html' %}
 
 {% block content %}
-    {% if regform.retention_period %}
+    {% if regform.is_purged %}
+        {%- call message_box('error', fixed_width=true) -%}
+            {% trans %}Registrations have been deleted due to an expired retention period.{% endtrans %}
+        {%- endcall %}
+    {% elif regform.retention_period %}
         {%- call message_box('warning', fixed_width=true) -%}
             {% trans count=(regform.retention_period.days // 7), date=(event.end_dt + regform.retention_period)|format_date %}
                 Registrations will be permanently deleted {{ count }} week after the event ended (on {{ date }}).
@@ -91,7 +95,12 @@
                     {% endblock %}
                 </div>
                 <div class="group">
-                    <a href="{{ url_for('.manage_reglist', regform) }}" class="i-button icon-settings">
+                    {% set purged_title %}
+                        {% trans %}Registration is disabled due to an expired retention period{% endtrans %}
+                    {% endset %}
+                    <a href="{{ url_for('.manage_reglist', regform) }}"
+                       class="i-button icon-settings {% if regform.is_purged %}disabled{% endif %}"
+                       {% if regform.is_purged %}title="{{ purged_title }}"{% endif %}>
                         {% trans %}Manage{% endtrans %}
                     </a>
                 </div>

--- a/indico/modules/events/registration/templates/management/regform_list.html
+++ b/indico/modules/events/registration/templates/management/regform_list.html
@@ -100,7 +100,12 @@
                     </div>
                     <div class="toolbar">
                         <div class="group">
-                            <a href="{{ url_for('.manage_reglist', regform) }}" class="i-button icon-users">
+                            {% set purged_title %}
+                                {% trans %}Registration is disabled due to an expired retention period{% endtrans %}
+                            {% endset %}
+                            <a href="{{ url_for('.manage_reglist', regform) }}"
+                               class="i-button icon-users {% if regform.is_purged %}disabled{% endif %}"
+                               {% if regform.is_purged %}title="{{ purged_title }}"{% endif %}>
                                 {%- trans %}Registrations{% endtrans -%}
                                 {% block existing_count scoped %}
                                     <span class="badge">

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -1,5 +1,6 @@
 {% extends 'events/management/full_width_base.html' %}
 {% from 'events/registration/management/_reglist.html' import render_registration_list %}
+{% from 'message_box.html' import message_box %}
 
 {% block title %}
     {%- trans %}Registration{% endtrans -%}
@@ -10,6 +11,18 @@
 {% endblock %}
 
 {% block content %}
+    {% if regform.is_purged %}
+        {% call message_box('error', fixed_width=true, large_icon=true) %}
+            <div class="label">
+                {% trans %}Registration is disabled due to an expired retention period.{% endtrans %}
+            </div>
+        {% endcall %}
+    {% else %}
+        {{ render_registrations() }}
+    {% endif %}
+{% endblock %}
+
+{% macro render_registrations() -%}
     <div class="list registrations">
         <div class="toolbars space-after">
             <div class="toolbar">
@@ -23,11 +36,11 @@
                 </div>
                 <div class="group">
                     <button class="i-button icon-settings js-dialog-action js-customize-list {% if filtering_enabled %} highlight{% endif %}"
-                       data-href="{{ url_for('.customize_reglist', regform) }}"
-                       data-title="{% trans %}Registration list configuration{% endtrans %}"
-                       data-dialog-classes="list-filter-dialog"
-                       data-update='#registration-list'
-                       data-ajax-dialog>
+                            data-href="{{ url_for('.customize_reglist', regform) }}"
+                            data-title="{% trans %}Registration list configuration{% endtrans %}"
+                            data-dialog-classes="list-filter-dialog"
+                            data-update='#registration-list'
+                            data-ajax-dialog>
                         {% trans %}Customize list{% endtrans %}
                     </button>
                 </div>
@@ -242,4 +255,4 @@
     <script>
         setupRegistrationList();
     </script>
-{% endblock %}
+{%- endmacro %}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -42,7 +42,7 @@ from indico.modules.events.registration.notifications import (notify_invitation,
                                                               notify_registration_modification)
 from indico.modules.logs import LogKind
 from indico.modules.users.util import get_user_by_email
-from indico.util.date_time import format_date
+from indico.util.date_time import format_date, now_utc
 from indico.util.i18n import _
 from indico.util.signals import values_from_signal
 from indico.util.spreadsheets import csv_text_io_wrapper, unique_col
@@ -814,3 +814,9 @@ def diff_registration_data(old_data, new_data):
                 'new': {'price': new['price'], 'friendly_data': new['friendly_data']}
             }
     return diff
+
+
+def close_registration(regform):
+    regform.end_dt = now_utc()
+    if not regform.has_started:
+        regform.start_dt = regform.end_dt


### PR DESCRIPTION
Disable registrations and show warnings for regforms with expired retention periods.

Management regform view:
![image](https://user-images.githubusercontent.com/8739637/162193450-6f4521ad-5f24-4080-9ad8-03fb0c77f769.png)
reglist view:
![image](https://user-images.githubusercontent.com/8739637/162193591-eddf36c5-280a-4d9e-9b42-841bca288442.png)
Disabled link:
![image](https://user-images.githubusercontent.com/8739637/162193687-25fc5fc6-9bd2-48e2-95a7-930d05ad0e98.png)
Disabled link:
![image](https://user-images.githubusercontent.com/8739637/162193776-b35b6c28-61cc-423b-a9bd-c2bce39cf390.png)
Display view:
![image](https://user-images.githubusercontent.com/8739637/162193843-14456e03-478a-4f5f-a865-1452f1f4290d.png)
Disabled register button:
![image](https://user-images.githubusercontent.com/8739637/162193975-af81b657-0ac1-4ead-b1bc-d613d8a2de77.png)
