### PR TITLE
Docs: add RegistrationForm model docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,21 @@
-requirements_file: docs/requirements.txt
+version: 2
+
 build:
-  image: testing
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+    nodejs: "19"
+  jobs:
+    post_install:
+      - npm install -g @mermaid-js/mermaid-cli
+
+sphinx:
+  configuration: docs/source/conf.py
+
 python:
-  version: 3.9
-  setup_py_install: false
-  pip_install: true
+  install:
+    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - dev

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@ Bugfixes
 Internal Changes
 ^^^^^^^^^^^^^^^^
 
-- None so far
+- Some basic but useful docs for the Registration Form model classes
 
 
 Version 3.2.4

--- a/docs/requirements.in
+++ b/docs/requirements.in
@@ -6,3 +6,4 @@ plantweb
 sphinx
 sphinx-issues
 sphinx-rtd-theme
+sphinxcontrib-mermaid

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -86,6 +86,8 @@ sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
+sphinxcontrib-mermaid==0.9.2
+    # via -r docs/requirements.in
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5

--- a/docs/source/api/registration.rst
+++ b/docs/source/api/registration.rst
@@ -1,8 +1,48 @@
 Registration
 ============
 
-.. todo::
-    Docstrings (module, models, utilities, statistics)
+Introduction
+++++++++++++
+
+The Registration Form module relies on a data model which can be slightly complex at a first glance, due to the
+basic "version control" of fields which Indico does, in order to allow for modifications after users have registered.
+
+.. mermaid::
+
+    classDiagram
+        class RegistrationData {
+            data
+        }
+        class RegistrationFormFieldData {
+            versioned_data
+        }
+
+        RegistrationForm --o RegistrationFormItem
+        RegistrationFormItem --o RegistrationFormItem : children
+        RegistrationForm --o Registration
+        Registration "1" --o RegistrationData : field_data
+        RegistrationFormFieldData "1" --o RegistrationData
+        RegistrationFormFieldData "1" -- "1" RegistrationFormItem : current_data
+        RegistrationFormItem "1" --o RegistrationFormFieldData : data_versions
+
+Some notes on these model classes:
+
+ * :class:`~indico.modules.events.registration.models.forms.RegistrationForm` - the actual registration form. There can
+   be several per event;
+ * :class:`~indico.modules.events.registration.models.items.RegistrationFormItem` - those can be fields or sections
+   (personal or not). Sections can contain "children" (fields). They specialize into
+   :class:`~indico.modules.events.registration.models.form_fields.RegistrationFormField`,
+   :class:`~indico.modules.events.registration.models.form_fields.RegistrationFormPersonalDataField`,
+   :class:`~indico.modules.events.registration.models.items.RegistrationFormSection` and
+   :class:`~indico.modules.events.registration.models.items.RegistrationFormPersonalDataSection`;
+ * :class:`~indico.modules.events.registration.models.registrations.Registration` - someone's registrations at an
+   event, in a given registration form;
+ * :class:`~indico.modules.events.registration.models.form_fields.RegistrationFormFieldData` - this represents the
+   state of the "configuration" of a form item at a given point in time;
+ * :class:`~indico.modules.events.registration.models.registrations.RegistrationData` - this class "links" a
+   ``RegistrationFormFieldData`` and a ``Registration`` together. It is the registration's "value" for a field at a
+   given "configuration" state.
+
 
 .. automodule:: indico.modules.events.registration
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.imgmath',
               'sphinx.ext.intersphinx',
               'sphinx_issues',
+              'sphinxcontrib.mermaid',
               'exec_directive',
               'indico_uml_directive']
 
@@ -239,3 +240,6 @@ skinparam class {
     ArrowColor slategray
 }
 skinparam classStereotypeFontSize 1'''
+
+mermaid_version = '10.2.3'
+mermaid_verbose = True

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -22,5 +22,6 @@ sphinx-autobuild
 sphinx-issues
 sphinx-rtd-theme
 sphinx!=4.0.*  # not compatible with jinja 3 - https://github.com/sphinx-doc/sphinx/issues/9216
+sphinxcontrib-mermaid
 sqlparse
 watchfiles

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -219,6 +219,8 @@ sphinxcontrib-jquery==4.1
     # via sphinx-rtd-theme
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
+sphinxcontrib-mermaid==0.9.2
+    # via -r requirements.dev.in
 sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5


### PR DESCRIPTION
It only took us many years to get there, but I'm finally documenting `RegistrationForm` and friends. It's always very hard to wrap your head about this part and I think this will be a favour to future generations of developers. Also adding mermaid support to the tech docs, which could eventually replace the weird UML stuff we're using.