### PR TITLE
Correct the count for hidden registrations in the participant list

### DIFF
--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -152,7 +152,8 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
         return {'headers': headers,
                 'rows': registrations,
                 'show_checkin': any(registration['checked_in'] for registration in registrations),
-                'num_participants': query.count()}
+                'num_participants': len(registrations),
+                'num_hidden_participants': query.count() - len(registrations)}
 
     def _participant_list_table(self, regform):
         def _process_registration(reg, column_ids, active_fields):
@@ -199,7 +200,8 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
                 'rows': registrations,
                 'title': regform.title,
                 'show_checkin': any(registration['checked_in'] for registration in registrations),
-                'num_participants': query.count()}
+                'num_participants': len(registrations),
+                'num_hidden_participants': query.count() - len(registrations)}
 
     def _process(self):
         regforms = (RegistrationForm.query.with_parent(self.event)
@@ -224,13 +226,15 @@ class RHParticipantList(RHRegistrationFormDisplayBase):
             tables.extend(map(self._participant_list_table, regforms_dict.values()))
 
         num_participants = sum(table['num_participants'] for table in tables)
+        num_hidden_participants = sum(table['num_hidden_participants'] for table in tables)
 
         return self.view_class.render_template(
             'display/participant_list.html',
             self.event,
             tables=tables,
             published=bool(regforms),
-            num_participants=num_participants
+            num_participants=num_participants,
+            num_hidden_participants=num_hidden_participants,
         )
 
 

--- a/indico/modules/events/registration/templates/display/participant_list.html
+++ b/indico/modules/events/registration/templates/display/participant_list.html
@@ -55,7 +55,6 @@
 
 {% macro participant_table(table) %}
     <section>
-        {% set hidden_participants = table.num_participants - table.rows|length %}
         {% if table.title %}
             <div class="header">
                 <div class="header-row">
@@ -70,10 +69,10 @@
                     {% for row in table.rows %}
                         {{ table_row(row, table.show_checkin) }}
                     {% endfor %}
-                    {% if hidden_participants %}
+                    {% if num_hidden_participants %}
                         <tr class="i-table">
                             <td class="i-table empty" colspan="{{ table.headers|length+1 if table.show_checkin else table.headers|length }}">
-                                {% trans num=hidden_participants %}{{ num }} more participant{% pluralize %}{{ num }} more participants{% endtrans %}
+                                {% trans num=num_hidden_participants %}{{ num }} more participant{% pluralize %}{{ num }} more participants{% endtrans %}
                             </td>
                         </tr>
                     {% endif %}
@@ -81,7 +80,7 @@
             </table>
         {% elif table.num_participants %}
             {% call message_box('info', fixed_width=true) %}
-                {% trans num=hidden_participants %}There is {{ num }} hidden participant{% pluralize %}There are {{ num }} hidden participants{% endtrans %}
+                {% trans num=num_hidden_participants %}There is {{ num }} hidden participant{% pluralize %}There are {{ num }} hidden participants{% endtrans %}
             {% endcall %}
         {% else %}
             {% call message_box('info', fixed_width=true) %}


### PR DESCRIPTION
The participant list page shows a count for the hidden participants who don't want to display their data. That count was not adding all registration forms properly. This PR fixes that.