### PR TITLE
Fix fetching custom actions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,10 @@ Bugfixes
 - Fix editable filters not working simultaneously with editable search (:pr:`5796`)
 - Fix missing icons in Abstract Markdown editor (:pr:`5815`)
 - Fix text overflow in event manage button (:pr:`5816`)
+- Fix undone revisions being used instead of the latest valid one when downloading
+  revision files as a ZIP archive (:pr:`5820`)
+- Fix custom actions not showing on revisions if the latest revision has been undone
+  (:pr:`5820`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -123,7 +123,7 @@ class RHEditable(RHContributionEditableBase):
             return []
 
         try:
-            return service_get_custom_actions(self.editable, self.editable.revisions[-1], session.user)
+            return service_get_custom_actions(self.editable, self.editable.latest_revision, session.user)
         except ServiceRequestFailed:
             # unlikely to fail, but if it does we don't break the whole timeline
             return []

--- a/indico/modules/events/editing/models/editable.py
+++ b/indico/modules/events/editing/models/editable.py
@@ -238,7 +238,7 @@ class Editable(db.Model):
         from indico.modules.events.editing.models.review_conditions import EditingReviewCondition
         query = EditingReviewCondition.query.with_parent(self.event).filter_by(type=self.type)
         review_conditions = [{ft.id for ft in cond.file_types} for cond in query]
-        file_types = {file.file_type_id for file in self.revisions[-1].files}
+        file_types = {file.file_type_id for file in self.latest_revision.files}
         if not review_conditions:
             return True
         return any(file_types >= cond for cond in review_conditions)

--- a/indico/modules/events/editing/notifications.py
+++ b/indico/modules/events/editing/notifications.py
@@ -84,7 +84,7 @@ def notify_submitter_confirmation(revision, submitter, action):
     """Notify the editor(s) about submitter accepting/rejecting revision changes."""
     editable = revision.editable
     current_editor = editable.editor
-    prev_revision_editor = editable.revisions[-2].editor
+    prev_revision_editor = editable.valid_revisions[-2].editor
     recipients = {current_editor, prev_revision_editor}
     recipients.discard(None)
     if action == EditingConfirmationAction.accept:

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -425,7 +425,7 @@ def generate_editables_zip(event, editable_type, editables):
     buf = BytesIO()
     with ZipFile(buf, 'w', allowZip64=True) as zip_file:
         for editable in editables:
-            for revision_file in editable.revisions[-1].files:
+            for revision_file in editable.latest_revision.files:
                 file_obj = revision_file.file
                 with file_obj.get_local_path() as src_file:
                     zip_file.write(src_file, _compose_filepath(editable, revision_file))

--- a/indico/modules/events/editing/service.py
+++ b/indico/modules/events/editing/service.py
@@ -136,7 +136,7 @@ def service_get_status(event):
 
 
 def service_handle_new_editable(editable, user):
-    revision = editable.revisions[-1]
+    revision = editable.latest_revision
     data = {
         'editable': EditableBasicSchema().dump(editable),
         'revision': EditingRevisionSignedSchema().dump(revision),


### PR DESCRIPTION
This PR fixes a few bugs related to the latest revision being used instead of the latest **valid** revision. Namely, the most relevant ones being:
- Custom actions not showing on revisions if the latest revision has been undone
- Undone revisions being used instead of the latest valid one when downloading revision files as a ZIP archive