### PR TITLE
Fix missing timezone in Abstract/CfP schedule forms

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,7 @@ Bugfixes
 - Show the description of a subcontribution in conference events (:issue:`5946`, :pr:`6056`)
 - Only block templates containing a QR code via ``is_ticket_blocked`` (:pr:`6062`)
 - Use custom map URL in event API if one is set (:pr:`6111`, thanks :user:`stine-fohrmann`)
+- Use the event timezone when scheduling call for abstracts/papers (:pr:`6139`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -664,6 +664,7 @@ class AbstractsScheduleForm(IndicoForm):
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')
+        self.timezone = self.event.timezone
         super().__init__(*args, **kwargs)
 
 

--- a/indico/modules/events/papers/forms.py
+++ b/indico/modules/events/papers/forms.py
@@ -64,6 +64,7 @@ class PapersScheduleForm(IndicoForm):
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')
+        self.timezone = self.event.timezone
         super().__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
The `AbstractsScheduleForm` and `PapersScheduleForm` (unlike `RegistrationFormScheduleForm`) do not correctly set the event timezone which then defaults to the session timezone instead.