### PR TITLE
Add 'event cancelled' semantics for labels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Improvements
   thanks :user:`SegiNyn`)
 - Allow using a custom link text in the ``{event_link}`` email placeholder, using the
   ``{event_link:something-else-here}`` syntax (:issue:`5858`, :pr:`5860`)
+- Add option to add "event cancelled" semantics for event labels, which will disable
+  reminders for events having this label (:issue:`5285`, :pr:`5861`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20230719_1616_aba7935f9226_add_is_event_not_happening_to_eventlabel.py
+++ b/indico/migrations/versions/20230719_1616_aba7935f9226_add_is_event_not_happening_to_eventlabel.py
@@ -1,0 +1,26 @@
+"""Add is_event_not_happening to EventLabel
+
+Revision ID: aba7935f9226
+Revises: 9b3fc740b722
+Create Date: 2023-07-19 16:16:57.538875
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'aba7935f9226'
+down_revision = '9b3fc740b722'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('labels', sa.Column('is_event_not_happening', sa.Boolean(), server_default='false', nullable=False),
+                  schema='events')
+    op.alter_column('labels', 'is_event_not_happening', server_default=None, schema='events')
+
+
+def downgrade():
+    op.drop_column('labels', 'is_event_not_happening', schema='events')

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -481,6 +481,8 @@ class CategoryEventFetcher(IteratedDataFetcher, SerializerBase):
         if detail_level == 'sessions':
             options.append(sessions_strategy)
         options.append(undefer('effective_protection_mode'))
+        options.append(selectinload('label'))
+        options.append(selectinload('references'))
         return options
 
     def category(self, idlist, format):
@@ -624,6 +626,7 @@ class CategoryEventFetcher(IteratedDataFetcher, SerializerBase):
             'keywords': event.keywords,
             'organizer': event.organizer_info,
             'language': event.default_locale or None,
+            'label': self._serialize_event_label(event),
         })
 
         if event.is_unlisted:
@@ -676,6 +679,16 @@ class CategoryEventFetcher(IteratedDataFetcher, SerializerBase):
         ):
             data.update(update)
         return data
+
+    def _serialize_event_label(self, event):
+        if not (label := event.label):
+            return None
+        return {
+            'title': label.title,
+            'color': label.color,
+            'is_event_not_happening': label.is_event_not_happening,
+            'message': event.label_message,
+        }
 
 
 class EventBaseHook(HTTPAPIHook):

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -56,6 +56,10 @@ class ReferenceTypeForm(IndicoForm):
 class EventLabelForm(IndicoForm):
     title = StringField(_('Title'), [DataRequired()])
     color = SUIColorPickerField(_('Color'), [DataRequired()])
+    is_event_not_happening = BooleanField(_('Event does not happen'), widget=SwitchWidget(), default=False,
+                                          description=_('Enable this to indicate that an event with this label '
+                                                        'does not happen (e.g. cancelled or postponed). This will '
+                                                        'prevent event reminders from being sent.'))
 
     def __init__(self, *args, **kwargs):
         self.event_label = kwargs.pop('event_label', None)

--- a/indico/modules/events/management/templates/_settings.html
+++ b/indico/modules/events/management/templates/_settings.html
@@ -209,6 +209,13 @@
                     {% call with_default() %}
                         {{ event.get_label_markup('mini') }}
                     {% endcall %}
+                    {% if event.is_not_happening %}
+                        <p>
+                            {% trans %}
+                                This label indicates that the event is not happening. Reminders are disabled.
+                            {% endtrans %}
+                        </p>
+                    {% endif %}
                 </dd>
             {% endif %}
         </dl>

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -801,6 +801,10 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
             return ''
         return Markup(render_template('events/label.html', label=label, message=self.label_message, size=size))
 
+    @property
+    def is_not_happening(self):
+        return self.label is not None and self.label.is_event_not_happening
+
     def get_non_inheriting_objects(self):
         """Get a set of child objects that do not inherit protection."""
         return get_non_inheriting_objects(self)

--- a/indico/modules/events/models/labels.py
+++ b/indico/modules/events/models/labels.py
@@ -32,6 +32,11 @@ class EventLabel(db.Model):
         db.String,
         nullable=False
     )
+    is_event_not_happening = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
 
     # relationship backrefs:
     # - events (Event.label)

--- a/indico/modules/events/reminders/tasks.py
+++ b/indico/modules/events/reminders/tasks.py
@@ -10,6 +10,7 @@ from celery.schedules import crontab
 from indico.core.celery import celery
 from indico.core.db import db
 from indico.modules.events import Event
+from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.reminders import logger
 from indico.modules.events.reminders.models.reminders import EventReminder
 from indico.util.date_time import now_utc
@@ -20,6 +21,7 @@ def send_event_reminders():
     reminders = (EventReminder.query
                  .filter(~EventReminder.is_sent,
                          ~Event.is_deleted,
+                         ~Event.label.has(EventLabel.is_event_not_happening),
                          EventReminder.scheduled_dt <= now_utc())
                  .join(EventReminder.event)
                  .all())

--- a/indico/modules/events/reminders/templates/reminders.html
+++ b/indico/modules/events/reminders/templates/reminders.html
@@ -1,5 +1,7 @@
 {% extends 'events/management/base.html' %}
 
+{% from 'message_box.html' import message_box %}
+
 {% set pending_reminders = reminders|rejectattr('is_sent')|list %}
 {% set sent_reminders = reminders|selectattr('is_sent')|list %}
 {% set tzinfo = event.tzinfo %}
@@ -43,6 +45,14 @@
 {% endmacro %}
 
 {% block content %}
+    {% if event.is_not_happening %}
+        {% call message_box('info') %}
+            {% trans label=event.get_label_markup() %}
+                Since this event has the {{ label }} label, no reminders will be sent for it.
+            {% endtrans %}
+        {% endcall %}
+    {% endif %}
+
     <div class="i-box-group vert fixed-width reminders">
         <div class="i-box">
             <div class="i-box-header">


### PR DESCRIPTION
![image](https://github.com/indico/indico/assets/179599/3c97cf37-fb7f-46be-9dec-d8ba49751651)

![image](https://github.com/indico/indico/assets/179599/5710aac1-420a-47c9-acbe-4368b0bd2b0c)

The JSON API also contains this information:

```json
      "label": {
        "title": "Cancelled",
        "color": "red",
        "is_event_not_happening": true,
        "message": "one less useless meeting"
      }
```

fixes #5285
cc @jbenito3