### PR TITLE
Fix sender to Registration for Apple Wallet signal

### DIFF
--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -152,5 +152,5 @@ Called when a ticket object for an Apple Wallet has been generated. The `sender`
 
 apple_wallet_object = _signals.signal('apple-wallet-object', '''
 Called when the Pass object for an Apple Wallet has been generated. The `sender` is the
-`Event` object, the `obj` kwarg contains the Pass object.
+`Registration` object, the `obj` kwarg contains the Pass object.
 ''')

--- a/indico/modules/events/registration/wallets/apple.py
+++ b/indico/modules/events/registration/wallets/apple.py
@@ -126,7 +126,7 @@ class AppleWalletManager:
             passfile.add_file_from_url('logo.png', config.ABSOLUTE_WALLET_LOGO_URL)
         else:
             passfile.add_default_images()
-        signals.event.registration.apple_wallet_object.send(self.event, obj=passfile)
+        signals.event.registration.apple_wallet_object.send(registration, obj=passfile)
         return passfile
 
     def get_ticket(self, registration) -> str:


### PR DESCRIPTION
This is to fix the sender in the apple_wallet_object signal: 
the Registration is the object needed to add/update passfile properties.
In particular, to be able to add a banner (StripImage) based on the Registration info.