### PR TITLE
Rework badges using flexbox

### DIFF
--- a/indico/core/plugins/templates/index.html
+++ b/indico/core/plugins/templates/index.html
@@ -15,11 +15,11 @@
                     {%- if plugin.configurable %} href="{{ url_for('.details', plugin=plugin.name) }}"
                     {%- else %} title="{% trans %}This plugin has no configurable options{% endtrans %}"
                     {%- endif %}>
-                        <div class="i-badge-legend">
-                            <span class="i-badge-legend-right ellipsize">{{ plugin.version }}</span>
-                        </div>
                         <div class="i-badge-content">
                             <span class="i-badge-title">{{ plugin.title }}</span>
+                        </div>
+                        <div class="i-badge-legend">
+                            <span class="i-badge-legend-right ellipsize">{{ plugin.version }}</span>
                         </div>
                     </a>
                 {% endfor %}

--- a/indico/modules/events/payment/templates/admin_settings.html
+++ b/indico/modules/events/payment/templates/admin_settings.html
@@ -23,17 +23,17 @@
 
     {%- if plugins %}
         <p>{% trans %}The following payment plugins are available:{% endtrans %}</p>
-        <div class="i-badges-list left i-badges-list-hover i-payments-list">
+        <div class="i-badges-list i-payment-plugins-list">
             {%- for plugin in plugins %}
                 <a class="js-plugin-details i-badge i-badge-gray" href="{{ url_for('.admin_plugin_settings', plugin=plugin.name) }}">
-                    <div class="i-badge-legend">
-                        <span class="i-badge-legend-right">{{ plugin.version }}</span>
-                    </div>
                     <div class="i-badge-content">
                         <span class="i-badge-img">
                             <img src="{{ plugin.logo_url }}">
                         </span>
                         <span class="i-badge-title">{{ plugin.title }}</span>
+                    </div>
+                    <div class="i-badge-legend">
+                        <span class="i-badge-legend-right">{{ plugin.version }}</span>
                     </div>
                 </a>
             {%- endfor %}

--- a/indico/modules/events/payment/templates/management/payments.html
+++ b/indico/modules/events/payment/templates/management/payments.html
@@ -37,31 +37,28 @@
         {% trans %}Payment methods{% endtrans %}
     </h3>
 
-    <div class="i-badges-list left i-badges-list-hover i-payments-list">
-        <a class="i-badge i-payment-enabled i-payment-manual"
+    <div class="i-badges-list i-payments-list">
+        <a class="i-badge i-badge-disabled i-payment-enabled"
            title="{% trans %}Method only available for managers from the management area. Can't be disabled.{% endtrans %}">
-            <div class="i-badge-legend">
-                <span class="i-badge-legend-right i-payment-status-enabled">
-                    {% trans %}enabled{% endtrans %}
-                </span>
-            </div>
             <div class="i-badge-content">
                 <span class="i-badge-img icon-coins"></span>
                 <span class="i-badge-title">
                     {% trans %}Manual{% endtrans %}
                 </span>
             </div>
+            <div class="i-badge-legend">
+                <span class="i-badge-legend-right i-payment-status-enabled">
+                    {% trans %}enabled{% endtrans %}
+                </span>
+            </div>
         </a>
         {%- for short_name, method in methods %}
+            {% set payment_enabled = method in enabled_methods %}
             <a href="#" id="plugin-{{ method.name }}"
-               class="js-edit-method i-badge {%- if method in enabled_methods %} i-payment-enabled {% else %} i-payment-disabled {% endif -%}"
+               class="js-edit-method i-badge {%- if payment_enabled %} i-payment-enabled {% else %} i-payment-disabled {% endif -%}"
                data-title="{% trans method=method.title %}Payment settings: {{ method }}{% endtrans %}"
                data-href="{{ url_for('.event_plugin_edit', event, method=short_name) }}"
                data-ajax-dialog>
-                <div class="i-badge-legend">
-                    <span class="i-badge-legend-right i-payment-status-enabled">{% trans %}enabled{% endtrans %}</span>
-                    <span class="i-badge-legend-right i-payment-status-disabled">{% trans %}disabled{% endtrans %}</span>
-                </div>
                 <div class="i-badge-content">
                     <span class="i-badge-img">
                         <img src="{{ method.logo_url }}">
@@ -69,6 +66,13 @@
                     <span class="i-badge-title">
                         {{ method.title }}
                     </span>
+                </div>
+                <div class="i-badge-legend">
+                    {% if payment_enabled %}
+                        <span class="i-badge-legend-right i-payment-status-enabled">{% trans %}enabled{% endtrans %}</span>
+                    {% else %}
+                        <span class="i-badge-legend-right i-payment-status-disabled">{% trans %}disabled{% endtrans %}</span>
+                    {% endif %}
                 </div>
             </a>
         {%- endfor %}

--- a/indico/modules/events/requests/templates/event_requests.html
+++ b/indico/modules/events/requests/templates/event_requests.html
@@ -10,29 +10,29 @@
         {%- endtrans -%}
     </p>
 
-    <div class="i-requests-list i-badges-list left">
+    <div class="i-requests-list i-badges-list">
         {%- for name, definition in definitions.items()|sort(attribute='1.title') %}
             {% set req = requests[name] %}
             <a class="i-badge i-request-{{ req.state.name if req else 'none' }}"
                href="{{ url_for('requests.event_requests_details', event, type=name) }}">
-                <div class="i-badge-legend">
-                    <span class="i-badge-legend-right">
-                        {%- if not req -%}
-                            {# nothing to show #}
-                        {%- elif req.state.name == 'pending' -%}
-                            {% trans %}Pending{% endtrans %}
-                        {%- elif req.state.name == 'accepted' -%}
-                            {% trans %}Accepted{% endtrans %}
-                        {%- elif req.state.name == 'rejected' -%}
-                            {% trans %}Rejected{% endtrans %}
-                        {%- elif req.state.name == 'withdrawn' -%}
-                            {% trans %}Withdrawn{% endtrans %}
-                        {%- endif -%}
-                    </span>
-                </div>
                 <div class="i-badge-content">
                     <span class="i-badge-title">{{ definition.title }}</span>
                 </div>
+                {% if req %}
+                    <div class="i-badge-legend">
+                        <span class="i-badge-legend-right">
+                            {%- if req.state.name == 'pending' -%}
+                                {% trans %}Pending{% endtrans %}
+                            {%- elif req.state.name == 'accepted' -%}
+                                {% trans %}Accepted{% endtrans %}
+                            {%- elif req.state.name == 'rejected' -%}
+                                {% trans %}Rejected{% endtrans %}
+                            {%- elif req.state.name == 'withdrawn' -%}
+                                {% trans %}Withdrawn{% endtrans %}
+                            {%- endif -%}
+                        </span>
+                    </div>
+                {% endif %}
             </a>
         {%- endfor %}
     </div>

--- a/indico/modules/vc/templates/manage_event_select.html
+++ b/indico/modules/vc/templates/manage_event_select.html
@@ -6,7 +6,7 @@
             {% trans %}The following video services are available. Click on one to create a new room:{% endtrans %}
         {% endif %}
     </p>
-    <div class="i-badges-list-left i-badges-list-hover">
+    <div class="i-badges-list-space-evenly">
         {%- for plugin in plugins|sort(attribute='title') %}
             {% set action=_("Attach") if attach == '1' else _("Create") %}
             <a href="#" class="js-vc-plugin i-badge i-badge-gray"

--- a/indico/web/client/styles/modules/_agreements.scss
+++ b/indico/web/client/styles/modules/_agreements.scss
@@ -123,13 +123,6 @@
 
   .agreement-definition {
     vertical-align: top;
-
-    .i-badge {
-      margin: 0;
-      padding: 0.3em;
-      font-weight: bold;
-      font-size: 1.2em;
-    }
   }
 
   .action-box {

--- a/indico/web/client/styles/modules/_agreements.scss
+++ b/indico/web/client/styles/modules/_agreements.scss
@@ -121,10 +121,6 @@
 .agreement-dashboard {
   @extend .fixed-width;
 
-  .agreement-definition {
-    vertical-align: top;
-  }
-
   .action-box {
     .i-button {
       width: 10em;

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -120,10 +120,6 @@
       padding: 2% 2% 0 2%;
     }
   }
-
-  .i-badges-list > .i-badge {
-    width: 45%;
-  }
 }
 
 .category-sidebar {

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -98,28 +98,6 @@
 
 .category-statistics {
   max-width: 1600px;
-
-  .i-box {
-    margin-left: 0.8em;
-    margin-right: 0.8em !important;
-    width: 45%;
-
-    &:first-child {
-      margin-left: 0;
-    }
-
-    .i-box-header {
-      text-align: left;
-    }
-
-    .i-box-content {
-      display: inline-block;
-
-      width: 96%;
-      height: 350px;
-      padding: 2% 2% 0 2%;
-    }
-  }
 }
 
 .category-sidebar {

--- a/indico/web/client/styles/modules/_registrationform.scss
+++ b/indico/web/client/styles/modules/_registrationform.scss
@@ -472,10 +472,6 @@
       }
     }
 
-    & > .i-badges-list > .i-badge > .i-badge-content {
-      height: 6.5em;
-    }
-
     .jqplot-point-label {
       color: white;
       z-index: 100;

--- a/indico/web/client/styles/partials/_badges.scss
+++ b/indico/web/client/styles/partials/_badges.scss
@@ -6,196 +6,106 @@
 // LICENSE file for more details.
 
 @use 'base' as *;
+@use 'design_system';
 
-@mixin badges-list {
-  @extend .flexrow;
+%i-badges-list {
+  @extend %flex-row;
   flex-wrap: wrap;
-
-  margin-top: -0.8em;
-  margin-bottom: 0.8em;
+  align-items: stretch; // Ensure that all items inside the list have the same height
 }
 
 .i-badges-list {
-  @include badges-list();
-  text-align: center;
-  justify-content: space-around;
-
-  > .i-badge:first-child {
-    margin-left: 0;
-  }
-}
-
-.i-badges-list.left {
-  @include badges-list();
-  float: none; // disable default .left style
-  text-align: left;
+  @extend %i-badges-list;
   justify-content: flex-start;
 }
 
-.i-badges-list.center {
-  @include badges-list();
-  margin: -0.8em 0 0.8em 0; // disable default .center style
-  text-align: center;
-  justify-content: center;
+.i-badges-list-space-evenly {
+  @extend %i-badges-list;
+  justify-content: space-evenly;
 }
 
-.i-badges-list-hover {
-  @include badges-list();
+/// Sets the badge color
+@mixin i-badge-color($text-color, $bg-color, $border-color, $hover: false) {
+  background-color: $bg-color;
 
-  & > .i-badge {
-    @include transition(background-color $default-transition-duration $default-transition-function);
+  &,
+  & * {
+    color: $text-color;
+  }
 
-    width: 10em;
-    height: 10em;
+  & > .i-badge-legend {
+    border-color: $border-color;
+  }
 
+  @if $hover {
     &:not(.i-badge-disabled):hover {
-      background-color: darken($light-gray, 2 * $light-color-variation);
-    }
-
-    & > .i-badge-content {
-      height: 7em;
-
-      &:first-child {
-        height: 8.8em;
-      }
-
-      & > .i-badge-title {
-        font-size: 1em;
-      }
-
-      & .i-badge-img > img {
-        max-height: 4em;
-      }
+      background-color: darken($bg-color, $light-color-variation);
     }
   }
-}
-
-@mixin i-badge-elem {
-  position: relative;
-  display: block;
-  margin: 0 auto;
 }
 
 .i-badge {
   @include default-border-radius();
-  position: relative;
-  display: inline-block;
-  min-width: 10em;
-  margin: 0.8em;
-  padding: 0;
-  vertical-align: top;
+  @include transition(background-color $default-transition-duration $default-transition-function);
+
+  --flex-gap: 0;
+  @extend %flex-column;
+  justify-content: space-between; // This pushes the legend to the bottom
+
   text-align: center;
   box-shadow: 0 2px 1px 0 $gray;
-  background-color: $dark-blue;
-  box-sizing: initial;
-  line-height: initial;
-
-  &,
-  & * {
-    color: $light-blue;
-  }
+  min-width: 10em;
+  @include i-badge-color($light-blue, $dark-blue, $light-gray, true); // Default badge color
 
   &.i-badge-gray {
-    background-color: $light-gray;
-
-    &,
-    & * {
-      color: $light-black;
-    }
-
-    & > .i-badge-legend {
-      border-color: $gray;
-    }
+    @include i-badge-color($light-black, $light-gray, $gray, true);
   }
 
   &.i-badge-disabled {
     cursor: default;
-    background-color: $dark-gray;
   }
 
   & > .i-badge-content {
-    position: relative;
-    margin: 0 auto;
-
-    text-align: center;
-    display: inline-flex;
-    flex-direction: column;
-    justify-content: space-around;
-
-    width: 80%;
-    height: 100%;
-    padding: 0.4em 10% 0.8em;
+    --flex-gap: 0.5em;
+    @extend %flex-column;
+    flex-grow: 1;
+    justify-content: center;
+    padding: 1em;
 
     & > .i-badge-value {
-      @include i-badge-elem();
-
       font-size: 3.6em;
       font-weight: bold;
+      line-height: 1;
     }
 
     & > .i-badge-img {
-      @include i-badge-elem();
-
-      width: 100%;
+      font-size: 3em;
+      max-height: 1em;
 
       & > img {
-        display: block;
-        margin: auto;
-        max-width: 100%;
-        max-height: 100%;
+        max-height: 1em;
       }
     }
 
     & > .i-badge-title {
-      @include i-badge-elem();
-
       max-width: 100%;
-      margin-top: 0.2em;
-      margin-bottom: 0.2em;
-
       font-size: 1.1em;
       font-weight: bold;
-      text-overflow: ellipsis;
-      overflow: visible;
     }
-  }
-
-  /* The rule below adds a margin after the content to leave space
-     * for the legend.
-     * Since there is no 'previous sibling' selector in CSS,
-     * the legend needs to appear just before the content in the DOM.
-     * It will be placed correctly at the bottom below the content
-     * using CSS.
-     */
-  & > .i-badge-legend + .i-badge-content {
-    margin-bottom: 1.8em;
   }
 
   & > .i-badge-legend {
-    @include i-badge-elem();
-
-    display: block;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    margin: 0 0 0.5em;
-    padding: 0.4em 0.6em 0;
-    font-size: 1em;
-    height: 1em;
-    border-top: 1px solid $light-blue;
-
-    & > .i-badge-legend-left {
-      float: left;
-    }
+    display: flex;
+    padding: 0 0.5em;
+    border-top-width: 1px;
+    border-top-style: solid;
 
     & > .i-badge-legend-right {
-      float: right;
+      margin-left: auto;
     }
 
     & > .ellipsize {
       @include ellipsis();
-      max-width: 100%;
     }
   }
 }

--- a/indico/web/client/styles/partials/_badges.scss
+++ b/indico/web/client/styles/partials/_badges.scss
@@ -83,6 +83,7 @@
       max-height: 1em;
 
       & > img {
+        max-width: 100%;
         max-height: 1em;
       }
     }

--- a/indico/web/client/styles/partials/_payment.scss
+++ b/indico/web/client/styles/partials/_payment.scss
@@ -6,65 +6,20 @@
 // LICENSE file for more details.
 
 @use 'base' as *;
+@use 'partials/_badges' as badges;
 
-.i-payments-list {
-  & > .i-badge {
-    &.i-payment-enabled {
-      background-color: $light-green;
+.i-payments-list > .i-badge {
+  width: 10em;
 
-      &,
-      & * {
-        color: $green;
-      }
-
-      &:hover {
-        background-color: darken($light-green, $light-color-variation);
-      }
-
-      & > .i-badge-legend {
-        border-color: $dark-green;
-
-        & > .i-payment-status-disabled {
-          display: none;
-        }
-      }
-    }
-
-    &.i-payment-disabled {
-      background-color: $light-gray;
-
-      &,
-      & * {
-        color: $black;
-      }
-
-      &:hover {
-        background-color: darken($light-gray, $light-color-variation);
-      }
-
-      & > .i-badge-legend {
-        border-color: $dark-gray;
-
-        & > .i-payment-status-enabled {
-          display: none;
-        }
-      }
-    }
-
-    &.i-payment-manual {
-      &:hover {
-        cursor: default;
-        background-color: $light-green;
-      }
-
-      .i-badge-img {
-        color: $black;
-        font-size: 3em;
-
-        &::before {
-          vertical-align: text-bottom;
-        }
-      }
-    }
+  &.i-payment-enabled {
+    @include badges.i-badge-color($green, $light-green, $dark-green, true);
   }
+
+  &.i-payment-disabled {
+    @include badges.i-badge-color($black, $light-gray, $dark-gray, true);
+  }
+}
+
+.i-payment-plugins-list > .i-badge {
+  width: 10em;
 }

--- a/indico/web/client/styles/partials/_plugins.scss
+++ b/indico/web/client/styles/partials/_plugins.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base' as *;
+@use 'partials/_badges' as badges;
 
 .i-plugins-list {
   & > h2 {
@@ -13,17 +14,11 @@
   }
 
   & > .i-badges-list {
-    display: flex;
-    justify-content: flex-start;
-
     & > .i-badge {
-      @include transition(
-        background-color $default-transition-duration $default-transition-function
-      );
-
       width: 10em;
-      margin-left: 0;
-      margin-right: 1.6em;
+      min-height: 7em;
+
+      @include badges.i-badge-color($light-blue, $dark-blue, $light-gray, true);
 
       &.i-badge-disabled {
         background: repeating-linear-gradient(
@@ -33,14 +28,6 @@
           lighten($dark-blue, 0.5 * $light-color-variation) 10px,
           lighten($dark-blue, 0.5 * $light-color-variation) 20px
         );
-      }
-
-      &:not(.i-badge-disabled):hover {
-        background-color: darken($dark-blue, 2 * $light-color-variation);
-      }
-
-      & > .i-badge-content {
-        height: 4.2em;
       }
     }
   }

--- a/indico/web/client/styles/partials/_requests.scss
+++ b/indico/web/client/styles/partials/_requests.scss
@@ -6,43 +6,23 @@
 // LICENSE file for more details.
 
 @use 'base' as *;
+@use 'partials/_badges' as badges;
 
 @mixin i-request-state($state, $color, $light-color, $dark-color) {
   &.i-request-#{$state} {
-    background-color: $light-color;
-
-    &,
-    & * {
-      color: $color;
-    }
-
-    &:hover {
-      background-color: darken($light-color, $light-color-variation);
-    }
-
-    & > .i-badge-legend {
-      border-color: $dark-color;
-    }
+    @include badges.i-badge-color($color, $light-color, $dark-color, true);
   }
 }
 
 .i-requests-list {
   & > .i-badge {
-    @include transition(background-color $default-transition-duration $default-transition-function);
-
     width: 10em;
+    min-height: 6em;
 
+    @include i-request-state(none, $light-blue, $dark-blue, $light-gray);
     @include i-request-state(accepted, $green, $light-green, $dark-green);
     @include i-request-state(rejected, $red, $light-red, $dark-red);
     @include i-request-state(pending, $yellow, $light-yellow, $dark-yellow);
     @include i-request-state(withdrawn, $gray, $light-gray, $dark-gray);
-
-    & > .i-badge-content {
-      height: 4.2em;
-
-      & > .i-badge-title {
-        font-size: 1em;
-      }
-    }
   }
 }

--- a/indico/web/templates/_statistics.html
+++ b/indico/web/templates/_statistics.html
@@ -22,7 +22,7 @@
 {% endmacro %}
 
 {% macro stats_badge(label, value) %}
-    <div class="i-badge">
+    <div class="i-badge i-badge-disabled">
         <div class="i-badge-content">
             {% if value is none %}
                 <span class="i-badge-value">&ndash;</span>
@@ -36,7 +36,7 @@
 
 
 {% macro stats_badges(badges, classes='') %}
-    <div class="i-badges-list{% if classes %} {{ classes }}{%  endif %}">
+    <div class="i-badges-list-space-evenly{% if classes %} {{ classes }}{%  endif %}">
         {% for label, value in badges %}
             {{ stats_badge(label, value) }}
         {% endfor %}


### PR DESCRIPTION
Some of our badges look a bit broken right now:
![image](https://github.com/indico/indico/assets/8739637/8414f1b0-a876-4f9a-91ab-fef55e25614c)

I could've just fixed this but I noticed that badge CSS is (seemingly) unnecessarily complex and can be simplified.

Main improvements:
- no more overflowing text, alignment issues, etc..
- no more absolute positioning and juggling margins - badges now use flexbox with gaps
- no more fixed height - badges will grow as needed and all badges within a badge list will have the same height
- added color mixin `i-badge-color` to simplify setting badge colors which eliminates a lot of code duplication
- overall less code so should be easier to maintain

This is where the badges are used if you want to test them:
- plugin tab in admin area (`admin/plugins`)
- payments tab in admin area (`admin/payment`)
- payments in event management (`event/XXX/manage/payments`)
- logistics (`event/XXX/manage/requests`)
- registration stats (`event/XXX/manage/registration/YYY/stats`)
- Videoconference tab when multiple VC services are available when clicking on `Create new room` (`event/XXX/manage/videoconference/`)

## Before:
![image](https://github.com/indico/indico/assets/8739637/9ec95c33-6e9d-4161-95d1-73040ad34973)
![image](https://github.com/indico/indico/assets/8739637/8414f1b0-a876-4f9a-91ab-fef55e25614c)
![image](https://github.com/indico/indico/assets/8739637/9b671ece-4aed-44dc-96f2-6b6b5437bae3)
![image](https://github.com/indico/indico/assets/8739637/f1be4b45-b0f9-410f-8636-2a359e82ce1e)
![image](https://github.com/indico/indico/assets/8739637/9cc56529-b48f-458f-a784-f0bac591ff31)
![image](https://github.com/indico/indico/assets/8739637/a0ddc4b3-1b41-4b06-8d7c-0963a7240670)

## After:
![image](https://github.com/indico/indico/assets/8739637/c5056177-c68c-4149-bdf8-dcd3cfc9804e)
![image](https://github.com/indico/indico/assets/8739637/c1df0487-ae62-4ab4-8bbc-62e76e53e0a1)
![image](https://github.com/indico/indico/assets/8739637/03600da6-1460-4522-bfa6-75e227c4356f)
![image](https://github.com/indico/indico/assets/8739637/3bb7236e-49a5-48b6-afc5-e3a0a5c837f1)
![image](https://github.com/indico/indico/assets/8739637/43897dd3-1dba-4da4-8bd6-d15941b3dcc1)
![image](https://github.com/indico/indico/assets/8739637/c01a2906-17ba-46dc-bc92-0aee46748049)