### PR TITLE
Make registration counts consistent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ Improvements
 - Improve login page UI, allow overriding the logo URL (:data:`LOGIN_LOGO_URL` config option)
   and using custom logos for auth providers (``logo_url`` in the auth provider settings)
   (:pr:`5936`, thanks :user:`openprojects`)
+- Show only active registration counts on the registration form management dashboard, and add
+  an inactive registration count to the registration list (:pr:`5990`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/templates/management/regform.html
+++ b/indico/modules/events/registration/templates/management/regform.html
@@ -89,7 +89,7 @@
                 <div class="group">
                     {% block registrations_count_label %}
                         <span class="i-button label icon-user" title="{% trans %}Total registrations{% endtrans %}">
-                            {{ regform.existing_registrations_count }}
+                            {{ regform.active_registration_count }}
                             {%- if regform.registration_limit %}
                                 / {{ regform.registration_limit }}
                             {%- endif -%}

--- a/indico/modules/events/registration/templates/management/regform_list.html
+++ b/indico/modules/events/registration/templates/management/regform_list.html
@@ -111,7 +111,7 @@
                                 {%- trans %}Registrations{% endtrans -%}
                                 {% block existing_count scoped %}
                                     <span class="badge">
-                                        {{- regform.existing_registrations_count -}}
+                                        {{- regform.active_registration_count -}}
                                         {% if regform.registration_limit %}
                                             / {{ regform.registration_limit }}
                                         {%- endif -%}

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -212,12 +212,17 @@
                        title="{% trans %}Generate a URL for the selected filters and columns.{% endtrans %}"></button>
                 </div>
                 <div class="group">
-                    <span class="i-button label icon-user" title="{% trans %}Total registrations{% endtrans %}">
+                    <span class="i-button label icon-user" title="{% trans %}Total active registrations{% endtrans %}">
                         {{ regform.active_registration_count }}
                         {%- if regform.registration_limit %}
                             / {{ regform.registration_limit }}
                         {%- endif -%}
                     </span>
+                    {% if regform.existing_registrations_count > regform.active_registration_count -%}
+                        <span class="i-button label icon-user-block" title="{% trans %}Inactive registrations{% endtrans %}">
+                            {{ regform.existing_registrations_count - regform.active_registration_count }}
+                        </span>
+                    {%- endif %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR makes the registration counts shown on the regform list, regform dashboard and registration list consistent with each other - all of them now showing active registrations only.

The PR also adds an inactive registration count to the registration list:
<img width="238" alt="image" src="https://github.com/indico/indico/assets/27357203/698f75ce-0893-4d44-b416-1566b477c3ff">
