### PR TITLE
Enable CORS for endpoints used by the app

### DIFF
--- a/indico/modules/events/registration/api.py
+++ b/indico/modules/events/registration/api.py
@@ -14,7 +14,7 @@ from indico.modules.events.controllers.base import RHProtectedEventBase
 from indico.modules.events.models.events import Event
 from indico.modules.events.registration.models.registrations import RegistrationState
 from indico.modules.events.registration.util import build_registration_api_data, build_registrations_api_data
-from indico.web.rh import RH, oauth_scope
+from indico.web.rh import RH, oauth_scope, cors_enabled
 
 
 @oauth_scope('registrants')
@@ -33,6 +33,7 @@ class RHAPIRegistrant(RH):
                               .options(joinedload('data').joinedload('field_data'))
                               .first_or_404())
 
+    @cors_enabled
     def _process_GET(self):
         return jsonify(build_registration_api_data(self._registration))
 
@@ -64,6 +65,7 @@ class RHAPIRegistrants(RH):
     def _process_args(self):
         self.event = Event.query.filter_by(id=request.view_args['event_id'], is_deleted=False).first_or_404()
 
+    @cors_enabled
     def _process_GET(self):
         return jsonify(registrants=build_registrations_api_data(self.event))
 

--- a/indico/modules/events/registration/api.py
+++ b/indico/modules/events/registration/api.py
@@ -14,9 +14,10 @@ from indico.modules.events.controllers.base import RHProtectedEventBase
 from indico.modules.events.models.events import Event
 from indico.modules.events.registration.models.registrations import RegistrationState
 from indico.modules.events.registration.util import build_registration_api_data, build_registrations_api_data
-from indico.web.rh import RH, oauth_scope, cors_enabled
+from indico.web.rh import RH, cors_enabled, json_errors, oauth_scope
 
 
+@json_errors
 @oauth_scope('registrants')
 class RHAPIRegistrant(RH):
     """RESTful registrant API."""
@@ -54,6 +55,7 @@ class RHAPIRegistrant(RH):
         return jsonify(build_registration_api_data(self._registration))
 
 
+@json_errors
 @oauth_scope('registrants')
 class RHAPIRegistrants(RH):
     """RESTful registrants API."""

--- a/indico/modules/events/registration/api.py
+++ b/indico/modules/events/registration/api.py
@@ -11,15 +11,15 @@ from werkzeug.exceptions import BadRequest, Forbidden
 
 from indico.core import signals
 from indico.modules.events.controllers.base import RHProtectedEventBase
-from indico.modules.events.models.events import Event
+from indico.modules.events.controllers.base import RHEventBase
 from indico.modules.events.registration.models.registrations import RegistrationState
 from indico.modules.events.registration.util import build_registration_api_data, build_registrations_api_data
-from indico.web.rh import RH, cors_enabled, json_errors, oauth_scope
+from indico.web.rh import cors_enabled, json_errors, oauth_scope
 
 
 @json_errors
 @oauth_scope('registrants')
-class RHAPIRegistrant(RH):
+class RHAPIRegistrant(RHEventBase):
     """RESTful registrant API."""
 
     def _check_access(self):
@@ -27,7 +27,7 @@ class RHAPIRegistrant(RH):
             raise Forbidden()
 
     def _process_args(self):
-        self.event = Event.query.filter_by(id=request.view_args['event_id'], is_deleted=False).first_or_404()
+        RHEventBase._process_args(self)
         self._registration = (self.event.registrations
                               .filter_by(id=request.view_args['registrant_id'],
                                          is_deleted=False)
@@ -57,15 +57,12 @@ class RHAPIRegistrant(RH):
 
 @json_errors
 @oauth_scope('registrants')
-class RHAPIRegistrants(RH):
+class RHAPIRegistrants(RHEventBase):
     """RESTful registrants API."""
 
     def _check_access(self):
         if not self.event.can_manage(session.user, permission='registration'):
             raise Forbidden()
-
-    def _process_args(self):
-        self.event = Event.query.filter_by(id=request.view_args['event_id'], is_deleted=False).first_or_404()
 
     @cors_enabled
     def _process_GET(self):

--- a/indico/modules/oauth/controllers.py
+++ b/indico/modules/oauth/controllers.py
@@ -30,13 +30,14 @@ from indico.modules.users.controllers import RHUserBase
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults
-from indico.web.rh import RH, RHProtected
+from indico.web.rh import RH, RHProtected, cors_enabled
 from indico.web.util import jsonify_data, jsonify_form
 
 
 class RHOAuthMetadata(RH):
     """Return RFC8414 Authorization Server Metadata."""
 
+    @cors_enabled
     def _process(self):
         metadata = AuthorizationServerMetadata(
             authorization_endpoint=url_for('.oauth_authorize', _external=True),

--- a/indico/modules/oauth/controllers.py
+++ b/indico/modules/oauth/controllers.py
@@ -30,14 +30,15 @@ from indico.modules.users.controllers import RHUserBase
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults
-from indico.web.rh import RH, RHProtected, cors_enabled
+from indico.web.rh import RH, RHProtected
 from indico.web.util import jsonify_data, jsonify_form
 
 
 class RHOAuthMetadata(RH):
     """Return RFC8414 Authorization Server Metadata."""
 
-    @cors_enabled
+    CORS_ENABLED = True
+
     def _process(self):
         metadata = AuthorizationServerMetadata(
             authorization_endpoint=url_for('.oauth_authorize', _external=True),

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -408,3 +408,14 @@ def json_errors(rh):
     """
     rh._JSON_ERRORS = True
     return rh
+
+
+def cors_enabled(f):
+    """Enable CORS for this endpoint."""
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        response = f(*args, **kwargs)
+        response = current_app.make_response(response)
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        return response
+    return wrapper

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -42,6 +42,7 @@ class RH:
     CSRF_ENABLED = True  # require a csrf_token when accessing the RH with anything but GET
     EVENT_FEATURE = None  # require a certain event feature when accessing the RH. See `EventFeature` for details
     DENY_FRAMES = False  # whether to send an X-Frame-Options:DENY header
+    CORS_ENABLED = False  # whether CORS is allowed
 
     #: A dict specifying how the url should be normalized.
     #: `args` is a dictionary mapping view args keys to callables
@@ -307,6 +308,8 @@ class RH:
         response = current_app.make_response(res)
         if self.DENY_FRAMES:
             response.headers['X-Frame-Options'] = 'DENY'
+        if self.CORS_ENABLED:
+            response.headers['Access-Control-Allow-Origin'] = '*'
         return response
 
 
@@ -408,14 +411,3 @@ def json_errors(rh):
     """
     rh._JSON_ERRORS = True
     return rh
-
-
-def cors_enabled(f):
-    """Enable CORS for this endpoint."""
-    @wraps(f)
-    def wrapper(*args, **kwargs):
-        response = f(*args, **kwargs)
-        response = current_app.make_response(response)
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        return response
-    return wrapper


### PR DESCRIPTION
Enables CORS for endpoints needed by the check-in app:
- /.well-known/oauth-authorization-server
- /api/events/<int:event_id>/registrants
- /api/events/<int:event_id>/registrants/<int:registrant_id>

Not sure if the decorator is a good idea.. alternatively I could just explicitly do `return data, {'Access-Control-Allow-Origin': '*'}` for each endpoint instead.

Since I was already modifying the endpoints I switched to using `@use_kwargs` instead of manual validation and made the endpoints inherit from `RHEventBase`