### PR TITLE
Fix payment badge text overflow

### DIFF
--- a/indico/modules/events/payment/templates/admin_settings.html
+++ b/indico/modules/events/payment/templates/admin_settings.html
@@ -33,7 +33,7 @@
                         <span class="i-badge-title">{{ plugin.title }}</span>
                     </div>
                     <div class="i-badge-legend">
-                        <span class="i-badge-legend-right">{{ plugin.version }}</span>
+                        <span class="i-badge-legend-right ellipsize">{{ plugin.version }}</span>
                     </div>
                 </a>
             {%- endfor %}


### PR DESCRIPTION
Just a missing ellipsis (normal plugin badges already have it)

before
![image](https://github.com/indico/indico/assets/8739637/03a6ea58-738c-4e21-aec0-bee81067e338)
after
![image](https://github.com/indico/indico/assets/8739637/3358d55a-e8f2-445e-9f5b-d5fe7fc426fc)
