### PR TITLE
Show exact matches when searching for VC rooms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Bugfixes
 
 - Fix meeting timetable not showing custom locations when all top-level timetable
   entries are session blocks inheriting the custom location from its session (:pr:`6014`)
+- Always show exact matches when searching for existing videoconference rooms to attach to an
+  event (:pr:`6022`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/vc/controllers.py
+++ b/indico/modules/vc/controllers.py
@@ -326,7 +326,7 @@ class RHVCManageSearch(RHVCManageEventCreateBase):
                  .options((lazyload(r) for r in inspect(VCRoom).relationships.keys()),
                           joinedload('events').joinedload('event').joinedload('acl_entries'))
                  .group_by(VCRoom.id)
-                 .order_by(db.desc('event_count'))
+                 .order_by(func.lower(VCRoom.name) != self.query.lower(), db.desc('event_count'))
                  .limit(10))
 
         return ((room, count) for room, count in query if room.plugin.can_manage_vc_room(session.user, room))


### PR DESCRIPTION
This PR makes the exact search match for a VC rooms show up first, thus avoiding it being trimmed by the 10-result limit.

Before:
![image](https://github.com/indico/indico/assets/27357203/4722ba5e-e26f-49a7-ac73-e1007f711753)

After:
<img width="627" alt="image" src="https://github.com/indico/indico/assets/27357203/79cb158d-a943-41ea-bd36-1687a171a883">
