### PR TITLE
Fix double popup on overflown affiliations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -98,6 +98,7 @@ Bugfixes
 - Allow setting registration fees larger than 999999.99 (:pr:`6172`)
 - Populate fields such as first and last name from the multipass login provider (e.g. LDAP) during
   sign-up regardless of synchronization settings (:pr:`6182`)
+- Hide redundant affiliations tooltip on the Participant Roles list (:pr:`6201`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/management/client/js/index.js
+++ b/indico/modules/events/management/client/js/index.js
@@ -220,7 +220,11 @@ import {SeriesManagement} from './SeriesManagement';
 
     $('.js-event-person-list td').on('mouseenter', function() {
       const $this = $(this);
-      if (this.offsetWidth < this.scrollWidth && !$this.attr('title')) {
+      if (
+        this.offsetWidth < this.scrollWidth &&
+        !$this.attr('title') &&
+        !$this.find('.js-popup-container').length
+      ) {
         $this.attr('title', $this.text());
       }
     });

--- a/indico/modules/events/templates/_affiliation.html
+++ b/indico/modules/events/templates/_affiliation.html
@@ -2,7 +2,7 @@
     {% set details = person.affiliation_details %}
     {%- if details -%}
         {%- set uuid = uuid() -%}
-        <span id="affiliation-popup-container-{{ uuid }}">{#--#}
+        <span class="js-popup-container" id="affiliation-popup-container-{{ uuid }}">{#--#}
             <span id="affiliation-popup-{{ uuid }}"></span>{#--#}
             <span>{{ details.name }}</span>{#--#}
         </span>{#--#}


### PR DESCRIPTION
This PR fixes a bug in which two affiliation popups are shown in the Participant Roles when an affiliation link is used and the text overflows the cell:

![](https://user-images.githubusercontent.com/6997171/238138022-a834b3f9-7576-4708-881f-473cb14ff383.png)

This was caused by some jQuery code that creates the tooltips for overflown text. Unfortunately, the `.text()` method also returns any scripts inside, resulting in the tooltip above. These are now disabled for all affiliation links.