### PR TITLE
Add a template hook `regformBeforeSections` to the regform

### DIFF
--- a/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
+++ b/indico/modules/events/registration/client/js/form_submission/RegistrationFormSubmission.jsx
@@ -175,6 +175,7 @@ export default function RegistrationFormSubmission() {
     >
       {fprops => (
         <form onSubmit={fprops.handleSubmit}>
+          {renderPluginComponents('regformBeforeSections')}
           {sections.map(section => (
             <FormSection key={section.id} {...section} />
           ))}


### PR DESCRIPTION
Hello, At the UN plugin, we have a representation type section that should remain on the top, and it's not customizable by the users like the vehicle access plugin. Overall so far 80% of implementation, I just need this template hook upstream.