### PR TITLE
Prevent sidebar from overlapping with user dropdown menu

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,8 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- Nothing so far
+- Prevent room booking sidebar menu from overlapping with the user dropdown menu
+  (:pr:`5910`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/js/react/components/UserMenu.jsx
+++ b/indico/web/client/js/react/components/UserMenu.jsx
@@ -97,7 +97,8 @@ export default function UserMenu({userData, languages, hasLoadedConfig, hasLoade
   const [langName, langTerritory] = languages[language] || [language, null, false];
   return (
     <Dropdown trigger={avatar} pointing="top right">
-      <Dropdown.Menu>
+      {/* Set the z-index of the dropdown menu to a higher value than the sidebar menu to prevent overlapping */}
+      <Dropdown.Menu style={{zIndex: 103}}>
         <Dropdown.Header content={headerContent} />
         <Dropdown.Divider />
         <Dropdown.Item as="a" href={userDashboard()}>


### PR DESCRIPTION
This PR prevents the RB sidebar from overlapping with the user dropdown menu.

Before:
![image](https://github.com/indico/indico/assets/7736654/bd7f4386-2409-4cb9-b010-651448cea615)

After:
![image](https://github.com/indico/indico/assets/7736654/58c359af-fdd0-4dbb-a113-c931a2dd1f51)
