### PR TITLE
Fix access denied for managers in private form

### DIFF
--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -86,6 +86,7 @@ class RHRegistrationFormBase(RegistrationFormMixin, RHRegistrationFormDisplayBas
         RHRegistrationFormDisplayBase._check_access(self)
         if (
             not getattr(self, 'registration', None)
+            and not self.management
             and self.regform.private
             and self.regform.uuid != request.args.get('form_token')
         ):


### PR DESCRIPTION
Fix this case error in private form:
managers are denied access when registering users in the management area. 