### PR TITLE
Hide recurring booking tooltip from occurrences timeline

### DIFF
--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
@@ -311,6 +311,7 @@ class BookingDetails extends React.Component {
         fixedHeight={rows.length > 1 ? '70vh' : null}
         booking={booking}
         rowActions={{occurrence: true}}
+        hideRecurrence
       />
     );
   };

--- a/indico/modules/rb/client/js/common/bookings/BookingEditCalendar.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditCalendar.jsx
@@ -167,6 +167,7 @@ class BookingEditCalendar extends React.Component {
               }
               isLoading={isLoading}
               fixedHeight={currentBooking.dateRange.length > 0 ? '100%' : null}
+              hideRecurrence
             />
           </div>
           {newBooking && (
@@ -185,6 +186,7 @@ class BookingEditCalendar extends React.Component {
                   );
                 }}
                 fixedHeight={newBooking.dateRange.length > 0 ? '100%' : null}
+                hideRecurrence
               />
             </div>
           )}

--- a/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
+++ b/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
@@ -44,6 +44,7 @@ export default class DailyTimelineContent extends React.Component {
     rowActions: PropTypes.objectOf(PropTypes.bool),
     booking: PropTypes.object,
     gutterAllowed: PropTypes.bool,
+    hideRecurrence: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -66,6 +67,7 @@ export default class DailyTimelineContent extends React.Component {
     },
     booking: null,
     gutterAllowed: false,
+    hideRecurrence: false,
   };
 
   state = {
@@ -82,10 +84,10 @@ export default class DailyTimelineContent extends React.Component {
   };
 
   getEditableItem = room => {
-    const {onAddSlot} = this.props;
+    const {onAddSlot, hideRecurrence} = this.props;
     const editable = onAddSlot && (room.canUserBook || room.canUserPrebook);
     const ItemClass = editable ? EditableTimelineItem : TimelineItem;
-    const itemProps = editable ? {onAddSlot} : {};
+    const itemProps = editable ? {onAddSlot} : {hideRecurringTooltip: hideRecurrence};
     return {ItemClass, itemProps};
   };
 

--- a/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
+++ b/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
@@ -99,6 +99,7 @@ class TimelineItem extends React.Component {
     actions: PropTypes.exact({
       openBookingDetails: PropTypes.func.isRequired,
     }).isRequired,
+    hideRecurringTooltip: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -107,6 +108,7 @@ class TimelineItem extends React.Component {
     children: [],
     setSelectable: null,
     dayBased: false,
+    hideRecurringTooltip: false,
   };
 
   calculateWidth = (startDt, endDt) => {
@@ -139,7 +141,7 @@ class TimelineItem extends React.Component {
   };
 
   renderMessagePopup = (message, segmentStartDt, segmentEndDt, reservation) => {
-    const {dayBased} = this.props;
+    const {dayBased, hideRecurringTooltip} = this.props;
 
     function mapRecurrenceTypeToInfo(repeatFrequency, repeatInterval) {
       if (repeatFrequency === 'DAY') {
@@ -175,7 +177,7 @@ class TimelineItem extends React.Component {
           </div>
         )}
         <div>{message}</div>
-        {reservation && reservation.isRepeating && (
+        {reservation && reservation.isRepeating && !hideRecurringTooltip && (
           <Message info>
             <Message.Content>
               <Message.Header>
@@ -408,6 +410,7 @@ class TimelineItem extends React.Component {
       onClickReservation,
       setSelectable,
       dayBased,
+      hideRecurringTooltip,
       ...restProps
     } = this.props;
     return (


### PR DESCRIPTION
Closes: #5749 

Preview (visible on standard bookings timeline and hidden on occurrences timeline):
<img width="304" alt="Screenshot 2023-04-28 at 4 10 50 PM" src="https://user-images.githubusercontent.com/7736654/235172939-eee35b77-0a9b-40c8-be0e-b0699d74f162.png">
<img width="1044" alt="image" src="https://user-images.githubusercontent.com/7736654/235173021-2ba2d6c6-ca1f-404a-b94b-a499b4be2077.png">
