### PR TITLE
Display & enforce judging deadline

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Improvements
 
 - Enable better image linking UI in CKEditor (:pr:`5492`)
 - Restore the "fullscreen view" option in CKEditor (:pr:`5505`)
+- Display & enforce judging deadline (:pr:`5506`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/papers/controllers/management_test.py
+++ b/indico/modules/events/papers/controllers/management_test.py
@@ -7,17 +7,11 @@
 
 import pytest
 
-from indico.modules.events.papers.models.papers import Paper
 from indico.modules.events.papers.models.review_questions import PaperReviewQuestion
 from indico.modules.events.papers.models.review_ratings import PaperReviewRating
 from indico.modules.events.papers.models.reviews import PaperAction, PaperReview, PaperReviewType
 from indico.modules.events.papers.models.revisions import PaperRevision
 from indico.modules.events.papers.settings import paper_reviewing_settings
-
-
-@pytest.fixture
-def dummy_paper(dummy_contribution):
-    return Paper(dummy_contribution)
 
 
 @pytest.mark.parametrize(('value', 'scale_min', 'scale_max', 'expected'), (

--- a/indico/modules/events/papers/models/call_for_papers.py
+++ b/indico/modules/events/papers/models/call_for_papers.py
@@ -28,6 +28,7 @@ class CallForPapers:
     content_reviewing_enabled = EventSettingProperty(paper_reviewing_settings, 'content_reviewing_enabled')
     layout_reviewing_enabled = EventSettingProperty(paper_reviewing_settings, 'layout_reviewing_enabled')
     judge_deadline = EventSettingProperty(paper_reviewing_settings, 'judge_deadline')
+    judge_deadline_enforced = EventSettingProperty(paper_reviewing_settings, 'enforce_judge_deadline')
     layout_reviewer_deadline = EventSettingProperty(paper_reviewing_settings, 'layout_reviewer_deadline')
     content_reviewer_deadline = EventSettingProperty(paper_reviewing_settings, 'content_reviewer_deadline')
     content_reviewer_deadline_enforced = EventSettingProperty(paper_reviewing_settings,

--- a/indico/modules/events/papers/models/papers.py
+++ b/indico/modules/events/papers/models/papers.py
@@ -8,6 +8,7 @@
 from indico.core.settings import AttributeProxyProperty
 from indico.modules.events.models.reviews import ProposalMixin
 from indico.modules.events.papers.models.revisions import PaperRevisionState
+from indico.util.date_time import now_utc
 from indico.util.locators import locator_property
 
 
@@ -79,6 +80,8 @@ class Paper(ProposalMixin):
         if not user:
             return False
         elif check_state and self.is_in_final_state:
+            return False
+        elif self.cfp.judge_deadline_enforced and self.cfp.judge_deadline < now_utc():
             return False
         elif self.can_manage(user):
             return True

--- a/indico/modules/events/papers/models/papers_test.py
+++ b/indico/modules/events/papers/models/papers_test.py
@@ -1,0 +1,50 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from datetime import datetime
+
+import pytest
+
+from indico.modules.events.papers.models.revisions import PaperRevision, PaperRevisionState
+from indico.modules.events.papers.settings import paper_reviewing_settings
+from indico.util.date_time import localize_as_utc, now_utc
+
+
+@pytest.mark.usefixtures('dummy_contribution')
+def test_can_judge(dummy_paper, dummy_user, dummy_event):
+    assert not dummy_paper.can_judge(None)
+
+    # Judged papers cannot be judged again
+    PaperRevision(paper=dummy_paper, submitter=dummy_user)
+    dummy_paper.state = PaperRevisionState.accepted
+    dummy_paper.last_revision.judge = dummy_user
+    dummy_paper.last_revision.judgment_dt = now_utc()
+    assert not dummy_paper.can_judge(dummy_user, check_state=True)
+
+    # Make sure enforced judging deadline is respected
+    dummy_paper.reset_state()
+    paper_reviewing_settings.set(dummy_event, 'enforce_judge_deadline', True)
+    paper_reviewing_settings.set(dummy_event, 'judge_deadline', localize_as_utc(datetime(2020, 1, 1, 0, 0, 0)))
+    assert not dummy_paper.can_judge(dummy_user)
+    assert not dummy_paper.can_judge(dummy_user, check_state=True)
+
+    # Allow judging if the deadline is not enforced
+    paper_reviewing_settings.set(dummy_event, 'enforce_judge_deadline', False)
+    dummy_event.update_principal(dummy_user, full_access=True)
+    assert dummy_paper.can_judge(dummy_user)
+    assert dummy_paper.can_judge(dummy_user, check_state=True)
+
+    # Allow judging if the user can manage the paper
+    paper_reviewing_settings.set(dummy_event, 'judge_deadline', None)
+    assert dummy_paper.can_judge(dummy_user)
+    assert dummy_paper.can_judge(dummy_user, check_state=True)
+
+    # Allow judging if the user is a judge for the paper
+    dummy_event.update_principal(dummy_user, full_access=False)
+    dummy_paper.contribution.paper_judges.add(dummy_user)
+    assert dummy_paper.can_judge(dummy_user)
+    assert dummy_paper.can_judge(dummy_user, check_state=True)

--- a/indico/modules/events/papers/templates/display/judging_area.html
+++ b/indico/modules/events/papers/templates/display/judging_area.html
@@ -27,5 +27,23 @@
         {% endcall %}
     {% endif %}
 
-    {{ render_paper_assignment_content(event, total_entries, contribs, static_columns, selected_entry) }}
+    {% set judge_deadline = event.cfp.judge_deadline %}
+    {% if judge_deadline %}
+        <div class="deadline-info">
+            {% set tz = event.timezone %}
+            <span class="icon icon-calendar"></span>
+            <div class="label">{% trans %}Judging deadline{% endtrans %}</div>
+            <div class="text">
+                <span>
+                    {% trans date=judge_deadline|format_date(timezone=tz), time=judge_deadline|format_time(timezone=tz) -%}
+                        Paper judging ends on <strong>{{ date }}</strong> at <strong>{{ time }}</strong>.
+                    {%- endtrans %}
+                </span>
+            </div>
+        </div>
+    {% endif %}
+
+    <section>
+        {{ render_paper_assignment_content(event, total_entries, contribs, static_columns, selected_entry) }}
+    </section>
 {% endblock %}

--- a/indico/testing/fixtures/paper.py
+++ b/indico/testing/fixtures/paper.py
@@ -1,0 +1,15 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2022 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+
+from indico.modules.events.papers.models.papers import Paper
+
+
+@pytest.fixture
+def dummy_paper(dummy_contribution):
+    return Paper(dummy_contribution)

--- a/indico/testing/pytest_plugin.py
+++ b/indico/testing/pytest_plugin.py
@@ -20,9 +20,9 @@ os.environ['INDICO_CONFIG'] = os.devnull
 pytest_plugins = ('indico.testing.fixtures.abstract', 'indico.testing.fixtures.app', 'indico.testing.fixtures.cache',
                   'indico.testing.fixtures.category', 'indico.testing.fixtures.contribution',
                   'indico.testing.fixtures.database', 'indico.testing.fixtures.disallow',
-                  'indico.testing.fixtures.person', 'indico.testing.fixtures.user', 'indico.testing.fixtures.event',
-                  'indico.testing.fixtures.smtp', 'indico.testing.fixtures.storage', 'indico.testing.fixtures.util',
-                  'indico.testing.fixtures.session')
+                  'indico.testing.fixtures.paper', 'indico.testing.fixtures.person', 'indico.testing.fixtures.user',
+                  'indico.testing.fixtures.event', 'indico.testing.fixtures.smtp', 'indico.testing.fixtures.storage',
+                  'indico.testing.fixtures.util', 'indico.testing.fixtures.session')
 
 
 def pytest_configure(config):


### PR DESCRIPTION
Currently the judging deadline is not displayed in the judging area (unlike the content and layout reviewing deadlines)
The deadline is also not enforced if set so in the settings.

This PR adds an infobox to the judging area and disables judging if the deadline has passed and the deadline is enforced.

![image](https://user-images.githubusercontent.com/8739637/191020405-18f1512b-7a51-4869-a9fb-1fc6db3ce752.png)
