### PR TITLE
Add setting for mandatory Affiliation and Comment fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,8 +53,8 @@ Improvements
   (:issue:`5356`, :pr:`5372`, thanks :user:`rppt`)
 - Add the ability to include an optional static javascript file when defining
   custom conference themes from within a plugin (:pr:`5414`, thanks :user:`brittyazel`)
-- Add option to make 'Affiliation' and 'Comment' fields mandatory in the account request form
-  (:issue:`4819`, :pr:`5389`, thanks :user:`elsbethe`)
+- Add option to make the 'Affiliation' and 'Comment' fields mandatory in the account
+  request form (:issue:`4819`, :pr:`5389`, thanks :user:`elsbethe`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,7 @@ Improvements
 - Add the ability to include an optional static javascript file when defining
   custom conference themes from within a plugin (:pr:`5414`, thanks :user:`brittyazel`)
 - Add option to make 'Affiliation' and 'Comment' fields mandatory in the account request form
-  (:issue:`4819`, :pr:``, thanks :user:`elsbethe`)
+  (:issue:`4819`, :pr:`5389`, thanks :user:`elsbethe`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,8 @@ Improvements
   (:issue:`5356`, :pr:`5372`, thanks :user:`rppt`)
 - Add the ability to include an optional static javascript file when defining
   custom conference themes from within a plugin (:pr:`5414`, thanks :user:`brittyazel`)
+- Add option to make 'Affiliation' and 'Comment' fields mandatory in the account request form
+  (:issue:`4819`, :pr:``, thanks :user:`elsbethe`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -36,6 +36,13 @@ class IndicoMultipass(Multipass):
         return next((p for p in self.identity_providers.values() if p.settings.get('synced_fields')), None)
 
     @property
+    def has_moderated_providers(self):
+        return (
+            config.LOCAL_MODERATION or
+            any(p for p in self.identity_providers.values() if p.settings.get('moderated'))
+        )
+
+    @property
     def synced_fields(self):
         """The keys to be synchronized.
 

--- a/indico/modules/auth/client/js/signup.jsx
+++ b/indico/modules/auth/client/js/signup.jsx
@@ -197,6 +197,7 @@ function Signup({
               <FinalTextArea
                 required={mandatoryFields.includes('comment')}
                 name="comment"
+                initialValue=""
                 label={Translate.string('Comment')}
                 description={Translate.string(
                   'You can provide additional information or a comment for the administrators who will review your registration.'

--- a/indico/modules/auth/client/js/signup.jsx
+++ b/indico/modules/auth/client/js/signup.jsx
@@ -55,7 +55,10 @@ function Signup({
     try {
       resp = await indicoAxios.post(location.href, values);
     } catch (e) {
-      return handleSubmitError(e);
+      return handleSubmitError(
+        e,
+        hasPredefinedAffiliations ? {affiliation: 'affiliation_data'} : {}
+      );
     }
     location.href = resp.data.redirect;
     // never finish submitting to avoid fields being re-enabled
@@ -134,6 +137,7 @@ function Signup({
             {hasPredefinedAffiliations ? (
               <SyncedFinalAffiliationDropdown
                 name="affiliation_data"
+                required={moderated && mandatoryFields.includes('affiliation')}
                 syncName="affiliation"
                 syncedValues={syncedValues}
                 currentAffiliation={affiliationMeta}
@@ -232,7 +236,7 @@ Signup.propTypes = {
   emails: PropTypes.arrayOf(PropTypes.string).isRequired,
   affiliationMeta: PropTypes.object,
   hasPendingUser: PropTypes.bool,
-  mandatoryFields: PropTypes.arrayOf(PropTypes.string),
+  mandatoryFields: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 Signup.defaultProps = {

--- a/indico/modules/auth/client/js/signup.jsx
+++ b/indico/modules/auth/client/js/signup.jsx
@@ -38,6 +38,7 @@ function Signup({
   emails,
   affiliationMeta,
   hasPendingUser,
+  mandatoryFields,
 }) {
   const handleSubmit = async (data, form) => {
     const values = getValuesForFields(data, form);
@@ -141,6 +142,7 @@ function Signup({
               <SyncedFinalInput
                 name="affiliation"
                 label={Translate.string('Affiliation')}
+                required={ moderated && mandatoryFields.includes("Affiliation") }
                 syncedValues={syncedValues}
               />
             )}
@@ -189,8 +191,9 @@ function Signup({
                 </Translate>
               </Message>
               <FinalTextArea
+                required={ mandatoryFields.includes("Comment") } 
                 name="comment"
-                initialValue=""
+                label={Translate.string('Comment')}
                 description={Translate.string(
                   'You can provide additional information or a comment for the administrators who will review your registration.'
                 )}
@@ -229,6 +232,7 @@ Signup.propTypes = {
   emails: PropTypes.arrayOf(PropTypes.string).isRequired,
   affiliationMeta: PropTypes.object,
   hasPendingUser: PropTypes.bool,
+  mandatoryFields: PropTypes.arrayOf(PropTypes.string),
 };
 
 Signup.defaultProps = {

--- a/indico/modules/auth/client/js/signup.jsx
+++ b/indico/modules/auth/client/js/signup.jsx
@@ -142,7 +142,7 @@ function Signup({
               <SyncedFinalInput
                 name="affiliation"
                 label={Translate.string('Affiliation')}
-                required={ moderated && mandatoryFields.includes("Affiliation") }
+                required={moderated && mandatoryFields.includes('affiliation')}
                 syncedValues={syncedValues}
               />
             )}
@@ -191,7 +191,7 @@ function Signup({
                 </Translate>
               </Message>
               <FinalTextArea
-                required={ mandatoryFields.includes("Comment") } 
+                required={mandatoryFields.includes('comment')}
                 name="comment"
                 label={Translate.string('Comment')}
                 description={Translate.string(

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -426,6 +426,7 @@ class RegistrationHandler:
 
     def create_schema(self):
         emails = self.get_all_emails()
+        mandatory_fields = user_management_settings.get('mandatory_fields_account_request')
 
         class SignupSchema(mm.Schema):
             class Meta:
@@ -435,14 +436,14 @@ class RegistrationHandler:
             first_name = fields.String(required=True)
             last_name = fields.String(required=True)
             address = fields.String(load_default='')
-            if self.moderate_registrations and 'affiliation' in user_management_settings.get('mandatory_fields_account_request'):
+            if self.moderate_registrations and 'affiliation' in mandatory_fields:
                 affiliation = fields.String(required=True, validate=not_empty)
             else:
                 affiliation = fields.String(load_default='')
             phone = fields.String(load_default='')
             affiliation_link = ModelField(Affiliation, data_key='affiliation_id', load_default=None)
             if self.moderate_registrations:
-                if 'comment' in user_management_settings.get('mandatory_fields_account_request'):
+                if 'comment' in mandatory_fields:
                     comment = fields.String(required=True, validate=not_empty)
                 else:
                     comment = fields.String(load_default='')

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -26,7 +26,7 @@ from indico.modules.auth.models.registration_requests import RegistrationRequest
 from indico.modules.auth.util import (impersonate_user, load_identity_info, register_user, undo_impersonate_user,
                                       url_for_logout)
 from indico.modules.auth.views import WPAuth, WPAuthUser, WPSignup
-from indico.modules.users import User
+from indico.modules.users import User, user_management_settings
 from indico.modules.users.controllers import RHUserBase
 from indico.modules.users.models.affiliations import Affiliation
 from indico.util.i18n import _
@@ -512,6 +512,7 @@ class MultipassRegistrationHandler(RegistrationHandler):
         }
         affiliation_meta = None
         pending_data = self.get_pending_initial_data(emails)
+        mandatory_fields = user_management_settings.get('mandatory_fields_account_request')
         if self.from_sync_provider:
             synced_fields = set(multipass.synced_fields)
             synced_values = {k: v or '' for k, v in self.identity_info['data'].items() if k in synced_fields}
@@ -539,6 +540,7 @@ class MultipassRegistrationHandler(RegistrationHandler):
             'emails': emails,
             'affiliationMeta': affiliation_meta,
             'hasPendingUser': bool(pending_data),
+            'mandatoryFields': mandatory_fields,
         }
 
     def create_schema(self):
@@ -629,6 +631,7 @@ class LocalRegistrationHandler(RegistrationHandler):
         initial_values = {'email': email, 'affiliation_data': {'id': None, 'text': ''}}
         pending_data = self.get_pending_initial_data([email])
         initial_values.update(pending_data)
+        mandatory_fields = user_management_settings.get('mandatory_fields_account_request')
         return {
             'cancelURL': url_for_logout(),
             'moderated': self.moderate_registrations,
@@ -638,6 +641,7 @@ class LocalRegistrationHandler(RegistrationHandler):
             'syncedValues': {},
             'emails': [email],
             'hasPendingUser': bool(pending_data),
+            'mandatoryFields': mandatory_fields,
         }
 
     def create_schema(self):

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -435,11 +435,17 @@ class RegistrationHandler:
             first_name = fields.String(required=True)
             last_name = fields.String(required=True)
             address = fields.String(load_default='')
-            affiliation = fields.String(load_default='')
+            if 'affiliation' in user_management_settings.get('mandatory_fields_account_request'):
+                affiliation = fields.String(required=True)
+            else:
+                affiliation = fields.String(load_default='')
             phone = fields.String(load_default='')
             affiliation_link = ModelField(Affiliation, data_key='affiliation_id', load_default=None)
             if self.moderate_registrations:
-                comment = fields.String(load_default='')
+                if 'comment' in user_management_settings.get('mandatory_fields_account_request'):
+                    comment = fields.String(required=True)
+                else:
+                    comment = fields.String(load_default='')
 
             @post_load
             def ensure_affiliation_text(self, data, **kwargs):

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -435,15 +435,15 @@ class RegistrationHandler:
             first_name = fields.String(required=True)
             last_name = fields.String(required=True)
             address = fields.String(load_default='')
-            if 'affiliation' in user_management_settings.get('mandatory_fields_account_request'):
-                affiliation = fields.String(required=True)
+            if self.moderate_registrations and 'affiliation' in user_management_settings.get('mandatory_fields_account_request'):
+                affiliation = fields.String(required=True, validate=not_empty)
             else:
                 affiliation = fields.String(load_default='')
             phone = fields.String(load_default='')
             affiliation_link = ModelField(Affiliation, data_key='affiliation_id', load_default=None)
             if self.moderate_registrations:
                 if 'comment' in user_management_settings.get('mandatory_fields_account_request'):
-                    comment = fields.String(required=True)
+                    comment = fields.String(required=True, validate=not_empty)
                 else:
                     comment = fields.String(load_default='')
 

--- a/indico/modules/users/__init__.py
+++ b/indico/modules/users/__init__.py
@@ -45,6 +45,7 @@ user_management_settings = SettingsProxy('user_management', {
     'notify_account_creation': False,
     'email_blacklist': [],
     'allow_personal_tokens': True,
+    'mandatory_fields_account_request': []
 })
 
 

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -616,7 +616,8 @@ class RHUsersAdmin(RHAdminBase):
         num_reg_requests = RegistrationRequest.query.count()
         return WPUsersAdmin.render_template('users_admin.html', 'users', form=form, search_results=search_results,
                                             num_of_users=num_of_users, num_deleted_users=num_deleted_users,
-                                            num_reg_requests=num_reg_requests)
+                                            num_reg_requests=num_reg_requests,
+                                            has_moderation=multipass.has_moderated_providers)
 
 
 class RHUsersAdminSettings(RHAdminBase):

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -116,10 +116,10 @@ class AdminUserSettingsForm(IndicoForm):
                                          description=_('Whether users are allowed to generate personal API tokens. '
                                                        'If disabled, only admins can create them, but users will '
                                                        'still be able to regenerate the tokens assigned to them.'))
-    if config.data['LOCAL_MODERATION']:
+    if config.LOCAL_MODERATION:
         mandatory_fields_account_request = IndicoSelectMultipleCheckboxField(_('Mandatory fields in account request'),
-                                                                         choices=[('affiliation',_('Affiliation')),('comment', _('Comment'))],
-                                                                         description=_('Fields a new user has to fill in when requesting an account'))
+                                                                             choices=[('affiliation', _('Affiliation')), ('comment', _('Comment'))],
+                                                                             description=_('Fields a new user has to fill in when requesting an account'))
 
 
 class AdminAccountRegistrationForm(LocalRegistrationForm):

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -118,7 +118,7 @@ class AdminUserSettingsForm(IndicoForm):
                                                        'still be able to regenerate the tokens assigned to them.'))
     if config.data['LOCAL_MODERATION']:
         mandatory_fields_account_request = IndicoSelectMultipleCheckboxField(_('Mandatory fields in account request'),
-                                                                         choices=['Affiliation','Comment'],
+                                                                         choices=[('affiliation',_('Affiliation')),('comment', _('Comment'))],
                                                                          description=_('Fields a new user has to fill in when requesting an account'))
 
 

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -11,6 +11,7 @@ from pytz import common_timezones, common_timezones_set
 from wtforms.fields import BooleanField, EmailField, IntegerField, SelectField, StringField
 from wtforms.validators import DataRequired, Email, NumberRange, ValidationError
 
+from indico.core.auth import multipass
 from indico.core.config import config
 from indico.modules.auth.forms import LocalRegistrationForm, _check_existing_email
 from indico.modules.users import User
@@ -125,7 +126,7 @@ class AdminUserSettingsForm(IndicoForm):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not config.LOCAL_MODERATION:
+        if not multipass.has_moderated_providers:
             del self.mandatory_fields_account_request
 
 

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -18,7 +18,8 @@ from indico.modules.users.models.emails import UserEmail
 from indico.modules.users.models.users import NameFormat
 from indico.util.i18n import _, get_all_locales
 from indico.web.forms.base import IndicoForm
-from indico.web.forms.fields import IndicoEnumSelectField, IndicoSelectMultipleCheckboxField, MultiStringField, PrincipalField, PrincipalListField
+from indico.web.forms.fields import (IndicoEnumSelectField, IndicoSelectMultipleCheckboxField, MultiStringField,
+                                     PrincipalField, PrincipalListField)
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless
 from indico.web.forms.widgets import SwitchWidget
@@ -116,10 +117,16 @@ class AdminUserSettingsForm(IndicoForm):
                                          description=_('Whether users are allowed to generate personal API tokens. '
                                                        'If disabled, only admins can create them, but users will '
                                                        'still be able to regenerate the tokens assigned to them.'))
-    if config.LOCAL_MODERATION:
-        mandatory_fields_account_request = IndicoSelectMultipleCheckboxField(_('Mandatory fields in account request'),
-                                                                             choices=[('affiliation', _('Affiliation')), ('comment', _('Comment'))],
-                                                                             description=_('Fields a new user has to fill in when requesting an account'))
+    mandatory_fields_account_request = IndicoSelectMultipleCheckboxField(
+        _('Mandatory fields in account request'),
+        choices=[('affiliation', _('Affiliation')), ('comment', _('Comment'))],
+        description=_('Fields a new user has to fill in when requesting an account')
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not config.LOCAL_MODERATION:
+            del self.mandatory_fields_account_request
 
 
 class AdminAccountRegistrationForm(LocalRegistrationForm):

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -18,7 +18,7 @@ from indico.modules.users.models.emails import UserEmail
 from indico.modules.users.models.users import NameFormat
 from indico.util.i18n import _, get_all_locales
 from indico.web.forms.base import IndicoForm
-from indico.web.forms.fields import IndicoEnumSelectField, MultiStringField, PrincipalField, PrincipalListField
+from indico.web.forms.fields import IndicoEnumSelectField, IndicoSelectMultipleCheckboxField, MultiStringField, PrincipalField, PrincipalListField
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import HiddenUnless
 from indico.web.forms.widgets import SwitchWidget
@@ -116,6 +116,10 @@ class AdminUserSettingsForm(IndicoForm):
                                          description=_('Whether users are allowed to generate personal API tokens. '
                                                        'If disabled, only admins can create them, but users will '
                                                        'still be able to regenerate the tokens assigned to them.'))
+    if config.data['LOCAL_MODERATION']:
+        mandatory_fields_account_request = IndicoSelectMultipleCheckboxField(_('Mandatory fields in account request'),
+                                                                         choices=['Affiliation','Comment'],
+                                                                         description=_('Fields a new user has to fill in when requesting an account'))
 
 
 class AdminAccountRegistrationForm(LocalRegistrationForm):

--- a/indico/modules/users/templates/users_admin.html
+++ b/indico/modules/users/templates/users_admin.html
@@ -42,7 +42,7 @@
                             {% trans %}Create new account{% endtrans %}
                         </a>
                     </div>
-                    {% if num_reg_requests or indico_config.LOCAL_MODERATION %}
+                    {% if num_reg_requests or has_moderation %}
                         <div class="group">
                             <a class="i-button icon-info" href="{{ url_for('.registration_request_list') }}">
                                 {% trans %}Registration requests{% endtrans %}

--- a/indico/web/client/js/react/components/syncedInputs.jsx
+++ b/indico/web/client/js/react/components/syncedInputs.jsx
@@ -104,7 +104,13 @@ export function SyncedFinalDropdown(props) {
 }
 
 // TODO: see if we can't converge with FinalAffiliationField to remove the duplicated code...
-export function SyncedFinalAffiliationDropdown({name, syncName, syncedValues, currentAffiliation}) {
+export function SyncedFinalAffiliationDropdown({
+  name,
+  required,
+  syncName,
+  syncedValues,
+  currentAffiliation,
+}) {
   const [_affiliationResults, setAffiliationResults] = useState([]);
   const affiliationResults =
     currentAffiliation && !_affiliationResults.find(x => x.id === currentAffiliation.id)
@@ -144,6 +150,10 @@ export function SyncedFinalAffiliationDropdown({name, syncName, syncedValues, cu
     <SyncedFinalField
       as={FinalComboDropdown}
       name={name}
+      required={required}
+      validate={v =>
+        required && !v?.text ? Translate.string('This field is required.') : undefined
+      }
       syncName={syncName}
       processSyncedValue={(value, values) => ({id: values.affiliation_id || null, text: value})}
       options={affiliationOptions}
@@ -163,12 +173,14 @@ export function SyncedFinalAffiliationDropdown({name, syncName, syncedValues, cu
 
 SyncedFinalAffiliationDropdown.propTypes = {
   name: PropTypes.string.isRequired,
+  required: PropTypes.bool,
   syncName: PropTypes.string,
   syncedValues: PropTypes.object.isRequired,
   currentAffiliation: PropTypes.object,
 };
 
 SyncedFinalAffiliationDropdown.defaultProps = {
+  required: false,
   syncName: null,
   currentAffiliation: null,
 };


### PR DESCRIPTION
Add a setting for making the 'Affiliation' and 'Comment' field mandatory when creating a new account. When setting is active, the corresponding field is mandatory in the sign up form.

closes #4819