### PR TITLE
Fix fetching image field stored values

### DIFF
--- a/indico/modules/receipts/client/js/printing/TemplateParameterEditor.jsx
+++ b/indico/modules/receipts/client/js/printing/TemplateParameterEditor.jsx
@@ -18,8 +18,6 @@ export const getDefaultFieldValue = f => {
     return f.attributes.options[f.attributes.default];
   } else if (f.type === 'checkbox') {
     return f.attributes.value || false;
-  } else if (f.type === 'image') {
-    return null;
   } else {
     return f.attributes.value || '';
   }


### PR DESCRIPTION
This PR fixes a bug in document generation in which the previously used value for image fields is not being fetched when using the "remember settings" option.