### PR TITLE
Add min and max constraints to DatePicker and DateInput

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,7 +81,7 @@ Internal Changes
 ^^^^^^^^^^^^^^^^
 
 - Use unguessable URLs for user avatar pictures (:pr:`6346`, thanks :user:`vtran99`)
-- Add ``<ind-date-picker>`` custom element (:pr:`6371`, thanks :user:`foxbunny`)
+- Add ``<ind-date-picker>`` custom element (:pr:`6371, 6406`, thanks :user:`foxbunny`)
 - Use native ESM for webpack config files (:pr:`6389`)
 
 

--- a/indico/modules/events/registration/client/js/form/fields/DateInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/DateInput.jsx
@@ -29,6 +29,8 @@ export function DateInputComponent({
   required,
   dateFormat,
   timeFormat,
+  minDate,
+  maxDate,
 }) {
   const dateValue = value.split('T')[0];
   const timeValue = value.includes('T') ? value.split('T')[1] : '';
@@ -54,6 +56,8 @@ export function DateInputComponent({
           onChange={handleDateChange}
           onFocus={onFocus}
           onBlur={onBlur}
+          min={minDate}
+          max={maxDate}
         />
       </Form.Field>
       {timeFormat && (
@@ -98,10 +102,14 @@ DateInputComponent.propTypes = {
     'YYYY',
   ]).isRequired,
   timeFormat: PropTypes.oneOf(['12h', '24h']),
+  minDate: PropTypes.string,
+  maxDate: PropTypes.string,
 };
 
 DateInputComponent.defaultProps = {
   timeFormat: null,
+  minDate: undefined,
+  maxDate: undefined,
 };
 
 export default function DateInput({

--- a/indico/web/client/js/custom_elements/ind_date_picker.js
+++ b/indico/web/client/js/custom_elements/ind_date_picker.js
@@ -23,19 +23,9 @@ customElements.define(
       return this.querySelector('input').value;
     }
 
-    get start() {
-      return this.getAttribute('start');
-    }
-
-    get end() {
-      return this.getAttribute('end');
-    }
-
     connectedCallback() {
       const id = `date-picker-${this.constructor.lastId++}`;
       const input = this.querySelector('input');
-      const startInput = document.getElementById(this.start);
-      const endInput = document.getElementById(this.end);
       const openCalendarButton = this.querySelector('button');
       const formatDescription = this.querySelector('[data-format]');
       const indCalendar = this.querySelector('ind-calendar');
@@ -83,12 +73,6 @@ customElements.define(
       });
       input.addEventListener('input', () => {
         indCalendar.value = toDateString(parseDate(this.value));
-      });
-      startInput?.addEventListener('input', () => {
-        indCalendar.rangeStart = toDateString(parseDate(startInput.value));
-      });
-      endInput?.addEventListener('input', () => {
-        indCalendar.rangeEnd = toDateString(parseDate(endInput.value));
       });
 
       function openDialog() {
@@ -142,20 +126,20 @@ customElements.define(
       this.setAttribute('value', value || '');
     }
 
-    get rangeStart() {
-      return this.getAttribute('range-start');
+    get min() {
+      return this.getAttribute('min');
     }
 
-    set rangeStart(value) {
-      this.setAttribute('range-start', value || '');
+    set min(dateString) {
+      this.setAttribute('min', dateString);
     }
 
-    get rangeEnd() {
-      return this.getAttribute('range-end');
+    get max() {
+      return this.getAttribute('max');
     }
 
-    set rangeEnd(value) {
-      this.setAttribute('range-end', value || '');
+    set max(dateString) {
+      this.setAttribute('max', dateString);
     }
 
     connectedCallback() {
@@ -400,13 +384,9 @@ customElements.define(
 
         // Populate the calendar cells
 
+        const min = toOptionalDate(indCalendar.min);
+        const max = toOptionalDate(indCalendar.max);
         const month = firstDayOfMonth.getMonth();
-        // Note that getDay() returns Sunday as 0, but we need 7 because of the weekInfo API
-
-        const rangeStart = toOptionalDate(indCalendar.rangeStart);
-        const rangeEnd = toOptionalDate(indCalendar.rangeEnd);
-        const markStart = rangeStart || (rangeEnd && selectedDate);
-        const markEnd = rangeEnd || (rangeStart && selectedDate);
 
         for (let i = 0; i < CALENDAR_CELL_COUNT; i++) {
           const date = new Date(firstDayOfCalendar);
@@ -430,10 +410,7 @@ customElements.define(
           calendarButton.value = toDateString(date);
 
           // Mark range
-          calendarButton.disabled = date < rangeStart || date > rangeEnd;
-          calendarButton.toggleAttribute('data-range-start', sameDate(date, markStart));
-          calendarButton.toggleAttribute('data-range-end', sameDate(date, markEnd));
-          calendarButton.toggleAttribute('data-range', date < markEnd && date > markStart);
+          calendarButton.disabled = date < min || date > max;
 
           // Mark selected
           if (calendarButton.value === indCalendar.value) {
@@ -453,7 +430,7 @@ customElements.define(
       this.cleanup();
     }
 
-    static observedAttributes = ['open', 'value', 'range-start', 'range-end'];
+    static observedAttributes = ['open', 'value', 'min', 'max'];
 
     attributeChangedCallback(name) {
       switch (name) {
@@ -461,8 +438,8 @@ customElements.define(
           this.dispatchEvent(new Event('attrchange.open'));
           break;
         case 'value':
-        case 'range-start':
-        case 'range-end':
+        case 'min':
+        case 'max':
           this.dispatchEvent(new Event('attrchange.value'));
           break;
       }
@@ -484,10 +461,6 @@ function getToday() {
   const now = new Date();
   now.setHours(0, 0, 0, 0);
   return now;
-}
-
-function sameDate(a, b) {
-  return a?.getTime() === b?.getTime();
 }
 
 function toDateString(date) {

--- a/indico/web/client/js/custom_elements/ind_date_picker.js
+++ b/indico/web/client/js/custom_elements/ind_date_picker.js
@@ -421,7 +421,8 @@ customElements.define(
         }
 
         const focusableButton =
-          listbox.querySelector('[aria-selected]') || listbox.firstElementChild;
+          listbox.querySelector('[aria-selected]') ||
+          listbox.querySelector('button:not(:disabled)');
         focusableButton.tabIndex = 0;
       }
     }

--- a/indico/web/client/js/custom_elements/ind_date_picker.scss
+++ b/indico/web/client/js/custom_elements/ind_date_picker.scss
@@ -175,6 +175,10 @@ ind-calendar {
     &:hover {
       background-color: var(--control-clickable-surface-focus-color);
     }
+
+    &:focus-visible {
+      z-index: 1;
+    }
   }
 
   [role='listbox'] :is([data-range-start], [data-range-end], [data-range]) {

--- a/indico/web/client/js/custom_elements/ind_date_picker.scss
+++ b/indico/web/client/js/custom_elements/ind_date_picker.scss
@@ -173,7 +173,7 @@ ind-calendar {
     border: none;
 
     &:hover {
-      background-color: var(--surface-highlight-color);
+      background-color: var(--control-clickable-surface-focus-color);
     }
   }
 
@@ -204,8 +204,12 @@ ind-calendar {
     opacity: 0.5;
   }
 
-  [data-current-month='false'] {
-    background-color: #fff;
-    color: #ddd;
+  button[data-current-month='true'] {
+    color: var(--control-text-color);
+  }
+
+  button[data-current-month='false'] {
+    color: var(--text-secondary-color);
+    background: var(--background-secondary);
   }
 }

--- a/indico/web/client/js/react/components/DatePicker.jsx
+++ b/indico/web/client/js/react/components/DatePicker.jsx
@@ -22,6 +22,8 @@ export default function DatePicker({
   onChange,
   value,
   format = moment.localeData().longDateFormat('L'),
+  min,
+  max,
   ...inputProps
 }) {
   function handleDateChange(ev) {
@@ -47,7 +49,10 @@ export default function DatePicker({
       <button type="button" disabled={inputProps.disabled}>
         <Translate as="span">Open a calendar</Translate>
       </button>
-      <ind-calendar>
+      <ind-calendar
+        min={fromISOLocalDate(min)?.toDateString()}
+        max={fromISOLocalDate(max)?.toDateString()}
+      >
         <dialog>
           <div className="controls">
             <button type="button" value="previous-year">
@@ -96,11 +101,15 @@ DatePicker.propTypes = {
   format: PropTypes.string,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.any,
+  min: PropTypes.string,
+  max: PropTypes.string,
 };
 
 DatePicker.defaultProps = {
   value: undefined,
   format: undefined,
+  min: undefined,
+  max: undefined,
 };
 
 /**

--- a/indico/web/client/js/react/components/DatePicker.jsx
+++ b/indico/web/client/js/react/components/DatePicker.jsx
@@ -118,10 +118,40 @@ DatePicker.defaultProps = {
 export function FinalDatePicker({name, ...rest}) {
   const validDate = val =>
     val === INVALID ? Translate.string('The entered date is not valid.') : undefined;
-  rest.validate = rest.validate ? v.chain(validDate, rest.validate) : validDate;
-  return <FinalField name={name} component={DatePicker} {...rest} />;
+  const validators = [validDate];
+  if (rest.min) {
+    validators.push(val =>
+      val < rest.min
+        ? Translate.string('The entered date cannot be earlier than {min}.', {
+            min: moment(rest.min).format('L'),
+          })
+        : undefined
+    );
+  }
+  if (rest.max) {
+    validators.push(val =>
+      val > rest.max
+        ? Translate.string('The entered date cannot be later than {max}.', {
+            max: moment(rest.max).format('L'),
+          })
+        : undefined
+    );
+  }
+  if (rest.validate) {
+    validators.push(rest.validate);
+  }
+  return (
+    <FinalField name={name} component={DatePicker} {...rest} validate={v.chain(...validators)} />
+  );
 }
 
 FinalDatePicker.propTypes = {
   name: PropTypes.string.isRequired,
+  min: PropTypes.string,
+  max: PropTypes.string,
+};
+
+FinalDatePicker.defaultProps = {
+  min: undefined,
+  max: undefined,
 };


### PR DESCRIPTION
This is a quick fix while I work out the design for the multi-calendar multi-input mode. The `min` and `max` props will be kept even when the redesigned implementation is done, so only the internal handling of these props is temporary.