### PR TITLE
Improve i18n support for `renderRecurrenceWeekdays()`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,15 +37,13 @@ Improvements
 - Store creation date of users and show it to admins (:pr:`5957`, thanks :user:`vasantvohra`)
 - Add option to hide links to Room Booking system for users who lack access (:pr:`5981`,
   thanks :user:`SegiNyn`)
-- Support weekly room bookings that take place on multiple weekdays (:pr:`5829`, :issue:`5806`)
+- Support weekly room bookings that take place on multiple weekdays (:pr:`5829`, :pr:`6000`,
+  :issue:`5806`)
 - Hide events marked as invisible from builtin search results unless the user is a manager
   (:pr:`5947`, thanks :user:`openprojects`)
 - Support sessions that expire at a certain date (specified by the used flask-multipass
   provider) regardless of activity when using an external login method (:pr:`5907`, thanks
   :user:`cbartz`)
-- Improve i18n support for ``renderRecurrenceWeekdays()`` using ``Intl.ListFormat`` (:pr:`6000`)
-- Support weekly room bookings that take place on multiple weekdays (:pr:`5829`,
-  :pr:`6000`, :issue:`5806`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,7 @@ Improvements
 - Support sessions that expire at a certain date (specified by the used flask-multipass
   provider) regardless of activity when using an external login method (:pr:`5907`, thanks
   :user:`cbartz`)
+- Improve i18n support for ``renderRecurrenceWeekdays()`` using ``Intl.ListFormat`` (:pr:`6000`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ Improvements
   provider) regardless of activity when using an external login method (:pr:`5907`, thanks
   :user:`cbartz`)
 - Improve i18n support for ``renderRecurrenceWeekdays()`` using ``Intl.ListFormat`` (:pr:`6000`)
+- Support weekly room bookings that take place on multiple weekdays (:pr:`5829`,
+  :pr:`6000`, :issue:`5806`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/rb/client/js/__tests__/util.test.js
+++ b/indico/modules/rb/client/js/__tests__/util.test.js
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import moment from 'moment';
+
 import {renderRecurrenceWeekdays} from '../util';
 
 describe('renderRecurrenceWeekdays', () => {
@@ -59,4 +61,34 @@ describe('renderRecurrenceWeekdays', () => {
     const expected = 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
     expect(renderRecurrenceWeekdays(weekdays)).toBe(expected);
   });
+});
+
+describe('renderLocalizedRecurrenceWeekdays', () => {
+  const unorderedWeekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
+  const cases = [
+    ['de', 'Montag, Dienstag, Mittwoch, Donnerstag, Freitag, Samstag und Sonntag'],
+    ['fr', 'lundi, mardi, mercredi, jeudi, vendredi, samedi et dimanche'],
+    [
+      'pt-br',
+      'segunda-feira, terça-feira, quarta-feira, quinta-feira, sexta-feira, sábado e domingo',
+    ],
+    ['es', 'lunes, martes, miércoles, jueves, viernes, sábado y domingo'],
+    ['it', 'lunedì, martedì, mercoledì, giovedì, venerdì, sabato e domenica'],
+    ['tr', 'Pazartesi, Salı, Çarşamba, Perşembe, Cuma, Cumartesi ve Pazar'],
+    ['pl', 'poniedziałek, wtorek, środa, czwartek, piątek, sobota i niedziela'],
+    ['mn', 'Даваа, Мягмар, Лхагва, Пүрэв, Баасан, Бямба, Ням'],
+    ['uk', 'понеділок, вівторок, середа, четвер, п’ятниця, субота і неділя'],
+    ['zh-cn', '星期一、星期二、星期三、星期四、星期五、星期六和星期日'],
+  ];
+
+  test.each(cases)(
+    'should localize all weekdays in non-sequential order in %s',
+    (locale, expected) => {
+      const oldLocale = moment.locale();
+      moment.locale(locale);
+      const formatted = renderRecurrenceWeekdays(unorderedWeekdays);
+      expect(formatted).toBe(expected);
+      moment.locale(oldLocale);
+    }
+  );
 });

--- a/indico/modules/rb/client/js/__tests__/util.test.js
+++ b/indico/modules/rb/client/js/__tests__/util.test.js
@@ -67,6 +67,8 @@ describe('renderLocalizedRecurrenceWeekdays', () => {
   const unorderedWeekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
   const cases = [
     ['de', 'Montag, Dienstag, Mittwoch, Donnerstag, Freitag, Samstag und Sonntag'],
+    ['en-gb', 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday and Sunday'],
+    ['en-us', 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday'],
     ['fr', 'lundi, mardi, mercredi, jeudi, vendredi, samedi et dimanche'],
     [
       'pt-br',

--- a/indico/modules/rb/client/js/__tests__/util.test.jsx
+++ b/indico/modules/rb/client/js/__tests__/util.test.jsx
@@ -1,0 +1,62 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import {renderRecurrenceWeekdays} from '../util';
+
+describe('renderRecurrenceWeekdays', () => {
+  it('should return null if weekdays array is empty', () => {
+    const weekdays = [];
+    expect(renderRecurrenceWeekdays(weekdays)).toBeNull();
+  });
+
+  it('should return null if weekdays array is null', () => {
+    const weekdays = null;
+    expect(renderRecurrenceWeekdays(weekdays)).toBeNull();
+  });
+
+  it('should handle a single unknown/bad weekday', () => {
+    const weekdays = ['xyz'];
+    expect(renderRecurrenceWeekdays(weekdays)).toBeNull();
+  });
+
+  it('should handle multiple unknown/bad weekdays', () => {
+    const weekdays = ['xyz', 'abc', 'def'];
+    expect(renderRecurrenceWeekdays(weekdays)).toBeNull();
+  });
+
+  it('correctly formats a single weekday', () => {
+    const formatted = renderRecurrenceWeekdays(['mon']);
+    expect(formatted).toBe('Monday');
+  });
+
+  it('correctly formats two weekdays', () => {
+    const formatted = renderRecurrenceWeekdays(['mon', 'tue']);
+    expect(formatted).toBe('Monday and Tuesday');
+  });
+
+  it('correctly formats multiple weekdays', () => {
+    const formatted = renderRecurrenceWeekdays(['mon', 'tue', 'wed']);
+    expect(formatted).toBe('Monday, Tuesday, and Wednesday');
+  });
+
+  it('correctly formats weekdays in non-sequential order', () => {
+    const formatted = renderRecurrenceWeekdays(['wed', 'mon', 'fri']);
+    expect(formatted).toBe('Monday, Wednesday, and Friday');
+  });
+
+  it('should handle all weekdays', () => {
+    const weekdays = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+    const expected = 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
+    expect(renderRecurrenceWeekdays(weekdays)).toBe(expected);
+  });
+
+  it('should handle all weekdays in non-sequential order', () => {
+    const weekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
+    const expected = 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
+    expect(renderRecurrenceWeekdays(weekdays)).toBe(expected);
+  });
+});

--- a/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
+++ b/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
@@ -206,7 +206,13 @@ class TimelineItem extends React.Component {
             attached="bottom"
           >
             <Message.Content>
-              {renderRecurrenceWeekdays(reservation.recurrenceWeekdays)}
+              <Translate>
+                Every{' '}
+                <Param
+                  name="weekdays"
+                  value={renderRecurrenceWeekdays(reservation.recurrenceWeekdays)}
+                />
+              </Translate>
             </Message.Content>
           </Message>
         )}

--- a/indico/modules/rb/client/js/components/TimeInformation.jsx
+++ b/indico/modules/rb/client/js/components/TimeInformation.jsx
@@ -79,12 +79,10 @@ function TimeInformation({
             <div>
               <div>
                 <Icon name="sync alternate" />
-                <strong>
-                  <Translate>
-                    Every{' '}
-                    <Param name="weekdays" value={renderRecurrenceWeekdays(recurrenceWeekdays)} />
-                  </Translate>
-                </strong>
+                <Translate as="strong">
+                  Every{' '}
+                  <Param name="weekdays" value={renderRecurrenceWeekdays(recurrenceWeekdays)} />
+                </Translate>
               </div>
             </div>
           </Segment>

--- a/indico/modules/rb/client/js/components/TimeInformation.jsx
+++ b/indico/modules/rb/client/js/components/TimeInformation.jsx
@@ -79,7 +79,12 @@ function TimeInformation({
             <div>
               <div>
                 <Icon name="sync alternate" />
-                <strong>{renderRecurrenceWeekdays(recurrenceWeekdays)}</strong>
+                <strong>
+                  <Translate>
+                    Every{' '}
+                    <Param name="weekdays" value={renderRecurrenceWeekdays(recurrenceWeekdays)} />
+                  </Translate>
+                </strong>
               </div>
             </div>
           </Segment>

--- a/indico/modules/rb/client/js/util.jsx
+++ b/indico/modules/rb/client/js/util.jsx
@@ -263,34 +263,14 @@ export function renderRecurrenceWeekdays(weekdays) {
     (a, b) => orderedWeekdays.indexOf(a) - orderedWeekdays.indexOf(b)
   );
 
-  if (sortedWeekdays.length === 1) {
-    return (
-      <Translate>
-        Every <Param name="weekday" value={weekdaysMap[sortedWeekdays[0]]} />
-      </Translate>
-    );
-  }
-
-  if (sortedWeekdays.length === 2) {
-    return (
-      <Translate>
-        Every <Param name="weekday1" value={weekdaysMap[sortedWeekdays[0]]} /> and{' '}
-        <Param name="weekday2" value={weekdaysMap[sortedWeekdays[1]]} />
-      </Translate>
-    );
-  }
-
-  // join all weekdays but the last one with commas
-  const weekdaysString = sortedWeekdays
-    .slice(0, -1)
-    .map(weekday => weekdaysMap[weekday])
-    .join(', ');
-  const lastWeekday = weekdaysMap[sortedWeekdays[sortedWeekdays.length - 1]];
+  const formattedWeekdays = new Intl.ListFormat(moment.locale(), {
+    style: 'long',
+    type: 'conjunction',
+  }).format(sortedWeekdays.map(weekday => weekdaysMap[weekday]));
 
   return (
     <Translate>
-      Every <Param name="weekdays" value={weekdaysString} /> and{' '}
-      <Param name="last_weekday" value={lastWeekday} />
+      Every <Param name="weekdays" value={formattedWeekdays} />
     </Translate>
   );
 }

--- a/indico/modules/rb/client/js/util.jsx
+++ b/indico/modules/rb/client/js/util.jsx
@@ -252,7 +252,12 @@ export function renderRecurrenceWeekdays(weekdays) {
     sun: moment.weekdays(0),
   };
 
-  if (weekdays.length === 0) {
+  if (weekdays === null || weekdays.length === 0) {
+    return null;
+  }
+
+  // handle unknown/bad weekdays
+  if (weekdays.some(weekday => !Object.keys(weekdaysMap).includes(weekday))) {
     return null;
   }
 
@@ -268,11 +273,7 @@ export function renderRecurrenceWeekdays(weekdays) {
     type: 'conjunction',
   }).format(sortedWeekdays.map(weekday => weekdaysMap[weekday]));
 
-  return (
-    <Translate>
-      Every <Param name="weekdays" value={formattedWeekdays} />
-    </Translate>
-  );
+  return formattedWeekdays;
 }
 
 const _legendLabels = {


### PR DESCRIPTION
This PR is an i18n improvement for the `renderRecurrenceWeekdays()` function (part of #5829) which uses the [Intl.ListFormat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) API instead.