### PR TITLE
Allow plugin's input_type without prefix ext__

### DIFF
--- a/indico/modules/events/registration/client/js/form/fields/registry.js
+++ b/indico/modules/events/registration/client/js/form/fields/registry.js
@@ -201,8 +201,16 @@ export function getFieldRegistry() {
   const pluginFields = Object.fromEntries(
     getPluginObjects('regformCustomFields').map(({name, ...rest}) => [name, rest])
   );
-  if (Object.keys(pluginFields).some(x => !x.startsWith('ext__'))) {
-    throw new Error('Field names from plugins must begin with `ext__`');
+  if (
+    Object.entries(pluginFields).some(
+      ([name, data]) =>
+        !name.startsWith('ext__') && !(data.unsafeOverrideField && fieldRegistry[name])
+    )
+  ) {
+    throw new Error(
+      'Field names from plugins must begin with `ext__` or match an existing field name and set ' +
+        'the `unsafeOverrideField` property to true'
+    );
   }
   return {...fieldRegistry, ...pluginFields};
 }


### PR DESCRIPTION
Request this change to allow plugins to use custom input_type name without the prefix 'ext__' although the registration form custom field still be named 'ext__<name>'.
(without this change, the InputComponent for the custom field can't be found in FormItems)