### PR TITLE
Add a setting to disable entering persons manually

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Improvements
 - Enable better image linking UI in CKEditor (:pr:`5492`)
 - Restore the "fullscreen view" option in CKEditor (:pr:`5505`)
 - Display & enforce judging deadline (:pr:`5506`)
+- Add a setting to disable entering persons in person link fields manually (:pr:`5499`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -8,6 +8,7 @@
 import json
 from operator import attrgetter
 
+from flask import session
 from marshmallow import EXCLUDE
 from sqlalchemy import inspect
 from wtforms import RadioField, SelectField
@@ -20,6 +21,7 @@ from indico.modules.events.layout import theme_settings
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.persons import EventPersonLink
 from indico.modules.events.models.references import ReferenceType
+from indico.modules.events.persons import persons_settings
 from indico.modules.events.persons.util import get_event_person
 from indico.modules.users.models.affiliations import Affiliation
 from indico.modules.users.util import get_user_by_email
@@ -95,6 +97,10 @@ class PersonLinkListFieldBase(PrincipalListField):
     @property
     def has_predefined_affiliations(self):
         return Affiliation.query.filter(~Affiliation.is_deleted).has_rows()
+
+    @property
+    def can_enter_manually(self):
+        return persons_settings.get(self.event, 'allow_custom_persons') or self.event.can_manage(session.user)
 
     @no_autoflush
     def _get_person_link(self, data):

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -100,7 +100,7 @@ class PersonLinkListFieldBase(PrincipalListField):
 
     @property
     def can_enter_manually(self):
-        return persons_settings.get(self.event, 'allow_custom_persons') or self.event.can_manage(session.user)
+        return self.event.can_manage(session.user) or not persons_settings.get(self.event, 'disallow_custom_persons')
 
     @no_autoflush
     def _get_person_link(self, data):

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -107,6 +107,8 @@ class PersonLinkListFieldBase(PrincipalListField):
         from indico.modules.events.persons.schemas import PersonLinkSchema
         identifier = data.get('identifier')
         data = PersonLinkSchema(unknown=EXCLUDE).load(data)
+        if not self.can_enter_manually and not data.get('type'):
+            raise UserValueError('Manually entered persons are not allowed')
         if identifier and identifier.startswith('ExternalUser:'):
             # if the data came from an external user, look up their affiliation if the names still match;
             # we do not have an affiliation ID yet since it may not exist in the local DB yet

--- a/indico/modules/events/fields_test.py
+++ b/indico/modules/events/fields_test.py
@@ -7,6 +7,8 @@
 
 import json
 
+import pytest
+
 from indico.modules.events.fields import EventPersonLinkListField
 from indico.modules.events.models.persons import EventPerson, EventPersonLink
 from indico.web.forms.base import IndicoForm
@@ -20,6 +22,7 @@ class MockForm(IndicoForm):
         super().__init__(*args, **kwargs)
 
 
+@pytest.mark.usefixtures('request_context')
 def test_serialize_principal(app, dummy_event, dummy_user):
     from indico.modules.events.persons.schemas import EventPersonSchema
     with app.test_request_context():
@@ -37,6 +40,7 @@ def test_serialize_principal(app, dummy_event, dummy_user):
     assert result[0].get('affiliation') == 'Test'
 
 
+@pytest.mark.usefixtures('request_context')
 def test_submitter_permissions(app, db, dummy_event, dummy_user):
     from indico.modules.events.persons.schemas import PersonLinkSchema
     person = EventPerson.create_from_user(dummy_user, dummy_event)

--- a/indico/modules/events/persons/__init__.py
+++ b/indico/modules/events/persons/__init__.py
@@ -9,6 +9,7 @@ from flask import session
 
 from indico.core import signals
 from indico.core.logger import Logger
+from indico.modules.events.settings import EventSettingsProxy
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.menu import SideMenuItem
@@ -38,3 +39,8 @@ def _get_placeholders(sender, person, event, register_link=False, **kwargs):
     yield ContributionsPlaceholder
     if register_link:
         yield RegisterLinkPlaceholder
+
+
+persons_settings = EventSettingsProxy('persons', {
+    'allow_custom_persons': True,  # Submitters can enter persons manually on person lists
+})

--- a/indico/modules/events/persons/__init__.py
+++ b/indico/modules/events/persons/__init__.py
@@ -42,5 +42,5 @@ def _get_placeholders(sender, person, event, register_link=False, **kwargs):
 
 
 persons_settings = EventSettingsProxy('persons', {
-    'allow_custom_persons': True,  # Submitters can enter persons manually on person lists
+    'disallow_custom_persons': False,  # Disallow manually entering persons on person lists
 })

--- a/indico/modules/events/persons/blueprint.py
+++ b/indico/modules/events/persons/blueprint.py
@@ -7,8 +7,8 @@
 
 from indico.modules.events.persons.controllers import (RHDeleteUnusedEventPerson, RHEmailEventPersons,
                                                        RHEventPersonSearch, RHGrantModificationRights,
-                                                       RHGrantSubmissionRights, RHPersonsList, RHRevokeSubmissionRights,
-                                                       RHUpdateEventPerson)
+                                                       RHGrantSubmissionRights, RHManagePersonLists, RHPersonsList,
+                                                       RHRevokeSubmissionRights, RHUpdateEventPerson)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
@@ -28,3 +28,7 @@ _bp.add_url_rule('/persons/revoke-submission', 'revoke_submission_rights', RHRev
 _bp.add_url_rule('/persons/<int:person_id>', 'update_person', RHUpdateEventPerson, methods=('PATCH',))
 _bp.add_url_rule('/persons/<int:person_id>', 'delete_unused_person', RHDeleteUnusedEventPerson, methods=('DELETE',))
 _bp.add_url_rule('/api/persons/search', 'event_person_search', RHEventPersonSearch)
+
+
+# Manage person list settings
+_bp.add_url_rule('/persons/person-lists', 'manage_person_lists', RHManagePersonLists, methods=('GET', 'POST'))

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -31,8 +31,8 @@ from indico.modules.events.management.controllers import RHManageEventBase
 from indico.modules.events.models.persons import EventPerson
 from indico.modules.events.models.principals import EventPrincipal
 from indico.modules.events.models.roles import EventRole
-from indico.modules.events.persons import logger
-from indico.modules.events.persons.forms import EmailEventPersonsForm
+from indico.modules.events.persons import logger, persons_settings
+from indico.modules.events.persons.forms import EmailEventPersonsForm, ManagePersonListsForm
 from indico.modules.events.persons.operations import update_person
 from indico.modules.events.persons.schemas import EventPersonSchema, EventPersonUpdateSchema
 from indico.modules.events.persons.views import WPManagePersons
@@ -460,3 +460,15 @@ class RHEventPersonSearch(RHAuthenticatedEventBase):
             users=EventPersonSchema(only=EventPersonSchema.Meta.public_fields).dump(matches, many=True),
             total=total
         )
+
+
+class RHManagePersonLists(RHManageEventBase):
+    """Dialog to configure person list settings."""
+
+    def _process(self):
+        form = ManagePersonListsForm(allow_custom_persons=persons_settings.get(self.event, 'allow_custom_persons'))
+        if form.validate_on_submit():
+            persons_settings.set(self.event, 'allow_custom_persons', form.allow_custom_persons.data)
+            flash(_('Submitter edit settings changed successfully'), 'success')
+            return jsonify_data()
+        return jsonify_form(form)

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -466,9 +466,10 @@ class RHManagePersonLists(RHManageEventBase):
     """Dialog to configure person list settings."""
 
     def _process(self):
-        form = ManagePersonListsForm(allow_custom_persons=persons_settings.get(self.event, 'allow_custom_persons'))
+        form = ManagePersonListsForm(disallow_custom_persons=persons_settings.get(self.event,
+                                                                                  'disallow_custom_persons'))
         if form.validate_on_submit():
-            persons_settings.set(self.event, 'allow_custom_persons', form.allow_custom_persons.data)
-            flash(_('Submitter edit settings changed successfully'), 'success')
+            persons_settings.set(self.event, 'disallow_custom_persons', form.disallow_custom_persons.data)
+            flash(_('Person lists settings changed successfully'), 'success')
             return jsonify_data()
         return jsonify_form(form)

--- a/indico/modules/events/persons/forms.py
+++ b/indico/modules/events/persons/forms.py
@@ -38,3 +38,9 @@ class EmailEventPersonsForm(IndicoForm):
 
     def is_submitted(self):
         return super().is_submitted() and 'submitted' in request.form
+
+
+class ManagePersonListsForm(IndicoForm):
+    allow_custom_persons = BooleanField(_('Submitters can enter persons manually'), widget=SwitchWidget(),
+                                        description=_('If disabled, submitters can only list existing Indico users on '
+                                                      'person lists.'))

--- a/indico/modules/events/persons/forms.py
+++ b/indico/modules/events/persons/forms.py
@@ -42,5 +42,5 @@ class EmailEventPersonsForm(IndicoForm):
 
 class ManagePersonListsForm(IndicoForm):
     disallow_custom_persons = BooleanField(_('Disallow manually entering persons'), widget=SwitchWidget(),
-                                           description=_('Only allow submitters to list existing Indico users as '
-                                                         'speakers/authors.'))
+                                           description=_('Prohibit submitters from adding new speakers/authors '
+                                                         'manually and only allow searching for existing users.'))

--- a/indico/modules/events/persons/forms.py
+++ b/indico/modules/events/persons/forms.py
@@ -41,6 +41,6 @@ class EmailEventPersonsForm(IndicoForm):
 
 
 class ManagePersonListsForm(IndicoForm):
-    allow_custom_persons = BooleanField(_('Submitters can enter persons manually'), widget=SwitchWidget(),
-                                        description=_('If disabled, submitters can only list existing Indico users on '
-                                                      'person lists.'))
+    disallow_custom_persons = BooleanField(_('Disallow manually entering persons'), widget=SwitchWidget(),
+                                           description=_('Only allow submitters to list existing Indico users as '
+                                                         'speakers/authors.'))

--- a/indico/modules/events/persons/templates/management/person_list.html
+++ b/indico/modules/events/persons/templates/management/person_list.html
@@ -8,6 +8,25 @@
     {% trans %}Participant Roles{% endtrans %}
 {% endblock %}
 
+{% block title_actions %}
+    {%- if event.type == 'conference' -%}
+        <a class="i-button borderless icon-settings arrow js-dropdown"
+           data-toggle="dropdown">{% trans %}Settings{% endtrans %}</a>
+        <ul class="i-dropdown">
+            <li>
+                <a href="#"
+                   title="{% trans %}Manage person lists{% endtrans %}"
+                   data-reload-after="customData"
+                   data-title="{% trans %}Manage person lists{% endtrans %}"
+                   data-href="{{ url_for('.manage_person_lists', event) }}"
+                   data-qtip-position="right"
+                   data-ajax-dialog>
+                    {% trans %}Person lists{% endtrans %}</a>
+            </li>
+        </ul>
+    {%- endif -%}
+{% endblock %}
+
 {% block content %}
     {%- set has_no_account = persons|selectattr('roles.no_account')|any -%}
     {%- set has_uninvited = persons|selectattr('roles.no_account')|selectattr('person.invited_dt', 'none')|any -%}

--- a/indico/web/client/js/jquery/widgets/jinja/person_link_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/person_link_widget.js
@@ -13,7 +13,15 @@ import {camelizeKeys} from 'indico/utils/case';
 
 (function(global) {
   global.setupPersonLinkWidget = function setupPersonLinkWidget(options) {
-    const {fieldId, eventId, roles, sessionUser, hasPredefinedAffiliations, ...rest} = options;
+    const {
+      fieldId,
+      eventId,
+      roles,
+      sessionUser,
+      hasPredefinedAffiliations,
+      canEnterManually,
+      ...rest
+    } = options;
     const field = document.getElementById(fieldId);
     const persons = JSON.parse(field.value);
     const user = sessionUser &&
@@ -41,6 +49,7 @@ import {camelizeKeys} from 'indico/utils/case';
         roles={roles || []}
         sessionUser={user}
         hasPredefinedAffiliations={hasPredefinedAffiliations}
+        canEnterManually={canEnterManually}
         {...rest}
       />,
       document.getElementById(`person-link-field-${fieldId}`)

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -223,6 +223,7 @@ function PersonLinkField({
   autoSort,
   setAutoSort,
   hasPredefinedAffiliations,
+  canEnterManually,
 }) {
   const [favoriteUsers] = useFavoriteUsers(null, !sessionUser);
   const [modalOpen, setModalOpen] = useState(false);
@@ -335,10 +336,12 @@ function PersonLinkField({
             eventId={eventId}
             disabled={!sessionUser}
           />
-          <Button type="button" onClick={() => setModalOpen(true)}>
-            <Icon name="keyboard" />
-            <Translate>Enter manually</Translate>
-          </Button>
+          {canEnterManually && (
+            <Button type="button" onClick={() => setModalOpen(true)}>
+              <Icon name="keyboard" />
+              <Translate>Enter manually</Translate>
+            </Button>
+          )}
           {modalOpen && (
             <PersonDetailsModal
               onClose={onClose}
@@ -363,6 +366,7 @@ PersonLinkField.propTypes = {
   autoSort: PropTypes.bool,
   setAutoSort: PropTypes.func,
   hasPredefinedAffiliations: PropTypes.bool,
+  canEnterManually: PropTypes.bool,
 };
 
 PersonLinkField.defaultProps = {
@@ -373,6 +377,7 @@ PersonLinkField.defaultProps = {
   autoSort: true,
   setAutoSort: null,
   hasPredefinedAffiliations: false,
+  canEnterManually: true,
 };
 
 export function WTFPersonLinkField({
@@ -383,6 +388,7 @@ export function WTFPersonLinkField({
   sessionUser,
   emptyMessage,
   hasPredefinedAffiliations,
+  canEnterManually,
 }) {
   const [persons, setPersons] = useState(
     defaultValue.sort((a, b) => a.displayOrder - b.displayOrder)
@@ -435,6 +441,7 @@ export function WTFPersonLinkField({
       autoSort={autoSort}
       setAutoSort={setAutoSort}
       hasPredefinedAffiliations={hasPredefinedAffiliations}
+      canEnterManually={canEnterManually}
     />
   );
 }
@@ -447,6 +454,7 @@ WTFPersonLinkField.propTypes = {
   sessionUser: PropTypes.object,
   emptyMessage: PropTypes.string,
   hasPredefinedAffiliations: PropTypes.bool,
+  canEnterManually: PropTypes.bool,
 };
 
 WTFPersonLinkField.defaultProps = {
@@ -456,4 +464,5 @@ WTFPersonLinkField.defaultProps = {
   sessionUser: null,
   emptyMessage: null,
   hasPredefinedAffiliations: false,
+  canEnterManually: true,
 };

--- a/indico/web/templates/forms/person_link_widget.html
+++ b/indico/web/templates/forms/person_link_widget.html
@@ -28,6 +28,7 @@
             sortByLastName: {{ field.sort_by_last_name | default(false) | tojson }},
             emptyMessage: {{ field.empty_message | default(none) | tojson }},
             hasPredefinedAffiliations: {{ field.has_predefined_affiliations | tojson }},
+            canEnterManually: {{ field.can_enter_manually | tojson }},
             sessionUser: Indico.User
         });
     </script>


### PR DESCRIPTION
This PR adds a setting to disable the option of submitters writing in persons manually in the PersonLinkField.

The setting is located in the Participant Roles page in the management area:
![image](https://user-images.githubusercontent.com/27357203/190440663-89729490-1452-4ffa-8f8a-e69a07183755.png)
![image](https://user-images.githubusercontent.com/27357203/190440731-eae624fa-6353-4069-b5f2-16df9aaf2319.png)

Disabled:
![image](https://user-images.githubusercontent.com/27357203/190441743-8d2cbda4-3443-4dc1-b21b-c146244c2976.png)


Enabled:
![image](https://user-images.githubusercontent.com/27357203/190441630-fd6fbd3b-2fe1-416e-b92a-98185d9039d9.png)

Progress:
- [x] Add setting in the management area
- [x] Hide the "enter manually" button when the setting is disabled
- [x] Add server side check