### PR TITLE
Update urllib3

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -92,7 +92,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.15
+urllib3==1.26.17
     # via requests
 werkzeug==2.3.4
     # via flask

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -144,6 +144,7 @@ pyflakes==3.0.1
     # via flake8
 pygments==2.15.1
     # via
+    #   -c requirements.txt
     #   -r requirements.dev.in
     #   sphinx
 pyproject-hooks==1.0.0
@@ -246,7 +247,7 @@ tomli==2.0.1
     #   pytest
 tornado==6.3.2
     # via livereload
-urllib3==1.26.15
+urllib3==1.26.17
     # via
     #   -c requirements.txt
     #   requests

--- a/requirements.in
+++ b/requirements.in
@@ -61,6 +61,7 @@ sqlalchemy<2  # major upgrade
 terminaltables
 translitcodec
 ua-parser
+urllib3<2  # not compatible with centos7 openssl + not yet compatible with botocore (s3 plugin)
 webargs
 werkzeug
 wtforms[email]

--- a/requirements.txt
+++ b/requirements.txt
@@ -348,8 +348,9 @@ tzdata==2023.3
     # via celery
 ua-parser==0.16.1
     # via -r requirements.in
-urllib3==1.26.15
+urllib3==1.26.17
     # via
+    #   -r requirements.in
     #   requests
     #   sentry-sdk
 vine==5.0.0


### PR DESCRIPTION
Note that this vulnerability (GHSA-v845-jxx5-vc9f) does not affect Indico since we do not use requests/urllib3 to send requests with Cookie headers; this update is mainly to make dependabot and similar tools happy.