### PR TITLE
Make the 'Reset judgment' icon more visible

### DIFF
--- a/indico/modules/events/abstracts/templates/reviewing/public.html
+++ b/indico/modules/events/abstracts/templates/reviewing/public.html
@@ -200,14 +200,14 @@
                 </div>
                 {% if abstract.event.can_manage(session.user, permission='abstracts') %}
                     <div class="hide-if-locked">
-                        <a class="i-link icon-remove"
+                        <i class="red link icon undo"
                            title="{% trans %}Reset judgment{% endtrans %}"
                            data-href="{{ url_for('.reset_abstract_state', abstract) }}"
                            data-method="POST"
                            data-update="#reviewing-page"
                            data-replace-update
                            data-title="{% trans %}Reset judgment{% endtrans %}"
-                           data-confirm="{% trans %}Do you really want to reset the judgment? This operation is irreversible.{% endtrans %}"></a>
+                           data-confirm="{% trans %}Do you really want to reset the judgment? This operation is irreversible.{% endtrans %}"></i>
                     </div>
                 {% endif %}
             </div>

--- a/indico/modules/events/papers/client/js/components/RevisionJudgment.jsx
+++ b/indico/modules/events/papers/client/js/components/RevisionJudgment.jsx
@@ -65,7 +65,7 @@ export default function RevisionJudgment({revision}) {
                   position="bottom center"
                   content={Translate.string('Reset judgment')}
                   trigger={
-                    <Icon link className="undo" color="grey" onClick={() => setConfirmOpen(true)} />
+                    <Icon link className="undo" color="red" onClick={() => setConfirmOpen(true)} />
                   }
                 />
               </div>

--- a/indico/modules/events/papers/client/js/components/RevisionJudgment.jsx
+++ b/indico/modules/events/papers/client/js/components/RevisionJudgment.jsx
@@ -63,6 +63,7 @@ export default function RevisionJudgment({revision}) {
               <div>
                 <Popup
                   position="bottom center"
+                  offset={[0, 5]}
                   content={Translate.string('Reset judgment')}
                   trigger={
                     <Icon link className="undo" color="red" onClick={() => setConfirmOpen(true)} />


### PR DESCRIPTION
Based on a recent feedback about the visibility of the 'Reset judgment' icon.
Also made the cfa icon use the same undo icon instead of the trash can icon.

![image](https://user-images.githubusercontent.com/8739637/191931538-7df66111-abb1-4533-976a-40a86b26b53c.png)
![image](https://user-images.githubusercontent.com/8739637/191931609-8c376a91-9dc1-4132-91e4-20ddc086ba93.png)
