### PR TITLE
Improve SessionsField friendly data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Bugfixes
 
 - Fix display of empty session selection in registration summary (:pr:`6421`,
   thanks :user:`jbtwist`)
+- Include date when displaying session field data in registration summary (:pr:`6431`,
+  thanks :user:`jbtwist`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/fields/sessions.py
+++ b/indico/modules/events/registration/fields/sessions.py
@@ -95,7 +95,7 @@ class SessionsField(RegistrationFormFieldBase):
                   .all())
         if for_humans or for_search:
             return '; '.join(b.full_title for b in blocks)
-        return ['{day}: {block}'.format(day=format_skeleton(b.start_dt, 'EdM', timezone=tzinfo),
+        return ['{day}: {block}'.format(day=format_skeleton(b.start_dt, 'EdMM', timezone=tzinfo),
                                         block=_format_block(b, tzinfo))
                 for b in blocks]
 

--- a/indico/modules/events/registration/fields/sessions.py
+++ b/indico/modules/events/registration/fields/sessions.py
@@ -18,7 +18,7 @@ from indico.modules.events.registration.fields.base import RegistrationFormField
 from indico.modules.events.registration.models.registrations import RegistrationData
 from indico.modules.events.sessions.models.blocks import SessionBlock
 from indico.modules.events.sessions.models.sessions import Session
-from indico.util.date_time import format_interval
+from indico.util.date_time import format_interval, format_skeleton
 from indico.util.i18n import _
 
 
@@ -95,7 +95,9 @@ class SessionsField(RegistrationFormFieldBase):
                   .all())
         if for_humans or for_search:
             return '; '.join(b.full_title for b in blocks)
-        return [_format_block(b, tzinfo) for b in blocks]
+        return ['{day}: {block}'.format(day=format_skeleton(b.start_dt, 'EdM', timezone=tzinfo),
+                                        block=_format_block(b, tzinfo))
+                for b in blocks]
 
     def create_sql_filter(self, data_list):
         data_list = json.dumps(list(map(int, data_list)))


### PR DESCRIPTION
At UN side we have realised there are parts where SessionsField data is not descriptive enough since, out of context, might be hard to identify sessions with similar names just by start hour, since the day it's unknown.

I have decided to add only the weekly day and month number to avoid generating a too large string, I feel this way is more than enough to identify sessions, but feedback is appreciated

<img width="759" alt="Screenshot 2024-07-04 at 18 40 36" src="https://github.com/indico/indico/assets/11741165/2d28344d-3768-4965-ab51-16b510a918a1">

<img width="996" alt="Screenshot 2024-07-04 at 18 41 39" src="https://github.com/indico/indico/assets/11741165/e2aeb228-23d5-4a50-831c-00c38272e9d9">

<img width="1445" alt="Screenshot 2024-07-04 at 18 42 54" src="https://github.com/indico/indico/assets/11741165/af1c0a80-bac8-4909-98c5-07b00bbcf7c3">

