### PR TITLE
Improve HiddenUnless for composite field

### DIFF
--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -573,16 +573,6 @@ class RegistrationPrivacyForm(IndicoForm):
     require_privacy_policy_agreement = BooleanField(_('Privacy policy'), widget=SwitchWidget(),
                                                     description=_('Specify whether users are required to agree to '
                                                                   "the event's privacy policy when registering"))
-    test_hidden = BooleanField(_('TEST HIDDEN'), widget=SwitchWidget(),
-                               validators=[HiddenUnless('visibility',
-                                           value=['show_all', 'hide_all', None], composite=True)],
-                               description=_('Test hiddenUnless with value [show_all, hide_all, None]'))
-    test_hidden_inverted = BooleanField(_('TEST HIDDEN INVERTED'), widget=SwitchWidget(),
-                                        validators=[HiddenUnless('visibility',
-                                                    value=[None, 'show_with_consent', None],
-                                                    composite=True, inverted=True)],
-                                        description=_('Test hiddenUnless inverted with value '
-                                                      '[None, show_with_consent, None]'))
 
     def __init__(self, *args, regform, **kwargs):
         self.regform = regform

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -594,8 +594,6 @@ class RegistrationPrivacyForm(IndicoForm):
     def data(self):
         data = super().data
         del data['visibility']
-        del data['test_hidden']
-        del data['test_hidden_inverted']
         return data
 
     def validate_visibility(self, field):

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -573,6 +573,16 @@ class RegistrationPrivacyForm(IndicoForm):
     require_privacy_policy_agreement = BooleanField(_('Privacy policy'), widget=SwitchWidget(),
                                                     description=_('Specify whether users are required to agree to '
                                                                   "the event's privacy policy when registering"))
+    test_hidden = BooleanField(_('TEST HIDDEN'), widget=SwitchWidget(),
+                               validators=[HiddenUnless('visibility',
+                                           value=['show_all', 'hide_all', None], composite=True)],
+                               description=_('Test hiddenUnless with value [show_all, hide_all, None]'))
+    test_hidden_inverted = BooleanField(_('TEST HIDDEN INVERTED'), widget=SwitchWidget(),
+                                        validators=[HiddenUnless('visibility',
+                                                    value=[None, 'show_with_consent', None],
+                                                    composite=True, inverted=True)],
+                                        description=_('Test hiddenUnless inverted with value '
+                                                      '[None, show_with_consent, None]'))
 
     def __init__(self, *args, regform, **kwargs):
         self.regform = regform
@@ -594,6 +604,8 @@ class RegistrationPrivacyForm(IndicoForm):
     def data(self):
         data = super().data
         del data['visibility']
+        del data['test_hidden']
+        del data['test_hidden_inverted']
         return data
 
     def validate_visibility(self, field):

--- a/indico/web/client/js/react/components/WTFParticipantVisibilityField.jsx
+++ b/indico/web/client/js/react/components/WTFParticipantVisibilityField.jsx
@@ -19,7 +19,7 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
 
   // Trigger change only after the DOM has changed
   useEffect(() => {
-    parentElement.dispatchEvent(new Event('change', {bubbles: true}));
+    $('#visibility').trigger('change');
   }, [participantVisibility, publicVisibility, visibilityDuration, parentElement]);
 
   const choiceMap = {

--- a/indico/web/forms/jinja_helpers.py
+++ b/indico/web/forms/jinja_helpers.py
@@ -73,7 +73,8 @@ def _attrs_for_validators(field, validators):
 
             attrs['data-hidden-unless'] = json.dumps({'field': condition_field.name,
                                                       'values': values,
-                                                      'checked_only': checked_only})
+                                                      'checked_only': checked_only,
+                                                      'inverted': validator.inverted})
     return attrs
 
 

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -46,18 +46,46 @@ class HiddenUnless:
     :param preserve_data: If True, a disabled field will keep whatever
                           ``object_data`` it had before (i.e. data set
                           via `FormDefaults`).
+    :param inverted: If True, the mechanism is inverted:
+                     the hide happens when the field doesn't have the value.
+    :param composite: The field is composed of a list of other fields in the form,
+                      the single value of composite field is a list.
+                      Note: Require to trigger change event on the parent field for each
+                      change of the child field.
     """
 
     field_flags = {'initially_hidden': True}
 
-    def __init__(self, field, value=None, preserve_data=False):
+    def __init__(self, field, value=None, preserve_data=False, inverted=False, composite=False):
         self.field = field
-        self.value = value if value is None or isinstance(value, (set, list, tuple)) else {value}
+        self.value = value if value is None or isinstance(value, (set, list, tuple)) else [value]
+        if composite and value and not isinstance(value, list):
+            raise ValidationError(_('Composite field value must be a list'))
+        if composite:
+            for i in range(len(value)):
+                self.value[i] = value[i] if value[i] is None or isinstance(value[i], (set, list, tuple)) else [value[i]]
         self.preserve_data = preserve_data
+        self.inverted = inverted
+        self.composite = composite
 
     def __call__(self, form, field):
+        def _match_criteria(v, values):
+            if not self.composite:
+                return v in values
+            # composite field: v is a list
+            if len(values) != len(v):
+                raise ValidationError(_('Length of value does not match length of composite field'))
+            i = 0
+            while i < len(v):
+                if values[i] is not None and v[i] not in values[i]:
+                    return False
+                i += 1
+            return True
+
         value = form[self.field].data
-        active = (value and self.value is None) or (self.value is not None and value in self.value)
+        active = ((value and self.value is None) or (self.value is not None and _match_criteria(value, self.value)))
+        if self.inverted:
+            active = not active
 
         if not active:
             field.errors[:] = []

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -75,11 +75,8 @@ class HiddenUnless:
             # composite field: v is a list
             if len(values) != len(v):
                 raise ValueError('Length of value does not match length of composite field')
-            i = 0
-            while i < len(v):
-                if values[i] is not None and v[i] not in values[i]:
-                    return False
-                i += 1
+            if any(i for i in range(len(v)) if values[i] and v[i] not in values[i]):
+                return False
             return True
 
         value = form[self.field].data

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -60,7 +60,7 @@ class HiddenUnless:
         self.field = field
         self.value = value if value is None or isinstance(value, (set, list, tuple)) else [value]
         if composite and value and not isinstance(value, list):
-            raise ValidationError(_('Composite field value must be a list'))
+            raise ValueError('Composite field value must be a list')
         if composite:
             for i in range(len(value)):
                 self.value[i] = value[i] if value[i] is None or isinstance(value[i], (set, list, tuple)) else [value[i]]
@@ -74,7 +74,7 @@ class HiddenUnless:
                 return v in values
             # composite field: v is a list
             if len(values) != len(v):
-                raise ValidationError(_('Length of value does not match length of composite field'))
+                raise ValueError('Length of value does not match length of composite field')
             i = 0
             while i < len(v):
                 if values[i] is not None and v[i] not in values[i]:


### PR DESCRIPTION
Request change for HiddenUnless validator:
this change renders the validator working on field composed of list of other fields (like "visibility" in Participant List Privacy form),
it also adds an option "inverted" for the validator.

Note:
I added 2 test fields on RegistrationPrivacyForm for visual testing.