### PR TITLE
Prevent text wrap in event manage button

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Bugfixes
   (:pr:`5813`)
 - Fix editable filters not working simultaneously with editable search (:pr:`5796`)
 - Fix missing icons in Abstract Markdown editor (:pr:`5815`)
+- Fix text overflow in event manage button (:pr:`5816`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -115,7 +115,7 @@
         {% set dropdown_options = item.get_manage_button_options(note_may_exist=show_note_operations) %}
         {% if dropdown_options %}
             <div class="group manage-button">
-                <button class="tiny compact ui icon button js-dropdown" data-toggle="dropdown" title="{% trans %}Manage{% endtrans %}">
+                <button class="tiny compact ui icon button js-dropdown" style="white-space: nowrap;" data-toggle="dropdown" title="{% trans %}Manage{% endtrans %}">
                     <i class="edit icon"></i>
                     <i class="caret down icon"></i>
                 </button>


### PR DESCRIPTION
before:
![image](https://github.com/indico/indico/assets/8739637/289acf2a-1f59-474c-b629-d80223ad4a5e)
after:
![image](https://github.com/indico/indico/assets/8739637/5f841f0d-ee54-451c-8da3-85a4abcdfb92)
