### PR TITLE
Parse escaped quotes (&quot;) in ckeditor output correctly.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,7 +18,7 @@ Bugfixes
 - Fix meeting minutes being shown when they are expected to be hidden (:pr:`5475`)
 - Force default locale when generating Book of Abstracts (:pr:`5477`)
 - Fix width and height calculation when printing badges (:pr:`5479`)
-- Parse escaped quotes (&quot;) in ckeditor output correctly (:pr:`5487`)
+- Parse escaped quotes (``&quot;``) in ckeditor output correctly (:pr:`5487`)
 
 
 Version 3.2

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Bugfixes
 - Fix meeting minutes being shown when they are expected to be hidden (:pr:`5475`)
 - Force default locale when generating Book of Abstracts (:pr:`5477`)
 - Fix width and height calculation when printing badges (:pr:`5479`)
+- Parse escaped quotes (&quot;) in ckeditor output correctly (:pr:`5487`)
 
 
 Version 3.2

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -468,8 +468,23 @@ def sanitize_email(email, require_valid=False):
         return None
 
 
+class IndicoCSSSanitizer(CSSSanitizer):
+    """Correctly parses escaped quotes.
+
+    ckeditor puts `&quot;` around font family names:
+    https://github.com/ckeditor/ckeditor4/issues/2750
+
+    However, the css parser used by bleach cannot handle escaped quotes inside
+    the style attribute and filters them out which breaks the styling.
+    """
+
+    def sanitize_css(self, style):
+        style = style.replace('&quot;', '"')
+        return super().sanitize_css(style)
+
+
 def sanitize_html(string):
-    css_sanitizer = CSSSanitizer(allowed_css_properties=BLEACH_ALLOWED_STYLES_HTML)
+    css_sanitizer = IndicoCSSSanitizer(allowed_css_properties=BLEACH_ALLOWED_STYLES_HTML)
     return bleach.clean(string, tags=BLEACH_ALLOWED_TAGS_HTML, attributes=BLEACH_ALLOWED_ATTRIBUTES_HTML,
                         css_sanitizer=css_sanitizer)
 

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -469,7 +469,7 @@ def sanitize_email(email, require_valid=False):
 
 
 class IndicoCSSSanitizer(CSSSanitizer):
-    """Correctly parses escaped quotes.
+    """Correctly parse escaped quotes.
 
     ckeditor puts `&quot;` around font family names:
     https://github.com/ckeditor/ckeditor4/issues/2750

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -238,3 +238,16 @@ def test_sanitize_for_platypus_relative_urls():
         </p>
     ''').strip()
     assert sanitize_for_platypus(html) == expected
+
+
+@pytest.mark.parametrize(('input', 'output'), (
+    ('<span style=\'font-family:"Liberation Serif",serif;\'>test</span>',
+     '<span style=\'font-family:"Liberation Serif",serif;\'>test</span>'),
+    ('<span style="font-family:&quot;Liberation Serif&quot;,serif">test</span>',
+     '<span style=\'font-family:"Liberation Serif",serif;\'>test</span>'),
+    ('<span style="font-family:&quot;Liberation Serif&quot;,serif;font-size:14px">test</span>',
+     '<span style=\'font-family:"Liberation Serif",serif;font-size:14px;\'>test</span>'),
+    ('<span>test &quot;</span>', '<span>test &quot;</span>'),  # Only convert escaped quotes inside style attributes
+))
+def test_sanitize_html_escaped_quotes(input, output):
+    assert sanitize_html(input) == output


### PR DESCRIPTION
Seems like ckeditor4  (and maybe 5) escapes quotes in font family names.
The css sanitizer doesn't like this and throws the quotes out which in turn breaks the styles altogether.

Related ckeditor issue: https://github.com/ckeditor/ckeditor4/issues/2750