### PR TITLE
Allow sending reminders to pending invitees

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Improvements
   :pr:`5607`, thanks :user:`vasantvohra`)
 - Fail nicely when trying to import an event from another Indico instance (:issue:`5619`,
   :pr:`5653`)
+- Add option to send reminders to invited registrants who have not yet responsed
+  (:issue:`5579`, :pr:`5654`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/persons/__init__.py
+++ b/indico/modules/events/persons/__init__.py
@@ -28,29 +28,25 @@ def _sidemenu_items(sender, event, **kwargs):
 @signals.core.get_placeholders.connect_via('event-persons-email')
 def _get_placeholders(sender, person, event, contribution=None, abstract=None, register_link=False, object_context=None,
                       **kwargs):
-    from indico.modules.events.persons.placeholders import (AbstractIDPlaceholder, AbstractTitlePlaceholder,
-                                                            ContributionCodePlaceholder, ContributionIDPlaceholder,
-                                                            ContributionsPlaceholder, ContributionTitlePlaceholder,
-                                                            EmailPlaceholder, EventLinkPlaceholder,
-                                                            EventTitlePlaceholder, FirstNamePlaceholder,
-                                                            LastNamePlaceholder, RegisterLinkPlaceholder)
+    from indico.modules.events import placeholders as event_placeholders
+    from indico.modules.events.persons import placeholders as person_placeholders
 
-    yield FirstNamePlaceholder
-    yield LastNamePlaceholder
-    yield EmailPlaceholder
-    yield EventTitlePlaceholder
-    yield EventLinkPlaceholder
+    yield person_placeholders.FirstNamePlaceholder
+    yield person_placeholders.LastNamePlaceholder
+    yield person_placeholders.EmailPlaceholder
+    yield event_placeholders.EventTitlePlaceholder
+    yield event_placeholders.EventLinkPlaceholder
     if register_link:
-        yield RegisterLinkPlaceholder
+        yield person_placeholders.RegisterLinkPlaceholder
     if object_context == 'abstracts':
-        yield AbstractIDPlaceholder
-        yield AbstractTitlePlaceholder
+        yield person_placeholders.AbstractIDPlaceholder
+        yield person_placeholders.AbstractTitlePlaceholder
     elif object_context == 'contributions':
-        yield ContributionIDPlaceholder
-        yield ContributionTitlePlaceholder
-        yield ContributionCodePlaceholder
+        yield person_placeholders.ContributionIDPlaceholder
+        yield person_placeholders.ContributionTitlePlaceholder
+        yield person_placeholders.ContributionCodePlaceholder
     else:
-        yield ContributionsPlaceholder
+        yield person_placeholders.ContributionsPlaceholder
 
 
 persons_settings = EventSettingsProxy('persons', {

--- a/indico/modules/events/persons/client/js/EmailDialog.jsx
+++ b/indico/modules/events/persons/client/js/EmailDialog.jsx
@@ -9,7 +9,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {FormSpy} from 'react-final-form';
-import {Form, Button, Message} from 'semantic-ui-react';
+import {Form, Button, Message, Input, Popup, Icon} from 'semantic-ui-react';
 
 import {FinalEmailList} from 'indico/react/components';
 import PlaceholderInfo from 'indico/react/components/PlaceholderInfo';
@@ -18,6 +18,41 @@ import {FinalCheckbox, FinalDropdown, FinalInput} from 'indico/react/forms';
 import {FinalModalForm} from 'indico/react/forms/final-form';
 import {Translate, PluralTranslate, Singular, Plural, Param} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
+
+function RecipientsField({recipients}) {
+  return (
+    <Form.Field>
+      <Translate as="label">Recipients</Translate>
+      <Input
+        value={recipients.join(', ')}
+        readOnly
+        icon={
+          navigator.clipboard && (
+            <Popup
+              content={Translate.string('Copied!')}
+              on="click"
+              position="top center"
+              inverted
+              trigger={
+                <Icon
+                  name="copy"
+                  color="black"
+                  title={Translate.string('Copy to clipboard')}
+                  onClick={() => navigator.clipboard.writeText(recipients.join(', '))}
+                  link
+                />
+              }
+            />
+          )
+        }
+      />
+    </Form.Field>
+  );
+}
+
+RecipientsField.propTypes = {
+  recipients: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
 
 export function EmailSentMessage({count}) {
   return (
@@ -45,6 +80,7 @@ export function EmailDialog({
   previewURL,
   previewContext,
   placeholders,
+  recipients,
   recipientsField,
   initialFormValues,
 }) {
@@ -124,7 +160,7 @@ export function EmailDialog({
             <PlaceholderInfo placeholders={placeholders} />
           </Form.Field>
         )}
-        {recipientsField}
+        {recipientsField || <RecipientsField recipients={recipients} />}
         <FinalEmailList
           name="bcc_addresses"
           label={Translate.string('BCC addresses')}
@@ -177,7 +213,10 @@ EmailDialog.propTypes = {
   previewURL: PropTypes.string.isRequired,
   previewContext: PropTypes.object,
   placeholders: PropTypes.array.isRequired,
-  recipientsField: PropTypes.node.isRequired,
+  /** Array of email addresses passed to <RecipientsField /> */
+  recipients: PropTypes.arrayOf(PropTypes.string),
+  /** React node to render instead of the default <RecipientsField /> component. */
+  recipientsField: PropTypes.node,
   initialFormValues: PropTypes.object,
 };
 
@@ -185,4 +224,6 @@ EmailDialog.defaultProps = {
   previewContext: {},
   initialFormValues: {},
   sentEmailsCount: 0,
+  recipients: [],
+  recipientsField: null,
 };

--- a/indico/modules/events/persons/client/js/EmailParticipantRoles.jsx
+++ b/indico/modules/events/persons/client/js/EmailParticipantRoles.jsx
@@ -11,11 +11,10 @@ import emailPreviewURL from 'indico-url:persons.email_event_persons_preview';
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Form, Dimmer, Loader, Popup, Input, Icon} from 'semantic-ui-react';
+import {Dimmer, Loader} from 'semantic-ui-react';
 
 import {handleSubmitError} from 'indico/react/forms';
 import {useIndicoAxios} from 'indico/react/hooks';
-import {Translate} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
 
 import {EmailDialog} from './EmailDialog';
@@ -84,34 +83,6 @@ export function EmailParticipantRoles({
       placeholders={placeholders}
       initialFormValues={{subject: defaultSubject, body: defaultBody}}
       sentEmailsCount={sentCount}
-      recipientsField={
-        <Form.Field>
-          <Translate as="label">Recipients</Translate>
-          <Input
-            value={recipients.join(', ')}
-            readOnly
-            icon={
-              navigator.clipboard && (
-                <Popup
-                  content={Translate.string('Copied!')}
-                  on="click"
-                  position="top center"
-                  inverted
-                  trigger={
-                    <Icon
-                      name="copy"
-                      color="black"
-                      title={Translate.string('Copy to clipboard')}
-                      onClick={() => navigator.clipboard.writeText(recipients.join(', '))}
-                      link
-                    />
-                  }
-                />
-              )
-            }
-          />
-        </Form.Field>
-      }
     />
   );
 }

--- a/indico/modules/events/persons/placeholders.py
+++ b/indico/modules/events/persons/placeholders.py
@@ -47,25 +47,6 @@ class EmailPlaceholder(Placeholder):
         return person.email
 
 
-class EventTitlePlaceholder(Placeholder):
-    name = 'event_title'
-    description = _('The title of the event')
-
-    @classmethod
-    def render(cls, person, event, **kwargs):
-        return event.title
-
-
-class EventLinkPlaceholder(Placeholder):
-    name = 'event_link'
-    description = _('Link to the event')
-
-    @classmethod
-    def render(cls, person, event, **kwargs):
-        return Markup('<a href="{url}" title="{title}">{url}</a>').format(url=event.short_external_url,
-                                                                          title=event.title)
-
-
 class ContributionsPlaceholder(ParametrizedPlaceholder):
     name = 'contributions'
     param_required = False

--- a/indico/modules/events/placeholders.py
+++ b/indico/modules/events/placeholders.py
@@ -1,0 +1,30 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from markupsafe import Markup
+
+from indico.util.i18n import _
+from indico.util.placeholders import Placeholder
+
+
+class EventTitlePlaceholder(Placeholder):
+    name = 'event_title'
+    description = _('The title of the event')
+
+    @classmethod
+    def render(cls, event, **kwargs):
+        return event.title
+
+
+class EventLinkPlaceholder(Placeholder):
+    name = 'event_link'
+    description = _('Link to the event')
+
+    @classmethod
+    def render(cls, event, **kwargs):
+        return Markup('<a href="{url}" title="{title}">{url}</a>').format(url=event.short_external_url,
+                                                                          title=event.title)

--- a/indico/modules/events/registration/__init__.py
+++ b/indico/modules/events/registration/__init__.py
@@ -195,6 +195,19 @@ def _get_registration_placeholders(sender, regform, registration, **kwargs):
     yield FieldPlaceholder
 
 
+@signals.core.get_placeholders.connect_via('registration-invitation-reminder-email')
+def _get_placeholders(sender, invitation=None, event=None, **kwargs):
+    from indico.modules.events import placeholders as event_placeholders
+    from indico.modules.events.registration.placeholders import invitations as invitation_placeholders
+
+    yield invitation_placeholders.InvitationLinkPlaceholder
+    yield invitation_placeholders.FirstNamePlaceholder
+    yield invitation_placeholders.LastNamePlaceholder
+    yield invitation_placeholders.EmailPlaceholder
+    yield event_placeholders.EventTitlePlaceholder
+    yield event_placeholders.EventLinkPlaceholder
+
+
 @signals.event.get_feature_definitions.connect
 def _get_feature_definitions(sender, **kwargs):
     return RegistrationFeature

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -119,6 +119,15 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/invitations/<int:invita
                  'manager_decline_invitation', invitations.RHRegistrationFormManagerDeclineInvitation,
                  methods=('POST',))
 
+# Invitation reminders API
+_bp.add_url_rule('/api/registration/<int:reg_form_id>/invitations/reminders/send', 'api_invitations_reminders_send',
+                 invitations.RHRegistrationFormRemindersSend, methods=('POST',))
+_bp.add_url_rule('/api/registration/<int:reg_form_id>/invitations/reminders/metadata',
+                 'api_invitations_reminders_metadata', invitations.RHRegistrationFormRemindersMetadata)
+_bp.add_url_rule('/api/registration/<int:reg_form_id>/invitations/reminders/preview',
+                 'api_invitations_reminders_preview', invitations.RHRegistrationFormRemindersPreview,
+                 methods=('POST',))
+
 # E-ticket management
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/tickets', 'tickets', tickets.RHRegistrationFormTickets,
                  methods=('GET', 'POST'))

--- a/indico/modules/events/registration/client/js/components/EmailPendingInvitations.jsx
+++ b/indico/modules/events/registration/client/js/components/EmailPendingInvitations.jsx
@@ -1,0 +1,69 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+import {Dimmer, Loader} from 'semantic-ui-react';
+
+import {EmailDialog} from 'indico/modules/events/persons/EmailDialog';
+import {handleSubmitError} from 'indico/react/forms';
+import {useIndicoAxios} from 'indico/react/hooks';
+import {indicoAxios} from 'indico/utils/axios';
+
+export default function EmailPendingInvitations({metadataURL, previewURL, sendURL, onClose}) {
+  const successTimeout = 5000;
+  const [sentCount, setSentCount] = useState(0);
+
+  const {data, loading} = useIndicoAxios(metadataURL);
+  const {
+    senders = [],
+    recipients = [],
+    subject: defaultSubject,
+    body: defaultBody,
+    placeholders = [],
+  } = data || {};
+
+  const handleSubmit = async data => {
+    data.body = data.body.getData ? data.body.getData() : data.body;
+    let resp;
+    try {
+      resp = await indicoAxios.post(sendURL, data);
+    } catch (err) {
+      return handleSubmitError(err);
+    }
+    setSentCount(resp.data.count);
+    setTimeout(() => onClose(), successTimeout);
+  };
+
+  if (loading) {
+    return (
+      <Dimmer active page inverted>
+        <Loader />
+      </Dimmer>
+    );
+  }
+
+  return (
+    <EmailDialog
+      onSubmit={handleSubmit}
+      onClose={onClose}
+      senders={senders}
+      recipients={recipients}
+      previewURL={previewURL}
+      placeholders={placeholders}
+      initialFormValues={{subject: defaultSubject, body: defaultBody}}
+      sentEmailsCount={sentCount}
+    />
+  );
+}
+
+EmailPendingInvitations.propTypes = {
+  metadataURL: PropTypes.string.isRequired,
+  previewURL: PropTypes.string.isRequired,
+  sendURL: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/indico/modules/events/registration/client/js/components/EmailPendingInvitationsButton.jsx
+++ b/indico/modules/events/registration/client/js/components/EmailPendingInvitationsButton.jsx
@@ -1,0 +1,51 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import emailMetadataURL from 'indico-url:event_registration.api_invitations_reminders_metadata';
+import emailPreviewURL from 'indico-url:event_registration.api_invitations_reminders_preview';
+import emailSendURL from 'indico-url:event_registration.api_invitations_reminders_send';
+
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+
+import {Translate} from 'indico/react/i18n';
+
+import EmailPendingInvitations from './EmailPendingInvitations';
+
+export default function EmailPendingInvitationsButton({eventId, regformId, hasPendingInvitations}) {
+  const [open, setOpen] = useState(false);
+  const metadataURL = emailMetadataURL({event_id: eventId, reg_form_id: regformId});
+  const previewURL = emailPreviewURL({event_id: eventId, reg_form_id: regformId});
+  const sendURL = emailSendURL({event_id: eventId, reg_form_id: regformId});
+
+  return (
+    <>
+      <button
+        type="button"
+        className="i-button icon-mail"
+        disabled={!hasPendingInvitations}
+        onClick={() => setOpen(true)}
+      >
+        <Translate>Send reminders</Translate>
+      </button>
+      {open && (
+        <EmailPendingInvitations
+          metadataURL={metadataURL}
+          previewURL={previewURL}
+          sendURL={sendURL}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+EmailPendingInvitationsButton.propTypes = {
+  eventId: PropTypes.number.isRequired,
+  regformId: PropTypes.number.isRequired,
+  hasPendingInvitations: PropTypes.bool.isRequired,
+};

--- a/indico/modules/events/registration/client/js/invitations.js
+++ b/indico/modules/events/registration/client/js/invitations.js
@@ -8,8 +8,17 @@
 /* eslint-disable import/unambiguous */
 /* global handleAjaxError:false */
 
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import EmailPendingInvitationsButton from './components/EmailPendingInvitationsButton';
+
 (function(global) {
-  global.setupInvitationPage = function setupInvitationPage() {
+  global.setupInvitationPage = function setupInvitationPage({
+    eventId,
+    regformId,
+    hasPendingInvitations,
+  }) {
     $('#invitation-list').on('indico:confirmed', '.js-invitation-action', function(evt) {
       evt.preventDefault();
 
@@ -21,6 +30,11 @@
         error: handleAjaxError,
         success(data) {
           $('#invitation-list').html(data.invitation_list);
+          renderEmailInvitationsBtn({
+            eventId,
+            regformId,
+            hasPendingInvitations: data.has_pending_invitations,
+          });
         },
       });
     });
@@ -29,8 +43,27 @@
       onClose(data) {
         if (data) {
           $('#invitation-list').html(data.invitation_list);
+          renderEmailInvitationsBtn({
+            eventId,
+            regformId,
+            hasPendingInvitations: data.has_pending_invitations,
+          });
         }
       },
     });
+
+    renderEmailInvitationsBtn({eventId, regformId, hasPendingInvitations});
   };
+
+  function renderEmailInvitationsBtn({eventId, regformId, hasPendingInvitations}) {
+    const container = document.getElementById('email-pending-invitations-container');
+    ReactDOM.render(
+      <EmailPendingInvitationsButton
+        eventId={eventId}
+        regformId={regformId}
+        hasPendingInvitations={hasPendingInvitations}
+      />,
+      container
+    );
+  }
 })(window);

--- a/indico/modules/events/registration/controllers/management/invitations.py
+++ b/indico/modules/events/registration/controllers/management/invitations.py
@@ -5,19 +5,33 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from flask import flash, request
+from flask import flash, jsonify, request, session
+from marshmallow import fields
 from sqlalchemy.orm import joinedload
+from webargs import validate
+from webargs.flaskparser import abort
+from werkzeug.exceptions import BadRequest
 
 from indico.core.db import db
+from indico.core.notifications import make_email, send_email
 from indico.modules.events.registration.controllers.management import RHManageRegFormBase
 from indico.modules.events.registration.forms import ImportInvitationsForm, InvitationFormExisting, InvitationFormNew
 from indico.modules.events.registration.models.invitations import InvitationState, RegistrationInvitation
 from indico.modules.events.registration.util import create_invitation, import_invitations_from_csv
 from indico.modules.events.registration.views import WPManageRegistration
 from indico.util.i18n import ngettext
+from indico.util.marshmallow import LowercaseString, not_empty
+from indico.util.placeholders import get_sorted_placeholders, replace_placeholders
+from indico.web.args import use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.forms.base import FormDefaults
 from indico.web.util import jsonify_data, jsonify_template
+
+
+def _query_pending_invitations(regform):
+    return (RegistrationInvitation.query.with_parent(regform)
+            .filter(RegistrationInvitation.state == InvitationState.pending)
+            .all())
 
 
 def _query_invitation_list(regform):
@@ -40,8 +54,10 @@ class RHRegistrationFormInvitations(RHManageRegFormBase):
 
     def _process(self):
         invitations = _query_invitation_list(self.regform)
+        has_pending_invitations = any(invitation.state == InvitationState.pending for invitation in invitations)
         return WPManageRegistration.render_template('management/regform_invitations.html', self.event,
-                                                    regform=self.regform, invitations=invitations)
+                                                    regform=self.regform, invitations=invitations,
+                                                    has_pending_invitations=has_pending_invitations)
 
 
 class RHRegistrationFormInvite(RHManageRegFormBase):
@@ -64,6 +80,75 @@ class RHRegistrationFormInvite(RHManageRegFormBase):
                            num).format(n=num), 'success')
             return jsonify_data(invitation_list=_render_invitation_list(self.regform))
         return jsonify_template('events/registration/management/regform_invite.html', regform=self.regform, form=form)
+
+
+class RHRegistrationFormRemindersSend(RHManageRegFormBase):
+    """Send a reminder to pending invitees."""
+
+    @use_kwargs({
+        'from_address': fields.String(required=True, validate=not_empty),
+        'body': fields.String(required=True, validate=not_empty),
+        'subject': fields.String(required=True, validate=not_empty),
+        'bcc_addresses': fields.List(LowercaseString(validate=validate.Email())),
+        'copy_for_sender': fields.Bool(load_default=False),
+    })
+    def _process(self, from_address, body, subject, bcc_addresses, copy_for_sender):
+        if from_address not in self.event.get_allowed_sender_emails():
+            abort(422, messages={'from_address': ['Invalid sender address']})
+        invitations = _query_pending_invitations(self.regform)
+        for invitation in invitations:
+            email_body = replace_placeholders('registration-invitation-reminder-email', body, event=self.event,
+                                              invitation=invitation)
+            email_subject = replace_placeholders('registration-invitation-reminder-email', subject,
+                                                 event=self.event, invitation=invitation)
+            bcc = {session.user.email} if copy_for_sender else set()
+            bcc.update(bcc_addresses)
+            with self.event.force_event_locale():
+                tpl = get_template_module('emails/custom.html', subject=email_subject, body=email_body)
+                email = make_email(to_list=invitation.email, bcc_list=bcc, from_address=from_address,
+                                   template=tpl, html=True)
+            send_email(email, self.event, 'Registration')
+        return jsonify(count=len(invitations))
+
+
+class RHRegistrationFormRemindersMetadata(RHManageRegFormBase):
+    """Get the metadata for registration reminder emails."""
+
+    def _process(self):
+        with self.event.force_event_locale():
+            tpl = get_template_module('events/registration/emails/registration_reminder_default.html', event=self.event)
+            body = tpl.get_html_body()
+            subject = tpl.get_subject()
+        placeholders = get_sorted_placeholders('registration-invitation-reminder-email')
+        invitations = _query_pending_invitations(self.regform)
+        recipients = sorted(invitation.email for invitation in invitations)
+        return jsonify({
+            'senders': list(self.event.get_allowed_sender_emails().items()),
+            'recipients': recipients,
+            'body': body,
+            'subject': subject,
+            'placeholders': [p.serialize() for p in placeholders],
+        })
+
+
+class RHRegistrationFormRemindersPreview(RHManageRegFormBase):
+    """Preview a registration reminder email."""
+
+    @use_kwargs({
+        'body': fields.String(required=True),
+        'subject': fields.String(required=True),
+    })
+    def _process(self, body, subject):
+        invitations = _query_pending_invitations(self.regform)
+        if not invitations:
+            raise BadRequest('No pending invitations')
+        email_body = replace_placeholders('registration-invitation-reminder-email', body, event=self.event,
+                                          invitation=invitations[0])
+        email_subject = replace_placeholders('registration-invitation-reminder-email', subject, event=self.event,
+                                             invitation=invitations[0])
+        tpl = get_template_module('events/persons/emails/custom_email.html', email_subject=email_subject,
+                                  email_body=email_body)
+        return jsonify(subject=tpl.get_subject(), body=tpl.get_body())
 
 
 class RHRegistrationFormInviteImport(RHManageRegFormBase):

--- a/indico/modules/events/registration/placeholders/invitations.py
+++ b/indico/modules/events/registration/placeholders/invitations.py
@@ -17,7 +17,7 @@ class FirstNamePlaceholder(Placeholder):
     description = _('First name of the person')
 
     @classmethod
-    def render(cls, invitation):
+    def render(cls, invitation, **kwargs):
         return invitation.first_name
 
 
@@ -26,8 +26,17 @@ class LastNamePlaceholder(Placeholder):
     description = _('Last name of the person')
 
     @classmethod
-    def render(cls, invitation):
+    def render(cls, invitation, **kwargs):
         return invitation.last_name
+
+
+class EmailPlaceholder(Placeholder):
+    name = 'email'
+    description = _('Email of the person')
+
+    @classmethod
+    def render(cls, invitation, **kwargs):
+        return invitation.email
 
 
 class InvitationLinkPlaceholder(Placeholder):
@@ -36,6 +45,6 @@ class InvitationLinkPlaceholder(Placeholder):
     required = True
 
     @classmethod
-    def render(cls, invitation):
+    def render(cls, invitation, **kwargs):
         url = url_for('.display_regform', invitation.locator.uuid, _external=True)
         return Markup('<a href="{0}">{0}</a>'.format(url))

--- a/indico/modules/events/registration/templates/emails/registration_reminder_default.html
+++ b/indico/modules/events/registration/templates/emails/registration_reminder_default.html
@@ -1,0 +1,19 @@
+{% macro get_subject() -%}
+    {% trans %}Reminder to register{% endtrans %}
+{%- endmacro %}
+
+{% macro get_html_body() -%}
+    {% trans %}Dear {first_name},{% endtrans %}<br>
+    <br>
+    {% trans %}This is a reminder to register for the following event:{% endtrans %}<br>
+    <strong>{{ event.title }}</strong><br><br>
+
+    {% trans %}You can register (or decline the invitation) by using this link:{% endtrans %}<br>
+    {invitation_link}
+
+    {% if session %}
+        <br><br>
+        {% trans %}Best regards{% endtrans %}<br>
+        {{ session.user.full_name }}
+    {% endif %}
+{%- endmacro %}

--- a/indico/modules/events/registration/templates/management/regform_invitations.html
+++ b/indico/modules/events/registration/templates/management/regform_invitations.html
@@ -49,6 +49,16 @@
                     </button>
                 </div>
             </div>
+            <div class="section">
+                <div class="icon icon-mail"></div>
+                <div class="text">
+                    <div class="label">
+                        {% trans %}Remind pending invitees{% endtrans %}
+                    </div>
+                    {% trans %}Send email reminders to users who have not yet registered.{% endtrans %}
+                </div>
+                <div class="toolbar" id="email-pending-invitations-container"></div>
+            </div>
         </div>
     {% endif %}
 
@@ -57,6 +67,10 @@
     </div>
 
     <script>
-        setupInvitationPage();
+        setupInvitationPage({
+            eventId: {{ event.id | tojson }},
+            regformId: {{ regform.id | tojson }},
+            hasPendingInvitations: {{ has_pending_invitations | tojson }}
+        });
     </script>
 {% endblock %}

--- a/indico/modules/events/surveys/__init__.py
+++ b/indico/modules/events/surveys/__init__.py
@@ -104,10 +104,12 @@ class SurveysPermission(ManagementPermission):
 
 @signals.core.get_placeholders.connect_via('survey-link-email')
 def _get_placeholders(sender, event, survey, **kwargs):
-    from indico.modules.events.surveys import placeholders
-    yield placeholders.EventTitlePlaceholder
-    yield placeholders.SurveyTitlePlaceholder
-    yield placeholders.SurveyLinkPlaceholder
+    from indico.modules.events import placeholders as event_placeholders
+    from indico.modules.events.surveys import placeholders as survey_placeholders
+
+    yield event_placeholders.EventTitlePlaceholder
+    yield survey_placeholders.SurveyTitlePlaceholder
+    yield survey_placeholders.SurveyLinkPlaceholder
 
 
 @signals.event_management.get_cloners.connect

--- a/indico/modules/events/surveys/placeholders.py
+++ b/indico/modules/events/surveys/placeholders.py
@@ -12,15 +12,6 @@ from indico.util.placeholders import Placeholder
 from indico.web.flask.util import url_for
 
 
-class EventTitlePlaceholder(Placeholder):
-    name = 'event_title'
-    description = _('The title of the event')
-
-    @classmethod
-    def render(cls, event, survey, **kwargs):
-        return event.title
-
-
 class SurveyTitlePlaceholder(Placeholder):
     name = 'survey_title'
     description = _('The title of the survey')


### PR DESCRIPTION
Closes #5579 

Adds a new section on the invitations page to email invitees who have not yet registered.
Uses the new React `<EmailDialog />` component.

The button is disabled if there are no pending invitations.

![image](https://user-images.githubusercontent.com/8739637/216974721-31bed722-a211-4574-ac98-edd7fb854120.png)
