### PR TITLE
Keep state of undone timeline revisions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Improvements
 
 - Use the revision's timestamp when downloading its files as a ZIP archive (:pr:`5686`)
 - Use more consistent colors on the editing judgment button (:issue:`5687`, :pr:`5697`)
+- Keep history when undoing judgments on editables (:pr:`5630`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20230112_1116_5d05eda06776_add_undone_state_to_editing_revisions.py
+++ b/indico/migrations/versions/20230112_1116_5d05eda06776_add_undone_state_to_editing_revisions.py
@@ -1,0 +1,35 @@
+"""Add undone state to editing revisions
+
+Revision ID: 5d05eda06776
+Revises: b45847c0e62f
+Create Date: 2023-01-12 11:16:55.539279
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '5d05eda06776'
+down_revision = 'b45847c0e62f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('ck_revisions_valid_enum_final_state', 'revisions', schema='event_editing')
+    op.create_check_constraint('valid_enum_final_state', 'revisions',
+                               '(final_state = ANY (ARRAY[0, 1, 2, 3, 4, 5, 6]))', schema='event_editing')
+    op.drop_constraint('ck_revisions_valid_state_combination', 'revisions', schema='event_editing')
+    op.create_check_constraint('valid_state_combination', 'revisions',
+                               '(initial_state=1 AND final_state IN (0,1)) OR (initial_state=2) OR '
+                               '(initial_state=3 AND (final_state IN (0,3,4,6)))', schema='event_editing')
+
+
+def downgrade():
+    op.drop_constraint('ck_revisions_valid_enum_final_state', 'revisions', schema='event_editing')
+    op.create_check_constraint('valid_enum_final_state', 'revisions',
+                               '(final_state = ANY (ARRAY[0, 1, 2, 3, 4, 5]))', schema='event_editing')
+    op.drop_constraint('ck_revisions_valid_state_combination', 'revisions', schema='event_editing')
+    op.create_check_constraint('valid_state_combination', 'revisions',
+                               '(initial_state=1 AND final_state IN (0,1)) OR (initial_state=2) OR '
+                               '(initial_state=3 AND (final_state IN (0,3,4)))', schema='event_editing')

--- a/indico/migrations/versions/20230209_1214_5d05eda06776_add_undone_state_to_editing_revisions.py
+++ b/indico/migrations/versions/20230209_1214_5d05eda06776_add_undone_state_to_editing_revisions.py
@@ -39,9 +39,9 @@ def upgrade():
                                '(initial_state=1 AND final_state IN (0,1)) OR (initial_state=2) OR '
                                '(initial_state=3 AND (final_state IN (0,3,4,6)))', schema='event_editing')
     op.add_column('comments',
-                  sa.Column('undone_judgement', PyIntEnum(_FinalRevisionState), nullable=False, server_default='0'),
+                  sa.Column('undone_judgment', PyIntEnum(_FinalRevisionState), nullable=False, server_default='0'),
                   schema='event_editing')
-    op.alter_column('comments', 'undone_judgement', server_default=None, schema='event_editing')
+    op.alter_column('comments', 'undone_judgment', server_default=None, schema='event_editing')
 
 
 def downgrade():
@@ -52,4 +52,4 @@ def downgrade():
     op.create_check_constraint('valid_state_combination', 'revisions',
                                '(initial_state=1 AND final_state IN (0,1)) OR (initial_state=2) OR '
                                '(initial_state=3 AND (final_state IN (0,3,4)))', schema='event_editing')
-    op.drop_column('comments', 'undone_judgement', schema='event_editing')
+    op.drop_column('comments', 'undone_judgment', schema='event_editing')

--- a/indico/migrations/versions/20230209_1214_5d05eda06776_add_undone_state_to_editing_revisions.py
+++ b/indico/migrations/versions/20230209_1214_5d05eda06776_add_undone_state_to_editing_revisions.py
@@ -1,18 +1,33 @@
 """Add undone state to editing revisions
 
 Revision ID: 5d05eda06776
-Revises: b45847c0e62f
-Create Date: 2023-01-12 11:16:55.539279
+Revises: 7551bd141960
+Create Date: 2023-02-09 12:14:55.539279
 """
 
+from enum import Enum
+
+import sqlalchemy as sa
 from alembic import op
+
+from indico.core.db.sqlalchemy import PyIntEnum
 
 
 # revision identifiers, used by Alembic.
 revision = '5d05eda06776'
-down_revision = 'b45847c0e62f'
+down_revision = '7551bd141960'
 branch_labels = None
 depends_on = None
+
+
+class _FinalRevisionState(int, Enum):
+    none = 0
+    replaced = 1
+    needs_submitter_confirmation = 2
+    needs_submitter_changes = 3
+    accepted = 4
+    rejected = 5
+    undone = 6
 
 
 def upgrade():
@@ -23,6 +38,10 @@ def upgrade():
     op.create_check_constraint('valid_state_combination', 'revisions',
                                '(initial_state=1 AND final_state IN (0,1)) OR (initial_state=2) OR '
                                '(initial_state=3 AND (final_state IN (0,3,4,6)))', schema='event_editing')
+    op.add_column('comments',
+                  sa.Column('undone_judgement', PyIntEnum(_FinalRevisionState), nullable=False, server_default='0'),
+                  schema='event_editing')
+    op.alter_column('comments', 'undone_judgement', server_default=None, schema='event_editing')
 
 
 def downgrade():
@@ -33,3 +52,4 @@ def downgrade():
     op.create_check_constraint('valid_state_combination', 'revisions',
                                '(initial_state=1 AND final_state IN (0,1)) OR (initial_state=2) OR '
                                '(initial_state=3 AND (final_state IN (0,3,4)))', schema='event_editing')
+    op.drop_column('comments', 'undone_judgement', schema='event_editing')

--- a/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
@@ -11,19 +11,28 @@ import React from 'react';
 import {useSelector} from 'react-redux';
 
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
+import {Translate} from 'indico/react/i18n';
 import {serializeDate} from 'indico/utils/date';
+
+import {FinalRevisionState} from '../../models';
 
 import ResetReview from './ResetReview';
 import * as selectors from './selectors';
 import StateIndicator from './StateIndicator';
 import {blockItemPropTypes} from './util';
 
-export default function CustomItem({item: {header, user, reviewedDt, html, revisionId}, state}) {
+import '../../../styles/timeline.module.scss';
+
+export default function CustomItem({
+  item: {header, user, reviewedDt, html, revisionId, undoneJudgement},
+  state,
+}) {
   const lastRevertableRevisionId = useSelector(selectors.getLastRevertableRevisionId);
-  // TODO: display differently if item is undone
+  const isUndone = undoneJudgement && undoneJudgement.name !== FinalRevisionState.none;
+  state = isUndone ? undoneJudgement.name : state;
 
   return (
-    <div className="i-timeline-item">
+    <div className="i-timeline-item" styleName={isUndone ? 'undone-item' : undefined}>
       <UserAvatar user={user} />
       <div className="flexrow i-timeline-item-content">
         <div className="i-timeline-item-box">
@@ -31,14 +40,21 @@ export default function CustomItem({item: {header, user, reviewedDt, html, revis
             className={`i-box-header flexrow ${!html ? 'header-only' : ''}`}
             style={{alignItems: 'center'}}
           >
-            <div className="f-self-stretch">
+            <div className="f-self-stretch" styleName="item-header">
               {header}{' '}
               <time dateTime={serializeDate(reviewedDt, moment.HTML5_FMT.DATETIME_LOCAL_SECONDS)}>
                 {serializeDate(reviewedDt, 'LL')}
-              </time>
+              </time>{' '}
+              {isUndone && (
+                <Translate as="span" styleName="undone-indicator">
+                  Retracted
+                </Translate>
+              )}
             </div>
-            {revisionId === lastRevertableRevisionId && <ResetReview revisionId={revisionId} />}
-            {state && <StateIndicator state={state} circular />}
+            {!isUndone && revisionId === lastRevertableRevisionId && (
+              <ResetReview revisionId={revisionId} />
+            )}
+            {state && <StateIndicator state={state} circular basic={isUndone} />}
           </div>
           {html && (
             <div className="i-box-content js-form-container">

--- a/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
@@ -20,6 +20,7 @@ import {blockItemPropTypes} from './util';
 
 export default function CustomItem({item: {header, user, reviewedDt, html, revisionId}, state}) {
   const lastRevertableRevisionId = useSelector(selectors.getLastRevertableRevisionId);
+  // TODO: display differently if item is undone
 
   return (
     <div className="i-timeline-item">

--- a/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
@@ -24,12 +24,12 @@ import {blockItemPropTypes} from './util';
 import '../../../styles/timeline.module.scss';
 
 export default function CustomItem({
-  item: {header, user, reviewedDt, html, revisionId, undoneJudgement},
+  item: {header, user, reviewedDt, html, revisionId, undoneJudgment},
   state,
 }) {
   const lastRevertableRevisionId = useSelector(selectors.getLastRevertableRevisionId);
-  const isUndone = undoneJudgement && undoneJudgement.name !== FinalRevisionState.none;
-  state = isUndone ? undoneJudgement.name : state;
+  const isUndone = undoneJudgment && undoneJudgment.name !== FinalRevisionState.none;
+  state = isUndone ? undoneJudgment.name : state;
 
   return (
     <div className="i-timeline-item" styleName={isUndone ? 'undone-item' : undefined}>

--- a/indico/modules/events/editing/client/js/editing/timeline/StateIndicator.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/StateIndicator.jsx
@@ -35,10 +35,15 @@ const labelColors = {
   ready_for_review: Palette.blue,
 };
 
-export default function StateIndicator({label, circular, tooltip, state, monochrome}) {
+export default function StateIndicator({label, circular, basic, tooltip, state, monochrome}) {
   const labelColor = labelColors[state] || Palette.black;
   const trigger = (
-    <Label size="tiny" color={monochrome ? 'grey' : colors[state]} circular={circular} />
+    <Label
+      size="tiny"
+      color={monochrome ? 'grey' : colors[state]}
+      circular={circular}
+      basic={basic}
+    />
   );
 
   return (
@@ -62,6 +67,7 @@ export default function StateIndicator({label, circular, tooltip, state, monochr
 StateIndicator.propTypes = {
   label: PropTypes.bool,
   circular: PropTypes.bool,
+  basic: PropTypes.bool,
   tooltip: PropTypes.string,
   state: PropTypes.string.isRequired,
   monochrome: PropTypes.bool,
@@ -70,6 +76,7 @@ StateIndicator.propTypes = {
 StateIndicator.defaultProps = {
   label: false,
   circular: false,
+  basic: false,
   tooltip: null,
   monochrome: false,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -26,6 +26,7 @@ import * as selectors from './selectors';
 import StateIndicator from './StateIndicator';
 import {blockPropTypes, isRequestChangesWithFiles} from './util';
 
+import '../../../styles/timeline.module.scss';
 import './TimelineItem.module.scss';
 
 export default function TimelineItem({block, index}) {
@@ -68,7 +69,7 @@ export default function TimelineItem({block, index}) {
             id={`block-info-${block.id}`}
           >
             <div className="i-box-header flexrow">
-              <div className="f-self-stretch" styleName="header">
+              <div className="f-self-stretch" styleName="item-header">
                 <span styleName="item-index">#{index + 1}</span>{' '}
                 <span>
                   {block.header ? (

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -9,10 +9,13 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
+import {Icon, Message} from 'semantic-ui-react';
 
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {Param, Translate} from 'indico/react/i18n';
 import {serializeDate} from 'indico/utils/date';
+
+import {FinalRevisionState} from '../../models';
 
 import ChangesConfirmation from './ChangesConfirmation';
 import CustomActions from './CustomActions';
@@ -27,32 +30,38 @@ import './TimelineItem.module.scss';
 
 export default function TimelineItem({block, index}) {
   const {submitter, createdDt} = block;
-  const lastBlock = useSelector(selectors.getLastTimelineBlock);
-  const secondLastBlock = useSelector(selectors.getSecondLastTimelineBlock);
+  const timelineBlocks = useSelector(selectors.getTimelineBlocks);
+  const validTimelineBlocks = useSelector(selectors.getValidTimelineBlocks);
   const needsSubmitterConfirmation = useSelector(selectors.needsSubmitterConfirmation);
   const canPerformSubmitterActions = useSelector(selectors.canPerformSubmitterActions);
   const {canComment, state: editableState} = useSelector(selectors.getDetails);
   const {fileTypes} = useSelector(selectors.getStaticData);
-  const isLastBlock = lastBlock.id === block.id;
+  const isLastBlock = timelineBlocks[timelineBlocks.length - 1].id === block.id;
+  const isLastValidBlock = validTimelineBlocks[validTimelineBlocks.length - 1].id === block.id;
   const isVisibleByDefault =
-    isLastBlock ||
-    (secondLastBlock &&
-      secondLastBlock.id === block.id &&
-      (isRequestChangesWithFiles(lastBlock, secondLastBlock) || needsSubmitterConfirmation));
+    isLastValidBlock ||
+    (validTimelineBlocks.length >= 2 &&
+      validTimelineBlocks[validTimelineBlocks.length - 2].id === block.id &&
+      (isRequestChangesWithFiles(
+        validTimelineBlocks[validTimelineBlocks.length - 1],
+        validTimelineBlocks[validTimelineBlocks.length - 2]
+      ) ||
+        needsSubmitterConfirmation));
   const [visible, setVisible] = useState(isVisibleByDefault);
+  const isUndone = block.finalState.name === FinalRevisionState.undone;
 
   useEffect(() => {
     // when undoing a judgment deletes the last revision this revision may become the
     // latest one, and thus needs to be unhidden if it had been collapsed before.
-    if (isVisibleByDefault && !visible) {
+    if (isLastValidBlock && isVisibleByDefault && !visible) {
       setVisible(true);
     }
-  }, [isVisibleByDefault, visible]);
+  }, [isLastValidBlock, isVisibleByDefault, visible]);
 
   return (
     <>
       <div className="i-timeline">
-        <div className="i-timeline-item">
+        <div className="i-timeline-item" styleName={isUndone ? 'undone-item' : undefined}>
           <UserAvatar user={block.submitter} />
           <div
             className={`i-timeline-item-box header-indicator-left ${!visible ? 'header-only' : ''}`}
@@ -73,9 +82,14 @@ export default function TimelineItem({block, index}) {
                 </span>{' '}
                 <time dateTime={serializeDate(createdDt, moment.HTML5_FMT.DATETIME_LOCAL_SECONDS)}>
                   {serializeDate(createdDt, 'LLL')}
-                </time>
+                </time>{' '}
+                {isUndone && (
+                  <Translate as="span" styleName="undone-indicator">
+                    Retracted
+                  </Translate>
+                )}
               </div>
-              {!isLastBlock && (
+              {!isLastValidBlock && (
                 <>
                   <a className="block-info-link i-link" onClick={() => setVisible(!visible)}>
                     {visible ? <Translate>Hide</Translate> : <Translate>Show details</Translate>}
@@ -90,13 +104,19 @@ export default function TimelineItem({block, index}) {
             </div>
             {visible && (
               <div className="i-box-content">
+                {isUndone && (
+                  <Message warning>
+                    <Icon name="warning sign" />
+                    <Translate>This revision has been retracted by the editor.</Translate>
+                  </Message>
+                )}
                 <FileDisplay
                   fileTypes={fileTypes}
                   files={block.files}
                   downloadURL={block.downloadFilesURL}
                   tags={block.tags}
                 />
-                {canPerformSubmitterActions && needsSubmitterConfirmation && isLastBlock && (
+                {canPerformSubmitterActions && needsSubmitterConfirmation && isLastValidBlock && (
                   <ChangesConfirmation />
                 )}
               </div>
@@ -109,9 +129,9 @@ export default function TimelineItem({block, index}) {
       </div>
       {visible && (
         <RevisionLog items={block.items} state={block.finalState.name} separator={isLastBlock}>
-          {isLastBlock && !['accepted', 'rejected'].includes(editableState.name) && canComment && (
-            <ReviewForm block={block} />
-          )}
+          {isLastValidBlock &&
+            !['accepted', 'rejected'].includes(editableState.name) &&
+            canComment && <ReviewForm block={block} />}
         </RevisionLog>
       )}
     </>

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
@@ -7,6 +7,17 @@
 
 @import 'base/palette';
 
+.undone-item {
+  :global(.i-box-header) {
+    background-image: repeating-linear-gradient(-45deg, $pastel-gray 0 2px, $light-gray 3px 15px);
+  }
+
+  .undone-indicator {
+    color: $light-black;
+    font-weight: bold;
+  }
+}
+
 .state-indicator {
   margin-left: 5px;
 }

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
@@ -7,27 +7,10 @@
 
 @import 'base/palette';
 
-.undone-item {
-  :global(.i-box-header) {
-    background-image: repeating-linear-gradient(-45deg, $pastel-gray 0 2px, $light-gray 3px 15px);
-  }
-
-  .undone-indicator {
-    color: $light-black;
-    font-weight: bold;
-  }
-}
-
 .state-indicator {
   margin-left: 5px;
 }
 
 .item-index {
-  color: $gray;
-}
-
-.header > :not(:first-child)::before {
-  content: '\00B7' !important;
-  padding-right: 0.3em;
   color: $gray;
 }

--- a/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
@@ -21,7 +21,7 @@ describe('timeline selectors', () => {
             user: {
               fullName: 'Indico Janitor',
             },
-            undoneJudgement: {
+            undoneJudgment: {
               name: FinalRevisionState.none,
             },
           },
@@ -130,7 +130,7 @@ describe('timeline selectors', () => {
             user: {
               fullName: 'Indico Janitor',
             },
-            undoneJudgement: {
+            undoneJudgment: {
               name: FinalRevisionState.none,
             },
           },
@@ -154,7 +154,7 @@ describe('timeline selectors', () => {
             user: {
               fullName: 'Indico Janitor',
             },
-            undoneJudgement: {
+            undoneJudgment: {
               name: FinalRevisionState.none,
             },
           },
@@ -164,7 +164,7 @@ describe('timeline selectors', () => {
             user: {
               fullName: 'Indico Janitor',
             },
-            undoneJudgement: {
+            undoneJudgment: {
               name: FinalRevisionState.none,
             },
           },

--- a/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/__tests__/selectors.test.js
@@ -21,6 +21,9 @@ describe('timeline selectors', () => {
             user: {
               fullName: 'Indico Janitor',
             },
+            undoneJudgement: {
+              name: FinalRevisionState.none,
+            },
           },
         ],
         initialState: {
@@ -127,6 +130,9 @@ describe('timeline selectors', () => {
             user: {
               fullName: 'Indico Janitor',
             },
+            undoneJudgement: {
+              name: FinalRevisionState.none,
+            },
           },
         ],
         initialState: {
@@ -148,12 +154,18 @@ describe('timeline selectors', () => {
             user: {
               fullName: 'Indico Janitor',
             },
+            undoneJudgement: {
+              name: FinalRevisionState.none,
+            },
           },
           {
             id: 2,
             text: 'done',
             user: {
               fullName: 'Indico Janitor',
+            },
+            undoneJudgement: {
+              name: FinalRevisionState.none,
             },
           },
         ],

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -27,7 +27,19 @@ export const isRequestChangesWithFiles = (revision, previousRevision) =>
 export function processRevisions(revisions) {
   let revisionState;
   return revisions.map((revision, i) => {
-    const items = [...revision.comments];
+    const items = revision.comments.map(c =>
+      c.undoneJudgement.name === FinalRevisionState.none
+        ? c
+        : {
+            ...c,
+            header: getRevisionTransition(
+              {...revision, finalState: c.undoneJudgement},
+              {isLatestRevision: true}
+            ),
+            reviewedDt: c.createdDt,
+            custom: true,
+          }
+    );
     const header = revisionState;
     const isLatestRevision = i === revisions.length - 1;
     revisionState = getRevisionTransition(revision, {isLatestRevision});
@@ -38,8 +50,8 @@ export function processRevisions(revisions) {
     }
     return {
       ...revision,
-      // use the previous state transition as current block header
-      header: header || revision.header,
+      // use the previous state transition as current block header, unless the revision has been undone
+      header: revision.finalState.name !== FinalRevisionState.undone && (header || revision.header),
       items,
     };
   });
@@ -123,6 +135,7 @@ export const blockItemPropTypes = {
   internal: PropTypes.bool,
   system: PropTypes.bool,
   custom: PropTypes.bool,
+  undoneJudgement: PropTypes.shape(statePropTypes),
   modifyCommentURL: PropTypes.string,
 };
 

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -28,12 +28,12 @@ export function processRevisions(revisions) {
   let revisionState;
   return revisions.map((revision, i) => {
     const items = revision.comments.map(c =>
-      c.undoneJudgement.name === FinalRevisionState.none
+      c.undoneJudgment.name === FinalRevisionState.none
         ? c
         : {
             ...c,
             header: getRevisionTransition(
-              {...revision, finalState: c.undoneJudgement},
+              {...revision, finalState: c.undoneJudgment},
               {isLatestRevision: true}
             ),
             reviewedDt: c.createdDt,
@@ -120,7 +120,6 @@ const statePropTypes = {
 
 // Type that represents a revision comment block
 // (a simplified-ish version of the revision blocks below)
-// TODO: add undone prop
 export const blockItemPropTypes = {
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   revisionId: PropTypes.number.isRequired,
@@ -135,7 +134,7 @@ export const blockItemPropTypes = {
   internal: PropTypes.bool,
   system: PropTypes.bool,
   custom: PropTypes.bool,
-  undoneJudgement: PropTypes.shape(statePropTypes),
+  undoneJudgment: PropTypes.shape(statePropTypes),
   modifyCommentURL: PropTypes.string,
 };
 

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -108,6 +108,7 @@ const statePropTypes = {
 
 // Type that represents a revision comment block
 // (a simplified-ish version of the revision blocks below)
+// TODO: add undone prop
 export const blockItemPropTypes = {
   id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
   revisionId: PropTypes.number.isRequired,

--- a/indico/modules/events/editing/client/js/models.js
+++ b/indico/modules/events/editing/client/js/models.js
@@ -14,6 +14,7 @@ export const FinalRevisionState = {
   needs_submitter_changes: 'needs_submitter_changes',
   accepted: 'accepted',
   rejected: 'rejected',
+  undone: 'undone',
 };
 
 export const InitialRevisionState = {

--- a/indico/modules/events/editing/client/styles/timeline.module.scss
+++ b/indico/modules/events/editing/client/styles/timeline.module.scss
@@ -1,0 +1,26 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@import 'base/palette';
+
+.undone-item {
+  :global(.i-box-header) {
+    background-image: repeating-linear-gradient(-45deg, $pastel-gray 0 2px, $light-gray 3px 15px);
+  }
+
+  .undone-indicator {
+    color: $light-black;
+    font-weight: bold;
+  }
+}
+
+.item-header > :not(:first-child)::before {
+  content: '\00B7' !important;
+  padding-right: 0.3em;
+  color: $gray;
+  font-weight: normal;
+}

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -130,7 +130,7 @@ class RHEditable(RHContributionEditableBase):
 
     def _process(self):
         custom_actions = self._get_custom_actions()
-        custom_actions_ctx = {self.editable.revisions[-1]: custom_actions}
+        custom_actions_ctx = {self.editable.valid_revisions[-1]: custom_actions}
         schema = EditableSchema(context={
             'user': session.user,
             'custom_actions': custom_actions_ctx,

--- a/indico/modules/events/editing/models/comments.py
+++ b/indico/modules/events/editing/models/comments.py
@@ -6,11 +6,13 @@
 # LICENSE file for more details.
 
 from indico.core.db import db
-from indico.core.db.sqlalchemy import UTCDateTime
+from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
 from indico.core.db.sqlalchemy.descriptions import RenderMode, RenderModeMixin
 from indico.util.date_time import now_utc
 from indico.util.locators import locator_property
 from indico.util.string import format_repr, text_to_repr
+
+from .revisions import FinalRevisionState
 
 
 class EditingRevisionComment(RenderModeMixin, db.Model):
@@ -61,6 +63,12 @@ class EditingRevisionComment(RenderModeMixin, db.Model):
         nullable=False,
         default=False
     )
+    #: Undone revision state if the comment comes from an undone judgement
+    undone_judgement = db.Column(
+        PyIntEnum(FinalRevisionState),
+        nullable=False,
+        default=FinalRevisionState.none
+    )
     _text = db.Column(
         'text',
         db.Text,
@@ -107,5 +115,7 @@ class EditingRevisionComment(RenderModeMixin, db.Model):
         elif self.system:
             return False
         elif self.internal and not authorized_editor:
+            return False
+        elif self.undone_judgement != FinalRevisionState.none:
             return False
         return authorized_editor or authorized_submitter

--- a/indico/modules/events/editing/models/comments.py
+++ b/indico/modules/events/editing/models/comments.py
@@ -63,8 +63,8 @@ class EditingRevisionComment(RenderModeMixin, db.Model):
         nullable=False,
         default=False
     )
-    #: Undone revision state if the comment comes from an undone judgement
-    undone_judgement = db.Column(
+    #: Undone revision state if the comment comes from an undone judgment
+    undone_judgment = db.Column(
         PyIntEnum(FinalRevisionState),
         nullable=False,
         default=FinalRevisionState.none
@@ -116,6 +116,6 @@ class EditingRevisionComment(RenderModeMixin, db.Model):
             return False
         elif self.internal and not authorized_editor:
             return False
-        elif self.undone_judgement != FinalRevisionState.none:
+        elif self.undone_judgment != FinalRevisionState.none:
             return False
         return authorized_editor or authorized_submitter

--- a/indico/modules/events/editing/models/editable.py
+++ b/indico/modules/events/editing/models/editable.py
@@ -12,7 +12,6 @@ from sqlalchemy.sql import select
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum
-from indico.util.caching import memoize_request
 from indico.util.enum import RichIntEnum
 from indico.util.i18n import _
 from indico.util.locators import locator_property
@@ -111,7 +110,6 @@ class Editable(db.Model):
         return self.contribution.event
 
     @property
-    @memoize_request
     def valid_revisions(self):
         from .revisions import FinalRevisionState
         return [r for r in self.revisions if r.final_state != FinalRevisionState.undone]

--- a/indico/modules/events/editing/models/revisions.py
+++ b/indico/modules/events/editing/models/revisions.py
@@ -32,7 +32,7 @@ class InitialRevisionState(RichIntEnum):
 class FinalRevisionState(RichIntEnum):
     __titles__ = [None, _('Replaced'), _('Needs Confirmation'), _('Needs Changes'), _('Accepted'), _('Rejected'),
                   _('Undone')]
-    __css_classes__ = [None, 'highlight', 'warning', 'warning', 'success', 'error', 'disabled']
+    __css_classes__ = [None, 'highlight', 'warning', 'warning', 'success', 'error', None]
     #: A revision that is awaiting some action
     none = 0
     #: A revision that has been replaced by its next revision

--- a/indico/modules/events/editing/models/revisions.py
+++ b/indico/modules/events/editing/models/revisions.py
@@ -30,8 +30,9 @@ class InitialRevisionState(RichIntEnum):
 
 
 class FinalRevisionState(RichIntEnum):
-    __titles__ = [None, _('Replaced'), _('Needs Confirmation'), _('Needs Changes'), _('Accepted'), _('Rejected')]
-    __css_classes__ = [None, 'highlight', 'warning', 'warning', 'success', 'error']
+    __titles__ = [None, _('Replaced'), _('Needs Confirmation'), _('Needs Changes'), _('Accepted'), _('Rejected'),
+                  _('Undone')]
+    __css_classes__ = [None, 'highlight', 'warning', 'warning', 'success', 'error', 'disabled']
     #: A revision that is awaiting some action
     none = 0
     #: A revision that has been replaced by its next revision
@@ -44,20 +45,24 @@ class FinalRevisionState(RichIntEnum):
     accepted = 4
     #: A revision that has been rejected (no followup revision)
     rejected = 5
+    #: A revision that has been undone
+    undone = 6
 
 
 def _make_state_check():
     return re.sub(r'\s+', ' ', '''
         (initial_state={i_new} AND final_state IN ({f_none}, {f_replaced})) OR
         (initial_state={i_ready_for_review}) OR
-        (initial_state={i_needs_confirmation} AND (final_state IN ({f_none}, {f_needs_changes}, {f_accepted})))
+        (initial_state={i_needs_confirmation} AND
+         (final_state IN ({f_none}, {f_needs_changes}, {f_accepted}, {f_undone})))
     '''.format(i_new=InitialRevisionState.new,
                i_ready_for_review=InitialRevisionState.ready_for_review,
                i_needs_confirmation=InitialRevisionState.needs_submitter_confirmation,
                f_none=FinalRevisionState.none,
                f_replaced=FinalRevisionState.replaced,
                f_needs_changes=FinalRevisionState.needs_submitter_changes,
-               f_accepted=FinalRevisionState.accepted)).strip()
+               f_accepted=FinalRevisionState.accepted,
+               f_undone=FinalRevisionState.undone)).strip()
 
 
 def _make_reviewed_dt_check():

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -266,8 +266,12 @@ def undo_review(revision):
     elif revision.final_state == FinalRevisionState.accepted:
         revision.editable.published_revision = None
     db.session.flush()
+    # Keep comment history:
+    comment = EditingRevisionComment(user=revision.editor or revision.submitter, created_dt=revision.reviewed_dt,
+                                     undone_judgement=revision.final_state, text=revision.comment)
+    revision.comments.append(comment)
     revision.final_state = FinalRevisionState.none
-    #revision.comment = ''  # TODO keep comments
+    revision.comment = ''
     revision.reviewed_dt = None
     db.session.flush()
     logger.info('Revision %r review undone', revision)

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -269,6 +269,11 @@ def undo_review(revision):
     # Keep comment history:
     comment = EditingRevisionComment(user=revision.editor or revision.submitter, created_dt=revision.reviewed_dt,
                                      undone_judgement=revision.final_state, text=revision.comment)
+    num_revisions = len(revision.editable.valid_revisions)
+    revision.tags = {tag for tag in revision.tags if tag.system}
+    if num_revisions >= 3 or (num_revisions >= 2 and revision == latest_revision):
+        previous_revision = revision.editable.valid_revisions[-2 if revision == latest_revision else -3]
+        revision.tags |= {tag for tag in previous_revision.tags if not tag.system}
     revision.comments.append(comment)
     revision.final_state = FinalRevisionState.none
     revision.comment = ''

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -259,8 +259,9 @@ def undo_review(revision):
     if ((revision.initial_state == InitialRevisionState.needs_submitter_confirmation and
          revision.final_state == FinalRevisionState.accepted and revision.editor is not None)
             or _is_request_changes_with_files(latest_revision)):
-        revision = revision.editable.valid_revisions[-2]
         revision.editable.published_revision = None
+        db.session.flush()
+        revision = revision.editable.valid_revisions[-2]
         latest_revision.final_state = FinalRevisionState.undone
         latest_revision.reviewed_dt = now_utc()
     elif revision.final_state == FinalRevisionState.accepted:
@@ -268,7 +269,7 @@ def undo_review(revision):
     db.session.flush()
     # Keep comment history:
     comment = EditingRevisionComment(user=revision.editor or revision.submitter, created_dt=revision.reviewed_dt,
-                                     undone_judgement=revision.final_state, text=revision.comment)
+                                     undone_judgment=revision.final_state, text=revision.comment)
     num_revisions = len(revision.editable.valid_revisions)
     revision.tags = {tag for tag in revision.tags if tag.system}
     if num_revisions >= 3 or (num_revisions >= 2 and revision == latest_revision):

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -49,7 +49,7 @@ class InvalidEditableState(BadRequest):
 
 
 def ensure_latest_revision(revision):
-    if revision != revision.editable.revisions[-1]:
+    if revision != revision.editable.valid_revisions[-1]:
         raise InvalidEditableState
 
 
@@ -217,9 +217,9 @@ def create_submitter_revision(prev_revision, user, files):
 
 @memoize_request
 def _is_request_changes_with_files(revision):
-    if not revision or len(revision.editable.revisions) < 2:
+    if not revision or len(revision.editable.valid_revisions) < 2:
         return False
-    previous_revision = revision.editable.revisions[-2]
+    previous_revision = revision.editable.valid_revisions[-2]
     # when a request-changes-with-files revision is made, the previous revision's final_state
     # is set to needs_submitter_changes, and a new one is created with the same reviewed_dt,
     # editor, and final_state. if any of these are different, then the two revisions are
@@ -234,7 +234,8 @@ def _is_request_changes_with_files(revision):
 
 
 def _ensure_latest_revision_with_final_state(revision):
-    final_revisions = (r for r in revision.editable.revisions[::-1] if r.final_state != FinalRevisionState.none)
+    final_revisions = (r for r in revision.editable.revisions[::-1]
+                       if r.final_state not in (FinalRevisionState.none, FinalRevisionState.undone))
     expected = next(final_revisions, None)
     if _is_request_changes_with_files(expected):
         expected = next(final_revisions, None)
@@ -245,26 +246,28 @@ def _ensure_latest_revision_with_final_state(revision):
 @no_autoflush
 def undo_review(revision):
     _ensure_latest_revision_with_final_state(revision)
-    latest_revision = revision.editable.revisions[-1]
+    latest_revision = revision.editable.valid_revisions[-1]
     if revision != latest_revision and not _is_request_changes_with_files(latest_revision):
-        if revision.editable.revisions[-2:] != [revision, latest_revision]:
+        if revision.editable.valid_revisions[-2:] != [revision, latest_revision]:
             raise InvalidEditableState
         _ensure_state(revision, final=FinalRevisionState.needs_submitter_confirmation)
         _ensure_state(latest_revision,
                       initial=InitialRevisionState.needs_submitter_confirmation,
                       final=FinalRevisionState.none)
-        db.session.delete(latest_revision)
+        latest_revision.final_state = FinalRevisionState.undone
+        latest_revision.reviewed_dt = now_utc()
     if ((revision.initial_state == InitialRevisionState.needs_submitter_confirmation and
          revision.final_state == FinalRevisionState.accepted and revision.editor is not None)
             or _is_request_changes_with_files(latest_revision)):
-        revision = revision.editable.revisions[-2]
+        revision = revision.editable.valid_revisions[-2]
         revision.editable.published_revision = None
-        db.session.delete(latest_revision)
+        latest_revision.final_state = FinalRevisionState.undone
+        latest_revision.reviewed_dt = now_utc()
     elif revision.final_state == FinalRevisionState.accepted:
         revision.editable.published_revision = None
     db.session.flush()
     revision.final_state = FinalRevisionState.none
-    revision.comment = ''
+    #revision.comment = ''  # TODO keep comments
     revision.reviewed_dt = None
     db.session.flush()
     logger.info('Revision %r review undone', revision)

--- a/indico/modules/events/editing/operations_test.py
+++ b/indico/modules/events/editing/operations_test.py
@@ -79,26 +79,33 @@ def test_can_undo_review(db, dummy_contribution, dummy_user, is1, fs1, ok1, is2,
     db.session.expire(editable)  # so a deleted revision shows up in the relationship
     if ok1:
         assert rev1.final_state == FinalRevisionState.none
-        assert len(editable.revisions) == 1
+        if is2 is None:
+            assert len(editable.revisions) == 1
+        else:
+            assert rev2.final_state == FinalRevisionState.undone
+            assert len(editable.revisions) == 2
     elif ok2:
         assert rev2.final_state == FinalRevisionState.none
         assert len(editable.revisions) == 2
 
 
 def test_can_undo_review_request_changes(db, dummy_contribution, dummy_user):
-    from indico.modules.events.editing.operations import undo_review
+    from indico.modules.events.editing.operations import InvalidEditableState, undo_review
     editable = Editable(contribution=dummy_contribution, type=EditableType.paper)
     reviewed_dt = now_utc()
     rev1 = EditingRevision(editable=editable, submitter=dummy_user, editor=dummy_user,
                            initial_state=InitialRevisionState.ready_for_review,
                            final_state=FinalRevisionState.needs_submitter_changes, reviewed_dt=reviewed_dt)
-    EditingRevision(editable=editable, submitter=dummy_user, editor=dummy_user,
-                    initial_state=InitialRevisionState.ready_for_review,
-                    final_state=FinalRevisionState.needs_submitter_changes, reviewed_dt=reviewed_dt)
+    rev2 = EditingRevision(editable=editable, submitter=dummy_user, editor=dummy_user,
+                           initial_state=InitialRevisionState.ready_for_review,
+                           final_state=FinalRevisionState.needs_submitter_changes, reviewed_dt=reviewed_dt)
     db.session.flush()
 
     undo_review(rev1)
+    with pytest.raises(InvalidEditableState):
+        undo_review(rev2)
 
     db.session.expire(editable)  # so a deleted revision shows up in the relationship
     assert rev1.final_state == FinalRevisionState.none
-    assert len(editable.revisions) == 1
+    assert rev2.final_state == FinalRevisionState.undone
+    assert len(editable.revisions) == 2

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -132,11 +132,12 @@ class EditingRevisionSignedFileSchema(EditingRevisionFileSchema):
 class EditingRevisionCommentSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = EditingRevisionComment
-        fields = ('id', 'user', 'created_dt', 'modified_dt', 'internal', 'system', 'text', 'html', 'can_modify',
-                  'modify_comment_url', 'revision_id')
+        fields = ('id', 'user', 'created_dt', 'modified_dt', 'internal', 'system', 'undone_judgement', 'text', 'html',
+                  'can_modify', 'modify_comment_url', 'revision_id')
 
     revision_id = fields.Int(attribute='revision.id')
     user = fields.Nested(EditingUserSchema)
+    undone_judgement = fields.Nested(RevisionStateSchema)
     html = fields.Function(lambda comment: escape(comment.text))
     can_modify = fields.Function(lambda comment, ctx: comment.can_modify(ctx.get('user')))
     modify_comment_url = fields.Function(lambda comment: url_for('event_editing.api_edit_comment', comment))

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -132,12 +132,12 @@ class EditingRevisionSignedFileSchema(EditingRevisionFileSchema):
 class EditingRevisionCommentSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = EditingRevisionComment
-        fields = ('id', 'user', 'created_dt', 'modified_dt', 'internal', 'system', 'undone_judgement', 'text', 'html',
+        fields = ('id', 'user', 'created_dt', 'modified_dt', 'internal', 'system', 'undone_judgment', 'text', 'html',
                   'can_modify', 'modify_comment_url', 'revision_id')
 
     revision_id = fields.Int(attribute='revision.id')
     user = fields.Nested(EditingUserSchema)
-    undone_judgement = fields.Nested(RevisionStateSchema)
+    undone_judgment = fields.Nested(RevisionStateSchema)
     html = fields.Function(lambda comment: escape(comment.text))
     can_modify = fields.Function(lambda comment, ctx: comment.can_modify(ctx.get('user')))
     modify_comment_url = fields.Function(lambda comment: url_for('event_editing.api_edit_comment', comment))

--- a/indico/web/client/styles/partials/_timelines.scss
+++ b/indico/web/client/styles/partials/_timelines.scss
@@ -17,7 +17,6 @@
 }
 
 .i-timeline {
-  z-index: 0;
   position: relative;
 
   & .i-timeline {


### PR DESCRIPTION
Depends on #5612

This PR turns the "Undo revision" feature of the Editing Timeline into a "soft" undo, keeping all files and comments available in the timeline:
![image](https://user-images.githubusercontent.com/27357203/213504091-aad7dc3a-0755-42dc-87c0-ff6b7cc4f85c.png)

Progress:
- [x] Change revision's state to Undone instead of deleting it
- [x] Keep all revision comments and display them as undone
- [x] Test all undo scenarios
- [x] Test microsservice integration