### PR TITLE
Wrap overflowing text in event email log

### DIFF
--- a/indico/modules/logs/templates/entry_email.html
+++ b/indico/modules/logs/templates/entry_email.html
@@ -72,7 +72,7 @@
             {% trans %}Subject{% endtrans %}
         </td>
         <td class="i-table value searchable">
-            {{ data.subject }}
+            <p style="white-space: pre-wrap; word-break: break-word;">{{ data.subject }}</p>
         </td>
     </tr>
     <tr class="i-table content">

--- a/indico/web/client/js/react/components/style/modal.scss
+++ b/indico/web/client/js/react/components/style/modal.scss
@@ -41,7 +41,7 @@ $modal-footer-height: 60px;
       background-color: $light-gray;
       border-bottom: 1px solid darken($light-gray, 5%);
       padding: 1em;
-      height: $modal-header-height;
+      height: auto;
       width: 100%;
 
       a.icon-cross {


### PR DESCRIPTION
This is to fix some texts in the email log not wrapping/showing completely when the text is too long. 

1. The modal description/title had a fixed width so long text gets cut off.
Before:
<img width="891" alt="Screenshot 2023-12-04 at 15 24 35" src="https://github.com/indico/indico/assets/54508387/943e8c49-c909-467a-9d78-f228b8138113">
After:
<img width="895" alt="Screenshot 2023-12-04 at 15 24 53" src="https://github.com/indico/indico/assets/54508387/727ec110-8550-4f6e-9ac0-78dd5c3f9557">

2. When the subject is too long it shows an ellipse. While in core the user can still see the subject from the modal title/description but in our plugin we use a different title for the modal and would like the subject to be fully visible.
Before:
<img width="759" alt="Screenshot 2023-12-04 at 15 29 54" src="https://github.com/indico/indico/assets/54508387/7f75ec9b-0f1a-43b6-aaa5-c1df54cb6951">
After:
<img width="787" alt="Screenshot 2023-12-04 at 15 29 42" src="https://github.com/indico/indico/assets/54508387/71b14e93-6ed1-419b-bceb-b25a79564226">
