### PR TITLE
Add session filter to editable lists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Improvements
 - Add task to delete old registration files when they become orphaned due to a new
   file being uploaded (:pr:`6434`, thanks :user:`SegiNyn`)
 - Allow searching for author names in editable lists (:pr:`6451`)
+- Add ability to filter editable lists by the parent session of the editable's
+  contribution (:pr:`6453`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -192,13 +192,14 @@ function EditableListDisplay({
           selectedOptions.includes(contrib.c.editable.editor.identifier),
       },
       {
-        key: 'code',
-        text: Translate.string('Program code'),
-        options: _.uniq(contribList.map(c => c.code).filter(x => x)).map(code => ({
-          value: code,
-          text: code,
+        key: 'session',
+        text: Translate.string('Session'),
+        options: _.uniqBy(contribList.map(c => c.session).filter(x => x), 'id').map(session => ({
+          value: `${session.id}`,
+          text: session.code ? `${session.code} - ${session.title}` : session.title,
         })),
-        isMatch: (contrib, selectedOptions) => selectedOptions.includes(contrib.c.code),
+        isMatch: (contrib, selectedOptions) =>
+          contrib.c.session && selectedOptions.includes(`${contrib.c.session.id}`),
       },
       {
         key: 'keywords',

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -89,13 +89,17 @@ function NextEditableDisplay({eventId, editableType, onClose, fileTypes, managem
   const filterOptions = useMemo(
     () => [
       {
-        key: 'code',
-        text: Translate.string('Program code'),
-        options: _.uniq(editables?.map(e => e.contributionCode).filter(x => x)).map(code => ({
-          value: code,
-          text: code,
-        })),
-        isMatch: (editable, selectedOptions) => selectedOptions.includes(editable.contributionCode),
+        key: 'session',
+        text: Translate.string('Session'),
+        options: _.uniqBy(editables?.map(e => e.contributionSession).filter(x => x), 'id').map(
+          session => ({
+            value: `${session.id}`,
+            text: session.code ? `${session.code} - ${session.title}` : session.title,
+          })
+        ),
+        isMatch: (editable, selectedOptions) =>
+          editable.contributionSession &&
+          selectedOptions.includes(`${editable.contributionSession.id}`),
       },
       {
         key: 'keywords',

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -46,7 +46,7 @@ class RHEditableList(RHEditableTypeEditorBase):
         self.contributions = (Contribution.query
                               .with_parent(self.event)
                               .options(joinedload('editables').selectinload('revisions').selectinload('tags'),
-                                       joinedload('person_links'))
+                                       joinedload('person_links'), joinedload('session'))
                               .order_by(Contribution.friendly_id)
                               .all())
 
@@ -235,7 +235,8 @@ class RHFilterEditablesByFileTypes(RHEditableTypeEditorBase):
         revision_query = revision_query.subquery()
         return (Editable.query
                 .join(revision_query, revision_query.c.editable_id == Editable.id)
-                .options(joinedload('contribution').selectinload('person_links'))
+                .options(joinedload('contribution').selectinload('person_links'),
+                         joinedload('contribution').joinedload('session'))
                 .all())
 
     @use_kwargs({

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -46,7 +46,8 @@ class RHEditableList(RHEditableTypeEditorBase):
         self.contributions = (Contribution.query
                               .with_parent(self.event)
                               .options(joinedload('editables').selectinload('revisions').selectinload('tags'),
-                                       joinedload('person_links'), joinedload('session'))
+                                       joinedload('person_links'),
+                                       joinedload('session'))
                               .order_by(Contribution.friendly_id)
                               .all())
 
@@ -233,10 +234,12 @@ class RHFilterEditablesByFileTypes(RHEditableTypeEditorBase):
             )
 
         revision_query = revision_query.subquery()
+        contribution_strategy = joinedload('contribution')
+        contribution_strategy.selectinload('person_links')
+        contribution_strategy.joinedload('session')
         return (Editable.query
                 .join(revision_query, revision_query.c.editable_id == Editable.id)
-                .options(joinedload('contribution').selectinload('person_links'),
-                         joinedload('contribution').joinedload('session'))
+                .options(contribution_strategy)
                 .all())
 
     @use_kwargs({


### PR DESCRIPTION
This PR adds the ability to filter editable lists by the parent session of the editable's contribution. It also removes the programme code filter, which is pointless since every editable has a different code.