### PR TITLE
Use explicit none check in room acl update

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- None so far :)
+- Fix not being able to remove the last entry from a room ACL (:pr:`5863`, thanks
+  :user:`SegiNyn`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/rb/operations/admin.py
+++ b/indico/modules/rb/operations/admin.py
@@ -56,7 +56,7 @@ def update_room_availability(room, availability):
 
 def update_room(room, args):
     acl_entries = args.pop('acl_entries', None)
-    if acl_entries:
+    if acl_entries is not None:
         current = {e.principal: get_unified_permissions(e) for e in room.acl_entries}
         update_principals_permissions(room, current, acl_entries)
     _populate_room(room, args)


### PR DESCRIPTION
In the Room permission section, try removing **all** the persons assigned to a permission in the room and save the dialog and then reopen the dialog again, you will notice that the permissions do not actually get unassigned. 

<img width="1160" alt="Screenshot 2023-07-24 at 12 00 48" src="https://github.com/indico/indico/assets/54508387/0aed6ae2-9aa2-4b74-8bdd-98bbbf3cd8a0">
