### PR TITLE
Add lang attribute that matches the currently selected language

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Improvements
 - Allow room managers to add internal notes to bookings (:issue:`5746`, :pr:`5791`)
 - Support generating tickets and badges for each of the registrant's accompanying
   persons (:pr:`5424`)
+- Include current language in page metadata (:pr:`5894`, thanks :user:`foxbunny`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/web/templates/base.html
+++ b/indico/web/templates/base.html
@@ -1,6 +1,6 @@
 {#- Base template for standalone pages (no "indico look") -#}
 <!DOCTYPE html>
-<html>
+<html lang="{{ current_locale.language }}">
 <head>
     <title>Indico{% if self.title() %} - {% endif %}{% block title %}{% endblock %}</title>
     <meta charset="UTF-8">

--- a/indico/web/templates/indico_base.html
+++ b/indico/web/templates/indico_base.html
@@ -1,7 +1,8 @@
 {#- Base template for indico pages (standard "indico look") -#}
 <!DOCTYPE html>
 
-<html prefix="og: http://ogp.me/ns#"
+<html lang="{{ current_locale.language }}"
+      prefix="og: http://ogp.me/ns#"
       data-static-site="{{ g.get('static_site', false)|tojson|forceescape }}">
 <head>
     <title>


### PR DESCRIPTION
Adds the `lang` attribute to the `HTML` element in the `layout/indico_base.html` and `layout/base.html` templates.