### PR TITLE
Format code & blockquote in editor output

### DIFF
--- a/indico/modules/events/layout/templates/page.html
+++ b/indico/modules/events/layout/templates/page.html
@@ -20,5 +20,5 @@
 {% endblock %}
 
 {% block content %}
-    <div class="ck-output">{{ page.html|sanitize_html }}</div>
+    <div class="editor-output">{{ page.html|sanitize_html }}</div>
 {% endblock %}

--- a/indico/modules/events/notes/templates/_note.html
+++ b/indico/modules/events/notes/templates/_note.html
@@ -30,7 +30,7 @@
         <div class="padded-box-pad icon-file-text"></div>
         <div class="padded-box-content">
             {{ _render_note_actions(note=note, event=event, hidden=hidden, can_edit=can_edit, anchor=anchor) }}
-            <div class="note-text ck-output {% if event %}{{ _togglable_classes(hidden=hidden) }}{% endif %}">
+            <div class="note-text editor-output {% if event %}{{ _togglable_classes(hidden=hidden) }}{% endif %}">
                 {{ note.html|sanitize_html }}
             </div>
             {% if event %}

--- a/indico/modules/events/templates/display/conference.html
+++ b/indico/modules/events/templates/display/conference.html
@@ -4,7 +4,7 @@
 
 {% block content %}
     <div class="conferenceDetails">
-        <div itemprop="description" class="description js-mathjax ck-output">
+        <div itemprop="description" class="description js-mathjax editor-output">
             {{ event.description }}
         </div>
 

--- a/indico/modules/events/templates/display/indico/_details.html
+++ b/indico/modules/events/templates/display/indico/_details.html
@@ -8,7 +8,7 @@
     {% if event.description %}
         <div class="event-details-row">
             <div class="event-details-label">{% trans %}Description{% endtrans %}</div>
-            <div class="event-details-content">{{ render_description(event, class='event-description ck-output') }}</div>
+            <div class="event-details-content">{{ render_description(event, class='event-description editor-output') }}</div>
         </div>
     {% endif %}
     {% if event.references and event.type_.name == "meeting" %}

--- a/indico/web/client/styles/ckeditor.scss
+++ b/indico/web/client/styles/ckeditor.scss
@@ -18,12 +18,13 @@
   height: 100% !important; /* overrides i-form auto height */
 }
 
-// When positioning images, ckeditor5 just applies certain classes that have to be manually implemented:
-// https://ckeditor.com/docs/ckeditor5/latest/features/images/images-styles.html
-// Inspired by the default ckeditor styles:
-// https://github.com/ckeditor/ckeditor5/blob/06d11a85d01aece904a6bdd25e72abd94a4dd314/packages/ckeditor5-image/theme/imagestyle.css
-// Applies to conference & event description, minutes and custom conference pages
-.ck-output {
+// Neither ckeditor nor the markdown editor implement the styles shown in their preview - they need to be manually implemented.
+// These styles apply to the generated output in conference & event description, minutes and custom conference pages.
+.editor-output {
+  // Image positioning for ckeditor5
+  // https://ckeditor.com/docs/ckeditor5/latest/features/images/images-styles.html
+  // Inspired by the default ckeditor styles:
+  // https://github.com/ckeditor/ckeditor5/blob/06d11a85d01aece904a6bdd25e72abd94a4dd314/packages/ckeditor5-image/theme/imagestyle.css
   $image-spacing: 1.5em;
   display: flow-root;
 
@@ -60,5 +61,17 @@
 
   &.weak-hidden {
     display: none;
+  }
+
+  // Nicer quote & code formatting
+  blockquote {
+    padding: 5px 8px 5px 30px;
+    background-color: rgba(102, 128, 153, 0.05);
+    border-left: 10px solid #d6dbdf;
+  }
+
+  pre,
+  code {
+    background-color: #f5f5f5;
   }
 }


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8739637/196123968-a9f9bd5f-0f54-43ba-820c-9d252d9d665d.png)


Multiline code blocks don't work very well in ckeditor. 
![image](https://user-images.githubusercontent.com/8739637/196124256-3bf8c8c1-28ab-416e-8f0e-f8e2e5999ffb.png)

If we want to support them we'll probably need to add the Code blocks plugin.