### PR TITLE
Store editable list filters in local storage

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,6 +94,7 @@ Improvements
 - Add ``indico user anonymize`` CLI to permanently anonymize a user (:pr:`5838`)
 - Add possibility to link room reservations to multiple events, session blocks and contributions
   (:issue:`6113`, :pr:`6114`, thanks :user:`omegak, unconventionaldotdev`)
+- Store editable list filters in the browser's local storage (:pr:`6192`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -590,7 +590,8 @@ function EditableListDisplay({
           )}
         </div>
         <ListFilter
-          list={filterableContribs}
+          name="editable-list-filter"
+          list={filterableContribs || []}
           filterOptions={filterOptions}
           searchableId={e => e.searchableId}
           searchableFields={e => e.searchableFields}

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -209,7 +209,8 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
       <Modal.Content>
         <div styleName="filetype-list">
           <ListFilter
-            list={editables}
+            name="get-next-editable-filter"
+            list={editables || []}
             filters={filters}
             filterOptions={filterOptions}
             searchableId={e => e.contributionFriendlyId}

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -135,10 +135,10 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
     const filetypesKeyExpr = /^filetypes_(\d+)$/;
     const formatFilterOptions = options => {
       const extOptionExpr = /^has_ext_(.*)$/;
-      const extensionOptions = options.filter(o => extOptionExpr.exec(o));
+      const extensionOptions = Object.keys(options).filter(o => extOptionExpr.exec(o));
       return extensionOptions.length > 0
         ? extensionOptions.map(o => extOptionExpr.exec(o)[1])
-        : !options.includes('has_no_files');
+        : !options.has_no_files;
     };
     const newFilters = Object.keys(activeFilters)
       .filter(f => filetypesKeyExpr.exec(f))
@@ -159,7 +159,8 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
     }
     const filtered = _editables.filter(x =>
       filterOptions.every(
-        ({key, isMatch}) => !activeFilters[key] || !isMatch || isMatch(x, activeFilters[key] || [])
+        ({key, isMatch}) =>
+          !activeFilters[key] || !isMatch || isMatch(x, Object.keys(activeFilters[key] || {}))
       )
     );
     setFilters(activeFilters);

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -11,7 +11,7 @@ import editableListURL from 'indico-url:event_editing.api_filter_editables_by_fi
 
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, {useState, useEffect, useMemo, useRef, useCallback} from 'react';
+import React, {useState, useMemo, useRef} from 'react';
 import {useHistory} from 'react-router-dom';
 import {Button, Loader, Modal, Table, Checkbox, Dimmer} from 'semantic-ui-react';
 
@@ -72,25 +72,19 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
     }
   };
 
-  const getEditables = useCallback(
-    async _filters => {
-      let response;
-      try {
-        response = await indicoAxios.post(
-          editableListURL({event_id: eventId, type: editableType}),
-          {
-            extensions: _.pickBy(_filters, x => Array.isArray(x)),
-            has_files: _.pickBy(_filters, x => !Array.isArray(x)),
-          }
-        );
-      } catch (e) {
-        handleAxiosError(e);
-        return;
-      }
-      return camelizeKeys(response.data);
-    },
-    [eventId, editableType]
-  );
+  const getEditables = async _filters => {
+    let response;
+    try {
+      response = await indicoAxios.post(editableListURL({event_id: eventId, type: editableType}), {
+        extensions: _.pickBy(_filters, x => Array.isArray(x)),
+        has_files: _.pickBy(_filters, x => !Array.isArray(x)),
+      });
+    } catch (e) {
+      handleAxiosError(e);
+      return;
+    }
+    return camelizeKeys(response.data);
+  };
 
   const filterOptions = useMemo(
     () => [
@@ -192,17 +186,6 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
       history.push(selectedEditable.timelineURL);
     }
   };
-
-  useEffect(() => {
-    (async () => {
-      setSelectedEditable(null);
-      setLoading(true);
-      const _editables = await getEditables();
-      setEditables(_editables);
-      _setFilteredSet(new Set(_editables.map(e => e.id)));
-      setLoading(false);
-    })();
-  }, [eventId, editableType, getEditables]);
 
   return (
     <Modal onClose={onClose} closeOnDimmerClick={false} open>


### PR DESCRIPTION
This PR makes it so that filters applied in editable lists (both the main editable list and the "get next editable") get stored in the browser's local storage. It also fixes a bug with external filters in which active filter options disappear when they become unavailable (such as a keyword no longer being present in the filtered search results).