### PR TITLE
Show "go to timeline" button for anyone with access

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,8 +19,8 @@ Improvements
   thanks :user:`SegiNyn`)
 - Allow filtering the contribution list in the management area by custom fields
   (:issue:`6213`, :pr:`6214`)
-- Show "go to timeline" button in the contribution page to everyone who can see the its
-  editables' timelines (:pr:`6344`)
+- Show "Go to timeline" button on the contribution page to everyone who can see the
+  timeline of one of its editables instead of just submitters (:pr:`6344`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Improvements
   thanks :user:`SegiNyn`)
 - Allow filtering the contribution list in the management area by custom fields
   (:issue:`6213`, :pr:`6214`)
+- Show "go to timeline" button in the contribution page to everyone who can see the its
+  editables' timelines (:pr:`6344`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/models/contributions.py
+++ b/indico/modules/events/contributions/models/contributions.py
@@ -529,6 +529,11 @@ class Contribution(SearchableTitleMixin, SearchableDescriptionMixin, ProtectionM
     def has_published_editables(self):
         return any(e.published_revision_id is not None for e in self.enabled_editables)
 
+    def can_see_any_editables(self, user):
+        if not user:
+            return False
+        return any(e.can_see_timeline(user) for e in self.enabled_editables)
+
     @property
     def slug(self):
         return slugify(self.friendly_id, self.title, maxlen=30)

--- a/indico/modules/events/papers/templates/_contributions.html
+++ b/indico/modules/events/papers/templates/_contributions.html
@@ -41,17 +41,11 @@
 {% endmacro %}
 
 {% macro render_editables_section(contribution) %}
-    {% set ns = namespace(can_see_timeline=false) %}
     {% set can_create_editable = contribution.allowed_types_for_editable|length > 0 %}
     {% set can_submit = contribution.can_submit_proceedings(session.user) %}
     {% set enabled_editables = contribution.enabled_editables %}
     {% set has_enabled_types = enabled_editables|length > 0 %}
-    {% for editable in enabled_editables %}
-        {% if editable.can_see_timeline(session.user) %}
-            {% set ns.can_see_timeline = true %}
-        {% endif %}
-    {% endfor %}
-    {% set can_see_timeline = ns.can_see_timeline %}
+    {% set can_see_timeline = contribution.can_see_any_editables(session.user) %}
     {% set show_submit_btn = can_submit and can_create_editable %}
     {% set show_goto_timeline = (can_submit or can_see_timeline) and has_enabled_types %}
 

--- a/indico/modules/events/papers/templates/_contributions.html
+++ b/indico/modules/events/papers/templates/_contributions.html
@@ -41,35 +41,46 @@
 {% endmacro %}
 
 {% macro render_editables_section(contribution) %}
+    {% set ns = namespace(can_see_timeline=false) %}
     {% set can_create_editable = contribution.allowed_types_for_editable|length > 0 %}
     {% set can_submit = contribution.can_submit_proceedings(session.user) %}
     {% set enabled_editables = contribution.enabled_editables %}
     {% set has_enabled_types = enabled_editables|length > 0 %}
+    {% for editable in enabled_editables %}
+        {% if editable.can_see_timeline(session.user) %}
+            {% set ns.can_see_timeline = true %}
+        {% endif %}
+    {% endfor %}
+    {% set can_see_timeline = ns.can_see_timeline %}
+    {% set show_submit_btn = can_submit and can_create_editable %}
+    {% set show_goto_timeline = (can_submit or can_see_timeline) and has_enabled_types %}
 
-    {% if can_submit and (has_enabled_types or can_create_editable) %}
+    {% if show_submit_btn or show_goto_timeline %}
         <section>
             <div class="header">
                 <div class="header-row">
                     <h2>{% trans %}Editing{% endtrans %}</h2>
                 </div>
             </div>
-            {% if has_enabled_types %}
+            {% if show_goto_timeline %}
                 <div class="action-box">
                     {% for editable in enabled_editables -%}
-                        <div class="section f-j-space-between">
-                            <div class="i-tag {{ editable.state.css_class }}">
-                                {{ editable.type.title }}: {{ editable.state.title }}
+                        {% if editable.can_see_timeline(session.user) %}
+                            <div class="section f-j-space-between">
+                                <div class="i-tag {{ editable.state.css_class }}">
+                                    {{ editable.type.title }}: {{ editable.state.title }}
+                                </div>
+                                <div>
+                                    <a href="{{ url_for('event_editing.editable', editable) }}">
+                                        {%- trans %}Go to timeline{% endtrans -%}
+                                    </a>
+                                </div>
                             </div>
-                            <div>
-                                <a href="{{ url_for('event_editing.editable', editable) }}">
-                                    {%- trans %}Go to timeline{% endtrans -%}
-                                </a>
-                            </div>
-                        </div>
+                        {% endif %}
                     {%- endfor %}
                 </div>
             {% endif %}
-            {% if can_create_editable %}
+            {% if show_submit_btn %}
                 <div class="action-box highlight" style="margin-top: 10px;">
                     <div class="section flexrow">
                         <div class="icon icon-file"></div>


### PR DESCRIPTION
TBD
Currently only the contribution's submitters can see the "go to timeline" button on their contribution page. This PR makes it so anyone who has an editable's `can_see_timeline` permission also gets the "go to timeline" button, for added convenience.
![image](https://github.com/indico/indico/assets/27357203/3a546936-19b2-4c86-9717-4cfaf858c1be)
