### PR TITLE
Fix Authors List filters

### DIFF
--- a/indico/modules/events/abstracts/controllers/abstract_list.py
+++ b/indico/modules/events/abstracts/controllers/abstract_list.py
@@ -250,7 +250,7 @@ class RHAbstractPersonList(RHManageAbstractsActionsBase):
             person_dict = _get_or_create_person_dict(submitter)
             person_dict['submitter'] = True
             person_dict['registered'] = get_event_person_for_user(self.event, submitter) in registered_persons
-        return jsonify(event_persons=[p for _, p in sorted(abstract_persons_dict.items())])
+        return jsonify(event_persons=abstract_persons_dict)
 
 
 class RHManageAbstractsExportActionsBase(RHManageAbstractsActionsBase):

--- a/indico/modules/events/management/controllers/base.py
+++ b/indico/modules/events/management/controllers/base.py
@@ -66,7 +66,7 @@ class RHContributionPersonListMixin:
         contribution_persons_dict = defaultdict(lambda: {'speaker': False, 'primary_author': False,
                                                          'secondary_author': False, 'not_registered': True})
         for contrib_person in contribution_persons:
-            person_dict = contribution_persons_dict[contrib_person.person.id]
+            person_dict = contribution_persons_dict[contrib_person.person.identifier]
             person_dict['identifier'] = contrib_person.person.identifier
             person_dict['full_name'] = contrib_person.person.full_name
             person_dict['email'] = contrib_person.person.email
@@ -76,4 +76,4 @@ class RHContributionPersonListMixin:
             person_dict['secondary_author'] |= contrib_person.author_type == AuthorType.secondary
             person_dict['registered'] = contrib_person.person in registered_persons
 
-        return jsonify(event_persons=[p for __, p in sorted(contribution_persons_dict.items())])
+        return jsonify(event_persons=contribution_persons_dict)

--- a/indico/modules/events/persons/client/js/AuthorsList.jsx
+++ b/indico/modules/events/persons/client/js/AuthorsList.jsx
@@ -10,7 +10,7 @@ import contribsPersonListURL from 'indico-url:contributions.person_list';
 import sessionsPersonListURL from 'indico-url:sessions.person_list';
 
 import PropTypes from 'prop-types';
-import React, {useMemo, useState} from 'react';
+import React, {useState} from 'react';
 import {Button, Dimmer, Loader, Message, Modal} from 'semantic-ui-react';
 
 import {useIndicoAxios} from 'indico/react/hooks';
@@ -78,9 +78,6 @@ export function AuthorsList({eventId, sourceIds, objectContext, onClose}) {
     },
     {camelize: true}
   );
-  const eventPersons = useMemo(() => new Map(data?.eventPersons.map(p => [p.identifier, p])), [
-    data,
-  ]);
   const extraRoles =
     objectContext === 'abstracts'
       ? [
@@ -131,9 +128,9 @@ export function AuthorsList({eventId, sourceIds, objectContext, onClose}) {
           <Dimmer active>
             <Loader />
           </Dimmer>
-        ) : eventPersons.size ? (
+        ) : Object.keys(data.eventPersons).length ? (
           <PersonList
-            persons={data.eventPersons}
+            persons={Object.values(data.eventPersons)}
             selectedPersons={selectedPersons}
             onChangeSelection={persons => setSelectedPersons(persons)}
             isSelectable={person => !!person.email}
@@ -147,7 +144,7 @@ export function AuthorsList({eventId, sourceIds, objectContext, onClose}) {
       <Modal.Actions>
         <EmailParticipantRolesButton
           eventId={eventId}
-          persons={selectedPersons.filter(id => isVisible(eventPersons.get(id)))}
+          persons={selectedPersons.filter(id => isVisible(data.eventPersons[id]))}
           onSubmitSucceeded={count => setSentEmailCount(count)}
           successTimeout={0}
           primary

--- a/indico/modules/events/persons/client/js/AuthorsList.jsx
+++ b/indico/modules/events/persons/client/js/AuthorsList.jsx
@@ -78,7 +78,9 @@ export function AuthorsList({eventId, sourceIds, objectContext, onClose}) {
     },
     {camelize: true}
   );
-  const eventPersons = useMemo(() => new Map(data?.eventPersons.map(p => [p.id, p])), [data]);
+  const eventPersons = useMemo(() => new Map(data?.eventPersons.map(p => [p.identifier, p])), [
+    data,
+  ]);
   const extraRoles =
     objectContext === 'abstracts'
       ? [

--- a/indico/modules/events/persons/client/js/PersonList.jsx
+++ b/indico/modules/events/persons/client/js/PersonList.jsx
@@ -72,7 +72,7 @@ export default function PersonList({
   const visibleSortedPersons = sortedPersons.filter(person => isVisible(person));
   const selectablePersons = visibleSortedPersons.filter(person => person.selectable);
   const visibleSelectedPersons = selectedPersons.filter(id =>
-    isVisible(persons.filter(p => p.identifier === id)[0])
+    isVisible(persons.find(person => person.identifier === id))
   ).length;
 
   const roles = [


### PR DESCRIPTION
This PR fixes a bug in which React crashes when trying to apply a filter in an Author List with selected items. It also simplifies the code by sending the author list to the front-end as a dictionary instead of a list.