### PR TITLE
Improve privacy notice button

### DIFF
--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -178,7 +178,10 @@
         {% endif %}
         {% if show_button %}
             <div class="group manage-button">
-                <a class="i-button icon-edit arrow js-dropdown" data-toggle="dropdown"></a>
+                <button class="small compact ui icon button js-dropdown" data-toggle="dropdown">
+                    <i class="edit icon"></i>
+                    <i class="caret down icon"></i>
+                </button>
                 {{ _render_dropdown(item, item_type, show_note_operations=show_note_operations) }}
             </div>
         {% endif %}

--- a/indico/modules/events/templates/display/common/_privacy_info_button.html
+++ b/indico/modules/events/templates/display/common/_privacy_info_button.html
@@ -4,8 +4,9 @@
         <div class="privacy-dropdown">
             <a href="#"
                onclick="return false;"
+               class="i-button highlight"
                title="{% trans %}Event privacy information{% endtrans %}">
-                <i class="info icon small"></i>
+                <i class="fitted balance scale icon"></i>
             </a>
             <div class="menu">
                 {% if data_controller_exists %}
@@ -55,19 +56,21 @@
     {% elif privacy_info.privacy_policy %}
         <a href="{{ url_for('events.display_privacy', event) }}"
            title="{% trans %}Event privacy notice{% endtrans %}"
+           class="i-button highlight"
            data-title="{% trans %}Event privacy notice{% endtrans %}"
            data-href="{{ url_for('events.display_privacy', event) }}"
            data-ajax-dialog
            data-hide-page-header
            data-close-button>
-            <i class="info icon small"></i>
+            <i class="fitted balance scale icon"></i>
         </a>
     {% elif privacy_info.privacy_policy_urls %}
         <a href="{{ privacy_info.privacy_policy_urls[0].url }}"
            target="_blank"
            rel="noopener noreferrer"
+           class="i-button highlight"
            title="{% trans %}Event privacy notice{% endtrans %}">
-            <i class="info icon small"></i>
+            <i class="fitted balance scale icon"></i>
         </a>
     {% endif %}
 {%- endmacro %}

--- a/indico/modules/events/templates/display/common/_privacy_info_button.html
+++ b/indico/modules/events/templates/display/common/_privacy_info_button.html
@@ -2,12 +2,11 @@
     {% set data_controller_exists = privacy_info.data_controller_name or privacy_info.data_controller_email %}
     {% if data_controller_exists or privacy_info.privacy_policy_urls|length > 1 %}
         <div class="privacy-dropdown">
-            <a href="#"
-               onclick="return false;"
-               class="i-button highlight"
-               title="{% trans %}Event privacy information{% endtrans %}">
-                <i class="fitted balance scale icon"></i>
-            </a>
+            <button class="small compact ui blue icon button"
+                    title="{% trans %}Event privacy information{% endtrans %}">
+                <i class="balance scale icon"></i>
+                <i class="caret down icon"></i>
+            </button>
             <div class="menu">
                 {% if data_controller_exists %}
                     <div class="header">{% trans %}Data controller{% endtrans %}</div>
@@ -56,7 +55,7 @@
     {% elif privacy_info.privacy_policy %}
         <a href="{{ url_for('events.display_privacy', event) }}"
            title="{% trans %}Event privacy notice{% endtrans %}"
-           class="i-button highlight"
+           class="small compact ui blue icon button"
            data-title="{% trans %}Event privacy notice{% endtrans %}"
            data-href="{{ url_for('events.display_privacy', event) }}"
            data-ajax-dialog
@@ -68,7 +67,7 @@
         <a href="{{ privacy_info.privacy_policy_urls[0].url }}"
            target="_blank"
            rel="noopener noreferrer"
-           class="i-button highlight"
+           class="small compact ui blue icon button"
            title="{% trans %}Event privacy notice{% endtrans %}">
             <i class="fitted balance scale icon"></i>
         </a>

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -14,27 +14,32 @@
 <div class="event-wrapper">
     {% block header %}
         <div class="event-header event-header-lecture {%- if not has_subheader %} round-bottom-corners{% endif %}">
-            <div class="event-privacy-info-button">
-                {{ render_privacy_info_button(event, privacy_info) }}
+            <div class="event-title">
+                <div>
+                    {% if category %}
+                        {% if not g.static_site %}
+                            <a class="lecture-category" href="{{ url_for('categories.display', event.category) }}">
+                                {{ category }}
+                            </a>
+                        {% else %}
+                            <div>{{ category }}</div>
+                        {% endif %}
+                    {% endif %}
+                    <h1>
+                        {{- event.get_verbose_title(show_series_pos=true) -}}
+                        {{- event.get_label_markup() -}}
+                    </h1>
+                </div>
+                <div class="event-actions">
+                    {% set show_button = not event.is_locked and event.can_manage_attachments(session.user) %}
+                    <div class="event-manage-button">
+                        {{ render_manage_button(event, 'EVENT', show_button=show_button, toggle_notes=false) }}
+                    </div>
+                    <div class="event-privacy-info-button">
+                        {{ render_privacy_info_button(event, privacy_info) }}
+                    </div>
+                </div>
             </div>
-            {% if category %}
-                {% if not g.static_site %}
-                    <a class="lecture-category" href="{{ url_for('categories.display', event.category) }}">
-                        {{ category }}
-                    </a>
-                {% else %}
-                    <div>{{ category }}</div>
-                {% endif %}
-            {% endif %}
-            {% set show_button = not event.is_locked and event.can_manage_attachments(session.user) %}
-            <div class="event-manage-button">
-                {{ render_manage_button(event, 'EVENT', show_button=show_button, toggle_notes=false) }}
-            </div>
-
-            <h1>
-                {{- event.get_verbose_title(show_series_pos=true) -}}
-                {{- event.get_label_markup() -}}
-            </h1>
             {% set chairpersons = event.person_links %}
             {% if chairpersons %}
                 <h2>

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -15,22 +15,26 @@
 <div class="event-wrapper">
     {% block header %}
         <div class="event-header {%- if not has_subheader %} round-bottom-corners{% endif %}">
-            <div class="event-privacy-info-button">
-                {{ render_privacy_info_button(event, privacy_info) }}
+            <div class="event-title">
+                <div>
+                    {% if theme_settings.logo_link %}
+                        <a href="{{ theme_settings.logo_link }}" class="logo"></a>
+                    {% endif %}
+                    <h1 itemprop="name">
+                        {{- event.title -}}
+                        {{- event.get_label_markup() -}}
+                    </h1>
+                </div>
+                <div class="event-actions">
+                    {% set show_button = not event.is_locked and event.can_manage_attachments(session.user) %}
+                    <div class="event-manage-button">
+                        {{ render_manage_button(event, 'EVENT', show_button=show_button, toggle_notes=false) }}
+                    </div>
+                    <div class="event-privacy-info-button">
+                        {{ render_privacy_info_button(event, privacy_info) }}
+                    </div>
+                </div>
             </div>
-            {% set show_button = not event.is_locked and event.can_manage_attachments(session.user) %}
-            <div class="event-manage-button">
-                {{ render_manage_button(event, 'EVENT', show_button=show_button, toggle_notes=false) }}
-            </div>
-
-            {% if theme_settings.logo_link %}
-                <a href="{{ theme_settings.logo_link }}" class="logo"></a>
-            {% endif %}
-
-            <h1 itemprop="name">
-                {{- event.title -}}
-                {{- event.get_label_markup() -}}
-            </h1>
             <div class="details">
                 <div class="event-date">
                     {{ render_event_time(event, timezone) }}

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -213,7 +213,7 @@ div.event-header {
 
     .event-actions {
       display: flex;
-      gap: 0.5em;
+      gap: 0.2em;
       margin-top: 10px;
     }
   }
@@ -386,6 +386,14 @@ ul.day-list {
 
 .event-manage-button {
   font-size: 10pt;
+
+  button.open {
+    border-bottom-left-radius: 0;
+  }
+
+  .i-dropdown {
+    border-top-left-radius: 0;
+  }
 }
 
 .event-privacy-info-button {
@@ -400,8 +408,8 @@ ul.day-list {
       display: none;
       position: absolute;
       z-index: 1;
-      top: 1.5em;
-      right: 0;
+      top: 1.8em;
+      right: 0.2em;
       min-width: 10em;
       border-radius: 2px;
       background-color: $light-gray;

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -198,12 +198,24 @@ div.event-header {
   margin: 0;
   padding: 10px 30px 10px;
 
-  h1 {
-    font-size: 20pt;
-    color: $header-text-color;
-    font-weight: normal;
-    margin-top: 10px;
+  .event-title {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5em;
     margin-bottom: 10px;
+
+    h1 {
+      font-size: 20pt;
+      color: $header-text-color;
+      font-weight: normal;
+      margin-top: 10px;
+    }
+
+    .event-actions {
+      display: flex;
+      gap: 0.5em;
+      margin-top: 10px;
+    }
   }
 
   &.round-bottom-corners {
@@ -373,16 +385,11 @@ ul.day-list {
 }
 
 .event-manage-button {
-  margin-top: 10px;
   font-size: 10pt;
 }
 
 .event-privacy-info-button {
   @extend %font-family-body;
-
-  position: absolute;
-  top: 5px;
-  right: 5px;
   font-size: 12pt;
 
   .privacy-dropdown {


### PR DESCRIPTION
This PR improves the look of the privacy notice button on lectures and meetings by making it more visible and aligning it with the "Manage Event" button.

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/27357203/169324805-8aff9223-711f-466b-ba30-cc6f966f7e60.png">
