### PR TITLE
Do not include labels in registration details

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Bugfixes
 
 - Fix the dashboard iCal export returning old events instead of recent ones when the
   maximum number of events to include is reached (:pr:`6312`)
+- Fix an error when using the Checkin API to get registration details for a registration
+  that includes labels (:pr:`6326`) 
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,8 +21,8 @@ Bugfixes
 
 - Fix the dashboard iCal export returning old events instead of recent ones when the
   maximum number of events to include is reached (:pr:`6312`)
-- Fix an error when using the Checkin API to get registration details for a registration
-  that includes labels (:pr:`6326`) 
+- Fix an error in the Check-in app API wben retrieving details for a registration form
+  that includes static labels (:pr:`6326`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/schemas.py
+++ b/indico/modules/events/registration/schemas.py
@@ -105,6 +105,10 @@ class CheckinRegistrationSchema(mm.SQLAlchemyAutoSchema):
             }
 
         for field in fields:
+            if field['inputType'] == 'label':
+                # Do not include labels in the response
+                continue
+
             section = data[field['sectionId']]
             field_data = {
                 'id': field['id'],


### PR DESCRIPTION
This fixes a bug where we were trying to access `htmlName` and `defaultValue` which do not exist on a label (only on regular regform fields).
