### PR TITLE
Fix issues when editing contributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,8 @@ Bugfixes
 - Fix error when editing a room's nonbookable periods (:pr:`5390`)
 - Fix incorrect access check when directly accessing a registration form (:pr:`5406`)
 - Fix error in rate limiter when using Redis with a UNIX socket connection (:issue:`5391`)
+- Ensure that submitters with contribution edit privileges can only edit basic fields
+  (:pr:`5425`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ Bugfixes
 - Fix error in rate limiter when using Redis with a UNIX socket connection (:issue:`5391`)
 - Ensure that submitters with contribution edit privileges can only edit basic fields
   (:pr:`5425`)
+- Do not return the whole contribution list when editing a contribution from elsewhere
+  (:pr:`5425`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -201,13 +201,15 @@ class RHEditContribution(RHManageContributionBase):
         check_event_locked(self, self.event)
 
     def _process(self):
+        can_manage = self.contrib.can_manage(session.user)
         contrib_form_class = make_contribution_form(self.event)
         custom_field_values = {f'custom_{x.contribution_field_id}': x.data for x in self.contrib.field_values}
         parent_session_block = (self.contrib.timetable_entry.parent.session_block
                                 if (self.contrib.timetable_entry and self.contrib.timetable_entry.parent) else None)
         form = contrib_form_class(obj=FormDefaults(self.contrib, start_date=self.contrib.start_dt,
                                                    **custom_field_values),
-                                  event=self.event, contrib=self.contrib, session_block=parent_session_block)
+                                  event=self.event, contrib=self.contrib, session_block=parent_session_block,
+                                  submitter_edit=(not can_manage))
         if form.validate_on_submit():
             with (
                 track_time_changes(),
@@ -222,7 +224,6 @@ class RHEditContribution(RHManageContributionBase):
             return jsonify_data(flash=(request.args.get('flash') == '1'), **tpl_components)
         elif not form.is_submitted():
             handle_legacy_description(form.description, self.contrib)
-        can_manage = self.contrib.can_manage(session.user)
         self.commit = False
         return jsonify_template('events/contributions/forms/contribution.html', form=form, can_manage=can_manage)
 
@@ -362,14 +363,15 @@ class RHEditSubContribution(RHManageSubContributionBase):
         check_event_locked(self, self.event)
 
     def _process(self):
-        form = SubContributionForm(obj=FormDefaults(self.subcontrib), event=self.event, subcontrib=self.subcontrib)
+        can_manage = self.subcontrib.can_manage(session.user)
+        form = SubContributionForm(obj=FormDefaults(self.subcontrib), event=self.event, subcontrib=self.subcontrib,
+                                   submitter_edit=(not can_manage))
         if form.validate_on_submit():
             update_subcontribution(self.subcontrib, form.data)
             flash(_("Subcontribution '{}' updated successfully").format(self.subcontrib.title), 'success')
             return jsonify_data(html=_render_subcontribution_list(self.contrib))
         elif not form.is_submitted():
             handle_legacy_description(form.description, self.subcontrib)
-        can_manage = self.subcontrib.can_manage(session.user)
         self.commit = False
         return jsonify_template('events/contributions/forms/subcontribution.html', form=form, can_manage=can_manage)
 

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -218,6 +218,8 @@ class RHEditContribution(RHManageContributionBase):
             ):
                 update_contribution(self.contrib, *get_field_values(form.data))
             flash(_("Contribution '{}' successfully updated").format(self.contrib.title), 'success')
+            if not can_manage or request.args.get('standalone') == '1':
+                return jsonify_data(flash=False)
             tpl_components = self.list_generator.render_list(self.contrib)
             if tpl_components['hide_contrib']:
                 self.list_generator.flash_info_message(self.contrib)
@@ -369,6 +371,8 @@ class RHEditSubContribution(RHManageSubContributionBase):
         if form.validate_on_submit():
             update_subcontribution(self.subcontrib, form.data)
             flash(_("Subcontribution '{}' updated successfully").format(self.subcontrib.title), 'success')
+            if not can_manage or request.args.get('standalone') == '1':
+                return jsonify_data(flash=False)
             return jsonify_data(html=_render_subcontribution_list(self.contrib))
         elif not form.is_submitted():
             handle_legacy_description(form.description, self.subcontrib)

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -58,7 +58,7 @@ class ContributionForm(IndicoForm):
     def render_mode(self):
         return RenderMode.markdown
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, submitter_edit=False, **kwargs):
         self.event = kwargs.pop('event')
         self.contrib = kwargs.pop('contrib', None)
         self.session_block = kwargs.get('session_block')
@@ -72,6 +72,10 @@ class ContributionForm(IndicoForm):
             del self.type
         if not to_schedule and (self.contrib is None or not self.contrib.is_scheduled):
             del self.start_dt
+        if submitter_edit:
+            for field in list(self):
+                if field.name != self.meta.csrf_field_name and field.name not in self._submitter_editable_fields:
+                    delattr(self, field.name)
 
     def _get_earliest_start_dt(self):
         return self.session_block.start_dt if self.session_block else self.event.start_dt
@@ -126,10 +130,14 @@ class SubContributionForm(IndicoForm):
     def render_mode(self):
         return RenderMode.markdown
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, submitter_edit=False, **kwargs):
         self.event = kwargs.pop('event')
         self.subcontrib = kwargs.pop('subcontrib', None)
         super().__init__(*args, **kwargs)
+        if submitter_edit:
+            for field in list(self):
+                if field.name != self.meta.csrf_field_name and field.name not in self._submitter_editable_fields:
+                    delattr(self, field.name)
 
 
 class ContributionStartDateForm(IndicoForm):

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -122,7 +122,7 @@
         {% if contribution.can_edit(session.user) -%}
             <a href="#" class="i-button icon-edit"
                data-title="{% trans %}Edit contribution{% endtrans %}"
-               data-href="{{ url_for('contributions.manage_update_contrib', contribution) }}"
+               data-href="{{ url_for('contributions.manage_update_contrib', contribution, standalone=true) }}"
                data-ajax-dialog
                data-reload-after></a>
         {%- endif %}
@@ -257,7 +257,7 @@
                                 {% if subcontrib.can_edit(session.user) -%}
                                     <span>
                                         <a href="#" class="icon-edit"
-                                           data-href="{{ url_for('contributions.manage_edit_subcontrib', subcontrib) }}"
+                                           data-href="{{ url_for('contributions.manage_edit_subcontrib', subcontrib, standalone=true) }}"
                                            data-title="{% trans title=subcontrib.title %}Edit subcontribution '{{ title }}'{% endtrans %}"
                                            data-ajax-dialog
                                            data-reload-after></a>

--- a/indico/modules/events/contributions/templates/display/subcontribution_display.html
+++ b/indico/modules/events/contributions/templates/display/subcontribution_display.html
@@ -34,7 +34,7 @@
         {% if subcontrib.can_edit(session.user) -%}
             <a href="#" class="i-button icon-edit"
                data-title="{% trans title=subcontrib.title %}Edit subcontribution '{{ title }}'{% endtrans %}"
-               data-href="{{ url_for('.manage_edit_subcontrib', subcontrib) }}"
+               data-href="{{ url_for('.manage_edit_subcontrib', subcontrib, standalone=true) }}"
                data-ajax-dialog
                data-reload-after></a>
         {%- endif %}

--- a/indico/modules/events/contributions/templates/display/user_contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/user_contribution_list.html
@@ -21,7 +21,7 @@
                                     <a href="#" class="icon-edit js-edit-contribution"
                                        title="{% trans %}Edit this contribution{% endtrans %}"
                                        data-title="{% trans title=contrib.title %}Edit contribution '{{ title }}'{% endtrans %}"
-                                       data-href="{{ url_for('.manage_update_contrib', contrib) }}"
+                                       data-href="{{ url_for('.manage_update_contrib', contrib, standalone=true) }}"
                                        data-ajax-dialog
                                        data-reload-after></a>
                                 {%- endif %}

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -107,7 +107,7 @@
             {% if item.can_edit(session.user) %}
                 <li>
                     <a href="" class="contribution-edit"
-                               data-href="{{ url_for('contributions.manage_update_contrib', item) }}"
+                               data-href="{{ url_for('contributions.manage_update_contrib', item, standalone=true) }}"
                                data-title="{% trans title=item.title %}Edit contribution '{{ title }}'{% endtrans %}">
                         {% trans %}Edit contribution{% endtrans %}
                     </a>
@@ -136,7 +136,7 @@
                        class="subcontribution-edit"
                        data-title="{% trans %}Edit subcontribution{% endtrans %}"
                        data-subtitle="{{ item.title }}"
-                       data-href="{{ url_for('contributions.manage_edit_subcontrib', item) }}">
+                       data-href="{{ url_for('contributions.manage_edit_subcontrib', item, standalone=true) }}">
                         {% trans %}Edit subcontribution{% endtrans %}
                     </a>
                 </li>


### PR DESCRIPTION
- Remove unavailable fields on the server side when submitter can edit their own contributions
- Do not return the whole contribution list when editing a contribution from any place that's not the management contribution list