### PR TITLE
Include all authors in timetable export API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,7 @@ Improvements
   given editable type (:pr:`5755`)
 - Show only "ready to review" editables on the "get next editable" list (:pr:`5765`)
 - Disallow uploading empty files (:pr:`5767`)
+- Include non-speaker authors in the timetable export API (:issue:`5412`, :pr:`5738`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -72,7 +72,7 @@ class EventTimeTableHook(HTTPAPIHook):
     def _serialize_timetable(self, event, user):
         if not contribution_settings.get(event, 'published') and not event.can_manage(user):
             return {}
-        return TimetableSerializer(event, management=False, user=user).serialize_timetable()
+        return TimetableSerializer(event, management=False, user=user, api=True).serialize_timetable()
 
     def export_timetable(self, user):
         events = Event.query.filter(Event.id.in_(map(int, self._idList)), ~Event.is_deleted).all()


### PR DESCRIPTION
Closes #5412

Adds an `other_authors` field to the contributions in the timetable export API, which includes all authors which are not speakers (which are already included in the `presenters` field).