### PR TITLE
Fix ckeditor full screen plugin when rendered in <Modal>

### DIFF
--- a/indico/web/client/js/react/components/notes/NoteEditor.jsx
+++ b/indico/web/client/js/react/components/notes/NoteEditor.jsx
@@ -17,6 +17,8 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 import {FinalTextEditor} from '../TextEditor';
 
+import './NoteEditor.module.scss';
+
 export function NoteEditor({apiURL, imageUploadURL, closeModal, getNoteURL}) {
   const [currentInput, setCurrentInput] = useState(undefined);
   const [loading, setLoading] = useState(false);

--- a/indico/web/client/js/react/components/notes/NoteEditor.module.scss
+++ b/indico/web/client/js/react/components/notes/NoteEditor.module.scss
@@ -1,0 +1,14 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2022 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+// Fix for the ckeditor full screen plugin when rendered inside SUI's <Modal>.
+// Removes 'transform' from the 'will-change' property. This makes the
+// fixed positioning of the '.ck-plugin-full-screen' class work again.
+// https://stackoverflow.com/a/37953806
+:global(.ui.page.modals.dimmer > .ui.modal.transition) {
+  will-change: top, left, margin, opacity;
+}


### PR DESCRIPTION
Removes  `transform` from the `will-change` property.

Pretty hacky and I don't fully understand _why_ it works, but this should only effect performance (if at all) and not appearance so it should be safe.