### PR TITLE
Survey notifications: Include token if survey is private

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Bugfixes
 
 - Correctly show contribution authors in participant roles list (:pr:`5603`)
 - Disable Sentry trace propagation to outgoing HTTP requests (:pr:`5604`)
+- Include token in notification emails for private surveys (:pr:`5618`)
 
 
 Version 3.2.2

--- a/indico/modules/events/surveys/models/surveys.py
+++ b/indico/modules/events/surveys/models/surveys.py
@@ -297,9 +297,13 @@ class Survey(db.Model):
     def send_start_notification(self):
         if not self.notifications_enabled or self.start_notification_sent or not self.event.has_feature('surveys'):
             return
+        if not (recipients := self.start_notification_recipients):
+            # no recipients -> just mark as sent and not log an empty email...
+            self.start_notification_sent = True
+            return
         with self.event.force_event_locale():
             template_module = get_template_module('events/surveys/emails/start_notification_email.txt', survey=self)
-            email = make_email(bcc_list=self.start_notification_recipients, template=template_module)
+            email = make_email(bcc_list=recipients, template=template_module)
         send_email(email, event=self.event, module='Surveys')
         logger.info('Sending start notification for survey %s', self)
         self.start_notification_sent = True

--- a/indico/modules/events/surveys/templates/emails/start_notification_email.txt
+++ b/indico/modules/events/surveys/templates/emails/start_notification_email.txt
@@ -15,7 +15,7 @@
         {%- endtrans %}
 
         {% trans %}You may answer the survey by clicking the link below:{% endtrans %}
-        {{ url_for('surveys.display_survey_form', survey, _external=true) }}
+        {{ url_for('surveys.display_survey_form', survey.locator.token, _external=true) }}
     {%- endfilter -%}
 {%- endblock %}
 

--- a/indico/modules/events/surveys/templates/management/survey_actions/finished.html
+++ b/indico/modules/events/surveys/templates/management/survey_actions/finished.html
@@ -17,12 +17,12 @@
 
 {% block now_button %}
     <div class="group">
-        <button data-href="{{ url_for('.open_survey', survey) }}" 
-                data-method="POST" 
+        <button data-href="{{ url_for('.open_survey', survey) }}"
+                data-method="POST"
                 class="i-button"
                 data-confirm="{% trans %}The survey finished already. Do you want to open it again for submissions?{% endtrans %}
                     {%- if survey.notifications_enabled -%}
-                        {%- trans %} This will result in resending the survey start notification.{% endtrans %}
+                        {#- #} {% trans %}This will result in resending the survey start notification.{% endtrans %}
                     {%- endif %}">
             {% trans %}Reopen now{% endtrans %}
         </button>


### PR DESCRIPTION
Currently the automated notification that can be sent when a survey is opened doesn't contain the token even if the survey is private, which results in a broken link.

Since the notifications are opt-in and useless unless the recipient can access the survey, we should use the survey link with the proper token in that email.