### PR TITLE
Allow emailing users with no editable submissions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Improvements
 - Email verification attempts during signup now trigger rate limiting to prevent
   spamming large amounts of confirmation emails (:pr:`5727`)
 - Allow bulk-commenting editables in the editable list (:pr:`5747`)
+- Allow emailing contribution persons that have not yet made any submissions to a
+  given editable type (:pr:`5755`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -93,8 +93,8 @@ _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editors', 'api_ed
                  management.RHEditableTypeEditors)
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/list-with-filetypes',
                  'api_filter_editables_by_filetypes', editable_list.RHFilterEditablesByFileTypes, methods=('POST',))
-_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/not-submitted',
-                 'api_contribs_with_no_editables', management.RHEditablesNotSubmitted, methods=('POST',))
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/not-submitted', 'api_contribs_with_no_editables',
+                 management.RHEditablesNotSubmitted)
 
 # Emailing (management)
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/email-not-submitted/metadata',

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -93,6 +93,8 @@ _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editors', 'api_ed
                  management.RHEditableTypeEditors)
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/list-with-filetypes',
                  'api_filter_editables_by_filetypes', editable_list.RHFilterEditablesByFileTypes, methods=('POST',))
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/not-submitted',
+                 'api_contribs_with_no_editables', management.RHEditablesNotSubmitted, methods=('POST',))
 
 # Emailing (management)
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/email-not-submitted/metadata',

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -94,6 +94,14 @@ _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/editors', 'api_ed
 _bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/list-with-filetypes',
                  'api_filter_editables_by_filetypes', editable_list.RHFilterEditablesByFileTypes, methods=('POST',))
 
+# Emailing (management)
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/email-not-submitted/metadata',
+                 'api_email_not_submitted_metadata', management.RHEmailNotSubmittedEditablesMetadata, methods=('POST',))
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/email-not-submitted/preview',
+                 'api_email_not_submitted_preview', management.RHEmailNotSubmittedEditablesPreview, methods=('POST',))
+_bp.add_url_rule('/editing/api/<any(paper,slides,poster):type>/email-not-submitted/send',
+                 'api_email_not_submitted_send', management.RHEmailNotSubmittedEditablesSend, methods=('POST',))
+
 # Editable-level APIs
 contrib_api_prefix = '/api' + contrib_prefix
 _bp.add_url_rule(contrib_api_prefix + '/editor/', 'api_unassign_editable', timeline.RHEditableUnassign,

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
@@ -8,6 +8,7 @@
 /* global ajaxDialog:false */
 
 import anonymousTeamURL from 'indico-url:event_editing.api_anonymous_team';
+import contribsWithNoEditablesURL from 'indico-url:event_editing.api_contribs_with_no_editables';
 import enableEditingURL from 'indico-url:event_editing.api_editing_enabled';
 import emailMetadataURL from 'indico-url:event_editing.api_email_not_submitted_metadata';
 import emailPreviewURL from 'indico-url:event_editing.api_email_not_submitted_preview';
@@ -26,7 +27,7 @@ import {Checkbox, Loader} from 'semantic-ui-react';
 
 import {EmailContribAbstractRolesButton} from 'indico/modules/events/persons/EmailContribAbstractRolesButton';
 import {ManagementPageSubTitle, ManagementPageBackButton} from 'indico/react/components';
-import {useTogglableValue} from 'indico/react/hooks';
+import {useIndicoAxios, useTogglableValue} from 'indico/react/hooks';
 import {Translate} from 'indico/react/i18n';
 import {useNumericParam} from 'indico/react/util/routing';
 
@@ -78,6 +79,12 @@ export default function EditableTypeDashboard() {
     poster: Translate.string('Assign an editor to posters'),
     slides: Translate.string('Assign an editor to slides'),
   }[type];
+
+  const {data} = useIndicoAxios({
+    url: contribsWithNoEditablesURL({event_id: eventId, type}),
+    method: 'POST',
+  });
+  const numEditables = (data && data.no_contribs) || 0;
 
   return (
     <>
@@ -208,11 +215,15 @@ export default function EditableTypeDashboard() {
                 'Send an email to authors who have not submitted any files of this editable type'
               )}
             >
+              <span className="i-label" title={Translate.string('Contributions without editables')}>
+                {numEditables}
+              </span>
               <EmailContribAbstractRolesButton
                 objectContext="contributions"
                 metadataURL={emailMetadataURL({event_id: eventId, type})}
                 previewURL={emailPreviewURL({event_id: eventId, type})}
                 sendURL={emailSendURL({event_id: eventId, type})}
+                className={numEditables > 0 ? '' : 'disabled'}
               />
             </Section>
           </div>

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
@@ -80,11 +80,8 @@ export default function EditableTypeDashboard() {
     slides: Translate.string('Assign an editor to slides'),
   }[type];
 
-  const {data} = useIndicoAxios({
-    url: contribsWithNoEditablesURL({event_id: eventId, type}),
-    method: 'POST',
-  });
-  const numEditables = (data && data.no_contribs) || 0;
+  const {data} = useIndicoAxios(contribsWithNoEditablesURL({event_id: eventId, type}));
+  const numEditables = data?.count || 0;
 
   return (
     <>

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
@@ -121,6 +121,24 @@ export default function EditableTypeDashboard() {
                 {editingEnabled ? Translate.string('Close now') : Translate.string('Start now')}
               </button>
             </Section>
+            <Section
+              icon="bell"
+              label={Translate.string('Remind submitters')}
+              description={Translate.string(
+                'Send an email to authors who have not submitted any files of this editable type'
+              )}
+            >
+              <span className="i-label" title={Translate.string('Contributions without editables')}>
+                {numEditables}
+              </span>
+              <EmailContribAbstractRolesButton
+                objectContext="contributions"
+                metadataURL={emailMetadataURL({event_id: eventId, type})}
+                previewURL={emailPreviewURL({event_id: eventId, type})}
+                sendURL={emailSendURL({event_id: eventId, type})}
+                className={numEditables > 0 ? '' : 'disabled'}
+              />
+            </Section>
           </div>
           <div className="action-box">
             <Section
@@ -205,26 +223,6 @@ export default function EditableTypeDashboard() {
                   management
                 />
               )}
-            </Section>
-          </div>
-          <div className="action-box">
-            <Section
-              icon="bell"
-              label={Translate.string('Remind submitters')}
-              description={Translate.string(
-                'Send an email to authors who have not submitted any files of this editable type'
-              )}
-            >
-              <span className="i-label" title={Translate.string('Contributions without editables')}>
-                {numEditables}
-              </span>
-              <EmailContribAbstractRolesButton
-                objectContext="contributions"
-                metadataURL={emailMetadataURL({event_id: eventId, type})}
-                previewURL={emailPreviewURL({event_id: eventId, type})}
-                sendURL={emailSendURL({event_id: eventId, type})}
-                className={numEditables > 0 ? '' : 'disabled'}
-              />
             </Section>
           </div>
         </>

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableTypeDashboard.jsx
@@ -9,6 +9,9 @@
 
 import anonymousTeamURL from 'indico-url:event_editing.api_anonymous_team';
 import enableEditingURL from 'indico-url:event_editing.api_editing_enabled';
+import emailMetadataURL from 'indico-url:event_editing.api_email_not_submitted_metadata';
+import emailPreviewURL from 'indico-url:event_editing.api_email_not_submitted_preview';
+import emailSendURL from 'indico-url:event_editing.api_email_not_submitted_send';
 import selfAssignURL from 'indico-url:event_editing.api_self_assign_enabled';
 import enableSubmissionURL from 'indico-url:event_editing.api_submission_enabled';
 import contactEditingTeamURL from 'indico-url:event_editing.contact_team';
@@ -21,6 +24,7 @@ import React, {useState} from 'react';
 import {useParams, Link} from 'react-router-dom';
 import {Checkbox, Loader} from 'semantic-ui-react';
 
+import {EmailContribAbstractRolesButton} from 'indico/modules/events/persons/EmailContribAbstractRolesButton';
 import {ManagementPageSubTitle, ManagementPageBackButton} from 'indico/react/components';
 import {useTogglableValue} from 'indico/react/hooks';
 import {Translate} from 'indico/react/i18n';
@@ -194,6 +198,22 @@ export default function EditableTypeDashboard() {
                   management
                 />
               )}
+            </Section>
+          </div>
+          <div className="action-box">
+            <Section
+              icon="bell"
+              label={Translate.string('Remind submitters')}
+              description={Translate.string(
+                'Send an email to authors who have not submitted any files of this editable type'
+              )}
+            >
+              <EmailContribAbstractRolesButton
+                objectContext="contributions"
+                metadataURL={emailMetadataURL({event_id: eventId, type})}
+                previewURL={emailPreviewURL({event_id: eventId, type})}
+                sendURL={emailSendURL({event_id: eventId, type})}
+              />
             </Section>
           </div>
         </>

--- a/indico/modules/events/editing/controllers/backend/management.py
+++ b/indico/modules/events/editing/controllers/backend/management.py
@@ -261,6 +261,16 @@ class RHContactEditingTeam(RHEditableTypeManagementBase):
                                 event_persons=editors, event=self.event)
 
 
+class RHEditablesNotSubmitted(RHEditableTypeManagementBase):
+    """Return the number of contributions without editables of this type."""
+
+    def _process(self):
+        query = Contribution.query.with_parent(self.event).filter(
+            ~Contribution.editables.any(Editable.type == self.editable_type)
+        )
+        return jsonify(no_contribs=query.count())
+
+
 class RHEmailNotSubmittedEditablesMetadata(EmailRolesMetadataMixin, RHEditableTypeManagementBase):
     object_context = 'contributions'
 

--- a/indico/modules/events/editing/controllers/backend/management.py
+++ b/indico/modules/events/editing/controllers/backend/management.py
@@ -268,7 +268,7 @@ class RHEditablesNotSubmitted(RHEditableTypeManagementBase):
         query = Contribution.query.with_parent(self.event).filter(
             ~Contribution.editables.any(Editable.type == self.editable_type)
         )
-        return jsonify(no_contribs=query.count())
+        return jsonify(count=query.count())
 
 
 class RHEmailNotSubmittedEditablesMetadata(EmailRolesMetadataMixin, RHEditableTypeManagementBase):

--- a/indico/modules/events/editing/controllers/backend/management.py
+++ b/indico/modules/events/editing/controllers/backend/management.py
@@ -9,8 +9,9 @@ from flask import jsonify, request, session
 from werkzeug.exceptions import Forbidden
 
 from indico.core.errors import UserValueError
+from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.editing.controllers.base import RHEditableTypeManagementBase, RHEditingManagementBase
-from indico.modules.events.editing.models.editable import EditableType
+from indico.modules.events.editing.models.editable import Editable, EditableType
 from indico.modules.events.editing.models.file_types import EditingFileType
 from indico.modules.events.editing.models.review_conditions import EditingReviewCondition
 from indico.modules.events.editing.models.revision_files import EditingRevisionFile
@@ -23,6 +24,8 @@ from indico.modules.events.editing.schemas import (EditableFileTypeArgs, Editabl
                                                    EditingReviewConditionArgs, EditingTagSchema, EditingUserSchema)
 from indico.modules.events.editing.settings import editable_type_settings, editing_settings
 from indico.modules.events.editing.util import get_editors
+from indico.modules.events.management.controllers.emails import (EmailRolesMetadataMixin, EmailRolesPreviewMixin,
+                                                                 EmailRolesSendMixin)
 from indico.modules.logs import EventLogRealm, LogKind
 from indico.util.i18n import _, orig_string
 from indico.web.args import use_kwargs, use_rh_args, use_rh_kwargs
@@ -256,3 +259,31 @@ class RHContactEditingTeam(RHEditableTypeManagementBase):
         editors = get_editors(self.event, self.editable_type)
         return jsonify_template('events/editing/management/editor_list.html',
                                 event_persons=editors, event=self.event)
+
+
+class RHEmailNotSubmittedEditablesMetadata(EmailRolesMetadataMixin, RHEditableTypeManagementBase):
+    object_context = 'contributions'
+
+
+class RHEmailNotSubmittedEditablesPreview(EmailRolesPreviewMixin, RHEditableTypeManagementBase):
+    object_context = 'contributions'
+
+    def get_placeholder_kwargs(self):
+        contribution = Contribution.query.with_parent(self.event).first()
+        # none of the contributions are guaranteed to have a person so we use the event creator...
+        return {'person': self.event.creator, 'contribution': contribution}
+
+
+class RHEmailNotSubmittedEditablesSend(EmailRolesSendMixin, RHEditableTypeManagementBase):
+    object_context = 'contributions'
+    log_module = 'Editing'
+
+    def get_recipients(self, roles):
+        contribs = Contribution.query.with_parent(self.event).filter(
+            ~Contribution.editables.any(Editable.type == self.editable_type)
+        ).all()
+        for contrib in contribs:
+            log_metadata = {'contribution_id': contrib.id}
+            for person_link in contrib.person_links:
+                if person_link.email and self.get_roles_from_person_link(person_link) & roles:
+                    yield person_link.email, {'contribution': contrib, 'person': person_link}, log_metadata

--- a/indico/modules/events/management/client/js/index.js
+++ b/indico/modules/events/management/client/js/index.js
@@ -61,6 +61,7 @@ import {SeriesManagement} from './SeriesManagement';
         metadataURL={metadataUrl}
         previewURL={previewUrl}
         sendURL={sendUrl}
+        className="js-requires-selected-row disabled"
       />,
       element
     );

--- a/indico/modules/events/persons/client/js/EmailContribAbstractRolesButton.jsx
+++ b/indico/modules/events/persons/client/js/EmailContribAbstractRolesButton.jsx
@@ -19,16 +19,17 @@ export function EmailContribAbstractRolesButton({
   metadataURL,
   previewURL,
   sendURL,
+  className,
 }) {
   const [open, setOpen] = useState(false);
-  const ids = getIds(idSelector);
+  const ids = idSelector && getIds(idSelector);
   const idType = {abstracts: 'abstract_id', contributions: 'contribution_id'}[objectContext];
 
   return (
     <>
       <button
         type="button"
-        className="i-button icon-mail js-requires-selected-row disabled"
+        className={`i-button icon-mail ${className}`}
         onClick={evt => {
           if (!evt.target.classList.contains('disabled')) {
             setOpen(true);
@@ -52,8 +53,14 @@ export function EmailContribAbstractRolesButton({
 
 EmailContribAbstractRolesButton.propTypes = {
   objectContext: PropTypes.oneOf(['abstracts', 'contributions']).isRequired,
-  idSelector: PropTypes.string.isRequired,
+  idSelector: PropTypes.string,
   metadataURL: PropTypes.string.isRequired,
   previewURL: PropTypes.string.isRequired,
   sendURL: PropTypes.string.isRequired,
+  className: PropTypes.string,
+};
+
+EmailContribAbstractRolesButton.defaultProps = {
+  idSelector: null,
+  className: '',
 };


### PR DESCRIPTION
This PR adds the ability to email contribution persons that have not yet made any submissions to a given editable type:

![Screen Shot 2023-05-03 at 17 17 31](https://user-images.githubusercontent.com/27357203/235960981-e7c7be8f-706d-4590-99b0-a4f1026f1f38.png)
