### PR TITLE
Handle ValueError for RHSignURL

### DIFF
--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -295,7 +295,7 @@ class RHSignURL(RH):
                                                params)
             else:
                 url = url_for(endpoint, _external=True, **params)
-        except BuildError as exc:
+        except (BuildError, ValueError) as exc:
             # if building fails for a valid endpoint we can be pretty sure that it's due to
             # some required params missing
             abort(422, messages={'params': [str(exc)]})


### PR DESCRIPTION
Request to handle ValueError in RHSignURL to fix case when post requests /api/sign-url contain invalid params data for event_id, category_id..., ex:
data: {'endpoint': 'events.export_event_ical',
            'params': {'event_id': 'acx{{98991*97996}}xca', 'scope': 'session'}}.
          