### PR TITLE
Warn when a user does not have rights to create an event

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Improvements
 ^^^^^^^^^^^^
 
 - Display program codes in 'My contributions' (:pr:`5573`)
+- Warn when a user cannot create an event in the current category (:pr:`5572`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/categories/fields.py
+++ b/indico/modules/categories/fields.py
@@ -25,7 +25,7 @@ class CategoryField(HiddenField):
     widget = JinjaWidget('forms/category_picker_widget.html')
 
     def __init__(self, *args, **kwargs):
-        self.navigator_category_id = 0
+        self.navigator_category_id = None
         self.require_event_creation_rights = kwargs.pop('require_event_creation_rights', False)
         super().__init__(*args, **kwargs)
 

--- a/indico/modules/events/client/js/creation.js
+++ b/indico/modules/events/client/js/creation.js
@@ -58,7 +58,7 @@ import {camelizeKeys} from 'indico/utils/case';
     let multipleOccurrences = false;
 
     protectionMessage.appendTo(options.protectionModeFields.closest('.form-field'));
-    eventCreationMessage.appendTo(options.categoryField.closest('.form-field'));
+    eventCreationMessage.insertAfter($('#category-warning-event-creation-category'));
     listingMessage.appendTo($listingField.closest('.form-field'));
 
     $submitBtn.prop('disabled', true);

--- a/indico/modules/events/client/js/creation.js
+++ b/indico/modules/events/client/js/creation.js
@@ -101,13 +101,6 @@ import {camelizeKeys} from 'indico/utils/case';
       eventCreationMessage.toggleClass('hidden', canCreateInSelectedCategory());
     }
 
-    function updateWarningMessage() {
-      $(`#category-warning-event-creation-category`).toggleClass(
-        'hidden',
-        (currentCategory && currentCategory.has_events) || !currentCategory
-      );
-    }
-
     options.categoryField.on('indico:categorySelected', (evt, cat) => {
       if (!currentCategory) {
         options.protectionModeFields.filter('[value=inheriting]').prop('checked', true);
@@ -140,9 +133,8 @@ import {camelizeKeys} from 'indico/utils/case';
         options.categoryField.trigger('indico:categorySelected', []);
       }
 
-      // update listing and warning message boxes
+      // update listing
       listingMessage.toggleClass('hidden', JSON.parse($listingField.val()));
-      updateWarningMessage();
     });
 
     options.protectionModeFields.on('change', function() {

--- a/indico/modules/events/client/js/creation.js
+++ b/indico/modules/events/client/js/creation.js
@@ -33,7 +33,10 @@ import {camelizeKeys} from 'indico/utils/case';
     const messages = $($.parseHTML($('#event-creation-protection-messages').html()));
     const protectionMessage = $('<div>', {class: 'form-group', css: {marginTop: '5px'}});
     const listingMessage = $($.parseHTML($('#event-listing-message').html()));
+    const eventCreationMessage = $($.parseHTML($('#event-creation-message').html()));
 
+    const $form = options.categoryField.closest('form');
+    const $submitBtn = $form.find('input[type="submit"]').first();
     const $createBooking = $('#event-creation-create_booking');
     const $availableMessage = $('#room-available');
     const $availablePrebookMessage = $('#room-available-prebook');
@@ -55,7 +58,29 @@ import {camelizeKeys} from 'indico/utils/case';
     let multipleOccurrences = false;
 
     protectionMessage.appendTo(options.protectionModeFields.closest('.form-field'));
+    eventCreationMessage.appendTo(options.categoryField.closest('.form-field'));
     listingMessage.appendTo($listingField.closest('.form-field'));
+
+    $submitBtn.prop('disabled', true);
+    $form.on('change input', updateSubmitBtn);
+
+    function canCreateInSelectedCategory() {
+      return (
+        options.canCreateEvents ||
+        // unlisted events or no default category
+        !currentCategory ||
+        // categories other than the initial one cannot be selected unless the user can create events in them
+        currentCategory?.id !== options.initialCategory?.id
+      );
+    }
+
+    // like disabled-until-change but also disables submit when the user
+    // does not have the rights to create events in the selected category
+    function updateSubmitBtn() {
+      const untouched = $.param($form.serializeArray(), true) === $form.data('initialData');
+      const disabled = untouched || !canCreateInSelectedCategory();
+      $submitBtn.prop('disabled', disabled);
+    }
 
     function updateProtectionMessage() {
       if (!currentCategory) {
@@ -69,6 +94,11 @@ import {camelizeKeys} from 'indico/utils/case';
       const elem = messages.filter(`.${mode}-protection-message`);
       elem.find('.js-category-title').text(currentCategory && currentCategory.title);
       protectionMessage.html(elem);
+    }
+
+    // Display a warning if the user does not have the rights to create events in the selected category
+    function updateEventCreationMessage() {
+      eventCreationMessage.toggleClass('hidden', canCreateInSelectedCategory());
     }
 
     function updateWarningMessage() {
@@ -90,6 +120,8 @@ import {camelizeKeys} from 'indico/utils/case';
       }
       currentCategory = cat;
       updateProtectionMessage();
+      updateEventCreationMessage();
+      updateSubmitBtn();
     });
 
     $listingField.on('change', evt => {

--- a/indico/modules/events/controllers/creation.py
+++ b/indico/modules/events/controllers/creation.py
@@ -156,10 +156,13 @@ class RHCreateEvent(RHProtected):
             return jsonify_data(flash=False, redirect=url_for('event_management.settings', event))
         check_room_availability = rb_check_user_access(session.user) and config.ENABLE_ROOMBOOKING
         rb_excluded_categories = [c.id for c in rb_settings.get('excluded_categories')]
+        category = self._default_category
+        can_create_events = category.can_create_events(session.user) if category else True
         return jsonify_template('events/forms/event_creation_form.html', form=form, fields=form._field_order,
                                 event_type=self.event_type.name, single_category=(not self.root_category.has_children),
                                 check_room_availability=check_room_availability,
                                 rb_excluded_categories=rb_excluded_categories,
+                                can_create_events=can_create_events,
                                 can_create_unlisted_events=can_create_unlisted_events(session.user))
 
 

--- a/indico/modules/events/templates/forms/event_creation_form.html
+++ b/indico/modules/events/templates/forms/event_creation_form.html
@@ -114,7 +114,7 @@ purely client-side and are worded for event creation instead of being generic.
         <div class="section">
             <div class="icon icon-warning"></div>
             <div class="text">
-                <div class="label">
+                <div>
                     {% trans %}You are not allowed to create events in this category.{% endtrans %}
                 </div>
             </div>

--- a/indico/modules/events/templates/forms/event_creation_form.html
+++ b/indico/modules/events/templates/forms/event_creation_form.html
@@ -17,7 +17,7 @@
     {% endcall %}
 {% endif %}
 {% call form_footer(form) %}
-    <input class="i-button big highlight" type="submit" value="{% trans %}Create event{% endtrans %}" />
+    <input class="i-button big highlight" type="submit" value="{% trans %}Create event{% endtrans %}">
     <button type="button" class="i-button big" data-button-back>{% trans %}Cancel{% endtrans %}</button>
 {% endcall %}
 

--- a/indico/modules/events/templates/forms/event_creation_form.html
+++ b/indico/modules/events/templates/forms/event_creation_form.html
@@ -16,8 +16,7 @@
     {% endcall %}
 {% endif %}
 {% call form_footer(form) %}
-    <input class="i-button big highlight" type="submit" value="{% trans %}Create event{% endtrans %}"
-           data-disabled-until-change>
+    <input class="i-button big highlight" type="submit" value="{% trans %}Create event{% endtrans %}" />
     <button type="button" class="i-button big" data-button-back>{% trans %}Cancel{% endtrans %}</button>
 {% endcall %}
 
@@ -110,11 +109,25 @@ purely client-side and are worded for event creation instead of being generic.
     </div>
 </script>
 
+<script type="text/html" id="event-creation-message">
+    <div class="action-box mid-form for-form danger hidden">
+        <div class="section">
+            <div class="icon icon-warning"></div>
+            <div class="text">
+                <div class="label">
+                    {% trans %}You are not allowed to create events in this category.{% endtrans %}
+                </div>
+            </div>
+        </div>
+    </div>
+</script>
+
 <script>
     setupEventCreationDialog({
         categoryField: $('#{{ form.category.id }}'),
         protectionModeFields: $('input[name="{{ form.protection_mode.name }}"][id^="{{ form.protection_mode.id }}"]'),
         initialCategory: {{ category | tojson }},
+        canCreateEvents: {{ can_create_events | tojson }},
         checkAvailability: {{ check_room_availability | tojson }},
         rbExcludedCategories: {{ rb_excluded_categories | tojson }},
         serverDefaultTimezone: {{ indico_config.DEFAULT_TIMEZONE | tojson }}

--- a/indico/modules/events/templates/forms/event_creation_form.html
+++ b/indico/modules/events/templates/forms/event_creation_form.html
@@ -2,7 +2,8 @@
 {% set category = {'id': form.category.data.id,
                    'is_protected': form.category.data.is_protected,
                    'title': form.category.data.title,
-                   'has_events': form.category.data.has_events} if form.category.data else none %}
+                   'has_events': form.category.data.has_events,
+                   'has_children': form.category.data.has_children } if form.category.data else none %}
 
 {{ form_header(form, action=url_for('events.create', event_type=event_type)) }}
 {% if can_create_unlisted_events %}

--- a/indico/modules/events/templates/forms/event_creation_form.html
+++ b/indico/modules/events/templates/forms/event_creation_form.html
@@ -3,7 +3,7 @@
                    'is_protected': form.category.data.is_protected,
                    'title': form.category.data.title,
                    'has_events': form.category.data.has_events,
-                   'has_children': form.category.data.has_children } if form.category.data else none %}
+                   'has_children': form.category.data.has_children} if form.category.data else none %}
 
 {{ form_header(form, action=url_for('events.create', event_type=event_type)) }}
 {% if can_create_unlisted_events %}

--- a/indico/web/templates/forms/category_picker_widget.html
+++ b/indico/web/templates/forms/category_picker_widget.html
@@ -6,12 +6,19 @@
     <div>
         <div id="category-title-{{ field.id }}" class="text-holder-box flexrow f-a-center" data-tooltip-anchor></div>
         <div id="category-warning-{{ field.id }}" class="hidden">
-            {% call message_box('warning') %}
-                {% trans %}
-                    The selected category does not contain any events, only subcategories.
-                    Please make sure that you really want to create an event there.
-                {% endtrans %}
-            {% endcall %}
+            <div class="action-box mid-form for-form warning">
+                <div class="section">
+                    <div class="icon icon-warning"></div>
+                    <div class="text">
+                        <div>
+                            {% trans %}
+                                The selected category does not contain any events, only subcategories.
+                                Please make sure that you really want to create an event there.
+                            {% endtrans %}
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
         <button type="button"
                 class="i-button"


### PR DESCRIPTION
Closes #5469 

When using the 'Create event' in a category where a user cannot create events, a warning is displayed in the form and submit is disabled.

This way, users know right away instead of filling out the form and trying to submit.

![image](https://user-images.githubusercontent.com/8739637/203360462-55a61a36-c84a-4040-9af6-175c0abc9e1e.png)


![image](https://user-images.githubusercontent.com/8739637/203360277-792a92db-5cad-4e28-babd-53a467c4c506.png)

