### PR TITLE
Filter editable list by tags

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,7 @@ Improvements
 - Take visibility restrictions into account in the atom feed (:pr:`5472`, thanks :user:`bpedersen2`)
 - Allow linking badge templates to registration forms in order to use custom fields in them
   (:pr:`6088`)
+- Allow filtering the list of editables by tags (:issue:`6195`, :pr:`6197`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -216,8 +216,8 @@ function EditableListDisplay({
         options: _.uniqBy(
           contribsWithEditables
             .map(c => c.editable.tags)
-            .filter(x => x)
-            .reduce((pre, cur) => pre.concat(cur)),
+            .filter(x => x.length)
+            .reduce((pre, cur) => pre.concat(cur), []),
           'code'
         ).map(t => ({value: t.code, text: t.code, color: t.color})),
         isMatch: (contrib, selectedOptions) =>

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -210,6 +210,21 @@ function EditableListDisplay({
         isMatch: (contrib, selectedOptions) =>
           contrib.c.keywords.some(k => selectedOptions.includes(k)),
       },
+      {
+        key: 'tags',
+        text: Translate.string('Tags'),
+        options: _.uniq(
+          contribsWithEditables
+            .map(c => c.editable.tags)
+            .filter(x => x)
+            .reduce((pre, cur) => pre.concat(cur))
+            .map(t => ({value: t.code, text: t.code, color: t.color}))
+        ),
+        isMatch: (contrib, selectedOptions) =>
+          contrib.c.editable &&
+          contrib.c.editable.tags &&
+          selectedOptions.some(tag => contrib.c.editable.tags.map(t => t.code).includes(tag)),
+      },
     ],
     [contribList, contribsWithEditables]
   );

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -213,16 +213,15 @@ function EditableListDisplay({
       {
         key: 'tags',
         text: Translate.string('Tags'),
-        options: _.uniq(
+        options: _.uniqBy(
           contribsWithEditables
             .map(c => c.editable.tags)
             .filter(x => x)
-            .reduce((pre, cur) => pre.concat(cur))
-            .map(t => ({value: t.code, text: t.code, color: t.color}))
-        ),
+            .reduce((pre, cur) => pre.concat(cur)),
+          'code'
+        ).map(t => ({value: t.code, text: t.code, color: t.color})),
         isMatch: (contrib, selectedOptions) =>
-          contrib.c.editable &&
-          contrib.c.editable.tags &&
+          contrib.c.editable?.tags &&
           selectedOptions.some(tag => contrib.c.editable.tags.map(t => t.code).includes(tag)),
       },
     ],

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -45,7 +45,7 @@ class RHEditableList(RHEditableTypeEditorBase):
         RHEditableTypeEditorBase._process_args(self)
         self.contributions = (Contribution.query
                               .with_parent(self.event)
-                              .options(joinedload('editables'))
+                              .options(joinedload('editables').selectinload('revisions').selectinload('tags'))
                               .order_by(Contribution.friendly_id)
                               .all())
 

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -258,7 +258,8 @@ class EditableWithTagsSchema(EditableBasicSchema):
         model = Editable
         fields = (*EditableBasicSchema.Meta.fields, 'tags')
 
-    tags = fields.List(fields.Nested(EditingTagSchema), attribute='latest_revision.tags')
+    tags = fields.List(fields.Nested(EditingTagSchema, only=('id', 'code', 'title', 'color')),
+                       attribute='latest_revision.tags')
 
 
 class EditingEditableListSchema(mm.SQLAlchemyAutoSchema):

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -246,11 +246,15 @@ class EditableDumpSchema(EditableSchema):
 class EditableBasicSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Editable
-        fields = ('id', 'type', 'state', 'editor', 'timeline_url', 'revision_count')
+        fields = ('id', 'type', 'state', 'editor', 'timeline_url', 'revision_count', 'tags')
 
     state = EnumField(EditableState)
     editor = fields.Nested(EditingUserSchema)
     timeline_url = fields.String()
+    tags = fields.Method('_get_tags')
+
+    def _get_tags(self, editable):
+        return [EditingTagSchema().dump(t) for t in editable.latest_revision.tags]
 
 
 class EditingEditableListSchema(mm.SQLAlchemyAutoSchema):


### PR DESCRIPTION
closes #6195 

Adds a filter for the tags related to the Editables of contributions based on the `code` of the tags

![image](https://github.com/indico/indico/assets/53895656/5ca4454f-9ca0-4404-ba5e-6a8d47ce4ec2)
![image](https://github.com/indico/indico/assets/53895656/30a34888-5efb-4817-9e49-034f00955644)

