### PR TITLE
Add adapt columns width button to abstracts list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Improvements
 - Show which files were added or modified on each editing timeline revision (:pr:`5802`)
 - Support rendering Japanese, Chinese & Korean letters in PDFs (:issue:`3120`, :pr:`5842`,
   thanks :user:`adamjenkins`)
+- Add button to adapt columns widths on the reviewing area's abstracts list (:pr:`5837`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/templates/display/abstracts.html
+++ b/indico/modules/events/abstracts/templates/display/abstracts.html
@@ -74,6 +74,9 @@
                             </a>
                         </li>
                     </ul>
+                    <div class="group">
+                        <button class="i-button button change-columns-width" title="{% trans %}Adapt columns width{% endtrans %}"></button>
+                    </div>
                 </div>
                 <div class="toolbar">
                     <div class="group">
@@ -92,7 +95,6 @@
             </div>
             <div id="filter-placeholder"></div>
             <script>
-                setupListGenerator();
                 setupAbstractList();
             </script>
         </div>


### PR DESCRIPTION
This PR adds a button to adapt columns widths on the reviewing area's abstracts list:
![image](https://github.com/indico/indico/assets/27357203/5975c4e3-50d9-4f04-b056-47a29d3867c7)
