### PR TITLE
Fix incorrect width & height calculation in badges

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Bugfixes
 
 - Fix meeting minutes being shown when they are expected to be hidden (:pr:`5475`)
 - Force default locale when generating Book of Abstracts (:pr:`5477`)
+- Fix width and height calculation when printing badges (:pr:`5479`)
 
 
 Version 3.2

--- a/indico/modules/events/registration/badges.py
+++ b/indico/modules/events/registration/badges.py
@@ -51,9 +51,11 @@ class RegistrantsListToBadgesPDF(DesignerPDFBase):
         config = self.config
 
         available_width = self.width - (config.left_margin + config.right_margin + config.margin_columns) * cm
-        n_horizontal = int(available_width / ((self.tpl_data.width_cm + config.margin_columns) * cm))
+        n_horizontal = int((available_width + config.margin_columns*cm) /
+                           ((self.tpl_data.width_cm + config.margin_columns) * cm))
         available_height = self.height - (config.top_margin + config.bottom_margin + config.margin_rows) * cm
-        n_vertical = int(available_height / ((self.tpl_data.height_cm + config.margin_rows) * cm))
+        n_vertical = int((available_height + config.margin_rows*cm) /
+                         ((self.tpl_data.height_cm + config.margin_rows) * cm))
 
         if not n_horizontal or not n_vertical:
             raise BadRequest(_('The template dimensions are too large for the page size you selected'))
@@ -147,9 +149,11 @@ class RegistrantsListToBadgesPDFDoubleSided(RegistrantsListToBadgesPDF):
         config = self.config
 
         available_width = self.width - (config.left_margin + config.right_margin + config.margin_columns) * cm
-        n_horizontal = int(available_width / ((self.tpl_data.width_cm + config.margin_columns) * cm))
+        n_horizontal = int((available_width + config.margin_columns*cm) /
+                           ((self.tpl_data.width_cm + config.margin_columns) * cm))
         available_height = self.height - (config.top_margin + config.bottom_margin + config.margin_rows) * cm
-        n_vertical = int(available_height / ((self.tpl_data.height_cm + config.margin_rows) * cm))
+        n_vertical = int((available_height + config.margin_rows*cm) /
+                         ((self.tpl_data.height_cm + config.margin_rows) * cm))
 
         if not n_horizontal or not n_vertical:
             raise BadRequest(_('The template dimensions are too large for the page size you selected'))


### PR DESCRIPTION
When calculating how many columns of badges fit on a page,
the column margin between badges is counted for each badge while it should only count (N-1)-times.