### PR TITLE
Make avatar_url unguessable

### DIFF
--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -11,6 +11,7 @@ from operator import attrgetter
 
 from dateutil.relativedelta import relativedelta
 from flask import flash, jsonify, redirect, render_template, request, session
+from itsdangerous import BadSignature
 from markupsafe import Markup, escape
 from marshmallow import fields
 from marshmallow_enum import EnumField
@@ -57,6 +58,7 @@ from indico.util.i18n import _, force_locale
 from indico.util.images import square
 from indico.util.marshmallow import HumanizedDate, Principal, validate_with_message
 from indico.util.signals import values_from_signal
+from indico.util.signing import static_secure_serializer
 from indico.util.string import make_unique_token, remove_accents
 from indico.web.args import use_args, use_kwargs
 from indico.web.flask.templating import get_template_module
@@ -353,6 +355,12 @@ class RHProfilePictureDisplay(RH):
 
     def _process_args(self):
         self.user = User.get_or_404(request.view_args['user_id'])
+        try:
+            if (self.user.id !=
+                    static_secure_serializer.loads(request.view_args['slug'], salt='user_profile_picture_display')):
+                raise NotFound
+        except BadSignature:
+            raise NotFound
 
     def _process(self):
         return send_avatar(self.user)

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -35,6 +35,7 @@ from indico.util.date_time import now_utc
 from indico.util.enum import RichIntEnum
 from indico.util.i18n import _, force_locale
 from indico.util.locators import locator_property
+from indico.util.signing import static_secure_serializer
 from indico.util.string import format_full_name, format_repr, validate_email
 from indico.web.flask.util import url_for
 
@@ -596,7 +597,7 @@ class User(PersonMixin, db.Model):
             return url_for('assets.image', filename='robot.svg')
         elif self.id is None:
             return get_avatar_url_from_name(self.first_name)
-        slug = self.picture_metadata['hash'] if self.picture_metadata else 'default'
+        slug = static_secure_serializer.dumps(self.id, salt='user_profile_picture_display')
         return url_for('users.user_profile_picture_display', self, slug=slug)
 
     def __contains__(self, user):

--- a/indico/util/signing.py
+++ b/indico/util/signing.py
@@ -6,7 +6,7 @@
 # LICENSE file for more details.
 
 from flask import current_app
-from itsdangerous import URLSafeTimedSerializer
+from itsdangerous import URLSafeSerializer, URLSafeTimedSerializer
 from werkzeug.local import LocalProxy
 
 
@@ -15,3 +15,8 @@ from werkzeug.local import LocalProxy
 #: email.
 #: :type: :class:`~itsdangerous.URLSafeTimedSerializer`
 secure_serializer = LocalProxy(lambda: URLSafeTimedSerializer(current_app.config['SECRET_KEY'], b'indico'))
+
+#: An *itsdangerous*-based serializer that can be used to pass small
+#: amounts of data through url.
+#: :type: :class:`~itsdangerous.URLSafeSerializer`
+static_secure_serializer = LocalProxy(lambda: URLSafeSerializer(current_app.config['SECRET_KEY'], b'indico'))


### PR DESCRIPTION
Request to modify avatar_url to make it unguessable as with the current '/user/<id>/picture-default'
it's too easy for anyone to access other user's profile picture by changing randomly <id> number.

Notes:
This change breaks the tests on users as dataset used contain static value of 'avatar_url' which can't be set with the change.
What I can do is:
- either remove avatar_url from the tests;
- either set a fake value inside the test to match the value in the dataset;
- other suggestion ?  