### PR TITLE
Make i-form descriptions fluid and update PersonLinkField

### DIFF
--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -108,7 +108,7 @@ const PersonListItem = ({
   onClickRole,
   disabled,
 }) => (
-  <PrincipalItem as={List.Item}>
+  <PrincipalItem as={List.Item} styleName="person-link">
     <PrincipalItem.Icon type={PrincipalType.user} avatarURL={avatarURL} styleName="icon" />
     <PrincipalItem.Content
       name={firstName ? `${firstName} ${lastName}` : lastName}
@@ -364,7 +364,7 @@ export default function PersonLinkField({
           )}
           {persons.length === 0 && (emptyMessage || <Translate>There are no persons</Translate>)}
         </Segment>
-        <Button.Group size="small" attached="bottom" floated="right">
+        <Button.Group size="small" attached="bottom">
           <Button
             toggle
             icon="sort alphabet down"
@@ -373,14 +373,14 @@ export default function PersonLinkField({
             onClick={() => setAutoSort && setAutoSort(!autoSort)}
           />
           {sessionUser && (
-            <Translate
-              as={Button}
+            <Button
               type="button"
               onClick={() => onAdd([sessionUser])}
               disabled={persons.some(p => p.userId === sessionUser.userId)}
             >
-              Add myself
-            </Translate>
+              <Icon name="add user" />
+              <Translate>Add myself</Translate>
+            </Button>
           )}
           <UserSearch
             favorites={favoriteUsers}
@@ -388,6 +388,7 @@ export default function PersonLinkField({
             onAddItems={onAdd}
             triggerFactory={props => (
               <Button type="button" {...props}>
+                <Icon name="search" />
                 <Translate>Search</Translate>
               </Button>
             )}
@@ -395,9 +396,10 @@ export default function PersonLinkField({
             eventId={eventId}
             disabled={!sessionUser}
           />
-          <Translate as={Button} type="button" onClick={() => setModalOpen(true)}>
-            Enter manually
-          </Translate>
+          <Button type="button" onClick={() => setModalOpen(true)}>
+            <Icon name="keyboard" />
+            <Translate>Enter manually</Translate>
+          </Button>
           {modalOpen && (
             <ExternalPersonModal onClose={onClose} onSubmit={onSubmit} person={persons[selected]} />
           )}

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -108,7 +108,7 @@ const PersonListItem = ({
   onClickRole,
   disabled,
 }) => (
-  <PrincipalItem as={List.Item} styleName="person-link">
+  <PrincipalItem as={List.Item} styleName="principal">
     <PrincipalItem.Icon type={PrincipalType.user} avatarURL={avatarURL} styleName="icon" />
     <PrincipalItem.Content
       name={firstName ? `${firstName} ${lastName}` : lastName}
@@ -183,15 +183,13 @@ const DraggablePerson = ({drag, dragType, onMove, index, ...props}) => {
     separateHandle: true,
   });
   return (
-    <div ref={itemRef} style={style} styleName="drag-item">
+    <div ref={itemRef} style={style} styleName="person-link">
       {!drag && (
         <Ref innerRef={dragRef}>
           <div className="icon-drag-indicator" styleName="handle" />
         </Ref>
       )}
-      <div styleName="preview">
-        <PersonListItem {...props} />
-      </div>
+      <PersonListItem {...props} />
     </div>
   );
 };

--- a/indico/web/client/js/react/components/PersonLinkField.module.scss
+++ b/indico/web/client/js/react/components/PersonLinkField.module.scss
@@ -93,11 +93,11 @@
 
 .drag-item {
   display: flex;
-  align-items: center;
 }
 
 .drag-item .handle {
   cursor: pointer;
+  margin-top: 8px;
 }
 
 .drag-item .preview {

--- a/indico/web/client/js/react/components/PersonLinkField.module.scss
+++ b/indico/web/client/js/react/components/PersonLinkField.module.scss
@@ -15,12 +15,26 @@
   max-height: 40vh;
   overflow-y: auto;
   scroll-snap-type: y mandatory;
-  scroll-padding: 0.5em;
+  scroll-padding: 4px;
 }
 
 .person-link {
-  scroll-snap-align: start;
+  display: flex;
   padding: 1px 0;
+  scroll-snap-align: start;
+}
+
+.person-link:first-child {
+  scroll-margin-top: 1em;
+}
+
+.person-link .handle {
+  cursor: pointer;
+  margin-top: 8px;
+}
+
+.principal {
+  flex: 1;
 }
 
 .button {
@@ -89,17 +103,4 @@
 
 .icon {
   width: 32px !important;
-}
-
-.drag-item {
-  display: flex;
-}
-
-.drag-item .handle {
-  cursor: pointer;
-  margin-top: 8px;
-}
-
-.drag-item .preview {
-  flex: 1;
 }

--- a/indico/web/client/js/react/components/PersonLinkField.module.scss
+++ b/indico/web/client/js/react/components/PersonLinkField.module.scss
@@ -14,6 +14,12 @@
 .person-link-field .segment {
   max-height: 40vh;
   overflow-y: auto;
+  scroll-snap-type: y mandatory;
+}
+
+.person-link {
+  scroll-snap-align: start;
+  padding: 1px 0;
 }
 
 .button {

--- a/indico/web/client/js/react/components/PersonLinkField.module.scss
+++ b/indico/web/client/js/react/components/PersonLinkField.module.scss
@@ -15,6 +15,7 @@
   max-height: 40vh;
   overflow-y: auto;
   scroll-snap-type: y mandatory;
+  scroll-padding: 0.5em;
 }
 
 .person-link {

--- a/indico/web/client/js/react/components/PersonLinkField.module.scss
+++ b/indico/web/client/js/react/components/PersonLinkField.module.scss
@@ -62,7 +62,7 @@
 
 .roles {
   display: flex;
-  margin: 0 15px;
+  margin: 0 0.6em;
   flex-shrink: 0;
 }
 

--- a/indico/web/client/js/react/components/principals/items.module.scss
+++ b/indico/web/client/js/react/components/principals/items.module.scss
@@ -42,6 +42,7 @@
   text-align: center;
   color: $light-black;
   flex-shrink: 0;
+  align-self: start;
 }
 
 .content {

--- a/indico/web/client/styles/partials/_forms.scss
+++ b/indico/web/client/styles/partials/_forms.scss
@@ -162,7 +162,6 @@ form {
 }
 
 .i-form .form-group .form-label {
-  @extend %form-field-block;
   display: inline-block;
   line-height: $i-form-line-height;
   margin-top: 0;
@@ -170,6 +169,7 @@ form {
   min-height: 2.5em;
   position: relative;
   word-wrap: break-word;
+  padding-right: 1em;
 
   > .required {
     position: absolute;
@@ -202,7 +202,8 @@ form {
 
 // stylelint-disable-next-line no-duplicate-selectors
 .i-form .form-group .form-field {
-  @extend %form-field-block;
+  padding-left: 1em;
+  margin-bottom: 0.7em;
 
   @include apply-to-text-inputs('.i-form-field-fluid');
   @include apply-to-inputs('%form-field-input');

--- a/indico/web/client/styles/partials/_forms.scss
+++ b/indico/web/client/styles/partials/_forms.scss
@@ -123,7 +123,7 @@ form {
       font-style: italic;
       margin-top: 0.25em;
       margin-bottom: 0.5em;
-      width: 400px;
+      width: 90%;
     }
 
     .static-text {


### PR DESCRIPTION
`i-form` descriptions don't align very well with the fluid version from #5216. This change releases the width constraint on form descriptions to a reasonable degree.