### PR TITLE
Fix session legend items not being fully visible

### DIFF
--- a/indico/web/client/styles/modules/_timetable.scss
+++ b/indico/web/client/styles/modules/_timetable.scss
@@ -7,6 +7,7 @@
 
 @use 'base' as *;
 @use 'partials/boxes' as *;
+@use 'design_system';
 
 @mixin base-list-properties() {
   overflow: auto;
@@ -83,10 +84,12 @@
 
   .legendItem {
     @include default-border-radius();
+    @extend %flex-row;
+    --flex-gap: 0.2em;
+    align-items: center;
     background: $pastel-gray;
     color: $black;
     float: left;
-    height: 15px;
     margin: 2px;
     padding: 5px;
     overflow: hidden;
@@ -101,6 +104,7 @@
     margin-top: -2px;
     height: 15px;
     width: 15px;
+    min-width: 15px;
   }
 
   .legendCloseButton {


### PR DESCRIPTION
Not sure how/when this broke..

before
![image](https://github.com/indico/indico/assets/8739637/22f460a9-0cd0-41a6-a3ea-1ea860db6212)
after
![image](https://github.com/indico/indico/assets/8739637/bd65ef0e-f18b-4416-9e4e-47f06ede88e1)

Looks ok even with longer text:
![image](https://github.com/indico/indico/assets/8739637/296ccd9a-1f82-4a7b-be47-580ca8be32ee)
