### PR TITLE
Fix spacing when RB timeline error message is shown

### DIFF
--- a/indico/modules/rb/client/js/common/bookings/BookingEdit.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEdit.jsx
@@ -217,11 +217,16 @@ class BookingEdit extends React.Component {
                 onBookingPeriodChange={this.updateBookingCalendar}
               />
             </Grid.Column>
-            <Grid.Column stretched>
+            <Grid.Column stretched={!timelineError}>
               {timelineError ? (
                 <>
                   <div>
-                    <Message icon="times circle outline" error content={timelineError} />
+                    <Message
+                      icon="times circle outline"
+                      error
+                      content={timelineError}
+                      style={{marginBottom: '2rem'}}
+                    />
                   </div>
                   <DummyTimeline rows={10} />
                 </>


### PR DESCRIPTION
(Minor UI fix) This PR fixes the huge spacing between the RB timeline error message and the dummy/placeholder timeline.

Before:
![image](https://github.com/indico/indico/assets/7736654/1a2dbda3-0807-4297-8d63-a8b4eda761eb)

After:
![image](https://github.com/indico/indico/assets/7736654/4b113335-353e-4de7-a7cf-1b68a2da5237)
