### PR TITLE
Fix abstract submission success message

### DIFF
--- a/indico/modules/events/abstracts/controllers/abstract_list.py
+++ b/indico/modules/events/abstracts/controllers/abstract_list.py
@@ -183,8 +183,8 @@ class RHCreateAbstract(RHAbstractListBase):
                 data.pop('submitter')
 
             send_notifications = data.pop('send_notifications', is_invited)
-            abstract = create_abstract(self.event, *get_field_values(data), send_notifications=send_notifications,
-                                       submitter=submitter, is_invited=is_invited)
+            abstract, __ = create_abstract(self.event, *get_field_values(data), send_notifications=send_notifications,
+                                           submitter=submitter, is_invited=is_invited)
             flash(_("Abstract '{}' created successfully").format(abstract.title), 'success')
             tpl_components = self.list_generator.render_list(abstract)
             if tpl_components.get('hide_abstract'):

--- a/indico/modules/events/abstracts/controllers/display.py
+++ b/indico/modules/events/abstracts/controllers/display.py
@@ -65,10 +65,15 @@ class RHSubmitAbstract(RHAbstractsBase):
         abstract_form_class = make_abstract_form(self.event, session.user, management=self.management)
         form = abstract_form_class(event=self.event)
         if form.validate_on_submit():
-            abstract = create_abstract(self.event, *get_field_values(form.data), send_notifications=True)
-            flash(_("Your abstract '{}' has been successfully submitted. It is registered with the number "
-                    '#{}. You will be notified by email with the submission details.')
-                  .format(abstract.title, abstract.friendly_id), 'success')
+            abstract, notifications_sent = create_abstract(self.event, *get_field_values(form.data),
+                                                           send_notifications=True)
+            if notifications_sent:
+                flash(_("Your abstract '{}' has been successfully submitted. It is registered with the number "
+                        '#{}. You will be notified by email with the submission details.')
+                      .format(abstract.title, abstract.friendly_id), 'success')
+            else:
+                flash(_("Your abstract '{}' has been successfully submitted. It is registered with the number #{}.")
+                      .format(abstract.title, abstract.friendly_id), 'success')
             return jsonify_data(flash=False, redirect=url_for('.call_for_abstracts', self.event))
         return jsonify_template('events/abstracts/display/submission.html', event=self.event, form=form)
 

--- a/indico/modules/events/abstracts/operations.py
+++ b/indico/modules/events/abstracts/operations.py
@@ -110,11 +110,13 @@ def create_abstract(event, abstract_data, custom_fields_data=None, send_notifica
     signals.event.abstract_created.send(abstract)
 
     if send_notifications:
-        send_abstract_notifications(abstract)
+        notifications_sent = send_abstract_notifications(abstract)
+    else:
+        notifications_sent = False
     logger.info('Abstract %s created by %s', abstract, session.user)
     abstract.log(EventLogRealm.reviewing, LogKind.positive, 'Abstracts',
                  f'Abstract {abstract.verbose_title} created', session.user)
-    return abstract
+    return abstract, notifications_sent
 
 
 def update_abstract(abstract, abstract_data, custom_fields_data=None):


### PR DESCRIPTION
This PR fixes a misleading abstract submission success message, which incorrectly states "You will be notified by email with the submission details." even if no notifications are sent (e.g. no notification templates are set).