### PR TITLE
Fix poster and badge printing on unlisted events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,7 @@ Bugfixes
   participant roles list (:pr:`5308`)
 - Do not enforce personal token name uniqueness across different users (:pr:`5317`)
 - Fix last modification date not updating when an abstract is edited (:pr:`5325`)
+- Fix a bug with poster and badge printing in unlisted events (:pr:`5322`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/designer/placeholders.py
+++ b/indico/modules/designer/placeholders.py
@@ -170,7 +170,7 @@ class CategoryTitlePlaceholder(DesignerPlaceholder):
 
     @classmethod
     def render(cls, event):
-        return event.category.title
+        return event.category.title if not event.is_unlisted else ''
 
 
 class RegistrationFullNamePlaceholder(FullNamePlaceholderBase):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -21,6 +21,7 @@ from indico.core.db import db
 from indico.core.errors import NoReportError
 from indico.core.notifications import make_email, send_email
 from indico.legacy.pdfinterface.conference import RegistrantsListToBookPDF, RegistrantsListToPDF
+from indico.modules.categories.models.categories import Category
 from indico.modules.designer import PageLayout, TemplateType
 from indico.modules.designer.models.templates import DesignerTemplate
 from indico.modules.designer.util import get_badge_format, get_inherited_templates
@@ -413,9 +414,11 @@ class RHRegistrationsPrintBadges(RHRegistrationsActionBase):
     def _check_access(self):
         RHRegistrationsActionBase._check_access(self)
 
-        # Check that template belongs to this event or a category that
-        # is a parent
-        if self.template.owner != self.event and self.template.owner.id not in self.event.category_chain:
+        # Check that template belongs to this event or a category that is a parent
+        if self.template.owner == self.event:
+            return
+        valid_category_ids = self.event.category_chain or [Category.get_root().id]
+        if self.template.owner.id not in valid_category_ids:
             raise Forbidden
 
     def _process(self):


### PR DESCRIPTION
This PR fixes a breaking category check when printing a poster or badge in an unlisted event.