### PR TITLE
Fix slow/spammy queries in registration forms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Bugfixes
 - Fix wrong date in email subject for room booking occurrence cancellations (:pr:`5790`)
 - Fix excessive queries being sent in meetings that have registration form with limited
   places and many registrants (:pr:`5799`)
+- Fix extremely slow query when retrieving list of registration forms in conferences with
+  many registrants while not logged in (:pr:`5799`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Bugfixes
 
 - Fix width of time column in PDF timetable when using 12-hour time format (:pr:`5788`)
 - Fix wrong date in email subject for room booking occurrence cancellations (:pr:`5790`)
+- Fix excessive queries being sent in meetings that have registration form with limited
+  places and many registrants (:pr:`5799`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/controllers/display_test.py
+++ b/indico/modules/events/registration/controllers/display_test.py
@@ -50,6 +50,7 @@ def test_RHRegistrationForm_can_register(db, dummy_regform, dummy_reg, dummy_use
     dummy_regform.registration_limit = 1
     assert rh._can_register()  # withdrawn/rejected do not count against limit
     dummy_reg.state = RegistrationState.complete
+    db.session.expire(dummy_regform)
     assert not rh._can_register()  # exceeding limit
 
 

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -429,8 +429,7 @@ class RegistrationForm(db.Model):
 
     @property
     def limit_reached(self):
-        return (self.registration_limit
-                and sum(reg.occupied_slots for reg in self.active_registrations) >= self.registration_limit)
+        return self.registration_limit and self.active_registration_count >= self.registration_limit
 
     @property
     def is_active(self):

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -695,8 +695,9 @@ def get_event_regforms(event, user, with_registrations=False, only_in_acl=False)
     if only_in_acl:
         query = query.filter(RegistrationForm.in_event_acls.any(event=event))
     if with_registrations:
+        user_criterion = (Registration.user == user) if user else False
         query = query.outerjoin(Registration, db.and_(Registration.registration_form_id == RegistrationForm.id,
-                                                      Registration.user == user,
+                                                      user_criterion,
                                                       ~Registration.is_deleted))
     return query.all()
 


### PR DESCRIPTION
- O(n) (n=registrants) queries on meeting pages with limited-places registration forms
- O(n² * k) (n=registrants, k=fields) query execution complexity when querying the list of registration forms in a conference