### PR TITLE
Fix CategoryProxySettings on category creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -112,6 +112,7 @@ Bugfixes
 - Populate fields such as first and last name from the multipass login provider (e.g. LDAP) during
   sign-up regardless of synchronization settings (:pr:`6182`)
 - Hide redundant affiliations tooltip on the Participant Roles list (:pr:`6201`)
+- Fix CategoryProxySettings on category creation (:pr:`6230`, thanks :user:`jbtwist`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/categories/operations.py
+++ b/indico/modules/categories/operations.py
@@ -20,12 +20,12 @@ from indico.util.string import crc32
 
 
 def create_category(parent, data):
-    category = Category(parent=parent)
+    category = Category(parent=parent, title='default_title')
     data.setdefault('default_event_themes', parent.default_event_themes)
     data.setdefault('timezone', parent.timezone)
+    db.session.flush()
     category.populate_from_dict(data)
     db.session.add(category)
-    db.session.flush()
     signals.category.created.send(category)
     logger.info('Category %s created by %s', category, session.user)
     sep = ' \N{RIGHT-POINTING DOUBLE ANGLE QUOTATION MARK} '


### PR DESCRIPTION
As discussed per Element, Indico.UN team needs to use CategoryProxySettings on category creation, this PR fixes the issue of fetching for Category Id before it's flushed at `populate_from_dict`
