### PR TITLE
Fix showing custom locations in meeting timetable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- None so far :)
+- Fix meeting timetable not showing custom locations when all top-level timetable
+  entries are session blocks inheriting the custom location from its session (:pr:`6014`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/timetable/views/__init__.py
+++ b/indico/modules/events/timetable/views/__init__.py
@@ -99,7 +99,14 @@ def inject_meeting_body(event, **kwargs):
             entries.append(entry)
         elif entry.object.can_access(session.user):
             entries.append(entry)
-        if not entry.object.inherit_location:
+        if (
+            # the object itself does not inherit
+            not entry.object.inherit_location or
+            # the object is a session block and inherits from a session with a custom location
+            (entry.type == TimetableEntryType.SESSION_BLOCK and
+                entry.object.inherit_location and
+                not entry.object.session.inherit_location)
+        ):
             show_siblings_location = True
         show_children_location[entry.id] = not all(child.object.inherit_location for child in entry.children)
 


### PR DESCRIPTION
When the top-level timetable consisted exclusively of session blocks inheriting a custom location from their session, it did not trigger the logic to show the location of each top-level timetable entry, because it only considered whether the entry itself had a custom location set.