### PR TITLE
Update vendored django mail package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,20 +7,10 @@ Version 3.3.1
 
 *Unreleased*
 
-Improvements
-^^^^^^^^^^^^
-
-- Nothing so far :(
-
 Bugfixes
 ^^^^^^^^
 
-- Nothing so far :)
-
-Internal Changes
-^^^^^^^^^^^^^^^^
-
-- Nothing so far
+- Fix sending emails when using TLS (:data:`SMTP_USE_TLS`) (:pr:`6261`)
 
 
 Version 3.3

--- a/indico/vendor/django_mail/__init__.py
+++ b/indico/vendor/django_mail/__init__.py
@@ -11,7 +11,7 @@
 # The code in here is taken almost verbatim from `django.core.mail`,
 # which is licensed under the three-clause BSD license and is originally
 # available on the following URL:
-# https://github.com/django/django/blob/stable/2.2.x/django/core/mail/__init__.py
+# https://github.com/django/django/blob/425b26092f/django/core/mail/__init__.py
 # Credits of the original code go to the Django Software Foundation
 # and their contributors.
 

--- a/indico/vendor/django_mail/backends/base.py
+++ b/indico/vendor/django_mail/backends/base.py
@@ -8,7 +8,7 @@
 # The code in here is taken almost verbatim from `django.core.mail.backends.base`,
 # which is licensed under the three-clause BSD license and is originally
 # available on the following URL:
-# https://github.com/django/django/blob/stable/3.1.x/django/core/mail/backends/base.py
+# https://github.com/django/django/blob/425b26092f/django/core/mail/backends/base.py
 # Credits of the original code go to the Django Software Foundation
 # and their contributors.
 

--- a/indico/vendor/django_mail/backends/console.py
+++ b/indico/vendor/django_mail/backends/console.py
@@ -8,7 +8,7 @@
 # The code in here is taken almost verbatim from `django.core.mail.backends.console`,
 # which is licensed under the three-clause BSD license and is originally
 # available on the following URL:
-# https://github.com/django/django/blob/stable/3.1.x/django/core/mail/backends/console.py
+# https://github.com/django/django/blob/425b26092f/django/core/mail/backends/console.py
 # Credits of the original code go to the Django Software Foundation
 # and their contributors.
 

--- a/indico/vendor/django_mail/backends/locmem.py
+++ b/indico/vendor/django_mail/backends/locmem.py
@@ -8,13 +8,15 @@
 # The code in here is taken almost verbatim from `django.core.mail.backends.locmem`,
 # which is licensed under the three-clause BSD license and is originally
 # available on the following URL:
-# https://github.com/django/django/blob/stable/3.1.x/django/core/mail/backends/locmem.py
+# https://github.com/django/django/blob/425b26092f/django/core/mail/backends/locmem.py
 # Credits of the original code go to the Django Software Foundation
 # and their contributors.
 
 """
 Backend for test environment.
 """
+
+import copy
 
 from indico.vendor import django_mail
 
@@ -41,6 +43,6 @@ class EmailBackend(BaseEmailBackend):
         msg_count = 0
         for message in messages:  # .message() triggers header validation
             message.message()
-            django_mail.outbox.append(message)
+            django_mail.outbox.append(copy.deepcopy(message))
             msg_count += 1
         return msg_count

--- a/indico/vendor/django_mail/encoding_utils.py
+++ b/indico/vendor/django_mail/encoding_utils.py
@@ -8,33 +8,29 @@
 # The code in here is taken almost verbatim from `django.utils.encoding`,
 # which is licensed under the three-clause BSD license and is originally
 # available on the following URL:
-# https://github.com/django/django/blob/stable/3.1.x/django/utils/encoding.py
+# https://github.com/django/django/blob/425b26092f/django/utils/encoding.py
 # Credits of the original code go to the Django Software Foundation
 # and their contributors.
 
-
 import datetime
 from decimal import Decimal
+from types import NoneType
 
 
 DEFAULT_CHARSET = 'utf-8'
 
 
 class DjangoUnicodeDecodeError(UnicodeDecodeError):
-    def __init__(self, obj, *args):
-        self.obj = obj
-        super().__init__(*args)
-
     def __str__(self):
         return '%s. You passed in %r (%s)' % (
             super().__str__(),
-            self.obj,
-            type(self.obj),
+            self.object,
+            type(self.object),
         )
 
 
 _PROTECTED_TYPES = (
-    type(None),
+    NoneType,
     int,
     float,
     Decimal,
@@ -48,7 +44,7 @@ def is_protected_type(obj):
     """Determine if the object instance is of a protected type.
 
     Objects of protected types are preserved as-is when passed to
-    force_text(strings_only=True).
+    force_str(strings_only=True).
     """
     return isinstance(obj, _PROTECTED_TYPES)
 
@@ -57,6 +53,7 @@ def force_str(s, encoding='utf-8', strings_only=False, errors='strict'):
     """
     Similar to smart_str(), except that lazy instances are resolved to
     strings, rather than kept as lazy objects.
+
     If strings_only is True, don't convert (some) non-string-like objects.
     """
     # Handle the common case first for performance reasons.
@@ -70,7 +67,7 @@ def force_str(s, encoding='utf-8', strings_only=False, errors='strict'):
         else:
             s = str(s)
     except UnicodeDecodeError as e:
-        raise DjangoUnicodeDecodeError(s, *e.args)
+        raise DjangoUnicodeDecodeError(*e.args) from None
     return s
 
 

--- a/indico/vendor/django_mail/module_loading_utils.py
+++ b/indico/vendor/django_mail/module_loading_utils.py
@@ -8,7 +8,7 @@
 # The code in here is taken almost verbatim from `django.utils.module_loading`,
 # which is licensed under the three-clause BSD license and is originally
 # available on the following URL:
-# https://github.com/django/django/blob/stable/3.1.x/django/utils/module_loading.py
+# https://github.com/django/django/blob/425b26092f/django/utils/module_loading.py
 # Credits of the original code go to the Django Software Foundation
 # and their contributors.
 

--- a/indico/vendor/django_mail/utils.py
+++ b/indico/vendor/django_mail/utils.py
@@ -8,7 +8,7 @@
 # The code in here is taken almost verbatim from `django.core.mail.utils`,
 # which is licensed under the three-clause BSD license and is originally
 # available on the following URL:
-# https://github.com/django/django/blob/stable/3.1.x/django/core/mail/utils.py
+# https://github.com/django/django/blob/425b26092f/django/core/mail/utils.py
 # Credits of the original code go to the Django Software Foundation
 # and their contributors.
 


### PR DESCRIPTION
Python 3.12 removed some deprecated smtplib args which were still used by our old version of django-mail, so when STARTTLS was used it failed due to those args being passed.