### PR TITLE
Fix abstract last modified date not updating

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,7 @@ Bugfixes
 - Do not mark participants with deleted/inactive registrations as registered in
   participant roles list (:pr:`5308`)
 - Do not enforce personal token name uniqueness across different users (:pr:`5317`)
+- Fix last modification date not updating when an abstract is edited (:pr:`5325`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/abstracts/operations.py
+++ b/indico/modules/events/abstracts/operations.py
@@ -134,6 +134,7 @@ def update_abstract(abstract, abstract_data, custom_fields_data=None):
     changes.update(abstract.populate_from_dict(abstract_data))
     if custom_fields_data:
         changes.update(set_custom_fields(abstract, custom_fields_data))
+    abstract.modified_dt = now_utc()
     db.session.flush()
     logger.info('Abstract %s modified by %s', abstract, session.user)
     log_fields = {


### PR DESCRIPTION
This PR sets `abstract.modified_dt` on the `update_abstract` operation.