### PR TITLE
Prevent calendar export popup from overflowing

### DIFF
--- a/indico/web/client/js/react/components/ICSCalendarLink.module.scss
+++ b/indico/web/client/js/react/components/ICSCalendarLink.module.scss
@@ -66,7 +66,7 @@
 .popup:global(.ui.wide.popup) {
   display: inline-flex;
   min-width: 350px;
-  max-width: 450px;
+  max-width: unset;
 }
 
 .popup .content {


### PR DESCRIPTION

before:
![obrazek](https://github.com/indico/indico/assets/8739637/5b1bbc75-d918-414b-9bb1-6fea43d8d63a)
![obrazek](https://github.com/indico/indico/assets/8739637/77ec585c-9bc9-4f45-ae08-009bc0c2e5de)

after:
![obrazek](https://github.com/indico/indico/assets/8739637/c87af25b-8a8b-4f65-81c7-cbb3648dea33)

I'm not going to touch the `<Or />` element cause I doubt we can make it look nice when the text is longer. Might be best to use something else.