### PR TITLE
Make setNativeInputValue a static method on CustomElementBase

### DIFF
--- a/indico/web/client/js/custom_elements/_base.js
+++ b/indico/web/client/js/custom_elements/_base.js
@@ -6,6 +6,15 @@
 // LICENSE file for more details.
 
 export default class CustomElementBase extends HTMLElement {
+  static setValue = (element, value) => {
+    // This is a hack to bypass the setter that React adds to the
+    // value property. Apparently, modifying a value before firing
+    // an event will cause React to not handle the event at all,
+    // probably because it expects values to only ever be modified
+    // through React.
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(element, value);
+  };
+
   connectedCallback() {
     // Custom elements may get temporarily disconnected. Since the
     // setup method may run operations that should not be repeated

--- a/indico/web/client/js/custom_elements/ind_combobox.js
+++ b/indico/web/client/js/custom_elements/ind_combobox.js
@@ -10,12 +10,6 @@ import {topBottomPosition} from 'indico/utils/positioning';
 
 import './ind_combobox.scss';
 
-function setNativeInputValue(input, value) {
-  // React adds its own setter to the input and messes with the native event mechanism.
-  // In order for the value to be set in a standard way, we need to resort to this hack.
-  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(input, value);
-}
-
 customElements.define(
   'ind-combo-box',
   class extends CustomElementBase {
@@ -263,7 +257,7 @@ customElements.define(
         // Omit the option to clear the selection and reset the input
         deselectCurrentSelection();
         option?.setAttribute('aria-selected', true);
-        setNativeInputValue(input, option?.dataset.value);
+        CustomElementBase.setValue(input, option?.dataset.value);
       }
 
       function moveVirtualCursorToOption(option) {

--- a/indico/web/client/js/custom_elements/ind_date_picker.js
+++ b/indico/web/client/js/custom_elements/ind_date_picker.js
@@ -63,7 +63,7 @@ customElements.define(
         openCalendarButton.focus();
       });
       indCalendar.addEventListener('x-select', () => {
-        setNativeInputValue(input, formatDate(dateFormat, new Date(indCalendar.value)));
+        CustomElementBase.setValue(input, formatDate(dateFormat, new Date(indCalendar.value)));
         input.select();
         input.focus();
         input.dispatchEvent(new Event('input', {bubbles: true}));
@@ -438,14 +438,6 @@ customElements.define(
     }
   }
 );
-
-// React hacks
-
-function setNativeInputValue(input, value) {
-  // React adds its own setter to the input and messes with the native event mechanism.
-  // In order for the value to be set in a standard way, we need to resort to this hack.
-  Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(input, value);
-}
 
 // Date functions
 


### PR DESCRIPTION
Since this method is generally needed in custom elements, but not elsewhere, it makes more sense to attach it to the custom element base class.

(This supersedes/duplicates some changes made in currently open a11y PRs).