### PR TITLE
Apply DS to older fixes, improve color contrast

### DIFF
--- a/indico/modules/rb/client/js/common/timeline/TimelineItem.module.scss
+++ b/indico/modules/rb/client/js/common/timeline/TimelineItem.module.scss
@@ -16,7 +16,6 @@
   align-items: center;
 
   .timeline-occurrence {
-    box-sizing: border-box;
     margin: 0;
     position: absolute;
     padding: 0.7em 0.2em;

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoom.module.scss
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoom.module.scss
@@ -75,7 +75,6 @@
 
     .loading-indicator {
       padding: 8px;
-      box-sizing: border-box;
       width: 100%;
       height: 43.6px;
 

--- a/indico/modules/rb/client/js/modules/landing/Landing.module.scss
+++ b/indico/modules/rb/client/js/modules/landing/Landing.module.scss
@@ -32,7 +32,6 @@
     content: ' ';
     position: absolute;
     left: 0;
-    box-sizing: border-box;
     width: 120%;
     animation: fade-slide-down 2s ease-out forwards;
   }

--- a/indico/modules/search/client/js/components/SearchBar.module.scss
+++ b/indico/modules/search/client/js/components/SearchBar.module.scss
@@ -6,7 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
-@use 'base/utilities' as *;
+@use 'design_system';
 
 .placeholder {
   font-size: 0.95em;

--- a/indico/modules/search/client/js/components/SearchBox.jsx
+++ b/indico/modules/search/client/js/components/SearchBox.jsx
@@ -14,7 +14,7 @@ import {Translate} from 'indico/react/i18n';
 import './SearchBox.module.scss';
 
 const renderResult = ({label}, keyword) => (
-  <div styleName="option">
+  <div styleName="search-type-option">
     <span>
       <Icon name="search" />
       {keyword}
@@ -51,7 +51,7 @@ export default function SearchBox({onSearch, category, isAdmin}) {
       onClick: () => {},
       // eslint-disable-next-line react/display-name
       renderer: () => (
-        <div styleName="option">
+        <div styleName="search-type-option">
           <Label content={Translate.string('ADMIN')} size="small" color="red" />
           <Checkbox
             id="checkbox-admin-search"

--- a/indico/modules/search/client/js/components/SearchBox.module.scss
+++ b/indico/modules/search/client/js/components/SearchBox.module.scss
@@ -7,8 +7,10 @@
 
 @use 'base/palette' as *;
 @use 'base/utilities' as *;
+@use 'design_system';
 
-.option {
+.search-type-option {
+  @extend %flex-row;
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/indico/web/client/js/custom_elements/ind_bypass_block_links.README.md
+++ b/indico/web/client/js/custom_elements/ind_bypass_block_links.README.md
@@ -1,11 +1,11 @@
-This element is used to create a set of bypass block [links][1] in the page. The
+This element is used to create a set of [bypass block links][1] in the page. The
 custom element is added to the base template, so there is no need to add it
 manually anywhere on the page.
 
 The bypass block links are created by marking elements on the page as a bypass
 block target. The target element is usually a heading. For an element to be a
 valid target, it must have the 'id' and 'data-bypass-target' attributes. The
-'data-bypass-target' should contain a text that will be used as the label for
+'data-bypass-target' should contain text that will be used as the label for
 the bypass block link.
 
 Example:
@@ -17,10 +17,10 @@ Example:
 ```
 
 Note that the bypass block link target does not need to be visible on the
-page. The utility placeholder selector can be used to hide it. For example:
+page. For example:
 
 ```scss
-@use "base/utilities";
+@use 'design_system';
 
 #category-list {
     @extend %visually-hidden;

--- a/indico/web/client/js/custom_elements/ind_bypass_block_links.scss
+++ b/indico/web/client/js/custom_elements/ind_bypass_block_links.scss
@@ -5,31 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-@use 'base/palette' as *;
-@use 'base/utilities';
-
-ind-bypass-block-links {
-  // FIXME: Local reset, should be fixed in the base
-  * {
-    box-sizing: border-box;
-  }
-
-  font-size: 1.5em;
-}
+@use 'design_system';
 
 ind-bypass-block-links:not(:focus-within) {
   @extend %visually-hidden;
 }
 
 ind-bypass-block-links:focus-within {
-  --color-bypass-block-links-bg: #{$postit-yellow};
-  --color-bypass-block-links-fg: #{$dark-black};
-
-  display: flex;
-  align-items: center;
-  gap: 0.5em;
-  padding: 1em;
-
-  background: var(--color-bypass-block-links-bg);
-  color: var(--color-bypass-block-links-fg);
+  @extend %notice;
+  @extend %flex-row;
 }

--- a/indico/web/client/js/react/components/style/modal.scss
+++ b/indico/web/client/js/react/components/style/modal.scss
@@ -28,7 +28,6 @@ $modal-footer-height: 60px;
   }
 
   .modal-dialog-content {
-    box-sizing: border-box;
     padding: 1em;
     max-height: 100%;
   }
@@ -39,7 +38,6 @@ $modal-footer-height: 60px;
     }
 
     .modal-dialog-header {
-      box-sizing: border-box;
       background-color: $light-gray;
       border-bottom: 1px solid darken($light-gray, 5%);
       padding: 1em;
@@ -58,7 +56,6 @@ $modal-footer-height: 60px;
   }
 
   %modal-dialog-footer {
-    box-sizing: border-box;
     background-color: $light-gray;
     border-top: 1px solid darken($light-gray, 5%);
     padding: 1em;

--- a/indico/web/client/styles/base/_layout.scss
+++ b/indico/web/client/styles/base/_layout.scss
@@ -38,7 +38,6 @@ body > * {
 .layout-wrapper {
   .row {
     .column {
-      box-sizing: border-box;
       float: left;
       padding: 0 1em 0 1em;
 

--- a/indico/web/client/styles/base/_utilities.scss
+++ b/indico/web/client/styles/base/_utilities.scss
@@ -77,11 +77,3 @@
 .ellipsis {
   @include ellipsis();
 }
-
-%visually-hidden {
-  position: absolute;
-  clip-path: inset(50%);
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-}

--- a/indico/web/client/styles/design_system/_link.scss
+++ b/indico/web/client/styles/design_system/_link.scss
@@ -1,0 +1,29 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@use './variables';
+
+%link {
+  color: var(--clickable-text-color);
+  text-decoration: none;
+
+  &:active {
+    color: var(--clickable-text-active-color);
+  }
+
+  &[aria-disabled='true'] {
+    color: var(--clickable-text-disabled-color);
+  }
+}
+
+%link-with-visited-state {
+  @extend %link;
+
+  &:visited {
+    color: var(--clickable-text-used-color);
+  }
+}

--- a/indico/web/client/styles/design_system/_notice.scss
+++ b/indico/web/client/styles/design_system/_notice.scss
@@ -6,12 +6,11 @@
 // LICENSE file for more details.
 
 @use './variables';
-@use './button';
-@use './button_group';
-@use './form_controls';
-@use './layout';
-@use './link';
-@use './notice';
-@use './popup';
-@use './visibility';
-@use './utils';
+
+%notice {
+  padding: var(--container-padding);
+
+  background: var(--message-important-surface-color);
+  color: var(--message-important-text-color);
+  font-size: calc(var(--text-size-global-adjust) * var(--text-size-rel-l));
+}

--- a/indico/web/client/styles/design_system/_visibility.scss
+++ b/indico/web/client/styles/design_system/_visibility.scss
@@ -6,10 +6,9 @@
 // LICENSE file for more details.
 
 %visually-hidden {
-  position: fixed;
-  right: 100vw;
-  width: 0;
-  height: 0;
+  position: absolute;
+  clip-path: inset(50%);
+  width: 1px;
+  height: 1px;
   overflow: hidden;
-  opacity: 0;
 }

--- a/indico/web/client/styles/design_system/variables.scss
+++ b/indico/web/client/styles/design_system/variables.scss
@@ -5,46 +5,83 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-@use 'base/defaults' as *;
-@use 'base/palette' as *;
-
 body {
-  --color-text: #{$dark-black};
-  --color-accent: #{$dark-blue};
+  // Color palette
+  --text-color: #333;
+  --text-inverse-color: #fff;
+  --text-disabled-color: #999;
+  --surface-default: #e8e8e8;
+  --surface-highlight-color: #c4c4c4;
+  --surface-disabled-color: #f9f9f9;
+  --border-default-color: #5a5a5a;
+  --border-disabled-color: #c4c4c4;
+  --accent-color: #007cac;
+  --accent-highlight-color: #035e81;
+  --active-color: #db1a1a;
+  --visited-color: #8d14f0;
 
-  --control-border-color: #{$dark-gray};
-  --control-text-color: var(--color-text);
-  --control-clickable-surface-color: #{$pastel-gray};
-  --control-clickable-surface-focus-color: #{darken($pastel-gray, $color-variation)};
-  --control-alt-text-color: #{$white};
-  --control-alt-clickable-surface-color: #{$dark-blue};
-  --control-alt-clickable-surface-focus-color: #{darken($dark-blue, $color-variation)};
-  --control-alt-border-color: #{darken($dark-blue, $color-variation)};
-  --control-disabled-text-color: #{$dark-gray};
-  --control-disabled-clickable-surface-color: #{$light-gray};
-  --control-disabled-border-color: #{$pastel-gray};
-  --control-indented-bg-color: #{$light-gray};
-  --control-disabled-indented-bg-color: #{$light-gray};
-  --control-disabled-inset-indented-color: #{$dark-gray};
-
+  // Generic controls
+  --control-border-color: var(--border-default-color);
+  --control-text-color: var(--text-color);
+  --control-clickable-surface-color: var(--surface-default);
+  --control-clickable-surface-focus-color: var(--surface-highlight-color);
+  --control-clickable-border-color: var(--control-border-color);
+  --control-alt-text-color: var(--text-inverse-color);
+  --control-alt-clickable-surface-color: var(--accent-color);
+  --control-alt-clickable-surface-focus-color: var(--accent-highlight-color);
+  --control-alt-border-color: var(--accent-color);
+  --control-disabled-text-color: var(--text-disabled-color);
+  --control-disabled-clickable-surface-color: var(--surface-disabled-color);
+  --control-disabled-border-color: var(--surface-disabled-color);
+  --control-indented-bg-color: var(--surface-disabled-color);
+  --control-disabled-indented-bg-color: var(--text-disabled-color);
+  --control-disabled-inset-indented-color: var(--text-disabled-color);
   --control-border: 1px solid var(--control-border-color);
-  --control-border-radius: #{$default-border-radius};
+  --control-border-radius: 0.15em;
   --control-padding: 0.5em;
   --control-internal-gap: 0.2em;
 
+  // Clickable texts (e.g., link)
+  --clickable-text-color: var(--accent-color);
+  --clickable-text-active-color: var(--active-color);
+  --clickable-text-used-color: var(--visited-color);
+  --clickable-text-disabled-color: var(--text-disabled-color);
+
+  // Generic container
   --container-padding: 1em;
   --container-narrow-padding: 1em 0.5em;
   --container-element-spacing: 0.5em;
 
+  // Messages (banners, notifications, etc)
+  --message-important-surface-color: #fff9b8;
+  --message-important-text-color: var(--text-color);
+
+  // Text sizes (relative)
   --text-size-rel-s: 75%;
   --text-size-rel-n: 100%;
   --text-size-rel-l: 120%;
   --text-size-rel-xl: 150%;
   --text-size-rel-xxl: 200%;
 
+  // Text sizes (absolute)
   --text-size-abs-s: 0.875rem;
   --text-size-abs-n: 1rem;
   --text-size-abs-l: 1.2rem;
   --text-size-abs-xl: 1.5rem;
   --text-size-abs-xxl: 2rem;
+
+  // TODO: Compensates from base font size of 14px coming from SUI.
+  // This should be set to 1 once SUI is removed.
+  //
+  // How to use:
+  //
+  // In your container block, multiply the `font-size` with this value.
+  // For example:
+  //
+  //    .foo {
+  //      font-size: calc(var(--text-size-global-adjust) * var(--text-size-rel-n));
+  //    }
+  //
+  // You don't need to do this for descendants. Just once in the outermost container.
+  --text-size-global-adjust: 1.14;
 }

--- a/indico/web/client/styles/modules/_attachments.scss
+++ b/indico/web/client/styles/modules/_attachments.scss
@@ -430,7 +430,6 @@ div.main > .attachments-package {
   color: white;
   padding: 10px;
   z-index: 10;
-  box-sizing: border-box;
   align-items: center;
 
   .attachment-title {
@@ -502,7 +501,6 @@ div.main > .attachments-package {
           padding: 2vw;
           background-color: white;
           overflow: auto;
-          box-sizing: border-box;
         }
       }
     }

--- a/indico/web/client/styles/modules/_bootstrap.scss
+++ b/indico/web/client/styles/modules/_bootstrap.scss
@@ -157,8 +157,6 @@
       }
 
       .step-icon {
-        box-sizing: border-box;
-
         float: left;
 
         width: 100px;

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -7,6 +7,7 @@
 
 @use 'base' as *;
 @use 'partials/buttons' as *;
+@use 'design_system';
 
 .confirmation-dialog .body ul.categ-list {
   padding-left: 13px;
@@ -126,7 +127,6 @@
 }
 
 .category-sidebar {
-  box-sizing: border-box;
   background: #fafafa;
   background-image: linear-gradient(to bottom, #fafafa 95%, #fff 100%);
   border-left: 1px solid #f2f2f2;

--- a/indico/web/client/styles/modules/_dashboard.scss
+++ b/indico/web/client/styles/modules/_dashboard.scss
@@ -61,9 +61,6 @@
 .dashboard-box {
   border: 1px solid #ddd;
   border-radius: 0.3em;
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  -webkit-box-sizing: border-box;
   margin-bottom: 44px;
 }
 

--- a/indico/web/client/styles/modules/_designer.scss
+++ b/indico/web/client/styles/modules/_designer.scss
@@ -47,7 +47,6 @@
   }
 
   .ruler .marking {
-    box-sizing: border-box;
     position: absolute;
     border: 1px solid #aaa;
     color: #aaa;

--- a/indico/web/client/styles/modules/_event_management.scss
+++ b/indico/web/client/styles/modules/_event_management.scss
@@ -328,7 +328,6 @@
       text-align: right;
       background-image: linear-gradient(to top, $black, rgba($black, 0));
       border-radius: 0 0 2px 2px;
-      box-sizing: border-box;
       padding: 0.5em 1em;
       position: absolute;
       bottom: 0;

--- a/indico/web/client/styles/modules/_markdown.scss
+++ b/indico/web/client/styles/modules/_markdown.scss
@@ -146,7 +146,7 @@ $display-preview-bg-color: white;
   max-width: 800px;
   position: relative;
   padding: 0.5em;
-  height: 2em;
+  height: 3em;
   margin: 0;
   background-color: $light-gray;
   display: flex;
@@ -164,7 +164,6 @@ $display-preview-bg-color: white;
 }
 
 .wmd-button-bar {
-  box-sizing: content-box;
   position: relative;
 
   .save-button {

--- a/indico/web/client/styles/modules/_registrationform.scss
+++ b/indico/web/client/styles/modules/_registrationform.scss
@@ -620,7 +620,6 @@
 
   a {
     padding: 0 10px;
-    box-sizing: border-box;
     color: $dark-gray;
   }
 }

--- a/indico/web/client/styles/modules/_roles.scss
+++ b/indico/web/client/styles/modules/_roles.scss
@@ -38,7 +38,6 @@
 
 .role-list {
   padding: 10px;
-  box-sizing: border-box;
   list-style-type: none;
 
   li {

--- a/indico/web/client/styles/modules/_users.scss
+++ b/indico/web/client/styles/modules/_users.scss
@@ -98,7 +98,6 @@
 
   li {
     display: table;
-    box-sizing: border-box;
     width: 100%;
     height: 3em;
     padding: 0.4em;
@@ -235,7 +234,6 @@
 
 .category-box {
   position: relative;
-  box-sizing: border-box;
   padding: 0.5rem !important;
 
   > div {

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -55,7 +55,6 @@
 .event-message {
   margin: 20px auto 5px auto;
   width: 1000px !important;
-  box-sizing: border-box;
   line-height: initial;
 }
 

--- a/indico/web/client/styles/partials/_actionboxes.scss
+++ b/indico/web/client/styles/partials/_actionboxes.scss
@@ -15,7 +15,6 @@
 @use 'base/animation' as *;
 
 @mixin action-box {
-  box-sizing: border-box;
   @include default-border-radius();
   margin-bottom: 1rem;
   padding: 10px;

--- a/indico/web/client/styles/partials/_boxes.scss
+++ b/indico/web/client/styles/partials/_boxes.scss
@@ -139,7 +139,6 @@ $i-box-padding: 10px;
   @include single-box-shadow();
   @include transition(padding-bottom);
 
-  box-sizing: border-box;
   background: white;
   color: $black;
 

--- a/indico/web/client/styles/partials/_buttons.scss
+++ b/indico/web/client/styles/partials/_buttons.scss
@@ -14,7 +14,6 @@ $i-button-spacing: 0.3rem;
   user-select: none;
   @include default-border-radius();
   @include border-all();
-  box-sizing: border-box;
   display: inline-block;
   cursor: pointer;
   color: $light-black;

--- a/indico/web/client/styles/partials/_forms.scss
+++ b/indico/web/client/styles/partials/_forms.scss
@@ -47,7 +47,6 @@ form {
 
 .i-form {
   @include font-family-form();
-  box-sizing: border-box;
   max-width: 800px;
   display: block;
   font-size: 1em;

--- a/indico/web/client/styles/partials/_infogrids.scss
+++ b/indico/web/client/styles/partials/_infogrids.scss
@@ -33,12 +33,6 @@
   flex-flow: row nowrap;
   line-height: initial;
 
-  &,
-  &::after,
-  &::before {
-    box-sizing: border-box;
-  }
-
   .icon {
     color: $gray;
     font-size: 2rem;

--- a/indico/web/client/styles/partials/_inputs.scss
+++ b/indico/web/client/styles/partials/_inputs.scss
@@ -18,7 +18,6 @@
 @mixin text-input-base {
   @include border-all();
   @include default-border-radius();
-  box-sizing: border-box;
   @include transition(border-color 0.12s);
   color: $black;
   font-family: inherit;

--- a/indico/web/client/styles/partials/_jquery-indico-multitextfield.scss
+++ b/indico/web/client/styles/partials/_jquery-indico-multitextfield.scss
@@ -23,7 +23,6 @@
     @include border-vert();
     @include transition(background);
     @include transition(color);
-    box-sizing: border-box;
     border-top-left-radius: $default-border-radius;
     border-bottom-left-radius: $default-border-radius;
     user-select: none;

--- a/indico/web/client/styles/partials/_labels.scss
+++ b/indico/web/client/styles/partials/_labels.scss
@@ -15,7 +15,6 @@ $i-label-color: $light-black;
   @include default-border-radius();
   @include border-all($gray);
   user-select: none;
-  box-sizing: border-box;
   display: inline-flex;
   color: $i-label-color;
   outline: none;

--- a/indico/web/client/styles/partials/_lists.scss
+++ b/indico/web/client/styles/partials/_lists.scss
@@ -55,7 +55,6 @@ dl.i-data-list {
 
   dt,
   dd {
-    box-sizing: border-box;
     display: inline-block;
     margin: 0 0 0.7em 0;
     padding: 0.3em 1em 0.3em 1em;

--- a/indico/web/client/styles/partials/_object-lists.scss
+++ b/indico/web/client/styles/partials/_object-lists.scss
@@ -222,7 +222,6 @@
     max-height: 12em;
     overflow: auto;
     min-width: 12em;
-    box-sizing: border-box;
 
     > li {
       @extend .flexrow;

--- a/indico/web/client/styles/partials/_paddedboxes.scss
+++ b/indico/web/client/styles/partials/_paddedboxes.scss
@@ -9,7 +9,6 @@
 @use 'partials/boxes' as *;
 
 .padded-box {
-  box-sizing: border-box;
   @include border-all($color: $pastel-gray, $width: 2px);
   background: $pastel-gray;
   display: table;

--- a/indico/web/client/styles/partials/_spinner.scss
+++ b/indico/web/client/styles/partials/_spinner.scss
@@ -16,7 +16,6 @@
   &::after {
     border-radius: 50%;
     @include border-all($width: 0.1em);
-    box-sizing: border-box;
     content: '';
     position: absolute;
     width: 100%;

--- a/indico/web/client/styles/partials/_tables.scss
+++ b/indico/web/client/styles/partials/_tables.scss
@@ -100,7 +100,6 @@ tr.details-row {
 
 td.i-table,
 th.i-table {
-  box-sizing: border-box;
   @include ellipsis();
 
   padding: 5px 3px 5px 3px;
@@ -295,7 +294,6 @@ th {
       display: inline-block;
       float: left;
       padding: 0.4em;
-      box-sizing: border-box;
     }
 
     dt {

--- a/indico/web/client/styles/partials/_timelines.scss
+++ b/indico/web/client/styles/partials/_timelines.scss
@@ -53,7 +53,6 @@
   .i-timeline-item-label {
     @include default-border-radius();
     @include border-all($color: transparent);
-    box-sizing: border-box;
     margin-right: 12px;
     outline: 2px solid white;
     flex-shrink: 0;

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -64,7 +64,6 @@ body {
 .item-location {
   @include ellipsis();
 
-  box-sizing: border-box;
   border-radius: 0.2em;
   color: $tt-secondary-color;
   font-size: 1em;
@@ -321,7 +320,6 @@ ul.day-list {
       margin: 0.5rem 0.7em 0 0;
       min-width: 4em;
       text-align: right;
-      box-sizing: border-box;
       color: $dark-gray;
 
       &::before {

--- a/indico/web/client/styles/themes/weeks.scss
+++ b/indico/web/client/styles/themes/weeks.scss
@@ -48,8 +48,6 @@
   width: 100%;
   padding: 0;
   list-style: none;
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
 }
 
 .week-timetable > ul > li {
@@ -58,8 +56,6 @@
   display: inline-block;
   border: 1px #bbb solid;
   background: #fff;
-  box-sizing: border-box;
-  -moz-box-sizing: border-box;
   border-radius: 0.2em;
   box-shadow: 1px 1px 1px #e1e1e1;
 }
@@ -81,7 +77,6 @@
   height: 18px;
   position: relative;
   border-top: solid 1px #f9f9f9;
-  box-sizing: border-box;
 }
 
 .week-timetable .row .title {
@@ -149,8 +144,6 @@
   position: absolute;
   padding-left: 40px;
   width: 100%;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
 }
 
 .week-timetable .row.has-session .main,
@@ -190,7 +183,6 @@
 .qtip-content {
   display: inline-block;
   padding: 10px;
-  box-sizing: border-box;
 
   span {
     line-height: 1.1em;

--- a/indico/web/client/styles/widgets/_tz_selector.scss
+++ b/indico/web/client/styles/widgets/_tz_selector.scss
@@ -18,12 +18,12 @@
     text-align: left;
     padding: var(--container-narrow-padding);
     @extend %flex-column;
-    --flex-gap: 1em;
+    --flex-gap: var(--container-padding);
   }
 
   form {
     @extend %flex-column;
-    --flex-gap: 1em;
+    --flex-gap: var(--container-padding);
   }
 
   fieldset {


### PR DESCRIPTION
- Apply DS features to some of the older fixes
- Remove all box-sizing overrides as it is now in the reset
- Remove DS' dependency on older SCSS modules
- Fix color contrast in the DS

Note: this is a maintenance patch. It does not address any specific issue nor does it add any significant features.

See #5967 