### PR TITLE
Fix empty sessions and multi_choice fields in registration summary blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- Nothing so far :)
+- Fix display of empty session selection in registration summary (:pr:`6421`,
+  thanks :user:`jbtwist`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
+++ b/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
@@ -92,7 +92,7 @@
                 <strong>Accommodation:</strong> {{ accommodation }}
             {%- endtrans %}
         </div>
-    {% elif field.input_type in ('multi_choice', 'sessions') and friendly_data %}
+    {% elif field.input_type in ('multi_choice', 'sessions') %}
         <ul>
             {% for item in friendly_data -%}
                 <li>{{ item }}</li>


### PR DESCRIPTION
Registration summary blocks are showing an empty list `[]` when they are not filled. This change makes them show an empty string instead, making them match with the rest of the fields in the system
