### PR TITLE
Add bulk contribution details JSON export

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,7 @@ Improvements
   :user:`openprojects`)
 - Add a new event management permission that grants access only to the contributions
   module (:pr:`6348`)
+- Add bulk JSON export option in management contribution list (:pr:`6370`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/blueprint.py
+++ b/indico/modules/events/contributions/blueprint.py
@@ -29,14 +29,16 @@ _bp.add_url_rule('/manage/contributions/person-list', 'person_list', management.
                  methods=('POST',))
 _bp.add_url_rule('/manage/contributions/material-package', 'material_package',
                  management.RHContributionsMaterialPackage, methods=('POST',))
+_bp.add_url_rule('/manage/contributions/contributions.json', 'contributions_json_export',
+                 management.RHContributionsExportJSON, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/contributions/contributions.csv', 'contributions_csv_export',
-                 management.RHContributionsExportCSV, methods=('POST',))
+                 management.RHContributionsExportCSV, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/contributions/contributions.xlsx', 'contributions_excel_export',
-                 management.RHContributionsExportExcel, methods=('POST',))
+                 management.RHContributionsExportExcel, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/contributions/contributions.pdf', 'contributions_pdf_export',
-                 management.RHContributionsExportPDF, methods=('POST',))
+                 management.RHContributionsExportPDF, methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/contributions/contributions.zip', 'contributions_tex_export',
-                 management.RHContributionsExportTeX, methods=('POST',))
+                 management.RHContributionsExportTeX, methods=('GET', 'POST'))
 
 # Emailing (management)
 _bp.add_url_rule('/manage/contributions/api/email-roles/metadata', 'api_email_contrib_roles_metadata',

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -487,6 +487,14 @@ class RHManageContributionsExportActionsBase(RHManageContributionsActionsBase):
     ALLOW_LOCKED = True
     _allow_get_all = True
 
+    _contrib_query_options = (subqueryload('field_values'),
+                              subqueryload('person_links'),
+                              joinedload('track').joinedload('track_group'),
+                              joinedload('type'),
+                              joinedload('session_block'),
+                              joinedload('timetable_entry').lazyload('*'),
+                              undefer('is_scheduled'))
+
     def _process_args(self):
         RHManageContributionsActionsBase._process_args(self)
         # some PDF export options do not sort the contribution list so we keep
@@ -511,12 +519,6 @@ class RHContributionsMaterialPackage(RHManageContributionsExportActionsBase, Att
 
 class RHContributionsExportJSON(RHManageContributionsExportActionsBase):
     """Export list of contributions to JSON."""
-
-    _contrib_query_options = (subqueryload('field_values'),
-                              subqueryload('person_links'),
-                              joinedload('type'),
-                              joinedload('session_block'),
-                              joinedload('timetable_entry').lazyload('*'))
 
     def _process(self):
         from indico.modules.events.contributions.schemas import FullContributionSchema

--- a/indico/modules/events/contributions/templates/management/contributions.html
+++ b/indico/modules/events/contributions/templates/management/contributions.html
@@ -141,6 +141,10 @@
                             </a>
                         </li>
                         <li>
+                            <a href="#" class="icon-file-css js-submit-form js-enable-if-checked disabled"
+                               data-href="{{ url_for('.contributions_json_export', event) }}">JSON</a>
+                        </li>
+                        <li>
                             <a href="#" class="icon-file-text js-submit-form js-enable-if-checked disabled"
                                data-href="{{ url_for('.contributions_tex_export', event) }}">
                                 {%- trans %}LaTeX{% endtrans -%}

--- a/indico/modules/events/contributions/util.py
+++ b/indico/modules/events/contributions/util.py
@@ -162,7 +162,7 @@ def generate_spreadsheet_from_contributions(contributions):
         if has_board_number:
             contrib_data['Board number'] = c.board_number
 
-        attached_items = get_attached_items(c)
+        attached_items = get_attached_items(c, preload_event=(len(contributions) > 10))
         attachments = [att.absolute_download_url for att in attached_items.get('files', [])]
         attachments.extend(attachment.absolute_download_url
                            for folder in attached_items.get('folders', [])


### PR DESCRIPTION
Also allow GET requests for the other contribution exports to export everything instead of just selected ones, and avoid spamming queries for those exports.