### PR TITLE
Prevent concurrent assignment of editors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,7 @@ Improvements
 - Disallow repeated filenames in editing revisions (:pr:`5681`)
 - Add setting to hide peer-reviewed papers from participants even after they have
   been accepted (:issue:`5666`, :pr:`5671`)
+- Prevent concurrent assignment of editors to editables (:pr:`5684`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -111,6 +111,11 @@ function EditableListDisplay({
   const checkedContribsWithEditables = contribsWithEditables.filter(x =>
     checkedSet.has(x.editable.id)
   );
+  const editorAssignments = Object.fromEntries(
+    checkedContribsWithEditables
+      .filter(x => x.editable.editor)
+      .map(x => [x.editable.id, x.editable.editor.identifier])
+  );
   const [activeRequest, setActiveRequest] = useState(null);
 
   const editorOptions = useMemo(
@@ -398,7 +403,10 @@ function EditableListDisplay({
 
   const updateCheckedEditablesRequest = async (type, urlFunc, data = {}) => {
     setActiveRequest(type);
-    const rv = await checkedEditablesRequest(urlFunc, data);
+    const rv = await checkedEditablesRequest(urlFunc, {
+      ...data,
+      editor_assignments: editorAssignments,
+    });
     if (rv) {
       patchList(rv);
     }

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -13,9 +13,9 @@ from flask import jsonify, request, session
 from marshmallow import EXCLUDE, fields
 from marshmallow_enum import EnumField
 from sqlalchemy.orm import joinedload
-from werkzeug.exceptions import BadRequest, Forbidden, NotFound, ServiceUnavailable
+from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound, ServiceUnavailable
 
-from indico.core.errors import UserValueError
+from indico.core.errors import NoReportError, UserValueError
 from indico.modules.events.editing.controllers.base import RHContributionEditableBase, TokenAccessMixin
 from indico.modules.events.editing.fields import EditingFilesField, EditingTagsField
 from indico.modules.events.editing.models.comments import EditingRevisionComment
@@ -440,7 +440,7 @@ class RHEditableAssignMe(RHContributionEditableBase):
     def _check_access(self):
         RHContributionEditableBase._check_access(self)
         if self.editable.editor:
-            raise Forbidden(_('This contribution already has an assigned editor'))
+            raise NoReportError.wrap_exc(Conflict(_('This editable already has an editor assigned')))
         if not self.editable.can_assign_self(session.user):
             raise Forbidden(_('You do not have the permission to assign yourself'))
 

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -439,6 +439,8 @@ class RHEditableUnassign(RHContributionEditableBase):
 class RHEditableAssignMe(RHContributionEditableBase):
     def _check_access(self):
         RHContributionEditableBase._check_access(self)
+        if self.editable.editor:
+            raise Forbidden(_('This contribution already has an assigned editor'))
         if not self.editable.can_assign_self(session.user):
             raise Forbidden(_('You do not have the permission to assign yourself'))
 


### PR DESCRIPTION
This PR prevents the assignment of editors to editables if changes have occurred in parallel. In bulk assignments, it also allows users to proceed with the assignment anyway.

![image](https://user-images.githubusercontent.com/27357203/220149546-d38154b0-0225-4947-ad6d-36976654b4d1.png)

