### PR TITLE
Use abstract default roles in contrib persons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ Improvements
 - Add a new event management permission that grants access only to the contributions
   module (:pr:`6348`)
 - Add bulk JSON export option in management contribution list (:pr:`6370`)
+- Make the default roles of the contribution person link list field more similar to the
+  abstract person link list field when there is a linked abstract (:pr:`6342`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/fields.py
+++ b/indico/modules/events/contributions/fields.py
@@ -24,13 +24,14 @@ class ContributionPersonLinkListField(PersonLinkListFieldBase):
 
     @property
     def roles(self):
-        roles = [{'name': 'speaker', 'label': _('Speaker'), 'icon': 'microphone', 'default': True}]
+        roles = [{'name': 'speaker', 'label': _('Speaker'), 'icon': 'microphone', 'default': self.default_is_speaker}]
         if self.allow_submitters:
             roles.append({'name': 'submitter', 'label': _('Submitter'), 'icon': 'paperclip',
                           'default': self.default_is_submitter})
         if self.allow_authors:
             roles += [
-                {'name': 'primary', 'label': _('Author'), 'plural': _('Authors'), 'section': True},
+                {'name': 'primary', 'label': _('Author'), 'plural': _('Authors'), 'section': True,
+                 'default': self.default_is_author},
                 {'name': 'secondary', 'label': _('Co-author'), 'plural': _('Co-authors'), 'section': True},
             ]
         return roles
@@ -38,6 +39,8 @@ class ContributionPersonLinkListField(PersonLinkListFieldBase):
     def __init__(self, *args, **kwargs):
         self.allow_authors = kwargs.pop('allow_authors', kwargs['_form'].event.type == 'conference')
         self.allow_submitters = kwargs.pop('allow_submitters', True)
+        self.default_is_author = kwargs.pop('default_is_author', False)
+        self.default_is_speaker = kwargs.pop('default_is_speaker', True)
         self.default_is_submitter = kwargs.pop('default_is_submitter', True)
         self.empty_message = _('There are no authors')
         super().__init__(*args, **kwargs)

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -69,6 +69,11 @@ class ContributionForm(IndicoForm):
         self.type.query = self.event.contribution_types
         if self.event.type != 'conference':
             self.person_link_data.label.text = _('Speakers')
+        # if there is a linked abstract, we use the same defaults as the AbstractPersonLinkListField
+        elif self.contrib and self.contrib.abstract:
+            self.person_link_data.default_is_author = True
+            self.person_link_data.default_is_speaker = False
+            self.person_link_data.default_is_submitter = False
         if not self.type.query.count():
             del self.type
         if not to_schedule and (self.contrib is None or not self.contrib.is_scheduled):


### PR DESCRIPTION
Currently, when adding people to contributions, they are attributed the "speaker" and "submitter" roles, but no author roles. Most people then save without realizing that they need to set the proper roles. WIth no default roles, the field validation will fail, making it obvious to the users that they need to set them.

This will also make the behavior of the field more similar to CfA.
