### PR TITLE
docs: Fix a few typos

### DIFF
--- a/indico/core/cache.py
+++ b/indico/core/cache.py
@@ -133,7 +133,7 @@ class ScopedCache:
 
 class IndicoCache(Cache):
     """
-    This is basicaly the Cache class from Flask-Caching but it silences all
+    This is basically the Cache class from Flask-Caching but it silences all
     exceptions that happen during a cache operation since cache failures should
     not take down the whole page.
 

--- a/indico/core/db/sqlalchemy/util/queries.py
+++ b/indico/core/db/sqlalchemy/util/queries.py
@@ -149,7 +149,7 @@ def get_n_matching(query, n, predicate, *, prefetch_factor=5, preload_bulk=None)
     :param predicate: A callable used to filter the found objects
     :param prefetch_factor: Prefetch ``n * factor`` objects in each query
     :param preload_bulk: Function that's called with the full set of objects
-                         to allow for bulk-preloading of data neede in the
+                         to allow for bulk-preloading of data needed in the
                          predicate function
     """
     _offset = 0

--- a/indico/modules/events/registration/client/js/form_submission/selectors.js
+++ b/indico/modules/events/registration/client/js/form_submission/selectors.js
@@ -32,7 +32,7 @@ export const getModeration = createSelector(
   staticData => staticData.moderated
 );
 
-/** Indicates whether this is rendered in the mangement area */
+/** Indicates whether this is rendered in the management area */
 export const getManagement = createSelector(
   getStaticData,
   staticData => staticData.management || false

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -38,7 +38,7 @@ class RegistrationFormFieldBase:
     setup_schema_base_cls = mm.Schema
     #: a dict with extra marshmallow fields to include in the setup schema
     setup_schema_fields = {}
-    #: whether this field is assocated with a file instead of normal data
+    #: whether this field is associated with a file instead of normal data
     is_file_field = False
     #: whether this field is invalid and cannot be used
     is_invalid_field = False

--- a/indico/modules/rb/client/js/common/map/util.js
+++ b/indico/modules/rb/client/js/common/map/util.js
@@ -86,7 +86,7 @@ export function withHoverListener(RoomComponent) {
 
     shouldComponentUpdate({hoveredRoomId: newId, actions, room, ...restProps}) {
       const {hoveredRoomId: currentId, room: oldRoom, actions: __, ...oldRestProps} = this.props;
-      // IMPORTANT: we only want this update to occurr when really needed
+      // IMPORTANT: we only want this update to occur when really needed
       // - whenever this room is going from hovered -> non-hovered
       // - whenever this room is going from non-hovered -> hovered
       // - whenever any of the other props change (selection)


### PR DESCRIPTION
There are small typos in:
- indico/core/cache.py
- indico/core/db/sqlalchemy/util/queries.py
- indico/modules/events/registration/client/js/form_submission/selectors.js
- indico/modules/events/registration/fields/base.py
- indico/modules/rb/client/js/common/map/util.js

Fixes:
- Should read `occur` rather than `occurr`.
- Should read `needed` rather than `neede`.
- Should read `management` rather than `mangement`.
- Should read `basically` rather than `basicaly`.
- Should read `associated` rather than `assocated`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md