### PR TITLE
Add tests for designer placeholders

### DIFF
--- a/indico/modules/designer/placeholders_test.py
+++ b/indico/modules/designer/placeholders_test.py
@@ -68,7 +68,7 @@ def _prepare_registration_data(dummy_reg):
     for data in dummy_reg.data:
         field = data.field_data.field
         if field.personal_data_type and field.personal_data_type.name == 'title':
-            uuid = list(data.field_data.field.data['captions'].keys())[0]
+            uuid = list(data.field_data.field.data['captions'])[0]
             data.data = {uuid: 1}
 
     dummy_reg.base_price = 100

--- a/indico/modules/designer/placeholders_test.py
+++ b/indico/modules/designer/placeholders_test.py
@@ -5,64 +5,123 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import itertools
+from datetime import datetime
+from operator import attrgetter
+from pathlib import Path
+
 import pytest
+from PIL import Image
 
-from indico.modules.designer.placeholders import (RegistrationAccompanyingPersonsAbbrevPlaceholder,
-                                                  RegistrationAccompanyingPersonsCountPlaceholder,
-                                                  RegistrationAccompanyingPersonsPlaceholder)
-from indico.modules.events.registration.models.form_fields import RegistrationFormField
-from indico.modules.events.registration.models.items import RegistrationFormSection
-from indico.modules.events.registration.models.registrations import RegistrationData
+from indico.modules.designer import placeholders
+from indico.modules.events.models.persons import EventPerson, EventPersonLink
+from indico.modules.events.registration.util import modify_registration
 
 
-pytest_plugins = ('indico.modules.events.registration.testing.fixtures',)
+pytest_plugins = ('indico.modules.events.registration.testing.fixtures', 'indico.modules.designer.testing.fixtures')
 
 
-def _id(n):
-    assert 0 <= n < 10000000
-    return f'{n:08d}-0000-0000-0000-000000000000'
+def _get_placeholders():
+    """Get a list of all designer placeholders."""
+    exports = [getattr(placeholders, name) for name in placeholders.__all__]
+    phs = [obj for obj in exports if issubclass(obj, placeholders.DesignerPlaceholder)]
+    return sorted(phs, key=attrgetter('group', 'name'))
 
 
-def _create_accompanying_persons(n):
-    return [{'id': _id(i), 'firstName': 'Guinea', 'lastName': 'Pig'} for i in range(n)]
+text_placeholders = [ph for ph in _get_placeholders() if not ph.is_image]
+image_placeholders = [ph for ph in _get_placeholders() if ph.is_image]
 
 
-@pytest.fixture
-def create_accompanying_persons_field(db, dummy_regform):
-    def _create_accompanying_persons_field(max_persons, persons_count_against_limit,
-                                           registration=None, data=None, num_persons=0):
-        section = RegistrationFormSection(
-            registration_form=dummy_regform,
-            title='dummy_section',
-            is_manager_only=False
-        )
-        db.session.add(section)
-        db.session.flush()
-        field = RegistrationFormField(
-            input_type='accompanying_persons',
-            title='Field',
-            parent=section,
-            registration_form=dummy_regform
-        )
-        field.field_impl.form_item.data = {
-            'max_persons': max_persons,
-            'persons_count_against_limit': persons_count_against_limit,
-        }
-        field.versioned_data = field.field_impl.form_item.data
-        if registration:
-            registration.data.append(RegistrationData(
-                field_data=field.current_data,
-                data=(data if data is not None else _create_accompanying_persons(num_persons))
-            ))
-            db.session.flush()
-        return field
-
-    return _create_accompanying_persons_field
+def _get_render_kwargs(ph, event, person, registration, item):
+    if ph.group == 'registrant':
+        if ph.data_source == 'person':
+            return {'person': person}
+        else:
+            return {'registration': registration}
+    elif ph.group == 'event':
+        return {'event': event}
+    elif ph.group == 'fixed':
+        return {'item': item}
 
 
-def test_accompanying_persons_placeholder(dummy_reg, create_accompanying_persons_field):
-    create_accompanying_persons_field(2, False, registration=dummy_reg, num_persons=2)
+def _prepare_event_data(dummy_event, dummy_user):
+    dummy_event.start_dt = datetime(2023, 1, 1, 10, 0)
+    dummy_event.end_dt = datetime(2023, 1, 2, 15, 0)
+    dummy_event.title = 'Dummy event title'
+    dummy_event.description = 'Dummy event description'
+    dummy_event.organizer_info = 'CERN'
+    dummy_event.room_name = 'Dummy room'
+    dummy_event.venue_name = 'Dummy venue'
 
-    assert RegistrationAccompanyingPersonsCountPlaceholder.render(dummy_reg) == '2'
-    assert RegistrationAccompanyingPersonsPlaceholder.render(dummy_reg) == 'Guinea PIG, Guinea PIG'
-    assert RegistrationAccompanyingPersonsAbbrevPlaceholder.render(dummy_reg) == 'G. PIG, G. PIG'
+    person = EventPerson.create_from_user(dummy_user, dummy_event)
+    person_link = EventPersonLink(person=person)
+    dummy_event.person_links = [person_link, person_link]
+
+
+def _prepare_registration_data(dummy_reg):
+    modify_registration(dummy_reg, {'email': '1337@example.test', 'first_name': 'Guinea', 'last_name': 'Pig',
+                                    'affiliation': 'CERN', 'address': '1211 Geneva 23, Switzerland',
+                                    'country': 'CH', 'phone': '+41227676000', 'position': 'Developer'},
+                        notify_user=False)
+
+    # Set the registration title
+    for data in dummy_reg.data:
+        field = data.field_data.field
+        if field.personal_data_type and field.personal_data_type.name == 'title':
+            uuid = list(data.field_data.field.data['captions'].keys())[0]
+            data.data = {uuid: 1}
+
+    dummy_reg.base_price = 100
+
+
+def _create_placeholder_template():
+    template = ''
+    for key, group in itertools.groupby(text_placeholders, key=attrgetter('group')):
+        template += f"Group '{key}':\n"
+        for ph in group:
+            template += f'\t{ph.name}: {{{ph.name}}}\n'
+    return template.strip()
+
+
+@pytest.mark.usefixtures('request_context', 'dummy_accompanying_persons_field')
+def test_replace_text_placeholders(snapshot, dummy_event, dummy_reg, dummy_user):
+    # For 'event' placeholders
+    _prepare_event_data(dummy_event, dummy_user)
+
+    # For 'registrant' placeholders
+    _prepare_registration_data(dummy_reg)
+
+    # For fixed text placeholder
+    dummy_item = {'text': 'Hello, world!'}
+
+    # For 'person' data_source
+    dummy_person = {'id': dummy_reg.id,
+                    'first_name': dummy_reg.first_name,
+                    'last_name': dummy_reg.last_name,
+                    'registration': dummy_reg,
+                    'is_accompanying': False}
+
+    template = _create_placeholder_template()
+    for ph in text_placeholders:
+        kwargs = _get_render_kwargs(ph, dummy_event, dummy_person, dummy_reg, dummy_item)
+        template = ph.replace(template, **kwargs)
+
+    snapshot.snapshot_dir = Path(__file__).parent / 'tests'
+    snapshot.assert_match(template, 'test_replace_text_placeholders.txt')
+
+
+@pytest.mark.usefixtures('request_context', 'dummy_event_logo')
+def test_render_image_placeholders(dummy_event, dummy_reg, dummy_designer_image_file):
+    # For fixed image placeholder
+    dummy_item = {'image_id': dummy_designer_image_file.id}
+    # For 'person' data_source
+    dummy_person = {'id': dummy_reg.id,
+                    'first_name': dummy_reg.first_name,
+                    'last_name': dummy_reg.last_name,
+                    'registration': dummy_reg,
+                    'is_accompanying': False}
+
+    for ph in image_placeholders:
+        kwargs = _get_render_kwargs(ph, dummy_event, dummy_person, dummy_reg, dummy_item)
+        res = ph.render(**kwargs)
+        assert isinstance(res, Image.Image)

--- a/indico/modules/designer/testing/fixtures.py
+++ b/indico/modules/designer/testing/fixtures.py
@@ -1,5 +1,5 @@
 # This file is part of Indico.
-# Copyright (C) 2002 - 2023 CERN
+# Copyright (C) 2002 - 2024 CERN
 #
 # Indico is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see the

--- a/indico/modules/designer/testing/fixtures.py
+++ b/indico/modules/designer/testing/fixtures.py
@@ -1,0 +1,43 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from io import BytesIO
+
+import pytest
+
+from indico.core.db import db
+from indico.core.db.sqlalchemy.util.management import DEFAULT_TICKET_DATA
+from indico.modules.designer import TemplateType
+from indico.modules.designer.models.images import DesignerImageFile
+from indico.modules.designer.models.templates import DesignerTemplate
+
+
+# https://github.com/mathiasbynens/small/blob/master/bmp.bmp
+DUMMY_BMP_IMAGE = (b'BM\x1e\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x0c\x00'
+                   b'\x00\x00\x01\x00\x01\x00\x01\x00\x18\x00\x00\x00\xff\x00')
+
+
+@pytest.fixture
+def create_dummy_designer_template(db):
+    def _create(event, title, type, data=DEFAULT_TICKET_DATA, **kwargs):
+        template = DesignerTemplate(event=event, title='Default ticket', type=TemplateType.badge, data=data, **kwargs)
+        db.session.flush()
+        return template
+    return _create
+
+
+@pytest.fixture
+def dummy_designer_template(dummy_event, create_dummy_designer_template):
+    return create_dummy_designer_template(dummy_event, 'Default ticket', TemplateType.badge)
+
+
+@pytest.fixture
+def dummy_designer_image_file(dummy_designer_template):
+    image = DesignerImageFile(filename='designer-image.bmp', content_type='image/bmp', template=dummy_designer_template)
+    image.save(BytesIO(DUMMY_BMP_IMAGE))
+    db.session.flush()
+    return image

--- a/indico/modules/designer/tests/test_replace_text_placeholders.txt
+++ b/indico/modules/designer/tests/test_replace_text_placeholders.txt
@@ -18,13 +18,13 @@ Group 'registrant':
 	country: Switzerland
 	email: 1337@example.test
 	first_name: Guinea
-	full_name: Mr PIG, G.
-	full_name_b: Mr G. PIG
-	full_name_b_no_title: G. PIG
-	full_name_c: Mr G. PIG
+	full_name: Mr Pig, Guinea
+	full_name_b: Mr Guinea Pig
+	full_name_b_no_title: Guinea Pig
+	full_name_c: Mr Guinea PIG
 	full_name_d: Mr G. PIG
-	full_name_no_title: PIG, G.
-	full_name_no_title_c: PIG, G.
+	full_name_no_title: Pig, Guinea
+	full_name_no_title_c: PIG, Guinea
 	full_name_no_title_d: PIG, G.
 	last_name: Pig
 	num_accompanying_persons: 5

--- a/indico/modules/designer/tests/test_replace_text_placeholders.txt
+++ b/indico/modules/designer/tests/test_replace_text_placeholders.txt
@@ -1,0 +1,35 @@
+Group 'event':
+	category_title: dummy
+	event_dates: 1–2 Jan 2023
+	event_description: <div class="preformatted">Dummy event description</div>
+	event_organizers: CERN
+	event_room: Dummy room
+	event_speakers: Guinea Pig, Guinea Pig
+	event_title: Dummy event title
+	event_venue: Dummy venue
+Group 'fixed':
+	fixed: Hello, world!
+Group 'registrant':
+	accompanying_persons: Wanda WHIZBANG, Quentin QUIBBLE, Gertrude GIGGLESNORT, Buford BUMBLEBEE, Penelope PUDDLEJUMPER
+	accompanying_persons_abbrev: W. WHIZBANG, Q. QUIBBLE, G. GIGGLESNORT, B. BUMBLEBEE, P. PUDDLEJUMPER
+	address: 1211 Geneva 23, Switzerland
+	affiliation: CERN
+	amount: 100.00
+	country: Switzerland
+	email: 1337@example.test
+	first_name: Guinea
+	full_name: Mr PIG, G.
+	full_name_b: Mr G. PIG
+	full_name_b_no_title: G. PIG
+	full_name_c: Mr G. PIG
+	full_name_d: Mr G. PIG
+	full_name_no_title: PIG, G.
+	full_name_no_title_c: PIG, G.
+	full_name_no_title_d: PIG, G.
+	last_name: Pig
+	num_accompanying_persons: 5
+	phone: +41227676000
+	position: Developer
+	price: US$100.00
+	registration_friendly_id: 1
+	title: Mr

--- a/indico/modules/events/registration/testing/fixtures.py
+++ b/indico/modules/events/registration/testing/fixtures.py
@@ -7,8 +7,10 @@
 
 import pytest
 
+from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.forms import RegistrationForm
-from indico.modules.events.registration.models.registrations import Registration, RegistrationState
+from indico.modules.events.registration.models.items import RegistrationFormSection
+from indico.modules.events.registration.models.registrations import Registration, RegistrationData, RegistrationState
 from indico.modules.events.registration.util import create_personal_data_fields
 
 
@@ -62,3 +64,63 @@ def create_registration(dummy_event):
         )
 
     return _create_registration
+
+
+def _id(n):
+    assert 0 <= n < 10000000
+    return f'{n:08d}-0000-0000-0000-000000000000'
+
+
+@pytest.fixture
+def create_accompanying_persons():
+    def _create_accompanying_persons(n):
+        names = [
+            {'firstName': 'Wanda', 'lastName': 'Whizbang'},
+            {'firstName': 'Quentin', 'lastName': 'Quibble'},
+            {'firstName': 'Gertrude', 'lastName': 'Gigglesnort'},
+            {'firstName': 'Buford', 'lastName': 'Bumblebee'},
+            {'firstName': 'Penelope', 'lastName': 'Puddlejumper'},
+            {'firstName': 'Winston', 'lastName': 'Wobblebottom'},
+        ]
+        length = len(names)
+        return [{'id': _id(i)} | names[i % length] for i in range(n)]
+    return _create_accompanying_persons
+
+
+@pytest.fixture
+def create_accompanying_persons_field(db, dummy_regform, create_accompanying_persons):
+    def _create_accompanying_persons_field(max_persons, persons_count_against_limit,
+                                           registration=None, data=None, num_persons=0):
+        section = RegistrationFormSection(
+            registration_form=dummy_regform,
+            title='dummy_section',
+            is_manager_only=False
+        )
+        db.session.add(section)
+        db.session.flush()
+        field = RegistrationFormField(
+            input_type='accompanying_persons',
+            title='Field',
+            parent=section,
+            registration_form=dummy_regform
+        )
+        field.field_impl.form_item.data = {
+            'max_persons': max_persons,
+            'persons_count_against_limit': persons_count_against_limit,
+        }
+        field.versioned_data = field.field_impl.form_item.data
+        if registration:
+            registration.data.append(RegistrationData(
+                field_data=field.current_data,
+                data=(data if data is not None else create_accompanying_persons(num_persons))
+            ))
+            db.session.flush()
+        return field
+
+    return _create_accompanying_persons_field
+
+
+@pytest.fixture
+def dummy_accompanying_persons_field(db, dummy_reg, create_accompanying_persons_field):
+    return create_accompanying_persons_field(max_persons=5, persons_count_against_limit=False,
+                                             registration=dummy_reg, num_persons=5)

--- a/indico/testing/fixtures/event.py
+++ b/indico/testing/fixtures/event.py
@@ -13,6 +13,12 @@ from indico.modules.events import Event
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.labels import EventLabel
 from indico.util.date_time import now_utc
+from indico.util.string import crc32
+
+
+# https://github.com/mathiasbynens/small/blob/master/bmp.bmp
+DUMMY_BMP_IMAGE = (b'BM\x1e\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x0c\x00'
+                   b'\x00\x00\x01\x00\x01\x00\x01\x00\x18\x00\x00\x00\xff\x00')
 
 
 @pytest.fixture
@@ -53,3 +59,14 @@ def create_label(db):
 def dummy_event(create_event):
     """Create a mocked dummy event."""
     return create_event(0)
+
+
+@pytest.fixture
+def dummy_event_logo(dummy_event):
+    dummy_event.logo = DUMMY_BMP_IMAGE
+    dummy_event.logo_metadata = {
+        'hash': crc32(dummy_event.logo),
+        'size': len(dummy_event.logo),
+        'filename': 'dummy-event-logo.bmp',
+        'content_type': 'image/bmp'
+    }


### PR DESCRIPTION
This PR adds missing tests for placeholders used by the badge/ticket designer.

For text placeholders, we render all of them in a template which is saved as a snapshot.
For image placeholders, we only check that the return value of `render()` is an image.

I moved the accompanying persons fixture into the registration fixures since it's now used in two places.
I also added some extra fixtures for designer templates and the event logo (with dummy (but valid) images)