### PR TITLE
Fix attaching large pictures in registration notification emails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,7 +65,7 @@ Bugfixes
 - Fix error when trying to import data from an unlisted event (:issue:`6350`, :pr:`6351`)
 - Show results from the Get Next Editable search on top of the list (:pr:`6353`)
 - Attach registration pictures and display them inline when sending email notifications
-  instead of just showing their filename (:pr:`6336`, thanks :user:`SegiNyn`)
+  instead of just showing their filename (:pr:`6336, 6411`, thanks :user:`SegiNyn`)
 - Fix editable list filter storage being shared between different editable types and
   events (:pr:`6359`)
 - Fix UI breaking when performing bulk actions via the list of editables (:pr:`6369`)

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -212,6 +212,8 @@ _bp.add_url_rule('/registrations/<int:reg_form_id>/', 'display_regform', display
                  methods=('GET', 'POST'))
 _bp.add_url_rule('/registrations/<int:reg_form_id>/upload', 'upload_registration_file',
                  display.RHUploadRegistrationFile, methods=('POST',))
+_bp.add_url_rule('/registrations/<int:reg_form_id>/upload-picture', 'upload_registration_picture',
+                 display.RHUploadRegistrationPicture, methods=('POST',))
 _bp.add_url_rule('/registrations/<int:reg_form_id>/edit', 'edit_registration_display',
                  display.RHRegistrationDisplayEdit, methods=('GET', 'POST'))
 _bp.add_url_rule('/registrations/<int:reg_form_id>/withdraw', 'withdraw_registration',

--- a/indico/modules/events/registration/client/js/form/fields/PictureInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/PictureInput.jsx
@@ -7,7 +7,7 @@
 
 import managementPreviewURL from 'indico-url:event_registration.manage_registration_file';
 import registrantPreviewURL from 'indico-url:event_registration.registration_picture';
-import uploadURL from 'indico-url:event_registration.upload_registration_file';
+import uploadURL from 'indico-url:event_registration.upload_registration_picture';
 
 import PropTypes from 'prop-types';
 import React, {useMemo} from 'react';
@@ -88,7 +88,7 @@ export function PictureSettings() {
       )}
       step="1"
       min="0"
-      max="1200"
+      max="1000"
       validate={v.optional(v.min(0))}
       fluid
       format={val => val || ''}

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from flask import flash, jsonify, redirect, request, session
 from sqlalchemy.orm import contains_eager, joinedload, lazyload, load_only, subqueryload
 from webargs import fields
-from werkzeug.exceptions import BadRequest, Forbidden, NotFound
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound, UnprocessableEntity
 
 from indico.core.db import db
 from indico.modules.auth.util import redirect_to_login
@@ -453,6 +453,8 @@ class RHUploadRegistrationPicture(RHUploadRegistrationFile):
 
     def _save_file(self, file, stream):
         resized_image_stream = process_uploaded_registration_picture(stream, 1000)
+        if not resized_image_stream:
+            raise UnprocessableEntity('Could not process image')
         return super()._save_file(file, resized_image_stream)
 
     def get_file_metadata(self):

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-import mimetypes
 from uuid import UUID
 
 from flask import flash, jsonify, redirect, request, session
@@ -35,7 +34,6 @@ from indico.modules.events.registration.views import (WPDisplayRegistrationFormC
                                                       WPDisplayRegistrationFormSimpleEvent,
                                                       WPDisplayRegistrationParticipantList)
 from indico.modules.files.controllers import UploadFileMixin
-from indico.modules.files.models.files import File
 from indico.modules.receipts.models.files import ReceiptFile
 from indico.modules.users.util import send_avatar, send_default_avatar
 from indico.util.fs import secure_filename
@@ -454,12 +452,8 @@ class RHUploadRegistrationPicture(RHUploadRegistrationFile):
     """Upload a picture from a registration form."""
 
     def _save_file(self, file, stream):
-        from indico.modules.files.schemas import FileSchema
-        context = self.get_file_context()
-        content_type = mimetypes.guess_type(file.filename)[0] or file.mimetype or 'application/octet-stream'
-        resized_image_bytes = resize_uploaded_registration_picture(stream, 1000)
-        f = File.create_from_stream(resized_image_bytes, file.filename, content_type, context)
-        return FileSchema().jsonify(f), 201
+        resized_image_stream = resize_uploaded_registration_picture(stream, 1000)
+        return super()._save_file(file, resized_image_stream)
 
 
 class RHRegistrationDisplayEdit(RegistrationEditMixin, RHRegistrationFormRegistrationBase):

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -29,7 +29,7 @@ from indico.modules.events.registration.notifications import notify_registration
 from indico.modules.events.registration.util import (check_registration_email, create_registration, generate_ticket,
                                                      get_event_regforms_registrations, get_flat_section_submission_data,
                                                      get_initial_form_values, get_user_data, make_registration_schema,
-                                                     resize_uploaded_registration_picture)
+                                                     process_uploaded_registration_picture)
 from indico.modules.events.registration.views import (WPDisplayRegistrationFormConference,
                                                       WPDisplayRegistrationFormSimpleEvent,
                                                       WPDisplayRegistrationParticipantList)
@@ -452,8 +452,11 @@ class RHUploadRegistrationPicture(RHUploadRegistrationFile):
     """Upload a picture from a registration form."""
 
     def _save_file(self, file, stream):
-        resized_image_stream = resize_uploaded_registration_picture(stream, 1000)
+        resized_image_stream = process_uploaded_registration_picture(stream, 1000)
         return super()._save_file(file, resized_image_stream)
+
+    def get_file_metadata(self):
+        return {'registration_picture_checked': True}
 
 
 class RHRegistrationDisplayEdit(RegistrationEditMixin, RHRegistrationFormRegistrationBase):

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -405,13 +405,15 @@ class PictureField(FileField):
             file = File.query.filter(File.uuid == value, ~File.claimed).first()
             if not file:
                 raise ValidationError('Invalid file')
+            if not file.meta.get('registration_picture_checked'):
+                raise ValidationError('Picture has not been properly validated')
             try:
                 with file.open() as f:
                     pic = Image.open(f)
             except OSError:
                 raise ValidationError(_('Invalid picture file.'))
-            if pic.format.lower() not in {'jpeg', 'png', 'gif', 'webp'}:
-                raise ValidationError(_('This field only accepts jpg, png, gif and webp picture formats.'))
+            if pic.format.lower() != 'jpeg':
+                raise ValidationError(_('This field only accepts jpg picture format.'))
             min_picture_size = self._get_min_size()
             if min_picture_size and min(pic.size) < min_picture_size:
                 raise ValidationError(_('The uploaded picture pixels is smaller than the minimum size of {}.')

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -395,7 +395,7 @@ class EmailField(RegistrationFormFieldBase):
 class PictureField(FileField):
     name = 'picture'
     setup_schema_fields = {
-        'min_picture_size': fields.Integer(load_default=0, validate=validate.Range(0, 1200)),
+        'min_picture_size': fields.Integer(load_default=0, validate=validate.Range(0, 1000)),
     }
 
     def get_validators(self, existing_registration):

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -406,14 +406,14 @@ class PictureField(FileField):
             if not file:
                 raise ValidationError('Invalid file')
             if not file.meta.get('registration_picture_checked'):
-                raise ValidationError('Picture has not been properly validated')
+                raise ValidationError('Picture has not been properly validated.')
             try:
                 with file.open() as f:
                     pic = Image.open(f)
             except OSError:
                 raise ValidationError(_('Invalid picture file.'))
             if pic.format.lower() != 'jpeg':
-                raise ValidationError(_('This field only accepts jpg picture format.'))
+                raise ValidationError('This field only accepts jpeg pictures.')
             min_picture_size = self._get_min_size()
             if min_picture_size and min(pic.size) < min_picture_size:
                 raise ValidationError(_('The uploaded picture pixels is smaller than the minimum size of {}.')

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -636,6 +636,7 @@ class Registration(db.Model):
 
     def get_picture_attachments(self):
         """Return a list of registration pictures as `MimeImage` attachments."""
+        from indico.modules.events.registration.util import resize_uploaded_registration_picture
         picture_attachements = []
         for data in self.data:
             if not data.field_data.field.is_active or data.field_data.field.input_type != 'picture':
@@ -645,7 +646,10 @@ class Registration(db.Model):
             if data.storage_file_id is None:
                 continue
             with data.open() as f:
-                attachment = MIMEImage(f.read())
+                thumbnail_bytes = resize_uploaded_registration_picture(f, 120)
+                if not thumbnail_bytes:
+                    continue
+                attachment = MIMEImage(thumbnail_bytes.read())
             attachment.add_header('Content-ID', f'<{data.attachment_cid}>')
             picture_attachements.append(attachment)
         return picture_attachements

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -646,8 +646,7 @@ class Registration(db.Model):
             if data.storage_file_id is None:
                 continue
             with data.open() as f:
-                thumbnail_bytes = resize_uploaded_registration_picture(f, 120)
-                if not thumbnail_bytes:
+                if not (thumbnail_bytes := resize_uploaded_registration_picture(f, 120)):
                     continue
                 attachment = MIMEImage(thumbnail_bytes.read())
             attachment.add_header('Content-ID', f'<{data.attachment_cid}>')

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -648,10 +648,7 @@ class Registration(db.Model):
             with data.open() as f:
                 if not (thumbnail_bytes := resize_uploaded_registration_picture(f, 120)):
                     continue
-                try:
-                    attachment = MIMEImage(thumbnail_bytes.read())
-                except TypeError:
-                    continue
+                attachment = MIMEImage(thumbnail_bytes.read(), _subtype='jpeg')
             attachment.add_header('Content-ID', f'<{data.attachment_cid}>')
             picture_attachements.append(attachment)
         return picture_attachements

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -648,7 +648,10 @@ class Registration(db.Model):
             with data.open() as f:
                 if not (thumbnail_bytes := resize_uploaded_registration_picture(f, 120)):
                     continue
-                attachment = MIMEImage(thumbnail_bytes.read())
+                try:
+                    attachment = MIMEImage(thumbnail_bytes.read())
+                except TypeError:
+                    continue
             attachment.add_header('Content-ID', f'<{data.attachment_cid}>')
             picture_attachements.append(attachment)
         return picture_attachements

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -636,7 +636,7 @@ class Registration(db.Model):
 
     def get_picture_attachments(self):
         """Return a list of registration pictures as `MimeImage` attachments."""
-        from indico.modules.events.registration.util import resize_uploaded_registration_picture
+        from indico.modules.events.registration.util import process_uploaded_registration_picture
         picture_attachements = []
         for data in self.data:
             if not data.field_data.field.is_active or data.field_data.field.input_type != 'picture':
@@ -646,9 +646,9 @@ class Registration(db.Model):
             if data.storage_file_id is None:
                 continue
             with data.open() as f:
-                if not (thumbnail_bytes := resize_uploaded_registration_picture(f, 120)):
+                if not (thumbnail_bytes := process_uploaded_registration_picture(f, 120)):
                     continue
-                attachment = MIMEImage(thumbnail_bytes.read(), _subtype='jpeg')
+                attachment = MIMEImage(thumbnail_bytes.read(), 'jpeg')
             attachment.add_header('Content-ID', f'<{data.attachment_cid}>')
             picture_attachements.append(attachment)
         return picture_attachements

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -1001,7 +1001,8 @@ def get_persons(registrations, include_accompanying_persons=False):
 
 def process_uploaded_registration_picture(source, size):
     """Process the uploaded registration picture.
-    By converting the picture to JPEG and resizing large pictures to the given `size`.
+
+    This converts the picture to JPEG and resizes it to a maximum size.
     """
     try:
         picture = Image.open(source)

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -1014,5 +1014,5 @@ def resize_uploaded_registration_picture(source, size):
         picture.save(image_bytes, 'PNG')
         image_bytes.seek(0)
         return image_bytes
-    except Exception:
+    except OSError:
         return None

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -999,22 +999,22 @@ def get_persons(registrations, include_accompanying_persons=False):
     return persons
 
 
-def resize_uploaded_registration_picture(source, size):
-    """Resize uploaded registration picture to the given size."""
+def process_uploaded_registration_picture(source, size):
+    """Process the uploaded registration picture.
+    By converting the picture to JPEG and resizing large pictures to the given `size`.
+    """
     try:
         picture = Image.open(source)
     except OSError:
         return None
     picture = ImageOps.exif_transpose(picture)
-    size_x, size_y = picture.size
-    if max(size_x, size_y) < size:
-        source.seek(0)
-        return source
-    ratio = size / max(size_x, size_y)
-    picture = picture.resize((int(ratio * size_x), int(ratio * size_y)), Image.Resampling.BICUBIC)
-    image_bytes = BytesIO()
     if picture.mode != 'RGB':
         picture = picture.convert('RGB')
+    size_x, size_y = picture.size
+    if max(size_x, size_y) > size:
+        ratio = size / max(size_x, size_y)
+        picture = picture.resize((int(ratio * size_x), int(ratio * size_y)), Image.Resampling.BICUBIC)
+    image_bytes = BytesIO()
     picture.save(image_bytes, 'JPEG')
     image_bytes.seek(0)
     return image_bytes

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -1003,16 +1003,18 @@ def resize_uploaded_registration_picture(source, size):
     """Resize uploaded registration picture to the given size."""
     try:
         picture = Image.open(source)
-        picture = ImageOps.exif_transpose(picture)
-        size_x, size_y = picture.size
-        if max(size_x, size_y) < size:
-            source.seek(0)
-            return source
-        ratio = float(size) / max(size_x, size_y)
-        picture = picture.resize((int(ratio * size_x), int(ratio * size_y)), Image.Resampling.BICUBIC)
-        image_bytes = BytesIO()
-        picture.save(image_bytes, 'PNG')
-        image_bytes.seek(0)
-        return image_bytes
     except OSError:
         return None
+    picture = ImageOps.exif_transpose(picture)
+    size_x, size_y = picture.size
+    if max(size_x, size_y) < size:
+        source.seek(0)
+        return source
+    ratio = size / max(size_x, size_y)
+    picture = picture.resize((int(ratio * size_x), int(ratio * size_y)), Image.Resampling.BICUBIC)
+    image_bytes = BytesIO()
+    if picture.mode != 'RGB':
+        picture = picture.convert('RGB')
+    picture.save(image_bytes, 'JPEG')
+    image_bytes.seek(0)
+    return image_bytes

--- a/indico/modules/receipts/controllers/event.py
+++ b/indico/modules/receipts/controllers/event.py
@@ -82,7 +82,7 @@ def _make_image_preview(img):
             preview = preview.convert('RGB')
         preview = square(preview)
         if preview.height > IMAGE_PREVIEW_SIZE:
-            preview = preview.resize((IMAGE_PREVIEW_SIZE, IMAGE_PREVIEW_SIZE), resample=Image.BICUBIC)
+            preview = preview.resize((IMAGE_PREVIEW_SIZE, IMAGE_PREVIEW_SIZE), resample=Image.Resampling.BICUBIC)
         image_bytes = BytesIO()
         imgtype = 'png' if preview.mode == 'RGBA' else 'jpeg'
         preview.save(image_bytes, imgtype.upper())

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -397,7 +397,7 @@ class RHSaveProfilePicture(RHUserBase):
                 pic = pic.convert('RGB')
             pic = square(pic)
             if pic.height > 256:
-                pic = pic.resize((256, 256), resample=Image.BICUBIC)
+                pic = pic.resize((256, 256), resample=Image.Resampling.BICUBIC)
             image_bytes = BytesIO()
             pic.save(image_bytes, 'PNG')
             image_bytes.seek(0)

--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -276,7 +276,9 @@ const PictureManager = ({
     multiple: false,
     noClick: true,
     noKeyboard: true,
-    maxSize: Indico.FileRestrictions.MaxUploadFileSize * 1024 * 1024,
+    maxSize: Indico.FileRestrictions.MaxUploadFileSize
+      ? Indico.FileRestrictions.MaxUploadFileSize * 1024 * 1024
+      : undefined,
   });
 
   let picture = null;

--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -276,6 +276,7 @@ const PictureManager = ({
     multiple: false,
     noClick: true,
     noKeyboard: true,
+    maxSize: Indico.FileRestrictions.MaxUploadFileSize * 2 ** 20,
   });
 
   let picture = null;

--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -201,7 +201,7 @@ const PictureManager = ({
       fetch(imageSrc)
         .then(res => res.blob())
         .then(blob => {
-          const file = new File([blob], 'picture.png', blob);
+          const file = new File([blob], 'picture.jpeg', blob);
           uploadPicture(file);
         });
     }

--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -201,7 +201,7 @@ const PictureManager = ({
       fetch(imageSrc)
         .then(res => res.blob())
         .then(blob => {
-          const file = new File([blob], 'picture.jpeg', blob);
+          const file = new File([blob], 'picture.jpg', blob);
           uploadPicture(file);
         });
     }

--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -276,7 +276,7 @@ const PictureManager = ({
     multiple: false,
     noClick: true,
     noKeyboard: true,
-    maxSize: Indico.FileRestrictions.MaxUploadFileSize * 2 ** 20,
+    maxSize: Indico.FileRestrictions.MaxUploadFileSize * 1024 * 1024,
   });
 
   let picture = null;


### PR DESCRIPTION
Hello @ThiefMaster , 

This is to fix the issue we are facing sending registration notification emails due to the emails being too large from the attached pictures. @OmeGak  told me that you proposed these 2:
1. Scaling the uploaded picture down to 1000px on the long edge, if it's bigger
2. Attaching a thumbnail in the notification email 
