### PR TITLE
Improve badge designer color validation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Bugfixes
   thanks :user:`SegiNyn`)
 - Fix validation error when clearing a date field in the registration form (:pr:`6470`)
 - Fix access error when a manager registers a user in a private registration form (:pr:`6486`)
+- Improve color handling in badge designer (auto-add ``#`` for hex colors) (:pr:`6492`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/designer/client/js/index.js
+++ b/indico/modules/designer/client/js/index.js
@@ -525,9 +525,17 @@ import {$T} from 'indico/utils/i18n';
       },
       color: function() {
         selectedItem.color = $('#text-color-selector').val();
+        if (/^[a-f0-9]{3,6}$/.test(selectedItem.color)) {
+          selectedItem.color = `#${selectedItem.color}`;
+          $('#text-color-selector').val(selectedItem.color);
+        }
       },
       background_color: function() {
         selectedItem.background_color = $('#bg-color-selector').val();
+        if (/^[a-f0-9]{3,6}$/.test(selectedItem.background_color)) {
+          selectedItem.background_color = `#${selectedItem.background_color}`;
+          $('#bg-color-selector').val(selectedItem.background_color);
+        }
       },
       alignment: function() {
         selectedItem.text_align = $('#alignment-selector').val();

--- a/indico/modules/designer/pdf.py
+++ b/indico/modules/designer/pdf.py
@@ -11,6 +11,7 @@ from io import BytesIO
 
 from PIL import Image
 from reportlab.lib import pagesizes
+from reportlab.lib.colors import getAllNamedColors
 from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT, TA_RIGHT
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import cm
@@ -95,12 +96,21 @@ class DesignerPDFBase:
         data.seek(0)
         return data
 
+    def _normalize_color(self, color):
+        if not color:
+            return None
+        elif color in getAllNamedColors():
+            return color
+        if re.match(r'^[a-f0-9]{3,6}$', color):
+            color = f'#{color}'
+        return color
+
     def _draw_item(self, canvas, item, tpl_data, content, margin_x, margin_y):
         font_size = _extract_font_size(item['font_size'])
         styles = {
             'alignment': ALIGNMENTS[item['text_align']],
-            'textColor': item.get('color') or '#000000',
-            'backColor': item.get('background_color') or None,
+            'textColor': self._normalize_color(item.get('color') or '#000000'),
+            'backColor': self._normalize_color(item.get('background_color') or None),
             'borderPadding': (0, 0, 4, 0),
             'fontSize': font_size,
             'leading': font_size


### PR DESCRIPTION
- Auto-add `#` to hex colors in the designer itself
- Validate that reportlab accepts the color whens aving
- Auto-add `#` when existing data is not a valid named color but looks like a hex color when generating badges (to handle bad existing data)

closes #6488