### PR TITLE
Send template data when calling signal draw_item_on_badge

### DIFF
--- a/indico/core/signals/event/designer.py
+++ b/indico/core/signals/event/designer.py
@@ -26,7 +26,8 @@ The signal returns a dictionary which is used to update the item `style`.
 draw_item_on_badge = _signals.signal('draw-item-on-badge', '''
 Called when drawing an item on a badge for a given registration.
 The `registration` object is the sender. The `items`, `self.height`,
-`self.width`, `item_data` and `person` are passed in the kwargs.
+`self.width`, `item_data`, `person` and `template_data` are passed in the kwargs.
 `item_data` is a dictionary containing `item`, `text`, `pos_x` and `pos_y`.
+`template_data` is a namedtuple containing the complete template structure.
 The signal returns a dictionary of updates for the contents of `item_data`.
 ''')

--- a/indico/modules/events/registration/badges.py
+++ b/indico/modules/events/registration/badges.py
@@ -129,7 +129,8 @@ class RegistrantsListToBadgesPDF(DesignerPDFBase):
             item_data = {'item': item, 'text': text, 'pos_x': pos_x, 'pos_y': pos_y}
             for update in values_from_signal(
                 signals.event.designer.draw_item_on_badge.send(person['registration'], items=items, height=self.height,
-                                                               width=self.width, data=item_data, person=person),
+                                                               width=self.width, data=item_data, person=person,
+                                                               template_data=tpl_data),
                 as_list=True
             ):
                 item_data.update(update)


### PR DESCRIPTION
This PR is about adding template data (ie dimension) to the designer signal `draw_item_on_badge`. 
It's required when template elements are adjusted dynamically.