### PR TITLE
Overflow long filter list dialogs with scrollbar

### DIFF
--- a/indico/modules/events/abstracts/templates/management/abstract_list_filter.html
+++ b/indico/modules/events/abstracts/templates/management/abstract_list_filter.html
@@ -76,37 +76,38 @@
     </div>
 </div>
 <form class="list-filter" method="POST">
-    <input id="visible-items" type="hidden" name="visible_items"
-           value="{{ visible_items | tojson | forceescape }}">
-    <h3>{% trans %}General abstract info{% endtrans %}</h3>
-    <div class="flexrow f-wrap">
-        {% for item_id, item in static_items.items() %}
-            {% set filter_choices = item.get('filter_choices') %}
-            {{ _render_column_selector(item_id, item, filter_choices, is_static_item=true) }}
-        {% endfor %}
-    </div>
-
-    {% if contrib_fields %}
-        <h3>{% trans %}Abstract fields{% endtrans %}</h3>
+    <div class="list-filter-content">
+        <input id="visible-items" type="hidden" name="visible_items"
+               value="{{ visible_items | tojson | forceescape }}">
+        <h3>{% trans %}General abstract info{% endtrans %}</h3>
         <div class="flexrow f-wrap">
-            {% for field in contrib_fields %}
-                {{ _render_column_selector(field.id, field, field.filter_choices) }}
+            {% for item_id, item in static_items.items() %}
+                {% set filter_choices = item.get('filter_choices') %}
+                {{ _render_column_selector(item_id, item, filter_choices, is_static_item=true) }}
             {% endfor %}
         </div>
-    {% endif %}
 
-    {% if extra_filters %}
-        <h3>{% trans %}Extra filters{% endtrans %}</h3>
-        <div class="i-form horizontal">
-            {% for item_id, item in extra_filters.items() %}
-                {% set name = 'field_{}'.format(item_id) %}
-                {% if item.type == 'bool' %}
-                    {{ _render_boolean_filter(id=item_id, name=name, label=item.title) }}
-                {% endif %}
-            {% endfor %}
-        </div>
-    {% endif %}
+        {% if contrib_fields %}
+            <h3>{% trans %}Abstract fields{% endtrans %}</h3>
+            <div class="flexrow f-wrap">
+                {% for field in contrib_fields %}
+                    {{ _render_column_selector(field.id, field, field.filter_choices) }}
+                {% endfor %}
+            </div>
+        {% endif %}
 
+        {% if extra_filters %}
+            <h3>{% trans %}Extra filters{% endtrans %}</h3>
+            <div class="i-form horizontal">
+                {% for item_id, item in extra_filters.items() %}
+                    {% set name = 'field_{}'.format(item_id) %}
+                    {% if item.type == 'bool' %}
+                        {{ _render_boolean_filter(id=item_id, name=name, label=item.title) }}
+                    {% endif %}
+                {% endfor %}
+            </div>
+        {% endif %}
+    </div>
     <div class="bottom-buttons">
         <input class="i-button big highlight" type="submit" data-disabled-until-change
                value="{% trans %}Apply{% endtrans %}">

--- a/indico/modules/events/contributions/templates/contrib_list_filter.html
+++ b/indico/modules/events/contributions/templates/contrib_list_filter.html
@@ -52,11 +52,13 @@
     </div>
 </div>
 <form class="list-filter" method="POST">
-    <h3>{% trans %}Available filtering options{% endtrans %}</h3>
-    <div class="flexrow f-wrap">
-        {% for item_id, item in static_items.items() %}
-            {{ _render_column_selector(item_id, item) }}
-        {% endfor %}
+    <div class="list-filter-content">
+        <h3>{% trans %}Available filtering options{% endtrans %}</h3>
+        <div class="flexrow f-wrap">
+            {% for item_id, item in static_items.items() %}
+                {{ _render_column_selector(item_id, item) }}
+            {% endfor %}
+        </div>
     </div>
     <div class="bottom-buttons">
         <input class="i-button big highlight" type="submit" data-disabled-until-change

--- a/indico/modules/events/papers/templates/paper_list_filter.html
+++ b/indico/modules/events/papers/templates/paper_list_filter.html
@@ -64,16 +64,17 @@
     </div>
 </div>
 <form class="list-filter" method="POST">
-    <input id="visible-items" type="hidden" name="visible_items"
-           value="{{ visible_items | tojson | forceescape }}">
-    <h3>{% trans %}General paper assignment info{% endtrans %}</h3>
-    <div class="flexrow f-wrap">
-        {% for item_id, item in static_items.items() %}
-            {% set filter_choices = item.get('filter_choices') %}
-            {{ _render_column_selector(item_id, item, filter_choices, is_static_item=true) }}
-        {% endfor %}
+    <div class="list-filter-content">
+        <input id="visible-items" type="hidden" name="visible_items"
+               value="{{ visible_items | tojson | forceescape }}">
+        <h3>{% trans %}General paper assignment info{% endtrans %}</h3>
+        <div class="flexrow f-wrap">
+            {% for item_id, item in static_items.items() %}
+                {% set filter_choices = item.get('filter_choices') %}
+                {{ _render_column_selector(item_id, item, filter_choices, is_static_item=true) }}
+            {% endfor %}
+        </div>
     </div>
-
     <div class="bottom-buttons">
         <input class="i-button big highlight" type="submit" data-disabled-until-change
                value="{% trans %}Apply{% endtrans %}">

--- a/indico/modules/events/registration/templates/management/reglist_filter.html
+++ b/indico/modules/events/registration/templates/management/reglist_filter.html
@@ -78,34 +78,35 @@
     </div>
 </div>
 <form class="list-filter" method="POST">
-    <input id="visible-items" type="hidden" name="visible_items"
-           value="{{ visible_items | tojson | forceescape }}">
-    <h3>{% trans %}General registration info{% endtrans %}</h3>
-    <div class="flexrow f-wrap">
-        {% for item_id, item in static_items.items() %}
-            {% set filter_choices = item.get('filter_choices') %}
-            {% set filter_only = item.get('filter_only', false) %}
-            {{ _render_column_selector(item_id, item, filter_choices, is_static_item=true, filter_only=filter_only) }}
-        {% endfor %}
-    </div>
-
-    {% for section in regform.sections if section.is_visible and section.active_fields %}
-        {{ _render_regform_item_col_selector(section) }}
-    {% endfor %}
-
-    {% set disabled_sections = regform.disabled_sections|selectattr('active_fields')|list %}
-    {% if disabled_sections %}
-        <h1 class="disabled-caption">
-            {%- trans %}Disabled sections{% endtrans -%}
-            <a class="button icon-next js-toggle-disabled" title="Click to show/hide disabled sections"></a>
-        </h1>
-        <div class="disabled-sections">
-            {% for section in disabled_sections %}
-                {{ _render_regform_item_col_selector(section) }}
+    <div class="list-filter-content">
+        <input id="visible-items" type="hidden" name="visible_items"
+               value="{{ visible_items | tojson | forceescape }}">
+        <h3>{% trans %}General registration info{% endtrans %}</h3>
+        <div class="flexrow f-wrap">
+            {% for item_id, item in static_items.items() %}
+                {% set filter_choices = item.get('filter_choices') %}
+                {% set filter_only = item.get('filter_only', false) %}
+                {{ _render_column_selector(item_id, item, filter_choices, is_static_item=true, filter_only=filter_only) }}
             {% endfor %}
         </div>
-    {% endif %}
 
+        {% for section in regform.sections if section.is_visible and section.active_fields %}
+            {{ _render_regform_item_col_selector(section) }}
+        {% endfor %}
+
+        {% set disabled_sections = regform.disabled_sections|selectattr('active_fields')|list %}
+        {% if disabled_sections %}
+            <h1 class="disabled-caption">
+                {%- trans %}Disabled sections{% endtrans -%}
+                <a class="button icon-next js-toggle-disabled" title="Click to show/hide disabled sections"></a>
+            </h1>
+            <div class="disabled-sections">
+                {% for section in disabled_sections %}
+                    {{ _render_regform_item_col_selector(section) }}
+                {% endfor %}
+            </div>
+        {% endif %}
+    </div>
     <div class="bottom-buttons">
         <input class="i-button big highlight" type="submit" data-disabled-until-change
                value="{% trans %}Apply{% endtrans %}">

--- a/indico/web/client/styles/partials/_object-lists.scss
+++ b/indico/web/client/styles/partials/_object-lists.scss
@@ -126,8 +126,12 @@
 }
 
 .list-filter {
-  padding-bottom: 14em;
   position: relative;
+
+  .list-filter-content {
+    max-height: 65vh;
+    overflow-y: auto;
+  }
 
   .list-column {
     @extend .flexrow;
@@ -237,9 +241,9 @@
   }
 
   > .bottom-buttons {
-    position: absolute;
-    bottom: 0;
-    right: 0;
+    display: flex;
+    justify-content: end;
+    padding-top: 15px;
   }
 }
 


### PR DESCRIPTION
This PR gives the filter list dialog a maximum height and overflow with a scrollbar. Indico core doesn't use this dialog to display long list of filters but this is the case sometimes in the UN plugin.

The dialog now looks like this when the filter list needs overflow:
<img width="1211" alt="image" src="https://github.com/indico/indico/assets/716307/cb611885-999c-4e9d-b43e-1e78be1f8b11">

In order to keep the bottom buttons always visible it was necessary to change the markup of the `.list-filter` form. This PR does that and here below is how the dialogs look now.

### Abstract list
<img width="1223" alt="image" src="https://github.com/indico/indico/assets/716307/b2c93597-76d0-490c-89e6-45f049b25ff1">

### Contribution list
<img width="1211" alt="image" src="https://github.com/indico/indico/assets/716307/6b39c161-f9b5-4597-b27b-bccbf3a6ae17">

### Paper list
<img width="1063" alt="image" src="https://github.com/indico/indico/assets/716307/c346ac28-49be-4454-a9f3-4a3bae8f0556">

### Registration list
<img width="1211" alt="image" src="https://github.com/indico/indico/assets/716307/d95acb96-26c7-4889-b06d-8bac7d879af3">