### PR TITLE
Allow many CSV delimiters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Improvements
 - Allow searching for author names in editable lists (:pr:`6451`)
 - Add ability to filter editable lists by the parent session of the editable's
   contribution (:pr:`6453`)
+- Allow alternative CSV delimiters when importing registration invitations (:pr:`6458`,
+  thanks :user:`Moliholy, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/controllers/management/invitations.py
+++ b/indico/modules/events/registration/controllers/management/invitations.py
@@ -183,13 +183,15 @@ class RHRegistrationFormInviteImport(RHManageRegFormBase):
         skip_moderation = form.skip_moderation.data if 'skip_moderation' in form else False
         skip_access_check = form.skip_access_check.data
         skip_existing = form.skip_existing.data
+        delimiter = form.delimiter.data.char()
         if form.validate_on_submit():
             invitations, skipped = import_invitations_from_csv(self.regform, form.source_file.data,
                                                                form.email_from.data, form.email_subject.data,
                                                                form.email_body.data,
                                                                skip_moderation=skip_moderation,
                                                                skip_access_check=skip_access_check,
-                                                               skip_existing=skip_existing)
+                                                               skip_existing=skip_existing,
+                                                               delimiter=delimiter)
             sent = len(invitations)
             flash(self._format_flash_message(sent, skipped), 'success' if sent > 0 else 'warning')
             return jsonify_data(**_get_invitation_data(self.regform))

--- a/indico/modules/events/registration/controllers/management/invitations.py
+++ b/indico/modules/events/registration/controllers/management/invitations.py
@@ -183,7 +183,7 @@ class RHRegistrationFormInviteImport(RHManageRegFormBase):
         skip_moderation = form.skip_moderation.data if 'skip_moderation' in form else False
         skip_access_check = form.skip_access_check.data
         skip_existing = form.skip_existing.data
-        delimiter = form.delimiter.enum[form.delimiter.data].delimiter
+        delimiter = form.delimiter.data
         if form.validate_on_submit():
             invitations, skipped = import_invitations_from_csv(self.regform, form.source_file.data,
                                                                form.email_from.data, form.email_subject.data,

--- a/indico/modules/events/registration/controllers/management/invitations.py
+++ b/indico/modules/events/registration/controllers/management/invitations.py
@@ -183,7 +183,7 @@ class RHRegistrationFormInviteImport(RHManageRegFormBase):
         skip_moderation = form.skip_moderation.data if 'skip_moderation' in form else False
         skip_access_check = form.skip_access_check.data
         skip_existing = form.skip_existing.data
-        delimiter = form.delimiter.data.char()
+        delimiter = form.delimiter.enum[form.delimiter.data].delimiter
         if form.validate_on_submit():
             invitations, skipped = import_invitations_from_csv(self.regform, form.source_file.data,
                                                                form.email_from.data, form.email_subject.data,

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -310,7 +310,7 @@ class ImportInvitationsForm(InvitationFormBase):
                             accepted_file_types='.csv')
     skip_existing = BooleanField(_('Skip existing invitations'), widget=SwitchWidget(), default=False,
                                  description=_('If enabled, users with existing invitations will be ignored.'))
-    delimiter = IndicoEnumSelectField(_('CSV field delimiter'), enum=CSVFieldDelimiter, default=CSVFieldDelimiter.comma)
+    delimiter = IndicoEnumSelectField(_('CSV field delimiter'), enum=CSVFieldDelimiter, default=CSVFieldDelimiter.comma.name)
 
 
 class EmailRegistrantsForm(IndicoForm):

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -305,13 +305,13 @@ class CSVFieldDelimiter(RichStrEnum):
 
 
 class ImportInvitationsForm(InvitationFormBase):
-    _invitation_fields = ('source_file', 'skip_existing', 'delimiter', *InvitationFormBase._invitation_fields)
+    _invitation_fields = ('source_file', 'delimiter', 'skip_existing', *InvitationFormBase._invitation_fields)
     source_file = FileField(_('Source File'), [DataRequired(_('You need to upload a CSV file.'))],
                             accepted_file_types='.csv')
-    skip_existing = BooleanField(_('Skip existing invitations'), widget=SwitchWidget(), default=False,
-                                 description=_('If enabled, users with existing invitations will be ignored.'))
     delimiter = IndicoEnumSelectField(_('CSV field delimiter'), enum=CSVFieldDelimiter,
                                       default=CSVFieldDelimiter.comma.name)
+    skip_existing = BooleanField(_('Skip existing invitations'), widget=SwitchWidget(), default=False,
+                                 description=_('If enabled, users with existing invitations will be ignored.'))
 
 
 class EmailRegistrantsForm(IndicoForm):

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -310,7 +310,8 @@ class ImportInvitationsForm(InvitationFormBase):
                             accepted_file_types='.csv')
     skip_existing = BooleanField(_('Skip existing invitations'), widget=SwitchWidget(), default=False,
                                  description=_('If enabled, users with existing invitations will be ignored.'))
-    delimiter = IndicoEnumSelectField(_('CSV field delimiter'), enum=CSVFieldDelimiter, default=CSVFieldDelimiter.comma.name)
+    delimiter = IndicoEnumSelectField(_('CSV field delimiter'), enum=CSVFieldDelimiter,
+                                      default=CSVFieldDelimiter.comma.name)
 
 
 class EmailRegistrantsForm(IndicoForm):

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -29,6 +29,7 @@ from indico.modules.events.registration.models.invitations import RegistrationIn
 from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import PublishRegistrationsMode, Registration
 from indico.modules.events.registration.models.tags import RegistrationTag
+from indico.util.enum import RichIntEnum
 from indico.util.i18n import _
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
 from indico.web.forms.base import IndicoForm, generated_data
@@ -278,12 +279,31 @@ class InvitationFormExisting(InvitationFormBase):
                                   .format(emails=', '.join(sorted(existing))))
 
 
+class CSVFieldDelimiter(RichIntEnum):
+    __titles__ = [_('Comma'), _('Semicolon'), _('Tab'), _('Space')]
+    __delimiters__ = {
+        0: ',',
+        1: ';',
+        2: '\t',
+        3: ' ',
+    }
+
+    comma = 0
+    semicolon = 1
+    tab = 2
+    space = 3
+
+    def char(self):
+        return self.__delimiters__[self.value]
+
+
 class ImportInvitationsForm(InvitationFormBase):
-    _invitation_fields = ('source_file', 'skip_existing', *InvitationFormBase._invitation_fields)
+    _invitation_fields = ('source_file', 'skip_existing', 'delimiter', *InvitationFormBase._invitation_fields)
     source_file = FileField(_('Source File'), [DataRequired(_('You need to upload a CSV file.'))],
                             accepted_file_types='.csv')
     skip_existing = BooleanField(_('Skip existing invitations'), widget=SwitchWidget(), default=False,
                                  description=_('If enabled, users with existing invitations will be ignored.'))
+    delimiter = IndicoEnumSelectField(_('CSV field delimiter'), enum=CSVFieldDelimiter, default=CSVFieldDelimiter.comma)
 
 
 class EmailRegistrantsForm(IndicoForm):

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -7,6 +7,7 @@
 
 from datetime import time, timedelta
 from decimal import Decimal
+from enum import auto
 from operator import itemgetter
 
 import jsonschema
@@ -29,7 +30,7 @@ from indico.modules.events.registration.models.invitations import RegistrationIn
 from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import PublishRegistrationsMode, Registration
 from indico.modules.events.registration.models.tags import RegistrationTag
-from indico.util.enum import RichIntEnum
+from indico.util.enum import RichStrEnum
 from indico.util.i18n import _
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
 from indico.web.forms.base import IndicoForm, generated_data
@@ -279,22 +280,28 @@ class InvitationFormExisting(InvitationFormBase):
                                   .format(emails=', '.join(sorted(existing))))
 
 
-class CSVFieldDelimiter(RichIntEnum):
-    __titles__ = [_('Comma'), _('Semicolon'), _('Tab'), _('Space')]
+class CSVFieldDelimiter(RichStrEnum):
+    __titles__ = {
+        'comma': _('Comma'),
+        'semicolon': _('Semicolon'),
+        'tab': _('Tab'),
+        'space': _('Space')
+    }
     __delimiters__ = {
-        0: ',',
-        1: ';',
-        2: '\t',
-        3: ' ',
+        'comma': ',',
+        'semicolon': ';',
+        'tab': '\t',
+        'space': ' ',
     }
 
-    comma = 0
-    semicolon = 1
-    tab = 2
-    space = 3
+    comma = auto()
+    semicolon = auto()
+    tab = auto()
+    space = auto()
 
-    def char(self):
-        return self.__delimiters__[self.value]
+    @property
+    def delimiter(self):
+        return self.__delimiters__[self.name]
 
 
 class ImportInvitationsForm(InvitationFormBase):

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -75,7 +75,7 @@ class ActionMenuEntry:
     extra_classes: str = ''
 
 
-def import_user_records_from_csv(fileobj, columns):
+def import_user_records_from_csv(fileobj, columns, delimiter=','):
     """Parse and do basic validation of user data from a CSV file.
 
     :param fileobj: the CSV file to be read
@@ -84,7 +84,7 @@ def import_user_records_from_csv(fileobj, columns):
              the keys of which are given by the column names.
     """
     with csv_text_io_wrapper(fileobj) as ftxt:
-        reader = csv.reader(ftxt.read().splitlines())
+        reader = csv.reader(ftxt.read().splitlines(), delimiter=delimiter)
     used_emails = set()
     email_row_map = {}
     user_records = []
@@ -891,14 +891,14 @@ def import_registrations_from_csv(regform, fileobj, skip_moderation=True, notify
 
 
 def import_invitations_from_csv(regform, fileobj, email_from, email_subject, email_body, *,
-                                skip_moderation=True, skip_access_check=True, skip_existing=False):
+                                skip_moderation=True, skip_access_check=True, skip_existing=False, delimiter=','):
     """Import invitations from a CSV file.
 
     :return: A list of invitations and the number of skipped records which
              is zero if skip_existing=False
     """
     columns = ['first_name', 'last_name', 'affiliation', 'email']
-    user_records = import_user_records_from_csv(fileobj, columns=columns)
+    user_records = import_user_records_from_csv(fileobj, columns=columns, delimiter=delimiter)
 
     reg_data = (db.session.query(Registration.user_id, Registration.email)
                 .with_parent(regform)

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -400,7 +400,7 @@ def strip_whitespace(s):
     This utility is useful in cases where you might get None or
     non-string values such as WTForms filters.
     """
-    if isinstance(s, str):
+    if isinstance(s, str) and not isinstance(s, Enum):
         s = s.strip()
     return s
 


### PR DESCRIPTION
# Description

This PR allows to specify the CSV delimiter when importing invitations to an event. Allowed values are:
- Comma
- Semicolon
- Tab
- Space

## Screenshots

![Screenshot 2024-07-28 at 20 19 06](https://github.com/user-attachments/assets/5b402db2-b6f7-4393-93b8-663c94135c55)


