### PR TITLE
Improve editing timeline UI

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/FileDisplay.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/FileDisplay.module.scss
@@ -10,6 +10,13 @@
 .file-display-wrapper {
   display: flex;
   flex-direction: column;
+
+  &.outdated {
+    padding: 0.5em;
+    background-image: repeating-linear-gradient(-45deg, $pastel-gray 0 2px, $white 3px 15px);
+    border: 1px solid $pastel-gray;
+    border-radius: 0.2em;
+  }
 }
 
 .file-display {

--- a/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/index.jsx
@@ -11,8 +11,10 @@ import {Button, Icon, Label, Popup} from 'semantic-ui-react';
 
 import {TooltipIfTruncated} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
+import {toClasses} from 'indico/react/util';
 
 import {fileTypePropTypes, filePropTypes, mapFileTypes} from '../FileManager/util';
+
 import './FileDisplay.module.scss';
 
 function FileListDisplay({files}) {
@@ -74,9 +76,14 @@ FileTypeDisplay.propTypes = {
   fileType: PropTypes.shape(fileTypePropTypes).isRequired,
 };
 
-export default function FileDisplay({downloadURL, fileTypes, files, tags}) {
+export default function FileDisplay({downloadURL, fileTypes, files, tags, outdated}) {
   return (
-    <div styleName="file-display-wrapper">
+    <div
+      styleName={toClasses({
+        'file-display-wrapper': true,
+        'outdated': outdated && files.length > 0,
+      })}
+    >
       {files.length !== 0 && (
         <div styleName="file-display">
           {mapFileTypes(fileTypes, files).map(fileType => (
@@ -122,4 +129,9 @@ FileDisplay.propTypes = {
       verboseTitle: PropTypes.string.isRequired,
     })
   ).isRequired,
+  outdated: PropTypes.bool,
+};
+
+FileDisplay.defaultProps = {
+  outdated: false,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineItem.jsx
@@ -43,13 +43,14 @@ export default function TimelineItem({block, index}) {
   const {fileTypes} = useSelector(selectors.getStaticData);
   const isLastBlock = lastTimelineBlock.id === block.id;
   const isLastValidBlock = lastValidTimelineBlock.id === block.id;
+  const isLastTimelineBlockWithFiles = lastTimelineBlockWithFiles.id === block.id;
   const canEdit = isLastValidBlock && canEditLastRevision;
   const hasContent =
     block.commentHtml ||
     !!block.files.length ||
     !!block.tags.length ||
     !!block.customActions.length;
-  const isAlwaysVisible = isLastValidBlock || lastTimelineBlockWithFiles.id === block.id;
+  const isAlwaysVisible = isLastValidBlock || isLastTimelineBlockWithFiles;
   const [visibilityToggle, setVisibilityToggle] = useState(false);
   const visible = visibilityToggle || isAlwaysVisible;
   const user = block.type.name === RevisionType.replacement ? INDICO_BOT_USER : block.user;
@@ -124,6 +125,7 @@ export default function TimelineItem({block, index}) {
                   files={block.files}
                   downloadURL={block.downloadFilesURL}
                   tags={block.tags}
+                  outdated={!isLastTimelineBlockWithFiles}
                 />
                 {canPerformSubmitterActions && needsSubmitterConfirmation && isLastValidBlock && (
                   <ChangesConfirmation />

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/TagInput.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/TagInput.jsx
@@ -30,7 +30,6 @@ function TagInput({onChange, value, placeholder, options}) {
     <Dropdown
       placeholder={placeholder}
       styleName="tag-input"
-      upward={false}
       fluid
       multiple
       search

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/TagInput.module.scss
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/TagInput.module.scss
@@ -5,6 +5,10 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-.tag-input {
+.tag-input:global(.ui.dropdown) {
   margin-bottom: 1em;
+
+  :global(.visible.menu.transition) {
+    max-height: 50vh;
+  }
 }


### PR DESCRIPTION
This PR contains two improvements to the Editing Timeline's UI.
- Grey out filebox when the files are outdated (superseded by a different revision): ![image](https://github.com/indico/indico/assets/27357203/47973eb7-bb28-44ea-b106-95cc937af547)
- Increase the size of the revision tag dropdown menu
![image](https://github.com/indico/indico/assets/27357203/ed4374bb-e72f-45fd-b23f-2a6a82695b7e)
