### PR TITLE
Display programme codes in 'My contributions'

### DIFF
--- a/indico/modules/events/contributions/templates/display/user_contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/user_contribution_list.html
@@ -15,6 +15,11 @@
                                 <a class="js-mathjax" href="{{ url_for('.display_contribution', contrib) }}">
                                     {{- contrib.title -}}
                                 </a>
+                                {% if contrib.code -%}
+                                    <span class="contrib-code">
+                                        ({{ contrib.code }})
+                                    </span>
+                                {%- endif %}
                             </span>
                             <div class="group">
                                 {% if contrib.can_edit(session.user) -%}


### PR DESCRIPTION
One of the JACoW suggestions is to add the program code to the 'My contributions' list.
Reused the same styles from the normal contribution list (`_contribution_list.html`)

![image](https://user-images.githubusercontent.com/8739637/203025049-78b91ceb-81b0-4aeb-a481-94e7ce556f9f.png)
