### PR TITLE
Add parameter editor to the document template editor

### DIFF
--- a/indico/modules/events/persons/client/js/EmailDialog.jsx
+++ b/indico/modules/events/persons/client/js/EmailDialog.jsx
@@ -11,8 +11,12 @@ import React, {useState} from 'react';
 import {FormSpy} from 'react-final-form';
 import {Form, Button, Message, Input, Popup, Icon} from 'semantic-ui-react';
 
-import {FinalEmailList, TinyMCETextEditor, FinalTinyMCETextEditor} from 'indico/react/components';
-import PlaceholderInfo from 'indico/react/components/PlaceholderInfo';
+import {
+  FinalEmailList,
+  FinalTinyMCETextEditor,
+  PlaceholderInfo,
+  TinyMCETextEditor,
+} from 'indico/react/components';
 import {FinalCheckbox, FinalDropdown, FinalInput} from 'indico/react/forms';
 import {FinalModalForm} from 'indico/react/forms/final-form';
 import {Translate, PluralTranslate, Singular, Plural, Param} from 'indico/react/i18n';

--- a/indico/modules/receipts/client/js/printing/PrintReceiptsModal.jsx
+++ b/indico/modules/receipts/client/js/printing/PrintReceiptsModal.jsx
@@ -32,7 +32,7 @@ import {snakifyKeys} from 'indico/utils/case';
 import Previewer from '../templates/Previewer.jsx';
 
 import {printReceipt} from './print.jsx';
-import TemplateParameterEditor from './TemplateParameterEditor.jsx';
+import TemplateParameterEditor, {getDefaultFieldValue} from './TemplateParameterEditor.jsx';
 
 const makeSubmitLabel = ({publish, notify_users: notifyUsers}, numRegistrants) => {
   if (publish) {
@@ -55,16 +55,6 @@ const makeSubmitLabel = ({publish, notify_users: notifyUsers}, numRegistrants) =
         numRegistrants
       )
     : PluralTranslate.string('Save to registration', 'Save to registrations', numRegistrants);
-};
-
-const getDefaultValue = f => {
-  if (f.type === 'dropdown') {
-    return f.attributes.options[f.attributes.default];
-  } else if (f.type === 'checkbox') {
-    return f.attributes.value || false;
-  } else {
-    return f.attributes.value || '';
-  }
 };
 
 const downloadOptions = [
@@ -104,7 +94,7 @@ export default function PrintReceiptsModal({onClose, registrationIds, eventId}) 
     form.change(
       'custom_fields',
       customFields
-        ? Object.assign({}, ...customFields.map(f => ({[f.name]: getDefaultValue(f)})))
+        ? Object.assign({}, ...customFields.map(f => ({[f.name]: getDefaultFieldValue(f)})))
         : {}
     );
     form.change('filename', defaultFilename || formatters.slugify(title));
@@ -209,6 +199,7 @@ export default function PrintReceiptsModal({onClose, registrationIds, eventId}) 
                     customFields={template ? getCustomFields(template) : []}
                     title={Translate.string('Template Parameters')}
                     disabled={receiptIds.length > 0}
+                    defaultOpen
                   />
                 )}
               </Field>

--- a/indico/modules/receipts/client/js/printing/TemplateParameterEditor.jsx
+++ b/indico/modules/receipts/client/js/printing/TemplateParameterEditor.jsx
@@ -9,6 +9,16 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Accordion, Form} from 'semantic-ui-react';
 
+export const getDefaultFieldValue = f => {
+  if (f.type === 'dropdown') {
+    return f.attributes.options[f.attributes.default];
+  } else if (f.type === 'checkbox') {
+    return f.attributes.value || false;
+  } else {
+    return f.attributes.value || '';
+  }
+};
+
 /**
  * This component represents a custom field which can contain a "text" (str), "choice" or "yes/no" (boolean).
  */
@@ -76,13 +86,19 @@ CustomField.defaultProps = {
   value: null,
 };
 
-export default function TemplateParameterEditor({customFields, value, onChange, title}) {
+export default function TemplateParameterEditor({
+  customFields,
+  value,
+  onChange,
+  title,
+  defaultOpen,
+}) {
   if (customFields.length === 0 || Object.keys(value).length === 0) {
     return null;
   }
   return (
     <Accordion
-      defaultActiveIndex={0}
+      defaultActiveIndex={defaultOpen ? 0 : undefined}
       panels={[
         {
           key: 'template-params',
@@ -115,8 +131,10 @@ TemplateParameterEditor.propTypes = {
   value: PropTypes.object.isRequired,
   onChange: PropTypes.func.isRequired,
   title: PropTypes.string,
+  defaultOpen: PropTypes.bool,
 };
 
 TemplateParameterEditor.defaultProps = {
   title: '',
+  defaultOpen: false,
 };

--- a/indico/modules/receipts/controllers/templates.py
+++ b/indico/modules/receipts/controllers/templates.py
@@ -166,16 +166,19 @@ class RHLivePreview(ReceiptAreaMixin, RHReceiptTemplatesManagementBase):
         'html': fields.String(required=True, validate=validate.Length(3)),
         'css': fields.String(required=True),
         'yaml': YAML(ReceiptTplMetadataSchema, required=True),
+        'custom_fields_values': fields.Dict(keys=fields.String, load_default=lambda: {}),
     })
-    def _process(self, html, css, yaml):
+    def _process(self, html, css, yaml, custom_fields_values):
         g.template_stack = [TemplateStackEntry(None)]
         # Just some dummy data to test the template
-        dummy_data = get_dummy_preview_data(yaml.get('custom_fields', []))
+        custom_fields = yaml.get('custom_fields', [])
+        dummy_data = get_dummy_preview_data(custom_fields, custom_fields_values)
         compiled_html = compile_jinja_code(html, dummy_data, use_stack=True)
         pdf_data = create_pdf(self.target, [compiled_html], css)
         return jsonify({
             'pdf': base64.b64encode(pdf_data.getvalue()),
-            'data': get_preview_placeholders(dummy_data)
+            'data': get_preview_placeholders(dummy_data),
+            'custom_fields': custom_fields,
         })
 
 

--- a/indico/modules/receipts/util.py
+++ b/indico/modules/receipts/util.py
@@ -233,7 +233,7 @@ def _get_default_value(field):
     return field['attributes'].get('value', '')
 
 
-def get_dummy_preview_data(custom_fields: dict) -> dict:
+def get_dummy_preview_data(custom_fields: dict, custom_fields_values: t.Optional[dict] = None) -> dict:
     """Get dummy preview data for rendering a document template.
 
     Most document templates are written inthe context of a category, so it is not
@@ -241,12 +241,15 @@ def get_dummy_preview_data(custom_fields: dict) -> dict:
     serializes dummy data that can be used instead.
     """
     from indico.modules.receipts.schemas import TemplateDataSchema
+    if custom_fields_values is None:
+        custom_fields_values = {}
     dummy_file = Path(current_app.root_path) / 'modules' / 'receipts' / 'dummy_data.yaml'
     dummy_data = yaml.safe_load(dummy_file.read_text())
     try:
         return TemplateDataSchema().load({
             **dummy_data,
-            'custom_fields': {f['name']: _get_default_value(f) for f in custom_fields},
+            'custom_fields': {f['name']: custom_fields_values.get(f['name'], _get_default_value(f))
+                              for f in custom_fields},
         })
     except ValidationError as exc:
         # This is a bug that generally happens only during development, but having the

--- a/indico/web/client/js/react/components/index.js
+++ b/indico/web/client/js/react/components/index.js
@@ -28,6 +28,7 @@ export {default as Carousel} from './Carousel';
 export {default as ScrollButton} from './ScrollButton';
 export {default as StickyWithScrollBack} from './StickyWithScrollBack';
 export {default as EmailListField, FinalEmailList} from './EmailListField';
+export {default as PlaceholderInfo} from './PlaceholderInfo';
 export {default as PopoverDropdownMenu} from './PopoverDropdownMenu';
 export {default as ResponsivePopup} from './ResponsivePopup';
 export {default as ListFilter} from './ListFilter';


### PR DESCRIPTION
This PR adds the parameter editor to the document module's template editor:

![image](https://github.com/indico/indico/assets/27357203/211a4da4-1fdb-44ee-8a62-2e847d75aeaa)

The selected values are also rendered on the preview.
