### PR TITLE
Improve ``indico i18n`` CLI to support plugin-related i18n operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Try extracting i18n strings (Python)
         if: success() || failure()
-        run: indico i18n extract-messages
+        run: indico i18n extract indico
 
       - name: Try extracting i18n strings (JS)
         if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,10 +164,7 @@ jobs:
 
       - name: Try extracting i18n strings (JS)
         if: success() || failure()
-        run: |
-          echo "::add-matcher::.github/matchers/react-jsx-i18n-problem-matcher.json"
-          FORCE_COLOR=1 npx react-jsx-i18n extract --ext jsx indico/web/client/ indico/modules/ > /dev/null
-          echo "::remove-matcher owner=react-jsx-i18n::"
+        run: indico i18n extract indico --javascript
 
       - name: Check i18n format strings
         if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,10 @@ jobs:
 
       - name: Try extracting i18n strings (JS)
         if: success() || failure()
-        run: indico i18n extract indico --javascript
+        run: |
+          echo "::add-matcher::.github/matchers/react-jsx-i18n-problem-matcher.json"
+          FORCE_COLOR=1 indico i18n extract indico --react
+          echo "::remove-matcher owner=react-jsx-i18n::"
 
       - name: Check i18n format strings
         if: success() || failure()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
 
       - name: Try extracting i18n strings (Python)
         if: success() || failure()
-        run: indico i18n extract indico
+        run: indico i18n extract indico --python
 
       - name: Try extracting i18n strings (JS)
         if: success() || failure()

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,7 +98,8 @@ Internal Changes
   :user:`vtran99`)
 - Support Python 3.12 (:pr:`5978`)
 - Remove watchman reloader support, use watchfiles instead (:pr:`5978`)
-- Improve i18n cli and add new i18n cli for plugins(:issue:`5906`, :pr:`5961`, thanks :user:`SegiNyn`)
+- Improve ``indico i18n`` CLI to support plugin-related i18n operations (:issue:`5906`, :pr:`5961`,
+  thanks :user:`SegiNyn`)
 
 
 ----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,7 @@ Internal Changes
   :user:`vtran99`)
 - Support Python 3.12 (:pr:`5978`)
 - Remove watchman reloader support, use watchfiles instead (:pr:`5978`)
+- Improve i18n cli and add new i18n cli for plugins(:issue:`5906`, :pr:`5961`, thanks :user:`SegiNyn`)
 
 
 ----

--- a/docs/source/installation/development.rst
+++ b/docs/source/installation/development.rst
@@ -162,8 +162,7 @@ To build the locales, use:
 
 .. code-block:: shell
 
-    indico i18n compile-catalog
-    indico i18n compile-catalog-react
+    indico i18n compile indico
 
 .. _run-dev:
 

--- a/docs/source/installation/translations.rst
+++ b/docs/source/installation/translations.rst
@@ -60,7 +60,7 @@ You can also consult the official
 
 Navigate to ``~/dev/indico/src`` (assuming you used the standard locations from the dev setup guide).
 
-Run ``indico i18n pull <language_code>``.
+Run ``indico i18n pull indico <language_code>``.
 Languages codes can be obtained `here <https://www.transifex.com/indico/>`_.
 
 For example, Chinese (China) is ``zh_CN.GB2312``.

--- a/docs/source/installation/translations.rst
+++ b/docs/source/installation/translations.rst
@@ -78,8 +78,7 @@ this could to lead to errors when Indico tries to use the translated string.
 6. Compile translations and run Indico
 --------------------------------------
 
-Run the command ``indico i18n compile indico``
-and:
+Run the command ``indico i18n compile indico`` and:
 
 - :ref:`launch Indico <run-dev>`, or
 - :ref:`build <building>` and :ref:`deploy your own version of Indico <install-prod>`,

--- a/docs/source/installation/translations.rst
+++ b/docs/source/installation/translations.rst
@@ -60,7 +60,7 @@ You can also consult the official
 
 Navigate to ``~/dev/indico/src`` (assuming you used the standard locations from the dev setup guide).
 
-Run ``tx pull -f -l <language_code>``.
+Run ``indico i18n pull <language_code>``.
 Languages codes can be obtained `here <https://www.transifex.com/indico/>`_.
 
 For example, Chinese (China) is ``zh_CN.GB2312``.
@@ -78,8 +78,7 @@ this could to lead to errors when Indico tries to use the translated string.
 6. Compile translations and run Indico
 --------------------------------------
 
-Run the commands ``indico i18n compile-catalog``
-and ``indico i18n compile-catalog-react``
+Run the command ``indico i18n compile indico``
 and:
 
 - :ref:`launch Indico <run-dev>`, or

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -511,10 +511,12 @@ def push_plugin(plugin_dir):
 
 
 @push.command('all-plugins', short_help='Push .pot files to Transifex for multiple plugins.')
-@click.argument('plugins_dir', type=click.Path(exists=True, file_okay=False, resolve_path=True))
+@click.argument('plugins_dir', type=click.Path(exists=True, file_okay=False, resolve_path=True),
+                callback=_validate_all_plugins_dir)
 def push_all_plugins(plugins_dir):
     """Push .pot files to transifex for multiple plugins in a directory."""
-    with _chdir(plugins_dir):
+    parent_directory = Path(plugins_dir[0]).parent.absolute()
+    with _chdir(parent_directory):
         _push()
 
 
@@ -573,12 +575,13 @@ def pull_plugin(plugin_dir, languages):
 
 
 @pull.command('all-plugins', short_help='Pull translated .po files from Transifex for multiple plugins.')
-@click.argument('plugins_dir', type=click.Path(exists=True, file_okay=False, resolve_path=True))
+@click.argument('plugins_dir', type=click.Path(exists=True, file_okay=False, resolve_path=True),
+                callback=_validate_all_plugins_dir)
 @click.argument('languages', nargs=-1, required=False)
 def pull_all_plugins(plugins_dir, languages):
     """Pull translated .po files from Transifex for multiple plugins."""
-    with _chdir(plugins_dir):
-        plugin_dirs = _validate_all_plugins_dir(None, None, plugins_dir)
+    parent_directory = Path(plugins_dir[0]).parent.absolute()
+    with _chdir(parent_directory):
         if 'en_US' in languages:
             languages.remove('en_US')
         language_renames = {'zh_Hans_CN': 'zh_CN.GB2312'}  # other lang codes requiring rename should be added here
@@ -594,7 +597,7 @@ def pull_all_plugins(plugins_dir, languages):
             sys.exit(1)
         else:
             for code in set(languages) & set(language_renames):
-                for plugin_dir in plugin_dirs:
+                for plugin_dir in plugins_dir:
                     translations_dir = _get_translations_dir(plugin_dir)
                     if os.path.exists(os.path.join(translations_dir, code)):
                         shutil.rmtree(os.path.join(translations_dir, code))

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -304,13 +304,13 @@ def extract_messages_react(directory=INDICO_DIR):
         assert len(packages) == 1
         client_path = os.path.join(directory, packages[0], 'client')
         module_path = os.path.join(directory, packages[0], 'modules')
-        if not os.path.exists(client_path) and not os.path.exists(module_path):
-            return
         paths = []
         if os.path.exists(client_path):
             paths.append(client_path)
         if os.path.exists(module_path):
             paths.append(module_path)
+        if not paths:
+            return
     with _chdir(INDICO_DIR):
         output = subprocess.check_output(['npx', 'react-jsx-i18n', 'extract'] + paths,
                                          env=dict(os.environ, FORCE_COLOR='1'))

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -301,7 +301,7 @@ def compile_catalog_react(directory=INDICO_DIR, locale=''):
 
 
 def extract_messages_react(directory=INDICO_DIR):
-    """Extract messagges for react."""
+    """Extract messages for react."""
     if directory is INDICO_DIR:
         paths = [os.path.join('indico', 'web', 'client'), os.path.join('indico', 'modules')]
     else:
@@ -325,6 +325,7 @@ def extract_messages_react(directory=INDICO_DIR):
 
 def remove_empty_pot_files(translations_dir, python=False, javascript=False, react=False):
     """Remove empty .pot files with no msgid strings after extraction."""
+
     def _message_id_count(file_name):
         count = 0
         with open(os.path.join(translations_dir, file_name), encoding='utf-8') as f:

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -261,7 +261,7 @@ def _common_translation_options(require_js=True, require_locale=False, plugins=F
         fn = click.option('--react', is_flag=True, help='i18n used in react code.')(fn)
         if require_js:
             fn = click.option('--javascript', is_flag=True, help='i18n used in javascript code.')(fn)
-        else:  # the only command that does not require js is compile_catalog which checks the string format at the end
+        else:  # the only command that does not require js is compile_catalog which checks the string format
             fn = click.option('--no-check', is_flag=True, required=False,
                               help='Skip running the string format validation.')(fn)
         if require_locale:
@@ -286,7 +286,8 @@ def compile_catalog_react(directory=INDICO_DIR):
             json_file = os.path.join(translations_dir, locale, 'LC_MESSAGES', 'messages-react.json')
             if not os.path.exists(po_file):
                 continue
-            output = subprocess.check_output(['npx', 'react-jsx-i18n', 'compile', po_file], encoding='utf-8')
+            with _chdir(INDICO_DIR):
+                output = subprocess.check_output(['npx', 'react-jsx-i18n', 'compile', po_file], encoding='utf-8')
             json.loads(output)  # just to be sure the JSON is valid
             with open(json_file, 'w') as f:
                 f.write(output)
@@ -416,33 +417,33 @@ def _command(**kwargs):
             _plugin_command(babel_cmd, python, javascript, react, locale, no_check, plugin_dir)
 
 
-def _make_command(group, cmd_name, babel_cmd, func, **kwargs):
+def _make_command(group, cmd_name, babel_cmd, **kwargs):
     cmd_group = group.command(cmd_name, short_help=f'Perform {babel_cmd} operation on {cmd_name}')
 
     @_common_translation_options(**kwargs)
     def wrapper(**kwargs):
-        func(babel_cmd=babel_cmd, **kwargs)
+        _command(babel_cmd=babel_cmd, **kwargs)
 
     return cmd_group(wrapper)
 
 
-_make_command(compile_catalog, 'indico', 'compile_catalog', _command, require_js=False)
-_make_command(extract_messages, 'indico', 'extract_messages', _command)
-_make_command(update_catalog, 'indico', 'update_catalog', _command)
-_make_command(init_catalog, 'indico', 'init_catalog', _command, require_locale=True)
+_make_command(compile_catalog, 'indico', 'compile_catalog', require_js=False)
+_make_command(extract_messages, 'indico', 'extract_messages')
+_make_command(update_catalog, 'indico', 'update_catalog')
+_make_command(init_catalog, 'indico', 'init_catalog', require_locale=True)
 
-_make_command(compile_catalog, 'plugins', 'compile_catalog', _command, require_js=False,
+_make_command(compile_catalog, 'plugins', 'compile_catalog', require_js=False,
               plugins=True)
-_make_command(extract_messages, 'plugins', 'extract_messages', _command, plugins=True)
-_make_command(update_catalog, 'plugins', 'update_catalog', _command, plugins=True)
-_make_command(init_catalog, 'plugins', 'init_catalog', _command, require_locale=True,
+_make_command(extract_messages, 'plugins', 'extract_messages', plugins=True)
+_make_command(update_catalog, 'plugins', 'update_catalog', plugins=True)
+_make_command(init_catalog, 'plugins', 'init_catalog', require_locale=True,
               plugins=True)
 
-_make_command(compile_catalog, 'all-plugins', 'compile_catalog', _command, require_js=False,
+_make_command(compile_catalog, 'all-plugins', 'compile_catalog', require_js=False,
               all_plugins=True)
-_make_command(extract_messages, 'all-plugins', 'extract_messages', _command, all_plugins=True)
-_make_command(update_catalog, 'all-plugins', 'update_catalog', _command, all_plugins=True)
-_make_command(init_catalog, 'all-plugins', 'init_catalog', _command, require_locale=True,
+_make_command(extract_messages, 'all-plugins', 'extract_messages', all_plugins=True)
+_make_command(update_catalog, 'all-plugins', 'update_catalog', all_plugins=True)
+_make_command(init_catalog, 'all-plugins', 'init_catalog', require_locale=True,
               all_plugins=True)
 
 

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -104,7 +104,8 @@ def _get_plugin_options(cmd_name, plugin_dir):
             'mapping_file': 'babel.cfg' if os.path.isfile(os.path.join(plugin_dir, 'babel.cfg')) else '../babel.cfg'
         },
         'compile_catalog': {
-            'directory': _get_translations_dir(plugin_dir)
+            'directory': _get_translations_dir(plugin_dir),
+            'use_fuzzy': True,
         },
         'update_catalog': {
             'input_file': _get_messages_pot(plugin_dir),

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import errno
 import json
 import os
 import re
@@ -323,24 +324,24 @@ def extract_messages_react(directory=INDICO_DIR):
 
 
 def po_file_empty(path):
-    if not os.path.exists(path):
-        return False
-    with open(path, 'rb') as f:
-        po_data = read_po(f)
+    try:
+        with open(path, 'rb') as f:
+            po_data = read_po(f)
+    except OSError as e:
+        if e.errno == errno.ENOENT:
+            return False
+        raise
     return not po_data
 
 
 def remove_empty_pot_files(path, python=False, javascript=False, react=False):
     """Remove empty .pot files with no msgid strings after extraction."""
-    if python:
-        if po_file_empty(_get_messages_pot(path)):
-            os.remove(_get_messages_pot(path))
-    if javascript:
-        if po_file_empty(_get_messages_js_pot(path)):
-            os.remove(_get_messages_js_pot(path))
-    if react:
-        if po_file_empty(_get_messages_react_pot(path)):
-            os.remove(_get_messages_react_pot(path))
+    if python and po_file_empty(_get_messages_pot(path)):
+        os.remove(_get_messages_pot(path))
+    if javascript and po_file_empty(_get_messages_js_pot(path)):
+        os.remove(_get_messages_js_pot(path))
+    if react and po_file_empty(_get_messages_react_pot(path)):
+        os.remove(_get_messages_react_pot(path))
 
 
 @cli.group('compile', short_help='Catalog compilation command for indico and indico plugins.')


### PR DESCRIPTION
### Indico i18n Improvements 
Closes #5906
The commands look like this: 
```
(indico-un) (base) segilolamustapha@Segilolas-MacBook-Pro indico % indico i18n --help
Usage: indico i18n [OPTIONS] COMMAND [ARGS]...

  Perform i18n-related operations.

Options:
  --help  Show this message and exit.

Commands:
  check-format-strings  Check whether format strings match.
  compile               Catalog compilation command for indico and indico
                        plugins.
  extract               Message extraction command for indico and indico
                        plugins.
  init                  New catalog initialization command for indico and
                        indico plugins.
  pull                  Pull translated .po files from Transifex.
  push                  Push .pot files to Transifex.
  update                Catalog merging command for indico and indico plugins.
```

As seen above, commands are grouped by the operation to be performed, `init, extract, update and compile`

Furthermore, `indico i18n compile --help` shows we can pass either `indico`, `plugins` or `all-plugins`

> `indico` is to perform the operation on indico

> `plugins` is to perform the operation on the given plugin paths 

> `all-plugins` is to perform the operation on a directory containing multiple plugins 

```
(indico-un) (base) segilolamustapha@Segilolas-MacBook-Pro indico % indico i18n compile --help
Usage: indico i18n compile [OPTIONS] COMMAND [ARGS]...

  Catalog compilation command for indico and indico plugins.

Options:
  --help  Show this message and exit.

Commands:
  all-plugins  Perform compile_catalog operation on all-plugins
  indico       Perform compile_catalog operation on indico
  plugins      Perform compile_catalog operation on plugins
```
Running the command like that e..g `indico i18n compile indico` would apply for python, javascript and react. If you want to specify a resource then pass the flag `--python`, `--javascript`, `--react`.

```
(indico-un) (base) segilolamustapha@Segilolas-MacBook-Pro indico % indico i18n compile indico --help
Usage: indico i18n compile indico [OPTIONS]

Options:
  --no-check  Skip running the string format validation.
  --react     i18n used in react code.
  --python    i18n used in python and Jinja code.
  --help      Show this message and exit.
```
As seen above, there is also a `--no-check` option for the compilation command. 
The `extract` and `update` commands are pretty much the same with the exception that they allow the `--javascript` flag and do not have a `--no-check` option. 

The `init` command requires an additional locale argument and can be used like this:
```
indico i18n init indico --locale pt_PT
```
In addition, there is now a pull and push command to pull and push from Transifex. This only applies to Indico translations on transifex. 
```
indico i18n push
indico i18n pull 
indico i18n pull fr_FR pt_PT
```
The pull command can take in `languages` as argument to pull only those specific languages and performs the language code rename. 

## Plugins 
The command for the plugins are the same as above, except that you specify `plugins` or `all-plugins` instead of `indico` and also pass in the plugin path
```
(indico-un) (base) segilolamustapha@Segilolas-MacBook-Pro indico % indico i18n compile plugins --help
Usage: indico i18n compile plugins [OPTIONS] PLUGIN_DIRS...

Options:
  --no-check  Skip running the string format validation.
  --react     i18n used in react code.
  --python    i18n used in python and Jinja code.
  --help      Show this message and exit.
```
Can be used like:
```
indico i18n extract plugins <plugin_dirs>
```
You can also target only `--python`, `--javascript` or `--react`
e.g
```
indico i18n extract plugins --javascript <plugin_dirs>  # here plugin_dirs is one or multiple plugin directories
```
The same applies to `all-plugins` e.g.
```
indico i18n update all-plugins --react <plugin_dirs>  # here plugin_dirs is a single directory containing multiple plugins
```

So for your common operations, you would most likely only need to do:
```
indico i18n extract indico; indico i18n push;
```
and then 
```
indico i18n pull; indico i18n compile indico;   # pass --no-check flag to skip the check_format_string
```