### PR TITLE
Align booking status label

### DIFF
--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
@@ -489,7 +489,7 @@ class BookingDetails extends React.Component {
     }
 
     const label = (
-      <Label color={color}>
+      <Label color={color} style={{verticalAlign: '50%'}}>
         {icon}
         {status}
       </Label>

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
@@ -489,7 +489,7 @@ class BookingDetails extends React.Component {
     }
 
     const label = (
-      <Label color={color} style={{verticalAlign: '50%'}}>
+      <Label color={color}>
         {icon}
         {status}
       </Label>

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.module.scss
@@ -43,6 +43,7 @@
   }
 
   .booking-status {
+    display: flex;
     flex: 4;
 
     @media (max-width: $tablet-width) {


### PR DESCRIPTION
This PR aligns the booking status label on the booking details modal.

Preview (before):
![image](https://github.com/indico/indico/assets/7736654/f012abb6-fec6-4189-b903-337740a338b8)

Preview (after):
![image](https://github.com/indico/indico/assets/7736654/f9b10097-0ece-4f19-88ed-f1ce75fd570c)
