### PR TITLE
Add backend validation for backside templates

### DIFF
--- a/indico/modules/designer/controllers.py
+++ b/indico/modules/designer/controllers.py
@@ -357,7 +357,7 @@ class RHEditDesignerTemplate(RHModifyDesignerTemplateBase):
             if image_item['image_id'] not in template_images:
                 raise UserValueError(_('The image file does not belong to this template'))
         update_template(self.template, title=request.json['title'], data=data,
-                        backside_template_id=request.json['backside_template_id'],
+                        backside_template_id=request.json.get('backside_template_id'),
                         is_clonable=request.json['is_clonable'],
                         clear_background=request.json['clear_background'])
         flash(_('Template successfully saved.'), 'success')

--- a/indico/modules/designer/controllers.py
+++ b/indico/modules/designer/controllers.py
@@ -39,6 +39,7 @@ from indico.modules.events.util import check_event_locked
 from indico.modules.logs import LogKind
 from indico.util.fs import secure_filename
 from indico.util.i18n import _
+from indico.util.marshmallow import ModelField
 from indico.web.args import use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for
@@ -336,14 +337,14 @@ class RHEditDesignerTemplate(RHModifyDesignerTemplateBase):
                                      template_data=template_data, backside_template_data=backside_template_data,
                                      related_tpls_per_owner=related_tpls_per_owner, tpls_count=len(backside_templates))
 
-    def _process_POST(self):
+    @use_kwargs({
+        'backside': ModelField(DesignerTemplate, data_key='backside_template_id', load_default=None),
+    })
+    def _process_POST(self, backside):
         data = dict({'background_position': 'stretch', 'items': []}, **request.json['template'])
         self.validate_json(TEMPLATE_DATA_JSON_SCHEMA, data)
-
-        if backside_template_id := request.json.get('backside_template_id'):
-            if backside := DesignerTemplate.get(backside_template_id):
-                self._validate_backside_template(backside)
-
+        if backside:
+            self._validate_backside_template(backside)
         placeholders = set(get_placeholder_options(regform=self.template.registration_form))
         invalid_placeholders = {x['type'] for x in data['items']} - placeholders
         if invalid_placeholders:

--- a/indico/modules/designer/models/templates_test.py
+++ b/indico/modules/designer/models/templates_test.py
@@ -9,20 +9,6 @@ pytest_plugins = ('indico.modules.designer.testing.fixtures',
                   'indico.modules.events.registration.testing.fixtures')
 
 
-def test_template_link_to_regform(dummy_regform, dummy_designer_template):
-    """Ensure that a template can be linked and unlinked from a registration form."""
-    dummy_designer_template.link_regform(dummy_regform)
-    assert dummy_designer_template.registration_form == dummy_regform
-
-    original_data = dummy_designer_template.data
-    # Add regform field placeholders to the template
-    items = {'items': [*original_data['items'], {'type': 'field-1'}, {'type': 'field-2'}]}
-    dummy_designer_template.data = dummy_designer_template.data | items
-
-    dummy_designer_template.unlink_regform()
-    assert dummy_designer_template.registration_form is None
-
-
 def test_template_is_unlinkable(dummy_designer_template):
     """`template.is_unlinkable` should be `False` if the template contains custom registration placeholders."""
     assert dummy_designer_template.is_unlinkable

--- a/indico/modules/designer/templates/backside_list.html
+++ b/indico/modules/designer/templates/backside_list.html
@@ -13,7 +13,7 @@
                                 title="{% trans %}This template has different dimension than your template{% endtrans %}"
                             {% elif not linked_to_same_regform %}
                                 class="not-selectable-backside"
-                                title="{% trans %}This template is already linked to a different registration form{% endtrans %}"
+                                title="{% trans %}This template is linked to a different registration form{% endtrans %}"
                             {% endif %}>
                             <a class="backside-template" data-href="{{ url_for('.get_template_data', tpl) }}">
                                 <i class="designer-template-type-icon template-icon-{{ tpl.type.name }}"


### PR DESCRIPTION
While working on https://github.com/indico/indico/pull/6088 we noticed that there is no backend check for the backside template in `RHEditDesignerTemplate`. There is only a frontend check in the form for selecting the backside template. So in theory, you could for example have a backside with different dimensions.

This PR adds additional backend validation.