### PR TITLE
Add spacing to Save button in RB admin settings menu

### DIFF
--- a/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
@@ -288,7 +288,10 @@ const SettingsPage = props => {
                 </Translate>
               }
             />
-            <FinalSubmitButton label={Translate.string('Save')} />
+            <FinalSubmitButton
+              label={Translate.string('Save')}
+              style={{marginBottom: '0.875rem'}}
+            />
           </Form>
         )}
       </FinalForm>


### PR DESCRIPTION
(Minor tweak) This PR adds spacing to the RB admin settings menu save button.

Before:
![image](https://github.com/indico/indico/assets/7736654/9428b4b2-2478-4063-840f-1ab0d38c186c)

After:
![image](https://github.com/indico/indico/assets/7736654/1252ce81-c46f-4719-a50c-f33d898fe6c8)
