### PR TITLE
Allow editors to edit the last revision comment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Improvements
   :user:`cbartz`)
 - Allow configuring future months threshold for categories (:issue:`2984`, :pr:`5928`, thanks
   :user:`kewisch`)
+- Allow editors to edit their review comments on editables (:pr:`6008`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20231030_1612_31b699664893_add_modified_dt_to_editing_revisions.py
+++ b/indico/migrations/versions/20231030_1612_31b699664893_add_modified_dt_to_editing_revisions.py
@@ -1,0 +1,26 @@
+"""Add modified date to editing revisions
+
+Revision ID: 31b699664893
+Revises: 155cfc134f0c
+Create Date: 2023-10-30 14:34:52.696469
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from indico.core.db.sqlalchemy.custom.utcdatetime import UTCDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = '31b699664893'
+down_revision = '155cfc134f0c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('revisions', sa.Column('modified_dt', UTCDateTime, nullable=True), schema='event_editing')
+
+
+def downgrade():
+    op.drop_column('revisions', 'modified_dt', schema='event_editing')

--- a/indico/modules/events/editing/blueprint.py
+++ b/indico/modules/events/editing/blueprint.py
@@ -119,15 +119,13 @@ _bp.add_url_rule(contrib_api_prefix + '/upload', 'api_upload', timeline.RHEditin
 _bp.add_url_rule(contrib_api_prefix + '/add-paper-file', 'api_add_contribution_file',
                  timeline.RHEditingUploadContributionFile, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/review', 'api_review_editable',
-                 timeline.RHReviewEditable, methods=('POST',))
+                 timeline.RHReviewEditable, methods=('POST', 'PATCH', 'DELETE'))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/confirm', 'api_confirm_changes',
                  timeline.RHConfirmEditableChanges, methods=('POST',),)
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/replace', 'api_replace_revision',
                  timeline.RHReplaceRevision, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/new', 'api_create_submitter_revision',
                  timeline.RHCreateSubmitterRevision, methods=('POST',),)
-_bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/review', 'api_undo_review',
-                 timeline.RHUndoReview, methods=('DELETE',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/reset', 'api_reset_editable',
                  timeline.RHResetEditable, methods=('POST',))
 _bp.add_url_rule(contrib_api_prefix + '/<int:revision_id>/comments/', 'api_create_revision_comment',

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentItem.jsx
@@ -64,17 +64,16 @@ export default function Comment({
               )}
               <time dateTime={serializeDate(createdDt, moment.HTML5_FMT.DATETIME_LOCAL_SECONDS)}>
                 {serializeDate(createdDt, 'LLL')}
-              </time>
+              </time>{' '}
               {modifiedDt && (
-                <span
-                  className="review-comment-edited"
-                  title={Translate.string('On {modificationDate}', {
-                    modificationDate: serializeDate(modifiedDt, 'LLL'),
-                  })}
+                <time
+                  dateTime={serializeDate(modifiedDt, moment.HTML5_FMT.DATETIME_LOCAL_SECONDS)}
+                  title={serializeDate(modifiedDt, 'LLL')}
                 >
-                  {' '}
-                  · <Translate>edited</Translate>
-                </span>
+                  <span className="review-comment-edited">
+                    <Translate>edited</Translate>
+                  </span>
+                </time>
               )}
             </div>
             {canModify && lastRevision.id === revisionId && (

--- a/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
@@ -5,42 +5,24 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import resetReviewsURL from 'indico-url:event_editing.api_undo_review';
-
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {useSelector, useDispatch} from 'react-redux';
+import {useDispatch} from 'react-redux';
 import {Icon, Popup} from 'semantic-ui-react';
 
 import {RequestConfirm} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 
 import {resetReviews} from './actions';
-import * as selectors from './selectors';
 
-export default function ResetReview({revisionId}) {
-  const {eventId, contributionId, editableType} = useSelector(selectors.getStaticData);
-  const allowed = useSelector(selectors.canPerformEditorActions);
+export default function ResetReview({reviewURL}) {
   const [submitting, setSubmitting] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const dispatch = useDispatch();
 
-  if (!allowed) {
-    return null;
-  }
-
   const resetRevisions = async () => {
     setSubmitting(true);
-    await dispatch(
-      resetReviews(
-        resetReviewsURL({
-          event_id: eventId,
-          contrib_id: contributionId,
-          type: editableType,
-          revision_id: revisionId,
-        })
-      )
-    );
+    await dispatch(resetReviews(reviewURL));
     setSubmitting(false);
   };
 
@@ -74,5 +56,5 @@ export default function ResetReview({revisionId}) {
 }
 
 ResetReview.propTypes = {
-  revisionId: PropTypes.number.isRequired,
+  reviewURL: PropTypes.string.isRequired,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewComment.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewComment.jsx
@@ -8,28 +8,33 @@
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {Form as FinalForm} from 'react-final-form';
+import {useDispatch} from 'react-redux';
 import {Button, Form} from 'semantic-ui-react';
 
 import {FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-import {RevisionType} from '../../models';
+import {RevisionTypeStates} from '../../models';
 
+import {modifyReviewComment} from './actions';
 import {blockPropTypes} from './util';
 
 import './ReviewComment.module.scss';
 
 export default function ReviewComment({block, canEdit}) {
   const [editFormOpen, setEditFormOpen] = useState(false);
+  const dispatch = useDispatch();
 
   const handleSubmit = async formData => {
-    console.log(formData, block);
-    // TODO
+    const rv = await dispatch(modifyReviewComment(block, formData));
+    if (rv.error) {
+      return rv.error;
+    }
     setEditFormOpen(false);
   };
 
   return (
-    <div styleName="revision-comment">
+    <div styleName="review-comment">
       {editFormOpen ? (
         <div className="f-self-stretch">
           <FinalForm
@@ -43,7 +48,7 @@ export default function ReviewComment({block, canEdit}) {
                   name="text"
                   placeholder={Translate.string('Leave a comment...')}
                   autoFocus
-                  required={block.type.name !== RevisionType.acceptance}
+                  required={RevisionTypeStates[block.type.name] !== 'accepted'}
                   hideValidationError
                 />
                 <Form.Group styleName="submit-buttons" inline>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewComment.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewComment.jsx
@@ -1,0 +1,82 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import React, {useState} from 'react';
+import {Form as FinalForm} from 'react-final-form';
+import {Button, Form} from 'semantic-ui-react';
+
+import {FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
+import {Translate} from 'indico/react/i18n';
+
+import {RevisionType} from '../../models';
+
+import {blockPropTypes} from './util';
+
+import './ReviewComment.module.scss';
+
+export default function ReviewComment({block, canEdit}) {
+  const [editFormOpen, setEditFormOpen] = useState(false);
+
+  const handleSubmit = async formData => {
+    console.log(formData, block);
+    // TODO
+    setEditFormOpen(false);
+  };
+
+  return (
+    <div styleName="revision-comment">
+      {editFormOpen ? (
+        <div className="f-self-stretch">
+          <FinalForm
+            onSubmit={handleSubmit}
+            initialValues={{text: block.comment}}
+            subscription={{submitting: true}}
+          >
+            {fprops => (
+              <Form onSubmit={fprops.handleSubmit}>
+                <FinalTextArea
+                  name="text"
+                  placeholder={Translate.string('Leave a comment...')}
+                  autoFocus
+                  required={block.type.name !== RevisionType.acceptance}
+                  hideValidationError
+                />
+                <Form.Group styleName="submit-buttons" inline>
+                  <FinalSubmitButton label={Translate.string('Save changes')} />
+                  <Button
+                    disabled={fprops.submitting}
+                    content={Translate.string('Cancel')}
+                    onClick={() => {
+                      setEditFormOpen(false);
+                    }}
+                  />
+                </Form.Group>
+              </Form>
+            )}
+          </FinalForm>
+        </div>
+      ) : (
+        <div className="markdown-text" dangerouslySetInnerHTML={{__html: block.commentHtml}} />
+      )}
+      <div styleName="action-buttons">
+        {canEdit && (
+          <a
+            onClick={() => setEditFormOpen(!editFormOpen)}
+            className="i-link icon-edit"
+            title={Translate.string('Edit review comment')}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+ReviewComment.propTypes = {
+  block: PropTypes.shape(blockPropTypes).isRequired,
+  canEdit: PropTypes.bool.isRequired,
+};

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewComment.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewComment.module.scss
@@ -1,0 +1,19 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2023 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+.revision-comment {
+  display: flex;
+
+  .action-buttons {
+    margin-left: auto;
+    padding-left: 0.5em;
+  }
+
+  .submit-buttons {
+    margin-bottom: 0.25em !important;
+  }
+}

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewComment.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewComment.module.scss
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-.revision-comment {
+.review-comment {
   display: flex;
 
   .action-buttons {

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -32,18 +32,18 @@ import '../../../styles/timeline.module.scss';
 import './TimelineItem.module.scss';
 
 export default function TimelineItem({block, index}) {
-  const {createdDt, isUndone} = block;
+  const {createdDt, modifiedDt, isUndone} = block;
   const lastTimelineBlock = useSelector(selectors.getLastTimelineBlock);
   const lastValidTimelineBlock = useSelector(selectors.getLastValidTimelineBlock);
   const lastTimelineBlockWithFiles = useSelector(selectors.getLastTimelineBlockWithFiles);
-  const lastRevertableRevisionId = useSelector(selectors.getLastRevertableRevisionId);
   const needsSubmitterConfirmation = useSelector(selectors.needsSubmitterConfirmation);
   const canPerformSubmitterActions = useSelector(selectors.canPerformSubmitterActions);
-  const canUndoLastValidBlock = useSelector(selectors.canUndoLastValidBlock);
+  const canEditLastRevision = useSelector(selectors.canEditLastRevision);
   const {canComment} = useSelector(selectors.getDetails);
   const {fileTypes} = useSelector(selectors.getStaticData);
   const isLastBlock = lastTimelineBlock.id === block.id;
   const isLastValidBlock = lastValidTimelineBlock.id === block.id;
+  const canEdit = isLastValidBlock && canEditLastRevision;
   const hasContent =
     block.commentHtml ||
     !!block.files.length ||
@@ -81,15 +81,23 @@ export default function TimelineItem({block, index}) {
                 <time dateTime={serializeDate(createdDt, moment.HTML5_FMT.DATETIME_LOCAL_SECONDS)}>
                   {serializeDate(createdDt, 'LLL')}
                 </time>{' '}
+                {modifiedDt && (
+                  <time
+                    dateTime={serializeDate(modifiedDt, moment.HTML5_FMT.DATETIME_LOCAL_SECONDS)}
+                    title={serializeDate(modifiedDt, 'LLL')}
+                  >
+                    <span className="review-comment-edited">
+                      <Translate>edited</Translate>
+                    </span>
+                  </time>
+                )}{' '}
                 {isUndone && (
                   <Translate as="span" styleName="undone-indicator">
                     Retracted
                   </Translate>
                 )}
               </div>
-              {visible && isLastValidBlock && canUndoLastValidBlock && (
-                <ResetReview revisionId={lastRevertableRevisionId} />
-              )}
+              {visible && canEdit && <ResetReview reviewURL={block.reviewURL} />}
               {!isAlwaysVisible && (hasContent || !!block.items.length) && (
                 <a
                   className="i-link"
@@ -109,12 +117,7 @@ export default function TimelineItem({block, index}) {
                     <Translate>This revision has been retracted by the editor.</Translate>
                   </Message>
                 )}
-                {block.commentHtml && (
-                  <ReviewComment
-                    block={block}
-                    canEdit={isLastValidBlock && canUndoLastValidBlock}
-                  />
-                )}
+                {block.commentHtml && <ReviewComment block={block} canEdit={canEdit} />}
                 {block.commentHtml && !!(block.files.length || block.tags.length) && <Divider />}
                 <FileDisplay
                   fileTypes={fileTypes}

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -21,6 +21,7 @@ import ChangesConfirmation from './ChangesConfirmation';
 import CustomActions from './CustomActions';
 import FileDisplay from './FileDisplay';
 import ResetReview from './ResetReview';
+import ReviewComment from './ReviewComment';
 import ReviewForm from './ReviewForm';
 import RevisionLog from './RevisionLog';
 import * as selectors from './selectors';
@@ -109,9 +110,9 @@ export default function TimelineItem({block, index}) {
                   </Message>
                 )}
                 {block.commentHtml && (
-                  <div
-                    className="markdown-text"
-                    dangerouslySetInnerHTML={{__html: block.commentHtml}}
+                  <ReviewComment
+                    block={block}
+                    canEdit={isLastValidBlock && canUndoLastValidBlock}
                   />
                 )}
                 {block.commentHtml && !!(block.files.length || block.tags.length) && <Divider />}

--- a/indico/modules/events/editing/client/js/editing/timeline/actions.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/actions.js
@@ -49,6 +49,12 @@ export function confirmEditableChanges(revision, formData) {
   );
 }
 
+export function modifyReviewComment(revision, formData) {
+  return submitFormAction(() => indicoAxios.patch(revision.reviewURL, formData), null, () =>
+    loadTimeline()
+  );
+}
+
 export function createRevisionComment(url, formData) {
   return submitFormAction(() => indicoAxios.post(url, formData), null, () => loadTimeline());
 }

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -113,23 +113,6 @@ export const hasPublishableFiles = createSelector(
   }
 );
 
-export const getLastRevertableRevisionId = createSelector(
-  getValidRevisions,
-  revisions => {
-    if (!revisions || !revisions.length) {
-      return null;
-    }
-    const latestRevision = revisions[revisions.length - 1];
-    if (
-      latestRevision.isUndone ||
-      [RevisionType.new, RevisionType.ready_for_review].includes(latestRevision.type.name)
-    ) {
-      return null;
-    }
-    return latestRevision.id;
-  }
-);
-
 export const canPerformSubmitterActions = createSelector(
   getDetails,
   details => details && details.canPerformSubmitterActions
@@ -156,9 +139,12 @@ export const canJudgeLastRevision = createSelector(
   (lastRevision, allowed) => lastRevision.type.name === RevisionType.ready_for_review && allowed
 );
 
-export const canUndoLastValidBlock = createSelector(
-  getValidTimelineBlocks,
-  getLastRevertableRevisionId,
-  (blocks, lastRevertableRevisionId) =>
-    blocks.length >= 2 && blocks[blocks.length - 1].id === lastRevertableRevisionId
+export const canEditLastRevision = createSelector(
+  getLastRevision,
+  canPerformEditorActions,
+  (latestRevision, allowed) =>
+    allowed &&
+    latestRevision &&
+    !latestRevision.isUndone &&
+    ![RevisionType.new, RevisionType.ready_for_review].includes(latestRevision.type.name)
 );

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -147,6 +147,7 @@ export const blockPropTypes = {
   id: PropTypes.number.isRequired,
   user: PropTypes.shape(userPropTypes).isRequired,
   createdDt: PropTypes.string.isRequired,
+  modifiedDt: PropTypes.string,
   type: PropTypes.shape(typePropTypes).isRequired,
   isUndone: PropTypes.bool,
   isEditorRevision: PropTypes.bool,

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -28,7 +28,7 @@ from indico.modules.events.editing.operations import (assign_editor, create_new_
                                                       create_submitter_revision, delete_editable,
                                                       delete_revision_comment, ensure_latest_revision, replace_revision,
                                                       reset_editable, unassign_editor, undo_review,
-                                                      update_revision_comment)
+                                                      update_review_comment, update_revision_comment)
 from indico.modules.events.editing.schemas import (EditableSchema, EditingConfirmationAction, EditingReviewAction,
                                                    ReviewEditableArgs)
 from indico.modules.events.editing.service import (ServiceRequestFailed, service_get_custom_actions,
@@ -213,11 +213,13 @@ class RHDeleteEditable(RHContributionEditableBase):
 class RHReviewEditable(RHContributionEditableRevisionBase):
     """Review the latest revision of an Editable."""
 
+    SERVICE_ALLOWED = True
+
     def _check_revision_access(self):
         return self.editable.can_perform_editor_actions(session.user)
 
     @use_kwargs(ReviewEditableArgs)
-    def _process(self, action, comment):
+    def _process_POST(self, action, comment):
         argmap = {'tags': EditingTagsField(self.event, load_default=lambda: set())}
         if action in (EditingReviewAction.update, EditingReviewAction.update_accept,
                       EditingReviewAction.request_update):
@@ -225,6 +227,17 @@ class RHReviewEditable(RHContributionEditableRevisionBase):
                                                 required=(action != EditingReviewAction.request_update))
         args = parser.parse(argmap, unknown=EXCLUDE)
         review_and_publish_editable(self.revision, action, comment, args['tags'], args.get('files'))
+        return '', 204
+
+    @use_kwargs({
+        'text': fields.String(required=True),
+    })
+    def _process_PATCH(self, text):
+        update_review_comment(self.revision, text)
+        return '', 204
+
+    def _process_DELETE(self):
+        undo_review(self.revision)
         return '', 204
 
 
@@ -289,19 +302,6 @@ class RHCreateSubmitterRevision(RHContributionEditableRevisionBase):
                                                self.revision, new_revision)
             except ServiceRequestFailed:
                 raise ServiceUnavailable(_('Failed processing review, please try again later.'))
-        return '', 204
-
-
-class RHUndoReview(RHContributionEditableRevisionBase):
-    """Undo the last review/confirmation on an Editable."""
-
-    SERVICE_ALLOWED = True
-
-    def _check_revision_access(self):
-        return self.editable.can_perform_editor_actions(session.user)
-
-    def _process(self):
-        undo_review(self.revision)
         return '', 204
 
 

--- a/indico/modules/events/editing/models/revisions.py
+++ b/indico/modules/events/editing/models/revisions.py
@@ -86,6 +86,10 @@ class EditingRevision(RenderModeMixin, db.Model):
         nullable=False,
         default=now_utc
     )
+    modified_dt = db.Column(
+        UTCDateTime,
+        nullable=True
+    )
     type = db.Column(
         PyIntEnum(RevisionType),
         nullable=False,

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -152,7 +152,7 @@ class EditingRevisionCommentSchema(mm.SQLAlchemyAutoSchema):
 class EditingRevisionSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = EditingRevision
-        fields = ('id', 'created_dt', 'user', 'files', 'comment', 'comment_html',
+        fields = ('id', 'created_dt', 'modified_dt', 'user', 'files', 'comment', 'comment_html',
                   'comments', 'type', 'is_undone', 'is_editor_revision', 'tags', 'create_comment_url',
                   'download_files_url', 'review_url', 'confirm_url', 'custom_actions', 'custom_action_url')
 

--- a/indico/modules/events/editing/service.py
+++ b/indico/modules/events/editing/service.py
@@ -293,7 +293,7 @@ def _get_revision_endpoints(revision):
         'revisions': {
             'details': url_for('.api_editable', revision, _external=True),
             'replace': url_for('.api_replace_revision', revision, _external=True),
-            'undo': url_for('.api_undo_review', revision, _external=True),
+            'undo': url_for('.api_review_editable', revision, _external=True),
             'reset': url_for('.api_reset_editable', revision, _external=True),
         },
         'file_upload': url_for('.api_upload', revision, _external=True)


### PR DESCRIPTION
This PR adds the ability for editors to edit their last judgement's revision comment:
![image](https://github.com/indico/indico/assets/27357203/04f3c7ab-e218-4255-b3f3-92ae34fc7512)
![image](https://github.com/indico/indico/assets/27357203/36d927a2-39ce-497b-ab25-313582a04baf)
![image](https://github.com/indico/indico/assets/27357203/37295bf2-66c6-4c75-baf4-d10300cf199d)
