### PR TITLE
Add program code to revision ZIP file name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -62,6 +62,7 @@ Improvements
   (:issue:`4698`, :pr:`5400`)
 - Account creation now requires a CAPTCHA by default to prevent spam account creation
   (:issue:`4698`, :pr:`5446`)
+- Add contribution's program code to revision's "Download ZIP" filename (:pr:`5449`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -388,9 +388,12 @@ class RHExportRevisionFiles(RHContributionEditableRevisionBase):
 
                 with file.storage.get_local_path(file.storage_file_id) as filepath:
                     zip_handler.write(filepath, os.path.join(folder_name, filename))
+        zip_filename = f'revision-{self.revision.id}.zip'
+        if self.contrib.code:
+            zip_filename = f'{self.contrib.code}-{zip_filename}'
 
         buf.seek(0)
-        return send_file(f'revision-{self.revision.id}.zip', buf, 'application/zip', inline=False)
+        return send_file(zip_filename, buf, 'application/zip', inline=False)
 
 
 class RHDownloadRevisionFile(RHContributionEditableRevisionBase):


### PR DESCRIPTION
This PR adds the contribution's program code to the revisions' "Download ZIP" file name:
<img width="843" alt="image" src="https://user-images.githubusercontent.com/27357203/184161130-5df55b98-418f-44bb-95a1-4682ea865451.png">
