### PR TITLE
Calendar: filter by room

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -80,6 +80,8 @@ Improvements
   thanks :user:`Moliholy, unconventionaldotdev`)
 - Add a "Picture" personal data field to registrations. When used, it allows including the
   picture provided by the user on badges/tickets (:pr:`6160`, thanks :user:`vtran99`)
+- Filter events by room in the calendar legend
+  (:issue:`6148, 6149`, :pr:`6158`, thanks :user:`Moliholy, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,9 +70,9 @@ Improvements
 - Use a more compact registration ticket QR code format which is faster to scan and less
   likely to fail in poor lighting conditions (:pr:`6123`)
 - Add a legend to the category calendar, allowing to filter events either by category, venue or room
-  (:issue:`6105, 6106, 6128, 6148, 6149`, :pr:`6110`, thanks :user:`Moliholy, unconventionaldotdev`)
+  (:issue:`6105, 6106, 6128, 6148, 6149`, :pr:`6110, 6158`, thanks :user:`Moliholy, unconventionaldotdev`)
 - Add week and day views in the category calendar and improve navigation controls
-  (:issue:`6108, 6129, 6107`, :pr:`6110, 6158`, thanks :user:`Moliholy, unconventionaldotdev`).
+  (:issue:`6108, 6129, 6107`, :pr:`6110`, thanks :user:`Moliholy, unconventionaldotdev`).
 - Add the ability to clone privacy settings (:pr:`6156`, thanks :user:`SegiNyn`)
 - Add option for managers to change the registration fee of a set of registrations (:issue:`6132`,
   :pr:`6138`)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,10 +69,10 @@ Improvements
   thanks :user:`SegiNyn`)
 - Use a more compact registration ticket QR code format which is faster to scan and less
   likely to fail in poor lighting conditions (:pr:`6123`)
-- Add a legend to the category calendar, allowing to filter events either by category or location
-  (:issue:`6105, 6106, 6128`, :pr:`6110`, thanks :user:`Moliholy, unconventionaldotdev`)
+- Add a legend to the category calendar, allowing to filter events either by category, venue or room
+  (:issue:`6105, 6106, 6128, 6148, 6149`, :pr:`6110`, thanks :user:`Moliholy, unconventionaldotdev`)
 - Add week and day views in the category calendar and improve navigation controls
-  (:issue:`6108, 6129, 6107`, :pr:`6110`, thanks :user:`Moliholy, unconventionaldotdev`).
+  (:issue:`6108, 6129, 6107`, :pr:`6110, 6158`, thanks :user:`Moliholy, unconventionaldotdev`).
 - Add the ability to clone privacy settings (:pr:`6156`, thanks :user:`SegiNyn`)
 - Add option for managers to change the registration fee of a set of registrations (:issue:`6132`,
   :pr:`6138`)

--- a/indico/modules/categories/client/js/calendar.js
+++ b/indico/modules/categories/client/js/calendar.js
@@ -200,7 +200,15 @@ import CalendarLegend from './components/CalendarLegend';
           );
         }
 
-        function setupLegendByAttribute(events, items, attr, defaultTitle, rootId, rootTitle) {
+        function setupLegendByAttribute(
+          events,
+          items,
+          attr,
+          defaultTitle,
+          rootId,
+          rootTitle,
+          sortMethod
+        ) {
           const itemMap = items.reduce(
             (acc, {id, title, url}) => ({
               ...acc,
@@ -237,17 +245,19 @@ import CalendarLegend from './components/CalendarLegend';
               } else if (b.isSpecial) {
                 return 1;
               }
-              return a.title.localeCompare(b.title);
+              return sortMethod ? sortMethod(a.title, b.title) : a.title.localeCompare(b.title);
             });
         }
 
         function setupLegendByRoom(events, locations, rooms) {
+          const collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});
           const result = setupLegendByAttribute(
             events,
             rooms,
             'roomId',
             Translate.string('No room'),
-            0
+            0,
+            collator.compare
           );
           // if there are no locations no need to indent
           if (locations.length <= 1) {

--- a/indico/modules/categories/client/js/calendar.js
+++ b/indico/modules/categories/client/js/calendar.js
@@ -105,19 +105,9 @@ import CalendarLegend from './components/CalendarLegend';
       },
       events({start, end}, successCallback, failureCallback) {
         function updateCalendar(data) {
-          let attr;
-          switch (groupBy) {
-            case 'category':
-              attr = 'categoryId';
-              break;
-            case 'location':
-              attr = 'venueId';
-              break;
-            case 'room':
-              attr = 'roomId';
-              break;
-            default:
-              throw new Error(`Invalid "groupBy": ${groupBy}`);
+          const attr = {category: 'categoryId', location: 'venueId', room: 'roomId'}[groupBy];
+          if (!attr) {
+            throw new Error(`Invalid "groupBy": ${groupBy}`);
           }
           const filteredEvents = data.events.filter(e => !filteredLegendElements.has(e[attr] ?? 0));
           successCallback(filteredEvents);

--- a/indico/modules/categories/client/js/calendar.js
+++ b/indico/modules/categories/client/js/calendar.js
@@ -257,6 +257,7 @@ import CalendarLegend from './components/CalendarLegend';
             'roomId',
             Translate.string('No room'),
             0,
+            Translate.string('No room'),
             collator.compare
           );
           // if there are no locations no need to indent

--- a/indico/modules/categories/client/js/calendar.js
+++ b/indico/modules/categories/client/js/calendar.js
@@ -153,6 +153,14 @@ import CalendarLegend from './components/CalendarLegend';
             }
             calendar.refetchEvents();
           };
+          const selectAll = () => {
+            items.forEach(({id}) => filteredLegendElements.delete(id));
+            calendar.refetchEvents();
+          };
+          const deselectAll = () => {
+            items.forEach(({id}) => filteredLegendElements.add(id));
+            calendar.refetchEvents();
+          };
           items = items.map(item => ({...item, checked: !filteredLegendElements.has(item.id)}));
           ReactDOM.render(
             <CalendarLegend
@@ -160,6 +168,8 @@ import CalendarLegend from './components/CalendarLegend';
               groupBy={data.group_by}
               onFilterChanged={onFilterChanged}
               onElementSelected={onElementSelected}
+              selectAll={selectAll}
+              deselectAll={deselectAll}
             />,
             legendContainer
           );

--- a/indico/modules/categories/client/js/calendar.js
+++ b/indico/modules/categories/client/js/calendar.js
@@ -200,15 +200,15 @@ import CalendarLegend from './components/CalendarLegend';
           );
         }
 
-        function setupLegendByAttribute(
+        function setupLegendByAttribute({
           events,
           items,
           attr,
           defaultTitle,
           rootId,
-          rootTitle,
-          sortMethod
-        ) {
+          rootTitle = undefined,
+          sortMethod = undefined,
+        }) {
           const itemMap = items.reduce(
             (acc, {id, title, url}) => ({
               ...acc,
@@ -251,15 +251,15 @@ import CalendarLegend from './components/CalendarLegend';
 
         function setupLegendByRoom(events, locations, rooms) {
           const collator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});
-          const result = setupLegendByAttribute(
+          const result = setupLegendByAttribute({
             events,
-            rooms,
-            'roomId',
-            Translate.string('No room'),
-            0,
-            Translate.string('No room'),
-            collator.compare
-          );
+            items: rooms,
+            attr: 'roomId',
+            defaultTitle: Translate.string('No room'),
+            rootId: 0,
+            rootTitle: Translate.string('No room'),
+            sortMethod: collator.compare,
+          });
           // if there are no locations no need to indent
           if (locations.length <= 1) {
             return result;
@@ -310,23 +310,23 @@ import CalendarLegend from './components/CalendarLegend';
           let items;
           switch (data.group_by) {
             case 'category':
-              items = setupLegendByAttribute(
-                data.events,
-                data.categories,
-                'categoryId',
-                Translate.string('No category'),
-                categoryId,
-                Translate.string('This category')
-              );
+              items = setupLegendByAttribute({
+                events: data.events,
+                items: data.categories,
+                attr: 'categoryId',
+                defaultTitle: Translate.string('No category'),
+                rootId: categoryId,
+                rootTitle: Translate.string('This category'),
+              });
               break;
             case 'location':
-              items = setupLegendByAttribute(
-                data.events,
-                data.locations,
-                'venueId',
-                Translate.string('No venue'),
-                0
-              );
+              items = setupLegendByAttribute({
+                events: data.events,
+                items: data.locations,
+                attr: 'venueId',
+                defaultTitle: Translate.string('No venue'),
+                rootId: 0,
+              });
               break;
             case 'room':
               items = setupLegendByRoom(data.events, data.locations, data.rooms);

--- a/indico/modules/categories/client/js/components/CalendarLegend.jsx
+++ b/indico/modules/categories/client/js/components/CalendarLegend.jsx
@@ -135,11 +135,11 @@ function CalendarLegend({
       />
       <div styleName="toggle-container">
         <span onClick={selectAll} style={{cursor: 'pointer', marginRight: '8px'}}>
-          {Translate.string('Select all')}
+          <Translate>Select all</Translate>
         </span>
         {' | '}
         <span onClick={deselectAll} style={{cursor: 'pointer', marginLeft: '8px'}}>
-          {Translate.string('Clear')}
+          <Translate>Clear</Translate>
         </span>
       </div>
       <div>{parsedItems}</div>

--- a/indico/modules/categories/client/js/components/CalendarLegend.jsx
+++ b/indico/modules/categories/client/js/components/CalendarLegend.jsx
@@ -29,11 +29,15 @@ function LegendItem({
       checkboxRef.current.handleChange();
     }
   };
+  const textStyle = {color: 'black'};
+  if (hasSubitems) {
+    textStyle.fontWeight = 'bold';
+  }
   return (
     <div styleName="legend-item" onClick={handleDivClick} style={{marginLeft: depth * 30}}>
       {color ? <div styleName="color-square" style={{backgroundColor: color}} /> : undefined}
-      {hasSubitems ? <div styleName="color-square">{'\u25BC'}</div> : undefined}
-      <span styleName={isSpecial ? 'italic' : undefined} style={{color: 'black'}}>
+      {hasSubitems ? <div styleName="color-square" /> : undefined}
+      <span styleName={isSpecial ? 'italic' : undefined} style={textStyle}>
         {url && !isSpecial ? (
           <a href={url} onClick={e => e.stopPropagation()}>
             {title}

--- a/indico/modules/categories/client/js/components/CalendarLegend.jsx
+++ b/indico/modules/categories/client/js/components/CalendarLegend.jsx
@@ -56,7 +56,14 @@ LegendItem.defaultProps = {
   isSpecial: false,
 };
 
-function CalendarLegend({items, groupBy, onFilterChanged, onElementSelected}) {
+function CalendarLegend({
+  items,
+  groupBy,
+  onFilterChanged,
+  onElementSelected,
+  selectAll,
+  deselectAll,
+}) {
   const [isOpen, setIsOpen] = useState(false);
   const parsedItems = items.map(({id, title, checked, url, color, isSpecial}) => (
     <LegendItem
@@ -88,6 +95,15 @@ function CalendarLegend({items, groupBy, onFilterChanged, onElementSelected}) {
         onBlur={() => setIsOpen(false)}
         onChange={onChange}
       />
+      <div styleName="toggle-container">
+        <span onClick={selectAll} style={{cursor: 'pointer', marginRight: '8px'}}>
+          {Translate.string('Select all')}
+        </span>
+        {' | '}
+        <span onClick={deselectAll} style={{cursor: 'pointer', marginLeft: '8px'}}>
+          {Translate.string('Clear')}
+        </span>
+      </div>
       <div>{parsedItems}</div>
     </div>
   );
@@ -98,5 +114,7 @@ CalendarLegend.propTypes = {
   groupBy: PropTypes.string.isRequired,
   onFilterChanged: PropTypes.func.isRequired,
   onElementSelected: PropTypes.func.isRequired,
+  selectAll: PropTypes.func.isRequired,
+  deselectAll: PropTypes.func.isRequired,
 };
 export default CalendarLegend;

--- a/indico/modules/categories/client/js/components/CalendarLegend.module.scss
+++ b/indico/modules/categories/client/js/components/CalendarLegend.module.scss
@@ -19,6 +19,9 @@
   height: 20px;
   margin-right: 10px;
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .italic {

--- a/indico/modules/categories/client/js/components/CalendarLegend.module.scss
+++ b/indico/modules/categories/client/js/components/CalendarLegend.module.scss
@@ -28,3 +28,8 @@
 .legend-checkbox {
   margin-left: auto;
 }
+
+.toggle-container {
+  margin-top: 5px;
+  margin-bottom: 10px;
+}

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -623,7 +623,7 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
             room = event.room
             if room and room.id not in rooms:
                 rooms[room.id] = {'id': room.id,
-                                  'title': room.verbose_name or room.generate_name(),
+                                  'title': room.full_name,
                                   'venueId': room.location_id}
             if self.group_by == self.GroupBy.category:
                 comparison_id = category_id

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -19,7 +19,7 @@ from dateutil.relativedelta import relativedelta
 from flask import flash, jsonify, redirect, request, session
 from marshmallow_enum import EnumField
 from pytz import utc
-from sqlalchemy.orm import joinedload, load_only, subqueryload, undefer, undefer_group
+from sqlalchemy.orm import joinedload, load_only, selectinload, subqueryload, undefer, undefer_group
 from webargs import fields, validate
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
@@ -564,6 +564,7 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
     class GroupBy(Enum):
         category = auto()
         location = auto()
+        room = auto()
 
     @use_kwargs({'group_by': EnumField(GroupBy, load_default=GroupBy.category)}, location='query')
     def _process_args(self, group_by):
@@ -582,8 +583,9 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
                          Event.is_visible_in(self.category.id),
                          ~Event.is_deleted)
                  .options(undefer(Event.detailed_category_chain),
-                          load_only('id', 'title', 'start_dt', 'end_dt', 'category_id', 'own_venue_id')))
-        events, categories = self._get_event_data(query)
+                          selectinload('own_room'),
+                          load_only('id', 'title', 'start_dt', 'end_dt', 'category_id', 'own_venue_id', 'own_room_id')))
+        events, categories, rooms = self._get_event_data(query)
         raw_locations = Location.query.options(load_only('id', 'name')).all()
         locations = [{'title': loc.name, 'id': loc.id} for loc in raw_locations]
         ongoing_events = (Event.query
@@ -594,7 +596,7 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
                           .options(load_only('id', 'title', 'start_dt', 'end_dt', 'timezone'))
                           .order_by(Event.title)
                           .all())
-        return jsonify_data(flash=False, events=events, categories=categories, locations=locations,
+        return jsonify_data(flash=False, events=events, categories=categories, locations=locations, rooms=rooms,
                             group_by=self.group_by.name,
                             ongoing_event_count=len(ongoing_events),
                             ongoing_events_html=self._render_ongoing_events(ongoing_events))
@@ -612,23 +614,35 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
     def _get_event_data(self, event_query):
         data = []
         categories = {}
+        rooms = {}
         tz = self.category.display_tzinfo
         for event in event_query:
             category_data = self._find_nearest_category(event.detailed_category_chain)
             category_id = category_data['id']
             category_data['url'] = url_for('categories.calendar', category_id=category_id)
-            comparison_id = category_id if self.group_by == self.GroupBy.category else event.own_venue_id or 0
+            room = event.room
+            if room and room.id not in rooms:
+                rooms[room.id] = {'id': room.id,
+                                  'title': room.verbose_name or room.generate_name(),
+                                  'venueId': room.location_id}
+            if self.group_by == self.GroupBy.category:
+                comparison_id = category_id
+            elif self.group_by == self.GroupBy.location:
+                comparison_id = event.own_venue_id or 0
+            else:
+                comparison_id = room.id if room else 0
             event_data = {'title': event.title,
                           'start': event.start_dt.astimezone(tz).replace(tzinfo=None).isoformat(),
                           'end': event.end_dt.astimezone(tz).replace(tzinfo=None).isoformat(),
                           'url': event.url,
                           'categoryId': category_id,
-                          'venueId': event.own_venue_id}
+                          'venueId': event.own_venue_id,
+                          'roomId': room.id if room else None}
             colors = generate_contrast_colors(comparison_id)
             event_data.update({'textColor': f'#{colors.text}', 'color': f'#{colors.background}'})
             data.append(event_data)
             categories[category_id] = category_data
-        return data, list(categories.values())
+        return data, list(categories.values()), list(rooms.values())
 
     def _render_ongoing_events(self, ongoing_events):
         template = get_template_module('categories/display/_calendar_ongoing_events.html')


### PR DESCRIPTION
Closes #6148
Closes #6149

This PR adds the following:
- Two actions to the calendar legend: one for selecting all items and another one for deselecting them all.
- Filtering by room in the legend.


### Screenshots

<img width="1487" alt="Screenshot 2024-01-31 at 18 04 15" src="https://github.com/indico/indico/assets/2722756/091f9620-03c8-4890-a7d1-3d48f7f8ca3f">

<img width="235" alt="Screenshot 2024-01-31 at 18 01 36" src="https://github.com/indico/indico/assets/2722756/0a1af8ae-a195-4b32-b373-192810103cf4">

