### PR TITLE
Add watchfiles-based reloader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,7 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 
 - Update Python & JavaScript dependencies (:pr:`5726`)
+- Add support for the watchfiles live reloader (:pr:`5732`)
 
 
 Version 3.2.3

--- a/indico/cli/core.py
+++ b/indico/cli/core.py
@@ -85,14 +85,21 @@ def maint():
 
 @cli.command(context_settings={'ignore_unknown_options': True, 'allow_extra_args': True}, add_help_option=False)
 @click.option('--watchman', is_flag=True, help='Run celery inside watchman auto-reloader')
+@click.option('--watchfiles', is_flag=True, help='Run celery inside watchfiles auto-reloader')
 @click.pass_context
-def celery(ctx, watchman=False):
+def celery(ctx, watchman=False, watchfiles=False):
     """Manage the Celery task daemon."""
     from indico.core.celery.cli import celery_cmd
 
-    if watchman:
+    if watchman and watchfiles:
+        raise click.UsageError('--watchman and --watchfiles are mutually exclusive')
+    elif watchman:
         from .devserver import run_watchman
         run_watchman()
+        return
+    elif watchfiles:
+        from .devserver import run_watchfiles
+        run_watchfiles()
         return
 
     celery_cmd(ctx.args)
@@ -143,8 +150,9 @@ def cleanup(temp, cache, verbose, dry_run, min_age):
 @click.option('--evalex-from', multiple=True,
               help='Restrict the debugger shell to the given ips (can be used multiple times)')
 @click.option('--proxy', is_flag=True, help='Use the ip and protocol provided by the proxy.')
-@click.option('--reloader', 'reloader_type', type=click.Choice(['auto', 'none', 'stat', 'watchdog', 'watchman']),
-              default='auto', help='The type of auto-reloader to use.')
+@click.option('--reloader', 'reloader_type',
+              type=click.Choice(['auto', 'none', 'stat', 'watchdog', 'watchman', 'watchfiles']),
+              default='watchfiles', help='The type of auto-reloader to use.')
 @pass_script_info
 def run(info, **kwargs):
     """Run the development webserver.

--- a/indico/cli/devserver.py
+++ b/indico/cli/devserver.py
@@ -31,6 +31,9 @@ def run_cmd(info, **kwargs):
             return
         run_watchman()
         return
+    elif kwargs['reloader_type'] == 'watchfiles':
+        run_watchfiles()
+        return
     run_server(info, **kwargs)
 
 
@@ -41,6 +44,11 @@ def run_watchman():
     except pywatchman.WatchmanError as exc:
         from indico.util.console import cformat
         print(cformat('%{red!}watchman error: {}').format(exc))
+
+
+def run_watchfiles():
+    from .watchfiles import Watchfiles
+    Watchfiles().run()
 
 
 def run_server(info, host, port, url, ssl, ssl_key, ssl_cert, quiet, proxy, enable_evalex, evalex_from, reloader_type):

--- a/indico/cli/watchfiles.py
+++ b/indico/cli/watchfiles.py
@@ -1,0 +1,133 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import atexit
+import functools
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import click
+from flask.helpers import get_root_path
+from watchfiles import DefaultFilter, watch
+from werkzeug._reloader import _find_watchdog_paths
+
+from indico.util.console import cformat
+
+
+def _disable_reloader(argv):
+    argv = list(argv)  # we usually pass sys.argv, so let's not modify that
+    for i, arg in enumerate(argv):
+        if arg == '--reloader' and argv[i + 1] == 'watchfiles':
+            argv[i + 1] = 'none'
+        elif arg.startswith('--reloader') and '=' in arg:
+            argv[i] = '--reloader=none'
+        elif arg == '--watchfiles':
+            del argv[i]
+            break
+    return argv
+
+
+class IndicoFilter(DefaultFilter):
+    PYTHON_SUFFIXES = ('.py', '.pyx', '.pyd', '/entry_points.txt')
+
+    def __init__(self, indico_root_path, indico_config_paths):
+        self.indico_config_paths = {str(x) for x in indico_config_paths}
+        ignore_dirs = set(super().ignore_dirs) - {'site-packages'}
+        ignore_paths = {indico_root_path / 'build'}
+        super().__init__(ignore_dirs=ignore_dirs, ignore_paths=ignore_paths)
+
+    def __call__(self, change, path):
+        if path in self.indico_config_paths:
+            # config paths are exact matches on full paths so we can always
+            # succeed there; no need to check blacklisted paths etc
+            return True
+        elif not path.endswith(self.PYTHON_SUFFIXES):
+            # anything that's not python-related doesn't matter
+            return False
+
+        # we blacklisted the main indico build dir on the filter level, but for plugins we simply
+        # consider any build dir adjacent to a setup.cfg irrelevant
+        if '/build/' in path or path.endswith('/build'):
+            path_obj = Path(path)
+            if (list(path_obj.parents)[-path_obj.parts.index('build')] / 'setup.cfg').exists():
+                return False
+
+        return super().__call__(change, path)
+
+
+class Watchfiles:
+    def __init__(self):
+        self._proc = None
+        self._paths = set()
+        atexit.register(self._terminate)
+
+    def run(self):
+        indico_root_path = Path(get_root_path('indico')).parent
+        paths = {Path(os.path.realpath(p)) for p in _find_watchdog_paths(set(), set()) if os.path.exists(p)}
+        if env_config_string := os.environ.get('INDICO_CONFIG'):
+            env_config = Path(env_config_string).expanduser()
+            if env_config.parent.exists():
+                paths.add(env_config.parent)
+            indico_config_paths = {env_config, env_config.parent / 'logging.yaml'}
+        else:
+            indico_project_root = indico_root_path / 'indico'
+            indico_config_paths = {indico_project_root / 'indico.conf', indico_project_root / 'logging.yaml'}
+
+        self._paths = sorted(paths)
+        watcher = watch(*paths, watch_filter=IndicoFilter(indico_root_path, indico_config_paths))
+        self._launch()
+        for changes in watcher:
+            self._print_changes(changes)
+            self._restart()
+
+    @functools.cache
+    def _get_root(self, path):
+        return next((p for p in self._paths if path.is_relative_to(p)), None)
+
+    def _print_changes(self, changes):
+        files = {Path(x[1]) for x in changes}
+        # sort but keep priority on indico paths in case we really have multiple roots...
+        files = sorted(files, key=lambda x: (not str(x).startswith(os.getcwd()), x))
+        # ...because this is a bit hacky as we assume that usually all files are from a single root
+        root = os.path.relpath(self._get_root(files[0].parent))
+        if root == '.':
+            click.secho('Changes found:', fg='cyan')
+        else:
+            print(cformat('%{cyan}Changes found in %{cyan!}{}%{reset}%{cyan}:').format(root))
+        for f in files:
+            rel = os.path.relpath(f, root)
+            print(cformat(' * %{blue!}{}').format(rel))
+
+    def _launch(self, quiet=False, retry=0):
+        assert not self._proc
+        if not quiet and not retry:
+            click.secho('Launching Indico', fg='green', bold=True)
+        try:
+            argv = _disable_reloader(sys.argv)
+            self._proc = subprocess.Popen(argv)
+        except OSError as exc:
+            delay = (retry + 1) * 0.5
+            click.secho(f'Could not launch Indico: {exc}', fg='red', bold=True)
+            click.secho(f'Retrying in {delay}s', fg='yellow')
+            time.sleep(delay)
+            self._launch(quiet=quiet, retry=(retry + 1))
+
+    def _terminate(self, quiet=False):
+        if not self._proc:
+            return
+        if not quiet:
+            click.secho('Terminating Indico', fg='red', bold=True)
+        self._proc.terminate()
+        self._proc = None
+
+    def _restart(self):
+        click.secho('Restarting Indico', fg='yellow', bold=True)
+        self._terminate(quiet=True)
+        self._launch(quiet=True)

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -23,3 +23,4 @@ sphinx-issues
 sphinx-rtd-theme
 sphinx!=4.0.*  # not compatible with jinja 3 - https://github.com/sphinx-doc/sphinx/issues/9216
 sqlparse
+watchfiles

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -8,6 +8,8 @@ aiosmtpd==1.4.4.post2
     # via pytest-localserver
 alabaster==0.7.13
     # via sphinx
+anyio==3.6.2
+    # via watchfiles
 async-timeout==4.0.2
     # via
     #   -c requirements.txt
@@ -73,6 +75,7 @@ greenlet==2.0.2
 idna==3.4
     # via
     #   -c requirements.txt
+    #   anyio
     #   requests
 imagesize==1.4.1
     # via sphinx
@@ -186,6 +189,8 @@ six==1.16.0
     #   plantweb
     #   python-dateutil
     #   sqlbag
+sniffio==1.3.0
+    # via anyio
 snowballstemmer==2.2.0
     # via sphinx
 sphinx==6.1.3
@@ -238,6 +243,8 @@ urllib3==1.26.15
     # via
     #   -c requirements.txt
     #   requests
+watchfiles==0.19.0
+    # via -r requirements.dev.in
 werkzeug==2.2.3
     # via
     #   -c requirements.txt


### PR DESCRIPTION
Watchman works great, but there's no proper release for Python 3.10+ and it requires installing the watchman binary.

[Watchfiles](https://watchfiles.helpmanual.io) on the other hand is much easier to install as it includes its (Rust-based) inotify backend in its wheel.

The only real drawback is that there's no magic that detects and fully groups Git changes (e.g. checkouts). But debouncing covers this just fine, and if needed the thresholds could be tuned (if some poor soul develops on a super slow machine where Git checkouts take ages).

---

I might refactor it a bit to remove the duplicate code between {watchman,watchfiles}.py but I mainly wanted to have a reloader that works well w/ Python 3.11 to make testing Python 3.11 compatibility less painful...