### PR TITLE
Fix wrong visibility state on meeting minutes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- None so far :)
+- Fix meeting minutes being shown when they are expected to be hidden (:pr:`5475`)
 
 
 Version 3.2

--- a/indico/web/client/styles/ckeditor.scss
+++ b/indico/web/client/styles/ckeditor.scss
@@ -57,4 +57,8 @@
   .image-style-side {
     max-width: 50%;
   }
+
+  &.weak-hidden {
+    display: none;
+  }
 }


### PR DESCRIPTION
This PR fixes a bug in which a meeting's minutes are shown when the "Show more" link is visible and hidden when the "Hide" link is visible.