### PR TITLE
Add registrations number to Event exporter (#5594)

### DIFF
--- a/docs/source/http-api/exporters/event.rst
+++ b/docs/source/http-api/exporters/event.rst
@@ -43,6 +43,7 @@ Result for https://indico.server/export/event/137346.json?occ=yes&pretty=yes::
                     "time": "08:00:00"
                 },
                 "_type": "Conference",
+                "registrations":1,
                 "endDate": {
                     "date": "2011-06-24",
                     "tz": "Europe/Zurich",
@@ -114,6 +115,7 @@ Output for https://indico.server/export/event/137346.json?detail=contributions&p
                     "time": "08:00:00"
                 },
                 "_type": "Conference",
+                "registrations":1,
                 "endDate": {
                     "date": "2011-06-24",
                     "tz": "Europe/Zurich",
@@ -258,6 +260,7 @@ For example, https://indico.server/export/event/137346.json?detail=sessions&pret
                     "time": "08:00:00"
                 },
                 "_type": "Conference",
+                "registrations":1,
                 "endDate": {
                     "date": "2011-06-24",
                     "tz": "Europe/Zurich",

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -265,12 +265,13 @@ class SerializerBase:
     }
 
     def _build_event_api_data_base(self, event):
+        is_participant = event.is_user_registered(self.user)
         return {
             '_type': 'Conference',
             'id': str(event.id),
             'title': event.title,
             'description': event.description,
-            'registrations': Registration.query.with_parent(event).count(),
+            'registrations': Registration.query.with_parent(event).filter(Registration.is_publishable(is_participant)).count(),
             'startDate': self._serialize_date(event.start_dt),
             'timezone': event.timezone,
             'endDate': self._serialize_date(event.end_dt),

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -30,6 +30,7 @@ from indico.modules.events import Event
 from indico.modules.events.contributions import contribution_settings
 from indico.modules.events.models.persons import PersonLinkBase
 from indico.modules.events.notes.util import build_note_api_data, build_note_legacy_api_data
+from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.events.sessions.models.sessions import Session
 from indico.modules.events.timetable.legacy import TimetableSerializer
 from indico.modules.events.timetable.models.entries import TimetableEntry
@@ -269,6 +270,7 @@ class SerializerBase:
             'id': str(event.id),
             'title': event.title,
             'description': event.description,
+            'registrations': Registration.query.with_parent(event).count(),
             'startDate': self._serialize_date(event.start_dt),
             'timezone': event.timezone,
             'endDate': self._serialize_date(event.end_dt),


### PR DESCRIPTION
Add a registration field with the number of registrations for a given event to the Event exporter (HTTP-API).