### PR TITLE
Add registration_form_field_deleted signal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,7 +63,8 @@ Internal Changes
 - Replace WYSIWYG (rich-text) editor with TinyMCE, due to the license and branding
   requirements of the previous editor (:pr:`5938`)
 - Add a new Indico design system (:pr:`5914`, thanks :user:`foxbunny`)
-  fields on a per-registration basis (:pr:`5424`, :pr:`5924`)
+- Add ``event.registration_form_field_deleted`` signal, allowing plugins to handle
+  the removal of registration form fields (:pr:`5924`)
 
 
 ----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,7 @@ Internal Changes
 - Replace WYSIWYG (rich-text) editor with TinyMCE, due to the license and branding
   requirements of the previous editor (:pr:`5938`)
 - Add a new Indico design system (:pr:`5914`, thanks :user:`foxbunny`)
+  fields on a per-registration basis (:pr:`5424`, :pr:`5924`)
 
 
 ----

--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -93,8 +93,9 @@ ticket for a registrant.
 ''')
 
 is_field_data_locked = _signals.signal('is-field-data-locked', '''
-Called when resolving whether Indico should let a registrant change a data value
-in their registration.  The participant's `Registration` is passed as `registration`.
+Called when resolving whether Indico should let a data value be modified
+in a registration, or let the corresponding field be deleted.
+The participant's `Registration` is passed as `registration`.
 The `sender` is the `RegistrationFormItem` object.
 
 This signal returns a string containing the reason for the item being locked,

--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -73,6 +73,11 @@ Called when a registration form is removed. The `sender` is the
 `RegistrationForm` object.
 ''')
 
+registration_form_field_deleted = _signals.signal('registration-form-field-deleted', '''
+Called when a registration form field is removed. The `sender` is the
+`RegistrationFormField` object.
+''')
+
 is_ticketing_handled = _signals.signal('is-ticketing-handled', '''
 Called when resolving whether Indico should send tickets with e-mails
 or it will be handled by other module. The `sender` is the
@@ -94,8 +99,7 @@ ticket for a registrant.
 
 is_field_data_locked = _signals.signal('is-field-data-locked', '''
 Called when resolving whether Indico should let a data value be modified
-in a registration, or let the corresponding field be deleted.
-The participant's `Registration` is passed as `registration`.
+in a registration. The participant's `Registration` is passed as `registration`.
 The `sender` is the `RegistrationFormItem` object.
 
 This signal returns a string containing the reason for the item being locked,

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -11,8 +11,8 @@ from flask import jsonify, request, session
 from marshmallow import EXCLUDE, ValidationError, fields, post_load, validates
 from werkzeug.exceptions import BadRequest
 
+from indico.core import signals
 from indico.core.db import db
-from indico.core.errors import UserValueError
 from indico.core.marshmallow import mm
 from indico.modules.events.registration import logger
 from indico.modules.events.registration.controllers.management.sections import RHManageRegFormSectionBase
@@ -143,8 +143,7 @@ class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
     def _process_DELETE(self):
         if self.field.type == RegistrationFormItemType.field_pd:
             raise BadRequest
-        if any(self.field.get_locked_reason(r) for r in self.regform.active_registrations):
-            raise UserValueError(_('Cannot delete a locked field.'))
+        signals.event.registration_form_field_deleted.send(self.field)
         self.field.is_deleted = True
         update_regform_item_positions(self.regform)
         db.session.flush()


### PR DESCRIPTION
This PR disallows deleting fields in which have been locked for any active registration by the `is_field_data_locked` signal.