### PR TITLE
Fix populating unsynced fields during login

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,6 +95,8 @@ Bugfixes
 - Use custom map URL in event API if one is set (:pr:`6111`, thanks :user:`stine-fohrmann`)
 - Use the event timezone when scheduling call for abstracts/papers (:pr:`6139`)
 - Allow setting registration fees larger than 999999.99 (:pr:`6172`)
+- Populate fields such as first and last name from the multipass login provider (e.g. LDAP) during
+  sign-up regardless of synchronization settings (:pr:`6182`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -547,7 +547,9 @@ class MultipassRegistrationHandler(RegistrationHandler):
             locked_fields = list(multipass.locked_fields - required_empty_fields)
         else:
             synced_values = {}
-            initial_values.update(pending_data)
+            allowed_fields = {'first_name', 'last_name', 'affiliation', 'phone', 'address'}
+            multipass_data = {k: v for k, v in self.identity_info['data'].items() if k in allowed_fields and v}
+            initial_values.update(pending_data or multipass_data)
             locked_fields = []
 
         return {


### PR DESCRIPTION
Bug reported here: https://talk.getindico.io/t/blank-first-last-name-in-create-a-new-indico-profile-with-ldap/3404/1