### PR TITLE
Align room feature popups

### DIFF
--- a/indico/modules/rb/client/js/components/Room.jsx
+++ b/indico/modules/rb/client/js/components/Room.jsx
@@ -110,7 +110,7 @@ class Room extends React.Component {
           key="not-bookable"
           trigger={<Icon name="dont" color="red" />}
           content={Translate.string('This space is not bookable')}
-          position="bottom center"
+          position="top center"
           hideOnScroll
         />
       );
@@ -120,7 +120,7 @@ class Room extends React.Component {
           key="check-pending"
           trigger={<Loader active inline size="tiny" />}
           content={Translate.string('Checking permissions...')}
-          position="bottom center"
+          position="top center"
           hideOnScroll
         />
       );
@@ -130,7 +130,7 @@ class Room extends React.Component {
           key="not-authorized"
           trigger={<Icon name="lock" color="red" />}
           content={Translate.string('This space is not publicly available')}
-          position="bottom center"
+          position="top center"
           hideOnScroll
         />
       );

--- a/indico/modules/rb/client/js/components/RoomFeatureEntry.jsx
+++ b/indico/modules/rb/client/js/components/RoomFeatureEntry.jsx
@@ -13,10 +13,10 @@ export default function RoomFeatureEntry({feature, color, size}) {
   const {icon, title, equipment} = feature;
   const trigger = <Icon name={icon} color={color} size={size} />;
   if (equipment.length === 1 && equipment[0] === title) {
-    return <Popup trigger={trigger} content={title} />;
+    return <Popup trigger={trigger} content={title} position="top center" />;
   }
   return (
-    <Popup trigger={trigger}>
+    <Popup trigger={trigger} position="top center">
       {title} ({equipment.filter(eq => eq !== title).join(', ')})
     </Popup>
   );


### PR DESCRIPTION
Just a slightly annoying misalignment..

before:
![image](https://github.com/indico/indico/assets/8739637/b5e69fac-01ea-43ff-983e-a91d1fbb22ad)

after:
![image](https://github.com/indico/indico/assets/8739637/79048a3c-fa22-4f08-9487-505a70fa4850)

I also put the room status popup at the top as well to keep it uniform:
![image](https://github.com/indico/indico/assets/8739637/d5db4cc4-88a2-43aa-b7ce-cf68edb630e8)
