### PR TITLE
Improve TZ selector markup and UX

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,7 @@ Accessibility
 - Make search result status messages more accessible (:issue:`5949`, :pr:`5950`,
   thanks :user:`foxbunny`)
 - Make search results tabs accessible (:issues:`5964`, :pr:`5965`, thanks :user:`foxbunny`)
+- Make timezone list accessible (:issue:`5908`, :pr:`5914`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^
@@ -61,6 +62,7 @@ Internal Changes
   fields on a per-registration basis (:pr:`5424`)
 - Replace WYSIWYG (rich-text) editor with TinyMCE, due to the license and branding
   requirements of the previous editor (:pr:`5938`)
+- Add a new Indico design system (:pr:`5914`, thanks :user:`foxbunny`)
 
 
 ----

--- a/indico/modules/core/client/js/session_bar.js
+++ b/indico/modules/core/client/js/session_bar.js
@@ -5,6 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+// eslint-disable-next-line import/unambiguous
 (function() {
   function setupProtection() {
     $('#protection-details-link').qtip({
@@ -40,20 +41,10 @@
 
   function setupTimezone() {
     const widget = $('#tz-selector-widget');
-    widget.on('change', 'input[name=tz_mode]', function() {
-      const customTZ = this.value === 'custom';
-      const customTZSelect = widget.find('select[name=tz]');
-      customTZSelect.prop('disabled', !customTZ);
-      if (customTZ) {
-        customTZSelect.focus();
-        scrollToCurrentTZ();
-      }
-    });
 
     $('#tz-selector-link').qtip({
       style: {
-        width: '300px',
-        classes: 'qtip-rounded qtip-shadow qtip-popup qtip-timezone',
+        classes: 'qtip-rounded qtip-shadow qtip-popup qtip-timezone qtip-wide',
         tip: {
           corner: true,
           width: 20,
@@ -80,6 +71,7 @@
       },
       events: {
         show() {
+          // eslint-disable-next-line no-undef
           _.defer(scrollToCurrentTZ);
         },
       },

--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -132,11 +132,11 @@ class RHChangeTimezone(RH):
             session.timezone = session.user.settings.get('timezone', config.DEFAULT_TIMEZONE)
         elif mode == 'custom' and tz in common_timezones_set:
             session.timezone = tz
+            if update_user and session.user:
+                session.user.settings.set('timezone', tz)
 
         if update_user and session.user:
             session.user.settings.set('force_timezone', mode != 'local')
-            if tz and tz in common_timezones_set:
-                session.user.settings.set('timezone', tz)
 
         return '', 204
 

--- a/indico/web/client/js/index.js
+++ b/indico/web/client/js/index.js
@@ -12,6 +12,7 @@ import './legacy/indico.js';
 import './legacy/timetable.js';
 
 import './custom_elements/ind_bypass_block_links.js';
+import './widgets/tz_selector.js';
 
 import '../styles/screen.scss';
 import '../styles/editor-output.scss';

--- a/indico/web/client/js/widgets/tz_selector.js
+++ b/indico/web/client/js/widgets/tz_selector.js
@@ -1,0 +1,40 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+// eslint-disable-next-line import/unambiguous
+window.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('#tz-selector-widget form');
+  const tzModes = document.getElementById('tz-modes');
+  const customRadio = document.getElementById('tz-mode-custom');
+  const tzCustomField = document.querySelector('#tz-custom-field select');
+
+  // No TZ selector?
+  if (!form) {
+    return;
+  }
+
+  tzCustomField.querySelector('option:checked')?.scrollIntoView();
+
+  function setCustomMode() {
+    customRadio.checked = true;
+  }
+
+  tzCustomField.addEventListener('click', setCustomMode);
+  tzCustomField.addEventListener('change', setCustomMode);
+
+  tzModes.addEventListener('change', evt => {
+    if (evt.target.value === 'user') {
+      tzCustomField.querySelector(`option[value="${evt.target.dataset.userTz}"]`)?.scrollIntoView();
+    } else if (evt.target.value === 'custom') {
+      tzCustomField.querySelector('option:checked')?.scrollIntoView();
+    }
+  });
+
+  form.addEventListener('submit', evt => {
+    evt.preventDefault();
+  });
+});

--- a/indico/web/client/styles/base/_defaults.scss
+++ b/indico/web/client/styles/base/_defaults.scss
@@ -19,6 +19,7 @@ $default-transition-delay: null;
 $default-border-color: $pastel-gray;
 $default-border-style: solid;
 $default-border-width: 1px;
+$default-border: $default-border-width $default-border-style $default-border-color;
 
 $color-variation: 15%;
 $light-color-variation: 5%;

--- a/indico/web/client/styles/base/_reset.scss
+++ b/indico/web/client/styles/base/_reset.scss
@@ -5,6 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+*,
+*::after,
+*::before {
+  box-sizing: border-box;
+}
+
 button,
 input,
 textarea,
@@ -13,7 +19,24 @@ isindex {
   font: inherit;
 }
 
+fieldset,
+legend {
+  padding: 0;
+}
+
+fieldset {
+  margin: 0;
+  border: none;
+}
+
+legend {
+  padding: 0;
+}
+
 button:not(:disabled),
+select:not(:disabled),
+input[type='checkbox']:not(:disabled),
+input[type='radio']:not(:disabled),
 label {
   cursor: pointer;
 }

--- a/indico/web/client/styles/design_system/README.md
+++ b/indico/web/client/styles/design_system/README.md
@@ -1,0 +1,163 @@
+# Indico Design System
+
+The SCSS design system for Indico.
+
+This design system is intended for use exclusively with the `@extend`
+feature. It does not provide any mixins, SCSS variables, and similar.
+
+## Basic usage
+
+The intended usage is as follows:
+
+```scss
+@use 'design_system';
+
+some-selector {
+  @extend %generic-container;
+  --container-element-spacing: 1em;
+}
+```
+
+This results in the following output:
+
+```css
+some-selector {
+  %generic-container declarations....
+}
+
+some-selector {
+  --container-element-spacing: 1em;
+}
+```
+
+Customization is done using CSS variables. They can be defined either
+on the selected element itself, or one of its ancestors. Using CSS
+variables on ancestors allows us to target any of its descendants, so
+we are able to override the styles for a particular region of the page.
+
+```scss
+some-region {
+  --control-clickable-surface-color: #{$some-other-color};
+}
+
+some-selector {
+  @extend %generic-container;
+  --container-element-spacing: 1em;
+}
+```
+
+## Background
+
+This is decidedly different from the common way of using CSS in which the
+appearance of the element is defined using classes. Instead of adding
+classes to elements in order to specify their appearance, we instead use
+placeholder selectors and `@extend` to specify the appearance for elements
+selected by the selector. However, in a way, it is also similar to how the
+class-based CSS works, in that we use the placeholder selectors the same
+way we use classes.
+
+This approach has the following benefits:
+
+- It reduces the amount of markup being sent over the wire (all elements
+  need a single class at most).
+- It restricts all appearance-related changes to the stylesheet.
+
+
+## Why extends and not mixins
+
+The placeholder selectors are not mixins. They do not take parameters.
+Instead, we use CSS variables to customize the appearance of the
+elements. This is a deliberate trade-off to avoid duplicating CSS
+across different selectors (with `@extend`, the selector is moved to the
+placeholder's declaration block, rather than the other way around).
+
+CSS variables also allow the third party stylesheet to override various
+aspects of the visual appearance using plain CSS. Another advantage of CSS
+variables is that they are subject to CSS cascade, so they can be used by
+the parent to override appearance for its descendants, etc.
+
+
+## Media queries
+
+One trade-off of using the `@extend` method is that placeholder selectors
+cannot be used in media queries. The following code shows why:
+
+```scss
+%placeholder {
+  flex: none;
+  width: 2em;
+}
+
+@media (width < 45em) {
+  .foo {
+    @extend %placeholder;
+  }
+}
+```
+
+The above code would have to compile to this:
+
+```scss
+.foo {
+  flex: none;
+}
+
+@media (width < 45em) {
+  .foo { }
+}
+```
+
+If SCSS were to compile the code the way we instructed, it would break the
+media query. Within at-rules, we still need to use mixins. In most cases, this
+can be achieved by converting the placeholder selector into a mixin like so:
+
+```scss
+@mixin placeholder {
+  flex: none;
+  width: 2em;
+}
+
+%placeholder {
+  @include placeholder();
+}
+
+// ...
+
+@media (width < 45em) {
+  .foo {
+    @include placeholder;
+  }
+}
+```
+
+Please be careful when converting placeholder selector that extend other
+placeholder selectors. Such placeholders cannot be converted into a mixin
+and you will need to figure out a different approach. However, in most
+cases such complex placeholder selectors are not intended for use within
+media queries to begin with, so do first check that what you're trying to
+do actually makes sense.
+
+## Maintenance
+
+In order to keep this system working, please keep in mind the following
+rules of thumb:
+
+- All variable parameters that are shared among the modules in this folder
+  should be defined *as CSS variables* in the `variables.scss` module.
+- All SCSS modules in this folder should only use CSS variables except for
+  the `variables.scss` module, which can use SCSS variables as well.
+- The CSS variable name loosely follows the following convention:
+
+```scss
+--{TOPIC}-{ELEMENT/SUBTOPIC}-{CHARACTERISTIC}
+```
+
+- Ensure the CSS variable names are searchable as there are no mechanisms
+  to spot typos.
+- Placeholder selectors contain information about the structure of the
+  elements they apply to. Do not require the developer to add classes to
+  the target elements if not needed. Do not over-prescribe the layout of
+  the elements if not needed: keep it as flexible as possible (this means
+  you need to keep the nesting to the minimum, among other things, one
+  level for namespacing, and sometimes another one for pseudo-classes or
+  pseudo-elements is enough).

--- a/indico/web/client/styles/design_system/_button.scss
+++ b/indico/web/client/styles/design_system/_button.scss
@@ -1,0 +1,82 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@use 'layout';
+
+%button-base {
+  @extend %flex-inline-center;
+  gap: var(--control-internal-gap);
+  padding: var(--control-padding);
+
+  border: var(--control-border);
+  color: var(--control-text-color);
+  background: var(--control-clickable-surface-color);
+
+  &:focus,
+  &:hover {
+    background-color: var(--control-clickable-surface-focus-color);
+  }
+}
+
+%button-rounded {
+  border-radius: var(--control-border-radius);
+}
+
+%button-rounded-left {
+  border-top-left-radius: var(--control-border-radius);
+  border-bottom-left-radius: var(--control-border-radius);
+}
+
+%button-rounded-right {
+  border-top-right-radius: var(--control-border-radius);
+  border-bottom-right-radius: var(--control-border-radius);
+}
+
+%button-rounded-top {
+  border-top-left-radius: var(--control-border-radius);
+  border-top-right-radius: var(--control-border-radius);
+}
+
+%button-rounded-bottom {
+  border-bottom-left-radius: var(--control-border-radius);
+  border-bottom-right-radius: var(--control-border-radius);
+}
+
+%button-disabled-state {
+  background: var(--control-disabled-clickable-surface-color);
+  color: var(--control-disabled-text-color);
+  border-color: var(--control-disabled-border-color);
+}
+
+%button {
+  @extend %button-base;
+  @extend %button-rounded;
+
+  &:disabled {
+    @extend %button-disabled-state;
+  }
+}
+
+%button-alt-state {
+  background: var(--control-alt-clickable-surface-color);
+  color: var(--control-alt-text-color);
+  border-color: var(--control-alt-border-color);
+}
+
+%button-alt-hover-state {
+  background: var(--control-alt-clickable-surface-focus-color);
+}
+
+%button-main-action {
+  @extend %button;
+  @extend %button-alt-state;
+
+  &:focus-visible,
+  &:hover {
+    @extend %button-alt-hover-state;
+  }
+}

--- a/indico/web/client/styles/design_system/_button_group.scss
+++ b/indico/web/client/styles/design_system/_button_group.scss
@@ -1,0 +1,99 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@use 'button';
+@use 'layout';
+@use 'form_controls';
+@use 'utils';
+@use 'partials/icons';
+
+%button-group-base {
+  // Recommended structure:
+  //
+  // FIELDSET
+  //   LEGEND
+  //   INPUT[type="radio"] LABEL
+  //   INPUT[type="radio"] LABEL
+
+  @extend %flex-row;
+  --flex-gap: 0;
+
+  legend {
+    @extend %form-label-block;
+  }
+
+  label {
+    @extend %button-base;
+    flex: 1;
+
+    &::before {
+      @extend %icon;
+      @extend %icon-checkmark;
+      visibility: hidden;
+    }
+
+    &::after {
+      // NB: fake icon to balance the layout
+      @extend %icon;
+      content: ' ';
+      width: 1ch;
+    }
+  }
+
+  :focus-visible + label {
+    @extend %default-focus-ring;
+    z-index: 1;
+  }
+
+  :checked + label {
+    @extend %button-alt-state;
+    cursor: default;
+
+    &::before {
+      visibility: visible;
+    }
+  }
+
+  :disabled + label {
+    @extend %button-disabled-state;
+  }
+}
+
+%button-group {
+  @extend %button-group-base;
+  align-items: center;
+
+  label:not(:last-child) {
+    margin-right: -1px;
+  }
+
+  label:first-of-type {
+    @extend %button-rounded-left;
+  }
+
+  label:last-of-type {
+    @extend %button-rounded-right;
+  }
+}
+
+%button-group-vertical {
+  @extend %button-group-base;
+  flex-direction: column;
+  align-items: stretch;
+
+  label {
+    justify-content: space-between;
+  }
+
+  label:first-of-type {
+    @extend %button-rounded-top;
+  }
+
+  label:last-of-type {
+    @extend %button-rounded-bottom;
+  }
+}

--- a/indico/web/client/styles/design_system/_form_controls.scss
+++ b/indico/web/client/styles/design_system/_form_controls.scss
@@ -1,0 +1,69 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@use 'utils';
+@use 'layout';
+@use 'partials/icons';
+
+%form-label {
+  @extend %reset-font-and-color;
+  font-weight: bold;
+}
+
+%form-label-block {
+  @extend %form-label;
+  display: block;
+  margin-bottom: 0.5em;
+}
+
+%select-list {
+  border: var(--control-border);
+  border-radius: var(--control-border-radius);
+
+  option:not(:checked):hover {
+    background: var(--control-clickable-surface-color);
+  }
+
+  option:checked {
+    background: var(--control-alt-clickable-surface-color);
+    color: var(--control-alt-text-color);
+  }
+}
+
+%checkbox {
+  @extend %flex-inline-center;
+  appearance: none;
+  width: 1.5em;
+  height: 1.5em;
+  background: var(--control-indented-bg-color);
+  border: var(--control-border);
+  border-radius: var(--control-border-radius);
+
+  &:checked {
+    background: var(--control-alt-clickable-surface-color);
+    color: var(--control-alt-text-color);
+  }
+
+  &:focus-visible:not(:checked) {
+    background: var(--control-clickable-surface-focus-color);
+  }
+
+  &:focus-visible:checked {
+    background: var(--control-alt-clickable-surface-focus-color);
+  }
+
+  &:disabled {
+    background: var(--control-disabled-indented-bg-color);
+    color: var(--control-disabled-text-color);
+    border-color: var(--control-disabled-border-color);
+  }
+
+  &:checked::before {
+    @extend %icon;
+    @extend %icon-checkmark;
+  }
+}

--- a/indico/web/client/styles/design_system/_index.scss
+++ b/indico/web/client/styles/design_system/_index.scss
@@ -5,8 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-@forward 'widgets/occurrences';
-@forward 'widgets/permissions';
-@forward 'widgets/session-bar';
-@forward 'widgets/sortable_list';
-@forward 'widgets/tz_selector';
+@use './variables';
+@use './button';
+@use './button_group';
+@use './form_controls';
+@use './layout';
+@use './popup';
+@use './visibility';
+@use './utils';

--- a/indico/web/client/styles/design_system/_layout.scss
+++ b/indico/web/client/styles/design_system/_layout.scss
@@ -1,0 +1,38 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@mixin flex-column {
+  --flex-gap: 0.5em;
+  display: flex;
+  flex-direction: column;
+  gap: var(--flex-gap);
+}
+
+%flex-column {
+  @include flex-column();
+}
+
+@mixin flex-row {
+  --flex-gap: 0.5em;
+  display: flex;
+  align-items: center;
+  gap: var(--flex-gap);
+}
+
+%flex-row {
+  @include flex-row();
+}
+
+@mixin flex-inline-center {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+}
+
+%flex-inline-center {
+  @include flex-inline-center();
+}

--- a/indico/web/client/styles/design_system/_popup.scss
+++ b/indico/web/client/styles/design_system/_popup.scss
@@ -5,8 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-@forward 'widgets/occurrences';
-@forward 'widgets/permissions';
-@forward 'widgets/session-bar';
-@forward 'widgets/sortable_list';
-@forward 'widgets/tz_selector';
+@use 'utils';
+
+%popup-title {
+  @extend %reset-font-and-color;
+  font-weight: bold;
+  font-size: var(--text-size-rel-l);
+}

--- a/indico/web/client/styles/design_system/_utils.scss
+++ b/indico/web/client/styles/design_system/_utils.scss
@@ -5,8 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-@forward 'widgets/occurrences';
-@forward 'widgets/permissions';
-@forward 'widgets/session-bar';
-@forward 'widgets/sortable_list';
-@forward 'widgets/tz_selector';
+%reset-font-and-color {
+  color: inherit;
+  font: inherit;
+}
+
+%default-focus-ring {
+  outline: medium solid Highlight;
+  outline: medium solid -webkit-focus-ring-color;
+}

--- a/indico/web/client/styles/design_system/_visibility.scss
+++ b/indico/web/client/styles/design_system/_visibility.scss
@@ -5,8 +5,11 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-@forward 'widgets/occurrences';
-@forward 'widgets/permissions';
-@forward 'widgets/session-bar';
-@forward 'widgets/sortable_list';
-@forward 'widgets/tz_selector';
+%visually-hidden {
+  position: fixed;
+  right: 100vw;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  opacity: 0;
+}

--- a/indico/web/client/styles/design_system/variables.scss
+++ b/indico/web/client/styles/design_system/variables.scss
@@ -1,0 +1,50 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@use "base/defaults" as *;
+@use "base/palette" as *;
+
+body {
+  --color-text: #{$dark-black};
+  --color-accent: #{$dark-blue};
+
+  --control-border-color: #{$dark-gray};
+  --control-text-color: var(--color-text);
+  --control-clickable-surface-color: #{$pastel-gray};
+  --control-clickable-surface-focus-color: #{darken($pastel-gray, $color-variation)};
+  --control-alt-text-color: #{$white};
+  --control-alt-clickable-surface-color: #{$dark-blue};
+  --control-alt-clickable-surface-focus-color: #{darken($dark-blue, $color-variation)};
+  --control-alt-border-color: #{darken($dark-blue, $color-variation)};
+  --control-disabled-text-color: #{$dark-gray};
+  --control-disabled-clickable-surface-color: #{$light-gray};
+  --control-disabled-border-color: #{$pastel-gray};
+  --control-indented-bg-color: #{$light-gray};
+  --control-disabled-indented-bg-color: #{$light-gray};
+  --control-disabled-inset-indented-color: #{$dark-gray};
+
+  --control-border: 1px solid var(--control-border-color);
+  --control-border-radius: #{$default-border-radius};
+  --control-padding: 0.5em;
+  --control-internal-gap: 0.2em;
+
+  --container-padding: 1em;
+  --container-narrow-padding: 1em 0.5em;
+  --container-element-spacing: 0.5em;
+
+  --text-size-rel-s: 75%;
+  --text-size-rel-n: 100%;
+  --text-size-rel-l: 120%;
+  --text-size-rel-xl: 150%;
+  --text-size-rel-xxl: 200%;
+
+  --text-size-abs-s: 0.875rem;
+  --text-size-abs-n: 1rem;
+  --text-size-abs-l: 1.2rem;
+  --text-size-abs-xl: 1.5rem;
+  --text-size-abs-xxl: 2rem;
+}

--- a/indico/web/client/styles/partials/_buttons.scss
+++ b/indico/web/client/styles/partials/_buttons.scss
@@ -287,21 +287,6 @@ a.i-big-button {
   }
 }
 
-.i-button.signin {
-  display: block;
-  text-align: left;
-  margin-top: 5px;
-
-  .auth-id {
-    font-weight: bold;
-  }
-
-  .login-arrow {
-    float: right;
-    @include icon-before('icon-arrow-right-sparse');
-  }
-}
-
 .i-button.next {
   @include icon-after('icon-next');
   font-weight: bold;
@@ -355,7 +340,7 @@ button::-moz-focus-inner {
 }
 
 .i-button.right {
-  margin-left: 5px;
+  margin-right: 5px;
   margin-top: 5px;
 }
 

--- a/indico/web/client/styles/partials/_icons.scss
+++ b/indico/web/client/styles/partials/_icons.scss
@@ -37,7 +37,8 @@ you can use the generic selector below, but it's slower:
 [class*="icon-"] {
 */
 [class^='icon-']::before,
-[class*=' icon-']::before {
+[class*=' icon-']::before,
+%icon {
   font-family: 'icomoon-ultimate';
   font-style: normal;
   font-weight: normal;
@@ -569,6 +570,12 @@ i[class^='icon-']::before {
   content: '\e907';
 }
 /* End of icomoon's icon definitions */
+
+/* placeholder aliases */
+
+%icon-checkmark {
+  content: '\e372';
+}
 
 /* animated spinner icon */
 .icon-spinner::before {

--- a/indico/web/client/styles/widgets/_tz_selector.scss
+++ b/indico/web/client/styles/widgets/_tz_selector.scss
@@ -1,0 +1,81 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@use 'design_system';
+
+// XXX: The following rule is a temporary hack to work around QTip2 styling.
+// It should be removed after the popup is converted into a pull-down menu.
+.qtip-wide {
+  max-width: none;
+}
+
+#tz-selector-widget {
+  > div {
+    text-align: left;
+    padding: var(--container-narrow-padding);
+    @extend %flex-column;
+    --flex-gap: 1em;
+  }
+
+  form {
+    @extend %flex-column;
+    --flex-gap: 1em;
+  }
+
+  fieldset {
+    @extend %button-group;
+  }
+
+  fieldset label {
+    flex: 1;
+  }
+
+  [type='radio'] {
+    @extend %visually-hidden;
+  }
+
+  select {
+    @extend %select-list;
+    width: 100%;
+  }
+
+  option[data-profile] {
+    font-weight: bold;
+  }
+
+  button {
+    @extend %button-main-action;
+  }
+
+  [type='checkbox'] {
+    @extend %checkbox;
+  }
+}
+
+#tz-profile-setting {
+  > :first-of-type {
+    @extend %form-label;
+  }
+}
+
+#tz-selector {
+  @extend %popup-title;
+}
+
+#tz-custom-field {
+  span {
+    @extend %visually-hidden;
+  }
+}
+
+#tz-remember-setting {
+  @extend %flex-row;
+
+  span {
+    @extend %form-label;
+  }
+}

--- a/indico/web/templates/_session_bar.html
+++ b/indico/web/templates/_session_bar.html
@@ -48,64 +48,76 @@
 
 
 {% macro _render_timezone_selector(timezone_data) %}
+    {% set active_tz_label = timezone_data.active_tz %}
     {% if timezone_data.disabled %}
-        <a class="i-button icon-time disabled">
-            {{- timezone_data.active_tz -}}
-        </a>
+        <span class="i-button icon-time disabled" aria-label="{% trans %}The active timezone is {{ active_tz_label }} and it cannot be changed{% endtrans %}">
+            {{- active_tz_label -}}
+        </span>
     {% else %}
-        <div id="tz-selector-widget" style="display: none;" class="tz-selector-widget settingsWidget">
-            <div style="line-height: 17px;">
-                <span class="settingsWidgetHeader">{% trans %}Choose Timezone{% endtrans %}</span><br>
-            </div>
-            <div class="settingsSeparator"></div>
-            <div class="tz-mode-container">
-                <div>
-                    <input type="radio" name="tz_mode" id="tz-mode-local" value="local"
-                           {{ 'checked' if timezone_data.tz_mode == 'local' }}>
-                    <label for="tz-mode-local">{% trans %}Use the event/category timezone{% endtrans %}</label>
+        {% set profile_timezone = session.user.settings.get('timezone') if session.user else '' %}
+        <article id="tz-selector-widget" style="display:none" aria-labelledby="tz-selector">
+            <div>
+                <h2 id="tz-selector">{% trans %}Choose timezone{% endtrans %}</h2>
+
+                <div id="tz-profile-setting">
+                    <span>{% trans %}Your profile timezone:{% endtrans %}</span>
+                    <span>{{ profile_timezone }}</span>
                 </div>
-                {% if session.user %}
-                    <div>
-                        <input type="radio" name="tz_mode" id="tz-mode-user" value="user"
-                               {{ 'checked' if timezone_data.tz_mode == 'user' }}>
-                        <label for="tz-mode-user">
-                            {% trans %}Your default timezone{% endtrans %}
-                            <em>({{ timezone_data.user_tz }})</em>
-                        </label>
-                    </div>
-                {% endif %}
-                <div>
-                    <input type="radio" name="tz_mode" id="tz-mode-custom" value="custom"
-                           {{ 'checked' if timezone_data.tz_mode == 'custom' }}>
-                    <label for="tz-mode-custom">{% trans %}Specify a timezone{% endtrans %}</label>
-                </div>
-            </div>
-            <select name="tz" class="tz-select" size="12" {{ 'disabled' if timezone_data.tz_mode != 'custom' }}>
-                {% for tz in timezone_data.timezones -%}
-                    <option value="{{ tz }}" {{ 'selected' if tz == session.tzinfo.zone }}>{{ tz }}</option>
-                {%- endfor %}
-            </select>
-            {% if session.user %}
-                <div class="tz-update-user-container">
-                    <input type="checkbox" name="update_user" id="tz-update-user" value="1">
-                    <label for="tz-update-user">
-                        {%- trans %}Remember these settings{% endtrans -%}
+
+                <form id="tz-mode-form" action="{{ url_for('core.change_tz') }}" method="post">
+                    <fieldset id="tz-modes">
+                        <legend>Use timezone based on:</legend>
+                        <input type="radio" name="tz_mode" id="tz-mode-local" value="local"
+                               {{ 'checked' if timezone_data.tz_mode == 'local' }}
+                               aria-label="{% trans %}Use the event/category timezone{% endtrans %}">
+                        <label for="tz-mode-local">{% trans %}Event/category{% endtrans %}</label>
+                        {% if session.user %}
+                            <input type="radio" name="tz_mode" id="tz-mode-user" value="user"
+                                   data-user-tz="{{ profile_timezone }}"
+                                   {{ 'checked' if timezone_data.tz_mode == 'user' }}
+                                   aria-label="{% trans %}Use the default timezone of your profile{% endtrans %}">
+                            <label for="tz-mode-user">
+                                {% trans %}Profile{% endtrans %}
+                            </label>
+                        {% endif %}
+                        <input type="radio" name="tz_mode" id="tz-mode-custom" value="custom"
+                               {{ 'checked' if timezone_data.tz_mode == 'custom' }}
+                               aria-label="{% trans %}Use a custom timezone{% endtrans %}">
+                        <label for="tz-mode-custom">{% trans %}Custom{% endtrans %}</label>
+                    </fieldset>
+                    <label id="tz-custom-field">
+                        <span>{% trans %}Select a custom timezone{% endtrans %}</span>
+                        <select name="tz" size="12">
+                            {% for tz in timezone_data.timezones -%}
+                                {% set is_profile_timezone = tz == profile_timezone %}
+                                <option value="{{ tz }}" {{ 'selected' if tz == session.tzinfo.zone }} {{ 'data-profile' if is_profile_timezone }}>
+                                    {% if is_profile_timezone -%}
+                                        {% trans %}{{ tz }} (your profile timezone){% endtrans %}
+                                    {%- else -%}
+                                        {{- tz -}}
+                                    {%- endif %}
+                                </option>
+                            {%- endfor %}
+                        </select>
                     </label>
-                </div>
-            {% endif %}
-            <div class="tz-save-container">
-                <button class="i-button highlight" type="button"
-                        data-href="{{ url_for('core.change_tz') }}"
-                        data-method="POST"
-                        data-params-selector="#tz-selector-widget input[name=tz_mode]:checked,
-                                              #tz-selector-widget select[name=tz]:not(:disabled),
-                                              #tz-update-user:checked"
-                        data-reload-after
-                        data-ajax>
-                    {% trans %}Save{% endtrans %}
-                </button>
+                    {% if session.user %}
+                        <label id="tz-remember-setting">
+                            <input type="checkbox" name="update_user" value="1">
+                            <span>{%- trans %}Remember these settings{% endtrans -%}</span>
+                        </label>
+                    {% endif %}
+                    <button data-href="{{ url_for('core.change_tz') }}"
+                            data-method="POST"
+                            data-params-selector="#tz-mode-form [name=tz_mode]:checked,
+                                                  #tz-mode-form [name=tz],
+                                                  #tz-mode-form [name=update_user]:checked"
+                            data-reload-after
+                            data-ajax>
+                        {% trans %}Save{% endtrans %}
+                    </button>
+                </form>
             </div>
-        </div>
+        </article>
 
         <button id="tz-selector-link" class="i-button icon-time arrow">{{ timezone_data.active_tz }}</button>
     {% endif %}


### PR DESCRIPTION
- Modify the TZ selector markup to be more keyboard accessible
- Modify the markup to convey information about states
- Modify the TZ select list behavior to automatically activate the "Custom" radio when selection is made
- Modify the TZ selector to not disable the select list when options other than "Custom" are used

This patch also adds some initial code for a design system.

Fixes #5908