### PR TITLE
Add hard expiration to Flask session

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,9 @@ Improvements
 - Support weekly room bookings that take place on multiple weekdays (:pr:`5829`, :issue:`5806`)
 - Hide events marked as invisible from builtin search results unless the user is a manager
   (:pr:`5947`, thanks :user:`openprojects`)
+- Support sessions that expire at a certain date (specified by the used flask-multipass
+  provider) regardless of activity when using an external login method (:pr:`5907`, thanks
+  :user:`cbartz`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/auth/__init__.py
+++ b/indico/modules/auth/__init__.py
@@ -4,6 +4,7 @@
 # Indico is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
+from datetime import datetime
 
 from flask import redirect, request, session
 from flask_multipass import MultipassException
@@ -71,6 +72,11 @@ def process_identity(identity_info):
         identity.data = identity_info.data
     if user.is_blocked:
         raise MultipassException(_('Your Indico profile has been blocked.'))
+
+    if session_expiry := identity.multipass_data.get('session_expiry'):
+        if not isinstance(session_expiry, datetime):
+            raise ValueError('Session expiry must be a datetime object')
+        session.hard_expiry = identity.multipass_data['session_expiry']
     login_user(user, identity)
 
 

--- a/indico/modules/auth/__init__.py
+++ b/indico/modules/auth/__init__.py
@@ -4,6 +4,7 @@
 # Indico is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
+
 from datetime import datetime
 
 from flask import redirect, request, session

--- a/indico/modules/auth/__init__.py
+++ b/indico/modules/auth/__init__.py
@@ -32,6 +32,12 @@ logger = Logger.get('auth')
 @multipass.identity_handler
 def process_identity(identity_info):
     logger.info('Received identity info: %s', identity_info)
+
+    if session_expiry := identity_info.multipass_data.get('session_expiry'):
+        if not isinstance(session_expiry, datetime):
+            raise ValueError('Session expiry must be a datetime object')
+        session.hard_expiry = session_expiry
+
     identity = Identity.query.filter_by(provider=identity_info.provider.name,
                                         identifier=identity_info.identifier).first()
     if identity is None:
@@ -74,10 +80,6 @@ def process_identity(identity_info):
     if user.is_blocked:
         raise MultipassException(_('Your Indico profile has been blocked.'))
 
-    if session_expiry := identity.multipass_data.get('session_expiry'):
-        if not isinstance(session_expiry, datetime):
-            raise ValueError('Session expiry must be a datetime object')
-        session.hard_expiry = identity.multipass_data['session_expiry']
     login_user(user, identity)
 
 

--- a/indico/modules/auth/__init__.py
+++ b/indico/modules/auth/__init__.py
@@ -33,7 +33,7 @@ logger = Logger.get('auth')
 def process_identity(identity_info):
     logger.info('Received identity info: %s', identity_info)
 
-    if session_expiry := identity_info.multipass_data.get('session_expiry'):
+    if (multipass_data := identity_info.multipass_data) and (session_expiry := multipass_data.get('session_expiry')):
         if not isinstance(session_expiry, datetime):
             raise ValueError('Session expiry must be a datetime object')
         session.hard_expiry = session_expiry

--- a/indico/modules/auth/auth_test.py
+++ b/indico/modules/auth/auth_test.py
@@ -1,0 +1,47 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from datetime import datetime, timezone
+
+import pytest
+from flask import session
+from flask_multipass import IdentityInfo, Multipass
+from flask_multipass.providers.static import StaticIdentityProvider
+
+from indico.modules.auth import process_identity
+
+
+@pytest.mark.usefixtures('database')
+def test_process_identity_sets_hard_expiry(app):
+    """Test that hard expiry is set on the session object if it is present in the multipass data."""
+    dt_now = datetime.now(timezone.utc)
+    identity_info = IdentityInfo(
+        provider=StaticIdentityProvider(
+            multipass=Multipass(), name='static', settings={}
+        ),
+        identifier='static', multipass_data={'session_expiry': dt_now}
+    )
+
+    with app.test_request_context('/ping', method='GET'):
+        process_identity(identity_info)
+
+        assert session.hard_expiry == dt_now
+
+
+@pytest.mark.usefixtures('database')
+def test_process_identity_raises_exc_for_non_dt_hard_expiry(app):
+    """Test that a ValueError is raised if the hard expiry is not a datetime object."""
+    identity_info = IdentityInfo(
+        provider=StaticIdentityProvider(
+            multipass=Multipass(), name='static', settings={}
+        ),
+        identifier='static', multipass_data={'session_expiry': 12345}
+    )
+
+    with app.test_request_context('/ping', method='GET'):
+        with pytest.raises(ValueError):
+            process_identity(identity_info)

--- a/indico/modules/auth/auth_test.py
+++ b/indico/modules/auth/auth_test.py
@@ -15,7 +15,7 @@ from flask_multipass.providers.static import StaticIdentityProvider
 from indico.modules.auth import process_identity
 
 
-@pytest.mark.usefixtures('database')
+@pytest.mark.usefixtures('db')
 def test_process_identity_sets_hard_expiry(app):
     """Test that hard expiry is set on the session object if it is present in the multipass data."""
     dt_now = datetime.now(timezone.utc)
@@ -32,7 +32,7 @@ def test_process_identity_sets_hard_expiry(app):
         assert session.hard_expiry == dt_now
 
 
-@pytest.mark.usefixtures('database')
+@pytest.mark.usefixtures('db')
 def test_process_identity_raises_exc_for_non_dt_hard_expiry(app):
     """Test that a ValueError is raised if the hard expiry is not a datetime object."""
     identity_info = IdentityInfo(

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -245,6 +245,10 @@ class IndicoSessionInterface(SessionInterface):
             cookie_lifetime = self.get_expiration_time(app, session)
             session['_expires'] = datetime.now() + storage_ttl
 
+        if refresh_sid:
+            self.storage.delete(session.sid)
+            session.sid = self.generate_sid()
+
         session['_secure'] = request.is_secure
         self.storage.set(session.sid, self.serializer.dumps(dict(session)), storage_ttl)
         response.set_cookie(app.session_cookie_name, session.sid, expires=cookie_lifetime, httponly=True,

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -181,7 +181,7 @@ class IndicoSessionInterface(SessionInterface):
             return self.temporary_session_lifetime
 
     def should_refresh_session(self, app, session):
-        if session.new or session.hard_expiry or '_expires' not in session:
+        if session.new or '_expires' not in session:
             return False
         threshold = self.get_storage_lifetime(app, session) / 2
         return session['_expires'] - datetime.now() < threshold

--- a/indico/web/flask/session_test.py
+++ b/indico/web/flask/session_test.py
@@ -33,14 +33,6 @@ def test_get_storage_lifetime_with_hard_expiry(app, mocker):
     assert IndicoSessionInterface().get_storage_lifetime(app, session) == timedelta(days=2)
 
 
-def test_should_refresh_session_with_hard_expiry(app):
-    """Test that a session with a hard expiry should never be refreshed"""
-    session = IndicoSession()
-    session.hard_expiry = datetime.now(timezone.utc)
-
-    assert not IndicoSessionInterface().should_refresh_session(app, session)
-
-
 def test_save_session_with_hard_expiry(app):
     """Test that a session with a hard expiry sets the cookie expiry to the hard expiry."""
     session = IndicoSession()

--- a/indico/web/flask/session_test.py
+++ b/indico/web/flask/session_test.py
@@ -1,0 +1,51 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
+
+import pytest
+from flask import Response
+
+from indico.web.flask.session import IndicoSession, IndicoSessionInterface
+
+
+def test_session_hard_expiry_dt_without_tz():
+    """Test that passing an unaware datetime raises an error."""
+    session = IndicoSession()
+
+    with pytest.raises(ValueError):
+        session.hard_expiry = datetime(2021, 1, 1, 0, 0, 0)
+
+
+def test_get_storage_lifetime_with_hard_expiry(app, mocker):
+    """Test that the storage lifetime is the hard expiry."""
+    dt_mock = Mock(spec_set=datetime)
+    dt_now = dt_mock.now.return_value = datetime.now(timezone.utc)
+    mocker.patch('indico.web.flask.session.datetime', dt_mock)
+    session = IndicoSession()
+    session.hard_expiry = dt_now + timedelta(days=2)
+
+    assert IndicoSessionInterface().get_storage_lifetime(app, session) == timedelta(days=2)
+
+
+def test_should_refresh_session_with_hard_expiry(app):
+    """Test that a session with a hard expiry should never be refreshed"""
+    session = IndicoSession()
+    session.hard_expiry = datetime.now(timezone.utc)
+
+    assert not IndicoSessionInterface().should_refresh_session(app, session)
+
+
+def test_save_session_with_hard_expiry(app):
+    """Test that a session with a hard expiry sets the cookie expiry to the hard expiry."""
+    session = IndicoSession()
+    expiry = datetime.now(timezone.utc) + timedelta(days=2)
+    session.hard_expiry = expiry
+    resp_mock = Mock(spec_set=Response)
+
+    with app.test_request_context(
+        '/user/2/edit', method='POST', data={'name': ''}
+    ):
+        IndicoSessionInterface().save_session(app, session, resp_mock)
+
+    assert session.permanent
+    resp_mock.set_cookie.assert_called_once()
+    assert resp_mock.set_cookie.call_args[1].get('expires') == expiry

--- a/indico/web/flask/session_test.py
+++ b/indico/web/flask/session_test.py
@@ -22,11 +22,10 @@ def test_session_hard_expiry_dt_without_tz():
         session.hard_expiry = datetime(2021, 1, 1, 0, 0, 0)
 
 
-def test_get_storage_lifetime_with_hard_expiry(app, mocker):
+def test_get_storage_lifetime_with_hard_expiry(app, freeze_time):
     """Test that the storage lifetime is the hard expiry."""
-    dt_mock = Mock(spec_set=datetime)
-    dt_now = dt_mock.now.return_value = datetime.now(timezone.utc)
-    mocker.patch('indico.web.flask.session.datetime', dt_mock)
+    dt_now = datetime.now(timezone.utc)
+    freeze_time(dt_now)
     session = IndicoSession()
     session.hard_expiry = dt_now + timedelta(days=2)
 
@@ -40,9 +39,7 @@ def test_save_session_with_hard_expiry(app):
     session.hard_expiry = expiry
     resp_mock = Mock(spec_set=Response)
 
-    with app.test_request_context(
-        '/user/2/edit', method='POST', data={'name': ''}
-    ):
+    with app.test_request_context('/ping', method='GET'):
         IndicoSessionInterface().save_session(app, session, resp_mock)
 
     assert session.permanent

--- a/indico/web/flask/session_test.py
+++ b/indico/web/flask/session_test.py
@@ -1,3 +1,10 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
 from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock
 


### PR DESCRIPTION
This PR adds the ability to set a hard expiration for the Flask session. This can be used in conjunction with a Flask Multipass identity provider that specifies the session expiration. See [this](https://talk.getindico.io/t/enhancing-multipass-saml-authentication-automated-refresh-for-extended-sessions/3223) post for more details on use cases and implementation considerations. 
