### PR TITLE
Add an option to sync event persons with users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,7 @@ Improvements
 - Add ``locked_fields`` to the identity provider settings in ``indico.conf`` to
   prevent non-admin users from turning off their profile's personal data
   synchronization (:pr:`5648`)
+- Add an option to sync event persons with users (:pr:`5677`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -284,6 +284,19 @@ class EventPerson(PersonMixin, db.Model):
                 db.session.delete(event_person)
         db.session.flush()
 
+    def get_unsynced_data(self):
+        """Return data no longer in sync with the user."""
+        if not self.user:
+            return {}
+        fields = ('first_name', 'last_name', '_title', 'email', 'affiliation', 'affiliation_link', 'address', 'phone')
+        changes = {}
+        for field in fields:
+            person_data = getattr(self, field)
+            user_data = getattr(self.user, field)
+            if person_data != user_data:
+                changes[field] = (person_data, user_data)
+        return changes
+
     def sync_user(self, *, notify=True):
         """Update all person data based on the current user data.
 
@@ -291,7 +304,7 @@ class EventPerson(PersonMixin, db.Model):
         """
         if not self.user:
             return
-        fields = ('first_name', 'last_name', 'email', 'affiliation', 'address', 'phone')
+        fields = ('first_name', 'last_name', '_title', 'email', 'affiliation', 'affiliation_link', 'address', 'phone')
         has_changes = False
         for field in fields:
             new = getattr(self.user, field)

--- a/indico/modules/events/persons/blueprint.py
+++ b/indico/modules/events/persons/blueprint.py
@@ -9,7 +9,7 @@ from indico.modules.events.persons.controllers import (RHAPIEmailEventPersonsMet
                                                        RHDeleteUnusedEventPerson, RHEmailEventPersonsPreview,
                                                        RHEventPersonSearch, RHGrantModificationRights,
                                                        RHGrantSubmissionRights, RHManagePersonLists, RHPersonsList,
-                                                       RHRevokeSubmissionRights, RHUpdateEventPerson)
+                                                       RHRevokeSubmissionRights, RHSyncEventPerson, RHUpdateEventPerson)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
@@ -32,6 +32,7 @@ _bp.add_url_rule('/persons/revoke-submission', 'revoke_submission_rights', RHRev
 
 # EventPerson operations
 _bp.add_url_rule('/persons/<int:person_id>', 'update_person', RHUpdateEventPerson, methods=('PATCH',))
+_bp.add_url_rule('/persons/<int:person_id>', 'sync_with_user', RHSyncEventPerson, methods=('POST',))
 _bp.add_url_rule('/persons/<int:person_id>', 'delete_unused_person', RHDeleteUnusedEventPerson, methods=('DELETE',))
 _bp.add_url_rule('/api/persons/search', 'event_person_search', RHEventPersonSearch)
 

--- a/indico/modules/events/persons/blueprint.py
+++ b/indico/modules/events/persons/blueprint.py
@@ -32,7 +32,7 @@ _bp.add_url_rule('/persons/revoke-submission', 'revoke_submission_rights', RHRev
 
 # EventPerson operations
 _bp.add_url_rule('/persons/<int:person_id>', 'update_person', RHUpdateEventPerson, methods=('PATCH',))
-_bp.add_url_rule('/persons/<int:person_id>', 'sync_with_user', RHSyncEventPerson, methods=('POST',))
+_bp.add_url_rule('/persons/<int:person_id>/sync', 'sync_with_user', RHSyncEventPerson, methods=('POST',))
 _bp.add_url_rule('/persons/<int:person_id>', 'delete_unused_person', RHDeleteUnusedEventPerson, methods=('DELETE',))
 _bp.add_url_rule('/api/persons/search', 'event_person_search', RHEventPersonSearch)
 

--- a/indico/modules/events/persons/templates/management/_person_list_row.html
+++ b/indico/modules/events/persons/templates/management/_person_list_row.html
@@ -98,6 +98,14 @@
             <a class="i-link icon-edit disabled"
                title="{%- trans %}This user does not play any public role{% endtrans -%}"></a>
         {% endif %}
+        {% if person_data.has_event_person and person_data.person.get_unsynced_data() %}
+            <a class="i-link icon-loop"
+               title="{%- trans %}Sync person with user{% endtrans -%}"
+               data-href="{{ url_for('persons.sync_with_user', person) }}"
+               data-title="{%- trans %}Sync person with user{% endtrans -%}"
+               data-method="POST"
+               data-update="#person-{{ person.id }}"></a>
+        {% endif %}
         {% if person_data.has_event_person and person_data.roles.no_builtin_roles %}
             <a class="i-link icon-remove"
                title="{%- trans %}Delete person{% endtrans -%}"


### PR DESCRIPTION
Adds a new sync button to the Participant roles page, which syncs the event person's personal data (name, title, ..) with its parent user.