### PR TITLE
Fix overflowing texts in registration form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Bugfixes
   thanks :user:`jbtwist`)
 - Fix the order of a day's session blocks in the registration form session field
   (:pr:`6428`, thanks :user:`jbtwist`)
+- Wrap overly long descriptions and filenames in registration form fields (:pr:`6436`,
+  thanks :user:`SegiNyn`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -129,7 +129,7 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
           <FinalTextArea
             name="description"
             label={Translate.string('Description')}
-            description={<Translate>You can use Markdown or basic HTML formatting tags.</Translate>}
+            description={<Translate>You may use Markdown for formatting.</Translate>}
           />
           {meta.hasPrice && (
             <FinalInput

--- a/indico/modules/events/registration/client/js/form_setup/SectionSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/SectionSettingsModal.jsx
@@ -54,7 +54,7 @@ export default function SectionSettingsModal({id, onClose}) {
       <FinalTextArea
         name="description"
         label={Translate.string('Description')}
-        description={<Translate>You can use Markdown or basic HTML formatting tags.</Translate>}
+        description={<Translate>You may use Markdown for formatting.</Translate>}
       />
       <FinalCheckbox
         disabled={isPersonalData}

--- a/indico/modules/events/registration/client/styles/regform.module.scss
+++ b/indico/modules/events/registration/client/styles/regform.module.scss
@@ -297,6 +297,7 @@
       font-style: italic;
       font-size: 0.9em;
       color: $dark-gray;
+      word-wrap: break-word;
     }
   }
 

--- a/indico/modules/events/registration/client/styles/regform.module.scss
+++ b/indico/modules/events/registration/client/styles/regform.module.scss
@@ -297,7 +297,7 @@
       font-style: italic;
       font-size: 0.9em;
       color: $dark-gray;
-      word-wrap: break-word;
+      overflow-wrap: break-word;
     }
   }
 

--- a/indico/web/client/js/react/components/files/FileArea.module.scss
+++ b/indico/web/client/js/react/components/files/FileArea.module.scss
@@ -26,6 +26,7 @@
       .filename {
         text-overflow: ellipsis;
         overflow: hidden;
+        max-width: 350px;
       }
     }
 


### PR DESCRIPTION
This is to add style for overflowing text I noticed. When the description of a registration form field is very long, e.g a very long link it tends to overflow outside of the container. The same with when a user uploads a file with a long name. 

<img width="1046" alt="Screenshot 2024-07-10 at 15 41 10" src="https://github.com/indico/indico/assets/54508387/846e823a-5a93-4ea8-a05b-c06024c707f7">
<img width="1179" alt="Screenshot 2024-07-10 at 17 04 10" src="https://github.com/indico/indico/assets/54508387/77359b04-5536-4afd-ad91-24217099f62b">

