### PR TITLE
Make action icons stack horizontally

### DIFF
--- a/indico/web/client/styles/modules/_admin.scss
+++ b/indico/web/client/styles/modules/_admin.scss
@@ -28,7 +28,6 @@
 }
 
 table.ip-network-group .actions {
-  width: 3em;
   text-align: right;
 }
 


### PR DESCRIPTION
In `Administration -> IP networks` & `News`

Before:
![image](https://user-images.githubusercontent.com/8739637/190100419-393d61be-5211-4808-bba3-5681deb5094e.png)
After:
![image](https://user-images.githubusercontent.com/8739637/190100326-e633dbc7-55d7-4ca6-892f-1d9b96593f36.png)

