### PR TITLE
Fix broken 'Reset judgment' link

### DIFF
--- a/indico/modules/events/abstracts/templates/reviewing/public.html
+++ b/indico/modules/events/abstracts/templates/reviewing/public.html
@@ -200,14 +200,15 @@
                 </div>
                 {% if abstract.event.can_manage(session.user, permission='abstracts') %}
                     <div class="hide-if-locked">
-                        <i class="red link icon undo"
-                           title="{% trans %}Reset judgment{% endtrans %}"
+                        <a title="{% trans %}Reset judgment{% endtrans %}"
                            data-href="{{ url_for('.reset_abstract_state', abstract) }}"
                            data-method="POST"
                            data-update="#reviewing-page"
                            data-replace-update
                            data-title="{% trans %}Reset judgment{% endtrans %}"
-                           data-confirm="{% trans %}Do you really want to reset the judgment? This operation is irreversible.{% endtrans %}"></i>
+                           data-confirm="{% trans %}Do you really want to reset the judgment? This operation is irreversible.{% endtrans %}">
+                            <i class="red link icon undo"></i>   
+                        </a>
                     </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
The confirm dialog doesn't seem to redirect properly (getting `undefined` in the url) when it's on the `<i>` element directly.
Fixed by reverting back to a link and putting the icon inside.