### PR TITLE
Disable judgments when timeline is disabled

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -28,6 +28,7 @@ export default function CommentForm({
   onCommentChange,
   syncComment,
   setSyncComment,
+  disabled,
 }) {
   const {canCreateInternalComments} = useSelector(getDetails);
   const [commentFormVisible, setCommentFormVisible] = useState(expanded);
@@ -88,6 +89,7 @@ export default function CommentForm({
                 <Form.Group styleName="submit-buttons" inline>
                   <FinalSubmitButton
                     label={Translate.string('Comment', 'Leave a comment (verb)')}
+                    disabled={disabled}
                   />
                   <Button
                     disabled={fprops.submitting}
@@ -121,6 +123,7 @@ CommentForm.propTypes = {
   commentValue: PropTypes.string,
   syncComment: PropTypes.bool,
   setSyncComment: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 CommentForm.defaultProps = {

--- a/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ResetReview.jsx
@@ -7,17 +7,19 @@
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {useDispatch} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 import {Icon, Popup} from 'semantic-ui-react';
 
 import {RequestConfirm} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 
 import {resetReviews} from './actions';
+import {isTimelineOutdated} from './selectors';
 
 export default function ResetReview({reviewURL}) {
   const [submitting, setSubmitting] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
+  const isOutdated = useSelector(isTimelineOutdated);
   const dispatch = useDispatch();
 
   const resetRevisions = async () => {
@@ -29,11 +31,15 @@ export default function ResetReview({reviewURL}) {
   return (
     <>
       <Popup
-        content={Translate.string('Undo review')}
+        content={
+          isOutdated
+            ? Translate.string('This timeline is outdated. Please refresh the page.')
+            : Translate.string('Undo review')
+        }
         trigger={
           <Icon
             name="undo"
-            disabled={submitting}
+            disabled={submitting || isOutdated}
             onClick={() => setIsOpen(true)}
             color="grey"
             size="large"
@@ -42,14 +48,14 @@ export default function ResetReview({reviewURL}) {
         }
       />
       <RequestConfirm
-        header={Translate.string('Reset review')}
-        confirmText={Translate.string('Reset')}
+        header={Translate.string('Undo review')}
+        confirmText={Translate.string('Yes')}
         onClose={() => setIsOpen(false)}
         requestFunc={resetRevisions}
         open={isOpen}
         negative
       >
-        <Translate>Are you sure you want to reset the review?</Translate>
+        <Translate>Are you sure you want to undo the review?</Translate>
       </RequestConfirm>
     </>
   );

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewComment.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewComment.jsx
@@ -8,7 +8,7 @@
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {Form as FinalForm} from 'react-final-form';
-import {useDispatch} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 import {Button, Form} from 'semantic-ui-react';
 
 import {FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
@@ -17,12 +17,14 @@ import {Translate} from 'indico/react/i18n';
 import {RevisionTypeStates} from '../../models';
 
 import {modifyReviewComment} from './actions';
+import {isTimelineOutdated} from './selectors';
 import {blockPropTypes} from './util';
 
 import './ReviewComment.module.scss';
 
 export default function ReviewComment({block, canEdit}) {
   const [editFormOpen, setEditFormOpen] = useState(false);
+  const isOutdated = useSelector(isTimelineOutdated);
   const dispatch = useDispatch();
 
   const handleSubmit = async formData => {
@@ -69,7 +71,7 @@ export default function ReviewComment({block, canEdit}) {
         <div className="markdown-text" dangerouslySetInnerHTML={{__html: block.commentHtml}} />
       )}
       <div styleName="action-buttons">
-        {canEdit && (
+        {canEdit && !isOutdated && (
           <a
             onClick={() => setEditFormOpen(!editFormOpen)}
             className="i-link icon-edit"

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -77,8 +77,6 @@ export default function ReviewForm() {
 
   const [judgmentType, setJudgmentType] = useState(null);
   const [loading, setLoading] = useState(false);
-  // TODO: (Michel) After the state for isOutDated changes and the component is
-  // rerendered we lose the comment value. We should find a way to keep it.
   const [commentValue, setCommentValue] = useState('');
   const [syncComment, setSyncComment] = useState(false);
   const files = getFilesFromRevision(fileTypes, lastRevisionWithFiles);

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -88,6 +88,7 @@ export default function ReviewForm() {
     if (rv.error) {
       return rv.error;
     }
+    localStorage.removeItem('editingCommentDraft');
     setTimeout(() => form.reset(), 0);
   };
 
@@ -103,10 +104,16 @@ export default function ReviewForm() {
     );
 
   useEffect(() => {
-    if (isOutdated) {
-      setSyncComment(true);
+    const savedComment = localStorage.getItem('editingCommentDraft');
+    if (savedComment !== null) {
+      setCommentValue(savedComment);
     }
-  }, [isOutdated]);
+  }, []);
+
+  useEffect(() => {
+    setSyncComment(true);
+    localStorage.setItem('editingCommentDraft', commentValue);
+  }, [isOutdated, commentValue]);
 
   const judgmentForm = (
     <Popup

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -110,6 +110,7 @@ export default function ReviewForm() {
             onCommentChange={setCommentValue}
             syncComment={syncComment}
             setSyncComment={setSyncComment}
+            disabled={isOutdated}
           />
           {canPerformSubmitterActions && canReview && !editor && (
             <>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -60,6 +60,8 @@ const judgmentOptions = [
   },
 ];
 
+let savedComment = null;
+
 export default function ReviewForm() {
   const dispatch = useDispatch();
   const lastRevision = useSelector(selectors.getLastRevision);
@@ -102,15 +104,18 @@ export default function ReviewForm() {
     );
 
   useEffect(() => {
-    const savedComment = localStorage.getItem('editingCommentDraft');
     if (savedComment !== null) {
       setCommentValue(savedComment);
     }
   }, []);
 
   useEffect(() => {
-    setSyncComment(true);
-    localStorage.setItem('editingCommentDraft', commentValue);
+    if (isOutdated) {
+      savedComment = commentValue;
+    }
+    if (savedComment !== null && savedComment === commentValue) {
+      setSyncComment(true);
+    }
   }, [isOutdated, commentValue]);
 
   const judgmentForm = (

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -8,7 +8,7 @@
 import submitRevisionURL from 'indico-url:event_editing.api_create_submitter_revision';
 
 import _ from 'lodash';
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {Field, Form as FinalForm} from 'react-final-form';
 import {useDispatch, useSelector} from 'react-redux';
 import {Dropdown, Form, Popup} from 'semantic-ui-react';
@@ -101,6 +101,12 @@ export default function ReviewForm() {
       }),
       formData
     );
+
+  useEffect(() => {
+    if (isOutdated) {
+      setSyncComment(true);
+    }
+  }, [isOutdated]);
 
   const judgmentForm = (
     <Popup

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -111,6 +111,7 @@ export default function ReviewForm() {
             syncComment={syncComment}
             setSyncComment={setSyncComment}
             disabled={isOutdated}
+            expanded={isOutdated}
           />
           {canPerformSubmitterActions && canReview && !editor && (
             <>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -77,6 +77,8 @@ export default function ReviewForm() {
 
   const [judgmentType, setJudgmentType] = useState(null);
   const [loading, setLoading] = useState(false);
+  // TODO: (Michel) After the state for isOutDated changes and the component is
+  // rerendered we lose the comment value. We should find a way to keep it.
   const [commentValue, setCommentValue] = useState('');
   const [syncComment, setSyncComment] = useState(false);
   const files = getFilesFromRevision(fileTypes, lastRevisionWithFiles);

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
@@ -20,7 +20,7 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 import {loadTimeline} from './actions';
 import DeleteEditable from './DeleteEditable';
-import {getDetails} from './selectors';
+import {getDetails, isTimelineOutdated} from './selectors';
 
 export default function TimelineHeader({children, contribution, state, submitter, eventId}) {
   const {
@@ -32,6 +32,7 @@ export default function TimelineHeader({children, contribution, state, submitter
     editingEnabled,
     reviewConditionsValid,
   } = useSelector(getDetails);
+  const isOutdated = useSelector(isTimelineOutdated);
   const dispatch = useDispatch();
 
   const unassignEditor = async () => {
@@ -105,7 +106,7 @@ export default function TimelineHeader({children, contribution, state, submitter
                     <Param name="editorName" value={editor.fullName} wrapper={<strong />} /> is the
                     assigned editor
                   </Translate>
-                  {canUnassign && (
+                  {canUnassign && !isOutdated && (
                     <>
                       {' ('}
                       <a onClick={unassignEditor}>
@@ -118,7 +119,7 @@ export default function TimelineHeader({children, contribution, state, submitter
               ) : (
                 <>
                   <Translate>No editor assigned</Translate>
-                  {canAssignSelf && (
+                  {canAssignSelf && !isOutdated && (
                     <>
                       {' ('}
                       <a onClick={assignMyself}>

--- a/indico/modules/events/editing/client/js/editing/timeline/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/index.jsx
@@ -52,10 +52,6 @@ export default function Timeline() {
     }
   }, [details]);
 
-  const refresh = () => {
-    dispatch(actions.useUpdatedTimeline());
-  };
-
   if (isInitialEditableDetailsLoading) {
     return <Loader active />;
   } else if (!details) {
@@ -67,10 +63,13 @@ export default function Timeline() {
       {isOutdated && (
         <Message
           warning
-          header={Translate.string('This revision has been updated')}
+          header={Translate.string('This timeline has been updated')}
           content={
             <Translate>
-              <Param name="link" wrapper={<a onClick={refresh} />}>
+              <Param
+                name="link"
+                wrapper={<a onClick={() => dispatch(actions.useUpdatedTimeline())} />}
+              >
                 Click here to refresh
               </Param>{' '}
               and see the most recent version.

--- a/indico/modules/events/editing/client/js/editing/timeline/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/index.jsx
@@ -19,6 +19,8 @@ import * as selectors from './selectors';
 import SubmitRevision from './SubmitRevision';
 import TimelineItem from './TimelineItem';
 
+import './editingTimeline.scss';
+
 const POLLING_SECONDS = 10;
 
 export default function Timeline() {
@@ -61,21 +63,23 @@ export default function Timeline() {
   return (
     <>
       {isOutdated && (
-        <Message
-          warning
-          header={Translate.string('This timeline has been updated')}
-          content={
-            <Translate>
-              <Param
-                name="link"
-                wrapper={<a onClick={() => dispatch(actions.useUpdatedTimeline())} />}
-              >
-                Click here to refresh
-              </Param>{' '}
-              and see the most recent version.
-            </Translate>
-          }
-        />
+        <div className="sticky-message">
+          <Message
+            warning
+            header={Translate.string('This timeline has been updated')}
+            content={
+              <Translate>
+                <Param
+                  name="link"
+                  wrapper={<a onClick={() => dispatch(actions.useUpdatedTimeline())} />}
+                >
+                  Click here to refresh
+                </Param>{' '}
+                and see the most recent version.
+              </Translate>
+            }
+          />
+        </div>
       )}
       <TimelineHeader
         contribution={details.contribution}

--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -53,7 +53,7 @@ class InvalidEditableState(BadRequest):
     """
 
     def __init__(self):
-        super().__init__(_('The requested action is not possible on this revision'))
+        super().__init__(_('The timeline is outdated. Please refresh the page and try again.'))
 
 
 def ensure_latest_revision(revision):

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -641,6 +641,7 @@ export function FinalSubmitButton({
   icon,
   fluid,
   style,
+  disabled,
   children,
   extraSubscription,
 }) {
@@ -656,20 +657,21 @@ export function FinalSubmitButton({
         ...extraSubscription,
       },
     });
-  const disabled =
+  const isDisabled =
+    disabled ||
     validating ||
     (disabledIfInvalid && hasValidationErrors) ||
     (disabledUntilChange && pristine) ||
     (disabledAfterSubmit && submitSucceeded) ||
     submitting;
   return (
-    <Form.Field disabled={disabled} style={style}>
+    <Form.Field disabled={isDisabled} style={style}>
       <Popup
         trigger={
           <Button
             type="submit"
             form={form}
-            disabled={disabled}
+            disabled={isDisabled}
             loading={submitting && activeSubmitButton}
             primary={color === null}
             content={label}
@@ -686,7 +688,7 @@ export function FinalSubmitButton({
       >
         <div styleName="field-error">{submitError}</div>
       </Popup>
-      {children && children(disabled)}
+      {children && children(isDisabled)}
     </Form.Field>
   );
 }
@@ -705,6 +707,7 @@ FinalSubmitButton.propTypes = {
   fluid: PropTypes.bool,
   size: PropTypes.string,
   style: PropTypes.object,
+  disabled: PropTypes.bool,
   extraSubscription: PropTypes.object,
   children: PropTypes.func,
 };
@@ -723,6 +726,7 @@ FinalSubmitButton.defaultProps = {
   fluid: false,
   size: null,
   style: null,
+  disabled: false,
   extraSubscription: {},
   children: null,
 };


### PR DESCRIPTION
This PR disables all editing actions on the timeline when it is detected that it became outdated, avoiding errors due to editing actions on the wrong revision.
![image](https://github.com/user-attachments/assets/85f1e23a-229b-4fb7-a691-6e86edc5dbcd)
