### PR TITLE
Split management/public registration file upload

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Bugfixes
   thanks :user:`SegiNyn`)
 - Fix validation error when clearing a date field in the registration form (:pr:`6470`)
 - Fix access error when a manager registers a user in a private registration form (:pr:`6486`)
+- Fix access error when a manager uploads files in a private registration form (:pr:`6487`,
+  thanks :user:`vtran99`)
 - Improve color handling in badge designer (auto-add ``#`` for hex colors) (:pr:`6492`)
 - Do not count deleted rooms for equipment/attribute usage numbers (:issue:`6493`, :pr:`6494`)
 - Allow deleting event persons which are linked to a deleted subcontribution (:pr:`6495`)

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -64,6 +64,8 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/delete', 
                  reglists.RHRegistrationDelete, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/upload', 'upload_file_management',
                  reglists.RHRegistrationUploadFile, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/upload-picture', 'upload_picture_management',
+                 reglists.RHRegistrationUploadPicture, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/', 'registration_details',
                  reglists.RHRegistrationDetails)
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/edit', 'edit_registration',

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -62,6 +62,8 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/check-ema
                  reglists.RHRegistrationCheckEmail)
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/delete', 'delete_registrations',
                  reglists.RHRegistrationDelete, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/upload', 'upload_file_management',
+                 reglists.RHRegistrationUploadFile, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/', 'registration_details',
                  reglists.RHRegistrationDetails)
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/edit', 'edit_registration',

--- a/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
@@ -5,8 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import uploadFileManagementURL from 'indico-url:event_registration.upload_file_management';
-import uploadFileURL from 'indico-url:event_registration.upload_registration_file';
+import managementUploadURL from 'indico-url:event_registration.upload_file_management';
+import participantUploadURL from 'indico-url:event_registration.upload_registration_file';
 
 import PropTypes from 'prop-types';
 import React, {useMemo} from 'react';
@@ -14,15 +14,16 @@ import {useSelector} from 'react-redux';
 
 import {FinalSingleFileManager} from 'indico/react/components';
 
-import {getUpdateMode} from '../../form_submission/selectors';
+import {getManagement, getUpdateMode} from '../../form_submission/selectors';
 import {getStaticData} from '../selectors';
 
 import '../../../styles/regform.module.scss';
 import './FileInput.module.scss';
 
 export default function FileInput({htmlName, disabled, isRequired}) {
-  const {eventId, regformId, registrationUuid, fileData, management} = useSelector(getStaticData);
+  const {eventId, regformId, registrationUuid, fileData} = useSelector(getStaticData);
   const isUpdateMode = useSelector(getUpdateMode);
+  const isManagement = useSelector(getManagement);
   const [invitationToken, formToken] = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return [params.get('invitation'), params.get('form_token')];
@@ -50,7 +51,7 @@ export default function FileInput({htmlName, disabled, isRequired}) {
         name={htmlName}
         disabled={disabled}
         required={isRequired}
-        uploadURL={management ? uploadFileManagementURL(urlParams) : uploadFileURL(urlParams)}
+        uploadURL={isManagement ? managementUploadURL(urlParams) : participantUploadURL(urlParams)}
         initialFileDetails={initialFileDetails}
       />
     </div>

--- a/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
@@ -5,6 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import uploadFileManagementURL from 'indico-url:event_registration.upload_file_management';
 import uploadFileURL from 'indico-url:event_registration.upload_registration_file';
 
 import PropTypes from 'prop-types';
@@ -20,7 +21,7 @@ import '../../../styles/regform.module.scss';
 import './FileInput.module.scss';
 
 export default function FileInput({htmlName, disabled, isRequired}) {
-  const {eventId, regformId, registrationUuid, fileData} = useSelector(getStaticData);
+  const {eventId, regformId, registrationUuid, fileData, management} = useSelector(getStaticData);
   const isUpdateMode = useSelector(getUpdateMode);
   const [invitationToken, formToken] = useMemo(() => {
     const params = new URLSearchParams(location.search);
@@ -49,7 +50,7 @@ export default function FileInput({htmlName, disabled, isRequired}) {
         name={htmlName}
         disabled={disabled}
         required={isRequired}
-        uploadURL={uploadFileURL(urlParams)}
+        uploadURL={management ? uploadFileManagementURL(urlParams) : uploadFileURL(urlParams)}
         initialFileDetails={initialFileDetails}
       />
     </div>

--- a/indico/modules/events/registration/client/js/form/fields/PictureInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/PictureInput.jsx
@@ -7,7 +7,8 @@
 
 import managementPreviewURL from 'indico-url:event_registration.manage_registration_file';
 import registrantPreviewURL from 'indico-url:event_registration.registration_picture';
-import uploadURL from 'indico-url:event_registration.upload_registration_picture';
+import managementUploadURL from 'indico-url:event_registration.upload_picture_management';
+import registrantUploadURL from 'indico-url:event_registration.upload_registration_picture';
 
 import PropTypes from 'prop-types';
 import React, {useMemo} from 'react';
@@ -33,6 +34,7 @@ export default function PictureInput({htmlName, disabled, isRequired, minPicture
   }, []);
 
   const previewURL = isManagement ? managementPreviewURL : registrantPreviewURL;
+  const uploadURL = isManagement ? managementUploadURL : registrantUploadURL;
   const uploadUrlParams = {
     event_id: eventId,
     reg_form_id: regformId,

--- a/indico/modules/events/registration/controllers/__init__.py
+++ b/indico/modules/events/registration/controllers/__init__.py
@@ -7,13 +7,14 @@
 
 from flask import jsonify, request, session
 from sqlalchemy.orm import defaultload
+from werkzeug.exceptions import UnprocessableEntity
 
 from indico.modules.events.payment import payment_event_settings
 from indico.modules.events.registration.fields.simple import KEEP_EXISTING_FILE_UUID
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.util import (check_registration_email, get_flat_section_submission_data,
                                                      get_form_registration_data, make_registration_schema,
-                                                     modify_registration)
+                                                     modify_registration, process_registration_picture)
 from indico.modules.files.controllers import UploadFileMixin
 from indico.util.marshmallow import LowercaseString, UUIDString, not_empty
 from indico.web.args import parser, use_kwargs
@@ -116,3 +117,18 @@ class UploadRegistrationFileMixin(UploadFileMixin):
 
     def get_file_context(self):
         return 'event', self.event.id, 'regform', self.regform.id, 'registration'
+
+
+class UploadRegistrationPictureMixin:
+    """Perform additional validation for regform picture uploads.
+
+    This mixin must be used in addition to `UploadRegistrationFileMixin`.
+    """
+
+    def _save_file(self, file, stream):
+        if not (resized_image_stream := process_registration_picture(stream)):
+            raise UnprocessableEntity('Could not process image, it may be corrupted or too big')
+        return super()._save_file(file, resized_image_stream)
+
+    def get_file_metadata(self):
+        return {'registration_picture_checked': True}

--- a/indico/modules/events/registration/controllers/__init__.py
+++ b/indico/modules/events/registration/controllers/__init__.py
@@ -14,6 +14,7 @@ from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.util import (check_registration_email, get_flat_section_submission_data,
                                                      get_form_registration_data, make_registration_schema,
                                                      modify_registration)
+from indico.modules.files.controllers import UploadFileMixin
 from indico.util.marshmallow import LowercaseString, UUIDString, not_empty
 from indico.web.args import parser, use_kwargs
 
@@ -103,3 +104,15 @@ class CheckEmailMixin:
                                                     management=management))
         else:
             return jsonify(check_registration_email(self.regform, self.email, management=management))
+
+
+class UploadRegistrationFileMixin(UploadFileMixin):
+    """Upload a file from a registration form.
+
+    Regform file fields do not wait for the regform to be submitted,
+    but upload the selected files immediately, saving just the generated uuid.
+    Only this uuid is then sent when the regform is submitted.
+    """
+
+    def get_file_context(self):
+        return 'event', self.event.id, 'regform', self.regform.id, 'registration'

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from flask import flash, jsonify, redirect, request, session
 from sqlalchemy.orm import contains_eager, joinedload, lazyload, load_only, subqueryload
-from werkzeug.exceptions import BadRequest, Forbidden, NotFound, UnprocessableEntity
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from indico.core.db import db
 from indico.modules.auth.util import redirect_to_login
@@ -19,7 +19,8 @@ from indico.modules.events.models.events import EventType
 from indico.modules.events.payment import payment_event_settings
 from indico.modules.events.registration import registration_settings
 from indico.modules.events.registration.controllers import (CheckEmailMixin, RegistrationEditMixin,
-                                                            RegistrationFormMixin, UploadRegistrationFileMixin)
+                                                            RegistrationFormMixin, UploadRegistrationFileMixin,
+                                                            UploadRegistrationPictureMixin)
 from indico.modules.events.registration.models.form_fields import RegistrationFormFieldData, RegistrationFormItem
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.invitations import InvitationState, RegistrationInvitation
@@ -28,8 +29,7 @@ from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.events.registration.notifications import notify_registration_state_update
 from indico.modules.events.registration.util import (create_registration, generate_ticket,
                                                      get_event_regforms_registrations, get_flat_section_submission_data,
-                                                     get_initial_form_values, get_user_data, make_registration_schema,
-                                                     process_registration_picture)
+                                                     get_initial_form_values, get_user_data, make_registration_schema)
 from indico.modules.events.registration.views import (WPDisplayRegistrationFormConference,
                                                       WPDisplayRegistrationFormSimpleEvent,
                                                       WPDisplayRegistrationParticipantList)
@@ -426,16 +426,8 @@ class RHUploadRegistrationFile(UploadRegistrationFileMixin, InvitationMixin, RHR
                     raise
 
 
-class RHUploadRegistrationPicture(RHUploadRegistrationFile):
+class RHUploadRegistrationPicture(UploadRegistrationPictureMixin, RHUploadRegistrationFile):
     """Upload a picture from a registration form."""
-
-    def _save_file(self, file, stream):
-        if not (resized_image_stream := process_registration_picture(stream)):
-            raise UnprocessableEntity('Could not process image, it may be corrupted or too big')
-        return super()._save_file(file, resized_image_stream)
-
-    def get_file_metadata(self):
-        return {'registration_picture_checked': True}
 
 
 class RHRegistrationDisplayEdit(RegistrationEditMixin, RHRegistrationFormRegistrationBase):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -39,7 +39,7 @@ from indico.modules.events.registration.badges import (RegistrantsListToBadgesPD
                                                        RegistrantsListToBadgesPDFDoubleSided,
                                                        RegistrantsListToBadgesPDFFoldable)
 from indico.modules.events.registration.controllers import (CheckEmailMixin, RegistrationEditMixin,
-                                                            UploadRegistrationFileMixin)
+                                                            UploadRegistrationFileMixin, UploadRegistrationPictureMixin)
 from indico.modules.events.registration.controllers.management import (RHManageRegFormBase, RHManageRegFormsBase,
                                                                        RHManageRegistrationBase)
 from indico.modules.events.registration.forms import (BadgeSettingsForm, CreateMultipleRegistrationsForm,
@@ -640,6 +640,10 @@ class RHRegistrationTogglePayment(RHManageRegistrationBase):
 
 class RHRegistrationUploadFile(UploadRegistrationFileMixin, RHManageRegFormBase):
     """Upload a file from a registration form."""
+
+
+class RHRegistrationUploadPicture(UploadRegistrationPictureMixin, RHRegistrationUploadFile):
+    """Upload a picture from a registration form."""
 
 
 def _modify_registration_status(registration, approve, rejection_reason='', attach_rejection_reason=False):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -57,6 +57,7 @@ from indico.modules.events.registration.util import (ActionMenuEntry, create_reg
                                                      import_registrations_from_csv, make_registration_schema)
 from indico.modules.events.registration.views import WPManageRegistration
 from indico.modules.events.util import ZipGeneratorMixin
+from indico.modules.files.controllers import UploadRegistrationFileMixin
 from indico.modules.logs import LogKind
 from indico.modules.logs.util import make_diff_log
 from indico.modules.receipts.models.files import ReceiptFile
@@ -635,6 +636,20 @@ class RHRegistrationTogglePayment(RHManageRegistrationBase):
         if pay != self.registration.is_paid:
             toggle_registration_payment(self.registration, paid=pay)
         return jsonify_data(html=_render_registration_details(self.registration))
+
+
+class RHRegistrationUploadFile(UploadRegistrationFileMixin, RHManageRegFormBase):
+    """
+    Upload a file from a registration form.
+
+    Regform file fields do not wait for the regform to be submitted,
+    but upload the selected files immediately, saving just the generated uuid.
+    Only this uuid is then sent when the regform is submitted.
+    """
+
+    def _process_args(self):
+        RHManageRegFormBase._process_args(self)
+        UploadRegistrationFileMixin._process_args(self)
 
 
 def _modify_registration_status(registration, approve, rejection_reason='', attach_rejection_reason=False):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -38,7 +38,8 @@ from indico.modules.events.registration import logger
 from indico.modules.events.registration.badges import (RegistrantsListToBadgesPDF,
                                                        RegistrantsListToBadgesPDFDoubleSided,
                                                        RegistrantsListToBadgesPDFFoldable)
-from indico.modules.events.registration.controllers import CheckEmailMixin, RegistrationEditMixin
+from indico.modules.events.registration.controllers import (CheckEmailMixin, RegistrationEditMixin,
+                                                            UploadRegistrationFileMixin)
 from indico.modules.events.registration.controllers.management import (RHManageRegFormBase, RHManageRegFormsBase,
                                                                        RHManageRegistrationBase)
 from indico.modules.events.registration.forms import (BadgeSettingsForm, CreateMultipleRegistrationsForm,
@@ -57,7 +58,6 @@ from indico.modules.events.registration.util import (ActionMenuEntry, create_reg
                                                      import_registrations_from_csv, make_registration_schema)
 from indico.modules.events.registration.views import WPManageRegistration
 from indico.modules.events.util import ZipGeneratorMixin
-from indico.modules.files.controllers import UploadRegistrationFileMixin
 from indico.modules.logs import LogKind
 from indico.modules.logs.util import make_diff_log
 from indico.modules.receipts.models.files import ReceiptFile
@@ -639,17 +639,7 @@ class RHRegistrationTogglePayment(RHManageRegistrationBase):
 
 
 class RHRegistrationUploadFile(UploadRegistrationFileMixin, RHManageRegFormBase):
-    """
-    Upload a file from a registration form.
-
-    Regform file fields do not wait for the regform to be submitted,
-    but upload the selected files immediately, saving just the generated uuid.
-    Only this uuid is then sent when the regform is submitted.
-    """
-
-    def _process_args(self):
-        RHManageRegFormBase._process_args(self)
-        UploadRegistrationFileMixin._process_args(self)
+    """Upload a file from a registration form."""
 
 
 def _modify_registration_status(registration, approve, rejection_reason='', attach_rejection_reason=False):

--- a/indico/modules/files/controllers.py
+++ b/indico/modules/files/controllers.py
@@ -16,7 +16,6 @@ from werkzeug.exceptions import Forbidden, UnprocessableEntity
 from indico.modules.files import logger
 from indico.modules.files.models.files import File
 from indico.modules.files.util import validate_upload_file_size
-from indico.util.marshmallow import UUIDString
 from indico.util.signing import secure_serializer
 from indico.web.args import use_kwargs
 from indico.web.rh import RHProtected
@@ -72,17 +71,6 @@ class UploadFileMixin:
         This is usually not needed, but could be used e.g. to add some flag which
         is then used in a validator of the form accepting the file uploaded here.
         """
-
-
-class UploadRegistrationFileMixin(UploadFileMixin):
-    @use_kwargs({
-        'token': UUIDString(load_default=None),
-    }, location='query')
-    def _process_args(self, token):
-        self.existing_registration = self.regform.get_registration(uuid=token) if token else None
-
-    def get_file_context(self):
-        return 'event', self.event.id, 'regform', self.regform.id, 'registration'
 
 
 class RHFileBase(RHProtected):

--- a/indico/modules/files/controllers.py
+++ b/indico/modules/files/controllers.py
@@ -16,6 +16,7 @@ from werkzeug.exceptions import Forbidden, UnprocessableEntity
 from indico.modules.files import logger
 from indico.modules.files.models.files import File
 from indico.modules.files.util import validate_upload_file_size
+from indico.util.marshmallow import UUIDString
 from indico.util.signing import secure_serializer
 from indico.web.args import use_kwargs
 from indico.web.rh import RHProtected
@@ -71,6 +72,17 @@ class UploadFileMixin:
         This is usually not needed, but could be used e.g. to add some flag which
         is then used in a validator of the form accepting the file uploaded here.
         """
+
+
+class UploadRegistrationFileMixin(UploadFileMixin):
+    @use_kwargs({
+        'token': UUIDString(load_default=None),
+    }, location='query')
+    def _process_args(self, token):
+        self.existing_registration = self.regform.get_registration(uuid=token) if token else None
+
+    def get_file_context(self):
+        return 'event', self.event.id, 'regform', self.regform.id, 'registration'
 
 
 class RHFileBase(RHProtected):


### PR DESCRIPTION
Request change to fix issue "Access denied" in private form when uploading file in registration from management area.

Tests done: upload file in front-end/back-end, with public and private form.

Notes:
I name the new RH for management similar to existing to be consistent, but in general the naming is a bit confusing to distinguish RH front/back-end.