### PR TITLE
Add clickable event link to registration emails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Improvements
   timeline of one of its editables instead of just submitters (:pr:`6344`)
 - Add a new "Timetable Sessions" registration form field type which allows selecting
   session blocks from the event (:pr:`6184`, thanks :user:`jbtwist`)
+- Link the event title to the event in registration emails (:pr:`6358`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_creation_to_registrant.html
@@ -9,8 +9,10 @@
     {% set event = registration.registration_form.event %}
     <p>{% trans name=registration.full_name %}Dear {{ name }},{% endtrans %}</p>
     <p>
+        {%- set strong %}<a href="{{ event.external_url }}"><strong>{% endset -%}
+        {%- set endstrong %}</a></strong>{% endset -%}
         {% block registration_header_text %}
-            {% trans title=event.title, strong='<strong>'|safe, endstrong='</strong>'|safe, at_time=render_registration_info() -%}
+            {% trans title=event.title, at_time=render_registration_info() -%}
                 Thank you! Your registration for the event {{ strong }}{{ title }}{{ endstrong }} {{ at_time }}
                 has been received.
             {%- endtrans %}

--- a/indico/modules/events/registration/templates/emails/registration_modification_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_modification_to_registrant.html
@@ -5,7 +5,9 @@
 {%- endblock %}
 
 {% block registration_header_text -%}
-    {% trans title=event.title, strong='<strong>'|safe, endstrong='</strong>'|safe, at_time=render_registration_info() -%}
+    {%- set strong %}<a href="{{ event.external_url }}"><strong>{% endset -%}
+    {%- set endstrong %}</a></strong>{% endset -%}
+    {% trans title=event.title, at_time=render_registration_info() -%}
         Your registration for the event {{ strong }}{{ title }}{{ endstrong }}{{ at_time }} has been modified.
     {%- endtrans %}
     {{ render_text_pending() }}

--- a/indico/modules/events/registration/templates/emails/registration_receipt_created_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_receipt_created_to_registrant.html
@@ -6,8 +6,10 @@
 {%- endblock %}
 
 {% block registration_header_text -%}
+    {%- set strong %}<a href="{{ event.external_url }}"><strong>{% endset -%}
+    {%- set endstrong %}</a></strong>{% endset -%}
     {% if receipt.is_published -%}
-        {% trans title=event.title, strong='<strong>'|safe, endstrong='</strong>'|safe, at_time=render_registration_info() -%}
+        {% trans title=event.title, at_time=render_registration_info() -%}
             A document regarding your registration for the event {{ strong }}{{ title }}{{ endstrong }} {{ at_time }}
             has been made available to you:
         {%- endtrans %}
@@ -17,7 +19,7 @@
             </li>
         </ul>
     {%- else -%}
-        {% trans title=event.title, strong='<strong>'|safe, endstrong='</strong>'|safe, at_time=render_registration_info() -%}
+        {% trans title=event.title, at_time=render_registration_info() -%}
             A document regarding your registration for the event {{ strong }}{{ title }}{{ endstrong }} {{ at_time }}
             has been made available to you and sent to you as an attachment.
         {%- endtrans %}

--- a/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
+++ b/indico/modules/events/registration/templates/emails/registration_state_update_to_registrant.html
@@ -16,29 +16,31 @@
 {%- endblock %}
 
 {% block registration_header_text -%}
+    {%- set link %}<a href="{{ event.external_url }}"><strong>{% endset -%}
+    {%- set endlink %}</a></strong>{% endset -%}
     {% if registration.state.name == 'complete' -%}
         {% trans title=event.title, strong='<strong>'|safe, endstrong='</strong>'|safe, at_time=render_registration_info() -%}
-            Your registration for the event {{ strong }}{{ title }}{{ endstrong }} {{ at_time }}
+            Your registration for the event {{ link }}{{ title }}{{ endlink }} {{ at_time }}
             is now {{ strong }}complete{{ endstrong }}.
         {%- endtrans %}
     {%- elif registration.state.name == 'pending' -%}
         {% trans title=event.title, strong='<strong>'|safe, endstrong='</strong>'|safe, at_time=render_registration_info() -%}
-            Your registration for the event {{ strong }}{{ title }}{{ endstrong }} {{ at_time }}
+            Your registration for the event {{ link }}{{ title }}{{ endlink }} {{ at_time }}
             is now {{ strong }}pending{{ endstrong }}.
         {%- endtrans %}
     {%- elif registration.state.name == 'rejected' -%}
         {% trans title=event.title, strong='<strong>'|safe, endstrong='</strong>'|safe, at_time=render_registration_info() -%}
-            Your registration for the event {{ strong }}{{ title }}{{ endstrong }} {{ at_time }}
+            Your registration for the event {{ link }}{{ title }}{{ endlink }} {{ at_time }}
             is now {{ strong }}rejected{{ endstrong }}.
         {%- endtrans %}
     {%- elif registration.state.name == 'withdrawn' -%}
         {% trans title=event.title, strong='<strong>'|safe, endstrong='</strong>'|safe, at_time=render_registration_info() -%}
-            Your registration for the event {{ strong }}{{ title }}{{ endstrong }} {{ at_time }}
+            Your registration for the event {{ link }}{{ title }}{{ endlink }} {{ at_time }}
             is now {{ strong }}withdrawn{{ endstrong }}.
         {%- endtrans %}
     {%- else -%}
         {% trans title=event.title, strong='<strong>'|safe, endstrong='</strong>'|safe, at_time=render_registration_info() -%}
-            Your registration for the event {{ strong }}{{ title }}{{ endstrong }} {{ at_time }}
+            Your registration for the event {{ link }}{{ title }}{{ endlink }} {{ at_time }}
             is now {{ strong }}unpaid{{ endstrong }}.
         {%- endtrans %}
     {%- endif %}


### PR DESCRIPTION
As noticed by @TimSmithCH - certain "great" email clients (Outlook) apparently don't use the ical description but rather the mail body when adding the event from the attached ical file to the calendar, and then there's only a (rather useless) "manage my registration" link instead of one pointing to the event itself.

And even without that bug it makes sense to have a link that goes directly to the event page in those emails.