### PR TITLE
Sync person links with event persons when editing

### DIFF
--- a/indico/modules/events/persons/schemas.py
+++ b/indico/modules/events/persons/schemas.py
@@ -35,6 +35,7 @@ class PersonLinkSchema(mm.Schema):
     display_order = fields.Int(load_default=0, dump_default=0)
     avatar_url = fields.Function(lambda o: o.person.user.avatar_url if o.person.user else None, dump_only=True)
     roles = fields.List(fields.String(), load_only=True)
+    sync_event_person = fields.Bool(load_default=False, load_only=True)
 
     @pre_load
     def load_nones(self, data, **kwargs):

--- a/indico/web/client/js/react/components/PersonDetailsModal.module.scss
+++ b/indico/web/client/js/react/components/PersonDetailsModal.module.scss
@@ -15,3 +15,9 @@
     float: unset;
   }
 }
+
+.sync-person-field {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -235,6 +235,8 @@ function PersonLinkField({
   canEnterManually,
   defaultSearchExternal,
   validateEmailUrl,
+  isUpdate,
+  syncPersonMessage,
 }) {
   const [favoriteUsers] = useFavoriteUsers(null, !sessionUser);
   const [modalOpen, setModalOpen] = useState(false);
@@ -363,6 +365,8 @@ function PersonLinkField({
               otherPersons={selected === null ? persons : _.without(persons, persons[selected])}
               hasPredefinedAffiliations={hasPredefinedAffiliations}
               validateEmailUrl={validateEmailUrl}
+              isUpdate={isUpdate}
+              syncPersonMessage={syncPersonMessage}
             />
           )}
         </Button.Group>
@@ -384,6 +388,8 @@ PersonLinkField.propTypes = {
   canEnterManually: PropTypes.bool,
   defaultSearchExternal: PropTypes.bool,
   validateEmailUrl: PropTypes.string,
+  isUpdate: PropTypes.bool.isRequired,
+  syncPersonMessage: PropTypes.string.isRequired,
 };
 
 PersonLinkField.defaultProps = {
@@ -410,6 +416,8 @@ export function WTFPersonLinkField({
   canEnterManually,
   defaultSearchExternal,
   validateEmailUrl,
+  isUpdate,
+  syncPersonMessage,
 }) {
   const [persons, setPersons] = useState(
     defaultValue.sort((a, b) => a.displayOrder - b.displayOrder)
@@ -433,6 +441,7 @@ export function WTFPersonLinkField({
         'identifier',
         'type',
         'personId',
+        'syncEventPerson', // Whether the personal data (name, title, ..) should be propagated to the parent event person
       ])
     );
     inputField.value = JSON.stringify(
@@ -465,6 +474,8 @@ export function WTFPersonLinkField({
       canEnterManually={canEnterManually}
       defaultSearchExternal={defaultSearchExternal}
       validateEmailUrl={validateEmailUrl}
+      isUpdate={isUpdate}
+      syncPersonMessage={syncPersonMessage}
     />
   );
 }
@@ -480,6 +491,8 @@ WTFPersonLinkField.propTypes = {
   canEnterManually: PropTypes.bool,
   defaultSearchExternal: PropTypes.bool,
   validateEmailUrl: PropTypes.string,
+  isUpdate: PropTypes.bool.isRequired,
+  syncPersonMessage: PropTypes.string.isRequired,
 };
 
 WTFPersonLinkField.defaultProps = {

--- a/indico/web/templates/forms/person_link_widget.html
+++ b/indico/web/templates/forms/person_link_widget.html
@@ -32,6 +32,8 @@
             defaultSearchExternal: {{ field.default_search_external | tojson }},
             sessionUser: Indico.User,
             validateEmailUrl: {{ field.validate_email_url | tojson }},
+            isUpdate: {{ (true if field.event else false) | tojson }},
+            syncPersonMessage: {{ field.sync_person_message | tojson }},
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
When editing person links in the person link widget,
event persons will be automatically synced unless the user explicitly chooses not to.

#TODO

- [x] Better user facing UI, explanation for the setting
- [x] Disable this when creating a lecture
- [ ] When syncing is disabled, show only placeholders in the fields so the user only enters the overridden information
- [ ] Test all link types