### PR TITLE
Include country_code in registrant API data

### DIFF
--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -45,6 +45,7 @@ from indico.modules.events.registration.notifications import (notify_invitation,
 from indico.modules.logs import LogKind
 from indico.modules.logs.util import make_diff_log
 from indico.modules.users.util import get_user_by_email
+from indico.util.countries import get_country_reverse
 from indico.util.date_time import format_date, now_utc
 from indico.util.i18n import _
 from indico.util.signals import values_from_signal
@@ -602,6 +603,7 @@ def _build_personal_data(registration):
     personal_data['firstName'] = personal_data.pop('first_name')
     personal_data['surname'] = personal_data.pop('last_name')
     personal_data['country'] = personal_data.pop('country', '')
+    personal_data['country_code'] = get_country_reverse(personal_data['country']) or ''
     personal_data['phone'] = personal_data.pop('phone', '')
     return personal_data
 

--- a/indico/util/countries.py
+++ b/indico/util/countries.py
@@ -33,6 +33,20 @@ def get_country(code, locale=None):
     return _get_country(code, locale)
 
 
+def get_country_reverse(name, locale=None):
+    """Get the country code from a country name.
+
+    Note: You almost certainly should not use this but rather store
+    the country code and use it directly.
+    The only reason this util exists is that the friendly_data handling
+    for registration form fields is one big mess (human-friendly vs
+    machine-friendly)...
+    """
+    if locale is None:
+        locale = get_current_locale()
+    return next((code for code, title in get_countries(locale).items() if title == name), None)
+
+
 @memoize
 def _get_country(code, locale):
     try:


### PR DESCRIPTION
This is a bit of a back, but the `friendly_data` logic for the regform fields is really one big mess that should be refactored at some point - but for now just doing a reverse lookup on the country title is much easier (and will make JACoW happy).