### PR TITLE
Fix error in XML serialization

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Bugfixes
   places and many registrants (:pr:`5799`)
 - Fix extremely slow query when retrieving list of registration forms in conferences with
   many registrants while not logged in (:pr:`5799`)
+- Fix title of session conveners being always empty in HTTP API with XML serialization
+  (:pr:`5813`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -37,6 +37,7 @@ from indico.modules.events.timetable.legacy import TimetableSerializer
 from indico.modules.events.timetable.models.entries import TimetableEntry
 from indico.modules.rb.models.reservation_occurrences import ReservationOccurrence
 from indico.util.date_time import iterdays
+from indico.util.i18n import orig_string
 from indico.util.signals import values_from_signal
 from indico.web.flask.util import send_file, url_for
 from indico.web.http_api.hooks.base import HTTPAPIHook, IteratedDataFetcher
@@ -197,7 +198,7 @@ class SerializerBase:
             'name': convener.get_full_name(last_name_upper=False, abbrev_first_name=False),
             'last_name': convener.last_name,
             'first_name': convener.first_name,
-            'title': convener.title,
+            'title': orig_string(convener.title),
             '_type': 'SlotChair',
             'affiliation': convener.affiliation,
             '_fossil': 'conferenceParticipation',


### PR DESCRIPTION
This just resulted in an empty `<title>` when serializing session conveners, because those errors just get logged but don't actually bubble up far enough to actually cause a failure...