### PR TITLE
Fix "Skip access check" checkbox accessibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -52,6 +52,8 @@ Accessibility
   thanks :user:`foxbunny`)
 - Make search results tabs accessible (:issues:`5964`, :pr:`5965`, thanks :user:`foxbunny`)
 - Make timezone list accessible (:issue:`5908`, :pr:`5914`, thanks :user:`foxbunny`)
+- Make "Skip access checks" checkbox in search keyboard-accessible (:issue:`5952`, :pr:`5953`,
+  thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/search/client/js/components/SearchApp.jsx
+++ b/indico/modules/search/client/js/components/SearchApp.jsx
@@ -322,6 +322,7 @@ export default function SearchApp({category, eventId, isAdmin}) {
           <div styleName="admin-search-container">
             <Label content={Translate.string('ADMIN')} size="small" color="red" />
             <Checkbox
+              id="checkbox-admin-search"
               label={Translate.string('Skip access checks')}
               checked={adminOverrideEnabled}
               onChange={(__, {checked}) => {

--- a/indico/modules/search/client/js/components/SearchBox.jsx
+++ b/indico/modules/search/client/js/components/SearchBox.jsx
@@ -54,6 +54,7 @@ export default function SearchBox({onSearch, category, isAdmin}) {
         <div styleName="option">
           <Label content={Translate.string('ADMIN')} size="small" color="red" />
           <Checkbox
+            id="checkbox-admin-search"
             styleName="checkbox-admin-search"
             label={Translate.string('Skip access checks')}
             checked={adminOverrideEnabled}

--- a/indico/web/client/styles/partials/_inputs.scss
+++ b/indico/web/client/styles/partials/_inputs.scss
@@ -435,3 +435,8 @@ code.placeholder {
   font-style: normal;
   font-size: 0.9em;
 }
+
+// The .hidden style should not apply to some elements
+.ui.checkbox > input.hidden {
+  display: inline-block !important;
+}


### PR DESCRIPTION
- Give the checkboxes an id to associate the label with them
- Add a style override to make checkboxes keyboard-focusable

Fixes #5952 