### PR TITLE
Add workarounds for Japanese locale

### DIFF
--- a/indico/web/client/js/utils/date.js
+++ b/indico/web/client/js/utils/date.js
@@ -33,7 +33,7 @@ export async function setMomentLocale(locale) {
   const territory = parts[parts.length - 1];
   let momentLocale;
 
-  if (language === territory || language === 'uk') {
+  if (language === territory || language === 'ja' || language === 'uk') {
     // XXX: see the comment on `moment_lang` in Python regarding this ugly hack
     momentLocale = language;
   } else {

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -83,7 +83,7 @@ class IndicoSession(BaseSession):
         parts = self.lang.lower().split('_')  # e.g. `en_GB` or `zh_Hans_CN`
         lang = parts[0]
         territory = parts[-1]
-        if lang == territory or lang == 'uk' or self.lang == 'en_US':
+        if lang == territory or lang in ('ja', 'uk') or self.lang == 'en_US':
             # TODO we should add some metadata that stores the canonical locale name and
             # the name of the moment locale to avoid hacks like the one here. for example,
             # fr_FR is handled somewhat nicely, but ukrainian (uk_UA) needs an explicit check


### PR DESCRIPTION
Like Ukrainian, Japanese is likely used officially only in Japan but the shortened name for the language (ja) and that for the country (jp) are different. Thus, a similar treatment is required.