### PR TITLE
Add option to translate title and description of categories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,7 +56,7 @@ Improvements
 - Add option to make the 'Affiliation' and 'Comment' fields mandatory in the account
   request form (:issue:`4819`, :pr:`5389`, thanks :user:`elsbethe`)
 - Add option to translate title and description of categories (:issue:`5353`, 
-  :pr:``, thanks :user:`elsbethe`)
+  :pr:`5408`, thanks :user:`elsbethe`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,8 @@ Improvements
   custom conference themes from within a plugin (:pr:`5414`, thanks :user:`brittyazel`)
 - Add option to make the 'Affiliation' and 'Comment' fields mandatory in the account
   request form (:issue:`4819`, :pr:`5389`, thanks :user:`elsbethe`)
+- Add option to translate title and description of categories (:issue:`5353`, 
+  :pr:``, thanks :user:`elsbethe`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20220630_1206_7c99d8f13df7_add_translation_of_title_and_.py
+++ b/indico/migrations/versions/20220630_1206_7c99d8f13df7_add_translation_of_title_and_.py
@@ -18,13 +18,13 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('categories', sa.Column('title_translations', postgresql.JSONB(astext_type=sa.Text()), nullable=True), schema='categories')
-    op.execute(r"UPDATE categories.categories SET title_translations = '{}'::jsonb")
-    op.alter_column('categories', 'title_translations', nullable=False, schema='categories')
+    op.add_column('categories', sa.Column('title_translations', postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default='{}'),
+                  schema='categories')
+    op.alter_column('categories', 'title_translations', server_default=None, schema='categories')
 
-    op.add_column('categories', sa.Column('description_translations', postgresql.JSONB(astext_type=sa.Text()), nullable=True), schema='categories')
-    op.execute(r"UPDATE categories.categories SET description_translations = '{}'::jsonb")
-    op.alter_column('categories', 'description_translations', nullable=False, schema='categories')
+    op.add_column('categories', sa.Column('description_translations', postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default='{}'),
+                  schema='categories')
+    op.alter_column('categories', 'description_translations', server_default=None, schema='categories')
 
 
 def downgrade():

--- a/indico/migrations/versions/20220630_1206_7c99d8f13df7_add_translation_of_title_and_.py
+++ b/indico/migrations/versions/20220630_1206_7c99d8f13df7_add_translation_of_title_and_.py
@@ -1,0 +1,32 @@
+"""Add translation of title and description to categories
+
+Revision ID: 7c99d8f13df7
+Revises: 0c4bb2973536
+Create Date: 2022-06-30 12:06:05.586959
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = '7c99d8f13df7'
+down_revision = '0c4bb2973536'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('categories', sa.Column('title_translations', postgresql.JSONB(astext_type=sa.Text()), nullable=True), schema='categories')
+    op.execute(r"UPDATE categories.categories SET title_translations = '{}'::jsonb")
+    op.alter_column('categories', 'title_translations', nullable=False, schema='categories')
+
+    op.add_column('categories', sa.Column('description_translations', postgresql.JSONB(astext_type=sa.Text()), nullable=True), schema='categories')
+    op.execute(r"UPDATE categories.categories SET description_translations = '{}'::jsonb")
+    op.alter_column('categories', 'description_translations', nullable=False, schema='categories')
+
+
+def downgrade():
+    op.drop_column('categories', 'description_translations', schema='categories')
+    op.drop_column('categories', 'title_translations', schema='categories')

--- a/indico/migrations/versions/20220725_1206_7c99d8f13df7_add_category_i18n.py
+++ b/indico/migrations/versions/20220725_1206_7c99d8f13df7_add_category_i18n.py
@@ -1,28 +1,27 @@
-"""Add translation of title and description to categories
+"""Add category title/description i18n
 
 Revision ID: 7c99d8f13df7
-Revises: 0c4bb2973536
+Revises: 33c3ab67d729
 Create Date: 2022-06-30 12:06:05.586959
 """
 
 import sqlalchemy as sa
 from alembic import op
-from sqlalchemy.dialects import postgresql
+from sqlalchemy.dialects import postgresql as pg
 
 
 # revision identifiers, used by Alembic.
 revision = '7c99d8f13df7'
-down_revision = '0c4bb2973536'
+down_revision = '33c3ab67d729'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column('categories', sa.Column('title_translations', postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default='{}'),
+    op.add_column('categories', sa.Column('title_translations', pg.JSONB(), nullable=False, server_default='{}'),
                   schema='categories')
     op.alter_column('categories', 'title_translations', server_default=None, schema='categories')
-
-    op.add_column('categories', sa.Column('description_translations', postgresql.JSONB(astext_type=sa.Text()), nullable=False, server_default='{}'),
+    op.add_column('categories', sa.Column('description_translations', pg.JSONB(), nullable=False, server_default='{}'),
                   schema='categories')
     op.alter_column('categories', 'description_translations', server_default=None, schema='categories')
 

--- a/indico/modules/categories/client/js/components/CategoryDescriptionTranslations.jsx
+++ b/indico/modules/categories/client/js/components/CategoryDescriptionTranslations.jsx
@@ -1,0 +1,60 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2022 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {Translate} from 'indico/react/i18n';
+
+export default function DescriptionTranslationFields({languages, counter}) {
+  const options = [];
+  for (const lang in languages) {
+    let text = languages[lang][1][0];
+    if (languages[lang][1][2]) {
+      const country = ` (${languages[lang][1][1]})`;
+      text = `${text} ${country}`;
+    }
+    options.push(
+      <option key={lang} value={languages[lang][0]}>
+        {text}
+      </option>
+    );
+  }
+  const languageName = `description_translation_languages-${counter}`;
+  const translationName = `description_translation_values-${counter}`;
+  let counterText = '';
+  if (counter >= 1) {
+    counterText = ` ${counter + 1}`;
+  }
+  return (
+    <div>
+      <div className="form-group">
+        <Translate as="label" className="form-label form-label-middle">
+          {`New language${counterText}`}
+        </Translate>
+        <div className="form-field">
+          <select className="description-language-select" name={languageName}>
+            {options}
+          </select>
+        </div>
+      </div>
+      <div className="form-group">
+        <Translate as="label" className="form-label form-label-middle">
+          {`New translation${counterText}`}
+        </Translate>
+        <div className="form-field">
+          <textarea name={translationName} rows={5} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+DescriptionTranslationFields.propTypes = {
+  languages: PropTypes.array.isRequired,
+  counter: PropTypes.number.isRequired,
+};

--- a/indico/modules/categories/client/js/components/CategoryDescriptionTranslations.jsx
+++ b/indico/modules/categories/client/js/components/CategoryDescriptionTranslations.jsx
@@ -6,55 +6,65 @@
 // LICENSE file for more details.
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState} from 'react';
 
 import {Translate} from 'indico/react/i18n';
 
-export default function DescriptionTranslationFields({languages, counter}) {
-  const options = [];
+export default function DescriptionTranslation({languages}) {
+  const [fieldList, setFieldList] = useState([]);
+  const addFields = () => {
+    setFieldList([...fieldList, 'field']);
+  };
+  const languageOptions = [];
+  // get the languages in the right format
   for (const lang in languages) {
     let text = languages[lang][1][0];
     if (languages[lang][1][2]) {
       const country = ` (${languages[lang][1][1]})`;
       text = `${text} ${country}`;
     }
-    options.push(
+    languageOptions.push(
       <option key={lang} value={languages[lang][0]}>
         {text}
       </option>
     );
   }
-  const languageName = `description_translation_languages-${counter}`;
-  const translationName = `description_translation_values-${counter}`;
-  let counterText = '';
-  if (counter >= 1) {
-    counterText = ` ${counter + 1}`;
-  }
   return (
     <div>
-      <div className="form-group">
-        <Translate as="label" className="form-label form-label-middle">
-          {`New language${counterText}`}
-        </Translate>
-        <div className="form-field">
-          <select className="description-language-select" name={languageName}>
-            {options}
-          </select>
+      {fieldList.map((_, index) => (
+        <div key={index}>
+          <div className="form-group">
+            <label className="form-label form-label-middle">
+              <Translate>New language</Translate>
+              {index >= 1 && <span> {index + 1}</span>}
+            </label>
+            <div className="form-field">
+              <select name={`description_translation_languages-${index}`}>{languageOptions}</select>
+            </div>
+          </div>
+          <div className="form-group">
+            <label className="form-label form-label-middle">
+              <Translate>New translation</Translate>
+              {index >= 1 && <span> {index + 1}</span>}
+            </label>
+            <div className="form-field">
+              <textarea rows={5} name={`description_translation_values-${index}`} />
+            </div>
+          </div>
         </div>
-      </div>
+      ))}
       <div className="form-group">
-        <Translate as="label" className="form-label form-label-middle">
-          {`New translation${counterText}`}
-        </Translate>
+        <div className="form-label" />
         <div className="form-field">
-          <textarea name={translationName} rows={5} />
+          <a className="i-button icon-edit" onClick={addFields}>
+            <Translate>Translate description to another language</Translate>
+          </a>
         </div>
       </div>
     </div>
   );
 }
 
-DescriptionTranslationFields.propTypes = {
+DescriptionTranslation.propTypes = {
   languages: PropTypes.array.isRequired,
-  counter: PropTypes.number.isRequired,
 };

--- a/indico/modules/categories/client/js/components/CategoryTitleTranslations.jsx
+++ b/indico/modules/categories/client/js/components/CategoryTitleTranslations.jsx
@@ -1,0 +1,60 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2022 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {Translate} from 'indico/react/i18n';
+
+export default function TitleTranslationFields({languages, counter}) {
+  const options = [];
+  for (const lang in languages) {
+    let text = languages[lang][1][0];
+    if (languages[lang][1][2]) {
+      const country = ` (${languages[lang][1][1]})`;
+      text = `${text} ${country}`;
+    }
+    options.push(
+      <option key={lang} value={languages[lang][0]}>
+        {text}
+      </option>
+    );
+  }
+  const languageName = `title_translation_languages-${counter}`;
+  const translationName = `title_translation_values-${counter}`;
+  let counterText = '';
+  if (counter >= 1) {
+    counterText = ` ${counter + 1}`;
+  }
+  return (
+    <div>
+      <div className="form-group">
+        <Translate as="label" className="form-label form-label-middle">
+          {`New language${counterText}`}
+        </Translate>
+        <div className="form-field">
+          <select className="title-language-select" name={languageName}>
+            {options}
+          </select>
+        </div>
+      </div>
+      <div className="form-group">
+        <Translate as="label" className="form-label form-label-middle">
+          {`New translation${counterText}`}
+        </Translate>
+        <div className="form-field">
+          <input type="text" name={translationName} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+TitleTranslationFields.propTypes = {
+  languages: PropTypes.array.isRequired,
+  counter: PropTypes.number.isRequired,
+};

--- a/indico/modules/categories/client/js/components/CategoryTitleTranslations.jsx
+++ b/indico/modules/categories/client/js/components/CategoryTitleTranslations.jsx
@@ -6,55 +6,69 @@
 // LICENSE file for more details.
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState} from 'react';
 
 import {Translate} from 'indico/react/i18n';
 
-export default function TitleTranslationFields({languages, counter}) {
-  const options = [];
+export default function TitleTranslation({languages}) {
+  const [fieldList, setFieldList] = useState([]);
+  const addFields = () => {
+    setFieldList([...fieldList, 'field']);
+  };
+  const languageOptions = [];
   for (const lang in languages) {
     let text = languages[lang][1][0];
     if (languages[lang][1][2]) {
       const country = ` (${languages[lang][1][1]})`;
       text = `${text} ${country}`;
     }
-    options.push(
+    languageOptions.push(
       <option key={lang} value={languages[lang][0]}>
         {text}
       </option>
     );
   }
-  const languageName = `title_translation_languages-${counter}`;
-  const translationName = `title_translation_values-${counter}`;
-  let counterText = '';
-  if (counter >= 1) {
-    counterText = ` ${counter + 1}`;
-  }
   return (
     <div>
-      <div className="form-group">
-        <Translate as="label" className="form-label form-label-middle">
-          {`New language${counterText}`}
-        </Translate>
-        <div className="form-field">
-          <select className="title-language-select" name={languageName}>
-            {options}
-          </select>
+      {fieldList.map((_, index) => (
+        <div key={index}>
+          <div className="form-group">
+            <label className="form-label form-label-middle">
+              <Translate>New language</Translate>
+              {index >= 1 && <span> {index + 1}</span>}
+            </label>
+            <div className="form-field">
+              <select
+                className="title-language-select"
+                name={`title_translation_languages-${index}`}
+              >
+                {languageOptions}
+              </select>
+            </div>
+          </div>
+          <div className="form-group">
+            <label className="form-label form-label-middle">
+              <Translate>New translation</Translate>
+              {index >= 1 && <span> {index + 1}</span>}
+            </label>
+            <div className="form-field">
+              <input type="text" name={`title_translation_values-${index}`} />
+            </div>
+          </div>
         </div>
-      </div>
+      ))}
       <div className="form-group">
-        <Translate as="label" className="form-label form-label-middle">
-          {`New translation${counterText}`}
-        </Translate>
+        <div className="form-label" />
         <div className="form-field">
-          <input type="text" name={translationName} />
+          <a className="i-button icon-edit" onClick={addFields}>
+            <Translate>Translate title to another language</Translate>
+          </a>
         </div>
       </div>
     </div>
   );
 }
 
-TitleTranslationFields.propTypes = {
+TitleTranslation.propTypes = {
   languages: PropTypes.array.isRequired,
-  counter: PropTypes.number.isRequired,
 };

--- a/indico/modules/categories/client/js/management.js
+++ b/indico/modules/categories/client/js/management.js
@@ -16,6 +16,9 @@ import {SingleEventMove, BulkEventMove} from 'indico/modules/events/management/E
 import {showUserSearch} from 'indico/react/components/principals/imperative';
 import {$T} from 'indico/utils/i18n';
 
+import DescriptionTranslationFields from './components/CategoryDescriptionTranslations';
+import TitleTranslationFields from './components/CategoryTitleTranslations';
+
 (function(global) {
   // Category cache
   const _categories = {};
@@ -446,5 +449,35 @@ import {$T} from 'indico/utils/i18n';
   global.setupCategoryRolesList = function setupCategoryRolesList() {
     setupRolesToggle();
     setupRolesButtons();
+  };
+  let titleCounter = 0;
+  global.addTranslateTitleFields = function addTranslateTitleFields(untranslatedLanguages) {
+    const target = document.getElementById('target-new-title-translation-fields');
+    const languages = JSON.parse(untranslatedLanguages);
+    ReactDOM.render(
+      <TitleTranslationFields languages={languages} counter={titleCounter} />,
+      target
+    );
+    target.id = '';
+    const newTargetDiv = document.createElement('div');
+    newTargetDiv.id = 'target-new-title-translation-fields';
+    target.parentElement.appendChild(newTargetDiv);
+    titleCounter++;
+  };
+  let descriptionCounter = 0;
+  global.addTranslateDescriptionFields = function addTranslateDescriptionFields(
+    untranslatedLanguages
+  ) {
+    const target = document.getElementById('target-new-description-translation-fields');
+    const languages = JSON.parse(untranslatedLanguages);
+    ReactDOM.render(
+      <DescriptionTranslationFields languages={languages} counter={descriptionCounter} />,
+      target
+    );
+    target.id = '';
+    const newTargetDiv = document.createElement('div');
+    newTargetDiv.id = 'target-new-description-translation-fields';
+    target.parentElement.appendChild(newTargetDiv);
+    descriptionCounter++;
   };
 })(window);

--- a/indico/modules/categories/client/js/management.js
+++ b/indico/modules/categories/client/js/management.js
@@ -16,8 +16,8 @@ import {SingleEventMove, BulkEventMove} from 'indico/modules/events/management/E
 import {showUserSearch} from 'indico/react/components/principals/imperative';
 import {$T} from 'indico/utils/i18n';
 
-import DescriptionTranslationFields from './components/CategoryDescriptionTranslations';
-import TitleTranslationFields from './components/CategoryTitleTranslations';
+import DescriptionTranslation from './components/CategoryDescriptionTranslations';
+import TitleTranslation from './components/CategoryTitleTranslations';
 
 (function(global) {
   // Category cache
@@ -450,34 +450,20 @@ import TitleTranslationFields from './components/CategoryTitleTranslations';
     setupRolesToggle();
     setupRolesButtons();
   };
-  let titleCounter = 0;
-  global.addTranslateTitleFields = function addTranslateTitleFields(untranslatedLanguages) {
-    const target = document.getElementById('target-new-title-translation-fields');
-    const languages = JSON.parse(untranslatedLanguages);
-    ReactDOM.render(
-      <TitleTranslationFields languages={languages} counter={titleCounter} />,
-      target
-    );
-    target.id = '';
-    const newTargetDiv = document.createElement('div');
-    newTargetDiv.id = 'target-new-title-translation-fields';
-    target.parentElement.appendChild(newTargetDiv);
-    titleCounter++;
-  };
-  let descriptionCounter = 0;
-  global.addTranslateDescriptionFields = function addTranslateDescriptionFields(
-    untranslatedLanguages
+  global.setupCategoryTranslations = function setupCategoryTranslations(
+    titleLanguages,
+    descriptionLanguages
   ) {
-    const target = document.getElementById('target-new-description-translation-fields');
-    const languages = JSON.parse(untranslatedLanguages);
-    ReactDOM.render(
-      <DescriptionTranslationFields languages={languages} counter={descriptionCounter} />,
-      target
-    );
-    target.id = '';
-    const newTargetDiv = document.createElement('div');
-    newTargetDiv.id = 'target-new-description-translation-fields';
-    target.parentElement.appendChild(newTargetDiv);
-    descriptionCounter++;
+    if (titleLanguages.length) {
+      const titleTarget = document.getElementById('title-translation-container');
+      ReactDOM.render(<TitleTranslation languages={titleLanguages} />, titleTarget);
+    }
+    if (descriptionLanguages.length) {
+      const descriptionTarget = document.getElementById('description-translation-container');
+      ReactDOM.render(
+        <DescriptionTranslation languages={descriptionLanguages} />,
+        descriptionTarget
+      );
+    }
   };
 })(window);

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -9,12 +9,14 @@ import os
 import random
 from io import BytesIO
 
-from flask import flash, redirect, request, session
+from flask import flash, jsonify, redirect, request, session
+from json import dumps
 from marshmallow import EXCLUDE
 from PIL import Image
 from sqlalchemy.orm import joinedload, load_only, undefer_group
 from webargs import fields
 from werkzeug.exceptions import BadRequest, Forbidden
+from wtforms.fields import StringField
 
 from indico.core.db import db
 from indico.core.permissions import get_principal_permissions, update_permissions
@@ -39,15 +41,16 @@ from indico.modules.logs.models.entries import CategoryLogRealm, LogKind
 from indico.modules.rb.models.reservations import Reservation, ReservationLink
 from indico.modules.users import User
 from indico.util.fs import secure_filename
-from indico.util.i18n import _, ngettext
+from indico.util.i18n import _, get_all_locales, ngettext
 from indico.util.marshmallow import ModelField, PrincipalList, not_empty
 from indico.util.roles import ExportRoleMembersMixin, ImportRoleMembersMixin
 from indico.util.string import crc32
 from indico.web.args import parser, use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for
-from indico.web.forms.base import FormDefaults
+from indico.web.forms.base import FormDefaults, IndicoForm
 from indico.web.forms.colors import get_role_colors
+from indico.web.forms.fields import IndicoMarkdownField
 from indico.web.forms.fields.principals import serialize_principal
 from indico.web.util import jsonify_data, jsonify_form, jsonify_template, url_for_index
 
@@ -105,12 +108,66 @@ class RHManageCategorySettings(RHManageCategoryBase):
         defaults = FormDefaults(self.category,
                                 meeting_theme=self.category.default_event_themes['meeting'],
                                 lecture_theme=self.category.default_event_themes['lecture'])
+        
+        # Generate fields for existing translations
+        CategorySettingsForm.TITLE_FIELDS = ['title']
+        title_languages = get_all_locales()
+        for locale, translation in self.category.title_translations.items():
+            language = title_languages[locale]
+            language_text = f'{language[0]} ({language[1]})' if language[2] else language[0]
+            field_name = _('Title in ') + language_text
+            setattr(CategorySettingsForm,
+                    'title_translations/' + locale,
+                    StringField(field_name,
+                                default=translation,
+                                description=_(f'Users with {language_text} as their language see this title.')))
+            CategorySettingsForm.TITLE_FIELDS.append('title_translations/' + locale)
+            defaults.__setitem__('title_translations/' + locale, translation)
+            title_languages.pop(locale)
+
+        CategorySettingsForm.DESCRIPTION_FIELDS = ['description']
+        description_languages = get_all_locales()
+        for locale, translation in self.category.description_translations.items():
+            language = description_languages[locale]
+            language_text = f'{language[0]} ({language[1]})' if language[2] else language[0]
+            field_name = _('Description in ') + language_text
+            setattr(CategorySettingsForm,
+                    'description_translations/' + locale,
+                    IndicoMarkdownField(field_name,
+                                        default=translation,
+                                        description=_(f'Users with {language_text} as their language see this description.')))
+            CategorySettingsForm.DESCRIPTION_FIELDS.append('description_translations/' + locale)
+            defaults.__setitem__('description_translations/' + locale, translation)
+            description_languages.pop(locale)
+
         form = CategorySettingsForm(obj=defaults, category=self.category)
         icon_form = CategoryIconForm(obj=self.category)
         logo_form = CategoryLogoForm(obj=self.category)
 
         if form.validate_on_submit():
-            update_category(self.category, form.data, skip={'meeting_theme', 'lecture_theme'})
+            data = form.data
+            data['title_translations'] = {}
+            data['description_translations'] = {}
+
+            # retrieve the translations of existing languages from the form
+            for key, value in list(data.items()):
+                if key.startswith('title_translations/') or key.startswith('description_translations/'):
+                    data.pop(key)
+                    if value:
+                        data[key.split('/')[0]][key.split('/')[1]] = value
+            
+            # retrieve the translations of new languages from the form
+            for num, language in enumerate(data['title_translation_languages']):
+                if data['title_translation_values'][num]:
+                    data['title_translations'][language] = data['title_translation_values'][num]
+            
+            for num, language in enumerate(data['description_translation_languages']):
+                if data['description_translation_values'][num]:
+                    data['description_translations'][language] = data['description_translation_values'][num]
+            
+            update_category(self.category, data, skip={'meeting_theme', 'lecture_theme',
+                                                       'title_translation_languages','title_translation_values',
+                                                       'description_translation_languages','description_translation_values'})
             self.category.default_event_themes = {
                 'meeting': form.meeting_theme.data,
                 'lecture': form.lecture_theme.data
@@ -122,8 +179,13 @@ class RHManageCategorySettings(RHManageCategoryBase):
                 icon_form.icon.data = self.category
             if self.category.logo_metadata:
                 logo_form.logo.data = self.category
+        
+        untranslated_title_languages = dumps(sorted(title_languages.items(), key=lambda item: item[1]))
+        untranslated_description_languages = dumps(sorted(description_languages.items(), key=lambda item: item[1]))
         return WPCategoryManagement.render_template('management/settings.html', self.category, 'settings', form=form,
-                                                    icon_form=icon_form, logo_form=logo_form)
+                                                    icon_form=icon_form, logo_form=logo_form, 
+                                                    untranslated_title_languages=untranslated_title_languages,
+                                                    untranslated_description_languages=untranslated_description_languages)
 
 
 class RHAPIEventMoveRequests(RHManageCategoryBase):

--- a/indico/modules/categories/controllers/management.py
+++ b/indico/modules/categories/controllers/management.py
@@ -115,8 +115,8 @@ class RHManageCategorySettings(RHManageCategoryBase):
         for locale, translation in self.category.title_translations.items():
             language = title_languages[locale]
             language_text = f'{language[0]} ({language[1]})' if language[2] else language[0]
-            field_name = _('Title in ') + language_text
-            field_description = _('Users with ') + language_text + _(' as their language see this title.')
+            field_name = _('Title in {}').format(language_text)
+            field_description = _('Users with {} as their language see this title.').format(language_text)
             setattr(CategorySettingsForm,
                     'title_translations/' + locale,
                     StringField(field_name,
@@ -131,8 +131,8 @@ class RHManageCategorySettings(RHManageCategoryBase):
         for locale, translation in self.category.description_translations.items():
             language = description_languages[locale]
             language_text = f'{language[0]} ({language[1]})' if language[2] else language[0]
-            field_name = _('Description in ') + language_text
-            field_description = _('Users with ') + language_text + _(' as their language see this description.')
+            field_name = _('Description in {}').format(language_text)
+            field_description = _('Users with {} as their language see this description.').format(language_text )
             setattr(CategorySettingsForm,
                     'description_translations/' + locale,
                     IndicoMarkdownField(field_name,

--- a/indico/modules/categories/forms.py
+++ b/indico/modules/categories/forms.py
@@ -41,11 +41,11 @@ class CategorySettingsForm(IndicoForm):
     title = StringField(_('Title'), [DataRequired()])
     title_translation_languages = FieldList(StringField(_('New language')))
     title_translation_values = FieldList(StringField(_('New translation')))
-    
+
     description = IndicoMarkdownField(_('Description'))
     description_translation_languages = FieldList(StringField(_('New language')))
     description_translation_values = FieldList(StringField(_('New translation')))
-    
+
     timezone = IndicoTimezoneSelectField(_('Timezone'), [DataRequired()],
                                          description=_('Default timezone event lists will show up in. It will also be '
                                                        'used as a default for new events.'))

--- a/indico/modules/categories/forms.py
+++ b/indico/modules/categories/forms.py
@@ -8,7 +8,7 @@
 from functools import partial
 
 from flask import request
-from wtforms.fields import BooleanField, HiddenField, IntegerField, SelectField, StringField
+from wtforms.fields import BooleanField, FieldList, HiddenField, IntegerField, SelectField, StringField
 from wtforms.validators import DataRequired, InputRequired, Length, NumberRange, Optional, ValidationError
 
 from indico.core.permissions import FULL_ACCESS_PERMISSION, READ_ACCESS_PERMISSION
@@ -31,13 +31,21 @@ from indico.web.forms.widgets import HiddenCheckbox, SwitchWidget
 
 
 class CategorySettingsForm(IndicoForm):
-    BASIC_FIELDS = ('title', 'description', 'timezone', 'lecture_theme', 'meeting_theme', 'visibility',
+    TITLE_FIELDS = ['title']
+    DESCRIPTION_FIELDS = ['description']
+    BASIC_FIELDS = ('timezone', 'lecture_theme', 'meeting_theme', 'visibility',
                     'suggestions_disabled', 'is_flat_view_enabled', 'event_creation_notification_emails',
                     'notify_managers')
     EVENT_HEADER_FIELDS = ('event_message_mode', 'event_message')
 
     title = StringField(_('Title'), [DataRequired()])
+    title_translation_languages = FieldList(StringField(_('New language')))
+    title_translation_values = FieldList(StringField(_('New translation')))
+    
     description = IndicoMarkdownField(_('Description'))
+    description_translation_languages = FieldList(StringField(_('New language')))
+    description_translation_values = FieldList(StringField(_('New translation')))
+    
     timezone = IndicoTimezoneSelectField(_('Timezone'), [DataRequired()],
                                          description=_('Default timezone event lists will show up in. It will also be '
                                                        'used as a default for new events.'))

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -190,6 +190,16 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
         nullable=True,
         index=True
     )
+    title_translations = db.Column(
+        JSONB,
+        nullable=False,
+        default=lambda: {}
+    )
+    description_translations = db.Column(
+        JSONB,
+        nullable=False,
+        default=lambda: {}
+    )
 
     children = db.relationship(
         'Category',
@@ -594,6 +604,12 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
     def logo_url(self):
         """Get the HTTP URL of the logo."""
         return url_for('categories.display_logo', self, slug=self.logo_metadata['hash'])
+
+    def get_title(self):
+        return self.title_translations.get(session.lang, self.title)
+
+    def get_description(self):
+        return self.description_translations.get(session.lang, self.description)
 
 
 Category.register_protection_events()

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -605,10 +605,12 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
         """Get the HTTP URL of the logo."""
         return url_for('categories.display_logo', self, slug=self.logo_metadata['hash'])
 
-    def get_title(self):
+    @property
+    def i18n_title(self):
         return self.title_translations.get(session.lang, self.title)
 
-    def get_description(self):
+    @property
+    def i18n_description(self):
         return self.description_translations.get(session.lang, self.description)
 
 

--- a/indico/modules/categories/operations.py
+++ b/indico/modules/categories/operations.py
@@ -53,7 +53,7 @@ def update_category(category, data, skip=()):
     assert set(data) <= {
         'title', 'description', 'timezone', 'suggestions_disabled', 'is_flat_view_enabled',
         'event_message_mode', 'event_message', 'notify_managers', 'event_creation_notification_emails',
-        *skip
+        'title_translations', 'description_translations', *skip
     }
     changes = category.populate_from_dict(data, skip=skip)
     db.session.flush()
@@ -88,7 +88,9 @@ def _log_category_update(category, changes):
         'event_message_mode': 'Event header message type',
         'event_message': 'Event header message',
         'notify_managers': 'Notify managers about event creation',
-        'event_creation_notification_emails': 'Event creation notification emails'
+        'event_creation_notification_emails': 'Event creation notification emails',
+        'title_translations': 'Translations of the title',
+        'description_translations': 'Translations of the description'
     }
     if changes:
         what = 'Settings'

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -11,7 +11,7 @@
                         {% trans %}All events{% endtrans %}
                     {% endif %}
                 {% else %}
-                    {{ category.title }}
+                    {{ category.get_title() }}
                 {% endif %}
             {% endblock %}
         </h1>

--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -11,7 +11,7 @@
                         {% trans %}All events{% endtrans %}
                     {% endif %}
                 {% else %}
-                    {{ category.get_title() }}
+                    {{ category.i18n_title }}
                 {% endif %}
             {% endblock %}
         </h1>

--- a/indico/modules/categories/templates/display/category.html
+++ b/indico/modules/categories/templates/display/category.html
@@ -13,7 +13,7 @@
         {% endif %}
         {% block category_description %}
             <div class="category-description">
-                {{ category.description }}
+                {{ category.get_description() }}
             </div>
         {% endblock %}
     </div>

--- a/indico/modules/categories/templates/display/category.html
+++ b/indico/modules/categories/templates/display/category.html
@@ -13,7 +13,7 @@
         {% endif %}
         {% block category_description %}
             <div class="category-description">
-                {{ category.get_description() }}
+                {{ category.i18n_description }}
             </div>
         {% endblock %}
     </div>

--- a/indico/modules/categories/templates/display/category_list.html
+++ b/indico/modules/categories/templates/display/category_list.html
@@ -5,7 +5,7 @@
                 <li>
                     <span class="protection {{ 'icon-shield' if category.is_self_protected }}"></span>
                     <span class="number-events" id="category-event-count-{{ category.id }}"></span>
-                    <a href="{{ url_for('.display', category) }}" class="name">{{ category.title }}</a>
+                    <a href="{{ url_for('.display', category) }}" class="name">{{ category.get_title() }}</a>
                 </li>
             {% endfor %}
         </ul>

--- a/indico/modules/categories/templates/display/category_list.html
+++ b/indico/modules/categories/templates/display/category_list.html
@@ -5,7 +5,7 @@
                 <li>
                     <span class="protection {{ 'icon-shield' if category.is_self_protected }}"></span>
                     <span class="number-events" id="category-event-count-{{ category.id }}"></span>
-                    <a href="{{ url_for('.display', category) }}" class="name">{{ category.get_title() }}</a>
+                    <a href="{{ url_for('.display', category) }}" class="name">{{ category.i18n_title }}</a>
                 </li>
             {% endfor %}
         </ul>

--- a/indico/modules/categories/templates/display/root_category.html
+++ b/indico/modules/categories/templates/display/root_category.html
@@ -10,7 +10,7 @@
 {% block category_description %}
     {% if category.description %}
         <div class="category-description">
-            {{ category.description }}
+            {{ category.get_description() }}
         </div>
     {% else %}
         <p>

--- a/indico/modules/categories/templates/display/root_category.html
+++ b/indico/modules/categories/templates/display/root_category.html
@@ -10,7 +10,7 @@
 {% block category_description %}
     {% if category.description %}
         <div class="category-description">
-            {{ category.get_description() }}
+            {{ category.i18n_description }}
         </div>
     {% else %}
         <p>

--- a/indico/modules/categories/templates/management/settings.html
+++ b/indico/modules/categories/templates/management/settings.html
@@ -1,6 +1,6 @@
 {% extends 'categories/management/base.html' %}
 
-{% from 'forms/_form.html' import form_header, form_rows, form_fieldset, form_footer %}
+{% from 'forms/_form.html' import form_header, form_rows, form_row, form_fieldset, form_footer %}
 
 {% macro render_image_form(image_form, type, endpoint, title, deletion_prompt_title, deletion_prompt) %}
     {{ form_header(image_form, classes='image-form', action=url_for(endpoint, category)) }}
@@ -27,6 +27,42 @@
 
 {% block content %}
     {{ form_header(form) }}
+        {{ form_rows(form, fields=form.TITLE_FIELDS) }}
+        {% if untranslated_title_languages != '[]' %}
+            <div id="title-translation-container">
+                <div id="target-new-title-translation-fields"></div>
+            </div>
+            <div class="form-group">
+                <div class="form-label"></div>
+                <div class="form-field">
+                    <a class="i-button icon-edit"
+                    onclick="return addTranslateTitleFields('{{untranslated_title_languages}}')"
+                    id="add-title-translation">
+                        {% trans %}Translate title to another language{% endtrans %}
+                    </a>
+                </div>
+            </div>
+            
+        {% endif %}
+        
+        {{ form_rows(form, fields=form.DESCRIPTION_FIELDS) }}
+        {% if untranslated_description_languages != '[]' %}
+            <div id="description-translation-container">
+                <div id="target-new-description-translation-fields"></div>
+            </div>
+            <div class="form-group">
+                <div class="form-label"></div>
+                <div class="form-field">
+                    <a class="i-button icon-edit"
+                    onclick="return addTranslateDescriptionFields('{{untranslated_description_languages}}')"
+                    id="add-description-translation">
+                        {% trans %}Translate description to another language{% endtrans %}
+                    </a>
+                </div>
+            </div>
+            
+        {% endif %}
+
         {{ form_rows(form, fields=form.BASIC_FIELDS) }}
         {% call form_fieldset(_('Event Header')) %}
             {{ form_rows(form, fields=form.EVENT_HEADER_FIELDS) }}

--- a/indico/modules/categories/templates/management/settings.html
+++ b/indico/modules/categories/templates/management/settings.html
@@ -28,40 +28,10 @@
 {% block content %}
     {{ form_header(form) }}
         {{ form_rows(form, fields=form.TITLE_FIELDS) }}
-        {% if untranslated_title_languages != '[]' %}
-            <div id="title-translation-container">
-                <div id="target-new-title-translation-fields"></div>
-            </div>
-            <div class="form-group">
-                <div class="form-label"></div>
-                <div class="form-field">
-                    <a class="i-button icon-edit"
-                    onclick="return addTranslateTitleFields('{{untranslated_title_languages}}')"
-                    id="add-title-translation">
-                        {% trans %}Translate title to another language{% endtrans %}
-                    </a>
-                </div>
-            </div>
-            
-        {% endif %}
+        <div id="title-translation-container"></div>
         
         {{ form_rows(form, fields=form.DESCRIPTION_FIELDS) }}
-        {% if untranslated_description_languages != '[]' %}
-            <div id="description-translation-container">
-                <div id="target-new-description-translation-fields"></div>
-            </div>
-            <div class="form-group">
-                <div class="form-label"></div>
-                <div class="form-field">
-                    <a class="i-button icon-edit"
-                    onclick="return addTranslateDescriptionFields('{{untranslated_description_languages}}')"
-                    id="add-description-translation">
-                        {% trans %}Translate description to another language{% endtrans %}
-                    </a>
-                </div>
-            </div>
-            
-        {% endif %}
+        <div id="description-translation-container"></div>
 
         {{ form_rows(form, fields=form.BASIC_FIELDS) }}
         {% call form_fieldset(_('Event Header')) %}
@@ -80,6 +50,10 @@
     {% block after_forms %}{% endblock %}
 
     <script>
+        let titleLanguages = JSON.parse('{{ untranslated_title_languages | safe }}')
+        let descriptionLanguages = JSON.parse('{{ untranslated_description_languages | safe }}')
+        setupCategoryTranslations(titleLanguages, descriptionLanguages);
+
         (function() {
             'use strict';
 

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -19,10 +19,10 @@
                     {% if category %}
                         {% if not g.static_site %}
                             <a class="lecture-category" href="{{ url_for('categories.display', event.category) }}">
-                                {{ category }}
+                                {{ event.category.get_title() }}
                             </a>
                         {% else %}
-                            <div>{{ category }}</div>
+                            <div>{{ event.category.get_title() }}</div>
                         {% endif %}
                     {% endif %}
                     <h1>

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -19,10 +19,10 @@
                     {% if category %}
                         {% if not g.static_site %}
                             <a class="lecture-category" href="{{ url_for('categories.display', event.category) }}">
-                                {{ event.category.get_title() }}
+                                {{ event.category.i18n_title }}
                             </a>
                         {% else %}
-                            <div>{{ event.category.get_title() }}</div>
+                            <div>{{ event.category.i18n_title }}</div>
                         {% endif %}
                     {% endif %}
                     <h1>

--- a/indico/web/breadcrumbs.py
+++ b/indico/web/breadcrumbs.py
@@ -66,7 +66,7 @@ def render_breadcrumbs(*titles, category=None, event=None, management=False, cat
                                                             if management and cat.can_manage(session.user)
                                                             else cat.url)
         for cat in category.chain_query[::-1]:
-            items.append(Breadcrumb(cat.get_title(), category_url_factory(cat, management=management)))
+            items.append(Breadcrumb(cat.i18n_title, category_url_factory(cat, management=management)))
         items.reverse()
 
     items += [Breadcrumb(title) if isinstance(title, str) else title for title in titles]

--- a/indico/web/breadcrumbs.py
+++ b/indico/web/breadcrumbs.py
@@ -66,7 +66,7 @@ def render_breadcrumbs(*titles, category=None, event=None, management=False, cat
                                                             if management and cat.can_manage(session.user)
                                                             else cat.url)
         for cat in category.chain_query[::-1]:
-            items.append(Breadcrumb(cat.title, category_url_factory(cat, management=management)))
+            items.append(Breadcrumb(cat.get_title(), category_url_factory(cat, management=management)))
         items.reverse()
 
     items += [Breadcrumb(title) if isinstance(title, str) else title for title in titles]


### PR DESCRIPTION
Add the possibility to translate the title and description of categories.

In the settings I've added buttons to create new fields to add a translation for a language

![screenshot1](https://user-images.githubusercontent.com/82754908/178012392-aa57f473-24ba-47d2-a51f-a4b984f48e18.png)

With the button you get a select field to select the desired language and an input field to enter the translation. You can add multiple translations if you click the button multiple times.

![screenshot2](https://user-images.githubusercontent.com/82754908/178012417-a5c6f588-3aaa-4e31-b2cf-fb052f6a36af.png)


When the translations are saved, they appear in the form, so you can always edit them. When you empty the field, the translation is discarded.

![screenshot3](https://user-images.githubusercontent.com/82754908/178012447-e97b880f-7f97-40a4-ab81-d47a005cbb35.png)

When browsing through the categories/events the user sees the title and description of the category in the language he chose, if there is a translation available for that language. If no translation is available, the default title/description is shown.

closes #5353
