### PR TITLE
Disallow uploading zero-byte files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,7 @@ Improvements
 - Allow emailing contribution persons that have not yet made any submissions to a
   given editable type (:pr:`5755`)
 - Show only "ready to review" editables on the "get next editable" list (:pr:`5765`)
+- Disallow uploading zero-byte files (:pr:`5767`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,7 +41,7 @@ Improvements
 - Allow emailing contribution persons that have not yet made any submissions to a
   given editable type (:pr:`5755`)
 - Show only "ready to review" editables on the "get next editable" list (:pr:`5765`)
-- Disallow uploading zero-byte files (:pr:`5767`)
+- Disallow uploading empty files (:pr:`5767`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/files/controllers.py
+++ b/indico/modules/files/controllers.py
@@ -42,6 +42,9 @@ class UploadFileMixin:
         content_type = mimetypes.guess_type(file.filename)[0] or file.mimetype or 'application/octet-stream'
         f = File(filename=file.filename, content_type=content_type)
         f.save(context, stream)
+        if not f.size:
+            f.delete()
+            raise UnprocessableEntity
         db.session.add(f)
         db.session.flush()
         logger.info('File %r uploaded (context: %r)', f, context)


### PR DESCRIPTION
This PR disallows uploading zero-byte files, which may help prevent user-errors.

<img width="613" alt="image" src="https://github.com/indico/indico/assets/27357203/51725c85-a81d-4f4e-9cbd-e4ed934725a3">
