### PR TITLE
Fix reset editable on Needs Submitter Changes

### DIFF
--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -278,6 +278,8 @@ def reset_editable(revision):
     was_published = editable.published_revision is not None
     editable.published_revision = None
     db.session.flush()
+    if editable.valid_revisions[-2].type == RevisionType.needs_submitter_confirmation:
+        editable.valid_revisions[-2].is_undone = True
     revision.is_undone = True
     new_revision = EditingRevision(user=editable.editor, type=RevisionType.reset)
     editable.revisions.append(new_revision)


### PR DESCRIPTION
This PR fixes a bug in which the reset editable doesn't revert to the correct state when there is a Needs Submitter Changes revision before the last one.

Note: to be closed once #6364 is merged