### PR TITLE
Add relative 'node_modules' to webpack resolve paths

### DIFF
--- a/webpack/base.js
+++ b/webpack/base.js
@@ -92,6 +92,9 @@ export function webpackDefaults(env, config, bundles, isPlugin = false) {
   const globalBuildConfig = config.indico ? config.indico.build : config.build;
   const currentEnv = (env ? env.NODE_ENV : null) || 'development';
   const nodeModules = [
+    // Pass relative 'node_modules' first, so that nested node_modules are checked first.
+    // https://webpack.js.org/configuration/resolve/#resolvemodules
+    'node_modules',
     path.join(
       config.build.indicoSourcePath || path.resolve(config.build.rootPath, '..'),
       'node_modules'


### PR DESCRIPTION
When only an absolute path is provided, webpack does not do the normal node-like bubbling up when looking for modules.

This is a problem when a library has a nested node_modules directory with a dependency which has a different version than the dependency in the top-level node_modules.

https://webpack.js.org/configuration/resolve/#resolvemodules

There is a problem currently in #5571 where `sanitize-html` depends on `is-plain-object:5.0.0`. There is already a version `2.0.4` installed in the top-level `node_modules` and those two are incompatible (one has a default export, one doesn't)

Quick&dirty way to check what path a library import resolves to:

```js
console.log("is-plain-object resolve path:", require('path').resolve(require.resolve('is-plain-object')))
```



