### PR TITLE
Remove `ms-vscode.references-view` extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,7 +11,6 @@
     "redhat.vscode-yaml",
     "samuelcolvin.jinjahtml",
     // misc
-    "ms-vscode.references-view",
     "jakearl.search-editor-apply-changes",
   ],
   "unwantedRecommendations": [


### PR DESCRIPTION
This extension in now bundled by default in Visual Studio Code versions 1.29 and later - it no longer has to be installed.

See: https://github.com/microsoft/vscode-references-view
