### PR TITLE
Fix interaction between disabled and borderless buttons

### DIFF
--- a/indico/web/client/styles/partials/_buttons.scss
+++ b/indico/web/client/styles/partials/_buttons.scss
@@ -23,11 +23,14 @@ $i-button-spacing: 0.3rem;
 }
 
 @mixin button-disabled {
-  border-color: $default-border-color !important;
-  background: $i-button-background-color !important;
-  box-shadow: none !important;
   color: $gray !important;
   cursor: default;
+
+  &:not(.borderless) {
+    border-color: $default-border-color !important;
+    background: $i-button-background-color !important;
+    box-shadow: none !important;
+  }
 }
 
 @mixin _i-button-borderless($color, $dark-color) {


### PR DESCRIPTION
Accidentally introduced by the sass changes:

![image](https://github.com/indico/indico/assets/8739637/50880ed4-a555-4ad4-a4ce-079c2dcded0d)

The delete button should just be grayed out w/o any background. The fix is to set the `button-disabled()` mixin to only apply the background when the button does not have the `.borderless` class.