### PR TITLE
Use a more compact QR code data format

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,8 @@ Improvements
 - Add a picture field for registration forms which can use the local webcam to take a picture
   in addition to uploading one, and also supports cropping/rotating the picture (:pr:`5922`,
   thanks :user:`SegiNyn`)
+- Use a more compact registration ticket QR code format which is faster to scan and less
+  likely to fail in poor lighting conditions (:pr:`6123`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/tests/ticket_qr_code_data-0.json
+++ b/indico/modules/events/registration/tests/ticket_qr_code_data-0.json
@@ -1,0 +1,7 @@
+{
+  "": [
+    2,
+    "indico.cern.ch",
+    "mYK+TjLPRlangWKtRWCdEg=="
+  ]
+}

--- a/indico/modules/events/registration/tests/ticket_qr_code_data-0.json
+++ b/indico/modules/events/registration/tests/ticket_qr_code_data-0.json
@@ -1,5 +1,5 @@
 {
-  "": [
+  "i": [
     2,
     "indico.cern.ch",
     "mYK+TjLPRlangWKtRWCdEg=="

--- a/indico/modules/events/registration/tests/ticket_qr_code_data-1.json
+++ b/indico/modules/events/registration/tests/ticket_qr_code_data-1.json
@@ -1,5 +1,5 @@
 {
-  "": [
+  "i": [
     2,
     "http://indico.cern.ch",
     "mYK+TjLPRlangWKtRWCdEg=="

--- a/indico/modules/events/registration/tests/ticket_qr_code_data-1.json
+++ b/indico/modules/events/registration/tests/ticket_qr_code_data-1.json
@@ -1,0 +1,7 @@
+{
+  "": [
+    2,
+    "http://indico.cern.ch",
+    "mYK+TjLPRlangWKtRWCdEg=="
+  ]
+}

--- a/indico/modules/events/registration/tests/ticket_qr_code_data-2.json
+++ b/indico/modules/events/registration/tests/ticket_qr_code_data-2.json
@@ -1,5 +1,5 @@
 {
-  "": [
+  "i": [
     2,
     "indico.cern.ch",
     "mYK+TjLPRlangWKtRWCdEg==",

--- a/indico/modules/events/registration/tests/ticket_qr_code_data-2.json
+++ b/indico/modules/events/registration/tests/ticket_qr_code_data-2.json
@@ -1,0 +1,8 @@
+{
+  "": [
+    2,
+    "indico.cern.ch",
+    "mYK+TjLPRlangWKtRWCdEg==",
+    "X6bXG6goSBG/nH6Z3wTQrw=="
+  ]
+}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -11,7 +11,6 @@ import dataclasses
 import itertools
 import uuid
 from operator import attrgetter
-from urllib.parse import urlsplit
 
 from flask import json, session
 from marshmallow import RAISE, ValidationError, fields, validates
@@ -709,7 +708,7 @@ def get_ticket_qr_code_data(person):
     checkin_secret = person['registration'].ticket_uuid
 
     qr_code_version = 2  # Increment this if the QR code format changes
-    url = _strip_scheme_if_https(config.BASE_URL)
+    url = config.BASE_URL.removeprefix('https://')
 
     data = {
         '': [qr_code_version, url, _base64_encode_uuid(checkin_secret)]
@@ -719,13 +718,6 @@ def get_ticket_qr_code_data(person):
 
     signals.event.registration.generate_ticket_qr_code.send(registration, person=person, ticket_data=data)
     return data
-
-
-def _strip_scheme_if_https(url):
-    if urlsplit(config.BASE_URL).scheme == 'https':
-        return url.removeprefix('https://')
-    else:
-        return url
 
 
 def _base64_encode_uuid(uid):

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -744,7 +744,7 @@ def generate_ticket_qr_code(person):
         border=1
     )
     data = get_ticket_qr_code_data(person)
-    qr.add_data(json.dumps(data))
+    qr.add_data(json.dumps(data, separators=(',', ':')))
     qr.make(fit=True)
     return qr.make_image()._img
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -685,7 +685,7 @@ def get_ticket_qr_code_data(person):
     QR code format:
 
     {
-        '': [qr_code_version, indico_url, b64(checkin_secret), b64(person_id)],
+        'i': [qr_code_version, indico_url, b64(checkin_secret), b64(person_id)],
         # extra keys may be added by plugins (e.g. site access)
     }
 
@@ -711,10 +711,10 @@ def get_ticket_qr_code_data(person):
     url = config.BASE_URL.removeprefix('https://')
 
     data = {
-        '': [qr_code_version, url, _base64_encode_uuid(checkin_secret)]
+        'i': [qr_code_version, url, _base64_encode_uuid(checkin_secret)]
     }
     if is_accompanying:
-        data[''].append(_base64_encode_uuid(person_id))
+        data['i'].append(_base64_encode_uuid(person_id))
 
     signals.event.registration.generate_ticket_qr_code.send(registration, person=person, ticket_data=data)
     return data


### PR DESCRIPTION
Depends on #6101

From the linked PR:
> One feedback we have gotten on the app is that the QR code is rather large and consequently sometimes difficult to scan.

Based on the discussion in the previous PR, I propose this format:
```python
{
    "i": [2, "indico.cern.ch", b64(checkin_secret)]
}
```
- Since we need to stick with a dictionary, let's use the smallest possible key `""` (edit: we use `i` as a key)
- All data go inside the array, starting with the version
- If the base url uses `https`, we strip it
- Checkin secret is base64-encoded (saves 12 bytes)

Using `indico.cern.ch` as an example, we go from 178 to 49 characters, ~28% of the original size.

For accompanying persons, we could simply append the (base64-encoded) person id which would give us 76 characters (177 with the old format) so ~43% of the original size.

Visual comparison:

![image](https://github.com/indico/indico/assets/8739637/bf440dc1-7b7b-49a5-ac6b-2f00b1e122bb) ![image](https://github.com/indico/indico/assets/8739637/9bfb73e3-1a3b-443d-a563-168c5f6ef427)



