### PR TITLE
Fix title headings in the base template

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,7 @@ Accessibility
 - Make search fields more accessible (:issue:`5948`, :pr:`5950`, thanks :user:`foxbunny`)
 - Make search result status messages more accessible (:issue:`5949`, :pr:`5950`,
   thanks :user:`foxbunny`)
+- Fix title area heading structure on pages extending the layout/base.html template (:issue:`5958`, :pr:`5959`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/base/_pages.scss
+++ b/indico/web/client/styles/base/_pages.scss
@@ -46,33 +46,40 @@
 
     .title {
       display: flex;
-      align-items: flex-start;
-      padding-top: 0.4rem;
-      min-height: 2rem;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 0.5em;
+      margin-bottom: 1em;
+      padding: 0.5em 3em;
+
       border-bottom: 1px solid $separator-color;
-      margin-bottom: 1rem;
 
       > .text {
         flex-grow: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5em;
 
         > .title-with-actions {
-          h2,
-          h3 {
-            display: inline;
-            margin-right: 0;
-          }
+          display: flex;
+          gap: 0.5em;
+          align-items: center;
+          justify-content: space-between;
 
-          .actions {
-            display: inline-block;
-            vertical-align: bottom;
+          h1 {
+            // FIXME: font attributes of headings should not be defined globally, fix in the base styles later
+            font-weight: normal;
           }
+        }
+
+        .subtitle-container {
+          // FIXME: compensating for tiny base text size.
+          font-size: 1.14em;
         }
       }
 
       > .actions {
-        flex-grow: 0;
-        flex-shrink: 0;
-        white-space: nowrap;
+        flex: none;
       }
     }
 
@@ -248,8 +255,4 @@
 
 .search-page {
   @include indico-page-standalone();
-
-  .title .text {
-    margin-left: 2%;
-  }
 }

--- a/indico/web/templates/layout/base.html
+++ b/indico/web/templates/layout/base.html
@@ -14,9 +14,9 @@
                 <div class="title">
                     <div class="text">
                         <div class="title-with-actions">
-                            <h2>
+                            <h1>
                                 {%- block title %}{% endblock -%}
-                            </h2>
+                            </h1>
                             {%- if self.title_actions()|trim -%}
                                 <div class="actions">
                                     {% block title_actions %}{% endblock %}
@@ -25,7 +25,7 @@
                         </div>
                         <div class="subtitle-container">
                             {%- if self.subtitle()|trim -%}
-                                <h3>{% block subtitle %}{% endblock %}</h3>
+                                <div>{% block subtitle %}{% endblock %}</div>
                             {%- endif -%}
                         </div>
                     </div>


### PR DESCRIPTION
- Promote H2 to H1
- Demote H3 to DIV
- Convert the title area into a flexbox and add responsiveness

Fixes #5958 