### PR TITLE
Allow setting larger registration fees

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -88,6 +88,7 @@ Bugfixes
 - Only block templates containing a QR code via ``is_ticket_blocked`` (:pr:`6062`)
 - Use custom map URL in event API if one is set (:pr:`6111`, thanks :user:`stine-fohrmann`)
 - Use the event timezone when scheduling call for abstracts/papers (:pr:`6139`)
+- Allow setting registration fees larger than 999999.99 (:pr:`6172`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -79,7 +79,7 @@ class RegistrationFormEditForm(IndicoForm):
                                                             'the event page'))
     publish_checkin_enabled = BooleanField(_('Publish check-in status'), widget=SwitchWidget(),
                                            description=_('Check-in status will be shown publicly on the event page'))
-    base_price = DecimalField(_('Registration fee'), [NumberRange(min=0, max=999999.99), Optional(),
+    base_price = DecimalField(_('Registration fee'), [NumberRange(min=0, max=999999999.99), Optional(),
                               _check_if_payment_required], filters=[lambda x: x if x is not None else 0],
                               widget=NumberInput(step='0.01'),
                               description=_('A fixed fee all users have to pay when registering.'))


### PR DESCRIPTION
This PR solves the problem described in https://talk.getindico.io/t/i-cannot-set-the-registration-fee-larger-than-999999-99/3387, increasing the maximum registration fee from `999999.99` to `999999999.99`.