### PR TITLE
Do not propagate sentry traces

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Bugfixes
 ^^^^^^^^
 
 - Correctly show contribution authors in participant roles list (:pr:`5603`)
+- Disable Sentry trace propagation to outgoing HTTP requests (:pr:`5604`)
 
 
 Version 3.2.2

--- a/indico/core/sentry.py
+++ b/indico/core/sentry.py
@@ -35,6 +35,7 @@ def init_sentry(app):
         release=indico.__version__,
         send_default_pii=True,
         attach_stacktrace=True,
+        propagate_traces=False,
         in_app_include=({'indico'} | plugin_packages),
         integrations=[
             PureEvalIntegration(),


### PR DESCRIPTION
Trace propagation (on by default) apparently adds custom headers to ALL outgoing HTTP requests, and can break some WAFs (e.g. when making requests to the SIXpay API in that plugin)