### PR TITLE
Use the correct name format on person link fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- None so far :)
+- Use correct name formatting in person link fields (:pr:`5835`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/migrations/versions/20230712_1742_9b3fc740b722_fix_user_name_format_values.py
+++ b/indico/migrations/versions/20230712_1742_9b3fc740b722_fix_user_name_format_values.py
@@ -1,0 +1,47 @@
+"""Fix user name_format values
+
+Revision ID: 9b3fc740b722
+Revises: 5d05eda06776
+Create Date: 2023-07-12 17:42:02.247869
+"""
+
+import json
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '9b3fc740b722'
+down_revision = '5d05eda06776'
+branch_labels = None
+depends_on = None
+
+
+mapping = {
+    0: 'first_last',
+    1: 'last_first',
+    2: 'last_f',
+    3: 'f_last',
+    4: 'first_last_upper',
+    5: 'last_first_upper',
+    6: 'last_f_upper',
+    7: 'f_last_upper'
+}
+
+
+def upgrade():
+    for value, name in mapping.items():
+        op.execute(f'''
+            UPDATE users.settings
+            SET value = '{json.dumps(name)}'
+            WHERE module = 'users' AND name = 'name_format' AND value = '{value}'
+        ''')
+
+
+def downgrade():
+    for value, name in mapping.items():
+        op.execute(f'''
+            UPDATE users.settings
+            SET value = '{json.dumps(value)}'
+            WHERE module = 'users' AND name = 'name_format' AND value = '{json.dumps(name)}'
+        ''')

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -17,7 +17,7 @@ from indico.core import signals
 from indico.core.cache import make_scoped_cache
 from indico.core.db.sqlalchemy.util.session import no_autoflush
 from indico.core.errors import UserValueError
-from indico.modules.events.layout import theme_settings
+from indico.modules.events.layout import layout_settings, theme_settings
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.persons import EventPersonLink
 from indico.modules.events.models.references import ReferenceType
@@ -111,6 +111,14 @@ class PersonLinkListFieldBase(PrincipalListField):
         if self.event is None:
             return True
         return self.event.can_manage(session.user) or not persons_settings.get(self.event, 'disallow_custom_persons')
+
+    @property
+    def name_format(self):
+        from indico.modules.users.models.users import NameFormat
+        name_format = layout_settings.get(self.event, 'name_format') if self.event else None
+        if name_format is None and session.user:
+            name_format = session.user.settings.get('name_format')
+        return name_format if name_format is not None else NameFormat.first_last
 
     @property
     def validate_email_url(self):

--- a/indico/modules/events/settings.py
+++ b/indico/modules/events/settings.py
@@ -70,7 +70,10 @@ class EventACLProxy(ACLProxyBase):
         :param name: Setting name
         :param user: A :class:`.User`
         """
-        return any(user in principal for principal in iter_acl(self.get(event, name)))
+        # we need to use the original `get` method in case this acl proxy is bound to an event,
+        # in which case calling `self.get()` with an explicitly provided event argument would fail
+        acl_entries = EventACLProxy.get(self, event, name)
+        return any(user in principal for principal in iter_acl(acl_entries))
 
     @event_or_id
     def add_principal(self, event, name, principal):

--- a/indico/web/client/js/jquery/widgets/jinja/person_link_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/person_link_widget.js
@@ -21,6 +21,7 @@ import {camelizeKeys} from 'indico/utils/case';
       hasPredefinedAffiliations,
       canEnterManually,
       defaultSearchExternal,
+      nameFormat,
       ...rest
     } = options;
     const field = document.getElementById(fieldId);
@@ -28,7 +29,6 @@ import {camelizeKeys} from 'indico/utils/case';
     const user = sessionUser &&
       sessionUser.id !== undefined && {
         title: sessionUser.title,
-        name: sessionUser.fullName,
         userId: sessionUser.id,
         userIdentifier: `User:${sessionUser.id}`,
         avatarURL: sessionUser.avatarURL,
@@ -53,6 +53,7 @@ import {camelizeKeys} from 'indico/utils/case';
         hasPredefinedAffiliations={hasPredefinedAffiliations}
         canEnterManually={canEnterManually}
         defaultSearchExternal={defaultSearchExternal}
+        nameFormat={nameFormat}
         {...rest}
       />,
       document.getElementById(`person-link-field-${fieldId}`)

--- a/indico/web/templates/forms/person_link_widget.html
+++ b/indico/web/templates/forms/person_link_widget.html
@@ -30,6 +30,7 @@
             hasPredefinedAffiliations: {{ field.has_predefined_affiliations | tojson }},
             canEnterManually: {{ field.can_enter_manually | tojson }},
             defaultSearchExternal: {{ field.default_search_external | tojson }},
+            nameFormat: {{ field.name_format.name | tojson }},
             sessionUser: Indico.User,
             validateEmailUrl: {{ field.validate_email_url | tojson }},
         });


### PR DESCRIPTION
This PR makes the person link fields display the persons' name with the correct formatting, as set in the event layout settings or the user's preferences. Before, "[first name] [last name]" was always used.

![image](https://github.com/indico/indico/assets/27357203/5018d621-0288-49ac-84ca-554b11b41491)
