### PR TITLE
Change privacy sidemenu item icon

### DIFF
--- a/indico/modules/events/management/__init__.py
+++ b/indico/modules/events/management/__init__.py
@@ -31,7 +31,7 @@ def _sidemenu_items(sender, event, **kwargs):
         yield SideMenuItem('protection', _('Protection'), url_for('event_management.protection', event),
                            70, icon='shield')
         yield SideMenuItem('privacy_dashboard', _('Privacy'),
-                           url_for('event_management.privacy_dashboard', event), 69, icon='lock-center')
+                           url_for('event_management.privacy_dashboard', event), 69, sui_icon='balance scale')
         if event.type_ == EventType.conference:
             yield SideMenuItem('program_codes', _('Program Codes'), url_for('event_management.program_codes', event),
                                section='advanced')

--- a/indico/web/client/styles/partials/_sidebars.scss
+++ b/indico/web/client/styles/partials/_sidebars.scss
@@ -148,6 +148,13 @@
       &.active a.title {
         color: $darker-blue;
       }
+
+      i.icon {
+        width: 14.3px;
+        height: auto;
+        margin-right: 7.15px;
+        font-size: 0.83em;
+      }
     }
   }
 }

--- a/indico/web/menu.py
+++ b/indico/web/menu.py
@@ -73,7 +73,9 @@ class SideMenuItem:
 
     is_section = False
 
-    def __init__(self, name, title, url, weight=-1, active=False, disabled=False, section=None, icon=None, badge=None):
+    def __init__(self, name, title, url, weight=-1, active=False, disabled=False, section=None, icon=None,
+                 sui_icon=None, badge=None):
+        assert not (icon and sui_icon)
         self.name = name
         self.title = title
         self.url = url
@@ -82,6 +84,7 @@ class SideMenuItem:
         self.section = section
         self.weight = weight
         self.icon = ('icon-' + icon) if icon else None
+        self.sui_icon = sui_icon
         self.badge = badge
 
     def __repr__(self):

--- a/indico/web/templates/side_menu.html
+++ b/indico/web/templates/side_menu.html
@@ -9,6 +9,9 @@
     <li class="item {{ classes }}">
         {%- if item.disabled %}
             <span class="title {{ icon }}">
+                {%- if item.sui_icon %}
+                    <i class="{{ item.sui_icon }} icon"></i>
+                {%- endif -%}
                 <span class="side-menu-label">
                     {{- item.title -}}
                 </span>
@@ -18,6 +21,9 @@
             </span>
         {%- else -%}
             <a class="title {{ icon }}" href="{{ item.url }}">
+                {%- if item.sui_icon %}
+                    <i class="{{ item.sui_icon }} icon"></i>
+                {%- endif -%}
                 <span class="side-menu-label">
                     {{- item.title -}}
                 </span>


### PR DESCRIPTION
This PR changes the privacy sidemenu item icon from a lock to a balance scale, and adds the ability to use SUI icons in sidemenu items.

![screenshot](https://user-images.githubusercontent.com/27357203/171166265-f2b5f70b-5b67-4b7d-b27e-87a04e38fb30.png)