### PR TITLE
Make dropdowns in category view focusable

### DIFF
--- a/indico/modules/categories/templates/display/base.html
+++ b/indico/modules/categories/templates/display/base.html
@@ -48,7 +48,7 @@
                         <div id="category-calendar-link" data-category-id="{{ category.id }}"></div>
                     {% endblock %}
                     {% block cat_view_dropdown %}
-                        <a class="i-button icon-eye arrow js-dropdown"
+                        <a href="" class="i-button icon-eye arrow js-dropdown"
                            title="{% trans %}View{% endtrans %}"
                            data-toggle="dropdown"></a>
                         <ul class="i-dropdown">

--- a/indico/modules/events/templates/management/_create_event_button.html
+++ b/indico/modules/events/templates/management/_create_event_button.html
@@ -1,5 +1,5 @@
 {% macro create_event_button(category, classes="", text="", with_tooltip=true) %}
-    <a class="{{ classes }} i-button arrow js-dropdown"
+    <a href="" class="{{ classes }} i-button arrow js-dropdown"
        {% if with_tooltip %}title="{% trans %}Create event{% endtrans %}"{% endif %}
        data-toggle="dropdown">
         {{- text -}}


### PR DESCRIPTION
Makes the `Create event` and `Category view` dropdowns focusable