### PR TITLE
Only allow accessing avatars of published registrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Bugfixes
   that includes static labels (:pr:`6326`)
 - Fix action buttons being pushed outside the content area in the survey editor in case
   of very long survey option titles (:pr:`6325`)
+- Only allow accessing avatars for published registrations (:pr:`6347`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -526,6 +526,12 @@ class RHRegistrationAvatar(RHDisplayEventBase):
                                                                    'picture_source', 'picture_metadata', 'picture'))
                              .one())
 
+    def _check_access(self):
+        RHDisplayEventBase._check_access(self)
+        is_participant = self.registration.event.is_user_registered(session.user)
+        if not self.registration.is_publishable(is_participant):
+            raise Forbidden('Participant is not published')
+
     def _process(self):
         if self.registration.user:
             return send_avatar(self.registration.user)


### PR DESCRIPTION
The registration avatar is either the initial of the registrant's name (single character, so not sensitive) or the avatar of the linked Indico user (also not really sensitive since avatars should usually be considered public anyway).

It still makes no sense to serve the avatar in cases where the user has access to the event but the participant is not published in the event's participant list.