### PR TITLE
Add event dates to linkbar title

### DIFF
--- a/indico/modules/rb/client/js/common/linking/LinkBar.jsx
+++ b/indico/modules/rb/client/js/common/linking/LinkBar.jsx
@@ -5,7 +5,6 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
@@ -13,6 +12,7 @@ import {bindActionCreators} from 'redux';
 import {Icon, Popup} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
+import {serializeDateTimeRange} from 'indico/utils/date';
 
 import * as linkingActions from './actions';
 import {linkDataShape} from './props';
@@ -34,7 +34,6 @@ const LinkBar = ({visible, clear, data}) => {
   if (!visible) {
     return null;
   }
-  const fmtDate = date => moment(date).format('Do MMMM HH:mm');
   const {type, title, eventURL, eventTitle, startDt, endDt} = data;
   return (
     <header styleName="link-bar">
@@ -43,7 +42,7 @@ const LinkBar = ({visible, clear, data}) => {
         {messages[type]}{' '}
         {type === 'event' ? (
           <a href={eventURL} target="_blank" rel="noopener noreferrer">
-            <em>{`${title} (${fmtDate(startDt)} - ${fmtDate(endDt)})`}</em>
+            <em>{`${title} (${serializeDateTimeRange(startDt, endDt)})`}</em>
           </a>
         ) : (
           <span>

--- a/indico/modules/rb/client/js/common/linking/LinkBar.jsx
+++ b/indico/modules/rb/client/js/common/linking/LinkBar.jsx
@@ -34,7 +34,7 @@ const LinkBar = ({visible, clear, data}) => {
   if (!visible) {
     return null;
   }
-  const fmtDate = date => moment(date).format('Do MMMM ha');
+  const fmtDate = date => moment(date).format('Do MMMM HH:mm');
   const {type, title, eventURL, eventTitle, startDt, endDt} = data;
   return (
     <header styleName="link-bar">

--- a/indico/modules/rb/client/js/common/linking/LinkBar.jsx
+++ b/indico/modules/rb/client/js/common/linking/LinkBar.jsx
@@ -5,6 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
@@ -33,8 +34,8 @@ const LinkBar = ({visible, clear, data}) => {
   if (!visible) {
     return null;
   }
-
-  const {type, title, eventURL, eventTitle} = data;
+  const fmtDate = date => moment(date).format('Do MMMM ha');
+  const {type, title, eventURL, eventTitle, startDt, endDt} = data;
   return (
     <header styleName="link-bar">
       <Icon name="info circle" />
@@ -42,7 +43,7 @@ const LinkBar = ({visible, clear, data}) => {
         {messages[type]}{' '}
         {type === 'event' ? (
           <a href={eventURL} target="_blank" rel="noopener noreferrer">
-            <em>{title}</em>
+            <em>{`${title} (${fmtDate(startDt)} - ${fmtDate(endDt)})`}</em>
           </a>
         ) : (
           <span>

--- a/indico/modules/rb/client/js/components/App.jsx
+++ b/indico/modules/rb/client/js/components/App.jsx
@@ -167,7 +167,7 @@ class App extends React.Component {
           </header>
           <AdminOverrideBar />
           <AdminOverrideShortcut />
-          <LinkBar />
+          {!isInitializing && <LinkBar />}
           {this.renderContent()}
           <Dimmer.Dimmable>
             <Dimmer active={isInitializing} page>


### PR DESCRIPTION
# Description
This PR adds dates to the event title in the `LinkBar` component in order to better visualize the used timeframe, specially now that an event can be directly linked to booking occurrences.

## Screenshots

<img width="823" alt="Screenshot 2024-05-26 at 13 17 10" src="https://github.com/indico/indico/assets/2722756/19800ee7-e88a-49b0-8143-c67b27ae512d">
