### PR TITLE
Avoid automatic Email for CSS upload error

### DIFF
--- a/indico/modules/events/layout/controllers/layout.py
+++ b/indico/modules/events/layout/controllers/layout.py
@@ -188,7 +188,11 @@ class RHLayoutLogoDelete(RHLayoutBase):
 class RHLayoutCSSUpload(RHLayoutBase):
     def _process(self):
         f = request.files['css_file']
-        self.event.stylesheet = f.read().decode().strip()
+        try:
+            self.event.stylesheet = f.read().decode().strip()
+        except UnicodeDecodeError:
+            flash(_('Uploaded CSS file contains invalid characters.'), 'error')
+            return jsonify_data(success=False, content=None)
         self.event.stylesheet_metadata = {
             'hash': crc32(self.event.stylesheet),
             'size': len(self.event.stylesheet),

--- a/indico/modules/events/layout/controllers/layout.py
+++ b/indico/modules/events/layout/controllers/layout.py
@@ -191,7 +191,7 @@ class RHLayoutCSSUpload(RHLayoutBase):
         try:
             self.event.stylesheet = f.read().decode().strip()
         except UnicodeDecodeError:
-            flash(_('Uploaded CSS file contains invalid characters.'), 'error')
+            flash(_('CSS files must be ASCII or UTF-8 encoded.'), 'error')
             return jsonify_data(success=False, content=None)
         self.event.stylesheet_metadata = {
             'hash': crc32(self.event.stylesheet),


### PR DESCRIPTION
Everytime a css with invalid chars is uploaded, the error is logged and an Email is sent.
This code avoids the automatic Email that fulfills our mailbox.