### PR TITLE
Use the revision's timestamp on ZIP archives

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Version 3.2.4
 Improvements
 ^^^^^^^^^^^^
 
-- None so far :(
+- Use the revision's timestamp when downloading its files as a ZIP archive (:pr:`5686`)
 
 Bugfixes
 ^^^^^^^^


### PR DESCRIPTION
Use the revision's timestamp on ZIP archives' files instead of the datetime at the time of the download.