### PR TITLE
Add px() facade for pixel dimensions

### DIFF
--- a/indico/modules/categories/client/js/components/CategoryModeration.module.scss
+++ b/indico/modules/categories/client/js/components/CategoryModeration.module.scss
@@ -6,13 +6,14 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 :global(.ui.table).table {
   // fix to allow the table to be wider than
   // 800px set by .page-content
   /* stylelint-disable-next-line scss/media-feature-value-dollar-variable */
-  @media (min-width: 1500px) {
-    max-width: 1200px;
+  @media (min-width: px(1500)) {
+    max-width: px(1200);
     width: max-content;
   }
 }

--- a/indico/modules/categories/client/js/components/CategoryStatistics.module.scss
+++ b/indico/modules/categories/client/js/components/CategoryStatistics.module.scss
@@ -5,8 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .chart-container {
-  height: 300px;
+  height: px(300);
 }
 
 .chart > svg {

--- a/indico/modules/events/editing/client/js/editing/page_layout/EditingView.module.scss
+++ b/indico/modules/events/editing/client/js/editing/page_layout/EditingView.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .editing-view {
   display: flex;
@@ -16,8 +17,8 @@
     flex: 1;
 
     .timeline {
-      max-width: 800px;
-      margin-top: 25px;
+      max-width: px(800);
+      margin-top: px(25);
     }
 
     .timeline.header {

--- a/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.module.scss
+++ b/indico/modules/events/editing/client/js/editing/page_layout/MenuBar.module.scss
@@ -6,14 +6,15 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .menu-bar {
   color: $white;
-  padding: 20px 30px;
-  margin-right: 25px;
+  padding: px(20) px(30);
+  margin-right: px(25);
 
   .header {
-    border-radius: 3px;
+    border-radius: px(3);
     background-color: $dark-blue;
     text-align: center;
     padding: 0.5rem;

--- a/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/FileDisplay.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/FileDisplay.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .file-display-wrapper {
   display: flex;
@@ -54,10 +55,10 @@
 
   .tag-display {
     flex-grow: 1;
-    margin-left: -3px;
+    margin-left: px(-3);
 
     :global(.ui.label) {
-      margin: 3px 0 0 3px;
+      margin: px(3) 0 0 px(3);
     }
   }
 

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/FileManager.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .outer-dropzone {
   margin-top: auto;
@@ -13,8 +14,8 @@
 
 .dropzone {
   width: 100%;
-  border: 2px dashed $gray;
-  border-radius: 3px;
+  border: px(2) dashed $gray;
+  border-radius: px(3);
   text-align: center;
   padding: 0.5em;
   cursor: pointer;
@@ -42,8 +43,8 @@
     display: flex;
     flex-direction: column;
     margin-bottom: 1em;
-    border: 1px solid $gray;
-    border-radius: 3px;
+    border: px(1) solid $gray;
+    border-radius: px(3);
     padding: 1em;
     width: 31%;
     margin-left: 0.9em;

--- a/indico/modules/events/editing/client/js/editing/timeline/StateIndicator.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/StateIndicator.module.scss
@@ -5,8 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .label-text {
-  margin-left: 5px;
+  margin-left: px(5);
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.module.scss
@@ -6,11 +6,12 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .item-index {
   color: $gray;
 }
 
 .item-visibility-toggle {
-  margin-right: 5px;
+  margin-right: px(5);
 }

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.module.scss
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.module.scss
@@ -6,22 +6,23 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
-$border: 1px solid $pastel-gray;
+$border: px(1) solid $pastel-gray;
 
 .editable-topbar {
   display: flex;
   justify-content: space-between;
-  min-width: 1000px;
+  min-width: px(1000);
 
   .editable-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 5px;
+    gap: px(5);
 
     :global(.ui.button) {
       margin-right: 0;
-      min-height: 37px;
+      min-height: px(37);
     }
   }
 }
@@ -29,8 +30,8 @@ $border: 1px solid $pastel-gray;
 .editable-list {
   .table {
     font-family: 'Muli', 'Helvetica Neue', Arial, Helvetica, sans-serif;
-    margin-top: 20px;
-    margin-bottom: 50px;
+    margin-top: px(20);
+    margin-bottom: px(50);
   }
 
   .rowcolumn-tooltip {
@@ -67,14 +68,14 @@ $border: 1px solid $pastel-gray;
 
   :global(.ReactVirtualized__Table__headerColumn),
   :global(.ReactVirtualized__Table__rowColumn) {
-    margin-right: 10px;
+    margin-right: px(10);
     align-items: center;
     display: flex;
   }
 
   :global(.ReactVirtualized__Table__headerColumn:first-of-type),
   :global(.ReactVirtualized__Table__rowColumn:first-of-type) {
-    margin-left: 10px;
+    margin-left: px(10);
   }
 
   :global(.ReactVirtualized__Table__sortableHeaderColumn) {
@@ -88,7 +89,7 @@ $border: 1px solid $pastel-gray;
   }
 
   :global(.ReactVirtualized__Table__sortableHeaderIcon) {
-    flex: 0 0 24px;
+    flex: 0 0 px(24);
     height: 1em;
     width: 1em;
     /* stylelint-disable-next-line value-keyword-case */

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.module.scss
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.module.scss
@@ -6,10 +6,11 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .filetype-list {
   text-align: end;
-  padding: 0 8px 8px 8px;
+  padding: 0 px(8) px(8) px(8);
 }
 
 .filtered-editables {

--- a/indico/modules/events/editing/client/js/management/editable_type/file_types/FileTypeManager.module.scss
+++ b/indico/modules/events/editing/client/js/management/editable_type/file_types/FileTypeManager.module.scss
@@ -6,9 +6,10 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .file-types-container {
-  max-width: 300px !important;
+  max-width: px(300) !important;
 
   .filetype-segment {
     .filetype-header {

--- a/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ConditionInfo.module.scss
+++ b/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ConditionInfo.module.scss
@@ -5,16 +5,18 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .types-list {
   display: flex;
   flex: 1;
   flex-wrap: wrap;
   align-items: center;
-  margin-top: -5px;
-  margin-bottom: -5px;
+  margin-top: px(-5);
+  margin-bottom: px(-5);
 
   & > :global(.label) {
-    margin: 5px !important;
+    margin: px(5) !important;
     max-width: 150;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ReviewConditionsManager.module.scss
+++ b/indico/modules/events/editing/client/js/management/editable_type/review_conditions/ReviewConditionsManager.module.scss
@@ -5,13 +5,15 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .conditions-container {
-  max-width: 600px;
+  max-width: px(600);
 
   .condition-row {
     display: flex;
     align-items: center;
     margin: 1em 0;
-    min-height: 35px;
+    min-height: px(35);
   }
 }

--- a/indico/modules/events/editing/client/js/management/tags/TagManager.module.scss
+++ b/indico/modules/events/editing/client/js/management/tags/TagManager.module.scss
@@ -5,8 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .tags-container {
-  max-width: 600px !important;
+  max-width: px(600) !important;
 
   .tag-segment {
     display: flex;
@@ -14,7 +16,7 @@
     justify-content: space-between;
 
     .tag-actions {
-      width: 50px;
+      width: px(50);
       display: flex;
       align-items: center;
       justify-content: space-between;

--- a/indico/modules/events/editing/client/styles/timeline.module.scss
+++ b/indico/modules/events/editing/client/styles/timeline.module.scss
@@ -6,10 +6,15 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .undone-item {
   :global(.i-box-header) {
-    background-image: repeating-linear-gradient(-45deg, $pastel-gray 0 2px, $light-gray 3px 15px);
+    background-image: repeating-linear-gradient(
+      -45deg,
+      $pastel-gray 0 px(2),
+      $light-gray px(3) px(15)
+    );
   }
 
   .undone-indicator {

--- a/indico/modules/events/management/client/js/SeriesManagement.module.scss
+++ b/indico/modules/events/management/client/js/SeriesManagement.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 :global(.ui.list).evt-list {
   max-height: 30vh;
@@ -13,8 +14,8 @@
 
   :global(.item).evt-item {
     .detail {
-      margin-top: 2px;
-      width: 350px;
+      margin-top: px(2);
+      width: px(350);
       display: inline-block;
       overflow: hidden;
       white-space: nowrap;
@@ -31,7 +32,7 @@
 .list-flex {
   display: flex;
   justify-content: start;
-  gap: 15px;
+  gap: px(15);
 
   &.disabled {
     background-color: $pastel-gray;
@@ -41,7 +42,7 @@
 .date-span {
   flex-basis: 10%;
   flex-shrink: 0;
-  font-size: 12px;
+  font-size: px(12);
   color: $dark-gray;
 }
 
@@ -56,7 +57,7 @@
   overflow: hidden;
 
   a {
-    margin-right: 5px;
+    margin-right: px(5);
   }
 }
 
@@ -80,5 +81,5 @@
 
 .load-more > div {
   text-align: center;
-  padding: 11px 16px; // Same as <Dropdown.Item>
+  padding: px(11) px(16); // Same as <Dropdown.Item>
 }

--- a/indico/modules/events/papers/client/js/components/GroupReviewForm.module.scss
+++ b/indico/modules/events/papers/client/js/components/GroupReviewForm.module.scss
@@ -5,9 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .group-review-form {
   :global(.form-preface) {
-    font-size: 13px;
+    font-size: px(13);
     font-weight: bold;
   }
 

--- a/indico/modules/events/registration/client/js/components/ConsentToPublishEditor.module.scss
+++ b/indico/modules/events/registration/client/js/components/ConsentToPublishEditor.module.scss
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .consent-dropdown-container {
   display: flex;
   gap: 0.5em;
   align-items: center;
 
   :global(.ui.dropdown) {
-    margin-top: 5px;
+    margin-top: px(5);
   }
 }

--- a/indico/modules/events/registration/client/js/components/RegistrationTagsEditableList.module.scss
+++ b/indico/modules/events/registration/client/js/components/RegistrationTagsEditableList.module.scss
@@ -5,14 +5,16 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .removable-tags-container {
   display: flex;
   flex-wrap: wrap;
-  grid-gap: 4px;
+  grid-gap: px(4);
 }
 
 .selectable-tags-container {
-  max-height: 260px;
+  max-height: px(260);
   overflow-y: auto;
 
   & > div {

--- a/indico/modules/events/registration/client/js/form/fields/ChoicesSetup.module.scss
+++ b/indico/modules/events/registration/client/js/form/fields/ChoicesSetup.module.scss
@@ -19,7 +19,7 @@
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 1em;
-  padding-bottom: 25px;
+  padding-bottom: px(25);
 
   tr:hover .table-sortable-handle,
   td:active .table-sortable-handle {
@@ -28,7 +28,7 @@
 
   .table-sortable-handle {
     color: $dark-gray;
-    width: 15px;
+    width: px(15);
     cursor: grab;
 
     &:active {
@@ -39,7 +39,7 @@
   thead {
     th {
       @include border-bottom();
-      padding-bottom: 4px;
+      padding-bottom: px(4);
       vertical-align: top;
     }
 
@@ -54,7 +54,7 @@
 
   td,
   th {
-    padding: 4px 4px;
+    padding: px(4) px(4);
   }
 
   tr {
@@ -71,7 +71,11 @@
 
       input[type='text'],
       input[type='number'] {
-        background-image: repeating-linear-gradient(-45deg, $pastel-gray 0 2px, white 3px 15px);
+        background-image: repeating-linear-gradient(
+          -45deg,
+          $pastel-gray 0 px(2),
+          white px(3) px(15)
+        );
         border-color: $gray;
         color: $dark-black;
       }
@@ -82,7 +86,7 @@
     }
 
     td a {
-      padding: 2px;
+      padding: px(2);
     }
   }
 }

--- a/indico/modules/events/registration/client/js/form/fields/table.module.scss
+++ b/indico/modules/events/registration/client/js/form/fields/table.module.scss
@@ -5,17 +5,19 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 table.choice-table {
   border-collapse: collapse;
 
   tr {
     td:first-child {
-      padding-top: 15px;
-      padding-bottom: 15px;
+      padding-top: px(15);
+      padding-bottom: px(15);
     }
 
     td:not(:first-child) {
-      padding-left: 10px;
+      padding-left: px(10);
     }
 
     td :global(.ui.label) {
@@ -24,25 +26,25 @@ table.choice-table {
   }
 
   .dropdown:global(.ui.dropdown) {
-    padding-top: 6px;
-    padding-left: 12px;
-    min-height: 30px;
-    height: 30px;
-    min-width: 50px;
+    padding-top: px(6);
+    padding-left: px(12);
+    min-height: px(30);
+    height: px(30);
+    min-width: px(50);
 
     i:global(.dropdown.icon) {
-      padding-top: 7px;
+      padding-top: px(7);
       right: 0.8em;
     }
   }
 
   .row:not(:last-child) {
-    border-bottom: 1px solid rgba(34, 36, 38, 0.15);
+    border-bottom: px(1) solid rgba(34, 36, 38, 0.15);
   }
 
   .checkbox,
   .radio {
-    max-width: 300px;
+    max-width: px(300);
 
     label {
       overflow-wrap: anywhere;

--- a/indico/modules/events/registration/client/styles/regform.module.scss
+++ b/indico/modules/events/registration/client/styles/regform.module.scss
@@ -20,7 +20,7 @@
     justify-content: space-between;
 
     .actions {
-      min-width: 50px;
+      min-width: px(50);
       display: flex;
       align-items: center;
       justify-content: space-between;
@@ -35,11 +35,11 @@
 
 .form-item {
   display: flex;
-  margin-top: 10px;
-  padding-top: 3px;
+  margin-top: px(10);
+  padding-top: px(3);
 
   &:last-child {
-    padding-bottom: 7px;
+    padding-bottom: px(7);
   }
 
   &.disabled {
@@ -54,9 +54,9 @@
     background: repeating-linear-gradient(
       45deg,
       rgba(255, 229, 184, 0.5),
-      rgba(255, 229, 184, 0.5) 10px,
-      #fff 10px,
-      #fff 20px
+      rgba(255, 229, 184, 0.5) px(10),
+      #fff px(10),
+      #fff px(20)
     );
   }
 
@@ -64,9 +64,9 @@
     background: repeating-linear-gradient(
       45deg,
       rgba(255, 201, 184, 0.5),
-      rgba(255, 201, 184, 0.5) 10px,
-      #fff 10px,
-      #fff 20px
+      rgba(255, 201, 184, 0.5) px(10),
+      #fff px(10),
+      #fff px(20)
     );
   }
 
@@ -83,12 +83,12 @@
     }
 
     .label {
-      max-width: 500px;
+      max-width: px(500);
       overflow-wrap: anywhere;
     }
 
     .field {
-      margin-bottom: 3px;
+      margin-bottom: px(3);
 
       .price-tag {
         float: unset;
@@ -127,7 +127,7 @@
           display: flex;
           flex-direction: row;
           align-items: center;
-          margin-top: 10px;
+          margin-top: px(10);
         }
       }
 
@@ -136,7 +136,7 @@
         flex-direction: column;
 
         ul {
-          max-width: 500px;
+          max-width: px(500);
           padding-left: 1.5rem;
 
           li {
@@ -151,7 +151,7 @@
             }
 
             &:not(:last-child) {
-              border-bottom: 1px solid rgba(34, 36, 38, 0.15);
+              border-bottom: px(1) solid rgba(34, 36, 38, 0.15);
             }
 
             .light {
@@ -180,7 +180,7 @@
       }
 
       .country-dropdown {
-        max-width: 500px;
+        max-width: px(500);
       }
 
       .single-choice-dropdown {
@@ -199,8 +199,8 @@
           }
 
           .labels {
-            margin-top: -11px;
-            margin-bottom: -11px;
+            margin-top: px(-11);
+            margin-bottom: px(-11);
             margin-left: 0.5em;
             white-space: nowrap;
 
@@ -229,18 +229,18 @@
       input[type='email'],
       input[type='file'],
       input[type='text'] {
-        max-width: 500px;
+        max-width: px(500);
       }
 
       input[type='tel'],
       input[type='number'] {
-        max-width: 250px;
+        max-width: px(250);
       }
     }
 
     > .description {
-      max-width: 500px;
-      padding-left: 2px;
+      max-width: px(500);
+      padding-left: px(2);
       text-align: justify;
       font-style: italic;
       font-size: 0.9em;
@@ -252,19 +252,19 @@
     visibility: hidden;
 
     a + a {
-      margin-left: 3px;
+      margin-left: px(3);
     }
   }
 
   &.editable {
     .sortable-handle {
       color: $dark-gray;
-      margin-left: -10px;
-      width: 25px;
+      margin-left: px(-10);
+      width: px(25);
 
       &::before {
         position: relative;
-        left: 8px;
+        left: px(8);
       }
     }
 
@@ -295,19 +295,19 @@
   }
 
   :global(.SingleDatePickerInput) {
-    border-radius: 4px;
+    border-radius: px(4);
 
     & > :global(.DateInput) {
-      max-width: 130px;
+      max-width: px(130);
     }
 
     & > button {
-      margin-left: 5px;
+      margin-left: px(5);
     }
   }
 
   :global(.rc-time-picker) {
-    max-width: 110px;
+    max-width: px(110);
   }
 
   :global(.rc-time-picker-input) {
@@ -332,7 +332,7 @@
 
   .section-sortable-handle {
     font-size: 1.2em;
-    flex-basis: 20px;
+    flex-basis: px(20);
     align-self: flex-start;
   }
 
@@ -360,7 +360,7 @@
 
   a + a,
   a + div {
-    margin-left: 5px;
+    margin-left: px(5);
   }
 }
 
@@ -369,7 +369,7 @@
   grid-template-columns: 1fr 1fr;
 
   & > div:first-child {
-    border-right: 1px solid rgba(34, 36, 38, 0.15);
+    border-right: px(1) solid rgba(34, 36, 38, 0.15);
   }
 }
 
@@ -377,12 +377,12 @@
   cursor: pointer;
   line-height: 1em;
   color: rgba(0, 0, 0, 0.87);
-  padding: 11px 16px;
+  padding: px(11) px(16);
   font-size: 1rem;
   font-weight: normal;
 
   i {
-    padding-right: 10px;
+    padding-right: px(10);
 
     &::before {
       cursor: pointer;

--- a/indico/modules/logs/client/style/logs.scss
+++ b/indico/modules/logs/client/style/logs.scss
@@ -42,7 +42,7 @@
   position: absolute;
   font-size: 5em;
   left: 45%;
-  top: 250px;
+  top: px(250);
 }
 
 .event-log-list {
@@ -103,7 +103,7 @@
     display: flex;
     align-items: center;
     width: 100%;
-    border-bottom: 1px solid $pastel-gray;
+    border-bottom: px(1) solid $pastel-gray;
 
     .log-module {
       @extend .flexrow;
@@ -122,8 +122,8 @@
           line-height: 1em;
           font-size: 0.7em;
           position: absolute;
-          right: 3px;
-          top: 1px;
+          right: px(3);
+          top: px(1);
         }
       }
     }
@@ -149,8 +149,8 @@
 
       .user-picture {
         opacity: 0.8;
-        width: 25px;
-        height: 25px;
+        width: px(25);
+        height: px(25);
         border-radius: 50%;
       }
 
@@ -176,7 +176,7 @@ table.log-modal-details {
   margin: 0;
 
   td.log-caption {
-    width: 200px;
+    width: px(200);
   }
 
   td.email-body .html {

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.module.scss
@@ -7,6 +7,7 @@
 
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 :global(.ui.icon.message).message-icon :global(.icon) {
   font-size: 2em;
@@ -17,7 +18,7 @@
 }
 
 .log-list {
-  max-height: 140px;
+  max-height: px(140);
   overflow: auto;
 }
 
@@ -27,7 +28,7 @@
 
 .booking-logs,
 .concurrent-reservations {
-  margin-top: 20px;
+  margin-top: px(20);
 }
 
 :global(.ui.modal .header).booking-modal-header {
@@ -53,17 +54,17 @@
 }
 
 .rejection-form {
-  width: 350px;
+  width: px(350);
 }
 
 .accept-with-message {
-  border-left: 1px solid darken($green, 5%) !important;
+  border-left: px(1) solid darken($green, 5%) !important;
 }
 
 .concurrent-reservations-list {
-  max-height: 150px;
+  max-height: px(150);
   overflow: auto;
-  min-height: 20px;
+  min-height: px(20);
 }
 
 .weekday {

--- a/indico/modules/rb/client/js/common/bookings/BookingEdit.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingEdit.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .booking-edit-modal-header {
   display: flex !important;
   justify-content: space-between;
@@ -17,5 +19,5 @@
 
 .booking-conflicts-info {
   flex-grow: unset !important;
-  margin-top: 20px;
+  margin-top: px(20);
 }

--- a/indico/modules/rb/client/js/common/bookings/BookingEditCalendar.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditCalendar.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .original-booking-header,
 .new-booking-header {
   align-self: center;
@@ -39,14 +41,14 @@
   }
 
   .ongoing-booking-explanation {
-    height: 130px;
+    height: px(130);
 
     :global(.content) {
-      padding-top: 10px;
-      padding-bottom: 10px;
+      padding-top: px(10);
+      padding-bottom: px(10);
 
       :global(.ui.list) {
-        margin-top: 5px !important;
+        margin-top: px(5) !important;
       }
     }
   }

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
@@ -5,8 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .booking-edit-form {
-  margin-top: 15px;
+  margin-top: px(15);
 
   :global(.field .SingleDatePicker),
   :global(.field .DateRangePicker) {

--- a/indico/modules/rb/client/js/common/bookings/OccurrencesCounter.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/OccurrencesCounter.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .occurrence-count {
   display: flex;
   margin-left: auto !important;
@@ -25,7 +27,7 @@
 
     &:not(:global(.single-arrow)) {
       :global(.label) {
-        margin-top: 8px;
+        margin-top: px(8);
       }
 
       .arrow {
@@ -36,7 +38,7 @@
 
   .old-occurrences-count {
     :global(.label) {
-      margin-bottom: 8px;
+      margin-bottom: px(8);
     }
 
     .arrow {

--- a/indico/modules/rb/client/js/common/filters/FilterDropdown.module.scss
+++ b/indico/modules/rb/client/js/common/filters/FilterDropdown.module.scss
@@ -7,10 +7,11 @@
 
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 .filter-dropdown {
   .filter-dropdown-actions {
-    margin-top: 15px;
+    margin-top: px(15);
   }
 }
 
@@ -55,5 +56,5 @@
 }
 
 .filter-dropdown-footer:global(.ui.buttons) {
-  margin-top: 10px;
+  margin-top: px(10);
 }

--- a/indico/modules/rb/client/js/common/linking/LinkBar.module.scss
+++ b/indico/modules/rb/client/js/common/linking/LinkBar.module.scss
@@ -6,13 +6,14 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/palette' as *;
+@use 'base/utilities' as *;
 
 .link-bar {
   display: flex;
-  padding: 0 20px 0 10px;
+  padding: 0 px(20) 0 px(10);
   margin: 0;
-  height: 30px;
-  line-height: 30px;
+  height: px(30);
+  line-height: px(30);
   background-color: $primary-color;
   color: $white;
 

--- a/indico/modules/rb/client/js/common/map/RoomBookingMap.module.scss
+++ b/indico/modules/rb/client/js/common/map/RoomBookingMap.module.scss
@@ -7,11 +7,12 @@
 
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/util' as *;
+@use 'base/utilities' as *;
 
 .map-container {
   :global(.leaflet-container) {
-    @include remaining-screen-height(40px);
-    font-size: 14px;
+    @include remaining-screen-height(px(40));
+    font-size: px(14);
   }
 
   // Overrides leaflet control styles to match Semantic-UI ones.
@@ -33,30 +34,30 @@
 
   :global(.rb-map-cluster) {
     background-color: rgba($highlight-color, 0.8);
-    border: 2px solid darken($highlight-color, 10%);
+    border: px(2) solid darken($highlight-color, 10%);
     color: $light-gray;
-    height: 50px;
-    width: 50px;
-    line-height: 37px;
+    height: px(50);
+    width: px(50);
+    line-height: px(37);
     text-align: center;
     font-weight: bold;
     font-size: 1.1em;
     font-family: $sui-font-family;
-    text-shadow: 1px 1px $light-black;
+    text-shadow: px(1) px(1) $light-black;
 
     &:global(.highlight) {
       background-color: rgba($orange, 0.9);
-      border: 2px solid darken($orange, 10%);
+      border: px(2) solid darken($orange, 10%);
     }
   }
 
   :global(.rb-map-marker) {
     background-color: saturate(rgba($highlight-color, 0.9), 30%);
-    border: 2px solid darken($highlight-color, 20%);
+    border: px(2) solid darken($highlight-color, 20%);
 
     &:global(.highlight) {
       background-color: saturate(rgba($orange, 0.9), 30%);
-      border: 2px solid darken($orange, 10%);
+      border: px(2) solid darken($orange, 10%);
     }
   }
 

--- a/indico/modules/rb/client/js/common/rooms/RoomRenderer.module.scss
+++ b/indico/modules/rb/client/js/common/rooms/RoomRenderer.module.scss
@@ -5,7 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .selection-add-btn {
   pointer-events: all;
-  margin: 10px !important;
+  margin: px(10) !important;
 }

--- a/indico/modules/rb/client/js/common/rooms/edit/DailyAvailability.module.scss
+++ b/indico/modules/rb/client/js/common/rooms/edit/DailyAvailability.module.scss
@@ -5,8 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .availability-container {
   display: flex;
   align-items: center;
-  padding-bottom: 5px;
+  padding-bottom: px(5);
 }

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.module.scss
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.module.scss
@@ -5,11 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .button-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-bottom: 10px;
+  padding-bottom: px(10);
 }
 
 .submit-message {

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomPhoto.module.scss
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomPhoto.module.scss
@@ -6,15 +6,16 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/palette' as *;
+@use 'base/utilities' as *;
 
 .dropzone {
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 10px;
-  border-width: 2px;
-  border-radius: 2px;
+  padding: px(10);
+  border-width: px(2);
+  border-radius: px(2);
   border-color: $pastel-gray;
   border-style: dashed;
   background-color: $light-gray;
@@ -27,7 +28,7 @@
   display: flex;
   justify-content: flex-end;
   width: 100%;
-  padding-top: 10px;
+  padding-top: px(10);
 
   .upload-icon {
     background-color: $indico-blue !important;

--- a/indico/modules/rb/client/js/common/timeline/TimelineContent.module.scss
+++ b/indico/modules/rb/client/js/common/timeline/TimelineContent.module.scss
@@ -7,8 +7,9 @@
 
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/util' as *;
+@use 'base/utilities' as *;
 
-$row-height: 40px;
+$row-height: px(40);
 $split-row-height: $row-height / 2;
 
 @keyframes rotate90 {
@@ -49,7 +50,7 @@ $split-row-height: $row-height / 2;
   }
 
   .timeline-header-actions {
-    width: 70px;
+    width: px(70);
   }
 }
 
@@ -62,7 +63,7 @@ $split-row-height: $row-height / 2;
     position: absolute;
     top: 0;
     height: 100%;
-    border-left: 1px solid $light-gray;
+    border-left: px(1) solid $light-gray;
   }
 }
 
@@ -90,7 +91,7 @@ $split-row-height: $row-height / 2;
         text-align: right;
 
         &.gutter {
-          border-left: 5px solid lighten($highlight-color, 25%);
+          border-left: px(5) solid lighten($highlight-color, 25%);
           background-color: lighten($highlight-color, 35%);
         }
 
@@ -117,7 +118,7 @@ $split-row-height: $row-height / 2;
       font-size: 1.8em;
       z-index: 4;
       text-align: right;
-      width: 70px;
+      width: px(70);
     }
 
     &:hover .timeline-row-actions :global(.icon) {
@@ -144,7 +145,7 @@ $split-row-height: $row-height / 2;
   margin-top: 2em !important;
   color: rgba(0, 0, 0, 0.87) !important;
   position: fixed;
-  bottom: 10px;
+  bottom: px(10);
   top: auto;
 
   &::before {

--- a/indico/modules/rb/client/js/common/timeline/TimelineItem.module.scss
+++ b/indico/modules/rb/client/js/common/timeline/TimelineItem.module.scss
@@ -7,6 +7,7 @@
 
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/util' as *;
+@use 'base/utilities' as *;
 
 .timeline-item {
   position: relative;
@@ -22,7 +23,7 @@
     padding: 0.7em 0.2em;
     z-index: 3;
     border-radius: 0;
-    border: 0.5px solid rgba(0, 0, 0, 0.2);
+    border: px(0.5) solid rgba(0, 0, 0, 0.2);
 
     &:hover:not(:global(.other)) {
       opacity: 0.75;
@@ -157,39 +158,39 @@
 
     &:global(.unbookable-periods) {
       @include thin-stripes($unbookable-stripe-colors...);
-      background-size: 30px 30px;
+      background-size: px(30) px(30);
       z-index: 2;
-      height: 30px;
-      border: 1px solid $unbookable-color;
+      height: px(30);
+      border: px(1) solid $unbookable-color;
     }
 
     &:global(.unbookable-hours) {
       @include thin-stripes($unbookable-stripe-colors...);
-      background-size: 30px 30px;
+      background-size: px(30) px(30);
       z-index: 1;
-      height: 30px;
-      border: 1px solid $unbookable-color;
+      height: px(30);
+      border: px(1) solid $unbookable-color;
     }
 
     &:global(.blocking) {
       @include thin-stripes($blocking-stripe-colors...);
-      background-size: 30px 30px;
+      background-size: px(30) px(30);
       z-index: 1;
-      border: 1px solid lighten($conflict-color, 20%);
+      border: px(1) solid lighten($conflict-color, 20%);
       padding: 0.9em 0.2em;
     }
 
     &:global(.overridable-blocking) {
       @include thin-stripes($overridable-blocking-stripe-colors...);
-      background-size: 30px 30px;
+      background-size: px(30) px(30);
       z-index: 1;
-      border: 1px solid $overridable-blocking-color;
+      border: px(1) solid $overridable-blocking-color;
       padding: 0.9em 0.2em;
     }
 
     &:global(.cancellation) {
       background-color: $cancellation-color;
-      border: 1px solid darken($cancellation-color, 15%);
+      border: px(1) solid darken($cancellation-color, 15%);
 
       &.overflow-right {
         @include right-fade-out($conflicting-candidate-fadeout-colors...);
@@ -227,7 +228,7 @@
 
     &:global(.rejection) {
       background-color: $rejection-color;
-      border: 1px solid darken($rejection-color, 25%);
+      border: px(1) solid darken($rejection-color, 25%);
 
       &.overflow-right {
         @include right-fade-out($rejection-fadeout-colors...);
@@ -246,7 +247,7 @@
 
     &:global(.other) {
       background-color: $other-booking-color;
-      border: 1px solid darken($other-booking-color, 10%);
+      border: px(1) solid darken($other-booking-color, 10%);
 
       &.overflow-right {
         @include right-fade-out($other-booking-fadeout-colors...);
@@ -264,7 +265,7 @@
 
       &:hover {
         background-color: lighten($other-booking-color, 1%);
-        border: 1px solid darken($other-booking-color, 30%);
+        border: px(1) solid darken($other-booking-color, 30%);
         z-index: 4;
       }
     }

--- a/indico/modules/rb/client/js/common/timeline/TimelineLegend.module.scss
+++ b/indico/modules/rb/client/js/common/timeline/TimelineLegend.module.scss
@@ -7,6 +7,7 @@
 
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/util' as *;
+@use 'base/utilities' as *;
 
 .legend {
   display: flex;
@@ -29,13 +30,13 @@
     :global(.label) {
       color: white;
       font-weight: bold;
-      border: 1px solid rgba(0, 0, 0, 0.1);
+      border: px(1) solid rgba(0, 0, 0, 0.1);
       padding-top: 0.7em;
       padding-bottom: 0.7em;
 
       &.compact {
         padding: 0.5em;
-        border: 1px solid rgba(0, 0, 0, 0.2);
+        border: px(1) solid rgba(0, 0, 0, 0.2);
 
         & + .text {
           padding-left: 0.25em;
@@ -74,14 +75,14 @@
 
       &.cancellation {
         background-color: $cancellation-color;
-        border: 1px solid darken($cancellation-color, 15%);
+        border: px(1) solid darken($cancellation-color, 15%);
         color: darken($cancellation-color, 40%);
       }
 
       &.unbookable {
         @include thin-stripes($unbookable-stripe-colors...);
-        background-size: 35px 35px;
-        border: 1px solid $unbookable-color;
+        background-size: px(35) px(35);
+        border: px(1) solid $unbookable-color;
         color: darken($unbookable-color, 40%);
       }
 
@@ -91,27 +92,27 @@
 
       &.blocking {
         @include thin-stripes($blocking-stripe-colors...);
-        background-size: 35px 35px;
-        border: 1px solid lighten($conflict-color, 20%);
+        background-size: px(35) px(35);
+        border: px(1) solid lighten($conflict-color, 20%);
         color: darken($conflict-color, 10%);
       }
 
       &.overridable-blocking {
         @include thin-stripes($overridable-blocking-stripe-colors...);
-        background-size: 35px 35px;
-        border: 1px solid $overridable-blocking-color;
+        background-size: px(35) px(35);
+        border: px(1) solid $overridable-blocking-color;
         color: darken($overridable-blocking-color, 20%);
       }
 
       &.rejection {
         background-color: $rejection-color;
-        border: 1px solid darken($rejection-color, 25%);
+        border: px(1) solid darken($rejection-color, 25%);
         color: darken($rejection-color, 40%);
       }
 
       &.other {
         background-color: $other-booking-color;
-        border: 1px solid darken($other-booking-color, 25%);
+        border: px(1) solid darken($other-booking-color, 25%);
       }
     }
   }

--- a/indico/modules/rb/client/js/common/timeline/WeeklyTimelineContent.module.scss
+++ b/indico/modules/rb/client/js/common/timeline/WeeklyTimelineContent.module.scss
@@ -7,12 +7,13 @@
 
 @use 'rb:styles/palette' as *;
 @use './TimelineContent.module.scss' as *;
+@use 'base/utilities' as *;
 
 .timeline-day-divider {
   position: absolute;
   top: 0;
   height: 100%;
-  border-left: 1px solid $pastel-gray;
+  border-left: px(1) solid $pastel-gray;
 
   &:global(.hidden) {
     opacity: 0.35;

--- a/indico/modules/rb/client/js/components/AdminOverrideBar.module.scss
+++ b/indico/modules/rb/client/js/components/AdminOverrideBar.module.scss
@@ -6,13 +6,14 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/palette' as *;
+@use 'base/utilities' as *;
 
 .admin-override-bar {
   display: flex;
-  padding: 0 20px 0 10px;
+  padding: 0 px(20) 0 px(10);
   margin: 0;
-  height: 30px;
-  line-height: 30px;
+  height: px(30);
+  line-height: px(30);
   background-color: $orange;
   color: $white;
 

--- a/indico/modules/rb/client/js/components/App.module.scss
+++ b/indico/modules/rb/client/js/components/App.module.scss
@@ -8,6 +8,7 @@
 @use 'rb:styles/util' as *;
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 .rb-layout {
   // this will reset the stacking context,
@@ -18,7 +19,7 @@
 
 .rb-menu-bar {
   background-color: $highlight-color;
-  padding: 0 20px;
+  padding: 0 px(20);
   margin: 0;
   height: $menu-height;
   line-height: $menu-height;
@@ -93,13 +94,13 @@
 
 .rb-pushable {
   // make sure that side bar takes the whole remaining height of the page
-  min-height: calc(100vh - #{$menu-height} - var(--extra-bars, 0) * 50px - 50px);
+  min-height: calc(100vh - #{$menu-height} - var(--extra-bars, 0) * #{px(50)} - #{px(50)});
   // unset `transform` which breaks the Sticky filter bar and set `position` here
   // so that rb-pusher positions itself correctly
   transform: unset !important;
   position: relative;
 
   .rb-pusher:global(.pusher) {
-    min-height: calc(100vh - #{$menu-height} - var(--extra-bars, 0) * 50px - 50px);
+    min-height: calc(100vh - #{$menu-height} - var(--extra-bars, 0) * #{px(50)} - #{px(50)});
   }
 }

--- a/indico/modules/rb/client/js/components/BookingBootstrapForm.module.scss
+++ b/indico/modules/rb/client/js/components/BookingBootstrapForm.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 .booking-type-field {
   display: flex;
@@ -21,7 +22,7 @@
 
     :global(.ui.input input) {
       width: 100%;
-      min-width: 60px;
+      min-width: px(60);
     }
   }
 
@@ -32,6 +33,6 @@
 
 @media (max-width: $tablet-width) {
   :global(.DateInput) {
-    width: 110px;
+    width: px(110);
   }
 }

--- a/indico/modules/rb/client/js/components/DimmableImage.module.scss
+++ b/indico/modules/rb/client/js/components/DimmableImage.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 .dimmable-image {
   position: relative;
@@ -25,7 +26,7 @@
     left: 50%;
     transform: translate(-50%, -50%);
     text-align: center;
-    width: 160px;
+    width: px(160);
   }
   @media (max-width: $tablet-width) {
     .hover-content {
@@ -39,7 +40,7 @@
 
   @media (min-width: $tablet-width) {
     &:hover :global(.img) {
-      filter: blur(2px) contrast(150%) brightness(40%);
+      filter: blur(px(2)) contrast(150%) brightness(40%);
       transition: all 30ms ease;
     }
 

--- a/indico/modules/rb/client/js/components/Room.module.scss
+++ b/indico/modules/rb/client/js/components/Room.module.scss
@@ -5,9 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .room-card {
-  height: 320px;
-  width: 300px;
+  height: px(320);
+  width: px(300);
 
   .room-title {
     font-size: 1em;
@@ -33,7 +35,7 @@
 
     :global(.img) {
       width: 100%;
-      height: 170px !important;
+      height: px(170) !important;
     }
   }
 
@@ -45,12 +47,12 @@
       white-space: nowrap;
       text-overflow: ellipsis;
       overflow: hidden;
-      height: 40px;
+      height: px(40);
     }
   }
 
   :global(.content) {
-    max-height: 105px;
+    max-height: px(105);
   }
 
   .room-content {

--- a/indico/modules/rb/client/js/components/RoomBasicDetails.module.scss
+++ b/indico/modules/rb/client/js/components/RoomBasicDetails.module.scss
@@ -7,6 +7,7 @@
 
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 .photo-dimmable-width {
   width: 100%;
@@ -29,18 +30,18 @@
   pointer-events: none;
   position: absolute;
   display: flex;
-  bottom: -1px;
+  bottom: px(-1);
   width: 100%;
 
   .feature-entries {
     cursor: default;
     pointer-events: auto;
     background-color: $white;
-    border-radius: 3px 3px 0 0;
+    border-radius: px(3) px(3) 0 0;
     border-color: $pastel-gray $pastel-gray $white $pastel-gray;
-    border-width: 1px 1px 2px 1px;
+    border-width: px(1) px(1) px(2) px(1);
     border-style: solid;
-    padding: 5px;
+    padding: px(5);
     margin: auto;
   }
 
@@ -54,7 +55,7 @@
   overflow: hidden;
 
   .image-container {
-    border: 1px solid $pastel-gray;
+    border: px(1) solid $pastel-gray;
     position: relative;
     height: 100%;
     width: 100%;

--- a/indico/modules/rb/client/js/components/RoomSelector.module.scss
+++ b/indico/modules/rb/client/js/components/RoomSelector.module.scss
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .room-selector {
   .selected-rooms-row {
     padding-top: 0 !important;
 
     .rooms-list {
-      max-height: 140px;
+      max-height: px(140);
       overflow: hidden;
       overflow-y: auto;
 

--- a/indico/modules/rb/client/js/components/SearchBar.module.scss
+++ b/indico/modules/rb/client/js/components/SearchBar.module.scss
@@ -6,13 +6,14 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 .room-filters {
   .text-filter input {
-    width: 300px;
+    width: px(300);
 
     @media (max-width: $tablet-width) {
-      width: 275px;
+      width: px(275);
     }
 
     & + i.icon.remove {

--- a/indico/modules/rb/client/js/components/SidebarMenu.module.scss
+++ b/indico/modules/rb/client/js/components/SidebarMenu.module.scss
@@ -6,11 +6,14 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/palette' as *;
+@use 'base/utilities' as *;
 
 .sidebar:global(.inverted.menu) {
   background-color: darken($primary-color, 10%);
-  top: calc(125px + var(--extra-bars, 0) * 50px - var(--offset, 0) * 1px);
-  height: calc(100% - 125px - var(--extra-bars, 0) * 50px + var(--offset, 0) * 1px) !important;
+  top: calc(px(125) + var(--extra-bars, 0) * #{px(50)} - var(--offset, 0) * #{px(1)});
+  height: calc(
+    100% - px(125) - var(--extra-bars, 0) * #{px(50)} + var(--offset, 0) * #{px(1)}
+  ) !important;
   position: fixed !important;
 
   .bottom-align {

--- a/indico/modules/rb/client/js/components/TimeInformation.module.scss
+++ b/indico/modules/rb/client/js/components/TimeInformation.module.scss
@@ -5,10 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 @import 'rb:styles/palette';
 
 .booking-time-info {
-  margin-top: 10px;
+  margin-top: px(10);
 }
 
 .occurrences-details {

--- a/indico/modules/rb/client/js/components/TimeRangePicker.module.scss
+++ b/indico/modules/rb/client/js/components/TimeRangePicker.module.scss
@@ -5,24 +5,26 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .time-range-picker {
   display: flex;
   justify-content: space-between;
-  width: 200px;
+  width: px(200);
 
   .start-time-dropdown {
-    max-width: 100px !important;
-    min-width: 90px !important;
+    max-width: px(100) !important;
+    min-width: px(90) !important;
     text-align: center !important;
   }
 
   .end-time-dropdown {
-    max-width: 100px !important;
-    min-width: 90px !important;
+    max-width: px(100) !important;
+    min-width: px(90) !important;
     text-align: center !important;
 
     :global(.menu) {
-      min-width: 140px !important;
+      min-width: px(140) !important;
     }
   }
 

--- a/indico/modules/rb/client/js/modules/admin/AdminArea.module.scss
+++ b/indico/modules/rb/client/js/modules/admin/AdminArea.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .admin-area {
-  margin-top: 20px;
+  margin-top: px(20);
 }

--- a/indico/modules/rb/client/js/modules/admin/AdminRoomItem.module.scss
+++ b/indico/modules/rb/client/js/modules/admin/AdminRoomItem.module.scss
@@ -5,9 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .room-item {
   .room-item-image {
-    height: 90px !important;
+    height: px(90) !important;
   }
 
   .room-item-header {

--- a/indico/modules/rb/client/js/modules/admin/MapAreasPage.module.scss
+++ b/indico/modules/rb/client/js/modules/admin/MapAreasPage.module.scss
@@ -6,11 +6,12 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/util' as *;
+@use 'base/utilities' as *;
 
 .areas-map-container {
   :global(.leaflet-container) {
-    height: 1000px;
-    font-size: 14px;
+    height: px(1000);
+    font-size: px(14);
   }
 
   :global(.leaflet-draw-section) {
@@ -20,7 +21,7 @@
 }
 
 :global(.area-default) {
-  margin-left: 5px;
+  margin-left: px(5);
   font-weight: bold;
 }
 

--- a/indico/modules/rb/client/js/modules/admin/SettingsPage.module.scss
+++ b/indico/modules/rb/client/js/modules/admin/SettingsPage.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 :global(.ui.message) > :global(.header) + :global(.fields) {
-  margin-top: 3px;
+  margin-top: px(3);
 }

--- a/indico/modules/rb/client/js/modules/blockings/BlockingList.module.scss
+++ b/indico/modules/rb/client/js/modules/blockings/BlockingList.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 .blockings-container {
   padding: 2em;
@@ -15,10 +16,10 @@
 
   .blockings-list,
   :global(.blockings-placeholders) {
-    margin: 10px 0 0 -5px;
+    margin: px(10) 0 0 px(-5);
   }
 
   :global(.ui.stuck-container) + .blockings-list {
-    padding-top: 60px;
+    padding-top: px(60);
   }
 }

--- a/indico/modules/rb/client/js/modules/blockings/BlockingModal.module.scss
+++ b/indico/modules/rb/client/js/modules/blockings/BlockingModal.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 :global(.ui.modal .header).blocking-modal-header {
   display: flex;
   justify-content: space-between;
@@ -23,5 +25,5 @@
 }
 
 .rejection-form {
-  width: 350px;
+  width: px(350);
 }

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoom.module.scss
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoom.module.scss
@@ -7,6 +7,7 @@
 
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 .view-icons {
   height: 100%;
@@ -24,7 +25,7 @@
   }
 
   :global(i.icons) {
-    height: 32px;
+    height: px(32);
   }
 
   :global(i:not(.disabled):hover) {
@@ -47,7 +48,7 @@
 
 .available-room-list {
   .results-count {
-    margin-bottom: 10px;
+    margin-bottom: px(10);
 
     :global(.ui.menu .item > i.icon) {
       margin-right: 0.5em;
@@ -74,18 +75,18 @@
     }
 
     .loading-indicator {
-      padding: 8px;
+      padding: px(8);
       box-sizing: border-box;
       width: 100%;
-      height: 43.6px;
+      height: px(43.6);
 
       :global(.bar) {
         background: $pastel-gray;
         width: 100%;
-        height: 7px;
+        height: px(7);
 
         &:not(:last-child) {
-          margin-bottom: 4px;
+          margin-bottom: px(4);
         }
       }
     }
@@ -100,8 +101,8 @@
     cursor: pointer;
     color: $white;
     font-size: 0.8em;
-    right: 4px;
-    bottom: 2px;
+    right: px(4);
+    bottom: px(2);
     text-shadow: none;
   }
 }

--- a/indico/modules/rb/client/js/modules/bookRoom/filters/RecurrenceForm.module.scss
+++ b/indico/modules/rb/client/js/modules/bookRoom/filters/RecurrenceForm.module.scss
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .recurrence-every:global(.fields.inline) {
   :global .ui.selection.dropdown {
-    min-width: 100px;
+    min-width: px(100);
   }
 
   :global .field .ui.input input {
-    width: 80px;
+    width: px(80);
   }
 }

--- a/indico/modules/rb/client/js/modules/bookRoom/filters/TimeForm.module.scss
+++ b/indico/modules/rb/client/js/modules/bookRoom/filters/TimeForm.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .time-picker {
-  width: 90px;
+  width: px(90);
 }

--- a/indico/modules/rb/client/js/modules/calendar/Calendar.module.scss
+++ b/indico/modules/rb/client/js/modules/calendar/Calendar.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 :global(.ui.grid > .row).row {
   display: block;
@@ -16,7 +17,7 @@
   justify-content: space-between;
 
   > :not(:first-child) {
-    margin-bottom: 10px;
+    margin-bottom: px(10);
   }
 
   .view-switch {

--- a/indico/modules/rb/client/js/modules/calendar/CalendarListView.module.scss
+++ b/indico/modules/rb/client/js/modules/calendar/CalendarListView.module.scss
@@ -5,8 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .active-bookings {
-  margin-top: 15px;
+  margin-top: px(15);
 
   :global(.redux-lazy-scroll) {
     overflow: unset !important;
@@ -16,7 +18,7 @@
     .day-cards-header {
       display: flex;
       align-items: center;
-      height: 50px;
+      height: px(50);
     }
 
     .day-cards-container {

--- a/indico/modules/rb/client/js/modules/landing/Landing.module.scss
+++ b/indico/modules/rb/client/js/modules/landing/Landing.module.scss
@@ -8,6 +8,7 @@
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/util' as *;
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
 @keyframes fade-slide-down {
   0% {
@@ -88,11 +89,11 @@
     }
 
     @media (min-width: $tablet-width) {
-      min-width: 520px;
+      min-width: px(520);
     }
 
     // stylelint-disable-next-line scss/media-feature-value-dollar-variable
-    @media (max-height: 600px) {
+    @media (max-height: px(600)) {
       margin-top: auto;
     }
 
@@ -106,7 +107,7 @@
   }
 
   .landing-page-lower-row {
-    height: 300px;
+    height: px(300);
     background-color: #fff;
     padding: 1em 0 0 0;
     // to compensate margin from SUI containers
@@ -120,7 +121,7 @@
         }
 
         &:not(:last-child) {
-          margin-right: 70px;
+          margin-right: px(70);
         }
 
         :global(.statistic + .statistic) {

--- a/indico/modules/rb/client/js/modules/landing/UpcomingBookings.module.scss
+++ b/indico/modules/rb/client/js/modules/landing/UpcomingBookings.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/palette' as *;
+@use 'base/utilities' as *;
 
 :global(.ui.list) > .upcoming-bookings-item:global(.item) {
   cursor: pointer;
@@ -22,7 +23,7 @@
 
 .upcoming-bookings-list {
   overflow: hidden;
-  max-height: 150px;
+  max-height: px(150);
 }
 
 .upcoming-item-img-container {
@@ -38,7 +39,7 @@
     .upcoming-item-room-name {
       background: $white;
       padding: 0.2em 0.5em;
-      border-radius: 2px 0 0 2px;
+      border-radius: px(2) 0 0 px(2);
     }
   }
 }

--- a/indico/modules/rb/client/js/modules/roomList/RoomList.module.scss
+++ b/indico/modules/rb/client/js/modules/roomList/RoomList.module.scss
@@ -5,9 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .room-list {
   .results-count {
-    margin-bottom: 10px;
+    margin-bottom: px(10);
     font-weight: bold;
     font-size: 1.5em;
   }

--- a/indico/modules/rb/client/js/modules/roomList/filters/EquipmentForm.module.scss
+++ b/indico/modules/rb/client/js/modules/roomList/filters/EquipmentForm.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .equipment-accordion {
-  margin-top: 15px;
+  margin-top: px(15);
 }

--- a/indico/modules/rb/client/js/modules/roomList/filters/ShowOnlyForm.module.scss
+++ b/indico/modules/rb/client/js/modules/roomList/filters/ShowOnlyForm.module.scss
@@ -5,17 +5,19 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .show-only-filter {
   display: flex;
   align-items: center;
-  width: 300px;
+  width: px(300);
 
   &:not(:nth-last-child(2)) {
-    margin-bottom: 10px;
+    margin-bottom: px(10);
   }
 
   :global(.toggle.checkbox) {
-    margin-right: 10px;
+    margin-right: px(10);
   }
 
   :global(.icon) {

--- a/indico/modules/rb/client/styles/main.scss
+++ b/indico/modules/rb/client/styles/main.scss
@@ -9,8 +9,9 @@
 @use 'rb:styles/sui_fixes' as *;
 @use 'rb:styles/palette' as *;
 @use 'rb:styles/responsive' as *;
+@use 'base/utilities' as *;
 
-$indico-top-bar-height: 50px;
+$indico-top-bar-height: px(50);
 
 input {
   font-size: 100%;
@@ -37,14 +38,14 @@ a {
   height: $indico-top-bar-height;
   display: flex;
   align-items: center;
-  padding: 0 20px;
+  padding: 0 px(20);
 
   .indico-top-bar-logo {
     display: flex;
     align-items: center;
 
     img {
-      height: 30px;
+      height: px(30);
     }
   }
 
@@ -54,13 +55,13 @@ a {
 }
 
 .room-edit-modal-add-btn {
-  margin-bottom: 15px !important;
+  margin-bottom: px(15) !important;
 }
 
 .flex-container {
   display: flex;
   align-items: center;
-  margin-bottom: 5px;
+  margin-bottom: px(5);
 
   .DateRangePicker {
     padding-bottom: 0 !important;
@@ -71,7 +72,7 @@ a {
   cursor: pointer;
   color: $red;
   opacity: 0.5 !important;
-  padding-left: 15px;
+  padding-left: px(15);
 
   &:hover {
     opacity: 1 !important;
@@ -95,7 +96,7 @@ a {
   display: flex;
   align-items: baseline;
   flex-direction: row;
-  margin-bottom: 10px;
+  margin-bottom: px(10);
 
   .filter-row-filters {
     display: flex;
@@ -103,8 +104,8 @@ a {
     flex-wrap: wrap;
 
     > * {
-      margin-right: 10px !important;
-      margin-bottom: 10px !important;
+      margin-right: px(10) !important;
+      margin-bottom: px(10) !important;
     }
   }
 }
@@ -149,11 +150,11 @@ a {
 }
 
 @mixin banner-bar {
-  height: 50px;
+  height: px(50);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0 20px;
+  padding: 0 px(20);
 
   .content {
     display: flex;
@@ -199,10 +200,10 @@ $text-yellow: lighten($yellow, 15%);
 
 .impersonation-bar {
   @include banner-bar();
-  height: 50px;
+  height: px(50);
   background-color: $dark-black;
   color: $text-yellow;
-  box-shadow: 0 -5px 1px -2px rgba(#000, 0.2) inset;
+  box-shadow: 0 px(-5) px(1) px(-2) rgba(#000, 0.2) inset;
 
   strong {
     color: lighten($yellow, 30%);

--- a/indico/modules/rb/client/styles/responsive.scss
+++ b/indico/modules/rb/client/styles/responsive.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-$tablet-width: 768px;
-$computer-width: 992px;
-$wide-screen-width: 1200px;
+@use 'base/utilities' as *;
+
+$tablet-width: px(768);
+$computer-width: px(992);
+$wide-screen-width: px(1200);

--- a/indico/modules/rb/client/styles/util.scss
+++ b/indico/modules/rb/client/styles/util.scss
@@ -5,8 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-$indico-top-bar-height: 50px;
-$menu-height: 75px;
+@use 'base/utilities' as *;
+
+$indico-top-bar-height: px(50);
+$menu-height: px(75);
 $rb-content-padding: 2em;
 $sui-font-family: 'Muli', 'Helvetica Neue', 'Arial', 'Helvetica', sans-serif;
 
@@ -14,14 +16,14 @@ $sui-font-family: 'Muli', 'Helvetica Neue', 'Arial', 'Helvetica', sans-serif;
   background-image: repeating-linear-gradient(
     45deg,
     $first,
-    $first 15px,
-    $second 15px,
-    $second 30px
+    $first px(15),
+    $second px(15),
+    $second px(30)
   );
 }
 
 @mixin thiner-stripes($first, $second) {
-  background-image: repeating-linear-gradient(45deg, $first 0 5px, $second 5px 10px);
+  background-image: repeating-linear-gradient(45deg, $first 0 px(5), $second px(5) px(10));
 }
 
 @mixin thin-stripes($first, $second) {
@@ -43,37 +45,37 @@ $sui-font-family: 'Muli', 'Helvetica Neue', 'Arial', 'Helvetica', sans-serif;
 }
 
 @mixin left-fade-out($base, $fade) {
-  background-image: linear-gradient(to right, $fade, $base 30px);
+  background-image: linear-gradient(to right, $fade, $base px(30));
 }
 
 @mixin right-fade-out($base, $fade) {
-  background-image: linear-gradient(to left, $fade, $base 30px);
+  background-image: linear-gradient(to left, $fade, $base px(30));
 }
 
 @mixin fade-out($base, $fade) {
-  background-image: linear-gradient(to left, $fade, $base 30px, $base 50%, rgba(1, 1, 1, 0) 51%),
-    linear-gradient(to right, $fade, $base 30px, $base 50%, rgba(1, 1, 1, 0) 51%);
+  background-image: linear-gradient(to left, $fade, $base px(30), $base 50%, rgba(1, 1, 1, 0) 51%),
+    linear-gradient(to right, $fade, $base px(30), $base 50%, rgba(1, 1, 1, 0) 51%);
 }
 
 @mixin right-fade-out-stripes($first, $second) {
-  background-image: linear-gradient(to left, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0) 30px),
-    repeating-linear-gradient(45deg, $first, $first 15px, $second 15px, $second 30px);
+  background-image: linear-gradient(to left, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0) px(30)),
+    repeating-linear-gradient(45deg, $first, $first px(15), $second px(15), $second px(30));
 }
 
 @mixin left-fade-out-stripes($first, $second) {
-  background-image: linear-gradient(to right, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0) 30px),
-    repeating-linear-gradient(45deg, $first, $first 15px, $second 15px, $second 30px);
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0) px(30)),
+    repeating-linear-gradient(45deg, $first, $first px(15), $second px(15), $second px(30));
 }
 
 @mixin fade-out-stripes($first, $second) {
-  background-image: linear-gradient(to right, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0) 30px),
-    linear-gradient(to left, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0) 30px),
-    repeating-linear-gradient(45deg, $first, $first 15px, $second 15px, $second 30px);
+  background-image: linear-gradient(to right, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0) px(30)),
+    linear-gradient(to left, rgba(255, 255, 255, 1), rgba(255, 255, 255, 0) px(30)),
+    repeating-linear-gradient(45deg, $first, $first px(15), $second px(15), $second px(30));
 }
 
 // stylelint-disable-next-line length-zero-no-unit
-@mixin remaining-screen-height($offset: 0px) {
+@mixin remaining-screen-height($offset: px(0)) {
   height: calc(
-    100vh - (#{$indico-top-bar-height} + #{$menu-height} + var(--extra-bars, 0) * 50px) - #{$offset}
+    100vh - (#{$indico-top-bar-height} + #{$menu-height} + var(--extra-bars, 0) * px(50)) - #{$offset}
   );
 }

--- a/indico/modules/search/client/js/components/ResultList.module.scss
+++ b/indico/modules/search/client/js/components/ResultList.module.scss
@@ -6,20 +6,21 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .item {
   padding: 1em 0;
   margin-bottom: 0.3em;
 
   .header {
-    font-size: 18px;
+    font-size: px(18);
     line-height: 1.2;
   }
 
   .description {
     padding-top: 0.7em;
     margin-bottom: 0 !important; // `.conference-page .description` sets 1em
-    font-size: 13px;
+    font-size: px(13);
     font-style: italic;
     color: $black;
 

--- a/indico/modules/search/client/js/components/SearchApp.module.scss
+++ b/indico/modules/search/client/js/components/SearchApp.module.scss
@@ -5,9 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .menu {
   flex-wrap: wrap;
-  padding-bottom: 2px;
+  padding-bottom: px(2);
 }
 
 .grid {

--- a/indico/modules/search/client/js/components/results/Path.module.scss
+++ b/indico/modules/search/client/js/components/results/Path.module.scss
@@ -6,13 +6,14 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .path {
   white-space: nowrap;
 
   :global(.breadcrumb) {
     display: inline-block;
-    font-size: 13px;
+    font-size: px(13);
     line-height: 1.2;
     font-style: italic;
     width: 100%;

--- a/indico/modules/users/client/js/Favorites.module.scss
+++ b/indico/modules/users/client/js/Favorites.module.scss
@@ -6,24 +6,25 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 :global(.ui.button).submit-button {
-  margin-top: 15px;
+  margin-top: px(15);
 }
 
 :global(.ui.list).fav-list {
   :global(.item).fav-item {
-    margin: 0 -10px;
+    margin: 0 px(-10);
 
     .list-flex {
       display: flex;
       justify-content: start;
-      margin: 7px 0;
+      margin: px(7) 0;
     }
 
     .detail {
-      margin-top: 7px;
-      width: 350px;
+      margin-top: px(7);
+      width: px(350);
       display: inline-block;
       overflow: hidden;
       white-space: nowrap;
@@ -39,22 +40,22 @@
 }
 
 .empty-favorites {
-  margin: 5px;
+  margin: px(5);
 }
 
 :global(.ui.inline.loader.active).fav-loader {
-  margin: 10px 50%;
+  margin: px(10) 50%;
   width: auto;
 }
 
 .favorite-event-container {
-  margin-top: 15px;
+  margin-top: px(15);
 }
 
 .date-span {
   width: 15%;
-  margin-right: 7px;
-  font-size: 12px;
+  margin-right: px(7);
+  font-size: px(12);
   color: $dark-gray;
 }
 
@@ -65,6 +66,6 @@
   overflow: hidden;
 
   a {
-    margin-right: 5px;
+    margin-right: px(5);
   }
 }

--- a/indico/modules/users/client/js/ProfilePicture.module.scss
+++ b/indico/modules/users/client/js/ProfilePicture.module.scss
@@ -6,23 +6,24 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .profile-picture-selection {
-  margin: 15px 10px;
+  margin: px(15) px(10);
 
   :global(.ui.cards) {
     text-align: center;
 
     :global(.description) {
-      height: 160px;
-      margin: 0 8px;
+      height: px(160);
+      margin: 0 px(8);
       color: rgb(85, 85, 85);
     }
 
     :global(.ui.image) {
-      margin: 15px auto;
-      height: 80px;
-      width: 80px;
+      margin: px(15) auto;
+      height: px(80);
+      width: px(80);
       object-fit: cover;
     }
 
@@ -32,14 +33,14 @@
     }
 
     .placeholder {
-      font-size: 80px;
-      margin: 15px auto;
+      font-size: px(80);
+      margin: px(15) auto;
       display: table;
       color: $pastel-gray;
     }
   }
 
   :global(.ui.form .field) {
-    margin-top: 15px;
+    margin-top: px(15);
   }
 }

--- a/indico/web/client/js/react/components/Carousel.module.scss
+++ b/indico/web/client/js/react/components/Carousel.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'rb:styles/palette' as *;
+@use 'base/utilities' as *;
 
 .carousel {
   padding: 1em 0 0 0;
@@ -30,9 +31,9 @@
 .progress-indicator {
   transition: background-color 0.25s ease-in;
   background-color: $pastel-gray;
-  width: 100px;
-  height: 2px;
-  margin: 10px auto;
+  width: px(100);
+  height: px(2);
+  margin: px(10) auto;
 
   &:global(.disabled),
   &:global(.disabled) .progress-bar {
@@ -54,9 +55,9 @@
 
   .pane-switcher-item {
     display: inline-block;
-    border: 1px solid $primary-color;
-    width: 15px;
-    height: 15px;
+    border: px(1) solid $primary-color;
+    width: px(15);
+    height: px(15);
     border-radius: 100%;
     cursor: pointer;
     transition: background-color 0.25s ease-in;

--- a/indico/web/client/js/react/components/ICSCalendarLink.module.scss
+++ b/indico/web/client/js/react/components/ICSCalendarLink.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .height-full {
   height: 100%;
@@ -40,11 +41,11 @@
 
 .export-option::before,
 .export-option::after {
-  box-shadow: 1px 1px 1px $light-gray;
+  box-shadow: px(1) px(1) px(1) $light-gray;
   background-color: $pastel-gray;
   content: '';
   display: inline-block;
-  height: 1px;
+  height: px(1);
   position: relative;
   vertical-align: middle;
   width: 10%;
@@ -65,8 +66,8 @@
 
 .popup:global(.ui.wide.popup) {
   display: inline-flex;
-  min-width: 350px;
-  max-width: 450px;
+  min-width: px(350);
+  max-width: px(450);
 }
 
 .popup .content {

--- a/indico/web/client/js/react/components/PersonLinkField.module.scss
+++ b/indico/web/client/js/react/components/PersonLinkField.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .person-link-field {
   color: rgba(0, 0, 0, 0.87);
@@ -15,12 +16,12 @@
   max-height: 40vh;
   overflow-y: auto;
   scroll-snap-type: y mandatory;
-  scroll-padding: 4px;
+  scroll-padding: px(4);
 }
 
 .person-link {
   display: flex;
-  padding: 1px 0;
+  padding: px(1) 0;
   scroll-snap-align: start;
 }
 
@@ -30,7 +31,7 @@
 
 .person-link .handle {
   cursor: pointer;
-  margin-top: 8px;
+  margin-top: px(8);
 }
 
 .principal {
@@ -66,7 +67,7 @@
   content: '';
   flex: 1;
   background-color: #d4d4d5;
-  height: 1px;
+  height: px(1);
   display: inline-block;
   margin-left: 1rem;
 }
@@ -102,5 +103,5 @@
 }
 
 .icon {
-  width: 32px !important;
+  width: px(32) !important;
 }

--- a/indico/web/client/js/react/components/PopoverDropdownMenu.module.scss
+++ b/indico/web/client/js/react/components/PopoverDropdownMenu.module.scss
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .trigger-container {
   display: inline-block;
 }
 
 .dropdown-container {
-  padding: 2px;
+  padding: px(2);
   z-index: 1000;
   overflow: auto;
 

--- a/indico/web/client/js/react/components/ReviewRating.module.scss
+++ b/indico/web/client/js/react/components/ReviewRating.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .rating-field {
   display: flex;
@@ -17,8 +18,8 @@
   }
 
   .rating-value {
-    margin-left: 5px;
+    margin-left: px(5);
     text-align: center;
-    min-width: 15px;
+    min-width: px(15);
   }
 }

--- a/indico/web/client/js/react/components/ScrollButton.module.scss
+++ b/indico/web/client/js/react/components/ScrollButton.module.scss
@@ -6,13 +6,14 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 :global(.ui.button).scroll-btn {
   background-color: $teal;
   color: $light-gray;
   position: fixed;
-  bottom: 10px;
-  right: 10px;
+  bottom: px(10);
+  right: px(10);
   opacity: 0;
   z-index: 1001;
   transition: opacity 0.25s ease-in;

--- a/indico/web/client/js/react/components/StickyWithScrollBack.module.scss
+++ b/indico/web/client/js/react/components/StickyWithScrollBack.module.scss
@@ -6,9 +6,10 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .sticky-content {
-  margin-bottom: 10px;
+  margin-bottom: px(10);
 
   > :nth-child(2) {
     z-index: 15;
@@ -16,12 +17,12 @@
   }
 
   &:global(.ui.stuck-container + div) {
-    padding-top: 130px;
+    padding-top: px(130);
   }
 
   :global(.ui.sticky.fixed.top) {
-    padding-top: 30px;
-    box-shadow: rgba($black, 0.2) 0 25px 30px -20px;
+    padding-top: px(30);
+    box-shadow: rgba($black, 0.2) 0 px(25) px(30) px(-20);
     transition: all, 0.25s ease-in;
   }
 }

--- a/indico/web/client/js/react/components/WTFPrincipalField.module.scss
+++ b/indico/web/client/js/react/components/WTFPrincipalField.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .fixed-width {
-  width: 400px;
+  width: px(400);
 }

--- a/indico/web/client/js/react/components/WTFPrincipalListField.module.scss
+++ b/indico/web/client/js/react/components/WTFPrincipalListField.module.scss
@@ -6,8 +6,9 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .opaque {
   background-color: $light-gray;
-  padding: 15px !important;
+  padding: px(15) !important;
 }

--- a/indico/web/client/js/react/components/files/FileArea.module.scss
+++ b/indico/web/client/js/react/components/files/FileArea.module.scss
@@ -5,16 +5,18 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .dropzone-area {
   :global(.ui.segment) {
-    border: 2px dashed #007cac !important;
+    border: px(2) dashed #007cac !important;
   }
 
   .file-card {
     .action {
       position: absolute;
-      top: 3px;
-      right: 2px;
+      top: px(3);
+      right: px(2);
       cursor: pointer;
     }
 
@@ -35,7 +37,7 @@
   }
 
   .file-selection-btn {
-    margin-top: 10px;
+    margin-top: px(10);
     max-width: none !important;
   }
 }

--- a/indico/web/client/js/react/components/principals/PermissionTree.module.scss
+++ b/indico/web/client/js/react/components/principals/PermissionTree.module.scss
@@ -6,12 +6,13 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .permission-tree {
   padding: 0 1em 0.5em 1em;
 
   > .permission-tree {
-    border-left: 3px solid $pastel-gray;
+    border-left: px(3) solid $pastel-gray;
     padding: 0 0 0 0.3em;
     margin: 0 0 0.3em 0.3em;
   }

--- a/indico/web/client/js/react/components/principals/PrincipalListField.module.scss
+++ b/indico/web/client/js/react/components/principals/PrincipalListField.module.scss
@@ -6,10 +6,11 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .list {
   margin-top: 0 !important;
-  max-height: 200px;
+  max-height: px(200);
   overflow-y: scroll;
 }
 

--- a/indico/web/client/js/react/components/principals/Search.module.scss
+++ b/indico/web/client/js/react/components/principals/Search.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .header {
   min-height: 4.55rem;
@@ -54,12 +55,12 @@
 }
 
 .search-results .list {
-  max-height: 490px;
+  max-height: px(490);
   overflow-y: auto;
 }
 
 .has-avatar {
-  margin-left: 8px;
+  margin-left: px(8);
 }
 
 :global(.ui.list .item).result-item:first-child {

--- a/indico/web/client/js/react/components/principals/items.module.scss
+++ b/indico/web/client/js/react/components/principals/items.module.scss
@@ -8,13 +8,14 @@
 @use 'base/palette' as *;
 @use 'base/defaults' as *;
 @use 'base/borders' as *;
+@use 'base/utilities' as *;
 
 .item,
 :global(.ui.list) > .item,
 :global(.ui.list.list) > .item {
   display: flex;
   align-items: center;
-  min-height: 32px;
+  min-height: px(32);
 }
 
 .event-role {
@@ -51,8 +52,8 @@
 }
 
 .loader {
-  margin-right: 5px;
-  margin-bottom: 5px;
+  margin-right: px(5);
+  margin-bottom: px(5);
 }
 
 .actions {

--- a/indico/web/client/js/react/components/style/dates.scss
+++ b/indico/web/client/js/react/components/style/dates.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .ui.form input[type='text'].DateInput_input {
   border: none;
   text-align: center;
@@ -20,7 +22,7 @@
 }
 
 .CalendarMonth_caption {
-  padding-bottom: 42px !important;
+  padding-bottom: px(42) !important;
 }
 
 .DateRangePicker_picker,

--- a/indico/web/client/js/react/components/style/modal.scss
+++ b/indico/web/client/js/react/components/style/modal.scss
@@ -6,10 +6,11 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 $max-modal-height: 70vh;
-$modal-header-height: 60px;
-$modal-footer-height: 60px;
+$modal-header-height: px(60);
+$modal-footer-height: px(60);
 
 .modal-dialog {
   position: fixed;
@@ -20,7 +21,7 @@ $modal-footer-height: 60px;
   outline: none;
   padding: 0;
   width: 80%;
-  max-width: 900px;
+  max-width: px(900);
   max-height: $max-modal-height;
 
   .modal-overflow-container {
@@ -41,7 +42,7 @@ $modal-footer-height: 60px;
     .modal-dialog-header {
       box-sizing: border-box;
       background-color: $light-gray;
-      border-bottom: 1px solid darken($light-gray, 5%);
+      border-bottom: px(1) solid darken($light-gray, 5%);
       padding: 1em;
       height: $modal-header-height;
       width: 100%;
@@ -60,7 +61,7 @@ $modal-footer-height: 60px;
   %modal-dialog-footer {
     box-sizing: border-box;
     background-color: $light-gray;
-    border-top: 1px solid darken($light-gray, 5%);
+    border-top: px(1) solid darken($light-gray, 5%);
     padding: 1em;
     height: $modal-footer-height;
     width: 100%;

--- a/indico/web/client/js/react/components/syncedInputs.module.scss
+++ b/indico/web/client/js/react/components/syncedInputs.module.scss
@@ -7,6 +7,7 @@
 
 @use 'base/palette' as *;
 @use 'base/defaults' as *;
+@use 'base/utilities' as *;
 
 .syncable {
   input[readonly],
@@ -16,9 +17,9 @@
     background: repeating-linear-gradient(
       -40deg,
       lighten($gray, 0.7 * $color-variation),
-      lighten($gray, 0.7 * $color-variation) 10px,
-      lighten($gray, 0.9 * $color-variation) 10px,
-      lighten($gray, 0.9 * $color-variation) 20px
+      lighten($gray, 0.7 * $color-variation) px(10),
+      lighten($gray, 0.9 * $color-variation) px(10),
+      lighten($gray, 0.9 * $color-variation) px(20)
     ) !important;
     font-style: italic;
     color: $light-black !important;

--- a/indico/web/client/js/react/forms/fields.module.scss
+++ b/indico/web/client/js/react/forms/fields.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .field-error {
   color: $red !important;
@@ -28,7 +29,7 @@
   legend {
     font-weight: bold;
     font-size: 1.3em;
-    border-bottom: 1px solid $separator-color;
+    border-bottom: px(1) solid $separator-color;
     width: 100%;
     padding-left: 0;
     padding-bottom: 0.5em;

--- a/indico/web/client/styles/base/_borders.scss
+++ b/indico/web/client/styles/base/_borders.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use './defaults' as *;
+@use 'utilities' as *;
 
 @mixin inner-border-base {
   position: relative;

--- a/indico/web/client/styles/base/_defaults.scss
+++ b/indico/web/client/styles/base/_defaults.scss
@@ -10,23 +10,24 @@
 // -----------------------------------------------------------------------------
 
 @use './palette' as *;
+@use './utilities' as *;
 
-$default-border-radius: 2px;
+$default-border-radius: px(2);
 $default-transition-duration: 0.25s;
 $default-transition-function: ease-out;
 $default-transition-delay: null;
 
 $default-border-color: $pastel-gray;
 $default-border-style: solid;
-$default-border-width: 1px;
+$default-border-width: px(1);
 
 $color-variation: 15%;
 $light-color-variation: 5%;
 
 $default-box-shadow-inset: null;
-$default-box-shadow-h-offset: 1px;
-$default-box-shadow-v-offset: 1px;
-$default-box-shadow-blur: 1px;
+$default-box-shadow-h-offset: px(1);
+$default-box-shadow-v-offset: px(1);
+$default-box-shadow-blur: px(1);
 $default-box-shadow-spread: null;
 $default-box-shadow-color: lighten($gray, $color-variation);
 

--- a/indico/web/client/styles/base/_indicators.scss
+++ b/indico/web/client/styles/base/_indicators.scss
@@ -7,6 +7,7 @@
 
 @use './palette' as *;
 @use './defaults' as *;
+@use './utilities' as *;
 
 @mixin _indicator-base($top) {
   &::after,
@@ -18,12 +19,12 @@
   }
 
   &::after {
-    margin-top: 1px;
-    border-width: 7px;
+    margin-top: px(1);
+    border-width: px(7);
   }
 
   &::before {
-    border-width: 8px;
+    border-width: px(8);
   }
 }
 
@@ -34,22 +35,26 @@
     border-style: solid outset solid;
     content: '';
     position: absolute;
-    top: -15px;
+    top: px(-15);
   }
 
   &::after {
-    margin-top: 1px;
-    border-width: 7px;
+    margin-top: px(1);
+    border-width: px(7);
     border-bottom-color: $background-color;
   }
 
   &::before {
-    border-width: 7px;
+    border-width: px(7);
     border-bottom-color: $border-color;
   }
 }
 
-@mixin indicator-left($background-color: white, $border-color: $default-border-color, $top: 10px) {
+@mixin indicator-left(
+  $background-color: white,
+  $border-color: $default-border-color,
+  $top: px(10)
+) {
   @include _indicator-base($top);
 
   &::after,
@@ -60,7 +65,7 @@
 
   &::after {
     border-right-color: $background-color;
-    margin-left: 2px;
+    margin-left: px(2);
   }
 
   &::before {
@@ -68,7 +73,11 @@
   }
 }
 
-@mixin indicator-right($background-color: white, $border-color: $default-border-color, $top: 10px) {
+@mixin indicator-right(
+  $background-color: white,
+  $border-color: $default-border-color,
+  $top: px(10)
+) {
   @include _indicator-base($top);
 
   &::after,
@@ -79,7 +88,7 @@
 
   &::after {
     border-left-color: $background-color;
-    margin-right: 2px;
+    margin-right: px(2);
   }
 
   &::before {
@@ -90,7 +99,7 @@
 @mixin indicator-top-left(
   $background-color: white,
   $border-color: $default-border-color,
-  $left: 10px
+  $left: px(10)
 ) {
   @include _indicator-top-base($background-color, $border-color);
 
@@ -100,14 +109,14 @@
   }
 
   &::after {
-    margin-right: 2px;
+    margin-right: px(2);
   }
 }
 
 @mixin indicator-top-right(
   $background-color: white,
   $border-color: $default-border-color,
-  $right: 10px
+  $right: px(10)
 ) {
   @include _indicator-top-base($background-color, $border-color);
 

--- a/indico/web/client/styles/base/_layout.scss
+++ b/indico/web/client/styles/base/_layout.scss
@@ -26,7 +26,7 @@ body > * {
 }
 
 .fixed-width {
-  max-width: 800px !important;
+  max-width: px(800) !important;
 }
 
 .full-width-content-wrapper {
@@ -81,19 +81,19 @@ body > * {
 .layout-side-menu {
   @extend .flexrow;
   min-height: 100%;
-  margin-left: 30px;
-  margin-right: 30px;
+  margin-left: px(30);
+  margin-right: px(30);
 
   &:first-of-type {
-    margin-top: 20px;
+    margin-top: px(20);
   }
 
   .banner {
     > .menu-column {
       flex-grow: 0;
-      width: 200px;
-      margin-left: 30px;
-      margin-right: 30px;
+      width: px(200);
+      margin-left: px(30);
+      margin-right: px(30);
     }
 
     > .page-column {
@@ -107,16 +107,16 @@ body > * {
   }
 
   > .menu-column {
-    width: 200px;
-    margin-right: 30px;
+    width: px(200);
+    margin-right: px(30);
 
     .group:first-child {
-      margin-top: 5px;
-      margin-bottom: 23px;
+      margin-top: px(5);
+      margin-bottom: px(23);
 
       a {
         width: 100%;
-        padding: 5px 5px 5px 26px;
+        padding: px(5) px(5) px(5) px(26);
         text-align: left;
 
         span {

--- a/indico/web/client/styles/base/_pages.scss
+++ b/indico/web/client/styles/base/_pages.scss
@@ -9,6 +9,7 @@
 @use './typography' as *;
 @use './layout' as *;
 @use './flex' as *;
+@use './utilities' as *;
 
 @mixin indico-page {
   header {
@@ -34,9 +35,9 @@
 
     .back-button {
       position: absolute;
-      top: 11px;
-      left: -20px;
-      font-size: 15px;
+      top: px(11);
+      left: px(-20);
+      font-size: px(15);
       color: $pastel-gray;
 
       &:hover {
@@ -49,7 +50,7 @@
       align-items: flex-start;
       padding-top: 0.4rem;
       min-height: 2rem;
-      border-bottom: 1px solid $separator-color;
+      border-bottom: px(1) solid $separator-color;
       margin-bottom: 1rem;
 
       > .text {
@@ -106,11 +107,11 @@
   $banner-color: #000;
   $banner-title-color: $dark-orange;
   $banner-subtitle-color: $dark-gray;
-  $banner-title-margin: 19px;
+  $banner-title-margin: px(19);
 
   color: $banner-color;
-  max-width: 800px;
-  margin-top: 10px;
+  max-width: px(800);
+  margin-top: px(10);
 
   &.full-width {
     max-width: none;
@@ -140,7 +141,7 @@
       font-size: 0.5em;
 
       a {
-        border-bottom: 1px dashed;
+        border-bottom: px(1) dashed;
       }
     }
 
@@ -155,7 +156,7 @@
 .dialog-page {
   @include indico-page();
 
-  max-width: 800px;
+  max-width: px(800);
 }
 
 .management-page {
@@ -167,7 +168,7 @@
 
   &.wide {
     .page-content {
-      max-width: 1000px !important;
+      max-width: px(1000) !important;
     }
   }
 }
@@ -177,10 +178,10 @@
 
   margin-left: auto;
   margin-right: auto;
-  width: 1000px;
+  width: px(1000);
 
   .page-content {
-    max-width: 1000px;
+    max-width: px(1000);
   }
 }
 
@@ -190,10 +191,10 @@
   // which is rather small
   @extend .fixed-width-standalone-page;
 
-  width: 800px;
+  width: px(800);
 
   .page-content {
-    max-width: 800px;
+    max-width: px(800);
     font-size: 1.2em;
 
     p:first-child {
@@ -211,7 +212,7 @@
 
   header h2 {
     color: $dark-orange;
-    padding-right: 5px;
+    padding-right: px(5);
 
     .track-name {
       font-style: italic;
@@ -220,7 +221,7 @@
 }
 
 .meeting-header {
-  max-width: 800px;
+  max-width: px(800);
   margin: 2em auto 0 auto;
 
   h1 {
@@ -230,18 +231,18 @@
 
 .meeting-page {
   @include indico-page();
-  max-width: 800px;
+  max-width: px(800);
   margin: 2em auto 0 auto;
 }
 
 .event-wrapper {
-  width: 1000px;
-  margin: 30px auto;
-  margin-top: 18px;
+  width: px(1000);
+  margin: px(30) auto;
+  margin-top: px(18);
 }
 
 .conference-title-link {
-  font-size: 33px;
+  font-size: px(33);
   background: transparent;
   color: white;
 }

--- a/indico/web/client/styles/base/_typography.scss
+++ b/indico/web/client/styles/base/_typography.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use './palette' as *;
+@use './utilities' as *;
 
 @mixin font-family-body {
   font-family: 'Liberation Sans', sans-serif;
@@ -52,7 +53,7 @@
 }
 
 @mixin font-size-body {
-  font-size: 13px;
+  font-size: px(13);
 }
 
 html,
@@ -137,7 +138,7 @@ pre {
 }
 
 .group-title {
-  border-bottom: 2px solid #eaeaea;
+  border-bottom: px(2) solid #eaeaea;
   display: block;
   font-size: 2em;
   font-weight: normal;
@@ -155,11 +156,11 @@ pre {
   display: block;
   width: 100%;
   font-family: 'Helvetica Neue', Helvetica, Verdana, Arial, sans-serif;
-  font-size: 24px;
+  font-size: px(24);
   font-weight: normal;
   color: #4a4a4a;
-  padding: 3px 3px 5px 3px;
-  border-bottom: 1px solid #aaa;
+  padding: px(3) px(3) px(5) px(3);
+  border-bottom: px(1) solid #aaa;
   margin-bottom: 1em;
 }
 
@@ -180,9 +181,9 @@ td.groupSubTitle {
   font-family: 'Times New Roman', Verdana, Arial, sans-serif;
   font-size: 15pt;
   color: #4e4c46;
-  letter-spacing: 1px;
-  padding: 3px;
-  margin: 10px 0;
+  letter-spacing: px(1);
+  padding: px(3);
+  margin: px(10) 0;
 }
 
 .groupTitleNoBorder {
@@ -190,10 +191,10 @@ td.groupSubTitle {
 }
 
 .quotation {
-  margin: 10px;
-  padding-left: 10px;
+  margin: px(10);
+  padding-left: px(10);
   color: #777;
-  border-left: 4px solid #ddd;
+  border-left: px(4) solid #ddd;
 }
 
 /* Quick rules */
@@ -257,7 +258,7 @@ td.groupSubTitle {
 
 a.small-link {
   color: $light-black;
-  font-size: 11px;
+  font-size: px(11);
 }
 
 .mono,

--- a/indico/web/client/styles/base/_utilities.scss
+++ b/indico/web/client/styles/base/_utilities.scss
@@ -7,6 +7,10 @@
 
 @use 'partials/icons' as *;
 
+@function px($length) {
+  @return $length * 1px;
+}
+
 @mixin adjacent-icon {
   font-family: 'icomoon-ultimate';
   font-style: normal;

--- a/indico/web/client/styles/ckeditor.scss
+++ b/indico/web/client/styles/ckeditor.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .ck {
   height: auto;
   width: auto;
@@ -65,9 +67,9 @@
 
   // Nicer quote & code formatting
   blockquote {
-    padding: 5px 8px 5px 30px;
+    padding: px(5) px(8) px(5) px(30);
     background-color: rgba(102, 128, 153, 0.05);
-    border-left: 10px solid #d6dbdf;
+    border-left: px(10) solid #d6dbdf;
   }
 
   pre,

--- a/indico/web/client/styles/custom/_dropzone.scss
+++ b/indico/web/client/styles/custom/_dropzone.scss
@@ -13,24 +13,24 @@ $dropzone-padding: 20;
 $dropzone-border-width: 2;
 
 .dropzone {
-  border-radius: 2px;
-  border: 2px dashed $dark-blue;
-  padding: 30px 20px;
+  border-radius: px(2);
+  border: px(2) dashed $dark-blue;
+  padding: px(30) px(20);
   margin-bottom: 3em;
   width: (
       ($dropzone-padding + $dropzone-border-width) * 2 +
         ($image-preview-width + ($image-preview-margin * 2)) * 5
-    ) * 1px;
+    ) * px(1);
   cursor: pointer;
 
   .dz-preview.dz-file-preview .dz-image,
   .dz-preview .dz-image {
-    border-radius: 5px;
+    border-radius: px(5);
 
     > img {
       object-fit: cover;
-      width: 120px;
-      height: 120px;
+      width: px(120);
+      height: px(120);
     }
   }
 
@@ -68,7 +68,7 @@ $dropzone-border-width: 2;
   .dropzone {
     padding: 0;
     margin-bottom: 1em;
-    width: 400px;
+    width: px(400);
     display: table;
 
     .dropzone-inner {
@@ -89,7 +89,7 @@ $dropzone-border-width: 2;
         text-align: center;
 
         button {
-          margin: $image-preview-margin * 1px;
+          margin: $image-preview-margin * px(1);
           height: inherit;
         }
       }
@@ -100,7 +100,7 @@ $dropzone-border-width: 2;
 
       .dropzone-inner {
         display: block;
-        padding: 10px;
+        padding: px(10);
       }
 
       .dropzone-previews {
@@ -111,7 +111,7 @@ $dropzone-border-width: 2;
       .dz-preview {
         display: flex;
         min-height: inherit;
-        margin: 0 0 5px 0;
+        margin: 0 0 px(5) 0;
 
         &:hover {
           @include transition(background-color 0.2s);
@@ -129,14 +129,14 @@ $dropzone-border-width: 2;
         position: inherit;
         flex-grow: 1;
         cursor: inherit;
-        width: 300px;
+        width: px(300);
       }
 
       .select-files-btn {
         display: block;
 
         button {
-          margin: 5px 0 0 0;
+          margin: px(5) 0 0 0;
         }
       }
 
@@ -167,7 +167,7 @@ $dropzone-border-width: 2;
       }
 
       .dz-remove {
-        margin-left: 5px;
+        margin-left: px(5);
         color: $link;
 
         i::before {

--- a/indico/web/client/styles/custom/_jquery-multiselect.scss
+++ b/indico/web/client/styles/custom/_jquery-multiselect.scss
@@ -5,9 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .ui-multiselect-widget {
   background: none repeat scroll 0 0 #fafafa;
-  border: 1px solid #dadada;
+  border: px(1) solid #dadada;
 }
 
 .ui-multiselect-checkboxes {

--- a/indico/web/client/styles/custom/_jquery-ui-datepicker.scss
+++ b/indico/web/client/styles/custom/_jquery-ui-datepicker.scss
@@ -24,7 +24,7 @@
     .ui-datepicker-month,
     .ui-datepicker-year {
       width: 48%;
-      margin: 0 1px;
+      margin: 0 px(1);
     }
 
     .ui-datepicker-prev,
@@ -35,7 +35,7 @@
       color: $gray;
       margin-top: 0.1em;
       text-align: center;
-      top: 1px !important;
+      top: px(1) !important;
 
       &::before {
         vertical-align: -30%;
@@ -60,12 +60,12 @@
 
     .ui-datepicker-prev {
       @include icon-before('icon-prev');
-      left: 3px !important;
+      left: px(3) !important;
     }
 
     .ui-datepicker-next {
       @include icon-before('icon-next');
-      right: 3px !important;
+      right: px(3) !important;
     }
 
     .ui-icon {
@@ -88,7 +88,7 @@
       a,
       span {
         @include transition(background);
-        border: 1px solid white;
+        border: px(1) solid white;
         text-align: center;
       }
     }
@@ -123,7 +123,7 @@
       border: none !important;
       float: right;
       margin-bottom: 0.2em;
-      margin-right: 1px;
+      margin-right: px(1);
       margin-top: 0.2em;
       opacity: 1;
       outline: none;
@@ -149,8 +149,8 @@
   outline: none;
   padding: 0;
   position: relative;
-  right: 20px;
-  top: 2px;
+  right: px(20);
+  top: px(2);
 
   &:hover::before {
     color: $blue;
@@ -163,8 +163,8 @@
 
 input.hasDatepicker {
   @include icon-before('icon-calendar');
-  margin: 0 2px;
-  padding-right: 22px !important;
+  margin: 0 px(2);
+  padding-right: px(22) !important;
 
   &:disabled + button {
     pointer-events: none;

--- a/indico/web/client/styles/custom/_jquery-ui.scss
+++ b/indico/web/client/styles/custom/_jquery-ui.scss
@@ -23,7 +23,7 @@
 }
 
 .ui-dialog {
-  box-shadow: 0 0 24px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 0 px(24) rgba(0, 0, 0, 0.3);
 }
 
 .ui-dialog .dropdown .menu {

--- a/indico/web/client/styles/legacy/Conf_Basic.scss
+++ b/indico/web/client/styles/legacy/Conf_Basic.scss
@@ -14,6 +14,8 @@
 
 /*     this is the wrapper of whole conference page */
 
+@use 'base/utilities' as *;
+
 .conf {
   width: 100%;
   border: none;
@@ -35,19 +37,19 @@
 .confLogoBox {
   height: 100%;
   float: left;
-  padding-right: 10px;
+  padding-right: px(10);
   background: transparent none repeat scroll 0 0;
 }
 
 .confTitleBox {
   color: white;
-  min-height: 90px;
+  min-height: px(90);
   text-align: left;
   background: #1a64a0;
 }
 
 .confTitle {
-  width: 950px;
+  width: px(950);
   margin: 0 auto;
 }
 
@@ -59,14 +61,14 @@
 .conference-title-link {
   font-size: 22pt;
   display: block;
-  padding: 25px 0;
+  padding: px(25) 0;
   color: white;
 }
 
 .confSubTitleBox {
   background: #f5faff;
-  border-bottom: 1px solid #d5e4f1;
-  border-top: 1px solid #d5e4f1;
+  border-bottom: px(1) solid #d5e4f1;
+  border-top: px(1) solid #d5e4f1;
   padding: 0.5rem 0;
 }
 
@@ -75,7 +77,7 @@
 }
 
 .confSubTitleContent {
-  width: 950px;
+  width: px(950);
   margin: 0 auto;
   font-size: 11pt;
   color: #24425a;
@@ -90,7 +92,7 @@
 }
 
 div.datePlace > div.timezone {
-  font-size: 12px;
+  font-size: px(12);
   color: #777;
 }
 
@@ -105,7 +107,7 @@ div.event-details {
   }
 
   .event-details-label {
-    width: 120px;
+    width: px(120);
     text-align: right;
     font-weight: bold;
     margin-right: 1em;
@@ -123,9 +125,9 @@ div.event-details {
 /* ------Main content------ */
 
 #confSectionsBox {
-  width: 950px;
+  width: px(950);
   margin: 0 auto;
-  margin-top: 30px;
+  margin-top: px(30);
 }
 
 /* ------Menu------ */
@@ -139,7 +141,7 @@ div.event-details {
   position: relative;
   background: #f6f6f6;
 
-  border: 1px solid #ccc;
+  border: px(1) solid #ccc;
 
   list-style-image: none;
   list-style-position: outside;
@@ -170,7 +172,7 @@ div.event-details {
 
 .conf_leftMenu {
   float: left;
-  width: 200px;
+  width: px(200);
   background: transparent none repeat scroll 0 0;
 }
 
@@ -180,7 +182,7 @@ div.event-details {
 
 .menuConfTitle a {
   color: #275c86;
-  padding: 7px 12px;
+  padding: px(7) px(12);
 }
 
 /* sub menu item */
@@ -194,7 +196,7 @@ li.menuConfMiddleCell {
 }
 
 li.menuConfMiddleCell a {
-  padding: 0 0 0 30px;
+  padding: 0 0 0 px(30);
 }
 
 /* selected menu item */
@@ -203,8 +205,8 @@ li.menuConfMiddleCell a {
 .menuConfMiddleCellSelected {
   color: #bd891a;
   background: #dadada;
-  border-bottom: 1px solid #d0d0d0;
-  border-top: 1px solid #d0d0d0;
+  border-bottom: px(1) solid #d0d0d0;
+  border-top: px(1) solid #d0d0d0;
 }
 
 .menuConfBottomCell {
@@ -225,7 +227,7 @@ li.menuConfMiddleCell a {
   list-style-image: none;
   list-style-position: outside;
   list-style-type: none;
-  margin: 0 0 5px 0;
+  margin: 0 0 px(5) 0;
   padding: 0;
   width: 100%;
 }
@@ -249,8 +251,8 @@ li.menuConfMiddleCell a {
 /* End */
 
 li ul.inner li a {
-  padding: 3px 12px 3px 30px;
-  background: transparent url(/images/conf/left_menu_bullet.png) scroll no-repeat 15px center;
+  padding: px(3) px(12) px(3) px(30);
+  background: transparent url(/images/conf/left_menu_bullet.png) scroll no-repeat px(15) center;
 } /* Sub Menu Styles */
 
 li:hover ul,
@@ -263,7 +265,7 @@ li.over ul {
 /* wrapper of content and bradcrumps */
 
 .confBodyBox {
-  margin-left: 230px;
+  margin-left: px(230);
   background: transparent none repeat scroll 0 0;
 }
 
@@ -296,7 +298,7 @@ table.conferenceDetails .displayField {
   text-align: left;
   font-weight: bold;
   font-size: 10pt;
-  padding-right: 20px;
+  padding-right: px(20);
   color: #444;
 }
 
@@ -317,9 +319,9 @@ pre {
 }
 
 .simpleTextAnnouncement {
-  background: #f5faff url(static:images/conf/sprites_blue.png) repeat-x scroll 0 -400px;
-  border-top: 1px solid #c2d6e7;
-  padding: 8px 0;
+  background: #f5faff url(static:images/conf/sprites_blue.png) repeat-x scroll 0 px(-400);
+  border-top: px(1) solid #c2d6e7;
+  padding: px(8) 0;
   font-family: Verdana, sans-serif;
   font-weight: bold;
   font-size: 10pt;
@@ -340,24 +342,24 @@ ul.chair_list {
 }
 
 .support_box {
-  margin-top: 10px !important;
+  margin-top: px(10) !important;
   width: 100%;
   color: #aaa;
   background: #f6f6f6;
-  border: 1px solid #ccc;
+  border: px(1) solid #ccc;
 }
 
 .support_box > h3 {
   color: #f3f3f3;
   background: #1a64a0;
-  margin: 0 0 5px 0;
-  padding: 5px;
+  margin: 0 0 px(5) 0;
+  padding: px(5);
   font-weight: normal;
 }
 
 .support_box > ul > li {
   white-space: nowrap;
-  margin: 0 5px 5px 10px;
+  margin: 0 px(5) px(5) px(10);
   vertical-align: middle;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -370,7 +372,7 @@ ul.chair_list {
 }
 
 .support_box > ul > li > a {
-  margin-left: 5px;
+  margin-left: px(5);
   line-height: 1.5em;
   vertical-align: middle;
   min-width: 0;

--- a/indico/web/client/styles/modules/_admin.scss
+++ b/indico/web/client/styles/modules/_admin.scss
@@ -9,7 +9,7 @@
 
 .code {
   @include default-border-radius();
-  border: 1px solid $gray;
+  border: px(1) solid $gray;
   background: $light-gray;
   padding: 1em 1.5em;
 }

--- a/indico/web/client/styles/modules/_agreements.scss
+++ b/indico/web/client/styles/modules/_agreements.scss
@@ -14,10 +14,10 @@
   margin-bottom: 1em;
 
   .i-box.info-body {
-    padding: 20px 10px;
+    padding: px(20) px(10);
 
     .info-section {
-      padding: 0 20px;
+      padding: 0 px(20);
     }
 
     .info-person {
@@ -93,7 +93,7 @@
 
   .legal-body {
     @extend .text-paper;
-    padding: 10px 10em;
+    padding: px(10) 10em;
   }
 
   .legal-confirmation {
@@ -146,10 +146,10 @@
     width: 100%;
 
     td {
-      padding: 0.35rem 5px 0.35rem 0;
+      padding: 0.35rem px(5) 0.35rem 0;
 
       &:first-child {
-        padding-left: 5px;
+        padding-left: px(5);
       }
 
       &.agreement-checkbox,
@@ -157,7 +157,7 @@
         width: 1%;
 
         i {
-          margin: 4px;
+          margin: px(4);
 
           &.icon-disable {
             color: $red;
@@ -180,7 +180,7 @@
 
       &.agreement-actions {
         font-size: 1.2em;
-        padding: 0 5px;
+        padding: 0 px(5);
         width: 7%;
         white-space: nowrap;
 

--- a/indico/web/client/styles/modules/_attachments.scss
+++ b/indico/web/client/styles/modules/_attachments.scss
@@ -18,7 +18,7 @@
 
   font-size: 0.8rem;
 
-  width: 1px;
+  width: px(1);
 
   white-space: nowrap;
 }
@@ -34,7 +34,7 @@
 }
 
 .attachment-editor {
-  width: 800px;
+  width: px(800);
 }
 
 .dialog-window .attachments-container {
@@ -56,7 +56,7 @@
       &:first-child {
         @include ellipsis();
 
-        max-width: 1px;
+        max-width: px(1);
 
         &::before {
           display: inline-block;
@@ -186,8 +186,8 @@
 
       > td {
         &:first-child {
-          border-top-left-radius: 2px;
-          border-bottom-left-radius: 2px;
+          border-top-left-radius: px(2);
+          border-bottom-left-radius: px(2);
 
           font-weight: bold;
 
@@ -205,7 +205,7 @@
         }
 
         &:last-child {
-          border-top-right-radius: 2px;
+          border-top-right-radius: px(2);
         }
       }
 
@@ -224,7 +224,7 @@
       }
 
       > div > .tree {
-        border-radius: 2px;
+        border-radius: px(2);
 
         background-color: $light-gray;
 
@@ -243,7 +243,7 @@
 }
 
 @mixin protected-colors {
-  border-bottom: 2px solid $red;
+  border-bottom: px(2) solid $red;
 
   &:hover::before {
     color: $red !important;
@@ -279,7 +279,7 @@
 }
 
 .attachments-box {
-  padding: 5px;
+  padding: px(5);
 
   > .attachments-box-header {
     > * {
@@ -309,11 +309,11 @@
 }
 
 .category-sidebar > .attachments-box > .attachments-box-header {
-  margin-top: 20px;
+  margin-top: px(20);
   padding-bottom: 0.2em;
 
-  border-bottom: 1px solid #ebebeb;
-  box-shadow: 0 1px 0 #fafafa;
+  border-bottom: px(1) solid #ebebeb;
+  box-shadow: 0 px(1) 0 #fafafa;
 
   > h2 {
     padding-bottom: 0;
@@ -334,7 +334,7 @@
     margin: 0 !important;
   }
   padding-bottom: 0.5em;
-  border-bottom: 1px solid darken($light-gray, 10%);
+  border-bottom: px(1) solid darken($light-gray, 10%);
 }
 
 .inline-attachments-icon {
@@ -354,7 +354,7 @@
   .folder .attachment {
     @include ellipsis();
 
-    max-width: 150px;
+    max-width: px(150);
     padding-left: 0.2em !important;
 
     .title {
@@ -402,7 +402,7 @@
       padding: 0.1em 0.2em !important;
 
       .attachment {
-        max-width: 250px;
+        max-width: px(250);
 
         &.is-protected {
           color: $red;
@@ -414,7 +414,7 @@
 
 .folder-main,
 div.main > .attachments-package {
-  max-width: 1024px;
+  max-width: px(1024);
   margin: auto;
   margin-top: 2em;
   padding: 2em;
@@ -428,7 +428,7 @@ div.main > .attachments-package {
   width: 100%;
   background-color: $black;
   color: white;
-  padding: 10px;
+  padding: px(10);
   z-index: 10;
   box-sizing: border-box;
   align-items: center;
@@ -473,7 +473,7 @@ div.main > .attachments-package {
       height: auto;
       width: 100%;
       position: absolute;
-      top: 50px;
+      top: px(50);
       bottom: 0;
 
       .attachment-preview-content {
@@ -495,7 +495,7 @@ div.main > .attachments-package {
           left: 0;
           right: 0;
           height: 100%;
-          width: 900px;
+          width: px(900);
         }
 
         > .text-preview-content {
@@ -529,7 +529,7 @@ div.main > .attachments-package {
 }
 
 form#attachment-upload-form.full-width .dropzone {
-  width: 770px;
+  width: px(770);
 
   .select-files-btn,
   .dropzone-previews {

--- a/indico/web/client/styles/modules/_auth.scss
+++ b/indico/web/client/styles/modules/_auth.scss
@@ -26,25 +26,25 @@
 
     .centered-column-wrapper {
       margin: auto;
-      width: 800px;
+      width: px(800);
 
       // stylelint-disable-next-line scss/media-feature-value-dollar-variable
-      @media (max-width: 800px) {
-        width: 400px;
+      @media (max-width: px(800)) {
+        width: px(400);
       }
 
       .centered-column {
-        width: 300px;
-        margin: 100px auto;
+        width: px(300);
+        margin: px(100) auto;
 
         &.wide {
-          width: 500px;
+          width: px(500);
         }
       }
 
       .header-logo {
-        margin-bottom: 20px;
-        height: 100px;
+        margin-bottom: px(20);
+        height: px(100);
       }
 
       .footer {
@@ -57,7 +57,7 @@
   }
 
   form {
-    margin-bottom: 10px;
+    margin-bottom: px(10);
   }
 
   @mixin login-form-button() {
@@ -65,7 +65,7 @@
     height: 2.5em;
     padding: 0.5em 1em;
     line-height: 1.5;
-    margin-bottom: 10px;
+    margin-bottom: px(10);
     position: relative;
 
     &:last-of-type {
@@ -84,8 +84,8 @@
     line-height: 1.5;
     width: 100%;
     color: #555;
-    border: 1px solid #bbb;
-    margin-top: -1px;
+    border: px(1) solid #bbb;
+    margin-top: px(-1);
 
     &:first-of-type {
       border-top-right-radius: 0.2em;
@@ -100,7 +100,7 @@
   }
 
   .login-providers {
-    margin-top: 20px;
+    margin-top: px(20);
 
     .i-button {
       @include login-form-button();
@@ -147,7 +147,7 @@
   .titled-rule {
     color: $gray;
     font-size: 1em;
-    margin: 20px 0;
+    margin: px(20) 0;
 
     &::before,
     &::after {
@@ -157,12 +157,12 @@
 
   .link {
     text-align: left;
-    margin-top: 20px;
+    margin-top: px(20);
   }
 
   .forgot-my-password {
     text-align: right;
-    margin-top: 10px;
+    margin-top: px(10);
   }
 
   .register {
@@ -189,7 +189,7 @@
   font-size: 1.1em;
 
   .row {
-    padding: 20px;
+    padding: px(20);
 
     & + .row {
       padding-top: 0;
@@ -198,7 +198,7 @@
 }
 
 .auth-stakeholder-info {
-  width: 120px;
+  width: px(120);
 
   i {
     font-size: 4em;

--- a/indico/web/client/styles/modules/_bootstrap.scss
+++ b/indico/web/client/styles/modules/_bootstrap.scss
@@ -19,15 +19,15 @@
   display: block;
 
   width: 100%;
-  height: 350px;
-  padding-top: 20px;
+  height: px(350);
+  padding-top: px(20);
 
   text-align: center;
 
-  border-bottom: 5px solid white;
+  border-bottom: px(5) solid white;
   background-color: $darker-blue;
   background-repeat: no-repeat;
-  background-position: 20px 20px;
+  background-position: px(20) px(20);
 
   .header-logo {
     height: 50%;
@@ -38,7 +38,7 @@
   .header-title {
     @include font-family-logo();
 
-    font-size: 54px;
+    font-size: px(54);
 
     color: $pastel-blue;
   }
@@ -46,7 +46,7 @@
   .header-subtitle {
     @include font-family-logo();
 
-    font-size: 26px;
+    font-size: px(26);
 
     color: white;
   }
@@ -55,7 +55,7 @@
     position: fixed;
     top: 0;
 
-    height: 120px;
+    height: px(120);
 
     text-align: left;
 
@@ -63,21 +63,21 @@
       float: left;
 
       height: 75%;
-      margin-left: 50px;
-      padding-right: 30px;
+      margin-left: px(50);
+      padding-right: px(30);
     }
   }
 
   .language-selector {
     position: fixed;
     z-index: 1;
-    top: 10px;
-    right: 10px;
+    top: px(10);
+    right: px(10);
 
     padding: 0;
 
     .i-button.arrow {
-      width: 102px;
+      width: px(102);
 
       color: darken(white, 10%) !important;
       border: 0;
@@ -88,7 +88,7 @@
     }
 
     .i-dropdown {
-      width: 200px;
+      width: px(200);
 
       text-align: left;
     }
@@ -108,32 +108,32 @@
   @include font-family-form();
 
   width: 100%;
-  min-width: 800px;
-  max-width: 1140px;
+  min-width: px(800);
+  max-width: px(1140);
   margin-right: auto;
   margin-left: auto;
-  padding-top: 30px;
-  padding-bottom: 50px;
+  padding-top: px(30);
+  padding-bottom: px(50);
 
-  border-left: 3px $darker-blue solid;
+  border-left: px(3) $darker-blue solid;
   background: white;
   // stylelint-disable-next-line scss/media-feature-value-dollar-variable
-  @media only screen and (min-width: 481px) and (max-width: 768px) {
-    min-width: 480px;
-    max-width: 492px;
+  @media only screen and (min-width: px(481)) and (max-width: px(768)) {
+    min-width: px(480);
+    max-width: px(492);
   }
   // stylelint-disable-next-line scss/media-feature-value-dollar-variable
-  @media only screen and (min-width: 769px) and (max-width: 1024px) {
-    min-width: 600px;
-    max-width: 680px;
+  @media only screen and (min-width: px(769)) and (max-width: px(1024)) {
+    min-width: px(600);
+    max-width: px(680);
   }
   // stylelint-disable-next-line scss/media-feature-value-dollar-variable
-  @media only screen and (min-width: 1025px) and (max-width: 1230px) {
-    max-width: 937px;
+  @media only screen and (min-width: px(1025)) and (max-width: px(1230)) {
+    max-width: px(937);
   }
 
   &.mini {
-    margin-top: 120px;
+    margin-top: px(120);
   }
 
   #flashed-messages {
@@ -148,7 +148,7 @@
 
     .step-wrapper {
       width: 100%;
-      padding-top: 75px;
+      padding-top: px(75);
 
       color: $black;
 
@@ -161,23 +161,23 @@
 
         float: left;
 
-        width: 100px;
-        height: 100px;
+        width: px(100);
+        height: px(100);
         margin-top: 1em;
-        margin-left: -50px;
+        margin-left: px(-50);
         padding: 0;
 
-        border: 5px solid white;
+        border: px(5) solid white;
         border-radius: 50%;
         background-color: $darker-blue;
 
         i {
-          font-size: 50px;
+          font-size: px(50);
 
           position: relative;
           z-index: 0;
-          top: 20px;
-          left: 20px;
+          top: px(20);
+          left: px(20);
 
           color: white;
         }
@@ -232,7 +232,7 @@
 
           > .warning-message-box {
             margin-left: 1.2em;
-            width: 400px;
+            width: px(400);
           }
         }
 

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -9,11 +9,11 @@
 @use 'partials/buttons' as *;
 
 .confirmation-dialog .body ul.categ-list {
-  padding-left: 13px;
+  padding-left: px(13);
   margin: 0;
 
   span.event-date {
-    padding-left: 10px;
+    padding-left: px(10);
     color: #888;
     font-size: 0.9em;
     margin: 0;
@@ -27,15 +27,15 @@
 .category-container {
   font-family: 'Helvetica Neue', Helvetica, Verdana, Arial, sans-serif;
   background: #fff;
-  margin-bottom: 10px;
+  margin-bottom: px(10);
   overflow: hidden;
 }
 
 .category-header {
   background-image: linear-gradient(to bottom, #fcfcfc, #f2f2f2);
-  border-bottom: 1px solid #e6e6e6;
-  border-top: 1px solid #fff;
-  padding: 20px;
+  border-bottom: px(1) solid #e6e6e6;
+  border-top: px(1) solid #fff;
+  padding: px(20);
   line-height: initial;
 
   .back-button {
@@ -48,7 +48,7 @@
   color: $dark-orange;
   font-weight: normal;
   margin: auto;
-  max-width: 850px;
+  max-width: px(850);
   margin-left: 0;
   text-align: left;
 
@@ -64,7 +64,7 @@
 }
 
 .category-stats-container {
-  padding-top: 40px;
+  padding-top: px(40);
 
   .ui.segments > .segment {
     width: 50%;
@@ -77,7 +77,7 @@
 
 .category-content {
   width: 100%;
-  max-width: 850px;
+  max-width: px(850);
   padding: 0 1em 0 0;
   margin: auto;
 }
@@ -96,7 +96,7 @@
 }
 
 .category-statistics {
-  max-width: 1600px;
+  max-width: px(1600);
 
   .i-box {
     margin-left: 0.8em;
@@ -115,7 +115,7 @@
       display: inline-block;
 
       width: 96%;
-      height: 350px;
+      height: px(350);
       padding: 2% 2% 0 2%;
     }
   }
@@ -129,22 +129,22 @@
   box-sizing: border-box;
   background: #fafafa;
   background-image: linear-gradient(to bottom, #fafafa 95%, #fff 100%);
-  border-left: 1px solid #f2f2f2;
+  border-left: px(1) solid #f2f2f2;
   color: #666;
   float: right;
   height: 100%;
   padding: 1em;
-  width: 340px;
+  width: px(340);
 
   &:empty {
     padding: 0;
   }
 
   > .title {
-    border-bottom: 1px solid #ebebeb;
-    box-shadow: 0 1px 0 #fafafa;
-    margin-top: 20px;
-    margin-bottom: 10px;
+    border-bottom: px(1) solid #ebebeb;
+    box-shadow: 0 px(1) 0 #fafafa;
+    margin-top: px(20);
+    margin-bottom: px(10);
     padding-bottom: 0.2em;
     display: flex;
     align-items: center;
@@ -236,7 +236,7 @@
       display: block;
       margin-top: 0.2em;
       color: #777;
-      text-shadow: 1px 1px 0 #fefefe;
+      text-shadow: px(1) px(1) 0 #fefefe;
     }
   }
 }
@@ -256,8 +256,8 @@ ul.category-list {
   list-style-type: none;
   padding: 0;
 
-  border-left: 1px solid #fafafa;
-  border-right: 1px solid #e6e6e6;
+  border-left: px(1) solid #fafafa;
+  border-right: px(1) solid #e6e6e6;
 
   li {
     @include transition(color);
@@ -272,8 +272,8 @@ ul.category-list {
     color: #b3b3b3;
     cursor: pointer;
 
-    border-top: 1px solid #fafafa;
-    border-bottom: 1px solid #e6e6e6;
+    border-top: px(1) solid #fafafa;
+    border-bottom: px(1) solid #e6e6e6;
 
     .number-events {
       float: right;
@@ -330,8 +330,8 @@ ul.category-resource-qtip {
   padding-left: 0;
   margin: 0;
   color: #888;
-  font-size: 11px;
-  line-height: 15px;
+  font-size: px(11);
+  line-height: px(15);
 }
 
 #eventCreationForm {
@@ -344,30 +344,30 @@ ul.category-resource-qtip {
 
 .event-list {
   h3 {
-    font-size: 26px;
+    font-size: px(26);
     color: #999;
-    margin: 20px 10px;
+    margin: px(20) px(10);
     padding: 0;
   }
 
   h4 {
     color: #555;
     font-weight: normal;
-    font-size: 18px;
-    margin-top: 20px;
-    margin-left: 40px;
+    font-size: px(18);
+    margin-top: px(20);
+    margin-left: px(40);
     padding: 0;
-    border-bottom: 1px solid #ebebeb;
+    border-bottom: px(1) solid #ebebeb;
 
     &.current-month {
-      border-bottom: 1px solid #aaa;
+      border-bottom: px(1) solid #aaa;
 
       span {
-        padding: 5px 5px 0 5px;
+        padding: px(5) px(5) 0 px(5);
         color: #2f2506;
         background-color: #f6e8bd;
-        border-radius: 5px 5px 0 0;
-        border-bottom: 1px solid #aaa;
+        border-radius: px(5) px(5) 0 0;
+        border-bottom: px(1) solid #aaa;
       }
     }
   }
@@ -380,7 +380,7 @@ ul.category-resource-qtip {
   }
 
   li {
-    margin: 0 0 10px 60px;
+    margin: 0 0 px(10) px(60);
     padding: 0;
     display: flex;
     align-items: baseline;
@@ -391,20 +391,20 @@ ul.category-resource-qtip {
     }
 
     .date {
-      padding: 5px;
-      margin-right: 10px;
-      font-size: 13px;
+      padding: px(5);
+      margin-right: px(10);
+      font-size: px(13);
       color: #444;
       flex-shrink: 0;
     }
 
     .event-icons {
-      padding: 0 15px;
+      padding: 0 px(15);
       font-size: 1.2em;
       white-space: nowrap;
       color: $dark-gray;
-      max-width: 56px;
-      min-width: 56px;
+      max-width: px(56);
+      min-width: px(56);
 
       a,
       a:hover {
@@ -413,14 +413,14 @@ ul.category-resource-qtip {
     }
 
     .list-name a {
-      font-size: 17px;
+      font-size: px(17);
     }
 
     .today {
-      font-size: 13px;
+      font-size: px(13);
       color: #444;
       background-color: #f6e8bd;
-      border-radius: 5px;
+      border-radius: px(5);
     }
 
     .protected {
@@ -435,20 +435,20 @@ ul.category-resource-qtip {
 }
 
 .category-overview {
-  width: calc(100vw - 300px);
+  width: calc(100vw - #{px(300)});
 
   > .title {
-    height: 30px;
+    height: px(30);
 
     .text {
       font-size: 1.2em;
       font-style: italic;
-      margin-left: 5px;
-      margin-right: 5px;
+      margin-left: px(5);
+      margin-right: px(5);
     }
 
     .navigation a {
-      padding: 5px;
+      padding: px(5);
     }
   }
 
@@ -457,9 +457,9 @@ ul.category-resource-qtip {
     overflow-x: auto;
 
     > table:not(.day) {
-      border: 1px solid #aaa;
+      border: px(1) solid #aaa;
       border-collapse: separate;
-      border-spacing: 1px;
+      border-spacing: px(1);
 
       tr {
         background-color: #eee;
@@ -476,7 +476,7 @@ ul.category-resource-qtip {
         text-align: center;
         font-weight: normal;
         white-space: nowrap;
-        padding: 1px 15px;
+        padding: px(1) px(15);
       }
     }
 
@@ -486,10 +486,10 @@ ul.category-resource-qtip {
 
       &.day {
         vertical-align: top;
-        padding: 5px;
+        padding: px(5);
 
         &:not(:empty) {
-          min-width: 180px;
+          min-width: px(180);
         }
 
         > .calendar-date {
@@ -510,7 +510,7 @@ ul.category-resource-qtip {
               font-size: inherit;
 
               &.content-info {
-                padding-left: 10px;
+                padding-left: px(10);
               }
 
               .location-info,
@@ -529,12 +529,12 @@ ul.category-resource-qtip {
 
     tr.event {
       & > td {
-        padding: 8px 3px;
+        padding: px(8) px(3);
         font-size: 1.1em;
       }
 
       &:not(:first-of-type) td {
-        border-top: 1px dotted #aaa;
+        border-top: px(1) dotted #aaa;
       }
 
       .title .ui.label {
@@ -543,18 +543,18 @@ ul.category-resource-qtip {
 
       .category-icon {
         float: right;
-        margin-left: 3px;
+        margin-left: px(3);
       }
     }
 
     td.time {
       font-style: italic;
       white-space: nowrap;
-      width: 40px;
+      width: px(40);
     }
 
     td.content-info {
-      padding-left: 20px;
+      padding-left: px(20);
 
       table.timetable-entries {
         tr {
@@ -572,19 +572,19 @@ ul.category-resource-qtip {
 
           &:not(:first-of-type) {
             td {
-              border-top: 1px dashed #aaa;
+              border-top: px(1) dashed #aaa;
             }
           }
 
           td {
-            padding: 3px 2px;
+            padding: px(3) px(2);
           }
         }
       }
     }
 
     .location-info {
-      max-width: 220px;
+      max-width: px(220);
       text-overflow: ellipsis;
       overflow: hidden;
       color: darkblue;
@@ -598,7 +598,7 @@ ul.category-resource-qtip {
 
 .category-overview-side-menu {
   .ui-datepicker {
-    width: 192px;
+    width: px(192);
   }
 
   #display-options {
@@ -623,7 +623,7 @@ ul.category-resource-qtip {
 
 .category-calendar-side-menu {
   .ui-datepicker {
-    width: 192px;
+    width: px(192);
   }
 }
 
@@ -674,7 +674,7 @@ ul.category-resource-qtip {
       .ongoing-events-info {
         font-style: italic;
         line-height: 2.1em;
-        margin-right: 5px;
+        margin-right: px(5);
       }
     }
   }
@@ -682,12 +682,12 @@ ul.category-resource-qtip {
 
 .ongoing-events-dialog,
 .all-events-dialog {
-  max-height: 600px !important;
+  max-height: px(600) !important;
   overflow-y: scroll;
 
   ul {
     list-style-type: none;
-    padding: 0 10px;
+    padding: 0 px(10);
     margin-top: 0;
   }
 }

--- a/indico/web/client/styles/modules/_category_management.scss
+++ b/indico/web/client/styles/modules/_category_management.scss
@@ -10,7 +10,7 @@
 table.category-management,
 table.event-management {
   margin-top: 0;
-  margin-bottom: 25px;
+  margin-bottom: px(25);
 
   th {
     &.sortable-column {
@@ -58,7 +58,7 @@ table.event-management {
   }
 
   & + .pagination {
-    margin-top: 8px;
+    margin-top: px(8);
     float: right;
   }
 }

--- a/indico/web/client/styles/modules/_contributions.scss
+++ b/indico/web/client/styles/modules/_contributions.scss
@@ -43,7 +43,7 @@
 }
 
 .revision-file-row {
-  @include border-left($width: 3px);
+  @include border-left($width: px(3));
 
   &:hover {
     border-color: $blue;
@@ -63,7 +63,7 @@
     .label {
       @include ellipsis();
 
-      line-height: 15px;
+      line-height: px(15);
       vertical-align: middle;
     }
 
@@ -117,19 +117,19 @@
 }
 
 #subcontribution-list {
-  width: 600px;
+  width: px(600);
 
   table {
     td.subcontribution-title {
       @include ellipsis();
 
-      max-width: 150px;
+      max-width: px(150);
     }
   }
 }
 
 .qbubble-contrib-start-date {
-  max-width: 450px !important;
+  max-width: px(450) !important;
 
   .datetime-widget {
     width: 100% !important;
@@ -141,7 +141,7 @@
 }
 
 .qbubble-contrib-duration {
-  max-width: 420px !important;
+  max-width: px(420) !important;
 
   .qtip-content {
     overflow: visible;
@@ -149,7 +149,7 @@
 }
 
 #contributions-fixed-fields {
-  margin-bottom: 5px;
+  margin-bottom: px(5);
 }
 
 #display-contribution-list {

--- a/indico/web/client/styles/modules/_dashboard.scss
+++ b/indico/web/client/styles/modules/_dashboard.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 @use 'rb:styles/responsive' as *;
 
 .banner.user-dashboard,
@@ -47,35 +48,35 @@
 
 .dashboard-col:last-child {
   @media (min-width: $computer-width) {
-    padding-left: 10px;
+    padding-left: px(10);
   }
 }
 
 .dashboard-col:first-child {
   @media (min-width: $computer-width) {
-    padding-right: 10px;
+    padding-right: px(10);
     padding-left: 0;
   }
 }
 
 .dashboard-box {
-  border: 1px solid #ddd;
+  border: px(1) solid #ddd;
   border-radius: 0.3em;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
-  margin-bottom: 44px;
+  margin-bottom: px(44);
 }
 
 .dashboard-box h3 {
   background: #f7f7f7;
-  border-bottom: 1px solid #ddd;
+  border-bottom: px(1) solid #ddd;
   border-top-left-radius: 0.3em;
   border-top-right-radius: 0.3em;
-  font-size: 14px;
+  font-size: px(14);
   line-height: 100%;
   margin: 0;
-  padding: 10px;
+  padding: px(10);
 }
 
 .dashboard-box.suggestions h3 {
@@ -90,14 +91,14 @@
 }
 
 .dashboard-box ul li {
-  border-bottom: 1px solid #e5e5e5;
-  padding: 10px 10px 5px 10px;
+  border-bottom: px(1) solid #e5e5e5;
+  padding: px(10) px(10) px(5) px(10);
 }
 
 .dashboard-box ul li a,
 .dashboard-box ul li.no-event span {
   font-size: 1.2em;
-  line-height: 18px;
+  line-height: px(18);
   position: relative;
   user-select: none;
   -webkit-touch-callout: none;
@@ -107,12 +108,12 @@
 }
 
 .dashboard-box.suggestions ul li > a {
-  margin-right: 15px;
+  margin-right: px(15);
 }
 
 .dashboard-box ul li .actions {
-  font-size: 10px;
-  padding: 0 0 5px 10px;
+  font-size: px(10);
+  padding: 0 0 px(5) px(10);
 }
 
 .dashboard-box ul li .actions a:hover span {
@@ -146,8 +147,8 @@
 
 .dashboard-box ul .event-date {
   display: inline-block;
-  font-size: 12px;
-  width: 95px;
+  font-size: px(12);
+  width: px(95);
 }
 
 .dashboard-box ul .event-category {
@@ -156,18 +157,18 @@
 }
 
 .dashboard-box ul .item-legend {
-  max-width: 150px;
+  max-width: px(150);
   position: relative;
   float: right;
 }
 
 .dashboard-box ul li .close-box {
   display: none;
-  font-size: 18px;
+  font-size: px(18);
   position: absolute;
   right: 0;
   top: 0;
-  margin: 10px 10px 0 0;
+  margin: px(10) px(10) 0 0;
 }
 
 .dashboard-box ul li:hover .close-box {
@@ -176,7 +177,7 @@
 
 .item-legend [class*='icon-'] {
   color: #ddd;
-  font-size: 18px;
+  font-size: px(18);
 }
 
 .item-legend [class*='icon-'].active {
@@ -186,7 +187,7 @@
 .your-details {
   display: flex;
   flex-flow: row nowrap;
-  margin-bottom: 15px;
+  margin-bottom: px(15);
 
   .avatar-image {
     display: none;
@@ -197,14 +198,14 @@
 
     .ui.label {
       color: $light-gray;
-      margin-right: 34px;
+      margin-right: px(34);
 
       &.default-avatar {
-        font-size: 70px;
+        font-size: px(70);
       }
 
       &:not(.default-avatar) {
-        height: 140px;
+        height: px(140);
       }
     }
   }
@@ -213,17 +214,17 @@
     color: $black;
     font-size: 1.2em;
     line-height: 1.5;
-    max-width: 300px;
-    margin-right: 5px;
+    max-width: px(300);
+    margin-right: px(5);
 
     h3 {
       margin-top: 0;
-      margin-bottom: 10px;
+      margin-bottom: px(10);
     }
 
     i {
       color: $dark-gray;
-      margin-right: 10px;
+      margin-right: px(10);
     }
 
     .your-labels {
@@ -232,7 +233,7 @@
       margin-bottom: 1rem;
 
       .label {
-        margin: 0 7px 7px 0;
+        margin: 0 px(7) px(7) 0;
       }
     }
   }

--- a/indico/web/client/styles/modules/_designer.scss
+++ b/indico/web/client/styles/modules/_designer.scss
@@ -37,19 +37,19 @@
   }
 
   .ruler#horizontal-ruler {
-    top: -16px;
-    left: 16px;
+    top: px(-16);
+    left: px(16);
   }
 
   .ruler#vertical-ruler {
-    width: 10px;
-    left: -6px;
+    width: px(10);
+    left: px(-6);
   }
 
   .ruler .marking {
     box-sizing: border-box;
     position: absolute;
-    border: 1px solid #aaa;
+    border: px(1) solid #aaa;
     color: #aaa;
     background: #eee;
     vertical-align: middle;
@@ -57,28 +57,28 @@
   }
 
   .ruler#vertical-ruler .marking {
-    border-width: 1px 0 0 0;
+    border-width: px(1) 0 0 0;
     text-align: center;
-    width: 15px;
+    width: px(15);
   }
 
   .ruler#horizontal-ruler .marking {
-    border-width: 0 0 0 1px;
-    padding-left: 5px;
-    line-height: 15px;
-    height: 15px;
+    border-width: 0 0 0 px(1);
+    padding-left: px(5);
+    line-height: px(15);
+    height: px(15);
   }
 
   .designer-item {
-    border: 1px dashed $dark-blue;
+    border: px(1) dashed $dark-blue;
     line-height: initial;
 
     &.selected {
-      border-width: 3px;
+      border-width: px(3);
       background-color: $pastel-blue;
 
       &[data-type='fixed_image'] img {
-        padding: 3px;
+        padding: px(3);
       }
 
       &[data-type='fixed'] {
@@ -92,14 +92,14 @@
   }
 
   .template-container {
-    border: 1px solid $gray;
+    border: px(1) solid $gray;
     user-select: none;
-    width: 425px;
-    height: 270px;
+    width: px(425);
+    height: px(270);
     position: relative;
     left: 0;
     top: 0;
-    perspective: 1000px;
+    perspective: px(1000);
 
     .template-content {
       width: 100%;
@@ -140,24 +140,24 @@
 }
 
 #badge-settings-form .form-group-footer {
-  margin-top: 10px;
+  margin-top: px(10);
 }
 
 .margin-editor .form-group {
-  max-width: 120px;
+  max-width: px(120);
 
   .form-label {
     width: inherit;
   }
 
   .form-field input {
-    max-width: 90px;
+    max-width: px(90);
   }
 }
 
 .margin-editor .margins-between .form-group {
   .form-label {
-    width: 200px;
+    width: px(200);
   }
 
   &#form-group-margin_columns .form-label {
@@ -185,11 +185,11 @@
 }
 
 .custom-template-list {
-  margin-top: 20px;
+  margin-top: px(20);
 }
 
 .designer-tools {
-  min-height: 120px;
+  min-height: px(120);
 
   .designer-tools-row {
     display: flex;
@@ -199,7 +199,7 @@
 
     &:not(:first-child) {
       @include transition(opacity 0.2s);
-      border-top: 1px dashed $pastel-gray;
+      border-top: px(1) dashed $pastel-gray;
     }
   }
 
@@ -224,11 +224,11 @@
     display: flex;
     align-items: center;
     margin: 1em 0;
-    min-height: 37px;
+    min-height: px(37);
 
     &:not(:first-child) {
       padding-left: 1em;
-      border-left: 1px solid $gray;
+      border-left: px(1) solid $gray;
     }
 
     &:first-child {
@@ -301,7 +301,7 @@
   height: 100%;
 
   .placeholder-content {
-    padding: 40px;
+    padding: px(40);
     display: flex;
     flex-direction: column;
     text-align: center;
@@ -335,7 +335,7 @@
     a {
       display: flex;
       align-items: center;
-      padding: 10px;
+      padding: px(10);
     }
 
     .template-icon-badge {
@@ -393,8 +393,8 @@
 #bg-color-preview {
   width: 1em;
   height: 1.6em;
-  margin-right: -2px;
-  border: 1px solid rgb(223, 223, 223);
+  margin-right: px(-2);
+  border: px(1) solid rgb(223, 223, 223);
 }
 
 #text-color-selector,

--- a/indico/web/client/styles/modules/_event_management.scss
+++ b/indico/web/client/styles/modules/_event_management.scss
@@ -50,7 +50,7 @@
 }
 
 .static-sites {
-  width: 650px;
+  width: px(650);
 
   .i-table-widget {
     // date
@@ -78,7 +78,7 @@
 }
 
 .reminders {
-  width: 650px;
+  width: px(650);
 }
 
 #menu-entries > .menu-entries {
@@ -86,13 +86,13 @@
 }
 
 .menu-entries {
-  padding: 5px 10px;
+  padding: px(5) px(10);
   margin-top: 0;
 
   list-style: none;
 
   > li {
-    margin-top: 5px;
+    margin-top: px(5);
 
     &:first-child {
       margin-top: 0;
@@ -145,7 +145,7 @@
 
         > .actions {
           max-width: 33%;
-          margin-right: -5px;
+          margin-right: px(-5);
 
           a,
           a:active,
@@ -154,7 +154,7 @@
           }
 
           > * {
-            padding: 0 2px;
+            padding: 0 px(2);
 
             color: $dark-gray;
             opacity: 0.6;
@@ -242,15 +242,15 @@
 
     &.menu-entry-placeholder {
       background: $light-gray;
-      border: 1px dashed $gray;
-      margin: 4px -5px -1px 5px;
+      border: px(1) dashed $gray;
+      margin: px(4) px(-5) px(-1) px(5);
     }
   }
 
   > .ui-sortable-helper:first-child + .menu-entry-placeholder,
   > .menu-entry-placeholder:first-child {
     margin-top: 0;
-    margin-bottom: -2px;
+    margin-bottom: px(-2);
   }
 
   &.empty,
@@ -272,7 +272,7 @@
       font-style: italic;
       line-height: 2.8em;
       position: absolute;
-      padding-left: 20px;
+      padding-left: px(20);
     }
   }
 }
@@ -280,9 +280,9 @@
 // sub list of entries
 .menu-entry {
   > .menu-entries {
-    margin-left: 20px;
+    margin-left: px(20);
     padding-right: 0;
-    padding-left: 10px;
+    padding-left: px(10);
 
     > li > .menu-entry > .i-label {
       font-weight: normal;
@@ -306,36 +306,36 @@
   padding: 0;
 
   li {
-    border-radius: 2px;
+    border-radius: px(2);
     position: relative;
     display: inline-block;
 
-    margin: 5px;
+    margin: px(5);
 
-    width: 200px;
-    height: 200px;
-    box-shadow: 0 0 1px 2px rgba($gray, 0.4);
+    width: px(200);
+    height: px(200);
+    box-shadow: 0 0 px(1) px(2) rgba($gray, 0.4);
 
     img {
-      border-radius: 2px;
+      border-radius: px(2);
       object-fit: cover;
-      width: 200px;
-      height: 200px;
+      width: px(200);
+      height: px(200);
     }
 
     .menu {
       color: white;
       text-align: right;
       background-image: linear-gradient(to top, $black, rgba($black, 0));
-      border-radius: 0 0 2px 2px;
+      border-radius: 0 0 px(2) px(2);
       box-sizing: border-box;
       padding: 0.5em 1em;
       position: absolute;
       bottom: 0;
       left: 0;
       width: 100%;
-      height: 50px;
-      line-height: 50px;
+      height: px(50);
+      line-height: px(50);
 
       a:not(:hover) {
         color: inherit;
@@ -345,7 +345,7 @@
 }
 
 form#upload-images.full-width .dropzone {
-  width: 770px;
+  width: px(770);
 
   .select-files-btn,
   .dropzone-previews {
@@ -359,7 +359,7 @@ form#upload-images.full-width .dropzone {
     font-size: 1.2em;
     border-radius: 0.2em;
     width: 100%;
-    border: 1px solid $gray;
+    border: px(1) solid $gray;
     padding: 0.2em;
   }
 
@@ -493,7 +493,7 @@ th.i-table {
     }
 
     ~ tr td {
-      border-top-width: 1px;
+      border-top-width: px(1);
     }
   }
 }
@@ -502,13 +502,13 @@ th.i-table {
   padding: 0.15em 0;
 
   &:not(:last-child) {
-    border-bottom: 1px solid $pastel-gray;
+    border-bottom: px(1) solid $pastel-gray;
   }
 }
 
 #contribution-field-list {
   .contribution-field {
-    margin-bottom: 5px;
+    margin-bottom: px(5);
 
     .field-type {
       font-weight: bold;
@@ -524,57 +524,57 @@ th.i-table {
     @include default-border-radius();
 
     display: inline-block;
-    padding-left: 5px;
+    padding-left: px(5);
     width: 100%;
 
     button {
       position: absolute;
-      right: 15px;
+      right: px(15);
       top: 0;
       background: none;
       border: none;
-      padding: 0 5px;
+      padding: 0 px(5);
     }
   }
 
   .text p {
     word-wrap: break-word;
     width: 90%;
-    margin-top: 7px;
-    margin-bottom: 5px;
+    margin-top: px(7);
+    margin-bottom: px(5);
   }
 
   .recipients-smaller {
     @extend .flexrow;
     justify-content: space-between;
     width: 85%;
-    margin-right: 15px;
-    max-height: 200px;
+    margin-right: px(15);
+    max-height: px(200);
     overflow-y: auto;
     white-space: normal;
 
     a {
-      height: 30px;
+      height: px(30);
     }
 
     button {
-      right: 110px;
+      right: px(110);
     }
   }
 
   .scroll button {
-    right: 120px;
+    right: px(120);
   }
 
   .truncate {
     .text p {
       @include ellipsis();
 
-      max-height: 30px;
+      max-height: px(30);
     }
 
     button {
-      right: 110px;
+      right: px(110);
     }
   }
 }
@@ -585,10 +585,10 @@ th.i-table {
   background: rgba($light-blue, 0.2);
 
   & > .section {
-    margin-left: -10px;
-    margin-right: -10px;
-    padding-left: 10px;
-    padding-right: 10px;
+    margin-left: px(-10);
+    margin-right: px(-10);
+    padding-left: px(10);
+    padding-right: px(10);
     overflow: visible;
 
     & > .icon {
@@ -606,8 +606,8 @@ th.i-table {
     }
 
     &:not(:first-child) {
-      margin-top: 10px;
-      padding-top: 10px;
+      margin-top: px(10);
+      padding-top: px(10);
     }
   }
 
@@ -644,8 +644,8 @@ th.i-table {
 }
 
 .clone-event-dialog-content {
-  width: 600px;
-  min-height: 500px;
+  width: px(600);
+  min-height: px(500);
 }
 
 .qtip.cloned-event-list-qtip ul {
@@ -672,11 +672,11 @@ form.horizontal .clone-event-dialog-content {
 }
 
 .clone-event-dialog-content ul.steps {
-  margin-bottom: 30px;
+  margin-bottom: px(30);
 }
 
 form.horizontal .clone-event-dialog-footer .form-field {
-  margin-top: 10px;
+  margin-top: px(10);
   width: 100%;
 
   .clone-action-button {

--- a/indico/web/client/styles/modules/_eventservices.scss
+++ b/indico/web/client/styles/modules/_eventservices.scss
@@ -13,7 +13,7 @@ div.event-service-association-title {
 
   span.event-service-association-subtitle {
     color: #bbb;
-    font-size: 17px;
+    font-size: px(17);
     margin-left: 0.5em;
   }
 }
@@ -22,8 +22,8 @@ div.event-service-association-title {
   align-self: center;
 
   .event-service-row {
-    border-radius: 2px;
-    border: 1px solid $pastel-blue;
+    border-radius: px(2);
+    border: px(1) solid $pastel-blue;
     background-color: $light-gray;
   }
 }
@@ -33,9 +33,9 @@ div.event-service-association-title {
 }
 
 div.event-service-row {
-  border: 1px solid $pastel-gray;
+  border: px(1) solid $pastel-gray;
   background-color: $light-gray;
-  box-shadow: 0 2px 1px -1px $pastel-gray;
+  box-shadow: 0 px(2) px(1) px(-1) $pastel-gray;
   padding: 0.3em 0.6em;
   margin-bottom: 0.5em;
   position: relative;
@@ -43,7 +43,7 @@ div.event-service-row {
   &.info {
     background-color: $light-blue;
     border-color: $pastel-blue;
-    box-shadow: 0 2px 1px -1px $pastel-blue;
+    box-shadow: 0 px(2) px(1) px(-1) $pastel-blue;
   }
 
   & > .event-service-row-collapsed {
@@ -106,7 +106,7 @@ div.event-service-row {
       }
 
       & > dd {
-        margin-left: 100px;
+        margin-left: px(100);
         display: block;
       }
 
@@ -159,7 +159,7 @@ div.event-service-row {
     }
 
     & > dd {
-      margin-left: 100px;
+      margin-left: px(100);
       display: block;
     }
 

--- a/indico/web/client/styles/modules/_markdown.scss
+++ b/indico/web/client/styles/modules/_markdown.scss
@@ -49,7 +49,7 @@ $display-preview-bg-color: white;
 
   blockquote {
     font-style: italic;
-    border-left: 2px solid darken($blockquote-color, 10%);
+    border-left: px(2) solid darken($blockquote-color, 10%);
     padding: 0.2em 0.2em 0.2em 1em;
     margin-left: 0;
     background-color: darken($blockquote-color, 5%);
@@ -57,7 +57,7 @@ $display-preview-bg-color: white;
   }
 }
 
-@mixin md-preview-wrapper-mixin($background-color, $max-height: 500px) {
+@mixin md-preview-wrapper-mixin($background-color, $max-height: px(500)) {
   @include md-display-rules($background-color);
   @include transition(height 0.25s ease-out, background-color 1s ease-in, color 1s ease-in);
   @include border-all();
@@ -83,7 +83,7 @@ $display-preview-bg-color: white;
     font-size: 1em;
 
     .instructions {
-      padding: 10px;
+      padding: px(10);
       display: block;
     }
 
@@ -97,7 +97,7 @@ $display-preview-bg-color: white;
   }
 
   .wmd-preview {
-    padding: 10px;
+    padding: px(10);
 
     p {
       white-space: pre-line;
@@ -117,9 +117,9 @@ $display-preview-bg-color: white;
   box-shadow: none;
   @include border-all($width: 0);
 
-  min-height: 200px;
+  min-height: px(200);
   width: 100%;
-  max-width: 800px;
+  max-width: px(800);
   padding: 1em;
   font-size: 0.9em;
 
@@ -134,7 +134,7 @@ $display-preview-bg-color: white;
   border-top-left-radius: $default-border-radius;
   box-shadow: none;
   position: relative;
-  max-width: 800px;
+  max-width: px(800);
 
   &.focused {
     @include transition(border);
@@ -143,7 +143,7 @@ $display-preview-bg-color: white;
 }
 
 .wmd-button-row {
-  max-width: 800px;
+  max-width: px(800);
   position: relative;
   padding: 0.5em;
   height: 2em;
@@ -155,7 +155,7 @@ $display-preview-bg-color: white;
 }
 
 .wmd-spacer {
-  width: 1px;
+  width: px(1);
   height: 1em;
   margin: 0 1em 0 1em;
   display: inline-block;
@@ -170,13 +170,13 @@ $display-preview-bg-color: white;
   .save-button {
     @include transition(opacity);
     @include transition(background-color);
-    @include single-box-shadow(0, 0, 1px, 1px, #fff);
+    @include single-box-shadow(0, 0, px(1), px(1), #fff);
     position: absolute;
-    right: 50px;
+    right: px(50);
     display: inline-block;
     color: white;
     z-index: 1;
-    top: 8px;
+    top: px(8);
     opacity: 0;
     visibility: hidden;
 
@@ -279,7 +279,7 @@ $display-preview-bg-color: white;
 }
 
 .wmd-prompt-dialog {
-  border: 1px solid #999;
+  border: px(1) solid #999;
   background-color: #f5f5f5;
 }
 
@@ -289,24 +289,24 @@ $display-preview-bg-color: white;
 }
 
 .wmd-prompt-dialog > form > input[type='text'] {
-  border: 1px solid #999;
+  border: px(1) solid #999;
   color: black;
 }
 
 .wmd-prompt-dialog > form > input[type='button'] {
-  border: 1px solid #888;
+  border: px(1) solid #888;
   font-family: trebuchet MS, helvetica, sans-serif;
   font-size: 0.8em;
   font-weight: bold;
 }
 
 .md-preview-wrapper.edit {
-  max-width: 800px;
+  max-width: px(800);
   @include md-preview-wrapper-mixin($editor-preview-bg-color);
 }
 
 .markdown-help-qtip {
-  max-width: 500px;
+  max-width: px(500);
 }
 
 .max-length-info {

--- a/indico/web/client/styles/modules/_news.scss
+++ b/indico/web/client/styles/modules/_news.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .news-toolbar {
   padding: 1em;
@@ -14,8 +15,8 @@
 .news-item {
   background-color: lighten($light-gray, 1%);
   overflow: hidden;
-  border: 1px $gray solid;
-  box-shadow: 0 2px 1px -1px $pastel-gray;
+  border: px(1) $gray solid;
+  box-shadow: 0 px(2) px(1) px(-1) $pastel-gray;
   padding: 1em;
 
   &:not(:last-child) {

--- a/indico/web/client/styles/modules/_overviews.scss
+++ b/indico/web/client/styles/modules/_overviews.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 $result-group-padding: 1rem;
 $result-group-header-padding: 0.55rem;
@@ -70,7 +71,7 @@ $result-group-header-padding: 0.55rem;
       @include result-group();
 
       td .title {
-        border-bottom: 1px dotted $gray;
+        border-bottom: px(1) dotted $gray;
         color: $dark-gray;
         margin-bottom: -$result-group-header-padding;
         padding-bottom: $result-group-header-padding;

--- a/indico/web/client/styles/modules/_papers.scss
+++ b/indico/web/client/styles/modules/_papers.scss
@@ -26,20 +26,20 @@
     color: $light-black;
 
     &::before {
-      margin-right: 5px;
+      margin-right: px(5);
       color: $dark-gray;
     }
   }
 }
 
 #assign-role-table {
-  min-width: 500px;
-  margin-bottom: 15px;
+  min-width: px(500);
+  margin-bottom: px(15);
 
   .i-tag {
     display: inline-block;
     background-color: $pastel-blue;
-    margin-right: 5px;
+    margin-right: px(5);
     font-weight: normal;
     color: $light-black;
     border-width: 0;
@@ -77,8 +77,8 @@
   @include font-family-modern-body();
 
   .contribution-row {
-    @include border-left($width: 3px);
-    padding-left: 10px;
+    @include border-left($width: px(3));
+    padding-left: px(10);
     margin-bottom: 1em;
 
     &:hover {
@@ -92,12 +92,12 @@
 
     .submitter {
       color: $light-black;
-      margin-top: 7px;
+      margin-top: px(7);
     }
 
     .submission-link {
       color: inherit;
-      margin-left: -3px;
+      margin-left: px(-3);
     }
 
     .align-icon::before {
@@ -122,7 +122,7 @@
 
   .cfp-announcement {
     color: $light-black;
-    padding: 20px 0 10px;
+    padding: px(20) 0 px(10);
   }
 
   .template-list {
@@ -137,8 +137,8 @@
 }
 
 #select-contribution-dialog {
-  min-width: 500px;
-  padding: 0 20px;
+  min-width: px(500);
+  padding: 0 px(20);
 
   ul {
     list-style-type: none;
@@ -147,28 +147,28 @@
 
   ul li {
     @include border-bottom($light-gray);
-    padding-bottom: 3px;
-    margin-bottom: 10px;
+    padding-bottom: px(3);
+    margin-bottom: px(10);
     font-size: 1.1em;
   }
 
   .contrib-list {
-    max-height: 600px;
+    max-height: px(600);
     overflow-y: auto;
-    margin-bottom: 15px;
+    margin-bottom: px(15);
   }
 }
 
 .deadline-info {
   @include border-all($blue);
   background: $light-blue;
-  padding: 10px;
+  padding: px(10);
 
   .label {
     font-size: 11pt;
     font-weight: bold;
     color: $blue;
-    margin-bottom: 5px;
+    margin-bottom: px(5);
   }
 
   .text {
@@ -184,14 +184,14 @@
   }
 
   span {
-    margin-right: 5px;
+    margin-right: px(5);
   }
 }
 
 .paper-content {
   .paper-file {
     background-color: $light-gray !important;
-    border-bottom: 1px solid $pastel-gray !important;
+    border-bottom: px(1) solid $pastel-gray !important;
   }
 
   .spotlight-file {
@@ -210,7 +210,7 @@
 
     &::before {
       font-size: 2em;
-      margin-right: 5px;
+      margin-right: px(5);
     }
   }
 
@@ -219,17 +219,17 @@
   }
 
   .paper-files {
-    margin: 0 0 0 10px;
+    margin: 0 0 0 px(10);
     padding: 0;
     list-style-type: none;
-    margin-bottom: -5px; // In order to remove the margin of the last list items row
+    margin-bottom: px(-5); // In order to remove the margin of the last list items row
 
     li {
-      margin-right: 5px;
+      margin-right: px(5);
 
       a {
-        max-width: 150px;
-        margin-bottom: 5px;
+        max-width: px(150);
+        margin-bottom: px(5);
       }
     }
   }
@@ -246,12 +246,12 @@
 .paper-metadata {
   align-self: flex-end;
   color: $gray;
-  margin-top: 10px;
+  margin-top: px(10);
 
   .paper-metadata-dt {
-    border-bottom: 1px dotted $gray;
+    border-bottom: px(1) dotted $gray;
     color: $gray;
-    margin: 0 3px;
+    margin: 0 px(3);
 
     &:hover {
       color: $light-black;
@@ -260,5 +260,5 @@
 }
 
 .paper-timeline {
-  min-height: 500px;
+  min-height: px(500);
 }

--- a/indico/web/client/styles/modules/_payment.scss
+++ b/indico/web/client/styles/modules/_payment.scss
@@ -6,11 +6,12 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .payment-conditions-text {
   color: $black;
   font-size: 1.1em;
   line-height: 1.5em;
-  max-width: 400px;
+  max-width: px(400);
   text-align: justify;
 }

--- a/indico/web/client/styles/modules/_registrationform.scss
+++ b/indico/web/client/styles/modules/_registrationform.scss
@@ -19,7 +19,7 @@
 
 @mixin regform-section {
   @extend .i-box;
-  margin-top: 25px;
+  margin-top: px(25);
 }
 
 // ============================================================================
@@ -37,7 +37,7 @@
     }
 
     .clearableinput + .clearableinput {
-      margin-top: 3px;
+      margin-top: px(3);
     }
   }
 
@@ -45,7 +45,7 @@
     & > span {
       color: $gray;
       font-size: 1.2em;
-      margin-left: 4px;
+      margin-left: px(4);
       vertical-align: -8%;
     }
   }
@@ -57,7 +57,7 @@
 
 .regform-done {
   @include regform-section();
-  margin-bottom: 15px;
+  margin-bottom: px(15);
 
   table.registration-info {
     border-collapse: collapse;
@@ -65,7 +65,7 @@
 
     &.payment-info {
       td {
-        padding: 3px;
+        padding: px(3);
       }
     }
   }
@@ -73,7 +73,7 @@
   tr.regform-done-title {
     td {
       @include border-bottom(lighten($gray, $color-variation));
-      padding: 15px 0 5px 0;
+      padding: px(15) 0 px(5) 0;
       font-size: 1.3em;
     }
 
@@ -87,24 +87,24 @@
   }
 
   .regform-done-caption {
-    border-bottom: 1px dashed lighten($gray, $color-variation);
-    border-right: 1px dashed lighten($gray, $color-variation);
+    border-bottom: px(1) dashed lighten($gray, $color-variation);
+    border-right: px(1) dashed lighten($gray, $color-variation);
     color: $dark-gray;
     font-weight: normal;
     text-align: right;
-    padding: 0 8px 0 0;
-    width: 120px;
+    padding: 0 px(8) 0 0;
+    width: px(120);
   }
 
   .regform-done-data {
-    padding: 0 0 0 5px;
+    padding: 0 0 0 px(5);
     vertical-align: top;
 
     .regform-participant-visibility {
       display: flex;
       align-items: center;
       gap: 0.5em;
-      margin: 2px 0;
+      margin: px(2) 0;
 
       .old-visibility {
         color: $light-black;
@@ -122,7 +122,7 @@
     font-weight: bold;
 
     &:not(:first-child) {
-      padding: 0 0 0 15px;
+      padding: 0 0 0 px(15);
     }
   }
 
@@ -131,7 +131,7 @@
       vertical-align: top;
 
       &:not(:first-child) {
-        padding: 0 0 0 15px;
+        padding: 0 0 0 px(15);
       }
 
       span.section-name {
@@ -147,7 +147,7 @@
   .regform-done-table-total {
     @include border-top(lighten($gray, $color-variation));
     font-weight: bold;
-    padding-top: 5px;
+    padding-top: px(5);
 
     strong {
       padding-right: 1em;
@@ -155,11 +155,11 @@
   }
 
   .regform-done-footer {
-    margin-top: 20px;
+    margin-top: px(20);
 
     input[type='checkbox'] {
       float: left;
-      margin-left: 1px;
+      margin-left: px(1);
     }
 
     label {
@@ -179,7 +179,7 @@
 
   .regform-done-checkout {
     font-size: 1.1em;
-    margin-top: 10px;
+    margin-top: px(10);
   }
 
   .not-selected {
@@ -279,12 +279,12 @@
       thead {
         tr:last-child th {
           font-weight: bold;
-          border-bottom: 2px solid $gray;
-          padding-right: 5px;
+          border-bottom: px(2) solid $gray;
+          padding-right: px(5);
         }
 
         th {
-          padding-right: 10px;
+          padding-right: px(10);
           text-align: center;
         }
       }
@@ -307,7 +307,7 @@
             position: relative;
 
             &::after {
-              border-bottom: 2px solid $light-black;
+              border-bottom: px(2) solid $light-black;
               content: '';
               left: 1%;
               position: absolute;
@@ -319,7 +319,7 @@
         }
 
         td {
-          border-top: 1px solid $gray;
+          border-top: px(1) solid $gray;
 
           &:first-child,
           &:last-child {
@@ -359,11 +359,11 @@
           }
 
           &.stick-left {
-            padding-right: 1px;
+            padding-right: px(1);
           }
 
           &.stick-right {
-            padding-left: 1px;
+            padding-left: px(1);
           }
         }
       }
@@ -407,7 +407,7 @@
 
       th,
       td {
-        padding: 5px;
+        padding: px(5);
         text-align: right;
 
         &:first-child {
@@ -507,10 +507,10 @@
     width: 100%;
 
     td {
-      padding: 0.35rem 5px 0.35rem 0;
+      padding: 0.35rem px(5) 0.35rem 0;
 
       &:first-child {
-        padding-left: 5px;
+        padding-left: px(5);
       }
 
       &.name {
@@ -528,7 +528,7 @@
 
       &.actions {
         font-size: 1.2em;
-        padding: 0 5px;
+        padding: 0 px(5);
         width: 2%;
         white-space: nowrap;
 
@@ -616,15 +616,15 @@
 
 .disabled-caption {
   color: $dark-gray;
-  margin: 30px 0 0 0;
+  margin: px(30) 0 0 0;
 
   a {
-    padding: 0 10px;
+    padding: 0 px(10);
     box-sizing: border-box;
     color: $dark-gray;
   }
 }
 
 .registration-tags-assign-form {
-  width: 600px;
+  width: px(600);
 }

--- a/indico/web/client/styles/modules/_reviewing.scss
+++ b/indico/web/client/styles/modules/_reviewing.scss
@@ -40,8 +40,8 @@
   }
 
   .open-review-notification-log {
-    margin-top: 5px;
-    margin-right: 10px;
+    margin-top: px(5);
+    margin-right: px(10);
     position: absolute;
     right: 0;
     z-index: 1;
@@ -68,12 +68,12 @@
 
   .submission-code {
     font-size: 0.8em;
-    border: 1px solid $dark-gray;
-    border-radius: 3px;
+    border: px(1) solid $dark-gray;
+    border-radius: px(3);
     padding: 0 0.2em;
     background-color: $dark-gray;
     color: $light-gray;
-    margin-left: 5px;
+    margin-left: px(5);
   }
 
   .toolbar {
@@ -276,7 +276,7 @@
   .global-state-icon {
     @include semantic-background();
     align-self: flex-start;
-    margin-right: 10px;
+    margin-right: px(10);
     border-radius: 50%;
     width: 2em;
     height: 2em;
@@ -285,9 +285,9 @@
   .group-state-icon {
     @include semantic-outline();
     border: none !important;
-    margin-right: 10px;
+    margin-right: px(10);
     // Align with header icon by adding its width and border
-    width: calc(2em + 2px);
+    width: calc(2em + #{px(2)});
 
     > span {
       display: flex;
@@ -299,7 +299,7 @@
   }
 
   .global-review-summary {
-    margin-bottom: 10px;
+    margin-bottom: px(10);
     color: $light-black;
 
     .summary-title {
@@ -319,7 +319,7 @@
     padding: 0;
 
     &__summary {
-      padding: 5px 10px;
+      padding: px(5) px(10);
       min-height: 2em;
       min-width: 0;
     }
@@ -329,7 +329,7 @@
 
       .details-content-row {
         color: $dark-gray;
-        padding: 5px 10px 5px calc(22px + 2em);
+        padding: px(5) px(10) px(5) calc(#{px(22)} + 2em);
 
         &:not(:first-child) {
           @include border-top($style: dashed);
@@ -339,12 +339,12 @@
 
     &__link {
       font-size: small;
-      margin-right: 10px;
+      margin-right: px(10);
       flex-shrink: 0;
     }
 
     &__track {
-      margin-right: 10px;
+      margin-right: px(10);
     }
   }
 
@@ -353,7 +353,7 @@
   }
 
   .details-content-inner {
-    box-shadow: inset 0 15px 20px -20px $gray;
+    box-shadow: inset 0 px(15) px(20) px(-20) $gray;
 
     .i-tag {
       border-color: transparent;
@@ -375,7 +375,7 @@
     font-weight: bold;
     background: $pastel-gray;
     color: $light-black;
-    padding: 0 6px;
+    padding: 0 px(6);
   }
 
   .question-text {
@@ -484,7 +484,7 @@
       cursor: pointer;
 
       &::after {
-        @include border-all($color: $pastel-gray, $width: 2px);
+        @include border-all($color: $pastel-gray, $width: px(2));
         background: transparent;
       }
     }
@@ -501,8 +501,8 @@
 }
 
 .profile-picture {
-  width: 39px;
-  height: 39px;
-  max-width: 39px !important;
-  margin-right: 10px;
+  width: px(39);
+  height: px(39);
+  max-width: px(39) !important;
+  margin-right: px(10);
 }

--- a/indico/web/client/styles/modules/_roles.scss
+++ b/indico/web/client/styles/modules/_roles.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .role-list-row {
   background: #eee;
@@ -15,16 +16,16 @@
 
     .content-area {
       background: #fff;
-      margin: 0 0 0 58px !important;
+      margin: 0 0 0 px(58) !important;
 
       .empty {
-        padding: 10px;
+        padding: px(10);
         font-style: italic;
         color: $dark-gray;
       }
 
       .toolbar {
-        padding: 10px;
+        padding: px(10);
       }
     }
   }
@@ -37,12 +38,12 @@
 }
 
 .role-list {
-  padding: 10px;
+  padding: px(10);
   box-sizing: border-box;
   list-style-type: none;
 
   li {
-    font-size: 11px !important;
+    font-size: px(11) !important;
     display: inline-block;
     margin-right: 0.3em;
     margin-bottom: 0.7em;
@@ -54,12 +55,12 @@
 }
 
 .badge-column {
-  width: 20px;
+  width: px(20);
 }
 
 .role-badge {
   display: inline-block;
-  width: 25px;
+  width: px(25);
   text-align: center;
 }
 

--- a/indico/web/client/styles/modules/_surveys.scss
+++ b/indico/web/client/styles/modules/_surveys.scss
@@ -63,8 +63,8 @@
       background-color: white;
 
       .item-row {
-        margin-top: 10px;
-        margin-bottom: 10px;
+        margin-top: px(10);
+        margin-bottom: px(10);
 
         > .i-form {
           flex-grow: 1;

--- a/indico/web/client/styles/modules/_timetable.scss
+++ b/indico/web/client/styles/modules/_timetable.scss
@@ -18,7 +18,7 @@
       background: $light-blue;
     }
 
-    padding: 5px;
+    padding: px(5);
     cursor: pointer;
 
     &.selected {
@@ -26,13 +26,13 @@
     }
 
     &:not(:last-child) {
-      border-bottom: 1px solid $separator-color;
+      border-bottom: px(1) solid $separator-color;
     }
   }
 }
 
 #wholeLegend {
-  margin: 60px 0 0 0;
+  margin: px(60) 0 0 0;
 }
 
 #legendMainToggle {
@@ -41,11 +41,11 @@
   background: $gray;
   color: $black;
   cursor: pointer;
-  font-size: 11px;
-  padding: 4px 5px 3px 5px;
+  font-size: px(11);
+  padding: px(4) px(5) px(3) px(5);
   position: absolute;
   text-align: center;
-  width: 116px;
+  width: px(116);
 
   &:hover {
     color: white;
@@ -65,16 +65,16 @@
   @include border-all();
   @include default-border-radius();
   background: $light-gray;
-  font-size: 11px;
+  font-size: px(11);
   overflow: hidden;
-  padding: 5px;
+  padding: px(5);
   z-index: 1;
   box-sizing: initial;
 
   &.sticky-scrolling {
     @include single-box-shadow();
     position: fixed;
-    top: 1px;
+    top: px(1);
   }
 
   #legendItemContainer {
@@ -86,21 +86,21 @@
     background: $pastel-gray;
     color: $black;
     float: left;
-    height: 15px;
-    margin: 2px;
-    padding: 5px;
+    height: px(15);
+    margin: px(2);
+    padding: px(5);
     overflow: hidden;
-    max-width: 200px;
+    max-width: px(200);
   }
 
   .timeTableItemColour {
     border-radius: 50%;
-    @include border-all(white, $width: 2px);
+    @include border-all(white, $width: px(2));
     float: left;
-    margin-right: 3px;
-    margin-top: -2px;
-    height: 15px;
-    width: 15px;
+    margin-right: px(3);
+    margin-top: px(-2);
+    height: px(15);
+    width: px(15);
   }
 
   .legendCloseButton {
@@ -109,7 +109,7 @@
     cursor: pointer;
     float: right;
     font-size: 1.2em;
-    margin: 1px 2px 0 2px;
+    margin: px(1) px(2) 0 px(2);
 
     &:hover {
       color: $gray;
@@ -129,19 +129,19 @@
 }
 
 #move-timetable-entry-dialog {
-  width: 800px;
-  height: 440px;
+  width: px(800);
+  height: px(440);
 
   .section-title {
     font-size: 1.2em;
     color: $black;
-    margin-bottom: 5px;
-    margin-top: 10px;
+    margin-bottom: px(5);
+    margin-top: px(10);
   }
 
   .days {
     &.scrollable-container {
-      height: 70px;
+      height: px(70);
     }
 
     .scroll-btn {
@@ -156,11 +156,11 @@
 
       &.scroll-left {
         transform: rotate(180deg);
-        margin-right: 10px;
+        margin-right: px(10);
       }
 
       &.scroll-right {
-        margin-left: 10px;
+        margin-left: px(10);
       }
     }
   }
@@ -172,7 +172,7 @@
     position: relative;
 
     &.scrollable {
-      padding: 5px;
+      padding: px(5);
     }
 
     .day:not(:last-child) {
@@ -181,7 +181,7 @@
   }
 
   .days-container-wrapper {
-    max-width: 730px;
+    max-width: px(730);
     position: relative;
   }
 
@@ -219,7 +219,7 @@
   }
 
   .blocks {
-    max-height: 300px;
+    max-height: px(300);
     overflow: auto;
     overflow-y: auto;
   }
@@ -232,23 +232,23 @@
     }
 
     &.selected {
-      border-left: 4px solid $blue;
+      border-left: px(4) solid $blue;
     }
 
     .icon {
-      font-size: 22px;
+      font-size: px(22);
 
       &::before {
-        margin-right: 10px;
+        margin-right: px(10);
       }
     }
 
     .item-icon {
       flex-shrink: 0;
-      width: 22px;
-      height: 22px;
-      border-radius: 15px;
-      margin-right: 10px;
+      width: px(22);
+      height: px(22);
+      border-radius: px(15);
+      margin-right: px(10);
     }
 
     .start-dt {
@@ -259,8 +259,8 @@
 
     .move-btn {
       position: relative;
-      padding-left: 10px;
-      max-height: 22px; // Workaround to avoid jQuery "jumping" effect
+      padding-left: px(10);
+      max-height: px(22); // Workaround to avoid jQuery "jumping" effect
 
       &:not(.active) {
         display: none;
@@ -279,24 +279,24 @@
   background: $light-gray;
   color: $light-black;
   display: none;
-  padding: 10px;
+  padding: px(10);
   position: fixed;
-  bottom: 15px;
-  right: 20px;
+  bottom: px(15);
+  right: px(20);
   text-align: center;
 
   .circle {
     float: left;
     background: transparent url('static:images/circle.png') scroll no-repeat;
-    width: 20px;
-    height: 14px;
+    width: px(20);
+    height: px(14);
   }
 }
 
 @mixin timetable-entry-button {
   background: white;
-  height: 19px;
-  padding: 2px;
+  height: px(19);
+  padding: px(2);
 }
 
 .entry-arrows {
@@ -308,14 +308,14 @@
   cursor: default;
   position: absolute;
   right: 0;
-  right: 18px;
+  right: px(18);
   visibility: hidden;
 
   a {
     background: transparent !important;
 
     &:first-child {
-      margin-right: 2px;
+      margin-right: px(2);
     }
   }
 }

--- a/indico/web/client/styles/modules/_tracks.scss
+++ b/indico/web/client/styles/modules/_tracks.scss
@@ -13,10 +13,10 @@
   padding-left: 0;
 
   .track-row {
-    padding: 10px 10px 0 10px;
+    padding: px(10) px(10) 0 px(10);
 
     &:last-child {
-      margin-bottom: 150px;
+      margin-bottom: px(150);
     }
 
     .i-box-header {
@@ -25,7 +25,7 @@
 
     .i-box-content {
       word-wrap: break-word;
-      padding: 10px 0;
+      padding: px(10) 0;
     }
 
     .default-session::before {
@@ -43,25 +43,25 @@
 
   .track-content-collapsed {
     @extend .transparent-overlay;
-    max-height: 50px;
+    max-height: px(50);
     overflow: hidden;
   }
 }
 
 ul.sub-tracks {
   list-style-type: none;
-  padding-left: 30px;
+  padding-left: px(30);
 
   li h3 {
-    font-size: 14px !important;
+    font-size: px(14) !important;
   }
 }
 
 .embedded-track-list {
-  padding: 30px 20px;
-  border: 1px solid $pastel-gray;
+  padding: px(30) px(20);
+  border: px(1) solid $pastel-gray;
   background-color: $light-gray;
-  margin: 10px 0;
+  margin: px(10) 0;
 }
 
 .track-group-handle {
@@ -78,13 +78,13 @@ ul.sub-tracks {
 
 .track-placeholder {
   background: $light-gray;
-  border: 1px dashed $gray;
-  margin-bottom: 15px;
+  border: px(1) dashed $gray;
+  margin-bottom: px(15);
 }
 
 .track-review-list {
   ul {
-    padding-left: 10px;
+    padding-left: px(10);
   }
 }
 
@@ -100,8 +100,8 @@ ul.sub-tracks {
     border: none;
     cursor: default;
     display: inline-block;
-    margin: 10px 5px 10px 0;
-    padding: 3px;
+    margin: px(10) px(5) px(10) 0;
+    padding: px(3);
 
     &.no-unreviewed {
       background-color: $green;

--- a/indico/web/client/styles/modules/_types_dialog.scss
+++ b/indico/web/client/styles/modules/_types_dialog.scss
@@ -5,12 +5,14 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .manage-types {
-  max-width: 600px;
+  max-width: px(600);
 
   table.i-table {
     table-layout: auto;
-    min-width: 360px;
+    min-width: px(360);
     margin-bottom: 1.5em;
 
     th,
@@ -20,7 +22,7 @@
 
     .action-column {
       white-space: nowrap;
-      width: 1px;
+      width: px(1);
     }
   }
 }

--- a/indico/web/client/styles/modules/_users.scss
+++ b/indico/web/client/styles/modules/_users.scss
@@ -29,12 +29,12 @@
 }
 
 .suggested-users {
-  max-width: 250px;
-  max-height: 450px;
+  max-width: px(250);
+  max-height: px(450);
   overflow-y: scroll;
 
   .user-list li .info {
-    max-width: 200px;
+    max-width: px(200);
   }
 }
 
@@ -84,9 +84,9 @@
 }
 
 .user-search-results {
-  height: 300px;
-  border: 1px solid $gray;
-  width: 450px;
+  height: px(300);
+  border: px(1) solid $gray;
+  width: px(450);
   overflow: auto;
 }
 
@@ -94,7 +94,7 @@
   list-style-type: none;
   padding-left: 0;
   margin: 0;
-  max-width: 500px;
+  max-width: px(500);
 
   li {
     display: table;
@@ -135,13 +135,13 @@
     }
 
     &:not(:last-child) {
-      border-bottom: 1px solid lighten($gray, 20%);
+      border-bottom: px(1) solid lighten($gray, 20%);
     }
 
     .info {
       display: table-cell;
       overflow: hidden;
-      max-width: 500px;
+      max-width: px(500);
       vertical-align: middle;
 
       > * {
@@ -187,7 +187,7 @@
       }
 
       .name + .affiliation:last-child {
-        max-width: 400px;
+        max-width: px(400);
       }
     }
 

--- a/indico/web/client/styles/modules/abstracts/_abstract_page.scss
+++ b/indico/web/client/styles/modules/abstracts/_abstract_page.scss
@@ -14,7 +14,7 @@
 
 .abstract-content {
   @extend .text-paper;
-  padding: 10px 10em;
+  padding: px(10) 10em;
 
   .abstract-authorship-block {
     margin-top: 0.5em;

--- a/indico/web/client/styles/modules/abstracts/_cfa_page.scss
+++ b/indico/web/client/styles/modules/abstracts/_cfa_page.scss
@@ -6,15 +6,16 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 .call-for-abstracts {
   .cfa-announcement {
     color: $light-black;
-    padding: 20px 0 10px;
+    padding: px(20) 0 px(10);
   }
 
   .actions {
-    margin-top: 20px;
+    margin-top: px(20);
   }
 
   .info-message-box {
@@ -23,7 +24,7 @@
 
   .message-text {
     line-height: 1.3em;
-    padding-left: 5px;
+    padding-left: px(5);
   }
 
   .submit-abstract-btn {

--- a/indico/web/client/styles/modules/abstracts/_email_templates.scss
+++ b/indico/web/client/styles/modules/abstracts/_email_templates.scss
@@ -40,7 +40,7 @@
 }
 
 #email-template-manager {
-  max-width: 800px;
+  max-width: px(800);
 
   .email-template-wrapper {
     padding: 0 0 1em 1em;
@@ -50,17 +50,17 @@
     }
 
     .email-templates {
-      width: 800px;
-      max-height: 800px;
+      width: px(800);
+      max-height: px(800);
       overflow: auto;
 
       > ul {
         list-style-type: none;
         padding-left: 0;
-        padding-right: 20px;
+        padding-right: px(20);
 
         > li {
-          width: 775px;
+          width: px(775);
         }
       }
     }
@@ -69,7 +69,7 @@
       display: none;
 
       .email-subject {
-        padding-bottom: 10px;
+        padding-bottom: px(10);
       }
 
       .email-body {
@@ -86,7 +86,7 @@
     }
 
     .email-preview-btn {
-      padding-right: 5px;
+      padding-right: px(5);
       color: $link;
 
       &:hover {
@@ -113,6 +113,6 @@
   }
 
   .rule-list {
-    width: 700px;
+    width: px(700);
   }
 }

--- a/indico/web/client/styles/modules/abstracts/_notification_logs.scss
+++ b/indico/web/client/styles/modules/abstracts/_notification_logs.scss
@@ -10,9 +10,9 @@
 #abstract-notification-log {
   $padding: 0.25rem;
 
-  width: 800px;
-  min-height: 400px;
-  max-height: 400px;
+  width: px(800);
+  min-height: px(400);
+  max-height: px(400);
   overflow-y: auto;
 
   .log-entry {
@@ -48,14 +48,14 @@
 
     &:hover,
     &.open {
-      @include inner-border-left($gray, $width: 2px);
+      @include inner-border-left($gray, $width: px(2));
       background-color: $light-gray;
       background-origin: border-box;
     }
   }
 
   .log-entry .content {
-    @include inner-border-left($gray, $width: 2px);
+    @include inner-border-left($gray, $width: px(2));
     display: none;
     margin-left: -$padding;
     margin-top: $padding * 2;

--- a/indico/web/client/styles/modules/abstracts/_roles.scss
+++ b/indico/web/client/styles/modules/abstracts/_roles.scss
@@ -16,9 +16,9 @@
 }
 
 .abstract-role-widget {
-  padding-right: 20px;
-  max-height: 700px;
-  width: 800px;
+  padding-right: px(20);
+  max-height: px(700);
+  width: px(800);
   overflow-y: auto;
 }
 
@@ -27,7 +27,7 @@
   padding-left: 0;
 
   li.i-box {
-    margin: 20px 0;
+    margin: px(20) 0;
     display: block;
 
     &:first-child {
@@ -72,9 +72,9 @@
   }
 
   .reviewer-container {
-    margin: 0 -10px;
-    padding-left: 10px;
-    padding-right: 10px;
+    margin: 0 px(-10);
+    padding-left: px(10);
+    padding-right: px(10);
 
     &:not(:first-child) {
       @include border-top();

--- a/indico/web/client/styles/modules/contributions/_display.scss
+++ b/indico/web/client/styles/modules/contributions/_display.scss
@@ -11,6 +11,7 @@
 @use 'base/palette' as *;
 @use 'base/animation' as *;
 @use 'base/typography' as *;
+@use 'base/utilities' as *;
 
 $display-preview-bg-color: white;
 
@@ -52,7 +53,7 @@ $display-preview-bg-color: white;
 
   blockquote {
     font-style: italic;
-    border-left: 2px solid darken($blockquote-color, 10%);
+    border-left: px(2) solid darken($blockquote-color, 10%);
     padding: 0.2em 0.2em 0.2em 1em;
     margin-left: 0;
     background-color: darken($blockquote-color, 5%);
@@ -60,7 +61,7 @@ $display-preview-bg-color: white;
   }
 }
 
-@mixin md-preview-wrapper-mixin($background-color, $max-height: 500px) {
+@mixin md-preview-wrapper-mixin($background-color, $max-height: px(500)) {
   @include md-display-rules($background-color);
   @include transition(height 0.25s ease-out, background-color 1s ease-in, color 1s ease-in);
   @include font-family-serif();
@@ -82,7 +83,7 @@ $display-preview-bg-color: white;
     font-size: 1em;
 
     .instructions {
-      padding: 10px;
+      padding: px(10);
       display: block;
     }
 
@@ -96,7 +97,7 @@ $display-preview-bg-color: white;
   }
 
   .wmd-preview {
-    padding: 10px;
+    padding: px(10);
   }
 }
 

--- a/indico/web/client/styles/modules/contributions/_editor.scss
+++ b/indico/web/client/styles/modules/contributions/_editor.scss
@@ -11,6 +11,7 @@
 @use 'base/palette' as *;
 @use 'base/animation' as *;
 @use 'base/typography' as *;
+@use 'base/utilities' as *;
 @use 'partials/boxes' as *;
 @use 'modules/contributions/display' as *;
 
@@ -21,23 +22,23 @@ $editor-preview-bg-color: $light-gray;
   @include transition(height 0.25s ease-out);
 
   &:focus {
-    height: 300px;
+    height: px(300);
   }
 
-  height: 100px;
+  height: px(100);
 
   width: 100%;
-  max-width: 800px;
+  max-width: px(800);
   padding: 1em;
   font-size: 0.9em;
 }
 
 .wmd-panel {
-  max-width: 800px;
+  max-width: px(800);
 }
 
 .wmd-button-row {
-  max-width: 800px;
+  max-width: px(800);
   position: relative;
   padding: 0.5em;
   height: 2em;
@@ -46,7 +47,7 @@ $editor-preview-bg-color: $light-gray;
 }
 
 .wmd-spacer {
-  width: 1px;
+  width: px(1);
   height: 1em;
   margin: 0 1em 0 1em;
   display: inline-block;
@@ -60,13 +61,13 @@ $editor-preview-bg-color: $light-gray;
   .save-button {
     @include transition(opacity);
     @include transition(background-color);
-    @include single-box-shadow(0, 0, 1px, 1px, #fff);
+    @include single-box-shadow(0, 0, px(1), px(1), #fff);
     position: absolute;
-    right: 50px;
+    right: px(50);
     display: inline-block;
     color: white;
     z-index: 1;
-    top: 8px;
+    top: px(8);
     opacity: 0;
     visibility: hidden;
 
@@ -163,7 +164,7 @@ $editor-preview-bg-color: $light-gray;
 }
 
 .wmd-prompt-dialog {
-  border: 1px solid #999;
+  border: px(1) solid #999;
   background-color: #f5f5f5;
 }
 
@@ -173,18 +174,18 @@ $editor-preview-bg-color: $light-gray;
 }
 
 .wmd-prompt-dialog > form > input[type='text'] {
-  border: 1px solid #999;
+  border: px(1) solid #999;
   color: black;
 }
 
 .wmd-prompt-dialog > form > input[type='button'] {
-  border: 1px solid #888;
+  border: px(1) solid #888;
   font-family: trebuchet MS, helvetica, sans-serif;
   font-size: 0.8em;
   font-weight: bold;
 }
 
 .md-preview-wrapper.edit {
-  max-width: 800px;
+  max-width: px(800);
   @include md-preview-wrapper-mixin($editor-preview-bg-color);
 }

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -53,14 +53,14 @@
 }
 
 .event-message {
-  margin: 20px auto 5px auto;
-  width: 1000px !important;
+  margin: px(20) auto px(5) auto;
+  width: px(1000) !important;
   box-sizing: border-box;
   line-height: initial;
 }
 
 .search-box {
-  width: 250px;
+  width: px(250);
 }
 
 .event-page-header {
@@ -70,8 +70,8 @@
   }
 
   .main-action-bar {
-    height: 50px;
-    min-height: 50px;
+    height: px(50);
+    min-height: px(50);
   }
 
   .button-bar {
@@ -87,9 +87,9 @@
     }
 
     .separator {
-      margin: 10px 5px;
-      width: 1px;
-      border-right: 1px dotted $light-black;
+      margin: px(10) px(5);
+      width: px(1);
+      border-right: px(1) dotted $light-black;
     }
 
     .i-dropdown {
@@ -125,10 +125,10 @@
   }
 
   .event-filters {
-    margin-top: 5px;
-    padding: 10px 10px 10px 75px;
-    border-top: 1px solid black;
-    border-bottom: 1px solid black;
+    margin-top: px(5);
+    padding: px(10) px(10) px(10) px(75);
+    border-top: px(1) solid black;
+    border-bottom: px(1) solid black;
     background-color: #777;
     display: none;
 
@@ -147,7 +147,7 @@
   li {
     display: inline-block;
     margin: 0.2em 0.2em;
-    border-radius: 2px;
+    border-radius: px(2);
 
     .type-name {
       color: $light-black;

--- a/indico/web/client/styles/modules/event_display/_conferences.scss
+++ b/indico/web/client/styles/modules/event_display/_conferences.scss
@@ -12,7 +12,7 @@
 
   td {
     &.caption {
-      width: 150px;
+      width: px(150);
     }
   }
 }
@@ -50,7 +50,7 @@
 
     &[class^='icon-']::before,
     &[class*=' icon-']::before {
-      margin-right: 5px;
+      margin-right: px(5);
     }
   }
 
@@ -63,7 +63,7 @@
       color: $dark-orange;
       text-align: right;
       vertical-align: top;
-      max-width: 220px;
+      max-width: px(220);
     }
   }
 
@@ -168,7 +168,7 @@
 
         &[class^='icon-']::before,
         &[class*=' icon-']::before {
-          margin-right: 5px;
+          margin-right: px(5);
         }
       }
 
@@ -187,8 +187,8 @@
 
   .contribution-row,
   .track-review-row {
-    padding: 0 10px;
-    border-left: 3px solid $pastel-gray;
+    padding: 0 px(10);
+    border-left: px(3) solid $pastel-gray;
     margin-bottom: 1em;
 
     .contrib-title {
@@ -231,7 +231,7 @@
   @include ellipsis();
 
   display: inline-block;
-  margin-left: 5px;
+  margin-left: px(5);
   padding: 0.5em;
   max-width: 12em;
 
@@ -243,7 +243,7 @@
 }
 
 .contrib-type {
-  margin: 6px 3px 0 0;
+  margin: px(6) px(3) 0 0;
   padding: 0.5em;
   color: $light-gray;
   background-color: $dark-blue;
@@ -269,7 +269,7 @@ ul.author-list {
   padding: 0;
 
   .speaker-item {
-    border-bottom: 1px solid $pastel-gray;
+    border-bottom: px(1) solid $pastel-gray;
     margin-bottom: 0.5em;
 
     .affiliation {

--- a/indico/web/client/styles/modules/event_display/_meetings.scss
+++ b/indico/web/client/styles/modules/event_display/_meetings.scss
@@ -10,7 +10,7 @@
 #event-note-section {
   @include border-bottom($gray);
   background: white;
-  padding: 10px 50px;
+  padding: px(10) px(50);
 }
 
 .timetable-title {
@@ -164,7 +164,7 @@ li > table + .note-area-wrapper {
   font-size: 0.95em;
 
   display: inline-block;
-  margin-bottom: 4px;
+  margin-bottom: px(4);
   margin-left: 0.2em;
 
   &.checked-in {
@@ -174,5 +174,5 @@ li > table + .note-area-wrapper {
 }
 
 .session-block-form {
-  width: 840px !important;
+  width: px(840) !important;
 }

--- a/indico/web/client/styles/partials/_actionboxes.scss
+++ b/indico/web/client/styles/partials/_actionboxes.scss
@@ -13,12 +13,13 @@
 @use 'base/palette' as *;
 @use 'base/borders' as *;
 @use 'base/animation' as *;
+@use 'base/utilities' as *;
 
 @mixin action-box {
   box-sizing: border-box;
   @include default-border-radius();
   margin-bottom: 1rem;
-  padding: 10px;
+  padding: px(10);
   width: 100%;
 
   > .section {
@@ -53,9 +54,9 @@
     }
 
     &:not(:first-child) {
-      margin-top: 5px;
-      padding-top: 5px;
-      border-top: 1px solid $gray;
+      margin-top: px(5);
+      padding-top: px(5);
+      border-top: px(1) solid $gray;
     }
   }
 
@@ -173,13 +174,13 @@
   }
 
   &.draft-mode {
-    max-width: 800px;
+    max-width: px(800);
   }
 
   ul:not(.i-dropdown):not(.ck) {
     margin: 0;
     padding-left: 1.5em;
-    max-height: 100px;
+    max-height: px(100);
     overflow: auto;
   }
 
@@ -188,7 +189,7 @@
   }
 
   &.mid-form {
-    margin-top: 5px;
-    margin-bottom: 6px;
+    margin-top: px(5);
+    margin-bottom: px(6);
   }
 }

--- a/indico/web/client/styles/partials/_badges.scss
+++ b/indico/web/client/styles/partials/_badges.scss
@@ -85,7 +85,7 @@
   padding: 0;
   vertical-align: top;
   text-align: center;
-  box-shadow: 0 2px 1px 0 $gray;
+  box-shadow: 0 px(2) px(1) 0 $gray;
   background-color: $dark-blue;
   box-sizing: initial;
   line-height: initial;
@@ -183,7 +183,7 @@
     padding: 0.4em 0.6em 0;
     font-size: 1em;
     height: 1em;
-    border-top: 1px solid $light-blue;
+    border-top: px(1) solid $light-blue;
 
     & > .i-badge-legend-left {
       float: left;
@@ -201,7 +201,7 @@
 }
 
 span.badge {
-  border-radius: 5px;
+  border-radius: px(5);
   padding: 0.1em 0.4em;
   font-size: 0.8em;
   margin-left: 0.5em;

--- a/indico/web/client/styles/partials/_boxes.scss
+++ b/indico/web/client/styles/partials/_boxes.scss
@@ -23,7 +23,7 @@
 @mixin i-box-description {
   @include font-family-description();
   color: $dark-gray;
-  font-size: 14px;
+  font-size: px(14);
 }
 
 @mixin box-hr {
@@ -32,8 +32,8 @@
   overflow: hidden;
   background: transparent;
   border: none;
-  margin-left: -10px;
-  margin-right: -10px;
+  margin-left: px(-10);
+  margin-right: px(-10);
 
   &.inline {
     margin-left: 0;
@@ -83,7 +83,7 @@
 // Boxes
 // ============================================================================
 
-$i-box-padding: 10px;
+$i-box-padding: px(10);
 
 @mixin i-box-horizontal-padding {
   padding-left: $i-box-padding;
@@ -118,7 +118,7 @@ $i-box-padding: 10px;
 // Use the titled-rule as the top border of the i-box. Combine with .titled on the i-box.
 @mixin i-box-titled-rule-header {
   @include i-box-cancel-horizontal-margin();
-  margin-top: -18px; // Pure magic number to align the rule with the i-box border
+  margin-top: px(-18); // Pure magic number to align the rule with the i-box border
 }
 
 @mixin single-box-shadow(
@@ -159,18 +159,18 @@ $i-box-padding: 10px;
     );
 
     font-size: 1.2em;
-    height: 10px;
-    margin: -10px -10px 10px -10px;
+    height: px(10);
+    margin: px(-10) px(-10) px(10) px(-10);
     text-align: center;
 
     &:hover,
     &:active {
       @include border-bottom();
-      height: 20px;
+      height: px(20);
 
       &::before {
         color: $dark-gray;
-        top: 3px;
+        top: px(3);
       }
     }
 
@@ -179,13 +179,13 @@ $i-box-padding: 10px;
       transform: rotate(90deg);
       display: inline-block;
       position: relative;
-      top: -3px;
+      top: px(-3);
     }
   }
 
   .titled-rule {
-    margin-top: 5px;
-    margin-bottom: 5px;
+    margin-top: px(5);
+    margin-bottom: px(5);
   }
 
   > .titled-rule:first-child,
@@ -201,7 +201,7 @@ $i-box-padding: 10px;
   .i-box-footer {
     @include i-box-cancel-margin();
     background-color: $light-gray;
-    box-shadow: inset 0 15px 20px -20px $gray;
+    box-shadow: inset 0 px(15) px(20) px(-20) $gray;
     overflow: auto;
     padding: $i-box-padding;
     margin-top: $i-box-padding;
@@ -318,7 +318,7 @@ $i-box-padding: 10px;
 // ============================================================================
 
 .i-box-group {
-  $margin: 15px;
+  $margin: px(15);
 
   & + & {
     margin-top: $margin;
@@ -379,7 +379,7 @@ $i-box-padding: 10px;
       }
 
       &:last-child {
-        margin-bottom: 10px;
+        margin-bottom: px(10);
       }
     }
   }
@@ -395,7 +395,7 @@ $i-box-padding: 10px;
   color: $light-black;
   list-style: outside none none;
   padding: 0;
-  margin: 0 -10px;
+  margin: 0 px(-10);
 
   // Sortable <li> will use absolute positioning while being moved thus the
   // <ul> must use relative positioning for correct alignment.
@@ -403,10 +403,10 @@ $i-box-padding: 10px;
 
   > li {
     @include border-top();
-    padding: 10px;
+    padding: px(10);
 
     > span:not(:last-child) {
-      margin-right: 10px;
+      margin-right: px(10);
     }
 
     .list-item-title {
@@ -459,7 +459,7 @@ $i-box-padding: 10px;
 
     &.ui-sortable-helper {
       @include border-vert(lighten($gray, $color-variation));
-      border-top-width: 1px !important;
+      border-top-width: px(1) !important;
     }
   }
 
@@ -491,7 +491,7 @@ $i-box-padding: 10px;
   }
 
   &:last-child {
-    margin-bottom: -10px;
+    margin-bottom: px(-10);
   }
 }
 
@@ -500,16 +500,16 @@ $i-box-padding: 10px;
   font-size: 1.2em;
   padding: 2em;
   background-color: $light-gray;
-  width: 400px;
-  margin: 50px auto;
-  padding-top: 20px;
+  width: px(400);
+  margin: px(50) auto;
+  padding-top: px(20);
   text-align: center;
   border-radius: 0.5em;
 
   h1 {
     color: $dark-blue;
     font-size: 2em;
-    padding-bottom: 10px;
+    padding-bottom: px(10);
   }
 
   p {

--- a/indico/web/client/styles/partials/_buttons.scss
+++ b/indico/web/client/styles/partials/_buttons.scss
@@ -156,7 +156,7 @@ $i-button-spacing: 0.3rem;
   @include _i-button-borderless($light-black, $black);
   @include _i-button-outlines($light-black, $black);
   margin: 0;
-  padding: 4px 10px 4px;
+  padding: px(4) px(10) px(4);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -168,12 +168,12 @@ $i-button-spacing: 0.3rem;
   }
 
   &:hover {
-    box-shadow: 1px 1px 4px rgba(20, 20, 20, 0.1);
+    box-shadow: px(1) px(1) px(4) rgba(20, 20, 20, 0.1);
   }
 
   &:active,
   &.open {
-    box-shadow: 1px 1px 4px rgba(20, 20, 20, 0.1) inset;
+    box-shadow: px(1) px(1) px(4) rgba(20, 20, 20, 0.1) inset;
   }
 
   &:disabled,
@@ -249,7 +249,7 @@ input.i-button[type='submit'] {
 }
 
 a.i-big-button {
-  $size: 60px;
+  $size: px(60);
   @include button();
 
   background: #fff;
@@ -290,7 +290,7 @@ a.i-big-button {
 .i-button.signin {
   display: block;
   text-align: left;
-  margin-top: 5px;
+  margin-top: px(5);
 
   .auth-id {
     font-weight: bold;
@@ -321,8 +321,8 @@ button::-moz-focus-inner {
 
   border-color: #b6ad6f;
   color: #e2e28b !important;
-  text-shadow: 0 0 1px rgba(0, 0, 0, 0.5);
-  box-shadow: 0 0 6px #e6db64;
+  text-shadow: 0 0 px(1) rgba(0, 0, 0, 0.5);
+  box-shadow: 0 0 px(6) #e6db64;
 }
 
 /* ******************** */
@@ -345,9 +345,9 @@ button::-moz-focus-inner {
 }
 
 .i-button-small {
-  font-size: 11px;
-  line-height: 16px;
-  padding: 9px;
+  font-size: px(11);
+  line-height: px(16);
+  padding: px(9);
 }
 
 .i-button.inline {
@@ -355,8 +355,8 @@ button::-moz-focus-inner {
 }
 
 .i-button.right {
-  margin-left: 5px;
-  margin-top: 5px;
+  margin-left: px(5);
+  margin-top: px(5);
 }
 
 .i-button.bottom {
@@ -380,7 +380,7 @@ a.arrow,
 .i-button.color-button {
   @include icon-before(icon-text-color);
 
-  padding: 1px;
+  padding: px(1);
   border-radius: 50%;
   vertical-align: baseline;
 }

--- a/indico/web/client/styles/partials/_corner-messages.scss
+++ b/indico/web/client/styles/partials/_corner-messages.scss
@@ -23,7 +23,7 @@
   }
 
   to {
-    background-position: 50px 50px;
+    background-position: px(50) px(50);
   }
 }
 
@@ -41,21 +41,21 @@
       $light 75%,
       $light
     );
-    background-size: 50px 50px;
+    background-size: px(50) px(50);
   }
 }
 
 #corner-message-container {
   position: fixed;
-  bottom: 60px;
-  right: 20px;
-  max-width: 500px;
+  bottom: px(60);
+  right: px(20);
+  max-width: px(500);
 }
 
 .corner-message {
   @include font-family-title();
   @include border-all($light-black);
-  box-shadow: 0 3px 2px rgba(150, 150, 150, 0.2);
+  box-shadow: 0 px(3) px(2) rgba(150, 150, 150, 0.2);
   @include transition(background-color 0.5s, color 0.5s, border-color 0.5s, width 0.5s);
   @include indico-animation(_fadein, 0.5s, normal forwards ease-in-out, 1);
   @include _progress(darken($light-gray, 0.3 * $color-variation), $light-gray);
@@ -65,7 +65,7 @@
   margin-bottom: 1em;
   color: $light-black;
   background-color: $light-gray;
-  border-radius: 2px;
+  border-radius: px(2);
 
   &.success {
     @include _progress($light-green, lighten($light-green, 0.5 * $color-variation));

--- a/indico/web/client/styles/partials/_dialogs.scss
+++ b/indico/web/client/styles/partials/_dialogs.scss
@@ -10,13 +10,13 @@
 .message {
   color: #555;
   background: #f8f5f4;
-  border: 1px solid #e7e0dd;
+  border: px(1) solid #e7e0dd;
   padding: 1em;
 }
 
 .message.info {
   background: #ebf2f3;
-  border: 1px solid #cfdee0;
+  border: px(1) solid #cfdee0;
 }
 
 .confirmation-dialog {
@@ -25,11 +25,11 @@
 }
 
 .confirmation-dialog .body {
-  max-width: 600px;
-  padding: 8px 15px 8px 15px;
+  max-width: px(600);
+  padding: px(8) px(15) px(8) px(15);
   margin-bottom: 0.5em;
   background-color: #eee;
-  border: 1px solid;
+  border: px(1) solid;
   border-color: #dbdbdb #dbdbdb #c0c0c0 #dbdbdb;
 
   color: #555;
@@ -39,7 +39,7 @@
 
 .confirmation-dialog .body .target {
   font-family: Georgia, Times, serif;
-  padding-left: 10px;
+  padding-left: px(10);
   color: #777;
   margin: 1em 0 1em 0;
   font-size: 1.2em;
@@ -50,7 +50,7 @@
 }
 
 .confirmation-dialog .body.bordered {
-  border-left: 1px solid #cacaca;
+  border-left: px(1) solid #cacaca;
 }
 
 .confirmation-dialog .body h3 {
@@ -68,7 +68,7 @@
   margin-bottom: 0.1em;
   font-size: 1.7em;
   font-weight: bold;
-  padding-bottom: 10px;
+  padding-bottom: px(10);
 }
 
 .confirmation-dialog > h3.warning {
@@ -88,12 +88,12 @@
 }
 
 .confirmation-dialog .body ul.categ-list {
-  padding-left: 13px;
+  padding-left: px(13);
   margin: 0;
 }
 
 .confirmation-dialog ul.categ-list span.event-date {
-  padding-left: 10px;
+  padding-left: px(10);
   color: #888;
   font-size: 0.9em;
   margin: 0;
@@ -113,15 +113,15 @@
 
 .dialog-subtitle {
   background-color: $light-gray;
-  border-bottom: 1px solid $pastel-gray;
-  padding: 5px 15px;
-  box-shadow: inset 0 15px 20px -20px $gray;
+  border-bottom: px(1) solid $pastel-gray;
+  padding: px(5) px(15);
+  box-shadow: inset 0 px(15) px(20) px(-20) $gray;
   color: $black;
 }
 
 .confirmation-dialog-content {
   font-size: 1.2em;
-  margin-bottom: 15px;
+  margin-bottom: px(15);
 
   strong {
     font-size: 1.2em;
@@ -129,13 +129,13 @@
 
   ul {
     font-size: 0.85em;
-    max-height: 100px;
+    max-height: px(100);
     overflow: auto;
   }
 }
 
 form.confirmation-dialog {
-  max-width: 800px;
+  max-width: px(800);
 
   label {
     font-weight: bold;

--- a/indico/web/client/styles/partials/_footer.scss
+++ b/indico/web/client/styles/partials/_footer.scss
@@ -9,7 +9,7 @@
 
 .footer {
   color: $light-black;
-  padding: 10px 5px 10px 10px;
+  padding: px(10) px(5) px(10) px(10);
 
   &.dark {
     color: $gray;
@@ -20,11 +20,11 @@
   }
 
   .footer-logo {
-    height: 40px;
+    height: px(40);
   }
 
   * {
-    line-height: 40px;
+    line-height: px(40);
   }
 
   .footer-links {
@@ -60,7 +60,7 @@
 
 .social-button-container {
   display: none;
-  border-radius: 10px;
+  border-radius: px(10);
   opacity: 0.5;
 
   .social-button:hover {

--- a/indico/web/client/styles/partials/_forms.scss
+++ b/indico/web/client/styles/partials/_forms.scss
@@ -38,7 +38,7 @@ form {
 }
 
 .i-form-field-fixed-width {
-  width: 400px;
+  width: px(400);
 }
 
 .i-form-field-fluid {
@@ -48,7 +48,7 @@ form {
 .i-form {
   @include font-family-form();
   box-sizing: border-box;
-  max-width: 800px;
+  max-width: px(800);
   display: block;
   font-size: 1em;
   color: $light-black;
@@ -61,9 +61,9 @@ form {
   }
 
   &.management-area {
-    box-shadow: 0 2px 1px -1px $pastel-gray;
+    box-shadow: 0 px(2) px(1) px(-1) $pastel-gray;
     padding-top: 1em;
-    border: 1px solid $pastel-gray;
+    border: px(1) solid $pastel-gray;
     background-color: $light-gray;
   }
 
@@ -138,7 +138,7 @@ form {
       padding: 0.5em 0.5em 0 0;
       line-height: $i-form-line-height;
       color: $black;
-      width: 400px;
+      width: px(400);
 
       .form-field-description {
         font-style: italic;
@@ -188,7 +188,7 @@ form {
   }
 
   &.form-label-empty {
-    height: 1px;
+    height: px(1);
   }
 
   &.form-label-middle {
@@ -201,7 +201,7 @@ form {
 }
 
 .i-form .form-group .form-checkbox-label {
-  bottom: 1px;
+  bottom: px(1);
   display: inline-block;
   margin-left: 0.5em;
   position: relative;
@@ -236,7 +236,7 @@ form {
   }
 
   input[type='number'] {
-    min-width: 80px;
+    min-width: px(80);
   }
 
   input[type='number'],
@@ -266,16 +266,16 @@ form {
 
   .hasDatepicker {
     margin: 0;
-    padding-right: 26px !important;
+    padding-right: px(26) !important;
   }
 
   .ui-datepicker-trigger {
-    right: 24px;
+    right: px(24);
   }
 
   .multi-text-fields {
     max-height: none;
-    max-width: 400px;
+    max-width: px(400);
 
     .handle {
       height: $i-form-height;
@@ -305,7 +305,7 @@ form {
     }
 
     input:focus {
-      border-left: 1px solid $blue;
+      border-left: px(1) solid $blue;
     }
   }
 }
@@ -333,7 +333,7 @@ form {
   legend {
     font-weight: bold;
     font-size: 1.3em;
-    border-bottom: 1px solid #ebebeb;
+    border-bottom: px(1) solid #ebebeb;
     width: 100%;
     padding-left: 0;
     padding-bottom: 0.5em;
@@ -343,7 +343,7 @@ form {
   p.description {
     margin: 0.2em 0 0 0;
     font-size: 1.1em;
-    padding-left: 2px; // align it with the legend
+    padding-left: px(2); // align it with the legend
     color: $dark-gray;
   }
 
@@ -365,5 +365,5 @@ form {
 }
 
 .i-form .form-field-warning {
-  margin-top: 2px;
+  margin-top: px(2);
 }

--- a/indico/web/client/styles/partials/_infogrids.scss
+++ b/indico/web/client/styles/partials/_infogrids.scss
@@ -80,7 +80,7 @@
 }
 
 .infoline.info {
-  padding: 10px;
+  padding: px(10);
   clear: both;
   width: 100%;
   background: #f4f4f4;

--- a/indico/web/client/styles/partials/_inputs.scss
+++ b/indico/web/client/styles/partials/_inputs.scss
@@ -23,7 +23,7 @@
   color: $black;
   font-family: inherit;
   outline: none;
-  padding: 0 4px;
+  padding: 0 px(4);
 
   &:focus {
     @include border-all($blue);
@@ -99,8 +99,8 @@ input[type='time'] {
   &::-webkit-inner-spin-button,
   &::-webkit-outer-spin-button {
     cursor: pointer;
-    margin-left: 4px;
-    padding-top: 1px;
+    margin-left: px(4);
+    padding-top: px(1);
     position: relative;
   }
 }
@@ -187,11 +187,11 @@ ul {
 .checkbox-with-text {
   input[type='checkbox'] {
     float: left;
-    margin-left: 1px;
+    margin-left: px(1);
   }
 
   div {
-    margin-left: 21px;
+    margin-left: px(21);
   }
 }
 
@@ -258,8 +258,8 @@ $dropdown-transition: $dropdown-transition-step ease-out;
 
   .rc-time-picker-panel-input-wrap {
     // make sure time does not jump when opening the time picker
-    padding-left: calc(1em - 1px);
-    padding-top: calc(0.5em + 1px);
+    padding-left: calc(1em - #{px(1)});
+    padding-top: calc(0.5em + #{px(1)});
   }
 
   .rc-time-picker-panel-input,
@@ -274,7 +274,7 @@ $dropdown-transition: $dropdown-transition-step ease-out;
   }
 
   .SingleDatePicker {
-    width: 170px;
+    width: px(170);
   }
 
   .DayPicker_weekHeader_ul {
@@ -290,16 +290,16 @@ $dropdown-transition: $dropdown-transition-step ease-out;
     @include icon-before('icon-earth');
     color: $light-black;
     position: relative;
-    left: 15px;
-    top: 2px;
+    left: px(15);
+    top: px(2);
   }
 
   .clear-pickers {
     @include icon-before('icon-cross');
     font-size: 1.3em;
     position: relative;
-    left: 20px;
-    top: 4px;
+    left: px(20);
+    top: px(4);
 
     &:hover {
       color: $red;
@@ -317,7 +317,7 @@ $dropdown-transition: $dropdown-transition-step ease-out;
   .date-widget {
     input[type='text'] {
       font-size: 1em;
-      width: 150px;
+      width: px(150);
     }
   }
 }
@@ -333,7 +333,7 @@ $dropdown-transition: $dropdown-transition-step ease-out;
   input {
     flex-shrink: 0;
     flex-grow: 0;
-    margin-top: 2px;
+    margin-top: px(2);
   }
 
   label {
@@ -342,7 +342,7 @@ $dropdown-transition: $dropdown-transition-step ease-out;
   }
 
   i.icon-padding {
-    padding-left: 5px;
+    padding-left: px(5);
   }
 
   span.checkbox-label {
@@ -355,9 +355,9 @@ $dropdown-transition: $dropdown-transition-step ease-out;
   background: repeating-linear-gradient(
     -40deg,
     lighten($gray, 0.7 * $color-variation),
-    lighten($gray, 0.7 * $color-variation) 10px,
-    lighten($gray, 0.9 * $color-variation) 10px,
-    lighten($gray, 0.9 * $color-variation) 20px
+    lighten($gray, 0.7 * $color-variation) px(10),
+    lighten($gray, 0.9 * $color-variation) px(10),
+    lighten($gray, 0.9 * $color-variation) px(20)
   ) !important;
   font-style: italic;
   color: $light-black !important;
@@ -414,7 +414,7 @@ dd > .i-has-action {
   }
 
   > input {
-    width: 110px;
+    width: px(110);
   }
 }
 

--- a/indico/web/client/styles/partials/_jquery-indico-categorynavigator.scss
+++ b/indico/web/client/styles/partials/_jquery-indico-categorynavigator.scss
@@ -10,8 +10,8 @@
 @use 'partials/boxes' as *;
 
 @mixin categorynav-sizing {
-  width: 800px;
-  height: 600px;
+  width: px(800);
+  height: px(600);
 }
 
 .categorynav-dialog-content {
@@ -26,13 +26,13 @@
     @include form-field-input();
     width: 100%;
     flex-shrink: 0;
-    padding-left: 10px;
-    padding-right: 35px !important;
+    padding-left: px(10);
+    padding-right: px(35) !important;
   }
 
   .clearableinput {
     .button-box {
-      padding-right: 10px;
+      padding-right: px(10);
 
       a {
         padding-right: 0;
@@ -46,7 +46,7 @@
 
   background: $light-gray;
   flex-grow: 1;
-  margin-top: 10px;
+  margin-top: px(10);
 
   // Needed for Firefox to actually overflow on .group-list
   overflow: hidden;
@@ -68,10 +68,10 @@
     overflow-y: auto;
 
     // Needed to avoid double border in case of overflow
-    margin-bottom: -1px !important;
+    margin-bottom: px(-1) !important;
 
     &.with-protected .item {
-      padding-left: 27px;
+      padding-left: px(27);
     }
   }
 
@@ -90,11 +90,11 @@
   background: white;
 
   &:last-child {
-    border-bottom: 1px solid lighten($gray, $color-variation);
+    border-bottom: px(1) solid lighten($gray, $color-variation);
   }
 
   &:hover {
-    @include inner-border-left($indico-blue, $width: 3px);
+    @include inner-border-left($indico-blue, $width: px(3));
 
     .action-button {
       visibility: visible !important;
@@ -130,13 +130,13 @@
 
     .action-button {
       @extend .i-button, .highlight;
-      padding: 4px 10px 4px;
+      padding: px(4) px(10) px(4);
       visibility: hidden;
     }
   }
 
   .protection {
-    min-width: 13px;
+    min-width: px(13);
     display: inline-block;
 
     &::before {
@@ -175,13 +175,13 @@
 }
 
 .categorynav .category-list .item.current-category {
-  box-shadow: 0 2px 2px 0 $light-gray;
-  @include inner-border-left($indico-blue, $width: 3px);
-  border-bottom: 1px solid lighten($gray, $color-variation);
-  min-height: 40px;
-  margin-left: -10px;
-  margin-right: -10px;
-  padding: 10px 10px;
+  box-shadow: 0 px(2) px(2) 0 $light-gray;
+  @include inner-border-left($indico-blue, $width: px(3));
+  border-bottom: px(1) solid lighten($gray, $color-variation);
+  min-height: px(40);
+  margin-left: px(-10);
+  margin-right: px(-10);
+  padding: px(10) px(10);
   position: relative;
   overflow: hidden;
   color: $light-black;
@@ -198,7 +198,7 @@
   }
 
   .navigate-up {
-    padding: 10px;
+    padding: px(10);
 
     &:hover {
       background-color: $pastel-gray;
@@ -218,10 +218,10 @@
 
     i {
       border-radius: 50%;
-      border: 2px solid $blue;
+      border: px(2) solid $blue;
       color: $blue;
-      font-size: 16px;
-      margin-right: 10px;
+      font-size: px(16);
+      margin-right: px(10);
       text-align: center;
       height: 1.5em;
       width: 1.5em;
@@ -241,7 +241,7 @@
     line-height: 0.85;
 
     &::before {
-      margin-right: 5px;
+      margin-right: px(5);
     }
 
     .events-count {
@@ -275,10 +275,10 @@
 .categorynav .category-list .search-result-info {
   @extend .flexrow;
   align-items: center;
-  border-bottom: 1px solid lighten($gray, $color-variation);
+  border-bottom: px(1) solid lighten($gray, $color-variation);
   background-color: $light-gray;
-  margin: 0 -10px;
-  padding: 5px 10px;
+  margin: 0 px(-10);
+  padding: px(5) px(10);
   color: $light-black;
 
   .clear {

--- a/indico/web/client/styles/partials/_jquery-indico-clearableinput.scss
+++ b/indico/web/client/styles/partials/_jquery-indico-clearableinput.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/utilities' as *;
+
 .clearableinput {
   display: flex;
   align-items: center;
@@ -20,12 +22,12 @@
 
   .button-box {
     position: absolute;
-    padding: 0 2px;
+    padding: 0 px(2);
     right: 0;
     height: 1.1em;
 
     a.i-link {
-      padding-left: 2px;
+      padding-left: px(2);
       visibility: hidden;
 
       &::before {
@@ -33,7 +35,7 @@
       }
 
       &:last-child {
-        padding-right: 2px;
+        padding-right: px(2);
       }
     }
   }

--- a/indico/web/client/styles/partials/_jquery-indico-colorpicker.scss
+++ b/indico/web/client/styles/partials/_jquery-indico-colorpicker.scss
@@ -10,7 +10,7 @@
 @use 'partials/inputs' as *;
 
 .i-color-field {
-  max-width: 400px;
+  max-width: px(400);
 
   .clickable-wrapper {
     float: left;

--- a/indico/web/client/styles/partials/_jquery-indico-itempicker.scss
+++ b/indico/web/client/styles/partials/_jquery-indico-itempicker.scss
@@ -14,7 +14,7 @@
   @include border-all();
 
   .qtip-content {
-    width: 210px;
+    width: px(210);
   }
 
   .dropdown-container {
@@ -34,14 +34,14 @@
     .dropdown-items-container {
       overflow-x: hidden;
       overflow-y: auto;
-      margin: 0 -5px;
-      max-height: 250px;
+      margin: 0 px(-5);
+      max-height: px(250);
 
       .dropdown-item {
         @extend .flexrow;
         align-items: center;
-        margin-top: 5px;
-        padding: 5px 5px;
+        margin-top: px(5);
+        padding: px(5) px(5);
         cursor: pointer;
         font-size: 1em;
 
@@ -58,7 +58,7 @@
         }
 
         .active-item-icon {
-          margin: 0 4px;
+          margin: 0 px(4);
           visibility: hidden;
         }
 
@@ -68,7 +68,7 @@
 
         .item-title {
           flex-grow: 1;
-          margin: 0 2px;
+          margin: 0 px(2);
           white-space: normal;
           color: $black;
           overflow: hidden;
@@ -78,8 +78,8 @@
 
     .divider {
       background: $separator-color;
-      height: 1px;
-      margin: 5px -5px;
+      height: px(1);
+      margin: px(5) px(-5);
     }
   }
 }

--- a/indico/web/client/styles/partials/_jquery-indico-locationpicker.scss
+++ b/indico/web/client/styles/partials/_jquery-indico-locationpicker.scss
@@ -19,7 +19,7 @@
 
       &.venue-container {
         width: 40%;
-        padding-right: 10px;
+        padding-right: px(10);
       }
 
       &.room-container {
@@ -50,7 +50,7 @@
           }
 
           &.empty {
-            border-width: 0 0 1px 0;
+            border-width: 0 0 px(1) 0;
             border-style: solid;
             border-color: $gray;
 
@@ -64,7 +64,7 @@
           display: none;
           background-color: white;
           text-align: center;
-          border-width: 0 1px 1px 1px;
+          border-width: 0 px(1) px(1) px(1);
           border-style: solid;
           border-color: $gray;
           font-style: italic;
@@ -75,7 +75,7 @@
           }
 
           a {
-            padding: 6px 20px;
+            padding: px(6) px(20);
             display: block;
             color: $black;
           }
@@ -108,8 +108,8 @@
       }
 
       &:focus {
-        box-shadow: 0 0 5px $blue;
-        @include border-all($color: $blue !important, $width: 1px);
+        box-shadow: 0 0 px(5) $blue;
+        @include border-all($color: $blue !important, $width: px(1));
       }
 
       &::-ms-clear {
@@ -146,7 +146,7 @@
 
     .availability-message-container {
       display: none;
-      padding-top: 50px;
+      padding-top: px(50);
 
       .availability-message {
         align-items: center;
@@ -235,7 +235,7 @@
 
   display: none !important;
   background-color: $pastel-blue;
-  padding: 2px;
+  padding: px(2);
   position: absolute;
   top: 0.6em;
   left: 0.95em;

--- a/indico/web/client/styles/partials/_jquery-indico-multitextfield.scss
+++ b/indico/web/client/styles/partials/_jquery-indico-multitextfield.scss
@@ -10,10 +10,10 @@
 
 .multi-text-fields {
   $height: 1.6em;
-  $width: 200px;
-  $input-width: 160px;
+  $width: px(200);
+  $input-width: px(160);
 
-  max-height: 150px;
+  max-height: px(150);
   overflow-y: auto;
   overflow-x: hidden;
 
@@ -44,7 +44,7 @@
   .ui-sortable-helper {
     input,
     .handle {
-      box-shadow: 2px 2px 3px $gray;
+      box-shadow: px(2) px(2) px(3) $gray;
     }
   }
 
@@ -75,7 +75,7 @@
   }
 
   li {
-    margin-bottom: 3px;
+    margin-bottom: px(3);
     overflow: initial;
     width: $width;
 
@@ -84,7 +84,7 @@
     }
 
     &:last-of-type {
-      margin-bottom: 1px;
+      margin-bottom: px(1);
 
       .handle {
         cursor: default;

--- a/indico/web/client/styles/partials/_jquery-indico-palettepicker.scss
+++ b/indico/web/client/styles/partials/_jquery-indico-palettepicker.scss
@@ -14,33 +14,33 @@
   background: #fff;
   background-clip: padding-box;
   border: thin solid lighten($gray, $color-variation);
-  box-shadow: 0 6px 12px lighten($gray, $color-variation);
-  padding: 3px;
+  box-shadow: 0 px(6) px(12) lighten($gray, $color-variation);
+  padding: px(3);
 }
 
 table.palette-picker {
-  border-spacing: 8px;
+  border-spacing: px(8);
 
   .palette-color {
     cursor: pointer;
-    padding: 2px;
-    border-radius: 15px;
+    padding: px(2);
+    border-radius: px(15);
 
     .text-box {
-      width: 8px;
-      height: 8px;
+      width: px(8);
+      height: px(8);
       margin: auto;
-      border-radius: 3px;
+      border-radius: px(3);
     }
 
     .background-box {
       @extend .flexrow;
       justify-content: center;
       align-items: center;
-      width: 22px;
-      height: 22px;
-      border-radius: 15px;
-      border: 2px solid transparent;
+      width: px(22);
+      height: px(22);
+      border-radius: px(15);
+      border: px(2) solid transparent;
     }
 
     &.selected {

--- a/indico/web/client/styles/partials/_jquery-indico-qbubble.scss
+++ b/indico/web/client/styles/partials/_jquery-indico-qbubble.scss
@@ -17,7 +17,7 @@
   color: $light-black;
 
   .qtip-content {
-    padding: 5px;
+    padding: px(5);
     text-align: left;
   }
 
@@ -25,8 +25,8 @@
     @include transition(background);
     cursor: pointer;
     display: block;
-    margin: 0 -5px;
-    padding: 5px 10px;
+    margin: 0 px(-5);
+    padding: px(5) px(10);
 
     &:hover {
       color: $black;
@@ -35,8 +35,8 @@
   }
 
   .titled-rule {
-    margin-bottom: 5px;
-    margin-top: 5px;
+    margin-bottom: px(5);
+    margin-top: px(5);
   }
 
   &.no-max-width {

--- a/indico/web/client/styles/partials/_jquery-indico-taglist.scss
+++ b/indico/web/client/styles/partials/_jquery-indico-taglist.scss
@@ -38,7 +38,7 @@
         margin-right: 0.5rem;
         background: $pastel-blue;
         padding: 0.3rem 0.7rem;
-        border-radius: 2px;
+        border-radius: px(2);
         position: relative;
         cursor: pointer;
         transition: all 0.3s;
@@ -59,7 +59,7 @@
           top: 0.55em;
           right: 0;
           text-decoration: none;
-          padding-left: 2px;
+          padding-left: px(2);
           line-height: 0.5;
           color: #ccc;
           color: rgba(0, 0, 0, 0.2);
@@ -98,7 +98,7 @@
     padding: 0;
     margin: 0;
     position: absolute;
-    top: -500px;
+    top: px(-500);
     z-index: -1;
     visibility: hidden;
   }

--- a/indico/web/client/styles/partials/_labels.scss
+++ b/indico/web/client/styles/partials/_labels.scss
@@ -7,8 +7,8 @@
 
 @use 'base' as *;
 
-$i-label-horizontal-padding: 10px;
-$i-label-vertical-padding: 4px;
+$i-label-horizontal-padding: px(10);
+$i-label-vertical-padding: px(4);
 $i-label-color: $light-black;
 
 @mixin label {
@@ -97,9 +97,9 @@ $i-label-color: $light-black;
     background: repeating-linear-gradient(
       -40deg,
       $flavor-color,
-      $flavor-color 10px,
-      lighten($flavor-color, 0.3 * $color-variation) 10px,
-      lighten($flavor-color, 0.3 * $color-variation) 20px
+      $flavor-color px(10),
+      lighten($flavor-color, 0.3 * $color-variation) px(10),
+      lighten($flavor-color, 0.3 * $color-variation) px(20)
     );
   }
 }
@@ -109,20 +109,20 @@ $i-label-color: $light-black;
   @include _i-label-borderless($light-black);
   @include _i-label-outlines($light-black);
   background: white;
-  margin: 0 5px;
+  margin: 0 px(5);
 
   &.striped {
     background: repeating-linear-gradient(
       -40deg,
       lighten($pastel-gray, 0.5 * $color-variation),
-      lighten($pastel-gray, 0.5 * $color-variation) 10px,
-      lighten($pastel-gray, 0.7 * $color-variation) 10px,
-      lighten($pastel-gray, 0.7 * $color-variation) 20px
+      lighten($pastel-gray, 0.5 * $color-variation) px(10),
+      lighten($pastel-gray, 0.7 * $color-variation) px(10),
+      lighten($pastel-gray, 0.7 * $color-variation) px(20)
     );
   }
 
   &.small {
-    padding: 3px 5px;
+    padding: px(3) px(5);
   }
 
   // same as in _buttons.scss
@@ -156,9 +156,9 @@ $i-label-color: $light-black;
       background: repeating-linear-gradient(
         -40deg,
         $pastel-gray,
-        $pastel-gray 10px,
-        darken($pastel-gray, 0.3 * $color-variation) 10px,
-        darken($pastel-gray, 0.3 * $color-variation) 20px
+        $pastel-gray px(10),
+        darken($pastel-gray, 0.3 * $color-variation) px(10),
+        darken($pastel-gray, 0.3 * $color-variation) px(20)
       );
     }
   }
@@ -198,11 +198,11 @@ $i-label-color: $light-black;
     &:last-child {
       border-bottom-right-radius: $default-border-radius;
       border-top-right-radius: $default-border-radius;
-      border-right-width: 1px;
+      border-right-width: px(1);
     }
 
     &.highlight {
-      border-right-width: 1px;
+      border-right-width: px(1);
 
       + .i-label {
         border-left: none;

--- a/indico/web/client/styles/partials/_lists.scss
+++ b/indico/web/client/styles/partials/_lists.scss
@@ -16,30 +16,30 @@
   margin: 0;
   padding: 0;
   display: inline-block;
-  min-width: 450px;
+  min-width: px(450);
 }
 
 .ordered-list > li {
-  border-bottom: 1px solid #ddd;
-  padding: 5px 0;
+  border-bottom: px(1) solid #ddd;
+  padding: px(5) 0;
   list-style-type: none;
 }
 
 .ordered-list > li > .list-item-title {
-  font-size: 14px;
+  font-size: px(14);
   font-weight: bold;
   color: #666;
-  padding-bottom: 5px;
+  padding-bottom: px(5);
 }
 
 .ordered-list > li > .list-item-content {
   color: #888;
-  padding-top: 2px;
+  padding-top: px(2);
 }
 
 .ordered-list > li > .list-item-content > .list-item-content-title {
   font-weight: bold;
-  padding-right: 5px;
+  padding-right: px(5);
 }
 
 .ordered-list > li > .list-item-content > .list-item-content-data {
@@ -48,7 +48,7 @@
 
 dl.i-data-list {
   @include font-family-form();
-  max-width: 800px;
+  max-width: px(800);
   color: $light-black;
   margin-top: 1em;
   line-height: 1.5;

--- a/indico/web/client/styles/partials/_main.scss
+++ b/indico/web/client/styles/partials/_main.scss
@@ -17,7 +17,7 @@
   height: 3em;
   line-height: 3em;
 
-  padding: 0 0 0 20px;
+  padding: 0 0 0 px(20);
   background: $black;
   border: none;
   margin-bottom: 0;
@@ -30,7 +30,7 @@
     line-height: 3em;
 
     color: white;
-    padding: 0 20px;
+    padding: 0 px(20);
 
     &:first-child,
     &.arrow:last-of-type {
@@ -60,9 +60,9 @@ div.page-header {
   width: 100%;
 
   img.header-logo {
-    margin: 17px 0 10px 40px;
+    margin: px(17) 0 px(10) px(40);
     border: none;
-    height: 60px;
+    height: px(60);
   }
 }
 
@@ -141,8 +141,8 @@ div.main-breadcrumb {
   @include font-family-title();
 
   background-color: darken($light-gray, 5%);
-  border-bottom: 1px solid $gray;
-  padding: 0.6em 0 0.6em 40px;
+  border-bottom: px(1) solid $gray;
+  padding: 0.6em 0 0.6em px(40);
 
   &.management {
     background-color: #fff;
@@ -156,7 +156,7 @@ div.main-breadcrumb {
 
     .item {
       color: $light-black;
-      font-size: 12px;
+      font-size: px(12);
     }
 
     a.item:hover {
@@ -202,7 +202,7 @@ div.session-bar {
     box-shadow: none;
     right: 0;
     margin-top: 0;
-    padding: 0 0 5px 5px;
+    padding: 0 0 px(5) px(5);
     z-index: 999;
   }
 }
@@ -239,7 +239,7 @@ div.impersonation-header {
       color: lighten($yellow, 30%);
       margin: 0.1em;
       line-height: 1em;
-      max-width: 200px;
+      max-width: px(200);
     }
 
     &::before {
@@ -253,7 +253,7 @@ div.impersonation-header {
   .undo-login-as {
     color: inherit;
     float: right;
-    margin-right: 2px;
+    margin-right: px(2);
     vertical-align: middle;
     font-size: 1.5em;
     line-height: 1em;

--- a/indico/web/client/styles/partials/_messageboxes.scss
+++ b/indico/web/client/styles/partials/_messageboxes.scss
@@ -8,7 +8,7 @@
 @use 'base' as *;
 @use './boxes' as *;
 
-$default-spacing: 10px;
+$default-spacing: px(10);
 
 @mixin message-box {
   @include default-border-radius();
@@ -16,7 +16,7 @@ $default-spacing: 10px;
   flex-wrap: wrap;
   color: $light-black;
   padding: $default-spacing;
-  margin-bottom: 18px;
+  margin-bottom: px(18);
   // overrides custom line-height set by semantic ui that breaks message-boxes
   line-height: normal;
 
@@ -73,58 +73,58 @@ $default-spacing: 10px;
 
 @mixin message-tag {
   @include default-border-radius();
-  padding: 0 4px;
+  padding: 0 px(4);
 }
 
 .info-message {
   color: #3a87ad;
   background-color: #d9edf7;
-  padding: 8px 14px 8px 14px;
-  margin-bottom: 18px;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
-  border: 1px solid #bce8f1;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
+  padding: px(8) px(14) px(8) px(14);
+  margin-bottom: px(18);
+  text-shadow: 0 px(1) 0 rgba(255, 255, 255, 0.5);
+  border: px(1) solid #bce8f1;
+  -webkit-border-radius: px(4);
+  -moz-border-radius: px(4);
+  border-radius: px(4);
   text-align: center;
 }
 
 .error-message {
   color: #a76766;
   background-color: #f2dede;
-  padding: 8px 14px 8px 14px;
-  margin-bottom: 18px;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
-  border: 1px solid #a76766;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
+  padding: px(8) px(14) px(8) px(14);
+  margin-bottom: px(18);
+  text-shadow: 0 px(1) 0 rgba(255, 255, 255, 0.5);
+  border: px(1) solid #a76766;
+  -webkit-border-radius: px(4);
+  -moz-border-radius: px(4);
+  border-radius: px(4);
   text-align: center;
 }
 
 .warning-message {
   color: #be9056;
   background-color: #fff3e2;
-  padding: 8px 14px 8px 14px;
-  margin-bottom: 18px;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
-  border: 1px solid #be9056;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
+  padding: px(8) px(14) px(8) px(14);
+  margin-bottom: px(18);
+  text-shadow: 0 px(1) 0 rgba(255, 255, 255, 0.5);
+  border: px(1) solid #be9056;
+  -webkit-border-radius: px(4);
+  -moz-border-radius: px(4);
+  border-radius: px(4);
   text-align: center;
 }
 
 .success-message {
   color: #638864;
   background-color: #dbeed3;
-  padding: 8px 14px 8px 14px;
-  margin-bottom: 18px;
-  text-shadow: 0 1px 0 rgba(255, 255, 255, 0.5);
-  border: 1px solid #638864;
-  -webkit-border-radius: 4px;
-  -moz-border-radius: 4px;
-  border-radius: 4px;
+  padding: px(8) px(14) px(8) px(14);
+  margin-bottom: px(18);
+  text-shadow: 0 px(1) 0 rgba(255, 255, 255, 0.5);
+  border: px(1) solid #638864;
+  -webkit-border-radius: px(4);
+  -moz-border-radius: px(4);
+  border-radius: px(4);
   text-align: center;
 }
 
@@ -133,7 +133,7 @@ $default-spacing: 10px;
   // Needed for default category 'message' of flash() in flashed_messages.html
   @include message-box();
   background-color: #fafafa;
-  border: 1px solid #ddd;
+  border: px(1) solid #ddd;
 
   .icon {
     @include icon-before('icon-info');
@@ -147,7 +147,7 @@ $default-spacing: 10px;
 .highlight-message-box {
   @include message-box();
   background-color: $light-blue;
-  border: 1px solid $dark-blue;
+  border: px(1) solid $dark-blue;
 
   .icon {
     @include icon-before('icon-lamp');
@@ -162,7 +162,7 @@ $default-spacing: 10px;
 .success-message-box {
   @include message-box();
   background-color: #eefaee;
-  border: 1px solid #cdc;
+  border: px(1) solid #cdc;
 
   .icon {
     @include icon-before('icon-checkmark');
@@ -180,7 +180,7 @@ $default-spacing: 10px;
 .warning-message-box {
   @include message-box();
   background-color: #fff3e2;
-  border: 1px solid #be9056;
+  border: px(1) solid #be9056;
 
   .icon {
     @include icon-before('icon-warning');
@@ -195,7 +195,7 @@ $default-spacing: 10px;
 .error-message-box {
   @include message-box();
   background-color: $light-red;
-  border: 1px solid $dark-red;
+  border: px(1) solid $dark-red;
 
   .icon {
     @include icon-before('icon-disable');
@@ -210,7 +210,7 @@ $default-spacing: 10px;
 .danger-message-box {
   @include message-box();
   background-color: $light-red;
-  border: 1px solid $dark-red;
+  border: px(1) solid $dark-red;
 
   .icon {
     @include icon-before('icon-warning');

--- a/indico/web/client/styles/partials/_object-lists.scss
+++ b/indico/web/client/styles/partials/_object-lists.scss
@@ -12,7 +12,7 @@
   .i-table {
     thead {
       font-weight: bold;
-      border-bottom: 2px solid $pastel-gray;
+      border-bottom: px(2) solid $pastel-gray;
       color: $black;
 
       tr {
@@ -54,7 +54,7 @@
 
     td {
       vertical-align: top;
-      padding: 12px 5px;
+      padding: px(12) px(5);
 
       .vertical-aligner {
         display: block;
@@ -66,7 +66,7 @@
   .entry-action-buttons {
     > a {
       font-size: 1.2em;
-      margin-left: 3px;
+      margin-left: px(3);
     }
   }
 
@@ -75,7 +75,7 @@
 
     &::before {
       color: $gray;
-      margin-right: 5px;
+      margin-right: px(5);
     }
 
     &.inline {
@@ -113,7 +113,7 @@
 }
 
 .list-filter-dialog {
-  max-width: 1200px;
+  max-width: px(1200);
 }
 
 @mixin enabled-action {
@@ -131,7 +131,7 @@
 
   .list-column {
     @extend .flexrow;
-    margin: 5px;
+    margin: px(5);
     width: 14.2em;
 
     > .filter {
@@ -188,7 +188,7 @@
 
         flex-grow: 1;
         color: $dark-gray;
-        margin-left: 4px;
+        margin-left: px(4);
 
         &::before {
           margin-right: 0.5em;

--- a/indico/web/client/styles/partials/_paddedboxes.scss
+++ b/indico/web/client/styles/partials/_paddedboxes.scss
@@ -10,7 +10,7 @@
 
 .padded-box {
   box-sizing: border-box;
-  @include border-all($color: $pastel-gray, $width: 2px);
+  @include border-all($color: $pastel-gray, $width: px(2));
   background: $pastel-gray;
   display: table;
   table-layout: fixed;
@@ -23,25 +23,25 @@
   .padded-box-pad {
     color: $light-black;
     display: table-cell;
-    font-size: 25px;
-    padding: 10px 0 5px;
+    font-size: px(25);
+    padding: px(10) 0 px(5);
     text-align: center;
-    width: 40px;
+    width: px(40);
   }
 
   .padded-box-content {
     @include default-border-radius();
     color: $black;
     display: table-cell;
-    padding: 10px;
-    margin-left: 40px;
+    padding: px(10);
+    margin-left: px(40);
     background: white;
     vertical-align: middle;
     word-break: break-word;
 
     hr {
       @include box-hr();
-      @include border-bottom($color: $pastel-gray, $width: 2px);
+      @include border-bottom($color: $pastel-gray, $width: px(2));
     }
   }
 }

--- a/indico/web/client/styles/partials/_plugins.scss
+++ b/indico/web/client/styles/partials/_plugins.scss
@@ -29,9 +29,9 @@
         background: repeating-linear-gradient(
           -40deg,
           $dark-blue,
-          $dark-blue 10px,
-          lighten($dark-blue, 0.5 * $light-color-variation) 10px,
-          lighten($dark-blue, 0.5 * $light-color-variation) 20px
+          $dark-blue px(10),
+          lighten($dark-blue, 0.5 * $light-color-variation) px(10),
+          lighten($dark-blue, 0.5 * $light-color-variation) px(20)
         );
       }
 

--- a/indico/web/client/styles/partials/_progress.scss
+++ b/indico/web/client/styles/partials/_progress.scss
@@ -20,7 +20,7 @@
     vertical-align: middle;
   }
   overflow: hidden;
-  min-width: 100px;
+  min-width: px(100);
   background-color: $dark-gray;
 
   & > .i-progress-bar {

--- a/indico/web/client/styles/partials/_qtips.scss
+++ b/indico/web/client/styles/partials/_qtips.scss
@@ -19,7 +19,7 @@
 .qtip-default {
   @include default-border-radius();
   @include border-all($black);
-  box-shadow: 1px 0 0 1px rgba(0, 0, 0, 0.2);
+  box-shadow: px(1) 0 0 px(1) rgba(0, 0, 0, 0.2);
 
   color: $light-gray;
   background-color: $black;
@@ -27,7 +27,7 @@
 
   .qtip-titlebar {
     background-color: #f0f0f0;
-    border-bottom: solid 1px #888;
+    border-bottom: solid px(1) #888;
   }
 
   .qtip-content {
@@ -70,19 +70,19 @@
 
   &.qtip-popup {
     @include qtip-light();
-    border: solid 1px #e2e2e2;
+    border: solid px(1) #e2e2e2;
     color: #454545;
   }
 
   &.qtip-balloon {
-    border: solid 1px #c0c0c0;
+    border: solid px(1) #c0c0c0;
     background-color: #ffed92;
-    width: 120px;
+    width: px(120);
   }
 
   &.qtip-timezone {
     color: $black;
-    min-width: 320px;
+    min-width: px(320);
   }
 
   &.qtip-allow-overflow {
@@ -101,7 +101,7 @@
 
     .qtip-titlebar {
       @include border-bottom();
-      padding: 5px 0;
+      padding: px(5) 0;
     }
 
     .qtip-title {
@@ -111,7 +111,7 @@
     }
 
     .i-big-button {
-      margin: 2px 0;
+      margin: px(2) 0;
 
       .caption {
         font-size: 1.1em;
@@ -121,7 +121,7 @@
 
   &.informational {
     @include qtip-light();
-    box-shadow: rgba($dark-gray, 0.2) 0 0 3px 3px, lighten($light-gray, 20%) 0 1px 0 0 inset;
+    box-shadow: rgba($dark-gray, 0.2) 0 0 px(3) px(3), lighten($light-gray, 20%) 0 px(1) 0 0 inset;
     @include border-all(#add9ed);
     background-color: #edf3fd;
     color: $light-black;

--- a/indico/web/client/styles/partials/_rules.scss
+++ b/indico/web/client/styles/partials/_rules.scss
@@ -10,17 +10,17 @@
 .titled-rule {
   color: $gray;
   font-size: 0.9em;
-  margin: 10px 0;
+  margin: px(10) 0;
   overflow: hidden;
   text-align: center;
 
   &::before,
   &::after {
-    box-shadow: 1px 1px 1px $light-gray;
+    box-shadow: px(1) px(1) px(1) $light-gray;
     background-color: $default-border-color;
     content: '';
     display: inline-block;
-    height: 1px;
+    height: px(1);
     position: relative;
     vertical-align: middle;
     width: 50%;

--- a/indico/web/client/styles/partials/_sidebars.scss
+++ b/indico/web/client/styles/partials/_sidebars.scss
@@ -10,13 +10,13 @@
 
 .sideBar {
   float: right;
-  width: 340px;
+  width: px(340);
 
   h1 {
     margin: 0;
     padding: 0;
     color: $light-black;
-    font-size: 15px;
+    font-size: px(15);
   }
 
   ul {
@@ -41,7 +41,7 @@
 
     &.subLink {
       font-style: italic;
-      font-size: 14px;
+      font-size: px(14);
     }
   }
 }
@@ -98,11 +98,11 @@
         display: block;
         min-height: 2.6em;
         line-height: 2.6em;
-        padding-left: 9px;
+        padding-left: px(9);
 
         .title {
           display: inline;
-          padding-left: 3px;
+          padding-left: px(3);
         }
       }
 
@@ -112,7 +112,7 @@
         min-height: 2.6em;
         line-height: 2.6em;
         color: $black;
-        padding-left: 26px;
+        padding-left: px(26);
 
         &::before {
           margin-right: 0.5em;
@@ -132,7 +132,7 @@
           display: flex;
           min-height: 2em;
           line-height: 2em;
-          padding-left: 51px;
+          padding-left: px(51);
         }
       }
 
@@ -150,9 +150,9 @@
       }
 
       i.icon {
-        width: 14.3px;
+        width: px(14.3);
         height: auto;
-        margin-right: 7.15px;
+        margin-right: px(7.15);
         font-size: 0.83em;
       }
     }
@@ -160,7 +160,7 @@
 }
 
 ul.menu-items li.active {
-  @include inner-border-left($link, $width: 2px);
+  @include inner-border-left($link, $width: px(2));
   position: relative;
   background-color: $light-blue;
 

--- a/indico/web/client/styles/partials/_steps.scss
+++ b/indico/web/client/styles/partials/_steps.scss
@@ -91,34 +91,34 @@ ul.steps {
     text-align: center;
 
     &.top {
-      margin-bottom: 20px;
+      margin-bottom: px(20);
     }
 
     &.bottom {
-      margin-top: 10px;
+      margin-top: px(10);
     }
   }
 
   .horizontal-line {
-    height: 3px;
+    height: px(3);
     background-color: $pastel-gray;
   }
 
   .circle {
     &::before {
-      @include border-all($width: 2px);
-      border-radius: 25px;
+      @include border-all($width: px(2));
+      border-radius: px(25);
       content: '';
-      width: 25px;
-      height: 25px;
+      width: px(25);
+      height: px(25);
       background-color: white;
-      margin-top: -15px;
+      margin-top: px(-15);
     }
   }
 
   .text {
     position: relative;
     font-weight: bold;
-    margin-top: 10px;
+    margin-top: px(10);
   }
 }

--- a/indico/web/client/styles/partials/_tables.scss
+++ b/indico/web/client/styles/partials/_tables.scss
@@ -65,7 +65,7 @@ table.i-table {
   }
 
   thead th {
-    padding: 10px 5px;
+    padding: px(10) px(5);
     font-weight: bold;
     text-align: left;
 
@@ -76,7 +76,7 @@ table.i-table {
 }
 
 tr.i-table {
-  border-top: 1px solid $pastel-gray;
+  border-top: px(1) solid $pastel-gray;
 
   &.selected,
   &.selected + tr.details-row {
@@ -91,7 +91,7 @@ tr.i-table {
 
 tr.i-table:last-child,
 tr.details-row:last-child {
-  border-bottom: 1px solid $pastel-gray;
+  border-bottom: px(1) solid $pastel-gray;
 }
 
 tr.details-row {
@@ -103,7 +103,7 @@ th.i-table {
   box-sizing: border-box;
   @include ellipsis();
 
-  padding: 5px 3px 5px 3px;
+  padding: px(5) px(3) px(5) px(3);
   vertical-align: middle;
 
   &.empty {
@@ -123,14 +123,14 @@ h3.i-table {
   font-weight: bold;
   margin-bottom: 0;
   margin-top: 1em;
-  padding: 3px 3px 5px 3px;
+  padding: px(3) px(3) px(5) px(3);
 
   &.emphasis {
     font-style: italic;
   }
 
   &.border {
-    border-bottom: 1px solid $pastel-gray;
+    border-bottom: px(1) solid $pastel-gray;
   }
 
   & + table.i-table {
@@ -187,7 +187,7 @@ tr.i-table.content {
 
   > td.i-table.caption,
   > td.i-table.value {
-    padding: 3px 5px 3px 5px;
+    padding: px(3) px(5) px(3) px(5);
   }
 
   > td.i-table.caption {
@@ -199,7 +199,7 @@ tr.i-table.content {
   }
 
   > td.i-table.value {
-    border-bottom: 1px solid transparent;
+    border-bottom: px(1) solid transparent;
     color: $light-black;
 
     &.plain-text-email {
@@ -220,7 +220,7 @@ th {
   &.small-column,
   &.action-column {
     white-space: nowrap;
-    width: 1px;
+    width: px(1);
   }
 }
 
@@ -238,7 +238,7 @@ th {
 
   tr > td,
   tr > th {
-    padding: 8px;
+    padding: px(8);
     line-height: 1.5;
     vertical-align: top;
   }
@@ -262,7 +262,7 @@ th {
   }
 
   a.action-icon {
-    margin-right: 5px;
+    margin-right: px(5);
 
     &:first-child {
       margin-left: 0;
@@ -285,7 +285,7 @@ th {
 
   dl.details-container {
     text-align: left;
-    padding: 8px;
+    padding: px(8);
     overflow: hidden;
     display: none;
 
@@ -330,7 +330,7 @@ th {
 
     color: $gray;
     font-size: 1.2em;
-    height: 10px;
+    height: px(10);
     cursor: move;
     text-align: left;
     padding: 0;
@@ -338,7 +338,7 @@ th {
     &:hover,
     &:active {
       @include border-left();
-      height: 20px;
+      height: px(20);
 
       &::before {
         color: $dark-gray;
@@ -350,12 +350,12 @@ th {
       @include transition(top);
       display: inline-block;
       position: relative;
-      top: 1px;
+      top: px(1);
     }
   }
 
   .sortable-placeholder {
     @include border-all($style: dashed);
-    margin-bottom: 15px;
+    margin-bottom: px(15);
   }
 }

--- a/indico/web/client/styles/partials/_timelines.scss
+++ b/indico/web/client/styles/partials/_timelines.scss
@@ -23,7 +23,7 @@
   position: relative;
 
   & .i-timeline {
-    margin-left: 51px;
+    margin-left: px(51);
   }
 
   .with-line::before {
@@ -32,9 +32,9 @@
     position: absolute;
     top: 0;
     bottom: 0;
-    left: 19px;
+    left: px(19);
     display: block;
-    width: 2px;
+    width: px(2);
     z-index: -1;
   }
 
@@ -45,7 +45,7 @@
 
 .i-timeline-item {
   @extend .flexrow;
-  $min-height: 19px;
+  $min-height: px(19);
 
   align-items: start;
   margin-top: 1rem;
@@ -54,12 +54,12 @@
     @include default-border-radius();
     @include border-all($color: transparent);
     box-sizing: border-box;
-    margin-right: 12px;
-    outline: 2px solid white;
+    margin-right: px(12);
+    outline: px(2) solid white;
     flex-shrink: 0;
     // To match i-box-header height
-    height: 39px;
-    width: 39px;
+    height: px(39);
+    width: px(39);
   }
 
   .i-timeline-item-box {
@@ -74,7 +74,7 @@
       min-height: $min-height;
 
       &.header-only {
-        margin-bottom: -10px;
+        margin-bottom: px(-10);
       }
     }
 
@@ -111,8 +111,8 @@
     color: $light-black;
     // Matches .i-timeline-item-label height
     // Also keeps correct v-alignment and separation with i-timeline-item-box on multiline
-    min-height: 19px;
-    padding: 10px 0;
+    min-height: px(19);
+    padding: px(10) 0;
   }
 }
 
@@ -131,20 +131,20 @@
 }
 
 .ui.avatar.image.profile-picture {
-  width: 39px;
-  height: 39px;
-  max-width: 39px;
-  margin-right: 10px;
+  width: px(39);
+  height: px(39);
+  max-width: px(39);
+  margin-right: px(10);
 }
 
 .i-timeline-separator {
-  @include border-top($width: 2px);
+  @include border-top($width: px(2));
   margin: 2em 0;
 }
 
 .i-timeline-connect-down {
-  @include border-left($width: 2px);
-  margin-left: 19px;
+  @include border-left($width: px(2));
+  margin-left: px(19);
   height: 2em;
 
   &.to-separator {
@@ -153,8 +153,8 @@
 }
 
 .i-timeline-connect-up {
-  @include border-left($width: 2px);
-  margin-left: 19px;
+  @include border-left($width: px(2));
+  margin-left: px(19);
   height: 2em;
 
   &.from-separator {

--- a/indico/web/client/styles/partials/_timetable-balloons.scss
+++ b/indico/web/client/styles/partials/_timetable-balloons.scss
@@ -8,15 +8,15 @@
 @use 'base' as *;
 
 .balloon-qtip {
-  max-width: 300px;
-  min-width: 300px;
+  max-width: px(300);
+  min-width: px(300);
 
   .qtip-content {
-    padding: 10px !important;
+    padding: px(10) !important;
   }
 
   .title-container {
-    margin-bottom: 10px;
+    margin-bottom: px(10);
 
     .title {
       font-size: 1.3em;
@@ -63,7 +63,7 @@
 
   .section-title-container {
     .title-header {
-      margin-bottom: 5px;
+      margin-bottom: px(5);
     }
 
     .title-caption {
@@ -114,8 +114,8 @@
   }
 
   .i-data-list {
-    max-width: 300px;
-    margin: 10px 0;
+    max-width: px(300);
+    margin: px(10) 0;
 
     dt,
     dd {
@@ -151,18 +151,18 @@
   span.hr {
     width: 100%;
     display: block;
-    margin: 10px 0;
-    border-bottom: 1px solid $pastel-gray;
+    margin: px(10) 0;
+    border-bottom: px(1) solid $pastel-gray;
   }
 
   .bottom-link {
-    margin-top: 10px;
+    margin-top: px(10);
   }
 }
 
 .balloon-time-qtip {
-  max-width: 410px;
-  min-width: 410px;
+  max-width: px(410);
+  min-width: px(410);
 
   .i-form {
     input {

--- a/indico/web/client/styles/partials/_toolbars.scss
+++ b/indico/web/client/styles/partials/_toolbars.scss
@@ -12,7 +12,7 @@
 
 $toolbar-height: 2.2em;
 $toolbar-thin-height: 1.9em;
-$toolbar-spacing: 10px;
+$toolbar-spacing: px(10);
 
 @mixin toolbar-group {
   @include toolbar-group-inputs();
@@ -52,7 +52,7 @@ $toolbar-spacing: 10px;
     &:last-child {
       border-bottom-right-radius: $default-border-radius;
       border-top-right-radius: $default-border-radius;
-      border-right-width: 1px;
+      border-right-width: px(1);
     }
 
     &.label {
@@ -78,7 +78,7 @@ $toolbar-spacing: 10px;
     &:last-child .i-button {
       border-bottom-right-radius: $default-border-radius;
       border-top-right-radius: $default-border-radius;
-      border-right-width: 1px;
+      border-right-width: px(1);
     }
   }
 }
@@ -146,12 +146,12 @@ $toolbar-spacing: 10px;
     .slider {
       padding-left: 1em !important;
       padding-right: 1em !important;
-      width: 150px;
+      width: px(150);
 
       .ui-slider {
         display: inline-block !important;
-        margin-top: 3px;
-        margin-left: -2px;
+        margin-top: px(3);
+        margin-left: px(-2);
         width: 100% !important;
       }
     }
@@ -175,7 +175,7 @@ $toolbar-spacing: 10px;
         font-size: 1em;
         position: absolute;
         margin: 0;
-        right: 5px;
+        right: px(5);
         top: auto;
       }
 
@@ -253,7 +253,7 @@ $toolbar-spacing: 10px;
     }
 
     &.arrow:last-of-type:not(.borderless) {
-      border-right-width: 1px;
+      border-right-width: px(1);
       border-right-style: solid;
     }
   }
@@ -295,7 +295,7 @@ $toolbar-spacing: 10px;
   }
 
   .search-box {
-    min-width: 300px;
+    min-width: px(300);
   }
 }
 

--- a/indico/web/client/styles/partials/_widgets.scss
+++ b/indico/web/client/styles/partials/_widgets.scss
@@ -15,14 +15,14 @@
   img {
     cursor: pointer;
     float: right;
-    padding: 2px;
+    padding: px(2);
     position: absolute;
-    right: 2px;
+    right: px(2);
   }
 
   input {
-    width: 150px;
-    padding-right: 20px;
+    width: px(150);
+    padding-right: px(20);
   }
 }
 
@@ -73,7 +73,7 @@ i.info-helper {
 }
 
 .i-linking {
-  width: 400px;
+  width: px(400);
   min-height: 2.5em;
 
   > label {
@@ -109,8 +109,8 @@ i.info-helper {
 .text-holder-box {
   @include border-all($style: dashed);
   color: $light-black;
-  min-height: 25px;
-  min-width: 320px;
-  margin-bottom: 10px;
-  padding: 5px 10px;
+  min-height: px(25);
+  min-width: px(320);
+  margin-bottom: px(10);
+  padding: px(5) px(10);
 }

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -18,7 +18,7 @@ $tt-nested-time-color: $light-black !default;
 $tt-additional-text-color: $light-black !default;
 $selected-color: $indico-blue !default;
 
-@mixin header-logo($image, $position: 15px, $padding-left: 150px, $scale: none) {
+@mixin header-logo($image, $position: px(15), $padding-left: px(150), $scale: none) {
   div.event-header {
     background: $header-bg-color url($image) left top no-repeat;
     background-position: $position;
@@ -28,12 +28,12 @@ $selected-color: $indico-blue !default;
 }
 
 @mixin drop-shadow {
-  box-shadow: 0 2px 10px 1px rgba(50, 50, 50, 0.4);
+  box-shadow: 0 px(2) px(10) px(1) rgba(50, 50, 50, 0.4);
 }
 
 @mixin ribbon($color) {
   @include transition(background-color 0.5s linear);
-  border-radius: 0 2px 2px 0;
+  border-radius: 0 px(2) px(2) 0;
   $darkened-color: darken($color, 10%);
 
   background-color: $color;
@@ -45,7 +45,7 @@ $selected-color: $indico-blue !default;
     height: 0;
     left: 0;
     top: 100%;
-    border-width: 5px 5px;
+    border-width: px(5) px(5);
     border-style: solid;
     border-color: $darkened-color $darkened-color transparent transparent;
   }
@@ -69,7 +69,7 @@ body {
   color: $tt-secondary-color;
   font-size: 1em;
   float: right;
-  max-width: 200px;
+  max-width: px(200);
   margin: 0.5rem 0.7em 0 0;
 
   &::before {
@@ -115,7 +115,7 @@ body {
 .header-data {
   &::before {
     color: $header-icon-color;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+    text-shadow: px(1) px(1) px(2) rgba(0, 0, 0, 0.1);
     margin-right: 0.4em;
     vertical-align: middle;
   }
@@ -157,7 +157,7 @@ body {
 .speaker-list,
 .chairperson-list,
 .convener-list {
-  margin: 0.1em 55px 0 0;
+  margin: 0.1em px(55) 0 0;
 
   .label {
     font-weight: bold;
@@ -171,7 +171,7 @@ body {
 
 .chairperson-list .author {
   @include highlighted-header-data();
-  margin-bottom: 2px;
+  margin-bottom: px(2);
 }
 
 .speaker-list,
@@ -181,7 +181,7 @@ body {
 
 .details .address {
   color: #aaa;
-  font-size: 12px;
+  font-size: px(12);
   text-shadow: none;
 }
 
@@ -194,21 +194,21 @@ div.event-header {
   font-size: 12pt;
   position: relative;
 
-  min-height: 125px;
+  min-height: px(125);
   margin: 0;
-  padding: 10px 30px 10px;
+  padding: px(10) px(30) px(10);
 
   .event-title {
     display: flex;
     justify-content: space-between;
     gap: 0.5em;
-    margin-bottom: 10px;
+    margin-bottom: px(10);
 
     h1 {
       font-size: 20pt;
       color: $header-text-color;
       font-weight: normal;
-      margin-top: 10px;
+      margin-top: px(10);
     }
 
     .event-actions {
@@ -218,7 +218,7 @@ div.event-header {
         // XXX somehow this breaks printing in chrome (23k pages)
         gap: 0.2em;
       }
-      margin-top: 10px;
+      margin-top: px(10);
     }
   }
 
@@ -269,11 +269,11 @@ ul.day-list {
   list-style-type: none;
   padding-left: 0;
   margin-left: 0;
-  margin-top: 10px;
+  margin-top: px(10);
 }
 
 .day-header {
-  margin-top: 25px;
+  margin-top: px(25);
   position: relative;
   text-align: center;
 
@@ -415,9 +415,9 @@ ul.day-list {
       top: 1.8em;
       right: 0.2em;
       min-width: 10em;
-      border-radius: 2px;
+      border-radius: px(2);
       background-color: $light-gray;
-      box-shadow: 0 2px 10px 1px rgba(50, 50, 50, 0.4);
+      box-shadow: 0 px(2) px(10) px(1) rgba(50, 50, 50, 0.4);
       padding-top: 0.2em;
 
       .item,
@@ -439,7 +439,7 @@ ul.day-list {
       }
 
       .divider {
-        border-top: 1px dotted $dark-gray;
+        border-top: px(1) dotted $dark-gray;
         height: 0;
         margin-bottom: 0.2em;
       }
@@ -460,7 +460,7 @@ ul.day-list {
   padding: 0;
 
   .timetable-item.timetable-subcontrib {
-    border-left: 2px dotted $gray;
+    border-left: px(2) dotted $gray;
     padding-left: 1em;
 
     .timetable-title {
@@ -482,9 +482,9 @@ ul.day-list {
     .start-time {
       background-color: $tt-primary-color;
       font-weight: bold;
-      box-shadow: 1px 1px 2px 1px rgba(0, 0, 0, 0.1);
-      margin-left: -10px;
-      padding: 0 10px 0 20px;
+      box-shadow: px(1) px(1) px(2) px(1) rgba(0, 0, 0, 0.1);
+      margin-left: px(-10);
+      padding: 0 px(10) 0 px(20);
       position: relative;
       @include ribbon($tt-primary-color);
     }
@@ -493,10 +493,10 @@ ul.day-list {
   &.nested {
     @include transition(border-color 0.5s linear);
     margin-right: 0.5em;
-    border-right: 3px solid $tt-nested-time-color;
+    border-right: px(3) solid $tt-nested-time-color;
 
     .start-time {
-      padding: 0 5px 0 10px;
+      padding: 0 px(5) 0 px(10);
       background-color: $tt-nested-time-color;
     }
   }
@@ -520,7 +520,7 @@ ul.day-list {
 
   .start-time {
     @include highlighted-data();
-    border-radius: 2px 0 0 2px;
+    border-radius: px(2) 0 0 px(2);
     @include transition(background-color 0.5s linear);
     color: $light-gray !important;
   }
@@ -554,20 +554,20 @@ ul.day-list {
 }
 
 .event-sub-header {
-  border-radius: 0 0 2px 2px;
+  border-radius: 0 0 px(2) px(2);
   @include drop-shadow();
   @include font-family-title-light();
 
   background: white;
-  font-size: 12px;
+  font-size: px(12);
   color: black;
   margin: 0;
-  padding: 3px 10px;
+  padding: px(3) px(10);
 }
 
 .note-area-wrapper .note-area {
   @include font-family-modern-body();
-  margin-top: 10px;
+  margin-top: px(10);
 }
 
 // Lectures
@@ -627,11 +627,11 @@ a.lecture-series-link {
 .agenda-placeholder {
   @include default-border-radius();
   background-color: white;
-  margin-top: 10px;
+  margin-top: px(10);
   flex-grow: 1;
   color: $gray;
   text-align: center;
-  height: 250px;
+  height: px(250);
 
   .placeholder-icon {
     font-size: 5em;
@@ -665,7 +665,7 @@ div.event-details {
   }
 
   .event-details-label {
-    width: 120px;
+    width: px(120);
     text-align: right;
     font-weight: bold;
     margin-right: 1em;

--- a/indico/web/client/styles/themes/print/indico.scss
+++ b/indico/web/client/styles/themes/print/indico.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'base/utilities' as *;
 
 $header-bg-color: white;
 $header-icon-color: black;
@@ -84,11 +85,11 @@ body {
 
 .meeting-timetable {
   @include no-shadow();
-  border: 1px solid $gray;
+  border: px(1) solid $gray;
 
   .start-time {
     @include no-shadow();
-    border: 1px solid $gray;
+    border: px(1) solid $gray;
 
     &::before {
       display: none !important;

--- a/indico/web/client/styles/themes/weeks.scss
+++ b/indico/web/client/styles/themes/weeks.scss
@@ -8,12 +8,13 @@
 @use 'base/palette' as *;
 @use 'base/defaults' as *;
 @use 'base/borders' as *;
+@use 'base/utilities' as *;
 
 .event-info-header {
   color: white;
   text-align: left;
-  border-top: 3px solid #234173;
-  border-bottom: 1px solid #0f4c80;
+  border-top: px(3) solid #234173;
+  border-bottom: px(1) solid #0f4c80;
   background: #1a64a0;
 }
 
@@ -37,7 +38,7 @@
 .week-timetable {
   font-family: helvetica, verdana, sans-serif;
   font-size: 8pt;
-  line-height: 18px;
+  line-height: px(18);
 }
 
 .week-timetable + .week-timetable {
@@ -56,12 +57,12 @@
   float: left;
   width: 13.95%;
   display: inline-block;
-  border: 1px #bbb solid;
+  border: px(1) #bbb solid;
   background: #fff;
   box-sizing: border-box;
   -moz-box-sizing: border-box;
   border-radius: 0.2em;
-  box-shadow: 1px 1px 1px #e1e1e1;
+  box-shadow: px(1) px(1) px(1) #e1e1e1;
 }
 
 .week-timetable > ul > li.spacer {
@@ -78,9 +79,9 @@
 }
 
 .week-timetable .row {
-  height: 18px;
+  height: px(18);
   position: relative;
-  border-top: solid 1px #f9f9f9;
+  border-top: solid px(1) #f9f9f9;
   box-sizing: border-box;
 }
 
@@ -93,15 +94,15 @@
   color: #1756b5;
   text-align: center;
   font-weight: bold;
-  border-bottom: 1px solid #bbb;
+  border-bottom: px(1) solid #bbb;
 }
 
 .week-timetable .row.placeholder {
-  border-top: 1px solid #f9f9f9;
+  border-top: px(1) solid #f9f9f9;
 }
 
 .week-timetable .row.placeholder + .placeholder {
-  border-top: 1px dashed #ddd;
+  border-top: px(1) dashed #ddd;
 }
 
 .week-timetable .row.day-header + .row {
@@ -129,7 +130,7 @@
   background: rgba(0, 0, 0, 0.3);
   color: white;
   font-weight: bold;
-  width: 35px;
+  width: px(35);
   height: 100%;
   display: inline-block;
   text-align: center;
@@ -140,14 +141,14 @@
   position: absolute;
   left: 0;
   bottom: 0;
-  width: 35px;
+  width: px(35);
   margin: auto 0;
   color: #ccc;
 }
 
 .week-timetable .row .main {
   position: absolute;
-  padding-left: 40px;
+  padding-left: px(40);
   width: 100%;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
@@ -155,11 +156,11 @@
 
 .week-timetable .row.has-session .main,
 .week-timetable .row.has-multi .main {
-  padding-right: 19px;
+  padding-right: px(19);
 }
 
 .week-timetable .row.has-session.has-multi .main {
-  padding-right: 29px;
+  padding-right: px(29);
 }
 
 .week-timetable .row .more-contribs {
@@ -167,11 +168,11 @@
   position: absolute;
   right: 0;
   display: inline-block;
-  padding: 1px 5px 0 5px;
+  padding: px(1) px(5) 0 px(5);
 }
 
 .week-timetable .row .session-mark + .more-contribs {
-  margin-right: 18px;
+  margin-right: px(18);
 }
 
 .week-timetable .row .session-mark {
@@ -179,8 +180,8 @@
   position: absolute;
   right: 0;
   display: inline-block;
-  margin: 1px 2px 0 0;
-  text-shadow: -1px 0 #ccc, 0 1px #ccc, 1px 0 #ccc, 0 -1px #ccc;
+  margin: px(1) px(2) 0 0;
+  text-shadow: px(-1) 0 #ccc, 0 px(1) #ccc, px(1) 0 #ccc, 0 px(-1) #ccc;
 }
 
 .week-anchor {
@@ -189,7 +190,7 @@
 
 .qtip-content {
   display: inline-block;
-  padding: 10px;
+  padding: px(10);
   box-sizing: border-box;
 
   span {
@@ -231,7 +232,7 @@
 
       .time {
         height: 100%;
-        margin-right: 5px;
+        margin-right: px(5);
       }
 
       .title {

--- a/indico/web/client/styles/widgets/_occurrences.scss
+++ b/indico/web/client/styles/widgets/_occurrences.scss
@@ -9,7 +9,7 @@
 
 .occurrences-widget {
   .occurrence + .occurrence {
-    margin-top: 5px;
+    margin-top: px(5);
   }
 
   .DateInput_input {
@@ -30,8 +30,8 @@
 
   .rc-time-picker-panel-input-wrap {
     // make sure time does not jump when opening the time picker
-    padding-left: calc(1em - 1px);
-    padding-top: calc(0.5em + 1px);
+    padding-left: calc(1em - #{px(1)});
+    padding-top: calc(0.5em + #{px(1)});
   }
 
   .rc-time-picker-panel-input,
@@ -63,16 +63,16 @@
     @include icon-before('icon-earth');
     color: $light-black;
     position: relative;
-    right: 24px;
-    top: 2px;
+    right: px(24);
+    top: px(2);
   }
 
   .duration-info {
     @include icon-before('icon-time');
     color: $light-black;
     position: relative;
-    right: 24px;
-    top: 2px;
+    right: px(24);
+    top: px(2);
   }
 
   .remove-occurrence {

--- a/indico/web/client/styles/widgets/_permissions.scss
+++ b/indico/web/client/styles/widgets/_permissions.scss
@@ -25,7 +25,7 @@
   padding-bottom: 2em;
 
   .permissions-widget-list {
-    @include border-left($width: 3px);
+    @include border-left($width: px(3));
     padding-left: 1em;
 
     & > li {
@@ -58,7 +58,7 @@
       .role-code {
         flex-shrink: 0;
         text-align: center;
-        width: 35px;
+        width: px(35);
       }
 
       .entry-icon {
@@ -193,7 +193,7 @@
         line-height: normal;
         text-align: center;
         vertical-align: middle;
-        width: 35px;
+        width: px(35);
 
         &.role-code {
           @include role-code();
@@ -215,7 +215,7 @@
 
 @mixin circle-checkbox-checked() {
   background-color: $pastel-blue;
-  border: 2px solid $darker-blue;
+  border: px(2) solid $darker-blue;
 }
 
 .permissions-dialog {
@@ -227,7 +227,7 @@
       color: $light-black;
       cursor: pointer;
       font-family: 'Roboto', sans-serif;
-      font-size: 14px;
+      font-size: px(14);
       font-weight: normal;
     }
 
@@ -236,21 +236,21 @@
     }
 
     .permissions > .item {
-      @include border-left(lighten($pastel-gray, 7%), $width: 2px);
+      @include border-left(lighten($pastel-gray, 7%), $width: px(2));
     }
 
     .circle-checkbox {
       display: none;
 
       & + label::before {
-        @include border-all($gray, $width: 2px);
+        @include border-all($gray, $width: px(2));
         border-radius: 3em;
         content: '';
         display: inline-block;
         margin-right: 0.25em;
         vertical-align: middle;
-        height: 23px;
-        width: 23px;
+        height: px(23);
+        width: px(23);
       }
 
       &:hover:not(:checked) + label::before {

--- a/indico/web/client/styles/widgets/_sortable_list.scss
+++ b/indico/web/client/styles/widgets/_sortable_list.scss
@@ -11,7 +11,7 @@
 @use 'partials/labels' as *;
 
 .sortable-list {
-  margin-bottom: 10px;
+  margin-bottom: px(10);
 
   ul {
     @include i-box-cancel-horizontal-margin();
@@ -24,7 +24,7 @@
     li {
       @extend .flexrow;
       margin: 0;
-      padding: 10px;
+      padding: px(10);
 
       &.draggable {
         cursor: move;
@@ -72,7 +72,7 @@
       }
 
       &.placeholder {
-        border: 1px $i-label-color dashed;
+        border: px(1) $i-label-color dashed;
       }
 
       .handle.invisible {
@@ -89,9 +89,9 @@
         background: repeating-linear-gradient(
           -40deg,
           lighten($pastel-gray, 0.5 * $color-variation),
-          lighten($pastel-gray, 0.5 * $color-variation) 10px,
-          lighten($pastel-gray, 0.7 * $color-variation) 10px,
-          lighten($pastel-gray, 0.7 * $color-variation) 20px
+          lighten($pastel-gray, 0.5 * $color-variation) px(10),
+          lighten($pastel-gray, 0.7 * $color-variation) px(10),
+          lighten($pastel-gray, 0.7 * $color-variation) px(20)
         );
         background-color: lighten($i-label-color, 50%);
       }
@@ -121,7 +121,7 @@
       }
 
       &:nth-child(2) {
-        border-left: 1px solid $gray;
+        border-left: px(1) solid $gray;
 
         ul {
           margin-left: 0;
@@ -139,7 +139,7 @@
       @include default-border-radius();
 
       &:not(:last-child) {
-        margin-bottom: 5px;
+        margin-bottom: px(5);
       }
 
       &:not(.placeholder) {


### PR DESCRIPTION
This patch adds a `px()` utility SCSS function and changes all instances of pixel dimensions in all SCSS code to use it. For instance `300px` becomes `px(300)`. At the moment, the `px()` function simply outputs the pixel value as is.

This facade is added in order to aid the transition to text-relative units as described [here](https://talk.getindico.io/t/indico-accessibility/3179/29?u=hayavuk). 

After this patch is merged, all engineers working with CSS will be expected to follow this convention either permanently, or until the `px()` is replaced with adequate units, depending on how we decide to approach the text-relative units.

See #5888