### PR TITLE
Fix display of 12h times on room details dialog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Bugfixes
 
 - Fix adding additional event keywords when some keywords have already been set
   (:pr:`6264`, thanks :user:`SegiNyn`)
+- Fix the time display in the room details dialog when a 12 hour locale
+  is used (:pr:`6263`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,8 +17,8 @@ Bugfixes
 
 - Fix adding additional event keywords when some keywords have already been set
   (:pr:`6264`, thanks :user:`SegiNyn`)
-- Fix the time display in the room details dialog when a 12 hour locale
-  is used (:pr:`6263`)
+- Fix overlapping times in some room booking timelines when using a locale with
+  a 12-hour time format (:pr:`6263`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
@@ -331,6 +331,7 @@ class BookingDetails extends React.Component {
         booking={booking}
         rowActions={{occurrence: true}}
         hideRecurrence
+        trim12hMins
       />
     );
   };

--- a/indico/modules/rb/client/js/common/bookings/BookingEditCalendar.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditCalendar.jsx
@@ -174,6 +174,7 @@ class BookingEditCalendar extends React.Component {
               isLoading={isLoading}
               fixedHeight={currentBooking.dateRange.length > 0 ? '100%' : null}
               hideRecurrence
+              trim12hMins
             />
           </div>
           {newBooking && (
@@ -193,6 +194,7 @@ class BookingEditCalendar extends React.Component {
                 }}
                 fixedHeight={newBooking.dateRange.length > 0 ? '100%' : null}
                 hideRecurrence
+                trim12hMins
               />
             </div>
           )}

--- a/indico/modules/rb/client/js/common/rooms/RoomDetailsModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/RoomDetailsModal.jsx
@@ -241,6 +241,7 @@ function RoomDetails({
             <DailyTimelineContent
               rows={availability.map(rowSerializer)}
               onClickReservation={onClickReservation}
+              trim12hTimes
             />
           </Responsive.Tablet>
           <RoomStats roomId={room.id} />

--- a/indico/modules/rb/client/js/common/rooms/RoomDetailsModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/RoomDetailsModal.jsx
@@ -241,7 +241,7 @@ function RoomDetails({
             <DailyTimelineContent
               rows={availability.map(rowSerializer)}
               onClickReservation={onClickReservation}
-              trim12hTimes
+              trim12hMins
             />
           </Responsive.Tablet>
           <RoomStats roomId={room.id} />

--- a/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
+++ b/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
@@ -213,9 +213,7 @@ export default class DailyTimelineContent extends React.Component {
               style={{position: 'absolute', left: `${(i / hourSpan) * 100}%`}}
             >
               <span styleName="timeline-label-text">
-                {short12hTimes
-                  ? moment({hours: hourSeries[n]}).format('hA')
-                  : moment({hours: hourSeries[n]}).format('LT')}
+                {moment({hours: hourSeries[n]}).format(short12hTimes ? 'hA' : 'LT')}
               </span>
             </div>
           ))}

--- a/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
+++ b/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
@@ -215,8 +215,8 @@ export default class DailyTimelineContent extends React.Component {
               <span styleName="timeline-label-text">
                 {short12hTimes
                   ? moment({hours: hourSeries[n]})
-                      .format('hA')
-                      .replace('M', '')
+                      .format('ha')
+                      .replace('m', '')
                   : moment({hours: hourSeries[n]}).format('LT')}
               </span>
             </div>

--- a/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
+++ b/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
@@ -17,7 +17,7 @@ import {Icon, Message, Popup, Placeholder} from 'semantic-ui-react';
 import {TooltipIfTruncated} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {Responsive} from 'indico/react/util';
-import {toMoment} from 'indico/utils/date';
+import {toMoment, localeUses24HourTime} from 'indico/utils/date';
 
 import EditableTimelineItem from './EditableTimelineItem';
 import RowActionsDropdown from './RowActionsDropdown';
@@ -45,6 +45,7 @@ export default class DailyTimelineContent extends React.Component {
     booking: PropTypes.object,
     gutterAllowed: PropTypes.bool,
     hideRecurrence: PropTypes.bool,
+    trim12hTimes: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -68,6 +69,7 @@ export default class DailyTimelineContent extends React.Component {
     booking: null,
     gutterAllowed: false,
     hideRecurrence: false,
+    trim12hTimes: false,
   };
 
   state = {
@@ -196,8 +198,9 @@ export default class DailyTimelineContent extends React.Component {
   };
 
   renderDefaultHeader = (hourSpan, hourSeries, hasActions) => {
-    const {hourStep, longLabel} = this.props;
+    const {hourStep, longLabel, trim12hTimes} = this.props;
     const labelWidth = longLabel ? 200 : 150;
+    const short12hTimes = !localeUses24HourTime(moment.locale().replace('_', '-')) && trim12hTimes;
 
     return (
       <>
@@ -210,7 +213,11 @@ export default class DailyTimelineContent extends React.Component {
               style={{position: 'absolute', left: `${(i / hourSpan) * 100}%`}}
             >
               <span styleName="timeline-label-text">
-                {moment({hours: hourSeries[n]}).format('LT')}
+                {short12hTimes
+                  ? moment({hours: hourSeries[n]})
+                      .format('hA')
+                      .replace('M', '')
+                  : moment({hours: hourSeries[n]}).format('LT')}
               </span>
             </div>
           ))}

--- a/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
+++ b/indico/modules/rb/client/js/common/timeline/DailyTimelineContent.jsx
@@ -45,7 +45,7 @@ export default class DailyTimelineContent extends React.Component {
     booking: PropTypes.object,
     gutterAllowed: PropTypes.bool,
     hideRecurrence: PropTypes.bool,
-    trim12hTimes: PropTypes.bool,
+    trim12hMins: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -69,7 +69,7 @@ export default class DailyTimelineContent extends React.Component {
     booking: null,
     gutterAllowed: false,
     hideRecurrence: false,
-    trim12hTimes: false,
+    trim12hMins: false,
   };
 
   state = {
@@ -198,9 +198,9 @@ export default class DailyTimelineContent extends React.Component {
   };
 
   renderDefaultHeader = (hourSpan, hourSeries, hasActions) => {
-    const {hourStep, longLabel, trim12hTimes} = this.props;
+    const {hourStep, longLabel, trim12hMins} = this.props;
     const labelWidth = longLabel ? 200 : 150;
-    const short12hTimes = !localeUses24HourTime(moment.locale().replace('_', '-')) && trim12hTimes;
+    const short12hTimes = !localeUses24HourTime(moment.locale().replace('_', '-')) && trim12hMins;
 
     return (
       <>
@@ -214,9 +214,7 @@ export default class DailyTimelineContent extends React.Component {
             >
               <span styleName="timeline-label-text">
                 {short12hTimes
-                  ? moment({hours: hourSeries[n]})
-                      .format('ha')
-                      .replace('m', '')
+                  ? moment({hours: hourSeries[n]}).format('hA')
                   : moment({hours: hourSeries[n]}).format('LT')}
               </span>
             </div>


### PR DESCRIPTION
This PR fixes a UI bug where locales that use 12h times would appear squished/cramped together.

Before:
![image](https://github.com/indico/indico/assets/7736654/20050c47-3648-42f7-8c94-8ace0b660db0)

After:
![image](https://github.com/indico/indico/assets/7736654/6dca5c21-cbe6-48bd-a63f-55547f28630a)
