### PR TITLE
Make sure only assigned reviewers can review a paper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Bugfixes
 - Parse escaped quotes (``&quot;``) in ckeditor output correctly (:pr:`5487`)
 - Fix entering room name if room booking is enabled but has no locations (:pr:`5495`)
 - Fix privacy information dropdown not opening on Safari (:pr:`5507`)
+- Only let explicitly assigned reviewers review papers (:pr:`5527`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/papers/models/revisions.py
+++ b/indico/modules/events/papers/models/revisions.py
@@ -185,12 +185,13 @@ class PaperRevision(ProposalRevisionMixin, RenderModeMixin, db.Model):
         from indico.modules.events.papers.util import is_type_reviewing_possible
 
         cfp = self.paper.cfp
+        contrib = self.paper.contribution
         reviewed_for = set()
         if include_reviewed:
             reviewed_for = {x.type for x in self.reviews if x.user == user and is_type_reviewing_possible(cfp, x.type)}
-        if is_type_reviewing_possible(cfp, PaperReviewType.content) and user in self.paper.cfp.content_reviewers:
+        if is_type_reviewing_possible(cfp, PaperReviewType.content) and user in contrib.paper_content_reviewers:
             reviewed_for.add(PaperReviewType.content)
-        if is_type_reviewing_possible(cfp, PaperReviewType.layout) and user in self.paper.cfp.layout_reviewers:
+        if is_type_reviewing_possible(cfp, PaperReviewType.layout) and user in contrib.paper_layout_reviewers:
             reviewed_for.add(PaperReviewType.layout)
         return set(map(PaperTypeProxy, reviewed_for))
 


### PR DESCRIPTION
Currently, to verify that a user can review a paper (in peer reviewing), we only check if the user is part of the reviewing team, instead of checking if they've been assigned to the specific paper.

This change fixes that by ensuring they've been assigned to the paper.