### PR TITLE
Add alarm support to exported iCal.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Improvements
 - Add an option to send notifications of new abstract comments (:issue:`5266`, :pr:`5284`)
 - Badge/poster templates can have additional images besides the background image
   (:pr:`5273`, thanks :user:`SegiNyn`)
+- Add ability to add alerts to iCal exports (:issue:`5318`  :pr:`5320`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,7 +36,7 @@ Improvements
 - Badge/poster templates can have additional images besides the background image
   (:pr:`5273`, thanks :user:`SegiNyn`)
 - Add ability to add alerts to iCal exports (:issue:`5318`, :pr:`5320`, thanks
-  :user: `PerilousApricot`)
+  :user:`PerilousApricot`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,8 @@ Improvements
 - Add an option to send notifications of new abstract comments (:issue:`5266`, :pr:`5284`)
 - Badge/poster templates can have additional images besides the background image
   (:pr:`5273`, thanks :user:`SegiNyn`)
-- Add ability to add alerts to iCal exports (:issue:`5318`  :pr:`5320`)
+- Add ability to add alerts to iCal exports (:issue:`5318`, :pr:`5320`, thanks
+  :user: `PerilousApricot`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -5,8 +5,8 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-import datetime
 import typing as t
+from datetime import timedelta
 from email import message
 from email.mime.base import MIMEBase
 from email.policy import compat32
@@ -147,11 +147,10 @@ def generate_event_component(
         component['description'] = data['description']
 
     # If the user exists and the add_icloud_alerts preference isn't blank
-    if user and user.settings.get('add_ical_alerts', '') != '':
+    if user and (alerts := user.settings.get('add_ical_alerts', -1)) != -1:
         alarm = icalendar.Alarm()
-        alarm.add('prodid', '-//CERN//INDICO//EN')
-        alarm.add('action', 'AUDIO')
-        alarm.add('trigger', datetime.timedelta(seconds=-60.0 * float(user.settings.get('add_ical_alerts', ''))))
+        alarm.add('action', 'DISPLAY')
+        alarm.add('trigger', timedelta(minutes=-alerts))
         alarm.add('summary', component['summary'])
         if data['description']:
             alarm.add('description', data['description'])

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -147,10 +147,10 @@ def generate_event_component(
         component['description'] = data['description']
 
     # If the user exists and the add_icloud_alerts preference isn't blank
-    if user and (alerts := user.settings.get('add_ical_alerts', -1)) != -1:
+    if user and user.settings.get('add_ical_alerts', False):
         alarm = icalendar.Alarm()
         alarm.add('action', 'DISPLAY')
-        alarm.add('trigger', timedelta(minutes=-alerts))
+        alarm.add('trigger', timedelta(minutes=-user.settings.get('add_ical_alerts_mins')))
         alarm.add('summary', component['summary'])
         if data['description']:
             alarm.add('description', data['description'])

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import datetime
 import typing as t
 from email import message
 from email.mime.base import MIMEBase
@@ -144,6 +145,17 @@ def generate_event_component(
         data.update(update)
     if data['description']:
         component['description'] = data['description']
+
+    # If the user exists and the add_icloud_alerts preference isn't blank
+    if user and user.settings.get('add_ical_alerts', '') != '':
+        alarm = icalendar.Alarm()
+        alarm.add('prodid', '-//CERN//INDICO//EN')
+        alarm.add('action', 'AUDIO')
+        alarm.add('trigger', datetime.timedelta(seconds=-60.0 * float(user.settings.get('add_ical_alerts', ''))))
+        alarm.add('summary', component['summary'])
+        if data['description']:
+            alarm.add('description', data['description'])
+        component.add_component(alarm)
 
     return component
 

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -147,7 +147,7 @@ def generate_event_component(
         component['description'] = data['description']
 
     # If the user exists and the add_icloud_alerts preference isn't blank
-    if user and user.settings.get('add_ical_alerts', False):
+    if user and user.settings.get('add_ical_alerts'):
         alarm = icalendar.Alarm()
         alarm.add('action', 'DISPLAY')
         alarm.add('trigger', timedelta(minutes=-user.settings.get('add_ical_alerts_mins')))

--- a/indico/modules/users/__init__.py
+++ b/indico/modules/users/__init__.py
@@ -33,6 +33,7 @@ user_settings = UserSettingsProxy('users', {
     'show_past_events': False,
     'name_format': NameFormat.first_last,
     'use_previewer_pdf': True,
+    'add_ical_alerts': True,
     'synced_fields': None,  # None to synchronize all fields, empty set to not synchronize
     'suggest_categories': False,  # whether the user should receive category suggestions
 }, converters={

--- a/indico/modules/users/__init__.py
+++ b/indico/modules/users/__init__.py
@@ -33,7 +33,7 @@ user_settings = UserSettingsProxy('users', {
     'show_past_events': False,
     'name_format': NameFormat.first_last,
     'use_previewer_pdf': True,
-    'add_ical_alerts': True,
+    'add_ical_alerts': -1,
     'synced_fields': None,  # None to synchronize all fields, empty set to not synchronize
     'suggest_categories': False,  # whether the user should receive category suggestions
 }, converters={

--- a/indico/modules/users/__init__.py
+++ b/indico/modules/users/__init__.py
@@ -33,7 +33,8 @@ user_settings = UserSettingsProxy('users', {
     'show_past_events': False,
     'name_format': NameFormat.first_last,
     'use_previewer_pdf': True,
-    'add_ical_alerts': -1,
+    'add_ical_alerts': False,
+    'add_ical_alerts_mins': 5,
     'synced_fields': None,  # None to synchronize all fields, empty set to not synchronize
     'suggest_categories': False,  # whether the user should receive category suggestions
 }, converters={

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -58,7 +58,7 @@ class UserPreferencesForm(IndicoForm):
         description=_('Add an event reminder to exported iCal files/URLs.'))
 
     add_ical_alerts_mins = IntegerField(
-        _('Calendar notification time in minutes'),
+        _('iCal notification time'),
         [HiddenUnless('add_ical_alerts'), NumberRange(min=0)],
         description=_('Number of minutes to notify before an event.'))
 

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -8,7 +8,6 @@
 from operator import itemgetter
 
 from pytz import common_timezones, common_timezones_set
-
 from wtforms.fields import BooleanField, EmailField, IntegerField, SelectField, StringField
 from wtforms.validators import DataRequired, Email, NumberRange, ValidationError
 

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -8,8 +8,9 @@
 from operator import itemgetter
 
 from pytz import common_timezones, common_timezones_set
-from wtforms.fields import BooleanField, EmailField, SelectField, StringField
-from wtforms.validators import DataRequired, Email, ValidationError
+
+from wtforms.fields import BooleanField, EmailField, IntegerField, SelectField, StringField
+from wtforms.validators import DataRequired, Email, NumberRange, Optional, ValidationError
 
 from indico.core.config import config
 from indico.modules.auth.forms import LocalRegistrationForm, _check_existing_email
@@ -51,15 +52,12 @@ class UserPreferencesForm(IndicoForm):
         widget=SwitchWidget(),
         description=_('The previewer is used by default for image and text files, but not for PDF files.'))
 
-    add_ical_alerts = StringField(
+    add_ical_alerts = IntegerField(
         _('Add alerts to iCal'),
-        description=_('Add an alert to exported iCal files/URLs. ' +
-                      'Value should be number of minutes to notify before an event. ' +
-                      'A blank field disables this function.'))
-
-    def validate_add_ical_alerts(self, field):
-        if field.data != '' and not field.data.isnumeric():
-            raise ValidationError(_('Alert time must be either a number or blank (to disable).'))
+        [Optional(), NumberRange(min=-1)],
+        description=_('Add an alert to exported iCal files/URLs. '
+                      'Value should be number of minutes to notify before an event. '
+                      'A value of -1 disables this function.'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -10,7 +10,7 @@ from operator import itemgetter
 from pytz import common_timezones, common_timezones_set
 
 from wtforms.fields import BooleanField, EmailField, IntegerField, SelectField, StringField
-from wtforms.validators import DataRequired, Email, NumberRange, Optional, ValidationError
+from wtforms.validators import DataRequired, Email, NumberRange, ValidationError
 
 from indico.core.config import config
 from indico.modules.auth.forms import LocalRegistrationForm, _check_existing_email
@@ -58,8 +58,8 @@ class UserPreferencesForm(IndicoForm):
         description=_('Add an event reminder to exported iCal files/URLs.'))
 
     add_ical_alerts_mins = IntegerField(
-        _('Timeout for iCal alerts'),
-        [Optional(), NumberRange(min=0)],
+        _('Calendar notification time in minutes'),
+        [HiddenUnless('add_ical_alerts'), NumberRange(min=0)],
         description=_('Number of minutes to notify before an event.'))
 
     def __init__(self, *args, **kwargs):

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -52,12 +52,15 @@ class UserPreferencesForm(IndicoForm):
         widget=SwitchWidget(),
         description=_('The previewer is used by default for image and text files, but not for PDF files.'))
 
-    add_ical_alerts = IntegerField(
+    add_ical_alerts = BooleanField(
         _('Add alerts to iCal'),
-        [Optional(), NumberRange(min=-1)],
-        description=_('Add an alert to exported iCal files/URLs. '
-                      'Value should be number of minutes to notify before an event. '
-                      'A value of -1 disables this function.'))
+        widget=SwitchWidget(),
+        description=_('Add an event reminder to exported iCal files/URLs.'))
+
+    add_ical_alerts_mins = IntegerField(
+        _('Timeout for iCal alerts'),
+        [Optional(), NumberRange(min=0)],
+        description=_('Number of minutes to notify before an event.'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -51,6 +51,16 @@ class UserPreferencesForm(IndicoForm):
         widget=SwitchWidget(),
         description=_('The previewer is used by default for image and text files, but not for PDF files.'))
 
+    add_ical_alerts = StringField(
+        _('Add alerts to iCal'),
+        description=_('Add an alert to exported iCal files/URLs. ' +
+                      'Value should be number of minutes to notify before an event. ' +
+                      'A blank field disables this function.'))
+
+    def validate_add_ical_alerts(self, field):
+        if field.data != '' and not field.data.isnumeric():
+            raise ValidationError(_('Alert time must be either a number or blank (to disable).'))
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Many (all?) calendar clients do not support adding reminders ("alerts"
in iCal parlance) to external calendars syncrhonized via URL. Add a
per-user preference to attach reminders to any events exported to iCal.

Tested on local dev install both as a logged-in and anonymous user, both
with and without a reminder preference. This produced an iCal that Apple
Calendars properly recognized the reminders:

```
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//CERN//INDICO//EN
BEGIN:VEVENT
SUMMARY:testEvent title
DTSTART;VALUE=DATE-TIME:20220425T150000Z
DTEND;VALUE=DATE-TIME:20220425T170000Z
DTSTAMP;VALUE=DATE-TIME:20220412T151800Z
UID:indico-event-8@localhost
DESCRIPTION:testEvent Description\n\nhttp://localhost:8000/event/8/
URL:http://localhost:8000/event/8/
BEGIN:VALARM
ACTION:AUDIO
DESCRIPTION:testEvent Description\n\nhttp://localhost:8000/event/8/
PRODID:-//CERN//INDICO//EN
SUMMARY:testEvent title
TRIGGER:-PT5M
END:VALARM
END:VEVENT
END:VCALENDAR
```

closes #5318