### PR TITLE
Ensure emails do not contain relative URLs

### DIFF
--- a/indico/modules/events/agreements/forms.py
+++ b/indico/modules/events/agreements/forms.py
@@ -12,7 +12,7 @@ from indico.util.i18n import _
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.fields import IndicoRadioField
-from indico.web.forms.validators import UsedIf
+from indico.web.forms.validators import NoRelativeURLs, UsedIf
 from indico.web.forms.widgets import TinyMCEWidget
 
 
@@ -26,7 +26,7 @@ class AgreementEmailForm(IndicoForm):
     from_address = SelectField(_('From'), [DataRequired()])
     cc_addresses = EmailField(_('CC'), [Optional(), Email()],
                               description=_('Warning: this email address will be able to sign the agreement!'))
-    body = TextAreaField(_('Email body'), widget=TinyMCEWidget())
+    body = TextAreaField(_('Email body'), [NoRelativeURLs()], widget=TinyMCEWidget(absolute_urls=True))
 
     def __init__(self, *args, **kwargs):
         self._definition = kwargs.pop('definition')

--- a/indico/modules/events/management/controllers/emails.py
+++ b/indico/modules/events/management/controllers/emails.py
@@ -12,7 +12,7 @@ from webargs.flaskparser import abort
 from indico.core.notifications import make_email, send_email
 from indico.modules.events.contributions.models.persons import AuthorType
 from indico.util.i18n import _
-from indico.util.marshmallow import LowercaseString, not_empty
+from indico.util.marshmallow import LowercaseString, no_relative_urls, not_empty
 from indico.util.placeholders import get_sorted_placeholders, replace_placeholders
 from indico.web.args import use_kwargs
 from indico.web.flask.templating import get_template_module
@@ -91,7 +91,7 @@ class EmailRolesSendMixin:
 
     @use_kwargs({
         'from_address': fields.String(required=True, validate=not_empty),
-        'body': fields.String(required=True, validate=not_empty),
+        'body': fields.String(required=True, validate=[not_empty, no_relative_urls]),
         'subject': fields.String(required=True, validate=not_empty),
         'bcc_addresses': fields.List(LowercaseString(validate=validate.Email()), load_default=lambda: []),
         'copy_for_sender': fields.Bool(load_default=False),

--- a/indico/modules/events/persons/client/js/EmailDialog.jsx
+++ b/indico/modules/events/persons/client/js/EmailDialog.jsx
@@ -151,7 +151,7 @@ export function EmailDialog({
           name="body"
           label={Translate.string('Email body')}
           required
-          config={{images: false}}
+          config={{images: false, forceAbsoluteURLs: true}}
         />
         {placeholders.length > 0 && (
           <Form.Field>

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -45,7 +45,7 @@ from indico.modules.logs import LogKind
 from indico.modules.users.models.affiliations import Affiliation
 from indico.util.date_time import now_utc
 from indico.util.i18n import _, ngettext
-from indico.util.marshmallow import LowercaseString, not_empty, validate_with_message
+from indico.util.marshmallow import LowercaseString, no_relative_urls, not_empty, validate_with_message
 from indico.util.placeholders import get_sorted_placeholders, replace_placeholders
 from indico.util.user import principal_from_identifier
 from indico.web.args import use_args, use_kwargs
@@ -334,7 +334,7 @@ class RHAPIEmailEventPersonsMetadata(RHEmailEventPersonsBase):
 class RHAPIEmailEventPersonsSend(RHEmailEventPersonsBase):
     @use_kwargs({
         'from_address': fields.String(required=True, validate=not_empty),
-        'body': fields.String(required=True, validate=not_empty),
+        'body': fields.String(required=True, validate=[not_empty, no_relative_urls]),
         'subject': fields.String(required=True, validate=not_empty),
         'bcc_addresses': fields.List(LowercaseString(validate=validate.Email())),
         'copy_for_sender': fields.Bool(load_default=False),

--- a/indico/modules/events/registration/controllers/management/invitations.py
+++ b/indico/modules/events/registration/controllers/management/invitations.py
@@ -20,7 +20,7 @@ from indico.modules.events.registration.models.invitations import InvitationStat
 from indico.modules.events.registration.util import create_invitation, import_invitations_from_csv
 from indico.modules.events.registration.views import WPManageRegistration
 from indico.util.i18n import ngettext
-from indico.util.marshmallow import LowercaseString, not_empty
+from indico.util.marshmallow import LowercaseString, no_relative_urls, not_empty
 from indico.util.placeholders import get_sorted_placeholders, replace_placeholders
 from indico.web.args import use_kwargs
 from indico.web.flask.templating import get_template_module
@@ -100,7 +100,7 @@ class RHRegistrationFormRemindersSend(RHManageRegFormBase):
 
     @use_kwargs({
         'from_address': fields.String(required=True, validate=not_empty),
-        'body': fields.String(required=True, validate=not_empty),
+        'body': fields.String(required=True, validate=[not_empty, no_relative_urls]),
         'subject': fields.String(required=True, validate=not_empty),
         'bcc_addresses': fields.List(LowercaseString(validate=validate.Email())),
         'copy_for_sender': fields.Bool(load_default=False),

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -36,7 +36,7 @@ from indico.web.forms.fields.datetime import TimeDeltaField
 from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.fields.simple import (HiddenFieldList, IndicoEmailRecipientsField, IndicoMultipleTagSelectField,
                                             IndicoParticipantVisibilityField)
-from indico.web.forms.validators import HiddenUnless, IndicoEmail, LinkedDateTime
+from indico.web.forms.validators import HiddenUnless, IndicoEmail, LinkedDateTime, NoRelativeURLs
 from indico.web.forms.widgets import SwitchWidget, TinyMCEWidget
 
 
@@ -188,7 +188,8 @@ class InvitationFormBase(IndicoForm):
     _email_fields = ('email_from', 'email_subject', 'email_body')
     email_from = SelectField(_('From'), [DataRequired()])
     email_subject = StringField(_('Email subject'), [DataRequired()])
-    email_body = TextAreaField(_('Email body'), [DataRequired()], widget=TinyMCEWidget())
+    email_body = TextAreaField(_('Email body'), [DataRequired(), NoRelativeURLs()],
+                               widget=TinyMCEWidget(absolute_urls=True))
     skip_moderation = BooleanField(_('Skip moderation'), widget=SwitchWidget(),
                                    description=_("If enabled, the user's registration will be approved automatically."))
     skip_access_check = BooleanField(_('Skip access check'), widget=SwitchWidget(),
@@ -276,7 +277,7 @@ class EmailRegistrantsForm(IndicoForm):
                                   description=_('Beware, addresses in this field will receive one mail per '
                                                 'registrant.'))
     subject = StringField(_('Subject'), [DataRequired()])
-    body = TextAreaField(_('Email body'), [DataRequired()], widget=TinyMCEWidget())
+    body = TextAreaField(_('Email body'), [DataRequired(), NoRelativeURLs()], widget=TinyMCEWidget(absolute_urls=True))
     recipients = IndicoEmailRecipientsField(_('Recipients'))
     copy_for_sender = BooleanField(_('Send copy to me'), widget=SwitchWidget(),
                                    description=_('Send copy of each email to my mailbox'))

--- a/indico/modules/events/surveys/forms.py
+++ b/indico/modules/events/surveys/forms.py
@@ -18,7 +18,7 @@ from indico.util.i18n import _
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.fields import EmailListField, FileField, IndicoDateTimeField
-from indico.web.forms.validators import HiddenUnless, LinkedDateTime, UsedIf, ValidationError
+from indico.web.forms.validators import HiddenUnless, LinkedDateTime, NoRelativeURLs, UsedIf, ValidationError
 from indico.web.forms.widgets import SwitchWidget, TinyMCEWidget
 
 
@@ -114,7 +114,7 @@ class ImportQuestionnaireForm(IndicoForm):
 class InvitationForm(IndicoForm):
     from_address = SelectField(_('From'), [DataRequired()])
     subject = StringField(_('Subject'), [DataRequired()])
-    body = TextAreaField(_('Email body'), [DataRequired()], widget=TinyMCEWidget())
+    body = TextAreaField(_('Email body'), [DataRequired(), NoRelativeURLs()], widget=TinyMCEWidget(absolute_urls=True))
     recipients = EmailListField(_('Recipients'), [DataRequired()], description=_('One email address per line.'))
     copy_for_sender = BooleanField(_('Send copy to me'), widget=SwitchWidget())
     submitted = HiddenField()

--- a/indico/util/marshmallow.py
+++ b/indico/util/marshmallow.py
@@ -24,7 +24,7 @@ from indico.core.config import config
 from indico.core.permissions import get_unified_permissions
 from indico.util.date_time import now_utc
 from indico.util.i18n import _
-from indico.util.string import get_format_placeholders
+from indico.util.string import get_format_placeholders, has_relative_links
 from indico.util.user import principal_from_identifier
 
 
@@ -55,6 +55,12 @@ def not_empty(value):
     """
     if not value:
         raise ValidationError(_('This field cannot be empty.'))
+
+
+def no_relative_urls(value):
+    """Validator that checks links/images use absolute URLs."""
+    if value and has_relative_links(value):
+        raise ValidationError(_('Links and images may not use relative URLs.'))
 
 
 def validate_placeholders(format_string, valid_placeholders, required_placeholders=None):

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -18,6 +18,7 @@ from email.utils import escapesre, specialsre
 from enum import Enum
 from itertools import chain
 from operator import attrgetter
+from urllib.parse import urlsplit
 from uuid import uuid4
 from xml.etree.ElementTree import Element
 
@@ -282,6 +283,15 @@ def sanitize_for_platypus(text):
     doc = html.fromstring(res)
     doc.make_links_absolute(config.BASE_URL, resolve_base_href=False)
     return etree.tostring(doc).decode()
+
+
+def has_relative_links(html_text):
+    doc = html.fromstring(html_text)
+    return any(
+        (data := urlsplit(link)) and (not data.scheme or not data.netloc)
+        for el, attrib, link, _pos in doc.iterlinks()
+        if (el.tag, attrib) in {('a', 'href'), ('img', 'src')}
+    )
 
 
 def is_valid_mail(emails_string, multi=True):

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -12,9 +12,9 @@ from itertools import count
 import pytest
 
 from indico.util.string import (AutoLinkExtension, HTMLLinker, camelize, camelize_keys, crc32, format_email_with_name,
-                                format_repr, html_to_plaintext, make_unique_token, normalize_phone_number,
-                                render_markdown, sanitize_email, sanitize_for_platypus, sanitize_html, seems_html,
-                                slugify, snakify, snakify_keys, strip_tags, text_to_repr)
+                                format_repr, has_relative_links, html_to_plaintext, make_unique_token,
+                                normalize_phone_number, render_markdown, sanitize_email, sanitize_for_platypus,
+                                sanitize_html, seems_html, slugify, snakify, snakify_keys, strip_tags, text_to_repr)
 
 
 def test_seems_html():
@@ -276,6 +276,19 @@ def test_sanitize_for_platypus_relative_urls():
 ))
 def test_sanitize_html_escaped_quotes(input, output):
     assert sanitize_html(input) == output
+
+
+@pytest.mark.parametrize(('input', 'expected'), (
+    ('<a href="/foo">test</a>', True),
+    ('<img src="/bar">', True),
+    ('<a href="/foo">test</a><img src="/bar">', True),
+    ('<div><span><a href="/foo">test</a></span><img src="/bar"></div>', True),
+    ('<a href="//example.com/foo">test</a><img src="//example.com/bar">', True),
+    ('<a href="foo">test</a><img src="bar">', True),
+    ('<a href="https://example.com/foo">test</a><img src="https://example.com/bar">', False),
+))
+def test_has_relative_links(input, expected):
+    assert has_relative_links(input) == expected
 
 
 @pytest.mark.parametrize(('name', 'address', 'expected'), (

--- a/indico/web/client/js/jquery/widgets/jinja/tinymce_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/tinymce_widget.js
@@ -11,7 +11,13 @@ import {getConfig} from 'indico/tinymce';
 
 (function(global) {
   global.setupTinyMCEWidget = async function setupTinyMCEWidget(options) {
-    const {fieldId, images = true, imageUploadURL = null, height = 475} = options;
+    const {
+      fieldId,
+      images = true,
+      imageUploadURL = null,
+      forceAbsoluteURLs = false,
+      height = 475,
+    } = options;
     const contentCSS = JSON.parse(document.body.dataset.tinymceContentCss);
 
     const field = document.getElementById(fieldId);
@@ -22,6 +28,6 @@ import {getConfig} from 'indico/tinymce';
       // closed and then reopened) won't do anything
       tinymce.remove(old);
     }
-    tinymce.init(getConfig(field, {images, imageUploadURL, height, contentCSS}));
+    tinymce.init(getConfig(field, {images, imageUploadURL, forceAbsoluteURLs, height, contentCSS}));
   };
 })(window);

--- a/indico/web/client/js/tinymce.js
+++ b/indico/web/client/js/tinymce.js
@@ -59,6 +59,7 @@ export const getConfig = (
     imageUploadURL = null,
     fullScreen = true,
     showToolbar = true,
+    forceAbsoluteURLs = false,
     contentCSS = [],
     height = 475,
   } = {},
@@ -173,7 +174,8 @@ export const getConfig = (
         .filter(x => x)
         .join(' '),
   entity_encoding: 'raw',
-  relative_urls: false,
+  relative_urls: false, // kind of misleading: this just ensures domain-relative URLs
+  remove_script_host: !forceAbsoluteURLs, // this ensures fully absolute (`https://....`) URLs
   end_container_on_empty_block: true,
   paste_data_images: images && !!imageUploadURL,
   images_reuse_filename: true,

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -13,7 +13,7 @@ from wtforms.validators import EqualTo, Length, Regexp, StopValidation, Validati
 from indico.util.date_time import as_utc, format_date, format_datetime, format_human_timedelta, format_time, now_utc
 from indico.util.i18n import _, ngettext
 from indico.util.passwords import validate_secure_password
-from indico.util.string import is_valid_mail
+from indico.util.string import has_relative_links, is_valid_mail
 
 
 class UsedIf:
@@ -407,3 +407,15 @@ class SecurePassword:
         password = field.data or ''
         if error := validate_secure_password(self.context, password, username=username):
             raise ValidationError(error)
+
+
+class NoRelativeURLs:
+    """Validate that an HTML strings contains no relative URLs.
+
+    This checks only ``img[src]`` and ``a[href]``, but not URLs present as plain
+    text or in any other (unexpected) places.
+    """
+
+    def __call__(self, form, field):
+        if field.data and has_relative_links(field.data):
+            raise ValidationError(_('Links and images may not use relative URLs.'))

--- a/indico/web/forms/widgets.py
+++ b/indico/web/forms/widgets.py
@@ -115,15 +115,17 @@ class TinyMCEWidget(JinjaWidget):
     """Render a TinyMCE WYSIWYG editor.
 
     :param images: Whether to allow images.
-    :param html_embed: Whether to enable raw HTML embedding.
+    :param absolute_urls: Whether to use fully absolute URLs for links/images.
+                          This MUST be set for emails, and used together with
+                          the `NoRelativeURLs` validator on the field.
     :param height: The height of the editor.
 
     If the form has a ``editor_upload_url`` attribute and images are enabled,
     the editor will allow pasting/selecting images and upload them using that URL.
     """
 
-    def __init__(self, *, images=False, height=600):
-        super().__init__('forms/tinymce_widget.html', images=images, height=height)
+    def __init__(self, *, images=False, absolute_urls=False, height=600):
+        super().__init__('forms/tinymce_widget.html', images=images, absolute_urls=absolute_urls, height=height)
 
 
 class SwitchWidget(JinjaWidget):

--- a/indico/web/templates/forms/tinymce_widget.html
+++ b/indico/web/templates/forms/tinymce_widget.html
@@ -12,6 +12,7 @@
             fieldId: {{ field.id | tojson }},
             images: {{ images | tojson }},
             imageUploadURL: {{ field.get_form().editor_upload_url|default(none) | tojson }},
+            forceAbsoluteURLs: {{ absolute_urls | tojson }},
             height: {{ height | tojson }},
         });
     </script>


### PR DESCRIPTION
- Configure TinyMCE to use fully absolute URLs when used for emails
- Add validation that rejects email bodies containing images or links using any kind of relative URLs