### PR TITLE
Fix error when editing nonbookable periods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,7 @@ Bugfixes
   shortly before midnight (:pr:`5371`)
 - Do not fail when viewing an abstract that has been reviewed in a track which has
   been deleted in the meantime (:pr:`5386`)
+- Fix error when editing a room's nonbookable periods (:pr:`5390`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/rb/schemas.py
+++ b/indico/modules/rb/schemas.py
@@ -10,7 +10,7 @@ from operator import itemgetter
 from babel.dates import get_timezone
 from flask import session
 from marshmallow import ValidationError, fields, post_dump, validate, validates, validates_schema
-from marshmallow.fields import Boolean, DateTime, Function, Method, Nested, Number, Pluck, String
+from marshmallow.fields import Boolean, Date, DateTime, Function, Method, Nested, Number, Pluck, String
 from marshmallow_enum import EnumField
 from sqlalchemy import func
 
@@ -286,8 +286,8 @@ class BlockingSchema(mm.SQLAlchemyAutoSchema):
 
 
 class NonBookablePeriodSchema(mm.SQLAlchemyAutoSchema):
-    start_dt = NaiveDateTime()
-    end_dt = NaiveDateTime()
+    start_dt = Date()
+    end_dt = Date()
 
     class Meta:
         model = NonBookablePeriod


### PR DESCRIPTION
We were serializing them as datetime, but expecting just a date when saving, so when editing the field without touching existing entries, the full datetime was sent back, which broke validation