### PR TITLE
Add privacy policy checkbox to registration forms

### DIFF
--- a/indico/migrations/versions/20230504_1405_a59688f9ba40_add_require_privacy_policy_agreement.py
+++ b/indico/migrations/versions/20230504_1405_a59688f9ba40_add_require_privacy_policy_agreement.py
@@ -1,0 +1,26 @@
+"""Add require_privacy_policy_agreement to regforms
+
+Revision ID: a59688f9ba40
+Revises: 5d05eda06776
+Create Date: 2023-05-04 14:05:51.778169
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'a59688f9ba40'
+down_revision = '5d05eda06776'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('forms', sa.Column('require_privacy_policy_agreement', sa.Boolean(), nullable=False,
+                                     server_default='false'), schema='event_registration')
+    op.alter_column('forms', 'require_privacy_policy_agreement', server_default=None, schema='event_registration')
+
+
+def downgrade():
+    op.drop_column('forms', 'require_privacy_policy_agreement', schema='event_registration')

--- a/indico/migrations/versions/20230807_1200_a59688f9ba40_add_require_privacy_policy_agreement.py
+++ b/indico/migrations/versions/20230807_1200_a59688f9ba40_add_require_privacy_policy_agreement.py
@@ -1,7 +1,7 @@
 """Add require_privacy_policy_agreement to regforms
 
 Revision ID: a59688f9ba40
-Revises: 5d05eda06776
+Revises: e47fc6634291
 Create Date: 2023-05-04 14:05:51.778169
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'a59688f9ba40'
-down_revision = '5d05eda06776'
+down_revision = 'e47fc6634291'
 branch_labels = None
 depends_on = None
 

--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -147,6 +147,9 @@ export default function RegistrationFormSubmission() {
   const showConsentToPublish = !isManagement && publishToParticipants !== 'hide_all';
 
   const onSubmit = async (data, form) => {
+    // There is no need to store whether the user accepted the privacy policy
+    // as it is not possible to submit the form without accepting it.
+    data = _.omit(data, 'agreed_to_privacy_policy');
     let resp;
     const formData = isUpdateMode ? getChangedValues(data, form, ['notify_user']) : data;
     try {

--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import privacyNoticeURL from 'indico-url:events.display_privacy';
+
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -19,7 +21,7 @@ import {
   FinalCheckbox,
   getChangedValues,
 } from 'indico/react/forms';
-import {Translate} from 'indico/react/i18n';
+import {Param, Translate} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
 import {getPluginObjects, renderPluginComponents} from 'indico/utils/plugins';
 
@@ -36,6 +38,34 @@ import {
 } from './selectors';
 
 import '../../styles/regform.module.scss';
+
+function PrivacyPolicy({url}) {
+  const label = (
+    <label>
+      <Translate>
+        I have read and agree to the{' '}
+        <Param name="url" wrapper={<a href={url} target="_blank" rel="noreferrer" />}>
+          Privacy policy
+        </Param>
+      </Translate>
+    </label>
+  );
+
+  return (
+    <Message info style={{marginTop: 25}}>
+      <Message.Header>
+        <Translate>Privacy policy</Translate>
+      </Message.Header>
+      <Form as="div" style={{marginTop: 10}}>
+        <FinalCheckbox required label={label} name="agreed_to_privacy_policy" toggle />
+      </Form>
+    </Message>
+  );
+}
+
+PrivacyPolicy.propTypes = {
+  url: PropTypes.string.isRequired,
+};
 
 function ManagementOptions({isUpdateMode}) {
   return (
@@ -101,11 +131,13 @@ ConsentToPublish.propTypes = {
 export default function RegistrationFormSubmission() {
   const sections = useSelector(getNestedSections);
   const {
+    eventId,
     submitUrl,
     registrationData,
     initialValues,
     captchaRequired,
     captchaSettings,
+    policyAgreementRequired,
   } = useSelector(getStaticData);
   const isUpdateMode = useSelector(getUpdateMode);
   const isModerated = useSelector(getModeration);
@@ -153,6 +185,9 @@ export default function RegistrationFormSubmission() {
               />
             )}
             {captchaRequired && <Captcha settings={captchaSettings} />}
+            {!isManagement && !isUpdateMode && policyAgreementRequired && (
+              <PrivacyPolicy url={privacyNoticeURL({event_id: eventId})} />
+            )}
             <FinalSubmitButton
               disabledUntilChange={false}
               disabledIfInvalid={false}

--- a/indico/modules/events/registration/client/js/form_submission/index.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/index.jsx
@@ -32,6 +32,7 @@ export default function setupRegformSubmission(root) {
     publishToParticipants,
     publishToPublic,
     consentToPublish = null,
+    policyAgreementRequired,
     captchaRequired = false,
     captchaSettings = null,
     ...extraData
@@ -54,6 +55,7 @@ export default function setupRegformSubmission(root) {
       currency,
       publishToParticipants,
       publishToPublic,
+      policyAgreementRequired: JSON.parse(policyAgreementRequired),
       captchaRequired: JSON.parse(captchaRequired),
       captchaSettings: JSON.parse(captchaSettings),
       // XXX: do NOT use extraData for anything in the core; this is solely meant as a way to

--- a/indico/modules/events/registration/controllers/management/privacy.py
+++ b/indico/modules/events/registration/controllers/management/privacy.py
@@ -82,7 +82,7 @@ class RHRegistrationPrivacy(RHManageRegFormBase):
             self.regform.require_privacy_policy_agreement = form.require_privacy_policy_agreement.data
             db.session.flush()
             self.event.log(EventLogRealm.management, LogKind.change, 'Privacy',
-                           f'Participant visibility for "{self.regform.title}" modified', session.user,
+                           f'Privacy settings for "{self.regform.title}" modified', session.user,
                            data={'Changes': changes})
             flash(_('Settings saved'), 'success')
             return redirect(url_for('.manage_registration_privacy_settings', self.regform))

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -538,6 +538,9 @@ class RegistrationPrivacyForm(IndicoForm):
                                                     'Retention periods for individual fields can be set in the '
                                                     'registration form designer'),
                                       render_kw={'placeholder': _('Indefinite')})
+    require_privacy_policy_agreement = BooleanField(_('Privacy policy'), widget=SwitchWidget(),
+                                                    description=_('Specify whether users are required to agree to '
+                                                                  "the event's privacy policy when registering"))
 
     def __init__(self, *args, **kwargs):
         self.regform = kwargs.pop('regform')

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -265,6 +265,12 @@ class RegistrationForm(db.Model):
         default=False,
         nullable=False
     )
+    #: Whether users must accept the event's privacy policy when registering
+    require_privacy_policy_agreement = db.Column(
+        db.Boolean,
+        default=False,
+        nullable=False
+    )
 
     #: The Event containing this registration form
     event = db.relationship(

--- a/indico/modules/events/registration/templates/display/regform_display.html
+++ b/indico/modules/events/registration/templates/display/regform_display.html
@@ -134,6 +134,7 @@
              data-moderated="{{ moderated | tojson | forceescape }}"
              data-publish-to-participants="{{ regform.publish_registrations_participants.name }}"
              data-publish-to-public="{{ regform.publish_registrations_public.name }}"
+             data-policy-agreement-required="{{ regform.require_privacy_policy_agreement | tojson | forceescape }}"
              data-captcha-required="{{ captcha_required | tojson | forceescape }}"
              {% if captcha_settings is defined %}
                 data-captcha-settings="{{ captcha_settings | tojson | forceescape }}"

--- a/indico/modules/events/registration/templates/display/registration_modify.html
+++ b/indico/modules/events/registration/templates/display/registration_modify.html
@@ -30,6 +30,7 @@
          data-publish-to-participants="{{ regform.publish_registrations_participants.name }}"
          data-publish-to-public="{{ regform.publish_registrations_public.name }}"
          data-consent-to-publish="{{ registration.consent_to_publish.name }}"
+         data-policy-agreement-required="{{ regform.require_privacy_policy_agreement | tojson | forceescape }}"
          {{ regform_attrs_template_hook(event, registration.registration_form, false, registration) }}
     ></div>
 {% endblock %}

--- a/indico/modules/events/registration/templates/management/registration_modify.html
+++ b/indico/modules/events/registration/templates/management/registration_modify.html
@@ -23,6 +23,7 @@
          data-publish-to-participants="{{ regform.publish_registrations_participants.name }}"
          data-publish-to-public="{{ regform.publish_registrations_public.name }}"
          data-consent-to-publish="{{ registration.consent_to_publish.name }}"
+         data-policy-agreement-required="{{ regform.require_privacy_policy_agreement | tojson | forceescape }}"
          {{ regform_attrs_template_hook(event, regform, true, registration) }}
     ></div>
 {% endblock %}

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -497,7 +497,7 @@ export function FinalCheckbox({name, label, value, ...rest}) {
 
 FinalCheckbox.propTypes = {
   name: PropTypes.string.isRequired,
-  label: PropTypes.string.isRequired,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   value: PropTypes.string,
 };
 


### PR DESCRIPTION
Configurable in the privacy settings (each regform can be set separately):

![obrazek](https://user-images.githubusercontent.com/8739637/236210984-e7910e4e-b09b-44d7-ada1-7c6f0e1f0f4e.png)

When enabled, users will see this when registering:

![obrazek](https://user-images.githubusercontent.com/8739637/236211449-9277e96c-3c5f-4344-8ca5-7babe463a355.png)

It includes a link to the event's privacy policy.

