### PR TITLE
Make the affiliation dropdown item more compact

### DIFF
--- a/indico/modules/users/client/js/PersonalDataForm.jsx
+++ b/indico/modules/users/client/js/PersonalDataForm.jsx
@@ -143,25 +143,19 @@ function PersonalDataForm({
     await new Promise(() => {});
   };
 
+  const getSubheader = ({city, country_name: countryName}) => {
+    if (city && countryName) {
+      return `${city}, ${countryName}`;
+    }
+    return city || countryName;
+  };
+
   const titleOptions = titles.map(t => ({key: t.name, value: t.name, text: t.title}));
   const affiliationOptions = affiliationResults.map(res => ({
     key: res.id,
     value: res.id,
     text: `${res.name} `, // XXX: the space allows addition even if the entered text matches a result item
-    content: (
-      <Header
-        content={res.name}
-        subheader={[res.street, res.postcode, res.city, res.country_code]
-          .filter(x => x)
-          .map((x, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <React.Fragment key={i}>
-              {i !== 0 && <br />}
-              {x}
-            </React.Fragment>
-          ))}
-      />
-    ),
+    content: <Header style={{fontSize: 14}} content={res.name} subheader={getSubheader(res)} />,
   }));
 
   const searchAffiliationChange = async (evt, {searchQuery}) => {

--- a/indico/web/client/js/react/components/PersonDetailsModal.jsx
+++ b/indico/web/client/js/react/components/PersonDetailsModal.jsx
@@ -36,25 +36,19 @@ const FinalAffiliationField = ({hasPredefinedAffiliations, currentAffiliation}) 
       ? [currentAffiliation, ..._affiliationResults]
       : _affiliationResults;
 
+  const getSubheader = ({city, country_name: countryName}) => {
+    if (city && countryName) {
+      return `${city}, ${countryName}`;
+    }
+    return city || countryName;
+  };
+
   const affiliationOptions = affiliationResults.map(res => ({
     key: res.id,
     value: res.id,
     meta: res,
     text: `${res.name} `, // XXX: the space allows addition even if the entered text matches a result item
-    content: (
-      <Header
-        content={res.name}
-        subheader={[res.street, res.postcode, res.city, res.country_code]
-          .filter(x => x)
-          .map((x, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <React.Fragment key={i}>
-              {i !== 0 && <br />}
-              {x}
-            </React.Fragment>
-          ))}
-      />
-    ),
+    content: <Header style={{fontSize: 14}} content={res.name} subheader={getSubheader(res)} />,
   }));
 
   const searchAffiliationChange = async (evt, {searchQuery}) => {

--- a/indico/web/client/styles/_custom.scss
+++ b/indico/web/client/styles/_custom.scss
@@ -14,3 +14,4 @@
 @import 'custom/jquery-ui-style.css';
 @import 'custom/jquery-ui-datepicker';
 @import 'custom/jquery-multiselect';
+@import 'custom/sui';

--- a/indico/web/client/styles/custom/_sui.scss
+++ b/indico/web/client/styles/custom/_sui.scss
@@ -1,0 +1,12 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2022 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+// the 'noResultsMessage' of SUI Dropdown clips if
+// it is too long (or the dropdown too narrow)
+.ui.dropdown > .menu > .message {
+  white-space: unset;
+}


### PR DESCRIPTION
More compact affiliation dropdown items just showing the city and country:
![image](https://user-images.githubusercontent.com/8739637/169327975-4552aea5-3675-4737-a2b6-173072647f40.png)

Also fixes the `noResultsMessage` clipping if it's too long
before:
![image](https://user-images.githubusercontent.com/8739637/169328426-93b581c7-4d7f-416c-b700-47e967d51bc8.png)
after:
![image](https://user-images.githubusercontent.com/8739637/169328150-89b2bc89-2412-48e7-b817-8de835c55317.png)

