### PR TITLE
add sending signal for folder cloning

### DIFF
--- a/indico/modules/attachments/clone.py
+++ b/indico/modules/attachments/clone.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import flask
 from sqlalchemy.orm import joinedload, subqueryload
 
 from indico.core import signals
@@ -94,6 +95,7 @@ class AttachmentCloner(EventCloner):
         folder.populate_from_attrs(old_folder, folder_attrs)
         folder.acl_entries = clone_principals(AttachmentFolderPrincipal, old_folder.acl_entries,
                                               self._event_role_map, self._regform_map)
+        signals.attachments.folder_created.send(folder, user=flask.session.user, cloned=folder)
         for old_attachment in old_folder.attachments:
             self._attachment_map[old_attachment] = attachment = Attachment(folder=folder)
             attachment.populate_from_attrs(old_attachment, attachment_attrs)


### PR DESCRIPTION
Request signal sent to inform about new folder creation by cloning.
It would be preferable if we have a public "clone_attachment_folder" which returns the new folder cloned.
