### PR TITLE
Fix negative durations + add DB constraints

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,7 @@ Internal Changes
   package metadata is specified using ``pyproject.toml``. Developers who want to build
   their own plugins need to switch from ``setup.py`` and/or ``setup.cfg`` to ``pyproject.toml``
   as well (:pr:`6477`)
+- Prevent timetable entries with zero/negative durations (:pr:`6420`)
 
 
 Version 3.3.3

--- a/indico/migrations/versions/20240820_1408_0f7c3b642036_fix_negative_durations.py
+++ b/indico/migrations/versions/20240820_1408_0f7c3b642036_fix_negative_durations.py
@@ -1,0 +1,43 @@
+"""Set negative and zero-duration entries to a positive value
+
+Revision ID: 0f7c3b642036
+Revises: 5fa92194c124
+Create Date: 2024-06-26 11:01:00.506858
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '0f7c3b642036'
+down_revision = '5fa92194c124'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("UPDATE events.sessions SET default_contribution_duration = '1 minute' WHERE default_contribution_duration <= '0'")
+    op.execute("UPDATE events.session_blocks SET duration = '1 minute' WHERE duration < '0'")
+    op.execute("UPDATE events.contributions SET duration = '1 minute' WHERE duration < '0'")
+    op.execute("UPDATE events.breaks SET duration = '1 minute' WHERE duration < '0'")
+    op.execute("UPDATE events.subcontributions SET duration = '0' WHERE duration < '0'")
+
+    # After reseting the durations to a positive value, it is possible that some entries
+    # end after the parent block which must be fixed by extending the block duration.
+    entry_ends_after_parent = '''
+        FROM events.timetable_entries te
+        JOIN events.timetable_entries tep ON (tep.id = te.parent_id)
+        LEFT JOIN events.contributions c ON (c.id = te.contribution_id)
+        LEFT JOIN events.breaks b ON (b.id = te.break_id)
+        WHERE bl.id = tep.session_block_id AND te.parent_id IS NOT NULL AND te.type IN (2, 3) AND
+            (te.start_dt + COALESCE(c.duration, b.duration)) > (tep.start_dt + bl.duration)'''
+
+    op.execute(f'''
+        UPDATE events.session_blocks bl SET duration =
+            (SELECT MAX(te.start_dt + COALESCE(c.duration, b.duration) - tep.start_dt)
+             {entry_ends_after_parent})
+        {entry_ends_after_parent}''')  # noqa: S608
+
+
+def downgrade():
+    pass

--- a/indico/migrations/versions/20240820_1408_0f7c3b642036_fix_negative_durations.py
+++ b/indico/migrations/versions/20240820_1408_0f7c3b642036_fix_negative_durations.py
@@ -25,8 +25,9 @@ def upgrade():
     ''')
 
     op.execute("UPDATE events.sessions SET default_contribution_duration = '1 minute' WHERE default_contribution_duration <= '0'")
-    op.execute("UPDATE events.session_blocks SET duration = '1 minute' WHERE duration < '0'")
-    op.execute("UPDATE events.contributions SET duration = '1 minute' WHERE duration < '0'")
+    op.execute("UPDATE events.session_blocks SET duration = '1 minute' WHERE duration <= '0'")
+    op.execute("UPDATE events.contributions SET duration = '1 minute' WHERE duration <= '0'")
+    # Subcontributions and breaks are allowed to have a zero duration
     op.execute("UPDATE events.breaks SET duration = '1 minute' WHERE duration < '0'")
     op.execute("UPDATE events.subcontributions SET duration = '0' WHERE duration < '0'")
 

--- a/indico/migrations/versions/20240820_1408_0f7c3b642036_fix_negative_durations.py
+++ b/indico/migrations/versions/20240820_1408_0f7c3b642036_fix_negative_durations.py
@@ -38,6 +38,9 @@ def upgrade():
              {entry_ends_after_parent})
         {entry_ends_after_parent}''')  # noqa: S608
 
+    # force execution of trigger events
+    op.execute('SET CONSTRAINTS ALL IMMEDIATE')
+
 
 def downgrade():
     pass

--- a/indico/migrations/versions/20240820_1408_0f7c3b642036_fix_negative_durations.py
+++ b/indico/migrations/versions/20240820_1408_0f7c3b642036_fix_negative_durations.py
@@ -24,14 +24,18 @@ def upgrade():
         ALTER TABLE events.contributions DISABLE TRIGGER consistent_timetable;
     ''')
 
-    op.execute("UPDATE events.sessions SET default_contribution_duration = '1 minute' WHERE default_contribution_duration <= '0'")
-    op.execute("UPDATE events.session_blocks SET duration = '1 minute' WHERE duration <= '0'")
-    op.execute("UPDATE events.contributions SET duration = '1 minute' WHERE duration <= '0'")
+    op.execute('''
+        UPDATE events.sessions SET default_contribution_duration = '1 minute' WHERE default_contribution_duration <= '0';
+        UPDATE events.session_blocks SET duration = '1 minute' WHERE duration <= '0';
+        UPDATE events.contributions SET duration = '1 minute' WHERE duration <= '0';
+    ''')
     # Subcontributions and breaks are allowed to have a zero duration
-    op.execute("UPDATE events.breaks SET duration = '1 minute' WHERE duration < '0'")
-    op.execute("UPDATE events.subcontributions SET duration = '0' WHERE duration < '0'")
+    op.execute('''
+        UPDATE events.subcontributions SET duration = '0' WHERE duration < '0';
+        UPDATE events.breaks SET duration = '1 minute' WHERE duration < '0';
+    ''')
 
-    # After reseting the durations to a positive value, it is possible that some entries
+    # After resetting the durations to a positive value, it is possible that some entries
     # end after the parent block which must be fixed by extending the block duration.
     entry_ends_after_parent = '''
         FROM events.timetable_entries te

--- a/indico/migrations/versions/20240820_1409_75db3a4a4ed4_add_constraints_to_durations.py
+++ b/indico/migrations/versions/20240820_1409_75db3a4a4ed4_add_constraints_to_durations.py
@@ -1,0 +1,37 @@
+"""Add constraints to ensure positive durations
+
+Revision ID: 75db3a4a4ed4
+Revises: 0f7c3b642036
+Create Date: 2024-06-26 11:40:47.150327
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '75db3a4a4ed4'
+down_revision = '0f7c3b642036'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_check_constraint('positive_default_contribution_duration', 'sessions', "default_contribution_duration > '0'",
+                               schema='events')
+    op.create_check_constraint('positive_duration', 'session_blocks', "duration > '0'",
+                               schema='events')
+    op.create_check_constraint('positive_duration', 'contributions', "duration > '0'",
+                               schema='events')
+    # Subcontributions and breaks are allowed to have a zero duration
+    op.create_check_constraint('nonnegative_duration', 'breaks', "duration >= '0'",
+                               schema='events')
+    op.create_check_constraint('nonnegative_duration', 'subcontributions', "duration >= '0'",
+                               schema='events')
+
+
+def downgrade():
+    op.drop_constraint('ck_sessions_positive_default_contribution_duration', 'sessions', schema='events')
+    op.drop_constraint('ck_session_blocks_positive_duration', 'session_blocks', schema='events')
+    op.drop_constraint('ck_contributions_positive_duration', 'contributions', schema='events')
+    op.drop_constraint('ck_breaks_nonnegative_duration', 'breaks', schema='events')
+    op.drop_constraint('ck_subcontributions_nonnegative_duration', 'subcontributions', schema='events')

--- a/indico/modules/events/contributions/models/contributions.py
+++ b/indico/modules/events/contributions/models/contributions.py
@@ -87,6 +87,7 @@ class Contribution(SearchableTitleMixin, SearchableDescriptionMixin, ProtectionM
                          db.CheckConstraint('session_block_id IS NULL OR session_id IS NOT NULL',
                                             'session_block_if_session'),
                          db.CheckConstraint("date_trunc('minute', duration) = duration", 'duration_no_seconds'),
+                         db.CheckConstraint("duration > '0'", 'positive_duration'),
                          db.ForeignKeyConstraint(['session_block_id', 'session_id'],
                                                  ['events.session_blocks.id', 'events.session_blocks.session_id']),
                          {'schema': 'events'})

--- a/indico/modules/events/contributions/models/subcontributions.py
+++ b/indico/modules/events/contributions/models/subcontributions.py
@@ -42,6 +42,7 @@ class SubContribution(SearchableTitleMixin, SearchableDescriptionMixin, Attached
     __tablename__ = 'subcontributions'
     __auto_table_args = (db.Index(None, 'friendly_id', 'contribution_id', unique=True),
                          db.CheckConstraint("date_trunc('minute', duration) = duration", 'duration_no_seconds'),
+                         db.CheckConstraint("duration >= '0'", 'nonnegative_duration'),
                          {'schema': 'events'})
 
     PRELOAD_EVENT_ATTACHED_ITEMS = True

--- a/indico/modules/events/sessions/models/blocks.py
+++ b/indico/modules/events/sessions/models/blocks.py
@@ -26,6 +26,7 @@ class SessionBlock(LocationMixin, db.Model):
     __tablename__ = 'session_blocks'
     __auto_table_args = (db.UniqueConstraint('id', 'session_id'),  # useless but needed for the compound fkey
                          db.CheckConstraint("date_trunc('minute', duration) = duration", 'duration_no_seconds'),
+                         db.CheckConstraint("duration > '0'", 'positive_duration'),
                          {'schema': 'events'})
     location_backref_name = 'session_blocks'
     allow_relationship_preloading = True

--- a/indico/modules/events/sessions/models/sessions.py
+++ b/indico/modules/events/sessions/models/sessions.py
@@ -46,6 +46,8 @@ class Session(DescriptionMixin, ColorMixin, ProtectionManagersMixin, LocationMix
                          db.CheckConstraint("date_trunc('minute', default_contribution_duration) = "
                                             'default_contribution_duration',
                                             'default_contribution_duration_no_seconds'),
+                         db.CheckConstraint("default_contribution_duration > '0'",
+                                            'positive_default_contribution_duration'),
                          {'schema': 'events'})
     location_backref_name = 'sessions'
     disallowed_protection_modes = frozenset()

--- a/indico/modules/events/timetable/models/breaks.py
+++ b/indico/modules/events/timetable/models/breaks.py
@@ -22,6 +22,7 @@ from indico.util.string import format_repr
 class Break(DescriptionMixin, ColorMixin, LocationMixin, db.Model):
     __tablename__ = 'breaks'
     __auto_table_args = (db.CheckConstraint("date_trunc('minute', duration) = duration", 'duration_no_seconds'),
+                         db.CheckConstraint("duration >= '0'", 'nonnegative_duration'),
                          {'schema': 'events'})
     location_backref_name = 'breaks'
     default_colors = ColorTuple('#202020', '#90c0f0')


### PR DESCRIPTION
Session default contrib duration, contrib duration and block duration must all be >0.
Breaks and subcontribs must be >= 0.

There's still some psycopg issue that I need to fix where if you run both migrations (with `indico db upgrade`) it fails but if you run them separately it's fine..