### PR TITLE
Add email checker for person links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Improvements
 - Include speakers in abstract list columns and spreadsheet exports (:pr:`5615`)
 - Add an option to export all events in a series to ical at once (:issue:`5617`, :pr:`5620`)
 - Make it possible to load more events in series management (:pr:`5629`)
+- Check manually entered email addresses of speakers/authors/chairpersons
+  to avoid collisions and inconsistencies (:pr:`5478`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/blueprint.py
+++ b/indico/modules/events/blueprint.py
@@ -63,16 +63,16 @@ _bp.add_url_rule('/event/<int:event_id>/api/info-for-series', 'single_event_api'
 
 # Email checker for PersonLinkField
 # Depending on where the person link is used, the person link field generates the correct url.
-# Eeach object has its own url so that we can do proper access checks.
-event_object_url_prefixes = {
+# Each object has its own url so that we can do proper access checks.
+_event_object_url_prefixes = {
     'event': '',
-    'block': '/blocks/<int:block_id>',
+    'session_block': '/sessions/<int:session_id>/blocks/<int:session_block_id>',
     'abstract': '/abstracts/<int:abstract_id>',
     'contribution': '/contributions/<int:contrib_id>',
     'subcontribution': '/contributions/<int:contrib_id>/subcontributions/<int:subcontrib_id>',
 }
-for object_type, prefix in event_object_url_prefixes.items():
-    _bp.add_url_rule('/event/<int:event_id>/check-email' + prefix, 'check_email',
+for object_type, prefix in _event_object_url_prefixes.items():
+    _bp.add_url_rule(f'/event/<int:event_id>{prefix}/check-person-email', 'check_email',
                      RHEventCheckEmail, defaults={'object_type': object_type})
 
 

--- a/indico/modules/events/blueprint.py
+++ b/indico/modules/events/blueprint.py
@@ -60,7 +60,21 @@ _bp.add_url_rule('/event/<int:event_id>/other-view', 'display_other', redirect_v
 # Misc
 _bp.add_url_rule('/event/<int:event_id>/key-access', 'key_access', RHEventAccessKey, methods=('POST',))
 _bp.add_url_rule('/event/<int:event_id>/api/info-for-series', 'single_event_api', RHSingleEventAPI)
-_bp.add_url_rule('/event/<int:event_id>/check-email', 'check_email', RHEventCheckEmail)
+
+# Email checker for PersonLinkField
+# Depending on where the person link is used, the person link field generates the correct url.
+# Eeach object has its own url so that we can do proper access checks.
+event_object_url_prefixes = {
+    'event': '',
+    'block': '/blocks/<int:block_id>',
+    'abstract': '/abstracts/<int:abstract_id>',
+    'contribution': '/contributions/<int:contrib_id>',
+    'subcontribution': '/contributions/<int:contrib_id>/subcontributions/<int:subcontrib_id>',
+}
+for object_type, prefix in event_object_url_prefixes.items():
+    _bp.add_url_rule('/event/<int:event_id>/check-email' + prefix, 'check_email',
+                     RHEventCheckEmail, defaults={'object_type': object_type})
+
 
 # Privacy policy
 _bp.add_url_rule('/event/<int:event_id>/privacy', 'display_privacy', RHDisplayPrivacyPolicy)

--- a/indico/modules/events/blueprint.py
+++ b/indico/modules/events/blueprint.py
@@ -8,7 +8,7 @@
 from indico.modules.events.controllers.admin import (RHCreateEventLabel, RHCreateReferenceType, RHDeleteEventLabel,
                                                      RHDeleteReferenceType, RHEditEventLabel, RHEditReferenceType,
                                                      RHEventLabels, RHReferenceTypes, RHUnlistedEvents)
-from indico.modules.events.controllers.api import RHSingleEventAPI
+from indico.modules.events.controllers.api import RHEventCheckEmail, RHSingleEventAPI
 from indico.modules.events.controllers.creation import RHCreateEvent, RHPrepareEvent
 from indico.modules.events.controllers.display import RHDisplayPrivacyPolicy, RHEventAccessKey, RHExportEventICAL
 from indico.modules.events.controllers.entry import event_or_shorturl
@@ -60,6 +60,7 @@ _bp.add_url_rule('/event/<int:event_id>/other-view', 'display_other', redirect_v
 # Misc
 _bp.add_url_rule('/event/<int:event_id>/key-access', 'key_access', RHEventAccessKey, methods=('POST',))
 _bp.add_url_rule('/event/<int:event_id>/api/info-for-series', 'single_event_api', RHSingleEventAPI)
+_bp.add_url_rule('/event/<int:event_id>/check-email', 'check_email', RHEventCheckEmail)
 
 # Privacy policy
 _bp.add_url_rule('/event/<int:event_id>/privacy', 'display_privacy', RHDisplayPrivacyPolicy)

--- a/indico/modules/events/controllers/api.py
+++ b/indico/modules/events/controllers/api.py
@@ -8,7 +8,9 @@
 from flask import jsonify, session
 
 from indico.modules.events import Event
-from indico.util.marshmallow import ModelField
+from indico.modules.events.controllers.base import RHEventBase
+from indico.modules.events.persons.util import check_person_link_email
+from indico.util.marshmallow import LowercaseString, ModelField
 from indico.web.args import use_kwargs
 from indico.web.rh import RH
 
@@ -25,3 +27,13 @@ class RHSingleEventAPI(RH):
         elif not event.can_access(session.user):
             return jsonify(can_access=False)
         return EventDetailsForSeriesManagementSchema().jsonify(event)
+
+
+class RHEventCheckEmail(RHEventBase):
+    """Check a person's email when editing a person link."""
+
+    @use_kwargs({
+        'email': LowercaseString(required=True),
+    }, location='query')
+    def _process(self, email):
+        return jsonify(check_person_link_email(self.event, email))

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -27,6 +27,7 @@ from indico.modules.users.models.affiliations import Affiliation
 from indico.modules.users.models.users import UserTitle
 from indico.modules.users.util import get_user_by_email
 from indico.util.i18n import _
+from indico.web.flask.util import url_for
 from indico.web.forms.fields import MultipleItemsField
 from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.widgets import JinjaWidget
@@ -110,6 +111,10 @@ class PersonLinkListFieldBase(PrincipalListField):
         if self.event is None:
             return True
         return self.event.can_manage(session.user) or not persons_settings.get(self.event, 'disallow_custom_persons')
+
+    @property
+    def validate_email_url(self):
+        return url_for('events.check_email', self.object) if self.object else None
 
     @no_autoflush
     def _get_person_link(self, data):

--- a/indico/modules/events/persons/util.py
+++ b/indico/modules/events/persons/util.py
@@ -64,15 +64,19 @@ def check_person_link_email(event, email):
     email = email.lower().strip()
     person = event.persons.filter_by(email=email).first()
     user = get_user_by_email(email)
+    # Do not return personal data
+    excluded_fields = ['address', 'phone']
+    user_schema = UserSchema(exclude=excluded_fields)
+    event_person_schema = EventPersonSchema(exclude=excluded_fields)
 
     if user and person:
         return dict(status='warning', conflict='user-and-person-already-exists',
-                    event_person=EventPersonSchema().dump(person),
-                    user=UserSchema().dump(user))
+                    event_person=event_person_schema.dump(person),
+                    user=user_schema.dump(user))
     if person:
-        return dict(status='warning', conflict='person-already-exists', event_person=EventPersonSchema().dump(person))
+        return dict(status='warning', conflict='person-already-exists', event_person=event_person_schema.dump(person))
     elif user:
-        return dict(status='warning', conflict='user-already-exists', user=UserSchema().dump(user))
+        return dict(status='warning', conflict='user-already-exists', user=user_schema.dump(user))
     if email_err := validate_email_verbose(email):
         return dict(status='error', conflict='email-invalid', email_error=email_err)
     else:

--- a/indico/modules/events/persons/util.py
+++ b/indico/modules/events/persons/util.py
@@ -65,9 +65,8 @@ def check_person_link_email(event, email):
     person = event.persons.filter_by(email=email).first()
     user = get_user_by_email(email)
     # Do not return personal data
-    excluded_fields = ['address', 'phone']
-    user_schema = UserSchema(exclude=excluded_fields)
-    event_person_schema = EventPersonSchema(exclude=excluded_fields)
+    user_schema = UserSchema(exclude=['phone'])
+    event_person_schema = EventPersonSchema(exclude=['address', 'phone'])
 
     if user and person:
         return dict(status='warning', conflict='user-and-person-already-exists',

--- a/indico/modules/events/persons/util.py
+++ b/indico/modules/events/persons/util.py
@@ -77,6 +77,7 @@ def check_person_link_email(event, email):
     elif user:
         return dict(status='warning', conflict='user-already-exists', user=user_schema.dump(user))
     if email_err := validate_email_verbose(email):
-        return dict(status='error', conflict='email-invalid', email_error=email_err)
+        return dict(status=('error' if email_err != 'undeliverable' else 'warning'), conflict='email-invalid',
+                    email_error=email_err)
     else:
         return dict(status='ok')

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -84,8 +84,8 @@ def get_object_from_args(args=None):
         obj = event
     elif object_type == 'session':
         obj = Session.query.with_parent(event).filter_by(id=args['session_id']).first()
-    elif object_type == 'block':
-        obj = SessionBlock.get(args['block_id'])
+    elif object_type == 'session_block':
+        obj = SessionBlock.query.filter_by(id=args['session_block_id'], session_id=args['session_id']).first()
     elif object_type == 'contribution':
         obj = Contribution.query.with_parent(event).filter_by(id=args['contrib_id']).first()
     elif object_type == 'subcontribution':

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -85,7 +85,10 @@ def get_object_from_args(args=None):
     elif object_type == 'session':
         obj = Session.query.with_parent(event).filter_by(id=args['session_id']).first()
     elif object_type == 'session_block':
-        obj = SessionBlock.query.filter_by(id=args['session_block_id'], session_id=args['session_id']).first()
+        obj = (SessionBlock.query
+               .filter(SessionBlock.id == args['session_block_id'],
+                       SessionBlock.session.has(event=event, id=args['session_id'], is_deleted=False))
+               .first())
     elif object_type == 'contribution':
         obj = Contribution.query.with_parent(event).filter_by(id=args['contrib_id']).first()
     elif object_type == 'subcontribution':

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -39,6 +39,7 @@ from indico.modules.events.models.principals import EventPrincipal
 from indico.modules.events.models.roles import EventRole
 from indico.modules.events.models.static_list_links import StaticListLink
 from indico.modules.events.registration.models.forms import RegistrationForm
+from indico.modules.events.sessions.models.blocks import SessionBlock
 from indico.modules.events.sessions.models.sessions import Session
 from indico.modules.events.timetable.models.breaks import Break
 from indico.modules.events.timetable.models.entries import TimetableEntry
@@ -69,7 +70,7 @@ def get_object_from_args(args=None):
                  ``request.view_args`` is used.
     :return: An ``(object_type, event, object)`` tuple.  The event is
              always the :class:`Event` associated with the object.
-             The object may be an `Event`, `Session`, `Contribution`
+             The object may be an `Event`, `Session`, `SessionBlock`, `Contribution`
              or `SubContribution`.  If the object does not exist,
              ``(object_type, None, None)`` is returned.
     """
@@ -83,6 +84,8 @@ def get_object_from_args(args=None):
         obj = event
     elif object_type == 'session':
         obj = Session.query.with_parent(event).filter_by(id=args['session_id']).first()
+    elif object_type == 'block':
+        obj = SessionBlock.get(args['block_id'])
     elif object_type == 'contribution':
         obj = Contribution.query.with_parent(event).filter_by(id=args['contrib_id']).first()
     elif object_type == 'subcontribution':

--- a/indico/modules/users/schemas.py
+++ b/indico/modules/users/schemas.py
@@ -34,7 +34,7 @@ class UserSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = User
         fields = ('id', 'identifier', 'first_name', 'last_name', 'email', 'affiliation', 'affiliation_id',
-                  'address', 'title', 'affiliation_meta', 'full_name', 'phone', 'avatar_url')
+                  'title', 'affiliation_meta', 'full_name', 'phone', 'avatar_url')
 
     affiliation_id = fields.Integer(load_default=None, dump_only=True)
     affiliation_meta = fields.Nested(AffiliationSchema, attribute='affiliation_link', dump_only=True)

--- a/indico/modules/users/schemas.py
+++ b/indico/modules/users/schemas.py
@@ -7,7 +7,7 @@
 
 import pycountry
 from marshmallow import fields, post_dump, post_load, validate
-from marshmallow.fields import Function, List, String
+from marshmallow.fields import List, String
 
 from indico.core.marshmallow import mm
 from indico.modules.categories import Category
@@ -16,15 +16,6 @@ from indico.modules.users import User
 from indico.modules.users.models.affiliations import Affiliation
 from indico.modules.users.models.users import UserTitle, syncable_fields
 from indico.util.marshmallow import ModelField, NoneValueEnumField
-
-
-class UserSchema(mm.SQLAlchemyAutoSchema):
-    identifier = Function(lambda user: user.identifier)
-
-    class Meta:
-        model = User
-        fields = ('id', 'identifier', 'first_name', 'last_name', 'email', 'affiliation', 'full_name',
-                  'phone', 'avatar_url')
 
 
 class AffiliationSchema(mm.SQLAlchemyAutoSchema):
@@ -37,6 +28,16 @@ class AffiliationSchema(mm.SQLAlchemyAutoSchema):
         country = pycountry.countries.get(alpha_2=data['country_code'])
         data['country_name'] = country.name if country else ''
         return data
+
+
+class UserSchema(mm.SQLAlchemyAutoSchema):
+    class Meta:
+        model = User
+        fields = ('id', 'identifier', 'first_name', 'last_name', 'email', 'affiliation', 'affiliation_id',
+                  'affiliation_meta', 'full_name', 'phone', 'avatar_url')
+
+    affiliation_id = fields.Integer(load_default=None, dump_only=True)
+    affiliation_meta = fields.Nested(AffiliationSchema, attribute='affiliation_link', dump_only=True)
 
 
 class UserPersonalDataSchema(mm.SQLAlchemyAutoSchema):

--- a/indico/modules/users/schemas.py
+++ b/indico/modules/users/schemas.py
@@ -34,7 +34,7 @@ class UserSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = User
         fields = ('id', 'identifier', 'first_name', 'last_name', 'email', 'affiliation', 'affiliation_id',
-                  'affiliation_meta', 'full_name', 'phone', 'avatar_url')
+                  'address', 'affiliation_meta', 'full_name', 'phone', 'avatar_url')
 
     affiliation_id = fields.Integer(load_default=None, dump_only=True)
     affiliation_meta = fields.Nested(AffiliationSchema, attribute='affiliation_link', dump_only=True)

--- a/indico/modules/users/schemas.py
+++ b/indico/modules/users/schemas.py
@@ -34,10 +34,11 @@ class UserSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = User
         fields = ('id', 'identifier', 'first_name', 'last_name', 'email', 'affiliation', 'affiliation_id',
-                  'address', 'affiliation_meta', 'full_name', 'phone', 'avatar_url')
+                  'address', 'title', 'affiliation_meta', 'full_name', 'phone', 'avatar_url')
 
     affiliation_id = fields.Integer(load_default=None, dump_only=True)
     affiliation_meta = fields.Nested(AffiliationSchema, attribute='affiliation_link', dump_only=True)
+    title = NoneValueEnumField(UserTitle, none_value=UserTitle.none, attribute='_title')
 
 
 class UserPersonalDataSchema(mm.SQLAlchemyAutoSchema):

--- a/indico/web/client/js/react/components/PersonDetailsModal.jsx
+++ b/indico/web/client/js/react/components/PersonDetailsModal.jsx
@@ -5,11 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import validateEmailURL from 'indico-url:events.check_email';
 import searchAffiliationURL from 'indico-url:users.api_affiliations';
 
 import PropTypes from 'prop-types';
-import React, {useState, useMemo} from 'react';
+import React, {useState} from 'react';
 import {useForm, useFormState} from 'react-final-form';
 import {Form, Message, Header, Button, Icon} from 'semantic-ui-react';
 
@@ -102,12 +101,10 @@ export default function PersonDetailsModal({
   onSubmit,
   onClose,
   person,
-  eventId,
   otherPersons,
   hideEmailField,
+  validateEmailUrl,
 }) {
-  const shouldValidateEmail = eventId !== null;
-  const emailValidateUrl = useMemo(() => validateEmailURL({event_id: eventId}), [eventId]);
   return (
     <FinalModalForm
       id="person-link-details"
@@ -152,12 +149,7 @@ export default function PersonDetailsModal({
       {!hideEmailField && (
         <Form.Field>
           <Translate as="label">Email</Translate>
-          <EmailField
-            shouldValidate={shouldValidateEmail}
-            validateUrl={emailValidateUrl}
-            person={person}
-            otherPersons={otherPersons}
-          />
+          <EmailField validateUrl={validateEmailUrl} person={person} otherPersons={otherPersons} />
         </Form.Field>
       )}
       <Form.Group widths="equal">
@@ -178,20 +170,20 @@ PersonDetailsModal.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   person: PropTypes.object,
-  eventId: PropTypes.number,
   otherPersons: PropTypes.array,
   hasPredefinedAffiliations: PropTypes.bool.isRequired,
   hideEmailField: PropTypes.bool,
+  validateEmailUrl: PropTypes.string,
 };
 
 PersonDetailsModal.defaultProps = {
   person: undefined,
-  eventId: null,
   otherPersons: [],
   hideEmailField: false,
+  validateEmailUrl: null,
 };
 
-function EmailField({shouldValidate, validateUrl, person, otherPersons}) {
+function EmailField({validateUrl, person, otherPersons}) {
   let response, msg;
   const [message, setMessage] = useState({status: '', message: ''});
   const form = useForm();
@@ -339,7 +331,7 @@ function EmailField({shouldValidate, validateUrl, person, otherPersons}) {
     <FinalInput
       type="email"
       name="email"
-      validate={shouldValidate ? validateEmail : undefined}
+      validate={validateUrl ? validateEmail : undefined}
       // hide the normal error tooltip if we have an error from our async validation
       hideValidationError={message.status === 'error' ? 'message' : false}
       loaderWhileValidating
@@ -360,12 +352,12 @@ function EmailField({shouldValidate, validateUrl, person, otherPersons}) {
 }
 
 EmailField.propTypes = {
-  validateUrl: PropTypes.string.isRequired,
-  shouldValidate: PropTypes.bool.isRequired,
+  validateUrl: PropTypes.string,
   person: PropTypes.object,
   otherPersons: PropTypes.array.isRequired,
 };
 
 EmailField.defaultProps = {
   person: null,
+  validateUrl: null,
 };

--- a/indico/web/client/js/react/components/PersonDetailsModal.jsx
+++ b/indico/web/client/js/react/components/PersonDetailsModal.jsx
@@ -193,6 +193,7 @@ function EmailField({validateUrl, person, otherPersons}) {
 
   const validateEmail = useDebouncedAsyncValidate(async email => {
     form.change('personId', person?.personId);
+    form.change('avatarURL', null);
     email = email.trim();
 
     if (email === '' || email === person?.email) {

--- a/indico/web/client/js/react/components/PersonDetailsModal.jsx
+++ b/indico/web/client/js/react/components/PersonDetailsModal.jsx
@@ -11,7 +11,7 @@ import searchAffiliationURL from 'indico-url:users.api_affiliations';
 import PropTypes from 'prop-types';
 import React, {useState, useMemo} from 'react';
 import {useForm, useFormState} from 'react-final-form';
-import {Form, Message, Header, Button} from 'semantic-ui-react';
+import {Form, Message, Header, Button, Icon} from 'semantic-ui-react';
 
 import {FinalComboDropdown, FinalDropdown, FinalInput, FinalTextArea} from 'indico/react/forms';
 import {FinalModalForm} from 'indico/react/forms/final-form';
@@ -21,6 +21,8 @@ import {camelizeKeys} from 'indico/utils/case';
 import {makeAsyncDebounce} from 'indico/utils/debounce';
 
 import {Param, Translate} from '../i18n';
+
+import './PersonDetailsModal.module.scss';
 
 const debounce = makeAsyncDebounce(250);
 
@@ -292,14 +294,16 @@ function EmailField({shouldValidate, validateUrl, person, otherPersons}) {
     form.change('affiliationMeta', obj.affiliation_meta);
   };
 
-  const emailBtn = (
-    <div style={{textAlign: 'right'}}>
+  const emailBtns = (
+    <div styleName="email-buttons">
       {!isUpdate && (
-        <Button type="submit" primary size="tiny" onClick={onClick}>
+        <Button icon type="submit" primary size="tiny" labelPosition="right" onClick={onClick}>
+          <Icon name="add" />
           <Translate>Add</Translate>
         </Button>
       )}
-      <Button type="button" size="tiny" onClick={onClick}>
+      <Button icon type="button" size="tiny" labelPosition="right" onClick={onClick}>
+        <Icon name="sync" />
         <Translate>Update</Translate>
       </Button>
     </div>
@@ -322,7 +326,7 @@ function EmailField({shouldValidate, validateUrl, person, otherPersons}) {
           positive={message.status === 'ok'}
         >
           <div>{message.message}</div>
-          {(!!user || !!eventPerson) && emailBtn}
+          {(!!user || !!eventPerson) && emailBtns}
         </Message>
       )}
     </FinalInput>

--- a/indico/web/client/js/react/components/PersonDetailsModal.jsx
+++ b/indico/web/client/js/react/components/PersonDetailsModal.jsx
@@ -129,7 +129,14 @@ export default function PersonDetailsModal({
       <Form.Group widths="equal">
         <Form.Field>
           <Translate as="label">Title</Translate>
-          <FinalDropdown name="title" fluid search selection options={titles} />
+          <FinalDropdown
+            name="title"
+            fluid
+            search
+            selection
+            options={titles}
+            placeholder={Translate.string('None')}
+          />
         </Form.Field>
         <Form.Field>
           <Translate as="label">Affiliation</Translate>

--- a/indico/web/client/js/react/components/PersonDetailsModal.jsx
+++ b/indico/web/client/js/react/components/PersonDetailsModal.jsx
@@ -5,19 +5,22 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import validateEmailURL from 'indico-url:events.check_email';
 import searchAffiliationURL from 'indico-url:users.api_affiliations';
 
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
-import {Form, Message, Header} from 'semantic-ui-react';
+import React, {useState, useMemo} from 'react';
+import {useForm, useFormState} from 'react-final-form';
+import {Form, Message, Header, Button} from 'semantic-ui-react';
 
 import {FinalComboDropdown, FinalDropdown, FinalInput, FinalTextArea} from 'indico/react/forms';
 import {FinalModalForm} from 'indico/react/forms/final-form';
+import {useDebouncedAsyncValidate} from 'indico/react/hooks';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
 import {makeAsyncDebounce} from 'indico/utils/debounce';
 
-import {Translate} from '../i18n';
+import {Param, Translate} from '../i18n';
 
 const debounce = makeAsyncDebounce(250);
 
@@ -30,7 +33,9 @@ const titles = [
   {text: Translate.string('Mx'), value: 'mx'},
 ];
 
-const FinalAffiliationField = ({hasPredefinedAffiliations, currentAffiliation}) => {
+const FinalAffiliationField = ({hasPredefinedAffiliations}) => {
+  const formState = useFormState();
+  const currentAffiliation = formState.values.affiliationMeta;
   const [_affiliationResults, setAffiliationResults] = useState([]);
   const affiliationResults =
     currentAffiliation && !_affiliationResults.find(x => x.id === currentAffiliation.id)
@@ -88,11 +93,6 @@ const FinalAffiliationField = ({hasPredefinedAffiliations, currentAffiliation}) 
 
 FinalAffiliationField.propTypes = {
   hasPredefinedAffiliations: PropTypes.bool.isRequired,
-  currentAffiliation: PropTypes.object,
-};
-
-FinalAffiliationField.defaultProps = {
-  currentAffiliation: null,
 };
 
 export default function PersonDetailsModal({
@@ -100,8 +100,12 @@ export default function PersonDetailsModal({
   onSubmit,
   onClose,
   person,
+  eventId,
+  otherPersons,
   hideEmailField,
 }) {
+  const shouldValidateEmail = eventId !== null;
+  const emailValidateUrl = useMemo(() => validateEmailURL({event_id: eventId}), [eventId]);
   return (
     <FinalModalForm
       id="person-link-details"
@@ -113,7 +117,7 @@ export default function PersonDetailsModal({
       initialValues={
         person
           ? {...person, affiliationData: {id: person.affiliationId, text: person.affiliation}}
-          : {affiliationData: {id: null, text: ''}}
+          : {affiliationData: {id: null, text: ''}, email: ''}
       }
     >
       {/* eslint-disable-next-line eqeqeq */}
@@ -130,10 +134,7 @@ export default function PersonDetailsModal({
         </Form.Field>
         <Form.Field>
           <Translate as="label">Affiliation</Translate>
-          <FinalAffiliationField
-            currentAffiliation={person?.affiliationMeta}
-            hasPredefinedAffiliations={hasPredefinedAffiliations}
-          />
+          <FinalAffiliationField hasPredefinedAffiliations={hasPredefinedAffiliations} />
         </Form.Field>
       </Form.Group>
       <Form.Group widths="equal">
@@ -149,7 +150,12 @@ export default function PersonDetailsModal({
       {!hideEmailField && (
         <Form.Field>
           <Translate as="label">Email</Translate>
-          <FinalInput name="email" />
+          <EmailField
+            shouldValidate={shouldValidateEmail}
+            validateUrl={emailValidateUrl}
+            person={person}
+            otherPersons={otherPersons}
+          />
         </Form.Field>
       )}
       <Form.Group widths="equal">
@@ -170,11 +176,166 @@ PersonDetailsModal.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   person: PropTypes.object,
+  eventId: PropTypes.number,
+  otherPersons: PropTypes.array,
   hasPredefinedAffiliations: PropTypes.bool.isRequired,
   hideEmailField: PropTypes.bool,
 };
 
 PersonDetailsModal.defaultProps = {
   person: undefined,
+  eventId: null,
+  otherPersons: [],
   hideEmailField: false,
+};
+
+function EmailField({shouldValidate, validateUrl, person, otherPersons}) {
+  let response, msg;
+  const [message, setMessage] = useState({status: '', message: ''});
+  const form = useForm();
+  const [user, setUser] = useState(null);
+  const [eventPerson, setEventPerson] = useState(null);
+  const isUpdate = !!person;
+
+  const validateEmail = useDebouncedAsyncValidate(async email => {
+    form.change('personId', person?.personId);
+    email = email.trim();
+
+    if (email === '' || email === person?.email) {
+      setMessage({status: '', message: ''});
+      return;
+    }
+
+    // Prevent adding the same person twice
+    if (otherPersons.some(p => p.email === email)) {
+      msg = Translate.string('There is already a person with this email in the list.');
+      setMessage({
+        status: 'error',
+        message: msg,
+      });
+      return msg;
+    }
+
+    setMessage({
+      status: '',
+      message: Translate.string('Checking email address...'),
+    });
+
+    try {
+      response = await indicoAxios.get(validateUrl, {
+        params: {email},
+      });
+    } catch (error) {
+      return handleAxiosError(error);
+    }
+
+    const {data} = response;
+    const {status, conflict} = data;
+    setUser(data.user);
+    setEventPerson(data.event_person);
+
+    if (conflict === 'person-already-exists' || conflict === 'user-and-person-already-exists') {
+      form.change('personId', data.event_person.id);
+    }
+
+    if (conflict === 'user-already-exists' || conflict === 'user-and-person-already-exists') {
+      form.change('avatarURL', data.user.avatar_url);
+    }
+
+    if (
+      conflict === 'user-already-exists' ||
+      conflict === 'person-already-exists' ||
+      conflict === 'user-and-person-already-exists'
+    ) {
+      const obj = data.event_person || data.user;
+      const name = obj.full_name || obj.name;
+      if (isUpdate) {
+        msg = (
+          <Translate>
+            This email is already used by <Param name="name" wrapper={<strong />} value={name} />.
+            You can update the form with their information.
+          </Translate>
+        );
+      } else {
+        msg = (
+          <Translate>
+            This email is already used by <Param name="name" wrapper={<strong />} value={name} />.
+            You can add the person directly or update the form with their information.
+          </Translate>
+        );
+      }
+    } else if (conflict === 'email-invalid') {
+      if (data.email_error === 'undeliverable') {
+        msg = Translate.string('The domain used in the email address does not exist.');
+      } else {
+        msg = Translate.string('This email address is invalid.');
+      }
+    } else if (status === 'ok') {
+      msg = Translate.string('This email is currently not linked to this event.');
+    }
+
+    setMessage({status, message: msg});
+    if (status === 'error') {
+      setMessage({status, message: msg});
+      return msg;
+    }
+  }, 250);
+
+  const onClick = async () => {
+    const obj = eventPerson || user;
+    form.change('address', obj.address);
+    form.change('firstName', obj.first_name);
+    form.change('lastName', obj.last_name);
+    form.change('title', obj.title);
+    form.change('phone', obj.phone);
+    form.change('affiliationData', {id: obj.affiliation_id, text: obj.affiliation});
+    form.change('affiliationMeta', obj.affiliation_meta);
+  };
+
+  const emailBtn = (
+    <div style={{textAlign: 'right'}}>
+      {!isUpdate && (
+        <Button type="submit" primary size="tiny" onClick={onClick}>
+          <Translate>Add</Translate>
+        </Button>
+      )}
+      <Button type="button" size="tiny" onClick={onClick}>
+        <Translate>Update</Translate>
+      </Button>
+    </div>
+  );
+
+  return (
+    <FinalInput
+      type="email"
+      name="email"
+      validate={shouldValidate ? validateEmail : undefined}
+      // hide the normal error tooltip if we have an error from our async validation
+      hideValidationError={message.status === 'error' ? 'message' : false}
+      loaderWhileValidating
+    >
+      {!!message.message && (
+        <Message
+          visible
+          error={message.status === 'error'}
+          warning={message.status === 'warning'}
+          positive={message.status === 'ok'}
+        >
+          <div>{message.message}</div>
+          {(!!user || !!eventPerson) && emailBtn}
+        </Message>
+      )}
+    </FinalInput>
+  );
+}
+
+EmailField.propTypes = {
+  validateUrl: PropTypes.string.isRequired,
+  shouldValidate: PropTypes.bool.isRequired,
+  person: PropTypes.object,
+  otherPersons: PropTypes.array.isRequired,
+};
+
+EmailField.defaultProps = {
+  person: null,
 };

--- a/indico/web/client/js/react/components/PersonDetailsModal.module.scss
+++ b/indico/web/client/js/react/components/PersonDetailsModal.module.scss
@@ -1,0 +1,17 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+.email-buttons {
+  text-align: right;
+  margin-top: 1em;
+
+  button {
+    // SUI adds '.left' and '.right' classes which coincide with
+    // _core.scss definitions that apply float
+    float: unset;
+  }
+}

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -361,11 +361,7 @@ function PersonLinkField({
               onClose={onClose}
               onSubmit={onSubmit}
               person={persons[selected]}
-              otherPersons={
-                selected !== null
-                  ? persons.filter(p => p.email !== persons[selected].email)
-                  : persons
-              }
+              otherPersons={selected === null ? persons : _.without(persons, persons[selected])}
               hasPredefinedAffiliations={hasPredefinedAffiliations}
               validateEmailUrl={validateEmailUrl}
             />

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -234,6 +234,7 @@ function PersonLinkField({
   hasPredefinedAffiliations,
   canEnterManually,
   defaultSearchExternal,
+  validateEmailUrl,
 }) {
   const [favoriteUsers] = useFavoriteUsers(null, !sessionUser);
   const [modalOpen, setModalOpen] = useState(false);
@@ -360,13 +361,13 @@ function PersonLinkField({
               onClose={onClose}
               onSubmit={onSubmit}
               person={persons[selected]}
-              eventId={eventId}
               otherPersons={
                 selected !== null
                   ? persons.filter(p => p.email !== persons[selected].email)
                   : persons
               }
               hasPredefinedAffiliations={hasPredefinedAffiliations}
+              validateEmailUrl={validateEmailUrl}
             />
           )}
         </Button.Group>
@@ -387,6 +388,7 @@ PersonLinkField.propTypes = {
   hasPredefinedAffiliations: PropTypes.bool,
   canEnterManually: PropTypes.bool,
   defaultSearchExternal: PropTypes.bool,
+  validateEmailUrl: PropTypes.string,
 };
 
 PersonLinkField.defaultProps = {
@@ -399,6 +401,7 @@ PersonLinkField.defaultProps = {
   hasPredefinedAffiliations: false,
   canEnterManually: true,
   defaultSearchExternal: false,
+  validateEmailUrl: null,
 };
 
 export function WTFPersonLinkField({
@@ -411,6 +414,7 @@ export function WTFPersonLinkField({
   hasPredefinedAffiliations,
   canEnterManually,
   defaultSearchExternal,
+  validateEmailUrl,
 }) {
   const [persons, setPersons] = useState(
     defaultValue.sort((a, b) => a.displayOrder - b.displayOrder)
@@ -465,6 +469,7 @@ export function WTFPersonLinkField({
       hasPredefinedAffiliations={hasPredefinedAffiliations}
       canEnterManually={canEnterManually}
       defaultSearchExternal={defaultSearchExternal}
+      validateEmailUrl={validateEmailUrl}
     />
   );
 }
@@ -479,6 +484,7 @@ WTFPersonLinkField.propTypes = {
   hasPredefinedAffiliations: PropTypes.bool,
   canEnterManually: PropTypes.bool,
   defaultSearchExternal: PropTypes.bool,
+  validateEmailUrl: PropTypes.string,
 };
 
 WTFPersonLinkField.defaultProps = {
@@ -490,4 +496,5 @@ WTFPersonLinkField.defaultProps = {
   hasPredefinedAffiliations: false,
   canEnterManually: true,
   defaultSearchExternal: false,
+  validateEmailUrl: null,
 };

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -360,6 +360,12 @@ function PersonLinkField({
               onClose={onClose}
               onSubmit={onSubmit}
               person={persons[selected]}
+              eventId={eventId}
+              otherPersons={
+                selected !== null
+                  ? persons.filter(p => p.email !== persons[selected].email)
+                  : persons
+              }
               hasPredefinedAffiliations={hasPredefinedAffiliations}
             />
           )}

--- a/indico/web/templates/forms/person_link_widget.html
+++ b/indico/web/templates/forms/person_link_widget.html
@@ -30,7 +30,8 @@
             hasPredefinedAffiliations: {{ field.has_predefined_affiliations | tojson }},
             canEnterManually: {{ field.can_enter_manually | tojson }},
             defaultSearchExternal: {{ field.default_search_external | tojson }},
-            sessionUser: Indico.User
+            sessionUser: Indico.User,
+            validateEmailUrl: {{ field.validate_email_url | tojson }},
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
 - Email is not mandatory, but if used it is checked like in registrations
 - Prevents adding two people with the same email
 - Checks for secondary emails and prevents adding the same user with a different email
 - Warns if the person already has an Indico account
 - Warns if the person is already linked to the event - in this case if there is already a person link, it will be updated with the new data and the old link will be deleted. This takes care of the issue where there are existing person links linked to deleted objects preventing users from changing emails when updating person links.

![image](https://user-images.githubusercontent.com/8739637/195558875-f301eae5-55b0-40a8-9b04-0078e8284788.png)
![image](https://user-images.githubusercontent.com/8739637/195559226-3b0fe953-6669-4f86-8349-a54c9144ecea.png)
![image](https://user-images.githubusercontent.com/8739637/187206158-75ee09dd-f5ca-4f62-8e42-99ffcc1cbbf6.png)
![image](https://user-images.githubusercontent.com/8739637/204815834-d5fbf75f-ad4b-4af0-a3b2-a0151d7a2cb6.png)


