### PR TITLE
Introduce ACLs for menu entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -215,6 +215,8 @@ Improvements
   (:pr:`5784`)
 - Allow admins to change the password of local accounts (:pr:`5789`, thanks
   :user:`omegak`)
+- Menu entries now have full ACLs. This can be used to created pages that are restricted
+  to certain users, groups, registrations, or roles. (:pr:`5670`, thanks :user:`kewisch`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Improvements
 ^^^^^^^^^^^^
 
 - Invalidate password reset links once the password has been changed (:pr:`5878`)
+- Add full ACLs for custom conference menu items, instead of just being able to
+  restrict them to speakers or registrants (:pr:`5670`, thanks :user:`kewisch`)
 
 Bugfixes
 ^^^^^^^^
@@ -215,8 +217,6 @@ Improvements
   (:pr:`5784`)
 - Allow admins to change the password of local accounts (:pr:`5789`, thanks
   :user:`omegak`)
-- Menu entries now have full ACLs. This can be used to created pages that are restricted
-  to certain users, groups, registrations, or roles. (:pr:`5670`, thanks :user:`kewisch`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/core/db/sqlalchemy/protection.py
+++ b/indico/core/db/sqlalchemy/protection.py
@@ -93,7 +93,7 @@ class ProtectionMixin:
             )
 
     @declared_attr
-    def speaker_allowed(cls):
+    def speakers_can_access(cls):
         if cls.allow_speakers:
             return db.Column(
                 db.Boolean,
@@ -275,7 +275,7 @@ class ProtectionMixin:
         """Check whether speakers can access this protected object."""
         return (
             self.allow_speakers  # The class supports allowing speakers
-            and self.speaker_allowed  # The database says speakers are allowed here
+            and self.speakers_can_access  # The database says speakers are allowed here
             and getattr(self, 'event', None)  # We actually have an event!
             and self.event.is_user_speaker(user)
         )

--- a/indico/migrations/versions/20230306_0905_e47fc6634291_add_menu_entry_acls.py
+++ b/indico/migrations/versions/20230306_0905_e47fc6634291_add_menu_entry_acls.py
@@ -1,0 +1,350 @@
+"""Add menu entry ACLs
+
+Revision ID: e47fc6634291
+Revises: 5d05eda06776
+Create Date: 2023-03-06 09:05:08.848298
+"""
+
+from enum import Enum
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import expression
+
+from indico.core.db.sqlalchemy import PyIntEnum
+
+
+# revision identifiers, used by Alembic.
+revision = 'e47fc6634291'
+down_revision = '5d05eda06776'
+branch_labels = None
+depends_on = None
+
+
+class _ProtectionMode(int, Enum):
+    public = 0
+    inheriting = 1
+    protected = 2
+
+
+class _PrincipalType(int, Enum):
+    user = 1
+    local_group = 2
+    multipass_group = 3
+    email = 4
+    network = 5
+    event_role = 6
+    category_role = 7
+    registration_form = 8
+
+
+class _MenuEntryAccess(int, Enum):
+    everyone = 1
+    registered_participants = 2
+    speakers = 3
+
+
+class _MenuEntryType(int, Enum):
+    separator = 1
+    internal_link = 2
+    user_link = 3
+    plugin_link = 4
+    page = 5
+
+
+def _upgrade_access_data():
+    """
+    Upgrade the access column to protection_mode, speaker_allowed, and the principals.
+
+    Here is the mapping:
+        access                  || protection_mode | speaker_allowed | menu_entry_principals
+        ========================++=================+=================+==========================
+        everyone                ||  inheriting     |   false         | none set
+        ------------------------++-----------------+-----------------+--------------------------
+        registered_participants ||  protected      |   false         | One reg pincipal for each
+                                ||                 |                 | registration in the event
+        ------------------------++-----------------+-----------------+--------------------------
+        speakers                ||  protected      |   true          | none set
+    """
+    conn = op.get_bind()
+
+    # Update access mode to protected for registered_participants and speakers
+    conn.execute(
+        sa.text(
+            '''
+                    UPDATE events.menu_entries
+                       SET protection_mode = :protected
+                     WHERE access != :everyone
+            '''
+        ),
+        protected=_ProtectionMode.protected.value,
+        everyone=_MenuEntryAccess.everyone.value,
+    )
+
+    # Migrate "Registered participants" to principal entries for each registration form
+    conn.execute(
+        sa.text(
+            '''
+               INSERT INTO events.menu_entries_principals(menu_entry_id, type, registration_form_id)
+                    SELECT me.id AS menu_entry_id,
+                           :principal_type AS type,
+                           frm.id AS registration_form_id
+                      FROM events.menu_entries me
+          RIGHT OUTER JOIN event_registration.forms frm ON me.event_id = frm.event_id
+                     WHERE me.type NOT IN (:internal_link, :separator)
+                       AND me.access = :registered
+            '''
+        ),
+        principal_type=_PrincipalType.registration_form.value,
+        internal_link=_MenuEntryType.internal_link.value,
+        separator=_MenuEntryType.separator.value,
+        registered=_MenuEntryAccess.registered_participants.value,
+    )
+
+    # Migrate "Speaker" access to allowing speaker access, unless we've already provided broader
+    # access for registered participants
+    conn.execute(
+        sa.text(
+            '''
+                    UPDATE events.menu_entries
+                       SET speaker_allowed = TRUE
+                     WHERE access = :speakers
+                       AND id NOT IN (
+                         SELECT menu_entry_id AS id
+                           FROM events.menu_entries_principals mep
+                          WHERE mep.type = :regform
+                       )
+            '''
+        ),
+        speakers=_MenuEntryAccess.speakers.value,
+        regform=_PrincipalType.registration_form.value,
+    )
+
+
+def _downgrade_access_data():
+    """
+    Downgrade the protection_mode, speaker_allowed and principals to the access column. This isn't
+    lossless given the new feature is more fine-grained, but best effort.
+
+    Here is the mapping:
+
+         protection_mode | speaker_allowed | menu_entry_principals     || access
+        =================+=================+===========================++========================
+          protected      | true            | doesn't contain regform   ||  speakers
+                         |                 | principals                ||
+        -----------------+-----------------+---------------------------++------------------------
+          inheriting     |                 | doesn't contain regform   ||  speakers
+        parent=protected | parent=true     | principals                ||
+        -----------------+-----------------+---------------------------++------------------------
+          protected      | regardless      | at least one regform      ||  registered_participants
+                         |                 | principal                 ||
+        -----------------+-----------------+---------------------------++------------------------
+          inheriting     | regardless      | parent has at least one   ||  registered_participants
+                         |                 | regform principal         ||
+        -----------------+-----------------+---------------------------++------------------------
+          protected      | false           | doesn't contain regform   ||  everyone
+                         |                 | principals                ||  (no good mapping)
+        -----------------+-----------------+---------------------------++------------------------
+          inheriting     | false           | doesn't contain regform   ||  everyone
+                         |                 | principals                ||
+        -----------------+-----------------+---------------------------++------------------------
+          all other combinations                                       ||  everyone
+                                                                       ||  (no good mapping)
+        -----------------+-----------------+---------------------------++------------------------
+    """
+    conn = op.get_bind()
+
+    # The server_default is set to give everyone access to all menu entries. We need to restrict
+    # those appropriately now. Start with locking down for speakers, and then open up to registered
+    # participants if applicable
+
+    # Any menu entry that is accessible to speakers should only be open to speakers. If it is also
+    # open to registrants, we'll expand this later on.
+    conn.execute(
+        sa.text(
+            '''
+                    UPDATE events.menu_entries
+                       SET access = :speakers
+                     WHERE speaker_allowed = TRUE
+                       AND protection_mode = :protected
+            '''
+        ),
+        speakers=_MenuEntryAccess.speakers.value,
+        protected=_ProtectionMode.protected.value
+    )
+
+    # Inheriting menu entries with the parent accessible to speakers should be only open to
+    # speakers. Again expanding to others later on.
+    conn.execute(
+        sa.text(
+            '''
+                    UPDATE events.menu_entries
+                       SET access = :speakers
+                     WHERE menu_entries.id IN (
+                                      SELECT me.id
+                                        FROM events.menu_entries me
+                             LEFT OUTER JOIN events.menu_entries parent_me ON me.parent_id = parent_me.id
+                                       WHERE me.type NOT IN (:internal_link, :separator)
+                                         AND me.parent_id IS NOT NULL
+                                         AND me.protection_mode = :inheriting
+                                         AND parent_me.protection_mode = :protected
+                                         AND parent_me.speaker_allowed = TRUE
+                    )
+
+            '''
+        ),
+        speakers=_MenuEntryAccess.speakers.value,
+        internal_link=_MenuEntryType.internal_link.value,
+        separator=_MenuEntryType.separator.value,
+        inheriting=_ProtectionMode.inheriting.value,
+        protected=_ProtectionMode.protected.value,
+    )
+
+    # Any menu entry that has a registration attached to it should be registered participants only,
+    # provided its protection mode is set to protected
+    conn.execute(
+        sa.text(
+            '''
+                    UPDATE events.menu_entries
+                       SET access = :registered
+                     WHERE menu_entries.id IN (
+                             SELECT menu_entry_id
+                               FROM events.menu_entries_principals
+                              WHERE type = :regform
+                           )
+                       AND protection_mode = :protected
+            '''
+        ),
+        registered=_MenuEntryAccess.registered_participants.value,
+        regform=_PrincipalType.registration_form.value,
+        protected=_ProtectionMode.protected.value,
+    )
+
+    # Menu entries that are inheriting with their parent set to protected and containing
+    # registrations get the same treatment
+    conn.execute(
+        sa.text(
+            '''
+                    UPDATE events.menu_entries
+                       SET access = :registered
+                     WHERE id IN (
+                                      SELECT me.id
+                                        FROM events.menu_entries me
+                             LEFT OUTER JOIN events.menu_entries parent_me ON me.parent_id = parent_me.id
+                            RIGHT OUTER JOIN events.menu_entries_principals mep ON mep.menu_entry_id = parent_me.id
+                                       WHERE me.type NOT IN (:internal_link, :separator)
+                                         AND me.parent_id IS NOT NULL
+                                         AND me.protection_mode = :inheriting
+                                         AND parent_me.protection_mode = :protected
+                                         AND mep.type = :regform
+                           )
+            '''
+        ),
+        registered=_MenuEntryAccess.registered_participants.value,
+        internal_link=_MenuEntryType.internal_link.value,
+        separator=_MenuEntryType.separator.value,
+        inheriting=_ProtectionMode.inheriting.value,
+        protected=_ProtectionMode.protected.value,
+        regform=_PrincipalType.registration_form.value,
+    )
+
+
+def upgrade():
+    # Principals table
+    op.create_table(
+        'menu_entries_principals',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('menu_entry_id', sa.Integer(), nullable=False),
+        sa.Column('type', PyIntEnum(_PrincipalType, exclude_values={_PrincipalType.email, _PrincipalType.network}), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('local_group_id', sa.Integer(), nullable=True),
+        sa.Column('mp_group_provider', sa.String(), nullable=True),
+        sa.Column('mp_group_name', sa.String(), nullable=True),
+        sa.Column('event_role_id', sa.Integer(), nullable=True),
+        sa.Column('category_role_id', sa.Integer(), nullable=True),
+        sa.Column('registration_form_id', sa.Integer(), nullable=True),
+        sa.CheckConstraint(
+            'type != 1 OR (category_role_id IS NULL AND event_role_id IS NULL AND local_group_id IS NULL AND mp_group_name IS NULL AND mp_group_provider IS NULL AND registration_form_id IS NULL AND user_id IS NOT NULL)',
+            name=op.f('ck_menu_entries_principals_valid_user'),
+        ),
+        sa.CheckConstraint(
+            'type != 2 OR (category_role_id IS NULL AND event_role_id IS NULL AND mp_group_name IS NULL AND mp_group_provider IS NULL AND registration_form_id IS NULL AND user_id IS NULL AND local_group_id IS NOT NULL)',
+            name=op.f('ck_menu_entries_principals_valid_local_group'),
+        ),
+        sa.CheckConstraint(
+            'type != 3 OR (category_role_id IS NULL AND event_role_id IS NULL AND local_group_id IS NULL AND registration_form_id IS NULL AND user_id IS NULL AND mp_group_name IS NOT NULL AND mp_group_provider IS NOT NULL)',
+            name=op.f('ck_menu_entries_principals_valid_multipass_group'),
+        ),
+        sa.CheckConstraint(
+            'type != 6 OR (category_role_id IS NULL AND local_group_id IS NULL AND mp_group_name IS NULL AND mp_group_provider IS NULL AND registration_form_id IS NULL AND user_id IS NULL AND event_role_id IS NOT NULL)',
+            name=op.f('ck_menu_entries_principals_valid_event_role'),
+        ),
+        sa.CheckConstraint(
+            'type != 7 OR (event_role_id IS NULL AND local_group_id IS NULL AND mp_group_name IS NULL AND mp_group_provider IS NULL AND registration_form_id IS NULL AND user_id IS NULL AND category_role_id IS NOT NULL)',
+            name=op.f('ck_menu_entries_principals_valid_category_role'),
+        ),
+        sa.CheckConstraint(
+            'type != 8 OR (category_role_id IS NULL AND event_role_id IS NULL AND local_group_id IS NULL AND mp_group_name IS NULL AND mp_group_provider IS NULL AND user_id IS NULL AND registration_form_id IS NOT NULL)',
+            name=op.f('ck_menu_entries_principals_valid_registration_form'),
+        ),
+        sa.ForeignKeyConstraint(['category_role_id'], ['categories.roles.id'], name=op.f('fk_menu_entries_principals_category_role_id_roles')),
+        sa.ForeignKeyConstraint(['event_role_id'], ['events.roles.id'], name=op.f('fk_menu_entries_principals_event_role_id_roles')),
+        sa.ForeignKeyConstraint(['local_group_id'], ['users.groups.id'], name=op.f('fk_menu_entries_principals_local_group_id_groups')),
+        sa.ForeignKeyConstraint(['menu_entry_id'], ['events.menu_entries.id'], name=op.f('fk_menu_entries_principals_menu_entry_id_menu_entries')),
+        sa.ForeignKeyConstraint(['registration_form_id'], ['event_registration.forms.id'], name=op.f('fk_menu_entries_principals_registration_form_id_forms')),
+        sa.ForeignKeyConstraint(['user_id'], ['users.users.id'], name=op.f('fk_menu_entries_principals_user_id_users')),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_menu_entries_principals')),
+        schema='events',
+    )
+    op.create_index(op.f('ix_menu_entries_principals_category_role_id'), 'menu_entries_principals', ['category_role_id'], unique=False, schema='events')
+    op.create_index(op.f('ix_menu_entries_principals_event_role_id'), 'menu_entries_principals', ['event_role_id'], unique=False, schema='events')
+    op.create_index(op.f('ix_menu_entries_principals_local_group_id'), 'menu_entries_principals', ['local_group_id'], unique=False, schema='events')
+    op.create_index(op.f('ix_menu_entries_principals_mp_group_provider_mp_group_name'), 'menu_entries_principals', ['mp_group_provider', 'mp_group_name'], unique=False, schema='events')
+    op.create_index(op.f('ix_menu_entries_principals_registration_form_id'), 'menu_entries_principals', ['registration_form_id'], unique=False, schema='events')
+    op.create_index(op.f('ix_menu_entries_principals_user_id'), 'menu_entries_principals', ['user_id'], unique=False, schema='events')
+    op.create_index('ix_uq_menu_entries_principals_local_group', 'menu_entries_principals', ['local_group_id', 'menu_entry_id'], unique=True, schema='events', postgresql_where=sa.text('type = 2'))
+    op.create_index(
+        'ix_uq_menu_entries_principals_mp_group', 'menu_entries_principals', ['mp_group_provider', 'mp_group_name', 'menu_entry_id'], unique=True, schema='events', postgresql_where=sa.text('type = 3')
+    )
+    op.create_index('ix_uq_menu_entries_principals_user', 'menu_entries_principals', ['user_id', 'menu_entry_id'], unique=True, schema='events', postgresql_where=sa.text('type = 1'))
+
+    # Menu entries columns - protection_mode, speaker_allowed
+    op.add_column(
+        'menu_entries',
+        sa.Column('protection_mode', PyIntEnum(_ProtectionMode, exclude_values={_ProtectionMode.public}), nullable=False, server_default=str(_ProtectionMode.inheriting.value)),
+        schema='events',
+    )
+    op.add_column('menu_entries', sa.Column('speaker_allowed', sa.Boolean(), nullable=False, server_default=expression.false()), schema='events')
+    op.alter_column('menu_entries', 'speaker_allowed', server_default=None, schema='events')
+    op.alter_column('menu_entries', 'protection_mode', server_default=None, schema='events')
+
+    # Migrate data
+    _upgrade_access_data()
+
+    # Clear access column
+    op.drop_column('menu_entries', 'access', schema='events')
+
+
+def downgrade():
+    # Add back access column
+    op.add_column('menu_entries', sa.Column('access', sa.SMALLINT(), autoincrement=False, nullable=False, server_default=str(_MenuEntryAccess.everyone.value)), schema='events')
+    op.alter_column('menu_entries', 'access', server_default=None, schema='events')
+
+    # Unmigrate data
+    _downgrade_access_data()
+
+    # Drop menu entries columns - protection_mode, speaker_allowed
+    op.drop_column('menu_entries', 'speaker_allowed', schema='events')
+    op.drop_column('menu_entries', 'protection_mode', schema='events')
+
+    # Drop menu_entries_principals and their indices
+    op.drop_index('ix_uq_menu_entries_principals_user', table_name='menu_entries_principals', schema='events', postgresql_where=sa.text('type = 1'))
+    op.drop_index('ix_uq_menu_entries_principals_mp_group', table_name='menu_entries_principals', schema='events', postgresql_where=sa.text('type = 3'))
+    op.drop_index('ix_uq_menu_entries_principals_local_group', table_name='menu_entries_principals', schema='events', postgresql_where=sa.text('type = 2'))
+    op.drop_index(op.f('ix_menu_entries_principals_user_id'), table_name='menu_entries_principals', schema='events')
+    op.drop_index(op.f('ix_menu_entries_principals_registration_form_id'), table_name='menu_entries_principals', schema='events')
+    op.drop_index(op.f('ix_menu_entries_principals_mp_group_provider_mp_group_name'), table_name='menu_entries_principals', schema='events')
+    op.drop_index(op.f('ix_menu_entries_principals_local_group_id'), table_name='menu_entries_principals', schema='events')
+    op.drop_index(op.f('ix_menu_entries_principals_event_role_id'), table_name='menu_entries_principals', schema='events')
+    op.drop_index(op.f('ix_menu_entries_principals_category_role_id'), table_name='menu_entries_principals', schema='events')
+    op.drop_table('menu_entries_principals', schema='events')

--- a/indico/migrations/versions/20230802_1500_e47fc6634291_add_menu_entry_acls.py
+++ b/indico/migrations/versions/20230802_1500_e47fc6634291_add_menu_entry_acls.py
@@ -1,7 +1,7 @@
 """Add menu entry ACLs
 
 Revision ID: e47fc6634291
-Revises: 5d05eda06776
+Revises: aba7935f9226
 Create Date: 2023-03-06 09:05:08.848298
 """
 
@@ -16,7 +16,7 @@ from indico.core.db.sqlalchemy import PyIntEnum
 
 # revision identifiers, used by Alembic.
 revision = 'e47fc6634291'
-down_revision = '5d05eda06776'
+down_revision = 'aba7935f9226'
 branch_labels = None
 depends_on = None
 

--- a/indico/modules/categories/models/roles.py
+++ b/indico/modules/categories/models/roles.py
@@ -67,6 +67,7 @@ class CategoryRole(db.Model):
     # - in_contribution_acls (ContributionPrincipal.category_role)
     # - in_event_acls (EventPrincipal.category_role)
     # - in_event_settings_acls (EventSettingPrincipal.category_role)
+    # - in_menuentry_acls (MenuEntryPrincipal.category_role)
     # - in_session_acls (SessionPrincipal.category_role)
     # - in_track_acls (TrackPrincipal.category_role)
 

--- a/indico/modules/categories/models/roles.py
+++ b/indico/modules/categories/models/roles.py
@@ -67,7 +67,7 @@ class CategoryRole(db.Model):
     # - in_contribution_acls (ContributionPrincipal.category_role)
     # - in_event_acls (EventPrincipal.category_role)
     # - in_event_settings_acls (EventSettingPrincipal.category_role)
-    # - in_menuentry_acls (MenuEntryPrincipal.category_role)
+    # - in_menu_entry_acls (MenuEntryPrincipal.category_role)
     # - in_session_acls (SessionPrincipal.category_role)
     # - in_track_acls (TrackPrincipal.category_role)
 

--- a/indico/modules/events/contributions/lists_test.py
+++ b/indico/modules/events/contributions/lists_test.py
@@ -5,40 +5,18 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-import pytest
-
 from indico.modules.events.contributions.lists import ContributionListGenerator
 from indico.modules.events.contributions.models.persons import AuthorType, ContributionPersonLink
 from indico.modules.events.models.persons import EventPerson
-from indico.modules.events.registration.models.forms import RegistrationForm
-from indico.modules.events.registration.models.registrations import Registration, RegistrationState
 
 
-@pytest.fixture
-def create_registration(dummy_event):
-    """Return a callable that lets you create a contribution."""
-
-    def _create_registration(user, regform, **kwargs):
-        return Registration(
-            first_name='Guinea',
-            last_name='Pig',
-            checked_in=True,
-            state=RegistrationState.complete,
-            currency='USD',
-            email=user.email,
-            user=user,
-            registration_form=regform,
-            **kwargs
-        )
-
-    return _create_registration
+pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
 
 
-def test_filter_contrib_entries(app, db, dummy_event, create_user, create_contribution, create_registration):
+def test_filter_contrib_entries(app, dummy_event, create_user, create_contribution, dummy_regform, create_registration):
     registered_user = create_user(1)
     registered_speaker = create_user(2)
     unregistered_user = create_user(3)
-    dummy_regform = RegistrationForm(event=dummy_event, title='Registration Form', currency='USD')
     dummy_event.registrations.append(create_registration(registered_user, dummy_regform))
     dummy_event.registrations.append(create_registration(registered_speaker, dummy_regform))
     registered_speaker_contribution = create_contribution(dummy_event, 'Registered Speaker', person_links=[

--- a/indico/modules/events/controllers/display.py
+++ b/indico/modules/events/controllers/display.py
@@ -58,7 +58,11 @@ class RHDisplayEvent(RHDisplayEventBase):
         if self.event.type_ == EventType.conference:
             if self.theme_override:
                 return redirect(url_for('timetable.timetable', self.event, view=self.theme_id))
-            elif self.event.default_page and not self.force_overview:
+            elif (
+                not self.force_overview and
+                self.event.default_page and
+                self.event.default_page.menu_entry.can_access(session.user)
+            ):
                 return self._display_conference_page()
             else:
                 return self._display_conference()

--- a/indico/modules/events/export.yaml
+++ b/indico/modules/events/export.yaml
@@ -222,12 +222,10 @@ export:
       - event_role_id
 
   MenuEntryPrincipal:
-    skipif: ROW.type.name not in ('user', 'group', 'category_role', 'event_role', 'registration_form')
+    skipif: ROW.type.name not in ('user', 'event_role', 'registration_form')
     fks_out:
       - registration_form_id
-      - category_role_id
       - event_role_id
-
 
   # misc stuff
   EventLogEntry: {}
@@ -485,6 +483,7 @@ import:
     ContributionPrincipal.user_id: skip
     AttachmentPrincipal.user_id: skip
     AttachmentFolderPrincipal.user_id: skip
+    MenuEntryPrincipal.user_id: skip
     AbstractComment.user_id: skip
     AbstractReview.user_id: skip
     PaperCompetence.user_id: skip
@@ -493,7 +492,6 @@ import:
     Contribution.paper_content_reviewers.prop.secondary.c.user_id: skip
     Contribution.paper_layout_reviewers.prop.secondary.c.user_id: skip
     Contribution.paper_judges.prop.secondary.c.user_id: skip
-    MenuEntryPrincipal.user_id: skip
     # run custom code
     SurveySubmission.user_id: is_anonymous = True
 

--- a/indico/modules/events/export.yaml
+++ b/indico/modules/events/export.yaml
@@ -397,6 +397,8 @@ export:
   # conference menu
   MenuEntry:
     skipif: ROW.type.name == 'plugin_link'
+    fks:
+      - MenuEntryPrincipal.menu_entry_id
 
   EventPage: {}
 

--- a/indico/modules/events/export.yaml
+++ b/indico/modules/events/export.yaml
@@ -221,6 +221,14 @@ export:
     fks_out:
       - event_role_id
 
+  MenuEntryPrincipal:
+    skipif: ROW.type.name not in ('user', 'group', 'category_role', 'event_role', 'registration_form')
+    fks_out:
+      - registration_form_id
+      - category_role_id
+      - event_role_id
+
+
   # misc stuff
   EventLogEntry: {}
   EventReminder: {}
@@ -485,6 +493,7 @@ import:
     Contribution.paper_content_reviewers.prop.secondary.c.user_id: skip
     Contribution.paper_layout_reviewers.prop.secondary.c.user_id: skip
     Contribution.paper_judges.prop.secondary.c.user_id: skip
+    MenuEntryPrincipal.user_id: skip
     # run custom code
     SurveySubmission.user_id: is_anonymous = True
 

--- a/indico/modules/events/layout/__init__.py
+++ b/indico/modules/events/layout/__init__.py
@@ -12,6 +12,7 @@ from indico.core import signals
 from indico.core.logger import Logger
 from indico.core.settings.converters import EnumConverter
 from indico.modules.events.features.base import EventFeature
+from indico.modules.events.layout.models.principals import MenuEntryPrincipal
 from indico.modules.events.models.events import EventType
 from indico.modules.events.settings import EventSettingsProxy, ThemeSettingsProxy
 from indico.modules.logs import EventLogRealm, LogKind
@@ -112,6 +113,11 @@ def _log_image_deleted(image, user, **kwargs):
                     f'Deleted image "{image.filename}"', user, data={
                         'File name': image.filename
                     })
+
+
+@signals.users.merged.connect
+def _merge_users(target, source, **kwargs):
+    MenuEntryPrincipal.merge_users(target, source, 'menu_entry')
 
 
 class ImagesFeature(EventFeature):

--- a/indico/modules/events/layout/controllers/menu.py
+++ b/indico/modules/events/layout/controllers/menu.py
@@ -103,7 +103,7 @@ class RHMenuEntryEdit(RHMenuEntryEditBase):
             defaults = FormDefaults(self.entry, skip_attrs={'title'},
                                     title=self.entry.title or self.entry.default_data.title,
                                     custom_title=self.entry.title is not None)
-        form = form_cls(entry=self.entry, obj=defaults, **form_kwargs)
+        form = form_cls(entry=self.entry, obj=defaults, event=self.event, **form_kwargs)
         if form.validate_on_submit():
             form.populate_obj(self.entry, skip={'html', 'custom_title'})
             if self.entry.is_page:
@@ -195,7 +195,7 @@ class RHMenuAddEntry(RHMenuBase):
         else:
             raise BadRequest
 
-        form = form_cls(obj=defaults, **form_kwargs)
+        form = form_cls(obj=defaults, event=self.event, **form_kwargs)
         if form.validate_on_submit():
             entry = MenuEntry(event=self.event, type=MenuEntryType[entry_type])
             form.populate_obj(entry, skip={'html'})

--- a/indico/modules/events/layout/forms.py
+++ b/indico/modules/events/layout/forms.py
@@ -10,6 +10,7 @@ from wtforms.fields.simple import StringField
 from wtforms.validators import DataRequired, Optional, ValidationError
 
 from indico.core.config import config
+from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.events.layout import theme_settings
 from indico.modules.events.layout.models.menu import MenuEntry
 from indico.modules.events.layout.util import get_css_file_data, get_logo_data, get_plugin_conference_themes
@@ -163,8 +164,10 @@ class MenuUserEntryFormBase(IndicoForm):
     title = StringField(_('Title'), [DataRequired()])
     is_enabled = BooleanField(_('Show'), widget=SwitchWidget())
     new_tab = BooleanField(_('Open in a new tab'), widget=SwitchWidget())
+    protection_mode = IndicoProtectionField(_('Protection mode'), protected_object=lambda form: form.protected_object)
     acl = PrincipalListField(
-        _('Visibility'),
+        _('Access control list'),
+        [HiddenUnless('protection_mode', ProtectionMode.protected, preserve_data=True)],
         event=lambda form: form.event,
         allow_groups=True,
         allow_event_roles=True,
@@ -172,16 +175,21 @@ class MenuUserEntryFormBase(IndicoForm):
         allow_registration_forms=True,
     )
     speakers_can_access = BooleanField(
-        _('Speaker Visibility'),
+        _('Grant speakers access'),
+        [HiddenUnless('protection_mode', ProtectionMode.protected, preserve_data=True)],
         widget=SwitchWidget(),
-        description=_('In addition to the visibility settings, speakers will be allowed access to this entry'),
+        description=_('In addition to anyone listed in the Access control list, speakers will have access.'),
     )
-    protection_mode = IndicoProtectionField(_('Protection mode'), protected_object=lambda form: form.protected_object)
 
     def __init__(self, *args, event, **kwargs):
         self.event = event
         self.protected_object = kwargs.get('entry', MenuEntry(event=event))
         super().__init__(*args, **kwargs)
+
+    def __iter__(self):
+        # keep acl fields last when rendering the form
+        return iter(sorted(super().__iter__(),
+                           key=lambda x: x.short_name in ('protection_mode', 'acl', 'speakers_can_access')))
 
 
 class MenuLinkForm(MenuUserEntryFormBase):

--- a/indico/modules/events/layout/forms.py
+++ b/indico/modules/events/layout/forms.py
@@ -171,7 +171,7 @@ class MenuUserEntryFormBase(IndicoForm):
         allow_category_roles=True,
         allow_registration_forms=True,
     )
-    speaker_allowed = BooleanField(
+    speakers_can_access = BooleanField(
         _('Speaker Visibility'),
         widget=SwitchWidget(),
         description=_('In addition to the visibility settings, speakers will be allowed access to this entry'),

--- a/indico/modules/events/layout/models/menu.py
+++ b/indico/modules/events/layout/models/menu.py
@@ -183,8 +183,8 @@ class TransientMenuEntry(MenuEntryMixin):
     :param position: int -- The position in the menu the entry is at
     :param children: list[MenuEntry] -- The child entries of this menu entry
     :param new_tab: bool -- If the link/page should be opened in a new tab
-
     """
+
     def __init__(self, event, is_enabled, name, position, children, new_tab=False):
         super().__init__(event=event)
         self.is_enabled = is_enabled

--- a/indico/modules/events/layout/models/menu.py
+++ b/indico/modules/events/layout/models/menu.py
@@ -414,7 +414,7 @@ class MenuEntry(MenuEntryMixin, ProtectionMixin, db.Model):
 
     @property
     def protection_parent(self):
-        return self.parent or getattr(self, '_event_ref', self.event)
+        return self.parent or self.event_ref
 
 
 class EventPage(db.Model):

--- a/indico/modules/events/layout/models/menu.py
+++ b/indico/modules/events/layout/models/menu.py
@@ -6,11 +6,14 @@
 # LICENSE file for more details.
 
 from flask import g, session
+from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import joinedload
 from werkzeug.utils import cached_property
 
 from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum
+from indico.core.db.sqlalchemy.protection import ProtectionMixin
+from indico.modules.events.layout.models.principals import MenuEntryPrincipal
 from indico.util.enum import RichIntEnum
 from indico.util.i18n import _
 from indico.util.string import format_repr, slugify, text_to_repr
@@ -36,16 +39,9 @@ class MenuEntryType(RichIntEnum):
     page = 5
 
 
-class MenuEntryAccess(RichIntEnum):
-    __titles__ = [None, _('Everyone'), _('Registered participants'), _('Speakers')]
-    everyone = 1
-    registered_participants = 2
-    speakers = 3
-
-
 class MenuEntryMixin:
     def __init__(self, **kwargs):
-        event = kwargs.pop('event', kwargs.get('event'))
+        event = kwargs.pop('event', None)
         super().__init__(**kwargs)
         # XXX: not calling this `event` since this one should NOT use
         # the relationship to avoid mixing data from different DB sessions
@@ -175,19 +171,20 @@ class MenuEntryMixin:
             self.position,
         )
 
-    def can_access(self, user):
-        if self.access == MenuEntryAccess.everyone:
-            return True
-        elif self.event_ref.can_manage(user):
-            return True
-        elif self.access == MenuEntryAccess.registered_participants:
-            return self.event_ref.is_user_registered(user)
-        elif self.access == MenuEntryAccess.speakers:
-            return self.event_ref.is_user_speaker(user)
-        assert False, 'should not happen'
-
 
 class TransientMenuEntry(MenuEntryMixin):
+    """
+    Transient menu entries are used in case menu customization is disabled. They provide a
+    lightweight alternative for the internal links that appear by default.
+
+    :param event: Event -- The event reference the entry applies to
+    :param is_enabled: bool -- True, if the entry is enabled
+    :param name: str -- The name of the menu entry
+    :param position: int -- The position in the menu the entry is at
+    :param children: list[MenuEntry] -- The child entries of this menu entry
+    :param new_tab: bool -- If the link/page should be opened in a new tab
+
+    """
     def __init__(self, event, is_enabled, name, position, children, new_tab=False):
         super().__init__(event=event)
         self.is_enabled = is_enabled
@@ -201,7 +198,6 @@ class TransientMenuEntry(MenuEntryMixin):
         self.link_url = None
         self.page_id = None
         self.is_root = True
-        self.access = MenuEntryAccess.everyone
         for child in self.children:
             child.is_root = False
 
@@ -209,8 +205,14 @@ class TransientMenuEntry(MenuEntryMixin):
     def id(self):
         return self.name
 
+    def can_access(self, user, allow_admin=True):
+        return True
 
-class MenuEntry(MenuEntryMixin, db.Model):
+
+class MenuEntry(MenuEntryMixin, ProtectionMixin, db.Model):
+    #: Allow speakers in the ProtectionMixin
+    allow_speakers = True
+
     __tablename__ = 'menu_entries'
     __table_args__ = (
         db.CheckConstraint(
@@ -292,12 +294,15 @@ class MenuEntry(MenuEntryMixin, db.Model):
         nullable=False,
         default=False
     )
-    #: Which group of people should the menu entry be viewable by
-    access = db.Column(
-        PyIntEnum(MenuEntryAccess),
-        nullable=False,
-        default=MenuEntryAccess.everyone,
+    #: ACLs for page visibility
+    acl_entries = db.relationship(
+        'MenuEntryPrincipal',
+        backref='menu_entry',
+        cascade='all, delete-orphan',
+        collection_class=set
     )
+    acl = association_proxy('acl_entries', 'principal', creator=lambda v: MenuEntryPrincipal(principal=v))
+
     #: The target URL of a custom link
     link_url = db.Column(
         db.String,
@@ -406,6 +411,10 @@ class MenuEntry(MenuEntryMixin, db.Model):
 
         self.parent = parent
         self.position = position + 1
+
+    @property
+    def protection_parent(self):
+        return self.parent or getattr(self, '_event_ref', self.event)
 
 
 class EventPage(db.Model):

--- a/indico/modules/events/layout/models/menu_test.py
+++ b/indico/modules/events/layout/models/menu_test.py
@@ -112,5 +112,5 @@ def test_update_principal(
     subcontrib_person_link = SubContributionPersonLink(person=person)
     subcontrib.person_links.append(subcontrib_person_link)
     assert not menu_entry.can_access(speakeruser)
-    menu_entry.speaker_allowed = True
+    menu_entry.speakers_can_access = True
     assert menu_entry.can_access(speakeruser)

--- a/indico/modules/events/layout/models/menu_test.py
+++ b/indico/modules/events/layout/models/menu_test.py
@@ -7,80 +7,110 @@
 
 from datetime import timedelta
 
-import pytest
-
-from indico.modules.events.contributions.models.persons import ContributionPersonLink, SubContributionPersonLink
+from indico.core.db.sqlalchemy.protection import ProtectionMode
+from indico.modules.categories.models.roles import CategoryRole
+from indico.modules.events.contributions.models.persons import SubContributionPersonLink
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.features.util import set_feature_enabled
-from indico.modules.events.layout.models.menu import MenuEntry, MenuEntryAccess, MenuEntryType
+from indico.modules.events.layout.models.menu import EventPage, MenuEntry, MenuEntryType
 from indico.modules.events.models.persons import EventPerson
+from indico.modules.events.models.roles import EventRole
 
 
 pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
 
 
-def test_access_everyone(dummy_contribution, dummy_user, dummy_event):
-    menu_entry = MenuEntry(event=dummy_event, type=MenuEntryType.page, access=MenuEntryAccess.everyone)
-    person = EventPerson.create_from_user(dummy_user, dummy_event)
+def test_update_principal(
+    db,
+    dummy_user,
+    dummy_event,
+    dummy_group,
+    create_user,
+    dummy_contribution,
+    dummy_regform,
+    create_registration,
+    create_category,
+):
+    menu_page = EventPage(event=dummy_event, html='')
+    menu_entry = MenuEntry(
+        id=1,
+        event=dummy_event,
+        type=MenuEntryType.page,
+        page=menu_page,
+        title='Test Page',
+        protection_mode=ProtectionMode.inheriting,
+    )
+    assert not menu_entry.acl_entries
+    # Event is public by default, menu entry inherits
     assert menu_entry.can_access(dummy_user)
-    contrib_person_link = ContributionPersonLink(person=person)
-    dummy_contribution.person_links.append(contrib_person_link)
+
+    # With our event protected, the user should not have access
+    dummy_event.protection_mode = ProtectionMode.protected
+    assert not menu_entry.can_access(dummy_user)
+
+    # Giving the user access to the event should regain access
+    dummy_event.update_principal(dummy_user, read_access=True)
     assert menu_entry.can_access(dummy_user)
-    contrib_person_link.is_speaker = True
+
+    # Now do a number of checks with a protected entry. By default the user
+    # does not have access
+    menu_entry.protection_mode = ProtectionMode.protected
+    assert not menu_entry.can_access(dummy_user)
+
+    # Add a user
+    entry = menu_entry.update_principal(dummy_user, read_access=True)
+    assert menu_entry.acl_entries == {entry}
     assert menu_entry.can_access(dummy_user)
 
+    # Add a group with a user
+    groupuser = create_user(123, groups={dummy_group})
+    dummy_event.update_principal(dummy_group, read_access=True)
+    assert not menu_entry.can_access(groupuser)
+    entry = menu_entry.update_principal(dummy_group, read_access=True)
+    assert entry in menu_entry.acl_entries
+    assert menu_entry.can_access(groupuser)
 
-def test_access_participants_not_registered(dummy_contribution, dummy_user, dummy_event):
-    menu_entry = MenuEntry(event=dummy_event, type=MenuEntryType.page, access=MenuEntryAccess.registered_participants)
-    person = EventPerson.create_from_user(dummy_user, dummy_event)
-    assert not menu_entry.can_access(dummy_user)
-    contrib_person_link = ContributionPersonLink(person=person)
-    dummy_contribution.person_links.append(contrib_person_link)
-    assert not menu_entry.can_access(dummy_user)
-    contrib_person_link.is_speaker = True
-    assert not menu_entry.can_access(dummy_user)
-
-
-@pytest.mark.usefixtures('dummy_reg')
-def test_access_participants_registered(dummy_contribution, dummy_user, dummy_event):
+    # Add a registration form principal
     set_feature_enabled(dummy_event, 'registration', True)
-    menu_entry = MenuEntry(event=dummy_event, type=MenuEntryType.page, access=MenuEntryAccess.registered_participants)
-    person = EventPerson.create_from_user(dummy_user, dummy_event)
-    assert menu_entry.can_access(dummy_user)
-    contrib_person_link = ContributionPersonLink(person=person)
-    dummy_contribution.person_links.append(contrib_person_link)
-    assert menu_entry.can_access(dummy_user)
-    contrib_person_link.is_speaker = True
-    assert menu_entry.can_access(dummy_user)
+    reguser = create_user(234)
+    person = EventPerson.create_from_user(reguser, dummy_event)
+    dummy_event.registrations.append(create_registration(reguser, dummy_regform))
+    dummy_event.update_principal(dummy_regform, read_access=True)
+    assert not menu_entry.can_access(reguser)
+    entry = menu_entry.update_principal(dummy_regform, read_access=True)
+    assert entry in menu_entry.acl_entries
+    assert menu_entry.can_access(reguser)
 
+    # Add a category role
+    catuser = create_user(345)
+    category = create_category(25, title='target')
+    category_role = CategoryRole(category=category, name='category', code='CAT', color='005272')
+    db.session.flush()
+    category_role.members.add(catuser)
+    dummy_event.update_principal(category_role, read_access=True)
+    assert not menu_entry.can_access(catuser)
+    entry = menu_entry.update_principal(category_role, read_access=True)
+    assert entry in menu_entry.acl_entries
+    assert menu_entry.can_access(catuser)
 
-@pytest.mark.usefixtures('dummy_reg')
-def test_access_speakers_contrib(dummy_contribution, dummy_user, dummy_event):
-    set_feature_enabled(dummy_event, 'registration', True)
-    menu_entry = MenuEntry(event=dummy_event, type=MenuEntryType.page, access=MenuEntryAccess.speakers)
-    person = EventPerson.create_from_user(dummy_user, dummy_event)
-    assert not menu_entry.can_access(dummy_user)
-    contrib_person_link = ContributionPersonLink(person=person)
-    dummy_contribution.person_links.append(contrib_person_link)
-    assert not menu_entry.can_access(dummy_user)
-    contrib_person_link.is_speaker = True
-    assert menu_entry.can_access(dummy_user)
-    dummy_contribution.is_deleted = True
-    assert not menu_entry.can_access(dummy_user)
+    # Add an event role
+    eventuser = create_user(567)
+    event_role = EventRole(event=dummy_event, name='eventrole', code='EVT', color='005272')
+    db.session.flush()
+    event_role.members.add(eventuser)
+    dummy_event.update_principal(eventuser, read_access=True)
+    assert not menu_entry.can_access(eventuser)
+    entry = menu_entry.update_principal(event_role, read_access=True)
+    assert entry in menu_entry.acl_entries
+    assert menu_entry.can_access(eventuser)
 
-
-@pytest.mark.usefixtures('dummy_reg')
-def test_access_speakers_subcontrib(dummy_contribution, dummy_user, dummy_event):
-    set_feature_enabled(dummy_event, 'registration', True)
-    menu_entry = MenuEntry(event=dummy_event, type=MenuEntryType.page, access=MenuEntryAccess.speakers)
-    person = EventPerson.create_from_user(dummy_user, dummy_event)
-    assert not menu_entry.can_access(dummy_user)
+    # Allow Speakers
+    speakeruser = create_user(678)
+    person = EventPerson.create_from_user(speakeruser, dummy_event)
+    assert not menu_entry.can_access(speakeruser)
     subcontrib = SubContribution(contribution=dummy_contribution, title='sc', duration=timedelta(minutes=10))
     subcontrib_person_link = SubContributionPersonLink(person=person)
     subcontrib.person_links.append(subcontrib_person_link)
-    assert menu_entry.can_access(dummy_user)
-    dummy_contribution.is_deleted = True
-    assert not menu_entry.can_access(dummy_user)
-    dummy_contribution.is_deleted = False
-    subcontrib.is_deleted = True
-    assert not menu_entry.can_access(dummy_user)
+    assert not menu_entry.can_access(speakeruser)
+    menu_entry.speaker_allowed = True
+    assert menu_entry.can_access(speakeruser)

--- a/indico/modules/events/layout/models/principals.py
+++ b/indico/modules/events/layout/models/principals.py
@@ -1,0 +1,45 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from sqlalchemy.ext.declarative import declared_attr
+
+from indico.core.db import db
+from indico.core.db.sqlalchemy.principals import PrincipalMixin
+from indico.core.db.sqlalchemy.util.models import auto_table_args
+
+
+class MenuEntryPrincipal(PrincipalMixin, db.Model):
+    allow_event_roles = True
+    allow_category_roles = True
+    allow_registration_forms = True
+
+    __tablename__ = 'menu_entries_principals'
+    principal_backref_name = 'in_menuentry_acls'
+    unique_columns = ('menu_entry_id',)
+
+    @declared_attr
+    def __table_args__(cls):
+        return auto_table_args(cls, schema='events')
+
+    #: The ID of the acl entry
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+    #: The ID of the associated menu entry
+    # TODO This isn't filled out in the test, figure out why
+    menu_entry_id = db.Column(
+        db.Integer,
+        db.ForeignKey('events.menu_entries.id'),
+        nullable=False
+    )
+
+    # relationship backrefs:
+    # - menu_entry (MenuEntry.acl_entries)
+
+    def __repr__(self):
+        return f'<MenuEntryPrincipal({self.id}, {self.menu_entry_id}, {self.principal})>'

--- a/indico/modules/events/layout/models/principals.py
+++ b/indico/modules/events/layout/models/principals.py
@@ -31,7 +31,6 @@ class MenuEntryPrincipal(PrincipalMixin, db.Model):
         primary_key=True
     )
     #: The ID of the associated menu entry
-    # TODO This isn't filled out in the test, figure out why
     menu_entry_id = db.Column(
         db.Integer,
         db.ForeignKey('events.menu_entries.id'),

--- a/indico/modules/events/layout/models/principals.py
+++ b/indico/modules/events/layout/models/principals.py
@@ -17,8 +17,8 @@ class MenuEntryPrincipal(PrincipalMixin, db.Model):
     allow_category_roles = True
     allow_registration_forms = True
 
-    __tablename__ = 'menu_entries_principals'
-    principal_backref_name = 'in_menuentry_acls'
+    __tablename__ = 'menu_entry_principals'
+    principal_backref_name = 'in_menu_entry_acls'
     unique_columns = ('menu_entry_id',)
 
     @declared_attr

--- a/indico/modules/events/layout/templates/_menu.html
+++ b/indico/modules/events/layout/templates/_menu.html
@@ -12,6 +12,9 @@
             <span class="title">
                 {% if config.DEBUG %}<span class="position">{{ entry.position + 1}}</span>{% endif %}
                 {{ entry.localized_title }}
+                {% if entry.is_self_protected %}
+                    <span class="icon-shield" title="{% trans %}Protected{% endtrans %}"></span>
+                {% endif %}
             </span>
             <span class="actions hide-if-locked">
                 {% if entry.type.name == 'page' %}

--- a/indico/modules/events/models/roles.py
+++ b/indico/modules/events/models/roles.py
@@ -66,7 +66,7 @@ class EventRole(db.Model):
     # - in_contribution_acls (ContributionPrincipal.event_role)
     # - in_event_acls (EventPrincipal.event_role)
     # - in_event_settings_acls (EventSettingPrincipal.event_role)
-    # - in_menuentry_acls (MenuEntryPrincipal.event_role)
+    # - in_menu_entry_acls (MenuEntryPrincipal.event_role)
     # - in_session_acls (SessionPrincipal.event_role)
     # - in_track_acls (TrackPrincipal.event_role)
 

--- a/indico/modules/events/models/roles.py
+++ b/indico/modules/events/models/roles.py
@@ -66,6 +66,7 @@ class EventRole(db.Model):
     # - in_contribution_acls (ContributionPrincipal.event_role)
     # - in_event_acls (EventPrincipal.event_role)
     # - in_event_settings_acls (EventSettingPrincipal.event_role)
+    # - in_menuentry_acls (MenuEntryPrincipal.event_role)
     # - in_session_acls (SessionPrincipal.event_role)
     # - in_track_acls (TrackPrincipal.event_role)
 

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -325,7 +325,7 @@ class RegistrationForm(db.Model):
     # - in_attachment_folder_acls (AttachmentFolderPrincipal.registration_form)
     # - in_contribution_acls (ContributionPrincipal.registration_form)
     # - in_event_acls (EventPrincipal.registration_form)
-    # - in_menuentry_acls (MenuEntryPrincipal.registration_form)
+    # - in_menu_entry_acls (MenuEntryPrincipal.registration_form)
     # - in_session_acls (SessionPrincipal.registration_form)
 
     def __contains__(self, user):

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -325,6 +325,7 @@ class RegistrationForm(db.Model):
     # - in_attachment_folder_acls (AttachmentFolderPrincipal.registration_form)
     # - in_contribution_acls (ContributionPrincipal.registration_form)
     # - in_event_acls (EventPrincipal.registration_form)
+    # - in_menuentry_acls (MenuEntryPrincipal.registration_form)
     # - in_session_acls (SessionPrincipal.registration_form)
 
     def __contains__(self, user):

--- a/indico/modules/events/registration/testing/fixtures.py
+++ b/indico/modules/events/registration/testing/fixtures.py
@@ -42,3 +42,23 @@ def dummy_reg(db, dummy_event, dummy_regform, dummy_user):
     dummy_event.registrations.append(reg)
     db.session.flush()
     return reg
+
+
+@pytest.fixture
+def create_registration(dummy_event):
+    """Return a callable that lets you create a registration."""
+
+    def _create_registration(user, regform, **kwargs):
+        return Registration(
+            first_name='Guinea',
+            last_name='Pig',
+            checked_in=True,
+            state=RegistrationState.complete,
+            currency='USD',
+            email=user.email,
+            user=user,
+            registration_form=regform,
+            **kwargs
+        )
+
+    return _create_registration

--- a/indico/modules/groups/models/groups.py
+++ b/indico/modules/groups/models/groups.py
@@ -47,6 +47,7 @@ class LocalGroup(db.Model):
     # - in_contribution_acls (ContributionPrincipal.local_group)
     # - in_event_acls (EventPrincipal.local_group)
     # - in_event_settings_acls (EventSettingPrincipal.local_group)
+    # - in_menuentry_acls (MenuEntryPrincipal.local_group)
     # - in_room_acls (RoomPrincipal.local_group)
     # - in_session_acls (SessionPrincipal.local_group)
     # - in_settings_acls (SettingPrincipal.local_group)

--- a/indico/modules/groups/models/groups.py
+++ b/indico/modules/groups/models/groups.py
@@ -47,7 +47,7 @@ class LocalGroup(db.Model):
     # - in_contribution_acls (ContributionPrincipal.local_group)
     # - in_event_acls (EventPrincipal.local_group)
     # - in_event_settings_acls (EventSettingPrincipal.local_group)
-    # - in_menuentry_acls (MenuEntryPrincipal.local_group)
+    # - in_menu_entry_acls (MenuEntryPrincipal.local_group)
     # - in_room_acls (RoomPrincipal.local_group)
     # - in_session_acls (SessionPrincipal.local_group)
     # - in_settings_acls (SettingPrincipal.local_group)

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -451,7 +451,7 @@ class User(PersonMixin, db.Model):
     # - in_contribution_acls (ContributionPrincipal.user)
     # - in_event_acls (EventPrincipal.user)
     # - in_event_settings_acls (EventSettingPrincipal.user)
-    # - in_menuentry_acls (MenuEntryPrincipal.user)
+    # - in_menu_entry_acls (MenuEntryPrincipal.user)
     # - in_room_acls (RoomPrincipal.user)
     # - in_session_acls (SessionPrincipal.user)
     # - in_settings_acls (SettingPrincipal.user)

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -451,6 +451,7 @@ class User(PersonMixin, db.Model):
     # - in_contribution_acls (ContributionPrincipal.user)
     # - in_event_acls (EventPrincipal.user)
     # - in_event_settings_acls (EventSettingPrincipal.user)
+    # - in_menuentry_acls (MenuEntryPrincipal.user)
     # - in_room_acls (RoomPrincipal.user)
     # - in_session_acls (SessionPrincipal.user)
     # - in_settings_acls (SettingPrincipal.user)

--- a/indico/web/forms/fields/protection.py
+++ b/indico/web/forms/fields/protection.py
@@ -25,9 +25,10 @@ class IndicoProtectionField(IndicoEnumRadioField):
         self.acl_message_url = get_acl_message_url(kwargs['_form']) if get_acl_message_url else None
         self.can_inherit_protection = self.protected_object.protection_parent is not None
         self.is_unlisted_event = isinstance(self.protected_object, db.m.Event) and self.protected_object.is_unlisted
+        skip = set(self.protected_object.disallowed_protection_modes)
         if not self.can_inherit_protection and not self.is_unlisted_event:
-            kwargs['skip'] = {ProtectionMode.inheriting}
-        super().__init__(*args, enum=ProtectionMode, **kwargs)
+            skip.add(ProtectionMode.inheriting)
+        super().__init__(*args, enum=ProtectionMode, skip=skip, **kwargs)
 
     def render_protection_message(self):
         protected_object = self.get_form().protected_object
@@ -39,6 +40,8 @@ class IndicoProtectionField(IndicoEnumRadioField):
             parent_type = _('Event')
         elif isinstance(protected_object.protection_parent, db.m.Category):
             parent_type = _('Category')
+        elif isinstance(protected_object.protection_parent, db.m.MenuEntry):
+            parent_type = _('Menu Entry')
         else:
             parent_type = _('Session')
         rv = render_template('_protection_info.html', field=self, protected_object=protected_object,


### PR DESCRIPTION
Hey @ThiefMaster, I'd love to get some feedback on this approach, as it is turning out to be massively more complicated than I initially expected. There are still quite a few loose ends, but I want to see if I am going into the right direction.

**Is your feature request related to a problem? Please describe.**
We sometimes have sponsored attendees at our events. We'd like to show them a page in the sidebar with the expense policies. We don't want this page to be visible to everyone else.

**Describe the solution you'd like**
I'd like Menu Entries to have ACLs so I can restrict viewing the and their visibility in the menu to people who have registered using a specific form.

**Describe alternatives you've considered**
Right now, all we can do is send them the link to an unlisted page, or open up the expense policy page to everyone (non-sponsored attendees, random remote participants)

**Current Status**
I've hooked up UI using the permission list field and have taken a stab at the backend database. A few features are still missing:
* An explicit way to make it available to "Everyone" - I was thinking to either do so if the ACLs are empty, or add another token principal "Everyone" that needs to be explicitly added.
* Protection mode - I'll have to play around with this. I see a few ways protection modes could map to different scenarios, it could also be a way to avoid a specific "Everyone" principal.
* I've not yet managed to get saving settings to work due to some backref issues, it isn't finding the menu entry from the principal.
* Need to add a speakers button to the UI that uses the new principle.
* Probably makes sense to hook up event and category roles as well
* There are a few functions that need to be implemented for completeness, though I've not yet seen if they are used in this scenario.

Questions:
* Where I am struggling most is the database setup and fields. I've seen multiple ways to do this in the codebase (sqlalchemy schemas vs flask sqlalchemy), and there is no 1:1 comparison I can make. Am I missing anything substantial? Especially in the backrefs, I'm not sure when I need a db backref, a normal backref, and what properties I need to implement for a backref.
* I've given the speaker principal an id, which is the event id. I think we could do without and just make this a simple token principal, the event data being taken from context. Makes sense? I'd still need to have something in `SpeakerPrincipal` so that I can reference the event though.
* I'm using the`ProtectionMixin` since it provides many convenience functions. Is this the right path, or is it going overboard for a simple yes/no type of access?

Any other comments you might have are appreciated.

**Screenshots**
![image](https://user-images.githubusercontent.com/607198/218470698-54a01c95-9cb7-458b-a7de-7fb654a0ec0f.png)
