### PR TITLE
Fix PictureField cropped until no image left

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,8 @@ Bugfixes
 - Fix validation error in registration form date fields when using Safari (:issue:`6474`,
   :pr:`6501`, thanks :user:`foxbunny`)
 - Fix date picker month/year navigation not working in Safari (:pr:`6505`, thanks :user:`foxbunny`)
+- Enforce a minimum size on the registration form picture cropper to avoid sending an empty
+  image after repeated cropping (:pr:`6498`, thanks :user:`jbtwist`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/client/js/form/fields/PictureInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/PictureInput.jsx
@@ -91,10 +91,8 @@ export function PictureSettings() {
       step="1"
       min="25"
       max="1000"
-      validate={v.optional(v.min(0))}
+      validate={v.optional(v.range(25, 1000))}
       fluid
-      format={val => val || ''}
-      parse={val => +val || 0}
     />
   );
 }

--- a/indico/modules/events/registration/client/js/form/fields/PictureInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/PictureInput.jsx
@@ -89,7 +89,7 @@ export function PictureSettings() {
         'Minimum picture size that can be uploaded in pixels. Leave empty for no min size validation.'
       )}
       step="1"
-      min="0"
+      min="25"
       max="1000"
       validate={v.optional(v.min(0))}
       fluid

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -395,7 +395,7 @@ class EmailField(RegistrationFormFieldBase):
 class PictureField(FileField):
     name = 'picture'
     setup_schema_fields = {
-        'min_picture_size': fields.Integer(load_default=0, validate=validate.Range(0, 1000)),
+        'min_picture_size': fields.Integer(load_default=None, validate=validate.Range(25, 1000)),
     }
 
     def get_validators(self, existing_registration):

--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -196,7 +196,8 @@ const PictureManager = ({
 
   const onImageCrop = () => {
     if (cropperRef.current.cropper !== undefined) {
-      const imageSrc = cropperRef.current.cropper.getCroppedCanvas().toDataURL();
+      const settings = {minWidth: 25, minHeight: 25};
+      const imageSrc = cropperRef.current.cropper.getCroppedCanvas(settings).toDataURL();
       setPicturePreview(imageSrc);
       fetch(imageSrc)
         .then(res => res.blob())


### PR DESCRIPTION
As discussed via Element, there's a problem with cropping too much a picture in the registration form.

This PR solves the issue.