### PR TITLE
Include comment on email notifications for update and accept editing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,7 +63,7 @@ Improvements
 - Do not bother people registering using an invitation link with a CAPTCHA (:pr:`6095`)
 - Add option to allow people to register using an invitation link even if the event is
   restricted (:pr:`6094`)
-- Improve editing notifications emails (:issue:`6027`, :pr:`6042`)
+- Improve editing notifications emails (:issue:`6027`, :pr:`6042`, :pr:`6154`)
 - Add a picture field for registration forms which can use the local webcam to take a picture
   in addition to uploading one, and also supports cropping/rotating the picture (:pr:`5922`,
   thanks :user:`SegiNyn`)

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -153,12 +153,16 @@ def review_editable_revision(revision, editor, action, comment, tags, files=None
         _ensure_publishable_files(new_revision)
     revision.editable.revisions.append(new_revision)
     if action == EditingReviewAction.update_accept:
+        update_revision = new_revision
         new_revision = EditingRevision(user=editor,
                                        type=RevisionType.acceptance,
                                        tags=tags)
         revision.editable.revisions.append(new_revision)
-    db.session.flush()
-    notify_editor_judgment(new_revision, revision.user, action)
+        db.session.flush()
+        notify_editor_judgment(update_revision, revision.user, action)
+    else:
+        db.session.flush()
+        notify_editor_judgment(new_revision, revision.user, action)
     logger.info('Revision %r reviewed by %s [%s]', revision, editor, action.name)
     _log_review(revision.editable, LogKind.positive, f'Revision for {revision.editable.log_title} reviewed',
                 old_state=old_state)


### PR DESCRIPTION
When updating and accepting an editable, the notifications email for editors/authors was not including the comment made during the update. The acceptance revision was the one being passed to create the notification email, so the comment was not being included. Now the update revision is the one sent to create the notification email.