### PR TITLE
Extend user fixtures

### DIFF
--- a/indico/testing/fixtures/user.py
+++ b/indico/testing/fixtures/user.py
@@ -45,10 +45,10 @@ def dummy_user(create_user):
 @pytest.fixture
 def create_group(db):
     """Return a callable which lets you create dummy groups."""
-    def _create_group(id_):
+    def _create_group(id_, group_name=None):
         group = LocalGroup()
         group.id = id_
-        group.name = f'dummy-{id_}'
+        group.name = group_name or f'dummy-{id_}'
         db.session.add(group)
         db.session.flush()
         return group.proxy

--- a/indico/testing/fixtures/user.py
+++ b/indico/testing/fixtures/user.py
@@ -7,6 +7,7 @@
 
 import pytest
 
+from indico.modules.auth import Identity
 from indico.modules.groups.models.groups import LocalGroup
 from indico.modules.rb import rb_settings
 from indico.modules.users import User
@@ -60,3 +61,14 @@ def create_group(db):
 def dummy_group(create_group):
     """Create a mocked dummy group."""
     return create_group(1337)
+
+
+@pytest.fixture
+def create_identity(db):
+    """Return a callable which lets you create dummy identities."""
+    def _create_identity(user, provider, identifier):
+        identity = Identity(user=user, provider=provider, identifier=identifier)
+        db.session.flush()
+        return identity
+
+    return _create_identity


### PR DESCRIPTION
This adds a `create_identity` fixture and extends the `create_group` fixture to allow specifying the group name. If no group name is passed, the group name is autogenerated as before (i.e. existing behaviour is not changed). 

I found these two fixtures helpful in writing [tests for a plugin](https://github.com/unibonn/indico-sso-group-mapping/blob/bfd2e5239d032e7e86601ec02f500812c9ad8ff0/tests/plugin_test.py) dealing with users, groups and identities and they should be generic enough to rather be part of Indico than of the plugin code :smile:. 