### PR TITLE
Invalidate password reset links on password change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Internationalization
 Improvements
 ^^^^^^^^^^^^
 
-- Nothing so far
+- Invalidate password reset links once the password has been changed (:pr:`5878`)
 
 Bugfixes
 ^^^^^^^^


### PR DESCRIPTION
Suggested by the UNOG guys, and even though the links are only valid for 1 hour (ie the risk of a stale link being abused is basically zero), it's still better to invalidate them as soon as the password has been changed.

Considering how rare password resets are, and how short-lived those links are, I didn't add any special handling of links created before this change. People getting an error would probably just request a new link anyway.