### PR TITLE
Material package: Files linked to sessions are skipped

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Bugfixes
   entries are session blocks inheriting the custom location from its session (:pr:`6014`)
 - Always show exact matches when searching for existing videoconference rooms to attach to an
   event (:pr:`6022`)
+- Include materials linked to sessions in the material package (:pr:`6024`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/attachments/controllers/event_package.py
+++ b/indico/modules/attachments/controllers/event_package.py
@@ -34,13 +34,12 @@ from indico.web.util import jsonify_data
 
 
 def _get_start_dt(obj):
-    # TODO: adapt to new models (needs extra properties to use event TZ)
     if isinstance(obj, Contribution):
         return obj.timetable_entry.start_dt if obj.timetable_entry else None
     elif isinstance(obj, SubContribution):
         return obj.timetable_entry.start_dt if obj.timetable_entry else None
     elif isinstance(obj, Session):
-        return None
+        return obj.start_dt  # start_dt of the first block
     return obj.start_dt
 
 


### PR DESCRIPTION
This is most likely because `_get_start_dt` in `indico/modules/attachments/controllers/event_package.py` returns None for a session (sessions do not really have a start date).  However, we could use their `start_dt` nonetheless, because that uses the start date of its first block which would probably do the job well enough.