### PR TITLE
Add support for positioning images in ckeditor

### DIFF
--- a/indico/modules/events/layout/templates/page.html
+++ b/indico/modules/events/layout/templates/page.html
@@ -19,5 +19,5 @@
 {% endblock %}
 
 {% block content %}
-    {{ page.html|sanitize_html }}
+    <div class="ck-output">{{ page.html|sanitize_html }}</div>
 {% endblock %}

--- a/indico/modules/events/notes/templates/_note.html
+++ b/indico/modules/events/notes/templates/_note.html
@@ -30,7 +30,7 @@
         <div class="padded-box-pad icon-file-text"></div>
         <div class="padded-box-content">
             {{ _render_note_actions(note=note, event=event, hidden=hidden, can_edit=can_edit, anchor=anchor) }}
-            <div class="note-text {% if event %}{{ _togglable_classes(hidden=hidden) }}{% endif %}">
+            <div class="note-text ck-output {% if event %}{{ _togglable_classes(hidden=hidden) }}{% endif %}">
                 {{ note.html|sanitize_html }}
             </div>
             {% if event %}

--- a/indico/modules/events/templates/display/conference.html
+++ b/indico/modules/events/templates/display/conference.html
@@ -4,7 +4,7 @@
 
 {% block content %}
     <div class="conferenceDetails">
-        <div itemprop="description" class="description js-mathjax">
+        <div itemprop="description" class="description js-mathjax ck-output">
             {{ event.description }}
         </div>
 

--- a/indico/modules/events/templates/display/indico/_details.html
+++ b/indico/modules/events/templates/display/indico/_details.html
@@ -8,7 +8,7 @@
     {% if event.description %}
         <div class="event-details-row">
             <div class="event-details-label">{% trans %}Description{% endtrans %}</div>
-            <div class="event-details-content">{{ render_description(event, class='event-description') }}</div>
+            <div class="event-details-content">{{ render_description(event, class='event-description ck-output') }}</div>
         </div>
     {% endif %}
     {% if event.references and event.type_.name == "meeting" %}

--- a/indico/web/client/styles/ckeditor.scss
+++ b/indico/web/client/styles/ckeditor.scss
@@ -22,10 +22,8 @@
 // https://ckeditor.com/docs/ckeditor5/latest/features/images/images-styles.html
 // Inspired by the default ckeditor styles:
 // https://github.com/ckeditor/ckeditor5/blob/06d11a85d01aece904a6bdd25e72abd94a4dd314/packages/ckeditor5-image/theme/imagestyle.css
-// Applies to conference & event description and minutes
-.conferenceDetails .description,
-div.event-details .event-details-content,
-.note-area-wrapper .note-text {
+// Applies to conference & event description, minutes and custom conference pages
+.ck-output {
   $image-spacing: 1.5em;
   display: flow-root;
 

--- a/indico/web/client/styles/ckeditor.scss
+++ b/indico/web/client/styles/ckeditor.scss
@@ -17,3 +17,46 @@
 .ck-source-editing-area textarea {
   height: 100% !important; /* overrides i-form auto height */
 }
+
+// When positioning images, ckeditor5 just applies certain classes that have to be manually implemented:
+// https://ckeditor.com/docs/ckeditor5/latest/features/images/images-styles.html
+// Inspired by the default ckeditor styles:
+// https://github.com/ckeditor/ckeditor5/blob/06d11a85d01aece904a6bdd25e72abd94a4dd314/packages/ckeditor5-image/theme/imagestyle.css
+// Applies to conference & event description and minutes
+.conferenceDetails .description,
+div.event-details .event-details-content,
+.note-area-wrapper .note-text {
+  $image-spacing: 1.5em;
+  display: flow-root;
+
+  img {
+    max-width: 100%;
+  }
+
+  // Applies to centered images, which by default have no class added
+  figure {
+    margin: $image-spacing auto;
+  }
+
+  .image-style-align-left,
+  .image-style-align-right,
+  .image-style-side {
+    margin-top: $image-spacing;
+    margin-bottom: $image-spacing;
+  }
+
+  .image-style-align-left {
+    float: left;
+    margin-right: $image-spacing;
+  }
+
+  .image-style-align-right,
+  .image-style-side {
+    float: right;
+    margin-left: $image-spacing;
+  }
+
+  .image-style-side {
+    max-width: 50%;
+  }
+}


### PR DESCRIPTION
ckeditor adds classes to the images but does not actually style them.
This PR adds support for center, left and right aligned images.