### PR TITLE
Add tests for plaintext emails

### DIFF
--- a/indico/modules/events/agreements/notifications_test.py
+++ b/indico/modules/events/agreements/notifications_test.py
@@ -1,0 +1,32 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from pathlib import Path
+
+import pytest
+
+from indico.modules.events.agreements.models.agreements import AgreementState
+from indico.web.flask.templating import get_template_module
+
+
+pytest_plugins = 'indico.modules.events.agreements.testing.fixtures'
+
+
+@pytest.mark.parametrize(('state', 'reason', 'snapshot_name'), (
+    (AgreementState.rejected, '', 'email_to_managers_rejected_no_reason.txt'),
+    (AgreementState.accepted, '', 'email_to_managers_accepted_no_reason.txt'),
+    (AgreementState.accepted, 'I accept this.\n:)', 'email_to_managers_accepted_reason.txt'),
+    (AgreementState.rejected, 'I do not accept this.\n>:(', 'email_to_managers_rejected_reason.txt'),
+))
+@pytest.mark.usefixtures('request_context')
+def test_signature_email_to_manager_plaintext(snapshot, dummy_agreement, state, reason, snapshot_name):
+    dummy_agreement.state = state
+    dummy_agreement.reason = reason
+    template = get_template_module('events/agreements/emails/new_signature_email_to_manager.txt',
+                                   agreement=dummy_agreement)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), snapshot_name)

--- a/indico/modules/events/agreements/templates/emails/tests/email_to_managers_accepted_no_reason.txt
+++ b/indico/modules/events/agreements/templates/emails/tests/email_to_managers_accepted_no_reason.txt
@@ -1,0 +1,13 @@
+Dear event managers,
+
+A new agreement has been accepted for the event:
+dummy#0
+
+Person Info
+-----------
+Name:  dummy
+Email: dummy@test.com
+
+--
+Indico :: Agreements
+http://localhost/

--- a/indico/modules/events/agreements/templates/emails/tests/email_to_managers_accepted_reason.txt
+++ b/indico/modules/events/agreements/templates/emails/tests/email_to_managers_accepted_reason.txt
@@ -1,0 +1,18 @@
+Dear event managers,
+
+A new agreement has been accepted for the event:
+dummy#0
+
+Person Info
+-----------
+Name:  dummy
+Email: dummy@test.com
+
+Reason
+------
+I accept this.
+:)
+
+--
+Indico :: Agreements
+http://localhost/

--- a/indico/modules/events/agreements/templates/emails/tests/email_to_managers_rejected_no_reason.txt
+++ b/indico/modules/events/agreements/templates/emails/tests/email_to_managers_rejected_no_reason.txt
@@ -1,0 +1,13 @@
+Dear event managers,
+
+A new agreement has been rejected for the event:
+dummy#0
+
+Person Info
+-----------
+Name:  dummy
+Email: dummy@test.com
+
+--
+Indico :: Agreements
+http://localhost/

--- a/indico/modules/events/agreements/templates/emails/tests/email_to_managers_rejected_reason.txt
+++ b/indico/modules/events/agreements/templates/emails/tests/email_to_managers_rejected_reason.txt
@@ -1,0 +1,18 @@
+Dear event managers,
+
+A new agreement has been rejected for the event:
+dummy#0
+
+Person Info
+-----------
+Name:  dummy
+Email: dummy@test.com
+
+Reason
+------
+I do not accept this.
+>:(
+
+--
+Indico :: Agreements
+http://localhost/

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -768,7 +768,7 @@ class RHManageDescriptionField(RHManageContributionsBase):
 
 class RHCreateReferenceMixin:
     """
-    Common methods for RH class creating a ContibutionReference
+    Common methods for RH class creating a ContributionReference
     or SubContributionReference.
     """
 

--- a/indico/modules/events/editing/notifications_test.py
+++ b/indico/modules/events/editing/notifications_test.py
@@ -1,0 +1,52 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from pathlib import Path
+
+from indico.web.flask.templating import get_template_module
+
+
+def _assert_snapshot(snapshot, template_name, **context):
+    __tracebackhide__ = True
+    template = get_template_module(f'events/editing/emails/{template_name}', **context)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), template_name)
+
+
+def test_confirmation_email_plaintext(snapshot):
+    _assert_snapshot(snapshot, 'submitter_confirmation_notification.txt',
+                     recipient_name='John Doe',
+                     submitter_name='Jane Doe',
+                     timeline_url='http://localhost/timeline-url')
+
+
+def test_comment_email_plaintext(snapshot):
+    _assert_snapshot(snapshot, 'comment_notification.txt',
+                     recipient_name='John Doe',
+                     author_name='Jane Doe',
+                     timeline_url='http://localhost/timeline-url')
+
+
+def test_upload_email_plaintext(snapshot):
+    _assert_snapshot(snapshot, 'submitter_upload_notification.txt',
+                     recipient_name='John Doe',
+                     submitter_name='Jane Doe',
+                     timeline_url='http://localhost/timeline-url')
+
+
+def test_rejection_email_plaintext(snapshot):
+    _assert_snapshot(snapshot, 'submitter_rejection_notification.txt',
+                     recipient_name='John Doe',
+                     submitter_name='Jane Doe',
+                     timeline_url='http://localhost/timeline-url')
+
+
+def test_judgement_email_plaintext(snapshot):
+    _assert_snapshot(snapshot, 'editor_judgment_notification.txt',
+                     recipient_name='John Doe',
+                     editor_name='Jane Doe',
+                     timeline_url='http://localhost/timeline-url')

--- a/indico/modules/events/editing/templates/emails/tests/comment_notification.txt
+++ b/indico/modules/events/editing/templates/emails/tests/comment_notification.txt
@@ -1,0 +1,10 @@
+Dear John Doe,
+
+Jane Doe has posted a new comment.
+
+You can view details on the following URL:
+http://localhost/timeline-url
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/events/editing/templates/emails/tests/editor_judgment_notification.txt
+++ b/indico/modules/events/editing/templates/emails/tests/editor_judgment_notification.txt
@@ -1,0 +1,10 @@
+Dear John Doe,
+
+Jane Doe has left a judgment to an editable you are submitter of.
+
+You can view details on the following URL:
+http://localhost/timeline-url
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/events/editing/templates/emails/tests/submitter_confirmation_notification.txt
+++ b/indico/modules/events/editing/templates/emails/tests/submitter_confirmation_notification.txt
@@ -1,0 +1,10 @@
+Dear John Doe,
+
+Your revision changes have been confirmed by Jane Doe.
+
+You can view details on the following URL:
+http://localhost/timeline-url
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/events/editing/templates/emails/tests/submitter_rejection_notification.txt
+++ b/indico/modules/events/editing/templates/emails/tests/submitter_rejection_notification.txt
@@ -1,0 +1,10 @@
+Dear John Doe,
+
+Your revision changes have been rejected by Jane Doe.
+
+You can view details on the following URL:
+http://localhost/timeline-url
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/events/editing/templates/emails/tests/submitter_upload_notification.txt
+++ b/indico/modules/events/editing/templates/emails/tests/submitter_upload_notification.txt
@@ -1,0 +1,10 @@
+Dear John Doe,
+
+Jane Doe has uploaded a new revision to an editable you are editor of.
+
+You can view details on the following URL:
+http://localhost/timeline-url
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/events/notifications_test.py
+++ b/indico/modules/events/notifications_test.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -44,3 +45,12 @@ def test_move_request_closed_email_plaintext(snapshot, create_category, create_e
                                    events=events, target_category=cat, accept=accept, reason=reason)
     snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
     snapshot.assert_match(template.get_body(), snapshot_name)
+
+
+def test_event_creation_email_plaintext(snapshot, dummy_event):
+    dummy_event.start_dt = datetime(2022, 11, 11, 13, 37)
+    dummy_event.end_dt = datetime(2022, 11, 11, 22, 22)
+    template = get_template_module('events/emails/event_creation.txt',
+                                   event=dummy_event, occurrences=None)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), 'event_creation.txt')

--- a/indico/modules/events/payment/notifications_test.py
+++ b/indico/modules/events/payment/notifications_test.py
@@ -1,0 +1,27 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from pathlib import Path
+
+import pytest
+from flask import render_template
+
+from indico.modules.events.features.util import set_feature_enabled
+
+
+pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
+
+
+@pytest.mark.usefixtures('request_context')
+def test_inconsistency_email_to_manager_plaintext(snapshot, dummy_event, dummy_reg):
+    set_feature_enabled(dummy_event, 'registration', True)
+    dummy_reg.base_price = 1337
+    dummy_reg.currency = 'USD'
+    template = render_template('events/payment/emails/payment_inconsistency_email_to_manager.txt',
+                               event=dummy_event, registration=dummy_reg, amount=404, currency='EUR')
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template, 'payment_inconsistency_email_to_manager.txt')

--- a/indico/modules/events/payment/templates/emails/payment_inconsistency_email_to_manager.txt
+++ b/indico/modules/events/payment/templates/emails/payment_inconsistency_email_to_manager.txt
@@ -1,7 +1,7 @@
 Dear manager of the event {{ event.title }},
 
 It appears that the payment of the registration with ID {{ registration.friendly_id }} has an incorrect
-amount of money (received {{ format_currency(amount, currency, locale='en_GB') }} while expecting {{ registration.render_price() }}.
+amount of money (received {{ format_currency(amount, currency, locale='en_GB') }} while expecting {{ registration.render_price() }}).
 Please, check with the registrant to see if there was some misunderstanding.
 
 Regards.

--- a/indico/modules/events/payment/templates/emails/tests/payment_inconsistency_email_to_manager.txt
+++ b/indico/modules/events/payment/templates/emails/tests/payment_inconsistency_email_to_manager.txt
@@ -1,0 +1,7 @@
+Dear manager of the event dummy#0,
+
+It appears that the payment of the registration with ID 1 has an incorrect
+amount of money (received €404.00 while expecting US$1,337.00).
+Please, check with the registrant to see if there was some misunderstanding.
+
+Regards.

--- a/indico/modules/events/reminders/notifications_test.py
+++ b/indico/modules/events/reminders/notifications_test.py
@@ -1,0 +1,29 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from indico.web.flask.templating import get_template_module
+
+
+pytest_plugins = 'indico.modules.events.timetable.testing.fixtures'
+
+
+def test_event_reminder_email_plaintext(snapshot, create_contribution, create_entry, create_event):
+    event = create_event(start_dt=datetime(2022, 11, 11, 13, 37),
+                         end_dt=datetime(2022, 11, 11, 23, 37), title='Baking with Cats')
+    c1 = create_contribution(event, 'Kneading Dough', timedelta(minutes=23))
+    c2 = create_contribution(event, 'Pure Bread Cats', timedelta(minutes=40))
+    create_entry(c1, datetime(2022, 11, 11, 13, 37))
+    create_entry(c2, datetime(2022, 11, 11, 15, 50))
+    agenda = event.timetable_entries.filter_by(parent_id=None).all()
+    template = get_template_module('events/reminders/emails/event_reminder.txt',
+                                   event=event, url='http://localhost/', with_description=True,
+                                   note='Meow.\nNyah!', with_agenda=True, agenda=agenda)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), 'event_reminder.txt')

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder.txt
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder.txt
@@ -1,0 +1,21 @@
+Please note that the event "Baking with Cats" will start on 11 Nov 2022, 13:37 (UTC).
+
+You can access the full event here:
+http://localhost/
+
+
+Note
+----
+Meow.
+Nyah!
+
+
+Agenda for Baking with Cats
+---------------------------
+
+- [13:37 - 14:00] Kneading Dough
+- [15:50 - 16:30] Pure Bread Cats
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/events/requests/notifications_test.py
+++ b/indico/modules/events/requests/notifications_test.py
@@ -1,0 +1,81 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from indico.web.flask.templating import get_template_module
+
+
+@pytest.mark.parametrize(('snapshot_name'), (
+    'accepted_to_event_managers.txt',
+    'accepted_to_request_managers.txt',
+))
+def test_accepted_emails_plaintext(snapshot, snapshot_name, dummy_event):
+    request = {'definition': {'title': 'More cats'}, 'comment': 'Meow',
+               'created_by_user': {'full_name': 'Arthas Menethil', 'phone': '1337',
+                                   'email': 'arthas@frozenthrone.wow'},
+               'event_id': dummy_event.id, 'type': dummy_event.type}
+    dummy_event.start_dt = datetime(2022, 11, 11, 13, 37)
+    dummy_event.end_dt = datetime(2022, 11, 13, 13, 37)
+    template = get_template_module(f'events/requests/emails/{snapshot_name}',
+                                   req=request, event=dummy_event)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), snapshot_name)
+
+
+@pytest.mark.parametrize(('snapshot_name'), (
+    'new_modified_to_event_managers.txt',
+    'new_modified_to_request_managers.txt',
+))
+def test_new_modified_emails_plaintext(snapshot, snapshot_name, dummy_event):
+    request = {'definition': {'title': 'More cats'}, 'comment': 'Meow',
+               'created_by_user': {'full_name': 'Arthas Menethil', 'phone': '1337',
+                                   'email': 'arthas@frozenthrone.wow'},
+               'event_id': dummy_event.id, 'type': dummy_event.type}
+    dummy_event.start_dt = datetime(2022, 11, 11, 13, 37)
+    dummy_event.end_dt = datetime(2022, 11, 13, 13, 37)
+    template = get_template_module(f'events/requests/emails/{snapshot_name}',
+                                   req=request, event=dummy_event, new=False)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), snapshot_name)
+
+
+@pytest.mark.parametrize(('snapshot_name'), (
+    'rejected_to_event_managers.txt',
+    'rejected_to_request_managers.txt',
+))
+def test_rejected_emails_plaintext(snapshot, snapshot_name, dummy_event):
+    request = {'definition': {'title': 'More cats'}, 'comment': 'Meow',
+               'created_by_user': {'full_name': 'Arthas Menethil', 'phone': '1337',
+                                   'email': 'arthas@frozenthrone.wow'},
+               'event_id': dummy_event.id, 'type': dummy_event.type}
+    dummy_event.start_dt = datetime(2022, 11, 11, 13, 37)
+    dummy_event.end_dt = datetime(2022, 11, 13, 13, 37)
+    template = get_template_module(f'events/requests/emails/{snapshot_name}',
+                                   req=request, event=dummy_event)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), snapshot_name)
+
+
+@pytest.mark.parametrize(('snapshot_name'), (
+    'withdrawn_to_event_managers.txt',
+    'withdrawn_to_request_managers.txt',
+))
+def test_withdrawn_emails_plaintext(snapshot, snapshot_name, dummy_event):
+    request = {'definition': {'title': 'More cats'}, 'comment': 'Meow',
+               'created_by_user': {'full_name': 'Arthas Menethil', 'phone': '1337',
+                                   'email': 'arthas@frozenthrone.wow'},
+               'event_id': dummy_event.id, 'type': dummy_event.type}
+    dummy_event.start_dt = datetime(2022, 11, 11, 13, 37)
+    dummy_event.end_dt = datetime(2022, 11, 13, 13, 37)
+    template = get_template_module(f'events/requests/emails/{snapshot_name}',
+                                   req=request, event=dummy_event)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), snapshot_name)

--- a/indico/modules/events/requests/templates/emails/tests/accepted_to_event_managers.txt
+++ b/indico/modules/events/requests/templates/emails/tests/accepted_to_event_managers.txt
@@ -1,0 +1,13 @@
+Dear event managers,
+
+The More cats request for your event has been accepted.
+Comment: Meow
+
+Event: dummy#0
+Requested by: Arthas Menethil
+Details: http://localhost/event/0/manage/requests/meeting/?comment=Meow&created_by_user=%7B'full_name'%3A+'Arthas+Menethil',+'phone'%3A+'1337',+'email'%3A+'arthas%40frozenthrone.wow'%7D&definition=%7B'title'%3A+'More+cats'%7D
+
+
+--
+Indico :: Service Requests
+http://localhost/

--- a/indico/modules/events/requests/templates/emails/tests/accepted_to_request_managers.txt
+++ b/indico/modules/events/requests/templates/emails/tests/accepted_to_request_managers.txt
@@ -1,0 +1,26 @@
+A More cats request has been accepted.
+Comment: Meow
+http://localhost/event/0/manage/requests/meeting/?comment=Meow&created_by_user=%7B'full_name'%3A+'Arthas+Menethil',+'phone'%3A+'1337',+'email'%3A+'arthas%40frozenthrone.wow'%7D&definition=%7B'title'%3A+'More+cats'%7D
+
+Requested by
+------------
+Name:     Arthas Menethil
+Email:    arthas@frozenthrone.wow
+Phone:    1337
+
+Event created by
+----------------
+Name:     Guinea Pig
+Email:    1337@example.test
+
+Event details
+-------------
+Name:     dummy#0
+Dates:    11 Nov 2022, 13:37 - 13 Nov 2022, 13:37
+Location: 
+Details:  http://localhost/event/0/
+
+
+--
+Indico :: Service Requests
+http://localhost/

--- a/indico/modules/events/requests/templates/emails/tests/new_modified_to_event_managers.txt
+++ b/indico/modules/events/requests/templates/emails/tests/new_modified_to_event_managers.txt
@@ -1,0 +1,12 @@
+Dear event managers,
+
+A More cats request for your event has been modified.
+
+Event: dummy#0
+Requested by: Arthas Menethil
+Details: http://localhost/event/0/manage/requests/meeting/?comment=Meow&created_by_user=%7B'full_name'%3A+'Arthas+Menethil',+'phone'%3A+'1337',+'email'%3A+'arthas%40frozenthrone.wow'%7D&definition=%7B'title'%3A+'More+cats'%7D
+
+
+--
+Indico :: Service Requests
+http://localhost/

--- a/indico/modules/events/requests/templates/emails/tests/new_modified_to_request_managers.txt
+++ b/indico/modules/events/requests/templates/emails/tests/new_modified_to_request_managers.txt
@@ -1,0 +1,25 @@
+A More cats request has been modified.
+http://localhost/event/0/manage/requests/meeting/?comment=Meow&created_by_user=%7B'full_name'%3A+'Arthas+Menethil',+'phone'%3A+'1337',+'email'%3A+'arthas%40frozenthrone.wow'%7D&definition=%7B'title'%3A+'More+cats'%7D
+
+Requested by
+------------
+Name:     Arthas Menethil
+Email:    arthas@frozenthrone.wow
+Phone:    1337
+
+Event created by
+----------------
+Name:     Guinea Pig
+Email:    1337@example.test
+
+Event details
+-------------
+Name:     dummy#0
+Dates:    11 Nov 2022, 13:37 - 13 Nov 2022, 13:37
+Location: 
+Details:  http://localhost/event/0/
+
+
+--
+Indico :: Service Requests
+http://localhost/

--- a/indico/modules/events/requests/templates/emails/tests/rejected_to_event_managers.txt
+++ b/indico/modules/events/requests/templates/emails/tests/rejected_to_event_managers.txt
@@ -1,0 +1,13 @@
+Dear event managers,
+
+The More cats request for your event has been rejected.
+Comment: Meow
+
+Event: dummy#0
+Requested by: Arthas Menethil
+Details: http://localhost/event/0/manage/requests/meeting/?comment=Meow&created_by_user=%7B'full_name'%3A+'Arthas+Menethil',+'phone'%3A+'1337',+'email'%3A+'arthas%40frozenthrone.wow'%7D&definition=%7B'title'%3A+'More+cats'%7D
+
+
+--
+Indico :: Service Requests
+http://localhost/

--- a/indico/modules/events/requests/templates/emails/tests/rejected_to_request_managers.txt
+++ b/indico/modules/events/requests/templates/emails/tests/rejected_to_request_managers.txt
@@ -1,0 +1,26 @@
+A More cats request has been rejected.
+Comment: Meow
+http://localhost/event/0/manage/requests/meeting/?comment=Meow&created_by_user=%7B'full_name'%3A+'Arthas+Menethil',+'phone'%3A+'1337',+'email'%3A+'arthas%40frozenthrone.wow'%7D&definition=%7B'title'%3A+'More+cats'%7D
+
+Requested by
+------------
+Name:     Arthas Menethil
+Email:    arthas@frozenthrone.wow
+Phone:    1337
+
+Event created by
+----------------
+Name:     Guinea Pig
+Email:    1337@example.test
+
+Event details
+-------------
+Name:     dummy#0
+Dates:    11 Nov 2022, 13:37 - 13 Nov 2022, 13:37
+Location: 
+Details:  http://localhost/event/0/
+
+
+--
+Indico :: Service Requests
+http://localhost/

--- a/indico/modules/events/requests/templates/emails/tests/withdrawn_to_event_managers.txt
+++ b/indico/modules/events/requests/templates/emails/tests/withdrawn_to_event_managers.txt
@@ -1,0 +1,12 @@
+Dear event managers,
+
+The More cats request for your event has been withdrawn.
+
+Event: dummy#0
+Requested by: Arthas Menethil
+Details: http://localhost/event/0/manage/requests/meeting/?comment=Meow&created_by_user=%7B'full_name'%3A+'Arthas+Menethil',+'phone'%3A+'1337',+'email'%3A+'arthas%40frozenthrone.wow'%7D&definition=%7B'title'%3A+'More+cats'%7D
+
+
+--
+Indico :: Service Requests
+http://localhost/

--- a/indico/modules/events/requests/templates/emails/tests/withdrawn_to_request_managers.txt
+++ b/indico/modules/events/requests/templates/emails/tests/withdrawn_to_request_managers.txt
@@ -1,0 +1,25 @@
+A More cats request has been withdrawn.
+http://localhost/event/0/manage/requests/meeting/?comment=Meow&created_by_user=%7B'full_name'%3A+'Arthas+Menethil',+'phone'%3A+'1337',+'email'%3A+'arthas%40frozenthrone.wow'%7D&definition=%7B'title'%3A+'More+cats'%7D
+
+Requested by
+------------
+Name:     Arthas Menethil
+Email:    arthas@frozenthrone.wow
+Phone:    1337
+
+Event created by
+----------------
+Name:     Guinea Pig
+Email:    1337@example.test
+
+Event details
+-------------
+Name:     dummy#0
+Dates:    11 Nov 2022, 13:37 - 13 Nov 2022, 13:37
+Location: 
+Details:  http://localhost/event/0/
+
+
+--
+Indico :: Service Requests
+http://localhost/

--- a/indico/modules/events/static/notifications_test.py
+++ b/indico/modules/events/static/notifications_test.py
@@ -1,0 +1,28 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from pathlib import Path
+
+from indico.modules.events.papers.models.revisions import PaperRevisionState
+from indico.web.flask.templating import get_template_module
+
+
+def test_download_notification_email_plaintext(snapshot, dummy_event, dummy_user):
+    template = get_template_module('events/static/emails/download_notification_email.txt',
+                                   event=dummy_event, link='http://localhost/', user=dummy_user)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), 'download_notification_email.txt')
+
+
+def test_paper_judgement_email_plaintext(snapshot, dummy_user, dummy_contribution):
+    revision = {'submitter': dummy_user, 'state': PaperRevisionState.accepted,
+                'judgment_comment': 'This is a\n comment!'}
+    dummy_contribution.id = 0
+    template = get_template_module('events/static/emails/paper_judgment_notification_email.txt',
+                                   paper=revision, contribution=dummy_contribution)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), 'paper_judgment_notification_email.txt')

--- a/indico/modules/events/static/templates/emails/tests/download_notification_email.txt
+++ b/indico/modules/events/static/templates/emails/tests/download_notification_email.txt
@@ -1,0 +1,9 @@
+Dear Guinea,
+
+The offline copy of the event "dummy#0" is ready for download.
+
+Download link: http://localhost/
+
+--
+Indico :: Email Notifier
+http://localhost/event/0/

--- a/indico/modules/events/static/templates/emails/tests/paper_judgment_notification_email.txt
+++ b/indico/modules/events/static/templates/emails/tests/paper_judgment_notification_email.txt
@@ -1,0 +1,18 @@
+Dear Guinea,
+
+
+After the reviewing process your paper "Dummy Contribution (#1)", submitted for "dummy#0" has been accepted.
+
+Please see the comments from the reviewing team below:
+
+This is a
+comment!
+
+You may proceed to your paper page:
+
+
+http://localhost/event/0/papers/0/
+
+--
+Indico :: Email Notifier
+http://localhost/event/0/

--- a/indico/modules/events/surveys/notifications_test.py
+++ b/indico/modules/events/surveys/notifications_test.py
@@ -1,0 +1,37 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from pathlib import Path
+
+from indico.core.db import db
+from indico.modules.events.surveys.models.items import SurveyQuestion, SurveySection
+from indico.modules.events.surveys.models.submissions import SurveySubmission
+from indico.modules.events.surveys.models.surveys import Survey
+from indico.web.flask.templating import get_template_module
+
+
+def test_new_submission_email_plaintext(snapshot, dummy_event, dummy_user):
+    survey = Survey(event=dummy_event, title='test')
+    first_section = SurveySection(title='section 1', display_as_section=True, position=2)
+    survey.items.append(first_section)
+    question = SurveyQuestion(title='question in s1', field_type='text', is_required=True)
+    first_section.children.append(question)
+    submission = SurveySubmission(survey=survey, user=dummy_user)
+    db.session.flush()
+    template = get_template_module('events/surveys/emails/new_submission_email.txt',
+                                   submission=submission)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), 'new_submission_email.txt')
+
+
+def test_start_notification_email_plaintext(snapshot, dummy_event):
+    survey = Survey(event=dummy_event, title='test')
+    db.session.flush()
+    template = get_template_module('events/surveys/emails/start_notification_email.txt',
+                                   survey=survey)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), 'start_notification_email.txt')

--- a/indico/modules/events/surveys/templates/emails/tests/new_submission_email.txt
+++ b/indico/modules/events/surveys/templates/emails/tests/new_submission_email.txt
@@ -1,0 +1,11 @@
+A new submission has been made for the survey "test" on the event "dummy#0" by Guinea Pig.
+
+You can access the new submission here:
+http://localhost/event/0/manage/surveys/3/submission/1
+
+You can access all the submissions by clicking on the link below:
+http://localhost/event/0/manage/surveys/3/
+
+--
+Indico :: Surveys
+http://localhost/event/0/

--- a/indico/modules/events/surveys/templates/emails/tests/start_notification_email.txt
+++ b/indico/modules/events/surveys/templates/emails/tests/start_notification_email.txt
@@ -1,0 +1,8 @@
+The survey "test" on the event "dummy#0" is now open.
+
+You may answer the survey by clicking the link below:
+http://localhost/event/0/surveys/4
+
+--
+Indico :: Surveys
+http://localhost/event/0/

--- a/indico/modules/events/templates/emails/tests/event_creation.txt
+++ b/indico/modules/events/templates/emails/tests/event_creation.txt
@@ -1,0 +1,27 @@
+Title
+-----
+dummy#0
+
+Category
+--------
+Home » dummy
+
+Creator
+-------
+Guinea Pig
+
+Date
+----
+11 Nov 2022
+
+Time
+----
+13:37 - 22:22 (UTC)
+
+URL
+---
+http://localhost/event/0/
+
+--
+Indico :: Event notifications
+


### PR DESCRIPTION
In preparation for my next issue (#5263) I'm already opening the pull request here with some tests for plaintext mails :) 