### PR TITLE
Use server's default locale instead of en_US

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Bugfixes
 - Disallow nonsensical retention periods and visibility durations (:pr:`5576`)
 - Fix sorting by program code in editable list (:pr:`5582`)
 - Do not strip custom CSS classes from HTML in CKEditor (:issue:`5584`, :pr:`5585`)
+- Use the instance's default locale instead of "no locale" (US-English) in places
+  where no better information is known for email recipients (:pr:`5586`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/controllers/management/regforms.py
+++ b/indico/modules/events/registration/controllers/management/regforms.py
@@ -127,7 +127,7 @@ class RHManageRegistrationFormDisplay(RHManageRegFormBase):
 
 
 def _get_regform_creation_log_data(regform):
-    with force_locale(None):
+    with force_locale(None, default=False):
         return {
             'Visibility to participants': orig_string(regform.publish_registrations_participants.title),
             'Visibility to everyone': orig_string(regform.publish_registrations_public.title),

--- a/indico/modules/events/reminders/controllers.py
+++ b/indico/modules/events/reminders/controllers.py
@@ -128,6 +128,7 @@ class RHPreviewReminder(RHRemindersBase):
     def _process(self):
         include_summary = request.form.get('include_summary') == '1'
         include_description = request.form.get('include_description') == '1'
-        tpl = make_reminder_email(self.event, include_summary, include_description, request.form.get('message'))
-        html = render_template('events/reminders/preview.html', subject=tpl.get_subject(), body=tpl.get_body())
+        with self.event.force_event_locale():
+            tpl = make_reminder_email(self.event, include_summary, include_description, request.form.get('message'))
+            html = render_template('events/reminders/preview.html', subject=tpl.get_subject(), body=tpl.get_body())
         return jsonify(html=html)

--- a/indico/modules/logs/util.py
+++ b/indico/modules/logs/util.py
@@ -74,7 +74,7 @@ def make_diff_log(changes, fields):
             change = [x.isoformat() for x in change]
         elif not_none_change and all(isinstance(x, timedelta) for x in not_none_change):
             type_ = 'timedelta'
-            with force_locale(None):
+            with force_locale(None, default=False):
                 change = [format_human_timedelta(x) if x is not None else default for x in change]
         else:
             type_ = 'text'

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -203,13 +203,22 @@ def _remove_locale_script(locale):
     return f'{parts[0]}_{parts[-1]}'
 
 
-def force_locale(locale):
+def force_locale(locale, *, default=True):
     """Temporarily override the locale.
 
     Use this as a context manager in a ``with`` block.
     `locale` can be set to ``None`` to avoid translation and thus
     use the hardcoded string which is en_US.
+
+    :param locale: The locale to force
+    :param default: Whether to use the server default instead of en_US
+                    if no locale is specified. Should be disabled only
+                    for cases where an english string is always preferred,
+                    e.g. when generating log messages that include stuff
+                    like enum titles or dates
     """
+    if default and not locale:
+        locale = config.DEFAULT_LOCALE
     return _force_locale(locale or 'en_US')
 
 


### PR DESCRIPTION
This makes more sense since that way e.g. event reminders use the server's preferred locale instead of en_US.
Also fixing the event reminder preview to use the correct locale.