### PR TITLE
Disable editing the repeat frequency of existing recurring bookings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,7 @@ Bugfixes
 - Prevent room booking sidebar menu from overlapping with the user dropdown menu
   (:pr:`5910`)
 - Allow cancelling pending bookings even if they have already "started" (:pr:`5995`)
+- Disallow modifying the repeat frequency of an existing room booking (:pr:`5999`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,7 +51,8 @@ Bugfixes
 - Prevent room booking sidebar menu from overlapping with the user dropdown menu
   (:pr:`5910`)
 - Allow cancelling pending bookings even if they have already "started" (:pr:`5995`)
-- Disallow modifying the repeat frequency of an existing room booking (:pr:`5999`)
+- Disallow switching the repeat frequency of an existing room booking from weekly to monthly
+  or vice versa (:pr:`5999`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -157,6 +157,7 @@ class BookingEditForm extends React.Component {
     const bookingStarted = today.isAfter(startDt, 'day');
     const bookingFinished = today.isAfter(endDt, 'day');
     const recurringBookingInProgress = recurrence.type === 'every' && bookingStarted;
+    // TODO: Grab the repeat freq. of the booking itself (via this.props.bookings + a interval mapping? etc.) as this won't really work...
 
     // all but one option are hidden
     const showRecurrenceOptions =

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -30,7 +30,7 @@ import {serializeDate} from 'indico/utils/date';
 
 import {FinalTimeRangePicker} from '../../components/TimeRangePicker';
 import {FinalWeekdayRecurrencePicker} from '../../components/WeekdayRecurrencePicker';
-import {sanitizeRecurrence} from '../../util';
+import {sanitizeRecurrence, getRecurrenceInfo} from '../../util';
 import {selectors as userSelectors} from '../user';
 
 import './BookingEditForm.module.scss';
@@ -141,7 +141,7 @@ class BookingEditForm extends React.Component {
   render() {
     const {
       user: sessionUser,
-      booking: {bookedForUser, startDt, endDt, room, isAccepted},
+      booking: {bookedForUser, startDt, endDt, room, isAccepted, repetition},
       onBookingPeriodChange,
       formProps,
       hideOptions,
@@ -156,8 +156,7 @@ class BookingEditForm extends React.Component {
     const today = moment();
     const bookingStarted = today.isAfter(startDt, 'day');
     const bookingFinished = today.isAfter(endDt, 'day');
-    const recurringBookingInProgress = recurrence.type === 'every' && bookingStarted;
-    // TODO: Grab the repeat freq. of the booking itself (via this.props.bookings + a interval mapping? etc.) as this won't really work...
+    const recurringBookingInProgress = getRecurrenceInfo(repetition).type === 'every';
 
     // all but one option are hidden
     const showRecurrenceOptions =
@@ -167,9 +166,7 @@ class BookingEditForm extends React.Component {
         {recurringBookingInProgress && (
           <Message icon styleName="recurring-booking-warning">
             <Icon name="dont" />
-            <Translate>
-              You can't change the booking's recurrence interval once it has begun.
-            </Translate>
+            <Translate>You cannot modify the repeat frequency of an existing booking.</Translate>
           </Message>
         )}
         <Segment>

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -163,8 +163,8 @@ class BookingEditForm extends React.Component {
       ['single', 'daily', 'recurring'].filter(x => hideOptions[x]).length !== 2;
     return (
       <Form id="booking-edit-form" styleName="booking-edit-form" onSubmit={handleSubmit}>
-        {recurringBookingInProgress && (
-          <Message icon styleName="recurring-booking-warning">
+        {recurringBookingInProgress && recurrence.type === 'every' && (
+          <Message icon styleName="repeat-frequency-disabled-notice">
             <Icon name="dont" />
             <Translate>You cannot modify the repeat frequency of an existing booking.</Translate>
           </Message>

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -12,7 +12,7 @@ import {START_DATE} from 'react-dates/constants';
 import {Field, FormSpy} from 'react-final-form';
 import Overridable from 'react-overridable';
 import {connect} from 'react-redux';
-import {Form, Message, Segment} from 'semantic-ui-react';
+import {Form, Message, Segment, Icon} from 'semantic-ui-react';
 
 import {FinalSingleDatePicker, FinalDatePeriod, FinalPrincipal} from 'indico/react/components';
 import {
@@ -156,12 +156,21 @@ class BookingEditForm extends React.Component {
     const today = moment();
     const bookingStarted = today.isAfter(startDt, 'day');
     const bookingFinished = today.isAfter(endDt, 'day');
+    const recurringBookingInProgress = recurrence.type === 'every' && bookingStarted;
 
     // all but one option are hidden
     const showRecurrenceOptions =
       ['single', 'daily', 'recurring'].filter(x => hideOptions[x]).length !== 2;
     return (
       <Form id="booking-edit-form" styleName="booking-edit-form" onSubmit={handleSubmit}>
+        {recurringBookingInProgress && (
+          <Message icon styleName="recurring-booking-warning">
+            <Icon name="dont" />
+            <Translate>
+              You can't change the booking's recurrence interval once it has begun.
+            </Translate>
+          </Message>
+        )}
         <Segment>
           {showRecurrenceOptions && (
             <Form.Group inline>
@@ -220,7 +229,7 @@ class BookingEditForm extends React.Component {
                 {({input: {value: number}}) => (
                   <FinalDropdown
                     name="recurrence.interval"
-                    disabled={submitSucceeded}
+                    disabled={submitSucceeded || recurringBookingInProgress}
                     selection
                     required
                     options={[
@@ -280,7 +289,9 @@ class BookingEditForm extends React.Component {
               recurrence.type === 'every' && recurrence.interval === 'week' ? {} : {display: 'none'}
             }
           >
-            <div styleName="recurring-every-label">{Translate.string('Recurring every')}</div>
+            <div styleName="recurring-every-label">
+              <Translate>Recurring every</Translate>
+            </div>
             <FinalWeekdayRecurrencePicker
               name="recurrence.weekdays"
               requireOneSelected

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
@@ -30,6 +30,6 @@
   font-weight: bold;
 }
 
-.recurring-booking-warning :global(.icon.dont) {
+.repeat-frequency-disabled-notice :global(.icon.dont) {
   font-size: 1.5em !important;
 }

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
@@ -29,3 +29,7 @@
   margin-bottom: 0.5rem;
   font-weight: bold;
 }
+
+.recurring-booking-warning :global(.icon.dont) {
+  font-size: 1.5em !important;
+}

--- a/indico/modules/rb/controllers/backend/bookings.py
+++ b/indico/modules/rb/controllers/backend/bookings.py
@@ -34,10 +34,10 @@ from indico.modules.rb.operations.suggestions import get_suggestions
 from indico.modules.rb.schemas import (CreateBookingSchema, reservation_details_schema,
                                        reservation_linked_object_data_schema, reservation_occurrences_schema,
                                        reservation_user_event_schema)
-from indico.modules.rb.util import (WEEKDAYS, check_impossible_repetition, generate_spreadsheet_from_occurrences,
-                                    get_linked_object, get_prebooking_collisions, group_by_occurrence_date,
-                                    is_booking_start_within_grace_period, serialize_availability,
-                                    serialize_booking_details, serialize_occurrences)
+from indico.modules.rb.util import (WEEKDAYS, check_impossible_repetition, check_repeat_frequency,
+                                    generate_spreadsheet_from_occurrences, get_linked_object, get_prebooking_collisions,
+                                    group_by_occurrence_date, is_booking_start_within_grace_period,
+                                    serialize_availability, serialize_booking_details, serialize_occurrences)
 from indico.util.date_time import now_utc, utc_to_server
 from indico.util.i18n import _
 from indico.util.spreadsheets import send_csv, send_xlsx
@@ -294,6 +294,7 @@ class RHBookingEditCalendars(RHBookingBase):
     }, location='query')
     def _process(self, **kwargs):
         check_impossible_repetition(kwargs)
+        check_repeat_frequency(self.booking.repeat_frequency, kwargs['repeat_frequency'])
         return jsonify(get_booking_edit_calendar_data(self.booking, kwargs))
 
 
@@ -329,6 +330,8 @@ class RHUpdateBooking(RHBookingBase):
             'repeat_interval': args['repeat_interval'],
             'recurrence_weekdays': args['recurrence_weekdays'],
         }
+
+        check_repeat_frequency(self.booking.repeat_frequency, new_booking_data['repeat_frequency'])
 
         additional_booking_attrs = {}
         if not should_split_booking(self.booking, new_booking_data):

--- a/indico/modules/rb/util.py
+++ b/indico/modules/rb/util.py
@@ -374,3 +374,14 @@ def format_weekdays(weekdays):
     """Format a list of weekdays into a nice readable string."""
     assert weekdays
     return ', '.join(x.capitalize() for x in sorted(weekdays, key=lambda x: WEEKDAYS.index(x)))
+
+
+def check_repeat_frequency(old_frequency, new_frequency):
+    """Prevent changing the repeat frequency of an existing booking."""
+    from indico.modules.rb.models.reservations import RepeatFrequency
+
+    if ((old_frequency == RepeatFrequency.WEEK and
+            new_frequency == RepeatFrequency.MONTH) or
+            (old_frequency == RepeatFrequency.MONTH and
+                new_frequency == RepeatFrequency.WEEK)):
+        raise ExpectedError(_('You cannot modify the repeat frequency of an existing booking.'))

--- a/indico/modules/rb/util.py
+++ b/indico/modules/rb/util.py
@@ -380,8 +380,8 @@ def check_repeat_frequency(old_frequency, new_frequency):
     """Prevent changing the repeat frequency of an existing booking."""
     from indico.modules.rb.models.reservations import RepeatFrequency
 
-    if ((old_frequency == RepeatFrequency.WEEK and
-            new_frequency == RepeatFrequency.MONTH) or
-            (old_frequency == RepeatFrequency.MONTH and
-                new_frequency == RepeatFrequency.WEEK)):
+    if (
+        (old_frequency == RepeatFrequency.WEEK and new_frequency == RepeatFrequency.MONTH) or
+        (old_frequency == RepeatFrequency.MONTH and new_frequency == RepeatFrequency.WEEK)
+    ):
         raise ExpectedError(_('You cannot modify the repeat frequency of an existing booking.'))


### PR DESCRIPTION
This PR addresses an edge-case found in #5829 where editing a recurring 'by weekday' or 'by monthly' booking that was already in-progress would raise an error when either the booking recurrence interval was modified from weekly <-> monthly.

UI Preview:
![image](https://github.com/indico/indico/assets/7736654/b86ddfbb-284c-463d-95ba-ba74585a003a)