### PR TITLE
Add option to override pending transaction behavior

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Bugfixes
 - Prevent access to a badge design of a deleted category or an event (:issue:`5329`,
   :pr:`5334`, thanks :user:`vasantvohra`)
 
+Internal Changes
+^^^^^^^^^^^^^^^^
+
+- Let payment plugins ignore pending transactions if they are expired (:pr:`5357`)
+
 
 Version 3.1.1
 -------------

--- a/indico/modules/events/payment/models/transactions.py
+++ b/indico/modules/events/payment/models/transactions.py
@@ -215,6 +215,14 @@ class PaymentTransaction(db.Model):
         with plugin.plugin_context():
             return plugin.render_transaction_details(self)
 
+    def is_pending_expired(self):
+        if self.is_manual:
+            return False
+        if (plugin := self.plugin) is None:
+            return False
+        with plugin.plugin_context():
+            return plugin.is_pending_transaction_expired(self)
+
     @classmethod
     def create_next(cls, registration, amount, currency, action, provider=None, data=None):
         previous_transaction = registration.transaction

--- a/indico/modules/events/payment/plugins.py
+++ b/indico/modules/events/payment/plugins.py
@@ -140,3 +140,11 @@ class PaymentPluginMixin:
         return render_template([f'{transaction.plugin.name}:transaction_details.html',
                                 'events/payment/transaction_details.html'],
                                plugin=transaction.plugin, transaction=transaction)
+
+    def is_pending_transaction_expired(self, transaction):
+        """Check if the transaction is pending but expired.
+
+        If this returns true, it will show up as unpaid instead of pending
+        for the user and they can proceed to payment once again.
+        """
+        return False

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -601,6 +601,12 @@ class Registration(db.Model):
         """Log with prefilled metadata for the registration."""
         self.event.log(*args, meta={'registration_id': self.id}, **kwargs)
 
+    def is_pending_transaction_expired(self):
+        """Check if the registration has a pending transaction that expired."""
+        if not self.transaction or self.transaction.status != TransactionStatus.pending:
+            return False
+        return self.transaction.is_pending_expired()
+
 
 class RegistrationData(StoredFileMixin, db.Model):
     """Data entry within a registration for a field in a registration form."""

--- a/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
+++ b/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
@@ -90,7 +90,8 @@
                 <div class="i-box-title">
                     {% trans %}Invoice{% endtrans %}
                 </div>
-                {% if not registration.transaction or registration.transaction.status.name not in ('successful', 'pending') %}
+                {% if not registration.transaction or registration.transaction.status.name not in ('successful', 'pending')
+                   or registration.is_pending_transaction_expired() %}
                     <div class="payment-status payment-not-paid right">
                         {% trans %}Not paid{% endtrans %}
                         <i class="icon-time"></i>

--- a/indico/modules/events/registration/templates/display/registration_summary.html
+++ b/indico/modules/events/registration/templates/display/registration_summary.html
@@ -95,7 +95,8 @@
 
 {{ render_registration_summary(registration) }}
 {% call render_invoice(registration, payment_enabled, payment_conditions) %}
-    {% if payment_enabled and registration.state.name == 'unpaid' and not registration.is_paid %}
+    {% if payment_enabled and registration.state.name == 'unpaid' and
+       (not registration.is_paid or registration.is_pending_transaction_expired()) %}
         <table class="regform-done-footer" width="100%" cellpadding="0" cellspacing="0">
             <tr>
                 <td>


### PR DESCRIPTION
This is needed e.g. for the sixpay plugin which creates a pending transaction when you proceed to payment - if the user stops at that point and never actively cancels, they'd be stuck without the ability to get back to the payment site.

By letting the payment plugin override that behavior it can e.g. check if the transaction expired or simply ignore a pending transaction..