### PR TITLE
Create template block around rendering print dialog

### DIFF
--- a/indico/modules/events/registration/templates/management/print_badges.html
+++ b/indico/modules/events/registration/templates/management/print_badges.html
@@ -13,5 +13,7 @@
 {% endif %}
 
 {% if registrations %}
-    {{ render_badge_print_settings_form(settings_form, templates=templates, registrations=registrations) }}
+    {% block show_badge_printer_settings_form scoped %}
+        {{ render_badge_print_settings_form(settings_form, templates=templates, registrations=registrations) }}
+    {% endblock %}
 {% endif %}


### PR DESCRIPTION
In order to be able make some customization on the badge printing dialog it is needed to be "blockerized".