### PR TITLE
Do not auto-close note editor on save

### DIFF
--- a/indico/web/client/js/react/components/notes/ManageNotes.jsx
+++ b/indico/web/client/js/react/components/notes/ManageNotes.jsx
@@ -73,7 +73,13 @@ export default function ManageNotes({icon, title, apiURL, imageUploadURL, getNot
         <NoteEditor
           apiURL={apiURL}
           imageUploadURL={imageUploadURL}
-          closeModal={() => setModalOpen(false)}
+          closeModal={saved => {
+            if (saved) {
+              location.reload();
+            } else {
+              setModalOpen(false);
+            }
+          }}
           getNoteURL={getNoteURL}
         />
       )}

--- a/indico/web/client/js/react/components/notes/NoteEditor.jsx
+++ b/indico/web/client/js/react/components/notes/NoteEditor.jsx
@@ -31,6 +31,7 @@ export function NoteEditor({apiURL, imageUploadURL, closeModal, getNoteURL}) {
   const [loading, setLoading] = useState(false);
   const [allowWithoutChange, setAllowWithoutChange] = useState(false);
   const [converting, setConverting] = useState(false);
+  const [saved, setSaved] = useState(false);
   const [renderMode, setRenderMode] = useState(undefined);
 
   const combineNotes = (resp, mode) => {
@@ -116,9 +117,7 @@ export function NoteEditor({apiURL, imageUploadURL, closeModal, getNoteURL}) {
       return handleSubmitError(e);
     }
     setCurrentInput(data.source);
-    setTimeout(() => location.reload(), 10);
-    // never finish submitting to avoid fields being re-enabled
-    await new Promise(() => {});
+    setSaved(true);
   };
 
   const convertToHTML = markdownSource => async () => {
@@ -152,7 +151,7 @@ export function NoteEditor({apiURL, imageUploadURL, closeModal, getNoteURL}) {
           style={{minWidth: '65vw'}}
           size="large"
           initialValues={{source: currentInput}}
-          onClose={closeModal}
+          onClose={() => closeModal(saved)}
           onSubmit={handleSubmit}
           disabledUntilChange={!allowWithoutChange}
           unloadPrompt

--- a/indico/web/client/js/react/forms/final-form.jsx
+++ b/indico/web/client/js/react/forms/final-form.jsx
@@ -111,7 +111,7 @@ export function FinalModalForm({
   return (
     <FinalForm
       onSubmit={onSubmit}
-      subscription={{submitting: true, dirty: unloadPrompt}}
+      subscription={{submitting: true, dirty: true}}
       initialValues={initialValues}
       initialValuesEqual={initialValuesEqual}
       decorators={decorators}
@@ -148,7 +148,7 @@ export function FinalModalForm({
             />
             <Form.Field disabled={fprops.submitting}>
               <Button onClick={onClose} disabled={fprops.submitting}>
-                <Translate>Cancel</Translate>
+                {fprops.dirty ? <Translate>Cancel</Translate> : <Translate>Close</Translate>}
               </Button>
             </Form.Field>
           </Modal.Actions>


### PR DESCRIPTION
This restores the previous behavior where you could quickly save while writing minutes, and then explicitly close the minutes editor once you were done.

This change should also fix the occasional unload prompt happening right after saving when the page was auto-reloaded...

---

The alternative would be separate buttons or even making the behavior configurable for each user, but especially due to the unload prompt fix I went for this option since it completely avoids this bug.