### PR TITLE
Improve extension handling in secure_filename

### DIFF
--- a/indico/util/fs.py
+++ b/indico/util/fs.py
@@ -47,10 +47,13 @@ def secure_filename(filename, fallback):
     """
     if not filename:
         return fallback
-    filename = _secure_filename(str_to_ascii(filename))
     filename, ext = os.path.splitext(filename)
-    filename = f'{filename[:150]}{ext}'
-    return filename or fallback
+    if not (filename := _secure_filename(str_to_ascii(filename))):
+        # fallback to the name part of the fallback (it may or may not contain an extension)
+        filename = os.path.splitext(fallback)[0]
+    if ext and not (ext := _secure_filename(str_to_ascii(ext.lstrip('.')))):
+        ext = os.path.splitext(fallback)[1].lstrip('.')
+    return f'{filename[:150]}.{ext}' if ext else filename[:150]
 
 
 def secure_client_filename(filename, fallback='file'):

--- a/indico/util/fs_test.py
+++ b/indico/util/fs_test.py
@@ -27,21 +27,31 @@ def test_secure_client_filename(filename, expected):
     assert secure_client_filename(filename) == expected
 
 
-@pytest.mark.parametrize(('filename', 'expected'), (
-    ('', 'fallback'),
-    (None, 'fallback'),
-    ('foo.txt', 'foo.txt'),
-    ('../../../etc/passwd', 'etc_passwd'),
-    ('m\xf6p.txt', 'moep.txt'),
-    ('/m\xf6p.txt', 'moep.txt'),
-    (r'spacy   \filename', 'spacy_filename'),
-    ('.filename', 'filename'),
-    ('filename', 'filename'),
-    ('file.name', 'file.name'),
-    ('   ', 'fallback')
+@pytest.mark.parametrize(('filename', 'fallback_ext', 'expected'), (
+    ('', '', 'fallback'),
+    (None, '', 'fallback'),
+    ('foo.txt', '', 'foo.txt'),
+    ('foo.txt', 'example.zip', 'foo.txt'),
+    ('../../../etc/passwd', '', 'etc_passwd'),
+    ('m\xf6p.txt', '', 'moep.txt'),
+    ('/m\xf6p.txt', '', 'moep.txt'),
+    (r'spacy   \filename', '', 'spacy_filename'),
+    ('.filename', '', 'filename'),
+    ('filename.', '', 'filename'),
+    ('filename', '', 'filename'),
+    ('file.name', '', 'file.name'),
+    ('   ', '', 'fallback'),
+    ('foo', '.txt', 'foo'),
+    ('\u4e17', '', 'fallback'),
+    ('\u4e17.txt', '', 'fallback.txt'),
+    ('\u4e17.txt', '.zip', 'fallback.txt'),
+    ('\u4e17.\u4e17', '', 'fallback'),
+    ('\u4e17.', '.txt', 'fallback.txt'),
+    ('\u4e17.\u4e17', '.txt', 'fallback.txt'),
+    ('.\u4e17', '.txt', 'fallback'),
 ))
-def test_secure_filename(filename, expected):
-    assert secure_filename(filename, 'fallback') == expected
+def test_secure_filename(filename, fallback_ext, expected):
+    assert secure_filename(filename, f'fallback{fallback_ext}') == expected
 
 
 def test_secure_filename_max_length():


### PR DESCRIPTION
Previously a filename that contained e.g. just chinese or arab characters (besides the extension) was completely replaced with the fallback, instead of keeping at least the extension from the original filename.