### PR TITLE
Fix EventPerson has_links check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,7 @@ Bugfixes
 - Fix access error when a manager registers a user in a private registration form (:pr:`6486`)
 - Improve color handling in badge designer (auto-add ``#`` for hex colors) (:pr:`6492`)
 - Do not count deleted rooms for equipment/attribute usage numbers (:issue:`6493`, :pr:`6494`)
+- Allow deleting event persons which are linked to a deleted subcontribution (:pr:`6495`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/models/persons.py
+++ b/indico/modules/events/models/persons.py
@@ -391,7 +391,8 @@ class EventPerson(PersonMixin, db.Model):
             any(link for link in self.abstract_links if not link.abstract.is_deleted) or
             any(link for link in self.session_block_links if not link.session_block.session.is_deleted) or
             any(link for link in self.contribution_links if not link.contribution.is_deleted) or
-            any(link for link in self.subcontribution_links if not link.subcontribution.contribution.is_deleted)
+            any(link for link in self.subcontribution_links if (not link.subcontribution.is_deleted and
+                                                                not link.subcontribution.contribution.is_deleted))
         )
 
 


### PR DESCRIPTION
Being linked to a deleted subcontribution should not consider you having a link.