### PR TITLE
Fix some API calls with personal tokens

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Bugfixes
 - Correctly show contribution authors in participant roles list (:pr:`5603`)
 - Disable Sentry trace propagation to outgoing HTTP requests (:pr:`5604`)
 - Include token in notification emails for private surveys (:pr:`5618`)
+- Fix some API calls not working with personal access tokens (:pr:`5627`)
 
 
 Version 3.2.2

--- a/indico/web/util.py
+++ b/indico/web/util.py
@@ -383,6 +383,15 @@ def get_request_user():
         # we don't want that code to fail because of an invalid token in the URL
         return None, None
 
+    # XXX this is an awful workaround for API requests than call something (e.g.
+    # `display_full_name`) which accesses `session.user` and thus calls this,
+    # which will then fail because the API token usually doesn't have one of the
+    # `everything` scopes... this should be removed whenever we get rid of the legacy
+    # API since any new code would simply be using normal RHs with an oauth scope,
+    # and thus not end up doing this weird mix.
+    if g.get('current_api_user'):
+        return None, None
+
     current_exc = sys.exc_info()[1]
     rh = type(g.rh) if 'rh' in g else None
     oauth_scope_hint = getattr(rh, '_OAUTH_SCOPE', None)


### PR DESCRIPTION
When accessing APIs returning speaker information determining the sort order for speakers accesses `session.user` (as `display_full_name` uses a user preference), but doing so from an API call results in a call to `get_request_user` which does not know about the API and thus does another oauth scope check for the `everything` scopes, which fails if the token used to authenticate the API call doesn't have that scope.

The workaround (considering that the API is legacy) is to always return "no user" since legacy API calls are not really considered in the context of a user (except for access checks) anyway.