### PR TITLE
Fix percentage calculation for survey results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Bugfixes
   thanks :user:`bpedersen2`)
 - Fix accessing the conference overview page when the default conference home page is
   set to a custom page (:pr:`5882`)
+- Show percentages for multi-choice survey answers based on number of answers instead of
+  total number of choices selected (:pr:`5930`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/surveys/fields/choices.py
+++ b/indico/modules/events/surveys/fields/choices.py
@@ -31,7 +31,7 @@ class SurveySingleChoiceField(_AddUUIDMixin, SingleChoiceField, SurveyField):
         counter = Counter()
         for answer in self.object.answers:
             counter[answer.data] += 1
-        total = sum(counter.values())
+        total = len(self.object.answers)
         options = self.object.field_data['options']
         if counter[None]:
             no_option = {'id': None, 'option': _('No selection')}
@@ -47,7 +47,7 @@ class SurveyMultiSelectField(_AddUUIDMixin, MultiSelectField, SurveyField):
         counter = Counter()
         for answer in self.object.answers:
             counter.update(answer.data)
-        total = sum(counter.values())
+        total = len(self.object.answers)
         options = self.object.field_data['options']
         return {'total': total,
                 'labels': [alpha_enum(val).upper() for val in range(len(options))],


### PR DESCRIPTION
In case of multi-choice questions, the percentace should be based on the total number of answers, not the total number of choices selected.