### PR TITLE
Show only reviewable editables in Get Next dialog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,7 @@ Improvements
 - Allow bulk-commenting editables in the editable list (:pr:`5747`)
 - Allow emailing contribution persons that have not yet made any submissions to a
   given editable type (:pr:`5755`)
+- Show only "ready to review" editables on the "get next editable" list (:pr:`5765`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -20,7 +20,7 @@ from indico.modules.events.editing.controllers.backend.util import (confirm_and_
                                                                     review_and_publish_editable)
 from indico.modules.events.editing.controllers.base import (RHEditablesBase, RHEditableTypeEditorBase,
                                                             RHEditableTypeManagementBase)
-from indico.modules.events.editing.models.editable import Editable
+from indico.modules.events.editing.models.editable import Editable, EditableState
 from indico.modules.events.editing.models.revision_files import EditingRevisionFile
 from indico.modules.events.editing.models.revisions import EditingRevision, FinalRevisionState, InitialRevisionState
 from indico.modules.events.editing.operations import (assign_editor, create_revision_comment, generate_editables_json,
@@ -199,6 +199,7 @@ class RHFilterEditablesByFileTypes(RHEditableTypeEditorBase):
                             )
                         ),
                         Editable.type == self.editable_type,
+                        Editable.state == EditableState.ready_for_review,
                     )
                 )
             )


### PR DESCRIPTION
This PR makes the "get next editable" list show only "ready to review" editables.