### PR TITLE
Add settings to hide speakers/authors titles throughout event

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Improvements
 - Add bulk JSON export option in management contribution list (:pr:`6370`)
 - Make the default roles of the contribution person link list field more similar to the
   abstract person link list field when there is a linked abstract (:pr:`6342`)
+- Add option to hide person titles throughout the event (:issue:`038`, :pr:`6104`, thanks
+  :user:`vasantvohra`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/templates/display/call_for_abstracts.html
+++ b/indico/modules/events/abstracts/templates/display/call_for_abstracts.html
@@ -47,7 +47,7 @@
                     </div>
                     <div class="speaker-list icon-user" data-searchable="{{ abstract.speakers|map(attribute='name')|join(', ')|lower }}">
                         {{ render_users(abstract.speakers|sort(attribute='display_order_key'),
-                                        span_class='speaker-item-inline', show_title=abstract.event.show_titles) }}
+                                        span_class='speaker-item-inline', title=abstract.event.show_titles) }}
                     </div>
                     <div class="contrib-time icon-time">
                         {% set dt = abstract.modified_dt or abstract.submitted_dt %}

--- a/indico/modules/events/abstracts/templates/display/call_for_abstracts.html
+++ b/indico/modules/events/abstracts/templates/display/call_for_abstracts.html
@@ -47,7 +47,7 @@
                     </div>
                     <div class="speaker-list icon-user" data-searchable="{{ abstract.speakers|map(attribute='name')|join(', ')|lower }}">
                         {{ render_users(abstract.speakers|sort(attribute='display_order_key'),
-                                        span_class='speaker-item-inline') }}
+                                        span_class='speaker-item-inline', show_title=abstract.event.show_titles) }}
                     </div>
                     <div class="contrib-time icon-time">
                         {% set dt = abstract.modified_dt or abstract.submitted_dt %}

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -181,7 +181,7 @@ class SerializerBase:
                 data['email'] = person.email or None
             if person_type == 'ConferenceChair':
                 data['fullName'] = person.get_full_name(last_name_upper=False, abbrev_first_name=False,
-                                                        show_title=True)
+                                                        show_title=person.event.show_titles)
             return data
 
     def _serialize_persons(self, persons, person_type, can_manage=False):

--- a/indico/modules/events/contributions/templates/display/_contribution_list.html
+++ b/indico/modules/events/contributions/templates/display/_contribution_list.html
@@ -41,7 +41,7 @@
         {% if contrib.speakers -%}
             <div class="speaker-list icon-user" data-searchable="{{ contrib.speakers|lower }}">
                 {{ render_users(contrib.speakers|sort(attribute='display_order_key'),
-                                span_class='speaker-item-inline') }}
+                                span_class='speaker-item-inline', title=contrib.event.show_titles) }}
             </div>
         {%- endif %}
         {% if contrib.start_dt_display -%}

--- a/indico/modules/events/contributions/templates/display/contribution_author.html
+++ b/indico/modules/events/contributions/templates/display/contribution_author.html
@@ -17,7 +17,7 @@
 
 {% block content %}
     <section>
-        {{ details_table_row(_('Title:'), author.title) }}
+        {{ details_table_row(_('Title:'), author.title) if author.contribution.event.show_titles }}
         {{ details_table_row(_('Affiliation:'), author.affiliation) }}
     </section>
     {% if contribs -%}

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -27,7 +27,7 @@
     <div class="speaker-list">
         {% call(user_data) render_users(authors|sort(attribute='display_order_key'), separator='') %}
             <span itemprop="performers" itemscope itemtype="http://schema.org/Person" class="speaker-item icon-user">
-                {% if user_data.title -%}
+                {% if user_data.contribution.event.show_titles and user_data.title -%}
                     <span class="speaker-title">
                         {{ user_data.title }}
                     </span>

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -38,6 +38,7 @@ from indico.modules.categories.models.event_move_request import EventMoveRequest
 from indico.modules.events.management.util import get_non_inheriting_objects
 from indico.modules.events.models.persons import EventPerson, PersonLinkMixin
 from indico.modules.events.notifications import notify_event_creation
+from indico.modules.events.persons import persons_settings
 from indico.modules.events.settings import (EventSettingProperty, event_contact_settings, event_core_settings,
                                             event_language_settings)
 from indico.modules.events.timetable.models.entries import TimetableEntry
@@ -460,6 +461,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     supported_locales = _EventSettingProperty(event_language_settings, 'supported_locales')
     default_locale = _EventSettingProperty(event_language_settings, 'default_locale')
     enforce_locale = _EventSettingProperty(event_language_settings, 'enforce_locale')
+    show_titles = _EventSettingProperty(persons_settings, 'show_titles')
 
     @classmethod
     def category_chain_overlaps(cls, category_ids):

--- a/indico/modules/events/persons/__init__.py
+++ b/indico/modules/events/persons/__init__.py
@@ -52,5 +52,5 @@ def _get_placeholders(sender, person, event, contribution=None, abstract=None, r
 persons_settings = EventSettingsProxy('persons', {
     'disallow_custom_persons': False,  # Disallow manually entering persons on person lists
     'default_search_external': False,  # Enable "Users with no Indico account" by default
-    'show_titles': True,  # Show the title of a person within the event
+    'show_titles': True,  # Whether to show titles for people in the event
 })

--- a/indico/modules/events/persons/__init__.py
+++ b/indico/modules/events/persons/__init__.py
@@ -51,5 +51,6 @@ def _get_placeholders(sender, person, event, contribution=None, abstract=None, r
 
 persons_settings = EventSettingsProxy('persons', {
     'disallow_custom_persons': False,  # Disallow manually entering persons on person lists
-    'default_search_external': False,  # Enable "Users with no Indico account" by d efault
+    'default_search_external': False,  # Enable "Users with no Indico account" by default
+    'show_titles': True,  # Show the title of a person within the event
 })

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -519,4 +519,4 @@ class RHManagePersonLists(EditEventSettingsMixin, RHManageEventBase):
     log_message = 'Settings updated'
     log_fields = {'disallow_custom_persons': 'Disallow custom persons',
                   'default_search_external': 'Include users with no Indico account by default',
-                  'show_titles': 'Show the title of a person'}
+                  'show_titles': 'Show person titles'}

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -518,4 +518,5 @@ class RHManagePersonLists(EditEventSettingsMixin, RHManageEventBase):
     log_module = 'Persons'
     log_message = 'Settings updated'
     log_fields = {'disallow_custom_persons': 'Disallow custom persons',
-                  'default_search_external': 'Include users with no Indico account by default'}
+                  'default_search_external': 'Include users with no Indico account by default',
+                  'show_titles': 'Show the title of a person'}

--- a/indico/modules/events/persons/forms.py
+++ b/indico/modules/events/persons/forms.py
@@ -20,6 +20,9 @@ class ManagePersonListsForm(IndicoForm):
     default_search_external = BooleanField(_('Include users with no Indico account by default'), widget=SwitchWidget(),
                                            description=_('If enabled, searching people for speakers/authors will '
                                                          'include those with no Indico account by default.'))
+    show_titles = BooleanField(_('Show titles'), widget=SwitchWidget(),
+                               description=_('If disabled, the title of a person will be hidden everywhere in the event'
+                                             'display pages.'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/indico/modules/events/persons/forms.py
+++ b/indico/modules/events/persons/forms.py
@@ -21,8 +21,8 @@ class ManagePersonListsForm(IndicoForm):
                                            description=_('If enabled, searching people for speakers/authors will '
                                                          'include those with no Indico account by default.'))
     show_titles = BooleanField(_('Show titles'), widget=SwitchWidget(),
-                               description=_('If disabled, the title of a person will be hidden everywhere in the event'
-                                             'display pages.'))
+                               description=_('When disabled, the titles of persons participating in the event will not '
+                                             'be displayed in public areas.'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/indico/modules/events/templates/display/indico/_common.html
+++ b/indico/modules/events/templates/display/indico/_common.html
@@ -97,7 +97,7 @@
         </div>
         <div class="speaker-list">
             {{ render_users(contribution.speakers|sort(attribute='display_order_key'),
-                            span_class='speaker-item icon-user', separator='') }}
+                            span_class='speaker-item icon-user', separator='', title=contribution.event.show_titles) }}
         </div>
     </section>
 {% endmacro %}

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -43,7 +43,7 @@
             {% if chairpersons %}
                 <h2>
                     {% trans %}by{% endtrans %}
-                    {{ render_users(chairpersons|sort(attribute='display_order_key'), span_class='author', title=true) }}
+                    {{ render_users(chairpersons|sort(attribute='display_order_key'), span_class='author', title=event.show_titles) }}
                 </h2>
             {% endif %}
             <div class="details">

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -43,7 +43,8 @@
             {% if chairpersons %}
                 <h2>
                     {% trans %}by{% endtrans %}
-                    {{ render_users(chairpersons|sort(attribute='display_order_key'), span_class='author', title=event.show_titles) }}
+                    {{ render_users(chairpersons|sort(attribute='display_order_key'), span_class='author',
+                                    title=event.show_titles) }}
                 </h2>
             {% endif %}
             <div class="details">

--- a/indico/modules/events/timetable/legacy.py
+++ b/indico/modules/events/timetable/legacy.py
@@ -289,7 +289,7 @@ class TimetableSerializer:
                 'affiliation': person_link.affiliation,
                 'emailHash': md5(person.email.encode()).hexdigest() if person.email else None,
                 'name': person_link.get_full_name(last_name_first=False, last_name_upper=False,
-                                                  abbrev_first_name=False, show_title=True),
+                                                  abbrev_first_name=False, show_title=person.event.show_titles),
                 'displayOrderKey': person_link.display_order_key}
         if self.can_manage_event:
             data['email'] = person.email

--- a/indico/modules/events/timetable/templates/display/indico/_common.html
+++ b/indico/modules/events/timetable/templates/display/indico/_common.html
@@ -40,7 +40,7 @@
 {% macro render_speakers(speakers) -%}
     <div class="speaker-list">
         <span class="label">{{ ngettext("Speaker", "Speakers", speakers | length) }}</span>:
-        {{ render_users(speakers | sort(attribute="display_order_key")) }}
+        {{ render_users(speakers | sort(attribute="display_order_key"), title=speakers[0].contribution.event.show_titles) }}
     </div>
 {%- endmacro %}
 

--- a/indico/modules/events/timetable/templates/display/indico/_session_block.html
+++ b/indico/modules/events/timetable/templates/display/indico/_session_block.html
@@ -42,7 +42,7 @@
             {% if conveners %}
                 <div class="convener-list">
                     <span class="label">{{ ngettext("Convener", "Conveners", conveners|length) }}</span>:
-                    {{ render_users(conveners|sort(attribute='display_order_key')) -}}
+                    {{ render_users(conveners|sort(attribute='display_order_key'), title=event.show_titles) -}}
                 </div>
             {% endif %}
 


### PR DESCRIPTION
closes #6038

## Added a field to configure the display/visibility of Speaker titles

<img width="1280" alt=" Added a field to configure the display/visibility of Speaker titles" src="https://github.com/indico/indico/assets/20479333/53a94275-86e6-481a-a759-62869a0c87d4">

## Before
<img width="1280" alt="Screenshot 2023-12-20 at 12 29 02 AM" src="https://github.com/indico/indico/assets/20479333/8eb7ce53-a499-4fab-8321-80fb31966983">

<img width="1280" alt="Screenshot 2023-12-20 at 12 28 55 AM" src="https://github.com/indico/indico/assets/20479333/ac0af803-42f9-4eb1-8aa0-4536e09e6695">

## After
<img width="1280" alt="Screenshot 2023-12-20 at 12 29 15 AM" src="https://github.com/indico/indico/assets/20479333/7b1de4c4-0ef0-4f4d-a101-0559efaaaf86">

<img width="1280" alt="Screenshot 2023-12-20 at 12 28 48 AM" src="https://github.com/indico/indico/assets/20479333/60d0e0a7-c419-4ae3-ad5d-514d5a219a6f">
