### PR TITLE
Get plugin data for SingleDatePicker interval

### DIFF
--- a/indico/web/client/js/react/components/dates/SingleDatePicker.jsx
+++ b/indico/web/client/js/react/components/dates/SingleDatePicker.jsx
@@ -57,8 +57,19 @@ export default class SingleDatePicker extends React.Component {
   render() {
     const {focused} = this.state;
     const {disabledDate} = this.props;
-    const yearsInterval = getPluginObjects('datePickerInterval');
-    const {yearsBefore, yearsAfter} = yearsInterval.length ? yearsInterval[0] : this.props;
+    let {yearsBefore, yearsAfter} = this.props;
+    const pluginFunc = getPluginObjects('getDatePickerYearsRange');
+    if (pluginFunc.length && typeof pluginFunc[0] === 'function') {
+      const pluginData = pluginFunc[0](this.props);
+      yearsBefore =
+        pluginData.yearsBefore !== 'undefined' && pluginData.yearsBefore > 0
+          ? pluginData.yearsBefore
+          : yearsBefore;
+      yearsAfter =
+        pluginData.yearsAfter !== 'undefined' && pluginData.yearsAfter > 0
+          ? pluginData.yearsAfter
+          : yearsAfter;
+    }
     const filteredProps = Object.entries(this.props)
       .filter(([name]) => {
         return !PROP_BLACKLIST.has(name);

--- a/indico/web/client/js/react/components/dates/SingleDatePicker.jsx
+++ b/indico/web/client/js/react/components/dates/SingleDatePicker.jsx
@@ -13,6 +13,7 @@ import {SingleDatePicker as ReactDatesSinglePicker} from 'react-dates';
 
 import {FinalField} from 'indico/react/forms';
 import {serializeDate, toMoment} from 'indico/utils/date';
+import {getPluginObjects} from 'indico/utils/plugins';
 
 import {renderMonthElement, responsiveReactDates} from './util';
 
@@ -55,7 +56,9 @@ export default class SingleDatePicker extends React.Component {
 
   render() {
     const {focused} = this.state;
-    const {disabledDate, yearsBefore, yearsAfter} = this.props;
+    const {disabledDate} = this.props;
+    const yearsInterval = getPluginObjects('datePickerInterval');
+    const {yearsBefore, yearsAfter} = yearsInterval.length ? yearsInterval[0] : this.props;
     const filteredProps = Object.entries(this.props)
       .filter(([name]) => {
         return !PROP_BLACKLIST.has(name);

--- a/indico/web/client/js/react/components/dates/SingleDatePicker.jsx
+++ b/indico/web/client/js/react/components/dates/SingleDatePicker.jsx
@@ -61,14 +61,12 @@ export default class SingleDatePicker extends React.Component {
     const pluginFunc = getPluginObjects('getDatePickerYearsRange');
     if (pluginFunc.length && typeof pluginFunc[0] === 'function') {
       const pluginData = pluginFunc[0](this.props);
-      yearsBefore =
-        pluginData.yearsBefore !== 'undefined' && pluginData.yearsBefore > 0
-          ? pluginData.yearsBefore
-          : yearsBefore;
-      yearsAfter =
-        pluginData.yearsAfter !== 'undefined' && pluginData.yearsAfter > 0
-          ? pluginData.yearsAfter
-          : yearsAfter;
+      if (pluginData.yearsBefore !== undefined && pluginData.yearsBefore >= 0) {
+        yearsBefore = pluginData.yearsBefore;
+      }
+      if (pluginData.yearsAfter !== undefined && pluginData.yearsAfter >= 0) {
+        yearsAfter = pluginData.yearsAfter;
+      }
     }
     const filteredProps = Object.entries(this.props)
       .filter(([name]) => {


### PR DESCRIPTION
Request to change component SigngleDatePicker to get interval for years before/after from plugin's object,
as our users would like to have a bigger range when scrolling years of Date fields.