### PR TITLE
Use py312 target in ruff

### DIFF
--- a/indico/cli/shell.py
+++ b/indico/cli/shell.py
@@ -46,7 +46,7 @@ def _add_to_context_multi(namespace, info, elements, names=None, doc=None, color
         return
     if not names:
         names = [x.__name__ for x in elements]
-    for name, element in zip(names, elements):
+    for name, element in zip(names, elements, strict=True):
         namespace[name] = element
     if doc:
         info.append(cformat('+ %%{white!}{}:%%{reset} %%{%s}{}' % color).format(doc, ', '.join(names)))
@@ -68,7 +68,7 @@ def _add_to_context_smart(namespace, info, objects, get_name=attrgetter('__name_
 
     items = [(_get_module(obj), get_name(obj), obj) for obj in objects]
     for module, mod_items in itertools.groupby(sorted(items, key=itemgetter(0, 1)), key=itemgetter(0)):
-        names, elements = list(zip(*((x[1], x[2]) for x in mod_items)))
+        names, elements = list(zip(*((x[1], x[2]) for x in mod_items), strict=True))
         _add_to_context_multi(namespace, info, elements, names, doc=module, color=color)
 
 

--- a/indico/core/cache.py
+++ b/indico/core/cache.py
@@ -58,7 +58,7 @@ class IndicoRedisCache(RedisCache):
         return [CachedNone.unwrap(val, default) for val in super().get_many(*keys)]
 
     def get_dict(self, *keys, default=None):
-        return dict(zip(keys, self.get_many(*keys, default=default)))
+        return dict(zip(keys, self.get_many(*keys, default=default), strict=True))
 
     @classmethod
     def factory(cls, app, config, args, kwargs):
@@ -101,7 +101,7 @@ class ScopedCache:
         raise NotImplementedError('Clearing scoped caches is not supported')
 
     def get_dict(self, *keys, default=None):
-        return dict(zip(keys, self.get_many(*keys, default=default)))
+        return dict(zip(keys, self.get_many(*keys, default=default), strict=True))
 
     def get_many(self, *keys, default=None):
         keys = [self._scoped(key) for key in keys]
@@ -210,7 +210,7 @@ class IndicoCache(Cache):
                 raise
             logkeys = ', '.join(map(repr, keys))
             _logger.exception('get_dict(%s) failed', logkeys)
-            return dict(zip(keys, [default] * len(keys)))
+            return dict.fromkeys(keys, default)
 
 
 def make_scoped_cache(scope):

--- a/indico/core/db/sqlalchemy/util/management.py
+++ b/indico/core/db/sqlalchemy/util/management.py
@@ -64,7 +64,7 @@ def get_all_tables(db):
     """Return a dict containing all tables grouped by schema."""
     inspector = inspect(db.engine)
     schemas = sorted(set(inspector.get_schema_names()) - {'information_schema'})
-    return dict(zip(schemas, (inspector.get_table_names(schema=schema) for schema in schemas)))
+    return dict(zip(schemas, (inspector.get_table_names(schema=schema) for schema in schemas), strict=True))
 
 
 def delete_all_tables(db):

--- a/indico/modules/admin/notices.py
+++ b/indico/modules/admin/notices.py
@@ -9,7 +9,6 @@ import dataclasses
 import operator
 import platform
 import re
-import typing as t
 from enum import Enum
 
 import requests
@@ -46,9 +45,9 @@ class NoticeSeverity(str, Enum):
 
 @dataclass(frozen=True)
 class SystemNoticeCriteria:
-    python_version: t.Optional[str] = None
-    postgres_version: t.Optional[str] = None
-    indico_version: t.Optional[str] = None
+    python_version: str | None = None
+    postgres_version: str | None = None
+    indico_version: str | None = None
 
 
 @dataclass(frozen=True)

--- a/indico/modules/auth/auth_test.py
+++ b/indico/modules/auth/auth_test.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from flask import session
@@ -18,7 +18,7 @@ from indico.modules.auth import process_identity
 @pytest.mark.usefixtures('db')
 def test_process_identity_sets_hard_expiry(app):
     """Test that hard expiry is set on the session object if it is present in the multipass data."""
-    dt_now = datetime.now(timezone.utc)
+    dt_now = datetime.now(UTC)
     identity_info = IdentityInfo(
         provider=StaticIdentityProvider(
             multipass=Multipass(), name='static', settings={}

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -182,7 +182,7 @@ class RHLinkAccount(RH):
 
         if self.must_choose_email:
             form = SelectEmailForm()
-            form.email.choices = list(zip(self.emails, self.emails))
+            form.email.choices = list(zip(self.emails, self.emails, strict=True))
         else:
             form = IndicoForm()
 

--- a/indico/modules/events/contributions/clone.py
+++ b/indico/modules/events/contributions/clone.py
@@ -108,12 +108,12 @@ class ContributionCloner(EventCloner):
         """
         event = contribution.event
         cloner = cls(event)
-        cloner._event_role_map = dict(zip(event.roles, event.roles))
-        cloner._person_map = dict(zip(event.persons, event.persons))
+        cloner._event_role_map = dict(zip(event.roles, event.roles, strict=True))
+        cloner._person_map = dict(zip(event.persons, event.persons, strict=True))
         cloner._session_map = {contribution.session: contribution.session}
         cloner._session_block_map = {contribution.session_block: contribution.session_block}
         cloner._contrib_type_map = {contribution.type: contribution.type}
-        cloner._contrib_field_map = dict(zip(event.contribution_fields, event.contribution_fields))
+        cloner._contrib_field_map = dict(zip(event.contribution_fields, event.contribution_fields, strict=True))
         cloner._contrib_map = {}
         cloner._subcontrib_map = {}
         new_contribution = cloner._create_new_contribution(event, contribution,

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-import typing as t
 from datetime import timedelta
 from email import message
 from email.mime.base import MIMEBase
@@ -45,12 +44,12 @@ class CalendarScope(IndicoEnum):
 
 
 def generate_basic_component(
-    entity: t.Union[Event, Session, Contribution],
-    uid: t.Optional[str] = None,
-    url: t.Optional[str] = None,
-    title: t.Optional[str] = None,
-    description: t.Optional[str] = None,
-    organizer: t.Optional[tuple[str, str]] = None
+    entity: Event | Session | Contribution,
+    uid: str | None = None,
+    url: str | None = None,
+    title: str | None = None,
+    description: str | None = None,
+    organizer: tuple[str, str] | None = None
 ):
     """Generate an iCalendar component with basic common properties.
 
@@ -118,9 +117,9 @@ def generate_basic_component(
 
 def generate_event_component(
     event: Event,
-    user: t.Optional[User] = None,
-    organizer: t.Optional[tuple[str, str]] = None,
-    skip_access_check: t.Optional[bool] = False,
+    user: User | None = None,
+    organizer: tuple[str, str] | None = None,
+    skip_access_check: bool | None = False,
 ):
     """Generate an event icalendar component from an Indico event."""
     uid = f'indico-event-{event.id}@{urlsplit(config.BASE_URL).hostname}'
@@ -161,12 +160,12 @@ def generate_event_component(
 
 def event_to_ical(
     event: Event,
-    user: t.Optional[User] = None,
-    scope: t.Optional[str] = None,
+    user: User | None = None,
+    scope: str | None = None,
     *,
     skip_access_check: bool = False,
-    method: t.Optional[str] = None,
-    organizer: t.Optional[tuple[str, str]] = None
+    method: str | None = None,
+    organizer: tuple[str, str] | None = None
 ):
     """Serialize an event into an ical.
 
@@ -183,12 +182,12 @@ def event_to_ical(
 
 def events_to_ical(
     events: list[Event],
-    user: t.Optional[User] = None,
-    scope: t.Optional[str] = None,
+    user: User | None = None,
+    scope: str | None = None,
     *,
     skip_access_check: bool = False,
-    method: t.Optional[str] = None,
-    organizer: t.Optional[tuple[str, str]] = None
+    method: str | None = None,
+    organizer: tuple[str, str] | None = None
 ):
     """Serialize multiple events into an ical.
 

--- a/indico/modules/events/registration/badges.py
+++ b/indico/modules/events/registration/badges.py
@@ -63,7 +63,7 @@ class RegistrantsListToBadgesPDF(DesignerPDFBase):
             raise BadRequest(_('The template dimensions are too large for the page size you selected'))
 
         # Print a badge for each registration
-        for person, (x, y) in zip(self.persons, self._iter_position(canvas, n_horizontal, n_vertical)):
+        for person, (x, y) in zip(self.persons, self._iter_position(canvas, n_horizontal, n_vertical), strict=False):
             self._draw_badge(canvas, person, self.template, self.tpl_data, x * cm, y * cm)
 
     def _draw_badge(self, canvas, person, template, tpl_data, pos_x, pos_y):
@@ -142,7 +142,7 @@ class RegistrantsListToBadgesPDFFoldable(RegistrantsListToBadgesPDF):
         n_horizontal = 1
         n_vertical = 1
 
-        for person, (x, y) in zip(self.persons, self._iter_position(canvas, n_horizontal, n_vertical)):
+        for person, (x, y) in zip(self.persons, self._iter_position(canvas, n_horizontal, n_vertical), strict=False):
             self._draw_badge(canvas, person, self.template, self.tpl_data, x * cm, y * cm)
             if self.tpl_data.width > self.tpl_data.height:
                 canvas.translate(self.width, self.height)
@@ -194,7 +194,7 @@ class RegistrantsListToBadgesPDFDoubleSided(RegistrantsListToBadgesPDF):
         if page_used:
             badges_mix += ([None] * (per_page - page_used)) + badges_mix[-page_used:]
 
-        positioned_badges = zip(badges_mix, self._iter_position(canvas, n_horizontal, n_vertical))
+        positioned_badges = zip(badges_mix, self._iter_position(canvas, n_horizontal, n_vertical), strict=False)
         for i, (person, (x, y)) in enumerate(positioned_badges):
             if person is None:
                 # blank item for an incomplete last page

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -90,7 +90,7 @@ def import_user_records_from_csv(fileobj, columns):
         if len(columns) != len(values):
             raise UserValueError(_('Row {}: malformed CSV data - please check that the number of columns is correct')
                                  .format(row_num))
-        record = dict(zip(columns, values))
+        record = dict(zip(columns, values, strict=True))
 
         if not record['email']:
             raise UserValueError(_('Row {}: missing e-mail address').format(row_num))

--- a/indico/modules/events/sessions/ical.py
+++ b/indico/modules/events/sessions/ical.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-import typing as t
 from urllib.parse import urlsplit
 
 import icalendar
@@ -21,8 +20,8 @@ from indico.web.flask.util import url_for
 
 def generate_session_component(
     session: Session,
-    related_to_uid: t.Optional[str] = None,
-    organizer: t.Optional[tuple[str, str]] = None
+    related_to_uid: str | None = None,
+    organizer: tuple[str, str] | None = None
 ):
     """Generate an Event iCalendar component from an Indico Session."""
     uid = f'indico-session-{session.id}@{urlsplit(config.BASE_URL).hostname}'
@@ -37,8 +36,8 @@ def generate_session_component(
 
 def generate_session_block_component(
     block: SessionBlock,
-    related_to_uid: t.Optional[str] = None,
-    organizer: t.Optional[tuple[str, str]] = None
+    related_to_uid: str | None = None,
+    organizer: tuple[str, str] | None = None
 ):
     """Generate an Event iCalendar component for a session block in an Indico Session."""
     uid = f'indico-session-block-{block.id}@{urlsplit(config.BASE_URL).hostname}'
@@ -55,9 +54,9 @@ def generate_session_block_component(
 
 def session_to_ical(
     session: Session,
-    user: t.Optional[User] = None,
+    user: User | None = None,
     detailed: bool = False,
-    organizer: t.Optional[tuple[str, str]] = None
+    organizer: tuple[str, str] | None = None
 ):
     """Serialize a session into an iCal.
 

--- a/indico/modules/rb/api.py
+++ b/indico/modules/rb/api.py
@@ -259,17 +259,17 @@ def _export_reservations(hook, limit_per_room, include_rooms, extra_filters=None
         yield result['reservation'].room_id, _serializable_reservation(result, include_rooms)
 
 
-def _serializable_room(room_data, reservations=None):
-    """Serializable room data.
+def _serializable_room(room, reservations=None):
+    """Serializable room.
 
-    :param room_data: Room data
+    :param room: Room
     :param reservations: MultiDict mapping for room id => reservations
     """
     from indico.modules.rb.schemas import RoomLegacyAPISchema
-    data = RoomLegacyAPISchema().dump(room_data['room'])
+    data = RoomLegacyAPISchema().dump(room)
     data['_type'] = 'Room'
     if reservations is not None:
-        data['reservations'] = reservations.getlist(room_data['room'].id)
+        data['reservations'] = reservations.getlist(room.id)
     return data
 
 

--- a/indico/modules/rb/models/reservation_occurrences_test.py
+++ b/indico/modules/rb/models/reservation_occurrences_test.py
@@ -69,7 +69,7 @@ def test_date(dummy_occurrence):
 def test_create_series_for_reservation(dummy_reservation):
     occurrences = ReservationOccurrence.iter_create_occurrences(
         start=dummy_reservation.start_dt, end=dummy_reservation.end_dt, repetition=dummy_reservation.repetition)
-    for occ1, occ2 in zip(dummy_reservation.occurrences, occurrences):
+    for occ1, occ2 in zip(dummy_reservation.occurrences, occurrences, strict=True):
         assert occ1.start_dt == occ2.start_dt
         assert occ1.end_dt == occ2.end_dt
         assert occ1.is_cancelled == dummy_reservation.is_cancelled
@@ -79,7 +79,7 @@ def test_create_series_for_reservation(dummy_reservation):
 
 def test_create_series(creation_params):
     for occ1, occ2 in zip(list(ReservationOccurrence.iter_create_occurrences(**creation_params)),
-                          ReservationOccurrence.create_series(**creation_params)):
+                          ReservationOccurrence.create_series(**creation_params), strict=True):
         assert occ1.start_dt == occ2.start_dt
         assert occ1.end_dt == occ2.end_dt
 

--- a/indico/modules/rb/models/rooms_test.py
+++ b/indico/modules/rb/models/rooms_test.py
@@ -162,28 +162,17 @@ def test_find_with_attribute(dummy_room, create_room, create_room_attribute):
     assert set(Room.find_with_attribute('foo')) == expected
 
 
-def test_get_with_data_errors():
-    with pytest.raises(ValueError):
-        Room.get_with_data(foo='bar')
-
-
 @pytest.mark.parametrize('only_active', (True, False))
-def test_get_with_data(db, create_room, create_equipment_type, only_active):
-    eq = create_equipment_type('eq')
-
+def test_get_with_data(db, create_room, only_active):
     rooms = {
-        'inactive': {'room': create_room(is_deleted=True), 'equipment': []},
-        'no_eq': {'room': create_room(), 'equipment': []},
-        'all_eq': {'room': create_room(), 'equipment': [eq]}
+        'inactive': {'room': create_room(is_deleted=True)},
+        'active': {'room': create_room()},
     }
     room_types = {room_data['room']: type_ for type_, room_data in rooms.items()}
-    for room in rooms.values():
-        room['room'].available_equipment = room['equipment']
     db.session.flush()
     results = list(Room.get_with_data(only_active=only_active))
     assert len(results) == len(rooms) - only_active
-    for row in results:
-        room = row.pop('room')
+    for room in results:
         room_type = room_types[room]
         if room_type == 'inactive':
             assert not only_active

--- a/indico/modules/receipts/schemas.py
+++ b/indico/modules/receipts/schemas.py
@@ -173,7 +173,7 @@ class RegistrationDataSchema(mm.SQLAlchemyAutoSchema):
     personal_data = fields.Nested(PersonalDataSchema, required=True)
     transaction = fields.Nested(TransactionSchema, required=True, allow_none=True)
 
-    def get_attribute(self, obj: t.Union[Registration, dict], attr: str, default: t.Any):
+    def get_attribute(self, obj: Registration | dict, attr: str, default: t.Any):
         # Unfortunately marshmallow has no nice way to specify that a value is coming from a method
         # on the object, so we have to hack into the attribute lookup logic for this purpose...
         if isinstance(obj, dict):
@@ -191,7 +191,7 @@ class RegistrationDataSchema(mm.SQLAlchemyAutoSchema):
 
         return super().get_attribute(obj, attr, default)
 
-    def _dump_field_data(self, registration: t.Union[Registration, dict]):
+    def _dump_field_data(self, registration: Registration | dict):
         if isinstance(registration, dict):
             # Dummy preview data loaded from YAML
             return registration['field_data']

--- a/indico/modules/receipts/util.py
+++ b/indico/modules/receipts/util.py
@@ -93,7 +93,7 @@ class SilentUndefined(Undefined):
     __html__ = _fail_with_undefined_error
 
 
-def get_all_templates(obj: t.Union[Event, Category]) -> set[ReceiptTemplate]:
+def get_all_templates(obj: Event | Category) -> set[ReceiptTemplate]:
     """Get all templates usable by an event/category."""
     category = (obj.category or Category.get_root()) if isinstance(obj, Event) else obj
     return set(ReceiptTemplate.query.filter(~ReceiptTemplate.is_deleted,
@@ -118,7 +118,7 @@ def has_any_receipts(regform: RegistrationForm) -> bool:
             .has_rows())
 
 
-def get_inherited_templates(obj: t.Union[Event, Category]) -> set[ReceiptTemplate]:
+def get_inherited_templates(obj: Event | Category) -> set[ReceiptTemplate]:
     """Get all templates inherited by a given event/category."""
     return get_all_templates(obj) - set(obj.receipt_templates)
 
@@ -267,7 +267,7 @@ def _get_default_value(field):
     return field['attributes'].get('value', '')
 
 
-def get_dummy_preview_data(custom_fields: dict, custom_fields_values: t.Optional[dict] = None) -> dict:
+def get_dummy_preview_data(custom_fields: dict, custom_fields_values: dict | None = None) -> dict:
     """Get dummy preview data for rendering a document template.
 
     Most document templates are written inthe context of a category, so it is not

--- a/indico/modules/users/forms.py
+++ b/indico/modules/users/forms.py
@@ -81,7 +81,7 @@ class UserPreferencesForm(IndicoForm):
         locales = [(code, f'{name} ({territory})' if territory else name)
                    for code, (name, territory, __) in get_all_locales().items()]
         self.lang.choices = sorted(locales, key=itemgetter(1))
-        self.timezone.choices = list(zip(common_timezones, common_timezones))
+        self.timezone.choices = list(zip(common_timezones, common_timezones, strict=True))
         if self.timezone.object_data and self.timezone.object_data not in common_timezones_set:
             self.timezone.choices.append((self.timezone.object_data, self.timezone.object_data))
 

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -7,7 +7,6 @@
 
 import hashlib
 import os
-import typing as t
 from collections import defaultdict
 from datetime import datetime
 from io import BytesIO
@@ -476,7 +475,7 @@ def anonymize_user(user):
     signals.users.anonymized.send(user, flushed=True)
 
 
-def get_color_for_user_id(user_id: t.Union[int, str]):
+def get_color_for_user_id(user_id: int | str):
     """Calculate a unique color for a user based on their id.
 
     :param user_id: the user ID (int), or otherwise a string (external search results)
@@ -525,7 +524,7 @@ def set_user_avatar(user, avatar, filename, lastmod=None):
     }
 
 
-def send_default_avatar(user: t.Union[User, str, None]):
+def send_default_avatar(user: User | str | None):
     """Send a user's default avatar as an SVG.
 
     :param user: A `User` object, string (external search results, registrations) or `None` (blank avatar)

--- a/indico/testing/util.py
+++ b/indico/testing/util.py
@@ -76,7 +76,7 @@ def bool_matrix(template, mask=None, expect=None):
             raise ValueError('cannot combine ! with mask')
         if len(mask) != len(template):
             raise ValueError('mask length differs from template length')
-        if any(x != '.' and y != '.' for x, y in zip(template, mask)):
+        if any(x != '.' and y != '.' for x, y in zip(template, mask, strict=True)):
             raise ValueError('mask cannot have a value for a fixed column')
     else:
         mask = '.' * len(template)

--- a/indico/util/marshmallow.py
+++ b/indico/util/marshmallow.py
@@ -7,7 +7,6 @@
 
 import os
 import re
-import typing as t
 from datetime import datetime, time, timedelta
 from uuid import UUID
 
@@ -476,7 +475,7 @@ class NoneRemovingList(fields.List):
 class UUIDString(fields.UUID):
     """A UUID field that returns the UUID as a string instead of a native UUID."""
 
-    def _deserialize(self, value, attr, data, **kwargs) -> t.Optional[str]:
+    def _deserialize(self, value, attr, data, **kwargs) -> str | None:
         rv = self._validated(value)
         return str(rv) if isinstance(rv, UUID) else rv
 
@@ -484,7 +483,7 @@ class UUIDString(fields.UUID):
 class LowercaseString(fields.String):
     """A String field that converts it value to lowercase."""
 
-    def _deserialize(self, value, attr, data, **kwargs) -> t.Optional[str]:
+    def _deserialize(self, value, attr, data, **kwargs) -> str | None:
         return super()._deserialize(value, attr, data, **kwargs).lower()
 
 

--- a/indico/util/signals_test.py
+++ b/indico/util/signals_test.py
@@ -64,7 +64,8 @@ def test_values_from_signal_multi_value_types():
 def test_values_from_signal_return_plugins():
     vals = ('a', 'b', 'c')
     signal_response = [*_make_signal_response(vals), (MagicMock(indico_plugin='foo'), 'd')]
-    assert values_from_signal(signal_response, return_plugins=True) == {*zip([None] * 3, vals), ('foo', 'd')}
+    assert values_from_signal(signal_response, return_plugins=True) == {*zip([None] * 3, vals, strict=True),
+                                                                        ('foo', 'd')}
     assert values_from_signal(signal_response) == {*vals, 'd'}
 
 

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -633,7 +633,7 @@ class RichMarkup(Markup):
 
     __slots__ = ('_linker', '_preformatted')
 
-    def __new__(cls, content: str = '', preformatted: t.Optional[bool] = None):
+    def __new__(cls, content: str = '', preformatted: bool | None = None):
         obj = Markup.__new__(cls, content)
         if preformatted is None:
             tmp = content.lower()

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -9,7 +9,7 @@ import functools
 import pickle
 import re
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import yaml
@@ -186,7 +186,7 @@ class IndicoSessionInterface(SessionInterface):
             session_lifetime = self.temporary_session_lifetime
 
         if session.hard_expiry:
-            hard_lifetime = session.hard_expiry - datetime.now(timezone.utc)
+            hard_lifetime = session.hard_expiry - datetime.now(UTC)
             if not session_lifetime:
                 # if we have `SESSION_LIFETIME = 0` ("browser session"), the `min()` logic below
                 # would not work properly because 0 generally means 'no expiry'

--- a/indico/web/flask/session_test.py
+++ b/indico/web/flask/session_test.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock
 
 import pytest
@@ -28,7 +28,7 @@ def test_get_storage_lifetime_with_hard_expiry(app, freeze_time):
     The returned value should always be the minimum of the hard expiry and the
     app's permanent/temporary session lifetime.
     """
-    dt_now = datetime.now(timezone.utc)
+    dt_now = datetime.now(UTC)
     freeze_time(dt_now)
     session = IndicoSession()
     session.hard_expiry = dt_now + timedelta(days=2)
@@ -56,7 +56,7 @@ def test_get_storage_lifetime_with_hard_expiry(app, freeze_time):
 def test_save_session_with_hard_expiry(app):
     """Test that a session with a hard expiry sets the cookie expiry to the hard expiry."""
     session = IndicoSession()
-    expiry = datetime.now(timezone.utc) + timedelta(days=2)
+    expiry = datetime.now(UTC) + timedelta(days=2)
     session.hard_expiry = expiry
     resp_mock = Mock(spec_set=Response)
 

--- a/indico/web/forms/fields/colors.py
+++ b/indico/web/forms/fields/colors.py
@@ -67,4 +67,4 @@ class SUIColorPickerField(SelectField):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.choices = list(zip(get_sui_colors(), get_sui_colors()))
+        self.choices = list(zip(get_sui_colors(), get_sui_colors(), strict=True))

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-target-version = 'py39'
+target-version = 'py312'
 line-length = 120
 extend-exclude = ['docs', 'htmlcov', '*.egg-info', 'indico.conf']
 
@@ -46,6 +46,7 @@ ignore = [
     'RUF015',  # not always more readable, and we don't do it for huge lists
     'RUF022',  # autofix messes up out formatting instead of just sorting
     'RUF027',  # also triggers on i18n functions -> too noisy for now
+    'UP038',   # it looks kind of weird and it slower than a tuple
     'D205',    # too many docstrings which have no summary line
     'D301',    # https://github.com/astral-sh/ruff/issues/8696
     'D1',      # we have way too many missing docstrings :(


### PR DESCRIPTION
Also removed some dead code from the RB module.

And @tomasr8 you'll be happy to see that typing unions use `|` now :P 