### PR TITLE
Fix action buttons not being visible in survey designer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Bugfixes
   maximum number of events to include is reached (:pr:`6312`)
 - Fix an error in the Check-in app API wben retrieving details for a registration form
   that includes static labels (:pr:`6326`)
+- Fix action buttons being pushed outside the content area in the survey editor in case
+  of very long survey option titles (:pr:`6325`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/modules/_event_management.scss
+++ b/indico/web/client/styles/modules/_event_management.scss
@@ -670,6 +670,10 @@ form.horizontal .clone-event-dialog-content {
   }
 }
 
+.clone-event-dialog-content #form-group-selected_items .form-field {
+  width: 100%;
+}
+
 .clone-event-dialog-content ul.steps {
   margin-bottom: 30px;
 }

--- a/indico/web/client/styles/partials/_inputs.scss
+++ b/indico/web/client/styles/partials/_inputs.scss
@@ -346,7 +346,7 @@ $dropdown-transition: $dropdown-transition-step ease-out;
   }
 
   span.checkbox-label {
-    white-space: nowrap;
+    display: flex;
   }
 }
 


### PR DESCRIPTION
This only affects the checkbox group widget. Previously, it had a 'whitespace: nowrap' set which pushed the actions outside of the visible area.

Currently:
![image](https://github.com/indico/indico/assets/8739637/38195419-7e76-4f09-91c8-e58463144fa1)


After:
![image](https://github.com/indico/indico/assets/8739637/8e43b4f1-bbf9-43d0-8f3e-fdfde474d4ea)

The same checkbox widget is also used for cloning, this what it looks like with the change applied:
![image](https://github.com/indico/indico/assets/8739637/46022cf8-a6ee-4648-9464-cb56e4c383eb)

I went with center alignment because that's already used for the single choice widget:
![image](https://github.com/indico/indico/assets/8739637/0e48e953-4493-4a6b-b138-5d207d8c350b)


