### PR TITLE
Fix privacy information dropdown on Safari

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Bugfixes
 - Fix width and height calculation when printing badges (:pr:`5479`)
 - Parse escaped quotes (``&quot;``) in ckeditor output correctly (:pr:`5487`)
 - Fix entering room name if room booking is enabled but has no locations (:pr:`5495`)
+- Fix privacy information dropdown not opening on Safari (:pr:`5507`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/templates/display/common/_privacy_info_button.html
+++ b/indico/modules/events/templates/display/common/_privacy_info_button.html
@@ -1,7 +1,7 @@
 {% macro render_privacy_info_button(event, privacy_info) -%}
     {% set data_controller_exists = privacy_info.data_controller_name or privacy_info.data_controller_email %}
     {% if data_controller_exists or privacy_info.privacy_policy_urls|length > 1 %}
-        <div class="privacy-dropdown">
+        <div class="privacy-dropdown" tabindex="-1">
             <button class="small compact ui blue icon button"
                     title="{% trans %}Event privacy information{% endtrans %}">
                 <i class="balance scale icon"></i>

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -407,6 +407,7 @@ ul.day-list {
   .privacy-dropdown {
     display: inline-block;
     position: relative;
+    outline: none;
 
     .menu {
       display: none;


### PR DESCRIPTION
This PR fixes a bug in which the CSS-based privacy information dropdown didn't open on Safari. This was caused due to safari requiring a `tabindex` attribute in order to make elements focusable.