### PR TITLE
Many changes in VC code, to prepare for new Zoom Rooms plugin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,8 @@ Internal Changes
 
 - Make positioning logic from TipBase generic and reusable (:pr:`6577`, :pr:`6588`, thanks
   :user:`foxbunny`)
+- Add additional signals related to videoconferences and their event links (:pr:`6475`)
+- Videoconference plugins now need to implement a ``delete_room`` method (:pr:`6475`)
 
 
 Version 3.3.4

--- a/indico/core/plugins/__init__.py
+++ b/indico/core/plugins/__init__.py
@@ -29,6 +29,7 @@ from indico.util.i18n import NullDomain, _
 from indico.web.flask.templating import get_template_module, register_template_hook
 from indico.web.flask.util import url_for, url_rule_to_js
 from indico.web.flask.wrappers import IndicoBlueprint, IndicoBlueprintSetupState
+from indico.web.forms.base import IndicoForm
 from indico.web.menu import SideMenuItem
 from indico.web.views import WPJinjaMixin
 
@@ -63,7 +64,7 @@ class IndicoPlugin(Plugin):
 
     #: WTForm for the plugin's settings (requires `configurable=True`).
     #: All fields must return JSON-serializable types.
-    settings_form = None
+    settings_form: IndicoForm | None = None
     #: A dictionary which can contain the kwargs for a specific field in the `settings_form`.
     settings_form_field_opts = {}
     #: A dictionary containing default values for settings

--- a/indico/core/signals/__init__.py
+++ b/indico/core/signals/__init__.py
@@ -6,8 +6,8 @@
 # LICENSE file for more details.
 
 from indico.core.signals import (acl, agreements, attachments, category, core, event, event_management, menu, plugin,
-                                 rb, rh, users)
+                                 rb, rh, users, vc)
 
 
 __all__ = ('acl', 'agreements', 'attachments', 'category', 'core', 'event', 'event_management', 'menu', 'plugin', 'rb',
-           'rh', 'users')
+           'rh', 'users', 'vc')

--- a/indico/core/signals/event/core.py
+++ b/indico/core/signals/event/core.py
@@ -66,6 +66,8 @@ in the `changes` kwarg.
 
 session_updated = _signals.signal('session-updated', '''
 Called when a session is updated. The *sender* is the session.
+A dict containing ``old, new`` tuples for all changed values is passed
+in the ``changes`` kwarg.
 ''')
 
 session_deleted = _signals.signal('session-deleted', '''
@@ -74,6 +76,8 @@ Called when a session is deleted. The *sender* is the session.
 
 session_block_updated = _signals.signal('session-block-updated', '''
 Called when a session block is updated. The *sender* is the session block.
+A dict containing ``old, new`` tuples for all changed values is passed
+in the ``changes`` kwarg.
 ''')
 
 session_block_deleted = _signals.signal('session-block-deleted', '''

--- a/indico/core/signals/vc.py
+++ b/indico/core/signals/vc.py
@@ -11,52 +11,46 @@ from blinker import Namespace
 _signals = Namespace()
 
 
-new_vc_room = _signals.signal(
-    'new-vc-room',
-    '''Called whenever a new VC room is created. The *sender* is the new `VCRoom` object.
+new_vc_room = _signals.signal('new-vc-room', '''
+Called whenever a new VC room is created. The *sender* is the new `VCRoom` object.
 The `event` kwarg contains the event where the room was created, while `assoc` holds
-the actual `VCRoomEventAssociation`.''',
-)
+the actual `VCRoomEventAssociation`.
+''')
 
-deleted_vc_room = _signals.signal(
-    'deleted-vc-room',
-    '''Called whenever a VC room is deleted, right before the user is notified about the
+deleted_vc_room = _signals.signal('deleted-vc-room', '''
+Called whenever a VC room is deleted, right before the user is notified about the
 operation and the object deleted from the DB. The *sender* is the actual `VCRoom`
 object, in its most terminal state. An `event` kwarg holds the event the `VCRoom`
-used to be in.''',
-)
+used to be in.
+''')
 
-attached_vc_room = _signals.signal(
-    'attached-vc-room',
-    '''Called whenever a room is attached to a new object (e.g. event, contribution...),
+attached_vc_room = _signals.signal('attached-vc-room', '''
+Called whenever a room is attached to a new object (e.g. event, contribution...),
 as a consequence of a direct or indirect user action. This triggers on creation of
 a `VCRoom`, modification of the object it is linked to, or attachment of an existing
 `VCRoom` to an object (e.g. event, contribution...). The *sender* is the
 `VCRoomEventAssociation`, followed by the kwargs `vc_room` (the actual `VCRoom` which
 is being attached), `event` (event where the operation is being executed), `data` (form
 data) and `old_link` (object which the association was pointing to before, if any).
-`new_room` is a bool stating whether this is a newly-created room or one changing `link_object`''',
-)
+`new_room` is a bool stating whether this is a newly-created room or one changing `link_object`
+''')
 
-detached_vc_room = _signals.signal(
-    'detached-vc-room',
-    '''Called whenever a room is detached from an object (e.g. event, contribution...),
+detached_vc_room = _signals.signal('detached-vc-room', '''
+Called whenever a room is detached from an object (e.g. event, contribution...),
 as a consequence of a direct or indirect user action. This triggers on direct detachment
  of the object a `VCRoomEventAssociation` is linked to. The *sender* is the
 `VCRoomEventAssociation`, followed by the kwargs `vc_room` (the actual `VCRoom` which
 is being detached), `old_link` (what it is being detached from), `event` (event where the operation
-is being executed) and `data` (form data).''',
-)
+is being executed) and `data` (form data).
+''')
 
-cloned_vc_room = _signals.signal(
-    'cloned-vc-room',
-    '''Called whenever a `VCRoomEventAssociation` is cloned. The *sender* is the original object,
+cloned_vc_room = _signals.signal('cloned-vc-room', '''
+Called whenever a `VCRoomEventAssociation` is cloned. The *sender* is the original object,
 with the cloned object passed in the `new_assoc` kwarg. The `vc_room` in question is also
-passed along, as well as the new `link_object`.''',
-)
+passed along, as well as the new `link_object`.
+''')
 
-updated_vc_room_data = _signals.signal(
-    'updated-vc-room-data',
-    '''Called whenever a `VCRoom`'s data is changed. The *sender* is the `VCRoom` object,
-and the `data` arg contains a dictionary of tuples containing the new data.''',
-)
+updated_vc_room_data = _signals.signal('updated-vc-room-data', '''
+Called whenever a `VCRoom`'s data is changed. The *sender* is the `VCRoom` object,
+and the `data` arg contains a dictionary of tuples containing the new data.
+''')

--- a/indico/core/signals/vc.py
+++ b/indico/core/signals/vc.py
@@ -1,0 +1,62 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2023 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from blinker import Namespace
+
+
+_signals = Namespace()
+
+
+new_vc_room = _signals.signal(
+    'new-vc-room',
+    '''Called whenever a new VC room is created. The *sender* is the new `VCRoom` object.
+The `event` kwarg contains the event where the room was created, while `assoc` holds
+the actual `VCRoomEventAssociation`.''',
+)
+
+deleted_vc_room = _signals.signal(
+    'deleted-vc-room',
+    '''Called whenever a VC room is deleted, right before the user is notified about the
+operation and the object deleted from the DB. The *sender* is the actual `VCRoom`
+object, in its most terminal state. An `event` kwarg holds the event the `VCRoom`
+used to be in.''',
+)
+
+attached_vc_room = _signals.signal(
+    'attached-vc-room',
+    '''Called whenever a room is attached to a new object (e.g. event, contribution...),
+as a consequence of a direct or indirect user action. This triggers on creation of
+a `VCRoom`, modification of the object it is linked to, or attachment of an existing
+`VCRoom` to an object (e.g. event, contribution...). The *sender* is the
+`VCRoomEventAssociation`, followed by the kwargs `vc_room` (the actual `VCRoom` which
+is being attached), `event` (event where the operation is being executed), `data` (form
+data) and `old_link` (object which the association was pointing to before, if any).
+`new_room` is a bool stating whether this is a newly-created room or one changing `link_object`''',
+)
+
+detached_vc_room = _signals.signal(
+    'detached-vc-room',
+    '''Called whenever a room is detached from an object (e.g. event, contribution...),
+as a consequence of a direct or indirect user action. This triggers on direct detachment
+ of the object a `VCRoomEventAssociation` is linked to. The *sender* is the
+`VCRoomEventAssociation`, followed by the kwargs `vc_room` (the actual `VCRoom` which
+is being detached), `old_link` (what it is being detached from), `event` (event where the operation
+is being executed) and `data` (form data).''',
+)
+
+cloned_vc_room = _signals.signal(
+    'cloned-vc-room',
+    '''Called whenever a `VCRoomEventAssociation` is cloned. The *sender* is the original object,
+with the cloned object passed in the `new_assoc` kwarg. The `vc_room` in question is also
+passed along, as well as the new `link_object`.''',
+)
+
+updated_vc_room_data = _signals.signal(
+    'updated-vc-room-data',
+    '''Called whenever a `VCRoom`'s data is changed. The *sender* is the `VCRoom` object,
+and the `data` arg contains a dictionary of tuples containing the new data.''',
+)

--- a/indico/core/signals/vc.py
+++ b/indico/core/signals/vc.py
@@ -11,20 +11,20 @@ from blinker import Namespace
 _signals = Namespace()
 
 
-new_vc_room = _signals.signal('new-vc-room', '''
+vc_room_created = _signals.signal('vc-room-created', '''
 Called whenever a new VC room is created. The *sender* is the new `VCRoom` object.
 The `event` kwarg contains the event where the room was created, while `assoc` holds
 the actual `VCRoomEventAssociation`.
 ''')
 
-deleted_vc_room = _signals.signal('deleted-vc-room', '''
+vc_room_deleted = _signals.signal('vc-room-deleted', '''
 Called whenever a VC room is deleted, right before the user is notified about the
 operation and the object deleted from the DB. The *sender* is the actual `VCRoom`
 object, in its most terminal state. An `event` kwarg holds the event the `VCRoom`
 used to be in.
 ''')
 
-attached_vc_room = _signals.signal('attached-vc-room', '''
+vc_room_attached = _signals.signal('vc-room-attached', '''
 Called whenever a room is attached to a new object (e.g. event, contribution...),
 as a consequence of a direct or indirect user action. This triggers on creation of
 a `VCRoom`, modification of the object it is linked to, or attachment of an existing
@@ -35,7 +35,7 @@ data) and `old_link` (object which the association was pointing to before, if an
 `new_room` is a bool stating whether this is a newly-created room or one changing `link_object`
 ''')
 
-detached_vc_room = _signals.signal('detached-vc-room', '''
+vc_room_detached = _signals.signal('vc-room-detached', '''
 Called whenever a room is detached from an object (e.g. event, contribution...),
 as a consequence of a direct or indirect user action. This triggers on direct detachment
 of the object a `VCRoomEventAssociation` is linked to. The *sender* is the
@@ -44,13 +44,13 @@ is being detached), `old_link` (what it is being detached from), `event` (event 
 is being executed) and `data` (form data).
 ''')
 
-cloned_vc_room = _signals.signal('cloned-vc-room', '''
+vc_room_cloned = _signals.signal('vc-room-cloned', '''
 Called whenever a `VCRoomEventAssociation` is cloned. The *sender* is the original object,
 with the cloned object passed in the `new_assoc` kwarg. The `vc_room` in question is also
 passed along, as well as the new `link_object`.
 ''')
 
-updated_vc_room_data = _signals.signal('updated-vc-room-data', '''
+vc_room_data_updated = _signals.signal('vc-room-data-updated', '''
 Called whenever a `VCRoom`'s data is changed. The *sender* is the `VCRoom` object,
 and the `data` arg contains a dictionary of tuples containing the new data.
 ''')

--- a/indico/core/signals/vc.py
+++ b/indico/core/signals/vc.py
@@ -38,7 +38,7 @@ data) and `old_link` (object which the association was pointing to before, if an
 detached_vc_room = _signals.signal('detached-vc-room', '''
 Called whenever a room is detached from an object (e.g. event, contribution...),
 as a consequence of a direct or indirect user action. This triggers on direct detachment
- of the object a `VCRoomEventAssociation` is linked to. The *sender* is the
+of the object a `VCRoomEventAssociation` is linked to. The *sender* is the
 `VCRoomEventAssociation`, followed by the kwargs `vc_room` (the actual `VCRoom` which
 is being detached), `old_link` (what it is being detached from), `event` (event where the operation
 is being executed) and `data` (form data).

--- a/indico/core/signals/vc.py
+++ b/indico/core/signals/vc.py
@@ -1,5 +1,5 @@
 # This file is part of Indico.
-# Copyright (C) 2002 - 2023 CERN
+# Copyright (C) 2002 - 2024 CERN
 #
 # Indico is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see the

--- a/indico/modules/events/contributions/__init__.py
+++ b/indico/modules/events/contributions/__init__.py
@@ -66,12 +66,6 @@ def _check_field_definitions(app, **kwargs):
     get_contrib_field_types()
 
 
-@signals.event.session_deleted.connect
-def _unset_session(sess, **kwargs):
-    for contribution in sess.contributions:
-        contribution.session = None
-
-
 @signals.event_management.get_cloners.connect
 def _get_contribution_cloner(sender, **kwargs):
     from indico.modules.events.contributions import clone

--- a/indico/modules/events/contributions/operations.py
+++ b/indico/modules/events/contributions/operations.py
@@ -74,7 +74,7 @@ def create_contribution(event, contrib_data, custom_fields_data=None, session_bl
 
 
 @no_autoflush
-def update_contribution(contrib: Contribution, contrib_data, custom_fields_data=None):
+def update_contribution(contrib: Contribution, contrib_data: dict, custom_fields_data=None):
     """Update a contribution.
 
     :param contrib: The `Contribution` to update
@@ -250,7 +250,7 @@ def log_contribution_update(contrib, changes, *, visible_person_link_changes=Fal
             'convert': lambda changes: [x.name if x else None for x in changes]
         },
     }
-    split_log_location_changes(changes)
+    changes = split_log_location_changes(changes)
     if not visible_person_link_changes:
         # Don't log a person link change with no visible changes (changes
         # on an existing link or reordering). It would look quite weird in

--- a/indico/modules/events/notes/templates/_note.html
+++ b/indico/modules/events/notes/templates/_note.html
@@ -16,11 +16,13 @@
 
 
 {% macro render_toggle_button(note, note_is_hidden, anchor=none) %}
-    <div class="group i-selection note-visibility-toggle">
+    <div class="note-visibility-toggle">
         {% set hash = uuid() %}
-        <input type="checkbox" class="js-toggle-note-cb" id="toggle-note-{{ note.id }}-{{ hash }}" {% if not note_is_hidden %}checked{% endif %}>
-        <label for="toggle-note-{{ note.id }}-{{ hash }}" class="i-button icon-file-text js-show-note-toggle"
-               title="">{% trans %}Minutes{% endtrans %}</label>
+        <input type="checkbox" class="js-toggle-note-cb" id="toggle-note-{{ note.id }}-{{ hash }}" style="display:none;" {% if not note_is_hidden %}checked{% endif %}>
+        <label for="toggle-note-{{ note.id }}-{{ hash }}" class="ui basic mini icon button js-show-note-toggle"
+               title="{% trans %}Minutes{% endtrans %}">
+            <i class="icon file alternate outline"></i>
+        </label>
     </div>
 {% endmacro %}
 

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -259,7 +259,7 @@ def _log_event_update(event, changes, extra_log_fields, visible_person_link_chan
         'enforce_locale': 'Enforce language',
         **(extra_log_fields or {})
     }
-    split_log_location_changes(changes)
+    changes = split_log_location_changes(changes)
     if not visible_person_link_changes:
         # Don't log a person link change with no visible changes (changes
         # on an existing link or reordering). It would look quite weird in

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -149,6 +149,7 @@ def update_event(event, *, update_timetable=False, _extra_log_fields=None, **dat
         # (e.g. because the event had a different type before) we always update them
         # silently.
         start_dt = data.pop('start_dt')
+        changes['start_dt'] = (event.start_dt, start_dt)
         event.move_start_dt(start_dt)
     changes.update(event.populate_from_dict(data))
     # Person links are partially updated when the WTForms field is processed,

--- a/indico/modules/events/sessions/operations.py
+++ b/indico/modules/events/sessions/operations.py
@@ -43,9 +43,9 @@ def create_session_block(session_, data):
 
 def update_session(event_session, data):
     """Update a session based on the information in the `data`."""
-    event_session.populate_from_dict(data)
+    changes = event_session.populate_from_dict(data)
     db.session.flush()
-    signals.event.session_updated.send(event_session)
+    signals.event.session_updated.send(event_session, changes=changes)
     event_session.event.log(EventLogRealm.management, LogKind.change, 'Sessions',
                             f'Session "{event_session.title}" has been updated', session.user,
                             meta={'session_id': event_session.id})
@@ -74,9 +74,9 @@ def update_session_block(session_block, data):
     if start_dt is not None:
         session_block.timetable_entry.move(start_dt)
         update_timetable_entry(session_block.timetable_entry, {'start_dt': start_dt})
-    session_block.populate_from_dict(data)
+    changes = session_block.populate_from_dict(data)
     db.session.flush()
-    signals.event.session_block_updated.send(session_block)
+    signals.event.session_block_updated.send(session_block, changes=changes)
     session_block.event.log(EventLogRealm.management, LogKind.change, 'Sessions',
                             f'Session block "{session_block.title}" has been updated', session.user,
                             meta={'session_block_id': session_block.id})

--- a/indico/modules/events/sessions/operations.py
+++ b/indico/modules/events/sessions/operations.py
@@ -54,12 +54,15 @@ def update_session(event_session, data):
 
 def delete_session(event_session):
     """Delete session from the event."""
+    signals.event.session_deleted.send(event_session)
     event_session.is_deleted = True
-    for contribution in event_session.contributions[:]:
-        contribution.session = None
+
     for block in list(event_session.blocks):
         delete_session_block(block, delete_empty_session=False, log=False)
-    signals.event.session_deleted.send(event_session)
+
+    for contribution in event_session.contributions[:]:
+        contribution.session = None
+
     event_session.event.log(EventLogRealm.management, LogKind.negative, 'Sessions',
                             f'Session "{event_session.title}" has been deleted', session.user,
                             meta={'session_id': event_session.id})

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -115,7 +115,7 @@
         {% set dropdown_options = item.get_manage_button_options(note_may_exist=show_note_operations) %}
         {% if dropdown_options %}
             <div class="group manage-button">
-                <button class="tiny compact ui icon button js-dropdown" style="white-space: nowrap;" data-toggle="dropdown" title="{% trans %}Manage{% endtrans %}">
+                <button class="ui mini icon button js-dropdown" style="white-space: nowrap;" data-toggle="dropdown" title="{% trans %}Manage{% endtrans %}">
                     <i class="edit icon"></i>
                     <i class="caret down icon"></i>
                 </button>

--- a/indico/modules/events/templates/display/common/_privacy_info_button.html
+++ b/indico/modules/events/templates/display/common/_privacy_info_button.html
@@ -2,7 +2,7 @@
     {% set data_controller_exists = privacy_info.data_controller_name or privacy_info.data_controller_email %}
     {% if data_controller_exists or privacy_info.privacy_policy_urls|length > 1 %}
         <div class="privacy-dropdown" tabindex="-1">
-            <button class="tiny compact ui blue icon button"
+            <button class="mini ui blue icon button"
                     title="{% trans %}Event privacy information{% endtrans %}">
                 <i class="balance scale icon"></i>
                 <i class="caret down icon"></i>

--- a/indico/modules/events/timetable/controllers/legacy.py
+++ b/indico/modules/events/timetable/controllers/legacy.py
@@ -155,8 +155,7 @@ class RHLegacyTimetableDeleteEntry(RHManageTimetableEntryBase):
             delete_contribution(self.entry.contribution)
         else:
             delete_timetable_entry(self.entry)
-        return jsonify_data(update=serialize_day_update(self.event, day, block=block, session_=self.session),
-                            flash=False)
+        return jsonify_data(update=serialize_day_update(self.event, day, block=block, session_=self.session))
 
 
 class RHLegacyTimetableEditEntry(RHManageTimetableEntryBase):

--- a/indico/modules/events/timetable/operations.py
+++ b/indico/modules/events/timetable/operations.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from datetime import datetime
 from operator import attrgetter
 
 from flask import session
@@ -108,6 +109,7 @@ def delete_timetable_entry(entry, log=True):
     object_type, object_title = _get_object_info(entry)
     signals.event.timetable_entry_deleted.send(entry)
     entry.object = None
+    entry.parent = None
     db.session.flush()
     if log:
         logger.info('Timetable entry %s deleted by %s', entry, session.user)
@@ -131,7 +133,7 @@ def fit_session_block_entry(entry, log=True):
                         data={'Session block': entry.session_block.full_title})
 
 
-def move_timetable_entry(entry, parent=None, day=None):
+def move_timetable_entry(entry: TimetableEntry, parent: TimetableEntry | None = None, day: datetime | None = None):
     """Move the `entry` to another session or top-level timetable.
 
     :param entry: `TimetableEntry` to be moved

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -432,6 +432,9 @@ def track_time_changes(auto_extend=False, user=None):
         for obj, obj_changes in changes.items():
             entry = None if isinstance(obj, Event) else obj.timetable_entry
             signals.event.times_changed.send(type(obj), entry=entry, obj=obj, changes=obj_changes)
+            if isinstance(obj, Event):
+                # remove duration from the changes dict, as the event updated signal doesn't want/need it
+                signals.event.updated.send(obj, changes={k: v for k, v in obj_changes.items() if k != 'duration'})
 
 
 def register_time_change(entry):

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import copy
 import json
 import os
 import random
@@ -772,15 +773,20 @@ def _format_location(data):
         return None
 
 
-def split_log_location_changes(changes):
-    location_changes = changes.pop('location_data', None)
-    if location_changes is None:
-        return
+def split_log_location_changes(changes: dict) -> dict:
+    """Re-process change dict to include readable location information (for logging)."""
+    res = copy.copy(changes)
+
+    if (location_changes := res.get('location_data')) is None:
+        return res
+
     if location_changes[0]['address'] != location_changes[1]['address']:
-        changes['address'] = (location_changes[0]['address'], location_changes[1]['address'])
+        res['address'] = (location_changes[0]['address'], location_changes[1]['address'])
     venue_room_changes = (_get_venue_room_name(location_changes[0]), _get_venue_room_name(location_changes[1]))
     if venue_room_changes[0] != venue_room_changes[1]:
-        changes['venue_room'] = list(map(_format_location, venue_room_changes))
+        res['venue_room'] = list(map(_format_location, venue_room_changes))
+
+    return res
 
 
 def format_log_person(data):

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -777,7 +777,7 @@ def split_log_location_changes(changes: dict) -> dict:
     """Re-process change dict to include readable location information (for logging)."""
     res = copy.copy(changes)
 
-    if (location_changes := res.get('location_data')) is None:
+    if (location_changes := res.pop('location_data', None)) is None:
         return res
 
     if location_changes[0]['address'] != location_changes[1]['address']:

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-import copy
 import json
 import os
 import random
@@ -775,7 +774,7 @@ def _format_location(data):
 
 def split_log_location_changes(changes: dict) -> dict:
     """Re-process change dict to include readable location information (for logging)."""
-    res = copy.copy(changes)
+    res = dict(changes)
 
     if (location_changes := res.pop('location_data', None)) is None:
         return res

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -434,7 +434,9 @@ def track_time_changes(auto_extend=False, user=None):
             signals.event.times_changed.send(type(obj), entry=entry, obj=obj, changes=obj_changes)
             if isinstance(obj, Event):
                 # remove duration from the changes dict, as the event updated signal doesn't want/need it
-                signals.event.updated.send(obj, changes={k: v for k, v in obj_changes.items() if k != 'duration'})
+                signals.event.updated.send(
+                    obj, changes={k: v for k, v in obj_changes.items() if k in {'start_dt', 'end_dt'}}
+                )
 
 
 def register_time_change(entry):

--- a/indico/modules/vc/__init__.py
+++ b/indico/modules/vc/__init__.py
@@ -92,9 +92,11 @@ def _link_object_deleted(obj: Contribution | SessionBlock, **kwargs):
         return
 
     if isinstance(obj, Contribution):
-        message = _('There was a VC room associated with this contribution. It has been linked to the event instead')
+        message = _('There was a videoconference associated with this contribution. It has been linked to the event '
+                    'instead')
     else:
-        message = _('There was a VC room associated with this session block. It has been linked to the event instead')
+        message = _('There was a videoconference associated with this session block. It has been linked to the event '
+                    'instead')
     flash(message, 'warning')
 
 

--- a/indico/modules/vc/__init__.py
+++ b/indico/modules/vc/__init__.py
@@ -80,11 +80,11 @@ def _link_object_deleted(obj: Contribution | SessionBlock, **kwargs):
     assocs = list(obj.vc_room_associations)
     for event_vc_room in assocs:
         # tie the room to the event instead
-        signals.vc.detached_vc_room.send(event_vc_room, vc_room=event_vc_room.vc_room, old_link=obj, event=obj.event)
+        signals.vc.vc_room_detached.send(event_vc_room, vc_room=event_vc_room.vc_room, old_link=obj, event=obj.event)
 
         event_vc_room.link_object = obj.event
 
-        signals.vc.attached_vc_room.send(
+        signals.vc.vc_room_attached.send(
             event_vc_room, vc_room=event_vc_room.vc_room, event=obj.event, data={}, old_link=obj
         )
 

--- a/indico/modules/vc/__init__.py
+++ b/indico/modules/vc/__init__.py
@@ -5,17 +5,21 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from flask import has_request_context, render_template, session
+import typing as t
+
+from flask import flash, has_request_context, render_template, session
 
 from indico.core import signals
+from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.layout import layout_settings
 from indico.modules.events.layout.util import MenuEntryData
+from indico.modules.events.sessions.models.blocks import SessionBlock
 from indico.modules.users import User
 from indico.modules.vc.forms import VCPluginSettingsFormBase
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation
 from indico.modules.vc.plugins import VCPluginMixin
 from indico.modules.vc.util import get_managed_vc_plugins, get_vc_plugins
-from indico.util.i18n import _
+from indico.util.i18n import _, ngettext
 from indico.web.flask.templating import get_overridable_template_name, template_hook
 from indico.web.flask.util import url_for
 from indico.web.menu import SideMenuItem, TopMenuItem
@@ -71,9 +75,29 @@ def _extend_event_menu(sender, **kwargs):
 
 @signals.event.contribution_deleted.connect
 @signals.event.session_block_deleted.connect
-def _link_object_deleted(obj, **kwargs):
-    for event_vc_room in obj.vc_room_associations:
+def _link_object_deleted(obj: t.Union[Contribution, SessionBlock], **kwargs):
+    assocs = list(obj.vc_room_associations)
+    for event_vc_room in assocs:
+        # tie the room to the event instead
         event_vc_room.link_object = obj.event
+
+    n_objects = len(assocs)
+    if not n_objects:
+        return
+
+    if isinstance(obj, Contribution):
+        message = ngettext(
+            'There was a VC room associated to this contribution. It has been linked to the event instead',
+            'There were {} VC rooms associated to this contribution. They have been linked to the event instead',
+            n_objects
+        )
+    else:
+        message = ngettext(
+            'There was a VC room associated to this session block. It has been linked to the event instead',
+            'There were {} VC rooms associated to this session block. They have been linked to the event instead',
+            n_objects
+        )
+    flash(message, 'warning')
 
 
 @signals.event.session_deleted.connect

--- a/indico/modules/vc/clone.py
+++ b/indico/modules/vc/clone.py
@@ -17,7 +17,7 @@ from indico.util.i18n import _
 class VCCloner(EventCloner):
     name = 'vc'
     friendly_name = _('Videoconference')
-    uses = {'sessions', 'contributions'}
+    uses = {'sessions', 'contributions', 'timetable'}
     is_default = True
 
     @property

--- a/indico/modules/vc/clone.py
+++ b/indico/modules/vc/clone.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from indico.core import signals
 from indico.core.db import db
 from indico.modules.events.cloning import EventCloner
 from indico.modules.vc import VCRoomEventAssociation
@@ -64,6 +65,10 @@ class VCCloner(EventCloner):
             if not plugin:
                 continue
             clone = plugin.clone_room(old_event_vc_room, link_object)
+            signals.vc.cloned_vc_room.send(
+                old_event_vc_room, new_assoc=clone, vc_room=old_event_vc_room.vc_room, link_object=link_object
+            )
+
             if clone:
                 # the plugin may decide to not clone the room
                 old_event_vc_room.vc_room.events.append(clone)

--- a/indico/modules/vc/clone.py
+++ b/indico/modules/vc/clone.py
@@ -65,10 +65,10 @@ class VCCloner(EventCloner):
             if not plugin:
                 continue
             clone = plugin.clone_room(old_event_vc_room, link_object)
-            signals.vc.cloned_vc_room.send(
-                old_event_vc_room, new_assoc=clone, vc_room=old_event_vc_room.vc_room, link_object=link_object
-            )
 
             if clone:
                 # the plugin may decide to not clone the room
                 old_event_vc_room.vc_room.events.append(clone)
+                signals.vc.cloned_vc_room.send(
+                    old_event_vc_room, new_assoc=clone, vc_room=old_event_vc_room.vc_room, link_object=link_object
+                )

--- a/indico/modules/vc/clone.py
+++ b/indico/modules/vc/clone.py
@@ -69,6 +69,6 @@ class VCCloner(EventCloner):
             if clone:
                 # the plugin may decide to not clone the room
                 old_event_vc_room.vc_room.events.append(clone)
-                signals.vc.cloned_vc_room.send(
+                signals.vc.vc_room_cloned.send(
                     old_event_vc_room, new_assoc=clone, vc_room=old_event_vc_room.vc_room, link_object=link_object
                 )

--- a/indico/modules/vc/controllers.py
+++ b/indico/modules/vc/controllers.py
@@ -58,14 +58,14 @@ def process_vc_room_association(plugin: IndicoPlugin, event: Event, vc_room: VCR
             existing = {x.vc_room for x in q}
 
     if event_vc_room.link_type != VCRoomLinkType.event and existing:
-        db.session.rollback()
         flash(_("There is already a videoconference attached to '{link_object_title}'.").format(
             link_object_title=resolve_title(event_vc_room.link_object)), 'error')
+        db.session.rollback()
         return None
     elif event_vc_room.link_type == VCRoomLinkType.event and vc_room in existing:
-        db.session.rollback()
         flash(_('This {plugin_name} room is already attached to the event.').format(plugin_name=plugin.friendly_name),
               'error')
+        db.session.rollback()
         return None
     else:
         return event_vc_room

--- a/indico/modules/vc/controllers.py
+++ b/indico/modules/vc/controllers.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import typing as t
 from collections import defaultdict
 from operator import itemgetter
 
@@ -15,8 +16,10 @@ from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from indico.core.db import db
 from indico.core.logger import Logger
+from indico.core.plugins import IndicoPlugin
 from indico.modules.events.controllers.base import RHDisplayEventBase
 from indico.modules.events.management.controllers import RHManageEventBase
+from indico.modules.events.models.events import Event
 from indico.modules.vc.exceptions import VCRoomError, VCRoomNotFoundError
 from indico.modules.vc.forms import VCRoomListFilterForm
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomLinkType, VCRoomStatus
@@ -32,7 +35,9 @@ from indico.web.rh import RHProtected
 from indico.web.util import _pop_injected_js, jsonify_data, jsonify_template
 
 
-def process_vc_room_association(plugin, event, vc_room, form, event_vc_room=None, allow_same_room=False):
+def process_vc_room_association(plugin: IndicoPlugin, event: Event, vc_room: VCRoom, form,
+                                event_vc_room: t.Optional[VCRoomEventAssociation] = None,
+                                allow_same_room: bool = False):
     # disable autoflush, so that the new event_vc_room does not influence the result
     with db.session.no_autoflush:
         if event_vc_room is None:

--- a/indico/modules/vc/models/vc_rooms.py
+++ b/indico/modules/vc/models/vc_rooms.py
@@ -341,7 +341,7 @@ class VCRoomEventAssociation(db.Model):
         """Get a dict mapping link objects to event vc rooms."""
         return {vcr.link_object: vcr for vcr in cls.find_for_event(event)}
 
-    def delete(self, user: User, check_vc_room: bool = True):
+    def delete(self, user: User, *, check_vc_room: bool = True):
         """Delete a VC room from an event.
 
         If the room is not used anywhere else, the room itself is also deleted.
@@ -351,7 +351,7 @@ class VCRoomEventAssociation(db.Model):
                               (no more associations left)
         """
         # send signals
-        signals.vc.detached_vc_room.send(self, vc_room=self.vc_room, event=self.event)
+        signals.vc.detached_vc_room.send(self, vc_room=self.vc_room, old_link=self.link_object, event=self.event)
 
         Logger.get('modules.vc').info(
             'Detaching videoconference %s from event %s (%s)', self.vc_room, self.event, self.link_object

--- a/indico/modules/vc/models/vc_rooms.py
+++ b/indico/modules/vc/models/vc_rooms.py
@@ -23,6 +23,7 @@ from indico.modules.vc.notifications import notify_deleted
 from indico.util.caching import memoize_request
 from indico.util.date_time import now_utc
 from indico.util.enum import IndicoIntEnum
+from indico.util.string import format_repr
 
 
 class VCRoomLinkType(IndicoIntEnum):
@@ -313,7 +314,7 @@ class VCRoomEventAssociation(db.Model):
         return _LinkObjectComparator(cls)
 
     def __repr__(self):
-        return f'<VCRoomEventAssociation({self.event_id}, {self.vc_room})>'
+        return format_repr(self, 'id', 'link_object', 'vc_room')
 
     @classmethod
     def find_for_event(cls, event, include_hidden=False, include_deleted=False, only_linked_to_event=False, **kwargs):

--- a/indico/modules/vc/models/vc_rooms.py
+++ b/indico/modules/vc/models/vc_rooms.py
@@ -336,12 +336,16 @@ class VCRoomEventAssociation(db.Model):
                                           vc_room, self.event, self.link_object)
             vc_room.events.remove(self)
         db.session.flush()
-        if vc_room.plugin and not vc_room.events:
-            Logger.get('modules.vc').info(f'Deleting videoconference {vc_room}')
-            if vc_room.status != VCRoomStatus.deleted:
-                vc_room.plugin.delete_room(vc_room, self.event)
-                notify_deleted(vc_room.plugin, vc_room, self, self.event, user)
-            db.session.delete(vc_room)
+        if vc_room.plugin:
+            if vc_room.events:
+                # just detached
+                vc_room.plugin.detach_room(self, vc_room, self.event)
+            else:
+                Logger.get('modules.vc').info(f'Deleting videoconference {vc_room}')
+                if vc_room.status != VCRoomStatus.deleted:
+                    vc_room.plugin.delete_room(vc_room, self.event)
+                    notify_deleted(vc_room.plugin, vc_room, self, self.event, user)
+                db.session.delete(vc_room)
 
 
 VCRoomEventAssociation.register_link_events()

--- a/indico/modules/vc/models/vc_rooms.py
+++ b/indico/modules/vc/models/vc_rooms.py
@@ -133,6 +133,7 @@ class VCRoom(db.Model):
         """Delete a VC room and all its associations.
 
         :param user: the user performing the deletion
+        :param event: the event in which the deletion happened
         """
         for assoc in self.events[:]:
             Logger.get('modules.vc').info('Detaching videoconference %s from event %s (%s)',
@@ -141,7 +142,7 @@ class VCRoom(db.Model):
         db.session.flush()
 
         # send signal
-        signals.vc.deleted_vc_room.send(self, event=event)
+        signals.vc.vc_room_deleted.send(self, event=event)
 
         # process plugin actions
         Logger.get('modules.vc').info(f'Deleting videoconference {self}')
@@ -351,7 +352,7 @@ class VCRoomEventAssociation(db.Model):
                               (no more associations left)
         """
         # send signals
-        signals.vc.detached_vc_room.send(self, vc_room=self.vc_room, old_link=self.link_object, event=self.event)
+        signals.vc.vc_room_detached.send(self, vc_room=self.vc_room, old_link=self.link_object, event=self.event)
 
         Logger.get('modules.vc').info(
             'Detaching videoconference %s from event %s (%s)', self.vc_room, self.event, self.link_object

--- a/indico/modules/vc/plugins.py
+++ b/indico/modules/vc/plugins.py
@@ -202,9 +202,9 @@ class VCPluginMixin:
 
         return old_link_object != event_vc_room.link_object
 
-    def update_data_vc_room(self, vc_room: VCRoom, data: dict, is_new=False):
+    def update_data_vc_room(self, vc_room: VCRoom, data: dict, *, is_new=False):
         if not is_new:
-            signals.vc.updated_vc_room_data.send(vc_room, data=copy.copy(data))
+            signals.vc.vc_room_data_updated.send(vc_room, data=copy.copy(data))
 
         if 'name' in data:
             vc_room.name = data.pop('name')

--- a/indico/modules/vc/plugins.py
+++ b/indico/modules/vc/plugins.py
@@ -6,6 +6,7 @@
 # LICENSE file for more details.
 
 import re
+import typing as t
 
 from flask import render_template
 from flask_pluginengine import render_plugin_template
@@ -18,22 +19,22 @@ from indico.modules.vc.forms import VCPluginSettingsFormBase
 from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomLinkType
 from indico.util.decorators import classproperty
 from indico.web.flask.templating import get_overridable_template_name
-from indico.web.forms.base import FormDefaults
+from indico.web.forms.base import FormDefaults, IndicoForm
 
 
 PREFIX_RE = re.compile('^vc_')
 
 
 class VCPluginMixin:
-    settings_form = VCPluginSettingsFormBase
-    default_settings = {'notification_emails': []}
-    acl_settings = {'acl', 'managers'}
+    settings_form: IndicoForm = VCPluginSettingsFormBase
+    default_settings: dict[str, t.Any] = {'notification_emails': []}
+    acl_settings: set = {'acl', 'managers'}
     #: the :class:`IndicoForm` to use for the videoconference room form
-    vc_room_form = None
+    vc_room_form: t.Optional[IndicoForm] = None
     #: the :class:`IndicoForm` to use for the videoconference room attach form
-    vc_room_attach_form = None
+    vc_room_attach_form: t.Optional[IndicoForm] = None
     #: the readable name of the VC plugin
-    friendly_name = None
+    friendly_name: t.Optional[str] = None
 
     def init(self):
         super().init()

--- a/indico/modules/vc/plugins.py
+++ b/indico/modules/vc/plugins.py
@@ -12,9 +12,10 @@ from flask_pluginengine import render_plugin_template
 
 from indico.core import signals
 from indico.modules.events.contributions import Contribution
+from indico.modules.events.models.events import Event
 from indico.modules.events.sessions.models.blocks import SessionBlock
 from indico.modules.vc.forms import VCPluginSettingsFormBase
-from indico.modules.vc.models.vc_rooms import VCRoomEventAssociation, VCRoomLinkType
+from indico.modules.vc.models.vc_rooms import VCRoom, VCRoomEventAssociation, VCRoomLinkType
 from indico.util.decorators import classproperty
 from indico.web.flask.templating import get_overridable_template_name
 from indico.web.forms.base import FormDefaults
@@ -201,8 +202,14 @@ class VCPluginMixin:
         if vc_room.data is None:
             vc_room.data = {}
 
-    def create_room(self, vc_room, event):
+    def create_room(self, vc_room: VCRoom, event: Event):
         raise NotImplementedError('Plugin must implement create_room()')
+
+    def delete_room(self, vc_room: VCRoom, event: Event):
+        raise NotImplementedError('Plugin must implement delete_room()')
+
+    def detach_room(self, event_vc_room: VCRoomEventAssociation, vc_room: VCRoom, event: Event):
+        pass
 
     def clone_room(self, old_event_vc_room, link_object):
         """Clone the room, returning a new :class:`VCRoomEventAssociation`.

--- a/indico/modules/vc/plugins.py
+++ b/indico/modules/vc/plugins.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import copy
 import re
 import typing as t
 
@@ -186,6 +187,8 @@ class VCPluginMixin:
         block_id = data.pop('block')
         link_type = VCRoomLinkType[data.pop('linking')]
 
+        old_link_object = event_vc_room.link_object
+
         if link_type == VCRoomLinkType.event:
             event_vc_room.link_object = event
         elif link_type == VCRoomLinkType.contribution:
@@ -197,7 +200,12 @@ class VCPluginMixin:
         if event_vc_room.data is None:
             event_vc_room.data = {}
 
+        return old_link_object != event_vc_room.link_object
+
     def update_data_vc_room(self, vc_room: VCRoom, data: dict, is_new=False):
+        if not is_new:
+            signals.vc.updated_vc_room_data.send(vc_room, data=copy.copy(data))
+
         if 'name' in data:
             vc_room.name = data.pop('name')
 

--- a/indico/modules/vc/templates/conference_home.html
+++ b/indico/modules/vc/templates/conference_home.html
@@ -1,26 +1,7 @@
 {% from 'vc/list_vc_rooms.html' import render_conference_vc_rooms_list, render_vc_rooms_list  %}
 
 {% if not g.static_site and event_vc_rooms %}
-    <div class="action-box highlight">
-        <div class="section align-top">
-            <span class="icon icon-camera align-top"></span>
-            <div class="text">
-                <div class="label">
-                    {% trans count=event_vc_rooms|length -%}
-                        Videoconference
-                    {%- pluralize -%}
-                        Videoconferences
-                    {%- endtrans %}
-                </div>
-                {% if event_vc_rooms|length == 1 %}
-                    <div>
-                        {%- trans %}There is a videoconference for this event.{% endtrans -%}
-                    </div>
-                {% endif %}
-            </div>
-            <div class="text conference">
-                {{ render_conference_vc_rooms_list(event, event_vc_rooms) }}
-            </div>
-        </div>
+    <div class="vc-room-list attached">
+        {{ render_conference_vc_rooms_list(event, event_vc_rooms) }}
     </div>
 {% endif %}

--- a/indico/modules/vc/templates/event_buttons.html
+++ b/indico/modules/vc/templates/event_buttons.html
@@ -1,6 +1,4 @@
-<div class="event-service-toolbar vc-toolbar toolbar right">
-    <div class="group">
-        {% block buttons %}{% endblock %}
-    </div>
+<div class="event-service-toolbar right">
+    {% block buttons %}{% endblock %}
     {{ template_hook('event-vc-extra-buttons', event_vc_room=event_vc_room) }}
 </div>

--- a/indico/modules/vc/templates/event_header.html
+++ b/indico/modules/vc/templates/event_header.html
@@ -1,2 +1,2 @@
 {% from 'vc/list_vc_rooms.html' import render_vc_rooms_list  %}
-{{ render_vc_rooms_list(event, event_vc_rooms) }}
+{{ render_vc_rooms_list(event, event_vc_rooms) if not g.static_site }}

--- a/indico/modules/vc/templates/event_header.html
+++ b/indico/modules/vc/templates/event_header.html
@@ -1,7 +1,2 @@
 {% from 'vc/list_vc_rooms.html' import render_vc_rooms_list  %}
-{% if not g.static_site and event_vc_rooms %}
-    <div class="event-details-row">
-        <div class="event-details-label align-top">{% trans %}Videoconference{% endtrans %}</div>
-        <div class="event-details-content">{{ render_vc_rooms_list(event, event_vc_rooms) }}</div>
-    </div>
-{% endif %}
+{{ render_vc_rooms_list(event, event_vc_rooms) }}

--- a/indico/modules/vc/templates/list_vc_rooms.html
+++ b/indico/modules/vc/templates/list_vc_rooms.html
@@ -1,43 +1,59 @@
 {% macro render_vc_room(event_vc_room, event) -%}
     {% set vc_room = event_vc_room.vc_room %}
     {% set plugin = vc_room.plugin %}
-    <div class="event-service-row">
-        <div class="event-service-row-collapsed clearfix">
-            <div class="event-service-info event-service-row-toggle trigger left">
-                <img src="{{ plugin.icon_url }}" style="height: 16px;" alt="">
-                <span class="event-service-title">{{ vc_room.name }}</span>
+    <ind-vc-room-segment class="ui segment vc-room-segment">
+        <div class="ui secondary menu">
+            <div class="item vc-icon">
+                <img src="{{ plugin.logo_url }}">
             </div>
-            {{ plugin.render_event_buttons(vc_room, event_vc_room) | safe }}
+            <div class="item vc-room-name">
+                {{ vc_room.name }}
+            </div>
+            <div class="right menu">
+                <div class="item">
+                    {{ plugin.render_event_buttons(vc_room, event_vc_room) | safe }}
+                </div>
+                <div class="item">
+                    <a class="ui mini button basic expand-button icon">
+                        <i class="chevron down icon"></i>
+                    </a>
+                </div>
+            </div>
         </div>
-        <div class="event-service-details">
+        <div class="ui bottom attached secondary segment">
             {{ plugin.render_info_box(vc_room, event_vc_room, event) | safe }}
         </div>
-        <a class="trigger icon-expand" title="{% trans %}More info{% endtrans %}"></a>
-    </div>
+    </ind-vc-room-segment>
 {%- endmacro %}
 
 {%- macro render_conference_vc_rooms_list(event, event_vc_rooms) -%}
+    <div class="ui top attached blue inverted segment">
+        <i class="ui icon video"></i>
+        {% trans %}Videoconference{% endtrans %}
+    </div>
     {% for event_vc_room in event_vc_rooms %}
         {% set vc_room = event_vc_room.vc_room %}
         {% set plugin = vc_room.plugin %}
-        {% if loop.length == 1 %}
-            {{ plugin.render_event_buttons(vc_room, event_vc_room) | safe }}
-        {% else %}
-            <div class="event-service-row">
-                <div class="event-service-row-collapsed conference clearfix">
-                    <div class="event-service-info left">
-                        <img src="{{ plugin.icon_url }}" style="height: 16px;" alt="">
-                        <span class="event-service-title">{{ vc_room.name }}</span>
+        <ind-vc-room-segment class="ui {% if loop.last %}bottom{% endif %} attached segment">
+            <div class="ui compact secondary menu">
+                <div class="item vc-icon">
+                    <img src="{{ plugin.logo_url }}">
+                </div>
+                <div class="item vc-room-name">
+                    {{ vc_room.name }}
+                </div>
+                <div class="right menu">
+                    <div class="item">
+                        {{ plugin.render_event_buttons(vc_room, event_vc_room) | safe }}
                     </div>
-                    {{ plugin.render_event_buttons(vc_room, event_vc_room) | safe }}
                 </div>
             </div>
-        {% endif %}
+        </ind-vc-room-segment>
     {% endfor %}
 {%- endmacro %}
 
 {% macro render_vc_rooms_list(event, event_vc_rooms, linked_to=None) -%}
-    <div>
+    <div class="vc-room-list">
         {% if linked_to %}
             {% if linked_to.event %}
                 <div class="groupTitleNoBorder event-service-association-title">

--- a/indico/modules/vc/templates/manage_event.html
+++ b/indico/modules/vc/templates/manage_event.html
@@ -84,7 +84,7 @@
                             data-title="{% trans plugin_name=plugins[0].friendly_name %}Create {{ plugin_name }} room{% endtrans %}"
                             data-ajax-dialog
                             data-reload-after>
-                        <img src="{{ plugins[0].icon_url }}" alt="">
+                        <img src="{{ plugins[0].icon_url }}" alt="{{ plugins[0].service_name }}">
                         {% trans plugin_name=plugins[0].friendly_name %}Create {{ plugin_name }} room{% endtrans %}
                     </button>
                 {% elif plugins|length > 1 %}

--- a/indico/modules/vc/templates/manage_event.html
+++ b/indico/modules/vc/templates/manage_event.html
@@ -8,7 +8,7 @@
         {% if plugins %}
             {% if event_vc_rooms %}
                 {{ template_hook('before-vc-list', event=event) }}
-                <table class="i-table-widget">
+                <table class="i-table-widget vc-room-management-table">
                     <thead>
                          <tr>
                             <th class="small-column"></th>
@@ -25,8 +25,7 @@
                                 <td><a href="#" class="icon-next toggle-details"></a></td>
                                 <td>
                                     {%- if vc_room.plugin %}
-                                        <img class="plugin-logo"
-                                             src="{{ vc_room.plugin.logo_url}}"
+                                        <img src="{{ vc_room.plugin.logo_url }}"
                                              alt="{{ vc_room.plugin.friendly_name }}"
                                              title="{{ vc_room.plugin.friendly_name}}">
                                     {% else %}
@@ -34,30 +33,36 @@
                                     {% endif -%}
                                 </td>
                                 <td>{{ vc_room.name }}</td>
-                                <td>{{ template_hook('event-vc-room-list-item-labels', event=event, vc_room=vc_room) }}</td>
+                                <td>{{ template_hook('event-vc-room-list-item-labels', event=event, vc_room=vc_room, event_vc_room=event_vc_room) }}</td>
                                 <td>
-                                    <div class="toolbar vc-toolbar">
-                                        <div class="group">
+                                    <div class="toolbar vc-management-button-toolbar">
+                                        <div class="ui mini icon buttons">
                                             {% if vc_room.status.name != 'deleted' %}
-                                                <button class="i-button icon-loop js-vcroom-refresh hide-if-locked"
+                                                <button class="ui button js-vcroom-refresh hide-if-locked"
                                                         title="{% trans %}Check videoconference status{% endtrans %}"
-                                                        data-href="{{ url_for('.manage_vc_rooms_refresh', event_vc_room)}}"></button>
-                                                <button class="i-button icon-edit js-vcroom-edit hide-if-locked"
+                                                        data-href="{{ url_for('.manage_vc_rooms_refresh', event_vc_room)}}">
+                                                    <i class="icon refresh"></i>
+                                                </button>
+                                                <button class="ui button js-vcroom-edit hide-if-locked"
                                                         data-href="{{ url_for('.manage_vc_rooms_modify', event_vc_room) }}"
                                                         title="{% trans %}Edit{% endtrans %}"
                                                         data-title="{% trans %}Edit room{% endtrans %}"
                                                         data-ajax-dialog
-                                                        data-reload-after></button>
+                                                        data-reload-after>
+                                                    <i class="icon edit"></i>
+                                                </button>
                                             {% endif %}
                                             <button data-href="{{ url_for('.manage_vc_rooms_remove', event_vc_room) }}"
                                                     data-num-events="{{ vc_room.events | count }}"
                                                     data-extra-msg="{{ vc_room.plugin.get_extra_delete_msg(vc_room, event_vc_room) if vc_room.plugin else '' }}"
-                                                    class="i-button icon-remove js-vcroom-remove hide-if-locked"
-                                                    title="{% trans %}Detach{% endtrans %}"></button>
-                                            {% if vc_room.status.name != 'deleted' and vc_room.plugin %}
-                                                {{ vc_room.plugin.render_buttons(vc_room, event_vc_room) | safe }}
-                                            {% endif %}
+                                                    class="ui negative button js-vcroom-remove hide-if-locked"
+                                                    title="{% trans %}Detach{% endtrans %}">
+                                                <i class="icon trash"></i>
+                                            </button>
                                         </div>
+                                        {% if vc_room.status.name != 'deleted' and vc_room.plugin %}
+                                            {{ vc_room.plugin.render_buttons(vc_room, event_vc_room) | safe }}
+                                        {% endif %}
                                     </div>
                                 </td>
                             </tr>
@@ -78,7 +83,7 @@
             {% endif %}
             <div class="add-room-options right hide-if-locked">
                 {% if plugins|length == 1 %}
-                    <button class="i-button js-create-room"
+                    <button class="ui icon button js-create-room"
                             data-vc-system="{{ plugins[0].service_name }}"
                             data-href="{{ url_for('.manage_vc_rooms_create', event, service=plugins[0].service_name) }}"
                             data-title="{% trans plugin_name=plugins[0].friendly_name %}Create {{ plugin_name }} room{% endtrans %}"
@@ -88,17 +93,18 @@
                         {% trans plugin_name=plugins[0].friendly_name %}Create {{ plugin_name }} room{% endtrans %}
                     </button>
                 {% elif plugins|length > 1 %}
-                    <button class="i-button icon-plus js-create-room"
+                    <button class="ui button js-create-room"
                             data-href="{{ url_for('.manage_vc_rooms_select', event, vc_room_action='.manage_vc_rooms_create', attach=False) }}"
                             data-title="{% trans %}Create videoconference{% endtrans %}"
                             data-ajax-dialog
                             data-reload-after>
+                        <i class="icon plus"></i>
                         {%- trans %}Create new room{% endtrans -%}
                     </button>
                 {% endif %}
                 <span>
                     <a href="#" id="btn-add-existing"
-                       class="i-button icon-plus"
+                       class="ui icon button"
                        {% if plugins|length == 1 %}
                            data-href="{{ url_for('.manage_vc_rooms_search_form', event, service=plugins[0].service_name) }}"
                            data-title="{% trans plugin_name=plugins[0].friendly_name %}Attach {{ plugin_name }} room{% endtrans %}"
@@ -108,6 +114,7 @@
                        {% endif %}
                        data-ajax-dialog
                        data-reload-after>
+                        <i class="icon plus"></i>
                         {% trans %}Add existing room{% endtrans %}
                     </a>
                 </span>

--- a/indico/modules/vc/templates/manage_event_select.html
+++ b/indico/modules/vc/templates/manage_event_select.html
@@ -16,7 +16,7 @@
                data-reload-after>
                 <div class="i-badge-content">
                     <span class="i-badge-img">
-                        <img src="{{ plugin.logo_url }}">
+                        <img src="{{ plugin.icon_url }}">
                     </span>
                     <span class="i-badge-title">{{ plugin.title }}</span>
                 </div>

--- a/indico/modules/vc/templates/vc_room_timetable_buttons.html
+++ b/indico/modules/vc/templates/vc_room_timetable_buttons.html
@@ -1,11 +1,13 @@
 {% set vc_room = event_vc_room.vc_room %}
 {% set plugin = vc_room.plugin %}
 
-<div class="toolbar right vc-toolbar">
-    <div class="group">
-        <span class="i-button i-button-small label vc-room-info" id="vc-room-{{ event_vc_room.id }}"><img src="{{ vc_room.plugin.icon_url }}" style="width: 18px;"></span>
-        {% block buttons %}{% endblock %}
-    </div>
+<div class="right vc-toolbar">
+    <span class="ui basic icon label vc-room-info" id="vc-room-{{ event_vc_room.id }}">
+        <img src="{{ vc_room.plugin.icon_url }}">
+    </span>
+
+    {% block buttons %}{% endblock %}
+
     {{ template_hook('event-timetable-vc-extra-buttons', event_vc_room=event_vc_room) }}
 </div>
 <div style="display: none;">
@@ -14,7 +16,7 @@
 <script>
     $('#vc-room-{{ event_vc_room.id }}').qtip({
         content: {
-            text: $('#vc-room-{{ event_vc_room.id }}').closest('.toolbar.right.vc-toolbar').next('div')
+            text: $('#vc-room-{{ event_vc_room.id }}').closest('.right.vc-toolbar').next('div')
         },
         position: {
             my: 'top middle',

--- a/indico/util/locators.py
+++ b/indico/util/locators.py
@@ -101,3 +101,9 @@ class _LocatorDict(UserDict):
         except KeyError:
             raise AttributeError('No such locator: ' + name)
         return fn(self._obj)
+
+    def __repr__(self):
+        return f'<Locator {self.data}>'
+
+    def __reduce__(self):
+        return (dict, (self.data,))

--- a/indico/web/client/js/custom_elements/ind_vc_room_segment.js
+++ b/indico/web/client/js/custom_elements/ind_vc_room_segment.js
@@ -1,0 +1,41 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import './ind_vc_room_segment.scss';
+import {domReady} from 'indico/utils/domstate';
+
+let lastId = 0; // Track the assigned IDs to give each element a unique ID
+
+/** Little "segment" bar which show up once per VC room */
+customElements.define(
+  'ind-vc-room-segment',
+  class extends HTMLElement {
+    connectedCallback() {
+      domReady.then(() => {
+        const expand = this.querySelector('.expand-button');
+        const list = this.querySelector('.secondary.segment');
+
+        // The segment may include an "expand" button
+        if (expand) {
+          expand.setAttribute('aria-expanded', false);
+
+          list.id = list.id || `dropdown-list-${lastId++}`;
+          expand.setAttribute('aria-controls', list.id);
+
+          expand.addEventListener('click', () => {
+            expand.setAttribute('aria-expanded', expand.getAttribute('aria-expanded') !== 'true');
+            this.classList.toggle('expanded');
+            expand.classList.toggle('active');
+            expand.querySelector('i').classList.toggle('down');
+            expand.querySelector('i').classList.toggle('up');
+            return false;
+          });
+        }
+      });
+    }
+  }
+);

--- a/indico/web/client/js/custom_elements/ind_vc_room_segment.scss
+++ b/indico/web/client/js/custom_elements/ind_vc_room_segment.scss
@@ -1,0 +1,85 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+ind-vc-room-segment.ui.segment {
+  display: flex;
+  flex-direction: column;
+
+  padding: 0;
+  margin: 0;
+
+  .ui.secondary.menu {
+    margin: 0;
+    width: 100%;
+
+    > .item {
+      margin: 0;
+
+      &.vc-icon img {
+        height: 0.8em;
+        width: auto;
+      }
+
+      &.vc-room-name {
+        display: inline;
+        text-wrap: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        flex: 0 4 50%;
+      }
+    }
+
+    .right.menu > .item {
+      margin: 0;
+    }
+  }
+}
+
+ind-vc-room-segment .expand-button {
+  cursor: pointer;
+}
+
+ind-vc-room-segment .secondary.segment {
+  --time-menu-animation: 0.2s;
+  --length-menu-travel: -5em;
+  display: block;
+  z-index: 1;
+}
+
+ind-vc-room-segment.expanded .secondary.segment {
+  animation: menu-slide-down var(--time-menu-animation);
+}
+
+ind-vc-room-segment:not(.expanded) .secondary.segment {
+  display: none; // must be set to none to hide it from a11y tools and tab navigation as well
+  animation: menu-slide-up var(--time-menu-animation);
+}
+
+@keyframes menu-slide-down {
+  from {
+    display: block;
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes menu-slide-up {
+  from {
+    display: block;
+    opacity: 1;
+    transform: none;
+  }
+
+  to {
+    display: none;
+    opacity: 0;
+    transform: translateY(var(--length-menu-travel));
+  }
+}

--- a/indico/web/client/js/index.js
+++ b/indico/web/client/js/index.js
@@ -15,6 +15,7 @@ import './legacy/timetable.js';
 import './custom_elements/ind_bypass_block_links.js';
 import './custom_elements/ind_menu.js';
 import './custom_elements/ind_share_widget.js';
+import './custom_elements/ind_vc_room_segment.js';
 import './widgets/tz_selector.js';
 import './widgets/dynamic-tips.js';
 

--- a/indico/web/client/js/legacy/libs/timetable/Actions.js
+++ b/indico/web/client/js/legacy/libs/timetable/Actions.js
@@ -39,6 +39,7 @@ type(
         success: function(data) {
           if (data) {
             self.timetable._updateDay(data.update);
+            handleFlashes(data);
           }
         },
       });

--- a/indico/web/client/styles/modules/_eventservices.scss
+++ b/indico/web/client/styles/modules/_eventservices.scss
@@ -28,10 +28,6 @@ div.event-service-association-title {
   }
 }
 
-.conference > .event-service-toolbar.vc-toolbar.toolbar {
-  margin-right: 0;
-}
-
 div.event-service-row {
   border: 1px solid $pastel-gray;
   background-color: $light-gray;
@@ -53,10 +49,6 @@ div.event-service-row {
       margin-bottom: 0;
       padding: 0;
       margin-right: 2em;
-
-      .join-button {
-        min-width: 5em;
-      }
     }
 
     .event-service-row-toggle {
@@ -178,8 +170,4 @@ div.event-service-row {
       }
     }
   }
-}
-
-.vc-toolbar {
-  margin-right: 1em;
 }

--- a/indico/web/client/styles/modules/_vc.scss
+++ b/indico/web/client/styles/modules/_vc.scss
@@ -58,3 +58,45 @@ input[type='radio']:disabled + label {
 input[type='text']#vc-name.highlight {
   animation: text-changed 0.75s linear;
 }
+
+.vc-room-list {
+  display: flex;
+  flex-direction: column;
+
+  &:not(.attached) {
+    gap: 0.2em;
+  }
+}
+
+.ui.icon.message.vc-room-list-message {
+  display: flex;
+
+  > .icon {
+    width: 5%;
+  }
+
+  .content {
+    max-width: 90%;
+  }
+}
+
+.vc-room-management-table {
+  .vc-room-entry img {
+    height: 1em;
+    width: auto;
+  }
+}
+
+.vc-management-button-toolbar {
+  gap: 0.2em;
+}
+
+.ui.label.vc-room-info {
+  padding: 0.1em;
+  margin-right: 1em;
+
+  img {
+    width: 2em;
+    height: auto;
+  }
+}

--- a/indico/web/client/styles/modules/event_display/_meetings.scss
+++ b/indico/web/client/styles/modules/event_display/_meetings.scss
@@ -22,23 +22,20 @@
   }
 }
 
-.i-selection.note-visibility-toggle input[type='checkbox'] {
-  & + label {
-    border-style: dashed !important;
-  }
-
+.note-visibility-toggle input[type='checkbox'] {
   &:not(:checked) + label,
   &:not(:checked) + label:hover {
     background: transparent;
   }
 
   &:checked + label {
+    &:hover {
+      background: $postit-yellow !important;
+      color: $black !important;
+    }
+
     background: $postit-yellow !important;
     color: $light-black !important;
-  }
-
-  &:checked + label:hover {
-    color: $black !important;
   }
 }
 

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -570,7 +570,7 @@ ul.day-list {
   font-size: 12px;
   color: black;
   margin: 0;
-  padding: 3px 10px;
+  padding: 3px 3px;
 }
 
 .note-area-wrapper .note-area {


### PR DESCRIPTION
I think this is finally ready for a first pair of extra eyes. I still have to go over it a bit more carefully, but having someone else look at it will help find any issues.

Main changes:
 * New events targeting VC rooms and associations. I didn't go as far as replacing the whole plugin inheritance hell with it, but that should be the direction for future plugins;
 * Added a proper `VCRoom.delete` method which deals with the logic of deleting a whole room and its associations
 * Changed `session_updated` and `session_block_updated` to allow for a `changes` dict to be passed
 * Made `split_log_location_changes` non-destructive, since object mutation was messing with some tests
 * A few UI changes to use Semantic UI and custom elements instead of legacy CSS when rendering almost all VC-related stuff
 * Session delete operation changed in order to make signal logic more usable
 * Event test fixture: give creator management access by default (as is the case in prod)
 
 Unrelated things which are bundled too:
  *  Serialize locators as dicts and add clearer __repr__
  *  Add format_repr to VCRoomEventAssociation
   
  PRs for the CERN and general-purpose plugins will follow.