### PR TITLE
Warn about link materials being just links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Improvements
   (:issue:`5560`, :pr:`5571`)
 - Allow raw HTML snippets when editing custom conference pages and event
   descriptions (:issue:`5584`, :pr:`5587`)
+- Warn more clearly that link attachments are just a link and do not copy
+  the file (:issue:`5551`, :pr:`5593`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/attachments/templates/add_link.html
+++ b/indico/modules/attachments/templates/add_link.html
@@ -1,8 +1,15 @@
 {% from 'forms/_form.html' import form_header, form_footer, form_rows, form_row %}
+{% from 'message_box.html' import message_box %}
 
 {%- block content %}
+    {% call message_box('warning', fixed_width=true) %}
+        {% trans %}
+            Please be aware that only the URL will be stored and no copy of the referenced file
+            or website will be made. In case of a file, it is recommended to upload it to Indico instead.
+        {% endtrans %}
+    {% endcall %}
     {{ form_header(form, id='attachment-link-form')}}
-    {{ form_row(form.link_url, widget_attrs={'placeholder': 'Example: http://www.example.com/YourPDFFile.pdf'}) }}
+    {{ form_row(form.link_url, widget_attrs={'placeholder': 'Example: https://www.google.com'}) }}
     {{ form_rows(form, fields=('title', 'description', 'folder', 'protected')) }}
     {{ form_rows(form, fields=('acl',)) }}
     {{ protection_message | safe }}


### PR DESCRIPTION
Also replace the placeholder with a more appropriate one, since people should usually not link to external PDF files (those typically belong into Indico itself).

closes #5551