### PR TITLE
Fix printing badge w/ empty image placeholder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Bugfixes
   (:pr:`6264`, thanks :user:`SegiNyn`)
 - Fix overlapping times in some room booking timelines when using a locale with
   a 12-hour time format (:pr:`6263`)
+- Fix error when printing badges referencing a linked regform picture field that
+  contains no picture (:pr:`6276`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/designer/placeholders.py
+++ b/indico/modules/designer/placeholders.py
@@ -451,7 +451,8 @@ class RegistrationFormFieldPlaceholder(DesignerPlaceholder):
             return friendly_data
 
     def _render_image(self, data):
-        return Image.open(data.open())
+        if data.storage_file_id is not None:
+            return Image.open(data.open())
 
     def _render_accommodation(self, friendly_data):
         if friendly_data['is_no_accommodation']:


### PR DESCRIPTION
```
...
  File "indico/modules/designer/placeholders.py", line 454, in _render_image
    return Image.open(data.open())
  File "indico/core/storage/models.py", line 213, in open
    raise Exception('There is no file to open')
```