### PR TITLE
Fix date picker in Safari

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Bugfixes
 - Improve color handling in badge designer (auto-add ``#`` for hex colors) (:pr:`6492`)
 - Do not count deleted rooms for equipment/attribute usage numbers (:issue:`6493`, :pr:`6494`)
 - Allow deleting event persons which are linked to a deleted subcontribution (:pr:`6495`)
+- Fix validation error in registration form date fields when using Safari (:issue:`6474`,
+  :pr:`6501`, thanks :user:`foxbunny`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/react/components/DatePicker.jsx
+++ b/indico/web/client/js/react/components/DatePicker.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 
 import {FinalField, validators as v} from 'indico/react/forms';
 import {Param, Translate} from 'indico/react/i18n';
-import {formatDate} from 'indico/utils/date_format';
+import {formatDate, ISO_FORMAT} from 'indico/utils/date_format';
 import {fromISOLocalDate} from 'indico/utils/date_parser';
 
 import 'indico/custom_elements/ind_date_picker';
@@ -27,12 +27,9 @@ export default function DatePicker({
   ...inputProps
 }) {
   function handleDateChange(ev) {
-    const {date, value: pickerValue} = ev.target.closest('ind-date-picker');
-    const invalid = !!pickerValue && !date;
-    // en-CA uses the ISO format date (YYYY-MM-DD) but gives it in local time zone.
-    // Do not use toISOString() for this because it may result in incorrect date due
-    // to time zone differences.
-    onChange(invalid ? INVALID : date?.toLocaleDateString('en-CA'));
+    const {date} = ev.target.closest('ind-date-picker');
+    const invalid = !!ev.target.value && !date;
+    onChange(invalid ? INVALID : formatDate(ISO_FORMAT, date));
   }
 
   const formattedValue = formatDate(format, fromISOLocalDate(value));

--- a/indico/web/client/js/utils/date_format.js
+++ b/indico/web/client/js/utils/date_format.js
@@ -24,3 +24,5 @@ export function formatDate(formatString, date) {
     .replace(/m{1,2}/i, s => month.padStart(s.length, '0'))
     .replace(/d{1,2}/i, s => day.padStart(s.length, '0'));
 }
+
+export const ISO_FORMAT = 'yyyy-mm-dd';


### PR DESCRIPTION
This is just a backport of @foxbunny's fix from #6464 for the date picker incorrectly formatting the internal value in Safari.

For reference, the problem of Safari not using `yyyy-mm-dd` when formatting with `en-CA` could be reproduced in Safari 17.1, but not in 17.5 (by another person, so might also be related to some other system setting).

closes #6474