### PR TITLE
Improve labels for timeline actions

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -49,7 +49,7 @@ const judgmentOptions = [
   },
   {
     value: EditingReviewAction.update,
-    text: Translate.string('Make changes'),
+    text: Translate.string('Request approval'),
     color: 'yellow',
     class: 'needs-submitter-confirmation',
   },

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/RequestChangesForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/RequestChangesForm.jsx
@@ -75,7 +75,7 @@ export default function RequestChangesForm({setLoading, onSuccess}) {
           <Form.Field>
             <Checkbox
               toggle
-              label={Translate.string('Make changes to the submission')}
+              label={Translate.string('Upload files')}
               checked={uploadChanges}
               onChange={(__, {checked}) => setUploadChanges(checked)}
             />


### PR DESCRIPTION
This PR improves the label texts for some editing timeline actions, in order to make more sense for paper editors:

- Make changes -> Request approval
- Make changes to the submission -> Upload files