### PR TITLE
Make Editing Timeline less confusing

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/CommentItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentItem.jsx
@@ -73,7 +73,7 @@ export default function Comment({
                 <span
                   className="review-comment-edited"
                   title={Translate.string('On {modificationDate}', {
-                    modificationDate: serializeDate(modifiedDt, 'LL'),
+                    modificationDate: serializeDate(modifiedDt, 'LLL'),
                   })}
                 >
                   {' '}

--- a/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
@@ -43,7 +43,7 @@ export default function CustomItem({
             <div className="f-self-stretch" styleName="item-header">
               {header}{' '}
               <time dateTime={serializeDate(reviewedDt, moment.HTML5_FMT.DATETIME_LOCAL_SECONDS)}>
-                {serializeDate(reviewedDt, 'LL')}
+                {serializeDate(reviewedDt, 'LLL')}
               </time>{' '}
               {isUndone && (
                 <Translate as="span" styleName="undone-indicator">

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -9,7 +9,7 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
-import {Icon, Message} from 'semantic-ui-react';
+import {Divider, Icon, Message} from 'semantic-ui-react';
 
 import UserAvatar from 'indico/modules/events/reviewing/components/UserAvatar';
 import {Param, Translate} from 'indico/react/i18n';
@@ -20,11 +20,12 @@ import {FinalRevisionState} from '../../models';
 import ChangesConfirmation from './ChangesConfirmation';
 import CustomActions from './CustomActions';
 import FileDisplay from './FileDisplay';
+import ResetReview from './ResetReview';
 import ReviewForm from './ReviewForm';
 import RevisionLog from './RevisionLog';
 import * as selectors from './selectors';
 import StateIndicator from './StateIndicator';
-import {blockPropTypes, isRequestChangesWithFiles} from './util';
+import {blockPropTypes, getPreviousValidRevision, isEditorRevision} from './util';
 
 import '../../../styles/timeline.module.scss';
 import './TimelineItem.module.scss';
@@ -33,31 +34,28 @@ export default function TimelineItem({block, index}) {
   const {submitter, createdDt} = block;
   const timelineBlocks = useSelector(selectors.getTimelineBlocks);
   const validTimelineBlocks = useSelector(selectors.getValidTimelineBlocks);
+  const lastRevertableRevisionId = useSelector(selectors.getLastRevertableRevisionId);
   const needsSubmitterConfirmation = useSelector(selectors.needsSubmitterConfirmation);
   const canPerformSubmitterActions = useSelector(selectors.canPerformSubmitterActions);
   const {canComment, state: editableState} = useSelector(selectors.getDetails);
   const {fileTypes} = useSelector(selectors.getStaticData);
   const isLastBlock = timelineBlocks[timelineBlocks.length - 1].id === block.id;
   const isLastValidBlock = validTimelineBlocks[validTimelineBlocks.length - 1].id === block.id;
-  const isVisibleByDefault =
-    isLastValidBlock ||
-    (validTimelineBlocks.length >= 2 &&
-      validTimelineBlocks[validTimelineBlocks.length - 2].id === block.id &&
-      (isRequestChangesWithFiles(
-        validTimelineBlocks[validTimelineBlocks.length - 1],
-        validTimelineBlocks[validTimelineBlocks.length - 2]
-      ) ||
-        needsSubmitterConfirmation));
-  const [visible, setVisible] = useState(isVisibleByDefault);
+  const previousValidBlock = getPreviousValidRevision(timelineBlocks, index);
+  const [visible, setVisible] = useState(isLastValidBlock);
   const isUndone = block.finalState.name === FinalRevisionState.undone;
+  const isUndoable =
+    !isUndone &&
+    isEditorRevision(previousValidBlock, block) &&
+    previousValidBlock.id === lastRevertableRevisionId;
 
   useEffect(() => {
     // when undoing a judgment deletes the last revision this revision may become the
     // latest one, and thus needs to be unhidden if it had been collapsed before.
-    if (isLastValidBlock && isVisibleByDefault && !visible) {
+    if (isLastValidBlock && !visible) {
       setVisible(true);
     }
-  }, [isLastValidBlock, isVisibleByDefault, visible]);
+  }, [isLastValidBlock, visible]);
 
   return (
     <>
@@ -91,16 +89,20 @@ export default function TimelineItem({block, index}) {
                 )}
               </div>
               {!isLastValidBlock && (
-                <>
-                  <a className="block-info-link i-link" onClick={() => setVisible(!visible)}>
-                    {visible ? <Translate>Hide</Translate> : <Translate>Show details</Translate>}
-                  </a>
-                  {!visible && block.finalState && (
-                    <div styleName="state-indicator">
-                      <StateIndicator state={block.finalState.name} circular />
-                    </div>
-                  )}
-                </>
+                <a
+                  className="i-link"
+                  styleName="item-visibility-toggle"
+                  onClick={() => setVisible(!visible)}
+                >
+                  {visible ? <Translate>Hide</Translate> : <Translate>Show details</Translate>}
+                </a>
+              )}
+              {isUndoable && <ResetReview revisionId={lastRevertableRevisionId} />}
+              {(!isLastValidBlock || isUndoable) && block.finalState && (
+                <StateIndicator
+                  state={isUndoable ? previousValidBlock.finalState.name : block.finalState.name}
+                  circular
+                />
               )}
             </div>
             {visible && (
@@ -110,6 +112,15 @@ export default function TimelineItem({block, index}) {
                     <Icon name="warning sign" />
                     <Translate>This revision has been retracted by the editor.</Translate>
                   </Message>
+                )}
+                {block.revisionCommentHtml && (
+                  <>
+                    <div
+                      className="markdown-text"
+                      dangerouslySetInnerHTML={{__html: block.revisionCommentHtml}}
+                    />
+                    <Divider />
+                  </>
                 )}
                 <FileDisplay
                   fileTypes={fileTypes}

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
@@ -7,10 +7,10 @@
 
 @import 'base/palette';
 
-.state-indicator {
-  margin-left: 5px;
-}
-
 .item-index {
   color: $gray;
+}
+
+.item-visibility-toggle {
+  margin-right: 5px;
 }


### PR DESCRIPTION
Depends on #5630

This PR improves the layout of the Editing Timeline, making it less confusing by showing review comments inside the corresponding review:

![image](https://user-images.githubusercontent.com/27357203/218787674-688ec6f7-0c17-4a62-8e29-bb24f395f1a9.png)

As opposed to the previous behavior:

![image](https://user-images.githubusercontent.com/27357203/218787906-e4dddb06-42bd-4a97-8407-f18d5950782f.png)