### PR TITLE
Add scroll when material tooltip is too long

### DIFF
--- a/indico/web/client/styles/legacy/Default.css
+++ b/indico/web/client/styles/legacy/Default.css
@@ -792,6 +792,8 @@ body.cke_show_borders {
 
 .material_tip .qtip-content {
   background: #f8f8f8;
+  max-height: 50vh;
+  overflow-y: auto;
 }
 
 ul.material_list {


### PR DESCRIPTION
Adds max height with a scroll to prevent the tooltip from clipping and only showing a part of the materials.

![image](https://user-images.githubusercontent.com/8739637/183079210-1e003e6f-61b5-4e66-94a6-abba202014aa.png)
