### PR TITLE
Allow to filter by keywords

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,8 +69,11 @@ Improvements
   thanks :user:`SegiNyn`)
 - Use a more compact registration ticket QR code format which is faster to scan and less
   likely to fail in poor lighting conditions (:pr:`6123`)
-- Add a legend to the category calendar, allowing to filter events either by category, venue, room or keywords
-  (:issue:`6105, 6106, 6128, 6148, 6149, 6127`, :pr:`6110, 6158, 6183`, thanks :user:`Moliholy, unconventionaldotdev`)
+- Add a legend to the category calendar, allowing to filter events either by category, venue,
+  room or keywords (:issue:`6105, 6106, 6128, 6148, 6149, 6127`, :pr:`6110, 6158, 6183`,
+  thanks :user:`Moliholy, unconventionaldotdev`)
+- Allow to configure a restrictive set of allowed keywords (:issue:`6127`, :pr:`6183`,
+  thanks :user:`Moliholy, unconventionaldotdev`).
 - Add week and day views in the category calendar and improve navigation controls
   (:issue:`6108, 6129, 6107`, :pr:`6110`, thanks :user:`Moliholy, unconventionaldotdev`).
 - Add the ability to clone privacy settings (:pr:`6156`, thanks :user:`SegiNyn`)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,8 +69,8 @@ Improvements
   thanks :user:`SegiNyn`)
 - Use a more compact registration ticket QR code format which is faster to scan and less
   likely to fail in poor lighting conditions (:pr:`6123`)
-- Add a legend to the category calendar, allowing to filter events either by category, venue or room
-  (:issue:`6105, 6106, 6128, 6148, 6149`, :pr:`6110, 6158`, thanks :user:`Moliholy, unconventionaldotdev`)
+- Add a legend to the category calendar, allowing to filter events either by category, venue, room or keywords
+  (:issue:`6105, 6106, 6128, 6148, 6149, 6127`, :pr:`6110, 6158, 6183`, thanks :user:`Moliholy, unconventionaldotdev`)
 - Add week and day views in the category calendar and improve navigation controls
   (:issue:`6108, 6129, 6107`, :pr:`6110`, thanks :user:`Moliholy, unconventionaldotdev`).
 - Add the ability to clone privacy settings (:pr:`6156`, thanks :user:`SegiNyn`)

--- a/indico/modules/categories/client/js/calendar.js
+++ b/indico/modules/categories/client/js/calendar.js
@@ -119,7 +119,7 @@ import CalendarLegend from './components/CalendarLegend';
           const filteredEvents = data.events.filter(e => {
             let result = !filteredLegendElements.has(e[attr] ?? 0);
             if (filteringByKeyword() && e.keywords.length) {
-              result &&= !e.keywords.every(kw => filteredKeywords.has(kw));
+              result ||= !e.keywords.every(kw => filteredKeywords.has(kw));
             }
             return result;
           });
@@ -355,7 +355,7 @@ import CalendarLegend from './components/CalendarLegend';
                 events: manyKeywords,
                 items: keywords,
                 attr: 'keywordId',
-                defaultTitle: Translate.string('Many keywords'),
+                defaultTitle: Translate.string('Multiple keywords'),
                 rootId: 1,
               }),
             ];

--- a/indico/modules/categories/client/js/components/CalendarLegend.jsx
+++ b/indico/modules/categories/client/js/components/CalendarLegend.jsx
@@ -79,23 +79,19 @@ LegendItem.defaultProps = {
   hasSubitems: false,
 };
 
-function mapPlainItemToLegendItem(
-  {id, title, checked, url, color, isSpecial, subitems, parent},
-  onElementSelected,
-  depth
-) {
-  const hasSubitems = subitems.length > 0;
+function mapPlainItemToLegendItem(item, onElementSelected, depth) {
+  const hasSubitems = item.subitems.length > 0;
   const indeterminate =
-    hasSubitems && subitems.some(si => si.checked) && subitems.some(si => !si.checked);
+    hasSubitems && item.subitems.some(si => si.checked) && item.subitems.some(si => !si.checked);
   const result = (
     <LegendItem
-      key={id}
-      title={title}
-      color={color}
-      checked={checked}
-      onChange={(_, data) => onElementSelected(id, data.checked, subitems, parent)}
-      url={url}
-      isSpecial={isSpecial}
+      key={item.id}
+      title={item.title}
+      color={item.color}
+      checked={item.checked}
+      onChange={(_, data) => onElementSelected(item, data.checked)}
+      url={item.url}
+      isSpecial={item.isSpecial}
       depth={depth}
       indeterminate={indeterminate}
       hasSubitems={hasSubitems}
@@ -103,7 +99,7 @@ function mapPlainItemToLegendItem(
   );
   return [
     result,
-    ...subitems.map(si => mapPlainItemToLegendItem(si, onElementSelected, depth + 1)),
+    ...item.subitems.map(si => mapPlainItemToLegendItem(si, onElementSelected, depth + 1)),
   ];
 }
 

--- a/indico/modules/categories/client/js/components/CalendarLegend.jsx
+++ b/indico/modules/categories/client/js/components/CalendarLegend.jsx
@@ -114,6 +114,7 @@ function CalendarLegend({
   onElementSelected,
   selectAll,
   deselectAll,
+  filterByKeywords,
 }) {
   const [isOpen, setIsOpen] = useState(false);
   const parsedItems = items.map(item => mapPlainItemToLegendItem(item, onElementSelected, 0));
@@ -122,6 +123,9 @@ function CalendarLegend({
     {text: Translate.string('Venue'), value: 'location'},
     {text: Translate.string('Room'), value: 'room'},
   ];
+  if (filterByKeywords) {
+    options.push({text: Translate.string('Keywords'), value: 'keywords'});
+  }
   const onChange = (_, {value}) => {
     onFilterChanged(value);
     setIsOpen(false);
@@ -158,6 +162,11 @@ CalendarLegend.propTypes = {
   onElementSelected: PropTypes.func.isRequired,
   selectAll: PropTypes.func.isRequired,
   deselectAll: PropTypes.func.isRequired,
+  filterByKeywords: PropTypes.bool,
+};
+
+CalendarLegend.defaultProps = {
+  filterByKeywords: false,
 };
 
 export default CalendarLegend;

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -4,7 +4,7 @@
 # Indico is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
-
+import hashlib
 from datetime import date, datetime, time, timedelta
 from enum import Enum, auto
 from functools import partial
@@ -35,6 +35,7 @@ from indico.modules.categories.serialize import (serialize_categories_ical, seri
                                                  serialize_category_chain)
 from indico.modules.categories.util import get_category_stats, get_upcoming_events
 from indico.modules.categories.views import WPCategory, WPCategoryCalendar
+from indico.modules.events.management.settings import misc_settings
 from indico.modules.events.models.events import Event
 from indico.modules.events.timetable.util import get_category_timetable
 from indico.modules.news.util import get_recent_news
@@ -565,6 +566,7 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
         category = auto()
         location = auto()
         room = auto()
+        keywords = auto()
 
     @use_kwargs({'group_by': EnumField(GroupBy, load_default=GroupBy.category)}, location='query')
     def _process_args(self, group_by):
@@ -584,9 +586,11 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
                          ~Event.is_deleted)
                  .options(undefer(Event.detailed_category_chain),
                           selectinload('own_room'),
-                          load_only('id', 'title', 'start_dt', 'end_dt', 'category_id', 'own_venue_id', 'own_room_id')))
-        events, categories, rooms = self._get_event_data(query)
+                          load_only('id', 'title', 'start_dt', 'end_dt', 'category_id', 'own_venue_id', 'own_room_id',
+                                    'keywords')))
+        events, categories, rooms, keywords, allowed_keywords = self._get_event_data(query)
         raw_locations = Location.query.options(load_only('id', 'name')).all()
+        allow_keywords = len(allowed_keywords) > 0
         locations = [{'title': loc.name, 'id': loc.id} for loc in raw_locations]
         ongoing_events = (Event.query
                           .filter(Event.is_visible_in(self.category.id),
@@ -597,6 +601,7 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
                           .order_by(Event.title)
                           .all())
         return jsonify_data(flash=False, events=events, categories=categories, locations=locations, rooms=rooms,
+                            keywords=keywords, allow_keywords=allow_keywords,
                             group_by=self.group_by.name,
                             ongoing_event_count=len(ongoing_events),
                             ongoing_events_html=self._render_ongoing_events(ongoing_events))
@@ -612,9 +617,14 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
         raise Exception(f'Category {self.category.id} not found in category chain')
 
     def _get_event_data(self, event_query):
+        def calculate_keyword_id(kw):
+            return int(hashlib.sha256(kw.encode()).hexdigest()[:8], 16) + 3
+
         data = []
         categories = {}
         rooms = {}
+        keywords = []
+        allowed_keywords = misc_settings.get('allowed_keywords')
         tz = self.category.display_tzinfo
         for event in event_query:
             category_data = self._find_nearest_category(event.detailed_category_chain)
@@ -625,24 +635,38 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
                 rooms[room.id] = {'id': room.id,
                                   'title': room.full_name,
                                   'venueId': room.location_id}
-            if self.group_by == self.GroupBy.category:
-                comparison_id = category_id
-            elif self.group_by == self.GroupBy.location:
-                comparison_id = event.own_venue_id or 0
-            else:
-                comparison_id = room.id if room else 0
             event_data = {'title': event.title,
                           'start': event.start_dt.astimezone(tz).replace(tzinfo=None).isoformat(),
                           'end': event.end_dt.astimezone(tz).replace(tzinfo=None).isoformat(),
                           'url': event.url,
                           'categoryId': category_id,
                           'venueId': event.own_venue_id,
+                          'keywords': event.keywords,
                           'roomId': room.id if room else None}
-            colors = generate_contrast_colors(comparison_id)
+            if self.group_by == self.GroupBy.category:
+                colors = generate_contrast_colors(category_id)
+            elif self.group_by == self.GroupBy.location:
+                colors = generate_contrast_colors(event.own_venue_id or 0)
+            elif self.group_by == self.GroupBy.room:
+                colors = generate_contrast_colors(room.id if room else 0)
+            else:
+                # by keywords
+                if any(kw not in allowed_keywords for kw in event.keywords):
+                    keyword_id = -1
+                elif len(event.keywords) == 0:
+                    keyword_id = 0
+                elif len(event.keywords) > 1:
+                    keyword_id = 1
+                else:
+                    keyword = event.keywords[0]
+                    keyword_id = calculate_keyword_id(keyword)
+                    keywords.append({'id': keyword_id, 'title': keyword})
+                event_data['keywordId'] = keyword_id
+                colors = generate_contrast_colors(keyword_id)
             event_data.update({'textColor': f'#{colors.text}', 'color': f'#{colors.background}'})
             data.append(event_data)
             categories[category_id] = category_data
-        return data, list(categories.values()), list(rooms.values())
+        return data, list(categories.values()), list(rooms.values()), keywords, allowed_keywords
 
     def _render_ongoing_events(self, ongoing_events):
         template = get_template_module('categories/display/_calendar_ongoing_events.html')

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -35,7 +35,7 @@ from indico.modules.categories.serialize import (serialize_categories_ical, seri
                                                  serialize_category_chain)
 from indico.modules.categories.util import get_category_stats, get_upcoming_events
 from indico.modules.categories.views import WPCategory, WPCategoryCalendar
-from indico.modules.events.management.settings import misc_settings
+from indico.modules.events.management.settings import event_settings
 from indico.modules.events.models.events import Event
 from indico.modules.events.timetable.util import get_category_timetable
 from indico.modules.news.util import get_recent_news
@@ -625,7 +625,7 @@ class RHCategoryCalendarViewEvents(RHDisplayCategoryBase):
         categories = {}
         rooms = {}
         keywords = {}
-        allowed_keywords = misc_settings.get('allowed_keywords')
+        allowed_keywords = event_settings.get('allowed_keywords')
         allowed_keywords_set = set(allowed_keywords)
         tz = self.category.display_tzinfo
         for event in event_query:

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -144,6 +144,8 @@ def _sidemenu_items(sender, **kwargs):
                            section='customization')
         yield SideMenuItem('event_labels', _('Event Labels'), url_for('events.event_labels'),
                            section='customization')
+        yield SideMenuItem('event_keywords', _('Event Keywords'), url_for('events.event_keywords'),
+                           section='customization')
         yield SideMenuItem('unlisted_events', _('Unlisted events'), url_for('events.unlisted_events'),
                            section='customization')
         yield SideMenuItem('autolinker', _('Auto-linker'), url_for('events.autolinker_admin'),

--- a/indico/modules/events/abstracts/fields.py
+++ b/indico/modules/events/abstracts/fields.py
@@ -179,8 +179,10 @@ class AbstractField(QuerySelectField):
                 for key, abstract in super()._get_object_list()
                 if abstract.can_access(session.user)]
 
-    def _value(self):
-        return [self._serialize_abstract(self.data)] if self.data else None
+    def _value(self, for_react=False):
+        if not self.data:
+            return None
+        return [self._serialize_abstract(self.data)] if for_react else self.data.id
 
     def pre_validate(self, form):
         super().pre_validate(form)

--- a/indico/modules/events/blueprint.py
+++ b/indico/modules/events/blueprint.py
@@ -8,7 +8,7 @@
 from indico.modules.events.controllers.admin import (RHAutoLinker, RHAutoLinkerConfig, RHCreateEventLabel,
                                                      RHCreateReferenceType, RHDeleteEventLabel, RHDeleteReferenceType,
                                                      RHEditEventLabel, RHEditReferenceType, RHEventLabels,
-                                                     RHReferenceTypes, RHUnlistedEvents)
+                                                     RHReferenceTypes, RHUnlistedEvents, RHUpdateEventKeywords)
 from indico.modules.events.controllers.api import RHEventCheckEmail, RHSingleEventAPI
 from indico.modules.events.controllers.creation import RHCreateEvent, RHPrepareEvent
 from indico.modules.events.controllers.display import (RHAutoLinkerRules, RHDisplayPrivacyPolicy, RHEventAccessKey,
@@ -26,6 +26,7 @@ _bp.add_url_rule('/admin/external-id-types/create', 'create_reference_type', RHC
                  methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/event-labels/', 'event_labels', RHEventLabels, methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/event-labels/create', 'create_event_label', RHCreateEventLabel, methods=('GET', 'POST'))
+_bp.add_url_rule('/admin/event-keywords/', 'event_keywords', RHUpdateEventKeywords, methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/unlisted-events/', 'unlisted_events', RHUnlistedEvents, methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/autolinker/', 'autolinker_admin', RHAutoLinker)
 _bp.add_url_rule('/admin/autolinker/config', 'autolinker_config', RHAutoLinkerConfig, methods=('POST',))

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -127,14 +127,13 @@ class RHUpdateEventKeywords(RHAdminBase):
     """Update event keywords."""
 
     def _process(self):
-        form = EventKeywordsForm()
-        keywords = global_event_settings.get('allowed_keywords')
+        form = EventKeywordsForm(keywords=global_event_settings.get('allowed_keywords'))
         if form.validate_on_submit():
             keywords = sorted(set(form.data.get('keywords', [])), key=natural_sort_key)
             global_event_settings.set('allowed_keywords', keywords)
             flash(_('Allowed keywords have been saved'), 'success')
             return redirect(url_for('.event_keywords'))
-        return WPEventAdmin.render_template('admin/event_keywords.html', 'event_keywords', keywords=keywords, form=form)
+        return WPEventAdmin.render_template('admin/event_keywords.html', 'event_keywords', form=form)
 
 
 class RHEditEventLabel(RHManageEventLabelBase):

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -11,7 +11,7 @@ from webargs import fields
 from indico.core.db import db
 from indico.modules.admin import RHAdminBase
 from indico.modules.events.forms import EventKeywordsForm, EventLabelForm, ReferenceTypeForm, UnlistedEventsForm
-from indico.modules.events.management.settings import event_settings
+from indico.modules.events.management.settings import global_event_settings
 from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
 from indico.modules.events.operations import (create_event_label, create_reference_type, delete_event_label,
@@ -127,10 +127,10 @@ class RHUpdateEventKeywords(RHAdminBase):
 
     def _process(self):
         form = EventKeywordsForm()
-        keywords = event_settings.get('allowed_keywords')
+        keywords = global_event_settings.get('allowed_keywords')
         if form.validate_on_submit():
             keywords = sorted({kw.lower() for kw in form.data.get('keywords', [])})
-            event_settings.set('allowed_keywords', keywords)
+            global_event_settings.set('allowed_keywords', keywords)
             flash(_('Allowed keywords have been saved'), 'success')
             return redirect(url_for('.event_keywords'))
         return WPEventAdmin.render_template('admin/event_keywords.html', 'event_keywords', keywords=keywords, form=form)

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -11,7 +11,7 @@ from webargs import fields
 from indico.core.db import db
 from indico.modules.admin import RHAdminBase
 from indico.modules.events.forms import EventKeywordsForm, EventLabelForm, ReferenceTypeForm, UnlistedEventsForm
-from indico.modules.events.management.settings import misc_settings
+from indico.modules.events.management.settings import event_settings
 from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
 from indico.modules.events.operations import (create_event_label, create_reference_type, delete_event_label,
@@ -127,10 +127,10 @@ class RHUpdateEventKeywords(RHAdminBase):
 
     def _process(self):
         form = EventKeywordsForm()
-        keywords = misc_settings.get('allowed_keywords')
+        keywords = event_settings.get('allowed_keywords')
         if form.validate_on_submit():
             keywords = sorted({kw.lower() for kw in form.data.get('keywords', [])})
-            misc_settings.set('allowed_keywords', keywords)
+            event_settings.set('allowed_keywords', keywords)
             flash(_('Allowed keywords have been saved'), 'success')
             return redirect(url_for('.event_keywords'))
         return WPEventAdmin.render_template('admin/event_keywords.html', 'event_keywords', keywords=keywords, form=form)

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -20,6 +20,7 @@ from indico.modules.events.schemas import AutoLinkerRuleSchema
 from indico.modules.events.settings import autolinker_settings, unlisted_events_settings
 from indico.modules.events.views import WPEventAdmin
 from indico.util.i18n import _
+from indico.util.string import natural_sort_key
 from indico.web.args import use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for
@@ -129,7 +130,7 @@ class RHUpdateEventKeywords(RHAdminBase):
         form = EventKeywordsForm()
         keywords = global_event_settings.get('allowed_keywords')
         if form.validate_on_submit():
-            keywords = sorted({kw.lower() for kw in form.data.get('keywords', [])})
+            keywords = sorted(set(form.data.get('keywords', [])), key=natural_sort_key)
             global_event_settings.set('allowed_keywords', keywords)
             flash(_('Allowed keywords have been saved'), 'success')
             return redirect(url_for('.event_keywords'))

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -10,7 +10,8 @@ from webargs import fields
 
 from indico.core.db import db
 from indico.modules.admin import RHAdminBase
-from indico.modules.events.forms import EventLabelForm, ReferenceTypeForm, UnlistedEventsForm
+from indico.modules.events.forms import EventKeywordsForm, EventLabelForm, ReferenceTypeForm, UnlistedEventsForm
+from indico.modules.events.management.settings import misc_settings
 from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
 from indico.modules.events.operations import (create_event_label, create_reference_type, delete_event_label,
@@ -119,6 +120,21 @@ class RHCreateEventLabel(RHAdminBase):
             flash(_("Event label '{}' created successfully").format(event_label.title), 'success')
             return jsonify_data(html=_render_event_label_list())
         return jsonify_form(form)
+
+
+class RHUpdateEventKeywords(RHAdminBase):
+    """Update event keywords."""
+
+    def _process(self):
+        form = EventKeywordsForm()
+        keywords = None
+        if form.validate_on_submit():
+            keywords = sorted({kw.lower() for kw in form.data.get('keywords', [])})
+            misc_settings.set('allowed_keywords', keywords)
+            flash(_('Allowed keywords have been saved'), 'success')
+        if not keywords:
+            keywords = misc_settings.get('allowed_keywords')
+        return WPEventAdmin.render_template('admin/event_keywords.html', 'event_keywords', keywords=keywords, form=form)
 
 
 class RHEditEventLabel(RHManageEventLabelBase):

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -127,13 +127,12 @@ class RHUpdateEventKeywords(RHAdminBase):
 
     def _process(self):
         form = EventKeywordsForm()
-        keywords = None
+        keywords = misc_settings.get('allowed_keywords')
         if form.validate_on_submit():
             keywords = sorted({kw.lower() for kw in form.data.get('keywords', [])})
             misc_settings.set('allowed_keywords', keywords)
             flash(_('Allowed keywords have been saved'), 'success')
-        if not keywords:
-            keywords = misc_settings.get('allowed_keywords')
+            return redirect(url_for('.event_keywords'))
         return WPEventAdmin.render_template('admin/event_keywords.html', 'event_keywords', keywords=keywords, form=form)
 
 

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -76,6 +76,16 @@ class EventLabelForm(IndicoForm):
 class EventKeywordsForm(IndicoForm):
     keywords = IndicoTagListField(_('Keywords'))
 
+    def post_validate(self):
+        # case-insensitive keywords deduplication
+        keywords = []
+        seen_keywords = set()
+        for keyword in self.keywords.data:
+            if keyword.lower() not in seen_keywords:
+                keywords.append(keyword)
+                seen_keywords.add(keyword.lower())
+        self.keywords.data = keywords
+
 
 class EventCreationFormBase(IndicoForm):
     listing = IndicoButtonsBooleanField(_('Listing'), default=True,

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -21,7 +21,7 @@ from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm
-from indico.web.forms.fields import (IndicoDateTimeField, IndicoEnumRadioField, IndicoLocationField,
+from indico.web.forms.fields import (IndicoDateTimeField, IndicoEnumRadioField, IndicoLocationField, IndicoTagListField,
                                      IndicoTimezoneSelectField, JSONField, OccurrencesField)
 from indico.web.forms.fields.colors import SUIColorPickerField
 from indico.web.forms.fields.principals import PrincipalListField
@@ -71,6 +71,10 @@ class EventLabelForm(IndicoForm):
             query = query.filter(EventLabel.id != self.event_label.id)
         if query.has_rows():
             raise ValidationError(_('This title is already in use.'))
+
+
+class EventKeywordsForm(IndicoForm):
+    keywords = IndicoTagListField(_('Keywords'))
 
 
 class EventCreationFormBase(IndicoForm):

--- a/indico/modules/events/management/controllers/settings.py
+++ b/indico/modules/events/management/controllers/settings.py
@@ -16,7 +16,7 @@ from indico.modules.events.management.controllers.base import RHManageEventBase
 from indico.modules.events.management.forms import (EventClassificationForm, EventContactInfoForm, EventDataForm,
                                                     EventDatesForm, EventLanguagesForm, EventLocationForm,
                                                     EventPersonsForm)
-from indico.modules.events.management.settings import event_settings
+from indico.modules.events.management.settings import global_event_settings
 from indico.modules.events.management.util import flash_if_unregistered
 from indico.modules.events.management.views import WPEventSettings, render_event_management_header_right
 from indico.modules.events.models.labels import EventLabel
@@ -152,15 +152,12 @@ class RHEditEventClassification(RHEditEventDataBase):
 
     @property
     def form_class(self):
-        if allowed_keywords := event_settings.get('allowed_keywords'):
+        if allowed_keywords := global_event_settings.get('allowed_keywords'):
             choices = [{'id': kw, 'name': kw} for kw in (set(allowed_keywords) | set(self.event.keywords))]
             keywords = IndicoStrictKeywordsField(_('Keywords'), choices=choices)
         else:
             keywords = IndicoTagListField(_('Keywords'))
         return type('_EventClassificationForm', (EventClassificationForm,), {'keywords': keywords})
-
-    def render_form(self, form):
-        return jsonify_form(form, footer_align_right=True, disabled_until_change=False)
 
 
 class RHEditEventLanguages(RHEditEventDataBase):

--- a/indico/modules/events/management/controllers/settings.py
+++ b/indico/modules/events/management/controllers/settings.py
@@ -32,7 +32,7 @@ from indico.util.i18n import _
 from indico.util.signals import values_from_signal
 from indico.web.flask.templating import get_template_module
 from indico.web.forms.base import FormDefaults
-from indico.web.forms.fields import IndicoSelectMultipleCheckboxField, IndicoTagListField
+from indico.web.forms.fields import IndicoStrictKeywordsField, IndicoTagListField
 from indico.web.util import jsonify_data, jsonify_form, jsonify_template
 
 
@@ -153,9 +153,8 @@ class RHEditEventClassification(RHEditEventDataBase):
     @property
     def form_class(self):
         if allowed_keywords := event_settings.get('allowed_keywords'):
-            default = sorted(set(allowed_keywords) & set(self.event.keywords))
-            choices = set(allowed_keywords) | set(self.event.keywords)
-            keywords = IndicoSelectMultipleCheckboxField(_('Keywords'), choices=choices, default=default)
+            choices = [{'id': kw, 'name': kw} for kw in (set(allowed_keywords) | set(self.event.keywords))]
+            keywords = IndicoStrictKeywordsField(_('Keywords'), choices=choices)
         else:
             keywords = IndicoTagListField(_('Keywords'))
         return type('_EventClassificationForm', (EventClassificationForm,), {'keywords': keywords})

--- a/indico/modules/events/management/controllers/settings.py
+++ b/indico/modules/events/management/controllers/settings.py
@@ -16,7 +16,7 @@ from indico.modules.events.management.controllers.base import RHManageEventBase
 from indico.modules.events.management.forms import (EventClassificationForm, EventContactInfoForm, EventDataForm,
                                                     EventDatesForm, EventLanguagesForm, EventLocationForm,
                                                     EventPersonsForm)
-from indico.modules.events.management.settings import misc_settings
+from indico.modules.events.management.settings import event_settings
 from indico.modules.events.management.util import flash_if_unregistered
 from indico.modules.events.management.views import WPEventSettings, render_event_management_header_right
 from indico.modules.events.models.labels import EventLabel
@@ -152,10 +152,10 @@ class RHEditEventClassification(RHEditEventDataBase):
 
     @property
     def form_class(self):
-        if allowed_keywords := misc_settings.get('allowed_keywords'):
-            allowed_keywords_set = set(allowed_keywords)
-            default = [kw in allowed_keywords_set for kw in self.event.keywords]
-            keywords = IndicoSelectMultipleCheckboxField(_('Keywords'), choices=allowed_keywords, default=default)
+        if allowed_keywords := event_settings.get('allowed_keywords'):
+            default = sorted(set(allowed_keywords) & set(self.event.keywords))
+            choices = set(allowed_keywords) | set(self.event.keywords)
+            keywords = IndicoSelectMultipleCheckboxField(_('Keywords'), choices=choices, default=default)
         else:
             keywords = IndicoTagListField(_('Keywords'))
         return type('_EventClassificationForm', (EventClassificationForm,), {'keywords': keywords})

--- a/indico/modules/events/management/controllers/settings.py
+++ b/indico/modules/events/management/controllers/settings.py
@@ -148,18 +148,17 @@ class RHEditEventContactInfo(RHEditEventDataBase):
 
 
 class RHEditEventClassification(RHEditEventDataBase):
-    form_class = EventClassificationForm
     section_name = 'classification'
 
-    def _process(self):
-        allowed_keywords = misc_settings.get('allowed_keywords')
-        if allowed_keywords:
-            default = list(filter(lambda kw: kw in allowed_keywords, self.event.keywords))
-            self.form_class.keywords = IndicoSelectMultipleCheckboxField(_('Keywords'), choices=allowed_keywords,
-                                                                         default=default)
+    @property
+    def form_class(self):
+        if allowed_keywords := misc_settings.get('allowed_keywords'):
+            allowed_keywords_set = set(allowed_keywords)
+            default = [kw in allowed_keywords_set for kw in self.event.keywords]
+            keywords = IndicoSelectMultipleCheckboxField(_('Keywords'), choices=allowed_keywords, default=default)
         else:
-            self.form_class.keywords = IndicoTagListField(_('Keywords'))
-        return super()._process()
+            keywords = IndicoTagListField(_('Keywords'))
+        return type('_EventClassificationForm', (EventClassificationForm,), {'keywords': keywords})
 
     def render_form(self, form):
         return jsonify_form(form, footer_align_right=True, disabled_until_change=False)

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -28,7 +28,7 @@ from indico.modules.designer.util import get_inherited_templates
 from indico.modules.events import Event, LegacyEventMapping
 from indico.modules.events.cloning import EventCloner
 from indico.modules.events.fields import EventPersonLinkListField, ReferencesField
-from indico.modules.events.management.settings import event_settings
+from indico.modules.events.management.settings import global_event_settings
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import EventReference, ReferenceType
@@ -216,6 +216,7 @@ class EventContactInfoForm(IndicoForm):
 
 
 class EventClassificationForm(IndicoForm):
+    # The 'keywords' field is dynamically added when creating the form.
     references = ReferencesField(_('External IDs'), reference_class=EventReference)
     label = QuerySelectField(_('Label'), allow_blank=True, get_label='title')
     label_message = TextAreaField(_('Label message'),
@@ -233,7 +234,7 @@ class EventClassificationForm(IndicoForm):
             del self.label_message
 
     def validate_keywords(self, field):
-        allowed_keywords = set(event_settings.get('allowed_keywords'))
+        allowed_keywords = set(global_event_settings.get('allowed_keywords')) | set(field.object_data)
         keywords = set(field.data)
         if allowed_keywords and not (keywords <= allowed_keywords):
             raise ValidationError('Invalid keyword found')

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -234,7 +234,8 @@ class EventClassificationForm(IndicoForm):
 
     def validate_keywords(self, field):
         allowed_keywords = set(misc_settings.get('allowed_keywords'))
-        if allowed_keywords and field.data and not all(kw in allowed_keywords for kw in field.data):
+        keywords = set(field.data)
+        if allowed_keywords and not (keywords <= allowed_keywords):
             raise ValidationError(_('Keyword not allowed'))
 
 

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -236,7 +236,7 @@ class EventClassificationForm(IndicoForm):
         allowed_keywords = set(event_settings.get('allowed_keywords'))
         keywords = set(field.data)
         if allowed_keywords and not (keywords <= allowed_keywords):
-            raise ValidationError(_('Keyword not allowed'))
+            raise ValidationError('Invalid keyword found')
 
 
 class EventPrivacyForm(IndicoForm):

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -28,7 +28,7 @@ from indico.modules.designer.util import get_inherited_templates
 from indico.modules.events import Event, LegacyEventMapping
 from indico.modules.events.cloning import EventCloner
 from indico.modules.events.fields import EventPersonLinkListField, ReferencesField
-from indico.modules.events.management.settings import misc_settings
+from indico.modules.events.management.settings import event_settings
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import EventReference, ReferenceType
@@ -233,7 +233,7 @@ class EventClassificationForm(IndicoForm):
             del self.label_message
 
     def validate_keywords(self, field):
-        allowed_keywords = set(misc_settings.get('allowed_keywords'))
+        allowed_keywords = set(event_settings.get('allowed_keywords'))
         keywords = set(field.data)
         if allowed_keywords and not (keywords <= allowed_keywords):
             raise ValidationError(_('Keyword not allowed'))

--- a/indico/modules/events/management/forms.py
+++ b/indico/modules/events/management/forms.py
@@ -28,6 +28,7 @@ from indico.modules.designer.util import get_inherited_templates
 from indico.modules.events import Event, LegacyEventMapping
 from indico.modules.events.cloning import EventCloner
 from indico.modules.events.fields import EventPersonLinkListField, ReferencesField
+from indico.modules.events.management.settings import misc_settings
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import EventReference, ReferenceType
@@ -41,7 +42,7 @@ from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.fields import (IndicoDateField, IndicoDateTimeField, IndicoEnumSelectField, IndicoLocationField,
                                      IndicoPasswordField, IndicoProtectionField, IndicoRadioField,
-                                     IndicoSelectMultipleCheckboxField, IndicoTagListField, IndicoTimezoneSelectField,
+                                     IndicoSelectMultipleCheckboxField, IndicoTimezoneSelectField,
                                      IndicoWeekDayRepetitionField, MultiStringField, RelativeDeltaField)
 from indico.web.forms.fields.principals import PermissionsField
 from indico.web.forms.fields.simple import IndicoLinkListField
@@ -215,7 +216,6 @@ class EventContactInfoForm(IndicoForm):
 
 
 class EventClassificationForm(IndicoForm):
-    keywords = IndicoTagListField(_('Keywords'))
     references = ReferencesField(_('External IDs'), reference_class=EventReference)
     label = QuerySelectField(_('Label'), allow_blank=True, get_label='title')
     label_message = TextAreaField(_('Label message'),
@@ -231,6 +231,11 @@ class EventClassificationForm(IndicoForm):
         if not self.label.query.has_rows():
             del self.label
             del self.label_message
+
+    def validate_keywords(self, field):
+        allowed_keywords = set(misc_settings.get('allowed_keywords'))
+        if allowed_keywords and field.data and not all(kw in allowed_keywords for kw in field.data):
+            raise ValidationError(_('Keyword not allowed'))
 
 
 class EventPrivacyForm(IndicoForm):

--- a/indico/modules/events/management/settings.py
+++ b/indico/modules/events/management/settings.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from indico.core.settings import SettingsProxy
 from indico.modules.events.settings import EventSettingsProxy
 
 
@@ -21,4 +22,8 @@ privacy_settings = EventSettingsProxy('privacy', {
     'data_controller_email': '',
     'privacy_policy_urls': [],
     'privacy_policy': '',
+})
+
+misc_settings = SettingsProxy('misc', {
+    'allowed_keywords': [],
 })

--- a/indico/modules/events/management/settings.py
+++ b/indico/modules/events/management/settings.py
@@ -24,6 +24,6 @@ privacy_settings = EventSettingsProxy('privacy', {
     'privacy_policy': '',
 })
 
-event_settings = SettingsProxy('events', {
+global_event_settings = SettingsProxy('events', {
     'allowed_keywords': [],
 })

--- a/indico/modules/events/management/settings.py
+++ b/indico/modules/events/management/settings.py
@@ -24,6 +24,6 @@ privacy_settings = EventSettingsProxy('privacy', {
     'privacy_policy': '',
 })
 
-misc_settings = SettingsProxy('misc', {
+event_settings = SettingsProxy('events', {
     'allowed_keywords': [],
 })

--- a/indico/modules/events/templates/admin/event_keywords.html
+++ b/indico/modules/events/templates/admin/event_keywords.html
@@ -1,0 +1,33 @@
+{% extends 'layout/admin_page.html' %}
+{% from 'forms/_form.html' import simple_form %}
+
+{% block title %}
+    {% trans %}Allowed event keywords{% endtrans %}
+{% endblock %}
+
+{% block description %}
+    {% trans %}Define the list of allowed event keywords. An empty list implies any keyword is valid.
+    {% endtrans %}
+{% endblock %}
+
+{% block content %}
+    {{ simple_form(form, back_button=false, disabled_until_change=False) }}
+
+    <script language="javascript">
+        $(document).ready(function () {
+            const id = 'keyword-continer';
+            const input = $('#keywords');
+            const field = input.parent();
+            field.attr('id', id).addClass('i-taglist-field');
+            input.remove();
+            new Taggle(id, {
+                tags: {{ keywords|tojson }},
+                allowDuplicates: false,
+                preserveCase: true,
+                saveOnBlur: true,
+                placeholder: '',
+                hiddenInputName: 'keywords',
+            });
+        });
+    </script>
+{% endblock %}

--- a/indico/modules/events/templates/admin/event_keywords.html
+++ b/indico/modules/events/templates/admin/event_keywords.html
@@ -12,24 +12,5 @@
 {% endblock %}
 
 {% block content %}
-    {{ simple_form(form, back_button=false, disabled_until_change=false) }}
-
-    <script>
-        domReady.then(() => {
-            const id = 'keyword-container';
-            const input = document.querySelector('#{{ form.keywords.id }}');
-            const field = input.parentElement;
-            field.id = id;
-            field.classList.add('i-taglist-field');
-            input.remove();
-            new Taggle(id, {
-                tags: {{ keywords|tojson }},
-                allowDuplicates: false,
-                preserveCase: true,
-                saveOnBlur: true,
-                placeholder: '',
-                hiddenInputName: 'keywords',
-            });
-        });
-    </script>
+    {{ simple_form(form, back_button=false) }}
 {% endblock %}

--- a/indico/modules/events/templates/admin/event_keywords.html
+++ b/indico/modules/events/templates/admin/event_keywords.html
@@ -12,10 +12,10 @@
 {% endblock %}
 
 {% block content %}
-    {{ simple_form(form, back_button=false, disabled_until_change=False) }}
+    {{ simple_form(form, back_button=false, disabled_until_change=false) }}
 
     <script>
-        domReady.then(function () {
+        domReady.then(() => {
             const id = 'keyword-container';
             const input = document.querySelector('#{{ form.keywords.id }}');
             const field = input.parentElement;

--- a/indico/modules/events/templates/admin/event_keywords.html
+++ b/indico/modules/events/templates/admin/event_keywords.html
@@ -6,19 +6,21 @@
 {% endblock %}
 
 {% block description %}
-    {% trans %}Define the list of allowed event keywords. An empty list implies any keyword is valid.
+    {% trans %}
+        Define the list of allowed event keywords. An empty list implies any keyword is valid.
     {% endtrans %}
 {% endblock %}
 
 {% block content %}
     {{ simple_form(form, back_button=false, disabled_until_change=False) }}
 
-    <script language="javascript">
-        $(document).ready(function () {
-            const id = 'keyword-continer';
-            const input = $('#keywords');
-            const field = input.parent();
-            field.attr('id', id).addClass('i-taglist-field');
+    <script>
+        domReady.then(function () {
+            const id = 'keyword-container';
+            const input = document.querySelector('#{{ form.keywords.id }}');
+            const field = input.parentElement;
+            field.id = id;
+            field.classList.add('i-taglist-field');
             input.remove();
             new Taggle(id, {
                 tags: {{ keywords|tojson }},

--- a/indico/modules/rb/event/fields.py
+++ b/indico/modules/rb/event/fields.py
@@ -20,7 +20,7 @@ class LinkedObjectField(Field):
         self.ajax_endpoint = kwargs.pop('ajax_endpoint')
         super().__init__(*args, **kwargs)
 
-    def _value(self):
+    def _value(self, for_react=False):
         pass
 
     @property

--- a/indico/modules/vc/forms.py
+++ b/indico/modules/vc/forms.py
@@ -33,8 +33,10 @@ class VCRoomField(HiddenField):
         if valuelist and valuelist[0].isdigit():
             self.data = VCRoom.get(valuelist[0])
 
-    def _value(self):
-        return [{'id': self.data.id}] if self.data is not None else None
+    def _value(self, for_react=False):
+        if not self.data:
+            return None
+        return [{'id': self.data.id}] if for_react else self.data.id
 
 
 class LinkingWidget(JinjaWidget):

--- a/indico/util/colors.py
+++ b/indico/util/colors.py
@@ -6,6 +6,7 @@
 # LICENSE file for more details.
 
 import colorsys
+import functools
 
 from indico.core.db.sqlalchemy.colors import ColorTuple
 
@@ -46,6 +47,7 @@ def _rgb_to_hex(rgb):
     return f'#{int(rgb[0] * 255):02x}{int(rgb[1] * 255):02x}{int(rgb[2] * 255):02x}'
 
 
+@functools.cache
 def generate_contrast_colors(seed):
     """Generates a background and text colors with sufficient contrast given a seed."""
     hue = 1.0 / (1.0 + seed % 20)

--- a/indico/web/client/js/utils/domstate.js
+++ b/indico/web/client/js/utils/domstate.js
@@ -12,3 +12,5 @@ export const domReady = new Promise(resolve => {
     window.addEventListener('DOMContentLoaded', resolve);
   }
 });
+
+window.domReady = domReady;

--- a/indico/web/forms/fields/__init__.py
+++ b/indico/web/forms/fields/__init__.py
@@ -13,7 +13,7 @@
 # XXX: keep `simple` on top; other modules may need fields from there (especially JSONField)
 from .simple import (EmailListField, HiddenFieldList, IndicoEmailRecipientsField, IndicoPasswordField, IndicoRadioField,
                      IndicoSelectMultipleCheckboxBooleanField, IndicoSelectMultipleCheckboxField, IndicoStaticTextField,
-                     IndicoTagListField, JSONField, TextListField)
+                     IndicoStrictKeywordsField, IndicoTagListField, JSONField, TextListField)
 
 from .colors import IndicoPalettePickerField, IndicoSinglePalettePickerField
 from .datetime import (IndicoDateField, IndicoDateTimeField, IndicoTimeField, IndicoTimezoneSelectField,
@@ -36,4 +36,4 @@ __all__ = ('IndicoSelectMultipleCheckboxField', 'IndicoRadioField', 'JSONField',
            'PrincipalListField', 'PrincipalField', 'AccessControlListField', 'IndicoQuerySelectMultipleField',
            'EditableFileField', 'IndicoQuerySelectMultipleCheckboxField', 'IndicoLocationField', 'IndicoMarkdownField',
            'IndicoDateField', 'IndicoProtectionField', 'IndicoSelectMultipleCheckboxBooleanField', 'RelativeDeltaField',
-           'IndicoWeekDayRepetitionField', 'IndicoEmailRecipientsField', 'IndicoTimeField')
+           'IndicoWeekDayRepetitionField', 'IndicoEmailRecipientsField', 'IndicoTimeField', 'IndicoStrictKeywordsField')

--- a/indico/web/forms/fields/simple.py
+++ b/indico/web/forms/fields/simple.py
@@ -17,7 +17,7 @@ from indico.modules.events.registration.models.registrations import PublishRegis
 from indico.util.i18n import _
 from indico.util.string import sanitize_email, validate_email
 from indico.web.forms.fields.util import is_preprocessed_formdata
-from indico.web.forms.widgets import HiddenInputs, JinjaWidget, PasswordWidget
+from indico.web.forms.widgets import DropdownWidget, HiddenInputs, JinjaWidget, PasswordWidget
 
 
 class IndicoSelectMultipleCheckboxField(SelectMultipleField):
@@ -169,6 +169,21 @@ class IndicoEmailRecipientsField(Field):
         self.data = sorted(data, key=str.lower)
         self.text_value = ', '.join(data)
         self.count = len(data)
+
+
+class IndicoStrictKeywordsField(Field):
+    widget = DropdownWidget(allow_additions=False, multiple=True)
+
+    def __init__(self, *args, **kwargs):
+        self.serialized_choices = kwargs.pop('choices', [])
+        super().__init__(*args, **kwargs)
+
+    def process_formdata(self, valuelist):
+        super().process_formdata(valuelist)
+        self.data = sorted(json.loads(self.data))
+
+    def _value(self):
+        return [{'id': d, 'name': d} for d in self.data]
 
 
 class IndicoTagListField(HiddenFieldList):

--- a/indico/web/forms/fields/simple.py
+++ b/indico/web/forms/fields/simple.py
@@ -182,8 +182,8 @@ class IndicoStrictKeywordsField(Field):
         super().process_formdata(valuelist)
         self.data = sorted(json.loads(self.data))
 
-    def _value(self):
-        return [{'id': d, 'name': d} for d in self.data]
+    def _value(self, for_react=False):
+        return [{'id': d, 'name': d} for d in self.data] if for_react else self.data
 
 
 class IndicoTagListField(HiddenFieldList):

--- a/indico/web/templates/forms/sui_search_dropdown_widget.html
+++ b/indico/web/templates/forms/sui_search_dropdown_widget.html
@@ -12,7 +12,7 @@
     <script>
         setupSearchDropdownWidget({
             fieldId: {{ field.id | tojson }},
-            defaultValue: {{ (field._value() or []) | tojson }},
+            defaultValue: {{ (field._value(for_react=true) or []) | tojson }},
             minTriggerLength: {{ min_trigger_length | tojson }},
             searchUrl: {{ search_url | tojson }},
             searchMethod: {{ search_method | tojson }},


### PR DESCRIPTION
Closes #6127

## Description
This PR adds the possibility to filter in the calendar by keywords.

Keywords can now be registered system-wise so that there is a limited amount of allowed one. If there is no system-wide allowed keywords then the option to filter by keyword is not shown.

Also when editing a booking's keywords different widgets are used to limit the possibilities if needed. Otherwise the old widget is used.

## Screenshots

<img width="1011" alt="Screenshot 2024-02-14 at 16 23 13" src="https://github.com/indico/indico/assets/2722756/14fc1c0d-9e83-44cc-99cf-f205ea33779f">
<img width="1631" alt="Screenshot 2024-02-14 at 16 22 55" src="https://github.com/indico/indico/assets/2722756/720d8a0c-42fb-4038-9fbb-8446c1b136a9">
