### PR TITLE
Add form kwargs when sending signal add_form_fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -90,6 +90,8 @@ Internal Changes
   the removal of registration form fields (:pr:`5924`)
 - Add a tool ``bin/managemnent/icons_generate.py`` to generate CSS for icomoon icons based
   on ``selection.json`` (:pr:`5986`, thanks :user:`foxbunny`)
+- Pass form class arguments to ``core.add_form_fields`` signal handlers (:pr:`6020`, thanks
+  :user:`vtran99`)
 
 
 ----

--- a/indico/core/signals/core.py
+++ b/indico/core/signals/core.py
@@ -40,7 +40,9 @@ Expected to return one or more Storage subclasses.
 
 add_form_fields = _signals.signal('add-form-fields', '''
 Lets you add extra fields to a form.  The *sender* is the form class
-and should always be specified when subscribing to this signal.
+and should always be specified when subscribing to this signal. Any
+arguments passed while instantiating the form are being passed in
+`form_args` and `form_kwargs`.
 
 The signal handler should return one or more ``'name', Field`` tuples.
 Each field will be added to the form as ``ext__<name>`` and is

--- a/indico/web/forms/base.py
+++ b/indico/web/forms/base.py
@@ -52,7 +52,7 @@ class IndicoFormMeta(FormMeta):
         # if the signal receiver didn't specify a sender.
         if kwargs.pop('__extended', False):
             return super().__call__(*args, **kwargs)
-        extra_fields = values_from_signal(signals.core.add_form_fields.send(cls))
+        extra_fields = values_from_signal(signals.core.add_form_fields.send(cls, form_args=args, form_kwargs=kwargs))
         # If there are no extra fields, we don't need any custom logic
         # and simply create an instance of the original form.
         if not extra_fields:


### PR DESCRIPTION
Request to add arguments of form constructor to the signal 'add_form_fields', so the connect signal can know the context of the form creation. 