### PR TITLE
Fix dropdown to work with multiple=true and preload=false

### DIFF
--- a/indico/modules/vc/forms.py
+++ b/indico/modules/vc/forms.py
@@ -36,7 +36,7 @@ class VCRoomField(HiddenField):
     def _value(self, for_react=False):
         if not self.data:
             return None
-        return [{'id': self.data.id}] if for_react else self.data.id
+        return [{'id': self.data.id, 'name': self.data.name}] if for_react else self.data.id
 
 
 class LinkingWidget(JinjaWidget):

--- a/indico/web/client/js/react/components/WTFSearchDropdown.jsx
+++ b/indico/web/client/js/react/components/WTFSearchDropdown.jsx
@@ -148,10 +148,31 @@ export function SearchDropdown({
       } finally {
         setLoading(false);
       }
-
-      setOptions(transformOptions(response.data));
+      if (!preload && multiple) {
+        if (response.data.length !== 0) {
+          const id = response.data[0][valueField];
+          setOptions(prevOptions => {
+            const prevKeys = prevOptions.map(opt => opt.key);
+            if (prevKeys.includes(id)) {
+              return prevOptions;
+            }
+            return [...prevOptions, ...transformOptions(response.data)];
+          });
+        }
+      } else {
+        setOptions(transformOptions(response.data));
+      }
     },
-    [searchUrl, searchMethod, searchPayload, transformOptions, debounce]
+    [
+      searchUrl,
+      searchPayload,
+      preload,
+      multiple,
+      debounce,
+      searchMethod,
+      valueField,
+      transformOptions,
+    ]
   );
 
   useEffect(() => {
@@ -159,10 +180,13 @@ export function SearchDropdown({
       setOptions(transformOptions(optionsFromProps));
       return;
     }
+    if (!preload && defaultValue.length !== 0) {
+      setOptions(prevOptions => [...prevOptions, ...transformOptions(defaultValue)]);
+    }
     if (preload) {
       fetchData();
     }
-  }, [preload, fetchData, optionsFromProps, transformOptions]);
+  }, [preload, fetchData, optionsFromProps, transformOptions, defaultValue]);
 
   const onChange = (evt, {value: newValue}) => {
     setSearchQuery('');


### PR DESCRIPTION
Sorry, I hope this is the last of the corner cases with the dropdown. Currently multiple only works correctly when passing the options or when preload is true but it does not display the selected values when no options are passed and preload is false.

The Sui dropdown expects the selected value to be included in the available options so it doesn’t display correctly by just setting only the newly fetched option (`setOptions(transformOptions(response.data));`) and causes to loose the display of previously selected values if they are not in the fetched data. So I'm adding some extra checks to update the options correctly after fetching the data when multiple is selected.
