### PR TITLE
Add default receipt templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,7 @@ Improvements
 - Stop overwhelmingly showing past events in the 'Events at hand' section in the user dashboard
   (:pr:`6049`)
 - Add document templates to generate PDF receipts, certificates, and similar documents for
-  event participants (:pr:`5123`, :pr:`6078`)
+  event participants (:pr:`5123`, :pr:`6078`, :pr:`6250`)
 - Show which persons are external in the user search dialog (:pr:`6074`)
 - Add feature for users to export all data linked to them (:pr:`5757`)
 - Add Outlook online calendar button to share widget (:issue:`6075`, :pr:`6077`)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,7 +54,8 @@ Improvements
 - Stop overwhelmingly showing past events in the 'Events at hand' section in the user dashboard
   (:pr:`6049`)
 - Add document templates to generate PDF receipts, certificates, and similar documents for
-  event participants (:pr:`5123`, :pr:`6078`, :pr:`6250`)
+  event participants (:issue:`751`, :issue:`5060`, :issue:`6246`, :pr:`5123`, :pr:`6078`,
+  :pr:`6250`)
 - Show which persons are external in the user search dialog (:pr:`6074`)
 - Add feature for users to export all data linked to them (:pr:`5757`)
 - Add Outlook online calendar button to share widget (:issue:`6075`, :pr:`6077`)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ recursive-include indico *.html *.txt *.js *.yaml *.tex *.svg
 exclude indico/logging.yaml
 
 graft indico/core/plugins/alembic/
+graft indico/modules/receipts/default_templates/
 graft indico/migrations/
 graft indico/translations/
 graft indico/web/static
@@ -11,5 +12,5 @@ prune indico/htdocs
 prune indico/**/htmlcov
 include indico/legacy/pdfinterface/texmf.cnf
 
-global-exclude *.pyc __pycache__ .keep
+global-exclude *.pyc __pycache__ .keep .no-header
 include indico/migrations/versions/.keep

--- a/bin/maintenance/dump-template.py
+++ b/bin/maintenance/dump-template.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# This file is part of Indico.
+# Copyright (C) 2002 - 2024 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from pathlib import Path
+
+import click
+import yaml
+
+from indico.web.flask.app import make_app
+
+
+def _main(name, template_id, target):
+    from indico.modules.receipts.models.templates import ReceiptTemplate
+    from indico.modules.receipts.schemas import ReceiptTemplateDBSchema
+    template = ReceiptTemplate.get(template_id)
+    data = ReceiptTemplateDBSchema(only=('title', 'default_filename')).dump(template)
+
+    metadata_file = target / f'{name}.yaml'
+    if metadata_file.exists():
+        existing_data = yaml.safe_load(metadata_file.read_text())
+        data['version'] = existing_data.get('version', 0) + 1
+    else:
+        data['version'] = 1
+    template_path = target / name
+    template_path.mkdir(parents=True, exist_ok=True)
+
+    metadata_file.write_text(yaml.dump(data))
+    (template_path / 'template.html').write_text(template.html)
+    (template_path / 'theme.css').write_text(template.css)
+    (template_path / 'metadata.yaml').write_text(template.yaml)
+
+
+@click.command()
+@click.argument('name')
+@click.argument('template_id', type=int)
+@click.option('-t', '--target', type=click.Path(), default='indico/modules/receipts/default_templates',
+              help='Output directory for the template files')
+def main(name, template_id, target):
+    with make_app().app_context():
+        _main(name, template_id, Path(target))
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/maintenance/dump-template.py
+++ b/bin/maintenance/dump-template.py
@@ -6,6 +6,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import sys
 from pathlib import Path
 
 import click
@@ -17,7 +18,9 @@ from indico.web.flask.app import make_app
 def _main(name, template_id, target):
     from indico.modules.receipts.models.templates import ReceiptTemplate
     from indico.modules.receipts.schemas import ReceiptTemplateDBSchema
-    template = ReceiptTemplate.get(template_id)
+    if not (template := ReceiptTemplate.get(template_id)):
+        click.secho('This template does not exist', fg='red')
+        sys.exit(1)
     data = ReceiptTemplateDBSchema(only=('title', 'default_filename')).dump(template)
 
     metadata_file = target / f'{name}.yaml'
@@ -38,11 +41,11 @@ def _main(name, template_id, target):
 @click.command()
 @click.argument('name')
 @click.argument('template_id', type=int)
-@click.option('-t', '--target', type=click.Path(), default='indico/modules/receipts/default_templates',
+@click.option('-t', '--target', type=click.Path(path_type=Path), default='indico/modules/receipts/default_templates',
               help='Output directory for the template files')
 def main(name, template_id, target):
     with make_app().app_context():
-        _main(name, template_id, Path(target))
+        _main(name, template_id, target)
 
 
 if __name__ == '__main__':

--- a/bin/maintenance/dump-template.py
+++ b/bin/maintenance/dump-template.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import click
 import yaml
 
+from indico.util.string import normalize_linebreaks
 from indico.web.flask.app import make_app
 
 
@@ -32,10 +33,10 @@ def _main(name, template_id, target):
     template_path = target / name
     template_path.mkdir(parents=True, exist_ok=True)
 
-    metadata_file.write_text(yaml.dump(data))
-    (template_path / 'template.html').write_text(template.html)
-    (template_path / 'theme.css').write_text(template.css)
-    (template_path / 'metadata.yaml').write_text(template.yaml)
+    metadata_file.write_text(normalize_linebreaks(yaml.dump(data)))
+    (template_path / 'template.html').write_text(normalize_linebreaks(template.html))
+    (template_path / 'theme.css').write_text(normalize_linebreaks(template.css))
+    (template_path / 'metadata.yaml').write_text(normalize_linebreaks(template.yaml))
 
 
 @click.command()

--- a/indico/modules/receipts/blueprint.py
+++ b/indico/modules/receipts/blueprint.py
@@ -24,6 +24,10 @@ def _dispatch(event_rh, category_rh):
 
 _bp = IndicoBlueprint('receipts', __name__, template_folder='templates', virtual_template_folder='receipts')
 
+# Global endpoints
+_bp.add_url_rule('/receipts/default-templates/<template_name>', 'get_default_template',
+                 templates.RHGetDefaultTemplate)
+
 # Global admin endpoints
 _bp.add_url_rule('/admin/receipts/', 'admin_settings', admin.RHGlobalReceiptsSettings, methods=('GET', 'POST'))
 
@@ -40,6 +44,8 @@ for object_type in ('event', 'category'):
     # Template management pages (same RHs/backend, display routing is done in react)
     _bp.add_url_rule(f'{prefix}/', 'template_list', _management_page, defaults=defaults)
     _bp.add_url_rule(f'{prefix}/add', 'add_template_page', _management_page, defaults=defaults)
+    _bp.add_url_rule(f'{prefix}/add/<template_name>', 'add_default_template', _management_page,
+                     defaults=defaults)
     _bp.add_url_rule(f'{prefix}/<int:template_id>/', 'template', _management_page, defaults=defaults)
     # Add a new template
     _bp.add_url_rule(f'{prefix}/add', 'add_template', templates.RHAddTemplate, defaults=defaults, methods=('POST',))

--- a/indico/modules/receipts/client/js/templates/Editor.jsx
+++ b/indico/modules/receipts/client/js/templates/Editor.jsx
@@ -98,6 +98,7 @@ export default function Editor({
               name="title"
               label={Translate.string('Title')}
               type="text"
+              disabled={loading}
               required
               rows={24}
             />
@@ -108,6 +109,7 @@ export default function Editor({
               componentLabel="-{n}.pdf"
               labelPosition="right"
               format={formatters.slugify}
+              disabled={loading}
               formatOnBlur
             />
           </Form.Group>

--- a/indico/modules/receipts/client/js/templates/Editor.jsx
+++ b/indico/modules/receipts/client/js/templates/Editor.jsx
@@ -15,7 +15,7 @@ import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 import {Form as FinalForm, FormSpy} from 'react-final-form';
 import {Link} from 'react-router-dom';
-import {Button, Form, Message} from 'semantic-ui-react';
+import {Button, Dimmer, Form, Loader, Message, Segment} from 'semantic-ui-react';
 
 import {
   FinalField,
@@ -52,7 +52,15 @@ const FILES = {
   },
 };
 
-export default function Editor({template, onChange, onSubmit, editorHeight, targetLocator}) {
+export default function Editor({
+  template,
+  onChange,
+  onSubmit,
+  editorHeight,
+  targetLocator,
+  loading,
+  add,
+}) {
   const [currentFileExt, setFileExt] = useState('html');
   const codeValues = _.pick(template, ['html', 'css', 'yaml']);
   const editorRef = useRef(null);
@@ -128,26 +136,34 @@ export default function Editor({template, onChange, onSubmit, editorHeight, targ
                     target={<div style={{height: `${editorHeight}px`, width: '100%'}} />}
                     open={fileExt === currentFileExt}
                   >
-                    <MonacoEditor
-                      height={`${editorHeight}px`}
-                      theme="vs-dark"
-                      path={FILES[fileExt].fileName}
-                      defaultLanguage={FILES[fileExt].syntax}
-                      value={input.value}
-                      onChange={value => {
-                        onChange({...values, [fileExt]: value});
-                        input.onChange(value);
-                      }}
-                      onMount={(editor, monaco) => {
-                        editorRef.current = editor;
-                        editor.addCommand(
-                          // eslint-disable-next-line no-bitwise
-                          monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS,
-                          handleSubmit
-                        );
-                      }}
-                      options={{minimap: {enabled: false}}}
-                    />
+                    {loading ? (
+                      <Segment style={{height: `${editorHeight}px`}} styleName="loading-segment">
+                        <Dimmer active>
+                          <Loader />
+                        </Dimmer>
+                      </Segment>
+                    ) : (
+                      <MonacoEditor
+                        height={`${editorHeight}px`}
+                        theme="vs-dark"
+                        path={FILES[fileExt].fileName}
+                        defaultLanguage={FILES[fileExt].syntax}
+                        value={input.value}
+                        onChange={value => {
+                          onChange({...values, [fileExt]: value});
+                          input.onChange(value);
+                        }}
+                        onMount={(editor, monaco) => {
+                          editorRef.current = editor;
+                          editor.addCommand(
+                            // eslint-disable-next-line no-bitwise
+                            monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS,
+                            handleSubmit
+                          );
+                        }}
+                        options={{minimap: {enabled: false}}}
+                      />
+                    )}
                   </Nexus>
                   <Message error visible={!!meta.submitError}>
                     {meta.submitError}
@@ -157,7 +173,7 @@ export default function Editor({template, onChange, onSubmit, editorHeight, targ
             </FinalField>
           ))}
           <Form.Group styleName="buttons">
-            <FinalSubmitButton label={Translate.string('Save')} />
+            <FinalSubmitButton label={Translate.string('Save')} disabledUntilChange={!add} />
             <Link to={templateListURL(targetLocator)} className="ui button">
               <Translate>Cancel</Translate>
             </Link>
@@ -174,4 +190,11 @@ Editor.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   editorHeight: PropTypes.number.isRequired,
   targetLocator: targetLocatorSchema.isRequired,
+  loading: PropTypes.bool,
+  add: PropTypes.bool,
+};
+
+Editor.defaultProps = {
+  loading: false,
+  add: false,
 };

--- a/indico/modules/receipts/client/js/templates/Editor.module.scss
+++ b/indico/modules/receipts/client/js/templates/Editor.module.scss
@@ -11,3 +11,8 @@
   justify-content: flex-end;
   margin-top: 1em;
 }
+
+.loading-segment {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}

--- a/indico/modules/receipts/client/js/templates/Editor.module.scss
+++ b/indico/modules/receipts/client/js/templates/Editor.module.scss
@@ -12,7 +12,7 @@
   margin-top: 1em;
 }
 
-.loading-segment {
+.loading-segment:global(.ui.segment) {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }

--- a/indico/modules/receipts/client/js/templates/TemplateListPane.jsx
+++ b/indico/modules/receipts/client/js/templates/TemplateListPane.jsx
@@ -5,6 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import addDefaultTemplateURL from 'indico-url:receipts.add_default_template';
 import addTemplatePageURL from 'indico-url:receipts.add_template_page';
 import cloneTemplateURL from 'indico-url:receipts.clone_template';
 import deleteTemplateURL from 'indico-url:receipts.delete_template';
@@ -16,13 +17,13 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {Link} from 'react-router-dom';
-import {Button, Icon, Label} from 'semantic-ui-react';
+import {Dropdown, Icon, Label} from 'semantic-ui-react';
 
 import {RequestConfirmDelete} from 'indico/react/components';
 import {Param, Translate} from 'indico/react/i18n';
 import {handleAxiosError, indicoAxios} from 'indico/utils/axios';
 
-import {targetLocatorSchema, templateSchema} from './util';
+import {defaultTemplateSchema, targetLocatorSchema, templateSchema} from './util';
 
 import './TemplateListPane.module.scss';
 
@@ -142,6 +143,7 @@ TemplateRow.defaultProps = {
 export default function TemplateListPane({
   ownTemplates,
   inheritedTemplates,
+  defaultTemplates,
   targetLocator,
   dispatch,
 }) {
@@ -183,16 +185,33 @@ export default function TemplateListPane({
           <h3>
             <Translate>Custom templates</Translate>
           </h3>
-          <Link to={addTemplatePageURL(targetLocator)}>
-            <Button
-              primary
-              size="mini"
-              title={Translate.string('Add a new blank receipt/certificate template')}
-            >
-              <Icon name="plus" />
-              <Translate>Add new</Translate>
-            </Button>
-          </Link>
+          <Dropdown
+            button
+            labeled
+            title={Translate.string('Add a new template')}
+            icon="plus"
+            text={Translate.string('Add new')}
+            className="mini primary icon"
+            direction="left"
+          >
+            <Dropdown.Menu>
+              {_.sortBy(Object.entries(defaultTemplates), ([, t]) => t.title).map(
+                ([name, {title, version}]) => (
+                  <Dropdown.Item
+                    key={name}
+                    as={Link}
+                    to={addDefaultTemplateURL({...targetLocator, template_name: name})}
+                    text={`${title} (v${version})`}
+                  />
+                )
+              )}
+              <Dropdown.Item
+                as={Link}
+                to={addTemplatePageURL(targetLocator)}
+                text={Translate.string('Blank template')}
+              />
+            </Dropdown.Menu>
+          </Dropdown>
         </div>
         {ownTemplates.length ? (
           <table className="i-table-widget">
@@ -221,6 +240,7 @@ export default function TemplateListPane({
 TemplateListPane.propTypes = {
   ownTemplates: PropTypes.arrayOf(templateSchema).isRequired,
   inheritedTemplates: PropTypes.arrayOf(templateSchema).isRequired,
+  defaultTemplates: PropTypes.objectOf(defaultTemplateSchema).isRequired,
   dispatch: PropTypes.func.isRequired,
   targetLocator: targetLocatorSchema.isRequired,
 };

--- a/indico/modules/receipts/client/js/templates/TemplateListPane.jsx
+++ b/indico/modules/receipts/client/js/templates/TemplateListPane.jsx
@@ -195,6 +195,11 @@ export default function TemplateListPane({
             direction="left"
           >
             <Dropdown.Menu>
+              <Dropdown.Item
+                as={Link}
+                to={addTemplatePageURL(targetLocator)}
+                text={Translate.string('Blank template')}
+              />
               {_.sortBy(Object.entries(defaultTemplates), ([, t]) => t.title).map(
                 ([name, {title, version}]) => (
                   <Dropdown.Item
@@ -205,11 +210,6 @@ export default function TemplateListPane({
                   />
                 )
               )}
-              <Dropdown.Item
-                as={Link}
-                to={addTemplatePageURL(targetLocator)}
-                text={Translate.string('Blank template')}
-              />
             </Dropdown.Menu>
           </Dropdown>
         </div>

--- a/indico/modules/receipts/client/js/templates/TemplateManagement.jsx
+++ b/indico/modules/receipts/client/js/templates/TemplateManagement.jsx
@@ -145,7 +145,7 @@ NewTemplatePane.defaultProps = {
   defaultTemplate: '',
 };
 
-export default function ReceiptTemplateManagement({initialState, defaultTemplates, targetLocator}) {
+export default function TemplateManagement({initialState, defaultTemplates, targetLocator}) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const targetIdParams = Object.keys(targetLocator);
 
@@ -214,7 +214,7 @@ export default function ReceiptTemplateManagement({initialState, defaultTemplate
   );
 }
 
-ReceiptTemplateManagement.propTypes = {
+TemplateManagement.propTypes = {
   initialState: PropTypes.shape({
     ownTemplates: PropTypes.arrayOf(templateSchema),
     inheritedTemplates: PropTypes.arrayOf(templateSchema),

--- a/indico/modules/receipts/client/js/templates/TemplatePane.jsx
+++ b/indico/modules/receipts/client/js/templates/TemplatePane.jsx
@@ -10,7 +10,7 @@ import templateLivePreviewURL from 'indico-url:receipts.template_live_preview';
 
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Grid, Header, Icon, Segment} from 'semantic-ui-react';
 
 import {ManagementPageSubTitle} from 'indico/react/components';
@@ -20,11 +20,22 @@ import Editor from './Editor';
 import Previewer from './Previewer';
 import {targetLocatorSchema, templateSchema} from './util';
 
-export default function TemplatePane({template, onSubmit, targetLocator, editorHeight, add}) {
-  const [data, setData] = useState({
-    title: template.title,
-    ..._.pick(template, ['html', 'css', 'yaml']),
-  });
+export default function TemplatePane({
+  template,
+  onSubmit,
+  targetLocator,
+  editorHeight,
+  add,
+  loading,
+}) {
+  const [data, setData] = useState({});
+
+  useEffect(() => {
+    setData({
+      title: template.title,
+      ..._.pick(template, ['html', 'css', 'yaml']),
+    });
+  }, [template]);
 
   return (
     <>
@@ -44,6 +55,8 @@ export default function TemplatePane({template, onSubmit, targetLocator, editorH
               editorHeight={editorHeight}
               targetLocator={targetLocator}
               onChange={setData}
+              loading={loading}
+              add={add}
             />
           </Grid.Column>
           <Grid.Column>
@@ -74,10 +87,12 @@ TemplatePane.propTypes = {
   targetLocator: targetLocatorSchema.isRequired,
   editorHeight: PropTypes.number,
   add: PropTypes.bool,
+  loading: PropTypes.bool,
 };
 
 TemplatePane.defaultProps = {
   template: {html: '', css: '', yaml: ''},
   editorHeight: 800,
   add: false,
+  loading: false,
 };

--- a/indico/modules/receipts/client/js/templates/index.jsx
+++ b/indico/modules/receipts/client/js/templates/index.jsx
@@ -10,10 +10,20 @@ import ReactDOM from 'react-dom';
 
 import Router from './TemplateManagement';
 
-window.setupReceiptTemplateList = function(elem, ownTemplates, inheritedTemplates, targetLocator) {
+window.setupReceiptTemplateList = function(
+  elem,
+  ownTemplates,
+  inheritedTemplates,
+  defaultTemplates,
+  targetLocator
+) {
   document.addEventListener('DOMContentLoaded', () => {
     ReactDOM.render(
-      <Router initialState={{ownTemplates, inheritedTemplates}} targetLocator={targetLocator} />,
+      <Router
+        initialState={{ownTemplates, inheritedTemplates}}
+        defaultTemplates={defaultTemplates}
+        targetLocator={targetLocator}
+      />,
       elem
     );
   });

--- a/indico/modules/receipts/client/js/templates/index.jsx
+++ b/indico/modules/receipts/client/js/templates/index.jsx
@@ -8,7 +8,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import Router from './TemplateManagement';
+import TemplateManagement from './TemplateManagement';
 
 window.setupReceiptTemplateList = function(
   elem,
@@ -19,7 +19,7 @@ window.setupReceiptTemplateList = function(
 ) {
   document.addEventListener('DOMContentLoaded', () => {
     ReactDOM.render(
-      <Router
+      <TemplateManagement
         initialState={{ownTemplates, inheritedTemplates}}
         defaultTemplates={defaultTemplates}
         targetLocator={targetLocator}

--- a/indico/modules/receipts/client/js/templates/util.js
+++ b/indico/modules/receipts/client/js/templates/util.js
@@ -24,3 +24,8 @@ export const templateSchema = PropTypes.shape({
     locator: PropTypes.object,
   }),
 });
+
+export const defaultTemplateSchema = PropTypes.shape({
+  title: PropTypes.string.isRequired,
+  version: PropTypes.number.isRequired,
+});

--- a/indico/modules/receipts/default_templates/receipt.yaml
+++ b/indico/modules/receipts/default_templates/receipt.yaml
@@ -1,0 +1,3 @@
+default_filename: receipt
+title: Receipt
+version: 1

--- a/indico/modules/receipts/default_templates/receipt/metadata.yaml
+++ b/indico/modules/receipts/default_templates/receipt/metadata.yaml
@@ -1,0 +1,40 @@
+custom_fields:
+  - name: address_from
+    type: textarea
+    attributes:
+      label: Organizer Address
+
+  - name: address_to_override
+    type: textarea
+    attributes:
+      label: Override participant address
+
+  - name: venue
+    type: input
+    attributes:
+      label: Venue
+
+  - name: fee_category
+    type: input
+    attributes:
+      label: Fee category
+
+  - name: receipt_number
+    type: input
+    attributes:
+      label: Receipt number
+
+  - name: add_logo
+    type: checkbox
+    attributes:
+      label: Add logo?
+
+  - name: add_url
+    type: checkbox
+    attributes:
+      label: Add event URL?
+
+  - name: add_affiliation
+    type: checkbox
+    attributes:
+      label: Add registrant affiliation?

--- a/indico/modules/receipts/default_templates/receipt/metadata.yaml
+++ b/indico/modules/receipts/default_templates/receipt/metadata.yaml
@@ -24,17 +24,17 @@ custom_fields:
     attributes:
       label: Receipt number
 
-  - name: add_logo
-    type: checkbox
+  - name: logo
+    type: image
     attributes:
-      label: Add logo?
+      label: Logo
 
   - name: add_url
     type: checkbox
     attributes:
-      label: Add event URL?
+      label: Add event URL
 
   - name: add_affiliation
     type: checkbox
     attributes:
-      label: Add registrant affiliation?
+      label: Add registrant affiliation

--- a/indico/modules/receipts/default_templates/receipt/template.html
+++ b/indico/modules/receipts/default_templates/receipt/template.html
@@ -1,6 +1,5 @@
 {% set personal_data = registration.personal_data %}
 {% set txn = registration.transaction %}
-{% set card_fee = none %}
 
 <h1>Receipt</h1>
 
@@ -30,8 +29,8 @@
   </div>
 
   <!-- Logo -->
-  {% if custom_fields.add_logo %}
-    <img src="event://logo">
+  {% if custom_fields.logo %}
+    <img src="{{ custom_fields.logo }}">
   {% endif %}
 </aside>
 
@@ -94,15 +93,9 @@
       </tr>
     {% endfor %}
     <tr class="total">
-        <td><strong>{% if card_fee %}Subtotal{% else %}Total{% endif %}</strong></td>
+        <td><strong>Total</strong></td>
         <td>{{ registration.total_price|format_currency(registration.currency) }}</td>
     </tr>
-    {% if card_fee and card_fee.price %}
-      <tr>
-        <td>Payment method fee ({{ card_fee.brand }})</td>
-        <td>{{ card_fee.formatted_price }}</td>
-      </tr>
-    {% endif %}
     {% if txn and txn.status == 'successful' and txn.provider != '_manual' %}
       <tr class="total">
         <td><strong>Total paid</strong></td>

--- a/indico/modules/receipts/default_templates/receipt/template.html
+++ b/indico/modules/receipts/default_templates/receipt/template.html
@@ -1,0 +1,113 @@
+{% set personal_data = registration.personal_data %}
+{% set txn = registration.transaction %}
+{% set card_fee = none %}
+
+<h1>Receipt</h1>
+
+<aside id="title">
+  <div class="title">
+    <!-- Title -->
+    <h2>{{ event.title }}</h2>
+    <!-- Date(s) -->
+    {% if event.start_dt.date() != event.end_dt.date() %}
+      {{ event.start_dt | format_date('dd MMM') }}
+      -
+      {{ event.end_dt | format_date('dd MMM') }}
+    {% else %}
+      {{ event.start_dt | format_date('dd MMM YYYY') }}
+    {% endif %}
+
+    <!-- Venue -->
+    {% if custom_fields.venue %}
+      - {{ custom_fields.venue }}
+    {% elif event.venue_name %}
+      - {{ event.venue_name }}
+    {% endif %}
+
+    {% if custom_fields.add_url %}
+      <p>{{ event.url }}</p>
+    {% endif %}
+  </div>
+
+  <!-- Logo -->
+  {% if custom_fields.add_logo %}
+    <img src="event://logo">
+  {% endif %}
+</aside>
+
+<aside id="addresses">
+  <!-- Address of organizer -->
+  <address id="from">
+    {{ custom_fields.address_from }}
+  </address>
+
+  <!-- Address of participant -->
+  <address id="to">
+    <strong>{{ personal_data.first_name }} {{ personal_data.last_name }}</strong>
+    {%- if custom_fields.add_affiliation %}
+      {{ personal_data.affiliation }}
+    {%- endif %}
+    {%- if custom_fields.address_to_override %}
+      {{ custom_fields.address_to_override }}
+    {% elif personal_data.address %}
+      {{ personal_data.address }}
+      {{ personal_data.country }}
+    {% else %}
+      {{ personal_data.country }}
+    {% endif %}
+  </address>
+</aside>
+
+<!-- Receipt number and date -->
+<dl id="information">
+  {% set today = now_utc() %}
+  <dt>Number</dt>
+  <dd>
+    {% if custom_fields.receipt_number %}
+      {{ custom_fields.receipt_number }}
+    {% else %}
+      {{ today | format_datetime('YMMddHHMM')}}/{{ registration.friendly_id }}
+    {% endif %}
+  </dd>
+  <dt>Date</dt>
+  <dd>{{ today | format_date }}</dd>
+</dl>
+
+<table>
+  <thead>
+    <tr>
+      <th>Description</th>
+      <th>Price</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% if registration.base_price %}
+      <tr>
+        <td>Registration fee {% if custom_fields.fee_category %}({{ custom_fields.fee_category }}){% endif %}</td>
+        <td>{{ registration.base_price|format_currency(registration.currency) }}</td>
+      </tr>
+    {% endif %}
+    {% for field in registration.field_data if field.actual_price %}
+      <tr>
+        <td>{{ field.title }}{% if field.friendly_value %} ({{ field.friendly_value }}){% endif %}</td>
+        <td>{{ field.actual_price|format_currency(registration.currency) }}</td>
+      </tr>
+    {% endfor %}
+    <tr class="total">
+        <td><strong>{% if card_fee %}Subtotal{% else %}Total{% endif %}</strong></td>
+        <td>{{ registration.total_price|format_currency(registration.currency) }}</td>
+    </tr>
+    {% if card_fee and card_fee.price %}
+      <tr>
+        <td>Payment method fee ({{ card_fee.brand }})</td>
+        <td>{{ card_fee.formatted_price }}</td>
+      </tr>
+    {% endif %}
+    {% if txn and txn.status == 'successful' and txn.provider != '_manual' %}
+      <tr class="total">
+        <td><strong>Total paid</strong></td>
+        <td>{{ txn.amount|format_currency(txn.currency) }}</td>
+      </tr>
+    {% endif %}
+  </tbody>
+</table>

--- a/indico/modules/receipts/default_templates/receipt/theme.css
+++ b/indico/modules/receipts/default_templates/receipt/theme.css
@@ -1,0 +1,141 @@
+@page {
+  margin: 3cm;
+
+  @bottom-center {
+    color: #a9a;
+    content: 'Printed by Indico';
+    font-size: 9pt;
+  }
+}
+
+html {
+  color: #14213d;
+  font-family: sans-serif;
+  font-size: 11pt;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+}
+
+aside {
+  display: flex;
+  margin: 2em 0 4em;
+  width: 100%;
+}
+
+aside#title {
+  flex: 2;
+  align-items: center;
+}
+
+aside#title div.title {
+  flex: 2;
+}
+
+aside#addresses {
+  justify-content: space-between;
+}
+
+aside img {
+  max-width: 5cm;
+  max-height: 5cm;
+  margin-left: 0.5cm;
+}
+
+address {
+  display: block;
+  white-space: pre-line;
+}
+
+h1 {
+  color: #18597d;
+  font-size: 40pt;
+  margin: 0;
+}
+
+aside address#from {
+  color: #a9a;
+  flex: 1;
+}
+
+aside address#to {
+  text-align: right;
+  flex: 1;
+}
+
+dl#information {
+  position: absolute;
+  right: 0;
+  text-align: right;
+  top: 0;
+}
+
+dt,
+dd {
+  display: inline;
+  margin: 0;
+}
+
+dt {
+  color: #a9a;
+}
+
+dt::before {
+  content: '';
+  display: block;
+}
+
+dt::after {
+  content: ':';
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+}
+
+tr.total {
+  padding-top: 5cm;
+}
+
+tr.total td {
+  margin-top: 2cm;
+  padding-top: 0.25cm;
+  border-top: 0.2mm solid #a9a;
+}
+
+th {
+  border-bottom: 0.2mm solid #a9a;
+  color: #a9a;
+  font-size: 10pt;
+  font-weight: 400;
+  padding-bottom: 0.25cm;
+  text-transform: uppercase;
+}
+
+td {
+  padding-top: 2mm;
+}
+
+td:last-of-type {
+  color: #18597d;
+  font-weight: bold;
+  text-align: right;
+}
+
+th,
+td {
+  text-align: center;
+}
+
+th:first-of-type,
+td:first-of-type {
+  text-align: left;
+}
+
+th:last-of-type,
+td:last-of-type {
+  text-align: right;
+}

--- a/indico/modules/receipts/templates/list.html
+++ b/indico/modules/receipts/templates/list.html
@@ -19,6 +19,7 @@
             document.querySelector('#template-list'),
             {{ own_templates | tojson }},
             {{ inherited_templates | tojson }},
+            {{ default_templates | tojson }},
             {{ target_locator | tojson }}
         );
     </script>

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -712,3 +712,7 @@ def format_email_with_name(name, address):
         quotes = '"'
     name = escapesre.sub(r'\\\g<0>', name)
     return f'{quotes}{name}{quotes} <{address}>'
+
+
+def normalize_linebreaks(string, *, _normre=re.compile(r'(\r\n|\r)')):
+    return _normre.sub('\n', string)

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -13,8 +13,9 @@ import pytest
 
 from indico.util.string import (AutoLinkExtension, HTMLLinker, camelize, camelize_keys, crc32, format_email_with_name,
                                 format_repr, has_relative_links, html_to_plaintext, make_unique_token,
-                                normalize_phone_number, render_markdown, sanitize_email, sanitize_for_platypus,
-                                sanitize_html, seems_html, slugify, snakify, snakify_keys, strip_tags, text_to_repr)
+                                normalize_linebreaks, normalize_phone_number, render_markdown, sanitize_email,
+                                sanitize_for_platypus, sanitize_html, seems_html, slugify, snakify, snakify_keys,
+                                strip_tags, text_to_repr)
 
 
 def test_seems_html():
@@ -328,3 +329,14 @@ def test_html_linker(input, output):
 ))
 def test_markdown_linker(input, output):
     assert render_markdown(input, extensions=('nl2br', AutoLinkExtension(LINKER_RULES))) == output
+
+
+@pytest.mark.parametrize(('input', 'output'), (
+    ('hello world', 'hello world'),
+    ('hello\nworld', 'hello\nworld'),
+    ('hello\r\nworld', 'hello\nworld'),
+    ('hello\rworld', 'hello\nworld'),
+    ('hello\n\nworld', 'hello\n\nworld'),
+))
+def test_normalize_linebreaks(input, output):
+    assert normalize_linebreaks(input) == output


### PR DESCRIPTION
This PR adds two default templates, which can be added to any event/category in the "Document Templates" mgmt page:
![image](https://github.com/indico/indico/assets/27357203/a1d14c6a-4a79-4563-83ae-7b0a7f610108)

It also includes a util to dump a template from the DB onto the `default_templates` directory, which can be run as such:

```
./bin/maintenance/dump-template.py <name-of-template> <template-id> [-t/--target <target output directory>]
```

Closes #6246
