### PR TITLE
Fail gracefully when uploading very large pictures

### DIFF
--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -453,7 +453,7 @@ class RHUploadRegistrationPicture(RHUploadRegistrationFile):
 
     def _save_file(self, file, stream):
         if not (resized_image_stream := process_registration_picture(stream)):
-            raise UnprocessableEntity('Could not process image')
+            raise UnprocessableEntity('Could not process image, it may be corrupted or too big')
         return super()._save_file(file, resized_image_stream)
 
     def get_file_metadata(self):

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -1016,7 +1016,7 @@ def process_registration_picture(source, *, thumbnail=False):
     max_size = REGISTRATION_PICTURE_THUMBNAIL_SIZE if thumbnail else REGISTRATION_PICTURE_SIZE
     try:
         picture = Image.open(source)
-    except OSError:
+    except (OSError, Image.DecompressionBombError):
         return None
     picture = ImageOps.exif_transpose(picture)
     if picture.mode != 'RGB':


### PR DESCRIPTION
Request to manage error on uploading of very big picture in registration.
We experienced this issue on real use case:
PIL.Image.DecompressionBombError: Image size (181845225 pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack.

Note:
Code could be improved to display another message instead of "UnprocessableEntity('Could not process image')",
but that would require more info returned from "process_registration_picture".