### PR TITLE
Add a ticket placeholder for Accompanying persons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@ Security fixes
 Improvements
 ^^^^^^^^^^^^
 
-- None so far :(
+- Add placeholders for accompanying persons to the badge/ticket designer (:pr:`6033`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/designer/placeholders.py
+++ b/indico/modules/designer/placeholders.py
@@ -291,10 +291,9 @@ class AccompanyinPersonsPlaceholderBase(RegistrationPlaceholder):
 
     @classmethod
     def render(cls, registration):
-        if persons := registration.accompanying_persons:
-            names = [format_full_name(p['firstName'], p['lastName'], **cls.name_options) for p in persons]
-            return ', '.join(names)
-        return ''
+        names = [format_full_name(p['firstName'], p['lastName'], **cls.name_options)
+                 for p in registration.accompanying_persons]
+        return ', '.join(names)
 
 
 class RegistrationAccompanyingPersonsPlaceholder(AccompanyinPersonsPlaceholderBase):

--- a/indico/modules/designer/placeholders.py
+++ b/indico/modules/designer/placeholders.py
@@ -28,7 +28,8 @@ __all__ = ('EventDatesPlaceholder', 'EventDescriptionPlaceholder', 'Registration
            'RegistrationPositionPlaceholder', 'RegistrationAddressPlaceholder', 'RegistrationCountryPlaceholder',
            'RegistrationPhonePlaceholder', 'EventTitlePlaceholder', 'CategoryTitlePlaceholder', 'EventRoomPlaceholder',
            'EventVenuePlaceholder', 'EventSpeakersPlaceholder', 'EventLogoPlaceholder', 'FixedTextPlaceholder',
-           'FixedImagePlaceholder', 'RegistrationAccompanyingPersonsCountPlaceholder')
+           'FixedImagePlaceholder', 'RegistrationAccompanyingPersonsCountPlaceholder',
+           'RegistrationAccompanyingPersonsPlaceholder', 'RegistrationAccompanyingPersonsAbbrevPlaceholder')
 
 
 GROUP_TITLES = {
@@ -283,6 +284,29 @@ class RegistrationAccompanyingPersonsCountPlaceholder(RegistrationPlaceholder):
     @classmethod
     def render(cls, registration):
         return str(registration.num_accompanying_persons)
+
+
+class AccompanyinPersonsPlaceholderBase(RegistrationPlaceholder):
+    name_options = None
+
+    @classmethod
+    def render(cls, registration):
+        if persons := registration.accompanying_persons:
+            names = [format_full_name(p['firstName'], p['lastName'], **cls.name_options) for p in persons]
+            return ', '.join(names)
+        return ''
+
+
+class RegistrationAccompanyingPersonsPlaceholder(AccompanyinPersonsPlaceholderBase):
+    name = 'accompanying_persons'
+    description = _('Accompanying persons')
+    name_options = {'abbrev_first_name': False, 'last_name_first': False}
+
+
+class RegistrationAccompanyingPersonsAbbrevPlaceholder(AccompanyinPersonsPlaceholderBase):
+    name = 'accompanying_persons_abbrev'
+    description = _('Accompanying persons (abbrev.)')
+    name_options = {'last_name_first': False}
 
 
 class RegistrationFriendlyIDPlaceholder(RegistrationPlaceholder):

--- a/indico/modules/designer/placeholders.py
+++ b/indico/modules/designer/placeholders.py
@@ -15,6 +15,7 @@ from indico.modules.events.registration.util import generate_ticket_qr_code
 from indico.util.date_time import format_date, format_datetime, format_interval
 from indico.util.i18n import _
 from indico.util.placeholders import Placeholder
+from indico.util.string import format_full_name
 
 
 __all__ = ('EventDatesPlaceholder', 'EventDescriptionPlaceholder', 'RegistrationFullNamePlaceholder',

--- a/indico/modules/designer/placeholders.py
+++ b/indico/modules/designer/placeholders.py
@@ -279,7 +279,7 @@ class RegistrationPricePlaceholder(RegistrationPlaceholder):
 
 class RegistrationAccompanyingPersonsCountPlaceholder(RegistrationPlaceholder):
     name = 'num_accompanying_persons'
-    description = _('Number of Accompanying persons')
+    description = _('Number of accompanying persons')
 
     @classmethod
     def render(cls, registration):

--- a/indico/modules/designer/placeholders.py
+++ b/indico/modules/designer/placeholders.py
@@ -28,7 +28,7 @@ __all__ = ('EventDatesPlaceholder', 'EventDescriptionPlaceholder', 'Registration
            'RegistrationPositionPlaceholder', 'RegistrationAddressPlaceholder', 'RegistrationCountryPlaceholder',
            'RegistrationPhonePlaceholder', 'EventTitlePlaceholder', 'CategoryTitlePlaceholder', 'EventRoomPlaceholder',
            'EventVenuePlaceholder', 'EventSpeakersPlaceholder', 'EventLogoPlaceholder', 'FixedTextPlaceholder',
-           'FixedImagePlaceholder')
+           'FixedImagePlaceholder', 'RegistrationAccompanyingPersonsCountPlaceholder')
 
 
 GROUP_TITLES = {
@@ -274,6 +274,15 @@ class RegistrationPricePlaceholder(RegistrationPlaceholder):
     def render(cls, registration):
         # XXX: Use event locale once we have such a setting
         return format_currency(registration.price, registration.currency, locale='en_GB')
+
+
+class RegistrationAccompanyingPersonsCountPlaceholder(RegistrationPlaceholder):
+    name = 'num_accompanying_persons'
+    description = _('Number of Accompanying persons')
+
+    @classmethod
+    def render(cls, registration):
+        return str(registration.num_accompanying_persons)
 
 
 class RegistrationFriendlyIDPlaceholder(RegistrationPlaceholder):

--- a/indico/modules/events/registration/fields/accompanying_test.py
+++ b/indico/modules/events/registration/fields/accompanying_test.py
@@ -221,22 +221,27 @@ def test_registration_count_multiple_fields(dummy_regform, create_accompanying_p
 
     _assert_registration_count(dummy_regform, 0)
     reg_1 = create_registration(1)
+    assert reg_1.num_accompanying_persons == 0
     _assert_occupied_slots(reg_1, 1)
     _assert_registration_count(dummy_regform, 1)
 
     create_accompanying_persons_field(0, False, registration=reg_1, num_persons=1)
+    assert reg_1.num_accompanying_persons == 1
     _assert_occupied_slots(reg_1, 1)
     _assert_registration_count(dummy_regform, 1)
 
     create_accompanying_persons_field(0, True, registration=reg_1, num_persons=1)
+    assert reg_1.num_accompanying_persons == 2
     _assert_occupied_slots(reg_1, 2)
     _assert_registration_count(dummy_regform, 2)
 
     create_accompanying_persons_field(0, True, registration=reg_1, num_persons=2)
+    assert reg_1.num_accompanying_persons == 4
     _assert_occupied_slots(reg_1, 4)
     _assert_registration_count(dummy_regform, 4)
 
     reg_2 = create_registration(2)
+    assert reg_2.num_accompanying_persons == 0
     _assert_occupied_slots(reg_2, 1)
     _assert_registration_count(dummy_regform, 5)
 

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -857,3 +857,13 @@ def _mapper_configured():
              .correlate_except(RegistrationData)
              .scalar_subquery())
     Registration.occupied_slots = column_property(query, deferred=True)
+
+    query = (select([db.func.coalesce(db.func.sum(db.func.jsonb_array_length(RegistrationData.data)), 0)])
+             .where(db.and_(RegistrationData.registration_id == Registration.id,
+                            RegistrationData.field_data_id == RegistrationFormFieldData.id,
+                            RegistrationFormFieldData.field_id == RegistrationFormItem.id,
+                            RegistrationFormItem.input_type == 'accompanying_persons',
+                            ~RegistrationFormItem.is_deleted))
+             .correlate_except(RegistrationData)
+             .scalar_subquery())
+    Registration.num_accompanying_persons = column_property(query, deferred=True)


### PR DESCRIPTION
New placeholders for
- Accompanying persons
- Accompanying persons abbreviated (first initial + last name) - to save space if there are lots of people
- Number of Accompanying persons