### PR TITLE
Disable l10n when formatting booking log entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Bugfixes
 - Fix validation error when using a ``mailto:`` link in an email body (:pr:`6286`)
 - Clear the flags indicating that registrations or a registration form field have been
   purged when cloning an event (:pr:`6288`)
+- Use English locale when formatting dates for room booking log entries (:pr:`6295`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/rb/models/reservations.py
+++ b/indico/modules/rb/models/reservations.py
@@ -31,7 +31,7 @@ from indico.modules.rb.notifications.reservations import (notify_cancellation, n
 from indico.modules.rb.util import format_weekdays, get_prebooking_collisions, rb_is_admin
 from indico.util.date_time import format_date, format_time, now_utc
 from indico.util.enum import IndicoIntEnum
-from indico.util.i18n import _
+from indico.util.i18n import _, force_locale
 from indico.util.string import format_repr
 from indico.web.flask.util import url_for
 
@@ -632,8 +632,9 @@ class Reservation(db.Model):
         for field, change in changes.items():
             field_title = field_names.get(field, field)
             converter = change['converter']
-            old = converter(change['old'])
-            new = converter(change['new'])
+            with force_locale(None):
+                old = converter(change['old'])
+                new = converter(change['new'])
             if not old:
                 log.append(f"The {field_title} was set to '{new}'")
             elif not new:


### PR DESCRIPTION
Most languages use a digits-only format so it wasn't really noticeable, but at least Turkish has some strings in there which looks really weird. And since those log entries are not localized, neither should be the dates embedded in them.

![image](https://github.com/indico/indico/assets/179599/a3a488ee-388b-4539-a005-c641237d3792)
