### PR TITLE
Invisible focus outline 

### DIFF
--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -289,7 +289,6 @@ ul.category-list {
       display: block;
       color: lighten($dark-blue, 6%);
       padding: 0 0 0 1em;
-      outline: none;
 
       &.invisible-block {
         color: inherit !important;

--- a/indico/web/client/styles/partials/_buttons.scss
+++ b/indico/web/client/styles/partials/_buttons.scss
@@ -16,7 +16,6 @@ $i-button-spacing: 0.3rem;
   display: inline-block;
   cursor: pointer;
   color: $light-black;
-  outline: none;
   text-align: center;
   vertical-align: middle;
 }


### PR DESCRIPTION
After focusing on some elements using keyboard the outline is not visible. Maybe it is worth restoring the default values? When using firefox it looks like this:
Before:
![button-b](https://user-images.githubusercontent.com/52355067/184215142-371a47d3-cdb8-4f1c-a2ba-91347e3d8b07.png)
![category-b](https://user-images.githubusercontent.com/52355067/184215808-88c43d84-0b2a-463b-9285-606bef2088d8.png)
After:
![button-a](https://user-images.githubusercontent.com/52355067/184215141-ffccb244-8e0f-4db5-8329-a5cd0d7e47b9.png)
![category-a](https://user-images.githubusercontent.com/52355067/184215146-28f5d966-95a9-40d5-8cfa-252c9e6b3a54.png)

