### PR TITLE
Show which persons are external in the user search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,7 @@ Improvements
   (:pr:`6049`)
 - Add document templates to generate PDF receipts, certificates, and similar documents for
   event participants (:pr:`5123`)
+- Show which persons are external in the user search dialog (:pr:`6074`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -366,7 +366,7 @@ function PersonLinkField({
             triggerFactory={props => (
               <Button type="button" {...props}>
                 <Icon name="search" />
-                <Translate>Search</Translate>
+                <Translate>Add from Search</Translate>
               </Button>
             )}
             withExternalUsers

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -366,7 +366,7 @@ function PersonLinkField({
             triggerFactory={props => (
               <Button type="button" {...props}>
                 <Icon name="search" />
-                <Translate>Add from Search</Translate>
+                <Translate>Add from search</Translate>
               </Button>
             )}
             withExternalUsers

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -201,7 +201,7 @@ const searchFactory = config => {
               )}
               {external && (
                 <Popup
-                  content={Translate.string('Person does not yet have an Indico account')}
+                  content={Translate.string('Person does not have an Indico account yet')}
                   trigger={<Icon name="external" styleName="event-person" corner="top right" />}
                   offset={[-15, 0]}
                   position="top left"

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -173,6 +173,7 @@ const searchFactory = config => {
     onAdd,
     onRemove,
     existsInEvent,
+    external,
     avatarURL,
   }) => {
     const avatar = avatarURL ? (
@@ -194,6 +195,14 @@ const searchFactory = config => {
                 <Popup
                   content={Translate.string('Person exists in event')}
                   trigger={<Icon name="ticket" styleName="event-person" corner="top right" />}
+                  offset={[-15, 0]}
+                  position="top left"
+                />
+              )}
+              {external && (
+                <Popup
+                  content={Translate.string('Person does not yet have an Indico account')}
+                  trigger={<Icon name="external" styleName="event-person" corner="top right" />}
                   offset={[-15, 0]}
                   position="top left"
                 />
@@ -247,6 +256,7 @@ const searchFactory = config => {
                 onAdd={() => onAdd(r)}
                 onRemove={() => onRemove(r)}
                 existsInEvent={r.existsInEvent}
+                external={r.type === 'user' && r.userId === null}
                 avatarURL={r.avatarURL}
               />
             ))}


### PR DESCRIPTION
This PR adds an indication to whether a person has an indico account or not when searching for users:
<img width="633" alt="image" src="https://github.com/indico/indico/assets/27357203/7fd4c3db-cba9-4c52-a917-ceb52882b8e2">

Also, the "Search" button from the PersonLinkField was changed to "Add from Search" for clarity.