### PR TITLE
Update docs to mention WeasyPrint

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -255,5 +255,5 @@ redirects = {
     'installation/production/centos/nginx': '../../rpm/nginx',
     'installation/production/debian/apache': '../../deb/apache',
     'installation/production/debian/nginx': '../../deb/nginx',
-    'installation/latex': 'pdf_generation',
+    'installation/latex': '../pdf_generation',
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -255,4 +255,5 @@ redirects = {
     'installation/production/centos/nginx': '../../rpm/nginx',
     'installation/production/debian/apache': '../../deb/apache',
     'installation/production/debian/nginx': '../../deb/nginx',
+    'installation/latex': 'pdf_generation',
 }

--- a/docs/source/installation/index.rst
+++ b/docs/source/installation/index.rst
@@ -12,4 +12,4 @@ Installation guides
     Development <development.rst>
     Plugins <plugins.rst>
     Translations <translations.rst>
-    LaTeX <latex.rst>
+    PDF Generation <pdf_generation.rst>

--- a/docs/source/installation/pdf_generation.rst
+++ b/docs/source/installation/pdf_generation.rst
@@ -1,7 +1,28 @@
-.. _latex:
+.. _pdf_generation:
+
+PDF Generation
+==============
+
+WeasyPrint
+----------
+
+Indico uses `WeasyPrint <weasyprint_>`_ to generate PDF files from `Document
+templates <DT_>`_. WeasyPrint generally works out of the box and does not
+require any setup.
+
+.. note::
+
+    WeasyPrint uses fonts installed on the system to render the PDFs. If you are
+    generating documents containing character sets like CJK (Chinese, Japanese,
+    Korean), make sure to install the necessary fonts. Note that, the exact
+    procedure to install new fonts depends on the distribution.
+
+.. _weasyprint: https://github.com/Kozea/WeasyPrint
+.. _DT: https://learn.getindico.io/document_templates/about/
 
 LaTeX
-=====
+-----
+.. _latex:
 
 Indico uses LaTeX (xelatex to be exact) to generate some PDF files such
 as the *Book of Abstracts* and the PDF versions of contributions.  If

--- a/docs/source/installation/production/deb/apache.rst
+++ b/docs/source/installation/production/deb/apache.rst
@@ -379,11 +379,11 @@ Access ``https://YOURHOSTNAME`` in your browser and follow the steps
 displayed there to create your initial user.
 
 
-11. Install TeXLive
--------------------
+11. Set up PDF Document Generation
+----------------------------------
 
-Follow the :ref:`LaTeX install guide <latex>` to install TeXLive so
-Indico can generate PDF files in various places.
+Follow the :ref:`PDF generation guide <pdf_generation>` to setup PDF document
+generation in Indico.
 
 
 .. _deb-apache-shib:

--- a/docs/source/installation/production/deb/apache.rst
+++ b/docs/source/installation/production/deb/apache.rst
@@ -379,8 +379,8 @@ Access ``https://YOURHOSTNAME`` in your browser and follow the steps
 displayed there to create your initial user.
 
 
-11. Set up PDF Document Generation
-----------------------------------
+11. Install TeXLive
+-------------------
 
 Follow the :ref:`PDF generation guide <pdf_generation>` to setup PDF document
 generation in Indico.

--- a/docs/source/installation/production/deb/nginx.rst
+++ b/docs/source/installation/production/deb/nginx.rst
@@ -405,8 +405,8 @@ Access ``https://YOURHOSTNAME`` in your browser and follow the steps
 displayed there to create your initial user.
 
 
-11. Set up PDF Document Generation
-----------------------------------
+11. Install TeXLive
+-------------------
 
 Follow the :ref:`PDF generation guide <pdf_generation>` to setup PDF document
 generation in Indico.

--- a/docs/source/installation/production/deb/nginx.rst
+++ b/docs/source/installation/production/deb/nginx.rst
@@ -405,11 +405,11 @@ Access ``https://YOURHOSTNAME`` in your browser and follow the steps
 displayed there to create your initial user.
 
 
-11. Install TeXLive
--------------------
+11. Set up PDF Document Generation
+----------------------------------
 
-Follow the :ref:`LaTeX install guide <latex>` to install TeXLive so
-Indico can generate PDF files in various places.
+Follow the :ref:`PDF generation guide <pdf_generation>` to setup PDF document
+generation in Indico.
 
 
 .. _PostgreSQL wiki: https://wiki.postgresql.org/wiki/YUM_Installation#Configure_your_YUM_repository

--- a/docs/source/installation/production/rpm/apache.rst
+++ b/docs/source/installation/production/rpm/apache.rst
@@ -408,8 +408,8 @@ Access ``https://YOURHOSTNAME`` in your browser and follow the steps
 displayed there to create your initial user.
 
 
-13. Set up PDF Document Generation
-----------------------------------
+13. Install TeXLive
+-------------------
 
 Follow the :ref:`PDF generation guide <pdf_generation>` to setup PDF document
 generation in Indico.

--- a/docs/source/installation/production/rpm/apache.rst
+++ b/docs/source/installation/production/rpm/apache.rst
@@ -408,11 +408,11 @@ Access ``https://YOURHOSTNAME`` in your browser and follow the steps
 displayed there to create your initial user.
 
 
-13. Install TeXLive
--------------------
+13. Set up PDF Document Generation
+----------------------------------
 
-Follow the :ref:`LaTeX install guide <latex>` to install TeXLive so
-Indico can generate PDF files in various places.
+Follow the :ref:`PDF generation guide <pdf_generation>` to setup PDF document
+generation in Indico.
 
 
 .. _rpm-apache-shib:

--- a/docs/source/installation/production/rpm/nginx.rst
+++ b/docs/source/installation/production/rpm/nginx.rst
@@ -436,8 +436,8 @@ Access ``https://YOURHOSTNAME`` in your browser and follow the steps
 displayed there to create your initial user.
 
 
-13. Set up PDF Document Generation
-----------------------------------
+13. Install TeXLive
+-------------------
 
 Follow the :ref:`PDF generation guide <pdf_generation>` to setup PDF document
 generation in Indico.

--- a/docs/source/installation/production/rpm/nginx.rst
+++ b/docs/source/installation/production/rpm/nginx.rst
@@ -436,11 +436,11 @@ Access ``https://YOURHOSTNAME`` in your browser and follow the steps
 displayed there to create your initial user.
 
 
-13. Install TeXLive
--------------------
+13. Set up PDF Document Generation
+----------------------------------
 
-Follow the :ref:`LaTeX install guide <latex>` to install TeXLive so
-Indico can generate PDF files in various places.
+Follow the :ref:`PDF generation guide <pdf_generation>` to setup PDF document
+generation in Indico.
 
 
 .. _PostgreSQL wiki: https://wiki.postgresql.org/wiki/YUM_Installation#Configure_your_YUM_repository


### PR DESCRIPTION
WeasyPrint uses system fonts to generate PDFs unlike Latex which uses `indico_fonts`.
This means that support for CJK, etc.. within Document templates depends on whether or not an appropriate font is installed.
This PR adds an explicit note about this to the docs.