### PR TITLE
Fix incorrect redirect on /event/xxx/overview

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Bugfixes
 
 - Fix error when sending registration invitation reminders (:issue:`5879`, :pr:`5880`,
   thanks :user:`bpedersen2`)
+- Fix accessing the conference overview page when the default conference home page is
+  set to a custom page (:pr:`5882`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/controllers/entry.py
+++ b/indico/modules/events/controllers/entry.py
@@ -17,7 +17,6 @@ from indico.util.i18n import _
 from indico.util.string import is_legacy_id
 
 
-# XXX: force_overview is not used by passed by flask, so it needs to remain here
 def event_or_shorturl(event_id, shorturl_namespace=False, force_overview=False):
     event = Event.get(int(event_id)) if event_id.isdigit() and (event_id[0] != '0' or event_id == '0') else None
     if event and event.is_deleted:
@@ -28,7 +27,7 @@ def event_or_shorturl(event_id, shorturl_namespace=False, force_overview=False):
         # we call the RH to display the event
         if shorturl_namespace:
             return redirect(event.url)
-        elif not request.path.endswith('/'):
+        elif not force_overview and not request.path.endswith('/'):
             return redirect(event.url, 301)
         else:
             request.view_args['event_id'] = int(event_id)


### PR DESCRIPTION
When a conference has a custom home page set, the `.../overview` URL is necessary to view the default page. This redirect prevented users from doing so, even though the redirect is only supposed to happen when accessing /event/xxx (to add the trailing slash)