### PR TITLE
Fix required boolean fields not accepting No

### DIFF
--- a/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
@@ -102,12 +102,19 @@ export default function BooleanInput({
   placesLimit,
   placesUsed,
 }) {
+  const validateBoolean = value => {
+    if (isRequired && value === null) {
+      return Translate.string('This field is required.');
+    }
+  };
+
   return (
     <FinalField
       id={id}
       name={htmlName}
       component={BooleanInputComponent}
-      required={isRequired}
+      required={isRequired ? 'no-validator' : isRequired}
+      validate={validateBoolean}
       disabled={disabled}
       isPurged={isPurged}
       allowNull


### PR DESCRIPTION
This PR fixes a bug in the `BooleanInput` validation logic which prevented the "No" value to be selected when the field is marked as required.

This bug happened because the `validators.required` validator checks for the truethiness of the value instead of checking if it is null.