### PR TITLE
Update werkzeug & revert old form parts fix

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -92,7 +92,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 urllib3==1.26.15
     # via requests
-werkzeug==2.3.3
+werkzeug==2.3.4
     # via flask
 zipp==3.15.0
     # via importlib-metadata

--- a/indico/web/flask/app.py
+++ b/indico/web/flask/app.py
@@ -323,7 +323,6 @@ def extend_url_map(app):
 
 
 def add_handlers(app):
-    app.before_request(allow_many_formdata_args)
     app.before_request(canonicalize_url)
     app.before_request(reject_nuls)
     app.after_request(inject_current_url)
@@ -352,11 +351,6 @@ def add_plugin_blueprints(app):
         blueprint_names.add(blueprint.name)
         with plugin.plugin_context():
             app.register_blueprint(blueprint)
-
-
-def allow_many_formdata_args():
-    if request.mimetype == 'application/x-www-form-urlencoded':
-        request.max_form_parts = 50000
 
 
 def canonicalize_url():

--- a/indico/web/flask/wrappers_test.py
+++ b/indico/web/flask/wrappers_test.py
@@ -42,3 +42,16 @@ def test_multi_test_client_no_g_leak(app, test_client):
     assert resp.text == 'notset'
     resp = test_client.get('test-tc-multi')
     assert resp.text == 'notset'
+
+
+def test_many_form_parts(app, test_client, monkeypatch):
+    monkeypatch.setattr('indico.web.flask.wrappers.IndicoRequest.max_form_parts', 1)
+
+    @app.route('/test-many-form-parts', methods=('POST',))
+    def test_many_form_parts_endpoint():
+        # make sure normal form posts are not subject to multipart limits
+        assert request.form.getlist('foo') == ['1', '2']
+        return str(len(request.form.getlist('foo')))
+
+    resp = test_client.post('test-many-form-parts', data={'foo': ['1', '2']})
+    assert resp.text == '2'

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -248,7 +248,7 @@ urllib3==1.26.15
     #   requests
 watchfiles==0.19.0
     # via -r requirements.dev.in
-werkzeug==2.3.3
+werkzeug==2.3.4
     # via
     #   -c requirements.txt
     #   flask

--- a/requirements.txt
+++ b/requirements.txt
@@ -363,7 +363,7 @@ webencodings==0.5.1
     #   bleach
     #   html5lib
     #   tinycss2
-werkzeug==2.3.3
+werkzeug==2.3.4
     # via
     #   -r requirements.in
     #   flask


### PR DESCRIPTION
My werkzeug PR changed the form parts limit to only apply to multipart data and not regular POST data.