### PR TITLE
Fix session legend on timetable's All days view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Bugfixes
 - Only let explicitly assigned reviewers review papers (:pr:`5527`)
 - Never count participants from a registration forms with a fully hidden participant
   list for the total count on the participant page (:pr:`5532`)
+- Fix "Session Legend" not working in all-days timetable view (:pr:`5539`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/js/legacy/libs/timetable/Base.js
+++ b/indico/web/client/js/legacy/libs/timetable/Base.js
@@ -1373,7 +1373,7 @@ type(
       });
 
       // for "all days", put it all together
-      days['all'] = _(days)
+      days['all'] = _(Object.values(days))
         .chain()
         .flatten(true)
         .groupBy(function(e) {


### PR DESCRIPTION
This PR fixes a bug in the Timetable that causes the session legend to not be displayed when viewing for all days.