### PR TITLE
Fix default value for type parameter in RHAPISearch

### DIFF
--- a/indico/modules/search/controllers.py
+++ b/indico/modules/search/controllers.py
@@ -46,7 +46,7 @@ class RHAPISearch(RH):
     @use_kwargs({
         'page': fields.Int(load_default=None),
         'q': fields.String(required=True),
-        'type': fields.List(EnumField(SearchTarget), load_default=None),
+        'type': fields.List(EnumField(SearchTarget), required=True),
         'admin_override_enabled': fields.Bool(
             load_default=False,
             validate=validate_with_message(lambda value: session.user and session.user.is_admin,


### PR DESCRIPTION
The default value for a List field should be list otherwise it causes trouble later as the search providers expect list.