### PR TITLE
Sort Get Next Editable search results

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Bugfixes
   of very long survey option titles (:pr:`6325`)
 - Only allow accessing avatars for published registrations (:pr:`6347`)
 - Fix error when trying to import data from an unlisted event (:issue:`6350`, :pr:`6351`)
+- Show results from the Get Next Editable search on top of the list (:pr:`6353`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -163,7 +163,14 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
 
   const filteredEditables = useMemo(
     () =>
-      editables?.map(e => ({...e, canAssignSelf: filteredSet.has(e.id) ? e.canAssignSelf : false})),
+      _.orderBy(
+        editables?.map(e => ({
+          ...e,
+          canAssignSelf: filteredSet.has(e.id) ? e.canAssignSelf : false,
+        })) || [],
+        'canAssignSelf',
+        'desc'
+      ),
     [editables, filteredSet]
   );
 


### PR DESCRIPTION
This PR fixes a bug in which the Get Next Editable search results weren't being pushed to the top, and instead being scattered along the list.