### PR TITLE
Add a workaround to fix reportlab bug and generate smaller PDF

### DIFF
--- a/indico/modules/designer/pdf.py
+++ b/indico/modules/designer/pdf.py
@@ -129,16 +129,9 @@ class DesignerPDFBase:
         item_height = (item['height'] / PIXELS_CM * cm) if item.get('height') is not None else None
         item_preserve_aspect_ratio = item.get('preserve_aspect_ratio', True)
 
-        if isinstance(content, Image.Image):
-            # Due to an `ImageReader` bug JPEG image is not identified if it's a PIL Image,
-            # so they are placed into the PDF in uncompressed size.
-            # Passing the image in its original format as file-like object is a workaround until it is fixed.
-            with BytesIO() as img_bytes:
-                content.save(img_bytes, format=content.format)
-                img_bytes.seek(0)
-                canvas.drawImage(ImageReader(img_bytes),
-                                 margin_x + item_x, self.height - margin_y - item_height - item_y,
-                                 item_width, item_height, mask='auto', preserveAspectRatio=item_preserve_aspect_ratio)
+        if isinstance(content, BytesIO):
+            canvas.drawImage(ImageReader(content), margin_x + item_x, self.height - margin_y - item_height - item_y,
+                             item_width, item_height, mask='auto', preserveAspectRatio=item_preserve_aspect_ratio)
         else:
             content = content.unescape() if isinstance(content, RichMarkup) else content
             content = sanitize_html(strip_tags(content))

--- a/indico/modules/designer/pdf.py
+++ b/indico/modules/designer/pdf.py
@@ -130,8 +130,15 @@ class DesignerPDFBase:
         item_preserve_aspect_ratio = item.get('preserve_aspect_ratio', True)
 
         if isinstance(content, Image.Image):
-            canvas.drawImage(ImageReader(content), margin_x + item_x, self.height - margin_y - item_height - item_y,
-                             item_width, item_height, mask='auto', preserveAspectRatio=item_preserve_aspect_ratio)
+            # Due to an `ImageReader` bug JPEG image is not identified if it's a PIL Image,
+            # so they are placed into the PDF in uncompressed size.
+            # Passing the image in its original format as file-like object is a workaround until it is fixed.
+            with BytesIO() as img_bytes:
+                content.save(img_bytes, format=content.format)
+                img_bytes.seek(0)
+                canvas.drawImage(ImageReader(img_bytes),
+                                 margin_x + item_x, self.height - margin_y - item_height - item_y,
+                                 item_width, item_height, mask='auto', preserveAspectRatio=item_preserve_aspect_ratio)
         else:
             content = content.unescape() if isinstance(content, RichMarkup) else content
             content = sanitize_html(strip_tags(content))

--- a/indico/modules/designer/placeholders.py
+++ b/indico/modules/designer/placeholders.py
@@ -8,7 +8,6 @@
 from io import BytesIO
 
 from babel.numbers import format_currency
-from PIL import Image
 
 from indico.modules.designer.models.images import DesignerImageFile
 from indico.modules.events.registration.util import generate_ticket_qr_code
@@ -106,8 +105,7 @@ class EventLogoPlaceholder(DesignerPlaceholder):
     def render(cls, event):
         if not event.has_logo:
             return ''
-        buf = BytesIO(event.logo)
-        return Image.open(buf)
+        return BytesIO(event.logo)
 
 
 class EventDatesPlaceholder(DesignerPlaceholder):
@@ -381,8 +379,8 @@ class RegistrationPicturePlaceholder(RegistrationPDPlaceholder):
     @classmethod
     def render(cls, registration):
         if picture_data := registration.get_personal_data_picture():
-            buf = picture_data.open()
-            return Image.open(buf)
+            with picture_data.open() as fd:
+                return BytesIO(fd.read())
         return None
 
 
@@ -417,8 +415,8 @@ class FixedImagePlaceholder(DesignerPlaceholder):
 
     @classmethod
     def render(cls, item):
-        buf = DesignerImageFile.get(item['image_id']).open()
-        return Image.open(buf)
+        with DesignerImageFile.get(item['image_id']).open() as fd:
+            return BytesIO(fd.read())
 
 
 class RegistrationFormFieldPlaceholder(DesignerPlaceholder):
@@ -463,7 +461,8 @@ class RegistrationFormFieldPlaceholder(DesignerPlaceholder):
 
     def _render_image(self, data):
         if data.storage_file_id is not None:
-            return Image.open(data.open())
+            with data.open() as fd:
+                return BytesIO(fd.read())
 
     def _render_accommodation(self, friendly_data):
         if friendly_data['is_no_accommodation']:

--- a/indico/modules/designer/placeholders_test.py
+++ b/indico/modules/designer/placeholders_test.py
@@ -7,11 +7,11 @@
 
 import itertools
 from datetime import datetime
+from io import BytesIO
 from operator import attrgetter
 from pathlib import Path
 
 import pytest
-from PIL import Image
 
 from indico.modules.designer import placeholders
 from indico.modules.events.models.persons import EventPerson, EventPersonLink
@@ -124,4 +124,4 @@ def test_render_image_placeholders(dummy_event, dummy_reg, dummy_designer_image_
     for ph in image_placeholders:
         kwargs = _get_render_kwargs(ph, dummy_event, dummy_person, dummy_reg, dummy_item)
         res = ph.render(**kwargs)
-        assert isinstance(res, Image.Image) or res is None
+        assert isinstance(res, BytesIO) or res is None

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -736,9 +736,10 @@ def _base64_encode_uuid(uid):
 
 
 def generate_ticket_qr_code(person):
-    """Generate a Pillow `Image` with a QR Code encoding a check-in ticket.
+    """Generate an image with a QR code encoding a check-in ticket.
 
     :param registration: corresponding `Registration` object
+    :return: A `BytesIO` containing the image data
     """
     qr = QRCode(
         version=None,
@@ -750,7 +751,10 @@ def generate_ticket_qr_code(person):
     qr_data = json.dumps(data, separators=(',', ':')) if not isinstance(data, str) else data
     qr.add_data(qr_data)
     qr.make(fit=True)
-    return qr.make_image()._img
+    buf = BytesIO()
+    qr.make_image().save(buf)
+    buf.seek(0)
+    return buf
 
 
 def get_event_regforms(event, user, with_registrations=False, only_in_acl=False):


### PR DESCRIPTION
This PR is about to set a workaround to fix reportlab `ImageReader` bug and generate smaller PDF. 
For further details see comment in code.

The bug is still there even in the latest reportlab version (4.2.2). I sent a bug report but I think it's worth to fix this problem until they manage to fix that on their side. Especially because in some cases the large PDF files cause issues.
