### PR TITLE
Add option to keep track when accepting abstracts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Improvements
 - Make it possible to load more events in series management (:pr:`5629`)
 - Check manually entered email addresses of speakers/authors/chairpersons
   to avoid collisions and inconsistencies (:pr:`5478`)
+- Add option to use review track as accepted track when bulk-accepting abstracts
+  (:pr:`5608`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/operations.py
+++ b/indico/modules/events/abstracts/operations.py
@@ -206,7 +206,11 @@ def judge_abstract(abstract, abstract_data, judgment, judge, contrib_session=Non
     log_data = {'Judgment': orig_string(judgment.title)}
     if judgment == AbstractAction.accept:
         abstract.state = AbstractState.accepted
-        abstract.accepted_track = abstract_data.get('accepted_track')
+        if abstract_data.get('use_review_track'):
+            tracks = abstract.reviewed_for_tracks
+            abstract.accepted_track = list(tracks)[0] if len(tracks) == 1 else None
+        else:
+            abstract.accepted_track = abstract_data.get('accepted_track')
         if abstract_data.get('override_contrib_type') or abstract_data.get('accepted_contrib_type'):
             abstract.accepted_contrib_type = abstract_data.get('accepted_contrib_type')
         else:


### PR DESCRIPTION
This PR adds an option to bulk-accept abstracts in their respective "reviewed for" tracks, instead of always having to manually select the accepted track:
<img width="894" alt="image" src="https://user-images.githubusercontent.com/27357203/210993160-63d611ed-e024-43ec-be85-6af8472f7e70.png">
 