### PR TITLE
Expose room location in room booking's UI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Improvements
 - Support Markdown when writing global announcement and apply standard HTML
   sanitization to the message (:pr:`5640`)
 - Add BCC field on contribution email dialogs (:pr:`5637`)
+- Allow filtering by location in room booking (:issue:`4291`, :pr:`5622`,
+  thanks :user:`mindouro`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/rb/client/js/common/roomSearch/queryString.js
+++ b/indico/modules/rb/client/js/common/roomSearch/queryString.js
@@ -98,6 +98,10 @@ export const rules = {
   building: {
     stateField: 'filters.building',
   },
+  location_id: {
+    sanitizer: v.toInt(),
+    stateField: 'filters.locationId',
+  },
   text: {
     stateField: 'filters.text',
   },

--- a/indico/modules/rb/client/js/common/roomSearch/serializers.js
+++ b/indico/modules/rb/client/js/common/roomSearch/serializers.js
@@ -32,6 +32,7 @@ export const ajax = {
     serializer: ({onlyMine}) => onlyMine,
   },
   building: ({building}) => building,
+  location_id: ({locationId}) => locationId,
   text: ({text}) => text,
   division: ({division}) => division,
   start_dt: {

--- a/indico/modules/rb/client/js/common/rooms/selectors.js
+++ b/indico/modules/rb/client/js/common/rooms/selectors.js
@@ -137,3 +137,8 @@ export const getBuildings = createSelector(
     return Array.from(buildings).sort((a, b) => parseInt(a, 10) - parseInt(b, 10));
   }
 );
+
+export const getLocations = createSelector(
+  getAllRooms,
+  allRooms => new Map(Object.values(allRooms).map(room => [room.locationId, room.locationName]))
+);

--- a/indico/modules/rb/client/js/components/Room.jsx
+++ b/indico/modules/rb/client/js/components/Room.jsx
@@ -16,7 +16,6 @@ import {TooltipIfTruncated, ResponsivePopup} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {Markdown, Slot} from 'indico/react/util';
 
-import {selectors as roomsSelectors} from '../common/rooms';
 import {actions as userActions, selectors as userSelectors} from '../common/user';
 
 import DimmableImage from './DimmableImage';
@@ -34,7 +33,6 @@ class Room extends React.Component {
     isCheckingUserRoomPermissions: PropTypes.bool.isRequired,
     addFavoriteRoom: PropTypes.func.isRequired,
     delFavoriteRoom: PropTypes.func.isRequired,
-    allLocations: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -151,11 +149,9 @@ class Room extends React.Component {
       addFavoriteRoom,
       delFavoriteRoom,
       isCheckingUserRoomPermissions,
-      allLocations,
       ...restProps
     } = this.props;
     const {content, actions} = Slot.split(children);
-    const showLocation = allLocations.size > 1;
 
     return (
       <Card styleName="room-card" {...restProps}>
@@ -180,11 +176,6 @@ class Room extends React.Component {
         </Card.Content>
         <Card.Content styleName="room-content" extra>
           <Icon name="user" /> {room.capacity || Translate.string('Not specified')}
-          {showLocation && (
-            <div>
-              <Icon name="map pin" /> {room.locationName || Translate.string('Not specified')}
-            </div>
-          )}
           <span styleName="room-details">
             {room.features.map(feature => (
               <RoomFeatureEntry key={feature.name} feature={feature} color="green" />
@@ -203,7 +194,6 @@ export default connect(
     return (state, props) => ({
       isFavorite: isFavoriteRoom(state, props),
       isCheckingUserRoomPermissions: userSelectors.isCheckingUserRoomPermissions(state),
-      allLocations: roomsSelectors.getLocations(state),
     });
   },
   dispatch =>

--- a/indico/modules/rb/client/js/components/Room.jsx
+++ b/indico/modules/rb/client/js/components/Room.jsx
@@ -16,6 +16,7 @@ import {TooltipIfTruncated, ResponsivePopup} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {Markdown, Slot} from 'indico/react/util';
 
+import {selectors as roomsSelectors} from '../common/rooms';
 import {actions as userActions, selectors as userSelectors} from '../common/user';
 
 import DimmableImage from './DimmableImage';
@@ -33,6 +34,7 @@ class Room extends React.Component {
     isCheckingUserRoomPermissions: PropTypes.bool.isRequired,
     addFavoriteRoom: PropTypes.func.isRequired,
     delFavoriteRoom: PropTypes.func.isRequired,
+    allLocations: PropTypes.object.isRequired,
   };
 
   static defaultProps = {
@@ -149,9 +151,11 @@ class Room extends React.Component {
       addFavoriteRoom,
       delFavoriteRoom,
       isCheckingUserRoomPermissions,
+      allLocations,
       ...restProps
     } = this.props;
     const {content, actions} = Slot.split(children);
+    const showLocation = allLocations.size > 1;
 
     return (
       <Card styleName="room-card" {...restProps}>
@@ -175,9 +179,12 @@ class Room extends React.Component {
           </Card.Description>
         </Card.Content>
         <Card.Content styleName="room-content" extra>
-          <>
-            <Icon name="user" /> {room.capacity || Translate.string('Not specified')}
-          </>
+          <Icon name="user" /> {room.capacity || Translate.string('Not specified')}
+          {showLocation && (
+            <div>
+              <Icon name="map pin" /> {room.locationName || Translate.string('Not specified')}
+            </div>
+          )}
           <span styleName="room-details">
             {room.features.map(feature => (
               <RoomFeatureEntry key={feature.name} feature={feature} color="green" />
@@ -196,6 +203,7 @@ export default connect(
     return (state, props) => ({
       isFavorite: isFavoriteRoom(state, props),
       isCheckingUserRoomPermissions: userSelectors.isCheckingUserRoomPermissions(state),
+      allLocations: roomsSelectors.getLocations(state),
     });
   },
   dispatch =>

--- a/indico/modules/rb/client/js/components/Room.module.scss
+++ b/indico/modules/rb/client/js/components/Room.module.scss
@@ -6,7 +6,6 @@
 // LICENSE file for more details.
 
 .room-card {
-  height: 320px;
   width: 300px;
 
   .room-title {

--- a/indico/modules/rb/client/js/components/Room.module.scss
+++ b/indico/modules/rb/client/js/components/Room.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 .room-card {
+  height: 320px;
   width: 300px;
 
   .room-title {

--- a/indico/modules/rb/client/js/components/RoomBasicDetails.jsx
+++ b/indico/modules/rb/client/js/components/RoomBasicDetails.jsx
@@ -144,12 +144,19 @@ export default class RoomBasicDetails extends React.PureComponent {
             <Header.Subheader>{division}</Header.Subheader>
           </Header>
           <ul styleName="room-basic-details">
-            <li>{location}</li>
+            <li className="has-icon">
+              {location && (
+                <>
+                  <AnnotatedIcon name="map pin" text={Translate.string('Location')} />
+                  {location}
+                </>
+              )}
+            </li>
             <li className="has-icon">
               {site && (
                 <>
                   <AnnotatedIcon name="street view" text={Translate.string('Site')} />
-                  {room.site}
+                  {site}
                 </>
               )}
             </li>
@@ -161,7 +168,7 @@ export default class RoomBasicDetails extends React.PureComponent {
               {telephone && (
                 <>
                   <AnnotatedIcon name="phone" text={Translate.string('Phone number')} />
-                  {room.telephone}
+                  {telephone}
                 </>
               )}
             </li>

--- a/indico/modules/rb/client/js/modules/roomList/filters/LocationForm.jsx
+++ b/indico/modules/rb/client/js/modules/roomList/filters/LocationForm.jsx
@@ -1,0 +1,56 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Form} from 'semantic-ui-react';
+
+import {Translate} from 'indico/react/i18n';
+
+import {FilterFormComponent} from '../../../common/filters';
+
+export default class LocationForm extends FilterFormComponent {
+  static propTypes = {
+    locations: PropTypes.object.isRequired,
+    location: PropTypes.number,
+    ...FilterFormComponent.propTypes,
+  };
+
+  static defaultProps = {
+    location: null,
+  };
+
+  setLocation = locationId => {
+    const {setParentField} = this.props;
+
+    setParentField('locationId', locationId);
+  };
+
+  render() {
+    const {locations, location} = this.props;
+    const options = Array.from(locations, ([id, name]) => ({
+      text: name,
+      value: id,
+    }));
+
+    return (
+      <Form.Group>
+        <Form.Dropdown
+          options={options}
+          value={location}
+          placeholder={Translate.string('Location')}
+          onChange={(__, {value}) => this.setLocation(value || null)}
+          closeOnChange
+          closeOnBlur
+          search
+          selection
+          clearable
+        />
+      </Form.Group>
+    );
+  }
+}

--- a/indico/modules/rb/controllers/backend/common.py
+++ b/indico/modules/rb/controllers/backend/common.py
@@ -27,5 +27,6 @@ search_room_args = {
     'sw_lat': fields.Float(validate=lambda x: -90 <= x <= 90),
     'sw_lng': fields.Float(validate=lambda x: -180 <= x <= 180),
     'ne_lat': fields.Float(validate=lambda x: -90 <= x <= 90),
-    'ne_lng': fields.Float(validate=lambda x: -180 <= x <= 180)
+    'ne_lng': fields.Float(validate=lambda x: -180 <= x <= 180),
+    'location_id': fields.Int(),
 }

--- a/indico/modules/rb/operations/rooms.py
+++ b/indico/modules/rb/operations/rooms.py
@@ -144,6 +144,8 @@ def search_for_rooms(filters, allow_admin=False, availability=None):
         query = query.filter(Room.capacity >= filters['capacity'])
     if 'building' in filters:
         criteria['building'] = filters['building']
+    if 'location_id' in filters:
+        criteria['location_id'] = filters['location_id']
     if 'division' in filters:
         criteria['division'] = filters['division']
     query = query.filter_by(**criteria)


### PR DESCRIPTION
Closes #4291

This PR adds the possibility to filter by location in the Room Booking, when there are more than one location.
This also adds the location value in the room's card and inside the room's details modal.

![SCR-20230112-ehz](https://user-images.githubusercontent.com/36622624/212045979-2d910f2d-2b87-4e22-8d81-2f1838b08bb0.png)
![SCR-20230112-eig](https://user-images.githubusercontent.com/36622624/212045984-8e48bcf7-abec-4c77-8a94-58461a222d3d.png)
![SCR-20230112-ejl](https://user-images.githubusercontent.com/36622624/212045985-a772a9a0-f1d3-4606-a696-b058de837810.png)
