### PR TITLE
Add 'Adapt columns width' button to papers & contributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Improvements
 - Add BCC field on contribution email dialogs (:pr:`5637`)
 - Allow filtering by location in room booking (:issue:`4291`, :pr:`5622`,
   thanks :user:`mindouro`)
+- Add button to adapt column widths in paper & contribution lists (:pr:`5642`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/templates/management/_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/_abstract_list.html
@@ -121,14 +121,14 @@
                                 title="{{ accepted_other_msg | forceescape }}"
                                 data-friendly-id="{{ abstract.friendly_id }}"
                                 data-title="{{ abstract.title }}">
-                                <td class="i-table id-column">
+                                <td class="i-table thin-column">
                                     <input type="checkbox" class="select-row" name="abstract_id"
                                            value="{{ abstract.id }}">
                                 </td>
                                 <td class="i-table id-column">
                                     {{- abstract.friendly_id -}}
                                 </td>
-                                <td class="i-table" data-searchable="{{ abstract.title | lower }}">
+                                <td class="i-table title-column" data-searchable="{{ abstract.title | lower }}">
                                     <a class="js-mathjax" href="{{ url_for('.display_abstract', abstract) }}">
                                         {{- abstract.title -}}
                                     </a>

--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -312,7 +312,7 @@ document.addEventListener('DOMContentLoaded', () => {
       placeholder: '#filter-placeholder',
     };
 
-    $('.list-section [data-toggle=dropdown]')
+    $('.list [data-toggle=dropdown]')
       .closest('.toolbar')
       .dropdown();
     setupTableSorter('#contribution-list .tablesorter');

--- a/indico/modules/events/contributions/templates/management/_contribution_list.html
+++ b/indico/modules/events/contributions/templates/management/_contribution_list.html
@@ -8,252 +8,253 @@
         {% set has_types = contribs|selectattr('type')|any %}
         <form method="POST">
             <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
-            <table class="i-table tablesorter" data-session-items="{{ sessions | tojson | forceescape }}"
-                   data-track-items="{{ tracks | tojson | forceescape }}">
-                <thead>
-                    <tr class="i-table">
-                        <th class="i-table thin-column" data-sorter="false"></th>
-                        <th class="i-table id-column">
-                            {% trans %}ID{% endtrans %}
-                        </th>
-                        <th class="i-table protection-column" data-sorter="false"></th>
-                        <th class="i-table title-column">
-                            {% trans %}Title{% endtrans %}
-                        </th>
-                        <th class="i-table time-column" data-sorter="text">
-                            {% trans %}Time{% endtrans %}
-                        </th>
-                        <th class="i-table duration-column">
-                            {% trans %}Duration{% endtrans %}
-                        </th>
-                        <th class="i-table" data-sorter="false">
-                            {% trans %}Presenters{% endtrans %}
-                        </th>
-                        {% if has_codes %}
-                            <th class="i-table code-column">
-                                {% trans %}Code{% endtrans %}
+            <div class="js-list-table-wrapper">
+                <table class="i-table tablesorter" data-session-items="{{ sessions | tojson | forceescape }}"
+                       data-track-items="{{ tracks | tojson | forceescape }}">
+                    <thead>
+                        <tr class="i-table">
+                            <th class="i-table thin-column" data-sorter="false"></th>
+                            <th class="i-table id-column">
+                                {% trans %}ID{% endtrans %}
                             </th>
-                        {% endif %}
-                        {% if has_types %}
-                            <th class="i-table type-column">
-                                {% trans %}Type{% endtrans %}
+                            <th class="i-table protection-column" data-sorter="false"></th>
+                            <th class="i-table title-column">
+                                {% trans %}Title{% endtrans %}
                             </th>
-                        {% endif %}
-                        <th class="i-table">
-                            {% trans %}Subcontributions{% endtrans %}
-                        </th>
-                        <th class="i-table">
-                            {% trans %}Session{% endtrans %}
-                        </th>
-                        <th class="i-table">
-                            {% trans %}Track{% endtrans %}
-                        </th>
-                        <th class="i-table material-column">
-                            {% trans %}Material{% endtrans %}
-                        </th>
-                        <th class="actions-column hide-if-locked" data-sorter="false">
-                            {# Actions #}
-                        </th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for contrib in contribs %}
-                        <tr id="contrib-{{ contrib.id }}" class="i-table contribution-row"
-                            data-friendly-id="{{ contrib.friendly_id }}"
-                            data-title="{{ contrib.title }}">
-                            <td class="i-table id-column">
-                                <span class="vertical-aligner">
-                                    <input type="checkbox" class="select-row" name="contribution_id"
-                                           value="{{ contrib.id }}">
-                                </span>
-                            </td>
-                            <td class="i-table id-column">
-                                <span class="vertical-aligner">{{ contrib.friendly_id }}</span>
-                            </td>
-                            <td class="i-table">
-                                <span class="vertical-aligner">
-                                    <i class="{% if contrib.is_self_protected %}icon-protection-self
-                                              {% elif contrib.is_public %}icon-protection-public{% endif %}"></i>
-                                </span>
-                            </td>
-                            <td class="i-table title-column" data-searchable="{{ contrib.title | lower }}"
-                                data-text="{{ contrib.title | lower }}">
-                                <span class="vertical-aligner">
-                                    {% if event.type == 'conference' %}
-                                        <a href="{{ url_for('.display_contribution', contrib) }}">{{ contrib.title }}</a>
-                                    {% else %}
-                                        {{ contrib.title }}
-                                    {% endif %}
-                                </span>
-                            </td>
-                            <td class="i-table start-date" data-text="{{ contrib.start_dt.isoformat()
-                                                                         if contrib.is_scheduled else ''}}">
-                                <span class="vertical-aligner">
-                                    {% if contrib.is_scheduled %}
-                                        {% if not contrib.session_block %}
-                                            <a href="#" class="icon-calendar js-contrib-start-date hide-if-locked"
-                                               data-href="{{ url_for('.manage_start_date', contrib) }}">
-                                            </a>
-                                        {% else %}
-                                            <i class="icon-calendar text-superfluous hide-if-locked"
-                                               title="{% trans %}This contribution is scheduled within a session block and time can't be modified.{% endtrans %}"></i>
-                                        {% endif %}
-                                        <span class="label">
-                                            {{ contrib.start_dt|format_datetime('short', timezone=event.timezone) }}
-                                        </span>
-                                    {%- else -%}
-                                        <em>
-                                            {% trans %}Not scheduled{% endtrans %}
-                                        </em>
-                                    {%- endif %}
-                                </span>
-                            </td>
-                            <td class="i-table duration-column">
-                                <span class="vertical-aligner">
-                                    {% if not contrib.session_block %}
-                                        <a href="#" class="icon-time js-contrib-duration hide-if-locked"
-                                           data-href="{{ url_for('.manage_duration', contrib) }}">
-                                        </a>
-                                    {% else %}
-                                        <i class="icon-time text-superfluous hide-if-locked"
-                                           title="{% trans %}This contribution is scheduled within a session block and duration can't be modified.{% endtrans %}"></i>
-                                    {% endif %}
-                                    <span class="label">
-                                        {{ contrib.duration|format_human_timedelta(narrow=true) if contrib.duration else 'n/a' }}
-                                    </span>
-                                </span>
-                            </td>
-                            <td class="i-table person-row-cell" data-searchable="{{ contrib.speakers|map(attribute='name')|join(', ')|lower }}">
-                                <span class="vertical-aligner">
-                                    {% for speaker in contrib.speakers | sort(attribute='display_order_key') -%}
-                                        {% set speaker_is_registered = speaker.person in registered_persons %}
-                                        <div class="person-row">
-                                            {% set tooltip %}
-                                                {% if speaker_is_registered %}
-                                                    {%- trans %}This speaker registered for the event{% endtrans -%}
-                                                {% else %}
-                                                    {%- trans %}This speaker did not register yet{% endtrans -%}
-                                                {% endif %}
-                                            {% endset %}
-                                            <i class="icon-user js-show-registrations {{ 'exists' if speaker_is_registered }}"
-                                               title="{{ tooltip }}"
-                                               data-qtip-position="bottom"></i>
-                                            {{ speaker.display_full_name }}
-                                            {% if speaker.affiliation %}
-                                                <span class="text-superfluous">({{ render_affiliation(speaker) }})</span>
-                                            {% endif %}
-                                        </div>
-                                    {%- endfor %}
-                                </span>
-                            </td>
+                            <th class="i-table time-column" data-sorter="text">
+                                {% trans %}Time{% endtrans %}
+                            </th>
+                            <th class="i-table duration-column">
+                                {% trans %}Duration{% endtrans %}
+                            </th>
+                            <th class="i-table" data-sorter="false">
+                                {% trans %}Presenters{% endtrans %}
+                            </th>
                             {% if has_codes %}
-                                <td class="i-table code-column" data-text="{{ contrib.code }}" data-searchable="{{ contrib.code|lower }}">
-                                    <span class="vertical-aligner">
-                                        {% if contrib.code -%}
-                                            {{ contrib.code }}
-                                        {%- else %}
-                                            {% trans %}n/a{% endtrans %}
-                                        {%- endif %}
-                                    </span>
-                                </td>
+                                <th class="i-table code-column">
+                                    {% trans %}Code{% endtrans %}
+                                </th>
                             {% endif %}
                             {% if has_types %}
-                                <td class="i-table type-column" data-text="{{ contrib.type.name if contrib.type else '' }}">
+                                <th class="i-table type-column">
+                                    {% trans %}Type{% endtrans %}
+                                </th>
+                            {% endif %}
+                            <th class="i-table">
+                                {% trans %}Subcontributions{% endtrans %}
+                            </th>
+                            <th class="i-table">
+                                {% trans %}Session{% endtrans %}
+                            </th>
+                            <th class="i-table">
+                                {% trans %}Track{% endtrans %}
+                            </th>
+                            <th class="i-table material-column">
+                                {% trans %}Material{% endtrans %}
+                            </th>
+                            <th class="actions-column hide-if-locked" data-sorter="false">
+                                {# Actions #}
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for contrib in contribs %}
+                            <tr id="contrib-{{ contrib.id }}" class="i-table contribution-row"
+                                data-friendly-id="{{ contrib.friendly_id }}"
+                                data-title="{{ contrib.title }}">
+                                <td class="i-table thin-column">
                                     <span class="vertical-aligner">
-                                        {% if contrib.type -%}
-                                            {{ contrib.type.name }}
-                                        {%- else %}
-                                            {% trans %}n/a{% endtrans %}
+                                        <input type="checkbox" class="select-row" name="contribution_id"
+                                               value="{{ contrib.id }}">
+                                    </span>
+                                </td>
+                                <td class="i-table id-column">
+                                    <span class="vertical-aligner">{{ contrib.friendly_id }}</span>
+                                </td>
+                                <td class="i-table">
+                                    <span class="vertical-aligner">
+                                        <i class="{% if contrib.is_self_protected %}icon-protection-self
+                                                {% elif contrib.is_public %}icon-protection-public{% endif %}"></i>
+                                    </span>
+                                </td>
+                                <td class="i-table title-column" data-searchable="{{ contrib.title | lower }}"
+                                    data-text="{{ contrib.title | lower }}">
+                                    <span class="vertical-aligner">
+                                        {% if event.type == 'conference' %}
+                                            <a href="{{ url_for('.display_contribution', contrib) }}">{{ contrib.title }}</a>
+                                        {% else %}
+                                            {{ contrib.title }}
+                                        {% endif %}
+                                    </span>
+                                </td>
+                                <td class="i-table start-date" data-text="{{ contrib.start_dt.isoformat()
+                                                                          if contrib.is_scheduled else ''}}">
+                                    <span class="vertical-aligner">
+                                        {% if contrib.is_scheduled %}
+                                            {% if not contrib.session_block %}
+                                                <a href="#" class="icon-calendar js-contrib-start-date hide-if-locked"
+                                                   data-href="{{ url_for('.manage_start_date', contrib) }}">
+                                                </a>
+                                            {% else %}
+                                                <i class="icon-calendar text-superfluous hide-if-locked"
+                                                   title="{% trans %}This contribution is scheduled within a session block and time can't be modified.{% endtrans %}"></i>
+                                            {% endif %}
+                                            <span class="label">
+                                                {{ contrib.start_dt|format_datetime('short', timezone=event.timezone) }}
+                                            </span>
+                                        {%- else -%}
+                                            <em>
+                                                {% trans %}Not scheduled{% endtrans %}
+                                            </em>
                                         {%- endif %}
                                     </span>
                                 </td>
-                            {% endif %}
-                            <td class="i-table" data-text="{{ contrib.subcontribution_count }}">
-                                <a href="#" class="i-label subcontribution-count"
-                                   title="{% trans %}Manage subcontributions{% endtrans %}"
-                                   data-href="{{ url_for('.manage_subcontributions', contrib) }}"
-                                   data-title="{% trans id=contrib.friendly_id %}Subcontributions of contribution #{{ id }}{% endtrans %}"
-                                   data-ajax-dialog>
-                                    <span class="label">
-                                        {%- trans %}Subcontributions{% endtrans -%}
-                                    </span>
-                                    <span class="badge">
-                                        {{- contrib.subcontribution_count -}}
-                                    </span>
-                                </a>
-                            </td>
-                            <td class="i-table">
-                                <button class="i-button {{ 'session-item-picker' if not event.is_locked else 'disabled' }}"
-                                        style="{{ contrib.session.colors.css if contrib.session }}"
-                                        data-href="{{ url_for('.manage_contrib_rest', contrib) }}"
-                                        data-method="PATCH"
-                                        data-contrib-id="{{ contrib.id }}"
-                                        data-selected-item-id="{{ contrib.session.id or None | tojson }}">
-                                    <span class="label">
-                                        {% if contrib.session %}
-                                            {% trans title=contrib.session.title -%}
-                                                {{ title }}
-                                            {%- endtrans %}
+                                <td class="i-table duration-column">
+                                    <span class="vertical-aligner">
+                                        {% if not contrib.session_block %}
+                                            <a href="#" class="icon-time js-contrib-duration hide-if-locked"
+                                               data-href="{{ url_for('.manage_duration', contrib) }}">
+                                            </a>
                                         {% else %}
-                                            {%- trans %}No session{% endtrans -%}
+                                            <i class="icon-time text-superfluous hide-if-locked"
+                                               title="{% trans %}This contribution is scheduled within a session block and duration can't be modified.{% endtrans %}"></i>
                                         {% endif %}
+                                        <span class="label">
+                                            {{ contrib.duration|format_human_timedelta(narrow=true) if contrib.duration else 'n/a' }}
+                                        </span>
                                     </span>
-                                    {% if not event.is_locked %}<span class="icon-arrow-down"></span>{% endif %}
-                                </button>
-                            </td>
-                            <td class="i-table">
-                                <button class="i-button {{ 'track-item-picker' if not event.is_locked else 'disabled' }}"
-                                        data-href="{{ url_for('.manage_contrib_rest', contrib) }}"
-                                        data-method="PATCH"
-                                        data-selected-item-id="{{ (contrib.track_id if contrib.track_id is not none else None) | tojson }}">
-                                    <span class="label">
-                                        {% if contrib.track %}
-                                            {% if contrib.track.track_group %}
-                                                {{ contrib.track.track_group.title | truncate(9, true, '…') }}:
+                                </td>
+                                <td class="i-table person-row-cell" data-searchable="{{ contrib.speakers|map(attribute='name')|join(', ')|lower }}">
+                                    <span class="vertical-aligner">
+                                        {% for speaker in contrib.speakers | sort(attribute='display_order_key') -%}
+                                            {% set speaker_is_registered = speaker.person in registered_persons %}
+                                            <div class="person-row">
+                                                {% set tooltip %}
+                                                    {% if speaker_is_registered %}
+                                                        {%- trans %}This speaker registered for the event{% endtrans -%}
+                                                    {% else %}
+                                                        {%- trans %}This speaker did not register yet{% endtrans -%}
+                                                    {% endif %}
+                                                {% endset %}
+                                                <i class="icon-user js-show-registrations {{ 'exists' if speaker_is_registered }}"
+                                                   title="{{ tooltip }}" data-qtip-position="bottom"></i>
+                                                {{ speaker.display_full_name }}
+                                                {% if speaker.affiliation %}
+                                                    <span class="text-superfluous">({{ render_affiliation(speaker) }})</span>
+                                                {% endif %}
+                                            </div>
+                                        {%- endfor %}
+                                    </span>
+                                </td>
+                                {% if has_codes %}
+                                    <td class="i-table code-column" data-text="{{ contrib.code }}" data-searchable="{{ contrib.code|lower }}">
+                                        <span class="vertical-aligner">
+                                            {% if contrib.code -%}
+                                                {{ contrib.code }}
+                                            {%- else %}
+                                                {% trans %}n/a{% endtrans %}
+                                            {%- endif %}
+                                        </span>
+                                    </td>
+                                {% endif %}
+                                {% if has_types %}
+                                    <td class="i-table type-column" data-text="{{ contrib.type.name if contrib.type else '' }}">
+                                        <span class="vertical-aligner">
+                                            {% if contrib.type -%}
+                                                {{ contrib.type.name }}
+                                            {%- else %}
+                                                {% trans %}n/a{% endtrans %}
+                                            {%- endif %}
+                                        </span>
+                                    </td>
+                                {% endif %}
+                                <td class="i-table" data-text="{{ contrib.subcontribution_count }}">
+                                    <a href="#" class="i-label subcontribution-count"
+                                       title="{% trans %}Manage subcontributions{% endtrans %}"
+                                       data-href="{{ url_for('.manage_subcontributions', contrib) }}"
+                                       data-title="{% trans id=contrib.friendly_id %}Subcontributions of contribution #{{ id }}{% endtrans %}"
+                                       data-ajax-dialog>
+                                        <span class="label">
+                                            {%- trans %}Subcontributions{% endtrans -%}
+                                        </span>
+                                        <span class="badge">
+                                            {{- contrib.subcontribution_count -}}
+                                        </span>
+                                    </a>
+                                </td>
+                                <td class="i-table">
+                                    <button class="i-button {{ 'session-item-picker' if not event.is_locked else 'disabled' }}"
+                                            style="{{ contrib.session.colors.css if contrib.session }}"
+                                            data-href="{{ url_for('.manage_contrib_rest', contrib) }}"
+                                            data-method="PATCH"
+                                            data-contrib-id="{{ contrib.id }}"
+                                            data-selected-item-id="{{ contrib.session.id or None | tojson }}">
+                                        <span class="label">
+                                            {% if contrib.session %}
+                                                {% trans title=contrib.session.title -%}
+                                                    {{ title }}
+                                                {%- endtrans %}
+                                            {% else %}
+                                                {%- trans %}No session{% endtrans -%}
                                             {% endif %}
-                                            {{ contrib.track.title }}
-                                        {% else %}
-                                            {% trans %}No track{% endtrans %}
-                                        {% endif %}
-                                    </span>
-                                    {% if not event.is_locked %}<span class="icon-arrow-down"></span>{% endif %}
-                                </button>
-                            </td>
-                            {{ render_attachment_info(contrib) }}
-                            <td class="i-table actions-column hide-if-locked">
-                                <div class="group right entry-action-buttons vertical-aligner">
-                                    <a href="#" class="icon-edit i-link highlight js-dialog-action"
-                                       data-href="{{ url_for('.manage_update_contrib', contrib, flash=true) }}"
-                                       data-title="{% trans title=contrib.title %}Edit contribution '{{ title }}'{% endtrans %}"
-                                       title="{% trans %}Edit contribution{% endtrans %}"
-                                       data-update='{"html": "#contribution-list", "filter_statistics": "#filter-statistics"}'
-                                       data-ajax-dialog></a>
-                                    <a href="#" class="icon-copy i-link highlight"
-                                       title="{% trans %}Clone contribution{% endtrans %}"
-                                       data-title="{% trans title=contrib.title %}Clone contribution '{{ title }}' {% endtrans %}"
-                                       data-href="{{ url_for('.clone_contribution', contrib) }}"
-                                       data-method="POST"
-                                       data-update="#contribution-list"
-                                       data-confirm="{% trans %}Are you sure you want to clone this contribution?{% endtrans %}"></a>
-                                    <a href="#" class="icon-shield i-link highlight"
-                                       title="{% trans %}Manage contribution protection{% endtrans %}"
-                                       data-href="{{ url_for('.manage_contrib_protection', contrib) }}"
-                                       data-title="{% trans %}Manage contribution protection{% endtrans %}"
-                                       data-update="#contribution-list"
-                                       data-ajax-dialog></a>
-                                    <a href="#" class="icon-remove i-link danger js-delete"
-                                       data-title="{% trans title=contrib.title %}Delete contribution '{{ title }}'?{% endtrans %}"
-                                       title="{% trans %}Delete contribution{% endtrans %}"
-                                       data-confirm="{% trans title=contrib.title %}Are you sure you want to completely delete contribution '{{ title }}'?{% endtrans %}"
-                                       data-update='{"html": "#contribution-list", "filter_statistics": "#filter-statistics"}'
-                                       data-method="DELETE"
-                                       data-href="{{ url_for('.manage_contrib_rest', contrib) }}"></a>
-                               </div>
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                                        </span>
+                                        {% if not event.is_locked %}<span class="icon-arrow-down"></span>{% endif %}
+                                    </button>
+                                </td>
+                                <td class="i-table">
+                                    <button class="i-button {{ 'track-item-picker' if not event.is_locked else 'disabled' }}"
+                                            data-href="{{ url_for('.manage_contrib_rest', contrib) }}"
+                                            data-method="PATCH"
+                                            data-selected-item-id="{{ (contrib.track_id if contrib.track_id is not none else None) | tojson }}">
+                                        <span class="label">
+                                            {% if contrib.track %}
+                                                {% if contrib.track.track_group %}
+                                                    {{ contrib.track.track_group.title | truncate(9, true, '…') }}:
+                                                {% endif %}
+                                                {{ contrib.track.title }}
+                                            {% else %}
+                                                {% trans %}No track{% endtrans %}
+                                            {% endif %}
+                                        </span>
+                                        {% if not event.is_locked %}<span class="icon-arrow-down"></span>{% endif %}
+                                    </button>
+                                </td>
+                                {{ render_attachment_info(contrib) }}
+                                <td class="i-table actions-column hide-if-locked">
+                                    <div class="group right entry-action-buttons vertical-aligner">
+                                        <a href="#" class="icon-edit i-link highlight js-dialog-action"
+                                           data-href="{{ url_for('.manage_update_contrib', contrib, flash=true) }}"
+                                           data-title="{% trans title=contrib.title %}Edit contribution '{{ title }}'{% endtrans %}"
+                                           title="{% trans %}Edit contribution{% endtrans %}"
+                                           data-update='{"html": "#contribution-list", "filter_statistics": "#filter-statistics"}'
+                                           data-ajax-dialog></a>
+                                        <a href="#" class="icon-copy i-link highlight"
+                                           title="{% trans %}Clone contribution{% endtrans %}"
+                                           data-title="{% trans title=contrib.title %}Clone contribution '{{ title }}' {% endtrans %}"
+                                           data-href="{{ url_for('.clone_contribution', contrib) }}"
+                                           data-method="POST"
+                                           data-update="#contribution-list"
+                                           data-confirm="{% trans %}Are you sure you want to clone this contribution?{% endtrans %}"></a>
+                                        <a href="#" class="icon-shield i-link highlight"
+                                           title="{% trans %}Manage contribution protection{% endtrans %}"
+                                           data-href="{{ url_for('.manage_contrib_protection', contrib) }}"
+                                           data-title="{% trans %}Manage contribution protection{% endtrans %}"
+                                           data-update="#contribution-list"
+                                           data-ajax-dialog></a>
+                                        <a href="#" class="icon-remove i-link danger js-delete"
+                                           data-title="{% trans title=contrib.title %}Delete contribution '{{ title }}'?{% endtrans %}"
+                                           title="{% trans %}Delete contribution{% endtrans %}"
+                                           data-confirm="{% trans title=contrib.title %}Are you sure you want to completely delete contribution '{{ title }}'?{% endtrans %}"
+                                           data-update='{"html": "#contribution-list", "filter_statistics": "#filter-statistics"}'
+                                           data-method="DELETE"
+                                           data-href="{{ url_for('.manage_contrib_rest', contrib) }}"></a>
+                                </div>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </form>
     {%- else %}
         {%- call message_box('info') %}

--- a/indico/modules/events/contributions/templates/management/contributions.html
+++ b/indico/modules/events/contributions/templates/management/contributions.html
@@ -63,7 +63,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="list-section">
+    <div class="list">
         <div class="toolbars space-after">
             <div class="toolbar">
                 <button class="i-button icon-checkbox-checked arrow js-dropdown" data-toggle="dropdown"></button>
@@ -173,6 +173,9 @@
                         data-reload-after>
                     {%- trans %}Assign program codes{% endtrans -%}
                 </button>
+                <div class="group">
+                    <button class="i-button button change-columns-width" title="{% trans %}Adapt columns width{% endtrans %}"></button>
+                </div>
             </div>
             <div class="toolbar">
                 <div class="group" id="filter-statistics">
@@ -195,7 +198,7 @@
                 </div>
             </div>
         </div>
-        <div class="list" id="contribution-list">
+        <div class="list-content" id="contribution-list">
             {{ render_contrib_list(event, total_entries, contribs, sessions, tracks, registered_persons) }}
         </div>
         <div id="filter-placeholder"></div>

--- a/indico/modules/events/papers/templates/_paper_list.html
+++ b/indico/modules/events/papers/templates/_paper_list.html
@@ -31,362 +31,369 @@
     {%- else %}
         <form method="POST">
             <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
-            <table class="i-table tablesorter">
-                <thead>
-                    <tr class="i-table">
-                        <th class="i-table thin-column" data-sorter="false"></th>
-                        <th class="i-table id-column">
-                            {%- trans %}ID{% endtrans -%}
-                        </th>
-                        <th class="i-table title-column">
-                            {%- trans %}Title{% endtrans -%}
-                        </th>
-                        {% for item in static_columns %}
-                            <th class="i-table">{{ item.caption }}</th>
-                        {% endfor %}
-                        <th class="i-table {{ 'revision-column' if not management }}">
-                            {%- trans %}Revision{% endtrans -%}
-                        </th>
-                        {% if management %}
-                            <th class="i-table judge-column" data-sorter="false">
-                                {%- trans %}Judges{% endtrans -%}
+            <div class="js-list-table-wrapper">
+                <table class="i-table tablesorter">
+                    <thead>
+                        <tr class="i-table">
+                            <th class="i-table thin-column" data-sorter="false"></th>
+                            <th class="i-table id-column">
+                                {%- trans %}ID{% endtrans -%}
                             </th>
-                        {% endif %}
-                        {% if event.cfp.content_reviewing_enabled %}
-                            <th class="i-table content-reviewers-column" data-sorter="false">
-                                {%- trans %}Content reviewers{% endtrans -%}
+                            <th class="i-table title-column">
+                                {%- trans %}Title{% endtrans -%}
                             </th>
-                        {% endif %}
-                        {% if event.cfp.layout_reviewing_enabled %}
-                            <th class="i-table layout-reviewers-column" data-sorter="false">
-                                {%- trans %}Layout reviewers{% endtrans -%}
-                            </th>
-                        {% endif %}
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for contrib in contribs %}
-                        {% if contrib.paper %}
-                            {% set last_revision_state = contrib.paper.last_revision.state.title %}
-                        {% else %}
-                            {% set last_revision_state %}
-                                {%- trans %}Paper not yet submitted{% endtrans -%}
-                            {% endset %}
-                        {% endif %}
-                        <tr id="contrib-{{ contrib.id }}" class="i-table contribution-row"
-                            data-friendly-id="{{ contrib.friendly_id }}"
-                            data-title="{{ contrib.title }}">
-                            <td class="i-table id-column">
-                                <span class="vertical-aligner">
-                                    <input type="checkbox" class="select-row"
-                                           name="contribution_id"
-                                           value="{{ contrib.id }}">
-                                </span>
-                            </td>
-                            <td class="i-table id-column">
-                                <span class="vertical-aligner">{{ contrib.friendly_id }}</span>
-                            </td>
-                            <td class="i-table title-column"
-                                data-searchable="{{ contrib.title | lower }}"
-                                data-text="{{ contrib.title | lower }}">
-                                <span class="vertical-aligner">
-                                    {% if contrib.paper %}
-                                        <a href="{{ url_for('.paper_timeline', contrib) }}">
-                                            {{- contrib.title -}}
-                                        </a>
-                                    {% else %}
-                                        {{- contrib.title -}}
-                                    {% endif %}
-                                </span>
-                            </td>
                             {% for item in static_columns %}
-                                {% if item.id == 'state' %}
-                                    {% set sort_text = '' %}
-                                    {% if contrib.paper %}
-                                        {% set acceptances = contrib.paper.last_revision.reviews|selectattr('proposed_action.name', 'equalto', 'accept')|list|length %}
-                                        {% set sort_text = '{}-{}-{}'.format('1' if contrib.paper.is_in_final_state else '0', contrib.paper.last_revision.state.name, acceptances) %}
-                                    {% endif %}
-                                    <td class="i-table"
-                                        data-searchable="{{ last_revision_state|lower }}"
-                                        data-text="{{ sort_text }}">
+                                <th class="i-table">{{ item.caption }}</th>
+                            {% endfor %}
+                            <th class="i-table {{ 'revision-column' if not management }}">
+                                {%- trans %}Revision{% endtrans -%}
+                            </th>
+                            {% if management %}
+                                <th class="i-table judge-column" data-sorter="false">
+                                    {%- trans %}Judges{% endtrans -%}
+                                </th>
+                            {% endif %}
+                            {% if event.cfp.content_reviewing_enabled %}
+                                <th class="i-table content-reviewers-column" data-sorter="false">
+                                    {%- trans %}Content reviewers{% endtrans -%}
+                                </th>
+                            {% endif %}
+                            {% if event.cfp.layout_reviewing_enabled %}
+                                <th class="i-table layout-reviewers-column" data-sorter="false">
+                                    {%- trans %}Layout reviewers{% endtrans -%}
+                                </th>
+                            {% endif %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for contrib in contribs %}
+                            {% if contrib.paper %}
+                                {% set last_revision_state = contrib.paper.last_revision.state.title %}
+                            {% else %}
+                                {% set last_revision_state %}
+                                    {%- trans %}Paper not yet submitted{% endtrans -%}
+                                {% endset %}
+                            {% endif %}
+                            <tr id="contrib-{{ contrib.id }}" class="i-table contribution-row"
+                                data-friendly-id="{{ contrib.friendly_id }}"
+                                data-title="{{ contrib.title }}">
+                                <td class="i-table thin-column">
+                                    <span class="vertical-aligner">
+                                        <input type="checkbox" class="select-row"
+                                               name="contribution_id"
+                                               value="{{ contrib.id }}">
+                                    </span>
+                                </td>
+                                <td class="i-table id-column">
+                                    <span class="vertical-aligner">{{ contrib.friendly_id }}</span>
+                                </td>
+                                <td class="i-table title-column"
+                                    data-searchable="{{ contrib.title | lower }}"
+                                    data-text="{{ contrib.title | lower }}">
+                                    <span class="vertical-aligner">
                                         {% if contrib.paper %}
-                                            <span class="vertical-aligner">
-                                                {{ _render_paper_state(contrib.paper) }}
-                                            </span>
+                                            <a href="{{ url_for('.paper_timeline', contrib) }}">
+                                                {{- contrib.title -}}
+                                            </a>
                                         {% else %}
-                                            <span class="i-tag outline semantic-text state-badge">
-                                                {% trans %}Not submitted{% endtrans %}
-                                            </span>
+                                            {{- contrib.title -}}
                                         {% endif %}
-                                    </td>
-                                {% elif item.id == 'track' %}
-                                    <td class="i-table track-column"
-                                        data-searchable="{{ contrib.track.title|lower if contrib.track }}">
+                                    </span>
+                                </td>
+                                {% for item in static_columns %}
+                                    {% if item.id == 'state' %}
+                                        {% set sort_text = '' %}
+                                        {% if contrib.paper %}
+                                            {% set acceptances = contrib.paper.last_revision.reviews|selectattr('proposed_action.name', 'equalto', 'accept')|list|length %}
+                                            {% set sort_text = '{}-{}-{}'.format('1' if contrib.paper.is_in_final_state else '0', contrib.paper.last_revision.state.name, acceptances) %}
+                                        {% endif %}
+                                        <td class="i-table"
+                                            data-searchable="{{ last_revision_state|lower }}"
+                                            data-text="{{ sort_text }}">
+                                            {% if contrib.paper %}
+                                                <span class="vertical-aligner">
+                                                    {{ _render_paper_state(contrib.paper) }}
+                                                </span>
+                                            {% else %}
+                                                <span class="i-tag outline semantic-text state-badge">
+                                                    {% trans %}Not submitted{% endtrans %}
+                                                </span>
+                                            {% endif %}
+                                        </td>
+                                    {% elif item.id == 'track' %}
+                                        <td class="i-table track-column"
+                                            data-searchable="{{ contrib.track.title|lower if contrib.track }}">
+                                            <span class="vertical-aligner">
+                                                {%- if contrib.track -%}
+                                                    {{ contrib.track.title_with_group }}
+                                                {%- else -%}
+                                                    {% trans %}No track{% endtrans %}
+                                                {%- endif -%}
+                                            </span>
+                                        </td>
+                                    {% elif item.id == 'session' %}
+                                        <td class="i-table"
+                                            data-searchable="{{ contrib.session.title|lower if contrib.session }}">
+                                            <span class="vertical-aligner">
+                                                {%- if contrib.session -%}
+                                                    {% trans title=contrib.session.title -%}
+                                                        {{ title }}
+                                                    {%- endtrans %}
+                                                {%- else -%}
+                                                    {% trans %}No session{% endtrans %}
+                                                {%- endif -%}
+                                            </span>
+                                        </td>
+                                    {% elif item.id == 'type' %}
+                                        <td class="i-table"
+                                            data-searchable="{{ contrib.type.name|lower if contrib.type }}">
+                                            <span class="vertical-aligner">
+                                                {%- if contrib.type -%}
+                                                    {{ contrib.type.name }}
+                                                {%- else -%}
+                                                    {% trans %}n/a{% endtrans %}
+                                                {%- endif -%}
+                                            </span>
+                                        </td>
+                                    {% endif %}
+                                {% endfor %}
+                                <td class="i-table revision-column">
+                                    <span class="vertical-aligner">
+                                        {%- if contrib.paper.revision_count -%}
+                                            {{ contrib.paper.revision_count }}
+                                        {%- endif -%}
+                                    </span>
+                                </td>
+                                {% if management %}
+                                    <td class="i-table person-row-cell"
+                                        data-searchable="{{ contrib.paper_judges|join(', ', attribute='name')|lower }}">
                                         <span class="vertical-aligner">
-                                            {%- if contrib.track -%}
-                                                {{ contrib.track.title_with_group }}
-                                            {%- else -%}
-                                                {% trans %}No track{% endtrans %}
-                                            {%- endif -%}
-                                        </span>
-                                    </td>
-                                {% elif item.id == 'session' %}
-                                    <td class="i-table"
-                                        data-searchable="{{ contrib.session.title|lower if contrib.session }}">
-                                        <span class="vertical-aligner">
-                                            {%- if contrib.session -%}
-                                                {% trans title=contrib.session.title -%}
-                                                    {{ title }}
-                                                {%- endtrans %}
-                                            {%- else -%}
-                                                {% trans %}No session{% endtrans %}
-                                            {%- endif -%}
-                                        </span>
-                                    </td>
-                                {% elif item.id == 'type' %}
-                                    <td class="i-table"
-                                        data-searchable="{{ contrib.type.name|lower if contrib.type }}">
-                                        <span class="vertical-aligner">
-                                            {%- if contrib.type -%}
-                                                {{ contrib.type.name }}
-                                            {%- else -%}
-                                                {% trans %}n/a{% endtrans %}
-                                            {%- endif -%}
+                                            {% for judge in contrib.paper_judges|sort(attribute='display_full_name') -%}
+                                                <div class="person-row icon-user">{{ judge.display_full_name }}</div>
+                                            {%- endfor %}
                                         </span>
                                     </td>
                                 {% endif %}
-                            {% endfor %}
-                            <td class="i-table revision-column">
-                                <span class="vertical-aligner">
-                                    {%- if contrib.paper.revision_count -%}
-                                        {{ contrib.paper.revision_count }}
-                                    {%- endif -%}
-                                </span>
-                            </td>
-                            {% if management %}
-                                <td class="i-table person-row-cell"
-                                    data-searchable="{{ contrib.paper_judges|join(', ', attribute='name')|lower }}">
-                                    <span class="vertical-aligner">
-                                        {% for judge in contrib.paper_judges|sort(attribute='display_full_name') -%}
-                                            <div class="person-row icon-user">{{ judge.display_full_name }}</div>
-                                        {%- endfor %}
-                                    </span>
-                                </td>
-                            {% endif %}
-                            {% if event.cfp.content_reviewing_enabled %}
-                                <td class="i-table person-row-cell"
-                                    data-searchable="{{ contrib.paper_content_reviewers|join(', ', attribute='name')|lower }}">
-                                    <span class="vertical-aligner">
-                                        {% for reviewer in contrib.paper_content_reviewers|sort(attribute='display_full_name') -%}
-                                            <div class="person-row icon-user">{{ reviewer.display_full_name }}</div>
-                                        {%- endfor %}
-                                    </span>
-                                </td>
-                            {% endif %}
-                            {% if event.cfp.layout_reviewing_enabled %}
-                                <td class="i-table person-row-cell"
-                                    data-searchable="{{ contrib.paper_layout_reviewers|join(', ', attribute='name')|lower }}">
-                                    <span class="vertical-aligner">
-                                        {% for reviewer in contrib.paper_layout_reviewers|sort(attribute='display_full_name') -%}
-                                            <div class="person-row icon-user">{{ reviewer.display_full_name }}</div>
-                                        {%- endfor %}
-                                    </span>
-                                </td>
-                            {% endif %}
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                                {% if event.cfp.content_reviewing_enabled %}
+                                    <td class="i-table person-row-cell"
+                                        data-searchable="{{ contrib.paper_content_reviewers|join(', ', attribute='name')|lower }}">
+                                        <span class="vertical-aligner">
+                                            {% for reviewer in contrib.paper_content_reviewers|sort(attribute='display_full_name') -%}
+                                                <div class="person-row icon-user">{{ reviewer.display_full_name }}</div>
+                                            {%- endfor %}
+                                        </span>
+                                    </td>
+                                {% endif %}
+                                {% if event.cfp.layout_reviewing_enabled %}
+                                    <td class="i-table person-row-cell"
+                                        data-searchable="{{ contrib.paper_layout_reviewers|join(', ', attribute='name')|lower }}">
+                                        <span class="vertical-aligner">
+                                            {% for reviewer in contrib.paper_layout_reviewers|sort(attribute='display_full_name') -%}
+                                                <div class="person-row icon-user">{{ reviewer.display_full_name }}</div>
+                                            {%- endfor %}
+                                        </span>
+                                    </td>
+                                {% endif %}
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
         </form>
     {%- endif %}
 {% endmacro %}
 
 {% macro render_paper_assignment_content(event, total_entries, contribs, static_columns, selected_entry=none,
                                          management=false) %}
-    <div class="toolbars space-after">
-        <div class="toolbar">
-            <button class="i-button icon-checkbox-checked arrow js-dropdown" data-toggle="dropdown"></button>
-            <ul class="i-dropdown">
-                <li>
-                    <a href="#" data-select-all="#assignment-list input:checkbox">{% trans %}All{% endtrans %}</a>
-                </li>
-                <li>
-                    <a href="#" data-select-none="#assignment-list input:checkbox">{% trans %}None{% endtrans %}</a>
-                </li>
-            </ul>
-            <button class="i-button icon-settings js-dialog-action js-customize-list highlight"
-                    data-href="{{ url_for('.customize_paper_list', event) }}"
-                    data-title="{% trans %}Customize list{% endtrans %}"
-                    data-dialog-classes="list-filter-dialog"
-                    data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
-                    data-ajax-dialog>
-                {%- trans %}Customize list{% endtrans -%}
-            </button>
-            <button class="i-button arrow js-dropdown js-enable-if-checked disabled hide-if-locked"
-                    data-toggle="dropdown">
-                {%- trans %}Assign{% endtrans -%}
-            </button>
-            <ul class="i-dropdown hide-if-locked">
-                {% if management %}
+    <div class="list">
+        <div class="toolbars space-after">
+            <div class="toolbar">
+                <button class="i-button icon-checkbox-checked arrow js-dropdown" data-toggle="dropdown"></button>
+                <ul class="i-dropdown">
                     <li>
-                        <a class="js-requires-selected-row disabled"
-                           data-title="{% trans %}Assign judges to selected contributions{% endtrans %}"
-                           data-href="{{ url_for('.assign_papers', event, role='judge') }}"
-                           data-params-selector="#assignment-list input[name=contribution_id]:checked"
-                           data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
-                           data-method="POST"
-                           data-ajax-dialog>
-                            {%- trans %}Judges{% endtrans %}
-                        </a>
+                        <a href="#" data-select-all="#assignment-list input:checkbox">{% trans %}All{% endtrans %}</a>
                     </li>
-                {% endif %}
-                {% if event.cfp.content_reviewing_enabled %}
                     <li>
-                        <a class="js-requires-selected-row disabled"
-                           data-title="{% trans %}Assign content reviewers to selected contributions{% endtrans %}"
-                           data-href="{{ url_for('.assign_papers', event, role='content_reviewer') }}"
-                           data-params-selector="#assignment-list input[name=contribution_id]:checked"
-                           data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
-                           data-method="POST"
-                           data-ajax-dialog>
-                            {%- trans %}Content reviewers{% endtrans %}
-                        </a>
+                        <a href="#" data-select-none="#assignment-list input:checkbox">{% trans %}None{% endtrans %}</a>
                     </li>
-                {% endif %}
-                {% if event.cfp.layout_reviewing_enabled %}
-                    <li>
-                        <a class="js-requires-selected-row disabled"
-                           data-title="{% trans %}Assign layout reviewers to selected contributions{% endtrans %}"
-                           data-href="{{ url_for('.assign_papers', event, role='layout_reviewer') }}"
-                           data-params-selector="#assignment-list input[name=contribution_id]:checked"
-                           data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
-                           data-method="POST"
-                           data-ajax-dialog>
-                            {%- trans %}Layout reviewers{% endtrans %}
-                        </a>
-                    </li>
-                {% endif %}
-            </ul>
-            <button class="i-button arrow js-dropdown js-enable-if-checked disabled hide-if-locked"
-                    data-toggle="dropdown">
-                {%- trans %}Unassign{% endtrans -%}
-            </button>
-            <ul class="i-dropdown hide-if-locked">
-                {% if management %}
-                    <li>
-                        <a class="js-requires-selected-row disabled"
-                           data-title="{% trans %}Unassign judges from selected contributions{% endtrans %}"
-                           data-href="{{ url_for('.unassign_papers', event, role='judge') }}"
-                           data-params-selector="#assignment-list input[name=contribution_id]:checked"
-                           data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
-                           data-method="POST"
-                           data-ajax-dialog>
-                            {%- trans %}Judges{% endtrans %}
-                        </a>
-                    </li>
-                {% endif %}
-                {% if event.cfp.content_reviewing_enabled %}
-                    <li>
-                        <a class="js-requires-selected-row disabled"
-                           data-title="{% trans %}Unassign content reviewers from selected contributions{% endtrans %}"
-                           data-href="{{ url_for('.unassign_papers', event, role='content_reviewer') }}"
-                           data-params-selector="#assignment-list input[name=contribution_id]:checked"
-                           data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
-                           data-method="POST"
-                           data-ajax-dialog>
-                            {%- trans %}Content reviewers{% endtrans %}
-                        </a>
-                    </li>
-                {% endif %}
-                {% if event.cfp.layout_reviewing_enabled %}
-                    <li>
-                        <a class="js-requires-selected-row disabled"
-                           data-title="{% trans %}Unassign layout reviewers from selected contributions{% endtrans %}"
-                           data-href="{{ url_for('.unassign_papers', event, role='layout_reviewer') }}"
-                           data-params-selector="#assignment-list input[name=contribution_id]:checked"
-                           data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
-                           data-method="POST"
-                           data-ajax-dialog>
-                            {%- trans %}Layout reviewers{% endtrans %}
-                        </a>
-                    </li>
-                {% endif %}
-            </ul>
-            <button class="i-button arrow js-dropdown icon-hammer js-requires-selected-row disabled hide-if-locked"
-                    data-toggle="dropdown">
-                {%- trans %}Judge{% endtrans -%}
-            </button>
-            <ul class="i-dropdown hide-if-locked">
-                <li>
-                    <a class="js-requires-selected-row js-dialog-action"
-                       data-href="{{ url_for('.judge_papers', event) }}"
-                       data-title="{% trans %}Accept selected papers{% endtrans %}"
-                       data-params-selector="#assignment-list input[name=contribution_id]:checked"
-                       data-params='{"judgment": "accept"}'
-                       data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
-                       data-method="POST"
-                       data-ajax-dialog>
-                        {%- trans %}Accepted{% endtrans -%}
-                    </a>
-                </li>
-                <li>
-                    <a class="js-requires-selected-row js-dialog-action"
-                       data-href="{{ url_for('.judge_papers', event) }}"
-                       data-title="{% trans %}Reject selected papers{% endtrans %}"
-                       data-params-selector="#assignment-list input[name=contribution_id]:checked"
-                       data-params='{"judgment": "reject"}'
-                       data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
-                       data-method="POST"
-                       data-ajax-dialog>
-                        {%- trans %}Rejected{% endtrans -%}
-                    </a>
-                </li>
-                <li>
-                    <a class="js-requires-selected-row js-dialog-action"
-                       data-href="{{ url_for('.judge_papers', event) }}"
-                       data-title="{% trans %}Mark to be corrected selected papers{% endtrans %}"
-                       data-params-selector="#assignment-list input[name=contribution_id]:checked"
-                       data-params='{"judgment": "to_be_corrected"}'
-                       data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
-                       data-method="POST"
-                       data-ajax-dialog>
-                        {%- trans %}To be corrected{% endtrans -%}
-                    </a>
-                </li>
-            </ul>
-            <div id="authors-list-container"
-                 class="group"
-                 data-event-id="{{ event.id }}"
-                 data-object-context="contributions"
-                 data-params-selector="#assignment-list input[name=contribution_id]:checked">
-            </div>
-            <button class="i-button icon-attachment js-requires-selected-row disabled js-submit-list-form"
-                    data-href="{{ url_for('.download_papers', event) }}">
-                {%- trans %}Download papers{% endtrans -%}
-            </button>
-            {% if management %}
-                <button class="i-button icon-attachment js-requires-selected-row disabled js-submit-list-form"
-                        data-href="{{ url_for('.export_json', event) }}">
-                    {%- trans %}Export as JSON{% endtrans -%}
+                </ul>
+                <button class="i-button icon-settings js-dialog-action js-customize-list highlight"
+                        data-href="{{ url_for('.customize_paper_list', event) }}"
+                        data-title="{% trans %}Customize list{% endtrans %}"
+                        data-dialog-classes="list-filter-dialog"
+                        data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
+                        data-ajax-dialog>
+                    {%- trans %}Customize list{% endtrans -%}
                 </button>
-            {% endif %}
-        </div>
-        <div class="toolbar">
-            <div class="group">
-                <div id="filter-statistics">
-                    {{ render_displayed_entries_fragment(contribs|length, total_entries) }}
+                <button class="i-button arrow js-dropdown js-enable-if-checked disabled hide-if-locked"
+                        data-toggle="dropdown">
+                    {%- trans %}Assign{% endtrans -%}
+                </button>
+                <ul class="i-dropdown hide-if-locked">
+                    {% if management %}
+                        <li>
+                            <a class="js-requires-selected-row disabled"
+                               data-title="{% trans %}Assign judges to selected contributions{% endtrans %}"
+                               data-href="{{ url_for('.assign_papers', event, role='judge') }}"
+                               data-params-selector="#assignment-list input[name=contribution_id]:checked"
+                               data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
+                               data-method="POST"
+                               data-ajax-dialog>
+                                {%- trans %}Judges{% endtrans %}
+                            </a>
+                        </li>
+                    {% endif %}
+                    {% if event.cfp.content_reviewing_enabled %}
+                        <li>
+                            <a class="js-requires-selected-row disabled"
+                               data-title="{% trans %}Assign content reviewers to selected contributions{% endtrans %}"
+                               data-href="{{ url_for('.assign_papers', event, role='content_reviewer') }}"
+                               data-params-selector="#assignment-list input[name=contribution_id]:checked"
+                               data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
+                               data-method="POST"
+                               data-ajax-dialog>
+                                {%- trans %}Content reviewers{% endtrans %}
+                            </a>
+                        </li>
+                    {% endif %}
+                    {% if event.cfp.layout_reviewing_enabled %}
+                        <li>
+                            <a class="js-requires-selected-row disabled"
+                               data-title="{% trans %}Assign layout reviewers to selected contributions{% endtrans %}"
+                               data-href="{{ url_for('.assign_papers', event, role='layout_reviewer') }}"
+                               data-params-selector="#assignment-list input[name=contribution_id]:checked"
+                               data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
+                               data-method="POST"
+                               data-ajax-dialog>
+                                {%- trans %}Layout reviewers{% endtrans %}
+                            </a>
+                        </li>
+                    {% endif %}
+                </ul>
+                <button class="i-button arrow js-dropdown js-enable-if-checked disabled hide-if-locked"
+                        data-toggle="dropdown">
+                    {%- trans %}Unassign{% endtrans -%}
+                </button>
+                <ul class="i-dropdown hide-if-locked">
+                    {% if management %}
+                        <li>
+                            <a class="js-requires-selected-row disabled"
+                               data-title="{% trans %}Unassign judges from selected contributions{% endtrans %}"
+                               data-href="{{ url_for('.unassign_papers', event, role='judge') }}"
+                               data-params-selector="#assignment-list input[name=contribution_id]:checked"
+                               data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
+                               data-method="POST"
+                               data-ajax-dialog>
+                                {%- trans %}Judges{% endtrans %}
+                            </a>
+                        </li>
+                    {% endif %}
+                    {% if event.cfp.content_reviewing_enabled %}
+                        <li>
+                            <a class="js-requires-selected-row disabled"
+                               data-title="{% trans %}Unassign content reviewers from selected contributions{% endtrans %}"
+                               data-href="{{ url_for('.unassign_papers', event, role='content_reviewer') }}"
+                               data-params-selector="#assignment-list input[name=contribution_id]:checked"
+                               data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
+                               data-method="POST"
+                               data-ajax-dialog>
+                                {%- trans %}Content reviewers{% endtrans %}
+                            </a>
+                        </li>
+                    {% endif %}
+                    {% if event.cfp.layout_reviewing_enabled %}
+                        <li>
+                            <a class="js-requires-selected-row disabled"
+                               data-title="{% trans %}Unassign layout reviewers from selected contributions{% endtrans %}"
+                               data-href="{{ url_for('.unassign_papers', event, role='layout_reviewer') }}"
+                               data-params-selector="#assignment-list input[name=contribution_id]:checked"
+                               data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
+                               data-method="POST"
+                               data-ajax-dialog>
+                                {%- trans %}Layout reviewers{% endtrans %}
+                            </a>
+                        </li>
+                    {% endif %}
+                </ul>
+                <button class="i-button arrow js-dropdown icon-hammer js-requires-selected-row disabled hide-if-locked"
+                        data-toggle="dropdown">
+                    {%- trans %}Judge{% endtrans -%}
+                </button>
+                <ul class="i-dropdown hide-if-locked">
+                    <li>
+                        <a class="js-requires-selected-row js-dialog-action"
+                           data-href="{{ url_for('.judge_papers', event) }}"
+                           data-title="{% trans %}Accept selected papers{% endtrans %}"
+                           data-params-selector="#assignment-list input[name=contribution_id]:checked"
+                           data-params='{"judgment": "accept"}'
+                           data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
+                           data-method="POST"
+                           data-ajax-dialog>
+                            {%- trans %}Accepted{% endtrans -%}
+                        </a>
+                    </li>
+                    <li>
+                        <a class="js-requires-selected-row js-dialog-action"
+                           data-href="{{ url_for('.judge_papers', event) }}"
+                           data-title="{% trans %}Reject selected papers{% endtrans %}"
+                           data-params-selector="#assignment-list input[name=contribution_id]:checked"
+                           data-params='{"judgment": "reject"}'
+                           data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
+                           data-method="POST"
+                           data-ajax-dialog>
+                            {%- trans %}Rejected{% endtrans -%}
+                        </a>
+                    </li>
+                    <li>
+                        <a class="js-requires-selected-row js-dialog-action"
+                           data-href="{{ url_for('.judge_papers', event) }}"
+                           data-title="{% trans %}Mark to be corrected selected papers{% endtrans %}"
+                           data-params-selector="#assignment-list input[name=contribution_id]:checked"
+                           data-params='{"judgment": "to_be_corrected"}'
+                           data-update='{"html": "#assignment-list", "filter_statistics": "#filter-statistics"}'
+                           data-method="POST"
+                           data-ajax-dialog>
+                            {%- trans %}To be corrected{% endtrans -%}
+                        </a>
+                    </li>
+                </ul>
+                <div id="authors-list-container"
+                     class="group"
+                     data-event-id="{{ event.id }}"
+                     data-object-context="contributions"
+                     data-params-selector="#assignment-list input[name=contribution_id]:checked">
+                </div>
+                <button class="i-button icon-attachment js-requires-selected-row disabled js-submit-list-form"
+                        data-href="{{ url_for('.download_papers', event) }}">
+                    {%- trans %}Download papers{% endtrans -%}
+                </button>
+                {% if management %}
+                    <button class="i-button icon-attachment js-requires-selected-row disabled js-submit-list-form"
+                            data-href="{{ url_for('.export_json', event) }}">
+                        {%- trans %}Export as JSON{% endtrans -%}
+                    </button>
+                {% endif %}
+                <div class="group">
+                    <button class="i-button button change-columns-width" title="{% trans %}Adapt columns width{% endtrans %}"></button>
                 </div>
             </div>
-            <div class="group">
-                <span class="i-button label icon-search"></span>
-                <input type="text" id="search-input" placeholder="{% trans %}Enter #id or search string{% endtrans %}">
+            <div class="toolbar">
+                <div class="group">
+                    <div id="filter-statistics">
+                        {{ render_displayed_entries_fragment(contribs|length, total_entries) }}
+                    </div>
+                </div>
+                <div class="group">
+                    <span class="i-button label icon-search"></span>
+                    <input type="text" id="search-input" placeholder="{% trans %}Enter #id or search string{% endtrans %}">
+                </div>
             </div>
         </div>
+        <div class="list-content" id="assignment-list">
+            {{ render_paper_assignment_list(event, total_entries, contribs, static_columns, management=management) }}
+        </div>
+        <div id="filter-placeholder"></div>
     </div>
-    <div class="list" id="assignment-list">
-        {{ render_paper_assignment_list(event, total_entries, contribs, static_columns, management=management) }}
-    </div>
-    <div id="filter-placeholder"></div>
     <script>
         {% if selected_entry %}
             $('#search-input').val('#{{ selected_entry }}').trigger('change');

--- a/indico/web/client/styles/partials/_object-lists.scss
+++ b/indico/web/client/styles/partials/_object-lists.scss
@@ -91,6 +91,12 @@
     table {
       width: auto;
       table-layout: auto;
+
+      td.title-column {
+        // Allow contribution, abstract & paper titles to wrap when 'Adapt columns width' is active.
+        // This prevents horizontal scroll on the table when the title is too long.
+        white-space: initial;
+      }
     }
   }
 


### PR DESCRIPTION
In the recent Jacow meeting, we got feedback about the paper titles not being fully visible when they are longer.

Adds the `Adapt columns width` toggle to contributions and papers. When active, it allows abstract/contribution/paper titles to wrap to avoid having super wide tables