### PR TITLE
Allow cancelling pending bookings at any time

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,7 @@ Bugfixes
 
 - Prevent room booking sidebar menu from overlapping with the user dropdown menu
   (:pr:`5910`)
+- Allow cancelling pending bookings even if they have already "started" (:pr:`5995`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/rb/models/reservation_occurrences.py
+++ b/indico/modules/rb/models/reservation_occurrences.py
@@ -199,7 +199,7 @@ class ReservationOccurrence(db.Model):
         booked_or_owned_by_user = booking.is_owned_by(user) or booking.is_booked_for(user)
         if booking.is_rejected or booking.is_cancelled or booking.is_archived:
             return False
-        if booked_or_owned_by_user and self.is_within_cancel_grace_period:
+        if booked_or_owned_by_user and (booking.is_pending or self.is_within_cancel_grace_period):
             return True
         return allow_admin and rb_is_admin(user)
 


### PR DESCRIPTION
Usually one can only cancel a booking if it has at least one occurrence that's still within the cancellation grace period. But for a pending booking it makes no sense to apply this limit, since you are not supposed to be using the room anyway.