### PR TITLE
Add support for authorized submitters in CfP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Improvements
   corresponding contributions (:pr:`5711`)
 - Allow commenting on accepted/rejected editables (:issue:`5712`, :pr:`5722`)
 - Hide deleted sections and fields from registration summary (:pr:`5716`)
+- Add support for authorized submitters in Call for Papers (:pr:`5728`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/papers/controllers/display.py
+++ b/indico/modules/events/papers/controllers/display.py
@@ -37,7 +37,7 @@ class RHSubmitPaper(RHPaperBase):
 
     def _check_access(self):
         RHPaperBase._check_access(self)
-        if not self.event.cfp.is_open:
+        if not self.event.cfp.can_submit_proceedings(session.user):
             raise NoReportError.wrap_exc(Forbidden(_('The Call for Papers is closed. '
                                                      'Please contact the event organizer for further assistance.')))
 
@@ -122,7 +122,7 @@ class RHSelectContribution(RHCallForPapers):
 
     def _check_access(self):
         RHCallForPapers._check_access(self)
-        if not self.event.cfp.is_open:
+        if not self.event.cfp.can_submit_proceedings(session.user):
             raise NoReportError.wrap_exc(Forbidden(_('The Call for Papers is closed. '
                                                      'Please contact the event organizer for further assistance.')))
 

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -91,6 +91,11 @@ class PaperReviewingSettingsForm(IndicoForm):
     hide_accepted = BooleanField(_('Keep papers hidden'), widget=SwitchWidget(),
                                  description=_("Keep papers hidden from participants even after they've "
                                                'been accepted.'))
+    authorized_submitters = PrincipalListField(_('Authorized submitters'), event=lambda form: form.event,
+                                               allow_external_users=True, allow_groups=True,
+                                               allow_event_roles=True, allow_category_roles=True,
+                                               description=_('These users may always submit papers, '
+                                                             'even outside the regular submission period.'))
     email_settings = PaperEmailSettingsField(_('Email notifications'))
 
     def __init__(self, *args, **kwargs):

--- a/indico/modules/events/papers/models/call_for_papers.py
+++ b/indico/modules/events/papers/models/call_for_papers.py
@@ -163,6 +163,19 @@ class CallForPapers:
             return (self.is_reviewer(user, PaperReviewingRole.content_reviewer) or
                     self.is_reviewer(user, PaperReviewingRole.layout_reviewer))
 
+    def is_authorized_submitter(self, user):
+        """Check if the user can submit papers even when the CfP is closed."""
+        return paper_reviewing_settings.acls.contains_user(self.event, 'authorized_submitters', user)
+
+    def can_submit_proceedings(self, user):
+        """Check if the user can theoretically submit papers.
+
+        This does not check if the user actually has any contributions for which they can
+        submit a paper. To check if a user can submit a paper for a specific contribution, use
+        :meth:`Contribution.can_submit_proceedings <.Contribution.can_submit_proceedings>` instead.
+        """
+        return self.is_open or self.is_authorized_submitter(user)
+
     def can_access_reviewing_area(self, user):
         return self.is_staff(user)
 

--- a/indico/modules/events/papers/models/call_for_papers_test.py
+++ b/indico/modules/events/papers/models/call_for_papers_test.py
@@ -1,0 +1,33 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from indico.modules.events.papers.settings import paper_reviewing_settings
+
+
+def test_is_authorized_submitter(dummy_user, dummy_event):
+    assert not dummy_event.cfp.is_authorized_submitter(dummy_user)
+    paper_reviewing_settings.acls.add_principal(dummy_event, 'authorized_submitters', dummy_user)
+    assert dummy_event.cfp.is_authorized_submitter(dummy_user)
+
+
+def test_can_submit_proceedings(dummy_user, dummy_event):
+    cfp = dummy_event.cfp
+
+    assert not cfp.can_submit_proceedings(dummy_user)
+    cfp.open()
+    assert cfp.is_open
+    assert cfp.can_submit_proceedings(dummy_user)
+
+    paper_reviewing_settings.acls.add_principal(dummy_event, 'authorized_submitters', dummy_user)
+    assert cfp.can_submit_proceedings(dummy_user)
+
+    cfp.close()
+    assert not cfp.is_open
+    assert cfp.can_submit_proceedings(dummy_user)
+
+    paper_reviewing_settings.acls.remove_principal(dummy_event, 'authorized_submitters', dummy_user)
+    assert not cfp.can_submit_proceedings(dummy_user)

--- a/indico/modules/events/papers/settings.py
+++ b/indico/modules/events/papers/settings.py
@@ -71,4 +71,6 @@ paper_reviewing_settings = EventSettingsProxy('paper_reviewing', {
     'notify_on_added_to_event': RoleConverter,
     'notify_on_assigned_contrib': RoleConverter,
     'notify_on_paper_submission': RoleConverter
+}, acls={
+    'authorized_submitters'
 })

--- a/indico/modules/events/papers/templates/display/_common.html
+++ b/indico/modules/events/papers/templates/display/_common.html
@@ -1,14 +1,19 @@
-{% macro render_cfp_infoline(event, cfp, contributions, show_icon=true) %}
+{% macro render_cfp_infoline(event, cfp, contributions) %}
     <div class="action-box highlight">
         <div class="section">
-            {% if show_icon %}
-                <span class="icon icon-file-content"></span>
-            {% endif %}
+            {% set is_authorized = cfp.is_authorized_submitter(session.user) %}
+            {% set can_submit = cfp.can_submit_proceedings(session.user) %}
             <div class="text">
-                {%- if cfp.is_open %}
-                    <div class="label">
+                <div class="label">
+                    {%- if cfp.is_open %}
                         {%- trans %}The call for papers is open{% endtrans -%}
-                    </div>
+                    {% elif is_authorized %}
+                        {%- trans %}You have been authorized to submit papers{% endtrans -%}
+                    {% else %}
+                        <div class="label">{% trans %}The call for papers is closed.{% endtrans %}</div>
+                    {% endif -%}
+                </div>
+                {%- if can_submit %}
                     <div>
                         {% if contributions|length == 1 %}
                             {% set contrib = contributions|first %}
@@ -20,11 +25,9 @@
                             {%- trans %}You can submit a paper{% endtrans -%}
                         {% endif %}
                     </div>
-                {% else %}
-                    <div class="label">{% trans %}The call for papers is closed.{% endtrans %}</div>
                 {% endif -%}
             </div>
-            {%- if cfp.is_open %}
+            {%- if can_submit %}
                 <div class="toolbar">
                     {% if contributions|length == 1 %}
                         {% set contrib = contributions|first %}

--- a/indico/modules/events/papers/templates/display/call_for_papers.html
+++ b/indico/modules/events/papers/templates/display/call_for_papers.html
@@ -17,9 +17,9 @@
                 <div class="cfp-announcement">{{ cfp.announcement }}</div>
             </section>
         {% endif %}
-        {% if contributions or not cfp.is_open %}
+        {% if contributions or not cfp.can_submit_proceedings(session.user) %}
             <section class="cfp-infoline-section">
-                {{ render_cfp_infoline(event, cfp, contributions, show_icon=false) }}
+                {{ render_cfp_infoline(event, cfp, contributions) }}
             </section>
         {% endif %}
         {% if event.paper_templates %}


### PR DESCRIPTION
We don't have a `Submission` section in CfP like we do in CfA so I added this option to the `Reviewing settings` which already has options like `Announcement` that are in submission settings in CfA.

![image](https://user-images.githubusercontent.com/8739637/230353025-446dcb00-d840-4830-a321-563319099c84.png)
