### PR TITLE
Allow managers to ignore required field restrictions in registrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ Improvements
 - Include non-speaker authors in the timetable export API (:issue:`5412`, :pr:`5738`)
 - Add setting to force track selection when accepting abstracts (:pr:`5771`)
 - Log detailed changes when editing contributions (:pr:`5777`)
+- Allow managers to ignore required field restrictions in registration forms
+  (:issue:`5644`, :pr:`5682`, thanks :user:`kewisch`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -96,8 +96,8 @@ export default function FormItem({
     );
   }
 
-  const required = meta.alwaysRequired || isRequired;
-  const managementRequired = meta.alwaysRequired || (!isManagement && isRequired);
+  const showAsRequired = meta.alwaysRequired || isRequired;
+  const inputRequired = !isManagement && showAsRequired;
   return (
     <div
       styleName={`form-item ${toClasses({
@@ -112,19 +112,19 @@ export default function FormItem({
         {InputComponent ? (
           meta.customFormItem ? (
             <InputComponent
-              showAsRequired={required}
-              isRequired={managementRequired}
+              showAsRequired={showAsRequired}
+              isRequired={inputRequired}
               disabled={disabled}
               isPurged={showPurged}
               retentionPeriodIcon={retentionPeriodIcon}
               {...inputProps}
             />
           ) : (
-            <Form.Field required={required} styleName="field">
+            <Form.Field required={showAsRequired} styleName="field">
               <label style={{opacity: disabled ? 0.8 : 1, display: 'inline-block'}}>{title}</label>
               {retentionPeriodIcon}
               <InputComponent
-                isRequired={managementRequired}
+                isRequired={inputRequired}
                 disabled={disabled}
                 isPurged={showPurged}
                 {...inputProps}

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -112,6 +112,7 @@ export default function FormItem({
         {InputComponent ? (
           meta.customFormItem ? (
             <InputComponent
+              showAsRequired={required}
               isRequired={managementRequired}
               disabled={disabled}
               isPurged={showPurged}

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -97,6 +97,7 @@ export default function FormItem({
   }
 
   const required = meta.alwaysRequired || isRequired;
+  const managementRequired = meta.alwaysRequired || (!isManagement && isRequired);
   return (
     <div
       styleName={`form-item ${toClasses({
@@ -111,7 +112,7 @@ export default function FormItem({
         {InputComponent ? (
           meta.customFormItem ? (
             <InputComponent
-              isRequired={required}
+              isRequired={managementRequired}
               disabled={disabled}
               isPurged={showPurged}
               retentionPeriodIcon={retentionPeriodIcon}
@@ -122,7 +123,7 @@ export default function FormItem({
               <label style={{opacity: disabled ? 0.8 : 1, display: 'inline-block'}}>{title}</label>
               {retentionPeriodIcon}
               <InputComponent
-                isRequired={required}
+                isRequired={managementRequired}
                 disabled={disabled}
                 isPurged={showPurged}
                 {...inputProps}

--- a/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
@@ -218,7 +218,7 @@ export default function AccommodationInput({
       placesUsed={placesUsed}
       validate={value => {
         if (value.choice === null) {
-          return Translate.string('You must select an option');
+          return isRequired ? Translate.string('You must select an option') : undefined;
         } else if (!value.isNoAccommodation && (!value.arrivalDate || !value.departureDate)) {
           return Translate.string('You must select the arrival and departure date');
         }

--- a/indico/modules/events/registration/client/js/form/fields/CheckboxInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/CheckboxInput.jsx
@@ -27,6 +27,7 @@ export default function CheckboxInput({
   disabled,
   title,
   isRequired,
+  showAsRequired,
   price,
   placesLimit,
   placesUsed,
@@ -37,7 +38,7 @@ export default function CheckboxInput({
 
   return (
     <FinalCheckbox
-      fieldProps={{className: styles.field}}
+      fieldProps={{className: `${styles.field} ${showAsRequired ? 'required' : ''}`}}
       name={htmlName}
       label={title}
       disabled={disabled || (placesLimit > 0 && placesUsed >= placesLimit && !existingValue)}
@@ -68,6 +69,7 @@ CheckboxInput.propTypes = {
   disabled: PropTypes.bool,
   title: PropTypes.string.isRequired,
   isRequired: PropTypes.bool.isRequired,
+  showAsRequired: PropTypes.bool.isRequired,
   price: PropTypes.number,
   placesLimit: PropTypes.number.isRequired,
   placesUsed: PropTypes.number.isRequired,

--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -37,22 +37,34 @@ import {
 
 import '../../styles/regform.module.scss';
 
-function EmailNotification() {
+function ManagementOptions({isUpdateMode}) {
   return (
     <Message info style={{marginTop: 25}}>
       <Message.Header>
-        <Translate>Email notifications</Translate>
+        <Translate>Management Options</Translate>
       </Message.Header>
-      <div style={{marginTop: 10}}>
+      <div>
         <FinalCheckbox
+          style={{marginTop: 10}}
           label={Translate.string('Send an email notification to the user')}
           name="notify_user"
           toggle
         />
+        {!isUpdateMode && (
+          <FinalCheckbox
+            style={{marginTop: 10}}
+            label={Translate.string('Ignore field requirements for custom fields')}
+            name="override_required"
+            toggle
+          />
+        )}
       </div>
     </Message>
   );
 }
+ManagementOptions.propTypes = {
+  isUpdateMode: PropTypes.bool.isRequired,
+};
 
 function ConsentToPublish({publishToParticipants, publishToPublic}) {
   const isWarning = publishToParticipants === 'show_all' && publishToPublic === 'show_all';
@@ -133,7 +145,7 @@ export default function RegistrationFormSubmission() {
           ))}
           {renderPluginComponents('regformAfterSections')}
           <div>
-            {isManagement && <EmailNotification />}
+            {isManagement && <ManagementOptions isUpdateMode={isUpdateMode} />}
             {showConsentToPublish && (
               <ConsentToPublish
                 publishToParticipants={publishToParticipants}

--- a/indico/modules/events/registration/controllers/__init__.py
+++ b/indico/modules/events/registration/controllers/__init__.py
@@ -54,7 +54,8 @@ class RegistrationEditMixin:
         schema = make_registration_schema(
             self.regform,
             management=self.management,
-            registration=self.registration
+            registration=self.registration,
+            override_required=self.management
         )(partial=optional_fields)
         form_data = parser.parse(schema)
 

--- a/indico/modules/events/registration/controllers/__init__.py
+++ b/indico/modules/events/registration/controllers/__init__.py
@@ -41,6 +41,10 @@ class RegistrationEditMixin:
 
     def _get_optional_fields(self):
         """Get fields for which we already have a value and thus are not required."""
+        if self.management:
+            # In management mode, all fields are optional
+            return True
+
         data_by_field = self.registration.data_by_field
         return [form_item.html_field_name for form_item in self.regform.active_fields
                 if data_by_field.get(form_item.id) is not None]
@@ -48,7 +52,9 @@ class RegistrationEditMixin:
     def _process_POST(self):
         optional_fields = self._get_optional_fields()
         schema = make_registration_schema(
-            self.regform, management=self.management, registration=self.registration
+            self.regform,
+            management=self.management,
+            registration=self.registration
         )(partial=optional_fields)
         form_data = parser.parse(schema)
 

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -403,7 +403,7 @@ class RHRegistrationDisplayEdit(RegistrationEditMixin, RHRegistrationFormRegistr
                 flash(_('We could not find a registration for you.  If have already registered, please use the '
                         'direct access link from the email you received after registering or log in to your Indico '
                         'account.'), 'warning')
-            return redirect(url_for('.display_regform', self.regform))
+            return redirect(url_for('event_registration.display_regform', self.regform))
 
     @property
     def success_url(self):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -167,7 +167,7 @@ class RHRegistrationEdit(RegistrationEditMixin, RHManageRegistrationBase):
 
     @property
     def success_url(self):
-        return url_for('.registration_details', self.registration)
+        return url_for('event_registration.registration_details', self.registration)
 
 
 class RHRegistrationsActionBase(RHManageRegFormBase):
@@ -283,12 +283,13 @@ class RHRegistrationCreate(RHManageRegFormBase):
     def _process_POST(self):
         if self.regform.is_purged:
             raise Forbidden(_('Registration is disabled due to an expired retention period'))
-        schema = make_registration_schema(self.regform, management=True)()
+        override_required = request.json.get('override_required', False)
+        schema = make_registration_schema(self.regform, management=True, override_required=override_required)()
         form = parser.parse(schema)
         session['registration_notify_user_default'] = notify_user = form.pop('notify_user', False)
         create_registration(self.regform, form, management=True, notify_user=notify_user)
         flash(_('The registration was created.'), 'success')
-        return jsonify({'redirect': url_for('.manage_reglist', self.regform)})
+        return jsonify({'redirect': url_for('event_registration.manage_reglist', self.regform)})
 
     def _process_GET(self):
         user_data = self._get_user_data()

--- a/indico/modules/events/registration/controllers/management/reglists_test.py
+++ b/indico/modules/events/registration/controllers/management/reglists_test.py
@@ -1,0 +1,95 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+from flask import request
+from werkzeug.exceptions import UnprocessableEntity
+
+from indico.modules.events.registration.controllers.management.fields import _fill_form_field_with_data
+from indico.modules.events.registration.controllers.management.reglists import RHRegistrationCreate, RHRegistrationEdit
+from indico.modules.events.registration.models.form_fields import RegistrationFormField
+from indico.modules.events.registration.models.items import RegistrationFormSection
+from indico.modules.events.registration.util import create_registration
+
+
+pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
+
+
+def test_registration_edit_override_required(
+    db, dummy_regform, app_context, create_user
+):
+    # Add a section and a required field
+    section = RegistrationFormSection(
+        registration_form=dummy_regform, title='dummy_section', is_manager_only=False
+    )
+    db.session.flush()
+
+    boolean_field = RegistrationFormField(parent_id=section.id, registration_form=dummy_regform)
+    _fill_form_field_with_data(
+        boolean_field, {'input_type': 'bool', 'is_required': True, 'title': 'Yes/No'}
+    )
+
+    # Register a new user
+    other_user = create_user(1, first_name='first', last_name='last', email='email@example.com')
+    data = {
+        'email': other_user.email,
+        'first_name': other_user.first_name,
+        'last_name': other_user.last_name,
+    }
+    reg = create_registration(
+        dummy_regform, data, invitation=None, management=True, notify_user=False
+    )
+
+    # Attempting to edit the registration without setting the required field works in edit mode
+    with app_context.test_request_context(json={}):
+        request.view_args = {
+            'registration_id': reg.id,
+            'reg_form_id': dummy_regform.id,
+            'event_id': dummy_regform.event_id,
+        }
+
+        rh = RHRegistrationEdit()
+        rh._process_args()
+        rh._process_POST()
+
+
+def test_registration_create_override_required(db, dummy_regform, app_context):
+    # Add a section and a required field
+    section = RegistrationFormSection(
+        registration_form=dummy_regform, title='dummy_section', is_manager_only=False
+    )
+
+    assert dummy_regform.active_registration_count == 0
+
+    boolean_field = RegistrationFormField(parent_id=section.id, registration_form=dummy_regform)
+    _fill_form_field_with_data(
+        boolean_field, {'input_type': 'bool', 'is_required': True, 'title': 'Yes/No'}
+    )
+
+    # Attempting to create a registration without required fields fails
+    jsondata = {'first_name': 'Greater', 'last_name': 'Capybara', 'email': 'indico@getindico.io'}
+    url = f'/event/{dummy_regform.event_id}/manage/registration/{dummy_regform.id}/registrations/create'
+
+    with app_context.test_request_context(url, json=jsondata):
+        rh = RHRegistrationCreate()
+        rh._process_args()
+
+        with pytest.raises(UnprocessableEntity) as excinfo:
+            rh._process_POST()
+
+        messages = excinfo.value.data['messages']
+        assert len(messages) == 1
+        assert messages[boolean_field.html_field_name][0] == 'Missing data for required field.'
+        assert dummy_regform.active_registration_count == 0
+
+    # Trying again with override works
+    jsondata['override_required'] = True
+    with app_context.test_request_context(url, json=jsondata):
+        rh = RHRegistrationCreate()
+        rh._process_args()
+        rh._process_POST()
+        assert dummy_regform.active_registration_count == 1

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -53,6 +53,14 @@ class RegistrationFormFieldBase:
     def default_value(self):
         return ''
 
+    @property
+    def empty_value(self):
+        # THis value is used when a manager edits an existing registration, and
+        # it should be something that, especially in case of choice fields, does
+        # not preselect any of the available choices (such as "no accommodation"
+        # or whatever default value is set for a field).
+        return self.default_value
+
     def get_validators(self, existing_registration):
         """Return a list of marshmallow validators for this field.
 

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -213,6 +213,10 @@ class SingleChoiceField(ChoiceBaseField):
         # only use the default item if it exists in the current version
         return {default_item: 1} if any(x['id'] == default_item for x in versioned_data['choices']) else {}
 
+    @property
+    def empty_value(self):
+        return {}
+
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):
         if not registration_data.data:
             return ''
@@ -459,6 +463,10 @@ class AccommodationField(RegistrationFormBillableItemsField):
             'arrivalDate': None,
             'departureDate': None,
         }
+
+    @property
+    def empty_value(self):
+        return {'choice': None}
 
     @classmethod
     def process_field_data(cls, data, old_data=None, old_versioned_data=None):

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -281,6 +281,10 @@ class BooleanField(RegistrationFormBillableField):
         data = self.form_item.data
         return {'yes': True, 'no': False}.get(data.get('default_value'))
 
+    @property
+    def empty_value(self):
+        return None
+
     def get_places_used(self):
         places_used = 0
         if self.form_item.data.get('places_limit'):

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -215,6 +215,8 @@ def get_form_registration_data(regform, registration, *, management=False):
             continue
         elif item.id in data_by_field:
             registration_data[item.html_field_name] = camelize_keys(data_by_field[item.id].user_data)
+        elif management:
+            registration_data[item.html_field_name] = item.field_impl.empty_value
         else:
             registration_data[item.html_field_name] = item.field_impl.default_value
     if management:
@@ -417,8 +419,11 @@ def modify_registration(registration, data, management=False, notify_user=True):
 
         if has_data and can_modify:
             value = data.get(form_item.html_field_name)
-        elif not has_data and form_item.id not in data_by_field:
-            # set default value for a field if it didn't have one before (including manager-only fields)
+        elif not has_data and form_item.id not in data_by_field and not management:
+            # set default value for a field if it didn't have one before (including manager-only fields).
+            # but we do so only if it's the user editing their registration - if a manager edits
+            # the registration, we keep those fields empty so it's clear they have never been
+            # filled in.
             value = field_impl.default_value
         else:
             # keep current value


### PR DESCRIPTION
Fixes #5644.

I've decided to leave out the checkbox and have this happen implicitly. This feels more natural and requires one less thing to click on.
