### PR TITLE
Add option to allow subcontrib speakers edit minutes/attachments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,8 @@ Improvements
 - Add option to make the 'Affiliation' and 'Comment' fields mandatory in the account
   request form (:issue:`4819`, :pr:`5389`, thanks :user:`elsbethe`)
 - Include tags in registrant API (:pr:`5441`)
+- Subcontribution speakers can now be granted submission privileges in the event's
+  protection settings (:issue:`2363`, :pr:`5444`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/attachments/util.py
+++ b/indico/modules/attachments/util.py
@@ -71,8 +71,8 @@ def can_manage_attachments(obj, user, allow_admin=True):
         return True
     if isinstance(obj, db.m.SubContribution):
         from indico.modules.events.contributions import subcontribution_settings
-        speakers_can_edit = subcontribution_settings.get(obj.contribution.event, 'speakers_can_edit')
-        if speakers_can_edit and any(speaker.person.user == user for speaker in obj.speakers):
+        speakers_can_submit = subcontribution_settings.get(obj.contribution.event, 'speakers_can_submit')
+        if speakers_can_submit and any(speaker.person.user == user for speaker in obj.speakers):
             return True
         return can_manage_attachments(obj.contribution, user, allow_admin=allow_admin)
     return False

--- a/indico/modules/attachments/util.py
+++ b/indico/modules/attachments/util.py
@@ -70,6 +70,10 @@ def can_manage_attachments(obj, user, allow_admin=True):
     if isinstance(obj, db.m.Contribution) and obj.can_manage(user, 'submit', allow_admin=allow_admin):
         return True
     if isinstance(obj, db.m.SubContribution):
+        from indico.modules.events.contributions import subcontribution_settings
+        speakers_can_edit = subcontribution_settings.get(obj.contribution.event, 'speakers_can_edit')
+        if speakers_can_edit and any(speaker.person.user == user for speaker in obj.speakers):
+            return True
         return can_manage_attachments(obj.contribution, user, allow_admin=allow_admin)
     return False
 

--- a/indico/modules/events/contributions/__init__.py
+++ b/indico/modules/events/contributions/__init__.py
@@ -135,3 +135,7 @@ contribution_settings = EventSettingsProxy('contributions', {
 }, converters={
     'default_duration': TimedeltaConverter
 })
+
+subcontribution_settings = EventSettingsProxy('subcontributions', {
+    'speakers_can_edit': False,  # Speakers can edit minutes and upload attachments
+})

--- a/indico/modules/events/contributions/__init__.py
+++ b/indico/modules/events/contributions/__init__.py
@@ -137,5 +137,5 @@ contribution_settings = EventSettingsProxy('contributions', {
 })
 
 subcontribution_settings = EventSettingsProxy('subcontributions', {
-    'speakers_can_edit': False,  # Speakers can edit minutes and upload attachments
+    'speakers_can_submit': False,  # Speakers can edit minutes and upload attachments
 })

--- a/indico/modules/events/management/controllers/protection.py
+++ b/indico/modules/events/management/controllers/protection.py
@@ -105,7 +105,7 @@ class RHEventProtection(RHManageEventBase):
         permissions = [[serialize_principal(p.principal), list(get_principal_permissions(p, Event))]
                        for p in self.event.acl_entries]
         permissions = [item for item in permissions if item[1]]
-        subcontrib_speakers = subcontribution_settings.get(self.event, 'speakers_can_edit')
+        subcontrib_speakers = subcontribution_settings.get(self.event, 'speakers_can_submit')
 
         return dict({'protection_mode': self.event.protection_mode, 'registration_managers': registration_managers,
                      'access_key': self.event.access_key, 'visibility': self.event.visibility,
@@ -120,7 +120,7 @@ class RHEventProtection(RHManageEventBase):
         update_session_coordinator_privs(self.event, data)
 
     def _update_subcontrib_settings(self, form):
-        subcontribution_settings.set(self.event, 'speakers_can_edit', form.subcontrib_speakers.data)
+        subcontribution_settings.set(self.event, 'speakers_can_submit', form.subcontrib_speakers.data)
 
 
 class RHPermissionsDialog(RH):

--- a/indico/modules/events/management/controllers/protection.py
+++ b/indico/modules/events/management/controllers/protection.py
@@ -17,6 +17,7 @@ from indico.modules.categories.models.roles import CategoryRole
 from indico.modules.categories.util import serialize_category_role
 from indico.modules.core.controllers import PrincipalsMixin
 from indico.modules.events import Event
+from indico.modules.events.contributions import subcontribution_settings
 from indico.modules.events.controllers.base import RHAuthenticatedEventBase
 from indico.modules.events.management.controllers.base import RHManageEventBase
 from indico.modules.events.management.forms import EventProtectionForm
@@ -90,6 +91,7 @@ class RHEventProtection(RHManageEventBase):
                 data['visibility'] = form.visibility.data
             update_event_protection(self.event, data)
             self._update_session_coordinator_privs(form)
+            self._update_subcontrib_settings(form)
             flash(_('Protection settings have been updated'), 'success')
             return redirect(url_for('.protection', self.event))
         return WPEventProtection.render_template('event_protection.html', self.event, 'protection', form=form)
@@ -103,17 +105,22 @@ class RHEventProtection(RHManageEventBase):
         permissions = [[serialize_principal(p.principal), list(get_principal_permissions(p, Event))]
                        for p in self.event.acl_entries]
         permissions = [item for item in permissions if item[1]]
+        subcontrib_speakers = subcontribution_settings.get(self.event, 'speakers_can_edit')
 
         return dict({'protection_mode': self.event.protection_mode, 'registration_managers': registration_managers,
                      'access_key': self.event.access_key, 'visibility': self.event.visibility,
                      'own_no_access_contact': self.event.own_no_access_contact,
                      'public_regform_access': self.event.public_regform_access,
-                     'permissions': permissions},
+                     'permissions': permissions,
+                     'subcontrib_speakers': subcontrib_speakers},
                     **coordinator_privs)
 
     def _update_session_coordinator_privs(self, form):
         data = {field: getattr(form, field).data for field in form.priv_fields}
         update_session_coordinator_privs(self.event, data)
+
+    def _update_subcontrib_settings(self, form):
+        subcontribution_settings.set(self.event, 'speakers_can_edit', form.subcontrib_speakers.data)
 
 
 class RHPermissionsDialog(RH):

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -271,6 +271,8 @@ class EventProtectionForm(IndicoForm):
                                                        'expose open registration forms to anyone with a link to the '
                                                        'event, so you can let users register without giving access '
                                                        'to anything else in your event.'))
+    subcontrib_speakers = BooleanField(_('Speakers can edit'), widget=SwitchWidget(),
+                                       description=_('Subcontribution speakers can edit minutes and upload materials.'))
     priv_fields = set()
 
     def __init__(self, *args, **kwargs):

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -271,7 +271,7 @@ class EventProtectionForm(IndicoForm):
                                                        'expose open registration forms to anyone with a link to the '
                                                        'event, so you can let users register without giving access '
                                                        'to anything else in your event.'))
-    subcontrib_speakers = BooleanField(_('Speakers can edit'), widget=SwitchWidget(),
+    subcontrib_speakers = BooleanField(_('Speakers can submit'), widget=SwitchWidget(),
                                        description=_('Subcontribution speakers can edit minutes and upload materials.'))
     priv_fields = set()
 

--- a/indico/modules/events/management/templates/event_protection.html
+++ b/indico/modules/events/management/templates/event_protection.html
@@ -6,7 +6,7 @@
 {% block content %}
     {{ form_header(form, id='event-protection-form', extra_attrs={'data-confirm-close-unsaved': True}) }}
     {{ form_row(form.permissions, skip_label=true) }}
-    {{ form_rows(form, skip=form.priv_fields.union(['permissions']),
+    {{ form_rows(form, skip=form.priv_fields.union(['permissions', 'subcontrib_speakers']),
                  widget_attrs={'own_no_access_contact': {'placeholder': event.no_access_contact}}) }}
     {% call form_fieldset(_("Session coordinator rights"), collapsible=true, initially_collapsed=true) %}
         <div class="action-box highlight">
@@ -24,6 +24,9 @@
             </div>
         </div>
         {{ form_rows(form, fields=form.priv_fields) }}
+    {% endcall %}
+    {% call form_fieldset(_("Subcontribution rights"), collapsible=true, initially_collapsed=true) %}
+        {{ form_rows(form, fields=["subcontrib_speakers"]) }}
     {% endcall %}
     {% call form_footer(form) %}
         <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}"

--- a/indico/modules/events/management/templates/event_protection.html
+++ b/indico/modules/events/management/templates/event_protection.html
@@ -25,9 +25,11 @@
         </div>
         {{ form_rows(form, fields=form.priv_fields) }}
     {% endcall %}
-    {% call form_fieldset(_("Subcontribution rights"), collapsible=true, initially_collapsed=true) %}
-        {{ form_rows(form, fields=["subcontrib_speakers"]) }}
-    {% endcall %}
+    {% if event.type != 'lecture' %}
+        {% call form_fieldset(_('Subcontribution rights'), collapsible=true, initially_collapsed=true) %}
+            {{ form_rows(form, fields=['subcontrib_speakers']) }}
+        {% endcall %}
+    {% endif %}
     {% call form_footer(form) %}
         <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}"
                data-disabled-until-change data-save-reminder>

--- a/indico/modules/events/notes/util.py
+++ b/indico/modules/events/notes/util.py
@@ -81,5 +81,9 @@ def can_edit_note(obj, user):
     if isinstance(obj, db.m.Contribution) and obj.can_manage(user, 'submit'):
         return True
     if isinstance(obj, db.m.SubContribution):
+        from indico.modules.events.contributions import subcontribution_settings
+        speakers_can_edit = subcontribution_settings.get(obj.contribution.event, 'speakers_can_edit')
+        if speakers_can_edit and any(speaker.person.user == user for speaker in obj.speakers):
+            return True
         return can_edit_note(obj.contribution, user)
     return False

--- a/indico/modules/events/notes/util.py
+++ b/indico/modules/events/notes/util.py
@@ -82,8 +82,8 @@ def can_edit_note(obj, user):
         return True
     if isinstance(obj, db.m.SubContribution):
         from indico.modules.events.contributions import subcontribution_settings
-        speakers_can_edit = subcontribution_settings.get(obj.contribution.event, 'speakers_can_edit')
-        if speakers_can_edit and any(speaker.person.user == user for speaker in obj.speakers):
+        speakers_can_submit = subcontribution_settings.get(obj.contribution.event, 'speakers_can_submit')
+        if speakers_can_submit and any(speaker.person.user == user for speaker in obj.speakers):
             return True
         return can_edit_note(obj.contribution, user)
     return False


### PR DESCRIPTION
Related to https://github.com/indico/indico/issues/2363

With this setting on, subcontrib speakers can edit their own minutes and/or attachments without having to be submitters of the parent contribution.

New setting added to the protection page:

![image](https://user-images.githubusercontent.com/8739637/183413384-a1df964b-30b6-4d3f-bcd6-74b108b6cd13.png)

Since this change only affects mettings, the setting is hidden for other event types.





