### PR TITLE
Add some missing checks for admin override mode

### DIFF
--- a/indico/modules/rb/models/reservations.py
+++ b/indico/modules/rb/models/reservations.py
@@ -299,8 +299,8 @@ class Reservation(db.Model):
             if prebook and not room.can_prebook(user, allow_admin=(not ignore_admin)):
                 raise NoReportError('You cannot book this room')
 
-        room.check_advance_days(data['end_dt'].date(), user)
-        room.check_bookable_hours(data['start_dt'].time(), data['end_dt'].time(), user)
+        room.check_advance_days(data['end_dt'].date(), user, allow_admin=(not ignore_admin))
+        room.check_bookable_hours(data['start_dt'].time(), data['end_dt'].time(), user, allow_admin=(not ignore_admin))
 
         if (
             force_internal_note or
@@ -483,7 +483,7 @@ class Reservation(db.Model):
 
         # Check for conflicts with nonbookable periods
         admin = allow_admin and rb_is_admin(user)
-        if not admin and not self.room.can_manage(user, permission='override'):
+        if not admin and not self.room.can_manage(user, allow_admin=allow_admin, permission='override'):
             nonbookable_periods = self.room.nonbookable_periods.filter(NonBookablePeriod.end_dt > self.start_dt)
             for occurrence in self.occurrences:
                 if not occurrence.is_valid:

--- a/indico/modules/rb/models/rooms.py
+++ b/indico/modules/rb/models/rooms.py
@@ -601,10 +601,10 @@ class Room(ProtectionManagersMixin, db.Model):
             return False
         return rb_is_admin(user)
 
-    def check_advance_days(self, end_date, user=None, quiet=False):
+    def check_advance_days(self, end_date, user=None, quiet=False, allow_admin=True):
         if not self.max_advance_days:
             return True
-        if user and (rb_is_admin(user) or self.can_manage(user)):
+        if user and ((allow_admin and rb_is_admin(user)) or self.can_override(user, allow_admin=allow_admin)):
             return True
         advance_days = (end_date - date.today()).days
         ok = advance_days < self.max_advance_days
@@ -614,8 +614,8 @@ class Room(ProtectionManagersMixin, db.Model):
             msg = _('You cannot book this room more than {} days in advance')
             raise NoReportError(msg.format(self.max_advance_days))
 
-    def check_bookable_hours(self, start_time, end_time, user=None, quiet=False):
-        if user and (rb_is_admin(user) or self.can_manage(user)):
+    def check_bookable_hours(self, start_time, end_time, user=None, quiet=False, allow_admin=True):
+        if user and ((allow_admin and rb_is_admin(user)) or self.can_override(user, allow_admin=allow_admin)):
             return True
         bookable_hours = self.bookable_hours.all()
         if not bookable_hours:


### PR DESCRIPTION
Admins were allowed to override nonbookable periods and bookable hours regardless of whether they enabled admin override mode.

This is generally not a problem because the UI has checks as well, but it's ugly and also made testing things harder (since just toggling off admin override before creating the booking was not enough).

This fix only applies to creating bookings but not to modifying existing bookings - in case of modifications there's some risk that if the booking was created e.g. before the setup of NBPs, and then edited by someone who does not have override permissions on the room.