### PR TITLE
[Axios] Replace cancel tokens with AbortController

### DIFF
--- a/indico/web/client/js/react/components/principals/PrincipalField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalField.jsx
@@ -57,14 +57,14 @@ const PrincipalField = props => {
       // nothing to do
       return;
     }
-    const source = indicoAxios.CancelToken.source();
+    const controller = new AbortController();
     (async () => {
       let response;
       try {
         response = await indicoAxios.post(
           principalsURL(),
           {values: [value]},
-          {cancelToken: source.token}
+          {signal: controller.signal}
         );
       } catch (error) {
         handleAxiosError(error);
@@ -74,7 +74,7 @@ const PrincipalField = props => {
     })();
 
     return () => {
-      source.cancel();
+      controller.abort();
     };
   }, [details, value]);
 

--- a/indico/web/client/js/utils/axios.js
+++ b/indico/web/client/js/utils/axios.js
@@ -19,7 +19,6 @@ export const indicoAxios = axios.create({
 });
 
 indicoAxios.isCancel = axios.isCancel;
-indicoAxios.CancelToken = axios.CancelToken;
 
 indicoAxios.interceptors.request.use(config => {
   if (isURLSameOrigin(config.url)) {


### PR DESCRIPTION
Cancel tokens have been deprecated in favor of the standard AbortController.