### PR TITLE
Add bulk-judgment for editables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Improvements
   room bookings (:issue:`5730`, :pr:`5740`)
 - Add day of the week to room booking details modal and timeline (:issue:`5718`,
   :pr:`5743`)
+- Allow acceptance and rejection of editables in the editable list (:pr:`5721`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -19,7 +19,7 @@ _bp.add_url_rule('/manage/editing/tags', 'manage_tags', frontend.RHEditingDashbo
 _bp.add_url_rule('/manage/editing/<any(paper,slides,poster):type>/', 'manage_editable_type',
                  frontend.RHEditingDashboard)
 _bp.add_url_rule('/manage/editing/<any(paper,slides,poster):type>/list', 'manage_editable_type_list',
-                 frontend.RHEditingDashboard)
+                 frontend.RHEditableListManagement)
 _bp.add_url_rule('/manage/editing/<any(paper,slides,poster):type>/types', 'manage_file_types',
                  frontend.RHEditingDashboard)
 _bp.add_url_rule('/manage/editing/<any(paper,slides,poster):type>/review-conditions', 'manage_review_conditions',

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -83,6 +83,8 @@ _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/assign/
                  editable_list.RHAssignMyselfAsEditor, methods=('POST',))
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/unassign', 'api_unassign_editor',
                  editable_list.RHUnassignEditor, methods=('POST',))
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/judge', 'api_apply_judgment',
+                 editable_list.RHApplyJudgment, methods=('POST',))
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/self-assign-allowed',
                  'api_editor_self_assign_allowed', common.RHEditableCheckSelfAssign)
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editors', 'api_editable_type_editors',

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -220,20 +220,20 @@ function EditableListDisplay({
 
   const skippedEditablesWarning = {
     [EditableType.paper]: PluralTranslate.string(
-      '{count} paper was skipped because it does not fulfill the reviewing conditions.',
-      '{count} papers were skipped because they do not fulfill the reviewing conditions.',
+      '{count} paper was skipped because of its current status.',
+      '{count} papers were skipped because of their current status.',
       skippedEditables,
       {count: skippedEditables}
     ),
     [EditableType.slides]: PluralTranslate.string(
-      '{count} slide was skipped because it does not fulfill the reviewing conditions.',
-      '{count} slides were skipped because they do not fulfill the reviewing conditions.',
+      '{count} slide was skipped because of its current status.',
+      '{count} slides were skipped because of their current status.',
       skippedEditables,
       {count: skippedEditables}
     ),
     [EditableType.poster]: PluralTranslate.string(
-      '{count} poster was skipped because it does not fulfill the reviewing conditions.',
-      '{count} posters were skipped because they do not fulfill the reviewing conditions.',
+      '{count} poster was skipped because of its current status.',
+      '{count} posters were skipped because of their current status.',
       skippedEditables,
       {count: skippedEditables}
     ),
@@ -241,7 +241,7 @@ function EditableListDisplay({
 
   const columnHeaders = [
     ['friendlyId', Translate.string('ID'), 60],
-    ...(codePresent ? [['code', Translate.string('Code'), 80]] : []),
+    ...(codePresent ? [['code', Translate.string('Code'), 110]] : []),
     ['title', Translate.string('Title'), 600],
     ['revision', Translate.string('Rev.'), 80],
     ['status', Translate.string('Status'), 200],
@@ -451,6 +451,7 @@ function EditableListDisplay({
     if (rv) {
       patchList(rv);
     }
+    return rv;
   };
 
   const checkedEditablesAssignmentRequest = async (type, urlFunc, data = {}) =>
@@ -471,14 +472,11 @@ function EditableListDisplay({
     checkedEditablesAssignmentRequest('unassign', unassignEditorURL);
   };
 
-  const applyJudgment = action => {
-    updateCheckedEditablesRequest('judgment', applyJudgmentURL, {action});
-    const isJudgeable = ({state}) =>
-      state === 'ready_for_review' ||
-      (state === 'needs_submitter_confirmation' && action === 'accept');
-    setSkippedEditables(
-      contribList.filter(({editable: e}) => e && checked.includes(e.id) && !isJudgeable(e)).length
-    );
+  const applyJudgment = async action => {
+    const rv = await updateCheckedEditablesRequest('judgment', applyJudgmentURL, {action});
+    if (rv) {
+      setSkippedEditables(checked.length - rv.length);
+    }
   };
 
   return (

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -460,7 +460,7 @@ function EditableListDisplay({
         <ManagementPageBackButton url={editableTypeURL({event_id: eventId, type: editableType})} />
       )}
       <div styleName="editable-topbar">
-        <div>
+        <div styleName="editable-actions">
           {canAssignSelf && (
             <Button
               content={GetNextEditableTitles[editableType]}
@@ -509,25 +509,23 @@ function EditableListDisplay({
                   onClick={unassignEditor}
                   loading={activeRequest === 'unassign'}
                 />
-              </Button.Group>{' '}
-              <Button.Group>
-                <Dropdown
-                  disabled={!hasCheckedContribs || !!activeRequest}
-                  options={judgmentOptions}
-                  scrolling
-                  icon={null}
-                  value={null}
-                  selectOnBlur={false}
-                  selectOnNavigation={false}
-                  onChange={(evt, {value}) => applyJudgment(value)}
-                  trigger={
-                    <Button icon loading={activeRequest === 'judgment'}>
-                      <Translate>Judge</Translate>
-                      <Icon name="caret down" />
-                    </Button>
-                  }
-                />
-              </Button.Group>{' '}
+              </Button.Group>
+              <Dropdown
+                disabled={!hasCheckedContribs || !!activeRequest}
+                options={judgmentOptions}
+                scrolling
+                icon={null}
+                value={null}
+                selectOnBlur={false}
+                selectOnNavigation={false}
+                onChange={(evt, {value}) => applyJudgment(value)}
+                trigger={
+                  <Button icon loading={activeRequest === 'judgment'}>
+                    <Translate>Judge</Translate>
+                    <Icon name="caret down" />
+                  </Button>
+                }
+              />
               <Button.Group>
                 <Button
                   disabled={!hasCheckedContribs || !!activeRequest}

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -5,6 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import applyJudgmentURL from 'indico-url:event_editing.api_apply_judgment';
 import assignEditorURL from 'indico-url:event_editing.api_assign_editor';
 import assignSelfEditorURL from 'indico-url:event_editing.api_assign_myself';
 import editableListURL from 'indico-url:event_editing.api_editable_list';
@@ -129,6 +130,21 @@ function EditableListDisplay({
       })),
     [editors]
   );
+
+  const judgmentOptions = [
+    {
+      key: 'accept',
+      value: 'accept',
+      text: Translate.string('Accept'),
+      label: {color: 'green', empty: true, circular: true},
+    },
+    {
+      key: 'reject',
+      value: 'reject',
+      text: Translate.string('Reject'),
+      label: {color: 'black', empty: true, circular: true},
+    },
+  ];
 
   const filterOptions = useMemo(
     () => [
@@ -409,25 +425,32 @@ function EditableListDisplay({
 
   const updateCheckedEditablesRequest = async (type, urlFunc, data = {}) => {
     setActiveRequest(type);
-    const rv = await checkedEditablesRequest(urlFunc, {
-      ...data,
-      editor_assignments: editorAssignments,
-    });
+    const rv = await checkedEditablesRequest(urlFunc, data);
     if (rv) {
       patchList(rv);
     }
   };
 
+  const checkedEditablesAssignmentRequest = async (type, urlFunc, data = {}) =>
+    updateCheckedEditablesRequest(type, urlFunc, {
+      ...data,
+      editor_assignments: editorAssignments,
+    });
+
   const assignEditor = editor => {
-    updateCheckedEditablesRequest('assign', assignEditorURL, {editor});
+    checkedEditablesAssignmentRequest('assign', assignEditorURL, {editor});
   };
 
   const assignSelfEditor = () => {
-    updateCheckedEditablesRequest('assign-self', assignSelfEditorURL);
+    checkedEditablesAssignmentRequest('assign-self', assignSelfEditorURL);
   };
 
   const unassignEditor = async () => {
-    updateCheckedEditablesRequest('unassign', unassignEditorURL);
+    checkedEditablesAssignmentRequest('unassign', unassignEditorURL);
+  };
+
+  const applyJudgment = action => {
+    updateCheckedEditablesRequest('judgment', applyJudgmentURL, {action});
   };
 
   return (
@@ -485,6 +508,24 @@ function EditableListDisplay({
                   content={Translate.string('Unassign')}
                   onClick={unassignEditor}
                   loading={activeRequest === 'unassign'}
+                />
+              </Button.Group>{' '}
+              <Button.Group>
+                <Dropdown
+                  disabled={!hasCheckedContribs || !!activeRequest}
+                  options={judgmentOptions}
+                  scrolling
+                  icon={null}
+                  value={null}
+                  selectOnBlur={false}
+                  selectOnNavigation={false}
+                  onChange={(evt, {value}) => applyJudgment(value)}
+                  trigger={
+                    <Button icon loading={activeRequest === 'judgment'}>
+                      <Translate>Judge</Translate>
+                      <Icon name="caret down" />
+                    </Button>
+                  }
                 />
               </Button.Group>{' '}
               <Button.Group>

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.module.scss
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.module.scss
@@ -11,8 +11,17 @@ $border: 1px solid $pastel-gray;
 
 .editable-topbar {
   display: flex;
-  width: 1000px;
   justify-content: space-between;
+
+  .editable-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+
+    :global(.ui.button) {
+      margin-right: 0;
+    }
+  }
 }
 
 .editable-list {

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.module.scss
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.module.scss
@@ -12,6 +12,7 @@ $border: 1px solid $pastel-gray;
 .editable-topbar {
   display: flex;
   justify-content: space-between;
+  min-width: 1000px;
 
   .editable-actions {
     display: flex;

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -142,6 +142,7 @@ class RHApplyJudgment(RHEditablesBase):
         'action': fields.String(required=True, validate=validate.OneOf(['accept', 'reject']))
     })
     def _process(self, action):
+        changed = []
         for editable in self.editables:
             revision = editable.latest_revision
             if revision.final_state != FinalRevisionState.none:
@@ -152,8 +153,11 @@ class RHApplyJudgment(RHEditablesBase):
                 confirm_and_publish_changes(revision, EditingConfirmationAction.accept, '')
                 revision.editor = session.user
                 db.session.flush()
+            else:
+                continue
             db.session.expire(editable)
-        return EditableBasicSchema(many=True).jsonify(self.editables)
+            changed.append(editable)
+        return EditableBasicSchema(many=True).jsonify(changed)
 
 
 class RHFilterEditablesByFileTypes(RHEditableTypeEditorBase):

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -147,6 +147,8 @@ class RHApplyJudgment(RHEditablesBase):
             revision = editable.latest_revision
             if revision.final_state != FinalRevisionState.none:
                 continue
+            elif action == 'accept' and not revision.has_publishable_files:
+                continue
             if revision.initial_state == InitialRevisionState.ready_for_review:
                 review_and_publish_editable(revision, EditingReviewAction[action], '')
             elif revision.initial_state == InitialRevisionState.needs_submitter_confirmation and action == 'accept':

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -130,7 +130,7 @@ class RHEditable(RHContributionEditableBase):
 
     def _process(self):
         custom_actions = self._get_custom_actions()
-        custom_actions_ctx = {self.editable.valid_revisions[-1]: custom_actions}
+        custom_actions_ctx = {self.editable.latest_revision: custom_actions}
         schema = EditableSchema(context={
             'user': session.user,
             'custom_actions': custom_actions_ctx,

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -17,17 +17,17 @@ from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import BadRequest, Conflict, Forbidden, NotFound, ServiceUnavailable
 
 from indico.core.errors import NoReportError, UserValueError
+from indico.modules.events.editing.controllers.backend.util import (confirm_and_publish_changes,
+                                                                    review_and_publish_editable)
 from indico.modules.events.editing.controllers.base import RHContributionEditableBase, TokenAccessMixin
 from indico.modules.events.editing.fields import EditingFilesField, EditingTagsField
 from indico.modules.events.editing.models.comments import EditingRevisionComment
 from indico.modules.events.editing.models.revision_files import EditingRevisionFile
 from indico.modules.events.editing.models.revisions import EditingRevision, InitialRevisionState
-from indico.modules.events.editing.operations import (assign_editor, confirm_editable_changes, create_new_editable,
-                                                      create_revision_comment, create_submitter_revision,
-                                                      delete_revision_comment, ensure_latest_revision,
-                                                      publish_editable_revision, replace_revision,
-                                                      review_editable_revision, unassign_editor, undo_review,
-                                                      update_revision_comment)
+from indico.modules.events.editing.operations import (assign_editor, create_new_editable, create_revision_comment,
+                                                      create_submitter_revision, delete_revision_comment,
+                                                      ensure_latest_revision, replace_revision, unassign_editor,
+                                                      undo_review, update_revision_comment)
 from indico.modules.events.editing.schemas import (EditableSchema, EditingConfirmationAction, EditingReviewAction,
                                                    ReviewEditableArgs)
 from indico.modules.events.editing.service import (ServiceRequestFailed, service_get_custom_actions,
@@ -205,21 +205,7 @@ class RHReviewEditable(RHContributionEditableRevisionBase):
             argmap['files'] = EditingFilesField(self.event, self.contrib, self.editable_type, allow_claimed_files=True,
                                                 required=(action != EditingReviewAction.request_update))
         args = parser.parse(argmap, unknown=EXCLUDE)
-        service_url = editing_settings.get(self.event, 'service_url')
-
-        new_revision = review_editable_revision(self.revision, session.user, action, comment, args['tags'],
-                                                args.get('files'))
-
-        publish = True
-        if service_url:
-            try:
-                resp = service_handle_review_editable(self.editable, session.user, action, self.revision, new_revision)
-                publish = resp.get('publish', True)
-            except ServiceRequestFailed:
-                raise ServiceUnavailable(_('Failed processing review, please try again later.'))
-
-        if publish and action in (EditingReviewAction.accept, EditingReviewAction.update_accept):
-            publish_editable_revision(new_revision or self.revision)
+        review_and_publish_editable(self.revision, action, comment, args['tags'], args.get('files'))
         return '', 204
 
 
@@ -234,19 +220,7 @@ class RHConfirmEditableChanges(RHContributionEditableRevisionBase):
         'comment': fields.String(load_default='')
     })
     def _process(self, action, comment):
-        confirm_editable_changes(self.revision, session.user, action, comment)
-
-        service_url = editing_settings.get(self.event, 'service_url')
-        publish = True
-        if service_url:
-            try:
-                resp = service_handle_review_editable(self.editable, session.user, action, self.revision)
-                publish = resp.get('publish', True)
-            except ServiceRequestFailed:
-                raise ServiceUnavailable(_('Failed processing review, please try again later.'))
-
-        if publish and action == EditingConfirmationAction.accept:
-            publish_editable_revision(self.revision)
+        confirm_and_publish_changes(self.revision, action, comment)
         return '', 204
 
 

--- a/indico/modules/events/editing/controllers/backend/util.py
+++ b/indico/modules/events/editing/controllers/backend/util.py
@@ -1,0 +1,44 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from flask import session
+from werkzeug.exceptions import ServiceUnavailable
+
+from indico.modules.events.editing.operations import (confirm_editable_changes, publish_editable_revision,
+                                                      review_editable_revision)
+from indico.modules.events.editing.schemas import EditingConfirmationAction, EditingReviewAction
+from indico.modules.events.editing.service import ServiceRequestFailed, service_handle_review_editable
+from indico.modules.events.editing.settings import editing_settings
+from indico.util.i18n import _
+
+
+def review_and_publish_editable(revision, action, comment, tags=set(), files=None):
+    service_url = editing_settings.get(revision.editable.event, 'service_url')
+    new_revision = review_editable_revision(revision, session.user, action, comment, tags, files)
+    publish = True
+    if service_url:
+        try:
+            resp = service_handle_review_editable(revision.editable, session.user, action, revision, new_revision)
+            publish = resp.get('publish', True)
+        except ServiceRequestFailed:
+            raise ServiceUnavailable(_('Failed processing review, please try again later.'))
+    if publish and action in (EditingReviewAction.accept, EditingReviewAction.update_accept):
+        publish_editable_revision(new_revision or revision)
+
+
+def confirm_and_publish_changes(revision, action, comment):
+    confirm_editable_changes(revision, session.user, action, comment)
+    service_url = editing_settings.get(revision.editable.event, 'service_url')
+    publish = True
+    if service_url:
+        try:
+            resp = service_handle_review_editable(revision.editable, session.user, action, revision)
+            publish = resp.get('publish', True)
+        except ServiceRequestFailed:
+            raise ServiceUnavailable(_('Failed processing review, please try again later.'))
+    if publish and action == EditingConfirmationAction.accept:
+        publish_editable_revision(revision)

--- a/indico/modules/events/editing/controllers/frontend.py
+++ b/indico/modules/events/editing/controllers/frontend.py
@@ -21,6 +21,13 @@ class RHEditingDashboard(RHEditingManagementBase):
         return WPEditing.render_template(f'management/{template}', self.event)
 
 
+class RHEditableListManagement(RHEditingManagementBase):
+    EVENT_FEATURE = None
+
+    def _process(self):
+        return WPEditing.render_template('management/editable_list.html', self.event)
+
+
 class RHEditableTimeline(RHContributionEditableBase):
     def _process_args(self):
         RHContributionEditableBase._process_args(self)

--- a/indico/modules/events/editing/controllers/frontend.py
+++ b/indico/modules/events/editing/controllers/frontend.py
@@ -22,8 +22,6 @@ class RHEditingDashboard(RHEditingManagementBase):
 
 
 class RHEditableListManagement(RHEditingManagementBase):
-    EVENT_FEATURE = None
-
     def _process(self):
         return WPEditing.render_template('management/editable_list.html', self.event)
 

--- a/indico/modules/events/editing/models/editable.py
+++ b/indico/modules/events/editing/models/editable.py
@@ -115,6 +115,10 @@ class Editable(db.Model):
         from .revisions import FinalRevisionState
         return [r for r in self.revisions if r.final_state != FinalRevisionState.undone]
 
+    @property
+    def latest_revision(self):
+        return self.valid_revisions[-1] if self.valid_revisions else None
+
     def _has_general_editor_permissions(self, user):
         """Whether the user has general editor permissions on the Editable.
 

--- a/indico/modules/events/editing/models/revisions.py
+++ b/indico/modules/events/editing/models/revisions.py
@@ -174,6 +174,10 @@ class EditingRevision(RenderModeMixin, db.Model):
     def __repr__(self):
         return format_repr(self, 'id', 'editable_id', 'initial_state', final_state=FinalRevisionState.none)
 
+    @property
+    def has_publishable_files(self):
+        return any(file.file_type.publishable for file in self.files)
+
     @locator_property
     def locator(self):
         return dict(self.editable.locator, revision_id=self.id)

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -445,5 +445,5 @@ def _compose_filepath(editable, revision_file):
 
 
 def _ensure_publishable_files(revision):
-    if not any(f.file_type.publishable for f in revision.files):
+    if not revision.has_publishable_files:
         raise InvalidEditableState

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -49,7 +49,7 @@ class InvalidEditableState(BadRequest):
 
 
 def ensure_latest_revision(revision):
-    if revision != revision.editable.valid_revisions[-1]:
+    if revision != revision.editable.latest_revision:
         raise InvalidEditableState
 
 
@@ -246,7 +246,7 @@ def _ensure_latest_revision_with_final_state(revision):
 @no_autoflush
 def undo_review(revision):
     _ensure_latest_revision_with_final_state(revision)
-    latest_revision = revision.editable.valid_revisions[-1]
+    latest_revision = revision.editable.latest_revision
     if revision != latest_revision and not _is_request_changes_with_files(latest_revision):
         if revision.editable.valid_revisions[-2:] != [revision, latest_revision]:
             raise InvalidEditableState

--- a/indico/modules/events/editing/templates/management/base.html
+++ b/indico/modules/events/editing/templates/management/base.html
@@ -1,4 +1,4 @@
-{% extends 'events/management/base.html' %}
+{% extends 'events/management/full_width_base.html' %}
 
 {% block title %}
     {% trans %}Editing{% endtrans %}

--- a/indico/modules/events/editing/templates/management/base.html
+++ b/indico/modules/events/editing/templates/management/base.html
@@ -1,4 +1,4 @@
-{% extends 'events/management/full_width_base.html' %}
+{% extends 'events/management/base.html' %}
 
 {% block title %}
     {% trans %}Editing{% endtrans %}

--- a/indico/modules/events/editing/templates/management/editable_list.html
+++ b/indico/modules/events/editing/templates/management/editable_list.html
@@ -1,0 +1,11 @@
+{% extends 'events/editing/management/base.html' %}
+
+{% block page %}
+    <div class="full-width-content-wrapper">
+        {{ super() }}
+    </div>
+{% endblock %}
+
+{% block content %}
+    <div id="editing-management"></div>
+{% endblock %}

--- a/indico/modules/events/editing/templates/management/editing.html
+++ b/indico/modules/events/editing/templates/management/editing.html
@@ -1,5 +1,5 @@
 {% extends 'events/editing/management/base.html' %}
 
 {% block content %}
-    <div class="page-content" id="editing-management"></div>
+    <div id="editing-management"></div>
 {% endblock %}

--- a/indico/web/client/js/react/components/ListFilter.jsx
+++ b/indico/web/client/js/react/components/ListFilter.jsx
@@ -117,7 +117,7 @@ export default function ListFilter({
   };
 
   return (
-    <div>
+    <div styleName="filters-container">
       <Dropdown
         text={Translate.string('Filter')}
         icon="filter"

--- a/indico/web/client/js/react/components/ListFilter.module.scss
+++ b/indico/web/client/js/react/components/ListFilter.module.scss
@@ -5,6 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+.filters-container {
+  margin-left: 0.5em;
+  white-space: nowrap;
+}
+
 .filters-menu {
   max-width: 15em;
 }


### PR DESCRIPTION
This PR adds a button for judging editables in bulk in the editables list. It allows performing "accept" and "reject" actions on editables which are on the "Ready for Review" or "Needs Submitter Confirmation" states.

![image](https://user-images.githubusercontent.com/27357203/229173622-74a8ac03-c831-4868-8462-d6bacac85a2a.png)

Progress

- [x] Add the judge button on the editables list
- [x] Implement judging functionality
- [x] Fix some UI bugs (particularly when the window is narrow)
- [x] Display warning when editables are skipped
- [x] Changelog entry