### PR TITLE
Limit atom feed to visible events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,6 +95,7 @@ Improvements
 - Add possibility to link room reservations to multiple events, session blocks and contributions
   (:issue:`6113`, :pr:`6114`, thanks :user:`omegak, unconventionaldotdev`)
 - Store editable list filters in the browser's local storage (:pr:`6192`)
+- Take visibility restrictions into account in the atom feed (:pr:`5472`, thanks :user:`bpedersen2`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/categories/serialize.py
+++ b/indico/modules/categories/serialize.py
@@ -72,6 +72,7 @@ def serialize_category_atom(category, url, user, event_filter):
     """
     query = (Event.query
              .filter(Event.category_chain_overlaps(category.id),
+                     Event.is_visible_in(category.id),
                      ~Event.is_deleted,
                      event_filter)
              .options(load_only('id', 'category_id', 'start_dt', 'title', 'description', 'protection_mode',


### PR DESCRIPTION
Only export events visible in a category by the atom feed to avoid
unnecessary exposure, especially in the case of exporting to public
displays.

See also[1].

[1] https://talk.getindico.io/t/atom-feeds-should-they-respect-the-visibility-settings/2776