### PR TITLE
Use Flask-SQLAlchemy v3

### DIFF
--- a/indico/core/db/sqlalchemy/core.py
+++ b/indico/core/db/sqlalchemy/core.py
@@ -9,6 +9,7 @@ import sys
 import typing as t
 from contextlib import contextmanager
 from functools import partial
+from threading import get_ident
 
 from flask import g
 from flask_sqlalchemy import SQLAlchemy
@@ -175,7 +176,8 @@ naming_convention = {
 }
 
 db = IndicoSQLAlchemy(model_class=declarative_base(cls=IndicoModel, metaclass=NoNameGenMeta, name='Model'),
-                      query_class=IndicoBaseQuery)
+                      query_class=IndicoBaseQuery, session_options={'scopefunc': get_ident})
 db.Model.metadata.naming_convention = naming_convention
+assert db.Model.metadata is db.metadata
 listen(db.Model.metadata, 'before_create', _before_create)
 listen(mapper, 'mapper_configured', _mapper_configured)

--- a/indico/modules/logs/controllers.py
+++ b/indico/modules/logs/controllers.py
@@ -90,7 +90,7 @@ class LogsAPIMixin:
         if metadata_query:
             query = query.filter(self.model.meta.contains(metadata_query))
 
-        query = query.paginate(page, LOG_PAGE_SIZE)
+        query = query.paginate(page=page, per_page=LOG_PAGE_SIZE)
         entries = [dict(serialize_log_entry(entry), index=index, html=entry.render())
                    for index, entry in enumerate(query.items)]
         return jsonify(current_page=page, pages=list(query.iter_pages()), total_page_count=query.pages, entries=entries)

--- a/indico/testing/fixtures/database.py
+++ b/indico/testing/fixtures/database.py
@@ -92,8 +92,8 @@ def database(app, postgresql):
     with app.app_context():
         create_all_tables(db_)
     yield db_
-    db_.session.remove()
     with app.app_context():
+        db_.session.remove()
         delete_all_tables(db_)
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,7 @@ python_files = *_test.py
 filterwarnings =
     error
     ignore:.*_app_ctx_stack.*:DeprecationWarning
+    ignore:The 'db' attribute is deprecated.*:DeprecationWarning
     ignore:.*not in session, add operation along.*:sqlalchemy.exc.SAWarning
     ignore::UserWarning
 ; use redis-server from $PATH

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ flask-marshmallow
 flask-migrate
 flask-multipass
 flask-pluginengine
-flask-sqlalchemy<3  # separate PR: https://github.com/indico/indico/pull/5522
+flask-sqlalchemy
 flask-webpackext
 flask-wtf
 flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ flask-multipass==0.4.9
     # via -r requirements.in
 flask-pluginengine==0.4.1
     # via -r requirements.in
-flask-sqlalchemy==2.5.1
+flask-sqlalchemy==3.0.2
     # via
     #   -r requirements.in
     #   flask-migrate


### PR DESCRIPTION
This is just from me testing if things are broken with the new major release of Flask-SQLAlchemy 3. But once the stable version is out we can probably upgrade to it, so I'm opening this draft PR for now to update to the regular FSA3 release at a later point (ideally when there's also an updated flask-marshmallow that doesn't trigger the deprecation warning).