### PR TITLE
Treat 'url' the same when camelizing in frontend/backend

### DIFF
--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -398,7 +398,9 @@ def camelize(name):
     if name.startswith('_'):
         underscore = '_'
         parts = parts[1:]
-    return underscore + parts[0] + ''.join(x.title() for x in parts[1:])
+    camelized = underscore + parts[0] + ''.join(x.title() for x in parts[1:])
+    # Always convert 'Url' into 'URL', same as camelizeKeys() in utils/case.js
+    return camelized.replace('Url', 'URL')
 
 
 def _convert_keys(value, convert_func):

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -141,6 +141,19 @@ def test_camelize_keys():
     assert d2 == {'fooBar': 'foo', 'barFoo': 123, 'mooBar': {'helloWorld': 'test'},
                   'nested': [{'isDict': True}, 'foo', ({'aB': 'c'},)]}
 
+    # Keys starting with an underscore should not change
+    d = camelize_keys({'_deleted': True})
+    assert d == {'_deleted': True}
+
+    # 'url' is always camelized as 'URL' instead of 'Url'
+    d = {'avatar_url': 'avatar/1', 'upload_url_materials': '/upload/materials',
+         'url_download': '/download', 'saveURL': '/save'}
+    orig = d.copy()
+    d2 = camelize_keys(d)
+    assert d == orig  # original dict not modified
+    assert d2 == {'avatarURL': 'avatar/1', 'uploadURLMaterials': '/upload/materials',
+                  'urlDownload': '/download', 'saveURL': '/save'}
+
 
 def test_snakify_keys():
     d = {'sn_case': 2, 'shouldBeSnakeCase': 3, 'snake': 4, 'snake-case': 5, 'inner': {'innerDict': 2}}


### PR DESCRIPTION
Currently, `camelizeKeys` always converts `xxx_url` into `xxxURL` while `camelize_keys` returns `xxxUrl`. This change makes sure the behavior is consistent.

The usage of `camelize_keys` is exclusive to registration fields (no usage outside in plugins).
It's used with choices/user_data/view_data/own_data/default_value neither of which use keys containing `url` so this should not break anything.





