### PR TITLE
Fix enum instance check in HiddenUnless validator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Bugfixes
 
 - Fix not being able to remove the last entry from a room ACL (:pr:`5863`, thanks
   :user:`SegiNyn`)
+- Fix conditional fields remaining hidden in abstract judgment form (:pr:`5873`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/forms/jinja_helpers.py
+++ b/indico/web/forms/jinja_helpers.py
@@ -6,12 +6,12 @@
 # LICENSE file for more details.
 
 import json
+from enum import Enum
 
 from wtforms.fields import BooleanField, RadioField
 from wtforms.validators import Length, NumberRange
 from wtforms.widgets.core import HiddenInput, Input, Select, TextArea
 
-from indico.util.enum import RichEnum
 from indico.web.forms.fields import (IndicoEnumRadioField, IndicoQuerySelectMultipleCheckboxField,
                                      IndicoSelectMultipleCheckboxField)
 from indico.web.forms.validators import (ConfirmPassword, HiddenUnless, IndicoRegexp, SecurePassword, SoftLength,
@@ -69,7 +69,7 @@ def _attrs_for_validators(field, validators):
                 val = []
             elif not isinstance(val, (set, list, tuple)):
                 val = [val]
-            values = [(v.name if isinstance(v, RichEnum) else v) for v in val]
+            values = [(v.name if isinstance(v, Enum) else v) for v in val]
 
             attrs['data-hidden-unless'] = json.dumps({'field': condition_field.name,
                                                       'values': values,


### PR DESCRIPTION
This caused conditional form fields (using HiddenUnless) depending on enum select fields to be always hidden, because the validator used the value instead of the name due to RichIntEnum/RichStrEnum on longer being a subclass of RichEnum