### PR TITLE
Fix registration form bugs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,8 @@ Bugfixes
   :pr:`5761`)
 - Fix ToS and Privacy Policy links in room booking module not working when using an
   external URL (:pr:`5774`)
+- Do not apply default values to new registration form fields when editing an existing
+  registration (:pr:`5781`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,8 @@ Bugfixes
   external URL (:pr:`5774`)
 - Do not apply default values to new registration form fields when editing an existing
   registration (:pr:`5781`)
+- Allow ``0`` for a required registration form numbe field (unless a higher minimum
+  value is set) (:pr:`5781`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -69,6 +69,7 @@ class NumberField(RegistrationFormBillableField):
     name = 'number'
     mm_field_class = fields.Integer
     setup_schema_base_cls = NumberFieldDataSchema
+    not_empty_if_required = False
 
     @property
     def mm_field_kwargs(self):

--- a/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
+++ b/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
@@ -99,7 +99,7 @@
         </ul>
     {% elif field.input_type == 'file' and friendly_data and from_management %}
         <a href="{{ url_for('.registration_file', data[field.id].locator.file) }}">{{ friendly_data }}</a>
-    {% elif friendly_data %}
+    {% elif friendly_data is not none %}
         {{- friendly_data -}}
     {% endif %}
 {% endmacro %}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -215,10 +215,14 @@ def get_form_registration_data(regform, registration, *, management=False):
             continue
         elif item.id in data_by_field:
             registration_data[item.html_field_name] = camelize_keys(data_by_field[item.id].user_data)
-        elif management:
-            registration_data[item.html_field_name] = item.field_impl.empty_value
         else:
-            registration_data[item.html_field_name] = item.field_impl.default_value
+            # we never use default values when editing a registration where data does not exist yet.
+            # such a field has been added after the registration has been created, and it's rather
+            # confusing when you see the default value when editing your own registration, even though
+            # you never set that value. and it also breaks things because when you submit the form there
+            # is no value sent (since nothing changed and we send partial updates when editing), but the
+            # field is required and thus validation fails
+            registration_data[item.html_field_name] = item.field_impl.empty_value
     if management:
         registration_data['notify_user'] = session.get('registration_notify_user_default', True)
     return registration_data


### PR DESCRIPTION
- do not apply default values when editing a registration
- allow 0 for required number fields (unless a higher minimum is set)
- do not convert 0 to an empty string in registration summary