### PR TITLE
Fix Timetable Sessions display order

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Bugfixes
   thanks :user:`jbtwist`)
 - Include date when displaying session field data in registration summary (:pr:`6431`,
   thanks :user:`jbtwist`)
+- Fix the order of a day's session blocks in the registration form session field
+  (:pr:`6428`, thanks :user:`jbtwist`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/controllers/api/misc.py
+++ b/indico/modules/events/registration/controllers/api/misc.py
@@ -47,4 +47,4 @@ class RHAPIEventSessionBlocks(RHProtectedEventBase):
             for sb in blocks
             if sb.can_access(session.user)
         ]
-        return group_list(res, key=itemgetter('start_date'), sort_by=itemgetter('start_date'))
+        return group_list(res, key=itemgetter('start_date'), sort_by=itemgetter('start_date', 'time'))


### PR DESCRIPTION
Timetable Session blocks are currently displayed in ascending order by day, but descending order by hour. This PR fixes the order since it was not the intended behaviour


<img width="606" alt="Screenshot 2024-07-03 at 15 36 06" src="https://github.com/indico/indico/assets/11741165/16a16269-da6c-47e5-9071-e94b768db9ba">
