### PR TITLE
Add 'max_choices' option to multi choice fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Improvements
 
 - Show actual recipient data in the email preview instead of the that of the event creator
   (:pr:`5794`)
+- Add an option to set a maximum number of choices in a multi-choice field (:pr:`5800`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
@@ -29,6 +29,8 @@ function MultiChoiceInputComponent({
   existingValue,
   value,
   onChange,
+  onFocus,
+  onBlur,
   disabled,
   choices,
   withExtraSlots,
@@ -38,7 +40,13 @@ function MultiChoiceInputComponent({
   const management = useSelector(getManagement);
   const currency = useSelector(getCurrency);
 
+  const markTouched = () => {
+    onFocus();
+    onBlur();
+  };
+
   const makeHandleChange = choice => () => {
+    markTouched();
     if (value[choice.id]) {
       onChange(_.omit(value, choice.id));
     } else {
@@ -46,6 +54,7 @@ function MultiChoiceInputComponent({
     }
   };
   const makeHandleSlotsChange = choice => (__, {value: newValue}) => {
+    markTouched();
     if (!+newValue) {
       onChange(_.omit(value, choice.id));
     } else {
@@ -160,6 +169,8 @@ function MultiChoiceInputComponent({
 MultiChoiceInputComponent.propTypes = {
   value: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
   choices: PropTypes.arrayOf(PropTypes.shape(choiceShape)).isRequired,
   withExtraSlots: PropTypes.bool.isRequired,

--- a/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
@@ -192,7 +192,7 @@ export default function MultiChoiceInput({
       validate={value => {
         if (maxChoices && _.keys(value).length > maxChoices) {
           return PluralTranslate.string(
-            'At most one option can be selected',
+            'At most {n} option can be selected',
             'At most {n} options can be selected',
             maxChoices,
             {n: maxChoices}

--- a/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
@@ -12,8 +12,8 @@ import {Field} from 'react-final-form';
 import {useSelector} from 'react-redux';
 import {Checkbox, Dropdown, Label} from 'semantic-ui-react';
 
-import {FinalCheckbox, FinalField} from 'indico/react/forms';
-import {Translate} from 'indico/react/i18n';
+import {FinalCheckbox, FinalField, FinalInput, validators as v} from 'indico/react/forms';
+import {Translate, PluralTranslate} from 'indico/react/i18n';
 
 import {getCurrency} from '../../form/selectors';
 import {getFieldValue, getManagement, getPaid} from '../../form_submission/selectors';
@@ -54,8 +54,8 @@ function MultiChoiceInputComponent({
   };
 
   const formatPrice = choice => {
-    const v = value[choice.id] || 0;
-    return ((v === 0 ? 0 : choice.extraSlotsPay ? v : 1) * choice.price).toFixed(2);
+    const val = value[choice.id] || 0;
+    return ((val === 0 ? 0 : choice.extraSlotsPay ? val : 1) * choice.price).toFixed(2);
   };
 
   const isPaidChoice = choice => choice.price > 0 && paid;
@@ -173,6 +173,7 @@ export default function MultiChoiceInput({
   disabled,
   isRequired,
   choices,
+  maxChoices,
   withExtraSlots,
   placesUsed,
 }) {
@@ -188,6 +189,16 @@ export default function MultiChoiceInput({
       placesUsed={placesUsed}
       existingValue={existingValue}
       isEqual={_.isEqual}
+      validate={value => {
+        if (maxChoices && _.keys(value).length > maxChoices) {
+          return PluralTranslate.string(
+            'At most one option can be selected',
+            'At most {n} options can be selected',
+            maxChoices,
+            {n: maxChoices}
+          );
+        }
+      }}
     />
   );
 }
@@ -198,6 +209,7 @@ MultiChoiceInput.propTypes = {
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,
   choices: PropTypes.arrayOf(PropTypes.shape(choiceShape)).isRequired,
+  maxChoices: PropTypes.number,
   withExtraSlots: PropTypes.bool,
   placesUsed: PropTypes.objectOf(PropTypes.number).isRequired,
 };
@@ -205,6 +217,7 @@ MultiChoiceInput.propTypes = {
 MultiChoiceInput.defaultProps = {
   disabled: false,
   isRequired: false,
+  maxChoices: null,
   withExtraSlots: false,
 };
 
@@ -216,6 +229,27 @@ export const multiChoiceSettingsInitialData = {
 export function MultiChoiceSettings() {
   return (
     <>
+      <Field name="choices" subscription={{value: true}}>
+        {({input: {value}}) => {
+          const min = value.length > 0 ? 1 : 0;
+          const max = value.length > 0 ? value.length : 0;
+          return (
+            <FinalInput
+              name="maxChoices"
+              type="number"
+              placeholder={Translate.string('Unlimited', 'Number of choices')}
+              step="1"
+              min={min}
+              max={max}
+              validate={v.optional(v.range(min, max))}
+              label={Translate.string('Maximum number of choices')}
+              description={Translate.string(
+                'Maximum number of choices that can be selected. Leave empty to unset.'
+              )}
+            />
+          );
+        }}
+      </Field>
       <FinalCheckbox name="withExtraSlots" label={Translate.string('Enable extra slots')} />
       <Field name="withExtraSlots" subscription={{value: true}}>
         {({input: {value: withExtraSlots}}) => (

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -294,7 +294,7 @@ class MultiChoiceField(ChoiceBaseField):
             # If `max_choices` is set, ensure that it is
             # less than or equal to the total number of choices.
             if max_choices and len(new_data) > max_choices:
-                raise ValidationError(ngettext('At most one option can be selected',
+                raise ValidationError(ngettext('At most {max_choices} option can be selected',
                                                'At most {max_choices} options can be selected', max_choices)
                                       .format(max_choices=max_choices))
         return [_check_max_choices] + super().get_validators(existing_registration)

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -290,7 +290,7 @@ class MultiChoiceField(ChoiceBaseField):
             if not new_data:
                 return
 
-            max_choices = self.form_item.data['max_choices']
+            max_choices = self.form_item.data.get('max_choices')
             # If `max_choices` is set, ensure that it is
             # less than or equal to the total number of choices.
             if max_choices and len(new_data) > max_choices:

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -287,12 +287,13 @@ class MultiChoiceField(ChoiceBaseField):
 
     def get_validators(self, existing_registration):
         def _check_max_choices(new_data):
-            """If `max_choices` is set, ensure that it is less than or equal to the total number of choices."""
             if not new_data:
                 return
 
             max_choices = self.form_item.data['max_choices']
-            if max_choices and len(new_data.keys()) > max_choices:
+            # If `max_choices` is set, ensure that it is
+            # less than or equal to the total number of choices.
+            if max_choices and len(new_data) > max_choices:
                 raise ValidationError(ngettext('At most one option can be selected',
                                                'At most {max_choices} options can be selected', max_choices)
                                       .format(max_choices=max_choices))

--- a/indico/modules/events/registration/fields/choices_test.py
+++ b/indico/modules/events/registration/fields/choices_test.py
@@ -189,7 +189,7 @@ def test_multi_choice_field_validate_max_choices(multi_choice_field):
 
     multi_choice_field.data['max_choices'] = 1
     run_validators(validators, {_id(1): 1})
-    with pytest.raises(ValidationError, match='At most one option can be selected'):
+    with pytest.raises(ValidationError, match='At most 1 option can be selected'):
         run_validators(validators, {_id(1): 1, _id(2): 1})
 
     multi_choice_field.data['max_choices'] = 2

--- a/indico/modules/events/registration/fields/choices_test.py
+++ b/indico/modules/events/registration/fields/choices_test.py
@@ -8,8 +8,9 @@
 from copy import deepcopy
 
 import pytest
+from marshmallow import ValidationError
 
-from indico.modules.events.registration.fields.choices import _hashable_choice
+from indico.modules.events.registration.fields.choices import MultiChoiceSetupSchema, _hashable_choice
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.registrations import RegistrationData
 
@@ -28,6 +29,14 @@ def multi_choice_field():
             {'id': _id(2), 'places_limit': 0, 'price': 0},
             {'id': _id(3), 'places_limit': 0, 'price': 10}
         ]
+    }
+    field.data = {
+        'captions': {
+            _id(1): 'Option 1',
+            _id(2): 'Option 2',
+            _id(3): 'Option 3',
+        },
+        'max_choices': None
     }
     return field
 
@@ -167,3 +176,49 @@ def test_multi_choice_field_process_form_data_price_change_deselected(multi_choi
     form_data = {_id(2): 1, _id(3): 1}
     rv = multi_choice_field.field_impl.process_form_data(None, form_data, new_data)
     assert RegistrationData(**rv).price == 510
+
+
+def test_multi_choice_field_validate_max_choices(multi_choice_field):
+    def run_validators(validators, value):
+        for v in validators:
+            v(value)
+
+    validators = multi_choice_field.field_impl.get_validators(None)
+    run_validators(validators, {})
+    run_validators(validators, {_id(1): 1, _id(2): 1})
+
+    multi_choice_field.data['max_choices'] = 1
+    run_validators(validators, {_id(1): 1})
+    with pytest.raises(ValidationError, match='At most one option can be selected'):
+        run_validators(validators, {_id(1): 1, _id(2): 1})
+
+    multi_choice_field.data['max_choices'] = 2
+    run_validators(validators, {_id(1): 1, _id(2): 1})
+    with pytest.raises(ValidationError, match='At most 2 options can be selected'):
+        run_validators(validators, {_id(1): 1, _id(2): 1, _id(3): 1})
+
+
+@pytest.mark.parametrize(('max_choices', 'n_choices', 'error'), (
+    (-3, 2, 'Maximum choices must be greater than 0'),
+    (None, 2, None),
+    (1, 2, None),
+    (2, 2, None),
+    (4, 3, 'Value must not be greater than the total number of choices')
+))
+def test_multi_choice_setup_schema_max_choices_validation(max_choices, n_choices, error):
+    def _choice(n):
+        return {
+            'id': _id(n),
+            'caption': f'Option {n}',
+            'is_enabled': True,
+        }
+
+    schema = MultiChoiceSetupSchema()
+    choices = [_choice(n) for n in range(n_choices)]
+    data = {'max_choices': max_choices, 'choices': choices}
+
+    if error:
+        with pytest.raises(ValidationError, match=error):
+            schema.load(data)
+    else:
+        schema.load(data)


### PR DESCRIPTION
Lets you configure the maximum number of options that can be selected in a multi-choice field, e.g., there are 5 options but only 2 can be selected at the same time. Sort of an extension of the single choice field which allows only one option at a time.

![obrazek](https://github.com/indico/indico/assets/8739637/e1036eb5-5186-488a-ad8f-a4df3aa0fb96)
