### PR TITLE
Hide participants from other regforms

### DIFF
--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -250,6 +250,10 @@ class EventPrivacyForm(IndicoForm):
                                                             'notices.'))
     privacy_policy = TextAreaField(_('Text'), widget=TinyMCEWidget(),
                                    description=_('Only used if no URL is provided'))
+    hide_participants_from_other_forms = (
+        BooleanField(_('Hide participants from other forms'), widget=SwitchWidget(),
+                     description=_('If a participant has consented to be shown to other participants, only show them to'
+                                   ' participants registered in the same registration form.')))
 
     def validate_privacy_policy(self, field):
         if self.privacy_policy_urls.data and self.privacy_policy.data:

--- a/indico/modules/events/management/settings.py
+++ b/indico/modules/events/management/settings.py
@@ -22,6 +22,7 @@ privacy_settings = EventSettingsProxy('privacy', {
     'data_controller_email': '',
     'privacy_policy_urls': [],
     'privacy_policy': '',
+    'hide_participants_from_other_forms': False,
 })
 
 global_event_settings = SettingsProxy('events', {

--- a/indico/modules/events/management/templates/privacy_dashboard.html
+++ b/indico/modules/events/management/templates/privacy_dashboard.html
@@ -12,14 +12,15 @@
     {% call form_fieldset(_('Privacy notice')) %}
         {{ form_rows(form, fields=form._privacy_policy_fields) }}
     {% endcall %}
+    {% if regforms %}
+        {% call form_fieldset(_('Registration forms')) %}
+            {{ form_row(form.hide_participants_from_other_forms) }}
+            {{ render_registrations_visibility_list(regforms) }}
+        {% endcall %}
+    {% endif %}
     {% call form_row_static() %}
         <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}"
                data-disabled-until-change data-save-reminder>
     {% endcall %}
-    {% if regforms %}
-        {% call form_fieldset(_('Registration forms')) %}
-            {{ render_registrations_visibility_list(regforms) }}
-        {% endcall %}
-    {% endif %}
     {{ form_footer(form) }}
 {% endblock %}

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -389,7 +389,8 @@ def update_event_privacy(event, data):
             'type': 'struct_list',
             'convert': lambda changes: [[dict(sorted(rec.items())) for rec in chg] for chg in changes]
         },
-        'privacy_policy': {'title': 'Privacy policy', 'type': 'text'}
+        'privacy_policy': {'title': 'Privacy policy', 'type': 'text'},
+        'hide_participants_from_other_forms': {'title': 'Hide participants from other forms', 'type': 'boolean'}
     }
     assert set(data.keys()) <= log_fields.keys()
     changes = {}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -591,15 +591,15 @@ def get_registrations_with_tickets(user, event):
     return [r for r in query if not _is_ticket_blocked(r)]
 
 
-def get_published_registrations(event, is_participant):
+def get_published_registrations(event, user):
     """Get a list of published registrations for an event.
 
     :param event: the `Event` to get registrations for
-    :param is_participant: whether the user accessing the registrations is a participant of the event
+    :param user: the user who can see the participants
     :return: list of `Registration` objects
     """
     query = (Registration.query.with_parent(event)
-             .filter(Registration.is_publishable(is_participant),
+             .filter(Registration.is_publishable(user, event.hide_participants_from_other_forms),
                      ~RegistrationForm.is_deleted,
                      ~Registration.is_deleted)
              .join(Registration.registration_form)
@@ -611,16 +611,17 @@ def get_published_registrations(event, is_participant):
     return query.all()
 
 
-def count_hidden_registrations(event, is_participant):
+def count_hidden_registrations(event, user, is_participant):
     """Get the number of hidden registrations for an event.
 
     :param event: the `Event` to get registrations for
+    :param user: the user who can see the participants
     :param is_participant: whether the user accessing the registrations is a participant of the event
     :return: number of registrations
     """
     query = (Registration.query.with_parent(event)
              .filter(Registration.is_state_publishable,
-                     ~Registration.is_publishable(is_participant),
+                     ~Registration.is_publishable(user, event.hide_participants_from_other_forms),
                      RegistrationForm.is_participant_list_visible(is_participant))
              .join(Registration.registration_form))
 


### PR DESCRIPTION
Request to add new privacy setting for Participant List: setting to hide participants from other registration forms.
This PR replaces https://github.com/indico/indico/pull/6167, the code is done following previous review from Duarte.

Note: I will fix the privacy_test.py once we agree on the code change, thanks.