### PR TITLE
Show more relevant events in 'Events at hand'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,8 @@ Improvements
 - Log editor actions in the Editing module (:pr:`6015`)
 - Grant subcontribution speakers submission privileges by default in newly created events
   (:issue:`5905`, :pr:`6025`)
+- Stop overwhelmingly showing past events in the 'Events at hand' section in the user dashboard
+  (:pr:`6049`)
 
 Bugfixes
 ^^^^^^^^


### PR DESCRIPTION
Currently, we show up to 10 events whose end date is at most 1 week in the past sorted by start_date. If a user has more than 10 events which ended in the last week, no future events are shown.

This change sorts the events based on the absolute difference with respect to the current date so that both past and future events are shown more equally.
