### PR TITLE
Log operations in the Editing module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,7 @@ Improvements
   :user:`kewisch`)
 - Allow editors to edit their review comments on editables (:pr:`6008`)
 - Auto-linking of patterns in minutes (e.g. issue trackers, Github repos...) (:pr:`5998`)
+- Log editor actions in the Editing module (:pr:`6015`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/controllers/backend/management.py
+++ b/indico/modules/events/editing/controllers/backend/management.py
@@ -61,7 +61,7 @@ class RHEditTag(RHEditingManagementBase):
     def _process_PATCH(self, data):
         if self.tag.system and not self.is_service_call:
             raise Forbidden
-        update_tag(self.tag, **data)
+        update_tag(self.tag, data)
         return EditingTagSchema().jsonify(self.tag)
 
     def _process_DELETE(self):

--- a/indico/modules/events/editing/models/editable.py
+++ b/indico/modules/events/editing/models/editable.py
@@ -13,7 +13,7 @@ from sqlalchemy.sql import select
 from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum
 from indico.util.enum import RichIntEnum
-from indico.util.i18n import _
+from indico.util.i18n import _, orig_string
 from indico.util.locators import locator_property
 from indico.util.string import format_repr
 from indico.web.flask.util import url_for
@@ -116,6 +116,10 @@ class Editable(db.Model):
     @property
     def event(self):
         return self.contribution.event
+
+    @property
+    def log_title(self):
+        return f'"{self.contribution.title}" ({orig_string(self.type.title)})'
 
     @property
     def valid_revisions(self):

--- a/indico/modules/events/editing/models/file_types.py
+++ b/indico/modules/events/editing/models/file_types.py
@@ -86,6 +86,10 @@ class EditingFileType(db.Model):
     # - files (EditingRevisionFile.file_type)
     # - review_conditions (EditingReviewCondition.file_types)
 
+    def log(self, *args, **kwargs):
+        """Log with prefilled metadata for the file type."""
+        return self.event.log(*args, meta={'editing_file_type_id': self.id}, **kwargs)
+
     def __repr__(self):
         return format_repr(self, 'id', 'event_id', 'extensions', allow_multiple_files=False, required=False,
                            publishable=False, filename_template=None, _text=self.name)

--- a/indico/modules/events/editing/models/tags.py
+++ b/indico/modules/events/editing/models/tags.py
@@ -66,6 +66,10 @@ class EditingTag(db.Model):
         """Properly formatted title, including tag code."""
         return f'{self.code}: {self.title}'
 
+    def log(self, *args, **kwargs):
+        """Log with prefilled metadata for the tag."""
+        return self.event.log(*args, meta={'tag_id': self.id}, **kwargs)
+
     def __repr__(self):
         return format_repr(self, 'id', 'event_id', system=False, _text=self.title)
 

--- a/indico/modules/events/editing/models/tags.py
+++ b/indico/modules/events/editing/models/tags.py
@@ -68,7 +68,7 @@ class EditingTag(db.Model):
 
     def log(self, *args, **kwargs):
         """Log with prefilled metadata for the tag."""
-        return self.event.log(*args, meta={'tag_id': self.id}, **kwargs)
+        return self.event.log(*args, meta={'editing_tag_id': self.id}, **kwargs)
 
     def __repr__(self):
         return format_repr(self, 'id', 'event_id', system=False, _text=self.title)

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -332,8 +332,8 @@ def update_tag(tag, updates):
 
 def delete_tag(tag):
     logger.info('Tag %r deleted by %r', tag, session.user)
-    db.session.delete(tag)
     tag.log(EventLogRealm.management, LogKind.negative, 'Editing', f'Tag {tag.verbose_title} deleted', session.user)
+    db.session.delete(tag)
 
 
 def create_new_file_type(event, editable_type, **data):
@@ -347,7 +347,7 @@ def create_new_file_type(event, editable_type, **data):
 
 
 def update_file_type(file_type, **data):
-    changes = file_type.populate_from_dict(data, keys=FILE_TYPE_ATTRS.keys())
+    changes = file_type.populate_from_dict(data, keys=FILE_TYPE_ATTRS)
     db.session.flush()
     logger.info('File type %r updated by %r', file_type, session.user)
     file_type.log(EventLogRealm.management, LogKind.change, 'Editing', f'File type {file_type.name} updated',

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -34,8 +34,14 @@ from indico.util.i18n import _, orig_string
 from indico.web.flask.util import send_file
 
 
-FILE_TYPE_ATTRS = {'name': 'Name', 'extensions': 'Extensions', 'allow_multiple_files': 'Multiple files',
-                   'required': 'File required', 'publishable': 'Publishable', 'filename_template': 'Filename template'}
+FILE_TYPE_ATTRS = {
+    'name': {'title': 'Name', 'type': 'string'},
+    'extensions': 'Extensions',
+    'allow_multiple_files': 'Multiple files',
+    'required': 'File required',
+    'publishable': 'Publishable',
+    'filename_template': {'title': 'Filename template', 'type': 'string'},
+}
 
 
 class InvalidEditableState(BadRequest):
@@ -104,7 +110,7 @@ def _log_review(editable, kind, log_msg, old_state=None, was_published=None):
     log_fields = {'state': 'Editable State', 'published': 'Published'}
     changes = {}
     if old_state is not None and old_state != editable.state:
-        changes['state'] = (orig_string(old_state.title), orig_string(editable.state.title))
+        changes['state'] = (old_state, editable.state)
     if was_published is not None and was_published != (editable.published_revision is not None):
         changes['published'] = (was_published, editable.published_revision is not None)
     editable.log(EventLogRealm.reviewing, kind, 'Editing', log_msg,
@@ -325,7 +331,11 @@ def update_tag(tag, updates):
     changes = tag.populate_from_dict({k: v for k, v in updates.items() if v is not None})
     db.session.flush()
     logger.info('Tag %r updated by %r', tag, session.user)
-    log_fields = {'code': 'Code', 'title': 'Title', 'color': 'Color'}
+    log_fields = {
+        'code': {'title': 'Code', 'type': 'string'},
+        'title': {'title': 'Title', 'type': 'string'},
+        'color': {'title': 'Color', 'type': 'string'},
+    }
     tag.log(EventLogRealm.management, LogKind.change, 'Editing', f'Tag {tag.verbose_title} updated', session.user,
             data={'Changes': make_diff_log(changes, log_fields)})
 


### PR DESCRIPTION
This PR adds logging for operations that might be destructive (such as comment edits or deletions) in the Editing module.