### PR TITLE
Bump babel to 2.16 and remove monkey-patching of (p)gettext

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@
 #    ./bin/maintenance/compile-python-deps.py
 alabaster==0.7.16
     # via sphinx
-babel==2.14.0
+babel==2.16.0
     # via
     #   -r docs/requirements.in
     #   flask-babel

--- a/indico/util/date_time_test.py
+++ b/indico/util/date_time_test.py
@@ -71,8 +71,8 @@ def test_iterdays(from_, to, skip_weekends, day_whitelist, day_blacklist, expect
 
 
 @pytest.mark.parametrize(('skeleton', 'expected'), (
-    ('EEEEdMMMM', 'Monday, 8 February'),
-    ('EEEdMMM', 'Mon, 8 Feb'),
+    ('EEEEdMMMM', 'Monday 8 February'),
+    ('EEEdMMM', 'Mon 8 Feb'),
 ))
 def test_format_skeleton(skeleton, expected):
     dt = as_utc(datetime(2021, 2, 8)).astimezone(timezone('Europe/Zurich'))

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -49,51 +49,12 @@ def get_translation_domain(plugin_name=_use_context):
             return get_domain()
 
 
-def _gettext(tr, message):
-    """Look for a translation in both the standard and plural translations.
-
-    Same as gettext.GNUTranslations.gettext but when the translation is not found,
-    it looks for a translation in plurals to find the singular case.
-    When neither is found, the gettext fallback is used.
-
-    This is needed because by default, gettext() only looks through non-pluralized translations.
-    For example, the following cannot be translated with gettext:
-
-    # Polish
-    msgid "Convener"
-    msgid_plural "Conveners"
-    msgstr[0] "Lider"
-
-    To get a translation for 'Convener', we need ngettext('Convener', 'Conveners', 1).
-
-    See GNUTranslations.gettext & ngettext for more details.
-    """
-    translation = tr.gettext(message)
-    if message != translation:
-        return translation
-    return tr.ngettext(message, message, 1)
-
-
-def _pgettext(tr, context, message):
-    # pgettext variant of _gettext
-    translation = tr.pgettext(context, message)
-    if message != translation:
-        return translation
-    return tr.npgettext(context, message, message, 1)
-
-
 def _indico_gettext(*args, **kwargs):
     func_name = kwargs.pop('func_name', 'gettext')
     plugin_name = kwargs.pop('plugin_name', None)
 
     translations = get_translation_domain(plugin_name).get_translations()
-
-    if func_name == 'gettext':
-        return _gettext(translations, *args, **kwargs)
-    elif func_name == 'pgettext':
-        return _pgettext(translations, *args, **kwargs)
-    else:
-        return getattr(translations, func_name)(*args, **kwargs)
+    return getattr(translations, func_name)(*args, **kwargs)
 
 
 def lazy_gettext(string, plugin_name=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ artifacts = [
 
 [tool.hatch.build.targets.sdist.hooks.custom]
 path = 'hatch_build.py'
-dependencies = ['babel==2.14.0']
+dependencies = ['babel==2.16.0']
 
 [tool.uv]
 # uv does not know about dynamic metadata so `pip install -e .` should always reinstall

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -14,7 +14,7 @@ attrs==23.2.0
     # via
     #   -c requirements.txt
     #   aiosmtpd
-babel==2.14.0
+babel==2.16.0
     # via
     #   -c requirements.txt
     #   sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ attrs==23.2.0
     #   referencing
 authlib==1.3.1
     # via -r requirements.in
-babel==2.14.0
+babel==2.16.0
     # via
     #   -r requirements.in
     #   flask-babel


### PR DESCRIPTION
Includes the latest CLDR version (not super important) but it also has bugfixes related to pgettext which means we can finally remove the monkey patching we do in this PR: https://github.com/indico/indico/pull/5105