### PR TITLE
Include custom map URL in API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,7 @@ Bugfixes
 - Ignore deleted fields when computing the number of occupied slots for a registration (:pr:`6035`)
 - Show the description of a subcontribution in conference events (:issue:`5946`, :pr:`6056`)
 - Only block templates containing a QR code via ``is_ticket_blocked`` (:pr:`6062`)
+- Use custom map URL in event API if one is set (:pr:`6111`, thanks :user:`stine-fohrmann`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -617,7 +617,7 @@ class CategoryEventFetcher(IteratedDataFetcher, SerializerBase):
             'creationDate': self._serialize_date(event.created_dt),
             'creator': self._serialize_person(event.creator, person_type='Avatar', can_manage=can_manage),
             'hasAnyProtection': event.effective_protection_mode != ProtectionMode.public,
-            'roomMapURL': event.room.map_url if event.room else event.map_url,
+            'roomMapURL': event.map_url,
             'folders': build_folders_api_data(event),
             'chairs': self._serialize_persons(event.person_links, person_type='ConferenceChair', can_manage=can_manage),
             'material': material_data,

--- a/indico/modules/events/api.py
+++ b/indico/modules/events/api.py
@@ -617,7 +617,7 @@ class CategoryEventFetcher(IteratedDataFetcher, SerializerBase):
             'creationDate': self._serialize_date(event.created_dt),
             'creator': self._serialize_person(event.creator, person_type='Avatar', can_manage=can_manage),
             'hasAnyProtection': event.effective_protection_mode != ProtectionMode.public,
-            'roomMapURL': event.room.map_url if event.room else None,
+            'roomMapURL': event.room.map_url if event.room else event.map_url,
             'folders': build_folders_api_data(event),
             'chairs': self._serialize_persons(event.person_links, person_type='ConferenceChair', can_manage=can_manage),
             'material': material_data,


### PR DESCRIPTION
Currently, a map URL is only available via the API if a room from the room booking module's database is selected.
With this change, the content of the "Map URL" field becomes available through the API.

If a room in the room booking module's database is selected **and** a custom URL is given, the room's URL will still be the one available via the API.