### PR TITLE
Add tests for plaintext mails for roombooking and users

### DIFF
--- a/indico/modules/rb/notifications/notifications_test.py
+++ b/indico/modules/rb/notifications/notifications_test.py
@@ -1,0 +1,137 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import os
+from datetime import date, datetime
+from pathlib import Path
+
+import pytest
+from flask import render_template
+
+from indico.modules.rb.models.blocked_rooms import BlockedRoomState
+from indico.modules.rb.models.reservation_occurrences import ReservationOccurrenceState
+from indico.modules.rb.models.reservations import RepeatFrequency, RepeatMapping
+
+
+pytest_plugins = 'indico.modules.rb.testing.fixtures'
+
+
+def _assert_snapshot(snapshot, template_name, type,  suffix='', /, **context):
+    __tracebackhide__ = True
+    template = render_template(f'rb/emails/{type}/{template_name}', **context)
+    snapshot.snapshot_dir = Path(__file__).parent.parent / f'templates/emails/{type}/tests'
+    snapshot_name, snapshot_ext = os.path.splitext(template_name)
+    snapshot.assert_match(template, snapshot_name + suffix + snapshot_ext)
+
+
+@pytest.mark.parametrize(('suffix', 'rooms'), (
+    ('', 1),
+    ('_rooms', 2),
+))
+def test_blocking_confirmation_email_plaintext(snapshot, dummy_room, dummy_user, create_blocking, suffix, rooms):
+    room = [{'room': dummy_room} for n in range(rooms)]
+    blocking = create_blocking(id=1, start_date=date(2022, 11, 11), end_date=date(2022, 11, 11))
+    _assert_snapshot(snapshot, 'awaiting_confirmation_email_to_manager.txt', 'blockings', suffix,
+                     blocking=blocking, blocked_rooms=room, owner=dummy_user)
+
+
+@pytest.mark.parametrize(('suffix', 'state'), (
+    ('_rejected', BlockedRoomState.rejected),
+    ('_accepted', BlockedRoomState.accepted),
+))
+def test_blocking_state_email_plaintext(snapshot, create_blocking, dummy_room, suffix, state):
+    blocking = create_blocking(id=2)
+    _assert_snapshot(snapshot, 'state_email_to_user.txt', 'blockings', suffix,
+                     blocking=blocking, verb='forgotten',
+                     blocked_room={'room': dummy_room, 'state': state,
+                                   'State': BlockedRoomState})
+
+
+@pytest.mark.parametrize('snapshot_name', (
+    'cancellation_email_to_manager.txt', 'cancellation_email_to_user.txt'
+))
+def test_reservation_cancellation_emails_plaintext(snapshot, snapshot_name, create_reservation):
+    res = create_reservation(id=0, start_dt=datetime(2022, 11, 11, 13, 37), end_dt=datetime(2022, 11, 11, 14, 37))
+    _assert_snapshot(snapshot, snapshot_name, 'reservations', reservation=res)
+
+
+@pytest.mark.parametrize('snapshot_name', (
+    'change_state_email_to_manager.txt', 'change_state_email_to_user.txt'
+))
+def test_reservation_change_state_emails_plaintext(snapshot, snapshot_name, create_reservation):
+    res = create_reservation(id=0, start_dt=datetime(2022, 11, 11, 13, 37), end_dt=datetime(2022, 11, 11, 14, 37))
+    _assert_snapshot(snapshot, snapshot_name, 'reservations', reservation=res)
+
+
+@pytest.mark.parametrize(('snapshot_name', 'suffix', 'reason'), (
+    ('confirmation_email_to_manager.txt', '_reason', 'Because I want to.'),
+    ('confirmation_email_to_user.txt', '_reason', 'Because I want to.'),
+    ('confirmation_email_to_manager.txt', '', ''),
+    ('confirmation_email_to_user.txt', '', '')
+))
+def test_reservation_confirmation_emails_plaintext(snapshot, snapshot_name, create_reservation, suffix, reason):
+    res = create_reservation(id=0, start_dt=datetime(2022, 11, 11, 13, 37), end_dt=datetime(2022, 11, 11, 14, 37))
+    _assert_snapshot(snapshot, snapshot_name, 'reservations', suffix,
+                     reservation=res, reason=reason)
+
+
+@pytest.mark.parametrize(('snapshot_name', 'suffix', 'excluded_days', 'repeat'), (
+    ('creation_email_to_manager.txt', '', None, RepeatFrequency.NEVER),
+    ('creation_email_to_user.txt', '', None, RepeatFrequency.NEVER),
+    ('creation_email_to_user.txt', '_repeat', None, RepeatFrequency.DAY),
+    ('creation_email_to_user.txt', '_repeat_excluded_1', 1, RepeatFrequency.DAY),
+    ('creation_email_to_user.txt', '_repeat_excluded_2', 2, RepeatFrequency.DAY),
+    ('creation_pre_email_to_manager.txt', '', None, RepeatFrequency.NEVER),
+    ('creation_pre_email_to_user.txt', '', None, RepeatFrequency.NEVER),
+    ('creation_pre_email_to_user.txt', '_repeat', None, RepeatFrequency.DAY),
+))
+def test_reservation_creation_emails_plaintext(
+    snapshot, snapshot_name, create_reservation, suffix, excluded_days, repeat
+):
+    res = create_reservation(id=1337, start_dt=datetime(2022, 11, 11, 13, 37), end_dt=datetime(2022, 11, 21, 14, 37),
+                             repeat_frequency=repeat)
+    if excluded_days:
+        for occ in res.occurrences[1:(excluded_days+1)]:
+            occ.state = ReservationOccurrenceState.cancelled
+    _assert_snapshot(snapshot, snapshot_name, 'reservations', suffix, reservation=res,
+                     RepeatMapping=RepeatMapping, RepeatFrequency=RepeatFrequency)
+
+
+@pytest.mark.parametrize('snapshot_name', (
+    'modification_email_to_manager.txt', 'modification_email_to_user.txt'
+))
+def test_reservation_modification_emails_plaintext(snapshot, snapshot_name, create_reservation):
+    res = create_reservation(id=0, start_dt=datetime(2022, 11, 11, 13, 37), end_dt=datetime(2022, 11, 11, 14, 37))
+    _assert_snapshot(snapshot, snapshot_name, 'reservations', reservation=res)
+
+
+@pytest.mark.parametrize('snapshot_name', (
+    'occurrence_cancellation_email_to_manager.txt', 'occurrence_cancellation_email_to_user.txt',
+    'occurrence_rejection_email_to_manager.txt', 'occurrence_rejection_email_to_user.txt'
+))
+def test_reservation_occurrence_emails_plaintext(snapshot, snapshot_name, create_reservation):
+    res = create_reservation(id=0, start_dt=datetime(2022, 11, 11, 13, 37), end_dt=datetime(2022, 11, 12, 14, 37))
+    occurrence = {'start_dt': datetime(2022, 11, 11, 13, 37), 'rejection_reason': 'A valid reason!'}
+    _assert_snapshot(snapshot, snapshot_name, 'reservations', reservation=res, occurrence=occurrence)
+
+
+@pytest.mark.parametrize('snapshot_name', (
+    'rejection_email_to_manager.txt', 'rejection_email_to_user.txt'
+))
+def test_reservation_rejection_emails_plaintext(snapshot, snapshot_name, create_reservation):
+    res = create_reservation(id=0, start_dt=datetime(2022, 11, 11, 13, 37), end_dt=datetime(2022, 11, 11, 14, 37))
+    _assert_snapshot(snapshot, snapshot_name, 'reservations',
+                     reservation=res, reason='Because I want to.')
+
+
+@pytest.mark.parametrize('snapshot_name', (
+    'reservation_info.txt', 'reservation_key_info.txt'
+))
+def test_reservation_emails_plaintext(snapshot, snapshot_name, create_reservation):
+    res = create_reservation(id=0, start_dt=datetime(2022, 11, 11, 13, 37), end_dt=datetime(2022, 11, 11, 14, 37))
+    res.room.key_location = 'In a pocket dimension reachable via interpretative dance.'
+    _assert_snapshot(snapshot, snapshot_name, 'reservations', reservation=res)

--- a/indico/modules/rb/templates/emails/base_email.txt
+++ b/indico/modules/rb/templates/emails/base_email.txt
@@ -1,5 +1,4 @@
 Dear {% block recipient %}{% endblock %},
 
-
 {% block email_body %}{% endblock %}
 {% include 'rb/emails/email_footer.txt' %}

--- a/indico/modules/rb/templates/emails/blockings/tests/awaiting_confirmation_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/blockings/tests/awaiting_confirmation_email_to_manager.txt
@@ -1,0 +1,16 @@
+Dear Guinea,
+
+Guinea Pig has created a blocking for a room you manage.
+
+Room: 1/2-3
+Reason: Blocked
+Dates: 11 Nov 2022 - 11 Nov 2022
+
+You can approve or reject this blocking request here:
+http://localhost/rooms/blocking/1
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/blockings/tests/awaiting_confirmation_email_to_manager_rooms.txt
+++ b/indico/modules/rb/templates/emails/blockings/tests/awaiting_confirmation_email_to_manager_rooms.txt
@@ -1,0 +1,19 @@
+Dear Guinea,
+
+Guinea Pig has created a blocking for some rooms you manage.
+
+Rooms:
+    1/2-3
+    1/2-3
+    
+Reason: Blocked
+Dates: 11 Nov 2022 - 11 Nov 2022
+
+You can approve or reject this blocking request here:
+http://localhost/rooms/blocking/1
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/blockings/tests/state_email_to_user_accepted.txt
+++ b/indico/modules/rb/templates/emails/blockings/tests/state_email_to_user_accepted.txt
@@ -1,0 +1,15 @@
+Dear Guinea,
+
+Your room blocking request has been forgotten by a room manager.
+
+Room: 1/2-3
+Action: forgotten
+
+You can view the details of your blocking here:
+http://localhost/rooms/blocking/2
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/blockings/tests/state_email_to_user_rejected.txt
+++ b/indico/modules/rb/templates/emails/blockings/tests/state_email_to_user_rejected.txt
@@ -1,0 +1,16 @@
+Dear Guinea,
+
+Your room blocking request has been forgotten by a room manager.
+
+Room: 1/2-3
+Action: forgotten
+Reason: (none)
+
+You can view the details of your blocking here:
+http://localhost/rooms/blocking/2
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/cancellation_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/cancellation_email_to_manager.txt
@@ -1,0 +1,12 @@
+Dear Guinea,
+
+A booking in your room '1/2-3' has been CANCELLED by the user.
+
+You can check the details of the booking here:
+http://localhost/rooms/booking/0
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/cancellation_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/cancellation_email_to_user.txt
@@ -1,0 +1,21 @@
+Dear Guinea,
+
+You have CANCELLED your booking:
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Friday 11/11/2022
+Hours:  13:37 - 14:37
+
+Booking details:
+http://localhost/rooms/booking/0
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/change_state_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/change_state_email_to_manager.txt
@@ -1,0 +1,12 @@
+Dear Guinea,
+
+A booking in a room you manage has been MODIFIED and the changes require approval.
+
+You can check the details of the booking here:
+http://localhost/rooms/booking/0
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/change_state_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/change_state_email_to_user.txt
@@ -1,0 +1,21 @@
+Dear Guinea,
+
+Your booking has been MODIFIED and the changes require approval.
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Friday 11/11/2022
+Hours:  13:37 - 14:37
+
+Booking details:
+http://localhost/rooms/booking/0
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/confirmation_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/confirmation_email_to_manager.txt
@@ -1,0 +1,12 @@
+Dear Guinea,
+
+A booking in your room '1/2-3' has been CONFIRMED by a room manager.
+
+You can check the details of the booking here:
+http://localhost/rooms/booking/0
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/confirmation_email_to_manager_reason.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/confirmation_email_to_manager_reason.txt
@@ -1,0 +1,15 @@
+Dear Guinea,
+
+A booking in your room '1/2-3' has been CONFIRMED by a room manager.
+
+The following message was provided by the room manager:
+Because I want to.
+
+You can check the details of the booking here:
+http://localhost/rooms/booking/0
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/confirmation_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/confirmation_email_to_user.txt
@@ -1,0 +1,22 @@
+Dear Guinea,
+
+Your booking has been ACCEPTED.
+This is the final confirmation.
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Friday 11/11/2022
+Hours:  13:37 - 14:37
+
+Booking details:
+http://localhost/rooms/booking/0
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/confirmation_email_to_user_reason.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/confirmation_email_to_user_reason.txt
@@ -1,0 +1,25 @@
+Dear Guinea,
+
+Your booking has been ACCEPTED.
+This is the final confirmation.
+
+The following message was provided by the room manager:
+Because I want to.
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Friday 11/11/2022
+Hours:  13:37 - 14:37
+
+Booking details:
+http://localhost/rooms/booking/0
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_manager.txt
@@ -1,0 +1,18 @@
+Dear Guinea,
+
+There is a new booking for your room.
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Monday 21/11/2022
+Hours:  13:37 - 14:37
+
+You can check the details of the booking here:
+http://localhost/rooms/booking/1337
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user.txt
@@ -1,0 +1,25 @@
+Dear Guinea,
+
+The conference room 1/2-3
+has been booked for Guinea Pig
+on Friday 11/11/2022 from 13:37 to 14:37.
+Reason: Testing
+
+If you end up not needing this room, please cancel the booking from the
+booking details so that the room can be booked by somebody else.
+
+Please be aware that in special (rare) cases the person responsible
+for this room may reject your booking. Should that happen you will
+be instantly notified by e-mail.
+
+Booking details:
+http://localhost/rooms/booking/1337
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat.txt
@@ -1,0 +1,25 @@
+Dear Guinea,
+
+The conference room 1/2-3
+has been booked for Guinea Pig
+daily booking from Friday 11/11/2022 to Monday 21/11/2022 between 13:37 and 14:37.
+Reason: Testing
+
+If you end up not needing this room, please cancel the booking from the
+booking details so that the room can be booked by somebody else.
+
+Please be aware that in special (rare) cases the person responsible
+for this room may reject your booking. Should that happen you will
+be instantly notified by e-mail.
+
+Booking details:
+http://localhost/rooms/booking/1337
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat_excluded_1.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat_excluded_1.txt
@@ -1,0 +1,26 @@
+Dear Guinea,
+
+The conference room 1/2-3
+has been booked for Guinea Pig
+daily booking from Friday 11/11/2022 to Monday 21/11/2022 between 13:37 and 14:37.
+Reason: Testing
+    (Note that there are 1 excluded days. For further info, check your reservation)
+
+If you end up not needing this room, please cancel the booking from the
+booking details so that the room can be booked by somebody else.
+
+Please be aware that in special (rare) cases the person responsible
+for this room may reject your booking. Should that happen you will
+be instantly notified by e-mail.
+
+Booking details:
+http://localhost/rooms/booking/1337
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat_excluded_2.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat_excluded_2.txt
@@ -1,0 +1,26 @@
+Dear Guinea,
+
+The conference room 1/2-3
+has been booked for Guinea Pig
+daily booking from Friday 11/11/2022 to Monday 21/11/2022 between 13:37 and 14:37.
+Reason: Testing
+    (Note that there are 2 excluded days. For further info, check your reservation)
+
+If you end up not needing this room, please cancel the booking from the
+booking details so that the room can be booked by somebody else.
+
+Please be aware that in special (rare) cases the person responsible
+for this room may reject your booking. Should that happen you will
+be instantly notified by e-mail.
+
+Booking details:
+http://localhost/rooms/booking/1337
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_pre_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_pre_email_to_manager.txt
@@ -1,0 +1,18 @@
+Dear Guinea,
+
+There is a new pre-booking for your room.
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Monday 21/11/2022
+Hours:  13:37 - 14:37
+
+You can check the details of the booking here:
+http://localhost/rooms/booking/1337
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_pre_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_pre_email_to_user.txt
@@ -1,0 +1,24 @@
+Dear Guinea,
+
+The conference room 1/2-3
+has been pre-booked for Guinea Pig
+on Friday 11/11/2022 from 13:37 to 14:37.
+Reason: Testing
+
+Note:
+Your pre-booking is NOT YET ACCEPTED by a room manager.
+Please be aware that pre-bookings are subject to acceptance
+or rejection. Expect an e-mail with acceptance/rejection
+information.
+
+Booking details:
+http://localhost/rooms/booking/1337
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_pre_email_to_user_repeat.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_pre_email_to_user_repeat.txt
@@ -1,0 +1,24 @@
+Dear Guinea,
+
+The conference room 1/2-3
+has been pre-booked for Guinea Pig
+daily booking from Friday 11/11/2022 to Monday 21/11/2022 between 13:37 and 14:37.
+Reason: Testing
+
+Note:
+Your pre-booking is NOT YET ACCEPTED by a room manager.
+Please be aware that pre-bookings are subject to acceptance
+or rejection. Expect an e-mail with acceptance/rejection
+information.
+
+Booking details:
+http://localhost/rooms/booking/1337
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/modification_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/modification_email_to_manager.txt
@@ -1,0 +1,12 @@
+Dear Guinea,
+
+A booking in a room you manage has been MODIFIED.
+
+You can check the details of the booking here:
+http://localhost/rooms/booking/0
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/modification_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/modification_email_to_user.txt
@@ -1,0 +1,21 @@
+Dear Guinea,
+
+Your booking has been MODIFIED.
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Friday 11/11/2022
+Hours:  13:37 - 14:37
+
+Booking details:
+http://localhost/rooms/booking/0
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/occurrence_cancellation_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/occurrence_cancellation_email_to_manager.txt
@@ -1,0 +1,12 @@
+Dear Guinea,
+
+The date Friday 11/11/2022 from a booking that concerns one of your rooms has been CANCELLED by the user.
+
+You can check the details of the booking here:
+http://localhost/rooms/booking/0
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/occurrence_cancellation_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/occurrence_cancellation_email_to_user.txt
@@ -1,0 +1,21 @@
+Dear Guinea,
+
+You have CANCELLED an occurrence of your booking on Friday 11/11/2022.
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Saturday 12/11/2022
+Hours:  13:37 - 14:37
+
+Booking details:
+http://localhost/rooms/booking/0
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/occurrence_rejection_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/occurrence_rejection_email_to_manager.txt
@@ -1,0 +1,21 @@
+Dear Guinea,
+
+A booking has been REJECTED by the manager of the room '1/2-3' for the Friday 11/11/2022.
+
+Rejection reason:
+A valid reason!
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Saturday 12/11/2022
+Hours:  13:37 - 14:37
+
+You can check the details of the booking here:
+http://localhost/rooms/booking/0
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/occurrence_rejection_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/occurrence_rejection_email_to_user.txt
@@ -1,0 +1,24 @@
+Dear Guinea,
+
+Your booking has been REJECTED by the manager of the room for the Friday 11/11/2022.
+
+Rejection reason:
+A valid reason!
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Saturday 12/11/2022
+Hours:  13:37 - 14:37
+
+Booking details:
+http://localhost/rooms/booking/0
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/rejection_email_to_manager.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/rejection_email_to_manager.txt
@@ -1,0 +1,21 @@
+Dear Guinea,
+
+A booking has been REJECTED by the manager of the room '1/2-3'.
+
+Rejection reason:
+None
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Friday 11/11/2022
+Hours:  13:37 - 14:37
+
+You can check the details of the booking here:
+http://localhost/rooms/booking/0
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/rejection_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/rejection_email_to_user.txt
@@ -1,0 +1,24 @@
+Dear Guinea,
+
+Your booking has been REJECTED by the manager of the room.
+
+Rejection reason:
+None
+
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Friday 11/11/2022
+Hours:  13:37 - 14:37
+
+Booking details:
+http://localhost/rooms/booking/0
+
+Remember you can always check your bookings here:
+http://localhost/rooms/my-bookings
+
+
+--
+Best regards,
+Indico :: Room Booking
+http://localhost/rooms/

--- a/indico/modules/rb/templates/emails/reservations/tests/reservation_info.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/reservation_info.txt
@@ -1,0 +1,5 @@
+Room:   1/2-3
+For:    Guinea Pig
+Reason: Testing
+Dates:  Friday 11/11/2022 - Friday 11/11/2022
+Hours:  13:37 - 14:37

--- a/indico/modules/rb/templates/emails/reservations/tests/reservation_key_info.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/reservation_key_info.txt
@@ -1,0 +1,4 @@
+
+
+How to find a key:
+In a pocket dimension reachable via interpretative dance.

--- a/indico/modules/users/notifications_test.py
+++ b/indico/modules/users/notifications_test.py
@@ -1,0 +1,55 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from pathlib import Path
+
+import pytest
+
+from indico.web.flask.templating import get_template_module
+
+
+@pytest.mark.parametrize(('test_file', 'affiliation'), (
+    ('profile_registered_admins_affil.txt', 'Illuminyati'),
+    ('profile_registered_admins.txt', None),
+))
+def test_profile_registered_email_plaintext(snapshot, dummy_user, test_file, affiliation):
+    dummy_user.affiliation = affiliation
+    template = get_template_module('users/emails/profile_registered_admins.txt',
+                                   user=dummy_user)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), test_file)
+
+
+@pytest.mark.parametrize(('test_file', 'comment', 'affiliation'), (
+    ('profile_requested_admins_comment.txt', 'A comment.\nMeow!', None),
+    ('profile_requested_admins_affil_comment.txt', 'A comment.\nMeow!', 'Illuminyati'),
+    ('profile_requested_admins_affil.txt', None, 'Illuminyati'),
+    ('profile_requested_admins.txt', None, None),
+))
+def test_profile_requested_email_plaintext(snapshot, dummy_user, comment, affiliation, test_file):
+    dummy_user.affiliation = affiliation
+    req = {'comment': comment, 'user_data': dummy_user, 'email': 'cat@meow.cat'}
+    template = get_template_module('users/emails/profile_requested_admins.txt',
+                                   req=req)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), test_file)
+
+
+@pytest.mark.usefixtures('request_context')
+def test_reg_req_accepted_email_plaintext(snapshot, dummy_user):
+    template = get_template_module('users/emails/registration_request_accepted.txt',
+                                   user=dummy_user)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), 'registration_request_accepted.txt')
+
+
+def test_reg_req_rejected_email_plaintext(snapshot, dummy_user):
+    req = {'user_data': dummy_user}
+    template = get_template_module('users/emails/registration_request_rejected.txt',
+                                   req=req)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    snapshot.assert_match(template.get_body(), 'registration_request_rejected.txt')

--- a/indico/modules/users/templates/emails/tests/profile_registered_admins.txt
+++ b/indico/modules/users/templates/emails/tests/profile_registered_admins.txt
@@ -1,0 +1,12 @@
+A new Indico profile has been registered.
+
+First name: Guinea
+Last name: Pig
+Email address: 1337@example.test
+
+User details:
+http://localhost/user/1337/profile/
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/users/templates/emails/tests/profile_registered_admins_affil.txt
+++ b/indico/modules/users/templates/emails/tests/profile_registered_admins_affil.txt
@@ -1,0 +1,13 @@
+A new Indico profile has been registered.
+
+First name: Guinea
+Last name: Pig
+Email address: 1337@example.test
+Affiliation: Illuminyati
+
+User details:
+http://localhost/user/1337/profile/
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/users/templates/emails/tests/profile_requested_admins.txt
+++ b/indico/modules/users/templates/emails/tests/profile_requested_admins.txt
@@ -1,0 +1,13 @@
+Someone has requested to register a new indico profile.
+Please review their registration request and approve/reject it accordingly.
+
+First name: Guinea
+Last name: Pig
+Email address: cat@meow.cat
+
+Manage pending requests:
+http://localhost/admin/users/registration-requests/
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/users/templates/emails/tests/profile_requested_admins_affil.txt
+++ b/indico/modules/users/templates/emails/tests/profile_requested_admins_affil.txt
@@ -1,0 +1,14 @@
+Someone has requested to register a new indico profile.
+Please review their registration request and approve/reject it accordingly.
+
+First name: Guinea
+Last name: Pig
+Email address: cat@meow.cat
+Affiliation: Illuminyati
+
+Manage pending requests:
+http://localhost/admin/users/registration-requests/
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/users/templates/emails/tests/profile_requested_admins_affil_comment.txt
+++ b/indico/modules/users/templates/emails/tests/profile_requested_admins_affil_comment.txt
@@ -1,0 +1,17 @@
+Someone has requested to register a new indico profile.
+Please review their registration request and approve/reject it accordingly.
+
+First name: Guinea
+Last name: Pig
+Email address: cat@meow.cat
+Affiliation: Illuminyati
+Comment:
+A comment.
+Meow!
+
+Manage pending requests:
+http://localhost/admin/users/registration-requests/
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/users/templates/emails/tests/profile_requested_admins_comment.txt
+++ b/indico/modules/users/templates/emails/tests/profile_requested_admins_comment.txt
@@ -1,0 +1,16 @@
+Someone has requested to register a new indico profile.
+Please review their registration request and approve/reject it accordingly.
+
+First name: Guinea
+Last name: Pig
+Email address: cat@meow.cat
+Comment:
+A comment.
+Meow!
+
+Manage pending requests:
+http://localhost/admin/users/registration-requests/
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/users/templates/emails/tests/registration_request_accepted.txt
+++ b/indico/modules/users/templates/emails/tests/registration_request_accepted.txt
@@ -1,0 +1,12 @@
+Dear Guinea,
+
+Your request to create an Indico profile has been approved.
+You may now log in to your new account:
+http://localhost/login/
+
+After logging in your can finish setting up your profile:
+http://localhost/user/profile/
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/users/templates/emails/tests/registration_request_rejected.txt
+++ b/indico/modules/users/templates/emails/tests/registration_request_rejected.txt
@@ -1,0 +1,7 @@
+Dear Guinea,
+
+Unfortunately your request to create an Indico profile has been denied.
+
+--
+Indico :: Email Notifier
+http://localhost/


### PR DESCRIPTION
I accidentally forgot the tests for roombooking's and users' plaintext emails.
So in addition to #5482, some more tests following :)