### PR TITLE
Roombooking: Improve popup positioning in admin override

### DIFF
--- a/indico/modules/rb/client/js/components/AdminOverrideBar.jsx
+++ b/indico/modules/rb/client/js/components/AdminOverrideBar.jsx
@@ -38,7 +38,7 @@ const AdminOverrideBar = ({visible, disable}) => {
         </Translate>
       </Popup>
       <span styleName="disable" onClick={disable}>
-        <Popup trigger={<Icon name="close" />} position="bottom right">
+        <Popup trigger={<Icon name="close" />} position="top right" offset={[10, 0]}>
           <Translate>Disable admin override</Translate>
         </Popup>
       </span>


### PR DESCRIPTION
The current position renders the popup above the icon which causes the annoying infinite flicker. I adjusted the position and moved it above the icon, which I think looks nicer.