### PR TITLE
Add setting to prevent disabling profile data sync

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,10 +35,8 @@ Improvements
 - Hide the top box with the latest files of an editable until it has been accepted
   and published (:issue:`5660`, :pr:`5665`)
 - Allow uploading files when requesting changes on the editing timeline (:pr:`5612`)
-- Add a :data:`locked_fields` setting to ``indico.conf`` to prevent non-admin
-  users of turning off their profile's personal data synchronization (:pr:`5648`)
 - Add ``locked_fields`` to the identity provider settings in ``indico.conf`` to
-  prevent non-admin users of turning off their profile's personal data
+  prevent non-admin users from turning off their profile's personal data
   synchronization (:pr:`5648`)
 
 Bugfixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,9 @@ Improvements
 - Allow uploading files when requesting changes on the editing timeline (:pr:`5612`)
 - Add a :data:`locked_fields` setting to ``indico.conf`` to prevent non-admin
   users of turning off their profile's personal data synchronization (:pr:`5648`)
+- Add ``locked_fields`` to the identity provider settings in ``indico.conf`` to
+  prevent non-admin users of turning off their profile's personal data
+  synchronization (:pr:`5648`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Improvements
 - Hide the top box with the latest files of an editable until it has been accepted
   and published (:issue:`5660`, :pr:`5665`)
 - Allow uploading files when requesting changes on the editing timeline (:pr:`5612`)
+- Add a :data:`locked_fields` setting to ``indico.conf`` to prevent non-admin
+  users of turning off their profile's personal data synchronization (:pr:`5648`)
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/config/auth.rst
+++ b/docs/source/config/auth.rst
@@ -78,7 +78,7 @@ The following keys are available in the provider data:
   approval of the registration by an Indico admin.  This results in
   the same workflow as :data:`LOCAL_MODERATION` in case of local
   accounts.
-- ``synced_fields`` -- This may be set in no more than once identity
+- ``synced_fields`` -- This may be set in no more than one identity
   provider and enables user data synchronization.  Its value should
   be a set of user attributes that can be synchronized during login.
   The following attributes can be synchronized:
@@ -93,6 +93,10 @@ The following keys are available in the provider data:
   has validated emails (ie ``trusted_email`` set to ``True``); otherwise
   users would get unvalidated (possibly even invalid) emails set on their
   account during sync.
+- ``locked_fields`` -- A set of fields which are always synchronized
+  with the identity provider. Its value must be a subset of the user
+  attributes listed in ``synced_fields``. The fields listed here can
+  still be desynchronized by an administrator.
 - ``mapping`` -- A dictionary that maps between keys given by the
   identity provider and keys expected by Indico for user information.
   The key of each entry is the Indico-side attribute name; the value

--- a/docs/source/config/auth.rst
+++ b/docs/source/config/auth.rst
@@ -95,8 +95,9 @@ The following keys are available in the provider data:
   account during sync.
 - ``locked_fields`` -- A set of fields which are always synchronized
   with the identity provider. Its value must be a subset of the user
-  attributes listed in ``synced_fields``. The fields listed here can
-  still be desynchronized by an administrator.
+  attributes listed in ``synced_fields``, and it it not possible to lock
+  the ``email`` field. The fields listed here can still be desynchronized
+  by an administrator.
 - ``locked_field_message`` -- A message displayed next to the fields
   listed in ``locked_fields``. The purpose is to guide the user on
   how they should proceed in order to change the locked field's data.

--- a/docs/source/config/auth.rst
+++ b/docs/source/config/auth.rst
@@ -97,6 +97,9 @@ The following keys are available in the provider data:
   with the identity provider. Its value must be a subset of the user
   attributes listed in ``synced_fields``. The fields listed here can
   still be desynchronized by an administrator.
+- ``locked_field_message`` -- A message displayed next to the fields
+  listed in ``locked_fields``. The purpose is to guide the user on
+  how they should proceed in order to change the locked field's data.
 - ``mapping`` -- A dictionary that maps between keys given by the
   identity provider and keys expected by Indico for user information.
   The key of each entry is the Indico-side attribute name; the value

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -66,7 +66,7 @@ class IndicoMultipass(Multipass):
         provider = self.sync_provider
         if provider is None:
             return set()
-        return set(provider.settings.get('locked_fields')) & self.synced_fields
+        return set(provider.settings.get('locked_fields', ())) & self.synced_fields
 
     def init_app(self, app):
         super().init_app(app)

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -56,6 +56,18 @@ class IndicoMultipass(Multipass):
         synced_fields &= set(current_app.config['MULTIPASS_IDENTITY_INFO_KEYS'])
         return synced_fields
 
+    @property
+    def locked_fields(self):
+        """The keys that cannot be desynchronized.
+
+        This is a subset of the keys listed in ``synced_fields`` that cannot be
+        desynchronized by a non-admin user.
+        """
+        provider = self.sync_provider
+        if provider is None:
+            return set()
+        return set(provider.settings.get('locked_fields')) & self.synced_fields
+
     def init_app(self, app):
         super().init_app(app)
         with app.app_context():

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -66,7 +66,7 @@ class IndicoMultipass(Multipass):
         provider = self.sync_provider
         if provider is None:
             return set()
-        return set(provider.settings.get('locked_fields', ())) & self.synced_fields
+        return (set(provider.settings.get('locked_fields', ())) & self.synced_fields) - {'email'}
 
     @property
     def locked_field_message(self):

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -68,6 +68,13 @@ class IndicoMultipass(Multipass):
             return set()
         return set(provider.settings.get('locked_fields', ())) & self.synced_fields
 
+    @property
+    def locked_field_message(self):
+        provider = self.sync_provider
+        if provider is None:
+            return ''
+        return provider.settings.get('locked_field_message', '')
+
     def init_app(self, app):
         super().init_app(app)
         with app.app_context():

--- a/indico/modules/auth/client/js/signup.jsx
+++ b/indico/modules/auth/client/js/signup.jsx
@@ -40,6 +40,7 @@ function Signup({
   hasPendingUser,
   mandatoryFields,
   lockedFields,
+  lockedFieldMessage,
 }) {
   const handleSubmit = async (data, form) => {
     const values = getValuesForFields(data, form);
@@ -112,6 +113,7 @@ function Signup({
                 }))}
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
                 required
               />
             ) : (
@@ -120,6 +122,7 @@ function Signup({
                 label={Translate.string('Email address')}
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
                 readOnly
               />
             )}
@@ -130,6 +133,7 @@ function Signup({
                 required
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
               />
               <SyncedFinalInput
                 name="last_name"
@@ -137,6 +141,7 @@ function Signup({
                 required
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
               />
             </Form.Group>
             {hasPredefinedAffiliations ? (
@@ -146,6 +151,7 @@ function Signup({
                 syncName="affiliation"
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
                 currentAffiliation={affiliationMeta}
               />
             ) : (
@@ -154,6 +160,8 @@ function Signup({
                 label={Translate.string('Affiliation')}
                 required={moderated && mandatoryFields.includes('affiliation')}
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
               />
             )}
             {'address' in syncedValues && (
@@ -162,6 +170,7 @@ function Signup({
                 label={Translate.string('Address')}
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
               />
             )}
             {'phone' in syncedValues && (
@@ -170,6 +179,7 @@ function Signup({
                 label={Translate.string('Phone number')}
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
               />
             )}
           </Fieldset>
@@ -247,12 +257,14 @@ Signup.propTypes = {
   hasPendingUser: PropTypes.bool,
   mandatoryFields: PropTypes.arrayOf(PropTypes.string).isRequired,
   lockedFields: PropTypes.arrayOf(PropTypes.string),
+  lockedFieldMessage: PropTypes.string,
 };
 
 Signup.defaultProps = {
   affiliationMeta: null,
   hasPendingUser: false,
   lockedFields: [],
+  lockedFieldMessage: '',
 };
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/indico/modules/auth/client/js/signup.jsx
+++ b/indico/modules/auth/client/js/signup.jsx
@@ -39,6 +39,7 @@ function Signup({
   affiliationMeta,
   hasPendingUser,
   mandatoryFields,
+  lockedFields,
 }) {
   const handleSubmit = async (data, form) => {
     const values = getValuesForFields(data, form);
@@ -110,6 +111,7 @@ function Signup({
                   text: e,
                 }))}
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
                 required
               />
             ) : (
@@ -117,6 +119,7 @@ function Signup({
                 name="email"
                 label={Translate.string('Email address')}
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
                 readOnly
               />
             )}
@@ -126,12 +129,14 @@ function Signup({
                 label={Translate.string('First name')}
                 required
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
               />
               <SyncedFinalInput
                 name="last_name"
                 label={Translate.string('Last name')}
                 required
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
               />
             </Form.Group>
             {hasPredefinedAffiliations ? (
@@ -140,6 +145,7 @@ function Signup({
                 required={moderated && mandatoryFields.includes('affiliation')}
                 syncName="affiliation"
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
                 currentAffiliation={affiliationMeta}
               />
             ) : (
@@ -155,6 +161,7 @@ function Signup({
                 name="address"
                 label={Translate.string('Address')}
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
               />
             )}
             {'phone' in syncedValues && (
@@ -162,6 +169,7 @@ function Signup({
                 name="phone"
                 label={Translate.string('Phone number')}
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
               />
             )}
           </Fieldset>
@@ -238,11 +246,13 @@ Signup.propTypes = {
   affiliationMeta: PropTypes.object,
   hasPendingUser: PropTypes.bool,
   mandatoryFields: PropTypes.arrayOf(PropTypes.string).isRequired,
+  lockedFields: PropTypes.arrayOf(PropTypes.string),
 };
 
 Signup.defaultProps = {
   affiliationMeta: null,
   hasPendingUser: false,
+  lockedFields: [],
 };
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -552,6 +552,7 @@ class MultipassRegistrationHandler(RegistrationHandler):
             'hasPendingUser': bool(pending_data),
             'mandatoryFields': mandatory_fields,
             'lockedFields': locked_fields,
+            'lockedFieldMessage': multipass.locked_field_message,
         }
 
     def create_schema(self):

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -549,6 +549,7 @@ class MultipassRegistrationHandler(RegistrationHandler):
             'affiliationMeta': affiliation_meta,
             'hasPendingUser': bool(pending_data),
             'mandatoryFields': mandatory_fields,
+            'lockedFields': list(multipass.locked_fields),
         }
 
     def create_schema(self):
@@ -584,6 +585,9 @@ class MultipassRegistrationHandler(RegistrationHandler):
                     raise ValidationError(_('This field cannot be empty.'), 'first_name')
                 if 'last_name' not in data['synced_fields'] and not data['last_name']:
                     raise ValidationError(_('This field cannot be empty.'), 'last_name')
+                for field in data['synced_fields']:
+                    if field not in multipass.locked_fields:
+                        raise ValidationError('Locked fields must be synced.', field)
 
         return MultipassSignupSchema
 

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -534,7 +534,7 @@ class MultipassRegistrationHandler(RegistrationHandler):
                     synced_values['affiliation_id'] = -1
             initial_values.update((k, v) for k, v in pending_data.items()
                                   if k not in synced_fields and k not in initial_values)
-            locked_fields = [x for x in multipass.locked_fields if x not in required_empty_fields]
+            locked_fields = list(multipass.locked_fields - required_empty_fields)
         else:
             synced_values = {}
             initial_values.update(pending_data)

--- a/indico/modules/users/client/js/PersonalDataForm.jsx
+++ b/indico/modules/users/client/js/PersonalDataForm.jsx
@@ -36,6 +36,7 @@ function PersonalDataForm({
   currentAffiliation,
   titles,
   syncedValues,
+  lockedFields,
   hasPredefinedAffiliations,
 }) {
   const userIdArgs = userId !== null ? {user_id: userId} : {};
@@ -87,12 +88,14 @@ function PersonalDataForm({
                 label={Translate.string('First name')}
                 required
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
               />
               <SyncedFinalInput
                 name="last_name"
                 label={Translate.string('Last name')}
                 required
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
               />
             </Form.Group>
             {hasPredefinedAffiliations ? (
@@ -101,28 +104,33 @@ function PersonalDataForm({
                 syncName="affiliation"
                 currentAffiliation={currentAffiliation}
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
               />
             ) : (
               <SyncedFinalInput
                 name="affiliation"
                 label={Translate.string('Affiliation')}
                 syncedValues={syncedValues}
+                lockedFields={lockedFields}
               />
             )}
             <SyncedFinalTextArea
               name="address"
               label={Translate.string('Address')}
               syncedValues={syncedValues}
+              lockedFields={lockedFields}
             />
             <SyncedFinalInput
               name="phone"
               label={Translate.string('Phone number')}
               syncedValues={syncedValues}
+              lockedFields={lockedFields}
             />
             <SyncedFinalInput
               name="email"
               label={Translate.string('Email address')}
               syncedValues={syncedValues}
+              lockedFields={lockedFields}
               readOnly
             >
               <Translate>
@@ -152,6 +160,7 @@ PersonalDataForm.propTypes = {
     })
   ).isRequired,
   syncedValues: PropTypes.objectOf(PropTypes.string).isRequired,
+  lockedFields: PropTypes.arrayOf(PropTypes.string).isRequired,
   hasPredefinedAffiliations: PropTypes.bool.isRequired,
 };
 
@@ -166,6 +175,7 @@ window.setupPersonalDataForm = function setupPersonalDataForm(
   currentAffiliation,
   titles,
   syncedValues,
+  lockedFields,
   hasPredefinedAffiliations
 ) {
   document.addEventListener('DOMContentLoaded', () => {
@@ -176,6 +186,7 @@ window.setupPersonalDataForm = function setupPersonalDataForm(
         currentAffiliation={currentAffiliation}
         titles={titles}
         syncedValues={syncedValues}
+        lockedFields={lockedFields}
         hasPredefinedAffiliations={hasPredefinedAffiliations}
       />,
       document.querySelector('#personal-details-form-container')

--- a/indico/modules/users/client/js/PersonalDataForm.jsx
+++ b/indico/modules/users/client/js/PersonalDataForm.jsx
@@ -37,6 +37,7 @@ function PersonalDataForm({
   titles,
   syncedValues,
   lockedFields,
+  lockedFieldMessage,
   hasPredefinedAffiliations,
 }) {
   const userIdArgs = userId !== null ? {user_id: userId} : {};
@@ -89,6 +90,7 @@ function PersonalDataForm({
                 required
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
               />
               <SyncedFinalInput
                 name="last_name"
@@ -96,6 +98,7 @@ function PersonalDataForm({
                 required
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
               />
             </Form.Group>
             {hasPredefinedAffiliations ? (
@@ -105,6 +108,7 @@ function PersonalDataForm({
                 currentAffiliation={currentAffiliation}
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
               />
             ) : (
               <SyncedFinalInput
@@ -112,6 +116,7 @@ function PersonalDataForm({
                 label={Translate.string('Affiliation')}
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
+                lockedFieldMessage={lockedFieldMessage}
               />
             )}
             <SyncedFinalTextArea
@@ -119,18 +124,21 @@ function PersonalDataForm({
               label={Translate.string('Address')}
               syncedValues={syncedValues}
               lockedFields={lockedFields}
+              lockedFieldMessage={lockedFieldMessage}
             />
             <SyncedFinalInput
               name="phone"
               label={Translate.string('Phone number')}
               syncedValues={syncedValues}
               lockedFields={lockedFields}
+              lockedFieldMessage={lockedFieldMessage}
             />
             <SyncedFinalInput
               name="email"
               label={Translate.string('Email address')}
               syncedValues={syncedValues}
               lockedFields={lockedFields}
+              lockedFieldMessage={lockedFieldMessage}
               readOnly
             >
               <Translate>
@@ -161,6 +169,7 @@ PersonalDataForm.propTypes = {
   ).isRequired,
   syncedValues: PropTypes.objectOf(PropTypes.string).isRequired,
   lockedFields: PropTypes.arrayOf(PropTypes.string).isRequired,
+  lockedFieldMessage: PropTypes.string.isRequired,
   hasPredefinedAffiliations: PropTypes.bool.isRequired,
 };
 
@@ -176,6 +185,7 @@ window.setupPersonalDataForm = function setupPersonalDataForm(
   titles,
   syncedValues,
   lockedFields,
+  lockedFieldMessage,
   hasPredefinedAffiliations
 ) {
   document.addEventListener('DOMContentLoaded', () => {
@@ -187,6 +197,7 @@ window.setupPersonalDataForm = function setupPersonalDataForm(
         titles={titles}
         syncedValues={syncedValues}
         lockedFields={lockedFields}
+        lockedFieldMessage={lockedFieldMessage}
         hasPredefinedAffiliations={hasPredefinedAffiliations}
       />,
       document.querySelector('#personal-details-form-container')

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -210,6 +210,7 @@ class RHPersonalData(RHUserBase):
         has_predefined_affiliations = Affiliation.query.filter(~Affiliation.is_deleted).has_rows()
         return WPUserPersonalData.render_template('personal_data.html', 'personal_data', user=self.user,
                                                   titles=titles, user_values=user_values, locked_fields=locked_fields,
+                                                  locked_field_message=multipass.locked_field_message,
                                                   current_affiliation=current_affiliation,
                                                   has_predefined_affiliations=has_predefined_affiliations)
 

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -222,7 +222,7 @@ class RHPersonalDataUpdate(RHUserBase):
         logger.info('Profile of user %r updated by %r: %r', self.user, session.user, changes)
         synced_fields = set(changes.pop('synced_fields', self.user.synced_fields))
         if not session.user.is_admin:
-            synced_fields |= multipass.locked_fields
+            synced_fields |= multipass.locked_fields & self.user.synced_fields
         syncable_fields = {k for k, v in self.user.synced_values.items()
                            if v or k not in ('first_name', 'last_name')}
         # we set this first so these fields are skipped below and only

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -203,12 +203,13 @@ class RHPersonalData(RHUserBase):
     def _process(self):
         titles = [{'name': t.name, 'title': t.title} for t in UserTitle if t != UserTitle.none]
         user_values = UserPersonalDataSchema().dump(self.user)
+        locked_fields = [] if session.user.is_admin else list(multipass.locked_fields)
         current_affiliation = None
         if self.user.affiliation_link:
             current_affiliation = AffiliationSchema().dump(self.user.affiliation_link)
         has_predefined_affiliations = Affiliation.query.filter(~Affiliation.is_deleted).has_rows()
         return WPUserPersonalData.render_template('personal_data.html', 'personal_data', user=self.user,
-                                                  titles=titles, user_values=user_values,
+                                                  titles=titles, user_values=user_values, locked_fields=locked_fields,
                                                   current_affiliation=current_affiliation,
                                                   has_predefined_affiliations=has_predefined_affiliations)
 
@@ -220,6 +221,8 @@ class RHPersonalDataUpdate(RHUserBase):
     def _process(self, changes):
         logger.info('Profile of user %r updated by %r: %r', self.user, session.user, changes)
         synced_fields = set(changes.pop('synced_fields', self.user.synced_fields))
+        if not session.user.is_admin:
+            synced_fields |= multipass.locked_fields
         syncable_fields = {k for k, v in self.user.synced_values.items()
                            if v or k not in ('first_name', 'last_name')}
         # we set this first so these fields are skipped below and only

--- a/indico/modules/users/templates/personal_data.html
+++ b/indico/modules/users/templates/personal_data.html
@@ -48,6 +48,7 @@
             {{ titles | tojson }},
             {{ user.synced_values | tojson }},
             {{ locked_fields | tojson }},
+            {{ locked_field_message | tojson }},
             {{ has_predefined_affiliations | tojson }}
         );
     </script>

--- a/indico/modules/users/templates/personal_data.html
+++ b/indico/modules/users/templates/personal_data.html
@@ -47,6 +47,7 @@
             {{ current_affiliation | tojson }},
             {{ titles | tojson }},
             {{ user.synced_values | tojson }},
+            {{ locked_fields | tojson }},
             {{ has_predefined_affiliations | tojson }}
         );
     </script>

--- a/indico/web/client/js/react/components/syncedInputs.jsx
+++ b/indico/web/client/js/react/components/syncedInputs.jsx
@@ -26,6 +26,7 @@ function SyncedFinalField({
   syncName,
   as: FieldComponent,
   syncedValues,
+  lockedFields,
   readOnly,
   required,
   processSyncedValue,
@@ -41,25 +42,28 @@ function SyncedFinalField({
   }
 
   const syncable = syncedValues[syncName] !== undefined && (!required || syncedValues[syncName]);
+  const synced = syncedFields.includes(syncName);
+  const locked = lockedFields.includes(syncName);
 
   return (
     <FieldComponent
       {...rest}
       name={name}
       styleName={syncable ? 'syncable' : ''}
-      readOnly={readOnly || (syncable && syncedFields.includes(syncName))}
+      readOnly={readOnly || (syncable && synced)}
       required={required}
       action={
         syncable
           ? {
               type: 'button',
-              active: syncedFields.includes(syncName),
+              active: synced && !locked,
+              disabled: synced && locked,
               icon: 'sync',
               toggle: true,
               className: 'ui-qtip',
               title: Translate.string('Toggle synchronization of this field'),
               onClick: () => {
-                if (syncedFields.includes(syncName)) {
+                if (synced) {
                   setSyncedFields(syncedFields.filter(x => x !== syncName));
                   form.change(name, form.getFieldState(name).initial);
                 } else {
@@ -79,6 +83,7 @@ SyncedFinalField.propTypes = {
   syncName: PropTypes.string,
   as: PropTypes.elementType.isRequired,
   syncedValues: PropTypes.object.isRequired,
+  lockedFields: PropTypes.arrayOf(PropTypes.string).isRequired,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   processSyncedValue: PropTypes.func,
@@ -109,6 +114,7 @@ export function SyncedFinalAffiliationDropdown({
   required,
   syncName,
   syncedValues,
+  lockedFields,
   currentAffiliation,
 }) {
   const [_affiliationResults, setAffiliationResults] = useState([]);
@@ -167,6 +173,7 @@ export function SyncedFinalAffiliationDropdown({
       )}
       label={Translate.string('Affiliation')}
       syncedValues={syncedValues}
+      lockedFields={lockedFields}
     />
   );
 }
@@ -176,6 +183,7 @@ SyncedFinalAffiliationDropdown.propTypes = {
   required: PropTypes.bool,
   syncName: PropTypes.string,
   syncedValues: PropTypes.object.isRequired,
+  lockedFields: PropTypes.arrayOf(PropTypes.string).isRequired,
   currentAffiliation: PropTypes.object,
 };
 

--- a/indico/web/client/js/react/components/syncedInputs.jsx
+++ b/indico/web/client/js/react/components/syncedInputs.jsx
@@ -57,7 +57,7 @@ function SyncedFinalField({
         syncable
           ? {
               type: 'button',
-              active: synced && !locked,
+              active: synced,
               disabled: synced && locked,
               icon: 'sync',
               toggle: true,

--- a/indico/web/client/js/react/components/syncedInputs.jsx
+++ b/indico/web/client/js/react/components/syncedInputs.jsx
@@ -10,7 +10,7 @@ import searchAffiliationURL from 'indico-url:users.api_affiliations';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {useField, useForm} from 'react-final-form';
-import {Header} from 'semantic-ui-react';
+import {Form, Header, Popup} from 'semantic-ui-react';
 
 import {FinalComboDropdown, FinalDropdown, FinalInput, FinalTextArea} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
@@ -27,6 +27,7 @@ function SyncedFinalField({
   as: FieldComponent,
   syncedValues,
   lockedFields,
+  lockedFieldMessage,
   readOnly,
   required,
   processSyncedValue,
@@ -45,7 +46,7 @@ function SyncedFinalField({
   const synced = syncedFields.includes(syncName);
   const locked = lockedFields.includes(syncName);
 
-  return (
+  const field = (
     <FieldComponent
       {...rest}
       name={name}
@@ -76,6 +77,18 @@ function SyncedFinalField({
       }
     />
   );
+  if (synced && locked && lockedFieldMessage) {
+    return (
+      <Popup
+        on="hover"
+        position="bottom left"
+        content={lockedFieldMessage}
+        trigger={<Form.Field>{field}</Form.Field>}
+      />
+    );
+  } else {
+    return field;
+  }
 }
 
 SyncedFinalField.propTypes = {
@@ -84,6 +97,7 @@ SyncedFinalField.propTypes = {
   as: PropTypes.elementType.isRequired,
   syncedValues: PropTypes.object.isRequired,
   lockedFields: PropTypes.arrayOf(PropTypes.string).isRequired,
+  lockedFieldMessage: PropTypes.string.isRequired,
   readOnly: PropTypes.bool,
   required: PropTypes.bool,
   processSyncedValue: PropTypes.func,
@@ -115,6 +129,7 @@ export function SyncedFinalAffiliationDropdown({
   syncName,
   syncedValues,
   lockedFields,
+  lockedFieldMessage,
   currentAffiliation,
 }) {
   const [_affiliationResults, setAffiliationResults] = useState([]);
@@ -174,6 +189,7 @@ export function SyncedFinalAffiliationDropdown({
       label={Translate.string('Affiliation')}
       syncedValues={syncedValues}
       lockedFields={lockedFields}
+      lockedFieldMessage={lockedFieldMessage}
     />
   );
 }
@@ -184,6 +200,7 @@ SyncedFinalAffiliationDropdown.propTypes = {
   syncName: PropTypes.string,
   syncedValues: PropTypes.object.isRequired,
   lockedFields: PropTypes.arrayOf(PropTypes.string).isRequired,
+  lockedFieldMessage: PropTypes.string.isRequired,
   currentAffiliation: PropTypes.object,
 };
 

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -764,6 +764,7 @@ function ActionButton({action}) {
       icon
       toggle={action.toggle}
       active={action.active}
+      disabled={action.disabled}
       className={action.className}
       title={action.title}
       style={{
@@ -784,6 +785,7 @@ ActionButton.propTypes = {
   action: PropTypes.shape({
     type: PropTypes.oneOf(['button']).isRequired,
     active: PropTypes.bool,
+    disabled: PropTypes.bool,
     icon: PropTypes.string.isRequired,
     toggle: PropTypes.bool,
     className: PropTypes.string,


### PR DESCRIPTION
This PR adds a setting to `indico.conf` to prevent non-admin users of turning off their profile's personal data synchronization.
Fields listed in the `locked_fields` setting can only be de-synced by an administrator.
![image](https://user-images.githubusercontent.com/27357203/216379209-2ba818f5-fe12-4c82-a81d-0a984bac2f68.png)

Α custom `locked_field_message` may also be set to help guide users:
<img width="581" alt="image" src="https://user-images.githubusercontent.com/27357203/218051216-2b07cbf5-3750-4fcb-9fcf-474cae3b19aa.png">
