### PR TITLE
Fix Poster contributions start and end times

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -77,6 +77,8 @@ Bugfixes
   have the same start time (:pr:`5426`)
 - Fix printing badges containing text elements with malformed HTML (:pr:`5437`,
   thanks :user:`omegak`)
+- Fix misleading start and end times for Poster contributions in the timetable HTTP API
+  and the contributions placeholder in emails (:pr:`5443`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/persons/templates/emails/_contributions.html
+++ b/indico/modules/events/persons/templates/emails/_contributions.html
@@ -3,15 +3,17 @@
         {% for contribution in contributions %}
             <li>
                 <a href="{{ url_for('contributions.display_contribution', contribution, _external=true) }}">{{ contribution.title }}</a>
-                (
-                {%- if contribution.timetable_entry -%}
-                    {{ contribution.timetable_entry.start_dt | format_datetime(format='EEEE', timezone=timezone) }}
-                    {{ contribution.timetable_entry.start_dt | format_datetime(format='medium', timezone=timezone) }}
-                    - {{ contribution.timetable_entry.end_dt | format_time(timezone=timezone) }}
-                {%- else -%}
-                    Not scheduled yet
-                {%- endif -%}
-                )
+                {% if not contribution.session or not contribution.session.is_poster %}
+                    (
+                    {%- if contribution.timetable_entry -%}
+                        {{ contribution.timetable_entry.start_dt | format_datetime(format='EEEE', timezone=timezone) }}
+                        {{ contribution.timetable_entry.start_dt | format_datetime(format='medium', timezone=timezone) }}
+                        - {{ contribution.timetable_entry.end_dt | format_time(timezone=timezone) }}
+                    {%- else -%}
+                        Not scheduled yet
+                    {%- endif -%}
+                    )
+                {% endif %}
             </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
This PR fixes a bug in which Poster contributions displayed a misleading start and end time in e-mails and the HTTP API.

The bug was caused by Poster contributions not having and inherent time schedule, and thus should display their parent session's start and end times instead of its own times.