### PR TITLE
Fix file upload when modifying registration in a protected event

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Bugfixes
 - Clone all protection settings (in particular submitter privileges) when cloning events
   (:pr:`5702`)
 - Fix searching in single-choice dropdown fields in registration forms (:pr:`5709`)
+- Fix uploading files in registration forms where the user only has access through the
+  registration's token (:pr:`5719`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
@@ -20,9 +20,17 @@ import '../../../styles/regform.module.scss';
 import './FileInput.module.scss';
 
 export default function FileInput({htmlName, disabled, isRequired}) {
-  const {eventId, regformId, fileData} = useSelector(getStaticData);
+  const {eventId, regformId, registrationUuid, fileData} = useSelector(getStaticData);
   const isUpdateMode = useSelector(getUpdateMode);
   const initialFileDetails = isUpdateMode ? fileData[htmlName] || null : null;
+
+  const urlParams = {
+    event_id: eventId,
+    reg_form_id: regformId,
+  };
+  if (registrationUuid) {
+    urlParams.token = registrationUuid;
+  }
 
   return (
     <div styleName="file-field">
@@ -30,7 +38,7 @@ export default function FileInput({htmlName, disabled, isRequired}) {
         name={htmlName}
         disabled={disabled}
         required={isRequired}
-        uploadURL={uploadFileURL({event_id: eventId, reg_form_id: regformId})}
+        uploadURL={uploadFileURL(urlParams)}
         initialFileDetails={initialFileDetails}
       />
     </div>

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -365,6 +365,17 @@ class RHUploadRegistrationFile(UploadFileMixin, RHRegistrationFormBase):
     Only this uuid is then sent when the regform is submitted.
     """
 
+    @use_kwargs({
+        'token': UUIDString(load_default=None),
+    }, location='query')
+    def _process_args(self, token):
+        RHRegistrationFormBase._process_args(self)
+        self.existing_registration = self.regform.get_registration(uuid=token) if token else None
+
+    def _check_access(self):
+        if not self.existing_registration:
+            RHRegistrationFormBase._check_access(self)
+
     def get_file_context(self):
         return 'event', self.event.id, 'regform', self.regform.id, 'registration'
 


### PR DESCRIPTION
When the event is protected and the user just accesses it via its registration token (e.g. because the user was originally logged in or used an access key to access the event), the file upload endpoint still enforced the access check, causing file uploads to fail.

Now we pass the registration token there as well and thus skip the access check when the endpoint is accessed in the context of an existing registration.