### PR TITLE
Only allow blocking ticket templates via `is_ticket_blocked`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -68,6 +68,7 @@ Bugfixes
 - Ignore deleted fields when computing the number of occupied slots for a registration (:pr:`6035`)
 - Show the description of a subcontribution in conference events (:issue:`5946`, :pr:`6056`)
 - Only allow blocking templates containing a QR code via `is_ticket_blocked` (:pr:`6062`)
+- Only block templates containing a QR code via ``is_ticket_blocked`` (:pr:`6062`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,7 @@ Bugfixes
   or vice versa (:pr:`5999`)
 - Ignore deleted fields when computing the number of occupied slots for a registration (:pr:`6035`)
 - Show the description of a subcontribution in conference events (:issue:`5946`, :pr:`6056`)
+- Only allow blocking templates containing a QR code via `is_ticket_blocked` (:pr:`6062`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,7 +67,6 @@ Bugfixes
   or vice versa (:pr:`5999`)
 - Ignore deleted fields when computing the number of occupied slots for a registration (:pr:`6035`)
 - Show the description of a subcontribution in conference events (:issue:`5946`, :pr:`6056`)
-- Only allow blocking templates containing a QR code via `is_ticket_blocked` (:pr:`6062`)
 - Only block templates containing a QR code via ``is_ticket_blocked`` (:pr:`6062`)
 
 Accessibility

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -27,8 +27,7 @@ from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.events.registration.notifications import notify_registration_state_update
 from indico.modules.events.registration.util import (check_registration_email, create_registration, generate_ticket,
                                                      get_event_regforms_registrations, get_flat_section_submission_data,
-                                                     get_initial_form_values, get_ticket_template, get_user_data,
-                                                     make_registration_schema)
+                                                     get_initial_form_values, get_user_data, make_registration_schema)
 from indico.modules.events.registration.views import (WPDisplayRegistrationFormConference,
                                                       WPDisplayRegistrationFormSimpleEvent,
                                                       WPDisplayRegistrationParticipantList)
@@ -455,7 +454,7 @@ class RHTicketDownload(RHRegistrationFormRegistrationBase):
         if (not self.regform.ticket_on_event_page and not self.regform.ticket_on_summary_page
                 and not self.regform.event.can_manage(session.user, 'registration')):
             raise Forbidden
-        ticket_template = get_ticket_template(self.regform)
+        ticket_template = self.regform.get_ticket_template()
         if ticket_template.is_ticket and self.registration.is_ticket_blocked:
             raise Forbidden
 

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -27,7 +27,8 @@ from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.events.registration.notifications import notify_registration_state_update
 from indico.modules.events.registration.util import (check_registration_email, create_registration, generate_ticket,
                                                      get_event_regforms_registrations, get_flat_section_submission_data,
-                                                     get_initial_form_values, get_user_data, make_registration_schema)
+                                                     get_initial_form_values, get_ticket_template, get_user_data,
+                                                     make_registration_schema)
 from indico.modules.events.registration.views import (WPDisplayRegistrationFormConference,
                                                       WPDisplayRegistrationFormSimpleEvent,
                                                       WPDisplayRegistrationParticipantList)
@@ -454,7 +455,8 @@ class RHTicketDownload(RHRegistrationFormRegistrationBase):
         if (not self.regform.ticket_on_event_page and not self.regform.ticket_on_summary_page
                 and not self.regform.event.can_manage(session.user, 'registration')):
             raise Forbidden
-        if self.registration.is_ticket_blocked:
+        ticket_template = get_ticket_template(self.regform)
+        if ticket_template.is_ticket and self.registration.is_ticket_blocked:
             raise Forbidden
 
     def _process(self):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -315,7 +315,7 @@ class RHRegistrationEmailRegistrants(RHRegistrationsActionBase):
                            '{num} emails were sent.', num_emails_sent).format(num=num_emails_sent), 'success')
             return jsonify_data()
 
-        template_is_ticket = self.regform.get_ticket_template()        .is_ticket
+        template_is_ticket = self.regform.get_ticket_template().is_ticket
         registrations_without_ticket = [r for r in self.registrations if template_is_ticket and r.is_ticket_blocked]
         return jsonify_template('events/registration/management/email.html', form=form, regform=self.regform,
                                 all_registrations_count=len(self.registrations),

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -315,9 +315,8 @@ class RHRegistrationEmailRegistrants(RHRegistrationsActionBase):
                            '{num} emails were sent.', num_emails_sent).format(num=num_emails_sent), 'success')
             return jsonify_data()
 
-        ticket_template = self.regform.get_ticket_template()
-        registrations_without_ticket = [r for r in self.registrations if (ticket_template.is_ticket and
-                                                                          r.is_ticket_blocked)]
+        template_is_ticket = self.regform.get_ticket_template()        .is_ticket
+        registrations_without_ticket = [r for r in self.registrations if template_is_ticket and r.is_ticket_blocked]
         return jsonify_template('events/registration/management/email.html', form=form, regform=self.regform,
                                 all_registrations_count=len(self.registrations),
                                 registrations_without_ticket_count=len(registrations_without_ticket))
@@ -600,8 +599,8 @@ class RHRegistrationsConfigTickets(RHRegistrationsConfigBadges):
         return str(self.regform.ticket_template_id) if self.regform.ticket_template_id else None
 
     def _filter_registrations(self, registrations):
-        template = DesignerTemplate.get_or_404(self.template_id)
-        return [r for r in registrations if not template.is_ticket or not r.is_ticket_blocked]
+        template_is_ticket = DesignerTemplate.get_or_404(self.template_id).is_ticket
+        return [r for r in registrations if not template_is_ticket or not r.is_ticket_blocked]
 
 
 class RHRegistrationTogglePayment(RHManageRegistrationBase):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -51,9 +51,8 @@ from indico.modules.events.registration.settings import event_badge_settings
 from indico.modules.events.registration.util import (ActionMenuEntry, create_registration,
                                                      generate_spreadsheet_from_registrations,
                                                      get_flat_section_submission_data, get_initial_form_values,
-                                                     get_ticket_attachments, get_ticket_template, get_title_uuid,
-                                                     get_user_data, import_registrations_from_csv,
-                                                     make_registration_schema)
+                                                     get_ticket_attachments, get_title_uuid, get_user_data,
+                                                     import_registrations_from_csv, make_registration_schema)
 from indico.modules.events.registration.views import WPManageRegistration
 from indico.modules.events.util import ZipGeneratorMixin
 from indico.modules.logs import LogKind
@@ -286,7 +285,7 @@ class RHRegistrationEmailRegistrants(RHRegistrationsActionBase):
                 template = get_template_module('events/registration/emails/custom_email.html',
                                                email_subject=email_subject, email_body=email_body)
                 bcc = [session.user.email] if form.copy_for_sender.data else []
-                ticket_template = get_ticket_template(self.regform)
+                ticket_template = self.regform.get_ticket_template()
                 is_ticket_blocked = ticket_template.is_ticket and registration.is_ticket_blocked
                 attach_ticket = (
                     'attach_ticket' in form and form.attach_ticket.data and not is_ticket_blocked
@@ -316,7 +315,7 @@ class RHRegistrationEmailRegistrants(RHRegistrationsActionBase):
                            '{num} emails were sent.', num_emails_sent).format(num=num_emails_sent), 'success')
             return jsonify_data()
 
-        ticket_template = get_ticket_template(self.regform)
+        ticket_template = self.regform.get_ticket_template()
         registrations_without_ticket = [r for r in self.registrations if (ticket_template.is_ticket and
                                                                           r.is_ticket_blocked)]
         return jsonify_template('events/registration/management/email.html', form=form, regform=self.regform,

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -519,6 +519,11 @@ class RegistrationForm(db.Model):
         if email:
             return Registration.query.with_parent(self).filter_by(email=email).filter(~Registration.is_deleted).first()
 
+    def get_ticket_template(self):
+        """Get the current ticket template or, if not set, the default category one."""
+        from indico.modules.designer.util import get_default_ticket_on_category
+        return self.ticket_template or get_default_ticket_on_category(self.event.category)
+
     def render_base_price(self):
         return format_currency(self.base_price, self.currency, locale=session.lang or 'en_GB')
 

--- a/indico/modules/events/registration/templates/display/registration_summary.html
+++ b/indico/modules/events/registration/templates/display/registration_summary.html
@@ -81,8 +81,9 @@
                     {% endif %}
                 </div>
             {% endif %}
+            {% set ticket_template = registration.registration_form.get_ticket_template() %}
             {% if registration.state.name == 'complete' and registration.registration_form.tickets_enabled and
-                  registration.registration_form.ticket_on_summary_page and not registration.is_ticket_blocked %}
+                  registration.registration_form.ticket_on_summary_page and (not ticket_template.is_ticket or not registration.is_ticket_blocked) %}
                 <div class="group">
                     <a href="{{ url_for('.ticket_download', registration.locator.registrant) }}" class="i-button accept icon-ticket">
                         {% trans %}Get ticket{% endtrans %}

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -166,7 +166,8 @@
         {%- endtrans %}
     </div>
     {% set can_reset = registration.registration_form.moderation_enabled and not registration.is_paid %}
-    {% set can_get_ticket = registration.registration_form.tickets_enabled and not registration.is_ticket_blocked %}
+    {% set ticket_template = registration.registration_form.get_ticket_template() %}
+    {% set can_get_ticket = registration.registration_form.tickets_enabled and (not ticket_template.is_ticket or not registration.is_ticket_blocked) %}
     {% if can_reset or can_get_ticket %}
         <div class="toolbar">
             {% if can_reset %}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -572,9 +572,9 @@ def get_registrations_with_tickets(user, event):
 
     def _is_ticket_blocked(registration):
         regform = registration.registration_form
-        if regform.id not in cached_templates:
-            cached_templates[regform.id] = regform.get_ticket_template()
-        return cached_templates[regform.id].is_ticket and registration.is_ticket_blocked
+        if regform not in cached_templates:
+            cached_templates[regform] = regform.get_ticket_template()
+        return cached_templates[regform].is_ticket and registration.is_ticket_blocked
 
     return [r for r in query if not _is_ticket_blocked(r)]
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -559,7 +559,6 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
 
 
 def get_registrations_with_tickets(user, event):
-    from indico.modules.events.registration.util import get_ticket_template
     query = (Registration.query.with_parent(event)
              .filter(Registration.user == user,
                      Registration.state == RegistrationState.complete,
@@ -574,7 +573,7 @@ def get_registrations_with_tickets(user, event):
     def _is_ticket_blocked(registration):
         regform = registration.registration_form
         if regform.id not in cached_templates:
-            cached_templates[regform.id] = get_ticket_template(regform)
+            cached_templates[regform.id] = regform.get_ticket_template()
         return cached_templates[regform.id].is_ticket and registration.is_ticket_blocked
 
     return [r for r in query if not _is_ticket_blocked(r)]
@@ -764,7 +763,7 @@ def get_event_regforms_registrations(event, user, include_scheduled=True, only_i
 
 def generate_ticket(registration):
     from indico.modules.events.registration.controllers.management.tickets import DEFAULT_TICKET_PRINTING_SETTINGS
-    template = get_ticket_template(registration.registration_form)
+    template = registration.registration_form.get_ticket_template()
     registrations = [registration]
     signals.event.designer.print_badge_template.send(template, regform=registration.registration_form,
                                                      registrations=registrations)
@@ -772,12 +771,6 @@ def generate_ticket(registration):
     pdf = pdf_class(template, DEFAULT_TICKET_PRINTING_SETTINGS, registration.event, registrations,
                     registration.registration_form.tickets_for_accompanying_persons)
     return pdf.get_pdf()
-
-
-def get_ticket_template(regform):
-    """Get the ticket template for a regform."""
-    from indico.modules.designer.util import get_default_ticket_on_category
-    return regform.ticket_template or get_default_ticket_on_category(regform.event.category)
 
 
 def get_ticket_attachments(registration):

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -569,9 +569,13 @@ def get_registrations_with_tickets(user, event):
                      ~Registration.is_deleted)
              .join(Registration.registration_form))
 
+    cached_templates = {}
+
     def _is_ticket_blocked(registration):
-        ticket_template = get_ticket_template(registration.registration_form)
-        return ticket_template.is_ticket and registration.is_ticket_blocked
+        regform = registration.registration_form
+        if regform.id not in cached_templates:
+            cached_templates[regform.id] = get_ticket_template(regform)
+        return cached_templates[regform.id].is_ticket and registration.is_ticket_blocked
 
     return [r for r in query if not _is_ticket_blocked(r)]
 


### PR DESCRIPTION
Currently plugins can block non-ticket templates (templates that do not contain a ticket QR code) via the 'is_ticket_blocked' signal.
This change only allows blocking templates which contain a QR code.

This is a followup fix to a SNOW ticket. There was an event with an active CERN access request which was preventing the organizers from sending a custom ticket (which did not contain a QR code) to the participants. The plugin was setting `is_ticket_blocked` and on the Indico side we were not distinguishing ticket and non-ticket templates.