### PR TITLE
Allow uploading files when requesting changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,7 @@ Improvements
   (:issue:`5579`, :pr:`5654`)
 - Hide the top box with the latest files of an editable until it has been accepted
   and published (:issue:`5660`, :pr:`5665`)
+- Allow uploading files when requesting changes on the editing timeline (:pr:`5612`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
@@ -49,7 +49,7 @@ export default function ResetReview({revisionId}) {
   return (
     <>
       <Popup
-        content="Undo review"
+        content={Translate.string('Undo review')}
         trigger={
           <Icon
             styleName="reset-button"

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -21,27 +21,33 @@ import ReviewForm from './ReviewForm';
 import RevisionLog from './RevisionLog';
 import * as selectors from './selectors';
 import StateIndicator from './StateIndicator';
-import {blockPropTypes} from './util';
+import {blockPropTypes, isRequestChangesWithFiles} from './util';
 
 import './TimelineItem.module.scss';
 
 export default function TimelineItem({block, index}) {
   const {submitter, createdDt} = block;
   const lastBlock = useSelector(selectors.getLastTimelineBlock);
+  const secondLastBlock = useSelector(selectors.getSecondLastTimelineBlock);
   const needsSubmitterConfirmation = useSelector(selectors.needsSubmitterConfirmation);
   const canPerformSubmitterActions = useSelector(selectors.canPerformSubmitterActions);
   const {canComment, state: editableState} = useSelector(selectors.getDetails);
   const {fileTypes} = useSelector(selectors.getStaticData);
   const isLastBlock = lastBlock.id === block.id;
-  const [visible, setVisible] = useState(isLastBlock);
+  const isVisibleByDefault =
+    isLastBlock ||
+    (secondLastBlock &&
+      secondLastBlock.id === block.id &&
+      (isRequestChangesWithFiles(lastBlock, secondLastBlock) || needsSubmitterConfirmation));
+  const [visible, setVisible] = useState(isVisibleByDefault);
 
   useEffect(() => {
     // when undoing a judgment deletes the last revision this revision may become the
     // latest one, and thus needs to be unhidden if it had been collapsed before.
-    if (isLastBlock && !visible) {
+    if (isVisibleByDefault && !visible) {
       setVisible(true);
     }
-  }, [isLastBlock, visible]);
+  }, [isVisibleByDefault, visible]);
 
   return (
     <>

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/RequestChangesForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/RequestChangesForm.jsx
@@ -5,26 +5,33 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import uploadURL from 'indico-url:event_editing.api_upload';
+
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState} from 'react';
 import {Form as FinalForm} from 'react-final-form';
 import {useDispatch, useSelector} from 'react-redux';
-import {Form} from 'semantic-ui-react';
+import {Checkbox, Form} from 'semantic-ui-react';
 
 import {FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
 import {EditingReviewAction} from '../../../models';
 import {reviewEditable} from '../actions';
-import {getLastRevision, getNonSystemTags} from '../selectors';
+import {FinalFileManager} from '../FileManager';
+import {getFileTypes, getLastRevision, getNonSystemTags, getStaticData} from '../selectors';
 
 import FinalTagInput from './TagInput';
 
 export default function RequestChangesForm({setLoading, onSuccess}) {
   const dispatch = useDispatch();
   const lastRevision = useSelector(getLastRevision);
+  const staticData = useSelector(getStaticData);
+  const {eventId, contributionId, editableType} = staticData;
+  const fileTypes = useSelector(getFileTypes);
   const tagOptions = useSelector(getNonSystemTags);
+  const [uploadChanges, setUploadChanges] = useState(false);
 
   const requestChanges = async formData => {
     setLoading(true);
@@ -65,6 +72,26 @@ export default function RequestChangesForm({setLoading, onSuccess}) {
             hideValidationError
             autoFocus
           />
+          <Form.Field>
+            <Checkbox
+              toggle
+              label={Translate.string('Make changes to the submission')}
+              checked={uploadChanges}
+              onChange={(__, {checked}) => setUploadChanges(checked)}
+            />
+          </Form.Field>
+          {uploadChanges && (
+            <FinalFileManager
+              name="files"
+              fileTypes={fileTypes}
+              files={lastRevision.files}
+              uploadURL={uploadURL({
+                event_id: eventId,
+                contrib_id: contributionId,
+                type: editableType,
+              })}
+            />
+          )}
           <FinalTagInput name="tags" options={tagOptions} />
           <div style={{display: 'flex', justifyContent: 'flex-end'}}>
             <FinalSubmitButton label={Translate.string('Submit')} />

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -10,6 +10,8 @@ import {createSelector} from 'reselect';
 
 import {FinalRevisionState, InitialRevisionState} from '../../models';
 
+import {isRequestChangesWithFiles} from './util';
+
 export const getDetails = state => (state.timeline ? state.timeline.details : null);
 export const getNewDetails = state => (state.timeline ? state.timeline.newDetails : null);
 export const isInitialEditableDetailsLoading = state =>
@@ -109,6 +111,11 @@ export const getLastRevertableRevisionId = createSelector(
         latestRevision.initialState.name !== InitialRevisionState.needs_submitter_confirmation
       ) {
         return null;
+      }
+    } else if (latestRevision.finalState.name === FinalRevisionState.needs_submitter_changes) {
+      const previousRevision = details.revisions[details.revisions.length - 2];
+      if (isRequestChangesWithFiles(latestRevision, previousRevision)) {
+        return previousRevision.id;
       }
     }
     return lastFinalRev.id;

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -26,6 +26,10 @@ export const getLastTimelineBlock = createSelector(
   getTimelineBlocks,
   blocks => blocks && blocks[blocks.length - 1]
 );
+export const getSecondLastTimelineBlock = createSelector(
+  getTimelineBlocks,
+  blocks => blocks && blocks[blocks.length - 2]
+);
 export const getLastRevision = createSelector(
   getDetails,
   details => details && details.revisions[details.revisions.length - 1]

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -12,6 +12,16 @@ import {Translate} from 'indico/react/i18n';
 
 import {filePropTypes} from './FileManager/util';
 
+export const isRequestChangesWithFiles = (revision, previousRevision) =>
+  previousRevision &&
+  revision.reviewedDt &&
+  revision.editor &&
+  previousRevision.editor &&
+  previousRevision.finalState.name === FinalRevisionState.needs_submitter_changes &&
+  revision.finalState.name === FinalRevisionState.needs_submitter_changes &&
+  revision.reviewedDt === previousRevision.reviewedDt &&
+  revision.editor.identifier === previousRevision.editor.identifier;
+
 // This method defines each revision as a block
 // with a label referring to its previous state transition
 export function processRevisions(revisions) {
@@ -22,7 +32,7 @@ export function processRevisions(revisions) {
     const isLatestRevision = i === revisions.length - 1;
     revisionState = getRevisionTransition(revision, {isLatestRevision});
     // Generate the comment header
-    if (revisionState) {
+    if (revisionState && !isRequestChangesWithFiles(revision, revisions[i - 1])) {
       const author = revision.editor || revision.submitter;
       items.push(commentFromState(revision, revisionState, author));
     }

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -199,9 +199,10 @@ class RHReviewEditable(RHContributionEditableRevisionBase):
     @use_kwargs(ReviewEditableArgs)
     def _process(self, action, comment):
         argmap = {'tags': EditingTagsField(self.event, load_default=set())}
-        if action in (EditingReviewAction.update, EditingReviewAction.update_accept):
+        if action in (EditingReviewAction.update, EditingReviewAction.update_accept,
+                      EditingReviewAction.request_update):
             argmap['files'] = EditingFilesField(self.event, self.contrib, self.editable_type, allow_claimed_files=True,
-                                                required=True)
+                                                required=action != EditingReviewAction.request_update)
         args = parser.parse(argmap, unknown=EXCLUDE)
         service_url = editing_settings.get(self.event, 'service_url')
 

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -202,7 +202,7 @@ class RHReviewEditable(RHContributionEditableRevisionBase):
         if action in (EditingReviewAction.update, EditingReviewAction.update_accept,
                       EditingReviewAction.request_update):
             argmap['files'] = EditingFilesField(self.event, self.contrib, self.editable_type, allow_claimed_files=True,
-                                                required=action != EditingReviewAction.request_update)
+                                                required=(action != EditingReviewAction.request_update))
         args = parser.parse(argmap, unknown=EXCLUDE)
         service_url = editing_settings.get(self.event, 'service_url')
 

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -220,7 +220,7 @@ def _is_request_changes_with_files(revision):
     if not revision or len(revision.editable.revisions) < 2:
         return False
     previous_revision = revision.editable.revisions[-2]
-    # when request-changes-with-files revision is made, the previous revision's final_state
+    # when a request-changes-with-files revision is made, the previous revision's final_state
     # is set to needs_submitter_changes, and a new one is created with the same reviewed_dt,
     # editor, and final_state. if any of these are different, then the two revisions are
     # actually separate request-changes, and not a request-changes-with-files

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -27,7 +27,7 @@ from indico.modules.events.editing.notifications import (notify_comment, notify_
 from indico.modules.events.editing.schemas import (EditableDumpSchema, EditingConfirmationAction, EditingFileTypeSchema,
                                                    EditingReviewAction)
 from indico.modules.logs import EventLogRealm, LogKind
-from indico.util.caching import memoize
+from indico.util.caching import memoize_request
 from indico.util.date_time import now_utc
 from indico.util.fs import secure_filename
 from indico.util.i18n import _, orig_string
@@ -215,7 +215,7 @@ def create_submitter_revision(prev_revision, user, files):
     return new_revision
 
 
-@memoize
+@memoize_request
 def _is_request_changes_with_files(revision):
     if not revision or len(revision.editable.revisions) < 2:
         return False

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -220,6 +220,10 @@ def _is_request_changes_with_files(revision):
     if not revision or len(revision.editable.revisions) < 2:
         return False
     previous_revision = revision.editable.revisions[-2]
+    # when request-changes-with-files revision is made, the previous revision's final_state
+    # is set to needs_submitter_changes, and a new one is created with the same reviewed_dt,
+    # editor, and final_state. if any of these are different, then the two revisions are
+    # actually separate request-changes, and not a request-changes-with-files
     return (revision != previous_revision and
             revision.reviewed_dt and
             revision.editor and

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -124,19 +124,24 @@ def review_editable_revision(revision, editor, action, comment, tags, files=None
     new_revision = None
     if action == EditingReviewAction.accept:
         _ensure_publishable_files(revision)
-    elif action in (EditingReviewAction.update, EditingReviewAction.update_accept):
+    elif files and action in (EditingReviewAction.update, EditingReviewAction.update_accept,
+                              EditingReviewAction.request_update):
+        initial_state = InitialRevisionState.needs_submitter_confirmation
         final_state = FinalRevisionState.none
         editable_editor = None
         if action == EditingReviewAction.update_accept:
             final_state = FinalRevisionState.accepted
             editable_editor = editor
+        elif action == EditingReviewAction.request_update:
+            initial_state = revision.initial_state
+            final_state = FinalRevisionState.needs_submitter_changes
         new_revision = EditingRevision(submitter=editor,
                                        editor=editable_editor,
-                                       initial_state=InitialRevisionState.needs_submitter_confirmation,
+                                       initial_state=initial_state,
                                        final_state=final_state,
                                        files=_make_editable_files(revision.editable, files),
                                        tags=revision.tags)
-        if action == EditingReviewAction.update_accept:
+        if action in (EditingReviewAction.update_accept, EditingReviewAction.request_update):
             new_revision.reviewed_dt = revision.reviewed_dt
         _ensure_publishable_files(new_revision)
         revision.editable.revisions.append(new_revision)

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -148,7 +148,8 @@ def review_editable_revision(revision, editor, action, comment, tags, files=None
                                        tags=revision.tags)
         if action in (EditingReviewAction.update_accept, EditingReviewAction.request_update):
             new_revision.reviewed_dt = revision.reviewed_dt
-        _ensure_publishable_files(new_revision)
+        if action != EditingReviewAction.request_update:
+            _ensure_publishable_files(new_revision)
         revision.editable.revisions.append(new_revision)
     db.session.flush()
     notify_editor_judgment(revision, editor)

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -125,18 +125,21 @@ def review_editable_revision(revision, editor, action, comment, tags, files=None
     new_revision = None
     if action == EditingReviewAction.accept:
         _ensure_publishable_files(revision)
-    elif files and action in (EditingReviewAction.update, EditingReviewAction.update_accept,
-                              EditingReviewAction.request_update):
-        initial_state = InitialRevisionState.needs_submitter_confirmation
-        final_state = FinalRevisionState.none
-        editable_editor = None
-        if action == EditingReviewAction.update_accept:
+    elif files:
+        if action == EditingReviewAction.update:
+            initial_state = InitialRevisionState.needs_submitter_confirmation
+            final_state = FinalRevisionState.none
+            editable_editor = None
+        elif action == EditingReviewAction.update_accept:
+            initial_state = InitialRevisionState.needs_submitter_confirmation
             final_state = FinalRevisionState.accepted
             editable_editor = editor
         elif action == EditingReviewAction.request_update:
             initial_state = revision.initial_state
             final_state = FinalRevisionState.needs_submitter_changes
             editable_editor = editor
+        else:
+            raise InvalidEditableState
         new_revision = EditingRevision(submitter=editor,
                                        editor=editable_editor,
                                        initial_state=initial_state,

--- a/indico/modules/events/editing/operations_test.py
+++ b/indico/modules/events/editing/operations_test.py
@@ -51,6 +51,9 @@ def test_cannot_undo_review_old_rev(dummy_contribution, dummy_user):
 
     (InitialRevisionState.ready_for_review, FinalRevisionState.needs_submitter_changes, False,
      InitialRevisionState.ready_for_review, FinalRevisionState.none, False),
+
+    (InitialRevisionState.ready_for_review, FinalRevisionState.needs_submitter_changes, False,
+     InitialRevisionState.ready_for_review, FinalRevisionState.needs_submitter_changes, True),
 ))
 def test_can_undo_review(db, dummy_contribution, dummy_user, is1, fs1, ok1, is2, fs2, ok2):
     from indico.modules.events.editing.operations import InvalidEditableState, undo_review
@@ -80,3 +83,24 @@ def test_can_undo_review(db, dummy_contribution, dummy_user, is1, fs1, ok1, is2,
     elif ok2:
         assert rev2.final_state == FinalRevisionState.none
         assert len(editable.revisions) == 2
+
+
+def test_can_undo_review_request_changes(db, dummy_contribution, dummy_user):
+    from indico.modules.events.editing.operations import InvalidEditableState, undo_review
+    editable = Editable(contribution=dummy_contribution, type=EditableType.paper)
+    reviewed_dt = now_utc()
+    rev1 = EditingRevision(editable=editable, submitter=dummy_user, editor=dummy_user,
+                           initial_state=InitialRevisionState.ready_for_review,
+                           final_state=FinalRevisionState.needs_submitter_changes, reviewed_dt=reviewed_dt)
+    rev2 = EditingRevision(editable=editable, submitter=dummy_user, editor=dummy_user,
+                           initial_state=InitialRevisionState.ready_for_review,
+                           final_state=FinalRevisionState.needs_submitter_changes, reviewed_dt=reviewed_dt)
+    db.session.flush()
+
+    undo_review(rev1)
+    with pytest.raises(InvalidEditableState):
+        undo_review(rev2)
+
+    db.session.expire(editable)  # so a deleted revision shows up in the relationship
+    assert rev1.final_state == FinalRevisionState.none
+    assert len(editable.revisions) == 1

--- a/indico/modules/events/editing/operations_test.py
+++ b/indico/modules/events/editing/operations_test.py
@@ -86,20 +86,18 @@ def test_can_undo_review(db, dummy_contribution, dummy_user, is1, fs1, ok1, is2,
 
 
 def test_can_undo_review_request_changes(db, dummy_contribution, dummy_user):
-    from indico.modules.events.editing.operations import InvalidEditableState, undo_review
+    from indico.modules.events.editing.operations import undo_review
     editable = Editable(contribution=dummy_contribution, type=EditableType.paper)
     reviewed_dt = now_utc()
     rev1 = EditingRevision(editable=editable, submitter=dummy_user, editor=dummy_user,
                            initial_state=InitialRevisionState.ready_for_review,
                            final_state=FinalRevisionState.needs_submitter_changes, reviewed_dt=reviewed_dt)
-    rev2 = EditingRevision(editable=editable, submitter=dummy_user, editor=dummy_user,
-                           initial_state=InitialRevisionState.ready_for_review,
-                           final_state=FinalRevisionState.needs_submitter_changes, reviewed_dt=reviewed_dt)
+    EditingRevision(editable=editable, submitter=dummy_user, editor=dummy_user,
+                    initial_state=InitialRevisionState.ready_for_review,
+                    final_state=FinalRevisionState.needs_submitter_changes, reviewed_dt=reviewed_dt)
     db.session.flush()
 
     undo_review(rev1)
-    with pytest.raises(InvalidEditableState):
-        undo_review(rev2)
 
     db.session.expire(editable)  # so a deleted revision shows up in the relationship
     assert rev1.final_state == FinalRevisionState.none


### PR DESCRIPTION
This PR adds the ability for an editor to upload a revision when requesting changes to a submitter in the Editing Timeline.

![image](https://user-images.githubusercontent.com/27357203/211327069-82f90846-6388-4b3b-8701-11b95e0ea542.png)

![image](https://user-images.githubusercontent.com/27357203/211817471-a64aea6f-0e93-46b7-b457-dd82b82eca5c.png)
