### PR TITLE
Allow direct editing of uploaded pics in picture field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Version 3.3.4
 Improvements
 ^^^^^^^^^^^^
 
-- Nothing so far :(
+- Allow cropping an existing picture in registration form picture fields (:pr:`6423`,
+  thanks :user:`SegiNyn`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/web/client/js/react/components/pictures/PictureArea.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureArea.jsx
@@ -30,7 +30,7 @@ import './Picture.module.scss';
 export function PictureArea({
   dropzone: {getRootProps, getInputProps, isDragActive, open: openUploadDialog, fileRejections},
   capture: {pictureCamera: PictureCamera, onOpenCameraDialog, isCameraActive, isCameraAllowed},
-  cropper: {pictureCropper: PictureCropper, isEditActive},
+  cropper: {pictureCropper: PictureCropper, onOpenEditDialog, isEditActive},
   picture,
   dragText,
   pictureAction,
@@ -124,6 +124,16 @@ export function PictureArea({
                                   'You need to grant this site camera permissions before taking a picture'
                                 )
                           }
+                        />
+                        <Divider horizontal>
+                          <Translate>Or</Translate>
+                        </Divider>
+                        <Button
+                          type="button"
+                          styleName="picture-selection-btn"
+                          icon="edit"
+                          content={Translate.string('Edit current picture')}
+                          onClick={() => onOpenEditDialog()}
                         />
                       </>
                     ) : (

--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -110,7 +110,7 @@ const PictureManager = ({
   }, [picturePreview, previewURL, isInitialPicture]);
 
   const deleteUploadedPicture = useCallback(() => {
-    if (uploadFinished) {
+    if (uploadFinished || pictureState.picture !== null) {
       deleteFile(pictureState.picture.uuid);
     }
   }, [uploadFinished, pictureState.picture]);
@@ -216,6 +216,13 @@ const PictureManager = ({
       cropperBackActionRef.current = 'initial';
     }
   }, [isCapturing, uploadFinished, isInitialPicture]);
+
+  const onOpenEditDialog = () => {
+    setCustomFileRejections(null);
+    fetch(getPreview())
+      .then(res => res.blob())
+      .then(blob => dispatch({type: 'START_EDITING', imageSrc: URL.createObjectURL(blob)}));
+  };
 
   const cropBackAction = () => {
     if (cropperBackActionRef.current === 'camera') {
@@ -339,6 +346,7 @@ const PictureManager = ({
   const cropper = {
     pictureCropper: Cropper,
     isEditActive: isEditing,
+    onOpenEditDialog,
   };
 
   return (

--- a/indico/web/client/js/react/components/pictures/util.js
+++ b/indico/web/client/js/react/components/pictures/util.js
@@ -11,5 +11,4 @@ export const PictureState = {
   ...UploadState, // initial, uploading, error, finished
   capturing: 'capturing', // the camera is active and picture may be captured
   editing: 'editing', // picture is being edited
-  dropzone: 'dropzone', // The picture was taken using the dropzone or upload dialog
 };


### PR DESCRIPTION
This PR is to allow users to edit uploaded registration pictures without needing to upload it again, this is useful if for example a registrant uploads a full body picture, then the event manages can just crop out the face. 

<img width="277" alt="Screenshot 2024-06-28 at 09 10 51" src="https://github.com/indico/indico/assets/54508387/89e154f0-7495-496d-9c8a-f732ea4040ff">
