### PR TITLE
Mention `check-format-strings` in the translation docs

### DIFF
--- a/docs/source/installation/translations.rst
+++ b/docs/source/installation/translations.rst
@@ -65,7 +65,17 @@ Languages codes can be obtained `here <https://www.transifex.com/indico/>`_.
 
 For example, Chinese (China) is ``zh_CN.GB2312``.
 
-5. Compile translations and run Indico
+5. Check the translations
+-------------------------
+
+Run ``indico i18n check-format-strings`` to make sure that all placeholders in the
+translated strings match.
+
+If this command finds any issues, we recommend fixing the translations in Transifex and
+reinstalling the updated translations before proceeding to the next step. Otherwise,
+this could to lead to errors when Indico tries to use the translated string.
+
+6. Compile translations and run Indico
 --------------------------------------
 
 Run the commands ``indico i18n compile-catalog``

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -185,6 +185,8 @@ def check_format_strings():
                            .format(item['orig'], item['trans'],
                                    list(item['orig_placeholders']), list(item['trans_placeholders'])))
             click.echo()
+    if all_valid:
+        click.secho('No issues found!', fg='green', bold=True)
     sys.exit(0 if all_valid else 1)
 
 


### PR DESCRIPTION
Related discussion: https://talk.getindico.io/t/programming-error-in-news-controller-when-using-a-new-language-italian/3276