### PR TITLE
Limit the height of the placeholders box

### DIFF
--- a/indico/web/client/js/react/components/PlaceholderInfo.module.scss
+++ b/indico/web/client/js/react/components/PlaceholderInfo.module.scss
@@ -13,6 +13,9 @@
   margin: 0;
   padding: 0;
   list-style: none;
+  line-height: 1.7;
+  max-height: 30em;
+  overflow-y: auto;
 
   li:not(:last-child) {
     margin-bottom: 0.3em;


### PR DESCRIPTION
This PR sets a `max-height` of `30em` for the placeholders box contents and displays a scrollbar if necessary.

Before:
![image](https://github.com/indico/indico/assets/27357203/e5104a3e-2ef0-48c0-81ce-8f5394ca3c45)

After:
![image](https://github.com/indico/indico/assets/27357203/96cde9ae-6b22-4035-9419-7a5a49deef02)
