### PR TITLE
Show which files were modified on each revision

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Internationalization
 Improvements
 ^^^^^^^^^^^^
 
-- None so far :(
+- Show which files were added or modified on each editing timeline revision (:pr:`5802`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/index.jsx
@@ -7,7 +7,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import {Button, Icon, Label} from 'semantic-ui-react';
+import {Button, Icon, Label, Popup} from 'semantic-ui-react';
 
 import {TooltipIfTruncated} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
@@ -16,12 +16,31 @@ import {fileTypePropTypes, filePropTypes, mapFileTypes} from '../FileManager/uti
 import './FileDisplay.module.scss';
 
 function FileListDisplay({files}) {
+  const stateIcon = {
+    modified: {
+      icon: 'dot circle',
+      color: 'yellow',
+      tooltip: Translate.string('This file was modified since the last revision.'),
+    },
+    added: {
+      icon: 'add circle',
+      color: 'green',
+      tooltip: Translate.string('This file was added since the last revision.'),
+    },
+  };
+
   return (
     <ul styleName="file-list-display">
-      {files.map(({filename, uuid, downloadURL}) => (
+      {files.map(({filename, uuid, downloadURL, state}) => (
         <li key={uuid} styleName="file-row">
           <TooltipIfTruncated>
             <span styleName="file-name">
+              {state && (
+                <Popup
+                  trigger={<Icon name={stateIcon[state].icon} color={stateIcon[state].color} />}
+                  content={stateIcon[state].tooltip}
+                />
+              )}
               <a href={downloadURL} target="_blank" rel="noopener noreferrer">
                 {filename}
               </a>

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/util.js
@@ -132,7 +132,5 @@ export function getFilesFromRevision(fileTypes, revision) {
 export function getFileToDelete(files, allowMultipleFiles = false) {
   // if we don't allow multiple files and have a file in the added or modified state,
   // that file can always be deleted from the server after the upload
-  return !allowMultipleFiles && files.length && ['added', 'modified'].includes(files[0].state)
-    ? files[0]
-    : null;
+  return !allowMultipleFiles && files.length && !files[0].claimed ? files[0] : null;
 }


### PR DESCRIPTION
This PR adds an indication to show which files were added or modified on each editing timeline revision.

![image](https://github.com/indico/indico/assets/27357203/6cb647d8-71da-4d39-8268-c802e5bb05bd)
