### PR TITLE
Make it possible to load more events in series management

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Improvements
 - Include co-authors in abstract list columns and spreadsheet exports (:pr:`5605`)
 - Include speakers in abstract list columns and spreadsheet exports (:pr:`5615`)
 - Add an option to export all events in a series to ical at once (:issue:`5617`, :pr:`5620`)
+- Make it possible to load more events in series management (:pr:`5629`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/core/db/sqlalchemy/util/queries.py
+++ b/indico/core/db/sqlalchemy/util/queries.py
@@ -137,7 +137,7 @@ def get_related_object(obj, relationship, criteria):
     return cls.query.with_parent(obj, relationship).filter_by(**criteria).first()
 
 
-def get_n_matching(query, n, predicate, *, prefetch_factor=5, preload_bulk=None):
+def get_n_matching(query, n, predicate, *, prefetch_factor=5, preload_bulk=None, offset=0):
     """Get N objects from a query that satisfy a condition.
 
     This queries for ``n * 5`` objects initially and then loads
@@ -151,8 +151,9 @@ def get_n_matching(query, n, predicate, *, prefetch_factor=5, preload_bulk=None)
     :param preload_bulk: Function that's called with the full set of objects
                          to allow for bulk-preloading of data needed in the
                          predicate function
+    :param offset: The initial query offset
     """
-    _offset = 0
+    _offset = offset
 
     def _get():
         nonlocal _offset

--- a/indico/modules/events/management/client/js/SeriesManagement.module.scss
+++ b/indico/modules/events/management/client/js/SeriesManagement.module.scss
@@ -67,3 +67,18 @@
 .positive-note {
   color: $dark-green;
 }
+
+:global(.ui.dropdown .menu) > :global(.item).load-more {
+  padding: 0 !important;
+  margin: 0;
+  cursor: default;
+
+  &:hover {
+    background: unset;
+  }
+}
+
+.load-more > div {
+  text-align: center;
+  padding: 11px 16px; // Same as <Dropdown.Item>
+}

--- a/indico/modules/events/series/schemas.py
+++ b/indico/modules/events/series/schemas.py
@@ -65,3 +65,8 @@ class EventDetailsForSeriesManagementSchema(mm.SQLAlchemyAutoSchema):
     category_chain = fields.List(fields.String(), attribute='category.chain_titles')
     can_manage = fields.Function(lambda event: event.can_manage(session.user))
     can_access = fields.Function(lambda event: event.can_access(session.user))
+
+
+class SeriesManagementSearchResultsSchema(mm.Schema):
+    events = fields.List(fields.Nested(EventDetailsForSeriesManagementSchema))
+    has_more = fields.Bool()


### PR DESCRIPTION
More matching events can be loaded in the dropdown which makes it easier to create event series with a larger number of events.

![image](https://user-images.githubusercontent.com/8739637/213420876-e8bcaea2-ba8b-4c17-958b-e7496daebed5.png)
