### PR TITLE
Fix contribution list filters being obscured

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Bugfixes
 - Fix the author/speaker selector (e.g. for abstracts) breaking when submitting the form and
   getting a validation error (:issue:`6043`, :pr:`6053`)
 - Do not cancel past linked room bookings when deleting an event (:issue:`6032`, :pr:`6051`)
+- Fix contribution list filters being obscured by the action dialog (:pr:`6055`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/client/js/util/list_generator.js
+++ b/indico/modules/events/client/js/util/list_generator.js
@@ -66,6 +66,14 @@
     const visibleItems = $('#visible-items');
     const hasColumnSelector = !!$('#visible-items').length;
 
+    // The form dialog has a combination of overflow: hidden and auto.
+    // Since the list filter is much larger when expanded, most of its
+    // options would not be visible without changing the overflow property to visible.
+    const popup = $(`.list-filter`).closest('.exclusivePopup');
+    const dialog = popup.parent();
+    popup.css('overflow', 'visible');
+    dialog.css('overflow', 'visible');
+
     $('.list-filter .filter').each(function() {
       const $filter = $(this).parent();
       const isOnlyFilter = !!$filter.find('[data-only-filter]').length;


### PR DESCRIPTION
This PR fixes a bug in which the contribution list filters get obscured by the action dialog:

![image](https://github.com/indico/indico/assets/27357203/c6ed6351-efe7-4584-8d49-4cf1738cf727)
