### PR TITLE
Update user in abstract email log when merging users

### DIFF
--- a/indico/migrations/versions/20240206_1223_5bb555dd91eb_update_merged_users_in_abstract_email_logs.py
+++ b/indico/migrations/versions/20240206_1223_5bb555dd91eb_update_merged_users_in_abstract_email_logs.py
@@ -1,0 +1,37 @@
+"""Update merged users in abstract email logs
+
+Revision ID: 5bb555dd91eb
+Revises: 8e08236a529f
+Create Date: 2024-02-06 12:23:43.406547
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '5bb555dd91eb'
+down_revision = '8e08236a529f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute('''
+        CREATE TEMPORARY TABLE merge_map AS
+        WITH RECURSIVE merge_map (user_id, current_user_id) AS (
+            SELECT id, id FROM users.users WHERE merged_into_id IS NULL
+            UNION ALL
+            SELECT u.id, mm.current_user_id FROM users.users u, merge_map mm WHERE u.merged_into_id = mm.user_id
+        ) SELECT * FROM merge_map WHERE user_id != current_user_id;
+
+        CREATE INDEX ix_merge_map_current_user_id ON merge_map USING btree (current_user_id);
+
+        UPDATE event_abstracts.email_logs eml
+        SET user_id = mm.current_user_id
+        FROM merge_map mm
+        WHERE mm.user_id = eml.user_id AND mm.current_user_id != eml.user_id;
+    ''')
+
+
+def downgrade():
+    pass

--- a/indico/modules/events/abstracts/__init__.py
+++ b/indico/modules/events/abstracts/__init__.py
@@ -66,6 +66,7 @@ def _get_cloners(sender, **kwargs):
 def _merge_users(target, source, **kwargs):
     from indico.modules.events.abstracts.models.abstracts import Abstract
     from indico.modules.events.abstracts.models.comments import AbstractComment
+    from indico.modules.events.abstracts.models.email_logs import AbstractEmailLogEntry
     from indico.modules.events.abstracts.models.reviews import AbstractReview
     from indico.modules.events.abstracts.settings import abstracts_settings
     Abstract.query.filter_by(submitter_id=source.id).update({Abstract.submitter_id: target.id})
@@ -74,6 +75,7 @@ def _merge_users(target, source, **kwargs):
     AbstractComment.query.filter_by(user_id=source.id).update({AbstractComment.user_id: target.id})
     AbstractComment.query.filter_by(modified_by_id=source.id).update({AbstractComment.modified_by_id: target.id})
     AbstractReview.query.filter_by(user_id=source.id).update({AbstractReview.user_id: target.id})
+    AbstractEmailLogEntry.query.filter_by(user_id=source.id).update({AbstractEmailLogEntry.user_id: target.id})
     abstracts_settings.acls.merge_users(target, source)
 
 


### PR DESCRIPTION
This is usually not causing any problems, except when using `indico event export` and trying to import that dump on a system where the user does not exist: The user is now included twice in the dump, so importing it fails since it tries to create the user twice (and duplicate emails may only exist on deleted users).

TODO

- [x] Test if it actually works
- [x] Alembic revision to fix broken data (using merge map similar to alembic rev `735dc4e8d2f3`)