### PR TITLE
Enable social share widget by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,7 @@ Improvements
   thanks :user:`hitenvidhani`)
 - Modernize the event social share widget and add support for sharing to
   Mastodon (:pr:`6289`)
+- Enable the calendaring + social sharing widget in events by default (:pr:`6398`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/core/settings.py
+++ b/indico/modules/core/settings.py
@@ -15,5 +15,5 @@ core_settings = SettingsProxy('core', {
 
 
 social_settings = SettingsProxy('social', {
-    'enabled': False,
+    'enabled': True,
 })


### PR DESCRIPTION
In the past it was disabled by default because it loaded JS code from Google, FB, etc., but that's no longer the case for quite some time now. It now simply has outgoing links to Google Calendar, MS Exchange Online Calendar, Twitter and Mastodon.

The changed default will apply to new Indico instances and those who never saved the social settings at some point.