### PR TITLE
Highlight editable updates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Improvements
 
 - Add a new "Accepted by Submitter" state for editables when a submitter approved
   the changes proposed by the editor (:issue:`6185`, :pr:`6186`)
+- Highlight editables in the editable list that have been updated since the last time
+  they were viewed (:pr:`6500`)
 
 Bugfixes
 ^^^^^^^^
@@ -85,8 +87,6 @@ Improvements
 - Improve readability of room booking room statistics card (:pr:`6616`)
 - Add option to use flat zip file structure when downloading registration attachments
   (:issue:`6536`, :pr:`6608`, thanks :user:`Moliholy, unconventionaldotdev`)
-- Highlight editables in the editable list that have been updated since the last time
-  they were viewed (:pr:`6500`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -85,6 +85,8 @@ Improvements
 - Improve readability of room booking room statistics card (:pr:`6616`)
 - Add option to use flat zip file structure when downloading registration attachments
   (:issue:`6536`, :pr:`6608`, thanks :user:`Moliholy, unconventionaldotdev`)
+- Highlight editables in the editable list that have been updated since the last time
+  they were viewed (:pr:`6500`)
 
 Bugfixes
 ^^^^^^^^
@@ -173,8 +175,6 @@ Improvements
   module (:issue:`6503`, :pr:`6502`)
 - Add quick setup button to configure default notifications in Call for Abstracts
   (:pr:`6454`, thanks :user:`jbtwist`)
-- Highlight editables in the editable list that have been updated since the last time
-  they were viewed (:pr:`6500`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -173,6 +173,8 @@ Improvements
   module (:issue:`6503`, :pr:`6502`)
 - Add quick setup button to configure default notifications in Call for Abstracts
   (:pr:`6454`, thanks :user:`jbtwist`)
+- Highlight editables in the editable list that have been updated since the last time
+  they were viewed (:pr:`6500`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/client/js/editing/timeline/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/index.jsx
@@ -46,6 +46,12 @@ export default function Timeline() {
     };
   }, [dispatch]);
 
+  useEffect(() => {
+    if (details) {
+      localStorage.setItem(`editable-${details.id}-last-update`, details.lastUpdateDt);
+    }
+  }, [details]);
+
   const refresh = () => {
     dispatch(actions.useUpdatedTimeline());
   };

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -17,11 +17,22 @@ import unassignEditorURL from 'indico-url:event_editing.api_unassign_editor';
 import editableTypeURL from 'indico-url:event_editing.manage_editable_type';
 
 import _ from 'lodash';
+import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, {useState, useMemo, useEffect} from 'react';
 import {useParams, Link} from 'react-router-dom';
 import {Column, Table, SortDirection, WindowScroller} from 'react-virtualized';
-import {Button, Icon, Loader, Checkbox, Message, Dropdown, Confirm} from 'semantic-ui-react';
+import {
+  Button,
+  Icon,
+  Loader,
+  Checkbox,
+  Message,
+  Dropdown,
+  Confirm,
+  Popup,
+  Label,
+} from 'semantic-ui-react';
 
 import {
   TooltipIfTruncated,
@@ -390,13 +401,28 @@ function EditableListDisplay({
     return <div>{title}</div>;
   };
   const renderStatus = (editable, rowIndex) => {
+    let updated = false;
+    if (editable) {
+      const lastUpdate = localStorage.getItem(`editable-${editable.id}-last-update`);
+      if (lastUpdate) {
+        updated = moment(lastUpdate).isBefore(editable.lastUpdateDt);
+      }
+    }
     return (
-      <StateIndicator
-        state={editable ? editable.state : 'not_submitted'}
-        circular
-        label
-        monochrome={!filteredSet.has(sortedList[rowIndex].id)}
-      />
+      <>
+        <StateIndicator
+          state={editable ? editable.state : 'not_submitted'}
+          circular
+          label
+          monochrome={!filteredSet.has(sortedList[rowIndex].id)}
+        />
+        {updated && (
+          <Popup
+            trigger={<Label size="mini" color="red" icon="exclamation" corner />}
+            content={Translate.string('There has been an update to the latest revision')}
+          />
+        )}
+      </>
     );
   };
   const renderFuncs = {

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.jsx
@@ -266,7 +266,6 @@ function EditableListDisplay({
           {value: 'false', text: Translate.string('No'), exclusive: true},
         ],
         isMatch: (contrib, selectedOptions) =>
-          console.debug('contrib', contrib) ||
           (selectedOptions.includes('true') && contrib.c.hasUpdates) ||
           (selectedOptions.includes('false') && !contrib.c.hasUpdates),
       },

--- a/indico/modules/events/editing/client/js/management/editable_type/EditableList.module.scss
+++ b/indico/modules/events/editing/client/js/management/editable_type/EditableList.module.scss
@@ -40,6 +40,11 @@ $border: 1px solid $pastel-gray;
     display: flex;
   }
 
+  .id-cell {
+    display: flex;
+    align-items: center;
+  }
+
   :global(.ReactVirtualized__Table__Grid) {
     outline: none;
   }

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -43,9 +43,12 @@ class RHEditableList(RHEditableTypeEditorBase):
 
     def _process_args(self):
         RHEditableTypeEditorBase._process_args(self)
+        revisions_strategy = joinedload('editables').selectinload('revisions')
+        revisions_strategy.selectinload('tags')
+        revisions_strategy.undefer('last_update_dt')
         self.contributions = (Contribution.query
                               .with_parent(self.event)
-                              .options(joinedload('editables').selectinload('revisions').selectinload('tags'),
+                              .options(revisions_strategy,
                                        joinedload('person_links'),
                                        joinedload('session'))
                               .order_by(Contribution.friendly_id)

--- a/indico/modules/events/editing/models/editable.py
+++ b/indico/modules/events/editing/models/editable.py
@@ -156,6 +156,10 @@ class Editable(db.Model):
                 .order_by(EditingRevision.created_dt.desc())
                 .first())
 
+    @property
+    def last_update_dt(self):
+        return self.latest_revision.last_update_dt if self.latest_revision else None
+
     def _has_general_editor_permissions(self, user):
         """Whether the user has general editor permissions on the Editable.
 

--- a/indico/modules/events/editing/models/revisions.py
+++ b/indico/modules/events/editing/models/revisions.py
@@ -7,6 +7,11 @@
 
 from collections import defaultdict
 
+from sqlalchemy import orm
+from sqlalchemy.event import listens_for
+from sqlalchemy.orm import column_property
+from sqlalchemy.sql import select
+
 from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
 from indico.core.db.sqlalchemy.descriptions import RenderMode, RenderModeMixin
@@ -177,7 +182,13 @@ class EditingRevision(RenderModeMixin, db.Model):
     def is_editor_revision(self):
         return self.type.is_editor_action
 
-    @property
-    def last_update_dt(self):
-        latest_comment_dt = max((comment.modified_dt or comment.created_dt for comment in self.comments), default=None)
-        return latest_comment_dt or self.modified_dt or self.created_dt
+    @listens_for(orm.mapper, 'after_configured', once=True)
+    def _mappers_configured():
+        from indico.modules.events.editing.models.comments import EditingRevisionComment
+        query = (select([db.func.greatest(db.func.max(EditingRevisionComment.modified_dt),
+                                          db.func.max(EditingRevisionComment.created_dt),
+                                          EditingRevision.modified_dt, EditingRevision.created_dt)])
+                 .where(EditingRevisionComment.revision_id == EditingRevision.id)
+                 .correlate_except(EditingRevisionComment)
+                 .scalar_subquery())
+        EditingRevision.last_update_dt = column_property(query)

--- a/indico/modules/events/editing/models/revisions.py
+++ b/indico/modules/events/editing/models/revisions.py
@@ -176,3 +176,8 @@ class EditingRevision(RenderModeMixin, db.Model):
     @property
     def is_editor_revision(self):
         return self.type.is_editor_action
+
+    @property
+    def last_update_dt(self):
+        latest_comment_dt = max((comment.modified_dt or comment.created_dt for comment in self.comments), default=None)
+        return latest_comment_dt or self.modified_dt or self.created_dt

--- a/indico/modules/events/editing/models/revisions.py
+++ b/indico/modules/events/editing/models/revisions.py
@@ -182,13 +182,14 @@ class EditingRevision(RenderModeMixin, db.Model):
     def is_editor_revision(self):
         return self.type.is_editor_action
 
-    @listens_for(orm.mapper, 'after_configured', once=True)
-    def _mappers_configured():
-        from indico.modules.events.editing.models.comments import EditingRevisionComment
-        query = (select([db.func.greatest(db.func.max(EditingRevisionComment.modified_dt),
-                                          db.func.max(EditingRevisionComment.created_dt),
-                                          EditingRevision.modified_dt, EditingRevision.created_dt)])
-                 .where(EditingRevisionComment.revision_id == EditingRevision.id)
-                 .correlate_except(EditingRevisionComment)
-                 .scalar_subquery())
-        EditingRevision.last_update_dt = column_property(query)
+
+@listens_for(orm.mapper, 'after_configured', once=True)
+def _mappers_configured():
+    from indico.modules.events.editing.models.comments import EditingRevisionComment
+    query = (select([db.func.greatest(db.func.max(EditingRevisionComment.modified_dt),
+                                      db.func.max(EditingRevisionComment.created_dt),
+                                      EditingRevision.modified_dt, EditingRevision.created_dt)])
+             .where(EditingRevisionComment.revision_id == EditingRevision.id)
+             .correlate_except(EditingRevisionComment)
+             .scalar_subquery())
+    EditingRevision.last_update_dt = column_property(query, deferred=True)

--- a/indico/modules/events/editing/schemas.py
+++ b/indico/modules/events/editing/schemas.py
@@ -204,7 +204,8 @@ class EditableSchema(mm.SQLAlchemyAutoSchema):
         model = Editable
         fields = ('id', 'type', 'editor', 'revisions', 'contribution', 'can_comment', 'review_conditions_valid',
                   'can_perform_editor_actions', 'can_perform_submitter_actions', 'can_create_internal_comments',
-                  'can_unassign', 'can_assign_self', 'can_delete', 'editing_enabled', 'state', 'has_published_revision')
+                  'can_unassign', 'can_assign_self', 'can_delete', 'editing_enabled', 'state', 'has_published_revision',
+                  'last_update_dt')
 
     contribution = fields.Nested(BasicContributionSchema)
     editor = fields.Nested(EditingUserSchema)
@@ -248,7 +249,7 @@ class EditableDumpSchema(EditableSchema):
 class EditableBasicSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Editable
-        fields = ('id', 'type', 'state', 'editor', 'timeline_url', 'revision_count', 'tags')
+        fields = ('id', 'type', 'state', 'editor', 'timeline_url', 'revision_count', 'tags', 'last_update_dt')
 
     state = EnumField(EditableState)
     editor = fields.Nested(EditingUserSchema)


### PR DESCRIPTION
This PR adds a label with a tooltip to editables in the editable list that have been updated since the last time they were viewed.

<img width="1214" alt="image" src="https://github.com/user-attachments/assets/1ae0f20e-0c19-47e5-8bd0-a63eb52cf4f5">
