### PR TITLE
Add stylelint-stylistic rules

### DIFF
--- a/.stylelintrc.yaml
+++ b/.stylelintrc.yaml
@@ -2,6 +2,7 @@ extends:
   - stylelint-prettier/recommended
   - stylelint-config-recommended
   - stylelint-config-recommended-scss
+  - stylelint-stylistic/config
 
 ignoreFiles:
   - indico/web/static/dist/**/*.css
@@ -72,3 +73,13 @@ rules:
   scss/at-extend-no-missing-placeholder: null
   # prettier's formatting can violate this
   scss/operator-no-newline-after: null
+  # single quotes are clearly superior
+  stylistic/string-quotes: single
+
+  # these rule conflict with stylelint-prettier formatting
+  stylistic/indentation: null
+  stylistic/selector-descendant-combinator-no-non-space: null
+  stylistic/declaration-colon-newline-after: null
+  stylistic/selector-combinator-space-before: null
+  stylistic/block-closing-brace-newline-after: null
+  stylistic/value-list-comma-newline-after: null

--- a/indico/web/client/js/custom_elements/ind_bypass_block_links.scss
+++ b/indico/web/client/js/custom_elements/ind_bypass_block_links.scss
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-@use "base/palette" as *;
-@use "base/utilities";
+@use 'base/palette' as *;
+@use 'base/utilities';
 
 ind-bypass-block-links {
   // FIXME: Local reset, should be fixed in the base

--- a/indico/web/client/styles/design_system/variables.scss
+++ b/indico/web/client/styles/design_system/variables.scss
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-@use "base/defaults" as *;
-@use "base/palette" as *;
+@use 'base/defaults' as *;
+@use 'base/palette' as *;
 
 body {
   --color-text: #{$dark-black};

--- a/indico/web/client/styles/editor-output.scss
+++ b/indico/web/client/styles/editor-output.scss
@@ -16,7 +16,7 @@
   // Image positioning for ckeditor5
   // https://ckeditor.com/docs/ckeditor5/latest/features/images/images-styles.html
   // Inspired by the default ckeditor styles:
-  // https://github.com/ckeditor/ckeditor5/blob/06d11a85d01aece904a6bdd25e72abd94a4dd314/packages/ckeditor5-image/theme/imagestyle.css
+  // https://github.com/ckeditor/ckeditor5/blob/06d11a85/packages/ckeditor5-image/theme/imagestyle.css
   $image-spacing: 1.5em;
   display: flow-root;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,6 +157,7 @@
         "stylelint-config-recommended-scss": "^12.0.0",
         "stylelint-prettier": "^1.2.0",
         "stylelint-scss": "^5.0.1",
+        "stylelint-stylistic": "^0.4.3",
         "terser-webpack-plugin": "^5.3.3",
         "uglify-js": "^3.16.0",
         "webpack": "^5.73.0",
@@ -14436,6 +14437,31 @@
         "stylelint": "^14.5.1 || ^15.0.0"
       }
     },
+    "node_modules/stylelint-stylistic": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/stylelint-stylistic/-/stylelint-stylistic-0.4.3.tgz",
+      "integrity": "sha512-WphmneK3MRrm5ixvRPWy7+c9+EQUh0FPvNMXW/N9VD85vyqtpxUejpD+mxubVVht0fRgidcqBxtW3s3tU2Ujhw==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^5.0.0",
+        "postcss": "^8.4.21",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-value-parser": "^4.2.0",
+        "style-search": "^0.1.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^15.0.0"
+      }
+    },
+    "node_modules/stylelint-stylistic/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/stylelint/node_modules/balanced-match": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
@@ -26349,6 +26375,27 @@
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-selector-parser": "^6.0.13",
         "postcss-value-parser": "^4.2.0"
+      }
+    },
+    "stylelint-stylistic": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/stylelint-stylistic/-/stylelint-stylistic-0.4.3.tgz",
+      "integrity": "sha512-WphmneK3MRrm5ixvRPWy7+c9+EQUh0FPvNMXW/N9VD85vyqtpxUejpD+mxubVVht0fRgidcqBxtW3s3tU2Ujhw==",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^5.0.0",
+        "postcss": "^8.4.21",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-value-parser": "^4.2.0",
+        "style-search": "^0.1.0"
+      },
+      "dependencies": {
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
+        }
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "stylelint-config-recommended-scss": "^12.0.0",
     "stylelint-prettier": "^1.2.0",
     "stylelint-scss": "^5.0.1",
+    "stylelint-stylistic": "^0.4.3",
     "terser-webpack-plugin": "^5.3.3",
     "uglify-js": "^3.16.0",
     "webpack": "^5.73.0",


### PR DESCRIPTION
Stylelint deprecated those rules in the core and recommends using prettier instead. We already use stylelint-prettier, but the ancient prettier version is no longer compatible with all our SCSS files (`@forward` seems to break it), so we cannot rely on this anymore.

Upgrading prettier is not an option for now either because of how much it screws up formatting in our JS code.

By using these rules we at least get some basic style enforcement, in particular enforcing single quotes.