### PR TITLE
Show an actual recipient on the emails' preview

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,8 @@ Security fixes
 Improvements
 ^^^^^^^^^^^^
 
-- None so far :(
+- Show actual recipient data in the email preview instead of the that of the event creator
+  (:pr:`5794`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/controllers/abstract_list.py
+++ b/indico/modules/events/abstracts/controllers/abstract_list.py
@@ -298,11 +298,11 @@ class RHAbstractsAPIEmailAbstractRolesMetadata(EmailRolesMetadataMixin, RHManage
     object_context = 'abstracts'
 
 
-class RHAbstractsAPIEmailAbstractRolesPreview(EmailRolesPreviewMixin, RHManageAbstractsBase):
+class RHAbstractsAPIEmailAbstractRolesPreview(EmailRolesPreviewMixin, RHManageAbstractsActionsBase):
     object_context = 'abstracts'
 
     def get_placeholder_kwargs(self):
-        abstract = self.event.abstracts[0]
+        abstract = self.abstracts[0]
         return {'person': abstract.submitter, 'abstract': abstract}
 
 

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -878,14 +878,11 @@ class RHContributionsAPIEmailContribRolesPreview(EmailRolesPreviewMixin, RHManag
     object_context = 'contributions'
 
     def get_placeholder_kwargs(self):
-        contribution = self.contribs[0]
-        person = self.event.creator
         for contrib in self.contribs:
-            for p in contribution.person_links:
+            for p in contrib.person_links:
                 if p.email:
-                    person = p
-                    contribution = contrib
-        return {'person': person, 'contribution': contribution}
+                    return {'person': p, 'contribution': contrib}
+        return {'person': self.event.creator, 'contribution': self.contribs[0]}
 
 
 class RHContributionsAPIEmailContribRolesSend(EmailRolesSendMixin, RHManageContributionsActionsBase):

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -874,13 +874,18 @@ class RHContributionsAPIEmailContribRolesMetadata(EmailRolesMetadataMixin, RHMan
     object_context = 'contributions'
 
 
-class RHContributionsAPIEmailContribRolesPreview(EmailRolesPreviewMixin, RHManageContributionsBase):
+class RHContributionsAPIEmailContribRolesPreview(EmailRolesPreviewMixin, RHManageContributionsActionsBase):
     object_context = 'contributions'
 
     def get_placeholder_kwargs(self):
-        contribution = Contribution.query.with_parent(self.event).first()
-        # none of the contributions are guaranteed to have a person so we use the event creator...
-        return {'person': self.event.creator, 'contribution': contribution}
+        contribution = self.contribs[0]
+        person = self.event.creator
+        for contrib in self.contribs:
+            for p in contribution.person_links:
+                if p.email:
+                    person = p
+                    contribution = contrib
+        return {'person': person, 'contribution': contribution}
 
 
 class RHContributionsAPIEmailContribRolesSend(EmailRolesSendMixin, RHManageContributionsActionsBase):

--- a/indico/modules/events/persons/client/js/EmailContribAbstractRoles.jsx
+++ b/indico/modules/events/persons/client/js/EmailContribAbstractRoles.jsx
@@ -59,6 +59,7 @@ export function EmailContribAbstractRoles({context, metadataURL, previewURL, sen
       onClose={onClose}
       senders={senders}
       previewURL={previewURL}
+      previewContext={context}
       placeholders={placeholders}
       initialFormValues={{subject: defaultSubject, body: defaultBody, recipient_roles: []}}
       sentEmailsCount={sentCount}

--- a/indico/modules/events/persons/client/js/EmailParticipantRoles.jsx
+++ b/indico/modules/events/persons/client/js/EmailParticipantRoles.jsx
@@ -79,7 +79,7 @@ export function EmailParticipantRoles({
       senders={senders}
       recipients={recipients}
       previewURL={emailPreviewURL({event_id: eventId})}
-      previewContext={{noAccount}}
+      previewContext={recipientData}
       placeholders={placeholders}
       initialFormValues={{subject: defaultSubject, body: defaultBody}}
       sentEmailsCount={sentCount}


### PR DESCRIPTION
This PR makes the email dialogs' preview screen use an actual recipient's data on the placeholders instead of the event's creator.

Note: roles of recipients are not taken into account on the `EmailContribAbstractRoles` due to the added complexity on the client-side (can implement if deemed necessary)