### PR TITLE
Improve regform section titles

### DIFF
--- a/indico/modules/events/registration/client/styles/regform.module.scss
+++ b/indico/modules/events/registration/client/styles/regform.module.scss
@@ -346,6 +346,8 @@
 }
 
 .section-actions {
+  white-space: nowrap;
+
   a {
     font-size: 1.2em;
   }

--- a/indico/modules/events/registration/client/styles/regform.module.scss
+++ b/indico/modules/events/registration/client/styles/regform.module.scss
@@ -328,9 +328,7 @@
 
   .section-sortable-handle {
     font-size: 1.2em;
-    width: 15px;
-    position: relative;
-    left: -3px;
+    flex-basis: 20px;
   }
 
   &:hover .section-sortable-handle {

--- a/indico/modules/events/registration/client/styles/regform.module.scss
+++ b/indico/modules/events/registration/client/styles/regform.module.scss
@@ -329,6 +329,7 @@
   .section-sortable-handle {
     font-size: 1.2em;
     flex-basis: 20px;
+    align-self: flex-start;
   }
 
   &:hover .section-sortable-handle {
@@ -346,6 +347,7 @@
 }
 
 .section-actions {
+  align-self: flex-start;
   white-space: nowrap;
 
   a {


### PR DESCRIPTION
- Prevents titles from sliding right when hovered (due to sortable handle taking more space)
- Prevents section actions from wrapping on a new line when the section title is too long