### PR TITLE
Allow raw HTML snippets in custom page ckeditor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Improvements
   submitter privileges (:pr:`5575`)
 - Apply stronger sanitization on rich-text content pasted into CKEditor
   (:issue:`5560`, :pr:`5571`)
+- Allow raw HTML snippets when editing custom conference pages and event
+  descriptions (:issue:`5584`, :pr:`5587`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/layout/forms.py
+++ b/indico/modules/events/layout/forms.py
@@ -171,7 +171,7 @@ class MenuLinkForm(MenuUserEntryFormBase):
 
 
 class MenuPageForm(MenuUserEntryFormBase):
-    html = TextAreaField(_('Content'), [DataRequired()], widget=CKEditorWidget(images=True))
+    html = TextAreaField(_('Content'), [DataRequired()], widget=CKEditorWidget(images=True, html_embed=True))
 
     def __init__(self, *args, ckeditor_upload_url, **kwargs):
         self.ckeditor_upload_url = ckeditor_upload_url

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -58,7 +58,7 @@ CLONE_REPEAT_CHOICES = (
 
 class EventDataForm(IndicoForm):
     title = StringField(_('Event title'), [DataRequired()])
-    description = TextAreaField(_('Description'), widget=CKEditorWidget(images=True, height=250))
+    description = TextAreaField(_('Description'), widget=CKEditorWidget(images=True, html_embed=True, height=250))
     url_shortcut = StringField(_('URL shortcut'), filters=[lambda x: (x or None)])
 
     def __init__(self, *args, event, **kwargs):

--- a/indico/web/client/js/ckeditor.js
+++ b/indico/web/client/js/ckeditor.js
@@ -12,6 +12,7 @@ export const getConfig = ({
   imageUploadURL = null,
   fullScreen = true,
   showToolbar = true,
+  htmlEmbed = false,
 } = {}) => ({
   removePlugins: images && imageUploadURL ? [] : ['ImageInsert', 'ImageUpload'],
   fontFamily: {
@@ -58,6 +59,7 @@ export const getConfig = ({
       fullScreen && 'fullscreen',
       fullScreen && '|',
       'sourceEditing',
+      htmlEmbed && 'htmlEmbed',
     ].filter(Boolean),
   },
   plugins: [
@@ -78,6 +80,7 @@ export const getConfig = ({
     'GeneralHtmlSupport',
     'Heading',
     'HorizontalLine',
+    htmlEmbed && 'HtmlEmbed',
     images && 'Image',
     images && 'ImageBlockEditing',
     images && 'ImageCaption',

--- a/indico/web/client/js/jquery/widgets/jinja/ckeditor_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/ckeditor_widget.js
@@ -12,10 +12,18 @@ import {getConfig, sanitizeHtmlOnPaste} from 'indico/ckeditor';
 
 (function(global) {
   global.setupCKEditorWidget = async function setupCKEditorWidget(options) {
-    const {fieldId, images = true, imageUploadURL = null, width, height = 475, ...rest} = options;
+    const {
+      fieldId,
+      images = true,
+      imageUploadURL = null,
+      htmlEmbed = false,
+      width,
+      height = 475,
+      ...rest
+    } = options;
     const field = document.getElementById(fieldId);
     const editor = await ClassicEditor.create(field, {
-      ...getConfig({images, imageUploadURL}),
+      ...getConfig({images, imageUploadURL, htmlEmbed}),
       ...rest,
     });
     editor.setData(field.value);

--- a/indico/web/forms/widgets.py
+++ b/indico/web/forms/widgets.py
@@ -115,14 +115,15 @@ class CKEditorWidget(JinjaWidget):
     """Render a CKEditor WYSIWYG editor.
 
     :param images: Whether to allow images.
+    :param html_embed: Whether to enable raw HTML embedding.
     :param height: The height of the editor.
 
     If the form has a ``ckeditor_upload_url`` attribute and images are enabled,
     the editor will allow pasting/selecting images and upload them using that URL.
     """
 
-    def __init__(self, *, images=False, height=475):
-        super().__init__('forms/ckeditor_widget.html', images=images, height=height)
+    def __init__(self, *, images=False, html_embed=False, height=475):
+        super().__init__('forms/ckeditor_widget.html', images=images, html_embed=html_embed, height=height)
 
 
 class SwitchWidget(JinjaWidget):

--- a/indico/web/templates/forms/ckeditor_widget.html
+++ b/indico/web/templates/forms/ckeditor_widget.html
@@ -13,6 +13,7 @@
             fieldId: {{ field.id | tojson }},
             images: {{ images | tojson }},
             imageUploadURL: {{ field.get_form().ckeditor_upload_url|default(none) | tojson }},
+            htmlEmbed: {{ html_embed | tojson }},
             height: {{ height | tojson }}
         });
     </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "axios": "^0.27.2",
         "axios-hooks": "^3.1.1",
         "chartist": "^0.11.4",
-        "ckeditor": "git+https://indico@github.com/indico/ckeditor.git#v1.9.0",
+        "ckeditor": "git+https://indico@github.com/indico/ckeditor.git#v1.10.0",
         "clipboard": "^2.0.11",
         "connected-react-router": "^6.9.2",
         "core-js": "^2.6.12",
@@ -4816,8 +4816,8 @@
       "dev": true
     },
     "node_modules/ckeditor": {
-      "version": "1.9.0",
-      "resolved": "git+https://indico@github.com/indico/ckeditor.git#086f8aea4acf033042740636f3356d892eaf0723",
+      "version": "1.10.0",
+      "resolved": "git+https://indico@github.com/indico/ckeditor.git#e9554d23ccd93539dbecf5e11d6c9b47dd0ac7d5",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/classnames": {
@@ -29653,8 +29653,8 @@
       "dev": true
     },
     "ckeditor": {
-      "version": "git+https://indico@github.com/indico/ckeditor.git#086f8aea4acf033042740636f3356d892eaf0723",
-      "from": "ckeditor@git+https://indico@github.com/indico/ckeditor.git#v1.9.0"
+      "version": "git+https://indico@github.com/indico/ckeditor.git#e9554d23ccd93539dbecf5e11d6c9b47dd0ac7d5",
+      "from": "ckeditor@git+https://indico@github.com/indico/ckeditor.git#v1.10.0"
     },
     "classnames": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "axios": "^0.27.2",
     "axios-hooks": "^3.1.1",
     "chartist": "^0.11.4",
-    "ckeditor": "git+https://indico@github.com/indico/ckeditor.git#v1.9.0",
+    "ckeditor": "git+https://indico@github.com/indico/ckeditor.git#v1.10.0",
     "clipboard": "^2.0.11",
     "connected-react-router": "^6.9.2",
     "core-js": "^2.6.12",


### PR DESCRIPTION
Custom conference pages - especially in combination with custom stylesheets - may want to have more control over the HTML, and going through CKEditor's WYSIWYG logic can break this (see #5584).

The HTMLEmbed plugin allow embedding HTML that is left unmodified by the editor (ie only subject to server-side sanitization).