### PR TITLE
Move affiliation info into users table

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11
+        image: postgres:12
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:
@@ -241,6 +241,7 @@ jobs:
 
       - name: Setup database
         run: |
+          sudo apt-get update
           sudo apt-get install postgresql-client libpq-dev
           export PGHOST=localhost
           export PGPORT=${{ job.services.postgres.ports[5432] }}

--- a/indico/migrations/versions/20220531_1439_0c4bb2973536_move_affiliation_into_users_table.py
+++ b/indico/migrations/versions/20220531_1439_0c4bb2973536_move_affiliation_into_users_table.py
@@ -1,0 +1,72 @@
+"""Move affiliation into users table
+
+Revision ID: 0c4bb2973536
+Revises: 1950e5d12ab5
+Create Date: 2022-05-31 14:39:54.326359
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '0c4bb2973536'
+down_revision = '1950e5d12ab5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('users', sa.Column('affiliation', sa.String(), nullable=False, server_default=''), schema='users')
+    op.add_column('users', sa.Column('affiliation_id', sa.Integer(), nullable=True), schema='users')
+    op.alter_column('users', 'affiliation', server_default=None, schema='users')
+    op.execute('''
+        UPDATE users.users u
+        SET affiliation = ua.name, affiliation_id = ua.affiliation_id
+        FROM users.affiliations ua
+        WHERE u.id = ua.user_id;
+    ''')
+    op.create_index(None, 'users', ['affiliation'], unique=False, schema='users')
+    op.create_index(None, 'users', ['affiliation_id'], unique=False, schema='users')
+    op.create_foreign_key(None, 'users', 'affiliations', ['affiliation_id'], ['id'],
+                          source_schema='users', referent_schema='indico')
+    op.create_index(
+        op.f('ix_users_affiliation_unaccent'),
+        'users',
+        [sa.text('indico.indico_unaccent(lower(affiliation))')],
+        postgresql_using='gin',
+        postgresql_ops={'indico.indico_unaccent(lower(affiliation))': 'gin_trgm_ops'},
+        schema='users'
+    )
+    op.drop_table('affiliations', schema='users')
+
+
+def downgrade():
+    op.create_table(
+        'affiliations',
+        sa.Column('id', sa.Integer(), server_default=sa.text("nextval('users.affiliations_id_seq'::regclass)"), autoincrement=True, nullable=False),
+        sa.Column('user_id', sa.Integer(), autoincrement=False, nullable=False),
+        sa.Column('name', sa.String(), autoincrement=False, nullable=False),
+        sa.Column('affiliation_id', sa.Integer(), autoincrement=False, nullable=True),
+        sa.ForeignKeyConstraint(['affiliation_id'], ['indico.affiliations.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['users.users.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='users'
+    )
+    op.execute('''
+        INSERT INTO users.affiliations (user_id, name, affiliation_id)
+        SELECT id, affiliation, affiliation_id FROM users.users;
+    ''')
+    op.create_index(None, 'affiliations', ['user_id'], unique=False, schema='users')
+    op.create_index(None, 'affiliations', ['name'], unique=False, schema='users')
+    op.create_index(None, 'affiliations', ['affiliation_id'], unique=False, schema='users')
+    op.create_index(
+        op.f('ix_affiliations_name_unaccent'),
+        'affiliations',
+        [sa.text('indico.indico_unaccent(lower(name))')],
+        postgresql_using='gin',
+        postgresql_ops={'indico.indico_unaccent(lower(name))': 'gin_trgm_ops'},
+        schema='users'
+    )
+    op.drop_column('users', 'affiliation_id', schema='users')
+    op.drop_column('users', 'affiliation', schema='users')

--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -201,9 +201,9 @@ class PrincipalsMixin:
                     'last_name': principal.last_name,
                     'email': principal.email,
                     'affiliation': principal.affiliation,
-                    'affiliation_id': principal._affiliation.affiliation_id,
-                    'affiliation_meta': (AffiliationSchema().dump(principal._affiliation.affiliation_link)
-                                         if principal._affiliation.affiliation_link else None),
+                    'affiliation_id': principal.affiliation_id,
+                    'affiliation_meta': (AffiliationSchema().dump(principal.affiliation_link)
+                                         if principal.affiliation_link else None),
                     'avatar_url': principal.avatar_url,
                     'detail': (f'{principal.email} ({principal.affiliation})'
                                if principal.affiliation else principal.email)}

--- a/indico/modules/events/abstracts/operations.py
+++ b/indico/modules/events/abstracts/operations.py
@@ -268,7 +268,8 @@ def _merge_person_links(target_abstract, source_abstract):
             else:
                 link.display_order = 0
             new_links.add(link)
-            for column_name in {'_title', '_affiliation', '_address', '_phone', '_first_name', '_last_name'}:
+            for column_name in {'_title', '_affiliation', '_affiliation_id', '_address', '_phone', '_first_name',
+                                '_last_name'}:
                 setattr(link, column_name, getattr(source_link, column_name))
 
     # Add new links in order

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -451,7 +451,6 @@ class CategoryEventFetcher(IteratedDataFetcher, SerializerBase):
         # remote group membership checks will trigger a load on _all_emails
         # but not all events use this so there's no need to eager-load them
         # acl_user_strategy.noload('_primary_email')
-        # acl_user_strategy.noload('_affiliation')
         creator_strategy = joinedload('creator')
         contributions_strategy = subqueryload('contributions')
         contributions_strategy.subqueryload('references')

--- a/indico/modules/events/export_test_1.yaml
+++ b/indico/modules/events/export_test_1.yaml
@@ -141,7 +141,7 @@ timestamp: 2017-08-24 09:00:00+00:00
 users:
   00000000-0000-4000-8000-000000000001:
     address: ''
-    affiliation: null
+    affiliation: ''
     all_emails:
     - 1337@example.com
     email: 1337@example.com

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -227,8 +227,8 @@ class EventPerson(PersonMixin, db.Model):
     def create_from_user(cls, user, event=None, is_untrusted=False):
         return EventPerson(user=user, event=event, first_name=user.first_name, last_name=user.last_name,
                            title=user._title, email=user.email, affiliation=user.affiliation,
-                           affiliation_link=(user._affiliation.affiliation_link if user._affiliation else None),
-                           address=user.address, phone=user.phone, is_untrusted=is_untrusted)
+                           affiliation_link=user.affiliation_link, address=user.address, phone=user.phone,
+                           is_untrusted=is_untrusted)
 
     @classmethod
     def for_user(cls, user, event=None, is_untrusted=False):

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -177,10 +177,10 @@ def get_user_data(regform, user, invitation=None):
         if (
             (country_field := get_country_field(regform)) and
             country_field.data.get('use_affiliation_country') and
-            (link := user._affiliation.affiliation_link) and
-            link.country_code
+            user.affiliation_link and
+            user.affiliation_link.country_code
         ):
-            user_data['country'] = link.country_code
+            user_data['country'] = user.affiliation_link.country_code
     if invitation:
         user_data.update((attr, getattr(invitation, attr)) for attr in ('first_name', 'last_name', 'email'))
         if invitation.affiliation:

--- a/indico/modules/search/internal.py
+++ b/indico/modules/search/internal.py
@@ -389,7 +389,7 @@ class InternalSearch(IndicoSearchProvider):
             Attachment.query
             .join(Attachment.folder)
             .filter(*attachment_filters)
-            .options(folder_strategy, attachment_strategy, joinedload(Attachment.user).joinedload('_affiliation'))
+            .options(folder_strategy, attachment_strategy, joinedload(Attachment.user))
             .outerjoin(AttachmentFolder.linked_event)
             .outerjoin(AttachmentFolder.contribution)
             .outerjoin(Contribution.event.of_type(contrib_event))
@@ -529,7 +529,7 @@ class InternalSearch(IndicoSearchProvider):
                 joinedload(EventNote.contribution),
                 joinedload(EventNote.subcontribution).joinedload(SubContribution.contribution),
                 joinedload(EventNote.event).options(undefer(Event.detailed_category_chain)),
-                joinedload(EventNote.current_revision).joinedload(EventNoteRevision.user).joinedload('_affiliation'),
+                joinedload(EventNote.current_revision).joinedload(EventNoteRevision.user),
             )
         )
         notes_by_id = {n.id: n for n in query}

--- a/indico/modules/users/client/js/PersonalDataForm.jsx
+++ b/indico/modules/users/client/js/PersonalDataForm.jsx
@@ -133,6 +133,14 @@ function PersonalDataForm({
 
   const handleSubmit = async (data, form) => {
     const changedValues = getChangedValues(data, form);
+    if (!hasPredefinedAffiliations) {
+      // value.affiliation is already there and used
+      delete changedValues.affiliation_data;
+    } else if (changedValues.affiliation_data) {
+      changedValues.affiliation = changedValues.affiliation_data.text.trim();
+      changedValues.affiliation_id = changedValues.affiliation_data.id;
+      delete changedValues.affiliation_data;
+    }
     try {
       await indicoAxios.patch(saveURL(userIdArgs), changedValues);
     } catch (e) {

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -204,8 +204,8 @@ class RHPersonalData(RHUserBase):
         titles = [{'name': t.name, 'title': t.title} for t in UserTitle if t != UserTitle.none]
         user_values = UserPersonalDataSchema().dump(self.user)
         current_affiliation = None
-        if self.user._affiliation.affiliation_link:
-            current_affiliation = AffiliationSchema().dump(self.user._affiliation.affiliation_link)
+        if self.user.affiliation_link:
+            current_affiliation = AffiliationSchema().dump(self.user.affiliation_link)
         has_predefined_affiliations = Affiliation.query.filter(~Affiliation.is_deleted).has_rows()
         return WPUserPersonalData.render_template('personal_data.html', 'personal_data', user=self.user,
                                                   titles=titles, user_values=user_values,
@@ -226,14 +226,6 @@ class RHPersonalDataUpdate(RHUserBase):
         # get updated in synchronize_data which will flash a message
         # informing the user about the changes made by the sync
         self.user.synced_fields = synced_fields & syncable_fields
-        if (affiliation_data := changes.pop('affiliation_data', None)) and 'affiliation' not in self.user.synced_fields:
-            if affiliation_data['affiliation_id']:
-                self.user._affiliation.affiliation_link = Affiliation.get_or_404(affiliation_data['affiliation_id'],
-                                                                                 is_deleted=False)
-                self.user._affiliation.name = self.user._affiliation.affiliation_link.name
-            else:
-                self.user._affiliation.affiliation_link = None
-                self.user._affiliation.name = affiliation_data['name']
         for key, value in changes.items():
             if key not in self.user.synced_fields:
                 setattr(self.user, key, value)

--- a/indico/modules/users/schemas.py
+++ b/indico/modules/users/schemas.py
@@ -6,8 +6,8 @@
 # LICENSE file for more details.
 
 import pycountry
-from marshmallow import fields, post_dump, post_load, pre_load, validate
-from marshmallow.fields import Function, Integer, List, Nested, String
+from marshmallow import fields, post_dump, post_load, validate
+from marshmallow.fields import Function, Integer, List, String
 
 from indico.core.marshmallow import mm
 from indico.modules.categories import Category
@@ -15,7 +15,7 @@ from indico.modules.events import Event
 from indico.modules.users import User
 from indico.modules.users.models.affiliations import Affiliation
 from indico.modules.users.models.users import UserTitle, syncable_fields
-from indico.util.marshmallow import NoneValueEnumField
+from indico.util.marshmallow import ModelField, NoneValueEnumField
 
 
 class UserSchema(mm.SQLAlchemyAutoSchema):
@@ -32,24 +32,31 @@ class _AffiliationDataSchema(mm.Schema):
     name = String(required=True, data_key='text')
 
 
+class AffiliationSchema(mm.SQLAlchemyAutoSchema):
+    class Meta:
+        model = Affiliation
+        fields = ('id', 'name', 'street', 'postcode', 'city', 'country_code', 'meta')
+
+    @post_dump
+    def add_country_name(self, data, **kwargs):
+        country = pycountry.countries.get(alpha_2=data['country_code'])
+        data['country_name'] = country.name if country else ''
+        return data
+
+
 class UserPersonalDataSchema(mm.SQLAlchemyAutoSchema):
     title = NoneValueEnumField(UserTitle, none_value=UserTitle.none, attribute='_title')
     email = String(dump_only=True)
     synced_fields = List(String(validate=validate.OneOf(syncable_fields)))
-    affiliation_data = Nested(_AffiliationDataSchema, attribute='_affiliation')
+    affiliation_link = ModelField(Affiliation, data_key='affiliation_id', load_default=None, load_only=True)
+    affiliation_data = fields.Function(lambda u: {'id': u.affiliation_id, 'text': u.affiliation}, dump_only=True)
 
     class Meta:
         model = User
         # XXX: this schema is also used for updating a user's personal data, so the fields here must
         # under no circumstances include sensitive fields that should not be modifiable by a user!
-        fields = ('title', 'first_name', 'last_name', 'email', 'affiliation', 'affiliation_data', 'address', 'phone',
-                  'synced_fields')
-
-    @pre_load
-    def wrap_plain_affiliation(self, data, **kwargs):
-        if (affiliation := data.pop('affiliation', None)) is not None:
-            data['affiliation_data'] = {'id': None, 'text': affiliation}
-        return data
+        fields = ('title', 'first_name', 'last_name', 'email', 'address', 'phone', 'synced_fields',
+                  'affiliation', 'affiliation_data', 'affiliation_link')
 
     @post_dump
     def sort_synced_fields(self, data, **kwargs):
@@ -57,9 +64,12 @@ class UserPersonalDataSchema(mm.SQLAlchemyAutoSchema):
         return data
 
     @post_load
-    def fix_key(self, data, **kwargs):
-        if affiliation := data.pop('_affiliation', None):
-            data['affiliation_data'] = affiliation
+    def ensure_affiliation_text(self, data, **kwargs):
+        if affiliation_link := data.get('affiliation_link'):
+            data['affiliation'] = affiliation_link.name
+        elif 'affiliation' in data:
+            # clear link if we update only the affiliation text for some reason
+            data['affiliation_link'] = None
         return data
 
 
@@ -77,15 +87,3 @@ class FavoriteEventSchema(mm.SQLAlchemyAutoSchema):
     location = fields.String(attribute='event.location.venue_name')
     chain_titles = fields.List(fields.String(), attribute='category.chain_titles')
     label_markup = fields.Function(lambda e: e.get_label_markup('mini'))
-
-
-class AffiliationSchema(mm.SQLAlchemyAutoSchema):
-    class Meta:
-        model = Affiliation
-        fields = ('id', 'name', 'street', 'postcode', 'city', 'country_code', 'meta')
-
-    @post_dump
-    def add_country_name(self, data, **kwargs):
-        country = pycountry.countries.get(alpha_2=data['country_code'])
-        data['country_name'] = country.name if country else ''
-        return data

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -30,7 +30,6 @@ from indico.modules.categories import Category
 from indico.modules.categories.models.principals import CategoryPrincipal
 from indico.modules.events import Event
 from indico.modules.users import User, logger
-from indico.modules.users.models.affiliations import UserAffiliation
 from indico.modules.users.models.emails import UserEmail
 from indico.modules.users.models.favorites import favorite_user_table
 from indico.modules.users.models.suggestions import SuggestedCategory
@@ -209,10 +208,6 @@ def build_user_search_query(criteria, exact=False, include_deleted=False, includ
         query = query.filter(~User.is_deleted)
     if not include_blocked:
         query = query.filter(~User.is_blocked)
-
-    affiliation = criteria.pop('affiliation', unspecified)
-    if affiliation is not unspecified:
-        query = query.join(UserAffiliation).filter(unaccent_match(UserAffiliation.name, affiliation, exact))
 
     email = criteria.pop('email', unspecified)
     if email is not unspecified:

--- a/indico/util/user.py
+++ b/indico/util/user.py
@@ -79,8 +79,8 @@ def principal_from_identifier(identifier, allow_groups=False, allow_external_use
                     address=external_user_data['address'], phone=external_user_data['phone'], _title=UserTitle.none,
                     is_pending=True)
         if affiliation_data := external_user_data.get('affiliation_data'):
-            user._affiliation.affiliation_link = Affiliation.get_or_create_from_data(affiliation_data)
-            user._affiliation.name = user._affiliation.affiliation_link.name
+            user.affiliation_link = Affiliation.get_or_create_from_data(affiliation_data)
+            user.affiliation = user.affiliation_link.name
         return user
     elif type_ == 'Group':
         if not allow_groups:

--- a/indico/web/assets/vars_js.py
+++ b/indico/web/assets/vars_js.py
@@ -78,9 +78,8 @@ def generate_user_file(user=None):
             'avatarURL': user.avatar_url,
             'isAdmin': user.is_admin,
             'affiliation': user.affiliation,
-            'affiliationId': user._affiliation.affiliation_id,
-            'affiliationMeta': (AffiliationSchema().dump(user._affiliation.affiliation_link)
-                                if user._affiliation.affiliation_link else None),
+            'affiliationId': user.affiliation_id,
+            'affiliationMeta': AffiliationSchema().dump(user.affiliation_link) if user.affiliation_link else None,
             'address': user.address,
             'phone': user.phone,
             'type': user.principal_type.name,  # always 'user'


### PR DESCRIPTION
The separate table required ugly hacks and never resulted in any benefits in the end (such as having multiple affiliations, which would not work well with everything else in Indico that assumes a single affiliation)