### PR TITLE
Fix missing icons in markdown editor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Bugfixes
 - Fix title of session conveners being always empty in HTTP API with XML serialization
   (:pr:`5813`)
 - Fix editable filters not working simultaneously with editable search (:pr:`5796`)
+- Fix missing icons in Abstract Markdown editor (:pr:`5815`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/modules/contributions/_editor.scss
+++ b/indico/web/client/styles/modules/contributions/_editor.scss
@@ -125,7 +125,7 @@ $editor-preview-bg-color: $light-gray;
 }
 
 [id^='wmd-image-button'] span::before {
-  content: '\e02b';
+  content: '\31';
 }
 
 [id^='wmd-olist-button'] span::before {
@@ -137,7 +137,7 @@ $editor-preview-bg-color: $light-gray;
 }
 
 [id^='wmd-heading-button'] span::before {
-  content: '\e449';
+  content: '\2a';
 }
 
 [id^='wmd-hr-button'] span::before {


### PR DESCRIPTION
before:
![ghfhgjfhg](https://github.com/indico/indico/assets/8739637/71b16195-f647-4c37-a00e-0edfb2d54770)

after:
![image](https://github.com/indico/indico/assets/8739637/b307eaf7-56d1-4c0c-996f-869c8ccb765c)
