### PR TITLE
Fix service handling of submitter approvals

### DIFF
--- a/indico/modules/events/editing/controllers/backend/util.py
+++ b/indico/modules/events/editing/controllers/backend/util.py
@@ -36,7 +36,7 @@ def confirm_and_publish_changes(revision, action, comment):
     publish = True
     if service_url:
         try:
-            resp = service_handle_review_editable(revision.editable, session.user, action, revision)
+            resp = service_handle_review_editable(revision.editable, session.user, action, revision, new_revision)
             publish = resp.get('publish', True)
         except ServiceRequestFailed:
             raise ServiceUnavailable(_('Failed processing review, please try again later.'))

--- a/indico/modules/events/editing/service.py
+++ b/indico/modules/events/editing/service.py
@@ -160,8 +160,7 @@ def service_handle_new_editable(editable, user):
         raise ServiceRequestFailed(exc)
 
 
-def service_handle_review_editable(editable, user, action, parent_revision, revision=None):
-    new_revision = revision or parent_revision
+def service_handle_review_editable(editable, user, action, parent_revision, new_revision):
     data = {
         'action': action.name,
         'revision': EditingRevisionSignedSchema().dump(new_revision),


### PR DESCRIPTION
This PR fixes a bug introduced in the Editing Timeline refactoring (#5674) in which the new revision wasn't being sent to the editing service in the case of submitters accepting editor changes, resulting in the comments and tags provided by the serviced to be attached to the parent revision.