### PR TITLE
Fix printing badges with malformed HTML

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -74,6 +74,8 @@ Bugfixes
   (:pr:`5425`)
 - Fix session blocks not being sorted properly in a timetable PDF export when they
   have the same start time (:pr:`5426`)
+- Fix printing badges containing text elements with malformed HTML (:pr:`5437`,
+  thanks :user:`omegak`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/designer/pdf.py
+++ b/indico/modules/designer/pdf.py
@@ -22,7 +22,7 @@ from indico.core import signals
 from indico.legacy.pdfinterface.base import setTTFonts
 from indico.modules.designer import PageOrientation
 from indico.util.signals import values_from_signal
-from indico.util.string import strip_tags
+from indico.util.string import RichMarkup, sanitize_html, strip_tags
 
 
 FONT_STYLES = {
@@ -132,7 +132,8 @@ class DesignerPDFBase:
             canvas.drawImage(ImageReader(content), margin_x + item_x, self.height - margin_y - item_height - item_y,
                              item_width, item_height, mask='auto')
         else:
-            content = strip_tags(content)
+            content = content.unescape() if isinstance(content, RichMarkup) else content
+            content = sanitize_html(strip_tags(content))
             for line in content.splitlines():
                 p = Paragraph(line, style)
                 available_height = (tpl_data.height_cm - (item_y / PIXELS_CM)) * cm


### PR DESCRIPTION
This fix handles both plain text and rich markdown elements. It's not perfect, as it strips unclosed tags, but at least it doesn't trigger an unhandled exception. These are examples of how different content is rendered in the badge.

Plain text input elements:
| content | rendering |
| ------- | --------- |
| <x      | <x        |
| <x foo  |           |

Rich markdown input elements:
| content                              | rendering |
| ------------------------------------ | --------- |
| <x                                   |           |
| &lt;span sytle="color: red;"&gt;foo&lt;/span&gt; | foo       |