### PR TITLE
Add datepicker to address registration form accessibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -301,6 +301,7 @@ Accessibility
   :pr:`6076`, thanks :user:`foxbunny`)
 - Make dropdown menu fully accessible (:issue:`5896`, :pr:`5897`, thanks :user:`foxbunny`)
 - Improve registration form color contrast and font sizes (:pr:`6098`, thanks :user:`foxbunny`)
+- Improve registration form date picker accessibility (:pr:`6371`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^
@@ -327,6 +328,7 @@ Internal Changes
 - Add ``<ind-menu>`` custom element for managing drop-down menus (:issue:`5896`, :pr:`5897`,
   thanks :user:`foxbunny`)
 - Allow plugins to add extra fields to the room booking form (:pr:`6126`, thanks :user:`VojtechPetru`)
+- Add ``<ind-date-picker>`` custom element (:pr:`6371`, thanks :user:`foxbunny`)
 
 
 ----

--- a/indico/modules/events/registration/client/js/form/fields/DateInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/DateInput.jsx
@@ -12,7 +12,7 @@ import React from 'react';
 import {Field} from 'react-final-form';
 import {Form, Input} from 'semantic-ui-react';
 
-import {SingleDatePicker} from 'indico/react/components';
+import {DatePicker} from 'indico/react/components';
 import {FinalDropdown, FinalField, parsers as p} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 import {toMoment} from 'indico/utils/date';
@@ -23,6 +23,8 @@ export function DateInputComponent({
   id,
   value,
   onChange,
+  onFocus,
+  onBlur,
   disabled,
   required,
   dateFormat,
@@ -32,7 +34,7 @@ export function DateInputComponent({
   const timeValue = value.includes('T') ? value.split('T')[1] : '';
 
   const handleDateChange = newDate => {
-    const dateString = newDate ? newDate.toISOString().split('T')[0] : '';
+    const dateString = newDate || '';
     const timeString = timeFormat ? timeValue : '00:00:00';
     onChange(`${dateString}T${timeString}`);
   };
@@ -42,18 +44,16 @@ export function DateInputComponent({
   return (
     <Form.Group styleName="date-field">
       <Form.Field>
-        <SingleDatePicker
+        <DatePicker
           id={id}
           name="date"
           disabled={disabled}
           required={required}
-          date={toMoment(dateValue, 'YYYY-MM-DD', true)}
-          onDateChange={handleDateChange}
-          placeholder={dateFormat}
-          displayFormat={dateFormat}
-          isOutsideRange={() => false}
-          verticalSpacing={10}
-          enableOutsideDays
+          format={dateFormat}
+          value={dateValue}
+          onChange={handleDateChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
         />
       </Form.Field>
       {timeFormat && (
@@ -82,6 +82,8 @@ DateInputComponent.propTypes = {
   id: PropTypes.string.isRequired,
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
+  onFocus: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
   disabled: PropTypes.bool.isRequired,
   required: PropTypes.bool.isRequired,
   dateFormat: PropTypes.oneOf([

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -119,6 +119,7 @@ def smart_func(func_name, plugin_name=None):
         else:
             # otherwise, defer translation to eval time
             return lazy_gettext(*args, plugin_name=plugin_name)
+
     if plugin_name is _use_context:
         _wrap.__name__ = f'<smart {func_name}>'
     else:
@@ -177,6 +178,11 @@ class IndicoLocale(Locale):
     def weekday(self, daynum, short=True):
         """Return the week day given the index."""
         return self.days['format']['abbreviated' if short else 'wide'][daynum]
+
+    @property
+    def html_locale(self):
+        """Return locale in HTML-compatible way (e.g., en-US instead of en_US)."""
+        return f'{self.language}-{self.territory}'
 
     @cached_property
     def time_formats(self):

--- a/indico/web/client/js/custom_elements/ind_date_picker.js
+++ b/indico/web/client/js/custom_elements/ind_date_picker.js
@@ -340,7 +340,7 @@ customElements.define(
       // Note that this may not work on iOS Safari. We are not currently explicitly
       // targeting this browser, so we'll leave this as is.
       window.addEventListener('click', handleDialogClose);
-      this.cleanup = function() {
+      this.cleanup = () => {
         window.removeEventListener('click', handleDialogClose);
       };
 
@@ -351,7 +351,7 @@ customElements.define(
         if (ev.target.closest('dialog') === dialog) {
           return;
         }
-        setTimeout(function() {
+        setTimeout(() => {
           indCalendar.open = false;
         });
       }

--- a/indico/web/client/js/custom_elements/ind_date_picker.js
+++ b/indico/web/client/js/custom_elements/ind_date_picker.js
@@ -1,0 +1,537 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import {formatDate} from 'indico/utils/date_format';
+import {createDateParser} from 'indico/utils/date_parser';
+
+import './ind_date_picker.scss';
+
+const DEFAULT_LOCALE = document.documentElement.dataset.canonicalLocale;
+const CALENDAR_CELL_COUNT = 42; // 6 rows, 7 days each
+
+customElements.define(
+  'ind-date-picker',
+  class extends HTMLElement {
+    // Last value of the internal id used in the widgets
+    static lastId = 0;
+
+    get value() {
+      return this.querySelector('input').value;
+    }
+
+    get start() {
+      return this.getAttribute('start');
+    }
+
+    get end() {
+      return this.getAttribute('end');
+    }
+
+    connectedCallback() {
+      const id = `date-picker-${this.constructor.lastId++}`;
+      const input = this.querySelector('input');
+      const startInput = document.getElementById(this.start);
+      const endInput = document.getElementById(this.end);
+      const openCalendarButton = this.querySelector('button');
+      const formatDescription = this.querySelector('[data-format]');
+      const indCalendar = this.querySelector('ind-calendar');
+
+      const dateFormat = formatDescription.textContent
+        .split(':')[1]
+        .trim()
+        .toLowerCase();
+      const parseDate = createDateParser(dateFormat);
+
+      indCalendar.format = dateFormat;
+      indCalendar.value = toDateString(parseDate(this.value));
+      formatDescription.id = `${id}-format`;
+      input.setAttribute('aria-describedby', formatDescription.id);
+      openCalendarButton.setAttribute('aria-haspopup', 'dialog');
+      openCalendarButton.setAttribute('aria-controls', true);
+
+      // This property is defined here rather than in the class because it
+      // relies on the parseDate() function created in this scope.
+      Object.defineProperty(this, 'date', {
+        get: () => parseDate(input.value),
+      });
+
+      openCalendarButton.addEventListener('click', () => {
+        openCalendarButton.disabled = true;
+        requestAnimationFrame(openDialog);
+      });
+      indCalendar.addEventListener('close', () => {
+        openCalendarButton.disabled = false;
+      });
+      indCalendar.addEventListener('x-keyclose', () => {
+        openCalendarButton.disabled = false;
+        openCalendarButton.focus();
+      });
+      indCalendar.addEventListener('x-select', () => {
+        setNativeInputValue(input, formatDate(dateFormat, new Date(indCalendar.value)));
+        input.select();
+        input.focus();
+        input.dispatchEvent(new Event('input', {bubbles: true}));
+      });
+      input.addEventListener('keydown', evt => {
+        if (evt.code === 'ArrowDown' && evt.altKey) {
+          openDialog();
+        }
+      });
+      input.addEventListener('input', () => {
+        indCalendar.value = toDateString(parseDate(this.value));
+      });
+      startInput?.addEventListener('input', () => {
+        indCalendar.rangeStart = toDateString(parseDate(startInput.value));
+      });
+      endInput?.addEventListener('input', () => {
+        indCalendar.rangeEnd = toDateString(parseDate(endInput.value));
+      });
+
+      function openDialog() {
+        indCalendar.toggleAttribute('data-position-check');
+        requestAnimationFrame(() => {
+          const inputRect = input.getBoundingClientRect();
+          const dialogRect = indCalendar.firstElementChild.getBoundingClientRect();
+          const dialogBottom = inputRect.bottom + dialogRect.height;
+          const dialogWillFitBelow = dialogBottom < window.innerHeight;
+          indCalendar.style.setProperty('--dialog-bottom', dialogWillFitBelow ? 'auto' : '100%');
+          indCalendar.toggleAttribute('data-position-check');
+          indCalendar.open = true;
+        });
+      }
+    }
+
+    disconnectedCallback() {
+      this.cleanup();
+    }
+  }
+);
+
+customElements.define(
+  'ind-calendar',
+  class extends HTMLElement {
+    static lastId = 0;
+
+    constructor() {
+      super();
+      this.calendarId = this.constructor.lastId++;
+      this.weekInfo = getWeekInfoForLocale(this.locale);
+    }
+
+    get open() {
+      return this.hasAttribute('open');
+    }
+
+    set open(isOpen) {
+      this.toggleAttribute('open', isOpen);
+    }
+
+    get locale() {
+      return this.getAttribute('lang') || DEFAULT_LOCALE;
+    }
+
+    get value() {
+      return this.getAttribute('value');
+    }
+
+    set value(value) {
+      this.setAttribute('value', value || '');
+    }
+
+    get rangeStart() {
+      return this.getAttribute('range-start');
+    }
+
+    set rangeStart(value) {
+      this.setAttribute('range-start', value || '');
+    }
+
+    get rangeEnd() {
+      return this.getAttribute('range-end');
+    }
+
+    set rangeEnd(value) {
+      this.setAttribute('range-end', value || '');
+    }
+
+    connectedCallback() {
+      const indCalendar = this;
+      const dialog = this.firstElementChild;
+      const monthYearGroup = this.querySelector('.month-year');
+      const editMonthSelect = monthYearGroup.querySelector('select');
+      const editYearInput = monthYearGroup.querySelector('input');
+      const weekdaysGroup = dialog.querySelector('.weekdays');
+      const listbox = dialog.querySelector('[role=listbox]');
+      let calendarDisplayDate;
+
+      // Populate month names in the select list
+      for (let i = 0; i < 12; i++) {
+        const date = new Date();
+        date.setMonth(i);
+        const monthName = date.toLocaleDateString(this.locale, {month: 'short'});
+        const monthOption = document.createElement('option');
+        monthOption.value = i;
+        monthOption.textContent = monthName;
+        editMonthSelect.append(monthOption);
+      }
+
+      // Populate weekday names in the calendar header
+      getWeekdayNames(this.weekInfo).forEach(({full, short}, i) => {
+        const headerCell = weekdaysGroup.children[i];
+        headerCell.setAttribute('aria-label', full);
+        headerCell.textContent = short;
+        headerCell.id = `calendar-${this.calendarId}-wkd-${i + 1}`;
+      });
+
+      // Populate calendar with blank buttons
+      for (let i = 0; i < CALENDAR_CELL_COUNT; i++) {
+        const calendarButton = document.createElement('button');
+        calendarButton.setAttribute('role', 'option');
+        calendarButton.setAttribute('aria-describedby', weekdaysGroup.children[i % 6].id);
+        calendarButton.tabIndex = -1;
+        calendarButton.type = 'button';
+        listbox.append(calendarButton);
+      }
+
+      this.addEventListener('attrchange.open', () => {
+        if (this.open) {
+          show();
+        } else {
+          close();
+        }
+      });
+      this.addEventListener('attrchange.value', updateCalendar);
+
+      dialog.addEventListener('focusout', () => {
+        // The focusout event is triggered on the dialog or somewhere in it.
+        // We use requestAnimationFrame to allow the target element to get
+        // focused so we know where the focus is going.
+        requestAnimationFrame(() => {
+          // If the focus has moved to an element outside the dialog, we close
+          if (dialog.contains(document.activeElement)) {
+            return;
+          }
+          this.open = false;
+        });
+      });
+
+      // Handle open/close to prep the dialog state
+      dialog.addEventListener('open', () => {
+        calendarDisplayDate = toOptionalDate(this.value) || getToday();
+        const focusTarget = dialog.querySelector('[aria-selected=true]') || dialog;
+        focusTarget.focus();
+      });
+      dialog.addEventListener('close', () => {
+        calendarDisplayDate = undefined;
+        updateCalendar();
+      });
+
+      // Handle calendar interaction
+      dialog.addEventListener('click', evt => {
+        const button = evt.target.closest('button[value]');
+        if (!button) {
+          return;
+        }
+        switch (button.value) {
+          case 'previous-year':
+            calendarDisplayDate.setFullYear(calendarDisplayDate.getFullYear() - 1);
+            updateCalendar();
+            break;
+          case 'next-year':
+            calendarDisplayDate.setFullYear(calendarDisplayDate.getFullYear() + 1);
+            updateCalendar();
+            break;
+          case 'previous-month':
+            calendarDisplayDate.setMonth(calendarDisplayDate.getMonth() - 1);
+            updateCalendar();
+            break;
+          case 'next-month':
+            calendarDisplayDate.setMonth(calendarDisplayDate.getMonth() + 1);
+            updateCalendar();
+            break;
+          default:
+            // Date selection
+            this.open = false;
+            this.value = button.value;
+            this.dispatchEvent(new Event('x-select'));
+        }
+      });
+      editYearInput.addEventListener('input', () => {
+        const year = parseInt(editYearInput.value, 10);
+        if (isNaN(year)) {
+          editYearInput.reportValidity();
+          return;
+        }
+        calendarDisplayDate.setFullYear(year);
+        updateCalendar();
+      });
+      editMonthSelect.addEventListener('change', () => {
+        calendarDisplayDate.setMonth(editMonthSelect.value);
+        updateCalendar();
+      });
+      listbox.addEventListener('keydown', evt => {
+        const currentDate = listbox.querySelector(':focus');
+        const currentDateIndex = Array.prototype.indexOf.call(listbox.children, currentDate);
+        switch (evt.code) {
+          case 'ArrowRight': {
+            evt.preventDefault();
+            let nextDate = currentDate?.nextElementSibling;
+            if (!nextDate) {
+              // We've reached the end. Flip to next month and start from the beginning.
+              calendarDisplayDate.setMonth(calendarDisplayDate.getMonth() + 1);
+              updateCalendar();
+              nextDate = listbox.firstElementChild;
+            }
+            focusCalendarButton(nextDate);
+            break;
+          }
+          case 'ArrowLeft': {
+            evt.preventDefault();
+            let previousDate = currentDate?.previousElementSibling;
+            if (!previousDate) {
+              // We've reached the end. Flip to previous month and start from the end.
+              calendarDisplayDate.setMonth(calendarDisplayDate.getMonth() - 1);
+              updateCalendar();
+              previousDate = listbox.lastElementChild;
+            }
+            focusCalendarButton(previousDate);
+            break;
+          }
+          case 'ArrowUp': {
+            evt.preventDefault();
+            let nextIndex = currentDateIndex - 7;
+            if (nextIndex < 1) {
+              // We've reached the end. Flip to previous month and start from last row.
+              nextIndex = listbox.children.length - 7 + currentDateIndex;
+              calendarDisplayDate.setMonth(calendarDisplayDate.getMonth() - 1);
+              updateCalendar();
+            }
+            focusCalendarButton(listbox.children[nextIndex] || listbox.lastElementChild);
+            break;
+          }
+          case 'ArrowDown': {
+            evt.preventDefault();
+            let nextIndex = currentDateIndex + 7;
+            if (nextIndex > listbox.children.length - 1) {
+              // We've reached the end. Flip to next month and start from the first row.
+              nextIndex = currentDateIndex % 7;
+              calendarDisplayDate.setMonth(calendarDisplayDate.getMonth() + 1);
+              updateCalendar();
+            }
+            focusCalendarButton(listbox.children[nextIndex] || listbox.firstElementChild);
+            break;
+          }
+        }
+      });
+
+      // Handle closing/opening the dialog by clicking outside
+      this.addEventListener('keydown', evt => {
+        if (evt.code !== 'Escape') {
+          return;
+        }
+        this.open = false;
+        this.dispatchEvent(new Event('x-keyclose'));
+      });
+
+      // Note that this may not work on iOS Safari. We are not currently explicitly
+      // targeting this browser, so we'll leave this as is.
+      window.addEventListener('click', handleDialogClose);
+      this.cleanup = function() {
+        window.removeEventListener('click', handleDialogClose);
+      };
+
+      function handleDialogClose(ev) {
+        if (!indCalendar.open) {
+          return;
+        }
+        if (ev.target.closest('dialog') === dialog) {
+          return;
+        }
+        setTimeout(function() {
+          indCalendar.open = false;
+        });
+      }
+
+      function focusCalendarButton(calendarButton) {
+        const currentlyFocusable = listbox.querySelector('[tabindex="0"]');
+        if (currentlyFocusable) {
+          currentlyFocusable.tabIndex = -1;
+        }
+        calendarButton.tabIndex = 0;
+        calendarButton.focus();
+      }
+
+      function show() {
+        if (!dialog) {
+          return;
+        }
+        if (dialog.open) {
+          return;
+        }
+        dialog.show();
+        dialog.dispatchEvent(new Event('open'));
+      }
+
+      function close() {
+        if (!dialog) {
+          return;
+        }
+        if (!dialog.open) {
+          return;
+        }
+        dialog.close();
+        indCalendar.dispatchEvent(new Event('close'));
+      }
+
+      function updateCalendar() {
+        const selectedDate = toOptionalDate(indCalendar.value);
+        const firstDayOfMonth = new Date(calendarDisplayDate || selectedDate || getToday());
+        firstDayOfMonth.setDate(1);
+        const firstDayOfCalendar = getFirstDayOfWeek(indCalendar.weekInfo, firstDayOfMonth);
+
+        // Populate the year/month controls
+
+        monthYearGroup.querySelector('select').value = firstDayOfMonth.getMonth();
+        editYearInput.value = firstDayOfMonth.getFullYear();
+
+        // Populate the calendar cells
+
+        const month = firstDayOfMonth.getMonth();
+        // Note that getDay() returns Sunday as 0, but we need 7 because of the weekInfo API
+
+        const rangeStart = toOptionalDate(indCalendar.rangeStart);
+        const rangeEnd = toOptionalDate(indCalendar.rangeEnd);
+        const markStart = rangeStart || (rangeEnd && selectedDate);
+        const markEnd = rangeEnd || (rangeStart && selectedDate);
+
+        for (let i = 0; i < CALENDAR_CELL_COUNT; i++) {
+          const date = new Date(firstDayOfCalendar);
+          date.setDate(date.getDate() + i);
+          const calendarButton = listbox.querySelector(`button:nth-of-type(${i + 1})`);
+          calendarButton.textContent = date.getDate();
+          calendarButton.dataset.currentMonth = date.getMonth() === month;
+          calendarButton.setAttribute(
+            'aria-label',
+            date.toLocaleDateString(indCalendar.locale, {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })
+          );
+          calendarButton.toggleAttribute(
+            'data-weekend',
+            indCalendar.weekInfo.weekend.includes(date.getDay() + 1)
+          );
+          calendarButton.tabIndex = -1; // reset tabIndex
+          calendarButton.value = toDateString(date);
+
+          // Mark range
+          calendarButton.disabled = date < rangeStart || date > rangeEnd;
+          calendarButton.toggleAttribute('data-range-start', sameDate(date, markStart));
+          calendarButton.toggleAttribute('data-range-end', sameDate(date, markEnd));
+          calendarButton.toggleAttribute('data-range', date < markEnd && date > markStart);
+
+          // Mark selected
+          if (calendarButton.value === indCalendar.value) {
+            calendarButton.setAttribute('aria-selected', true);
+          } else {
+            calendarButton.removeAttribute('aria-selected');
+          }
+        }
+
+        const focusableButton =
+          listbox.querySelector('[aria-selected]') || listbox.firstElementChild;
+        focusableButton.tabIndex = 0;
+      }
+    }
+
+    disconnectedCallback() {
+      this.cleanup();
+    }
+
+    static observedAttributes = ['open', 'value', 'range-start', 'range-end'];
+
+    attributeChangedCallback(name) {
+      switch (name) {
+        case 'open':
+          this.dispatchEvent(new Event('attrchange.open'));
+          break;
+        case 'value':
+        case 'range-start':
+        case 'range-end':
+          this.dispatchEvent(new Event('attrchange.value'));
+          break;
+      }
+    }
+  }
+);
+
+// React hacks
+
+function setNativeInputValue(input, value) {
+  // React adds its own setter to the input and messes with the native event mechanism.
+  // In order for the value to be set in a standard way, we need to resort to this hack.
+  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(input, value);
+}
+
+// Date functions
+
+function getToday() {
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+  return now;
+}
+
+function sameDate(a, b) {
+  return a?.getTime() === b?.getTime();
+}
+
+function toDateString(date) {
+  // We do not use ISO date format because it will be interpreted as UTC
+  return date?.toDateString();
+}
+
+function toOptionalDate(dateString) {
+  const date = new Date(dateString);
+  if (!date.getTime()) {
+    return;
+  }
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+// Localization
+
+function getWeekInfoForLocale(locale) {
+  let weekInfo = new Intl.Locale(locale).weekInfo;
+  weekInfo ??= {firstDay: 7, weekend: [6, 7]}; /* Firefox 😭 */
+  weekInfo.weekDays = [];
+  for (let i = weekInfo.firstDay, end = i + 7; i < end; i++) {
+    weekInfo.weekDays.push(i % 7 || 7);
+  }
+  return weekInfo;
+}
+
+function getFirstDayOfWeek(weekInfo, date) {
+  const offset = weekInfo.weekDays.indexOf(date.getDay() || 7);
+  const firstDayOfWeek = new Date(date);
+  firstDayOfWeek.setDate(firstDayOfWeek.getDate() - offset);
+  return firstDayOfWeek;
+}
+
+function getWeekdayNames(weekInfo, locale) {
+  const date = getFirstDayOfWeek(weekInfo, getToday());
+  const weekdayNames = [];
+  for (let i = 0; i < 7; i++) {
+    weekdayNames.push({
+      full: date.toLocaleDateString(locale, {weekday: 'long'}),
+      short: date.toLocaleDateString(locale, {weekday: 'narrow'}),
+    });
+    date.setDate(date.getDate() + 1);
+  }
+  return weekdayNames;
+}

--- a/indico/web/client/js/custom_elements/ind_date_picker.scss
+++ b/indico/web/client/js/custom_elements/ind_date_picker.scss
@@ -1,0 +1,211 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@use 'design_system';
+@use 'partials/icons';
+@use 'partials/sui_debt';
+
+ind-date-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2em;
+  align-items: flex-start;
+  position: relative;
+
+  > input {
+    padding-right: 2.5em;
+  }
+
+  > button {
+    @extend %text-size-reset;
+    @extend %button-icon-only;
+
+    position: absolute;
+    right: 0.2em;
+    top: 0.2em;
+    width: 2em;
+    aspect-ratio: 1;
+  }
+
+  > button::before {
+    @extend %icon;
+    @extend %icon-calendar;
+  }
+
+  > button span {
+    @extend %visually-hidden;
+  }
+
+  .date-format {
+    @extend %visually-hidden;
+  }
+}
+
+ind-calendar {
+  @extend %text-size-reset;
+
+  dialog[open],
+  &[data-position-check] dialog {
+    position: absolute;
+    left: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+    padding: 0.5em;
+    margin: 0;
+    z-index: 10;
+
+    border: 0;
+  }
+
+  dialog[open] {
+    bottom: var(--dialog-bottom);
+
+    box-shadow: var(--control-raised-shadow);
+  }
+
+  &[data-position-check] dialog {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .controls,
+  .month-year {
+    display: flex;
+    gap: 0.5em;
+  }
+
+  .controls > button {
+    @extend %button-icon-only;
+    flex: none;
+    width: 2em;
+
+    &::before {
+      @extend %icon;
+    }
+
+    > span {
+      @extend %visually-hidden;
+    }
+  }
+
+  .controls [value='previous-year']::before {
+    @extend %icon-first;
+  }
+
+  .controls [value='previous-month']::before {
+    @extend %icon-prev;
+  }
+
+  .controls [value='next-month']::before {
+    @extend %icon-next;
+  }
+
+  .controls [value='next-year']::before {
+    @extend %icon-last;
+  }
+
+  .controls .month-year {
+    width: 10em;
+  }
+
+  .month-year {
+    select,
+    input[type='number'] {
+      @include sui_debt.field-override() {
+        padding: 0.5em;
+        border-radius: var(--control-border-radius);
+        border-color: var(--control-border-color);
+        -webkit-appearance: auto;
+
+        &:focus-visible {
+          outline: revert;
+          -webkit-appearance: auto;
+        }
+
+        // Override for _input.scss select:-foz-focusring
+        &:-moz-focusring {
+          color: unset !important;
+          text-shadow: unset !important;
+          outline: revert;
+        }
+      }
+
+      @include sui_debt.field-error-override() {
+        border-color: var(--control-border-color);
+        background: transparent;
+        color: inherit;
+        -webkit-appearance: auto;
+
+        &:focus-visible {
+          outline: solid;
+          -webkit-appearance: auto;
+        }
+      }
+    }
+  }
+
+  [role='listbox'],
+  .weekdays {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    row-gap: 0.2em;
+    width: 100%;
+  }
+
+  [role='listbox'] {
+    aspect-ratio: 7/6; // 7 cells across x 6 rows
+  }
+
+  .weekdays span {
+    @extend %flex-inline-center;
+    aspect-ratio: 1;
+  }
+
+  [role='listbox'] button {
+    aspect-ratio: 1;
+
+    background-color: transparent;
+    border: none;
+
+    &:hover {
+      background-color: var(--surface-highlight-color);
+    }
+  }
+
+  [role='listbox'] :is([data-range-start], [data-range-end], [data-range]) {
+    background-color: var(--surface-accent-secondary-color);
+  }
+
+  [role='listbox'] [data-range-end] {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+
+  [role='listbox'] [data-range-start] {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+
+  [role='listbox'] [data-range] {
+    border-radius: 0;
+  }
+
+  [role='listbox'] [aria-selected] {
+    background-color: var(--surface-accent-color);
+    color: var(--text-inverse-color);
+  }
+
+  button[disabled] {
+    opacity: 0.5;
+  }
+
+  [data-current-month='false'] {
+    background-color: #fff;
+    color: #ddd;
+  }
+}

--- a/indico/web/client/js/react/components/DatePicker.jsx
+++ b/indico/web/client/js/react/components/DatePicker.jsx
@@ -1,0 +1,100 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import moment from 'moment';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {Param, Translate} from 'indico/react/i18n';
+import {formatDate} from 'indico/utils/date_format';
+import {fromISOLocalDate} from 'indico/utils/date_parser';
+
+import 'indico/custom_elements/ind_date_picker';
+
+export default function DatePicker({
+  onChange,
+  value,
+  format = moment.localeData().longDateFormat('L'),
+  ...inputProps
+}) {
+  function handleDateChange(ev) {
+    const {date} = ev.target.closest('ind-date-picker');
+    // en-CA uses the ISO format date (YYYY-MM-DD) but gives it in local time zone.
+    // Do not use toISOString() for this because it may result in incorrect date due
+    // to time zone differences.
+    onChange(date?.toLocaleDateString('en-CA'));
+  }
+
+  const formattedValue = formatDate(format, fromISOLocalDate(value));
+
+  return (
+    <ind-date-picker>
+      <input
+        type="text"
+        onChange={handleDateChange}
+        defaultValue={formattedValue}
+        placeholder={format}
+        {...inputProps}
+      />
+      <button type="button" disabled={inputProps.disabled}>
+        <Translate as="span">Open a calendar</Translate>
+      </button>
+      <ind-calendar>
+        <dialog>
+          <div className="controls">
+            <button type="button" value="previous-year">
+              <Translate as="span">Previous year</Translate>
+            </button>
+            <button type="button" value="previous-month">
+              <Translate as="span">Previous month</Translate>
+            </button>
+
+            <div className="month-year">
+              <select />
+              <input type="number" required />
+            </div>
+
+            <button type="button" value="next-month">
+              <Translate as="span">Next month</Translate>
+            </button>
+            <button type="button" value="next-year">
+              <Translate as="span">Next year</Translate>
+            </button>
+          </div>
+
+          <div className="weekdays">
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+            <span />
+          </div>
+          <div role="listbox" />
+        </dialog>
+      </ind-calendar>
+
+      <span className="date-format" data-format>
+        <Translate>
+          Date format: <Param name="format" value={format} />
+        </Translate>
+      </span>
+    </ind-date-picker>
+  );
+}
+
+DatePicker.propTypes = {
+  format: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.any,
+};
+
+DatePicker.defaultProps = {
+  value: undefined,
+  format: undefined,
+};

--- a/indico/web/client/js/react/components/index.js
+++ b/indico/web/client/js/react/components/index.js
@@ -20,6 +20,7 @@ export {default as Modal} from './Modal';
 export {default as Paginator} from './Paginator';
 export {default as TooltipIfTruncated} from './TooltipIfTruncated';
 export {default as SingleDatePicker, FinalSingleDatePicker} from './dates/SingleDatePicker';
+export {default as DatePicker} from './DatePicker';
 export {default as DateRangePicker} from './dates/DateRangePicker';
 export {default as CalendarSingleDatePicker} from './dates/CalendarSingleDatePicker';
 export {default as CalendarRangeDatePicker} from './dates/CalendarRangeDatePicker';

--- a/indico/web/client/js/utils/__tests__/date_parser.test.js
+++ b/indico/web/client/js/utils/__tests__/date_parser.test.js
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import {createDateParser} from './date_parser';
+import {createDateParser} from '../date_parser';
 
 describe('createDateParser', () => {
   test.each([['yyy.mm.dd'], ['yyyy.mm'], ['dd/mm/'], '[d//y]'])(

--- a/indico/web/client/js/utils/date_format.js
+++ b/indico/web/client/js/utils/date_format.js
@@ -1,0 +1,30 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+export function formatDate(formatString, date) {
+  if (!date) {
+    return '';
+  }
+
+  const year = `${date.getFullYear()}`;
+  const month = `${date.getMonth() + 1}`;
+  const day = `${date.getDate()}`;
+
+  return formatString
+    .replace(/yy+/i, function(s) {
+      if (s.length === 2) {
+        return year.slice(3);
+      }
+      return year;
+    })
+    .replace(/m{1,2}/i, function(s) {
+      return month.padStart(s.length, '0');
+    })
+    .replace(/d{1,2}/i, function(s) {
+      return day.padStart(s.length, '0');
+    });
+}

--- a/indico/web/client/js/utils/date_format.js
+++ b/indico/web/client/js/utils/date_format.js
@@ -15,16 +15,12 @@ export function formatDate(formatString, date) {
   const day = `${date.getDate()}`;
 
   return formatString
-    .replace(/yy+/i, function(s) {
+    .replace(/yy+/i, s => {
       if (s.length === 2) {
         return year.slice(3);
       }
       return year;
     })
-    .replace(/m{1,2}/i, function(s) {
-      return month.padStart(s.length, '0');
-    })
-    .replace(/d{1,2}/i, function(s) {
-      return day.padStart(s.length, '0');
-    });
+    .replace(/m{1,2}/i, s => month.padStart(s.length, '0'))
+    .replace(/d{1,2}/i, s => day.padStart(s.length, '0'));
 }

--- a/indico/web/client/js/utils/date_parser.js
+++ b/indico/web/client/js/utils/date_parser.js
@@ -1,0 +1,113 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+const TOKEN_START = Symbol('start');
+const TOKEN_ANY = Symbol('any');
+const TOKEN_MONTH = Symbol('month');
+const TOKEN_YEAR = Symbol('year');
+const TOKEN_DATE = Symbol('date');
+const CHAR_TO_TOKEN_TYPE = {
+  y: TOKEN_YEAR,
+  Y: TOKEN_YEAR,
+  m: TOKEN_MONTH,
+  M: TOKEN_MONTH,
+  d: TOKEN_DATE,
+  D: TOKEN_DATE,
+};
+
+export function createDateParser(formatString) {
+  const tokens = [];
+  const tokenTypesFound = new Set();
+  let lastCharType = TOKEN_START;
+  const buffer = [];
+
+  formatString = formatString.toLowerCase();
+
+  // Tokenize
+  for (let i = 0; i < formatString.length; i++) {
+    const char = formatString[i];
+    const type = CHAR_TO_TOKEN_TYPE[char] || TOKEN_ANY;
+
+    if (type !== lastCharType && buffer.length) {
+      tokenTypesFound.add(lastCharType);
+      tokens.push({
+        type: lastCharType,
+        text: buffer.join(''),
+      });
+      buffer.length = 0;
+    }
+
+    buffer.push(char);
+    lastCharType = type;
+  }
+
+  if (buffer.length) {
+    tokenTypesFound.add(lastCharType);
+    tokens.push({
+      type: lastCharType,
+      text: buffer.join(''),
+    });
+  }
+
+  // Sanity check
+  if (
+    !tokenTypesFound.has(TOKEN_YEAR) ||
+    !tokenTypesFound.has(TOKEN_MONTH) ||
+    !tokenTypesFound.has(TOKEN_DATE)
+  ) {
+    throw Error('Invalid date format: date format must include year, month, and date');
+  }
+
+  // Convert tokens to regex
+  let regexSource = '^';
+  for (const token of tokens) {
+    switch (token.type) {
+      case TOKEN_YEAR:
+        regexSource += '(?<year>\\d{4})';
+        break;
+      case TOKEN_MONTH:
+        regexSource += '(?<month>1[012]|0?[1-9])';
+        break;
+      case TOKEN_DATE:
+        regexSource += '(?<date>3[01]|[12][0-9]|0?[1-9])';
+        break;
+      default:
+        regexSource += `\\D{${token.text.length}}`;
+    }
+  }
+  regexSource += '$';
+  const regex = new RegExp(regexSource);
+
+  // Crate the parser function
+  return function(text) {
+    const match = regex.exec(text);
+    if (match) {
+      const year = Number(match.groups.year);
+      const month = Number(match.groups.month) - 1;
+      const date = Number(match.groups.date);
+      const output = new Date(year, month, date);
+
+      // JavaScript's Date constructor is too lenient when it comes to invalid
+      // combinations of month and date. For example, 2024-02-31 will be treated
+      // as 2021-03-02 (two days carrying over to March). We therefore reject
+      // inputs where the month does not match the input.
+      if (output.getMonth() !== month) {
+        return;
+      }
+
+      return output;
+    }
+  };
+}
+
+export function fromISOLocalDate(dateString) {
+  if (!dateString) {
+    return;
+  }
+  const [year, month, date] = dateString.split('-');
+  return new Date(year, month - 1, date);
+}

--- a/indico/web/client/js/utils/date_parser.js
+++ b/indico/web/client/js/utils/date_parser.js
@@ -83,7 +83,7 @@ export function createDateParser(formatString) {
   const regex = new RegExp(regexSource);
 
   // Crate the parser function
-  return function(text) {
+  return text => {
     const match = regex.exec(text);
     if (match) {
       const year = Number(match.groups.year);

--- a/indico/web/client/js/utils/date_parser.test.js
+++ b/indico/web/client/js/utils/date_parser.test.js
@@ -1,0 +1,61 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import {createDateParser} from './date_parser';
+
+describe('createDateParser', () => {
+  test.each([['yyy.mm.dd'], ['yyyy.mm'], ['dd/mm/'], '[d//y]'])(
+    'Given an incomplete format string like %s, creating the parser will fail',
+    formatString => {
+      expect(() => createDateParser(formatString)).toThrow();
+    }
+  );
+
+  test.each([
+    ['yyyy.mm.dd', '2024.02.11'],
+    ['yyyy/mm/dd', '2024/02/11'],
+    ['mm/dd/yyyy', '02/11/2024'],
+    ['dd.mm.yyyy.', '11.02.2024.'],
+  ])(
+    'Given a format string like %s, when passsed a formatted date like %s, it returns a Date object for that date',
+    (formatString, formattedDate) => {
+      const parse = createDateParser(formatString);
+      const actual = parse(formattedDate);
+      const expected = new Date(2024, 1, 11);
+      expect(actual).toEqual(expected);
+    }
+  );
+
+  test.each([['2/07/2024'], ['02/7/2024'], ['2/7/2024'], ['2.7.2024'], ['2-7.2024']])(
+    'Given a format string mm/dd/yyyy, when passed a formatted date that does not quite match, like %s, it will still successfully parse it',
+    formattedDate => {
+      const formatString = 'mm/dd/yyyy';
+      const parse = createDateParser(formatString);
+      const actual = parse(formattedDate);
+      const expected = new Date(2024, 1, 7);
+      expect(actual).toEqual(expected);
+    }
+  );
+
+  test.each([['2021.1.12'], ['01//12/2021'], ['13/02/2021'], ['11/65/2021'], ['1/2']])(
+    'Given a formatting string mm/dd/yyyy, when passed an invalid formatted date, like %s, it will return undefined',
+    formattedDate => {
+      const formatString = 'mm/dd/yyyy';
+      const parse = createDateParser(formatString);
+      const actual = parse(formattedDate);
+      expect(actual).toBeUndefined();
+    }
+  );
+
+  test('Given a format string like mm/dd/yyyy, when passed a correctly formatted date that represent an invalid date, it will return undefined', () => {
+    const formatString = 'mm/dd/yyyy';
+    const formattedDate = '02/31/2024';
+    const parse = createDateParser(formatString);
+    const actual = parse(formattedDate);
+    expect(actual).toBeUndefined();
+  });
+});

--- a/indico/web/client/styles/design_system/variables.scss
+++ b/indico/web/client/styles/design_system/variables.scss
@@ -15,6 +15,7 @@ body {
   --surface-default: #e8e8e8;
   --surface-inverse-color: #555;
   --surface-accent-color: var(--accent-color);
+  --surface-accent-secondary-color: #cee8f5;
   --surface-highlight-color: #c4c4c4;
   --surface-highlight-inverse-color: var(--text-secondary-color);
   --surface-disabled-color: #f9f9f9;
@@ -58,6 +59,7 @@ body {
   --control-border: var(--control-border-width) solid var(--control-border-color);
   --control-padding: 0.5em;
   --control-internal-gap: 0.2em;
+  --control-raised-shadow: 0 0.2em 0.5em rgba(0, 0, 0, 0.3);
 
   // Clickable texts (e.g., link)
   --clickable-text-color: var(--accent-color);

--- a/indico/web/client/styles/partials/_sui_debt.scss
+++ b/indico/web/client/styles/partials/_sui_debt.scss
@@ -1,0 +1,20 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+// Module that makes SUI overrides easy to track down. All SUI overrides should go here.
+
+@mixin field-override {
+  .ui.form & {
+    @content;
+  }
+}
+
+@mixin field-error-override {
+  .ui.form .field.error & {
+    @content;
+  }
+}

--- a/indico/web/templates/indico_base.html
+++ b/indico/web/templates/indico_base.html
@@ -5,6 +5,7 @@
 
 <html lang="{{ current_locale.language }}"
       prefix="og: http://ogp.me/ns#"
+      data-canonical-locale="{{ current_locale.html_locale }}"
       data-static-site="{{ g.get('static_site', false)|tojson|forceescape }}">
 <head>
     <title>


### PR DESCRIPTION
- Address registration form accessibility by introducing a custom datepicker
- Add `<ind-datepicker>` custom element

Note: The datepicker supports range selection which links two datepickers so that they limit each other's max/min values. This feature is not used in the registration form, and has thus only been tested out of the context of the Indico application. It "should" work in theory, but it should be considered untested. The feature will be revisited/re-tested when it is integrated into a context where it will be used (e.g., management area).