### PR TITLE
Add payment date to registrations API

### DIFF
--- a/indico/modules/events/registration/controllers/api/checkin.py
+++ b/indico/modules/events/registration/controllers/api/checkin.py
@@ -6,7 +6,7 @@
 # LICENSE file for more details.
 
 from flask import request
-from sqlalchemy.orm import selectinload, undefer
+from sqlalchemy.orm import joinedload, selectinload, undefer
 from webargs import fields
 from werkzeug.exceptions import NotFound
 
@@ -75,6 +75,7 @@ class RHCheckinAPIRegistrations(RHCheckinAPIRegFormBase):
                          .filter(~Registration.is_deleted)
                          .options(selectinload('data').joinedload('field_data'),
                                   selectinload('tags'),
+                                  joinedload('transaction'),
                                   undefer('occupied_slots'))
                          .all())
         return CheckinRegistrationSchema(many=True, exclude=('registration_data',)).jsonify(registrations)
@@ -94,6 +95,10 @@ class RHCheckinAPIRegistration(RHCheckinAPIRegFormBase):
         registration_id = request.view_args['registration_id']
         self.registration = (Registration.query
                              .with_parent(self.regform)
+                             .options(selectinload('data').joinedload('field_data'),
+                                      selectinload('tags'),
+                                      joinedload('transaction'),
+                                      undefer('occupied_slots'))
                              .filter_by(id=registration_id, is_deleted=False)
                              .first_or_404())
 

--- a/indico/modules/events/registration/controllers/api/test_snapshots/checkin_registration_details.yml
+++ b/indico/modules/events/registration/controllers/api/test_snapshots/checkin_registration_details.yml
@@ -9,6 +9,7 @@ full_name: Guinea Pig
 id: <id>
 is_paid: false
 occupied_slots: 1
+payment_date: null
 price: 0
 regform_id: <id>
 registration_data:

--- a/indico/modules/events/registration/controllers/api/test_snapshots/checkin_registrations.yml
+++ b/indico/modules/events/registration/controllers/api/test_snapshots/checkin_registrations.yml
@@ -9,6 +9,7 @@
   id: <id>
   is_paid: false
   occupied_slots: 1
+  payment_date: null
   price: 0
   regform_id: <id>
   registration_date: <timestamp>

--- a/indico/modules/events/registration/schemas.py
+++ b/indico/modules/events/registration/schemas.py
@@ -62,17 +62,23 @@ class CheckinRegistrationSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Registration
         fields = ('id', 'regform_id', 'event_id', 'full_name', 'email', 'state', 'checked_in', 'checked_in_dt',
-                  'checkin_secret', 'is_paid', 'price', 'currency', 'formatted_price', 'tags', 'occupied_slots',
-                  'registration_date', 'registration_data')
+                  'checkin_secret', 'is_paid', 'price', 'payment_date', 'currency', 'formatted_price', 'tags',
+                  'occupied_slots', 'registration_date', 'registration_data')
 
     regform_id = fields.Int(attribute='registration_form_id')
     full_name = fields.Str(attribute='display_full_name')
     state = fields.Enum(RegistrationState)
     checkin_secret = fields.UUID(attribute='ticket_uuid')
+    payment_date = fields.Method('_get_payment_date')
     formatted_price = fields.Function(lambda reg: reg.render_price())
     tags = fields.Function(lambda reg: sorted(t.title for t in reg.tags))
     registration_date = fields.DateTime(attribute='submitted_dt')
     registration_data = fields.Method('_get_registration_data')
+
+    def _get_payment_date(self, registration):
+        if registration.is_paid and (transaction := registration.transaction):
+            return fields.DateTime().serialize('timestamp', transaction)
+        return None
 
     def _get_filenames(self, registration):
         """Extract filenames from file fields."""


### PR DESCRIPTION
Following Stefano's request to add the `payment_date` attribute to the `/api/checkin/event/<int:event_id>/forms/<int:reg_form_id>/registrations/` endpoint