### PR TITLE
Fix dropdown overflow on legacy modals

### DIFF
--- a/indico/web/client/styles/custom/_jquery-ui.scss
+++ b/indico/web/client/styles/custom/_jquery-ui.scss
@@ -23,6 +23,15 @@
   box-shadow: 0 0 24px rgba(0, 0, 0, 0.3);
 }
 
+.ui-dialog .dropdown .menu {
+  max-width: 20.5em;
+}
+
+.ui-dialog .dropdown .menu .item {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .ui-widget {
   @extend %font-family-body;
 


### PR DESCRIPTION
Fixes a recurring issue caused by the usage of the brand new semantic styles within legacy modals. As the width within a modal is generally constrained, and overflow is set to scroll, an unrestrained dropdown can grow into an invisible space.

This commit will impose a fixed width and make sure the text is ellipsized.

![imagem](https://user-images.githubusercontent.com/12183954/169539344-5a772048-403f-4256-a35f-025b2cb54769.png)

---

![imagem](https://user-images.githubusercontent.com/12183954/169539036-f00e058c-ea88-43e0-8bb6-8332b93d8697.png)
