### PR TITLE
Allow managers to add internal notes to room bookings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -219,6 +219,7 @@ Improvements
   (:pr:`5784`)
 - Allow admins to change the password of local accounts (:pr:`5789`, thanks
   :user:`omegak`)
+- Allow room managers to add internal notes to bookings (:issue:`5746`, :pr:`5791`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Improvements
   restrict them to speakers or registrants (:pr:`5670`, thanks :user:`kewisch`)
 - Make editing timeline display much more straightforward (:pr:`5674`)
 - Allow event managers to delete editables from contributions (:pr:`5778`)
+- Allow room managers to add internal notes to bookings (:issue:`5746`, :pr:`5791`)
 
 Bugfixes
 ^^^^^^^^
@@ -219,7 +220,6 @@ Improvements
   (:pr:`5784`)
 - Allow admins to change the password of local accounts (:pr:`5789`, thanks
   :user:`omegak`)
-- Allow room managers to add internal notes to bookings (:issue:`5746`, :pr:`5791`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20230424_1511_cd7038a37646_add_notes_column_to_room_bookings.py
+++ b/indico/migrations/versions/20230424_1511_cd7038a37646_add_notes_column_to_room_bookings.py
@@ -1,0 +1,25 @@
+"""Add internal_note column to room bookings
+
+Revision ID: cd7038a37646
+Revises: 5d05eda06776
+Create Date: 2023-04-24 15:11:55.407209
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'cd7038a37646'
+down_revision = '5d05eda06776'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('reservations', sa.Column('internal_note', sa.Text(), nullable=False, server_default=''), schema='roombooking')
+    op.alter_column('reservations', 'internal_note', server_default=None, schema='roombooking')
+
+
+def downgrade():
+    op.drop_column('reservations', 'internal_note', schema='roombooking')

--- a/indico/migrations/versions/20230817_1300_cd7038a37646_add_notes_column_to_room_bookings.py
+++ b/indico/migrations/versions/20230817_1300_cd7038a37646_add_notes_column_to_room_bookings.py
@@ -1,7 +1,7 @@
 """Add internal_note column to room bookings
 
 Revision ID: cd7038a37646
-Revises: 5d05eda06776
+Revises: cb46beecbb93
 Create Date: 2023-04-24 15:11:55.407209
 """
 
@@ -11,13 +11,14 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'cd7038a37646'
-down_revision = '5d05eda06776'
+down_revision = 'cb46beecbb93'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column('reservations', sa.Column('internal_note', sa.Text(), nullable=False, server_default=''), schema='roombooking')
+    op.add_column('reservations', sa.Column('internal_note', sa.Text(), nullable=False, server_default=''),
+                  schema='roombooking')
     op.alter_column('reservations', 'internal_note', server_default=None, schema='roombooking')
 
 

--- a/indico/modules/rb/__init__.py
+++ b/indico/modules/rb/__init__.py
@@ -36,6 +36,7 @@ rb_settings = SettingsProxy('roombooking', {
     'end_notification_weekly': 3,
     'end_notification_monthly': 7,
     'end_notifications_enabled': True,
+    'internal_notes_enabled': False,
     'booking_limit': 365,
     'tileserver_url': None,
     'grace_period': None,

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
@@ -281,6 +281,23 @@ class BookingDetails extends React.Component {
     </Message>
   );
 
+  renderNotes = internalNote => {
+    if (!internalNote) {
+      return null;
+    }
+    return (
+      <Message warning icon styleName="message-icon">
+        <Icon name="clipboard list" style={{marginRight: '0.4em'}} />
+        <Message.Content>
+          <Message.Header>
+            <Translate>Internal notes</Translate>
+          </Message.Header>
+          {internalNote}
+        </Message.Content>
+      </Message>
+    );
+  };
+
   _getRowSerializer = day => {
     const {
       booking: {room},
@@ -829,6 +846,7 @@ class BookingDetails extends React.Component {
         room,
         bookedForUser,
         bookingReason,
+        internalNote,
         editLogs,
         createdDt,
         createdByUser,
@@ -896,6 +914,7 @@ class BookingDetails extends React.Component {
                 <>
                   {bookedForUser && this.renderBookedFor(bookedForUser)}
                   {this.renderReason(bookingReason)}
+                  {room.canUserViewInternalNotes && this.renderNotes(internalNote)}
                   {isLinkedToObject && (
                     <LazyBookingObjectLink type={_.camelCase(link.type)} id={link.id} />
                   )}

--- a/indico/modules/rb/client/js/common/bookings/BookingEdit.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEdit.jsx
@@ -51,6 +51,7 @@ class BookingEdit extends React.Component {
     user: PropTypes.object.isRequired,
     booking: PropTypes.object.isRequired,
     isOngoingBooking: PropTypes.bool.isRequired,
+    isAdminOverrideEnabled: PropTypes.bool.isRequired,
     actionButtons: PropTypes.func,
     onSubmit: PropTypes.func.isRequired,
     onClose: PropTypes.func,
@@ -297,6 +298,7 @@ class BookingEdit extends React.Component {
         room: {id: roomId},
       },
       onSubmit,
+      isAdminOverrideEnabled,
     } = this.props;
     const [repeatFrequency, repeatInterval] = serializeRecurrenceInfo(recurrence);
     const params = {
@@ -309,6 +311,9 @@ class BookingEdit extends React.Component {
       reason,
       internal_note: internalNote,
     };
+    if (isAdminOverrideEnabled) {
+      params.admin_override_enabled = true;
+    }
 
     const rv = await updateBooking(id, params);
     if (rv.error) {
@@ -342,6 +347,7 @@ export default connect(
   (state, {booking: {id}}) => ({
     user: userSelectors.getUserInfo(state),
     isOngoingBooking: bookingsSelectors.isOngoingBooking(state, {bookingId: id}),
+    isAdminOverrideEnabled: userSelectors.isUserAdminOverrideEnabled(state),
   }),
   dispatch => ({
     actions: bindActionCreators(

--- a/indico/modules/rb/client/js/common/bookings/BookingEdit.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEdit.jsx
@@ -98,7 +98,7 @@ class BookingEdit extends React.Component {
   get initialFormValues() {
     const {
       user: sessionUser,
-      booking: {repetition, startDt, endDt, bookedForUser, bookingReason},
+      booking: {repetition, startDt, endDt, bookedForUser, bookingReason, internalNote},
     } = this.props;
     const recurrence = getRecurrenceInfo(repetition);
     const isSingleBooking = recurrence.type === 'single';
@@ -116,6 +116,7 @@ class BookingEdit extends React.Component {
       usage,
       user: bookedForUser.identifier,
       reason: bookingReason,
+      internalNote,
     };
   }
 
@@ -287,6 +288,7 @@ class BookingEdit extends React.Component {
       user,
       reason,
       recurrence,
+      internalNote,
     } = data;
     const {
       actions: {updateBooking},
@@ -305,6 +307,7 @@ class BookingEdit extends React.Component {
       room_id: roomId,
       user,
       reason,
+      internal_note: internalNote,
     };
 
     const rv = await updateBooking(id, params);

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -295,6 +295,21 @@ class BookingEditForm extends React.Component {
             disabled={submitSucceeded}
           />
         </Segment>
+
+        {room.canUserViewInternalNotes && (
+          <Segment inverted styleName="booking-notes-section">
+            <p style={{marginBottom: '0.5em'}}>
+              <Translate>
+                Internal notes about the booking that will only be shown to managers
+              </Translate>
+            </p>
+            <FinalTextArea
+              name="internalNote"
+              placeholder={Translate.string('(Optional)')}
+              disabled={submitSucceeded}
+            />
+          </Segment>
+        )}
       </Form>
     );
   }

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -297,7 +297,7 @@ class BookingEditForm extends React.Component {
         </Segment>
 
         {room.canUserViewInternalNotes && (
-          <Segment inverted styleName="booking-notes-section">
+          <Segment inverted styleName="internal-notes-segment">
             <p style={{marginBottom: '0.5em'}}>
               <Translate>
                 Internal notes about the booking are only visible to room managers.

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -300,14 +300,10 @@ class BookingEditForm extends React.Component {
           <Segment inverted styleName="booking-notes-section">
             <p style={{marginBottom: '0.5em'}}>
               <Translate>
-                Internal notes about the booking that will only be shown to managers
+                Internal notes about the booking are only visible to room managers.
               </Translate>
             </p>
-            <FinalTextArea
-              name="internalNote"
-              placeholder={Translate.string('(Optional)')}
-              disabled={submitSucceeded}
-            />
+            <FinalTextArea name="internalNote" disabled={submitSucceeded} />
           </Segment>
         )}
       </Form>

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
@@ -20,6 +20,6 @@
   }
 }
 
-.booking-notes-section {
-  background: $booking-notes-section-color !important;
+:global(.ui.segment).internal-notes-segment {
+  background: $internal-notes-segment-color;
 }

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@import 'rb:styles/palette';
+
 .booking-edit-form {
   margin-top: 15px;
 
@@ -16,4 +18,8 @@
       z-index: 1000;
     }
   }
+}
+
+.booking-notes-section {
+  background: $booking-notes-section-color !important;
 }

--- a/indico/modules/rb/client/js/common/config/reducers.js
+++ b/indico/modules/rb/client/js/common/config/reducers.js
@@ -23,6 +23,7 @@ export const initialState = {
   hasTOS: false,
   tosHTML: null,
   hasPrivacyPolicy: false,
+  internalNotesEnabled: false,
   privacyPolicyHTML: null,
   contactEmail: null,
 };
@@ -47,6 +48,7 @@ export default combineReducers({
           tosHtml: tosHTML,
           privacyPolicyHtml: privacyPolicyHTML,
           tileserverURL: tileServerURL,
+          internalNotesEnabled,
         } = camelizeKeys(action.data);
         const {languages} = action.data;
         return {
@@ -61,6 +63,7 @@ export default combineReducers({
           hasPrivacyPolicy,
           privacyPolicyHTML,
           contactEmail,
+          internalNotesEnabled,
         };
       }
       case adminActions.SETTINGS_RECEIVED:

--- a/indico/modules/rb/client/js/common/config/selectors.js
+++ b/indico/modules/rb/client/js/common/config/selectors.js
@@ -19,3 +19,4 @@ export const getTOSHTML = ({config}) => config.data.tosHTML;
 export const hasPrivacyPolicy = ({config}) => config.data.hasPrivacyPolicy;
 export const getPrivacyPolicyHTML = ({config}) => config.data.privacyPolicyHTML;
 export const getContactEmail = ({config}) => config.data.contactEmail;
+export const hasInternalNotesEnabled = ({config}) => config.data.internalNotesEnabled;

--- a/indico/modules/rb/client/js/common/rooms/selectors.js
+++ b/indico/modules/rb/client/js/common/rooms/selectors.js
@@ -10,7 +10,7 @@ import {createSelector} from 'reselect';
 
 import {RequestState} from 'indico/utils/redux';
 
-import {canManagersEditRooms} from '../config/selectors';
+import {canManagersEditRooms, hasInternalNotesEnabled} from '../config/selectors';
 import {getAllUserRoomPermissions, isUserRBAdmin} from '../user/selectors';
 
 export const hasLoadedEquipmentTypes = ({rooms}) =>
@@ -65,7 +65,15 @@ export const getAllRooms = createSelector(
   getAllUserRoomPermissions,
   isUserRBAdmin,
   canManagersEditRooms,
-  (rawRooms, equipmentTypes, allUserPermissions, isRBAdmin, managersEditRooms) => {
+  hasInternalNotesEnabled,
+  (
+    rawRooms,
+    equipmentTypes,
+    allUserPermissions,
+    isRBAdmin,
+    managersEditRooms,
+    internalNotesEnabled
+  ) => {
     equipmentTypes = equipmentTypes.reduce((obj, eq) => ({...obj, [eq.id]: eq}), {});
     return _.fromPairs(
       rawRooms.map(room => {
@@ -99,6 +107,7 @@ export const getAllRooms = createSelector(
             ...roomData,
             equipment: equipment.map(id => equipmentTypes[id].name).sort(),
             features: sortedFeatures,
+            canUserViewInternalNotes: permissions.manage && internalNotesEnabled,
             canUserEdit: permissions.manage && (isRBAdmin || managersEditRooms),
             canUserBook: permissions.book,
             canUserPrebook: permissions.prebook,

--- a/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
@@ -240,6 +240,15 @@ const SettingsPage = props => {
                 </Form.Group>
               </Message>
             </FieldCondition>
+            <FinalCheckbox
+              name="internal_notes_enabled"
+              label={Translate.string('Enable internal booking notes')}
+              description={
+                <Translate>
+                  Enable managers to add notes to a booking that can only be seen by other managers.
+                </Translate>
+              }
+            />
             <FinalField
               name="excluded_categories"
               component={CategoryList}

--- a/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
@@ -245,7 +245,8 @@ const SettingsPage = props => {
               label={Translate.string('Enable internal booking notes')}
               description={
                 <Translate>
-                  Enable managers to add notes to a booking that can only be seen by other managers.
+                  Allow room owners/managers to add internal notes to bookings which are only
+                  visible to other room owners/managers.
                 </Translate>
               }
             />

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
@@ -629,6 +629,33 @@ class BookRoomModal extends React.Component {
                     fprops.form.mutators
                   )}
               </Form>
+
+              {room.canUserViewInternalNotes && (
+                <Form
+                  id="book-notes-form"
+                  onSubmit={fprops.handleSubmit}
+                  style={{paddingTop: '1em'}}
+                >
+                  <Segment inverted styleName="booking-notes-section">
+                    <h3 style={{marginBottom: '0.5em'}}>
+                      <Icon name="clipboard list" />
+                      <Translate>Notes</Translate>
+                    </h3>
+                    <p>
+                      <Translate>
+                        Internal notes about the booking that will only be shown to room booking
+                        managers
+                      </Translate>
+                    </p>
+                    <FinalTextArea
+                      name="internalNote"
+                      placeholder={Translate.string('(Optional)')}
+                      disabled={fprops.submitSucceeded}
+                    />
+                  </Segment>
+                </Form>
+              )}
+
               {preConflictsExist && !fprops.submitSucceeded && this.renderPreConflictMessage()}
               {conflictsExist &&
                 this.renderBookingConstraints(
@@ -719,7 +746,7 @@ export default connect(
         fetchRelatedEvents: actions.fetchRelatedEvents,
         resetRelatedEvents: actions.resetRelatedEvents,
         createBooking: (data, props) => {
-          const {reason, usage, user, linkType, linkId, linkBack} = data;
+          const {reason, internalNote, usage, user, linkType, linkId, linkBack} = data;
           const {
             bookingData: {recurrence, dates, timeSlot, isPrebooking},
             room,
@@ -728,6 +755,7 @@ export default connect(
           return actions.createBooking(
             {
               reason,
+              internalNote,
               usage,
               user,
               recurrence,

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
@@ -639,19 +639,14 @@ class BookRoomModal extends React.Component {
                   <Segment inverted styleName="booking-notes-section">
                     <h3 style={{marginBottom: '0.5em'}}>
                       <Icon name="clipboard list" />
-                      <Translate>Notes</Translate>
+                      <Translate>Internal notes (optional)</Translate>
                     </h3>
                     <p>
                       <Translate>
-                        Internal notes about the booking that will only be shown to room booking
-                        managers
+                        Internal notes about the booking are only visible to room managers.
                       </Translate>
                     </p>
-                    <FinalTextArea
-                      name="internalNote"
-                      placeholder={Translate.string('(Optional)')}
-                      disabled={fprops.submitSucceeded}
-                    />
+                    <FinalTextArea name="internalNote" disabled={fprops.submitSucceeded} />
                   </Segment>
                 </Form>
               )}

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
@@ -636,7 +636,7 @@ class BookRoomModal extends React.Component {
                   onSubmit={fprops.handleSubmit}
                   style={{paddingTop: '1em'}}
                 >
-                  <Segment inverted styleName="booking-notes-section">
+                  <Segment inverted styleName="internal-notes-segment">
                     <h3 style={{marginBottom: '0.5em'}}>
                       <Icon name="clipboard list" />
                       <Translate>Internal notes (optional)</Translate>

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.module.scss
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.module.scss
@@ -64,3 +64,7 @@
     padding-bottom: 0.5em;
   }
 }
+
+.booking-notes-section {
+  background: $booking-notes-section-color !important;
+}

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.module.scss
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.module.scss
@@ -65,6 +65,6 @@
   }
 }
 
-.booking-notes-section {
-  background: $booking-notes-section-color !important;
+:global(.ui.segment).internal-notes-segment {
+  background: $internal-notes-segment-color;
 }

--- a/indico/modules/rb/client/js/modules/bookRoom/serializers.js
+++ b/indico/modules/rb/client/js/modules/bookRoom/serializers.js
@@ -23,6 +23,7 @@ export const ajax = {
   },
   room_id: ({room: {id}}) => id,
   is_prebooking: ({isPrebooking}) => isPrebooking,
+  internal_note: ({internalNote}) => internalNote,
   link_type: ({linkType}) => linkType,
   link_id: ({linkId}) => linkId,
   link_back: ({linkBack}) => linkBack,

--- a/indico/modules/rb/client/styles/palette.scss
+++ b/indico/modules/rb/client/styles/palette.scss
@@ -48,6 +48,8 @@ $pending-cancellation-fadeout-colors: $pending-cancellation-color,
 $rejection-fadeout-colors: $rejection-color, lighten($rejection-color, 30%);
 $other-booking-fadeout-colors: $other-booking-color, lighten($other-booking-color, 30%);
 
+$booking-notes-section-color: #db9200;
+
 @mixin rb-splash-background {
   background-image: url('static:images/globe.png');
   background-size: cover;

--- a/indico/modules/rb/client/styles/palette.scss
+++ b/indico/modules/rb/client/styles/palette.scss
@@ -48,7 +48,7 @@ $pending-cancellation-fadeout-colors: $pending-cancellation-color,
 $rejection-fadeout-colors: $rejection-color, lighten($rejection-color, 30%);
 $other-booking-fadeout-colors: $other-booking-color, lighten($other-booking-color, 30%);
 
-$booking-notes-section-color: #db9200;
+$internal-notes-segment-color: #db9200;
 
 @mixin rb-splash-background {
   background-image: url('static:images/globe.png');

--- a/indico/modules/rb/controllers/backend/bookings.py
+++ b/indico/modules/rb/controllers/backend/bookings.py
@@ -175,10 +175,6 @@ class RHCreateBooking(RHRoomBookingBase):
                    .format(self.room.name, booking_limit_days))
             raise ExpectedError(msg)
 
-        # Prevent the submission of notes if the setting is disabled
-        if not rb_settings.get('internal_notes_enabled') or not self.room.can_manage(session.user):
-            args.pop('internal_note', None)
-
         try:
             resv = Reservation.create_from_data(self.room, args, session.user, prebook=self.prebook,
                                                 ignore_admin=(not admin_override))
@@ -305,8 +301,23 @@ class RHUpdateBooking(RHBookingBase):
 
     @use_args(CreateBookingSchema)
     def _process(self, args):
+        room = self.booking.room
+
+        # XXX this is a bit of an ugly hack: usually it's checked in the reservation create/update code
+        # whether internal notes are enabled and the user can touch them. but when splitting we need to
+        # create a new booking and want to preserve internal notes regardless of whether the user who does
+        # the splitting is allowed to manage them or not. however, if the user does have access to internal
+        # notes, we want to allow them to change it as well.
+        if (
+            not rb_settings.get('internal_notes_enabled') or
+            not room.can_manage(session.user, allow_admin=args['admin_override_enabled'])
+        ):
+            # remove the user-provided note (we fall back to the one from the xisting booking below)
+            args.pop('internal_note', None)
+
         new_booking_data = {
             'booking_reason': args['booking_reason'],
+            'internal_note': args.get('internal_note', self.booking.internal_note),
             'booked_for_user': args.get('booked_for_user', self.booking.booked_for_user),
             'start_dt': args['start_dt'],
             'end_dt': args['end_dt'],
@@ -314,18 +325,9 @@ class RHUpdateBooking(RHBookingBase):
             'repeat_interval': args['repeat_interval'],
         }
 
-        # allow updating the internal notes only if the setting is enabled
-        if (
-            rb_settings.get('internal_notes_enabled') and
-            'internal_note' in args and
-            self.booking.room.can_manage(session.user)
-        ):
-            new_booking_data['internal_note'] = args['internal_note']
-
         additional_booking_attrs = {}
         if not should_split_booking(self.booking, new_booking_data):
             has_slot_changed = not has_same_slots(self.booking, new_booking_data)
-            room = self.booking.room
             self.booking.modify(new_booking_data, session.user)
             if (has_slot_changed and not room.can_book(session.user, allow_admin=False) and
                     room.can_prebook(session.user, allow_admin=False) and self.booking.is_accepted):

--- a/indico/modules/rb/controllers/backend/bookings.py
+++ b/indico/modules/rb/controllers/backend/bookings.py
@@ -310,6 +310,10 @@ class RHUpdateBooking(RHBookingBase):
             'repeat_interval': args['repeat_interval'],
         }
 
+        # allow updating the internal notes only if the setting is enabled
+        if rb_settings.get('internal_notes_enabled'):
+            new_booking_data['internal_note'] = args['internal_note']
+
         additional_booking_attrs = {}
         if not should_split_booking(self.booking, new_booking_data):
             has_slot_changed = not has_same_slots(self.booking, new_booking_data)

--- a/indico/modules/rb/controllers/backend/bookings.py
+++ b/indico/modules/rb/controllers/backend/bookings.py
@@ -176,8 +176,8 @@ class RHCreateBooking(RHRoomBookingBase):
             raise ExpectedError(msg)
 
         # Prevent the submission of notes if the setting is disabled
-        if not rb_settings.get('internal_notes_enabled'):
-            del args['internal_note']
+        if not rb_settings.get('internal_notes_enabled') or not self.room.can_manage(session.user):
+            args.pop('internal_note', None)
 
         try:
             resv = Reservation.create_from_data(self.room, args, session.user, prebook=self.prebook,
@@ -315,7 +315,11 @@ class RHUpdateBooking(RHBookingBase):
         }
 
         # allow updating the internal notes only if the setting is enabled
-        if rb_settings.get('internal_notes_enabled'):
+        if (
+            rb_settings.get('internal_notes_enabled') and
+            'internal_note' in args and
+            self.booking.room.can_manage(session.user)
+        ):
             new_booking_data['internal_note'] = args['internal_note']
 
         additional_booking_attrs = {}

--- a/indico/modules/rb/controllers/backend/bookings.py
+++ b/indico/modules/rb/controllers/backend/bookings.py
@@ -175,6 +175,10 @@ class RHCreateBooking(RHRoomBookingBase):
                    .format(self.room.name, booking_limit_days))
             raise ExpectedError(msg)
 
+        # Prevent the submission of notes if the setting is disabled
+        if not rb_settings.get('internal_notes_enabled'):
+            del args['internal_note']
+
         try:
             resv = Reservation.create_from_data(self.room, args, session.user, prebook=self.prebook,
                                                 ignore_admin=(not admin_override))

--- a/indico/modules/rb/controllers/backend/misc.py
+++ b/indico/modules/rb/controllers/backend/misc.py
@@ -45,6 +45,7 @@ class RHConfig(RHRoomBookingBase):
                        tileserver_url=rb_settings.get('tileserver_url'),
                        grace_period=rb_settings.get('grace_period'),
                        managers_edit_rooms=rb_settings.get('managers_edit_rooms'),
+                       internal_notes_enabled=rb_settings.get('internal_notes_enabled'),
                        help_url=config.HELP_URL,
                        contact_email=config.PUBLIC_SUPPORT_EMAIL,
                        has_tos=bool(tos_url or tos_html),

--- a/indico/modules/rb/operations/bookings.py
+++ b/indico/modules/rb/operations/bookings.py
@@ -420,7 +420,7 @@ def split_booking(booking, new_booking_data):
 
     prebook = not room.can_book(session.user, allow_admin=False) and room.can_prebook(session.user, allow_admin=False)
     resv = Reservation.create_from_data(room, dict(new_booking_data, start_dt=new_start_dt), session.user,
-                                        prebook=prebook, ignore_admin=True)
+                                        prebook=prebook, ignore_admin=True, force_internal_note=True)
     for new_occ in resv.occurrences:
         new_occ_start = new_occ.start_dt.date()
         if new_occ_start in cancelled_dates:


### PR DESCRIPTION
Closes: #5746 

- [x] UI Mockups created and sent
- [x] Create migration
- [x] Add admin setting to toggle internal notes
- [x] Create, View and Edit internal notes (WIP: edit + fix over with correct perms - not `isAdmin` -> `canManage`)
- [x] Hookup setting w/ frontend
- [x] Implement `canManage` perms (+ admin override)
- [x] Ensure backend (API) returns notes to persons with the appropriate `canManage` permissions (room owners)
- [x] Remove notes field from edit logs (API)
- [x] Cleanup/Refactor
- [x] Update changelog