### PR TITLE
Replace HTML paragraphs and linebreaks with newlines in plaintext conversion

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Bugfixes
 - Disable Sentry trace propagation to outgoing HTTP requests (:pr:`5604`)
 - Include token in notification emails for private surveys (:pr:`5618`)
 - Fix some API calls not working with personal access tokens (:pr:`5627`)
+- Correctly handle paragraphs and linebreaks in plaintext conversion (:pr:`5623`)
 
 
 Version 3.2.2

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -506,7 +506,7 @@ def html_to_plaintext(string):
     doc = etree.HTML(string)
     for elem in doc.xpath('//p | //br'):
         elem.tail = '\n' + elem.tail if elem.tail else '\n'
-    return doc.xpath('string()')
+    return doc.xpath('string()').strip()
 
 
 class RichMarkup(Markup):

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -495,7 +495,18 @@ def sanitize_html(string):
 
 
 def html_to_plaintext(string):
-    return html.html5parser.fromstring(string).xpath('string()')
+    """Convert HTML to plaintext.
+
+    :param string: The HTML source string
+
+    <p> and <br> elements are converted into newline characters.
+    Any literal '\n' characters in the HTML source are removed.
+    """
+    string = string.replace('\n', '')
+    doc = etree.HTML(string)
+    for elem in doc.xpath('//p | //br'):
+        elem.tail = '\n' + elem.tail if elem.tail else '\n'
+    return doc.xpath('string()')
 
 
 class RichMarkup(Markup):

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -197,15 +197,15 @@ def test_sanitize_email(input, output):
 
 
 @pytest.mark.parametrize(('input', 'output'), (
+    ('Simple text', 'Simple text'),
     ('<span>Simple text</span>', 'Simple text'),
-    ('<p>Simple text</p>', 'Simple text\n'),
-    ('Simple text', 'Simple text\n'),  # lxml parses this as <p>...</p> which creates the extra newline
+    ('<p>Simple text</p>', 'Simple text'),
     ('<h1>Some html</h1>', 'Some html'),
-    ('foo &amp; bar <a href="test">xxx</a> 1<2 <test>', 'foo & bar xxx 1<2 \n'),
+    ('foo &amp; bar <a href="test">xxx</a> 1<2 <test>', 'foo & bar xxx 1<2'),
     ('<strong>m\xf6p</strong> test', 'm\xf6p test'),
-    ('<p>hello</p> <p>world</p>', 'hello\n world\n'),
-    ('Text <br> with <br> linebreaks', 'Text \n with \n linebreaks\n'),
-    ('<p>Combining paragraphs with <br> linebreaks </p>', 'Combining paragraphs with \n linebreaks \n'),
+    ('<p>hello</p> <p>world</p>', 'hello\n world'),
+    ('Text <br> with <br> linebreaks', 'Text \n with \n linebreaks'),
+    ('<p>Combining paragraphs with <br> linebreaks </p>', 'Combining paragraphs with \n linebreaks'),
 ))
 def test_html_to_plaintext(input, output):
     assert html_to_plaintext(input) == output

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -197,10 +197,15 @@ def test_sanitize_email(input, output):
 
 
 @pytest.mark.parametrize(('input', 'output'), (
-    ('Simple text', 'Simple text'),
+    ('<span>Simple text</span>', 'Simple text'),
+    ('<p>Simple text</p>', 'Simple text\n'),
+    ('Simple text', 'Simple text\n'),  # lxml parses this as <p>...</p> which creates the extra newline
     ('<h1>Some html</h1>', 'Some html'),
-    ('foo &amp; bar <a href="test">xxx</a> 1<2 <test>', 'foo & bar xxx 1<2 '),
-    ('<strong>m\xf6p</strong> test', 'm\xf6p test')
+    ('foo &amp; bar <a href="test">xxx</a> 1<2 <test>', 'foo & bar xxx 1<2 \n'),
+    ('<strong>m\xf6p</strong> test', 'm\xf6p test'),
+    ('<p>hello</p> <p>world</p>', 'hello\n world\n'),
+    ('Text <br> with <br> linebreaks', 'Text \n with \n linebreaks\n'),
+    ('<p>Combining paragraphs with <br> linebreaks </p>', 'Combining paragraphs with \n linebreaks \n'),
 ))
 def test_html_to_plaintext(input, output):
     assert html_to_plaintext(input) == output


### PR DESCRIPTION
Closes #5611 

