### PR TITLE
Add reset editable API endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,7 +64,7 @@ Internal Changes
 
 - Update Python & JavaScript dependencies (:pr:`5726`, :pr:`5752`)
 - Add support for the watchfiles live reloader (:pr:`5732`)
-- Add an endpoint to allow resetting the state of an accepted editable into "ready to
+- Add an endpoint to allow resetting the state of an accepted editable to "ready to
   review" (:pr:`5758`)
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,8 @@ Internal Changes
 
 - Update Python & JavaScript dependencies (:pr:`5726`, :pr:`5752`)
 - Add support for the watchfiles live reloader (:pr:`5732`)
+- Add an endpoint to allow resetting the state of an accepted editable into "ready to
+  review" (:pr:`5758`)
 
 
 Version 3.2.3

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -117,6 +117,8 @@ _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/new', 'api_create_subm
                  timeline.RHCreateSubmitterRevision, methods=('POST',),)
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/review', 'api_undo_review',
                  timeline.RHUndoReview, methods=('DELETE',))
+_bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/reset', 'api_reset_editable',
+                 timeline.RHResetEditable, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/comments/', 'api_create_revision_comment',
                  timeline.RHCreateRevisionComment, methods=('POST',),)
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/comments/<int:comment_id>',

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -26,8 +26,8 @@ from indico.modules.events.editing.models.revision_files import EditingRevisionF
 from indico.modules.events.editing.models.revisions import EditingRevision, InitialRevisionState
 from indico.modules.events.editing.operations import (assign_editor, create_new_editable, create_revision_comment,
                                                       create_submitter_revision, delete_revision_comment,
-                                                      ensure_latest_revision, replace_revision, unassign_editor,
-                                                      undo_review, update_revision_comment)
+                                                      ensure_latest_revision, replace_revision, reset_editable,
+                                                      unassign_editor, undo_review, update_revision_comment)
 from indico.modules.events.editing.schemas import (EditableSchema, EditingConfirmationAction, EditingReviewAction,
                                                    ReviewEditableArgs)
 from indico.modules.events.editing.service import (ServiceRequestFailed, service_get_custom_actions,
@@ -283,6 +283,19 @@ class RHUndoReview(RHContributionEditableRevisionBase):
 
     def _process(self):
         undo_review(self.revision)
+        return '', 204
+
+
+class RHResetEditable(RHContributionEditableRevisionBase):
+    """Undo the last review/confirmation on an Editable."""
+
+    SERVICE_ALLOWED = True
+
+    def _check_revision_access(self):
+        return self.editable.can_perform_editor_actions(session.user)
+
+    def _process(self):
+        reset_editable(self.revision)
         return '', 204
 
 

--- a/indico/modules/events/editing/service.py
+++ b/indico/modules/events/editing/service.py
@@ -288,7 +288,8 @@ def _get_revision_endpoints(revision):
         'revisions': {
             'details': url_for('.api_editable', revision, _external=True),
             'replace': url_for('.api_replace_revision', revision, _external=True),
-            'undo': url_for('.api_undo_review', revision, _external=True)
+            'undo': url_for('.api_undo_review', revision, _external=True),
+            'reset': url_for('.api_reset_editable', revision, _external=True),
         },
         'file_upload': url_for('.api_upload', revision, _external=True)
     }


### PR DESCRIPTION
This PR adds an API endpoint to reset an accepted editable to the "ready to review" state.

The operation changes the last revision's states into (Ready to review, None), regardless of its initial state.