### PR TITLE
Force default locale in Book of Abstracts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bugfixes
 ^^^^^^^^
 
 - Fix meeting minutes being shown when they are expected to be hidden (:pr:`5475`)
+- Force default locale when generating Book of Abstracts (:pr:`5477`)
 
 
 Version 3.2

--- a/indico/modules/events/abstracts/util.py
+++ b/indico/modules/events/abstracts/util.py
@@ -27,6 +27,7 @@ from indico.modules.events.contributions.models.fields import ContributionFieldV
 from indico.modules.events.models.persons import EventPerson
 from indico.modules.events.tracks.models.principals import TrackPrincipal
 from indico.modules.events.tracks.models.tracks import Track
+from indico.util.i18n import force_locale
 from indico.util.spreadsheets import unique_col
 from indico.web.flask.templating import get_template_module
 
@@ -301,8 +302,9 @@ def create_boa(event):
             # update file mtime so it's not deleted during cache cleanup
             os.utime(path, None)
             return path
-    pdf = AbstractBook(event)
-    tmp_path = pdf.generate()
+    with force_locale(config.DEFAULT_LOCALE):
+        pdf = AbstractBook(event)
+        tmp_path = pdf.generate()
     filename = f'boa-{event.id}.pdf'
     full_path = os.path.join(config.CACHE_DIR, filename)
     shutil.move(tmp_path, full_path)
@@ -315,8 +317,9 @@ def create_boa_tex(event):
 
     :return: A `BytesIO` containing the zip file.
     """
-    tex = AbstractBook(event)
-    return tex.generate_source_archive()
+    with force_locale(config.DEFAULT_LOCALE):
+        tex = AbstractBook(event)
+        return tex.generate_source_archive()
 
 
 def clear_boa_cache(event):

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -8,7 +8,6 @@
 import ast
 import re
 from collections import Counter
-from contextlib import contextmanager
 
 from babel import negotiate_locale
 from babel.core import LOCALE_ALIASES, Locale
@@ -294,16 +293,6 @@ def get_all_locales():
 def set_session_lang(lang):
     """Set the current language in the current request context."""
     session.lang = lang
-
-
-@contextmanager
-def session_language(lang):
-    """Context manager that temporarily sets session language."""
-    old_lang = session.lang
-
-    set_session_lang(lang)
-    yield
-    set_session_lang(old_lang)
 
 
 def parse_locale(locale):

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -17,7 +17,7 @@ from babel.support import NullTranslations
 from flask import current_app, g, has_app_context, has_request_context, request, session
 from flask_babel import Babel, Domain
 from flask_babel import force_locale as _force_locale
-from flask_babel import get_domain
+from flask_babel import get_domain, get_locale
 from flask_pluginengine import current_plugin
 from speaklater import is_lazy_string, make_lazy_string
 from werkzeug.utils import cached_property
@@ -267,9 +267,13 @@ def set_best_lang(check_session=True):
     return resolved_lang
 
 
-@memoize_request
 def get_current_locale():
-    return IndicoLocale.parse(set_best_lang())
+    return _get_current_locale(str(get_locale()))
+
+
+@memoize_request
+def _get_current_locale(locale):
+    return IndicoLocale.parse(locale)
 
 
 def get_all_locales():


### PR DESCRIPTION
Also fix `force_locale` so it's applied to date/time formats as well.

closes #5474