### PR TITLE
Fix broken internal note segment style in Burotel

### DIFF
--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.module.scss
@@ -20,7 +20,7 @@
   }
 }
 
-:global(.ui.segment).internal-notes-segment {
+:global(.ui.inverted.segment).internal-notes-segment {
   background: $internal-notes-segment-color;
 }
 

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.jsx
@@ -657,11 +657,9 @@ class BookRoomModal extends React.Component {
                       <Icon name="clipboard list" />
                       <Translate>Internal notes (optional)</Translate>
                     </h3>
-                    <p>
-                      <Translate>
-                        Internal notes about the booking are only visible to room managers.
-                      </Translate>
-                    </p>
+                    <Translate as="p">
+                      Internal notes about the booking are only visible to room managers.
+                    </Translate>
                     <FinalTextArea name="internalNote" disabled={fprops.submitSucceeded} />
                   </Segment>
                 </Form>

--- a/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.module.scss
+++ b/indico/modules/rb/client/js/modules/bookRoom/BookRoomModal.module.scss
@@ -65,6 +65,6 @@
   }
 }
 
-:global(.ui.segment).internal-notes-segment {
+:global(.ui.inverted.segment).internal-notes-segment {
   background: $internal-notes-segment-color;
 }


### PR DESCRIPTION
The PR fixes an issue where the internal notes segment appeared without its typical 'yellow' color.

Before:
![image](https://github.com/indico/indico/assets/7736654/9f6b59f6-1a9a-4874-91ae-e890b665eca4)

After:
![image](https://github.com/indico/indico/assets/7736654/f61a5408-e55f-463a-96a8-54673e1f0d0c)
