### PR TITLE
Enable search by author in editable lists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Improvements
   thanks :user:`SegiNyn`)
 - Add task to delete old registration files when they become orphaned due to a new
   file being uploaded (:pr:`6434`, thanks :user:`SegiNyn`)
+- Allow searching by the contribution's authors in editable lists (:pr:`6451`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Improvements
   thanks :user:`SegiNyn`)
 - Add task to delete old registration files when they become orphaned due to a new
   file being uploaded (:pr:`6434`, thanks :user:`SegiNyn`)
-- Allow searching by the contribution's authors in editable lists (:pr:`6451`)
+- Allow searching for author names in editable lists (:pr:`6451`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/schemas.py
+++ b/indico/modules/events/contributions/schemas.py
@@ -62,8 +62,8 @@ class ContributionPersonLinkSchema(mm.SQLAlchemyAutoSchema):
 
     class Meta:
         model = ContributionPersonLink
-        fields = ('id', 'person_id', 'email', 'email_hash', 'first_name', 'last_name', 'title', 'affiliation',
-                  'affiliation_link', 'address', 'phone', 'is_speaker', 'author_type')
+        fields = ('id', 'person_id', 'email', 'email_hash', 'first_name', 'last_name', 'full_name', 'title',
+                  'affiliation', 'affiliation_link', 'address', 'phone', 'is_speaker', 'author_type')
 
     @post_dump
     def _hide_sensitive_data(self, data, **kwargs):

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -325,8 +325,8 @@ function EditableListDisplay({
         searchableId: c.friendlyId,
         searchableFields:
           c.editable && c.editable.editor
-            ? [c.title, c.code, c.editable.editor.fullName]
-            : [c.title, c.code],
+            ? [c.title, c.code, c.persons.join(''), c.editable.editor.fullName]
+            : [c.title, c.code, c.persons.join('')],
         c,
       })),
     [contribList]

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -325,8 +325,8 @@ function EditableListDisplay({
         searchableId: c.friendlyId,
         searchableFields:
           c.editable && c.editable.editor
-            ? [c.title, c.code, c.persons.join(''), c.editable.editor.fullName]
-            : [c.title, c.code, c.persons.join('')],
+            ? [c.title, c.code, ...c.persons, c.editable.editor.fullName]
+            : [c.title, c.code, ...c.persons],
         c,
       })),
     [contribList]

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -208,7 +208,7 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
             searchableFields={e => [
               e.contributionTitle,
               e.contributionCode,
-              e.contributionPersons.join(''),
+              ...e.contributionPersons,
             ]}
             onChangeFilters={onChangeFilters}
             onChangeList={setFilteredSet}

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -205,11 +205,11 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
             filters={filters}
             filterOptions={filterOptions}
             searchableId={e => e.contributionFriendlyId}
-            searchableFields={e =>
-              e.editor
-                ? [e.contributionTitle, e.contributionCode, e.editor.fullName]
-                : [e.contributionTitle, e.contributionCode]
-            }
+            searchableFields={e => [
+              e.contributionTitle,
+              e.contributionCode,
+              e.contributionPersons.join(''),
+            ]}
             onChangeFilters={onChangeFilters}
             onChangeList={setFilteredSet}
           />

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -45,7 +45,8 @@ class RHEditableList(RHEditableTypeEditorBase):
         RHEditableTypeEditorBase._process_args(self)
         self.contributions = (Contribution.query
                               .with_parent(self.event)
-                              .options(joinedload('editables').selectinload('revisions').selectinload('tags'))
+                              .options(joinedload('editables').selectinload('revisions').selectinload('tags'),
+                                       joinedload('person_links'))
                               .order_by(Contribution.friendly_id)
                               .all())
 
@@ -234,7 +235,7 @@ class RHFilterEditablesByFileTypes(RHEditableTypeEditorBase):
         revision_query = revision_query.subquery()
         return (Editable.query
                 .join(revision_query, revision_query.c.editable_id == Editable.id)
-                .options(joinedload('contribution'))
+                .options(joinedload('contribution').selectinload('person_links'))
                 .all())
 
     @use_kwargs({


### PR DESCRIPTION
Very often editors need to find a paper from a specific author. This PR adds the ability to search for authors' (and other contrib persons') editables directly from the editable list.

Note: the ability to search by assigned editors in Get Next Editable was removed, since you can only search for unassigned editables in that dialog anyway.