### PR TITLE
Clean up previous registration file on registration modification

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Improvements
 
 - Allow cropping an existing picture in registration form picture fields (:pr:`6423`,
   thanks :user:`SegiNyn`)
+- Add task to delete old registration files when they become orphaned due to a new
+  file being uploaded (:pr:`6434`, thanks :user:`SegiNyn`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/tasks.py
+++ b/indico/modules/events/registration/tasks.py
@@ -104,9 +104,7 @@ def delete_registrations():
 
 @celery.task(name='delete_previous_registration_file')
 def delete_previous_registration_file(reg_data, storage_backend, storage_file_id):
-    if storage_file_id is None:
-        return
-    if reg_data.storage_file_id == storage_file_id:
+    if reg_data.storage_backend == storage_backend and reg_data.storage_file_id == storage_file_id:
         return
     logger.debug('Deleting registration file: %s', storage_file_id)
     storage = get_storage(storage_backend)

--- a/indico/modules/events/registration/tasks.py
+++ b/indico/modules/events/registration/tasks.py
@@ -106,6 +106,6 @@ def delete_registrations():
 def delete_previous_registration_file(reg_data, storage_backend, storage_file_id):
     if reg_data.storage_backend == storage_backend and reg_data.storage_file_id == storage_file_id:
         return
-    logger.debug('Deleting registration file: %s', storage_file_id)
+    logger.debug('Deleting registration file: %s from %s storage', storage_file_id, storage_backend)
     storage = get_storage(storage_backend)
     storage.delete(storage_file_id)

--- a/indico/modules/events/registration/tasks.py
+++ b/indico/modules/events/registration/tasks.py
@@ -12,6 +12,7 @@ from celery.schedules import crontab
 from indico.core import signals
 from indico.core.celery import celery
 from indico.core.db import db
+from indico.core.storage.backend import get_storage
 from indico.modules.events import Event
 from indico.modules.events.registration import logger
 from indico.modules.events.registration.models.form_fields import RegistrationFormField, RegistrationFormFieldData
@@ -99,3 +100,14 @@ def delete_registrations():
         regform.is_purged = True
 
     db.session.commit()
+
+
+@celery.task(name='delete_previous_registration_file')
+def delete_previous_registration_file(reg_data, storage_backend, storage_file_id):
+    if storage_file_id is None:
+        return
+    if reg_data.storage_file_id == storage_file_id:
+        return
+    logger.debug('Deleting registration file: %s', storage_file_id)
+    storage = get_storage(storage_backend)
+    storage.delete(storage_file_id)


### PR DESCRIPTION
This PR adds a task to remove previous registration files 10 minutes after registration update if the registration data is no longer linked to the same file. 