### PR TITLE
Add a new i18n command to check for mismatched HTML tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,10 @@ jobs:
         if: success() || failure()
         run: indico i18n check-format-strings
 
+      - name: Check i18n HTML tags
+        if: success() || failure()
+        run: indico i18n check-html-tags
+
       - name: Run eslint
         if: success() || failure()
         run: npx eslint --ext .js --ext .jsx

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -375,6 +375,10 @@ def _indico_command(babel_cmd, python, javascript, react, locale, no_check):
             click.secho('Exiting compile command for indico due to invalid format strings.', fg='red', bold=True,
                         err=True)
             sys.exit(1)
+        if not _check_mismatched_html_tags():
+            click.secho('Exiting compile command for indico due to mismatched HTML tags.', fg='red', bold=True,
+                        err=True)
+            sys.exit(1)
     try:
         if python:
             _run_command(babel_cmd, extra=extra)

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -604,13 +604,8 @@ def pull_all_plugins(plugins_dir, languages):
 
 
 def _check_format_strings(root_path='indico/translations'):
-    paths = set()
-    for root, _dirs, files in os.walk(root_path):
-        for file in files:
-            if file.endswith('.po'):
-                paths.add(os.path.join(root, file))
     all_valid = True
-    for path in paths:
+    for path in Path(root_path).glob('**/*.po'):
         invalid = _get_invalid_po_format_strings(path)
         if invalid:
             all_valid = False

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -610,8 +610,7 @@ def pull_all_plugins(plugins_dir, languages):
 def _check_format_strings(root_path='indico/translations'):
     all_valid = True
     for path in Path(root_path).glob('**/*.po'):
-        invalid = _get_invalid_po_format_strings(path)
-        if invalid:
+        if invalid := _get_invalid_po_format_strings(path):
             all_valid = False
             click.echo(f'Found invalid format strings in {path.relative_to(root_path)}')
             for item in invalid:

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -613,7 +613,7 @@ def _check_format_strings(root_path='indico/translations'):
         invalid = _get_invalid_po_format_strings(path)
         if invalid:
             all_valid = False
-            click.echo(f'Found invalid format strings in {os.path.relpath(path, root_path)}')
+            click.echo(f'Found invalid format strings in {path.relative_to(root_path)}')
             for item in invalid:
                 click.echo(cformat('%{yellow}{}%{reset} | %{yellow!}{}%{reset}\n%{red}{}%{reset} != %{red!}{}%{reset}')
                            .format(item['orig'], item['trans'],
@@ -627,7 +627,7 @@ def _check_mismatched_html_tags(root_path='indico/translations'):
     for path in Path(root_path).glob('**/*.po'):
         if invalid := _get_mismatched_html_tags(path):
             all_valid = False
-            click.echo(f'Found mismatched HTML tags in {os.path.relpath(path, root_path)}')
+            click.echo(f'Found mismatched HTML tags in {path.relative_to(root_path)}')
             for item in invalid:
                 click.echo(cformat('%{yellow}{}%{reset} | %{yellow!}{}%{reset}\n%{red}{}%{reset} != %{red!}{}%{reset}')
                            .format(item['orig'], item['trans'], list(item['orig_tags']), list(item['trans_tags'])))

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -738,13 +738,11 @@ def _iter_msg_pairs(catalog):
             continue
 
         if not msg.pluralizable:
-            msg_pairs = ((msg.id, msg.string),)
+            yield ((msg.id, msg.string),)
         elif catalog.num_plurals == 1:
             # Pluralized messages with nplurals=1 should be compared against the 'msgid_plural'
-            msg_pairs = ((msg.id[1], msg.string[0]),)
+            yield ((msg.id[1], msg.string[0]),)
         else:
             # Pluralized messages with nplurals>1 should compare 'msgstr[0]' against the singular and
             # any other 'msgstr[X]' against 'msgid_plural'.
-            msg_pairs = ((msg.id[0], msg.string[0]), *((msg.id[1], t) for t in msg.string[1:]))
-
-        yield msg_pairs
+            yield ((msg.id[0], msg.string[0]), *((msg.id[1], t) for t in msg.string[1:]))

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -630,8 +630,7 @@ def _check_mismatched_html_tags(root_path='indico/translations'):
             click.echo(f'Found mismatched HTML tags in {os.path.relpath(path, root_path)}')
             for item in invalid:
                 click.echo(cformat('%{yellow}{}%{reset} | %{yellow!}{}%{reset}\n%{red}{}%{reset} != %{red!}{}%{reset}')
-                           .format(item['orig'], item['trans'],
-                                   list(item['orig_tags']), list(item['trans_tags'])))
+                           .format(item['orig'], item['trans'], list(item['orig_tags']), list(item['trans_tags'])))
             click.echo()
     return all_valid
 

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -701,6 +701,10 @@ def _get_mismatched_html_tags(path):
             orig_tags = sorted(re.findall(r'<[^>]+>', orig))
             trans_tags = sorted(re.findall(r'<[^>]+>', trans))
 
+            # Ignore line breaks
+            orig_tags = [tag for tag in orig_tags if tag != '<br>']
+            trans_tags = [tag for tag in trans_tags if tag != '<br>']
+
             if orig_tags != trans_tags:
                 mismatched.append({
                     'orig': orig,

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -625,8 +625,7 @@ def _check_format_strings(root_path='indico/translations'):
 def _check_mismatched_html_tags(root_path='indico/translations'):
     all_valid = True
     for path in Path(root_path).glob('**/*.po'):
-        invalid = _get_mismatched_html_tags(path)
-        if invalid:
+        if invalid := _get_mismatched_html_tags(path):
             all_valid = False
             click.echo(f'Found mismatched HTML tags in {os.path.relpath(path, root_path)}')
             for item in invalid:
@@ -659,8 +658,7 @@ def check_html_tags():
     close the tags. Additionally, this ensures that no one sneaks in dangerous
     HTML (like a <script> tag) into the translations.
     """
-    all_valid = _check_mismatched_html_tags()
-    if all_valid:
+    if all_valid := _check_mismatched_html_tags():
         click.secho('No issues found!', fg='green', bold=True)
     sys.exit(0 if all_valid else 1)
 


### PR DESCRIPTION
Depends on #6178 

This helps check for missing or unclosed HTML tags and also guards against some bad actor sneaking in a `<script>` or similar
This helped find dozens of issues in our translations (missing and unclosed tags, no nasty stuff) which have already been fixed.
