### PR TITLE
Address base font size issue

### DIFF
--- a/indico/web/client/styles/base/_typography.scss
+++ b/indico/web/client/styles/base/_typography.scss
@@ -51,13 +51,10 @@
   font-family: 'Maven Pro', sans-serif;
 }
 
-@mixin font-size-body {
-  font-size: 13px;
-}
-
 html,
 body {
   height: 100%;
+  font-size: inherit; // override specific sizes set in semantic UI
 }
 
 body {
@@ -65,7 +62,6 @@ body {
   padding: 0;
   margin: 0;
   @include font-family-body();
-  @include font-size-body();
 }
 
 .ui {

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,6 +140,7 @@
         "path-browserify": "^1.0.1",
         "postcss": "^8.4.14",
         "postcss-loader": "^7.0.0",
+        "postcss-pxtorem": "^6.0.0",
         "postcss-scss": "^4.0.4",
         "postcss-url": "^10.1.3",
         "prettier": "~1.18.2",
@@ -11793,6 +11794,15 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-pxtorem": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-pxtorem/-/postcss-pxtorem-6.0.0.tgz",
+      "integrity": "sha512-ZRXrD7MLLjLk2RNGV6UA4f5Y7gy+a/j1EqjAfp9NdcNYVjUMvg5HTYduTjSkKBkRkfqbg/iKrjMO70V4g1LZeg==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": "^8.0.0"
       }
     },
     "node_modules/postcss-resolve-nested-selector": {
@@ -24341,6 +24351,12 @@
       "requires": {
         "icss-utils": "^5.0.0"
       }
+    },
+    "postcss-pxtorem": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-pxtorem/-/postcss-pxtorem-6.0.0.tgz",
+      "integrity": "sha512-ZRXrD7MLLjLk2RNGV6UA4f5Y7gy+a/j1EqjAfp9NdcNYVjUMvg5HTYduTjSkKBkRkfqbg/iKrjMO70V4g1LZeg==",
+      "dev": true
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "path-browserify": "^1.0.1",
     "postcss": "^8.4.14",
     "postcss-loader": "^7.0.0",
+    "postcss-pxtorem": "^6.0.0",
     "postcss-scss": "^4.0.4",
     "postcss-url": "^10.1.3",
     "prettier": "~1.18.2",

--- a/webpack/base.babel.js
+++ b/webpack/base.babel.js
@@ -11,6 +11,7 @@ import path from 'path';
 
 import autoprefixer from 'autoprefixer';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import pxToRem from 'postcss-pxtorem';
 import postcssURL from 'postcss-url';
 import TerserPlugin from 'terser-webpack-plugin';
 import webpack from 'webpack';
@@ -97,6 +98,12 @@ export function webpackDefaults(env, config, bundles, isPlugin = false) {
     url: true,
   };
 
+  const _pxToRemOptions = {
+    rootValue: 14,
+    mediaQuery: true,
+    propList: ['*'],
+  };
+
   const scssIncludePath = path.join(
     config.isPlugin
       ? path.resolve(config.build.indicoSourcePath, './indico/web/client')
@@ -172,6 +179,7 @@ export function webpackDefaults(env, config, bundles, isPlugin = false) {
           sourceMap: true,
           url: !config.isPlugin,
           ...cssLoaderOptions,
+          importLoaders: 2,
         },
       },
       {
@@ -186,6 +194,7 @@ export function webpackDefaults(env, config, bundles, isPlugin = false) {
           sourceMap: true,
           postcssOptions: {
             plugins: [
+              pxToRem(_pxToRemOptions),
               autoprefixer,
               postcssURL({
                 url: postCSSURLResolver,
@@ -263,7 +272,18 @@ export function webpackDefaults(env, config, bundles, isPlugin = false) {
                 },
                 {
                   loader: 'css-loader',
-                  options: _cssLoaderOptions,
+                  options: {
+                    ..._cssLoaderOptions,
+                  },
+                },
+                {
+                  loader: 'postcss-loader',
+                  options: {
+                    sourceMap: true,
+                    postcssOptions: {
+                      plugins: [pxToRem(_pxToRemOptions), autoprefixer],
+                    },
+                  },
                 },
               ],
             },
@@ -274,7 +294,6 @@ export function webpackDefaults(env, config, bundles, isPlugin = false) {
                   localIdentContext: path.resolve(globalBuildConfig.clientPath, '../../modules'),
                   localIdentName: '[path]___[name]__[local]___[contenthash:base64:5]',
                 },
-                importLoaders: 1,
               }),
             },
             {

--- a/webpack/base.babel.js
+++ b/webpack/base.babel.js
@@ -94,10 +94,6 @@ export function webpackDefaults(env, config, bundles, isPlugin = false) {
     nodeModules.push(path.resolve(config.build.rootPath, '../node_modules'));
   }
 
-  const _cssLoaderOptions = {
-    url: true,
-  };
-
   const _pxToRemOptions = {
     rootValue: 14,
     mediaQuery: true,
@@ -272,9 +268,7 @@ export function webpackDefaults(env, config, bundles, isPlugin = false) {
                 },
                 {
                   loader: 'css-loader',
-                  options: {
-                    ..._cssLoaderOptions,
-                  },
+                  options: {url: true},
                 },
                 {
                   loader: 'postcss-loader',


### PR DESCRIPTION
This patch introduces changes to address text metric issues. The following changes are made:

- Add [postcss-pxtorem](https://www.npmjs.com/package/postcss-pxtorem) plugin into the CSS build pipeline so that all `px` values are output as `rem`
- Set the font sizes on `<html>` and `<body>` to `inherit` to undo font size values specified in Semantic UI.

The `remValue` setting (the basis for `px` to `rem` conversion) is set to 14. An alternative was to set to 16. When setting to 16, the UI maintains its existing scale. However, this is inappropriate as it makes the UI text sizes 12.5% smaller than they should be. Setting it to 14 scales the UI up so that it appears as if has been developed at the standard base font size of 16px.

Please note that I'm still testing this patch.

See #5888 