### PR TITLE
Move print badge default fieldsets to BadgeSettingsForm

### DIFF
--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -454,6 +454,11 @@ class CreateMultipleRegistrationsForm(IndicoForm):
 
 
 class BadgeSettingsForm(IndicoForm):
+    _fieldsets = (
+        (None, ('template',)),
+        (_('Page configuration'), ('save_values', 'dashed_border', 'page_size', 'page_orientation', 'page_layout'))
+    )
+
     template = SelectField(_('Template'))
     save_values = BooleanField(_('Save values for next time'), widget=SwitchWidget(),
                                description=_('Save these values in the event settings'))

--- a/indico/modules/events/registration/templates/management/_print_badge_settings_form.html
+++ b/indico/modules/events/registration/templates/management/_print_badge_settings_form.html
@@ -1,15 +1,9 @@
 {% from 'forms/_form.html' import simple_form, form_fieldset, form_rows, form_row %}
 
-{% macro render_badge_print_settings_form(form, submit=_('Download PDF'), fields=none, templates=none, registrations=()) %}
-    {% if not fields %}
-        {% set fields = (
-            (none, ['template']),
-            (_('Page configuration'), ['save_values', 'dashed_border', 'page_size', 'page_orientation', 'page_layout'])
-        ) %}
-    {% endif %}
+{% macro render_badge_print_settings_form(form, submit=_('Download PDF'), templates=none, registrations=()) %}
     {% call simple_form(form, form_header_kwargs={'id': 'badge-settings-form'}, back=_('Cancel'),
                         submit=submit, disabled_until_change=false, disable_if_locked=false) %}
-        {% for legend, fieldset in fields %}
+        {% for legend, fieldset in form._fieldsets %}
             {% call form_fieldset(legend, render_as_fieldset=(legend is not none)) %}
                 {{ form_rows(form, fields=fieldset) }}
             {% endcall %}


### PR DESCRIPTION
This PR is further improvement on print badge form's fields moving the default set from the template macro to `BadgeSettingsForm`.
Please note that I renamed the `fields` parameter in `render_badge_print_settings_form` to `fieldsets` to be more expressive. Do you think that is safe?
