### PR TITLE
Add configuration for min and max data retention period allowed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Improvements
   thanks :user:`Moliholy, unconventionaldotdev`)
 - A room's bookable hours can now be applied to specific weekdays, making it
   unbookable on any other weekdays (:pr:`6439`)
+- Add global settings for min/max registration form data retention periods (:pr:`6445`,
+  thanks :user:`SegiNyn`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -150,6 +150,8 @@ def _sidemenu_items(sender, **kwargs):
                            section='customization')
         yield SideMenuItem('autolinker', _('Auto-linker'), url_for('events.autolinker_admin'),
                            section='customization')
+        yield SideMenuItem('data_retention', _('Data Retention'), url_for('events.data_retention'),
+                           section='customization')
 
 
 @signals.menu.sections.connect_via('top-menu')

--- a/indico/modules/events/blueprint.py
+++ b/indico/modules/events/blueprint.py
@@ -6,9 +6,10 @@
 # LICENSE file for more details.
 
 from indico.modules.events.controllers.admin import (RHAutoLinker, RHAutoLinkerConfig, RHCreateEventLabel,
-                                                     RHCreateReferenceType, RHDeleteEventLabel, RHDeleteReferenceType,
-                                                     RHEditEventLabel, RHEditReferenceType, RHEventLabels,
-                                                     RHReferenceTypes, RHUnlistedEvents, RHUpdateEventKeywords)
+                                                     RHCreateReferenceType, RHDataRetentionSettings, RHDeleteEventLabel,
+                                                     RHDeleteReferenceType, RHEditEventLabel, RHEditReferenceType,
+                                                     RHEventLabels, RHReferenceTypes, RHUnlistedEvents,
+                                                     RHUpdateEventKeywords)
 from indico.modules.events.controllers.api import RHEventCheckEmail, RHSingleEventAPI
 from indico.modules.events.controllers.creation import RHCreateEvent, RHPrepareEvent
 from indico.modules.events.controllers.display import (RHAutoLinkerRules, RHDisplayPrivacyPolicy, RHEventAccessKey,
@@ -29,6 +30,8 @@ _bp.add_url_rule('/admin/event-labels/create', 'create_event_label', RHCreateEve
 _bp.add_url_rule('/admin/event-keywords/', 'event_keywords', RHUpdateEventKeywords, methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/unlisted-events/', 'unlisted_events', RHUnlistedEvents, methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/autolinker/', 'autolinker_admin', RHAutoLinker)
+_bp.add_url_rule('/admin/data-retention/', 'data_retention', RHDataRetentionSettings,
+                 methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/autolinker/config', 'autolinker_config', RHAutoLinkerConfig, methods=('POST',))
 
 # Single reference type

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -196,5 +196,4 @@ class RHDataRetentionSettings(RHAdminBase):
             data_retention_settings.set_multi(form.data)
             flash(_('Settings have been saved'), 'success')
             return redirect(url_for('events.data_retention'))
-        return WPEventAdmin.render_template('admin/data_retention.html',
-                                            'data_retention', form=form)
+        return WPEventAdmin.render_template('admin/data_retention.html', 'data_retention', form=form)

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -10,14 +10,15 @@ from webargs import fields
 
 from indico.core.db import db
 from indico.modules.admin import RHAdminBase
-from indico.modules.events.forms import EventKeywordsForm, EventLabelForm, ReferenceTypeForm, UnlistedEventsForm
+from indico.modules.events.forms import (DataRetentionSettingsForm, EventKeywordsForm, EventLabelForm,
+                                         ReferenceTypeForm, UnlistedEventsForm)
 from indico.modules.events.management.settings import global_event_settings
 from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
 from indico.modules.events.operations import (create_event_label, create_reference_type, delete_event_label,
                                               delete_reference_type, update_event_label, update_reference_type)
 from indico.modules.events.schemas import AutoLinkerRuleSchema
-from indico.modules.events.settings import autolinker_settings, unlisted_events_settings
+from indico.modules.events.settings import autolinker_settings, data_retention_settings, unlisted_events_settings
 from indico.modules.events.views import WPEventAdmin
 from indico.util.i18n import _
 from indico.util.string import natural_sort_key
@@ -184,3 +185,16 @@ class RHAutoLinkerConfig(RHAdminBase):
     })
     def _process(self, rules):
         autolinker_settings.set('rules', rules)
+
+
+class RHDataRetentionSettings(RHAdminBase):
+    """Manage minimun and maximum data retention period in the admin area."""
+
+    def _process(self):
+        form = DataRetentionSettingsForm(obj=FormDefaults(**data_retention_settings.get_all()))
+        if form.validate_on_submit():
+            data_retention_settings.set_multi(form.data)
+            flash(_('Settings have been saved'), 'success')
+            return redirect(url_for('events.data_retention'))
+        return WPEventAdmin.render_template('admin/data_retention.html',
+                                            'data_retention', form=form)

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from datetime import time
+from datetime import time, timedelta
 
 from flask import session
 from wtforms.fields import BooleanField, StringField, TextAreaField, URLField
@@ -24,6 +24,7 @@ from indico.web.forms.base import IndicoForm
 from indico.web.forms.fields import (IndicoDateTimeField, IndicoEnumRadioField, IndicoLocationField, IndicoTagListField,
                                      IndicoTimezoneSelectField, JSONField, OccurrencesField)
 from indico.web.forms.fields.colors import SUIColorPickerField
+from indico.web.forms.fields.datetime import TimeDeltaField
 from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.fields.simple import IndicoButtonsBooleanField
 from indico.web.forms.validators import HiddenUnless, LinkedDateTime, UsedIf
@@ -135,3 +136,42 @@ class UnlistedEventsForm(IndicoForm):
     authorized_creators = PrincipalListField(_('Authorized users'), [HiddenUnless('enabled', preserve_data=True)],
                                              allow_external_users=True, allow_groups=True,
                                              description=_('These users may create unlisted events.'))
+
+
+class DataRetentionSettingsForm(IndicoForm):
+    minimum_data_retention = TimeDeltaField(_('Minimum data retention period'), units=('weeks',),
+                                            description=_('Specify the minimum data retention period (in weeks) '
+                                                          'configurable for registrations. This includes the '
+                                                          'retention period of individual registration form fields.'),
+                                            render_kw={'placeholder': _('Indefinite'), 'min': 1, 'max': 521})
+    maximum_data_retention = TimeDeltaField(_('Maximum data retention period'), units=('weeks',),
+                                            description=_(
+        'Specify the maximum data retention period (in weeks) configurable for registrations. This includes the '
+        'retention period of individual registration form fields. Note that setting this value will make the '
+        'retention period field mandatory during registration form setup.'),
+        render_kw={'placeholder': _('Indefinite'), 'min': 1, 'max': 521})
+
+    def validate_minimum_data_retention(self, field):
+        maximum_retention = self.data.get('maximum_data_retention')
+        if maximum_retention and not (minimum_retention := self._validate_data_rentention(field)):
+            raise ValidationError(_('The minimum retention period cannot be indefinite when a maximum is set.'))
+        if maximum_retention and minimum_retention > maximum_retention:
+            raise ValidationError(_('The minimum retention period cannot be greater than the maximum.'))
+
+    def validate_maximum_data_retention(self, field):
+        if not (maximum_retention := self._validate_data_rentention(field)):
+            return
+        minimum_retention = self.data.get('minimum_data_retention')
+        if minimum_retention and minimum_retention > maximum_retention:
+            raise ValidationError(_('The minimum retention period cannot be greater than the maximum.'))
+
+    def _validate_data_rentention(self, field):
+        retention_period = field.data
+        if retention_period is None:
+            return
+        if retention_period <= timedelta():
+            raise ValidationError(_('The retention period cannot be zero or negative.'))
+        elif retention_period > timedelta(days=3650):
+            raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field '
+                                    'empty for indefinite.'))
+        return retention_period

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -139,11 +139,16 @@ class UnlistedEventsForm(IndicoForm):
 
 
 class DataRetentionSettingsForm(IndicoForm):
-    minimum_data_retention = TimeDeltaField(_('Minimum data retention period'), [DataRequired()], units=('weeks',),
-                                            description=_('Specify the minimum data retention period (in weeks) '
-                                                          'configurable for registrations. This includes the '
-                                                          'retention period of individual registration form fields.'),
-                                            render_kw={'min': 1})
+    minimum_data_retention = TimeDeltaField(
+        _('Minimum data retention period'),
+        [DataRequired()],
+        units=('weeks',),
+        description=_(
+            'Specify the minimum data retention period (in weeks) configurable for registrations. This includes the '
+            'retention period of individual registration form fields.'
+        ),
+        render_kw={'min': 1},
+    )
     maximum_data_retention = TimeDeltaField(
         _('Maximum data retention period'),
         units=('weeks',),

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -143,7 +143,7 @@ class DataRetentionSettingsForm(IndicoForm):
                                             description=_('Specify the minimum data retention period (in weeks) '
                                                           'configurable for registrations. This includes the '
                                                           'retention period of individual registration form fields.'),
-                                            render_kw={'placeholder': _('Indefinite'), 'min': 1, 'max': 521})
+                                            render_kw={'placeholder': _('Indefinite'), 'min': 1})
     maximum_data_retention = TimeDeltaField(
         _('Maximum data retention period'),
         units=('weeks',),
@@ -152,7 +152,7 @@ class DataRetentionSettingsForm(IndicoForm):
             'retention period of individual registration form fields. Note that setting this value will make the '
             'retention period field mandatory during registration form setup.'
         ),
-        render_kw={'placeholder': _('Indefinite'), 'min': 1, 'max': 521},
+        render_kw={'placeholder': _('Indefinite'), 'min': 1},
     )
 
     def validate_minimum_data_retention(self, field):
@@ -175,7 +175,4 @@ class DataRetentionSettingsForm(IndicoForm):
             return
         if retention_period <= timedelta():
             raise ValidationError(_('The retention period cannot be zero or negative.'))
-        elif retention_period > timedelta(days=3650):
-            raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field '
-                                    'empty for indefinite.'))
         return retention_period

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -144,12 +144,16 @@ class DataRetentionSettingsForm(IndicoForm):
                                                           'configurable for registrations. This includes the '
                                                           'retention period of individual registration form fields.'),
                                             render_kw={'placeholder': _('Indefinite'), 'min': 1, 'max': 521})
-    maximum_data_retention = TimeDeltaField(_('Maximum data retention period'), units=('weeks',),
-                                            description=_(
-        'Specify the maximum data retention period (in weeks) configurable for registrations. This includes the '
-        'retention period of individual registration form fields. Note that setting this value will make the '
-        'retention period field mandatory during registration form setup.'),
-        render_kw={'placeholder': _('Indefinite'), 'min': 1, 'max': 521})
+    maximum_data_retention = TimeDeltaField(
+        _('Maximum data retention period'),
+        units=('weeks',),
+        description=_(
+            'Specify the maximum data retention period (in weeks) configurable for registrations. This includes the '
+            'retention period of individual registration form fields. Note that setting this value will make the '
+            'retention period field mandatory during registration form setup.'
+        ),
+        render_kw={'placeholder': _('Indefinite'), 'min': 1, 'max': 521},
+    )
 
     def validate_minimum_data_retention(self, field):
         maximum_retention = self.data.get('maximum_data_retention')

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -30,6 +30,7 @@ import {getStaticData, getItemById} from '../form/selectors';
 
 import * as actions from './actions';
 import ItemTypeDropdown from './ItemTypeDropdown';
+import {getDataRetentionRange} from './selectors';
 
 const EMPTY_DATA = {}; // avoid new object on every selector call since this triggers a warning
 
@@ -38,6 +39,7 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
   const [newItemType, setNewItemType] = useState(defaultNewItemType);
   const editing = id !== null;
   const staticData = useSelector(getStaticData);
+  const dataRetentionRange = useSelector(getDataRetentionRange);
   const {inputType: existingInputType, fieldIsRequired, ...itemData} = useSelector(state =>
     editing ? getItemById(state, id) : EMPTY_DATA
   );
@@ -158,9 +160,9 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
                 type="number"
                 placeholder={Translate.string('Permanent')}
                 step="1"
-                min="1"
-                max="521"
-                validate={v.optional(v.range(1, 521))}
+                min={dataRetentionRange[0]}
+                max={dataRetentionRange[1]}
+                validate={v.optional(v.range(dataRetentionRange[0], dataRetentionRange[1]))}
                 label={Translate.string('Retention period (weeks)')}
                 description={Translate.string(
                   'Specify how long user-provided data for this field will be preserved in the database.'

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -160,9 +160,9 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
                 type="number"
                 placeholder={Translate.string('Permanent')}
                 step="1"
-                min={dataRetentionRange[0]}
-                max={dataRetentionRange[1]}
-                validate={v.optional(v.range(dataRetentionRange[0], dataRetentionRange[1]))}
+                min={dataRetentionRange.min}
+                max={dataRetentionRange.max}
+                validate={v.optional(v.range(dataRetentionRange.min, dataRetentionRange.max))}
                 label={Translate.string('Retention period (weeks)')}
                 description={Translate.string(
                   'Specify how long user-provided data for this field will be preserved in the database.'

--- a/indico/modules/events/registration/client/js/form_setup/index.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/index.jsx
@@ -22,6 +22,7 @@ export default function setupRegformSetup(root) {
     eventEndDate,
     regformId,
     currency,
+    dataRetentionRange,
     hasPredefinedAffiliations,
     formData,
   } = root.dataset;
@@ -34,6 +35,7 @@ export default function setupRegformSetup(root) {
       eventStartDate,
       eventEndDate,
       currency,
+      dataRetentionRange: JSON.parse(dataRetentionRange),
     },
   };
   const store = createReduxStore('regform-setup', reducers, initialData);

--- a/indico/modules/events/registration/client/js/form_setup/selectors.js
+++ b/indico/modules/events/registration/client/js/form_setup/selectors.js
@@ -67,3 +67,9 @@ export const getURLParams = createSelector(
     };
   }
 );
+
+/** Get the maximum data retention configurable by the registration form and fields */
+export const getDataRetentionRange = createSelector(
+  getStaticData,
+  staticData => staticData.dataRetentionRange
+);

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -52,8 +52,9 @@ class GeneralFieldDataSchema(mm.Schema):
     @validates('retention_period')
     def _check_retention_period(self, retention_period, **kwargs):
         field = self.context['field']
-        min_retention_period = data_retention_settings.get('minimum_data_retention') or timedelta(days=7)
-        max_retention_period = data_retention_settings.get('maximum_data_retention')
+        with db.session.no_autoflush:
+            min_retention_period = data_retention_settings.get('minimum_data_retention') or timedelta(days=7)
+            max_retention_period = data_retention_settings.get('maximum_data_retention')
         if retention_period is not None:
             if field.type == RegistrationFormItemType.field_pd and field.personal_data_type.is_required:
                 raise ValidationError('Cannot add retention period to required field')

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -53,7 +53,7 @@ class GeneralFieldDataSchema(mm.Schema):
     def _check_retention_period(self, retention_period, **kwargs):
         field = self.context['field']
         with db.session.no_autoflush:
-            min_retention_period = data_retention_settings.get('minimum_data_retention') or timedelta(days=7)
+            min_retention_period = data_retention_settings.get('minimum_data_retention')
             max_retention_period = data_retention_settings.get('maximum_data_retention')
         if retention_period is not None:
             if field.type == RegistrationFormItemType.field_pd and field.personal_data_type.is_required:

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -23,7 +23,7 @@ from indico.modules.events.registration.util import get_flat_section_positions_s
 from indico.modules.events.settings import data_retention_settings
 from indico.modules.logs.models.entries import EventLogRealm, LogKind
 from indico.modules.logs.util import make_diff_log
-from indico.util.i18n import _
+from indico.util.i18n import _, ngettext
 from indico.util.marshmallow import not_empty
 from indico.util.string import snakify_keys
 
@@ -64,10 +64,14 @@ class GeneralFieldDataSchema(mm.Schema):
                 raise ValidationError(_('Retention period cannot be longer than that of the registration form'),
                                       'retention_period')
             if retention_period < min_retention_period:
-                raise ValidationError(_('The retention period cannot be less than {} weeks.')
+                raise ValidationError(ngettext('The retention period cannot be less than {} week.',
+                                               'The retention period cannot be less than {} weeks.',
+                                               min_retention_period.days // 7)
                                       .format(min_retention_period.days // 7))
             elif max_retention_period and retention_period > max_retention_period:
-                raise ValidationError(_('The retention period cannot be longer than {} weeks.')
+                raise ValidationError(ngettext('The retention period cannot be longer than {} week.',
+                                               'The retention period cannot be longer than {} weeks.',
+                                               max_retention_period.days // 7)
                                       .format(max_retention_period.days // 7))
             elif retention_period > timedelta(3650):
                 raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field empty '

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -73,7 +73,7 @@ class GeneralFieldDataSchema(mm.Schema):
                                                'The retention period cannot be longer than {} weeks.',
                                                max_retention_period.days // 7)
                                       .format(max_retention_period.days // 7))
-            elif retention_period > timedelta(3650):
+            elif not max_retention_period and retention_period > timedelta(3650):
                 raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field empty '
                                         'for indefinite.'))
 

--- a/indico/modules/events/registration/controllers/management/regforms.py
+++ b/indico/modules/events/registration/controllers/management/regforms.py
@@ -333,8 +333,8 @@ class RHRegistrationFormModify(RHManageRegFormBase):
         return WPManageRegistration.render_template('management/regform_modify.html', self.event,
                                                     form_data=get_flat_section_setup_data(self.regform),
                                                     regform=self.regform,
-                                                    data_retention_range=(min_data_retention.days // 7,
-                                                                          max_data_retention.days // 7),
+                                                    data_retention_range={'min': min_data_retention.days // 7,
+                                                                          'max': max_data_retention.days // 7},
                                                     has_predefined_affiliations=Affiliation.query.has_rows())
 
 

--- a/indico/modules/events/registration/controllers/management/regforms.py
+++ b/indico/modules/events/registration/controllers/management/regforms.py
@@ -31,6 +31,7 @@ from indico.modules.events.registration.util import (close_registration, create_
                                                      get_flat_section_setup_data)
 from indico.modules.events.registration.views import (WPManageParticipants, WPManageRegistration,
                                                       WPManageRegistrationStats)
+from indico.modules.events.settings import data_retention_settings
 from indico.modules.events.util import update_object_principals
 from indico.modules.logs.models.entries import EventLogRealm, LogKind
 from indico.modules.users.models.affiliations import Affiliation
@@ -327,9 +328,13 @@ class RHRegistrationFormModify(RHManageRegFormBase):
     """Modify the form of a registration form."""
 
     def _process(self):
+        min_data_retention = data_retention_settings.get('minimum_data_retention')
+        max_data_retention = data_retention_settings.get('maximum_data_retention') or timedelta(days=3650)
         return WPManageRegistration.render_template('management/regform_modify.html', self.event,
                                                     form_data=get_flat_section_setup_data(self.regform),
                                                     regform=self.regform,
+                                                    data_retention_range=(min_data_retention.days // 7,
+                                                                          max_data_retention.days // 7),
                                                     has_predefined_affiliations=Affiliation.query.has_rows())
 
 

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -32,7 +32,7 @@ from indico.modules.events.registration.models.registrations import PublishRegis
 from indico.modules.events.registration.models.tags import RegistrationTag
 from indico.modules.events.settings import data_retention_settings
 from indico.util.enum import RichStrEnum
-from indico.util.i18n import _
+from indico.util.i18n import _, ngettext
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
 from indico.web.forms.base import IndicoForm, generated_data
 from indico.web.forms.fields import EmailListField, FileField, IndicoDateTimeField, IndicoEnumSelectField, JSONField
@@ -170,8 +170,11 @@ class RegistrationFormCreateForm(IndicoForm):
             if visibility_duration <= timedelta():
                 raise ValidationError(_('The visibility duration cannot be zero.'))
             elif visibility_duration > max_retention_period:
-                raise ValidationError(_('The visibility duration cannot be longer than {} weeks. Leave the field empty '
-                                        'for indefinite.').format(max_retention_period.days // 7))
+                msg = ngettext('The visibility duration cannot be longer than {} week. Leave the field empty for '
+                               'indefinite.',
+                               'The visibility duration cannot be longer than {} weeks. Leave the field empty for '
+                               'indefinite.', max_retention_period.days // 7)
+                raise ValidationError(msg.format(max_retention_period.days // 7))
 
     def validate_retention_period(self, field):
         retention_period = field.data
@@ -681,8 +684,11 @@ class RegistrationPrivacyForm(IndicoForm):
             if visibility_duration < timedelta():
                 raise ValidationError(_('The visibility duration cannot be zero.'))
             elif visibility_duration > max_retention_period:
-                raise ValidationError(_('The visibility duration cannot be longer than {} weeks. Leave the field empty '
-                                        'for indefinite.').format(max_retention_period.days // 7))
+                raise ValidationError(ngettext('The visibility duration cannot be longer than {} week. Leave the '
+                                               'field empty for indefinite.',
+                                               'The visibility duration cannot be longer than {} weeks. Leave the '
+                                               'field empty for indefinite.', max_retention_period.days // 7)
+                                      .format(max_retention_period.days // 7))
 
     def validate_retention_period(self, field):
         retention_period = field.data

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -31,6 +31,7 @@ from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import PublishRegistrationsMode, Registration
 from indico.modules.events.registration.models.tags import RegistrationTag
 from indico.util.enum import RichStrEnum
+from indico.modules.events.settings import data_retention_settings
 from indico.util.i18n import _
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
 from indico.web.forms.base import IndicoForm, generated_data
@@ -40,7 +41,9 @@ from indico.web.forms.fields.datetime import TimeDeltaField
 from indico.web.forms.fields.principals import PrincipalListField
 from indico.web.forms.fields.simple import (HiddenFieldList, IndicoEmailRecipientsField, IndicoMultipleTagSelectField,
                                             IndicoParticipantVisibilityField)
-from indico.web.forms.validators import HiddenUnless, IndicoEmail, LinkedDateTime, NoRelativeURLs
+from indico.web.forms.util import inject_validators
+from indico.web.forms.validators import (DataRetentionPeriodValidator, HiddenUnless, IndicoEmail, LinkedDateTime,
+                                         NoRelativeURLs)
 from indico.web.forms.widgets import SwitchWidget, TinyMCEWidget
 
 
@@ -139,12 +142,22 @@ class RegistrationFormCreateForm(IndicoForm):
                                                   description=_('Specify under which conditions the participant list '
                                                                 'will be visible to other participants and everyone '
                                                                 'else who can access the event'))
-    retention_period = TimeDeltaField(_('Retention period'), units=('weeks',),
+    retention_period = TimeDeltaField(_('Retention period'), [DataRetentionPeriodValidator()], units=('weeks',),
                                       description=_('Specify for how many weeks the registration '
                                                     'data, including the participant list, should be stored. '
                                                     'Retention periods for individual fields can be set in the '
                                                     'registration form designer'),
                                       render_kw={'placeholder': _('Indefinite')})
+
+    def __init__(self, *args, **kwargs):
+        minimum_retention = data_retention_settings.get('minimum_data_retention') or timedelta(days=7)
+        maximum_retention = data_retention_settings.get('maximum_data_retention')
+        if maximum_retention:
+            inject_validators(self, 'retention_period', [DataRequired()])
+        maximum_retention = maximum_retention or timedelta(days=3650)
+        super().__init__(*args, **kwargs)
+        self.retention_period.render_kw.update({'min': minimum_retention.days // 7,
+                                                'max': maximum_retention.days // 7})
 
     def validate_visibility(self, field):
         participant_visibility, public_visibility = (PublishRegistrationsMode[v] for v in field.data[:-1])
@@ -153,21 +166,17 @@ class RegistrationFormCreateForm(IndicoForm):
                                     'for the public'))
         if field.data[2] is not None:
             visibility_duration = timedelta(weeks=field.data[2])
+            max_retention_period = data_retention_settings.get('maximum_data_retention') or timedelta(days=3650)
             if visibility_duration <= timedelta():
                 raise ValidationError(_('The visibility duration cannot be zero.'))
-            elif visibility_duration > timedelta(days=3650):
-                raise ValidationError(_('The visibility duration cannot be longer than 10 years. Leave the field empty '
-                                        'for indefinite.'))
+            elif visibility_duration > max_retention_period:
+                raise ValidationError(_('The visibility duration cannot be longer than {} weeks. Leave the field empty '
+                                        'for indefinite.').format(max_retention_period.days // 7))
 
     def validate_retention_period(self, field):
         retention_period = field.data
         if retention_period is None:
             return
-        elif retention_period <= timedelta():
-            raise ValidationError(_('The retention period cannot be zero or negative.'))
-        elif retention_period > timedelta(days=3650):
-            raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field empty for '
-                                    'indefinite.'))
         visibility_duration = (timedelta(weeks=self.visibility.data[2]) if self.visibility.data[2] is not None
                                else None)
         if visibility_duration and visibility_duration > retention_period:
@@ -607,7 +616,7 @@ class RegistrationPrivacyForm(IndicoForm):
                                                   description=_('Specify under which conditions the participant list '
                                                                 'will be visible to other participants and everyone '
                                                                 'else who can access the event'))
-    retention_period = TimeDeltaField(_('Retention period'), units=('weeks',),
+    retention_period = TimeDeltaField(_('Retention period'), [DataRetentionPeriodValidator()], units=('weeks',),
                                       description=_('Specify for how many weeks the registration '
                                                     'data, including the participant list, should be stored. '
                                                     'Retention periods for individual fields can be set in the '
@@ -619,7 +628,14 @@ class RegistrationPrivacyForm(IndicoForm):
 
     def __init__(self, *args, regform, **kwargs):
         self.regform = regform
+        minimum_retention = data_retention_settings.get('minimum_data_retention') or timedelta(days=7)
+        maximum_retention = data_retention_settings.get('maximum_data_retention')
+        if maximum_retention:
+            inject_validators(self, 'retention_period', [DataRequired()])
+        maximum_retention = maximum_retention or timedelta(days=3650)
         super().__init__(*args, **kwargs)
+        self.retention_period.render_kw.update({'min': minimum_retention.days // 7,
+                                                'max': maximum_retention.days // 7})
 
     @generated_data
     def publish_registrations_participants(self):
@@ -661,21 +677,17 @@ class RegistrationPrivacyForm(IndicoForm):
             raise ValidationError(_("'Show all participants' can only be set if there are no registered users."))
         if field.data[2] is not None:
             visibility_duration = timedelta(weeks=field.data[2])
-            if visibility_duration <= timedelta():
+            max_retention_period = data_retention_settings.get('maximum_data_retention') or timedelta(days=3650)
+            if visibility_duration < timedelta():
                 raise ValidationError(_('The visibility duration cannot be zero.'))
-            elif visibility_duration > timedelta(days=3650):
-                raise ValidationError(_('The visibility duration cannot be longer than 10 years. Leave the field empty '
-                                        'for indefinite.'))
+            elif visibility_duration > max_retention_period:
+                raise ValidationError(_('The visibility duration cannot be longer than {} weeks. Leave the field empty '
+                                        'for indefinite.').format(max_retention_period.days // 7))
 
     def validate_retention_period(self, field):
         retention_period = field.data
         if retention_period is None:
             return
-        elif retention_period <= timedelta():
-            raise ValidationError(_('The retention period cannot be zero or negative.'))
-        elif retention_period > timedelta(days=3650):
-            raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field empty for '
-                                    'indefinite.'))
         visibility_duration = (timedelta(weeks=self.visibility.data[2]) if self.visibility.data[2] is not None
                                else None)
         if visibility_duration and visibility_duration > retention_period:

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -154,8 +154,9 @@ class RegistrationFormCreateForm(IndicoForm):
         maximum_retention = data_retention_settings.get('maximum_data_retention')
         if maximum_retention:
             inject_validators(self, 'retention_period', [DataRequired()])
-        maximum_retention = maximum_retention or timedelta(days=3650)
         super().__init__(*args, **kwargs)
+        maximum_retention = maximum_retention or timedelta(days=3650)
+        self.visibility.max_visibility_period = maximum_retention.days // 7
         self.retention_period.render_kw.update({'min': minimum_retention.days // 7,
                                                 'max': maximum_retention.days // 7})
 
@@ -635,8 +636,9 @@ class RegistrationPrivacyForm(IndicoForm):
         maximum_retention = data_retention_settings.get('maximum_data_retention')
         if maximum_retention:
             inject_validators(self, 'retention_period', [DataRequired()])
-        maximum_retention = maximum_retention or timedelta(days=3650)
         super().__init__(*args, **kwargs)
+        maximum_retention = maximum_retention or timedelta(days=3650)
+        self.visibility.max_visibility_period = maximum_retention.days // 7
         self.retention_period.render_kw.update({'min': minimum_retention.days // 7,
                                                 'max': maximum_retention.days // 7})
 

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -30,8 +30,8 @@ from indico.modules.events.registration.models.invitations import RegistrationIn
 from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import PublishRegistrationsMode, Registration
 from indico.modules.events.registration.models.tags import RegistrationTag
-from indico.util.enum import RichStrEnum
 from indico.modules.events.settings import data_retention_settings
+from indico.util.enum import RichStrEnum
 from indico.util.i18n import _
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
 from indico.web.forms.base import IndicoForm, generated_data

--- a/indico/modules/events/registration/templates/management/regform_modify.html
+++ b/indico/modules/events/registration/templates/management/regform_modify.html
@@ -17,6 +17,7 @@
          data-event-end-date="{{ event.end_dt_local.date() }}"
          data-regform-id="{{ regform.id }}"
          data-currency="{{ regform.currency }}"
+         data-data-retention-range="{{ data_retention_range | tojson }}"
          data-has-predefined-affiliations="{{ has_predefined_affiliations | tojson | forceescape }}"
          data-form-data="{{ form_data | tojson | forceescape }}"></div>
 {% endblock %}

--- a/indico/modules/events/registration/templates/management/regform_modify.html
+++ b/indico/modules/events/registration/templates/management/regform_modify.html
@@ -17,7 +17,7 @@
          data-event-end-date="{{ event.end_dt_local.date() }}"
          data-regform-id="{{ regform.id }}"
          data-currency="{{ regform.currency }}"
-         data-data-retention-range="{{ data_retention_range | tojson }}"
+         data-data-retention-range="{{ data_retention_range | tojson | forceescape }}"
          data-has-predefined-affiliations="{{ has_predefined_affiliations | tojson | forceescape }}"
          data-form-data="{{ form_data | tojson | forceescape }}"></div>
 {% endblock %}

--- a/indico/modules/events/settings.py
+++ b/indico/modules/events/settings.py
@@ -6,6 +6,7 @@
 # LICENSE file for more details.
 
 import re
+from datetime import timedelta
 from functools import wraps
 from pathlib import Path
 
@@ -271,7 +272,7 @@ autolinker_settings = SettingsProxy('autolinker', {
 })
 
 data_retention_settings = SettingsProxy('data_retention', {
-    'minimum_data_retention': None,
+    'minimum_data_retention': timedelta(days=7),
     'maximum_data_retention': None,
 }, converters={
     'minimum_data_retention': TimedeltaConverter,

--- a/indico/modules/events/settings.py
+++ b/indico/modules/events/settings.py
@@ -14,7 +14,7 @@ from flask.helpers import get_root_path
 
 from indico.core import signals
 from indico.core.settings import ACLProxyBase, SettingProperty, SettingsProxyBase
-from indico.core.settings.converters import DatetimeConverter
+from indico.core.settings.converters import DatetimeConverter, TimedeltaConverter
 from indico.core.settings.proxy import SettingsProxy
 from indico.core.settings.util import get_all_settings, get_setting, get_setting_acl
 from indico.modules.events.models.settings import EventSetting, EventSettingPrincipal
@@ -268,4 +268,12 @@ unlisted_events_settings = SettingsProxy('unlisted_events', {
 
 autolinker_settings = SettingsProxy('autolinker', {
     'rules': []
+})
+
+data_retention_settings = SettingsProxy('data_retention', {
+    'minimum_data_retention': None,
+    'maximum_data_retention': None,
+}, converters={
+    'minimum_data_retention': TimedeltaConverter,
+    'maximum_data_retention': TimedeltaConverter
 })

--- a/indico/modules/events/templates/admin/data_retention.html
+++ b/indico/modules/events/templates/admin/data_retention.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block description %}
-    {% trans %}Allowed minumum and maximum data retention period can be configured here.{% endtrans %}
+    {% trans %}Allowed minimum and maximum data retention period can be configured here.{% endtrans %}
 {% endblock %}
 
 {% block content %}

--- a/indico/modules/events/templates/admin/data_retention.html
+++ b/indico/modules/events/templates/admin/data_retention.html
@@ -1,0 +1,14 @@
+{% extends 'layout/admin_page.html' %}
+{% from 'forms/_form.html' import simple_form %}
+
+{% block title %}
+    {% trans %}Data retention settings{% endtrans %}
+{% endblock %}
+
+{% block description %}
+    {% trans %}Allowed minumum and maximum data retention period can be configured here.{% endtrans %}
+{% endblock %}
+
+{% block content %}
+    {{ simple_form(form, back_button=false) }}
+{% endblock %}

--- a/indico/web/client/js/jquery/widgets/jinja/participant_visibility_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/participant_visibility_widget.js
@@ -14,6 +14,7 @@ window.setupParticipantVisibilityWidget = function setupParticipantVisibilityWid
   fieldId,
   values,
   choices,
+  maxVisibilityPeriod,
 }) {
   const wrapperId = `${fieldId}-wrapper`;
   ReactDOM.render(
@@ -22,6 +23,7 @@ window.setupParticipantVisibilityWidget = function setupParticipantVisibilityWid
       wrapperId={wrapperId}
       values={values}
       choices={choices}
+      maxVisibilityPeriod={maxVisibilityPeriod}
     />,
     document.getElementById(wrapperId)
   );

--- a/indico/web/client/js/react/components/WTFParticipantVisibilityField.jsx
+++ b/indico/web/client/js/react/components/WTFParticipantVisibilityField.jsx
@@ -11,7 +11,13 @@ import {Dropdown, Form, Icon, Input, Message} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
 
-export default function WTFParticipantVisibilityField({fieldId, wrapperId, values, choices}) {
+export default function WTFParticipantVisibilityField({
+  fieldId,
+  wrapperId,
+  values,
+  choices,
+  maxVisibilityPeriod,
+}) {
   const parentElement = useMemo(() => document.getElementById(wrapperId), [wrapperId]);
   const [participantVisibility, setParticipantVisibility] = useState(values[0]);
   const [publicVisibility, setPublicVisibility] = useState(values[1]);
@@ -91,7 +97,7 @@ export default function WTFParticipantVisibilityField({fieldId, wrapperId, value
             placeholder={Translate.string('Permanent')}
             step="1"
             min="1"
-            max="521"
+            max={maxVisibilityPeriod}
             value={visibilityDuration === null ? '' : visibilityDuration}
             onChange={(evt, {value}) => setVisibilityDuration(value === '' ? null : +value)}
             disabled={participantVisibility === 'hide_all'}
@@ -128,4 +134,5 @@ WTFParticipantVisibilityField.propTypes = {
   wrapperId: PropTypes.string.isRequired,
   values: PropTypes.array.isRequired,
   choices: PropTypes.array.isRequired,
+  maxVisibilityPeriod: PropTypes.number.isRequired,
 };

--- a/indico/web/client/js/react/components/files/SingleFileManager.jsx
+++ b/indico/web/client/js/react/components/files/SingleFileManager.jsx
@@ -215,7 +215,7 @@ export default function FinalSingleFileManager({name, ...rest}) {
   return (
     <Field
       name={`_${name}_invalidator`}
-      validate={value => console.log(value)}
+      validate={value => value || undefined}
       render={({input: {onChange: setDummyValue}}) => (
         <FinalField
           name={name}

--- a/indico/web/client/js/react/components/files/SingleFileManager.jsx
+++ b/indico/web/client/js/react/components/files/SingleFileManager.jsx
@@ -215,7 +215,7 @@ export default function FinalSingleFileManager({name, ...rest}) {
   return (
     <Field
       name={`_${name}_invalidator`}
-      validate={value => value || undefined}
+      validate={value => console.log(value)}
       render={({input: {onChange: setDummyValue}}) => (
         <FinalField
           name={name}

--- a/indico/web/forms/fields/simple.py
+++ b/indico/web/forms/fields/simple.py
@@ -216,3 +216,4 @@ class IndicoLinkListField(JSONField):
 class IndicoParticipantVisibilityField(JSONField):
     widget = JinjaWidget('forms/participant_visibility_widget.html', single_kwargs=True, single_line=True)
     choices = [(mode.name, mode.title) for mode in PublishRegistrationsMode]
+    max_visibility_period = 521

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -438,7 +438,7 @@ class MastodonServer:
 
 
 class DataRetentionPeriodValidator:
-    """Validates the data retention period."""
+    """Validate a data retention period against the global defaults."""
 
     def __call__(self, form, field):
         retention_period = field.data

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -447,7 +447,7 @@ class DataRetentionPeriodValidator:
             raise ValidationError(_('The retention period cannot be indefinite.'))
         elif retention_period is None:
             return
-        min_retention_period = data_retention_settings.get('minimum_data_retention') or timedelta(days=7)
+        min_retention_period = data_retention_settings.get('minimum_data_retention')
         if retention_period < min_retention_period:
             raise ValidationError(ngettext('The retention period cannot be less than {} week.',
                                            'The retention period cannot be less than {} weeks.',

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -458,6 +458,6 @@ class DataRetentionPeriodValidator:
                                            'The retention period cannot be longer than {} weeks.',
                                            max_retention_period.days // 7)
                                   .format(max_retention_period.days // 7))
-        elif retention_period > timedelta(3650):
+        elif not max_retention_period and retention_period > timedelta(3650):
             raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field empty for '
                                     'indefinite.'))

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -11,6 +11,7 @@ from urllib.parse import urlsplit
 
 from wtforms.validators import EqualTo, Length, Regexp, StopValidation, ValidationError
 
+from indico.modules.events.settings import data_retention_settings
 from indico.modules.users.util import get_mastodon_server_name
 from indico.util.date_time import as_utc, format_date, format_datetime, format_human_timedelta, format_time, now_utc
 from indico.util.i18n import _, ngettext
@@ -434,3 +435,25 @@ class MastodonServer:
 
             if not get_mastodon_server_name(field.data):
                 raise ValidationError(_('Invalid Mastodon server URL.'))
+
+
+class DataRetentionPeriodValidator:
+    """Validates the data retention period."""
+
+    def __call__(self, form, field):
+        retention_period = field.data
+        max_retention_period = data_retention_settings.get('maximum_data_retention')
+        if max_retention_period and retention_period is None:
+            raise ValidationError(_('The retention period cannot be indefinite.'))
+        elif retention_period is None:
+            return
+        min_retention_period = data_retention_settings.get('minimum_data_retention') or timedelta(days=7)
+        if retention_period < min_retention_period:
+            raise ValidationError(_('The retention period cannot be less than {} weeks.')
+                                  .format(min_retention_period.days // 7))
+        elif max_retention_period and retention_period > max_retention_period:
+            raise ValidationError(_('The retention period cannot be longer than {} weeks.')
+                                  .format(max_retention_period.days // 7))
+        elif retention_period > timedelta(3650):
+            raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field empty for '
+                                    'indefinite.'))

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -449,10 +449,14 @@ class DataRetentionPeriodValidator:
             return
         min_retention_period = data_retention_settings.get('minimum_data_retention') or timedelta(days=7)
         if retention_period < min_retention_period:
-            raise ValidationError(_('The retention period cannot be less than {} weeks.')
+            raise ValidationError(ngettext('The retention period cannot be less than {} week.',
+                                           'The retention period cannot be less than {} weeks.',
+                                           min_retention_period.days // 7)
                                   .format(min_retention_period.days // 7))
         elif max_retention_period and retention_period > max_retention_period:
-            raise ValidationError(_('The retention period cannot be longer than {} weeks.')
+            raise ValidationError(ngettext('The retention period cannot be longer than {} week.',
+                                           'The retention period cannot be longer than {} weeks.',
+                                           max_retention_period.days // 7)
                                   .format(max_retention_period.days // 7))
         elif retention_period > timedelta(3650):
             raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field empty for '

--- a/indico/web/templates/forms/participant_visibility_widget.html
+++ b/indico/web/templates/forms/participant_visibility_widget.html
@@ -10,6 +10,7 @@
             fieldId: {{ field.id | tojson }},
             values: {{ field.data | tojson }},
             choices: {{ field.choices | tojson }},
+            maxVisibilityPeriod: {{ field.max_visibility_period | tojson }},
         });
     </script>
 {% endblock %}

--- a/indico/web/templates/forms/timedelta_widget.html
+++ b/indico/web/templates/forms/timedelta_widget.html
@@ -7,7 +7,7 @@
         {# The order of these two fields matters! If you change it, update
            `process_formdata` and `_value` in TimeDeltaField accordingly! #}
         <input type="number" name="{{ field.name }}" id="{{ field.id }}-value" value="{{ current_value }}"
-               {% if field.flags.required %} required {% if not 'min' in input_args %} min="1" {% endif %} {% endif %}
+               {% if field.flags.required %} required {% if 'min' not in input_args %}min="1"{% endif %}{% endif %}
                {{ input_args|html_params }}>
         {% if field.choices|length > 1 %}
             <select id="{{ field.id }}-unit" name="{{ field.name }}" data-tooltip-anchor

--- a/indico/web/templates/forms/timedelta_widget.html
+++ b/indico/web/templates/forms/timedelta_widget.html
@@ -7,7 +7,7 @@
         {# The order of these two fields matters! If you change it, update
            `process_formdata` and `_value` in TimeDeltaField accordingly! #}
         <input type="number" name="{{ field.name }}" id="{{ field.id }}-value" value="{{ current_value }}"
-               {% if field.flags.required %} required min="1"{% endif %}
+               {% if field.flags.required %} required {% if not 'min' in input_args %} min="1" {% endif %} {% endif %}
                {{ input_args|html_params }}>
         {% if field.choices|length > 1 %}
             <select id="{{ field.id }}-unit" name="{{ field.name }}" data-tooltip-anchor


### PR DESCRIPTION
This PR is to add configuration for the min and max data retention period of registrations, so that each instance can configure their own. If no maximum is set then 10 years is the default maximum. The configuration page is at http://127.0.0.1:8000/admin/data-retention/