### PR TITLE
Improve `make_interceptable` and make a few functions interceptable

### DIFF
--- a/indico/modules/attachments/controllers/management/base.py
+++ b/indico/modules/attachments/controllers/management/base.py
@@ -22,6 +22,7 @@ from indico.modules.attachments.operations import add_attachment_link
 from indico.modules.attachments.util import get_attached_items
 from indico.util.fs import secure_client_filename
 from indico.util.i18n import _, ngettext
+from indico.util.signals import make_interceptable
 from indico.web.args import use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for
@@ -29,6 +30,7 @@ from indico.web.forms.base import FormDefaults
 from indico.web.util import jsonify_data, jsonify_template
 
 
+@make_interceptable
 def _render_attachment_list(linked_object):
     tpl = get_template_module('attachments/_attachments.html')
     return tpl.render_attachments(attachments=get_attached_items(linked_object), linked_object=linked_object)

--- a/indico/modules/attachments/util.py
+++ b/indico/modules/attachments/util.py
@@ -8,6 +8,7 @@
 from flask import session
 
 from indico.core.db import db
+from indico.util.signals import make_interceptable
 
 
 def get_attached_folders(linked_object, include_empty=True, include_hidden=True, preload_event=False):
@@ -32,6 +33,7 @@ def get_attached_folders(linked_object, include_empty=True, include_hidden=True,
     return folders
 
 
+@make_interceptable
 def get_attached_items(linked_object, include_empty=True, include_hidden=True, preload_event=False):
     """
     Return a structured representation of all the attachments linked


### PR DESCRIPTION
With this PR, `@make_interceptable` returns a wrapper that accepts any kwarg, making them available in the signal handler. An use case for this is the following:

```python
def get_numbers():
    return [1, 2, 3, 4]

@signals.plugin.interceptable_function.connect_via(interceptable_sender(get_numbers))
def _intercept_foo(sender, args, ctx, RETURN_NONE, **kwargs):
    func = kwargs.get('func')
    odds_only = args.arguments.pop('odds_only', False)
    numbers = func(*args.args, **args.kwargs)
    return [x for x in numbers if % 2 != 0] if odds_only else numbers
```