### PR TITLE
Use locale-aware time format

### DIFF
--- a/indico/web/client/js/utils/date.js
+++ b/indico/web/client/js/utils/date.js
@@ -152,9 +152,9 @@ export function localeUses24HourTime(locale) {
 
 export function serializeDateTimeRange(startDt, endDt) {
   const startDate = serializeDate(startDt, 'LL');
-  const startTime = serializeTime(startDt);
+  const startTime = serializeTime(startDt, 'LT');
   const endDate = serializeDate(endDt, 'LL');
-  const endTime = serializeTime(endDt);
+  const endTime = serializeTime(endDt, 'LT');
 
   return moment(startDt).isSame(moment(endDt), 'day')
     ? `${startDate} ${startTime} - ${endTime}`


### PR DESCRIPTION
Fixes missing locale-friendly time format in https://github.com/indico/indico/pull/6361

en-US
![image](https://github.com/indico/indico/assets/8739637/647af956-641b-4eeb-a872-cd12c6335c93)
en-GB
![image](https://github.com/indico/indico/assets/8739637/8119c292-6aaf-4278-be25-204ab73fc196)
