### PR TITLE
Do not skip access check on regform display page

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,7 @@ Bugfixes
 - Do not fail when viewing an abstract that has been reviewed in a track which has
   been deleted in the meantime (:pr:`5386`)
 - Fix error when editing a room's nonbookable periods (:pr:`5390`)
+- Fix incorrect access check when directly accessing a registration form (:pr:`5406`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -92,7 +92,7 @@ class RHRegistrationFormRegistrationBase(RHRegistrationFormBase):
             raise Forbidden
 
     def _check_access(self):
-        if not self.token and self.registration:
+        if not self.token:
             RHRegistrationFormBase._check_access(self)
 
 


### PR DESCRIPTION
This fixes a bug introduced in #4997 which resulted in the regform display page not checking whether the user actually has access to the event (which should only happen when accessing an existing registration with a token, but not when just accessing the regform display page outside the context of an existing registration),