### PR TITLE
Change PictureField rotate btn color and load image before validation

### DIFF
--- a/indico/web/client/js/react/components/pictures/PictureCropper.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureCropper.jsx
@@ -49,7 +49,6 @@ export function PictureCropper({cropperRef, src, onCrop, backAction, minCropSize
             styleName="cropper-action-btn"
             icon
             float="left"
-            primary
             type="button"
             onClick={() => {
               if (cropperRef.current.cropper) {

--- a/indico/web/client/js/react/components/pictures/PictureCropper.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureCropper.jsx
@@ -47,29 +47,23 @@ export function PictureCropper({cropperRef, src, onCrop, backAction, minCropSize
         <Button.Group>
           <Button
             styleName="cropper-action-btn"
-            icon
-            float="left"
+            icon="sync"
             type="button"
+            content={Translate.string('Rotate')}
             onClick={() => {
               if (cropperRef.current.cropper) {
                 cropperRef.current.cropper.rotate(90);
               }
             }}
-          >
-            <Translate>Rotate</Translate>
-            <Icon name="sync" />
-          </Button>
+          />
           <Button
             type="button"
-            float="left"
             styleName="cropper-action-btn"
-            icon
+            icon="check"
             primary
+            content={Translate.string('Done')}
             onClick={onCrop}
-          >
-            <Translate>Done</Translate>
-            <Icon name="check" />
-          </Button>
+          />
         </Button.Group>
       </div>
     </div>

--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -250,8 +250,8 @@ const PictureManager = ({
       });
     };
     let rejected = false;
+    const img = await loadImage(imageSrc);
     if (minPictureSize && minPictureSize !== 0) {
-      const img = await loadImage(imageSrc);
       if (Math.min(img.naturalWidth, img.naturalHeight) < minPictureSize) {
         setCustomFileRejections({
           code: 'min-size',


### PR DESCRIPTION
This pr is to change the following: 

1. Make the rotate button in the picture cropper not `primary` so that it appears gray and not display with the same importance as the done button 
<img width="254" alt="Screenshot 2024-05-24 at 15 35 24" src="https://github.com/indico/indico/assets/54508387/2570bf86-92fc-4e07-b6b0-6d5f3c66b9c6">

2. A user can disguise a pdf file as an image by changing the extension to e.g .png and they would be allowed to upload it. And while it's possible to pass the accepted file types to the dropzone, but this only checks the file extension not that it is actually an image. (There is another library which can actually check the file type https://github.com/sindresorhus/file-type but it doesn't seem to work well with the webpack so I didn't use it). Eventually, I moved the line to load the image up, so if it is an image, it gets loaded and can continue, but if it is not an image, it does not get loaded and nothing happens. 