### PR TITLE
Display all contributions in 'My contributions'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Improvements
 
 - Display program codes in 'My contributions' (:pr:`5573`)
 - Warn when a user cannot create an event in the current category (:pr:`5572`)
+- Display all contributions in 'My contributions' and not just those with
+  submitter privileges (:pr:`5575`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/__init__.py
+++ b/indico/modules/events/contributions/__init__.py
@@ -99,13 +99,13 @@ class SubmitterPermission(ManagementPermission):
 
 @signals.event.sidemenu.connect
 def _extend_event_menu(sender, **kwargs):
-    from indico.modules.events.contributions.util import has_contributions_with_user_as_submitter
+    from indico.modules.events.contributions.util import user_has_contributions
     from indico.modules.events.layout.util import MenuEntryData
 
     def _visible_my_contributions(event):
         if not session.user:
             return False
-        return has_contributions_with_user_as_submitter(event, session.user)
+        return user_has_contributions(event, session.user)
 
     def _visible_list_of_contributions(event):
         published = contribution_settings.get(event, 'published')

--- a/indico/modules/events/contributions/templates/display/_user_contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/_user_contribution_list.html
@@ -1,0 +1,49 @@
+{% macro render_contribution_section(contributions, title) %}
+    {% if contributions %}
+        <section>
+            <div class="header">
+                <div class="header-row">
+                    <h3>{{ title }}</h3>
+                </div>
+            </div>
+            {{ _render_contribution_list(contributions) }}
+        </section>
+    {%- endif %}
+{% endmacro %}
+
+{% macro _render_contribution_list(contributions) %}
+    <div class="i-box no-padding">
+        <div class="i-box-content">
+            <ul class="group-list no-content-before with-buttons">
+                {% for contrib in contributions | sort(attribute='title') %}
+                    {{ _render_contribution_row(contrib) }}
+                {%- endfor %}
+            </ul>
+        </div>
+    </div>
+{% endmacro %}
+
+{% macro _render_contribution_row(contrib) %}
+    <li class="flexrow f-j-space-between">
+        <span class="text">
+            <a class="js-mathjax" href="{{ url_for('.display_contribution', contrib) }}">
+                {{- contrib.title -}}
+            </a>
+            {% if contrib.code -%}
+                <span class="contrib-code">
+                    ({{ contrib.code }})
+                </span>
+            {%- endif %}
+        </span>
+        <div class="group">
+            {% if contrib.can_edit(session.user) -%}
+                <a href="#" class="icon-edit js-edit-contribution"
+                   title="{% trans %}Edit this contribution{% endtrans %}"
+                   data-title="{% trans title=contrib.title %}Edit contribution '{{ title }}'{% endtrans %}"
+                   data-href="{{ url_for('.manage_update_contrib', contrib, standalone=true) }}"
+                   data-ajax-dialog
+                   data-reload-after></a>
+            {%- endif %}
+        </div>
+    </li>
+{% endmacro %}

--- a/indico/modules/events/contributions/templates/display/user_contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/user_contribution_list.html
@@ -1,44 +1,15 @@
 {% extends 'events/display/conference/base.html' %}
+{% from 'events/contributions/display/_user_contribution_list.html' import render_contribution_section %}
 
 {% block title -%}
     {{- page_title -}}
 {%- endblock %}
 
 {% block content -%}
-    <section>
-        <div class="i-box no-padding">
-            <div class="i-box-content">
-                <ul class="group-list no-content-before with-buttons">
-                    {% for contrib in contributions %}
-                        <li class="flexrow f-j-space-between">
-                            <span class="text">
-                                <a class="js-mathjax" href="{{ url_for('.display_contribution', contrib) }}">
-                                    {{- contrib.title -}}
-                                </a>
-                                {% if contrib.code -%}
-                                    <span class="contrib-code">
-                                        ({{ contrib.code }})
-                                    </span>
-                                {%- endif %}
-                            </span>
-                            <div class="group">
-                                {% if contrib.can_edit(session.user) -%}
-                                    <a href="#" class="icon-edit js-edit-contribution"
-                                       title="{% trans %}Edit this contribution{% endtrans %}"
-                                       data-title="{% trans title=contrib.title %}Edit contribution '{{ title }}'{% endtrans %}"
-                                       data-href="{{ url_for('.manage_update_contrib', contrib, standalone=true) }}"
-                                       data-ajax-dialog
-                                       data-reload-after></a>
-                                {%- endif %}
-                            </div>
-                        </li>
-                    {% else %}
-                        <li>{% trans %}You don't have any contributions at the moment.{% endtrans %}</li>
-                    {%- endfor %}
-                </ul>
-            </div>
-        </div>
-    </section>
+    {{ render_contribution_section(contributions.speaker, title=_('Speaker')) }}
+    {{ render_contribution_section(contributions.primary, title=_('Primary author')) }}
+    {{ render_contribution_section(contributions.secondary, title=_('Co-author')) }}
+    {{ render_contribution_section(contributions.submitter, title=_('Submitter')) }}
     {% if event.type != 'conference' -%}
         <p>
             <a href="{{ event.url }}" class="i-button">


### PR DESCRIPTION
Instead of showing only contributions for which the user is a submitter,
we show all contributions categorized by primary/secondary author, speaker or submitter.

Contributions in the `Submitter` section are only shown if the user neither an author or a speaker.

Not-so-obvious edge case: a user can have submission rights on a contribution w/o having a person link (= not added in the `People` field in contribution settings) - these contributions are included.



![image](https://user-images.githubusercontent.com/8739637/203088579-e6cc96ba-280a-4950-99e3-c68071c67805.png)

