### PR TITLE
Implement admin override keyboard shortcut

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,7 @@ Improvements
 - Support generating tickets and badges for each of the registrant's accompanying
   persons (:pr:`5424`)
 - Include current language in page metadata (:pr:`5894`, thanks :user:`foxbunny`)
-- Add keyboard shortcut to toggle room booking admin override (:pr:`5909`)
+- Add keyboard shortcut (CTRL-SHIFT-A) to toggle room booking admin override (:pr:`5909`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Improvements
 - Support generating tickets and badges for each of the registrant's accompanying
   persons (:pr:`5424`)
 - Include current language in page metadata (:pr:`5894`, thanks :user:`foxbunny`)
+- Add keyboard shortcut to toggle room booking admin override (:pr:`5909`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/rb/client/js/components/AdminOverrideBar.jsx
+++ b/indico/modules/rb/client/js/components/AdminOverrideBar.jsx
@@ -11,7 +11,7 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {Icon, Popup} from 'semantic-ui-react';
 
-import {Translate} from 'indico/react/i18n';
+import {Translate, Param} from 'indico/react/i18n';
 
 import {actions as userActions, selectors as userSelectors} from '../common/user';
 
@@ -26,6 +26,19 @@ const AdminOverrideBar = ({visible, disable}) => {
     <span>
       <Icon name="exclamation triangle" />
       <Translate>Admin override enabled</Translate>
+      {' - '}
+      <Translate>
+        Use{' '}
+        <Param
+          name="shortcut"
+          value={
+            <>
+              <kbd>Ctrl</kbd> + <kbd>A</kbd>
+            </>
+          }
+        />{' '}
+        to toggle.
+      </Translate>
     </span>
   );
 

--- a/indico/modules/rb/client/js/components/AdminOverrideBar.jsx
+++ b/indico/modules/rb/client/js/components/AdminOverrideBar.jsx
@@ -25,15 +25,14 @@ const AdminOverrideBar = ({visible, disable}) => {
   const trigger = (
     <span>
       <Icon name="exclamation triangle" />
-      <Translate>Admin override enabled</Translate>
-      {' - '}
+      <Translate>Admin override enabled</Translate>.{' '}
       <Translate>
         Use{' '}
         <Param
           name="shortcut"
           value={
             <>
-              <kbd>Ctrl</kbd> + <kbd>A</kbd>
+              <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>A</kbd>
             </>
           }
         />{' '}

--- a/indico/modules/rb/client/js/components/AdminOverrideBar.module.scss
+++ b/indico/modules/rb/client/js/components/AdminOverrideBar.module.scss
@@ -20,4 +20,15 @@
     margin-left: auto;
     cursor: pointer;
   }
+
+  kbd {
+    display: inline-block;
+    border-radius: 0.25em;
+    padding: 0.1em 0.5em;
+    margin: 0 0.2em;
+    line-height: 1.25em;
+    background-color: $dark-black;
+    border: 0.031em solid $dark-gray;
+    box-shadow: inset 0 -0.1em 0 $dark-gray;
+  }
 }

--- a/indico/modules/rb/client/js/components/AdminOverrideShortcut.jsx
+++ b/indico/modules/rb/client/js/components/AdminOverrideShortcut.jsx
@@ -1,0 +1,47 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import {useEffect, useCallback} from 'react';
+import {connect} from 'react-redux';
+
+import {actions as userActions, selectors as userSelectors} from '../common/user';
+
+export function AdminOverrideShortcut({isAdmin, toggleAdminOverride}) {
+  const handleAdminKeypress = useCallback(
+    event => {
+      if (isAdmin && event.ctrlKey && event.key === 'a') {
+        event.preventDefault();
+        toggleAdminOverride();
+      }
+    },
+    [isAdmin, toggleAdminOverride]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleAdminKeypress);
+    return () => {
+      window.removeEventListener('keydown', handleAdminKeypress);
+    };
+  }, [handleAdminKeypress]);
+
+  return null;
+}
+
+AdminOverrideShortcut.propTypes = {
+  isAdmin: PropTypes.bool.isRequired,
+  toggleAdminOverride: PropTypes.func.isRequired,
+};
+
+export default connect(
+  state => ({
+    isAdmin: userSelectors.isUserRBAdmin(state),
+  }),
+  dispatch => ({
+    toggleAdminOverride: () => dispatch(userActions.toggleAdminOverride()),
+  })
+)(AdminOverrideShortcut);

--- a/indico/modules/rb/client/js/components/AdminOverrideShortcut.jsx
+++ b/indico/modules/rb/client/js/components/AdminOverrideShortcut.jsx
@@ -14,9 +14,11 @@ import {actions as userActions, selectors as userSelectors} from '../common/user
 export function AdminOverrideShortcut({isAdmin, toggleAdminOverride}) {
   const handleAdminKeypress = useCallback(
     event => {
-      if (isAdmin && event.ctrlKey && event.key === 'a') {
-        event.preventDefault();
-        toggleAdminOverride();
+      if (event.ctrlKey && event.shiftKey && event.key === 'A') {
+        if (isAdmin) {
+          event.preventDefault();
+          toggleAdminOverride();
+        }
       }
     },
     [isAdmin, toggleAdminOverride]

--- a/indico/modules/rb/client/js/components/App.jsx
+++ b/indico/modules/rb/client/js/components/App.jsx
@@ -33,6 +33,7 @@ import RoomList from '../modules/roomList';
 import * as globalSelectors from '../selectors';
 
 import AdminOverrideBar from './AdminOverrideBar';
+import AdminOverrideShortcut from './AdminOverrideShortcut';
 import Menu from './Menu';
 import SidebarMenu, {SidebarTrigger} from './SidebarMenu';
 import './App.module.scss';
@@ -165,6 +166,7 @@ class App extends React.Component {
             </div>
           </header>
           <AdminOverrideBar />
+          <AdminOverrideShortcut />
           <LinkBar />
           {this.renderContent()}
           <Dimmer.Dimmable>


### PR DESCRIPTION
This PR adds a <kbd>Ctrl</kbd> + <kbd>A</kbd> keyboard shortcut for toggling the RB admin override.

Preview:
![image](https://github.com/indico/indico/assets/7736654/c036b21f-1b05-44a1-b7e8-72818a96fb8d)
