### PR TITLE
Fix seralizing params for eventlink placeholders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- None so far :)
+- Fix error when sending registration invitation reminders (:issue:`5879`, :pr:`5880`,
+  thanks :user:`bpedersen2`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/placeholders.py
+++ b/indico/modules/events/placeholders.py
@@ -31,6 +31,6 @@ class EventLinkPlaceholder(ParametrizedPlaceholder):
                                                                            text=(param or event.short_external_url))
 
     @classmethod
-    def iter_param_info(cls, person, event, **kwargs):
+    def iter_param_info(cls, **kwargs):
         yield None, _('Link to the event')
         yield 'custom-text', _('Custom link text instead of the full URL')

--- a/indico/modules/events/registration/placeholders/registrations.py
+++ b/indico/modules/events/registration/placeholders/registrations.py
@@ -52,7 +52,7 @@ class EventLinkPlaceholder(ParametrizedPlaceholder):
                                                                            text=(param or event.short_external_url))
 
     @classmethod
-    def iter_param_info(cls, regform, registration, **kwargs):
+    def iter_param_info(cls, **kwargs):
         yield None, _('Link to the event')
         yield 'custom-text', _('Custom link text instead of the full URL')
 


### PR DESCRIPTION
Don't use unused required parameters in iter_param_info, otherwise serialize may fail.

Fixes: #5879

