### PR TITLE
Add a service handler for deleting editables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Improvements
 - Add full ACLs for custom conference menu items, instead of just being able to
   restrict them to speakers or registrants (:pr:`5670`, thanks :user:`kewisch`)
 - Make editing timeline display much more straightforward (:pr:`5674`)
-- Allow event managers to delete editables from contributions (:pr:`5778`)
+- Allow event managers to delete editables from contributions (:pr:`5778`, :pr:`5892`)
 - Allow room managers to add internal notes to bookings (:issue:`5746`, :pr:`5791`)
 
 Bugfixes

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -32,8 +32,8 @@ from indico.modules.events.editing.operations import (assign_editor, create_new_
 from indico.modules.events.editing.schemas import (EditableSchema, EditingConfirmationAction, EditingReviewAction,
                                                    ReviewEditableArgs)
 from indico.modules.events.editing.service import (ServiceRequestFailed, service_get_custom_actions,
-                                                   service_handle_custom_action, service_handle_new_editable,
-                                                   service_handle_review_editable)
+                                                   service_handle_custom_action, service_handle_delete_editable,
+                                                   service_handle_new_editable, service_handle_review_editable)
 from indico.modules.events.editing.settings import editing_settings
 from indico.modules.files.controllers import UploadFileMixin
 from indico.modules.users import User
@@ -202,6 +202,11 @@ class RHDeleteEditable(RHContributionEditableBase):
 
     def _process(self):
         delete_editable(self.editable)
+        if editing_settings.get(self.event, 'service_url'):
+            try:
+                service_handle_delete_editable(self.editable)
+            except ServiceRequestFailed:
+                raise ServiceUnavailable(_('Deletion failed, please try again later.'))
         return '', 204
 
 

--- a/indico/modules/events/editing/service.py
+++ b/indico/modules/events/editing/service.py
@@ -195,6 +195,20 @@ def service_handle_review_editable(editable, user, action, parent_revision, revi
         raise ServiceRequestFailed(exc)
 
 
+def service_handle_delete_editable(editable):
+    path = '/event/{}/editable/{}/{}'.format(
+        _get_event_identifier(editable.event),
+        editable.type.name,
+        editable.contribution_id
+    )
+    try:
+        resp = requests.delete(_build_url(editable.event, path), headers=_get_headers(editable.event))
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        _log_service_error(exc, 'Calling listener for delete editable failed')
+        raise ServiceRequestFailed(exc)
+
+
 def service_get_custom_actions(editable, revision, user):
     data = {
         'revision': EditingRevisionSignedSchema().dump(revision),


### PR DESCRIPTION
This PR adds a a service handler that is called whenever an editable is deleted.