### PR TITLE
Disable ckeditor full screen for minutes

### DIFF
--- a/indico/web/client/js/ckeditor.js
+++ b/indico/web/client/js/ckeditor.js
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-export const getConfig = ({images = true, imageUploadURL = null} = {}) => ({
+export const getConfig = ({images = true, imageUploadURL = null, fullScreen = true} = {}) => ({
   removePlugins: images && imageUploadURL ? [] : ['ImageInsert', 'ImageUpload'],
   fontFamily: {
     options: [
@@ -48,8 +48,8 @@ export const getConfig = ({images = true, imageUploadURL = null} = {}) => ({
       'undo',
       'redo',
       '|',
-      'fullscreen',
-      '|',
+      fullScreen && 'fullscreen',
+      fullScreen && '|',
       'sourceEditing',
     ].filter(Boolean),
   },
@@ -67,7 +67,7 @@ export const getConfig = ({images = true, imageUploadURL = null} = {}) => ({
     'FindAndReplace',
     'FontBackgroundColor',
     'FontColor',
-    'FullScreen',
+    fullScreen && 'FullScreen',
     'GeneralHtmlSupport',
     'Heading',
     'HorizontalLine',

--- a/indico/web/client/js/react/components/notes/NoteEditor.jsx
+++ b/indico/web/client/js/react/components/notes/NoteEditor.jsx
@@ -184,7 +184,7 @@ export function NoteEditor({apiURL, imageUploadURL, closeModal, getNoteURL}) {
               loading={loading}
               value={currentInput}
               parse={v => v}
-              config={{images: true, imageUploadURL}}
+              config={{images: true, imageUploadURL, fullScreen: false}}
               height="70vh"
             />
           )}


### PR DESCRIPTION
Related discussion: https://github.com/indico/indico/pull/5512
The full screen plugin does not play well with SUI's Modals. Rather than hacking the css, the full screen option is disabled for the minutes editor as the modal itself is large enough