### PR TITLE
Hide Events if not can_display - Visibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Improvements
 - Add option to hide links to Room Booking system for users who lack access (:pr:`5981`,
   thanks :user:`SegiNyn`)
 - Support weekly room bookings that take place on multiple weekdays (:pr:`5829`, :issue:`5806`)
+- Hide events marked as invisible from builtin search results unless the user is a manager
+  (:pr:`5947`, thanks :user:`openprojects`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -726,9 +726,9 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         """Check whether the user can lock/unlock the event."""
         return user and (user.is_admin or user == self.creator or (self.category and self.category.can_manage(user)))
 
-    def can_display(self, user):
+    def can_display(self, user, *, allow_admin=True):
         """Check whether the user can display the event in the category."""
-        return self.visibility != 0 or self.can_manage(user)
+        return self.visibility != 0 or self.can_manage(user, allow_admin=allow_admin)
 
     @materialize_iterable()
     def get_manage_button_options(self, *, note_may_exist=False):

--- a/indico/modules/search/internal.py
+++ b/indico/modules/search/internal.py
@@ -143,7 +143,8 @@ class InternalSearch(IndicoSearchProvider):
                                     admin_override_enabled=admin_override_enabled)
         else:
             raise Exception(f'Unexpected object: {obj}')
-        if isinstance(obj, Event) and not obj.can_display(user):
+
+        if isinstance(obj, Event) and not obj.can_display(user, allow_admin=admin_override_enabled):
             return False
 
         return (protection_mode == ProtectionMode.public or

--- a/indico/modules/search/internal.py
+++ b/indico/modules/search/internal.py
@@ -143,6 +143,9 @@ class InternalSearch(IndicoSearchProvider):
                                     admin_override_enabled=admin_override_enabled)
         else:
             raise Exception(f'Unexpected object: {obj}')
+        if isinstance(obj, Event) and not obj.can_display(user):
+            return False
+
         return (protection_mode == ProtectionMode.public or
                 obj.can_access(user, allow_admin=admin_override_enabled))
 


### PR DESCRIPTION
Hide Events in search if the Visibility is set to "Not visible" .