### PR TITLE
Improve accessibility of the registration form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,8 @@ Accessibility
   :pr:`5986`, thanks :user:`foxbunny`)
 - Add proper labels to the captcha play and reload buttons (:issue:`6064`, :pr:`6080`,
   :thanks:`foxbunny`)
+- Associate form labels with form controls in the registration form (:issue:`6059`, :issue:`6073`,
+  :pr:`6076`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -107,6 +107,21 @@ export default function FormItem({
 
   const showAsRequired = meta.alwaysRequired || isRequired;
   const inputRequired = !isManagement && showAsRequired;
+  const htmlId = `input-${inputProps.id}`;
+
+  const fieldControls = (
+    <>
+      {retentionPeriodIcon}
+      <InputComponent
+        isRequired={inputRequired}
+        disabled={disabled}
+        isPurged={showPurged}
+        htmlId={htmlId}
+        {...inputProps}
+      />
+    </>
+  );
+
   return (
     <div
       styleName={`form-item ${toClasses({
@@ -130,14 +145,24 @@ export default function FormItem({
             />
           ) : (
             <Form.Field required={showAsRequired} styleName="field">
-              <label style={{opacity: disabled ? 0.8 : 1, display: 'inline-block'}}>{title}</label>
-              {retentionPeriodIcon}
-              <InputComponent
-                isRequired={inputRequired}
-                disabled={disabled}
-                isPurged={showPurged}
-                {...inputProps}
-              />
+              {meta.renderAsFieldset ? (
+                <fieldset>
+                  <legend style={{opacity: disabled ? 0.8 : 1, display: 'inline-block'}}>
+                    {title}
+                  </legend>
+                  {fieldControls}
+                </fieldset>
+              ) : (
+                <>
+                  <label
+                    htmlFor={htmlId}
+                    style={{opacity: disabled ? 0.8 : 1, display: 'inline-block'}}
+                  >
+                    {title}
+                  </label>
+                  {fieldControls}
+                </>
+              )}
             </Form.Field>
           )
         ) : (

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -109,18 +109,19 @@ export default function FormItem({
   const inputRequired = !isManagement && showAsRequired;
   const htmlId = `input-${inputProps.id}`;
 
-  const fieldControls = (
-    <>
-      {retentionPeriodIcon}
-      <InputComponent
-        isRequired={inputRequired}
-        disabled={disabled}
-        isPurged={showPurged}
-        htmlId={htmlId}
-        {...inputProps}
-      />
-    </>
-  );
+  const fieldControls =
+    InputComponent && !meta.customFormItem ? (
+      <>
+        {retentionPeriodIcon}
+        <InputComponent
+          isRequired={inputRequired}
+          disabled={disabled}
+          isPurged={showPurged}
+          htmlId={htmlId}
+          {...inputProps}
+        />
+      </>
+    ) : null;
 
   return (
     <div

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -141,6 +141,7 @@ export default function FormItem({
               disabled={disabled}
               isPurged={showPurged}
               retentionPeriodIcon={retentionPeriodIcon}
+              htmlId={htmlId}
               {...inputProps}
             />
           ) : (

--- a/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
@@ -28,6 +28,7 @@ import '../../../styles/regform.module.scss';
 import './table.module.scss';
 
 function AccommodationInputComponent({
+  id,
   existingValue,
   value,
   onChange,
@@ -89,15 +90,16 @@ function AccommodationInputComponent({
 
   return (
     <div styleName="accommodation-field">
-      <table styleName="choice-table">
+      <table styleName="choice-table" role="presentation">
         <tbody>
           {choices
             .filter(c => c.isEnabled || !c.isNoAccommodation)
-            .map(c => {
+            .map((c, index) => {
               return (
                 <tr key={c.id} styleName="row">
                   <td>
                     <Form.Radio
+                      id={id ? `${id}-${index}` : ''}
                       style={{pointerEvents: 'auto'}} // keep label tooltips working when disabled
                       styleName="radio"
                       label={{
@@ -175,6 +177,7 @@ function AccommodationInputComponent({
 }
 
 AccommodationInputComponent.propTypes = {
+  id: PropTypes.string.isRequired,
   value: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
@@ -194,6 +197,7 @@ AccommodationInputComponent.propTypes = {
 
 export default function AccommodationInput({
   id,
+  htmlId,
   htmlName,
   disabled,
   isRequired,
@@ -206,6 +210,7 @@ export default function AccommodationInput({
   const existingValue = useSelector(state => getFieldValue(state, id)) || {choice: null};
   return (
     <FinalField
+      id={htmlId}
       name={htmlName}
       existingValue={existingValue}
       component={AccommodationInputComponent}
@@ -230,6 +235,7 @@ export default function AccommodationInput({
 
 AccommodationInput.propTypes = {
   id: PropTypes.number.isRequired,
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,

--- a/indico/modules/events/registration/client/js/form/fields/AccompanyingPersonsInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccompanyingPersonsInput.jsx
@@ -92,6 +92,7 @@ function calculatePlaces(availablePlaces, maxPersons, personsInCurrentField, ite
 }
 
 function AccompanyingPersonsComponent({
+  id,
   value,
   disabled,
   onChange,
@@ -128,12 +129,12 @@ function AccompanyingPersonsComponent({
     setOperation({type: 'ADD', person: null});
   };
 
-  const handleAccompanyingPersonEdit = id => {
-    setOperation({type: 'EDIT', person: value.find(p => p.id === id)});
+  const handleAccompanyingPersonEdit = personId => {
+    setOperation({type: 'EDIT', person: value.find(p => p.id === personId)});
   };
 
-  const handleAccompanyingPersonRemove = id => {
-    onChange(changeReducer({type: 'REMOVE', id}));
+  const handleAccompanyingPersonRemove = personId => {
+    onChange(changeReducer({type: 'REMOVE', id: personId}));
   };
 
   const handleModalClose = () => {
@@ -174,6 +175,7 @@ function AccompanyingPersonsComponent({
           type="button"
           onClick={handleAccompanyingPersonAdd}
           disabled={disabled || placesLimit - placesUsed === 0}
+          aria-describedby={id ? `${id}-placeslimit` : ''}
         >
           <Translate>Add accompanying person</Translate>
         </Button>
@@ -183,7 +185,7 @@ function AccompanyingPersonsComponent({
           </Label>
         )}
         {placesLimit !== Infinity && (
-          <div styleName="places-left">
+          <div id={`${id}-placeslimit`} styleName="places-left">
             <PlacesLeft placesLimit={placesLimit} placesUsed={placesUsed} isEnabled={!disabled} />
           </div>
         )}
@@ -208,6 +210,7 @@ function AccompanyingPersonsComponent({
 }
 
 AccompanyingPersonsComponent.propTypes = {
+  id: PropTypes.string.isRequired,
   value: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,
@@ -230,6 +233,7 @@ AccompanyingPersonsComponent.defaultProps = {
 };
 
 export default function AccompanyingPersonsInput({
+  htmlId,
   htmlName,
   disabled,
   price,
@@ -238,6 +242,7 @@ export default function AccompanyingPersonsInput({
 }) {
   return (
     <FinalField
+      id={htmlId}
       name={htmlName}
       component={AccompanyingPersonsComponent}
       disabled={disabled}
@@ -249,6 +254,7 @@ export default function AccompanyingPersonsInput({
 }
 
 AccompanyingPersonsInput.propTypes = {
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   price: PropTypes.number,

--- a/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
@@ -94,6 +94,7 @@ BooleanInputComponent.defaultProps = {
 
 export default function BooleanInput({
   id,
+  htmlId,
   htmlName,
   disabled,
   isRequired,
@@ -110,7 +111,7 @@ export default function BooleanInput({
 
   return (
     <FinalField
-      id={id}
+      id={htmlId || id}
       name={htmlName}
       component={BooleanInputComponent}
       required={isRequired ? 'no-validator' : isRequired}
@@ -127,6 +128,7 @@ export default function BooleanInput({
 
 BooleanInput.propTypes = {
   id: PropTypes.number.isRequired,
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,

--- a/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
@@ -22,6 +22,7 @@ import '../../../styles/regform.module.scss';
 
 function BooleanInputComponent({
   id,
+  htmlId,
   value,
   onChange,
   disabled,
@@ -47,6 +48,7 @@ function BooleanInputComponent({
       <Button.Group>
         <Button
           type="button"
+          id={htmlId}
           active={!isPurged && value === true}
           disabled={disabled || (placesLimit > 0 && placesUsed >= placesLimit && !existingValue)}
           onClick={makeOnClick(true)}
@@ -78,6 +80,7 @@ function BooleanInputComponent({
 
 BooleanInputComponent.propTypes = {
   id: PropTypes.number.isRequired,
+  htmlId: PropTypes.string.isRequired,
   value: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
@@ -111,7 +114,8 @@ export default function BooleanInput({
 
   return (
     <FinalField
-      id={htmlId || id}
+      id={id}
+      htmlId={htmlId}
       name={htmlName}
       component={BooleanInputComponent}
       required={isRequired ? 'no-validator' : isRequired}

--- a/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
@@ -22,7 +22,6 @@ import '../../../styles/regform.module.scss';
 
 function BooleanInputComponent({
   id,
-  htmlId,
   value,
   onChange,
   disabled,
@@ -48,7 +47,6 @@ function BooleanInputComponent({
       <Button.Group>
         <Button
           type="button"
-          id={htmlId}
           active={!isPurged && value === true}
           disabled={disabled || (placesLimit > 0 && placesUsed >= placesLimit && !existingValue)}
           onClick={makeOnClick(true)}
@@ -80,7 +78,6 @@ function BooleanInputComponent({
 
 BooleanInputComponent.propTypes = {
   id: PropTypes.number.isRequired,
-  htmlId: PropTypes.string.isRequired,
   value: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
@@ -97,7 +94,6 @@ BooleanInputComponent.defaultProps = {
 
 export default function BooleanInput({
   id,
-  htmlId,
   htmlName,
   disabled,
   isRequired,
@@ -115,7 +111,6 @@ export default function BooleanInput({
   return (
     <FinalField
       id={id}
-      htmlId={htmlId}
       name={htmlName}
       component={BooleanInputComponent}
       required={isRequired ? 'no-validator' : isRequired}
@@ -132,7 +127,6 @@ export default function BooleanInput({
 
 BooleanInput.propTypes = {
   id: PropTypes.number.isRequired,
-  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,

--- a/indico/modules/events/registration/client/js/form/fields/CheckboxInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/CheckboxInput.jsx
@@ -23,6 +23,7 @@ import styles from '../../../styles/regform.module.scss';
 
 export default function CheckboxInput({
   id,
+  htmlId,
   htmlName,
   disabled,
   title,
@@ -35,9 +36,11 @@ export default function CheckboxInput({
 }) {
   const currency = useSelector(getCurrency);
   const existingValue = useSelector(state => getFieldValue(state, id));
+  const checkboxId = `${htmlId}-checkbox`;
 
   return (
     <FinalCheckbox
+      id={checkboxId}
       fieldProps={{className: `${styles.field} ${showAsRequired ? 'required' : ''}`}}
       name={htmlName}
       label={title}
@@ -65,6 +68,7 @@ export default function CheckboxInput({
 
 CheckboxInput.propTypes = {
   id: PropTypes.number.isRequired,
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   title: PropTypes.string.isRequired,

--- a/indico/modules/events/registration/client/js/form/fields/CountryInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/CountryInput.jsx
@@ -51,9 +51,10 @@ CountryInputComponent.propTypes = {
   clearable: PropTypes.bool.isRequired,
 };
 
-export default function CountryInput({htmlName, disabled, isRequired, choices}) {
+export default function CountryInput({htmlId, htmlName, disabled, isRequired, choices}) {
   return (
     <FinalField
+      id={htmlId}
       name={htmlName}
       component={CountryInputComponent}
       required={isRequired}
@@ -66,6 +67,7 @@ export default function CountryInput({htmlName, disabled, isRequired, choices}) 
 }
 
 CountryInput.propTypes = {
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,

--- a/indico/modules/events/registration/client/js/form/fields/DateInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/DateInput.jsx
@@ -19,7 +19,7 @@ import {toMoment} from 'indico/utils/date';
 
 import '../../../styles/regform.module.scss';
 
-function DateInputComponent({value, onChange, disabled, required, dateFormat, timeFormat}) {
+function DateInputComponent({id, value, onChange, disabled, required, dateFormat, timeFormat}) {
   const dateValue = value.split('T')[0];
   const timeValue = value.includes('T') ? value.split('T')[1] : '';
 
@@ -35,6 +35,7 @@ function DateInputComponent({value, onChange, disabled, required, dateFormat, ti
     <Form.Group styleName="date-field">
       <Form.Field>
         <SingleDatePicker
+          id={id}
           name="date"
           disabled={disabled}
           required={required}
@@ -50,6 +51,7 @@ function DateInputComponent({value, onChange, disabled, required, dateFormat, ti
       {timeFormat && (
         <Form.Field>
           <TimePicker
+            id={id}
             name="time"
             disabled={disabled}
             required={required}
@@ -69,6 +71,7 @@ function DateInputComponent({value, onChange, disabled, required, dateFormat, ti
 }
 
 DateInputComponent.propTypes = {
+  id: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
@@ -91,7 +94,14 @@ DateInputComponent.defaultProps = {
   timeFormat: null,
 };
 
-export default function DateInput({htmlName, disabled, isRequired, dateFormat, timeFormat}) {
+export default function DateInput({
+  htmlId,
+  htmlName,
+  disabled,
+  isRequired,
+  dateFormat,
+  timeFormat,
+}) {
   const friendlyDateFormat = dateFormat.replace(
     /%([HMdmY])/g,
     (match, c) => ({H: 'HH', M: 'mm', d: 'DD', m: 'MM', Y: 'YYYY'}[c])
@@ -105,6 +115,7 @@ export default function DateInput({htmlName, disabled, isRequired, dateFormat, t
   if (dateFormat.includes('%d')) {
     return (
       <FinalField
+        id={htmlId}
         name={htmlName}
         component={DateInputComponent}
         required={isRequired}
@@ -145,6 +156,7 @@ export default function DateInput({htmlName, disabled, isRequired, dateFormat, t
     };
     return (
       <FinalField
+        id={htmlId}
         type="text"
         name={htmlName}
         component={Input}
@@ -160,6 +172,7 @@ export default function DateInput({htmlName, disabled, isRequired, dateFormat, t
 }
 
 DateInput.propTypes = {
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,

--- a/indico/modules/events/registration/client/js/form/fields/EmailInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/EmailInput.jsx
@@ -22,7 +22,7 @@ import {getStaticData} from '../selectors';
 
 import '../../../styles/regform.module.scss';
 
-export default function EmailInput({htmlName, disabled, isRequired}) {
+export default function EmailInput({htmlId, htmlName, disabled, isRequired}) {
   const isMainEmailField = htmlName === 'email';
   const [message, setMessage] = useState({status: '', message: '', forEmail: ''});
   const isUpdateMode = useSelector(getUpdateMode);
@@ -120,6 +120,7 @@ export default function EmailInput({htmlName, disabled, isRequired}) {
   return (
     <FinalInput
       type="email"
+      id={htmlId}
       name={htmlName}
       required={isRequired && isMainEmailField ? 'no-validator' : isRequired}
       disabled={disabled}
@@ -145,6 +146,7 @@ export default function EmailInput({htmlName, disabled, isRequired}) {
 }
 
 EmailInput.propTypes = {
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool.isRequired,

--- a/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
@@ -26,6 +26,7 @@ import '../../../styles/regform.module.scss';
 import './table.module.scss';
 
 function MultiChoiceInputComponent({
+  id,
   existingValue,
   value,
   onChange,
@@ -71,13 +72,14 @@ function MultiChoiceInputComponent({
   const isPaidChoiceLocked = choice => !management && isPaidChoice(choice);
 
   return (
-    <table styleName="choice-table">
+    <table styleName="choice-table" role="presentation">
       <tbody>
-        {choices.map(choice => {
+        {choices.map((choice, index) => {
           return (
             <tr key={choice.id} styleName="row">
               <td>
                 <Checkbox
+                  id={id ? `${id}-${index}` : ''}
                   styleName="checkbox"
                   style={{pointerEvents: 'auto'}} // keep label tooltips working when disabled
                   value={choice.id}
@@ -167,6 +169,7 @@ function MultiChoiceInputComponent({
 }
 
 MultiChoiceInputComponent.propTypes = {
+  id: PropTypes.string.isRequired,
   value: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func.isRequired,
@@ -180,6 +183,7 @@ MultiChoiceInputComponent.propTypes = {
 
 export default function MultiChoiceInput({
   id,
+  htmlId,
   htmlName,
   disabled,
   isRequired,
@@ -191,6 +195,7 @@ export default function MultiChoiceInput({
   const existingValue = useSelector(state => getFieldValue(state, id)) || {};
   return (
     <FinalField
+      id={htmlId}
       name={htmlName}
       component={MultiChoiceInputComponent}
       required={isRequired}
@@ -216,6 +221,7 @@ export default function MultiChoiceInput({
 
 MultiChoiceInput.propTypes = {
   id: PropTypes.number.isRequired,
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,

--- a/indico/modules/events/registration/client/js/form/fields/NumberInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/NumberInput.jsx
@@ -54,12 +54,21 @@ NumberInputComponent.defaultProps = {
   maxValue: null,
 };
 
-export default function NumberInput({htmlName, disabled, isRequired, price, minValue, maxValue}) {
+export default function NumberInput({
+  htmlId,
+  htmlName,
+  disabled,
+  isRequired,
+  price,
+  minValue,
+  maxValue,
+}) {
   const validate = isRequired
     ? v.chain(v.required, v.number(), v.range(minValue, maxValue || Infinity))
     : v.chain(v.optional(), v.number(), v.range(minValue, maxValue || Infinity));
   return (
     <FinalField
+      id={htmlId}
       name={htmlName}
       component={NumberInputComponent}
       required={isRequired}
@@ -75,6 +84,7 @@ export default function NumberInput({htmlName, disabled, isRequired, price, minV
 }
 
 NumberInput.propTypes = {
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,

--- a/indico/modules/events/registration/client/js/form/fields/NumberInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/NumberInput.jsx
@@ -17,13 +17,14 @@ import {getCurrency} from '../../form/selectors';
 
 import '../../../styles/regform.module.scss';
 
-function NumberInputComponent({value, onChange, disabled, price, minValue, maxValue}) {
+function NumberInputComponent({id, value, onChange, disabled, price, minValue, maxValue}) {
   const currency = useSelector(getCurrency);
   const total = (value * price).toFixed(2);
 
   return (
     <div styleName="number-field">
       <input
+        id={id}
         type="number"
         value={value !== null ? value : ''}
         min={minValue}
@@ -41,6 +42,7 @@ function NumberInputComponent({value, onChange, disabled, price, minValue, maxVa
 }
 
 NumberInputComponent.propTypes = {
+  id: PropTypes.string.isRequired,
   value: PropTypes.number,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,

--- a/indico/modules/events/registration/client/js/form/fields/PhoneInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/PhoneInput.jsx
@@ -12,11 +12,14 @@ import {FinalInput} from 'indico/react/forms';
 
 import '../../../styles/regform.module.scss';
 
-export default function PhoneInput({htmlName, isRequired, disabled}) {
-  return <FinalInput type="tel" name={htmlName} required={isRequired} disabled={disabled} />;
+export default function PhoneInput({htmlId, htmlName, isRequired, disabled}) {
+  return (
+    <FinalInput id={htmlId} type="tel" name={htmlName} required={isRequired} disabled={disabled} />
+  );
 }
 
 PhoneInput.propTypes = {
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   isRequired: PropTypes.bool.isRequired,
   disabled: PropTypes.bool,

--- a/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
@@ -27,6 +27,7 @@ import '../../../styles/regform.module.scss';
 import './table.module.scss';
 
 function SingleChoiceDropdown({
+  id,
   existingValue,
   value,
   onChange,
@@ -58,6 +59,7 @@ function SingleChoiceDropdown({
     }));
     extraSlotsDropdown = (
       <Form.Select
+        id={id ? `${id}-extraslots` : ''}
         options={options}
         disabled={
           disabled ||
@@ -108,6 +110,7 @@ function SingleChoiceDropdown({
     <Form.Group styleName="single-choice-dropdown">
       <Form.Field>
         <Dropdown
+          id={id}
           selection
           style={{width: 500, opacity: 1}}
           placeholder={Translate.string('Choose an option')}
@@ -137,6 +140,7 @@ function SingleChoiceDropdown({
 }
 
 SingleChoiceDropdown.propTypes = {
+  id: PropTypes.string.isRequired,
   value: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
@@ -149,6 +153,7 @@ SingleChoiceDropdown.propTypes = {
 };
 
 function SingleChoiceRadioGroup({
+  id,
   existingValue,
   value,
   onChange,
@@ -182,13 +187,14 @@ function SingleChoiceRadioGroup({
   const isPaidChoiceLocked = choice => !management && isPaidChoice(choice);
 
   return (
-    <table styleName="choice-table">
+    <table styleName="choice-table" role="presentation">
       <tbody>
-        {radioChoices.map(c => {
+        {radioChoices.map((c, index) => {
           return (
             <tr key={c.id} styleName="row">
               <td>
                 <Form.Radio
+                  id={id ? `${id}-${index}` : ''}
                   style={{pointerEvents: 'auto'}} // keep label tooltips working when disabled
                   styleName="radio"
                   label={{
@@ -230,6 +236,7 @@ function SingleChoiceRadioGroup({
                   <td>
                     {c.isEnabled && (
                       <Dropdown
+                        id={id ? `${id}-extraslot` : ''}
                         selection
                         styleName="dropdown"
                         disabled={
@@ -275,6 +282,7 @@ function SingleChoiceRadioGroup({
 }
 
 SingleChoiceRadioGroup.propTypes = {
+  id: PropTypes.string.isRequired,
   value: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
@@ -287,6 +295,7 @@ SingleChoiceRadioGroup.propTypes = {
 };
 
 function SingleChoiceInputComponent({
+  id,
   existingValue,
   value,
   onChange,
@@ -302,6 +311,7 @@ function SingleChoiceInputComponent({
   if (itemType === 'dropdown') {
     component = (
       <SingleChoiceDropdown
+        id={id}
         value={value}
         existingValue={existingValue}
         onChange={onChange}
@@ -316,6 +326,7 @@ function SingleChoiceInputComponent({
   } else if (itemType === 'radiogroup') {
     component = (
       <SingleChoiceRadioGroup
+        id={id}
         value={value}
         existingValue={existingValue}
         onChange={onChange}
@@ -335,6 +346,7 @@ function SingleChoiceInputComponent({
 }
 
 SingleChoiceInputComponent.propTypes = {
+  id: PropTypes.string.isRequired,
   disabled: PropTypes.bool.isRequired,
   isRequired: PropTypes.bool.isRequired,
   isPurged: PropTypes.bool.isRequired,
@@ -347,6 +359,7 @@ SingleChoiceInputComponent.propTypes = {
 
 export default function SingleChoiceInput({
   id,
+  htmlId,
   htmlName,
   disabled,
   isRequired,
@@ -359,6 +372,7 @@ export default function SingleChoiceInput({
   const existingValue = useSelector(state => getFieldValue(state, id)) || {};
   return (
     <FinalField
+      id={htmlId}
       name={htmlName}
       component={SingleChoiceInputComponent}
       format={v => v || {}}
@@ -383,6 +397,7 @@ export default function SingleChoiceInput({
 
 SingleChoiceInput.propTypes = {
   id: PropTypes.number.isRequired,
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   isRequired: PropTypes.bool,

--- a/indico/modules/events/registration/client/js/form/fields/TextAreaInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/TextAreaInput.jsx
@@ -20,10 +20,11 @@ const attributeMap = {
   numberOfRows: 'rows',
 };
 
-export default function TextAreaInput({htmlName, disabled, title, isRequired, ...props}) {
+export default function TextAreaInput({htmlId, htmlName, disabled, title, isRequired, ...props}) {
   const inputProps = mapPropsToAttributes(props, attributeMap, TextAreaInput.defaultProps);
   return (
     <FinalTextArea
+      id={htmlId}
       name={htmlName}
       {...inputProps}
       disabled={disabled}
@@ -34,6 +35,7 @@ export default function TextAreaInput({htmlName, disabled, title, isRequired, ..
 }
 
 TextAreaInput.propTypes = {
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   numberOfRows: PropTypes.number,

--- a/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
@@ -18,10 +18,11 @@ import '../../../styles/regform.module.scss';
 
 const attributeMap = {minLength: 'minLength', maxLength: 'maxLength'};
 
-export default function TextInput({htmlName, disabled, title, isRequired, ...props}) {
+export default function TextInput({htmlId, htmlName, disabled, title, isRequired, ...props}) {
   const inputProps = mapPropsToAttributes(props, attributeMap, TextInput.defaultProps);
   return (
     <FinalInput
+      id={htmlId}
       type="text"
       name={htmlName}
       {...inputProps}
@@ -32,6 +33,7 @@ export default function TextInput({htmlName, disabled, title, isRequired, ...pro
 }
 
 TextInput.propTypes = {
+  htmlId: PropTypes.string.isRequired,
   htmlName: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   title: PropTypes.string.isRequired,

--- a/indico/modules/events/registration/client/js/form/fields/registry.js
+++ b/indico/modules/events/registration/client/js/form/fields/registry.js
@@ -62,7 +62,8 @@ Available keys:
 - alwaysRequired: optional; always display the field as required
 - hasPrice: optional; show price field if the whole field can have a price attached
 - noRetentionPeriod: optional; hide the retention period setting
-- renderAsFieldset: optional; whether the field should be rendered in a fieldset; applies to fields that use multiple controls, like radios, checkboxes, multi-button controls
+- renderAsFieldset: optional; whether the field should be rendered in a fieldset; applies
+  to fields that use multiple controls, like radios, checkboxes, multi-button controls
 */
 
 const fieldRegistry = {

--- a/indico/modules/events/registration/client/js/form/fields/registry.js
+++ b/indico/modules/events/registration/client/js/form/fields/registry.js
@@ -62,6 +62,7 @@ Available keys:
 - alwaysRequired: optional; always display the field as required
 - hasPrice: optional; show price field if the whole field can have a price attached
 - noRetentionPeriod: optional; hide the retention period setting
+- renderAsFieldset: optional; whether the field should be rendered in a fieldset; applies to fields that use multiple controls, like radios, checkboxes, multi-button controls
 */
 
 const fieldRegistry = {
@@ -134,6 +135,7 @@ const fieldRegistry = {
     title: Translate.string('File'),
     inputComponent: FileInput,
     icon: 'upload',
+    renderAsFieldset: true,
   },
   email: {
     title: Translate.string('Email'),
@@ -148,6 +150,7 @@ const fieldRegistry = {
     settingsFormDecorators: [choiceFieldsSettingsFormDecorator, singleChoiceSettingsFormDecorator],
     settingsFormInitialData: singleChoiceSettingsInitialData,
     icon: 'dropmenu',
+    renderAsFieldset: true,
   },
   multi_choice: {
     title: Translate.string('Multiple Choice'),
@@ -157,6 +160,7 @@ const fieldRegistry = {
     settingsFormDecorators: [choiceFieldsSettingsFormDecorator],
     settingsFormInitialData: multiChoiceSettingsInitialData,
     icon: 'list',
+    renderAsFieldset: true,
   },
   accommodation: {
     title: Translate.string('Accommodation'),
@@ -169,6 +173,7 @@ const fieldRegistry = {
     noRequired: true,
     alwaysRequired: true,
     icon: 'home',
+    renderAsFieldset: true,
   },
   accompanying_persons: {
     title: Translate.string('Accompanying Persons'),
@@ -179,6 +184,7 @@ const fieldRegistry = {
     noRequired: true,
     hasPrice: true,
     icon: 'user',
+    renderAsFieldset: true,
   },
 };
 

--- a/indico/modules/events/registration/client/js/form/fields/registry.js
+++ b/indico/modules/events/registration/client/js/form/fields/registry.js
@@ -119,6 +119,7 @@ const fieldRegistry = {
     settingsComponent: BooleanSettings,
     hasPrice: true,
     icon: 'switchon',
+    renderAsFieldset: true,
   },
   phone: {
     title: Translate.string('Phone'),

--- a/indico/modules/events/registration/client/styles/regform.module.scss
+++ b/indico/modules/events/registration/client/styles/regform.module.scss
@@ -70,6 +70,24 @@
     );
   }
 
+  legend {
+    // XXX: Copy styles from Semantic UI
+    margin: 0 0 0.28571429rem 0;
+    color: rgba(0, 0, 0, 0.87);
+    font-size: 0.92857143em;
+    font-weight: bold;
+    text-transform: none;
+  }
+
+  :global(.required) > fieldset > legend::after {
+    // XXX: Copy styles from Semantic UI
+    display: inline-block;
+    vertical-align: top;
+    margin: -0.2em 0 0 0.2em;
+    content: '*';
+    color: #c00;
+  }
+
   > .content {
     flex-grow: 1;
 

--- a/indico/web/client/js/react/components/dates/SingleDatePicker.jsx
+++ b/indico/web/client/js/react/components/dates/SingleDatePicker.jsx
@@ -70,6 +70,7 @@ export default class SingleDatePicker extends React.Component {
       hideKeyboardShortcutsPanel: true,
       showDefaultInputIcon: true,
       focused,
+      ariaLabel: '', // XXX: Suppress aria-label as it interferes with input's label
       ...filteredProps,
     });
   }


### PR DESCRIPTION
- Introduce id and for attributes on inputs and labels
- Introduce aria-describedby for AccompanyingPeronInput button to provide additional context for the button
- Add a renderAsFieldset meta for registered fields which causes the fields to be renedered inside a fieldset with a legend
- Suppress the aria-label for react-dates datepicker as it interferes with the label associated with the control

Fixes #6059, fixes #6073