### PR TITLE
Fix forced-event-locale fallback

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Bugfixes
 - Always show exact matches when searching for existing videoconference rooms to attach to an
   event (:pr:`6022`)
 - Include materials linked to sessions in the material package (:pr:`6024`)
+- Use the correct locale when sending sending email notifications to others in an event
+  (:issue:`5987`, :pr:`6021`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/payment/util.py
+++ b/indico/modules/events/payment/util.py
@@ -37,7 +37,7 @@ def register_transaction(registration, amount, currency, action, provider=None, 
     :param currency: the currency used for the transaction
     :param action: the `TransactionAction` of the transaction
     :param provider: the payment method name of the transaction,
-                     or '_manual' if no payment method has been used
+                     or ``None`` if no payment method has been used
     :param data: arbitrary JSON-serializable data specific to the
                  transaction's provider
     """
@@ -48,8 +48,8 @@ def register_transaction(registration, amount, currency, action, provider=None, 
         db.session.flush()
         if new_transaction.status == TransactionStatus.successful:
             registration.update_state(paid=True)
-            notify_registration_state_update(registration)
+            notify_registration_state_update(registration, from_management=(provider is None))
         elif new_transaction.status == TransactionStatus.cancelled:
             registration.update_state(paid=False)
-            notify_registration_state_update(registration)
+            notify_registration_state_update(registration, from_management=(provider is None))
         return new_transaction

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -560,7 +560,8 @@ def _modify_registration_status(registration, approve, rejection_reason='', atta
         registration.rejection_reason = rejection_reason
         registration.update_state(rejected=True)
     db.session.flush()
-    notify_registration_state_update(registration, attach_rejection_reason)
+    notify_registration_state_update(registration, attach_rejection_reason=attach_rejection_reason,
+                                     from_management=True)
     status = 'approved' if approve else 'rejected'
     logger.info('Registration %s was %s by %s', registration, status, session.user)
 
@@ -600,7 +601,7 @@ class RHRegistrationReset(RHManageRegistrationBase):
             self.registration.update_state(rejected=False)
         elif self.registration.state == RegistrationState.withdrawn:
             self.registration.update_state(withdrawn=False)
-            notify_registration_state_update(self.registration)
+            notify_registration_state_update(self.registration, from_management=True)
         else:
             raise BadRequest(_('The registration cannot be reset in its current state.'))
         self.registration.checked_in = False
@@ -641,7 +642,7 @@ class RHRegistrationManageWithdraw(RHManageRegistrationBase):
         self.registration.update_state(withdrawn=True)
         flash(_('The registration has been withdrawn.'), 'success')
         logger.info('Registration %r was withdrawn by %r', self.registration, session.user)
-        notify_registration_state_update(self.registration)
+        notify_registration_state_update(self.registration, from_management=True)
         return jsonify_data(html=_render_registration_details(self.registration))
 
 

--- a/indico/modules/events/registration/notifications.py
+++ b/indico/modules/events/registration/notifications.py
@@ -29,8 +29,8 @@ def notify_invitation(invitation, email_subject, email_body, from_address):
 
 
 @make_interceptable
-def _notify_registration(registration, template_name, to_managers=False, attach_rejection_reason=False,
-                         diff=None, old_price=None):
+def _notify_registration(registration, template_name, *, to_managers=False, attach_rejection_reason=False,
+                         diff=None, old_price=None, allow_session_locale=False):
     from indico.modules.events.registration.util import get_ticket_attachments
     attachments = []
     regform = registration.registration_form
@@ -49,7 +49,8 @@ def _notify_registration(registration, template_name, to_managers=False, attach_
         registration.email if not to_managers else registration.registration_form.manager_notification_recipients
     )
     from_address = registration.registration_form.notification_sender_address if not to_managers else None
-    with registration.event.force_event_locale(registration.user if not to_managers else None):
+    with registration.event.force_event_locale(registration.user if not to_managers else None,
+                                               allow_session=allow_session_locale):
         tpl = get_template_module(f'events/registration/emails/{template_name}', registration=registration,
                                   attach_rejection_reason=attach_rejection_reason, diff=diff, old_price=old_price)
         mail = make_email(to_list=to_list, template=tpl, html=True, from_address=from_address, attachments=attachments)
@@ -61,24 +62,26 @@ def _notify_registration(registration, template_name, to_managers=False, attach_
                log_metadata={'registration_id': registration.id})
 
 
-def notify_registration_creation(registration, notify_user=True):
+def notify_registration_creation(registration, *, from_management=False, notify_user=True):
     if notify_user:
-        _notify_registration(registration, 'registration_creation_to_registrant.html')
+        _notify_registration(registration, 'registration_creation_to_registrant.html',
+                             allow_session_locale=(not from_management))
     if registration.registration_form.manager_notifications_enabled:
         _notify_registration(registration, 'registration_creation_to_managers.html', to_managers=True)
 
 
-def notify_registration_modification(registration, notify_user=True, diff=None, old_price=None):
+def notify_registration_modification(registration, *, from_management=False, notify_user=True, diff=None,
+                                     old_price=None):
     if notify_user:
         _notify_registration(registration, 'registration_modification_to_registrant.html',
-                             diff=diff, old_price=old_price)
+                             diff=diff, old_price=old_price, allow_session_locale=(not from_management))
     if registration.registration_form.manager_notifications_enabled:
         _notify_registration(registration, 'registration_modification_to_managers.html', to_managers=True,
                              diff=diff, old_price=old_price)
 
 
-def notify_registration_state_update(registration, attach_rejection_reason=False):
+def notify_registration_state_update(registration, *, attach_rejection_reason=False, from_management=False):
     _notify_registration(registration, 'registration_state_update_to_registrant.html',
-                         attach_rejection_reason=attach_rejection_reason)
+                         attach_rejection_reason=attach_rejection_reason, allow_session_locale=(not from_management))
     if registration.registration_form.manager_notifications_enabled:
         _notify_registration(registration, 'registration_state_update_to_managers.html', to_managers=True)

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -394,7 +394,7 @@ def create_registration(regform, data, invitation=None, management=False, notify
     registration.sync_state(_skip_moderation=skip_moderation)
     db.session.flush()
     signals.event.registration_created.send(registration, management=management, data=data)
-    notify_registration_creation(registration, notify_user)
+    notify_registration_creation(registration, notify_user=notify_user, from_management=management)
     logger.info('New registration %s by %s', registration, user)
     registration.log(EventLogRealm.management if management else EventLogRealm.participants,
                      LogKind.positive, 'Registration',
@@ -463,7 +463,8 @@ def modify_registration(registration, data, management=False, notify_user=True):
 
     new_data = snapshot_registration_data(registration)
     diff = diff_registration_data(old_data, new_data)
-    notify_registration_modification(registration, notify_user, diff=diff, old_price=old_price)
+    notify_registration_modification(registration, notify_user=notify_user, diff=diff, old_price=old_price,
+                                     from_management=management)
     logger.info('Registration %s modified by %s', registration, session.user)
     registration.log(EventLogRealm.management if management else EventLogRealm.participants,
                      LogKind.change, 'Registration',


### PR DESCRIPTION
Forcing the event locale without taking the session into account is done when sending emails to others, since those should pretty much never use the user's current session locale but rather the event (or server) default locale.

~~There's still an issue where registration notifications to an unauthenticated user will not use their locale but the default one, but this cannot be fixed without storing the locale used during registration since at the time where we send a notification we do not know if the user self-registered or it was a manager registering them, so we do not know if it's safe to take the session locale into account.~~

fixes #5987

---

TODO:
- [x] changelog
- [x] rebase onto 3.2.x after testing