### PR TITLE
Bugreport+ suggestion to fix identities.py

### DIFF
--- a/indico/modules/auth/models/identities.py
+++ b/indico/modules/auth/models/identities.py
@@ -14,6 +14,7 @@ from indico.core.db import db
 from indico.core.db.sqlalchemy import UTCDateTime
 from indico.util.date_time import as_utc, now_utc
 from indico.util.passwords import PasswordProperty
+import re
 
 
 class Identity(db.Model):
@@ -96,7 +97,7 @@ class Identity(db.Model):
     def register_login(self, ip):
         """Update the last login information."""
         self.last_login_dt = now_utc()
-        self.last_login_ip = ip.replace('%','\%')
+        self.last_login_ip = re.split("%",ip)[0]
 
     def __repr__(self):
         return f'<Identity({self.id}, {self.user_id}, {self.provider}, {self.identifier})>'

--- a/indico/modules/auth/models/identities.py
+++ b/indico/modules/auth/models/identities.py
@@ -96,7 +96,7 @@ class Identity(db.Model):
     def register_login(self, ip):
         """Update the last login information."""
         self.last_login_dt = now_utc()
-        self.last_login_ip = ip
+        self.last_login_ip = ip.replace('%','\%')
 
     def __repr__(self):
         return f'<Identity({self.id}, {self.user_id}, {self.provider}, {self.identifier})>'


### PR DESCRIPTION
The idea is that ipv6 adresses can contain %, e.g. fe80::a00:27ff:fe22:a069%enp0s3
This will break SQL syntax.

Best regards,
Andrii
