### PR TITLE
Show templates from non-inherited objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Improvements
 
 - Use more verbose page titles in management/admin areas (:pr:`6300`)
 - Prioritize exact matches when searching for users (:pr:`6254`)
+- Show document templates from non-parent categories and other events for cloning
+  as long as the user has management access (:pr:`6232`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/receipts/client/js/templates/TemplateListPane.jsx
+++ b/indico/modules/receipts/client/js/templates/TemplateListPane.jsx
@@ -74,16 +74,26 @@ function TemplateRow({
         )}
       </td>
       <td className="text-superfluous">
-        {inherited && (
-          <Translate>
-            from category{' '}
-            <Param
-              name="title"
-              value={owner.title}
-              wrapper={<a href={templateListURL(owner.locator)} />}
-            />
-          </Translate>
-        )}
+        {inherited &&
+          ('event_id' in owner.locator ? (
+            <Translate>
+              from event{' '}
+              <Param
+                name="title"
+                value={owner.title}
+                wrapper={<a href={templateListURL(owner.locator)} />}
+              />
+            </Translate>
+          ) : (
+            <Translate>
+              from category{' '}
+              <Param
+                name="title"
+                value={owner.title}
+                wrapper={<a href={templateListURL(owner.locator)} />}
+              />
+            </Translate>
+          ))}
       </td>
       <td styleName="template-actions">
         <div className="thin toolbar right">
@@ -143,13 +153,14 @@ TemplateRow.defaultProps = {
 export default function TemplateListPane({
   ownTemplates,
   inheritedTemplates,
+  otherTemplates,
   defaultTemplates,
   targetLocator,
   dispatch,
 }) {
   const [deletePrompt, setDeletePrompt] = useState(null);
   return (
-    <>
+    <div styleName="template-list">
       <RequestConfirmDelete
         onClose={() => setDeletePrompt(null)}
         requestFunc={deletePrompt?.func || (() => null)}
@@ -180,7 +191,27 @@ export default function TemplateListPane({
           </table>
         </section>
       )}
-      <section className="custom-template-list">
+      {!!otherTemplates.length && (
+        <section>
+          <h3>
+            <Translate>Other templates</Translate>
+          </h3>
+          <table className="i-table-widget">
+            <tbody>
+              {_.sortBy(otherTemplates, 'title').map(tpl => (
+                <TemplateRow
+                  key={tpl.id}
+                  template={tpl}
+                  dispatch={dispatch}
+                  targetLocator={targetLocator}
+                  inherited
+                />
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+      <section>
         <div className="flexrow f-a-center f-j-space-between">
           <h3>
             <Translate>Custom templates</Translate>
@@ -233,13 +264,14 @@ export default function TemplateListPane({
           </div>
         )}
       </section>
-    </>
+    </div>
   );
 }
 
 TemplateListPane.propTypes = {
   ownTemplates: PropTypes.arrayOf(templateSchema).isRequired,
   inheritedTemplates: PropTypes.arrayOf(templateSchema).isRequired,
+  otherTemplates: PropTypes.arrayOf(templateSchema).isRequired,
   defaultTemplates: PropTypes.objectOf(defaultTemplateSchema).isRequired,
   dispatch: PropTypes.func.isRequired,
   targetLocator: targetLocatorSchema.isRequired,

--- a/indico/modules/receipts/client/js/templates/TemplateListPane.jsx
+++ b/indico/modules/receipts/client/js/templates/TemplateListPane.jsx
@@ -17,7 +17,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {Link} from 'react-router-dom';
-import {Dropdown, Icon, Label} from 'semantic-ui-react';
+import {Accordion, Dropdown, Icon, Label} from 'semantic-ui-react';
 
 import {RequestConfirmDelete} from 'indico/react/components';
 import {Param, Translate} from 'indico/react/i18n';
@@ -193,22 +193,37 @@ export default function TemplateListPane({
       )}
       {!!otherTemplates.length && (
         <section>
-          <h3>
-            <Translate>Other templates</Translate>
-          </h3>
-          <table className="i-table-widget">
-            <tbody>
-              {_.sortBy(otherTemplates, 'title').map(tpl => (
-                <TemplateRow
-                  key={tpl.id}
-                  template={tpl}
-                  dispatch={dispatch}
-                  targetLocator={targetLocator}
-                  inherited
-                />
-              ))}
-            </tbody>
-          </table>
+          <Accordion
+            panels={[
+              {
+                key: 'other',
+                title: {
+                  content: (
+                    <h4>
+                      <Translate>Other templates</Translate>
+                    </h4>
+                  ),
+                },
+                content: {
+                  content: (
+                    <table className="i-table-widget">
+                      <tbody>
+                        {_.sortBy(otherTemplates, 'title').map(tpl => (
+                          <TemplateRow
+                            key={tpl.id}
+                            template={tpl}
+                            dispatch={dispatch}
+                            targetLocator={targetLocator}
+                            inherited
+                          />
+                        ))}
+                      </tbody>
+                    </table>
+                  ),
+                },
+              },
+            ]}
+          />
         </section>
       )}
       <section>

--- a/indico/modules/receipts/client/js/templates/TemplateListPane.module.scss
+++ b/indico/modules/receipts/client/js/templates/TemplateListPane.module.scss
@@ -18,3 +18,7 @@
     }
   }
 }
+
+.template-list > section:not(:first-child) {
+  margin-top: 1.5em;
+}

--- a/indico/modules/receipts/client/js/templates/TemplateListPane.module.scss
+++ b/indico/modules/receipts/client/js/templates/TemplateListPane.module.scss
@@ -19,6 +19,13 @@
   }
 }
 
-.template-list > section:not(:first-child) {
-  margin-top: 1.5em;
+.template-list {
+  & > section:not(:first-child) {
+    margin-top: 1.5em;
+  }
+
+  :global(.ui.accordion > .title) h4 {
+    display: inline-block;
+    margin-top: 0;
+  }
 }

--- a/indico/modules/receipts/client/js/templates/index.jsx
+++ b/indico/modules/receipts/client/js/templates/index.jsx
@@ -14,13 +14,14 @@ window.setupReceiptTemplateList = function(
   elem,
   ownTemplates,
   inheritedTemplates,
+  otherTemplates,
   defaultTemplates,
   targetLocator
 ) {
   document.addEventListener('DOMContentLoaded', () => {
     ReactDOM.render(
       <TemplateManagement
-        initialState={{ownTemplates, inheritedTemplates}}
+        initialState={{ownTemplates, inheritedTemplates, otherTemplates}}
         defaultTemplates={defaultTemplates}
         targetLocator={targetLocator}
       />,

--- a/indico/modules/receipts/controllers/templates.py
+++ b/indico/modules/receipts/controllers/templates.py
@@ -26,7 +26,7 @@ from indico.modules.receipts.models.templates import ReceiptTemplate
 from indico.modules.receipts.schemas import ReceiptTemplateAPISchema, ReceiptTemplateDBSchema, ReceiptTplMetadataSchema
 from indico.modules.receipts.util import (TemplateStackEntry, can_user_manage_receipt_templates, compile_jinja_code,
                                           create_pdf, get_dummy_preview_data, get_inherited_templates,
-                                          get_preview_placeholders)
+                                          get_other_templates, get_preview_placeholders)
 from indico.modules.receipts.views import WPCategoryReceiptTemplates, WPEventReceiptTemplates
 from indico.util.marshmallow import YAML
 from indico.web.args import use_args, use_kwargs
@@ -82,6 +82,9 @@ class ReceiptTemplateMixin(ReceiptAreaMixin):
         # Check that template belongs to this event or a category that is a parent
         if self.template.owner == self.target:
             return
+        # If the user can manage the template owner, no need to check further
+        if self.template.owner.can_manage(session.user):
+            return
         category_chain = self.target.chain_ids if isinstance(self.target, Category) else self.target.category_chain
         valid_category_ids = category_chain or [Category.get_root().id]
         if self.template.owner.id not in valid_category_ids:
@@ -91,6 +94,7 @@ class ReceiptTemplateMixin(ReceiptAreaMixin):
 class TemplateListMixin(ReceiptAreaMixin):
     def _process(self):
         inherited_templates = ReceiptTemplateDBSchema(many=True).dump(get_inherited_templates(self.target))
+        other_templates = ReceiptTemplateDBSchema(many=True).dump(get_other_templates(self.target, session.user))
         own_templates = ReceiptTemplateDBSchema(many=True).dump(self.target.receipt_templates)
         default_templates_dir = _get_default_templates_dir()
         default_templates = {f.stem: yaml.safe_load(f.read_text()) for f in default_templates_dir.glob('*.yaml')}
@@ -99,6 +103,7 @@ class TemplateListMixin(ReceiptAreaMixin):
             'list.html', self.target, 'receipts',
             target=self.target,
             inherited_templates=inherited_templates,
+            other_templates=other_templates,
             own_templates=own_templates,
             default_templates=default_templates,
             target_locator=self.target.locator

--- a/indico/modules/receipts/controllers/templates.py
+++ b/indico/modules/receipts/controllers/templates.py
@@ -93,8 +93,9 @@ class ReceiptTemplateMixin(ReceiptAreaMixin):
 
 class TemplateListMixin(ReceiptAreaMixin):
     def _process(self):
-        inherited_templates = ReceiptTemplateDBSchema(many=True).dump(get_inherited_templates(self.target))
-        other_templates = ReceiptTemplateDBSchema(many=True).dump(get_other_templates(self.target, session.user))
+        view_only_schema = ReceiptTemplateDBSchema(many=True, only={'id', 'title', 'owner'})
+        inherited_templates = view_only_schema.dump(get_inherited_templates(self.target))
+        other_templates = view_only_schema.dump(get_other_templates(self.target, session.user))
         own_templates = ReceiptTemplateDBSchema(many=True).dump(self.target.receipt_templates)
         default_templates_dir = _get_default_templates_dir()
         default_templates = {f.stem: yaml.safe_load(f.read_text()) for f in default_templates_dir.glob('*.yaml')}

--- a/indico/modules/receipts/templates/list.html
+++ b/indico/modules/receipts/templates/list.html
@@ -19,6 +19,7 @@
             document.querySelector('#template-list'),
             {{ own_templates | tojson }},
             {{ inherited_templates | tojson }},
+            {{ other_templates | tojson }},
             {{ default_templates | tojson }},
             {{ target_locator | tojson }}
         );

--- a/indico/modules/receipts/util.py
+++ b/indico/modules/receipts/util.py
@@ -123,6 +123,13 @@ def get_inherited_templates(obj: Event | Category) -> set[ReceiptTemplate]:
     return get_all_templates(obj) - set(obj.receipt_templates)
 
 
+def get_other_templates(obj: Event | Category, user) -> set[ReceiptTemplate]:
+    """Get all templates not owned or inherited by a given event/category."""
+    return ({t for t in ReceiptTemplate.query.filter_by(is_deleted=False) if t.owner.can_manage(user)}
+            - get_all_templates(obj)
+            - set(obj.receipt_templates))
+
+
 def _format_currency(amount, currency, locale=None):
     # XXX same logic as in render_price - should probably use the event language in both places!
     locale = session.lang or 'en_GB'

--- a/indico/modules/receipts/util.py
+++ b/indico/modules/receipts/util.py
@@ -125,6 +125,9 @@ def get_inherited_templates(obj: Event | Category) -> set[ReceiptTemplate]:
 
 def get_other_templates(obj: Event | Category, user) -> set[ReceiptTemplate]:
     """Get all templates not owned or inherited by a given event/category."""
+    # XXX the can_manage check here causes some amount of query spam, but this is acceptable because
+    # - usually only admins have access to manage templates (where access checks are short-circuited)
+    # - the total amount of templates in an indico instance is usually not too high
     return ({t for t in ReceiptTemplate.query.filter_by(is_deleted=False) if t.owner.can_manage(user)}
             - get_all_templates(obj)
             - set(obj.receipt_templates))


### PR DESCRIPTION
This PR adds a section on the document template list for templates which are not in the direct category chain, thus allowing to clone them onto the event/category.

All templates that can be managed by the user are shown.

![image](https://github.com/indico/indico/assets/27357203/ad310688-bc4a-4dd2-9701-3d919c6e1548)

