### PR TITLE
Add setting to force track selection on judgment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,7 @@ Improvements
 - Show only "ready to review" editables on the "get next editable" list (:pr:`5765`)
 - Disallow uploading empty files (:pr:`5767`)
 - Include non-speaker authors in the timetable export API (:issue:`5412`, :pr:`5738`)
+- Add setting to force track selection when accepting abstracts (:pr:`5771`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -163,6 +163,9 @@ class AbstractReviewingSettingsForm(IndicoForm):
                                                widget=SwitchWidget(),
                                                description=_('Enabling this allows track conveners to update the track '
                                                              'an abstract is part of.'))
+    force_track_selection = BooleanField(_('Force track selection on judgment'), widget=SwitchWidget(),
+                                         description=_('Enabling this makes the track selection mandatory when '
+                                                       'accepting an abstract.'))
     allow_comments = BooleanField(_('Allow comments'), widget=SwitchWidget(),
                                   description=_('Enabling this allows judges, conveners and reviewers to leave '
                                                 'comments on abstracts.'))
@@ -276,6 +279,8 @@ class AbstractJudgmentForm(AbstractJudgmentFormBase):
             kwargs.setdefault('accepted_contrib_type', candidate_contrib_types[0])
         elif not abstract.reviews:
             kwargs.setdefault('accepted_contrib_type', abstract.submitted_contrib_type)
+        if self.event.cfa.force_track_selection:
+            inject_validators(self, 'accepted_track', [DataRequired()])
         super().__init__(*args, **kwargs)
         self.duplicate_of.excluded_abstract_ids = {abstract.id}
         self.merged_into.excluded_abstract_ids = {abstract.id}

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -165,7 +165,8 @@ class AbstractReviewingSettingsForm(IndicoForm):
                                                              'an abstract is part of.'))
     force_track_selection = BooleanField(_('Force track selection on judgment'), widget=SwitchWidget(),
                                          description=_('Enabling this makes the track selection mandatory when '
-                                                       'accepting an abstract.'))
+                                                       'accepting an abstract. This does not affect bulk judgment by '
+                                                       'managers.'))
     allow_comments = BooleanField(_('Allow comments'), widget=SwitchWidget(),
                                   description=_('Enabling this allows judges, conveners and reviewers to leave '
                                                 'comments on abstracts.'))

--- a/indico/modules/events/abstracts/models/call_for_abstracts.py
+++ b/indico/modules/events/abstracts/models/call_for_abstracts.py
@@ -29,6 +29,7 @@ class CallForAbstracts:
                                                           'allow_contributors_in_comments')
     allow_convener_judgment = EventSettingProperty(abstracts_reviewing_settings, 'allow_convener_judgment')
     allow_convener_track_change = EventSettingProperty(abstracts_reviewing_settings, 'allow_convener_track_change')
+    force_track_selection = EventSettingProperty(abstracts_reviewing_settings, 'force_track_selection')
     allow_editing = EventSettingProperty(abstracts_settings, 'allow_editing')
     contribution_submitters = EventSettingProperty(abstracts_settings, 'contribution_submitters')
     submission_instructions = EventSettingProperty(abstracts_settings, 'submission_instructions')

--- a/indico/modules/events/abstracts/settings.py
+++ b/indico/modules/events/abstracts/settings.py
@@ -133,6 +133,7 @@ abstracts_reviewing_settings = EventSettingsProxy('abstracts_reviewing', {
     'allow_comments': True,
     'allow_convener_judgment': False,  # whether track conveners can make a judgment (e.g. accept/reject)
     'allow_convener_track_change': False,
+    'force_track_selection': False,
     'allow_contributors_in_comments': False,
     'notify_on_new_comments': False,
     'reviewing_instructions': '',


### PR DESCRIPTION
This PR adds a setting to force track selection when accepting abstracts:

<img width="965" alt="Screen Shot 2023-05-12 at 13 21 34" src="https://github.com/indico/indico/assets/27357203/3ca09886-7eca-4b20-b33e-0859deb69715">

<img width="994" alt="image" src="https://github.com/indico/indico/assets/27357203/4a3c465b-9654-4e6a-91ac-2cef8b571c4d">
