### PR TITLE
Fix sending emails containing `mailto:` links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Bugfixes
 - Fix error when creating a reminder for exactly one week before the event (:pr:`6283`)
 - Fix error when unassigning the editor of an editable that has no editor (:pr:`6284`)
 - Fix error when judging an editable from the list of editables (:pr:`6284`)
+- Fix validation error when using a ``mailto:`` link in an email body (:pr:`6286`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -301,7 +301,7 @@ def sanitize_for_platypus(text):
 def has_relative_links(html_text):
     doc = html.fromstring(html_text)
     return any(
-        (data := urlsplit(link)) and (not data.scheme or not data.netloc)
+        (data := urlsplit(link)) and data.scheme != 'mailto' and (not data.scheme or not data.netloc)
         for el, attrib, link, _pos in doc.iterlinks()
         if (el.tag, attrib) in {('a', 'href'), ('img', 'src')}
     )

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -287,6 +287,7 @@ def test_sanitize_html_escaped_quotes(input, output):
     ('<a href="//example.com/foo">test</a><img src="//example.com/bar">', True),
     ('<a href="foo">test</a><img src="bar">', True),
     ('<a href="https://example.com/foo">test</a><img src="https://example.com/bar">', False),
+    ('<a href="mailto:foobar@example.com">test</a>', False),
 ))
 def test_has_relative_links(input, expected):
     assert has_relative_links(input) == expected


### PR DESCRIPTION
Those links were considered relative, even though `mailto:` should have been ignored in that check.