### PR TITLE
Allow hiding specific recurrence types

### DIFF
--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -138,6 +138,22 @@ class BookingEditForm extends React.Component {
     }
   };
 
+  getRecurrenceLabel = number => {
+    const {hideOptions} = this.props;
+
+    if (hideOptions.recurringWeekly && hideOptions.recurringMonthly) {
+      return null;
+    }
+
+    if (hideOptions.recurringWeekly) {
+      return [{text: PluralTranslate.string('Month', 'Months', number || 0), value: 'month'}];
+    }
+
+    if (hideOptions.recurringMonthly) {
+      return [{text: PluralTranslate.string('Week', 'Weeks', number || 0), value: 'week'}];
+    }
+  };
+
   render() {
     const {
       user: sessionUser,
@@ -157,20 +173,20 @@ class BookingEditForm extends React.Component {
     const bookingStarted = today.isAfter(startDt, 'day');
     const bookingFinished = today.isAfter(endDt, 'day');
     const recurringBookingInProgress = getRecurrenceInfo(repetition).type === 'every';
+    const recurrenceHidden = hideOptions.recurringWeekly && hideOptions.recurringMonthly;
 
     // all but one option are hidden
     const showRecurrenceOptions =
       ['single', 'daily', 'recurring'].filter(x => hideOptions[x]).length !== 2;
+    const hideMessage = hideOptions.recurringWeekly || hideOptions.recurringMonthly;
     return (
       <Form id="booking-edit-form" styleName="booking-edit-form" onSubmit={handleSubmit}>
-        {recurringBookingInProgress &&
-          recurrence.type === 'every' &&
-          !hideOptions.recurringOptions && (
-            <Message icon styleName="repeat-frequency-disabled-notice">
-              <Icon name="dont" />
-              <Translate>You cannot modify the repeat frequency of an existing booking.</Translate>
-            </Message>
-          )}
+        {!hideMessage && recurringBookingInProgress && recurrence.type === 'every' && (
+          <Message icon styleName="repeat-frequency-disabled-notice">
+            <Icon name="dont" />
+            <Translate>You cannot modify the repeat frequency of an existing booking.</Translate>
+          </Message>
+        )}
         <Segment>
           {showRecurrenceOptions && (
             <Form.Group inline>
@@ -192,7 +208,7 @@ class BookingEditForm extends React.Component {
                   onClick={() => this.recurrenceTypeChanged('daily')}
                 />
               )}
-              {!hideOptions.recurring && (
+              {!recurrenceHidden && (
                 <FinalRadio
                   name="recurrence.type"
                   label={Translate.string('Recurring booking')}
@@ -225,8 +241,8 @@ class BookingEditForm extends React.Component {
                   }
                 }}
               />
-              {hideOptions.recurringOptions ? (
-                <label>{PluralTranslate.string('Week', 'Weeks', recurrence.number || 0)}</label>
+              {hideOptions.recurringWeekly || hideOptions.recurringMonthly ? (
+                <label>{this.getRecurrenceLabel(recurrence.number).map(x => x.text)}</label>
               ) : (
                 <Field name="recurrence.number" subscription={{}}>
                   {({input: {value: number}}) => (

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -163,12 +163,14 @@ class BookingEditForm extends React.Component {
       ['single', 'daily', 'recurring'].filter(x => hideOptions[x]).length !== 2;
     return (
       <Form id="booking-edit-form" styleName="booking-edit-form" onSubmit={handleSubmit}>
-        {recurringBookingInProgress && recurrence.type === 'every' && (
-          <Message icon styleName="repeat-frequency-disabled-notice">
-            <Icon name="dont" />
-            <Translate>You cannot modify the repeat frequency of an existing booking.</Translate>
-          </Message>
-        )}
+        {recurringBookingInProgress &&
+          recurrence.type === 'every' &&
+          !hideOptions.recurringMonthly && (
+            <Message icon styleName="repeat-frequency-disabled-notice">
+              <Icon name="dont" />
+              <Translate>You cannot modify the repeat frequency of an existing booking.</Translate>
+            </Message>
+          )}
         <Segment>
           {showRecurrenceOptions && (
             <Form.Group inline>

--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -165,7 +165,7 @@ class BookingEditForm extends React.Component {
       <Form id="booking-edit-form" styleName="booking-edit-form" onSubmit={handleSubmit}>
         {recurringBookingInProgress &&
           recurrence.type === 'every' &&
-          !hideOptions.recurringMonthly && (
+          !hideOptions.recurringOptions && (
             <Message icon styleName="repeat-frequency-disabled-notice">
               <Icon name="dont" />
               <Translate>You cannot modify the repeat frequency of an existing booking.</Translate>
@@ -225,30 +225,34 @@ class BookingEditForm extends React.Component {
                   }
                 }}
               />
-              <Field name="recurrence.number" subscription={{}}>
-                {({input: {value: number}}) => (
-                  <FinalDropdown
-                    name="recurrence.interval"
-                    disabled={submitSucceeded || recurringBookingInProgress}
-                    selection
-                    required
-                    options={[
-                      {
-                        value: 'week',
-                        text: PluralTranslate.string('Week', 'Weeks', number || 0),
-                      },
-                      {
-                        value: 'month',
-                        text: PluralTranslate.string('Month', 'Months', number || 0),
-                      },
-                    ]}
-                    onChange={newInterval => {
-                      onBookingPeriodChange(dates, timeSlot, this.clearWeekdays(newInterval));
-                      this.preselectWeekdayToday(form);
-                    }}
-                  />
-                )}
-              </Field>
+              {hideOptions.recurringOptions ? (
+                <label>{PluralTranslate.string('Week', 'Weeks', recurrence.number || 0)}</label>
+              ) : (
+                <Field name="recurrence.number" subscription={{}}>
+                  {({input: {value: number}}) => (
+                    <FinalDropdown
+                      name="recurrence.interval"
+                      disabled={submitSucceeded || recurringBookingInProgress}
+                      selection
+                      required
+                      options={[
+                        {
+                          value: 'week',
+                          text: PluralTranslate.string('Week', 'Weeks', number || 0),
+                        },
+                        {
+                          value: 'month',
+                          text: PluralTranslate.string('Month', 'Months', number || 0),
+                        },
+                      ]}
+                      onChange={newInterval => {
+                        onBookingPeriodChange(dates, timeSlot, this.clearWeekdays(newInterval));
+                        this.preselectWeekdayToday(form);
+                      }}
+                    />
+                  )}
+                </Field>
+              )}
             </Form.Group>
           )}
           {recurrence.type === 'single' ? (

--- a/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
+++ b/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
@@ -271,12 +271,14 @@ class BookingBootstrapForm extends React.Component {
       isAdminOverrideEnabled,
       bookingGracePeriod
     );
-    const recurrenceOptions = [
-      {text: PluralTranslate.string('Week', 'Weeks', number), value: 'week'},
-      ...(hideOptions.recurringMonthly
-        ? []
-        : [{text: PluralTranslate.string('Month', 'Months', number), value: 'month'}]),
-    ];
+    const recurrenceOptions = hideOptions.recurringOptions
+      ? []
+      : [
+          {text: PluralTranslate.string('Week', 'Weeks', number), value: 'week'},
+          ...(hideOptions.recurringMonthly
+            ? []
+            : [{text: PluralTranslate.string('Month', 'Months', number), value: 'month'}]),
+        ];
     // all but one option are hidden
     const showRecurrenceOptions =
       ['single', 'daily', 'recurring'].filter(x => hideOptions[x]).length !== 2;
@@ -330,12 +332,17 @@ class BookingBootstrapForm extends React.Component {
               step="1"
               onChange={(event, data) => this.updateNumber(data.value)}
             />
-            <Select
-              value={interval}
-              options={recurrenceOptions}
-              disabled={hideOptions.recurringMonthly}
-              onChange={(event, data) => this.updateInterval(data.value)}
-            />
+            {!hideOptions.recurringOptions && (
+              <Select
+                value={interval}
+                options={recurrenceOptions}
+                disabled={hideOptions.recurringOptions}
+                onChange={(event, data) => this.updateInterval(data.value)}
+              />
+            )}
+            {hideOptions.recurringOptions && (
+              <label>{PluralTranslate.string('Week', 'Weeks', number)}</label>
+            )}
           </Form.Group>
         )}
         {['every', 'daily'].includes(type) && (

--- a/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
+++ b/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
@@ -273,7 +273,9 @@ class BookingBootstrapForm extends React.Component {
     );
     const recurrenceOptions = [
       {text: PluralTranslate.string('Week', 'Weeks', number), value: 'week'},
-      {text: PluralTranslate.string('Month', 'Months', number), value: 'month'},
+      ...(hideOptions.recurringMonthly
+        ? []
+        : [{text: PluralTranslate.string('Month', 'Months', number), value: 'month'}]),
     ];
     // all but one option are hidden
     const showRecurrenceOptions =
@@ -331,6 +333,7 @@ class BookingBootstrapForm extends React.Component {
             <Select
               value={interval}
               options={recurrenceOptions}
+              disabled={hideOptions.recurringMonthly}
               onChange={(event, data) => this.updateInterval(data.value)}
             />
           </Form.Group>

--- a/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
+++ b/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
@@ -111,6 +111,23 @@ class BookingBootstrapForm extends React.Component {
     }
   }
 
+  updateIntervalOptions = () => {
+    const {hideOptions} = this.props;
+    const {recurrence} = this.state;
+
+    if (!hideOptions.recurringWeekly && !hideOptions.recurringMonthly) {
+      return null;
+    }
+
+    if (hideOptions.recurringWeekly && recurrence.interval !== 'month') {
+      this.updateInterval('month');
+    }
+
+    if (hideOptions.recurringMonthly && recurrence.interval !== 'week') {
+      this.updateInterval('week');
+    }
+  };
+
   triggerChange() {
     const {onChange} = this.props;
     onChange(this.serializedState);
@@ -250,6 +267,28 @@ class BookingBootstrapForm extends React.Component {
     this.triggerChange();
   };
 
+  getRecurrenceOptions = () => {
+    const {hideOptions} = this.props;
+    const {recurrence} = this.state;
+
+    if (hideOptions.recurringWeekly && hideOptions.recurringMonthly) {
+      return null;
+    }
+
+    if (hideOptions.recurringWeekly) {
+      return [{text: PluralTranslate.string('Month', 'Months', recurrence.number), value: 'month'}];
+    }
+
+    if (hideOptions.recurringMonthly) {
+      return [{text: PluralTranslate.string('Week', 'Weeks', recurrence.number), value: 'week'}];
+    }
+
+    return [
+      {text: PluralTranslate.string('Week', 'Weeks', recurrence.number), value: 'week'},
+      {text: PluralTranslate.string('Month', 'Months', recurrence.number), value: 'month'},
+    ];
+  };
+
   render() {
     const {
       timeSlot: {startTime, endTime},
@@ -271,12 +310,6 @@ class BookingBootstrapForm extends React.Component {
       isAdminOverrideEnabled,
       bookingGracePeriod
     );
-    const recurrenceOptions = hideOptions.recurringOptions
-      ? []
-      : [
-          {text: PluralTranslate.string('Week', 'Weeks', number), value: 'week'},
-          {text: PluralTranslate.string('Month', 'Months', number), value: 'month'},
-        ];
     // all but one option are hidden
     const showRecurrenceOptions =
       ['single', 'daily', 'recurring'].filter(x => hideOptions[x]).length !== 2;
@@ -285,6 +318,7 @@ class BookingBootstrapForm extends React.Component {
       isAdminOverrideEnabled,
       bookingGracePeriod
     );
+    const recurrenceHidden = hideOptions.recurringWeekly && hideOptions.recurringMonthly;
 
     return (
       <Form>
@@ -308,7 +342,7 @@ class BookingBootstrapForm extends React.Component {
                 onChange={(e, {value}) => this.updateBookingType(value)}
               />
             )}
-            {!hideOptions.recurring && (
+            {!recurrenceHidden && (
               <Form.Radio
                 label={Translate.string('Recurring booking')}
                 name="type"
@@ -330,17 +364,17 @@ class BookingBootstrapForm extends React.Component {
               step="1"
               onChange={(event, data) => this.updateNumber(data.value)}
             />
-            {!hideOptions.recurringOptions && (
+            {hideOptions.recurringWeekly || hideOptions.recurringMonthly ? (
+              <label>{this.getRecurrenceOptions().map(x => x.text)}</label>
+            ) : (
               <Select
                 value={interval}
-                options={recurrenceOptions}
-                disabled={hideOptions.recurringOptions}
+                options={this.getRecurrenceOptions()}
+                disabled={recurrenceHidden}
                 onChange={(event, data) => this.updateInterval(data.value)}
               />
             )}
-            {hideOptions.recurringOptions && (
-              <label>{PluralTranslate.string('Week', 'Weeks', number)}</label>
-            )}
+            {this.updateIntervalOptions()}
           </Form.Group>
         )}
         {['every', 'daily'].includes(type) && (

--- a/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
+++ b/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
@@ -275,9 +275,7 @@ class BookingBootstrapForm extends React.Component {
       ? []
       : [
           {text: PluralTranslate.string('Week', 'Weeks', number), value: 'week'},
-          ...(hideOptions.recurringMonthly
-            ? []
-            : [{text: PluralTranslate.string('Month', 'Months', number), value: 'month'}]),
+          {text: PluralTranslate.string('Month', 'Months', number), value: 'month'},
         ];
     // all but one option are hidden
     const showRecurrenceOptions =


### PR DESCRIPTION
This PR hides the 'monthly' recurring UI elements for the Burotel plugin.

See: https://github.com/indico/indico-plugins-cern/pull/151 for more info.