### PR TITLE
Replace PyPDF2 with pypdf

### DIFF
--- a/indico/legacy/pdfinterface/base.py
+++ b/indico/legacy/pdfinterface/base.py
@@ -557,7 +557,7 @@ class DocTemplateWithTOC(SimpleDocTemplate):
         self.mergePDFs(self.filename, contentFile)
 
     def mergePDFs(self, pdf1, pdf2):
-        from PyPDF2 import PdfReader, PdfWriter
+        from pypdf import PdfReader, PdfWriter
         output = PdfWriter()
         background_pages = PdfReader(pdf1)
         foreground_pages = PdfReader(pdf2)

--- a/requirements.in
+++ b/requirements.in
@@ -45,7 +45,7 @@ prompt-toolkit
 psycopg2
 pycountry
 pygments
-pypdf2
+pypdf
 python-dateutil
 pytz
 pywebpack

--- a/requirements.txt
+++ b/requirements.txt
@@ -262,7 +262,7 @@ pynpm==0.1.2
     # via
     #   flask-webpackext
     #   pywebpack
-pypdf2==3.0.1
+pypdf==3.12.1
     # via -r requirements.in
 pypng==0.20220715.0
     # via qrcode
@@ -339,7 +339,7 @@ typing-extensions==4.5.0
     #   kombu
     #   limits
     #   marshmallow-dataclass
-    #   pypdf2
+    #   pypdf
     #   qrcode
     #   typing-inspect
 typing-inspect==0.8.0


### PR DESCRIPTION
Same library, they just changed package names (and the old one is no longer maintained and contains a DoS vuln which is not relevant for us but dependabot complains about it nonetheless).