### PR TITLE
Add CC field on contribution email dialogs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Improvements
   contributions (:pr:`5597`)
 - Support Markdown when writing global announcement and apply standard HTML
   sanitization to the message (:pr:`5640`)
+- Add BCC field on contribution email dialogs (:pr:`5637`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/persons/client/js/EmailDialog.jsx
+++ b/indico/modules/events/persons/client/js/EmailDialog.jsx
@@ -5,11 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {FormSpy} from 'react-final-form';
 import {Form, Button, Message} from 'semantic-ui-react';
 
+import {FinalEmailList} from 'indico/react/components';
 import PlaceholderInfo from 'indico/react/components/PlaceholderInfo';
 import TextEditor, {FinalTextEditor} from 'indico/react/components/TextEditor';
 import {FinalCheckbox, FinalDropdown, FinalInput} from 'indico/react/forms';
@@ -105,9 +107,14 @@ export function EmailDialog({
           </Form.Field>
         )}
         {recipientsField}
+        <FinalEmailList
+          name="bcc_addresses"
+          label={Translate.string('BCC addresses')}
+          description={Translate.string('Send a copy of each email to every address in this list')}
+        />
         <FinalCheckbox
           name="copy_for_sender"
-          label={Translate.string('Send copy of each email to my mailbox')}
+          label={Translate.string('Send a copy of each email to my mailbox')}
           toggle
         />
       </Form.Field>
@@ -123,9 +130,11 @@ export function EmailDialog({
         from_address: senders[0][0],
         subject: '',
         body: '',
+        bcc_addresses: [],
         copy_for_sender: false,
         ...initialFormValues,
       }}
+      initialValuesEqual={_.isEqual}
       onClose={onClose}
       onSubmit={onSubmit}
       submitLabel={Translate.string('Send')}

--- a/indico/web/client/js/react/components/EmailListField.jsx
+++ b/indico/web/client/js/react/components/EmailListField.jsx
@@ -47,6 +47,7 @@ const EmailListField = props => {
       placeholder={Translate.string('Please enter an email address')}
       additionLabel={Translate.string('Add email') + ' '} // eslint-disable-line prefer-template
       onChange={handleChange}
+      icon=""
     />
   );
 };


### PR DESCRIPTION
This PR adds a CC field to the email dialog for contributions/author lists:

![image](https://user-images.githubusercontent.com/27357203/214548587-4c719f92-dab4-48bc-9504-4f51e289f990.png)

Note: the emails are sent as BCC, like the "send copy to myself" feature