### PR TITLE
Fix missing key password when requesting verification email

### DIFF
--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -271,7 +271,13 @@ class RHRegister(RH):
 
         signup_config = handler.get_signup_config()
         if request.method == 'POST':
-            return self._process_post(handler)
+            if request.data:
+                return self._process_post(handler)
+            elif request.form.get('email') != session.get('register_verified_email'):
+                # User somehow succeeded to trigger again the request to send verification email
+                # while the session is pending to a previously validated email
+                flash(_('You have to complete or cancel the registration with the email validated before proceeding '
+                        'registration of another email.'), 'warning')
         return WPSignup.render_template('register.html', signup_config=signup_config)
 
     def _process_verify(self, handler):

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -271,13 +271,13 @@ class RHRegister(RH):
 
         signup_config = handler.get_signup_config()
         if request.method == 'POST':
-            if request.data:
+            if 'is_email_verification' not in request.form:
                 return self._process_post(handler)
             elif request.form.get('email') != session.get('register_verified_email'):
                 # User somehow succeeded to trigger again the request to send verification email
                 # while the session is pending to a previously validated email
-                flash(_('You have to complete or cancel the registration with the email validated before proceeding '
-                        'registration of another email.'), 'warning')
+                flash(_('Please finish or cancel your pending registration before attempting to register with '
+                        'another email address.'), 'warning')
         return WPSignup.render_template('register.html', signup_config=signup_config)
 
     def _process_verify(self, handler):

--- a/indico/modules/auth/forms.py
+++ b/indico/modules/auth/forms.py
@@ -8,6 +8,7 @@
 from fnmatch import fnmatch
 
 from flask import session
+from wtforms import HiddenField
 from wtforms.fields import EmailField, PasswordField, SelectField, StringField
 from wtforms.validators import DataRequired, Email, Optional, ValidationError
 
@@ -97,6 +98,7 @@ class RegistrationEmailForm(IndicoForm):
                        [DataRequired(), Email(), _check_not_blacklisted, _check_existing_email],
                        filters=[_tolower])
     captcha = WTFCaptchaField()
+    is_email_verification = HiddenField()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
Request change to fix  "KeyError: 'password'" when user requests a verification email (for account creation) in a session when the verification email is already done.

How to reproduce:
User tries to create several accounts at the same time,
- Go to link account registration /register/ (browser tab 1),
- Go to same link in another tab (tab 2) of the same browser,
- Request the verification email in the first tab,
- Use the link received in email in another tab (tab 3) of the same browser, without completing the data input,
- At this time, the user' session has the 'register_verified_email' set,
- Go back to tab 2 (the page still displays the first step with captcha) and request a verification email for another email,

=> ERROR  KeyError: 'password
because as the session contains already the register_verified_email, it presumes the POST is to create the account with input data (password, first name...).

Solution proposed:
Check in the POST 
if data is received => POST for account creation,
if no data => POST for requesting verification email, 
then if the email is already verified, continue to the form to input data,
if email different than the one in session => message error to user.