### PR TITLE
Add hooks for final field

### DIFF
--- a/indico/web/client/js/react/forms/context.js
+++ b/indico/web/client/js/react/forms/context.js
@@ -1,0 +1,10 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import {createContext} from 'react';
+
+export const FinalModalFormIdContext = createContext();

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -7,7 +7,7 @@
 
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useContext} from 'react';
 import {Field, useFormState} from 'react-final-form';
 import {OnChange} from 'react-final-form-listeners';
 import {
@@ -22,6 +22,9 @@ import {
   Icon,
 } from 'semantic-ui-react';
 
+import {renderPluginComponents, getPluginObjects} from 'indico/utils/plugins';
+
+import {FinalModalFormIdContext} from './context';
 import formatters from './formatters';
 import parsers from './parsers';
 import validators from './validators';
@@ -337,8 +340,23 @@ ComboDropdownAdapter.defaultProps = {
  * A wrapper for final-form's Field component that handles the markup
  * around the field.
  */
-export function FinalField({name, adapter, component, description, required, onChange, ...rest}) {
+export function FinalField({
+  name,
+  adapter,
+  component,
+  label,
+  description,
+  required,
+  onChange,
+  ...rest
+}) {
+  const finalModalFormId = useContext(FinalModalFormIdContext);
   const extraProps = {};
+
+  if (label) {
+    const customLabel = getPluginObjects(`custom-label-for-${finalModalFormId}-${name}`);
+    extraProps.label = customLabel.length ? customLabel[0] : label;
+  }
 
   if (description) {
     extraProps.children = <p styleName="field-description">{description}</p>;
@@ -361,6 +379,7 @@ export function FinalField({name, adapter, component, description, required, onC
 
   return (
     <>
+      {renderPluginComponents(`before-final-field-${finalModalFormId}-${name}`)}
       <Field name={name} component={adapter} as={component} {...extraProps} {...rest} />
       {onChange && (
         <OnChange name={name}>
@@ -379,6 +398,7 @@ FinalField.propTypes = {
   name: PropTypes.string.isRequired,
   adapter: PropTypes.elementType,
   component: PropTypes.elementType,
+  label: PropTypes.string,
   description: PropTypes.node,
   required: PropTypes.oneOf([true, false, 'no-validator']),
   /** A function that is called with the new and old value whenever the value changes. */
@@ -388,6 +408,7 @@ FinalField.propTypes = {
 FinalField.defaultProps = {
   adapter: FormFieldAdapter,
   component: undefined,
+  label: null,
   description: null,
   required: false,
   onChange: null,

--- a/indico/web/client/js/react/forms/final-form.jsx
+++ b/indico/web/client/js/react/forms/final-form.jsx
@@ -17,6 +17,7 @@ import {Translate} from 'indico/react/i18n';
 
 import {handleAxiosError} from '../../utils/axios';
 
+import {FinalModalFormIdContext} from './context';
 import {handleSubmissionError} from './errors';
 import {FinalUnloadPrompt} from './unload';
 
@@ -150,7 +151,9 @@ export function FinalModalForm({
               className={className}
               onSubmit={fprops.handleSubmit}
             >
-              {_.isFunction(children) ? children(fprops) : children}
+              <FinalModalFormIdContext.Provider value={id}>
+                {_.isFunction(children) ? children(fprops) : children}
+              </FinalModalFormIdContext.Provider>
             </Form>
           </Modal.Content>
           <Modal.Actions style={{display: 'flex', justifyContent: 'flex-end'}}>


### PR DESCRIPTION
Hello! I'm opening this pr as draft so you can see if this is something we can add. The hooks added allows to change the label of a field from the plugin and to inject a field before another one. I am now passing the field id context from the FinalModalForm, so only fields inside this form will be able to change their label from the plugin or inject a field before it. I am open to exploring other approach to do this as well. Thank you. 
### Example of how it'll be used: 
1. Change the label of a field:
```
registerPluginObject('un', 'custom-label-for-send-email-from_address', Translate.string('Reply-To'));
```
In: 'custom-label-for-send-email-from_address', 'send-email' is the name passed to the FinalModalForm used in `EmailDialog`  component and 'from_address' is the name of the field to change.

2. Inject field before another field: 
```
registerPluginComponent('un', 'before-final-field-send-email-from_address', EmailDialogReplyAddress);
export default function EmailDialogReplyAddress() {
    return (
        <FinalInput
            name="reply_address"
            label={Translate.string('From')}
            defaultValue={UnPlugin.no_reply_email}
            readOnly
        />
    )
}
```
