### PR TITLE
Fix filter storage being shared between events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Bugfixes
 - Show results from the Get Next Editable search on top of the list (:pr:`6353`)
 - Attach registration pictures and display them inline when sending email notifications
   instead of just showing their filename (:pr:`6336`, thanks :user:`SegiNyn`)
+- Fix editable list filter storage being shared between different editable types and
+  events (:pr:`6359`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -604,7 +604,7 @@ function EditableListDisplay({
           )}
         </div>
         <ListFilter
-          name="editable-list-filter"
+          name={`${editableType}-list-filter-${eventId}`}
           list={filterableContribs || []}
           filterOptions={filterOptions}
           searchableId={e => e.searchableId}

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -200,7 +200,7 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
       <Modal.Content>
         <div styleName="filetype-list">
           <ListFilter
-            name="get-next-editable-filter"
+            name={`get-next-${editableType}-filter-${eventId}`}
             list={editables || []}
             filters={filters}
             filterOptions={filterOptions}


### PR DESCRIPTION
Fix bug introduced in #6192 in which the editable list filter storage is shared between editable types and events.