### PR TITLE
Fix error with viewing scored abstracts with a deleted track

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,7 @@ Bugfixes
   events (:pr:`6359`)
 - Fix UI breaking when performing bulk actions via the list of editables (:pr:`6369`)
 - Include registration documents in user data export (:issue:`6331`, :pr:`6338`)
+- Fix error when viewing an abstract with reviews in deleted tracks (:pr:`6393`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/abstracts/models/abstracts.py
+++ b/indico/modules/events/abstracts/models/abstracts.py
@@ -458,6 +458,8 @@ class Abstract(ProposalMixin, ProposalRevisionMixin, DescriptionMixin, CustomFie
         sums = defaultdict(Counter)
         lens = defaultdict(Counter)
         for r in self.reviews:
+            if not r.track:
+                continue
             sums[r.track.id] += Counter(r.scores)
             lens[r.track.id] += Counter(r.scores.keys())
         return {track: {question: score / lens[track][question]


### PR DESCRIPTION
This PR fixes a bug where viewing an abstract that has been given a score with a deleted track would raise an error.