### PR TITLE
Do not include unnecessary user data in JSON exports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -162,6 +162,7 @@ Bugfixes
 - Include comments in the Paper Peer Reviewing JSON export (:pr:`6253`)
 - Fail with a nicer error message when trying to upload a non-UTF8 CSV file (:issue:`6085`,
   :pr:`6259`)
+- Do not include unnecessary user data in JSON exports (:pr:`6260`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/abstracts/schemas.py
+++ b/indico/modules/events/abstracts/schemas.py
@@ -16,15 +16,15 @@ from indico.modules.events.abstracts.models.review_ratings import AbstractReview
 from indico.modules.events.abstracts.models.reviews import AbstractReview
 from indico.modules.events.contributions.schemas import ContributionFieldValueSchema, contribution_type_schema_basic
 from indico.modules.events.tracks.schemas import track_schema_basic
-from indico.modules.users.schemas import AffiliationSchema, UserSchema
+from indico.modules.users.schemas import AffiliationSchema, BasicUserSchema
 
 
 _basic_abstract_fields = ('id', 'friendly_id', 'title')
 
 
 class AbstractCommentSchema(mm.SQLAlchemyAutoSchema):
-    user = Nested(UserSchema)
-    modified_by = Nested(UserSchema)
+    user = Nested(BasicUserSchema)
+    modified_by = Nested(BasicUserSchema)
 
     class Meta:
         model = AbstractComment
@@ -47,7 +47,7 @@ class AbstractReviewRatingSchema(mm.SQLAlchemyAutoSchema):
 
 class AbstractReviewSchema(mm.SQLAlchemyAutoSchema):
     track = Nested(track_schema_basic)
-    user = Nested(UserSchema)
+    user = Nested(BasicUserSchema)
     proposed_related_abstract = Nested('AbstractSchema', only=_basic_abstract_fields)
     proposed_contrib_type = Nested(contribution_type_schema_basic, attribute='proposed_contribution_type')
     proposed_tracks = Nested(track_schema_basic, many=True)
@@ -70,9 +70,9 @@ class AbstractPersonLinkSchema(mm.SQLAlchemyAutoSchema):
 
 
 class AbstractSchema(mm.SQLAlchemyAutoSchema):
-    submitter = Nested(UserSchema)
-    judge = Nested(UserSchema)
-    modified_by = Nested(UserSchema)
+    submitter = Nested(BasicUserSchema)
+    judge = Nested(BasicUserSchema)
+    modified_by = Nested(BasicUserSchema)
     duplicate_of = Nested(lambda: AbstractSchema, only=_basic_abstract_fields)
     merged_into = Nested(lambda: AbstractSchema, only=_basic_abstract_fields)
     submitted_contrib_type = Nested(contribution_type_schema_basic)

--- a/indico/modules/events/papers/schemas.py
+++ b/indico/modules/events/papers/schemas.py
@@ -22,7 +22,7 @@ from indico.modules.events.papers.models.review_ratings import PaperReviewRating
 from indico.modules.events.papers.models.reviews import PaperReview
 from indico.modules.events.papers.models.revisions import PaperRevision, PaperRevisionState
 from indico.modules.events.papers.util import is_type_reviewing_possible
-from indico.modules.users.schemas import UserSchema
+from indico.modules.users.schemas import BasicUserSchema
 from indico.util.i18n import orig_string
 from indico.util.mimetypes import icon_from_mimetype
 from indico.web.flask.util import url_for
@@ -96,8 +96,8 @@ class PaperReviewTypeSchema(mm.Schema):
 
 
 class PaperRevisionSchema(mm.SQLAlchemyAutoSchema):
-    submitter = Nested(UserSchema)
-    judge = Nested(UserSchema)
+    submitter = Nested(BasicUserSchema)
+    judge = Nested(BasicUserSchema)
     spotlight_file = Nested(PaperFileSchema)
     files = List(Nested(PaperFileSchema))
     state = EnumField(PaperRevisionState)
@@ -149,7 +149,7 @@ class PaperRatingSchema(mm.SQLAlchemyAutoSchema):
 
 class PaperReviewSchema(mm.SQLAlchemyAutoSchema):
     score = Decimal(places=2, as_string=True)
-    user = Nested(UserSchema)
+    user = Nested(BasicUserSchema)
     visibility = Nested(PaperCommentVisibilitySchema)
     proposed_action = Nested(PaperAction)
     ratings = Nested(PaperRatingSchema, many=True)
@@ -174,9 +174,9 @@ class PaperReviewDumpSchema(PaperReviewSchema):
 
 
 class PaperReviewCommentSchema(mm.SQLAlchemyAutoSchema):
-    user = Nested(UserSchema)
+    user = Nested(BasicUserSchema)
     visibility = Nested(PaperCommentVisibilitySchema)
-    modified_by = Nested(UserSchema)
+    modified_by = Nested(BasicUserSchema)
     html = Function(lambda comment: escape(comment.text))
     can_edit = Function(lambda comment, ctx: comment.can_edit(ctx.get('user')))
     can_view = Function(lambda comment, ctx: comment.can_view(ctx.get('user')))

--- a/indico/modules/users/schemas.py
+++ b/indico/modules/users/schemas.py
@@ -29,6 +29,16 @@ class AffiliationSchema(mm.SQLAlchemyAutoSchema):
         return data
 
 
+class BasicAffiliationSchema(AffiliationSchema):
+    """
+    A schema containing basic information about a predefined affiliation that
+    is intended to be used in exports.
+    """
+
+    class Meta(AffiliationSchema.Meta):
+        fields = ('id', 'name', 'street', 'postcode', 'city', 'country_code')
+
+
 class UserSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = User
@@ -38,6 +48,19 @@ class UserSchema(mm.SQLAlchemyAutoSchema):
     affiliation_id = fields.Integer(load_default=None, dump_only=True)
     affiliation_meta = fields.Nested(AffiliationSchema, attribute='affiliation_link', dump_only=True)
     title = NoneValueEnumField(UserTitle, none_value=UserTitle.none, attribute='_title')
+
+
+class BasicUserSchema(UserSchema):
+    """
+    A schema containing basic information about the user that can be safely
+    exposed to event organizers.
+    """
+
+    affiliation_meta = fields.Nested(BasicAffiliationSchema, attribute='affiliation_link', dump_only=True)
+
+    class Meta(UserSchema.Meta):
+        fields = ('id', 'identifier', 'first_name', 'last_name', 'email', 'affiliation', 'affiliation_meta',
+                  'full_name', 'title', 'avatar_url')
 
 
 class UserPersonalDataSchema(mm.SQLAlchemyAutoSchema):

--- a/indico/util/roles.py
+++ b/indico/util/roles.py
@@ -15,7 +15,7 @@ from indico.core.marshmallow import mm
 from indico.modules.events.roles.forms import ImportMembersCSVForm
 from indico.modules.logs.models.entries import LogKind
 from indico.modules.users import User
-from indico.modules.users.schemas import UserSchema
+from indico.modules.users.schemas import BasicUserSchema
 from indico.util.i18n import _, ngettext
 from indico.util.spreadsheets import csv_text_io_wrapper, send_csv
 from indico.util.string import validate_email
@@ -98,7 +98,7 @@ class RoleSchema(mm.Schema):
     name = fields.String()
     code = fields.String()
     color = fields.String()
-    members = fields.List(fields.Nested(UserSchema, only=('id', 'identifier', 'full_name', 'email')))
+    members = fields.List(fields.Nested(BasicUserSchema, only=('id', 'identifier', 'full_name', 'email')))
 
 
 class RolesAPIMixin:


### PR DESCRIPTION
The address field is generally used for professional/institute addresses so its not truly personal data, but it's completely unnecessary when exporting abstracts or papers to JSON.