### PR TITLE
Add bulk commenting to editable list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Improvements
 - Allow acceptance and rejection of editables in the editable list (:pr:`5721`)
 - Email verification attempts during signup now trigger rate limiting to prevent
   spamming large amounts of confirmation emails (:pr:`5727`)
+- Allow bulk-commenting editables in the editable list (:pr:`5747`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -83,6 +83,8 @@ _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/assign/
                  editable_list.RHAssignMyselfAsEditor, methods=('POST',))
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/unassign', 'api_unassign_editor',
                  editable_list.RHUnassignEditor, methods=('POST',))
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/comment', 'api_create_comment',
+                 editable_list.RHCreateComment, methods=('POST',))
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/judge', 'api_apply_judgment',
                  editable_list.RHApplyJudgment, methods=('POST',))
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editables/self-assign-allowed',
@@ -115,7 +117,7 @@ _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/new', 'api_create_subm
                  timeline.RHCreateSubmitterRevision, methods=('POST',),)
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/review', 'api_undo_review',
                  timeline.RHUndoReview, methods=('DELETE',))
-_bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/comments/', 'api_create_comment',
+_bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/comments/', 'api_create_revision_comment',
                  timeline.RHCreateRevisionComment, methods=('POST',),)
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/comments/<int:comment_id>',
                  'api_edit_comment', timeline.RHEditRevisionComment, methods=('PATCH', 'DELETE'),)

--- a/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CustomItem.jsx
@@ -24,7 +24,7 @@ import {blockItemPropTypes} from './util';
 import '../../../styles/timeline.module.scss';
 
 export default function CustomItem({
-  item: {header, user, reviewedDt, html, revisionId, undoneJudgment},
+  item: {header, user, createdDt, html, revisionId, undoneJudgment},
   state,
 }) {
   const lastRevertableRevisionId = useSelector(selectors.getLastRevertableRevisionId);
@@ -42,8 +42,8 @@ export default function CustomItem({
           >
             <div className="f-self-stretch" styleName="item-header">
               {header}{' '}
-              <time dateTime={serializeDate(reviewedDt, moment.HTML5_FMT.DATETIME_LOCAL_SECONDS)}>
-                {serializeDate(reviewedDt, 'LLL')}
+              <time dateTime={serializeDate(createdDt, moment.HTML5_FMT.DATETIME_LOCAL_SECONDS)}>
+                {serializeDate(createdDt, 'LLL')}
               </time>{' '}
               {isUndone && (
                 <Translate as="span" styleName="undone-indicator">

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -37,7 +37,7 @@ export function processRevisions(revisions) {
               {...revision, finalState: c.undoneJudgment},
               {isLatestRevision: true}
             ),
-            reviewedDt: c.createdDt,
+            createdDt: c.createdDt,
             custom: true,
           }
     );
@@ -98,7 +98,7 @@ export function commentFromState(revision, state, user) {
     id: `custom-item-${id}-${reviewedDt}-${finalState.name}`,
     revisionId: id,
     header: state,
-    reviewedDt,
+    createdDt: reviewedDt,
     user: user || submitter,
     custom: true,
     html: revision.commentHtml,

--- a/indico/modules/events/editing/client/js/management/editable_type/CommentButton.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/CommentButton.jsx
@@ -1,0 +1,72 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+import {Button} from 'semantic-ui-react';
+
+import {FinalCheckbox, FinalTextArea} from 'indico/react/forms';
+import {FinalModalForm} from 'indico/react/forms/final-form';
+import {Translate} from 'indico/react/i18n';
+
+export default function CommentButton({onSubmit, loading, disabled}) {
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const handleSubmit = async (formData, form) => {
+    const rv = await onSubmit(formData, form);
+    if (!rv) {
+      setModalOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <Button
+        content={Translate.string('Comment')}
+        loading={loading}
+        disabled={disabled}
+        onClick={() => setModalOpen(true)}
+      />
+      {modalOpen && <CommentModal onSubmit={handleSubmit} onClose={() => setModalOpen(false)} />}
+    </>
+  );
+}
+
+CommentButton.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  loading: PropTypes.bool.isRequired,
+  disabled: PropTypes.bool.isRequired,
+};
+
+function CommentModal({onSubmit, onClose}) {
+  return (
+    <FinalModalForm
+      id="comment-form"
+      header={Translate.string('Comment')}
+      onSubmit={onSubmit}
+      onClose={onClose}
+    >
+      <FinalTextArea
+        name="text"
+        placeholder={Translate.string('Leave a comment...')}
+        hideValidationError
+        autoFocus
+        required
+      />
+      <FinalCheckbox
+        label={Translate.string('Restrict visibility of this comment to other editors')}
+        name="internal"
+        toggle
+      />
+    </FinalModalForm>
+  );
+}
+
+CommentModal.propTypes = {
+  onSubmit: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -8,6 +8,7 @@
 import applyJudgmentURL from 'indico-url:event_editing.api_apply_judgment';
 import assignEditorURL from 'indico-url:event_editing.api_assign_editor';
 import assignSelfEditorURL from 'indico-url:event_editing.api_assign_myself';
+import createCommentURL from 'indico-url:event_editing.api_create_comment';
 import editableListURL from 'indico-url:event_editing.api_editable_list';
 import editorsURL from 'indico-url:event_editing.api_editable_type_editors';
 import canAssignSelfURL from 'indico-url:event_editing.api_editor_self_assign_allowed';
@@ -40,6 +41,7 @@ import StateIndicator from '../../editing/timeline/StateIndicator';
 import {userPropTypes} from '../../editing/timeline/util';
 import {EditableType, GetNextEditableTitles} from '../../models';
 
+import CommentButton from './CommentButton';
 import NextEditable from './NextEditable';
 
 import './EditableList.module.scss';
@@ -472,6 +474,11 @@ function EditableListDisplay({
     checkedEditablesAssignmentRequest('unassign', unassignEditorURL);
   };
 
+  const createComment = data => {
+    setActiveRequest('comment');
+    checkedEditablesRequest(createCommentURL, data);
+  };
+
   const applyJudgment = async action => {
     const rv = await updateCheckedEditablesRequest('judgment', applyJudgmentURL, {action});
     if (rv) {
@@ -536,6 +543,11 @@ function EditableListDisplay({
                   loading={activeRequest === 'unassign'}
                 />
               </Button.Group>
+              <CommentButton
+                disabled={!hasCheckedContribs || !!activeRequest}
+                onSubmit={createComment}
+                loading={activeRequest === 'comment'}
+              />
               <Dropdown
                 disabled={!hasCheckedContribs || !!activeRequest}
                 options={judgmentOptions}

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.module.scss
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.module.scss
@@ -21,6 +21,7 @@ $border: 1px solid $pastel-gray;
 
     :global(.ui.button) {
       margin-right: 0;
+      min-height: 37px;
     }
   }
 }

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -23,14 +23,14 @@ from indico.modules.events.editing.controllers.base import (RHEditablesBase, RHE
 from indico.modules.events.editing.models.editable import Editable
 from indico.modules.events.editing.models.revision_files import EditingRevisionFile
 from indico.modules.events.editing.models.revisions import EditingRevision, FinalRevisionState, InitialRevisionState
-from indico.modules.events.editing.operations import (assign_editor, generate_editables_json, generate_editables_zip,
-                                                      unassign_editor)
+from indico.modules.events.editing.operations import (assign_editor, create_revision_comment, generate_editables_json,
+                                                      generate_editables_zip, unassign_editor)
 from indico.modules.events.editing.schemas import (EditableBasicSchema, EditingConfirmationAction,
                                                    EditingEditableListSchema, EditingReviewAction,
                                                    FilteredEditableSchema)
 from indico.modules.files.models.files import File
 from indico.util.i18n import _
-from indico.util.marshmallow import Principal
+from indico.util.marshmallow import Principal, not_empty
 from indico.web.args import use_kwargs
 from indico.web.flask.util import url_for
 
@@ -135,6 +135,17 @@ class RHUnassignEditor(RHEditorAssignmentBase):
 
     def _assign_editor(self, editable):
         unassign_editor(editable)
+
+
+class RHCreateComment(RHEditablesBase):
+    @use_kwargs({
+        'text': fields.String(required=True, validate=not_empty),
+        'internal': fields.Bool(load_default=False)
+    })
+    def _process(self, text, internal):
+        for editable in self.editables:
+            create_revision_comment(editable.latest_revision, session.user, text, internal)
+        return '', 201
 
 
 class RHApplyJudgment(RHEditablesBase):

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -165,7 +165,8 @@ class EditingRevisionSchema(mm.SQLAlchemyAutoSchema):
     comments = fields.Method('_get_comments')
     initial_state = fields.Nested(RevisionStateSchema)
     final_state = fields.Nested(RevisionStateSchema)
-    create_comment_url = fields.Function(lambda revision: url_for('event_editing.api_create_comment', revision))
+    create_comment_url = fields.Function(lambda revision: url_for('event_editing.api_create_revision_comment',
+                                                                  revision))
     download_files_url = fields.Function(lambda revision: url_for('event_editing.revision_files_export', revision))
     review_url = fields.Function(lambda revision: url_for('event_editing.api_review_editable', revision))
     confirm_url = fields.Method('_get_confirm_url')


### PR DESCRIPTION
Depends on #5721

This PR adds bulk-commenting functionality to the editable list.

![image](https://user-images.githubusercontent.com/27357203/234610571-fefb1ae3-154d-44e6-b07a-d987214eb760.png)

