### PR TITLE
Remove the 'Or' element from calendar export options

### DIFF
--- a/indico/web/client/js/react/components/ICSCalendarLink.jsx
+++ b/indico/web/client/js/react/components/ICSCalendarLink.jsx
@@ -59,7 +59,6 @@ const ICSExportOptions = ({options, selected, handleSetOption}) => (
             />
           }
         />
-        {idx < options.length - 1 && <Button.Or text={Translate.string('or')} />}
       </React.Fragment>
     ))}
   </Button.Group>


### PR DESCRIPTION
The element does not look good in languages where 'or' is longer than two letters.

currently:
![obrazek](https://github.com/indico/indico/assets/8739637/5f3be947-fca2-45d0-ab00-99cd2100d34f)


after removal:
![obrazek](https://github.com/indico/indico/assets/8739637/23a3eb98-2e04-48d6-9782-14cdb0717bd9)

