### PR TITLE
Add decorator to opt out from core auth handling

### DIFF
--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -374,6 +374,21 @@ def oauth_scope(scope):
     return decorator
 
 
+def custom_auth(rh):
+    """Use custom (bearer token) auth for this RH.
+
+    This is useful when creating endpoints that will handle Bearer tokens
+    on their own and should never try to verify a token against Indico's
+    own OAuth or personal tokens.
+
+    It completely disables any of the core auth features, so neither bearer
+    tokens nor session cookies nor signed URLs will be handled; this means
+    the "current user" is always going to be None.
+    """
+    rh._DISABLE_CORE_AUTH = True
+    return rh
+
+
 def allow_signed_url(rh):
     """Allow accessing this RH using persistent signed URLs.
 

--- a/indico/web/util.py
+++ b/indico/web/util.py
@@ -394,6 +394,10 @@ def get_request_user():
 
     current_exc = sys.exc_info()[1]
     rh = type(g.rh) if 'rh' in g else None
+
+    if getattr(rh, '_DISABLE_CORE_AUTH', False):
+        return None, None
+
     oauth_scope_hint = getattr(rh, '_OAUTH_SCOPE', None)
     allow_signed_url = getattr(rh, '_ALLOW_SIGNED_URL', False)
 


### PR DESCRIPTION
This is useful for code that handlers custom Bearer tokens (exclusively) and does not want any of the default auth logic (sessions, signed urls, bearer tokens) to run.