### PR TITLE
Add signal for blocking registration modifications

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,7 @@ Internal Changes
 - Add ``signal_query`` method in the ``IndicoBaseQuery`` class and the ``db_query``
   signal, allowing to intercept and modify queries by signal handlers (:pr:`4981`,
   thanks :user:`omegak`).
+- Add ``event.is_registration_blocked`` signal (:pr:`5421`)
 
 
 ----

--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -90,6 +90,14 @@ both users trying to get their own ticket and managers trying to get a
 ticket for a registrant.
 ''')
 
+is_registration_blocked = _signals.signal('is-registration-blocked', '''
+Called when resolving whether Indico should let a registrant modify their
+registration details.  The `sender` is the registrant's `Registration` object.
+
+If this signal returns ``True``, the user will not be able to modify their
+registration.
+''')
+
 filter_selectable_badges = _signals.signal('filter-selectable-badges', '''
 Called when composing lists of badge templates. The `sender` may be either
 ``BadgeSettingsForm``, ``RHListEventTemplates`` or ``RHListCategoryTemplates``.

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -408,7 +408,9 @@ class Registration(db.Model):
     @property
     def can_be_modified(self):
         regform = self.registration_form
-        return regform.is_modification_open and regform.is_modification_allowed(self)
+        return (regform.is_modification_open
+                and regform.is_modification_allowed(self)
+                and not any(values_from_signal(signals.event.is_registration_blocked.send(self), single_value=True)))
 
     @property
     def can_be_withdrawn(self):


### PR DESCRIPTION
Call a signal when resolving whether Indico should let a registrant modify their registration details.