### PR TITLE
Clarify rejected message in editing timeline

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
@@ -104,10 +104,9 @@ describe('timeline selectors', () => {
     expect(result[1].id).toBe(2);
     expect(result[1].items).toStrictEqual([
       expect.objectContaining({
-        header:
-          revisionStates[InitialRevisionState.needs_submitter_confirmation][
-            FinalRevisionState.needs_submitter_changes
-          ],
+        header: revisionStates[InitialRevisionState.needs_submitter_confirmation][
+          FinalRevisionState.needs_submitter_changes
+        ](result[1], {isLatestRevision: false}),
       }),
     ]);
     expect(result[2].id).toBe(3);


### PR DESCRIPTION
(One of the JACoW suggestions)

When an author rejects proposed changes by an editor and submits a new version themselves, the title of the revision item is still `Submitter rejected proposed changes` which is misleading.

This changes the title to `Submitter rejected proposed changes and uploaded a new revision` when a new revision has been uploaded by the author.

The distinction in the title of the revision is made based on whether the revision is the last one. If it's the last revision, no files have been uploaded yet and vice versa. 

![image](https://user-images.githubusercontent.com/8739637/203766812-e137a6d1-8f06-4f7a-8bad-89fe0bd97dc7.png)
![image](https://user-images.githubusercontent.com/8739637/203769098-699ab499-f22a-4eee-8715-8a4ad4551b26.png)


