### PR TITLE
Editing timeline email notifications - HTML to Markdown

### DIFF
--- a/indico/modules/events/editing/notifications.py
+++ b/indico/modules/events/editing/notifications.py
@@ -5,10 +5,9 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from html2text import HTML2Text
-
 from indico.core.notifications import make_email, send_email
 from indico.modules.events.editing.schemas import EditingConfirmationAction
+from indico.util.string import html_to_markdown
 from indico.web.flask.templating import get_template_module
 
 
@@ -27,8 +26,6 @@ def notify_comment(comment):
     editor = editable.editor
     submitter = next((r.user for r in editable.revisions[::-1] if r.is_submitter_revision), None)
     author = comment.user
-    ht = HTML2Text(bodywidth=0)
-    ht.pad_tables = True
     if comment.internal:
         # internal comments notify the editor and anyone who commented + can see internal comments
         recipients = _get_commenting_users(revision, check_internal_access=True) | {editor}
@@ -52,7 +49,7 @@ def notify_comment(comment):
                                       timeline_url=editable.external_timeline_url,
                                       recipient_name=recipient.first_name,
                                       contribution=editable.contribution,
-                                      text=ht.handle(comment.text))
+                                      text=html_to_markdown(comment.text))
             email = make_email(recipient.email, template=tpl)
         send_email(email, editable.event, 'Editing', log_metadata={'editable_id': editable.id})
 

--- a/indico/modules/events/editing/notifications.py
+++ b/indico/modules/events/editing/notifications.py
@@ -5,6 +5,8 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from html2text import HTML2Text
+
 from indico.core.notifications import make_email, send_email
 from indico.modules.events.editing.schemas import EditingConfirmationAction
 from indico.web.flask.templating import get_template_module
@@ -25,6 +27,8 @@ def notify_comment(comment):
     editor = editable.editor
     submitter = next((r.user for r in editable.revisions[::-1] if r.is_submitter_revision), None)
     author = comment.user
+    ht = HTML2Text(bodywidth=0)
+    ht.pad_tables = True
     if comment.internal:
         # internal comments notify the editor and anyone who commented + can see internal comments
         recipients = _get_commenting_users(revision, check_internal_access=True) | {editor}
@@ -48,7 +52,7 @@ def notify_comment(comment):
                                       timeline_url=editable.external_timeline_url,
                                       recipient_name=recipient.first_name,
                                       contribution=editable.contribution,
-                                      text=comment.text)
+                                      text=ht.handle(comment.text))
             email = make_email(recipient.email, template=tpl)
         send_email(email, editable.event, 'Editing', log_metadata={'editable_id': editable.id})
 

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -281,6 +281,18 @@ def render_markdown(text, escape_latex_math=True, md=None, extra_html=False, **k
         return result
 
 
+def html_to_markdown(html):
+    """Convert basic HTML to Markdown.
+
+    This util is meant for cases like comments where the text is generally written
+    in Markdown, but can also contain basic HTML tags, and needs to be used in a
+    plaintext context (e.g. text/plain email notification).
+    """
+    ht = HTML2Text(bodywidth=0)
+    ht.pad_tables = True
+    return ht.handle(html)
+
+
 def sanitize_for_platypus(text):
     """Sanitize HTML to be used in platypus."""
     from indico.core.config import config


### PR DESCRIPTION
Convert HTML comments made on the editing timeline to markdown when sending email notifications