### PR TITLE
Fix z-index of .i-dropdown elements

### DIFF
--- a/indico/web/client/styles/partials/_toolbars.scss
+++ b/indico/web/client/styles/partials/_toolbars.scss
@@ -268,7 +268,7 @@ $toolbar-spacing: 10px;
   }
 
   .i-dropdown {
-    z-index: 1;
+    z-index: 3;
 
     & > li {
       white-space: nowrap;


### PR DESCRIPTION
The `z-index` of `.i-dropdown` elements inside toolbars causes some unexpected overlap with other UI components. In particular, I found the `ui.toggle.checkbox` element appearing on top of the dropdown like in the screenshot below. This PR increases the z-index value so that this no longer happens.

<img width="440" alt="image" src="https://github.com/indico/indico/assets/716307/aebff7cb-c703-42c7-aa41-deccb412fc35">
