### PR TITLE
Track if a registration was self-service or by a manager & fix various issues

### DIFF
--- a/indico/migrations/versions/20220718_1534_33c3ab67d729_add_registration_created_by_manager_.py
+++ b/indico/migrations/versions/20220718_1534_33c3ab67d729_add_registration_created_by_manager_.py
@@ -1,0 +1,37 @@
+"""Add registration created_by_manager column
+
+Revision ID: 33c3ab67d729
+Revises: 0c4bb2973536
+Create Date: 2022-07-18 15:34:10.727423
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '33c3ab67d729'
+down_revision = '0c4bb2973536'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('registrations', sa.Column('created_by_manager', sa.Boolean(), nullable=False,
+                                             server_default='false'), schema='event_registration')
+    op.alter_column('registrations', 'created_by_manager', server_default=None, schema='event_registration')
+    op.execute('''
+        UPDATE event_registration.registrations reg
+        SET created_by_manager = true
+        FROM events.logs lo
+        WHERE
+        lo.realm = 2 AND
+        lo.module = 'Registration' AND
+        lo.summary LIKE 'New registration: %' AND
+        lo.meta ? 'registration_id' AND
+        reg.id = (lo.meta -> 'registration_id')::int;
+    ''')
+
+
+def downgrade():
+    op.drop_column('registrations', 'created_by_manager', schema='event_registration')

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -75,7 +75,7 @@ export default function FormItem({
   const fieldRegistry = getFieldRegistry();
   const meta = fieldRegistry[inputType] || {};
   const InputComponent = meta.inputComponent;
-  const inputProps = {title, description, isRequired, isEnabled, ...rest};
+  const inputProps = {title, description, isEnabled, ...rest};
   const showPurged = !setupMode && isPurged;
   const disabled = !isEnabled || showPurged || (paidItemLocked && !isManagement);
 
@@ -96,6 +96,7 @@ export default function FormItem({
     );
   }
 
+  const required = meta.alwaysRequired || isRequired;
   return (
     <div
       styleName={`form-item ${toClasses({
@@ -110,18 +111,18 @@ export default function FormItem({
         {InputComponent ? (
           meta.customFormItem ? (
             <InputComponent
-              isRequired={isRequired || meta.alwaysRequired}
+              isRequired={required}
               disabled={disabled}
               isPurged={showPurged}
               retentionPeriodIcon={retentionPeriodIcon}
               {...inputProps}
             />
           ) : (
-            <Form.Field required={isRequired || meta.alwaysRequired} styleName="field">
+            <Form.Field required={required} styleName="field">
               <label style={{opacity: disabled ? 0.8 : 1, display: 'inline-block'}}>{title}</label>
               {retentionPeriodIcon}
               <InputComponent
-                isRequired={isRequired || meta.alwaysRequired}
+                isRequired={required}
                 disabled={disabled}
                 isPurged={showPurged}
                 {...inputProps}

--- a/indico/modules/events/registration/client/js/form/fields/AccompanyingPersonsInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccompanyingPersonsInput.jsx
@@ -263,6 +263,11 @@ AccompanyingPersonsInput.defaultProps = {
   maxPersons: null,
 };
 
+export const accompanyingPersonsSettingsInitialData = {
+  maxPersons: 1,
+  personsCountAgainstLimit: false,
+};
+
 export function AccompanyingPersonsSettings() {
   return (
     <>
@@ -274,7 +279,6 @@ export function AccompanyingPersonsSettings() {
         step="1"
         min="0"
         validate={v.optional(v.min(0))}
-        defaultValue="1"
         fluid
         format={val => val || ''}
         parse={val => +val || 0}

--- a/indico/modules/events/registration/client/js/form/fields/EmailInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/EmailInput.jsx
@@ -12,7 +12,7 @@ import React, {useMemo, useState} from 'react';
 import {useSelector} from 'react-redux';
 import {Message} from 'semantic-ui-react';
 
-import {FinalInput} from 'indico/react/forms';
+import {FinalInput, validators as v} from 'indico/react/forms';
 import {useDebouncedAsyncValidate} from 'indico/react/hooks';
 import {Param, Translate} from 'indico/react/i18n';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
@@ -123,7 +123,7 @@ export default function EmailInput({htmlName, disabled, isRequired}) {
       name={htmlName}
       required={isRequired && isMainEmailField ? 'no-validator' : isRequired}
       disabled={disabled}
-      validate={isMainEmailField ? validateEmail : undefined}
+      validate={isMainEmailField ? validateEmail : isRequired ? v.required : undefined}
       // hide the normal error tooltip if we have an error from our async validation
       hideValidationError={
         isMainEmailField && message.status === 'error' && message.forEmail ? 'message' : false

--- a/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
@@ -31,7 +31,6 @@ export default function FileInput({htmlName, disabled, isRequired}) {
       required={isRequired}
       uploadURL={uploadFileURL({event_id: eventId, reg_form_id: regformId})}
       initialFileDetails={initialFileDetails}
-      hideValidationError
     />
   );
 }

--- a/indico/modules/events/registration/client/js/form/fields/PhoneInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/PhoneInput.jsx
@@ -12,12 +12,13 @@ import {FinalInput} from 'indico/react/forms';
 
 import '../../../styles/regform.module.scss';
 
-export default function PhoneInput({htmlName, disabled}) {
-  return <FinalInput type="tel" name={htmlName} disabled={disabled} />;
+export default function PhoneInput({htmlName, isRequired, disabled}) {
+  return <FinalInput type="tel" name={htmlName} required={isRequired} disabled={disabled} />;
 }
 
 PhoneInput.propTypes = {
   htmlName: PropTypes.string.isRequired,
+  isRequired: PropTypes.bool.isRequired,
   disabled: PropTypes.bool,
 };
 

--- a/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
@@ -116,6 +116,8 @@ function SingleChoiceDropdown({
           onChange={(e, data) => onChange(data.value ? {[data.value]: 1} : {})}
           clearable={!isRequired}
           search
+          selectOnNavigation={false}
+          selectOnBlur={false}
         />
       </Form.Field>
       {extraSlotsDropdown}

--- a/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
@@ -161,7 +161,7 @@ function SingleChoiceRadioGroup({
   const paid = useSelector(getPaid);
   const management = useSelector(getManagement);
   const currency = useSelector(getCurrency);
-  const selectedChoice = choices.find(c => c.id in value) || {};
+  const selectedChoice = choices.find(c => c.id in value) || {id: ''};
   const radioChoices = [...choices];
   if (!isRequired) {
     radioChoices.unshift({id: '', isEnabled: true, caption: Translate.string('None')});
@@ -175,8 +175,7 @@ function SingleChoiceRadioGroup({
     }
   };
 
-  const isChecked = (currentChoice, idx) =>
-    currentChoice.id === selectedChoice.id || (idx === 0 && !selectedChoice.id);
+  const isChecked = currentChoice => currentChoice.id === selectedChoice.id;
 
   const isPaidChoice = choice => choice.price > 0 && paid;
   const isPaidChoiceLocked = choice => !management && isPaidChoice(choice);
@@ -184,7 +183,7 @@ function SingleChoiceRadioGroup({
   return (
     <table styleName="choice-table">
       <tbody>
-        {radioChoices.map((c, idx) => {
+        {radioChoices.map(c => {
           return (
             <tr key={c.id} styleName="row">
               <td>
@@ -205,7 +204,7 @@ function SingleChoiceRadioGroup({
                     (c.placesLimit > 0 &&
                       (placesUsed[c.id] || 0) - (existingValue[c.id] || 0) >= c.placesLimit)
                   }
-                  checked={!isPurged && isChecked(c, idx)}
+                  checked={!isPurged && isChecked(c)}
                   onChange={() => handleChange(c.id)}
                 />
               </td>
@@ -364,6 +363,11 @@ export default function SingleChoiceInput({
       format={v => v || {}}
       required={isRequired}
       isRequired={isRequired}
+      validate={v =>
+        isRequired && (!v || !Object.keys(v).length)
+          ? Translate.string('This field is required.')
+          : undefined
+      }
       disabled={disabled}
       isPurged={isPurged}
       itemType={itemType}

--- a/indico/modules/events/registration/client/js/form/fields/registry.js
+++ b/indico/modules/events/registration/client/js/form/fields/registry.js
@@ -13,7 +13,10 @@ import AccommodationInput, {
   accommodationSettingsInitialData,
   accommodationSettingsFormValidator,
 } from './AccommodationInput';
-import AccompanyingPersonsInput, {AccompanyingPersonsSettings} from './AccompanyingPersonsInput';
+import AccompanyingPersonsInput, {
+  AccompanyingPersonsSettings,
+  accompanyingPersonsSettingsInitialData,
+} from './AccompanyingPersonsInput';
 import BooleanInput, {BooleanSettings} from './BooleanInput';
 import CheckboxInput, {CheckboxSettings} from './CheckboxInput';
 import {choiceFieldsSettingsFormDecorator} from './ChoicesSetup';
@@ -171,6 +174,7 @@ const fieldRegistry = {
     title: Translate.string('Accompanying Persons'),
     inputComponent: AccompanyingPersonsInput,
     settingsComponent: AccompanyingPersonsSettings,
+    settingsFormInitialData: accompanyingPersonsSettingsInitialData,
     settingsModalSize: 'tiny',
     noRequired: true,
     hasPrice: true,

--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {useSelector} from 'react-redux';
-import {Message} from 'semantic-ui-react';
+import {Form, Message} from 'semantic-ui-react';
 
 import {
   FinalSubmitButton,
@@ -68,12 +68,14 @@ function ConsentToPublish({publishToParticipants, publishToPublic}) {
           </Translate>
         </p>
       )}
-      <ConsentToPublishDropdown
-        name="consent_to_publish"
-        publishToParticipants={publishToParticipants}
-        publishToPublic={publishToPublic}
-        useFinalForms
-      />
+      <Form as="div">
+        <ConsentToPublishDropdown
+          name="consent_to_publish"
+          publishToParticipants={publishToParticipants}
+          publishToPublic={publishToPublic}
+          useFinalForms
+        />
+      </Form>
     </Message>
   );
 }

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -11,6 +11,7 @@ from marshmallow import fields, validate
 
 from indico.core.marshmallow import mm
 from indico.modules.events.registration.models.registrations import RegistrationData
+from indico.util.marshmallow import not_empty
 
 
 class BillableFieldDataSchema(mm.Schema):
@@ -42,6 +43,8 @@ class RegistrationFormFieldBase:
     is_file_field = False
     #: whether this field is invalid and cannot be used
     is_invalid_field = False
+    #: whether this field must not be "empty" (falsy value) if required
+    not_empty_if_required = True
 
     def __init__(self, form_item):
         self.form_item = form_item
@@ -92,9 +95,14 @@ class RegistrationFormFieldBase:
 
         :param registration: The previous registration if modifying an existing one, otherwise none
         """
+        validators = self.get_validators(registration) or []
+        if not isinstance(validators, list):
+            validators = [validators]
+        if self.form_item.is_required and self.not_empty_if_required:
+            validators.append(not_empty)
         return self.mm_field_class(*self.mm_field_args,
                                    required=self.form_item.is_required,
-                                   validate=self.get_validators(registration),
+                                   validate=validators,
                                    **self.mm_field_kwargs)
 
     def has_data_changed(self, value, old_data):

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -504,7 +504,7 @@ class AccommodationField(RegistrationFormBillableItemsField):
                 item = next((c for c in self.form_item.versioned_data['choices'] if c['id'] == new_data['choice']),
                             None)
             # this should never happen unless someone tampers with the data
-            if item is None:
+            if item is None or not item['is_enabled']:
                 raise ValidationError('Invalid choice')
             if item.get('is_no_accommodation', False) != new_data['isNoAccommodation']:
                 raise ValidationError('Invalid data')

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -68,8 +68,11 @@ class NumberFieldDataSchema(BillableFieldDataSchema):
 class NumberField(RegistrationFormBillableField):
     name = 'number'
     mm_field_class = fields.Integer
-    mm_field_kwargs = {'allow_none': True}
     setup_schema_base_cls = NumberFieldDataSchema
+
+    @property
+    def mm_field_kwargs(self):
+        return {'allow_none': not self.form_item.is_required}
 
     def get_validators(self, existing_registration):
         return validate.Range(min=self.form_item.data.get('min_value') or 0,
@@ -242,11 +245,15 @@ class BooleanFieldSetupSchema(LimitedPlacesBillableFieldDataSchema):
 class BooleanField(RegistrationFormBillableField):
     name = 'bool'
     mm_field_class = fields.Boolean
-    mm_field_kwargs = {'allow_none': True}
     setup_schema_base_cls = BooleanFieldSetupSchema
+    not_empty_if_required = False
     friendly_data_mapping = {None: '',
                              True: L_('Yes'),
                              False: L_('No')}
+
+    @property
+    def mm_field_kwargs(self):
+        return {'allow_none': not self.form_item.is_required}
 
     @property
     def filter_choices(self):
@@ -320,8 +327,11 @@ class CountryField(RegistrationFormFieldBase):
 class FileField(RegistrationFormFieldBase):
     name = 'file'
     mm_field_class = UUIDString
-    mm_field_kwargs = {'allow_none': True}
     is_file_field = True
+
+    @property
+    def mm_field_kwargs(self):
+        return {'allow_none': not self.form_item.is_required}
 
     def has_data_changed(self, value, old_data):
         if value == KEEP_EXISTING_FILE_UUID:

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -548,8 +548,9 @@ class RegistrationPrivacyForm(IndicoForm):
         )
         if (
             self.regform and
-            self.regform.existing_registrations_count > 0 and
-            (participant_visibility_changed_to_show_all or public_visibility_changed_to_show_all)
+            (participant_visibility_changed_to_show_all or public_visibility_changed_to_show_all) and
+            Registration.query.with_parent(self.regform).filter(~Registration.is_deleted,
+                                                                ~Registration.created_by_manager).has_rows()
         ):
             raise ValidationError(_("'Show all participants' can only be set if there are no registered users."))
         if field.data[2] is not None and not field.data[2]:

--- a/indico/modules/events/registration/models/form_fields.py
+++ b/indico/modules/events/registration/models/form_fields.py
@@ -102,6 +102,9 @@ class RegistrationFormField(RegistrationFormItem):
     def calculate_price(self, registration_data):
         return self.field_impl.calculate_price(registration_data.data, registration_data.field_data.versioned_data)
 
+    def _get_default_log_data(self):
+        return {'Field ID': self.id, 'Section': self.parent.title}
+
 
 class RegistrationFormPersonalDataField(RegistrationFormField):
     __mapper_args__ = {

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -240,6 +240,13 @@ class Registration(db.Model):
         nullable=False,
         default=False
     )
+    #: Whether the registration was created by a manager
+    created_by_manager = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
+
     #: The Event containing this registration
     event = db.relationship(
         'Event',

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -48,6 +48,9 @@
                                        {% if registration.state.name in ('rejected', 'withdrawn') %}style="text-decoration: line-through;"{% endif %}>
                                         {{- registration.display_full_name -}}
                                     </a>
+                                    {%- if registration.created_by_manager %}
+                                        <i class="icon-user-chairperson text-not-important" title="{% trans %}This user has been registered by an event manager.{% endtrans %}"></i>
+                                    {%- endif -%}
                                 </td>
                                 {% for item in static_columns if not item.get('filter_only') %}
                                     {% if item.id == 'reg_date' %}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -338,15 +338,14 @@ def create_registration(regform, data, invitation=None, management=False, notify
     if skip_moderation is None:
         skip_moderation = management
     for form_item in regform.active_fields:
+        if form_item.is_purged:
+            # Leave the registration data empty
+            continue
         default = form_item.field_impl.default_value
         can_modify = management or not form_item.parent.is_manager_only
         value = data.get(form_item.html_field_name, default) if can_modify else default
         data_entry = RegistrationData()
         registration.data.append(data_entry)
-        if form_item.is_purged:
-            # Leave the registration data empty
-            continue
-
         for attr, value in form_item.field_impl.process_form_data(registration, value).items():
             setattr(data_entry, attr, value)
         if form_item.type == RegistrationFormItemType.field_pd and form_item.personal_data_type.column:

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -334,7 +334,7 @@ def create_personal_data_fields(regform):
 def create_registration(regform, data, invitation=None, management=False, notify_user=True, skip_moderation=None):
     user = session.user if session else None
     registration = Registration(registration_form=regform, user=get_user_by_email(data['email']),
-                                base_price=regform.base_price, currency=regform.currency)
+                                base_price=regform.base_price, currency=regform.currency, created_by_manager=management)
     if skip_moderation is None:
         skip_moderation = management
     for form_item in regform.active_fields:

--- a/indico/web/client/styles/partials/_forms.scss
+++ b/indico/web/client/styles/partials/_forms.scss
@@ -154,6 +154,7 @@ form {
       input,
       select,
       textarea,
+      .ui.dropdown,
       .i-table-widget {
         @extend %input-invalid;
       }


### PR DESCRIPTION
- Registrations now track whether they have been created by a manager
- Ignore manager-created registrations when changing participant list privacy to "always visible"
- Correctly show error border around all the participant privacy fields (it was very misleading since only the retention period field showed the error, even though that one didn't cause the error)
- Registering when there was already a purged field failed
- Correctly highlight consent dropdown as invalid if no choice was made
- Fixed validation issues on various regform fields
- Log changes to regform items