### PR TITLE
[Checkin app] Add an endpoint to lookup registration by ticket uuid

### DIFF
--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -233,6 +233,8 @@ _bp.add_url_rule('!/api/checkin/event/<int:event_id>/forms/<int:reg_form_id>/reg
                  'api_checkin_registrations', api_checkin.RHCheckinAPIRegistrations)
 _bp.add_url_rule('!/api/checkin/event/<int:event_id>/forms/<int:reg_form_id>/registrations/<int:registration_id>',
                  'api_checkin_registration', api_checkin.RHCheckinAPIRegistration, methods=('GET', 'PATCH'))
+_bp.add_url_rule('!/api/checkin/ticket/<uuid:ticket_uuid>',
+                 'api_checkin_registration_uuid', api_checkin.RHCheckinAPIRegistrationUUID)
 
 # Deprecated Check-in app API
 _bp.add_url_rule('!/api/events/<int:event_id>/registrants/<int:registrant_id>', 'api_registrant',

--- a/indico/modules/events/registration/controllers/api/checkin.py
+++ b/indico/modules/events/registration/controllers/api/checkin.py
@@ -8,6 +8,7 @@
 from flask import request
 from sqlalchemy.orm import selectinload, undefer
 from webargs import fields
+from werkzeug.exceptions import NotFound
 
 from indico.core import signals
 from indico.modules.events.management.controllers.base import RHManageEventBase
@@ -119,6 +120,8 @@ class RHCheckinAPIRegistrationUUID(RHCheckinAPIBase):
                              .first_or_404())
         self.regform = self.registration.registration_form
         self.event = self.registration.event
+        if self.regform.is_deleted:
+            raise NotFound
 
     def _process_GET(self):
         return CheckinRegistrationSchema().jsonify(self.registration)

--- a/indico/modules/events/registration/controllers/api/checkin.py
+++ b/indico/modules/events/registration/controllers/api/checkin.py
@@ -107,3 +107,18 @@ class RHCheckinAPIRegistration(RHCheckinAPIRegFormBase):
         if paid is not None and paid != self.registration.is_paid and self.registration.price:
             toggle_registration_payment(self.registration, paid=paid)
         return CheckinRegistrationSchema().jsonify(self.registration)
+
+
+class RHCheckinAPIRegistrationUUID(RHCheckinAPIBase):
+    """Get full details for a specific registration from the ticket UUID (checkin secret)."""
+
+    def _process_args(self):
+        ticket_uuid = str(request.view_args['ticket_uuid'])
+        self.registration = (Registration.query
+                             .filter_by(ticket_uuid=ticket_uuid, is_deleted=False)
+                             .first_or_404())
+        self.regform = self.registration.registration_form
+        self.event = self.registration.event
+
+    def _process_GET(self):
+        return CheckinRegistrationSchema().jsonify(self.registration)

--- a/indico/modules/events/registration/controllers/api/checkin_test.py
+++ b/indico/modules/events/registration/controllers/api/checkin_test.py
@@ -45,6 +45,7 @@ def _assert_successful_request(snapshot, resp, name):
     '/api/checkin/event/{event_id}/forms/{regform_id}/',
     '/api/checkin/event/{event_id}/forms/{regform_id}/registrations/',
     '/api/checkin/event/{event_id}/forms/{regform_id}/registrations/{reg_id}',
+    '/api/checkin/ticket/{ticket_uuid}',
 ))
 def test_unauthorized(dummy_event, dummy_regform, dummy_reg, dummy_user, dummy_personal_token, test_client, auth, url):
     if auth == 'guest':
@@ -57,7 +58,8 @@ def test_unauthorized(dummy_event, dummy_regform, dummy_reg, dummy_user, dummy_p
             # missing scope on the token, so being a manager should not grant access
             dummy_event.update_principal(dummy_user, full_access=True)
 
-    url = url.format(event_id=dummy_event.id, regform_id=dummy_regform.id, reg_id=dummy_reg.id)
+    url = url.format(event_id=dummy_event.id, regform_id=dummy_regform.id,
+                     reg_id=dummy_reg.id, ticket_uuid=dummy_reg.ticket_uuid)
     resp = test_client.get(url, headers=headers)
     assert 'error' in resp.json
     assert resp.status_code == 403
@@ -90,6 +92,9 @@ def test_event_registrations(snapshot, dummy_event, dummy_regform, auth_headers,
 def test_event_registration_details(snapshot, dummy_event, dummy_regform, dummy_reg, auth_headers, test_client):
     resp = test_client.get(f'/api/checkin/event/{dummy_event.id}/forms/{dummy_regform.id}/registrations/{dummy_reg.id}',
                            headers=auth_headers)
+    _assert_successful_request(snapshot, resp, 'checkin_registration_details')
+
+    resp = test_client.get(f'/api/checkin/ticket/{dummy_reg.ticket_uuid}', headers=auth_headers)
     _assert_successful_request(snapshot, resp, 'checkin_registration_details')
 
 


### PR DESCRIPTION
One feedback we have gotten on the app is that the QR code is rather large and consequently sometimes difficult to scan.
We currently include lots of data in the QR code that is not strictly needed. Currently, we have:

```python
    qr_data = {
        'registrant_id': person['id'],  # accompanying person uuid if accompanying, otherwise same as registration_id
        'registration_id': person['registration'].id,
        'regform_id': registration.registration_form_id,
        'checkin_secret': checkin_secret,
        'event_id': str(registration.event.id),
        'server_url': config.BASE_URL,
        'version': 1
    }
```
(there's also some extra data when used with the site access plugin)
Since every registration has a unique ticket uuid (checkin secret), we don't need to provide `registration_id`, `regform_id` nor `event_id`.

Since we are getting rid of this data, we need a new endpoint in Indico which the app can use to lookup a registration by the ticket uuid only.




