### PR TITLE
Distinguish selected rows without colour

### DIFF
--- a/indico/web/client/styles/widgets/_person_link.scss
+++ b/indico/web/client/styles/widgets/_person_link.scss
@@ -65,6 +65,7 @@
         &.selected {
           color: $indico-blue !important;
           border-color: $indico-blue;
+          border-width: 0.15em;
         }
 
         &:not(.other) {


### PR DESCRIPTION
Under the current rules, selected persons are distinguished from unselected persons only by the colour. As the pair of colours (grey / indico blue) have similar lightness, this creates a confusing situation in situations when the user cannot distinguish colours (some forms of colour blindness; some accessibility features filtering colours globally). In general, distinguishing only via colour is not recommended.

To fix, add a second indication of a row being selected, by widening the border. Before/after screenshots (with a desaturation filter applied to simulate the conditions where this change matters):

https://rosenzweig.io/Before-Desaturated.png
https://rosenzweig.io/After-Desaturated.png

Note: I have tested this change on a live Indico instance with the browser CSS inspector. I have not tested the actual SCSS, although I believe this to be correct.

---

Per WCAG section 1.4.1 ("Use of Color"):

> Color is not used as the only visual means of conveying information, indicating an action, prompting a response, or distinguishing a visual element.

this falls under #5381 