### PR TITLE
Fix "Submit Answer For" form submission

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Bugfixes
 ^^^^^^^^
 
 - Fix broken links in some notification emails (:pr:`5567`)
+- Fix always-disabled submit button when submitting an agreement response
+  on someone's behalf (:pr:`5574`)
 
 
 Version 3.2.1

--- a/indico/modules/events/agreements/templates/dialogs/agreement_submit_answer_form.html
+++ b/indico/modules/events/agreements/templates/dialogs/agreement_submit_answer_form.html
@@ -34,7 +34,7 @@
                     return false;
                 }
                 var valid = true;
-                form.find(':input:visible').each(function() {
+                form.find(':input:visible:not(:button)').each(function() {
                     var $this = $(this);
                     if ($this.is(':checkbox:not(:checked)') || !$this.val()) {
                         valid = false;


### PR DESCRIPTION
This PR fixes a bug that made the "Submit" button always disabled in the "Submit Answer For" dialog for Agreements.

The bug was caused by the recent change of i-buttons from `<a>` to `<button>` (#5545), which caused the custom script in this form to interpret the "Cancel" button as one of the inputs to check. The check always failed because the value of the button was interpreted as `false`.