### PR TITLE
Add option to send reminders from noreply address

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ Improvements
 - Log detailed changes when editing contributions (:pr:`5777`)
 - Allow managers to ignore required field restrictions in registration forms
   (:issue:`5644`, :pr:`5682`, thanks :user:`kewisch`)
+- Allow selecting the global noreply address as the sender for event reminders
+  (:pr:`5784`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/reminders/forms.py
+++ b/indico/modules/events/reminders/forms.py
@@ -51,8 +51,9 @@ class ReminderForm(IndicoForm):
         self.event = kwargs.pop('event')
         self.timezone = self.event.timezone
         super().__init__(*args, **kwargs)
-        self.reply_to_address.choices = (list(self.event
-                                         .get_allowed_sender_emails(extra=self.reply_to_address.object_data).items()))
+        allowed_senders = self.event.get_allowed_sender_emails(include_noreply=True,
+                                                               extra=self.reply_to_address.object_data)
+        self.reply_to_address.choices = list(allowed_senders.items())
         if self.event.type_ == EventType.lecture:
             del self.include_summary
 


### PR DESCRIPTION
While it's often nicer to send from a more personal address, users on Exchange Online have problems with reminders sent from their own address when an ics file is attached - in that case ExO automatically trashes the email and creates a calendar entry.

With this change, the event organizer can select to send from noreply instead, which hopefully does not have the same problem.
We cannot send from noreply by default because sometimes recipients (mailing lists) may not allow every sender to send emails (noreply is unlikely to be whitelisted), but by making it an option people can choose what they want.