### PR TITLE
Show WP class in end-of-html debug comment

### DIFF
--- a/indico/web/templates/indico_base.html
+++ b/indico/web/templates/indico_base.html
@@ -81,4 +81,5 @@ Endpoint:        {{ request.endpoint }}
 {%- if g.rh %}
 RH:              {{ g.rh.__class__.__module__ }}.{{ g.rh.__class__.__name__ }}
 {%- endif %}
+WP:              {{ wp_class.__module__ }}.{{ wp_class.__name__ }}
 -->

--- a/indico/web/views.py
+++ b/indico/web/views.py
@@ -283,7 +283,7 @@ class WPBase(WPBundleMixin):
                                page_metadata=self.page_metadata,
                                page_title=' - '.join(str(x) for x in title_parts if x),
                                head_content=self._get_head_content(),
-                               body=body)
+                               body=body, wp_class=type(self))
 
 
 class WPNewBase(WPBundleMixin, WPJinjaMixin):
@@ -338,6 +338,7 @@ class WPNewBase(WPBundleMixin, WPJinjaMixin):
                                site_name=core_settings.get('site_title'),
                                social=social_settings.get_all(),
                                page_title=' - '.join(str(x) for x in title_parts if x),
+                               wp_class=cls,
                                **params)
 
 


### PR DESCRIPTION
We already show the RH, but sometimes quickly being able to see the WP class is useful as well.

Example:

```html
<!--
Queries:         4
Duration (sql):  0.005517s
Duration (req):  0.035661s
Worker:          eluvian
Endpoint:        core.settings
RH:              indico.modules.core.controllers.RHSettings
WP:              indico.modules.core.views.WPSettings
-->
```