### PR TITLE
Allow setting default locale w/o enforcing it

### DIFF
--- a/indico/modules/categories/controllers/util.py
+++ b/indico/modules/categories/controllers/util.py
@@ -16,7 +16,7 @@ from indico.core import signals
 from indico.core.db import db
 from indico.modules.categories.models.event_move_request import MoveRequestState
 from indico.modules.events.models.events import Event
-from indico.modules.events.util import serialize_event_for_json_ld
+from indico.modules.events.util import serialize_events_for_json_ld
 from indico.util.date_time import format_date, format_skeleton
 from indico.util.i18n import _
 from indico.util.signals import values_from_signal
@@ -162,7 +162,7 @@ def get_category_view_params(category, now, is_flat=False):
         'show_past_events': show_past_events,
         'past_threshold': past_threshold.strftime(threshold_format),
         'has_hidden_events': has_hidden_events,
-        'json_ld': list(map(serialize_event_for_json_ld, json_ld_events)),
+        'json_ld': serialize_events_for_json_ld(json_ld_events),
         'atom_feed_url': url_for('.export_atom', category),
         'atom_feed_title': _('Events of "{}"').format(category.title),
         'pending_event_moves': pending_event_moves,

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -596,6 +596,7 @@ class CategoryEventFetcher(IteratedDataFetcher, SerializerBase):
             'material': material_data,
             'keywords': event.keywords,
             'organizer': event.organizer_info,
+            'language': event.default_locale or None,
         })
 
         if event.is_unlisted:

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -480,12 +480,14 @@ class ImportContentsForm(ImportSourceEventForm):
 
 
 class EventLanguagesForm(IndicoForm):
-    default_locale = SelectField(_('Default language'), description=_('If set, Indico will use this language '
-                                                                      "instead of the user's language when displaying "
-                                                                      'the event or sending emails related to it. '
-                                                                      'This setting should be used only for events '
-                                                                      'where it is important that there is no mix of '
-                                                                      'languages e.g. due to custom menu titles.'))
+    default_locale = SelectField(_('Default language'), description=_('This is the primary language of the event. It '
+                                                                      'will be included in the metadata of the event.'))
+    enforce_locale = BooleanField(_('Enforce language'), widget=SwitchWidget(),
+                                  description=_('If set, Indico will use the default language instead of the '
+                                                "user's language when displaying the event or sending emails related "
+                                                'to it. This setting should be enabled only for events where it is '
+                                                'important that there is no mix of languages e.g. due to custom menu '
+                                                'titles.'))
     supported_locales = IndicoSelectMultipleCheckboxField(_('Additional languages'),
                                                           description=_('Languages from this list will be used if the '
                                                                         "user selected one of them, even if it's not "

--- a/indico/modules/events/management/templates/_settings.html
+++ b/indico/modules/events/management/templates/_settings.html
@@ -223,6 +223,9 @@
             <dt>{% trans %}Default language{% endtrans %}</dt>
             <dd>{{ with_default(event.default_language) }}</dd>
 
+            <dt>{% trans %}Enforce language{% endtrans %}</dt>
+            <dd>{{ _('Yes') if event.enforce_locale else _('No') }}</dd>
+
             <dt>{% trans %}Additional languages{% endtrans %}</dt>
             <dd>{{ with_default(event.supported_languages|join(', ')) }}</dd>
         </dl>
@@ -230,7 +233,8 @@
             (() => {
                 function disableDefaultLocale() {
                     const defaultLocaleValue = $('#default_locale').val();
-                    if (!defaultLocaleValue) {
+                    const enforceLocale = $('#enforce_locale').prop('checked');
+                    if (!defaultLocaleValue || !enforceLocale) {
                         // Disable all when no default locale is used
                         $(`input[name=supported_locales]`).prop('disabled', true);
                         return;
@@ -244,7 +248,7 @@
                     .on('ajaxForm:show', () => {
                         disableDefaultLocale();
                     })
-                    .on('change', '#default_locale', evt => {
+                    .on('change', '#default_locale, #enforce_locale', evt => {
                         disableDefaultLocale();
                     });
             })();

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -449,6 +449,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     public_regform_access = _EventSettingProperty(event_core_settings, 'public_regform_access')
     supported_locales = _EventSettingProperty(event_language_settings, 'supported_locales')
     default_locale = _EventSettingProperty(event_language_settings, 'default_locale')
+    enforce_locale = _EventSettingProperty(event_language_settings, 'enforce_locale')
 
     @classmethod
     def category_chain_overlaps(cls, category_ids):
@@ -1101,7 +1102,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         return f'{name} ({territory})' if territory else name
 
     def get_forced_event_locale(self, user=None, *, allow_session=False):
-        if not (locale := self.default_locale):
+        if not self.enforce_locale or not (locale := self.default_locale):
             return None
         if user:
             locale = user.settings.get('lang')

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -145,7 +145,7 @@ def update_event(event, update_timetable=False, **data):
                                 'person_link_data', 'start_dt', 'end_dt', 'timezone', 'keywords', 'references',
                                 'organizer_info', 'additional_info', 'contact_title', 'contact_emails',
                                 'contact_phones', 'start_dt_override', 'end_dt_override', 'label', 'label_message',
-                                'own_map_url', 'supported_locales', 'default_locale'}
+                                'own_map_url', 'supported_locales', 'enforce_locale', 'default_locale'}
     old_person_links = event.sorted_person_links[:]
     changes = {}
     if (update_timetable or event.type == EventType.lecture) and 'start_dt' in data:
@@ -260,7 +260,8 @@ def _log_event_update(event, changes, visible_person_link_changes=False):
         'label_message': 'Label message',
         'own_map_url': {'title': 'Map URL', 'type': 'string'},
         'supported_locales': 'Supported languages',
-        'default_locale': 'Default language'
+        'default_locale': 'Default language',
+        'enforce_locale': 'Enforce language',
     }
     _split_location_changes(changes)
     if not visible_person_link_changes:

--- a/indico/modules/events/settings.py
+++ b/indico/modules/events/settings.py
@@ -256,6 +256,7 @@ event_contact_settings = EventSettingsProxy('contact', {
 event_language_settings = EventSettingsProxy('language', {
     'supported_locales': [],
     'default_locale': '',
+    'enforce_locale': False,
 })
 
 unlisted_events_settings = SettingsProxy('unlisted_events', {


### PR DESCRIPTION
After discussing w/ @pferreir a few days ago we thought it could be nice to let people define an event language even without enforcing it, just for the sake of having better metadata.

The question is in which metadata we want to have this. The JSON-LD event metadata we have doesn't seem to have a way to specify the event language, so the only thing that comes to my mind is API responses and maybe the HTML `lang` metadata... but that should probably only be set if the language is actually being enforced (ie not if the user overrides it with their own language preference).