### PR TITLE
Enable image upload (paste/dragndrop) in ckeditor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,8 @@ Improvements
 - Event series can now specify a title pattern to use when cloning an event in the
   series (:pr:`5456`)
 - Insert new categories into the correct position if the list is already sorted (:pr:`5455`)
+- Images can now be uploaded by pasting or dropping them into the editor for minutes
+  or the event description (:pr:`5458`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/attachments/blueprint.py
+++ b/indico/modules/attachments/blueprint.py
@@ -14,14 +14,16 @@ from indico.modules.attachments.controllers.display.event import (RHDownloadEven
                                                                   RHListEventAttachmentFolder,
                                                                   RHPackageEventAttachmentsDisplay)
 from indico.modules.attachments.controllers.event_package import RHPackageEventAttachmentsStatus
-from indico.modules.attachments.controllers.management.category import (RHAddCategoryAttachmentFiles,
+from indico.modules.attachments.controllers.management.category import (RHAddCategoryAttachmentCKEditor,
+                                                                        RHAddCategoryAttachmentFiles,
                                                                         RHAddCategoryAttachmentLink,
                                                                         RHCreateCategoryFolder,
                                                                         RHDeleteCategoryAttachment,
                                                                         RHDeleteCategoryFolder,
                                                                         RHEditCategoryAttachment, RHEditCategoryFolder,
                                                                         RHManageCategoryAttachments)
-from indico.modules.attachments.controllers.management.event import (RHAddEventAttachmentFiles,
+from indico.modules.attachments.controllers.management.event import (RHAddEventAttachmentCKEditor,
+                                                                     RHAddEventAttachmentFiles,
                                                                      RHAddEventAttachmentLink,
                                                                      RHAttachmentManagementInfoColumn,
                                                                      RHCreateEventFolder, RHDeleteEventAttachment,
@@ -62,6 +64,9 @@ for object_type, prefixes in items:
         _bp.add_url_rule(prefix + '/attachments/info-column', 'management_info_column',
                          RHAttachmentManagementInfoColumn,
                          defaults={'object_type': object_type})
+        _bp.add_url_rule(prefix + '/attachments/add/ckeditor', 'upload_ckeditor',
+                         _dispatch(RHAddEventAttachmentCKEditor, RHAddCategoryAttachmentCKEditor),
+                         methods=('GET', 'POST'), defaults={'object_type': object_type})
         _bp.add_url_rule(prefix + '/attachments/add/files', 'upload',
                          _dispatch(RHAddEventAttachmentFiles, RHAddCategoryAttachmentFiles),
                          methods=('GET', 'POST'), defaults={'object_type': object_type})

--- a/indico/modules/attachments/controllers/management/category.py
+++ b/indico/modules/attachments/controllers/management/category.py
@@ -8,10 +8,11 @@
 from flask import session
 from werkzeug.exceptions import Forbidden
 
-from indico.modules.attachments.controllers.management.base import (AddAttachmentFilesMixin, AddAttachmentLinkMixin,
-                                                                    CreateFolderMixin, DeleteAttachmentMixin,
-                                                                    DeleteFolderMixin, EditAttachmentMixin,
-                                                                    EditFolderMixin, ManageAttachmentsMixin)
+from indico.modules.attachments.controllers.management.base import (AddAttachmentCKEditorMixin, AddAttachmentFilesMixin,
+                                                                    AddAttachmentLinkMixin, CreateFolderMixin,
+                                                                    DeleteAttachmentMixin, DeleteFolderMixin,
+                                                                    EditAttachmentMixin, EditFolderMixin,
+                                                                    ManageAttachmentsMixin)
 from indico.modules.attachments.util import can_manage_attachments
 from indico.modules.categories.controllers.base import RHManageCategoryBase
 from indico.modules.categories.views import WPCategoryManagement
@@ -33,6 +34,10 @@ class RHCategoryAttachmentManagementBase(RHManageCategoryBase):
 
 class RHManageCategoryAttachments(ManageAttachmentsMixin, RHCategoryAttachmentManagementBase):
     wp = WPCategoryManagement
+
+
+class RHAddCategoryAttachmentCKEditor(AddAttachmentCKEditorMixin, RHCategoryAttachmentManagementBase):
+    pass
 
 
 class RHAddCategoryAttachmentFiles(AddAttachmentFilesMixin, RHCategoryAttachmentManagementBase):

--- a/indico/modules/attachments/controllers/management/event.py
+++ b/indico/modules/attachments/controllers/management/event.py
@@ -9,10 +9,11 @@ from flask import jsonify, session
 from werkzeug.exceptions import Forbidden, NotFound
 
 from indico.modules.attachments.controllers.event_package import AttachmentPackageMixin
-from indico.modules.attachments.controllers.management.base import (AddAttachmentFilesMixin, AddAttachmentLinkMixin,
-                                                                    CreateFolderMixin, DeleteAttachmentMixin,
-                                                                    DeleteFolderMixin, EditAttachmentMixin,
-                                                                    EditFolderMixin, ManageAttachmentsMixin)
+from indico.modules.attachments.controllers.management.base import (AddAttachmentCKEditorMixin, AddAttachmentFilesMixin,
+                                                                    AddAttachmentLinkMixin, CreateFolderMixin,
+                                                                    DeleteAttachmentMixin, DeleteFolderMixin,
+                                                                    EditAttachmentMixin, EditFolderMixin,
+                                                                    ManageAttachmentsMixin)
 from indico.modules.attachments.util import can_manage_attachments
 from indico.modules.attachments.views import WPEventAttachments, WPPackageEventAttachmentsManagement
 from indico.modules.events.controllers.base import RHEventBase
@@ -50,6 +51,10 @@ class RHAttachmentManagementInfoColumn(RHEventAttachmentManagementBase):
     def _process(self):
         tpl = get_template_module('attachments/_management_info_column.html')
         return jsonify(html=tpl.render_attachment_info(self.object))
+
+
+class RHAddEventAttachmentCKEditor(AddAttachmentCKEditorMixin, RHEventAttachmentManagementBase):
+    pass
 
 
 class RHAddEventAttachmentFiles(AddAttachmentFilesMixin, RHEventAttachmentManagementBase):

--- a/indico/modules/attachments/models/folders.py
+++ b/indico/modules/attachments/models/folders.py
@@ -122,20 +122,24 @@ class AttachmentFolder(LinkMixin, ProtectionMixin, db.Model):
         return folder
 
     @classmethod
-    def get_or_create(cls, linked_object, title=None):
+    def get_or_create(cls, linked_object, title=None, **create_kwargs):
         """Get a folder for the given object or create it.
 
         If no folder title is specified, the default folder will be
         used.  It is the caller's responsibility to add the folder
         or an object (such as an attachment) associated with it
         to the SQLAlchemy session using ``db.session.add(...)``.
+
+        Additional kwargs will be used when creating a custom folder;
+        in case of a default folder they must not be used.
         """
         if title is None:
+            assert not create_kwargs
             return AttachmentFolder.get_or_create_default(linked_object)
         else:
             folder = AttachmentFolder.query.filter_by(object=linked_object, is_default=False, is_deleted=False,
                                                       title=title).first()
-            return folder or AttachmentFolder(object=linked_object, title=title)
+            return folder or AttachmentFolder(object=linked_object, title=title, **create_kwargs)
 
     @locator_property
     def locator(self):

--- a/indico/modules/events/layout/forms.py
+++ b/indico/modules/events/layout/forms.py
@@ -173,6 +173,10 @@ class MenuLinkForm(MenuUserEntryFormBase):
 class MenuPageForm(MenuUserEntryFormBase):
     html = TextAreaField(_('Content'), [DataRequired()], widget=CKEditorWidget(images=True))
 
+    def __init__(self, *args, ckeditor_upload_url, **kwargs):
+        self.ckeditor_upload_url = ckeditor_upload_url
+        super().__init__(*args, **kwargs)
+
 
 class AddImagesForm(IndicoForm):
     image = FileField('Image', multiple_files=True, accepted_file_types='image/jpeg,image/jpg,image/png,image/gif')

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -61,8 +61,9 @@ class EventDataForm(IndicoForm):
     description = TextAreaField(_('Description'), widget=CKEditorWidget(images=True, height=250))
     url_shortcut = StringField(_('URL shortcut'), filters=[lambda x: (x or None)])
 
-    def __init__(self, *args, **kwargs):
-        self.event = kwargs.pop('event')
+    def __init__(self, *args, event, **kwargs):
+        self.event = event
+        self.ckeditor_upload_url = url_for('attachments.upload_ckeditor', event)
         super().__init__(*args, **kwargs)
         prefix = f'{config.BASE_URL}/e/'
         self.url_shortcut.description = _('The URL shortcut must be unique within this Indico instance and '
@@ -198,8 +199,9 @@ class EventContactInfoForm(IndicoForm):
                                     widget=CKEditorWidget(images=True, height=250),
                                     description=_('This text is displayed on the main conference page.'))
 
-    def __init__(self, *args, **kwargs):
-        self.event = kwargs.pop('event')
+    def __init__(self, *args, event, **kwargs):
+        self.event = event
+        self.ckeditor_upload_url = url_for('attachments.upload_ckeditor', event)
         super().__init__(*args, **kwargs)
         if self.event.type_ != EventType.lecture:
             del self.organizer_info

--- a/indico/modules/events/notes/controllers.py
+++ b/indico/modules/events/notes/controllers.py
@@ -61,7 +61,8 @@ class RHEditNote(RHManageNoteBase):
         note = None
         if not source:
             note = EventNote.get_for_linked_object(self.object, preload_event=False)
-        return NoteForm(obj=self._get_defaults(note=note, source=source))
+        return NoteForm(obj=self._get_defaults(note=note, source=source),
+                        ckeditor_upload_url=url_for('attachments.upload_ckeditor', self.object))
 
     def _process_form(self, form, **kwargs):
         saved = False

--- a/indico/modules/events/notes/forms.py
+++ b/indico/modules/events/notes/forms.py
@@ -15,3 +15,7 @@ from indico.web.forms.widgets import CKEditorWidget
 class NoteForm(IndicoForm):
     # TODO: use something switchable
     source = TextAreaField(_('Minutes'), widget=CKEditorWidget(images=True))
+
+    def __init__(self, *args, ckeditor_upload_url, **kwargs):
+        self.ckeditor_upload_url = ckeditor_upload_url
+        super().__init__(*args, **kwargs)

--- a/indico/web/client/js/ckeditor.js
+++ b/indico/web/client/js/ckeditor.js
@@ -5,7 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-export const getConfig = ({images = true} = {}) => ({
+export const getConfig = ({images = true, imageUploadURL = null} = {}) => ({
+  removePlugins: images && imageUploadURL ? [] : ['ImageInsert', 'ImageUpload'],
   fontFamily: {
     options: [
       'Sans Serif/"Liberation Sans", sans-serif',
@@ -69,7 +70,8 @@ export const getConfig = ({images = true} = {}) => ({
     'HorizontalLine',
     images && 'Image',
     images && 'ImageCaption',
-    images && 'ImageInsertViaUrl',
+    images && !imageUploadURL && 'ImageInsertViaUrl',
+    images && imageUploadURL && 'ImageInsert',
     images && 'ImageResize',
     images && 'ImageStyle',
     images && 'ImageToolbar',
@@ -82,6 +84,7 @@ export const getConfig = ({images = true} = {}) => ({
     'Paragraph',
     'PasteFromOffice',
     'RemoveFormat',
+    images && imageUploadURL && 'SimpleUploadAdapter',
     'SourceEditing',
     'Strikethrough',
     'Subscript',
@@ -140,4 +143,14 @@ export const getConfig = ({images = true} = {}) => ({
       'imageStyle:alignRight',
     ],
   },
+  simpleUpload:
+    images && imageUploadURL
+      ? {
+          uploadUrl: imageUploadURL,
+          headers: {
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRF-Token': document.getElementById('csrf-token').getAttribute('content'),
+          },
+        }
+      : undefined,
 });

--- a/indico/web/client/js/jquery/widgets/jinja/ckeditor_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/ckeditor_widget.js
@@ -11,9 +11,12 @@ import {getConfig} from 'indico/ckeditor';
 
 (function(global) {
   global.setupCKEditorWidget = async function setupCKEditorWidget(options) {
-    const {fieldId, images = true, width, height = 475, ...rest} = options;
+    const {fieldId, images = true, imageUploadURL = null, width, height = 475, ...rest} = options;
     const field = document.getElementById(fieldId);
-    const editor = await ClassicEditor.create(field, {...getConfig({images}), ...rest});
+    const editor = await ClassicEditor.create(field, {
+      ...getConfig({images, imageUploadURL}),
+      ...rest,
+    });
     editor.setData(field.value);
     editor.model.document.on('change:data', () => {
       field.value = editor.getData();

--- a/indico/web/forms/widgets.py
+++ b/indico/web/forms/widgets.py
@@ -22,6 +22,7 @@ html_comment_re = re.compile(r'<!--.*?-->', re.MULTILINE)
 
 class ConcatWidget:
     """Render a list of fields as a simple string joined by an optional separator."""
+
     def __init__(self, separator='', prefix_label=True):
         self.separator = separator
         self.prefix_label = prefix_label
@@ -38,6 +39,7 @@ class ConcatWidget:
 
 class HiddenInputs(HiddenInput):
     """Render hidden inputs for list elements."""
+
     item_widget = HiddenInput()
 
     def __call__(self, field, **kwargs):
@@ -112,10 +114,14 @@ class PasswordWidget(JinjaWidget):
 class CKEditorWidget(JinjaWidget):
     """Render a CKEditor WYSIWYG editor.
 
-    :param images: Whether to allow images in simple mode.
+    :param images: Whether to allow images.
     :param height: The height of the editor.
+
+    If the form has a ``ckeditor_upload_url`` attribute and images are enabled,
+    the editor will allow pasting/selecting images and upload them using that URL.
     """
-    def __init__(self, images=False, height=475):
+
+    def __init__(self, *, images=False, height=475):
         super().__init__('forms/ckeditor_widget.html', images=images, height=height)
 
 

--- a/indico/web/templates/forms/ckeditor_widget.html
+++ b/indico/web/templates/forms/ckeditor_widget.html
@@ -12,6 +12,7 @@
         setupCKEditorWidget({
             fieldId: {{ field.id | tojson }},
             images: {{ images | tojson }},
+            imageUploadURL: {{ field.get_form().ckeditor_upload_url|default(none) | tojson }},
             height: {{ height | tojson }}
         });
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "axios": "^0.27.2",
         "axios-hooks": "^3.1.1",
         "chartist": "^0.11.4",
-        "ckeditor": "git+https://indico@github.com/indico/ckeditor.git#v1.6.1",
+        "ckeditor": "git+https://indico@github.com/indico/ckeditor.git#v1.7.0",
         "clipboard": "^2.0.11",
         "connected-react-router": "^6.9.2",
         "core-js": "^2.6.12",
@@ -4814,8 +4814,8 @@
       "dev": true
     },
     "node_modules/ckeditor": {
-      "version": "1.6.1",
-      "resolved": "git+https://indico@github.com/indico/ckeditor.git#12ce65ec1166e274076c627c84088e4dd7144029",
+      "version": "1.7.0",
+      "resolved": "git+https://indico@github.com/indico/ckeditor.git#860c808425ee02440bd609d5816cac28f9911e38",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/classnames": {
@@ -29537,8 +29537,8 @@
       "dev": true
     },
     "ckeditor": {
-      "version": "git+https://indico@github.com/indico/ckeditor.git#12ce65ec1166e274076c627c84088e4dd7144029",
-      "from": "ckeditor@git+https://indico@github.com/indico/ckeditor.git#v1.6.1"
+      "version": "git+https://indico@github.com/indico/ckeditor.git#860c808425ee02440bd609d5816cac28f9911e38",
+      "from": "ckeditor@git+https://indico@github.com/indico/ckeditor.git#v1.7.0"
     },
     "classnames": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "axios": "^0.27.2",
     "axios-hooks": "^3.1.1",
     "chartist": "^0.11.4",
-    "ckeditor": "git+https://indico@github.com/indico/ckeditor.git#v1.6.1",
+    "ckeditor": "git+https://indico@github.com/indico/ckeditor.git#v1.7.0",
     "clipboard": "^2.0.11",
     "connected-react-router": "^6.9.2",
     "core-js": "^2.6.12",


### PR DESCRIPTION
When uploading an image this way, it creates a material folder (hidden outside management views) in the event/contribution/... where the images are then added.