### PR TITLE
Add FAVICON_URL config option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Improvements
   :user:`Moliholy, unconventionaldotdev`)
 - Support including a picture (from a registration's picture field) in the conference
   participant list (:pr:`6228`, thanks :user:`vtran99`)
+- Add :data:`FAVICON_URL` config option to set a custom URL for the favicon (:pr:`6323`,
+  thanks :user:`SegiNyn`)
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -309,6 +309,13 @@ Customization
 
     Default: ``'https://learn.getindico.io'``
 
+.. data:: FAVICON_URL
+
+    The URL to a custom favicon.  If unset, the default monochrome Indico favicon is
+    used.
+
+    Default: ``None``
+
 .. data:: LOGO_URL
 
     The URL to a custom logo.  If unset, the default monochrome Indico logo is

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -54,6 +54,7 @@ DEFAULTS = {
     'EXTERNAL_REGISTRATION_URL': None,
     'HELP_URL': 'https://learn.getindico.io',
     'FAILED_LOGIN_RATE_LIMIT': '5 per 15 minutes; 10 per day',
+    'FAVICON_URL': None,
     'IDENTITY_PROVIDERS': {},
     'LOCAL_IDENTITIES': True,
     'LOCAL_MODERATION': False,

--- a/indico/web/assets/blueprint.py
+++ b/indico/web/assets/blueprint.py
@@ -124,7 +124,7 @@ def static_custom(folder, filename):
 
 @assets_blueprint.route('!/favicon.ico')
 def favicon():
-    return redirect(url_for('.image', filename='indico.ico'))
+    return redirect(config.FAVICON_URL or url_for('.image', filename='indico.ico'))
 
 
 @assets_blueprint.route('/avatar/<name>.svg')

--- a/indico/web/templates/base.html
+++ b/indico/web/templates/base.html
@@ -5,7 +5,8 @@
     <title>Indico{% if self.title() %} - {% endif %}{% block title %}{% endblock %}</title>
     <meta charset="UTF-8">
     <meta name="csrf-token" id="csrf-token" content="{{ session.csrf_token }}">
-    <link rel="shortcut icon" type="image/x-icon" href="{{ indico_config.IMAGES_BASE_URL }}/indico.ico">
+    {%- set favicon_url = indico_config.FAVICON_URL or (indico_config.IMAGES_BASE_URL + '/indico.ico') %}
+    <link rel="shortcut icon" type="image/x-icon" href="{{ favicon_url }}">
 
     <script type="text/javascript" src="{{ url_for('assets.i18n_locale', locale_name=current_locale) }}"></script>
     <script type="text/javascript" src="{{ url_for('assets.i18n_locale_react', locale_name=current_locale) }}"></script>

--- a/indico/web/templates/indico_base.html
+++ b/indico/web/templates/indico_base.html
@@ -15,7 +15,8 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="csrf-token" id="csrf-token" content="{{ session.csrf_token }}">
-    <link rel="shortcut icon" type="image/x-icon" href="{{ indico_config.IMAGES_BASE_URL }}/indico.ico">
+    {%- set favicon_url = indico_config.FAVICON_URL or (indico_config.IMAGES_BASE_URL + '/indico.ico') %}
+    <link rel="shortcut icon" type="image/x-icon" href="{{ favicon_url }}">
 
     {% include 'meta.html' %}
 


### PR DESCRIPTION
This will allow plugins to be able to set FAVICON_URL config to change the logo which appears on the left of the address bar. 
