### PR TITLE
Fix entering room name in events if RB is enabled but has no locations defined

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Bugfixes
 - Force default locale when generating Book of Abstracts (:pr:`5477`)
 - Fix width and height calculation when printing badges (:pr:`5479`)
 - Parse escaped quotes (``&quot;``) in ckeditor output correctly (:pr:`5487`)
+- Fix entering room name if room booking is enabled but has no locations (:pr:`5495`)
 
 
 Version 3.2

--- a/indico/web/forms/widgets.py
+++ b/indico/web/forms/widgets.py
@@ -225,7 +225,7 @@ class LocationWidget(JinjaWidget):
         rooms = {'data': []}
         venues = {'data': []}
         venue_map = {}
-        if config.ENABLE_ROOMBOOKING:
+        if config.ENABLE_ROOMBOOKING and field.locations:
             rooms = {loc.name: {'data': self.get_sorted_rooms(loc)} for loc in field.locations}
             venues = {'data': [{'id': loc.id, 'name': loc.name} for loc in field.locations]}
             venue_map = {loc['id']: loc['name'] for loc in venues['data']}


### PR DESCRIPTION
It was caused by `rooms` being a completely empty dict instead of having the empty `data` key. No idea why, the structure is weird for sure  (since the keys in that dict are usually the venue names), but this is old jQuery code and the fix works...