### PR TITLE
Reword internal comment toggle label

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -59,7 +59,9 @@ export default function CommentForm({onSubmit, onToggleExpand, initialValues, ex
               <>
                 {canCreateInternalComments && (
                   <FinalCheckbox
-                    label={Translate.string('Hide this comment from the submitter')}
+                    label={Translate.string(
+                      'Restrict visibility of this comment to other editors only'
+                    )}
                     name="internal"
                     toggle
                   />

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -59,7 +59,7 @@ export default function CommentForm({onSubmit, onToggleExpand, initialValues, ex
               <>
                 {canCreateInternalComments && (
                   <FinalCheckbox
-                    label={Translate.string('Restrict visibility of this comment to other editors')}
+                    label={Translate.string('Hide this comment from the submitter')}
                     name="internal"
                     toggle
                   />

--- a/indico/modules/events/editing/client/js/management/editable_type/CommentButton.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/CommentButton.jsx
@@ -58,7 +58,7 @@ function CommentModal({onSubmit, onClose}) {
         required
       />
       <FinalCheckbox
-        label={Translate.string('Restrict visibility of this comment to other editors')}
+        label={Translate.string('Hide this comment from the submitter')}
         name="internal"
         toggle
       />

--- a/indico/modules/events/editing/client/js/management/editable_type/CommentButton.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/CommentButton.jsx
@@ -58,7 +58,7 @@ function CommentModal({onSubmit, onClose}) {
         required
       />
       <FinalCheckbox
-        label={Translate.string('Hide this comment from the submitter')}
+        label={Translate.string('Restrict visibility of this comment to other editors only')}
         name="internal"
         toggle
       />


### PR DESCRIPTION
TBD
Suggestion from a native english speaker, who got confused if "Restrict visibility of this comment to other editors" meant that other editors couldn't see it.
We converged on "Hide this comment from the submitter", but an alternative could be "Restrict visibility of this comment to other editors **only**"
![image](https://github.com/indico/indico/assets/27357203/ca082595-6042-4b5e-949d-b8642e38088e)
