### PR TITLE
Update list of supported browsers

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,36 +1,39 @@
 [production-template]
 >0.5% in alt-eu and >0.5% in alt-as and >0.5% in alt-na and >0.5% in alt-sa and >0.5% in alt-af and >0.5% in alt-oc and >1%
 not ie > 0
-last 2 Chrome versions
-last 2 Edge versions
-last 2 Safari versions
-last 2 Firefox versions
-last 2 FirefoxAndroid versions
+last 4 Chrome versions
+last 4 Edge versions
+last 4 Safari versions
+last 4 Firefox versions
+last 4 FirefoxAndroid versions
 Firefox esr
-edge 18
-edge 17
 
 # begin generated code
 # use `npm run update-browsers` to update
 [production]
-and_chr 84
-and_ff 68
-chrome 84
-chrome 83
-chrome 81
-edge 84
-edge 83
-edge 18
-edge 17
-firefox 79
-firefox 78
-firefox 77
-firefox 68
-ios_saf 13.4-13.5
-ios_saf 13.3
-safari 13.1
-safari 13
-samsung 11.1-11.2
+and_chr 126
+and_ff 127
+chrome 126
+chrome 125
+chrome 124
+chrome 123
+chrome 109
+edge 126
+edge 125
+edge 124
+edge 123
+firefox 128
+firefox 127
+firefox 126
+firefox 125
+firefox 115
+ios_saf 17.4
+ios_saf 16.6-16.7
+safari 17.5
+safari 17.4
+safari 17.3
+safari 17.2
+samsung 25
 # end generated code
 
 [supported]
@@ -38,12 +41,9 @@ last 2 Chrome versions
 last 2 Firefox versions
 last 2 Edge versions
 last 2 Safari versions
-edge 18
-edge 17
 
 [development]
 last 2 Chrome versions
 last 2 Firefox versions
 last 2 Edge versions
 last 2 Safari versions
-edge 18

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,9 @@ Internal Changes
 
 - Indicate when a booking begins/ends in the booking calendar in day-based mode (when
   using a plugin to customize the room booking module) (:pr:`6414`)
+- Update the list of supported browsers so people using highly outdated browsers where
+  certain features are likely broken get a warning about having to update their browser
+  (:pr:`6442`)
 
 
 Version 3.3.3

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ much as possible, but only issues detected on those will be considered at critic
 <!-- BROWSERS - this is all machine-generated! Don't change it. -->
 | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" /><br>Firefox | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" /><br>Chrome | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" /><br>Safari | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="Edge" width="24px" height="24px" /><br>Edge |
 |:---------:|:---------:|:---------:|:---------:|
-| 78+ | 83+ | 13+ | 17+ |
+| 127+ | 125+ | 17.4+ | 125+ |
 
-However, if you have an issue with a browser [on this list](https://browserl.ist/?q=and_chr%2084%2C%20and_ff%2068%2C%20chrome%2084%2C%20chrome%2083%2C%20chrome%2081%2C%20edge%2084%2C%20edge%2083%2C%20edge%2018%2C%20edge%2017%2C%20firefox%2079%2C%20firefox%2078%2C%20firefox%2077%2C%20firefox%2068%2C%20ios_saf%2013.4-13.5%2C%20ios_saf%2013.3%2C%20safari%2013.1%2C%20safari%2013%2C%20samsung%2011.1-11.2), please feel free to open a bug report.
+However, if you have an issue with a browser [on this list](https://browserl.ist/?q=and_chr%20126%2C%20and_ff%20127%2C%20chrome%20126%2C%20chrome%20125%2C%20chrome%20124%2C%20chrome%20123%2C%20chrome%20109%2C%20edge%20126%2C%20edge%20125%2C%20edge%20124%2C%20edge%20123%2C%20firefox%20128%2C%20firefox%20127%2C%20firefox%20126%2C%20firefox%20125%2C%20firefox%20115%2C%20ios_saf%2017.4%2C%20ios_saf%2016.6-16.7%2C%20safari%2017.5%2C%20safari%2017.4%2C%20safari%2017.3%2C%20safari%2017.2%2C%20samsung%2025), please feel free to open a bug report.
 <!-- ENDBROWSERS -->
 
 ## Getting Indico

--- a/package-lock.json
+++ b/package-lock.json
@@ -5358,9 +5358,9 @@
       "integrity": "sha512-Tfn5JSE7hrUlFcOoaLzVvkbgIemIorMIyoMr3TgvszWW7jFt2C9PdeMLtysYD9RU0MmU17b69+XJG1eRY2OBRg=="
     },
     "node_modules/browserslist": {
-      "version": "4.23.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
-      "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
+      "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5376,10 +5376,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001587",
-        "electron-to-chromium": "^1.4.668",
+        "caniuse-lite": "^1.0.30001640",
+        "electron-to-chromium": "^1.4.820",
         "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.13"
+        "update-browserslist-db": "^1.1.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5480,9 +5480,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001596",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001596.tgz",
-      "integrity": "sha512-zpkZ+kEr6We7w63ORkoJ2pOfBwBkY/bJrG/UZ90qNb45Isblu8wzDgevEOrRL1r9dWayHjYiiyCMEXPn4DweGQ==",
+      "version": "1.0.30001642",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001642.tgz",
+      "integrity": "sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6667,9 +6667,9 @@
       "integrity": "sha512-Azk8kD/2/nJIuVPK+zQ9sjKMRIpRvNyqn9XwbBHNq+iNuSccbJS6hwm1Woy0pMST0erSo0u4j+KJaodndDk4vA=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.699",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.699.tgz",
-      "integrity": "sha512-I7q3BbQi6e4tJJN5CRcyvxhK0iJb34TV8eJQcgh+fR2fQ8miMgZcEInckCo1U9exDHbfz7DLDnFn8oqH/VcRKw=="
+      "version": "1.4.828",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.828.tgz",
+      "integrity": "sha512-QOIJiWpQJDHAVO4P58pwb133Cwee0nbvy/MV1CwzZVGpkH1RX33N3vsaWRCpR6bF63AAq366neZrRTu7Qlsbbw=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -13083,9 +13083,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -17213,9 +17213,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.13",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
-      "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
+      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -17231,8 +17231,8 @@
         }
       ],
       "dependencies": {
-        "escalade": "^3.1.1",
-        "picocolors": "^1.0.0"
+        "escalade": "^3.1.2",
+        "picocolors": "^1.0.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"


### PR DESCRIPTION
Last time we updated that file was in 2020, and browsers that were supported back then are no longer supported. For example, Safari 14.1 (EOL 2021) was supported back then, but now the registration form is broken in there.