### PR TITLE
Fix missing button border in draft mode warning dialog

### DIFF
--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -426,14 +426,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   global.setupDraftModeWarning = function setupDraftModeWarning() {
     const warning = document.querySelector('#draft-mode-warning');
-    const button = document.querySelector('#draft-mode-warning-button');
-    if (warning && button) {
+    const buttonContainer = document.querySelector('#draft-mode-warning-button-container');
+    if (warning && buttonContainer) {
       ReactDOM.render(
         <PublicationButton
-          eventId={button.dataset.eventId}
+          eventId={buttonContainer.dataset.eventId}
           onSuccess={() => warning.classList.add('hidden')}
         />,
-        button
+        buttonContainer
       );
     }
   };

--- a/indico/modules/events/contributions/templates/management/_draft_mode_warning.html
+++ b/indico/modules/events/contributions/templates/management/_draft_mode_warning.html
@@ -9,9 +9,7 @@
                 {% endtrans %}
             </div>
             <div class="toolbar">
-                <div class="group">
-                    <span id="draft-mode-warning-button" data-event-id="{{ event.id }}"></span>
-                </div>
+                <div id="draft-mode-warning-button-container" data-event-id="{{ event.id }}" class="group"></div>
             </div>
         </div>
 


### PR DESCRIPTION
`.i-button`s have to be direct descendants of `.group` containers, otherwise the right border is not set correctly for the last button in the group. This just removes wrapping span which fixes the issue.