### PR TITLE
Update dump_url_map.py to avoid execution of git commands 

### DIFF
--- a/bin/maintenance/dump_url_map.py
+++ b/bin/maintenance/dump_url_map.py
@@ -19,9 +19,10 @@ def get_map_version():
     # whenever something changed
     h = hashlib.md5()
     h.update(os.getcwd().encode())
-    h.update(subprocess.check_output(['git', 'describe', '--always']))
-    h.update(subprocess.check_output(['git', 'status']))
-    h.update(subprocess.check_output(['git', 'diff']))
+    if (not os.environ.get("INDICO_NO_GIT")):
+      h.update(subprocess.check_output(['git', 'describe', '--always']))
+      h.update(subprocess.check_output(['git', 'status']))
+      h.update(subprocess.check_output(['git', 'diff']))
     return h.hexdigest()
 
 


### PR DESCRIPTION
Update dump_url_map.py to avoid execution of git commands in case INDICO_NO_GIT is set in the environment