### PR TITLE
Add new changelog section for a11y

### DIFF
--- a/.github/utils/extract_changelog.py
+++ b/.github/utils/extract_changelog.py
@@ -18,6 +18,7 @@ EMOJIS = {
     'Internationalization': ':flags:',
     'Improvements': ':tada:',
     'Bugfixes': ':bug:',
+    'Accessibility': ':wheelchair:',
     'Internal Changes': ':wrench:',
 }
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,22 +28,28 @@ Improvements
 - Allow room managers to add internal notes to bookings (:issue:`5746`, :pr:`5791`)
 - Support generating tickets and badges for each of the registrant's accompanying
   persons (:pr:`5424`)
-- Include current language in page metadata (:pr:`5894`, thanks :user:`foxbunny`)
 - Add keyboard shortcut (CTRL-SHIFT-A) to toggle room booking admin override (:pr:`5909`)
-- Make language list accessible (:issue:`5899`, :pr:`5903`, thanks :user:`foxbunny`)
-- Add accessible label to the main page link (:issue:`5934`, :pr:`5935`, thanks :user:`foxbunny`)
-- Add bypass block links (:issue:`5932`, :pr:`5939`, thanks :user:`foxbunny`)
 - Improve login page UI, allow overriding the logo URL (:data:`LOGIN_LOGO_URL` config option)
   and using custom logos for auth providers (``logo_url`` in the auth provider settings)
   (:pr:`5936`, thanks :user:`openprojects`)
-- Make search fields more accessible (:issue:`5948`, :pr:`5950`, thanks :user:`foxbunny`)
-- Make search result status messages more accessible (:issue:`5949`, :pr:`5950`, thanks :user:`foxbunny`)
 
 Bugfixes
 ^^^^^^^^
 
 - Prevent room booking sidebar menu from overlapping with the user dropdown menu
   (:pr:`5910`)
+
+Accessibility
+^^^^^^^^^^^^^
+
+- Include current language in page metadata (:pr:`5894`, thanks :user:`foxbunny`)
+- Make language list accessible (:issue:`5899`, :pr:`5903`, thanks :user:`foxbunny`)
+- Add accessible label to the main page link (:issue:`5934`, :pr:`5935`, thanks
+  :user:`foxbunny`)
+- Add bypass block links (:issue:`5932`, :pr:`5939`, thanks :user:`foxbunny`)
+- Make search fields more accessible (:issue:`5948`, :pr:`5950`, thanks :user:`foxbunny`)
+- Make search result status messages more accessible (:issue:`5949`, :pr:`5950`,
+  thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/bin/maintenance/make-changelog.py
+++ b/bin/maintenance/make-changelog.py
@@ -23,17 +23,17 @@ CHANGELOG_STUB = '''
 Improvements
 ^^^^^^^^^^^^
 
-- None so far :(
+- Nothing so far :(
 
 Bugfixes
 ^^^^^^^^
 
-- None so far :)
+- Nothing so far :)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^
 
-- None so far
+- Nothing so far
 
 
 '''.lstrip()

--- a/bin/maintenance/make-changelog.py
+++ b/bin/maintenance/make-changelog.py
@@ -30,6 +30,11 @@ Bugfixes
 
 - Nothing so far :)
 
+Accessibility
+^^^^^^^^^^^^^
+
+- Nothing so far
+
 Internal Changes
 ^^^^^^^^^^^^^^^^
 
@@ -62,6 +67,11 @@ Improvements
 
 Bugfixes
 ^^^^^^^^
+
+- Nothing so far
+
+Accessibility
+^^^^^^^^^^^^^
 
 - Nothing so far
 

--- a/bin/maintenance/make-release.py
+++ b/bin/maintenance/make-release.py
@@ -25,17 +25,17 @@ CHANGELOG_STUB = '''
 Improvements
 ^^^^^^^^^^^^
 
-- None so far :(
+- Nothing so far :(
 
 Bugfixes
 ^^^^^^^^
 
-- None so far :)
+- Nothing so far :)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^
 
-- None so far
+- Nothing so far
 
 
 '''.lstrip()


### PR DESCRIPTION
With all the nice stuff from @foxbunny it's getting a bit crowded in the "Improvements" sections, and splitting between features and a11y makes sense in any case