### PR TITLE
i18n: Correctly expand fields in 'format_skeleton'

### DIFF
--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user.txt
@@ -2,7 +2,7 @@ Dear Guinea,
 
 The conference room 1/2-3
 has been booked for Guinea Pig
-on Friday, 11/11/2022 from 13:37 to 14:37.
+on Fri, 11/11/2022 from 13:37 to 14:37.
 Reason: Testing
 
 If you end up not needing this room, please cancel the

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_key.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_key.txt
@@ -2,7 +2,7 @@ Dear Guinea,
 
 The conference room 1/2-3
 has been booked for Guinea Pig
-on Friday, 11/11/2022 from 13:37 to 14:37.
+on Fri, 11/11/2022 from 13:37 to 14:37.
 Reason: Testing
 
 If you end up not needing this room, please cancel the

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_pre.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_pre.txt
@@ -2,7 +2,7 @@ Dear Guinea,
 
 The conference room 1/2-3
 has been pre-booked for Guinea Pig
-on Friday, 11/11/2022 from 13:37 to 14:37.
+on Fri, 11/11/2022 from 13:37 to 14:37.
 Reason: Testing
 
 Note:

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_pre_key.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_pre_key.txt
@@ -2,7 +2,7 @@ Dear Guinea,
 
 The conference room 1/2-3
 has been pre-booked for Guinea Pig
-on Friday, 11/11/2022 from 13:37 to 14:37.
+on Fri, 11/11/2022 from 13:37 to 14:37.
 Reason: Testing
 
 How to find a key:

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat.txt
@@ -2,7 +2,7 @@ Dear Guinea,
 
 The conference room 1/2-3
 has been booked for Guinea Pig
-daily booking from Friday, 11/11/2022 to Monday, 21/11/2022 between 13:37 and 14:37.
+daily booking from Fri, 11/11/2022 to Mon, 21/11/2022 between 13:37 and 14:37.
 Reason: Testing
 
 If you end up not needing this room, please cancel the

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat_excluded_1.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat_excluded_1.txt
@@ -2,7 +2,7 @@ Dear Guinea,
 
 The conference room 1/2-3
 has been booked for Guinea Pig
-daily booking from Friday, 11/11/2022 to Monday, 21/11/2022 between 13:37 and 14:37.
+daily booking from Fri, 11/11/2022 to Mon, 21/11/2022 between 13:37 and 14:37.
 Reason: Testing
 (Note that there are 1 excluded days. For further info, check your reservation.)
 

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat_excluded_2.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat_excluded_2.txt
@@ -2,7 +2,7 @@ Dear Guinea,
 
 The conference room 1/2-3
 has been booked for Guinea Pig
-daily booking from Friday, 11/11/2022 to Monday, 21/11/2022 between 13:37 and 14:37.
+daily booking from Fri, 11/11/2022 to Mon, 21/11/2022 between 13:37 and 14:37.
 Reason: Testing
 (Note that there are 2 excluded days. For further info, check your reservation.)
 

--- a/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat_pre.txt
+++ b/indico/modules/rb/templates/emails/reservations/tests/creation_email_to_user_repeat_pre.txt
@@ -2,7 +2,7 @@ Dear Guinea,
 
 The conference room 1/2-3
 has been pre-booked for Guinea Pig
-daily booking from Friday, 11/11/2022 to Monday, 21/11/2022 between 13:37 and 14:37.
+daily booking from Fri, 11/11/2022 to Mon, 21/11/2022 between 13:37 and 14:37.
 Reason: Testing
 
 Note:

--- a/indico/util/date_time_test.py
+++ b/indico/util/date_time_test.py
@@ -10,7 +10,8 @@ from datetime import datetime, timedelta
 import pytest
 from pytz import timezone
 
-from indico.util.date_time import as_utc, format_human_timedelta, format_skeleton, iterdays, strftime_all_years
+from indico.util.date_time import (_adjust_skeleton, as_utc, format_human_timedelta, format_skeleton, iterdays,
+                                   strftime_all_years)
 
 
 @pytest.mark.parametrize(('delta', 'granularity', 'expected'), (
@@ -68,6 +69,16 @@ iterdays_test_data = (
                          iterdays_test_data)
 def test_iterdays(from_, to, skip_weekends, day_whitelist, day_blacklist, expected):
     assert len(list(iterdays(from_, to, skip_weekends, day_whitelist, day_blacklist))) == expected
+
+
+@pytest.mark.parametrize(('skeleton', 'format', 'expected'), (
+    ('MMM', 'M', 'M'),  # Cannot expand numeric fields to alphabetic ones
+    ('ss', 's', 's'),  # Hours, minutes and seconds should never be expanded
+    ('MMdd', 'Md', 'MMdd'),  # Expand numeric fields
+    ('MMMMdddd', 'MMMddd', 'MMMMdddd')  # Expand alphabetic fields
+))
+def test__adjust_skeleton_skeleton(skeleton, format, expected):
+    assert _adjust_skeleton(format, skeleton) == expected
 
 
 @pytest.mark.parametrize(('skeleton', 'expected'), (


### PR DESCRIPTION
Originally came up here: https://talk.getindico.io/t/japanese-ja-translation-group/542/18

The current behaviour of `_adjust_skeleton` produces incorrect date formatting for Japanese. This fixes the function to only perform allowed expansions.

More on this: https://cldr-smoke.unicode.org/spec/main/ldml/tr35-dates.html#Matching_Skeletons

Here's the effect this has on the meeting page (`event/XXX`):

| Locale | meeting page before  | meeting page after  |
|---|---|---|
| de    | Montag, 20. November          | Mo., 20. November    |
| en_CA | Monday, November 20           | Mon, November 20     |
| en_GB | Monday, 20 November           | Mon, 20 November     |
| en_US | Monday, November 20           | Mon, November 20     |
| es    | lunes, 20 de noviembre        | lun, 20 de noviembre |
| fr    | lundi 20 novembre             | lun. 20 novembre     |
| it    | lunedì 20 novembre            | lun 20 novembre      |
| pl    | poniedziałek, 20 listopada    | pon., 20 listopada   |
| pt_BR | segunda-feira, 20 de novembro | seg., 20 de novembro |
| tr    | 20 Kasım Pazartesi            | 20 Kasım Pzt         |
| cs    | pondělí 20. listopadu         | po 20. listopadu     |
| uk    | понеділок, 20 листопада       | пн, 20 листопада     |
| ja    | 11月月20日月曜日                | 11月20日月曜日         |

The week overview page (`category/XXX/overview?period=week`) doesn't change except for displaying correctly in Japanese
`11月月20日月曜日` -> `11月20日月曜日`

~~FWIW, more recent versions of CLDR do have a specific skeleton for `EEEEdMMMM` so we'll be able to get the full week day once babel updates.~~
