### PR TITLE
Fix invalid unit error when selecting 7 days in TimeDeltaField

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Bugfixes
   a 12-hour time format (:pr:`6263`)
 - Fix error when printing badges referencing a linked regform picture field that
   contains no picture (:pr:`6276`)
+- Fix error when creating a reminder for exactly one week before the event (:pr:`6283`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/reminders/forms.py
+++ b/indico/modules/events/reminders/forms.py
@@ -26,7 +26,8 @@ class ReminderForm(IndicoForm):
                                      choices=[('relative', _('Relative to the event start time')),
                                               ('absolute', _('Fixed date/time')),
                                               ('now', _('Send immediately'))])
-    relative_delta = TimeDeltaField(_('Offset'), [HiddenUnless('schedule_type', 'relative'), DataRequired()])
+    relative_delta = TimeDeltaField(_('Offset'), [HiddenUnless('schedule_type', 'relative'), DataRequired()],
+                                    units=('weeks', 'days', 'hours'))
     absolute_dt = IndicoDateTimeField(_('Date'), [HiddenUnless('schedule_type', 'absolute'), DataRequired(),
                                                   DateTimeRange()])
     # Recipients


### PR DESCRIPTION
Just a hotfix for now. The better fix would be not allowing to convert to "less" precise units e.g. from days to weeks in this case.