### PR TITLE
Add setting to disable material uploads

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Improvements
   to avoid collisions and inconsistencies (:pr:`5478`)
 - Add option to use review track as accepted track when bulk-accepting abstracts
   (:pr:`5608`)
+- Add setting to only allow managers to upload attachments to events and
+  contributions (:pr:`5597`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/attachments/blueprint.py
+++ b/indico/modules/attachments/blueprint.py
@@ -29,7 +29,8 @@ from indico.modules.attachments.controllers.management.event import (RHAddEventA
                                                                      RHCreateEventFolder, RHDeleteEventAttachment,
                                                                      RHDeleteEventFolder, RHEditEventAttachment,
                                                                      RHEditEventFolder, RHManageEventAttachments,
-                                                                     RHPackageEventAttachmentsManagement)
+                                                                     RHPackageEventAttachmentsManagement,
+                                                                     RHSetUploadPermissions)
 from indico.modules.events import event_management_object_url_prefixes, event_object_url_prefixes
 from indico.util.caching import memoize
 from indico.web.flask.util import make_compat_redirect_func, make_view_func
@@ -116,6 +117,9 @@ _bp.add_url_rule('/event/<int:event_id>/manage/attachments/package', 'package_ma
 _bp.add_url_rule('/event/<int:event_id>/attachments/package/status/<task_id>', 'package_status',
                  RHPackageEventAttachmentsStatus)
 
+# Event-level settings
+_bp.add_url_rule('/event/<int:event_id>/manage/attachments/upload-permissions', 'set_upload_permissions',
+                 RHSetUploadPermissions, methods=('GET', 'POST'))
 
 # Legacy redirects for the old URLs
 _compat_bp = IndicoBlueprint('compat_attachments', __name__, url_prefix='/event/<int:event_id>')

--- a/indico/modules/attachments/controllers/management/event.py
+++ b/indico/modules/attachments/controllers/management/event.py
@@ -14,11 +14,14 @@ from indico.modules.attachments.controllers.management.base import (AddAttachmen
                                                                     DeleteAttachmentMixin, DeleteFolderMixin,
                                                                     EditAttachmentMixin, EditFolderMixin,
                                                                     ManageAttachmentsMixin)
+from indico.modules.attachments.forms import SetUploadPermissionsForm
+from indico.modules.attachments.settings import attachments_settings
 from indico.modules.attachments.util import can_manage_attachments
 from indico.modules.attachments.views import WPEventAttachments, WPPackageEventAttachmentsManagement
-from indico.modules.events.controllers.base import RHEventBase
+from indico.modules.events.controllers.base import EditEventSettingsMixin, RHEventBase
 from indico.modules.events.management.controllers import RHManageEventBase
 from indico.modules.events.util import check_event_locked, get_object_from_args
+from indico.util.i18n import _
 from indico.web.flask.templating import get_template_module
 from indico.web.rh import RHProtected
 
@@ -97,3 +100,12 @@ class RHPackageEventAttachmentsManagement(AttachmentPackageMixin, RHManageEventB
     wp = WPPackageEventAttachmentsManagement
     management = True
     ALLOW_LOCKED = True
+
+
+class RHSetUploadPermissions(EditEventSettingsMixin, RHManageEventBase):
+    settings_proxy = attachments_settings
+    form_cls = SetUploadPermissionsForm
+    success_message = _('Upload permissions changed successfully')
+    log_module = 'Attachments'
+    log_message = 'Upload settings updated'
+    log_fields = {'managers_only': 'Managers only'}

--- a/indico/modules/attachments/forms.py
+++ b/indico/modules/attachments/forms.py
@@ -158,3 +158,9 @@ class AttachmentPackageForm(IndicoForm):
                                                DataRequired()],
                                               description=_('Include materials from sessions/contributions scheduled '
                                                             'on the selected dates'))
+
+
+class SetUploadPermissionsForm(IndicoForm):
+    managers_only = BooleanField(_('Managers only'), widget=SwitchWidget(),
+                                 description=_('Only allow managers to upload materials to the event, '
+                                               'contributions and sessions.'))

--- a/indico/modules/attachments/settings.py
+++ b/indico/modules/attachments/settings.py
@@ -1,0 +1,13 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from indico.modules.events.settings import EventSettingsProxy
+
+
+attachments_settings = EventSettingsProxy('attachments', {
+    'managers_only': False,  # Only event managers can upload attachments
+})

--- a/indico/modules/attachments/templates/attachments.html
+++ b/indico/modules/attachments/templates/attachments.html
@@ -3,6 +3,25 @@
 
 {% block title %}{% trans %}Materials{% endtrans %}{% endblock %}
 
+{% block title_actions %}
+    {% if linked_object_type == 'event' and not request.is_xhr and event.can_manage(session.user) %}
+        <a id="attachments-settings-dropdown"
+           class="i-button borderless icon-settings arrow js-dropdown"
+           data-toggle="dropdown">{% trans %}Settings{% endtrans %}</a>
+        <ul class="i-dropdown">
+            <li>
+                <a href="#"
+                   title="{% trans %}Upload permissions{% endtrans %}"
+                   data-ajax-dialog
+                   data-title="{% trans %}Set upload permissions{% endtrans %}"
+                   data-href="{{ url_for('.set_upload_permissions', event) }}"
+                   data-qtip-position="right">
+                    {% trans %}Upload permissions{% endtrans %}</a>
+            </li>
+        </ul>
+    {% endif %}
+{% endblock %}
+
 {% block content %}
     {{ attachments_page(linked_object, linked_object_type, attachments) }}
 {% endblock %}

--- a/indico/modules/attachments/util.py
+++ b/indico/modules/attachments/util.py
@@ -61,10 +61,14 @@ def get_attached_items(linked_object, include_empty=True, include_hidden=True, p
 
 def can_manage_attachments(obj, user, allow_admin=True):
     """Check if a user can manage attachments for the object."""
+    from indico.modules.attachments.settings import attachments_settings
     if not user:
         return False
     if obj.can_manage(user, allow_admin=allow_admin):
         return True
+    event = getattr(obj, 'event', None)
+    if event and attachments_settings.get(event, 'managers_only'):
+        return False
     if isinstance(obj, db.m.Event) and obj.can_manage(user, 'submit', allow_admin=allow_admin):
         return True
     if isinstance(obj, db.m.Contribution) and obj.can_manage(user, 'submit', allow_admin=allow_admin):

--- a/indico/modules/events/notes/templates/_note.html
+++ b/indico/modules/events/notes/templates/_note.html
@@ -72,7 +72,9 @@
             <span class="manage-notes-container hide-if-locked"
                   data-icon
                   data-api-url="{{ url_for('event_notes.api', note) }}"
-                  data-image-upload-url="{{ url_for('attachments.upload_ckeditor', note) }}"></span>
+                  {% if note.event.can_manage_attachments(session.user) %}
+                      data-image-upload-url="{{ url_for('attachments.upload_ckeditor', note) }}"
+                  {% endif %}></span>
         {% endif %}
     </div>
 {% endmacro %}

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -9,7 +9,9 @@
         {% endif %}
         <div class="manage-notes-container"
              data-api-url="{{ url_for('event_notes.api', item) }}"
-             data-image-upload-url="{{ url_for('attachments.upload_ckeditor', item) }}"
+             {% if item.can_manage_attachments(session.user) %}
+                 data-image-upload-url="{{ url_for('attachments.upload_ckeditor', item) }}"
+             {% endif %}
              data-title="{{ title }}"></div>
     </li>
 {%- endmacro %}
@@ -40,7 +42,9 @@
                             <div class="manage-notes-container"
                                  data-get-note-url="{{ url_for('event_notes.compile', item) }}"
                                  data-api-url="{{ url_for('event_notes.api', item) }}"
-                                 data-image-upload-url="{{ url_for('attachments.upload_ckeditor', item) }}"
+                                 {% if item.can_manage_attachments(session.user) %}
+                                     data-image-upload-url="{{ url_for('attachments.upload_ckeditor', item) }}"
+                                 {% endif %}
                                  data-title="{% trans %}Compile minutes{% endtrans %}"></div>
                         </li>
                     {% endif %}
@@ -96,7 +100,7 @@
                 </li>
             {% endif %}
         {% elif item_type == 'CONTRIBUTION' %}
-            {% if item.can_manage_attachments(session.user) %}
+            {% if item.can_manage(session.user, 'submit') %}
                 {% if not item.has_note or show_note_operations %}
                     {{ _render_note_editor(item) }}
                 {% endif %}

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -1,189 +1,131 @@
 {% from 'events/notes/_note.html' import render_toggle_button %}
 
 {% macro _render_note_editor(item) -%}
-    <li>
-        {% if item.has_note %}
-            {% set title = _('Edit minutes') %}
-        {% else %}
-            {% set title = _('Add minutes') %}
-        {% endif %}
+    {% if item.has_note %}
+        {% set title = _('Edit minutes') %}
+    {% else %}
+        {% set title = _('Add minutes') %}
+    {% endif %}
+    <div class="manage-notes-container"
+         data-api-url="{{ url_for('event_notes.api', item) }}"
+         {% if item.can_manage_attachments(session.user) %}
+             data-image-upload-url="{{ url_for('attachments.upload_ckeditor', item) }}"
+         {% endif %}
+         data-title="{{ title }}"></div>
+{%- endmacro %}
+
+{%- macro _render_dropdown_option(opt, item, item_type) -%}
+    {%- if opt == 'event_edit' -%}
+        <a href="{{ url_for('event_management.settings', item) }}">
+            {%- trans -%}Edit Event{%- endtrans -%}
+        </a>
+    {%- elif opt == 'event_clone' -%}
+        <a data-href="{{ url_for('event_management.clone', item) }}"
+           data-title="{% trans %}Clone Event{%- endtrans -%}"
+           data-ajax-dialog
+           href="">
+            {%- trans -%}Clone Event{%- endtrans -%}
+        </a>
+    {%- elif opt == 'notes_edit' -%}
+        {% set note_item = item.session if item_type == 'SESSION_BLOCK' else item %}
+        {{ _render_note_editor(note_item) }}
+    {%- elif opt == 'notes_compile' -%}
         <div class="manage-notes-container"
+             data-get-note-url="{{ url_for('event_notes.compile', item) }}"
              data-api-url="{{ url_for('event_notes.api', item) }}"
              {% if item.can_manage_attachments(session.user) %}
                  data-image-upload-url="{{ url_for('attachments.upload_ckeditor', item) }}"
              {% endif %}
-             data-title="{{ title }}"></div>
-    </li>
-{%- endmacro %}
+             data-title="{% trans %}Compile minutes{% endtrans %}"></div>
+    {%- elif opt == 'attachments_edit' -%}
+        {% set attachment_item = item.session if item_type == 'SESSION_BLOCK' else item %}
+        <a href="" class="js-material-editor"
+                   data-attachment-editor
+                   data-reload-on-change
+                   data-title="{% trans title=attachment_item.title %}Manage materials for '{{ title }}'{% endtrans %}"
+                   data-locator="{{ attachment_item.locator | tojson | forceescape }}">
+            {%- trans %}Material editor{% endtrans -%}
+        </a>
+    {%- elif opt == 'session_block_edit' -%}
+        <a href="#"
+           data-href="{{ url_for('sessions.manage_session_block', item) }}"
+           data-title="{% trans title=item.full_title %}Edit session block '{{ title }}'{% endtrans %}"
+           data-params="{{ item.locator | tojson | forceescape }}"
+           data-dialog-classes="session-block-form"
+           data-ajax-dialog
+           data-reload-after>
+            {%- trans -%}Edit session block{%- endtrans -%}
+        </a>
+    {%- elif opt == 'session_timetable_edit' -%}
+        <a href="{{ url_for('timetable.manage_session', item.session,
+                            _anchor=item.start_dt.astimezone(item.session.event.tzinfo).strftime('%Y%m%d')) }}"
+           title="{% trans %}Edit the timetable for this session{% endtrans %}">
+            {%- trans -%}Edit session timetable{%- endtrans -%}
+        </a>
+    {%- elif opt == 'session_protection_edit' -%}
+        <a href="#"
+           data-href="{{ url_for('sessions.session_protection', item.session) }}"
+           data-title="{% trans %}Edit session protection{% endtrans %}"
+           data-subtitle="{{ item.session.title }}"
+           data-ajax-dialog>
+            {%- trans -%}Edit session protection{%- endtrans -%}
+        </a>
+    {%- elif opt == 'contribution_edit' -%}
+        <a href="" class="contribution-edit"
+                   data-href="{{ url_for('contributions.manage_update_contrib', item, standalone=true) }}"
+                   data-title="{% trans title=item.title %}Edit contribution '{{ title }}'{% endtrans %}">
+            {%- trans -%}Edit contribution{%- endtrans -%}
+        </a>
+    {%- elif opt == 'contribution_subcontributions_edit' -%}
+        <a href=""
+           class="subcontributions-edit"
+           data-href="{{ url_for('contributions.manage_subcontributions', item) }}"
+           data-title="{% trans title=item.title %}Manage subcontributions{% endtrans %}"
+           data-subtitle="{{ item.title }}">
+            {%- trans -%}Manage subcontributions{%- endtrans -%}
+        </a>
+    {%- elif opt == 'contribution_protection_edit' -%}
+        <a href=""
+           data-href="{{ url_for('contributions.manage_contrib_protection', item) }}"
+           data-title="{% trans %}Manage contribution protection{% endtrans %}"
+           data-subtitle="{{ item.title }}"
+           data-ajax-dialog>
+            {%- trans -%}Edit protection{%- endtrans -%}
+        </a>
+    {%- elif opt == 'subcontribution_edit' -%}
+        <a href=""
+           class="subcontribution-edit"
+           data-title="{% trans %}Edit subcontribution{% endtrans %}"
+           data-subtitle="{{ item.title }}"
+           data-href="{{ url_for('contributions.manage_edit_subcontrib', item, standalone=true) }}">
+            {%- trans -%}Edit subcontribution{%- endtrans -%}
+        </a>
+    {%- else -%}
+        ERROR: unknown option "{{ opt }}"
+    {%- endif -%}
+{%- endmacro -%}
 
-{% macro _render_dropdown(item, item_type, show_note_operations=false) -%}
-    <ul class="i-dropdown">
-        {% if item_type == 'EVENT' %}
-            {% if item.can_manage(session.user) %}
-                <li>
-                    <a href="{{ url_for('event_management.settings', item) }}">
-                        {% trans %}Edit Event{% endtrans %}
-                    </a>
-                </li>
-                <li>
-                    <a data-href="{{ url_for('event_management.clone', item) }}"
-                       data-title="{% trans %}Clone Event{% endtrans %}"
-                       data-ajax-dialog
-                       href="">
-                        {% trans %}Clone Event{% endtrans %}
-                    </a>
-                </li>
-            {% endif %}
-            {% if item.can_edit_note(session.user) %}
-                {% if item.type != 'lecture' %}
-                    {{ _render_note_editor(item) }}
-                    {% if item.scheduled_notes %}
-                        <li>
-                            <div class="manage-notes-container"
-                                 data-get-note-url="{{ url_for('event_notes.compile', item) }}"
-                                 data-api-url="{{ url_for('event_notes.api', item) }}"
-                                 {% if item.can_manage_attachments(session.user) %}
-                                     data-image-upload-url="{{ url_for('attachments.upload_ckeditor', item) }}"
-                                 {% endif %}
-                                 data-title="{% trans %}Compile minutes{% endtrans %}"></div>
-                        </li>
-                    {% endif %}
-                {% endif %}
-            {% endif %}
-        {% elif item_type == 'SESSION_BLOCK' %}
-            {% set session_ = item.session %}
-            {% if item.can_edit_note(session.user) %}
-                {% if not session_.has_note or show_note_operations %}
-                    {{ _render_note_editor(session_) }}
-                {% endif %}
-                <li>
-                    <a href="" class="js-material-editor"
-                               data-attachment-editor
-                               data-reload-on-change
-                               data-title="{% trans title=session_.title %}Manage materials for '{{ title }}'{% endtrans %}"
-                               data-locator="{{ session_.locator | tojson | forceescape }}">
-                        {%- trans %}Material Editor{% endtrans -%}
-                    </a>
-                </li>
-            {% endif %}
-            {% if item.can_manage(session.user) %}
-                <li>
-                    <a href="#"
-                       data-href="{{ url_for('sessions.manage_session_block', item) }}"
-                       data-title="{% trans title=item.full_title %}Edit session block '{{ title }}'{% endtrans %}"
-                       data-params="{{ item.locator | tojson | forceescape }}"
-                       data-dialog-classes="session-block-form"
-                       data-ajax-dialog
-                       data-reload-after>
-                        {% trans %}Edit session block{% endtrans %}
-                    </a>
-                </li>
-            {% endif %}
-            {% if session_.can_manage(session.user, 'coordinate') %}
-                <li>
-                    <a href="{{ url_for('timetable.manage_session', session_,
-                                        _anchor=item.start_dt.astimezone(session_.event.tzinfo).strftime('%Y%m%d')) }}"
-                       title="{% trans %}Edit the timetable for this session{% endtrans %}">
-                        {% trans %}Edit session timetable{% endtrans %}
-                    </a>
-                </li>
-            {% endif %}
-            {% if session_.can_manage(session.user) %}
-                <li>
-                    <a href="#"
-                       data-href="{{ url_for('sessions.session_protection', session_) }}"
-                       data-title="{% trans %}Edit session protection{% endtrans %}"
-                       data-subtitle="{{ session_.title }}"
-                       data-ajax-dialog>
-                        {% trans %}Edit session protection{% endtrans %}
-                    </a>
-                </li>
-            {% endif %}
-        {% elif item_type == 'CONTRIBUTION' %}
-            {% if item.can_manage(session.user, 'submit') %}
-                {% if not item.has_note or show_note_operations %}
-                    {{ _render_note_editor(item) }}
-                {% endif %}
-            {% endif %}
-            {% if item.can_edit(session.user) %}
-                <li>
-                    <a href="" class="contribution-edit"
-                               data-href="{{ url_for('contributions.manage_update_contrib', item, standalone=true) }}"
-                               data-title="{% trans title=item.title %}Edit contribution '{{ title }}'{% endtrans %}">
-                        {% trans %}Edit contribution{% endtrans %}
-                    </a>
-                </li>
-            {% endif %}
-            {% if item.can_manage(session.user) %}
-                <li>
-                    <a href=""
-                       data-href="{{ url_for('contributions.manage_contrib_protection', item) }}"
-                       data-title="{% trans %}Manage contribution protection{% endtrans %}"
-                       data-subtitle="{{ item.title }}"
-                       data-ajax-dialog>
-                        {% trans %}Edit protection{% endtrans %}
-                    </a>
-                </li>
-            {% endif %}
-        {% elif item_type == 'SUBCONTRIBUTION' %}
-            {% if item.can_edit_note(session.user) %}
-                {% if not item.has_note or show_note_operations %}
-                    {{ _render_note_editor(item) }}
-                {% endif %}
-            {% endif %}
-            {% if item.can_edit(session.user) %}
-                <li>
-                    <a href=""
-                       class="subcontribution-edit"
-                       data-title="{% trans %}Edit subcontribution{% endtrans %}"
-                       data-subtitle="{{ item.title }}"
-                       data-href="{{ url_for('contributions.manage_edit_subcontrib', item, standalone=true) }}">
-                        {% trans %}Edit subcontribution{% endtrans %}
-                    </a>
-                </li>
-            {% endif %}
-        {% endif %}
-        {% if item_type != 'SESSION_BLOCK' and item.can_manage_attachments(session.user) %}
-            <li>
-                <a href="" class="js-material-editor"
-                           data-attachment-editor
-                           data-reload-on-change
-                           data-title="{% trans title=item.title %}Manage materials for '{{ title }}'{% endtrans %}"
-                           data-locator="{{ item.locator | tojson | forceescape }}">
-                    {%- trans %}Material editor{% endtrans -%}
-                </a>
-            </li>
-        {% endif %}
-        {% if item_type == 'CONTRIBUTION' and item.can_manage(session.user) %}
-            <li>
-                <a href=""
-                   class="subcontributions-edit"
-                   data-href="{{ url_for('contributions.manage_subcontributions', item) }}"
-                   data-title="{% trans title=item.title %}Manage subcontributions{% endtrans %}"
-                   data-subtitle="{{ item.title }}">
-                    {% trans %}Manage subcontributions{% endtrans %}
-                </a>
-            </li>
-        {% endif %}
-    </ul>
-{%- endmacro %}
-
-{% macro render_manage_button(item, item_type, show_notes=true,
-                              toggle_notes=true, show_note_operations=false,
-                              show_button=true, anchor=none) -%}
+{% macro render_manage_button(item, item_type, show_notes=true, toggle_notes=true, show_note_operations=false, anchor=none) -%}
     <div class="toolbar right thin">
         {% if toggle_notes and item.has_note %}
             {% set req = request.args.get('note') %}
             {% set note_id = item.note.id|string %}
             {{ render_toggle_button(item.note, note_is_hidden=(req != note_id and not show_notes), anchor=anchor) }}
         {% endif %}
-        {% if show_button %}
+        {% set dropdown_options = item.get_manage_button_options(note_may_exist=show_note_operations) %}
+        {% if dropdown_options %}
             <div class="group manage-button">
                 <button class="tiny compact ui icon button js-dropdown" data-toggle="dropdown" title="{% trans %}Manage{% endtrans %}">
                     <i class="edit icon"></i>
                     <i class="caret down icon"></i>
                 </button>
-                {{ _render_dropdown(item, item_type, show_note_operations=show_note_operations) }}
+                <ul class="i-dropdown">
+                    {% for opt in dropdown_options %}
+                        <li>
+                            {{ _render_dropdown_option(opt, item, item_type) }}
+                        </li>
+                    {% endfor %}
+                </ul>
             </div>
         {% endif %}
         </div>

--- a/indico/modules/events/templates/display/conference.html
+++ b/indico/modules/events/templates/display/conference.html
@@ -80,14 +80,14 @@
                 </div>
             {% endif %}
 
-            {% set is_submitter = event.can_manage(session.user, 'submit') %}
-            {% if is_submitter or event.attached_items %}
+            {% set can_attach = event.can_manage_attachments(session.user) %}
+            {% if can_attach or event.attached_items %}
                 <div class="infoline material material-list">
                     <span title="{% trans %}Materials{% endtrans %}" class="icon icon-attachment" aria-hidden="true"></span>
                     <div class="text attachments-box">
                         {{ render_attachments(event.attached_items, management=false) }}
                     </div>
-                    {% if is_submitter %}
+                    {% if can_attach %}
                         <div>
                             <button class="i-button text-color subtle icon-edit hide-if-locked"
                                     title="{% trans %}Manage materials{% endtrans %}"

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -31,9 +31,8 @@
                     </h1>
                 </div>
                 <div class="event-actions">
-                    {% set show_button = not event.is_locked and event.can_manage_attachments(session.user) %}
                     <div class="event-manage-button">
-                        {{ render_manage_button(event, 'EVENT', show_button=show_button, toggle_notes=false) }}
+                        {{ render_manage_button(event, 'EVENT', toggle_notes=false) }}
                     </div>
                     <div class="event-privacy-info-button">
                         {{ render_privacy_info_button(event, privacy_info) }}

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -26,9 +26,8 @@
                     </h1>
                 </div>
                 <div class="event-actions">
-                    {% set show_button = not event.is_locked and event.can_manage(session.user, 'submit') %}
                     <div class="event-manage-button">
-                        {{ render_manage_button(event, 'EVENT', show_button=show_button, toggle_notes=false) }}
+                        {{ render_manage_button(event, 'EVENT', toggle_notes=false) }}
                     </div>
                     <div class="event-privacy-info-button">
                         {{ render_privacy_info_button(event, privacy_info) }}

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -26,7 +26,7 @@
                     </h1>
                 </div>
                 <div class="event-actions">
-                    {% set show_button = not event.is_locked and event.can_manage_attachments(session.user) %}
+                    {% set show_button = not event.is_locked and event.can_manage(session.user, 'submit') %}
                     <div class="event-manage-button">
                         {{ render_manage_button(event, 'EVENT', show_button=show_button, toggle_notes=false) }}
                     </div>

--- a/indico/modules/events/timetable/templates/display/indico/_break.html
+++ b/indico/modules/events/timetable/templates/display/indico/_break.html
@@ -1,4 +1,3 @@
-{% from 'events/display/common/_manage_button.html' import render_manage_button %}
 {% from 'events/display/indico/_common.html' import render_location %}
 {% from 'events/timetable/display/indico/_common.html' import render_description, render_time %}
 

--- a/indico/modules/events/timetable/templates/display/indico/_contribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_contribution.html
@@ -31,9 +31,7 @@
                     {{ render_location(contrib, parent=parent) }}
                 {%- endif %}
                 <div class="timetable-item-actions">
-                    {{ render_manage_button(contrib, 'CONTRIBUTION', show_notes=show_notes,
-                                            show_button=(not event.is_locked and
-                                                         contrib.can_manage(session.user, 'submit'))) }}
+                    {{ render_manage_button(contrib, 'CONTRIBUTION', show_notes=show_notes) }}
                     {{ template_hook('vc-actions', event=event, item=contrib) }}
                 </div>
             </div>

--- a/indico/modules/events/timetable/templates/display/indico/_contribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_contribution.html
@@ -33,7 +33,7 @@
                 <div class="timetable-item-actions">
                     {{ render_manage_button(contrib, 'CONTRIBUTION', show_notes=show_notes,
                                             show_button=(not event.is_locked and
-                                                         contrib.can_manage_attachments(session.user))) }}
+                                                         contrib.can_manage(session.user, 'submit'))) }}
                     {{ template_hook('vc-actions', event=event, item=contrib) }}
                 </div>
             </div>

--- a/indico/modules/events/timetable/templates/display/indico/_session_block.html
+++ b/indico/modules/events/timetable/templates/display/indico/_session_block.html
@@ -30,9 +30,7 @@
                     {{ render_location(block, parent=event) }}
                 {%- endif %}
                 <div class="timetable-item-actions">
-                    {{ render_manage_button(block, 'SESSION_BLOCK', show_notes=show_notes,
-                                            show_button=(not event.is_locked and block.can_manage(session.user)),
-                                            anchor=block.slug) }}
+                    {{ render_manage_button(block, 'SESSION_BLOCK', show_notes=show_notes, anchor=block.slug) }}
                     {{ template_hook('vc-actions', event=event, item=block) }}
                 </div>
             </div>

--- a/indico/modules/events/timetable/templates/display/indico/_session_block.html
+++ b/indico/modules/events/timetable/templates/display/indico/_session_block.html
@@ -31,8 +31,8 @@
                 {%- endif %}
                 <div class="timetable-item-actions">
                     {{ render_manage_button(block, 'SESSION_BLOCK', show_notes=show_notes,
-                                            show_button=(not event.is_locked and
-                                                         block.can_manage_attachments(session.user)), anchor=block.slug) }}
+                                            show_button=(not event.is_locked and block.can_manage(session.user)),
+                                            anchor=block.slug) }}
                     {{ template_hook('vc-actions', event=event, item=block) }}
                 </div>
             </div>

--- a/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
@@ -22,7 +22,7 @@
                 <div class="timetable-item-actions">
                     {{ render_manage_button(subcontrib, 'SUBCONTRIBUTION', show_notes=show_notes,
                                             show_button=(not event.is_locked and
-                                            subcontrib.can_manage_attachments(session.user))) }}
+                                                         subcontrib.can_manage(session.user, 'submit'))) }}
                 </div>
             </div>
 

--- a/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_subcontribution.html
@@ -20,9 +20,7 @@
                     </span>
                 {% endif %}
                 <div class="timetable-item-actions">
-                    {{ render_manage_button(subcontrib, 'SUBCONTRIBUTION', show_notes=show_notes,
-                                            show_button=(not event.is_locked and
-                                                         subcontrib.can_manage(session.user, 'submit'))) }}
+                    {{ render_manage_button(subcontrib, 'SUBCONTRIBUTION', show_notes=show_notes) }}
                 </div>
             </div>
 


### PR DESCRIPTION
This PR adds a setting that disallows non-managers of uploading materials to events, contributions and sessions.

The setting was added to the Materials page in the management area:
<img width="824" alt="image" src="https://user-images.githubusercontent.com/27357203/206168289-d9b152a1-36c2-4399-b58c-827e76165f6f.png">

Progress:
- [x] Add setting in management area
- [x] Disallow submitters of uploading materials to contributions
- [x] Disallow chairpersons/speakers of lectures of uploading materials to events
