### PR TITLE
Hide 'pending review' message when reviewing is disabled

### DIFF
--- a/indico/modules/events/papers/models/call_for_papers.py
+++ b/indico/modules/events/papers/models/call_for_papers.py
@@ -8,6 +8,7 @@
 from indico.modules.events.papers.models.competences import PaperCompetence
 from indico.modules.events.papers.models.reviews import PaperReviewType
 from indico.modules.events.papers.settings import PaperReviewingRole, paper_reviewing_settings
+from indico.modules.events.papers.util import is_type_reviewing_possible
 from indico.modules.events.settings import EventSettingProperty
 from indico.util.caching import memoize_request
 from indico.util.date_time import now_utc
@@ -166,3 +167,11 @@ class CallForPapers:
 
     def can_access_judging_area(self, user):
         return self.is_manager(user) or self.is_judge(user)
+
+    @property
+    def is_content_reviewing_possible(self):
+        return is_type_reviewing_possible(self, PaperReviewType.content)
+
+    @property
+    def is_layout_reviewing_possible(self):
+        return is_type_reviewing_possible(self, PaperReviewType.layout)

--- a/indico/modules/events/papers/templates/display/_paper_list.html
+++ b/indico/modules/events/papers/templates/display/_paper_list.html
@@ -43,7 +43,7 @@
                                                 <div class="icon-checkmark align-icon semantic-text success">
                                                     {%- trans -%}You have submitted a content review{%- endtrans -%}
                                                 </div>
-                                            {% else %}
+                                            {% elif contribution.paper.cfp.is_content_reviewing_possible %}
                                                 <div class="icon-hour-glass2 align-icon semantic-text warning">
                                                     <a href="{{ url_for('.paper_timeline', contribution) }}"
                                                        class="submission-link">
@@ -57,7 +57,7 @@
                                                 <div class="icon-checkmark align-icon semantic-text success">
                                                     {%- trans -%}You have submitted a layout review{%- endtrans -%}
                                                 </div>
-                                            {% else %}
+                                            {% elif contribution.paper.cfp.is_layout_reviewing_possible %}
                                                 <div class="icon-hour-glass2 align-icon semantic-text warning">
                                                     <a href="{{ url_for('.paper_timeline', contribution) }}"
                                                        class="submission-link">


### PR DESCRIPTION
Happens when content or layout reviewing is disabled but you have been previously assigned as a reviewer to a paper.
In that case, you still get the message saying you have a pending review even though you can't review at that point.

I reused the same logic we have for deciding whether you can actually review a paper - either the reviewing module is disabled or it's past an enforced deadline.

![image](https://user-images.githubusercontent.com/8739637/194536297-18d6b2a4-6d0a-4fde-bcd5-f728da7069bc.png)
