### PR TITLE
Log detailed changes when editing contributions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,7 @@ Improvements
 - Disallow uploading empty files (:pr:`5767`)
 - Include non-speaker authors in the timetable export API (:issue:`5412`, :pr:`5738`)
 - Add setting to force track selection when accepting abstracts (:pr:`5771`)
+- Log detailed changes when editing contributions (:pr:`5777`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -307,7 +307,7 @@ class RHContributionREST(RHManageContributionBase):
         if track_id is None:
             updates['track_id'] = None
         else:
-            track = Track.get(track_id)
+            track = Track.query.with_parent(self.event).filter_by(id=track_id).first()
             if not track:
                 raise BadRequest('Invalid track id')
             if track_id != self.contrib.track_id:

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -305,13 +305,13 @@ class RHContributionREST(RHManageContributionBase):
     def _get_contribution_track_updates(self, track_id):
         updates = {}
         if track_id is None:
-            updates['track_id'] = None
+            updates['track'] = None
         else:
             track = Track.query.with_parent(self.event).filter_by(id=track_id).first()
             if not track:
                 raise BadRequest('Invalid track id')
             if track_id != self.contrib.track_id:
-                updates['track_id'] = track_id
+                updates['track'] = track
         return updates
 
 

--- a/indico/modules/events/contributions/operations.py
+++ b/indico/modules/events/contributions/operations.py
@@ -19,7 +19,7 @@ from indico.modules.events.contributions.models.persons import AuthorType, Contr
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.timetable.operations import (delete_timetable_entry, schedule_contribution,
                                                         update_timetable_entry)
-from indico.modules.events.util import set_custom_fields
+from indico.modules.events.util import format_log_person, format_log_ref, set_custom_fields, split_log_location_changes
 from indico.modules.logs.models.entries import EventLogRealm, LogKind
 from indico.modules.logs.util import make_diff_log
 from indico.util.signals import make_interceptable
@@ -211,9 +211,6 @@ def log_contribution_update(contrib, changes, *, visible_person_link_changes=Fal
     if not changes:
         return
 
-    # TODO move this to more generic utils
-    from indico.modules.events.operations import _format_person, _format_ref, _split_location_changes
-
     log_fields = {
         'title': {'title': 'Title', 'type': 'string'},
         'description': 'Description',
@@ -226,11 +223,11 @@ def log_contribution_update(contrib, changes, *, visible_person_link_changes=Fal
         'protection_mode': 'Protection mode',
         'references': {
             'title': 'External IDs',
-            'convert': lambda changes: [list(map(_format_ref, refs)) for refs in changes]
+            'convert': lambda changes: [list(map(format_log_ref, refs)) for refs in changes]
         },
         'person_links': {
             'title': 'Persons',
-            'convert': lambda changes: [list(map(_format_person, persons)) for persons in changes]
+            'convert': lambda changes: [list(map(format_log_person, persons)) for persons in changes]
         },
         'track': {
             'title': 'Track',
@@ -253,7 +250,7 @@ def log_contribution_update(contrib, changes, *, visible_person_link_changes=Fal
             'convert': lambda changes: [x.name if x else None for x in changes]
         },
     }
-    _split_location_changes(changes)
+    split_log_location_changes(changes)
     if not visible_person_link_changes:
         # Don't log a person link change with no visible changes (changes
         # on an existing link or reordering). It would look quite weird in

--- a/indico/modules/events/timetable/operations.py
+++ b/indico/modules/events/timetable/operations.py
@@ -152,7 +152,7 @@ def move_timetable_entry(entry, parent=None, day=None):
         new_start_dt = entry.start_dt.replace(day=day.day, month=day.month)
         updates['start_dt'] = new_start_dt
         updates['parent'] = None
-        contrib_update_data = {'session_id': None, 'session_block_id': None}
+        contrib_update_data = {'session_block': None, 'session': None}
     elif parent:
         new_start_dt = find_latest_entry_end_dt(parent.object) or parent.start_dt
         tz = entry.event.tzinfo


### PR DESCRIPTION
Also refactor some cases of using IDs instead of relationships for updates and add a missing check to ensure the track ID set on a contribution actually belongs to the same event... 🤦‍♂️

closes #5754