### PR TITLE
Keep comment when opening judgment form

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -74,6 +74,7 @@ rules:
   no-restricted-globals:
     - error
     - event
+  react/require-default-props: off
 
 overrides:
   - files:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Improvements
   thanks :user:`SegiNyn`)
 - Always open links in registration form field/section descriptions in a new tab
   (:pr:`6512`)
+- Preserve entered text when switching between commenting and judging in the editing
+  module (:issue:`6503`, :pr:`6502`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -24,8 +24,10 @@ export default function CommentForm({
   onToggleExpand,
   initialValues,
   expanded,
-  textAreaValue,
-  onTextAreaChange,
+  commentValue,
+  onCommentChange,
+  syncComment,
+  setSyncComment,
 }) {
   const {canCreateInternalComments} = useSelector(getDetails);
   const [commentFormVisible, setCommentFormVisible] = useState(expanded);
@@ -43,7 +45,7 @@ export default function CommentForm({
     if (!rv) {
       setCommentFormVisible(false);
       onToggleExpand(false);
-      onTextAreaChange('');
+      onCommentChange('');
     }
   };
 
@@ -59,13 +61,19 @@ export default function CommentForm({
             <InputComponent
               {...inputProps}
               onFocus={onCommentClickHandler}
-              onChange={onTextAreaChange}
+              onChange={onCommentChange}
               name="text"
               placeholder={Translate.string('Leave a comment...')}
               hideValidationError
               required
             />
-            {textAreaValue && <DirtyInitialValue field="text" value={textAreaValue} />}
+            {syncComment && (
+              <DirtyInitialValue
+                field="text"
+                value={commentValue}
+                onUpdate={() => setSyncComment(false)}
+              />
+            )}
             {commentFormVisible && (
               <>
                 {canCreateInternalComments && (
@@ -85,7 +93,7 @@ export default function CommentForm({
                     onClick={() => {
                       setCommentFormVisible(false);
                       onToggleExpand(false);
-                      onTextAreaChange('');
+                      onCommentChange('');
                       fprops.form.reset();
                     }}
                   />
@@ -107,8 +115,10 @@ CommentForm.propTypes = {
     internal: PropTypes.bool,
   }),
   expanded: PropTypes.bool,
-  onTextAreaChange: PropTypes.func,
-  textAreaValue: PropTypes.string,
+  onCommentChange: PropTypes.func,
+  commentValue: PropTypes.string,
+  syncComment: PropTypes.bool,
+  setSyncComment: PropTypes.func,
 };
 
 CommentForm.defaultProps = {
@@ -118,6 +128,8 @@ CommentForm.defaultProps = {
   },
   expanded: false,
   onToggleExpand: () => {},
-  onTextAreaChange: null,
-  textAreaValue: '',
+  onCommentChange: () => {},
+  commentValue: '',
+  syncComment: false,
+  setSyncComment: () => {},
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -18,7 +18,13 @@ import {getDetails} from './selectors';
 
 import './CommentForm.module.scss';
 
-export default function CommentForm({onSubmit, onToggleExpand, initialValues, expanded}) {
+export default function CommentForm({
+  onSubmit,
+  onToggleExpand,
+  initialValues,
+  expanded,
+  onTextAreaChange,
+}) {
   const {canCreateInternalComments} = useSelector(getDetails);
   const [commentFormVisible, setCommentFormVisible] = useState(expanded);
 
@@ -49,6 +55,7 @@ export default function CommentForm({onSubmit, onToggleExpand, initialValues, ex
           <Form onSubmit={fprops.handleSubmit}>
             <InputComponent
               {...inputProps}
+              {...(commentFormVisible && {onTextAreaChange})}
               onFocus={onCommentClickHandler}
               name="text"
               placeholder={Translate.string('Leave a comment...')}

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -7,7 +7,7 @@
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Form as FinalForm} from 'react-final-form';
+import {Form as FinalForm, FormSpy} from 'react-final-form';
 import {useSelector} from 'react-redux';
 import {Button, Form} from 'semantic-ui-react';
 
@@ -55,12 +55,17 @@ export default function CommentForm({
           <Form onSubmit={fprops.handleSubmit}>
             <InputComponent
               {...inputProps}
-              {...(commentFormVisible && {onTextAreaChange})}
               onFocus={onCommentClickHandler}
               name="text"
               placeholder={Translate.string('Leave a comment...')}
               hideValidationError
               required
+            />
+            <FormSpy
+              subscription={{values: true}}
+              onChange={({values}) => {
+                commentFormVisible && onTextAreaChange ? onTextAreaChange(values.text) : null;
+              }}
             />
             {commentFormVisible && (
               <>
@@ -102,6 +107,7 @@ CommentForm.propTypes = {
     internal: PropTypes.bool,
   }),
   expanded: PropTypes.bool,
+  onTextAreaChange: PropTypes.func,
 };
 
 CommentForm.defaultProps = {
@@ -110,4 +116,5 @@ CommentForm.defaultProps = {
     internal: false,
   },
   expanded: false,
+  onTextAreaChange: null,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -12,6 +12,7 @@ import {useSelector} from 'react-redux';
 import {Button, Form} from 'semantic-ui-react';
 
 import {FinalCheckbox, FinalInput, FinalSubmitButton, FinalTextArea} from 'indico/react/forms';
+import {DirtyInitialValue} from 'indico/react/forms/final-form';
 import {Translate} from 'indico/react/i18n';
 
 import {getDetails} from './selectors';
@@ -23,6 +24,7 @@ export default function CommentForm({
   onToggleExpand,
   initialValues,
   expanded,
+  textAreaValue,
   onTextAreaChange,
 }) {
   const {canCreateInternalComments} = useSelector(getDetails);
@@ -62,6 +64,7 @@ export default function CommentForm({
               hideValidationError
               required
             />
+            {textAreaValue && <DirtyInitialValue field="text" value={textAreaValue} />}
             {commentFormVisible && (
               <>
                 {canCreateInternalComments && (
@@ -103,6 +106,7 @@ CommentForm.propTypes = {
   }),
   expanded: PropTypes.bool,
   onTextAreaChange: PropTypes.func,
+  textAreaValue: PropTypes.string,
 };
 
 CommentForm.defaultProps = {
@@ -113,4 +117,5 @@ CommentForm.defaultProps = {
   expanded: false,
   onToggleExpand: () => {},
   onTextAreaChange: null,
+  textAreaValue: '',
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -43,6 +43,7 @@ export default function CommentForm({
     if (!rv) {
       setCommentFormVisible(false);
       onToggleExpand(false);
+      onTextAreaChange('');
     }
   };
 
@@ -84,6 +85,7 @@ export default function CommentForm({
                     onClick={() => {
                       setCommentFormVisible(false);
                       onToggleExpand(false);
+                      onTextAreaChange('');
                       fprops.form.reset();
                     }}
                   />

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -33,14 +33,14 @@ export default function CommentForm({
   const onCommentClickHandler = () => {
     if (!commentFormVisible) {
       setCommentFormVisible(true);
-      onToggleExpand && onToggleExpand(true);
+      onToggleExpand(true);
     }
   };
   const handleSubmit = async (formData, form) => {
     const rv = await onSubmit(formData, form);
     if (!rv) {
       setCommentFormVisible(false);
-      onToggleExpand && onToggleExpand(false);
+      onToggleExpand(false);
     }
   };
 
@@ -85,7 +85,7 @@ export default function CommentForm({
                     content={Translate.string('Cancel')}
                     onClick={() => {
                       setCommentFormVisible(false);
-                      onToggleExpand && onToggleExpand(false);
+                      onToggleExpand(false);
                       fprops.form.reset();
                     }}
                   />
@@ -116,6 +116,6 @@ CommentForm.defaultProps = {
     internal: false,
   },
   expanded: false,
-  onToggleExpand: null,
+  onToggleExpand: () => {},
   onTextAreaChange: null,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -33,14 +33,14 @@ export default function CommentForm({
   const onCommentClickHandler = () => {
     if (!commentFormVisible) {
       setCommentFormVisible(true);
-      onToggleExpand(true);
+      onToggleExpand && onToggleExpand(true);
     }
   };
   const handleSubmit = async (formData, form) => {
     const rv = await onSubmit(formData, form);
     if (!rv) {
       setCommentFormVisible(false);
-      onToggleExpand(false);
+      onToggleExpand && onToggleExpand(false);
     }
   };
 
@@ -64,7 +64,7 @@ export default function CommentForm({
             <FormSpy
               subscription={{values: true}}
               onChange={({values}) => {
-                commentFormVisible && onTextAreaChange ? onTextAreaChange(values.text) : null;
+                commentFormVisible && onTextAreaChange && onTextAreaChange(values.text);
               }}
             />
             {commentFormVisible && (
@@ -85,7 +85,7 @@ export default function CommentForm({
                     content={Translate.string('Cancel')}
                     onClick={() => {
                       setCommentFormVisible(false);
-                      onToggleExpand(false);
+                      onToggleExpand && onToggleExpand(false);
                       fprops.form.reset();
                     }}
                   />
@@ -101,7 +101,7 @@ export default function CommentForm({
 
 CommentForm.propTypes = {
   onSubmit: PropTypes.func.isRequired,
-  onToggleExpand: PropTypes.func.isRequired,
+  onToggleExpand: PropTypes.func,
   initialValues: PropTypes.shape({
     text: PropTypes.string,
     internal: PropTypes.bool,
@@ -116,5 +116,6 @@ CommentForm.defaultProps = {
     internal: false,
   },
   expanded: false,
+  onToggleExpand: null,
   onTextAreaChange: null,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/CommentForm.jsx
@@ -7,7 +7,7 @@
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Form as FinalForm, FormSpy} from 'react-final-form';
+import {Form as FinalForm} from 'react-final-form';
 import {useSelector} from 'react-redux';
 import {Button, Form} from 'semantic-ui-react';
 
@@ -56,16 +56,11 @@ export default function CommentForm({
             <InputComponent
               {...inputProps}
               onFocus={onCommentClickHandler}
+              onChange={onTextAreaChange}
               name="text"
               placeholder={Translate.string('Leave a comment...')}
               hideValidationError
               required
-            />
-            <FormSpy
-              subscription={{values: true}}
-              onChange={({values}) => {
-                commentFormVisible && onTextAreaChange && onTextAreaChange(values.text);
-              }}
             />
             {commentFormVisible && (
               <>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -87,10 +87,6 @@ export default function ReviewForm() {
   const [textAreaValue, setTextAreaValue] = useState('');
   const files = getFilesFromRevision(fileTypes, lastRevisionWithFiles);
 
-  const handleTextAreaChange = value => {
-    setTextAreaValue(value);
-  };
-
   const createComment = async (formData, form) => {
     const rv = await dispatch(createRevisionComment(lastRevision.createCommentURL, formData));
     if (rv.error) {
@@ -115,7 +111,7 @@ export default function ReviewForm() {
       <CommentForm
         onSubmit={createComment}
         onToggleExpand={setCommentFormVisible}
-        onTextAreaChange={handleTextAreaChange}
+        onTextAreaChange={setTextAreaValue}
       />
       {canPerformSubmitterActions && canReview && !editor && (
         <>
@@ -133,7 +129,7 @@ export default function ReviewForm() {
           />
         </>
       )}
-      {canJudge && (
+      {commentFormVisible && canJudge && (
         <div className="review-trigger flexrow">
           <span className="comment-or-review">
             <Translate>or</Translate>
@@ -180,7 +176,7 @@ export default function ReviewForm() {
           {!judgmentType && judgmentForm}
           <FinalForm
             initialValues={{
-              comment: '',
+              comment: textAreaValue,
               tags: lastRevision.tags
                 .filter(t => !t.system)
                 .map(t => t.id)

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -133,27 +133,29 @@ export default function ReviewForm() {
         </>
       )}
       {canJudge && (
-        <div className="review-trigger flexrow">
-          <span className="comment-or-review">
-            <Translate>or</Translate>
-          </span>
-          <Dropdown
-            className="judgment-btn"
-            text={Translate.string('Judge')}
-            direction="left"
-            button
-            floating
-          >
-            <Dropdown.Menu>
-              <JudgmentDropdownItems
-                options={judgmentOptions}
-                setJudgmentType={type => {
-                  setSyncComment(true);
-                  setJudgmentType(type);
-                }}
-              />
-            </Dropdown.Menu>
-          </Dropdown>
+        <div className="flexcol allign-strech">
+          <div className="review-trigger flexrow">
+            <span className="comment-or-review">
+              <Translate>or</Translate>
+            </span>
+            <Dropdown
+              className="judgment-btn"
+              text={Translate.string('Judge')}
+              direction="left"
+              button
+              floating
+            >
+              <Dropdown.Menu>
+                <JudgmentDropdownItems
+                  options={judgmentOptions}
+                  setJudgmentType={type => {
+                    setSyncComment(true);
+                    setJudgmentType(type);
+                  }}
+                />
+              </Dropdown.Menu>
+            </Dropdown>
+          </div>
         </div>
       )}
     </div>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -84,7 +84,8 @@ export default function ReviewForm() {
 
   const [judgmentType, setJudgmentType] = useState(null);
   const [loading, setLoading] = useState(false);
-  const [textAreaValue, setTextAreaValue] = useState('');
+  const [commentValue, setCommentValue] = useState('');
+  const [syncComment, setSyncComment] = useState(false);
   const files = getFilesFromRevision(fileTypes, lastRevisionWithFiles);
 
   const createComment = async (formData, form) => {
@@ -110,8 +111,10 @@ export default function ReviewForm() {
     <div className="flexrow f-a-center" styleName="judgment-form">
       <CommentForm
         onSubmit={createComment}
-        textAreaValue={textAreaValue}
-        onTextAreaChange={setTextAreaValue}
+        commentValue={commentValue}
+        onCommentChange={setCommentValue}
+        syncComment={syncComment}
+        setSyncComment={setSyncComment}
       />
       {canPerformSubmitterActions && canReview && !editor && (
         <>
@@ -142,7 +145,13 @@ export default function ReviewForm() {
             floating
           >
             <Dropdown.Menu>
-              <JudgmentDropdownItems options={judgmentOptions} setJudgmentType={setJudgmentType} />
+              <JudgmentDropdownItems
+                options={judgmentOptions}
+                setJudgmentType={type => {
+                  setSyncComment(true);
+                  setJudgmentType(type);
+                }}
+              />
             </Dropdown.Menu>
           </Dropdown>
         </div>
@@ -193,7 +202,10 @@ export default function ReviewForm() {
                 <Form id="judgment-form" onSubmit={handleSubmit}>
                   <JudgmentBoxHeader
                     judgmentType={judgmentType}
-                    setJudgmentType={setJudgmentType}
+                    setJudgmentType={type => {
+                      setSyncComment(true);
+                      setJudgmentType(type);
+                    }}
                     options={judgmentOptions}
                     loading={loading}
                   />
@@ -203,10 +215,17 @@ export default function ReviewForm() {
                     hideValidationError
                     autoFocus
                     required={judgmentType !== EditingReviewAction.accept}
+                    onChange={setCommentValue}
                     /* otherwise changing required doesn't work properly if the field has been touched */
                     key={judgmentType}
                   />
-                  <DirtyInitialValue field="comment" value={textAreaValue} force={!judgmentType} />
+                  {syncComment && (
+                    <DirtyInitialValue
+                      field="comment"
+                      value={commentValue}
+                      onUpdate={() => setSyncComment(false)}
+                    />
+                  )}
                   {[EditingReviewAction.accept, EditingReviewAction.requestUpdate].includes(
                     judgmentType
                   ) && (

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -84,7 +84,12 @@ export default function ReviewForm() {
   const [commentFormVisible, setCommentFormVisible] = useState(false);
   const [judgmentType, setJudgmentType] = useState(null);
   const [loading, setLoading] = useState(false);
+  const [textAreaValue, setTextAreaValue] = useState('');
   const files = getFilesFromRevision(fileTypes, lastRevisionWithFiles);
+
+  const handleTextAreaChange = value => {
+    setTextAreaValue(value);
+  };
 
   const createComment = async (formData, form) => {
     const rv = await dispatch(createRevisionComment(lastRevision.createCommentURL, formData));
@@ -107,7 +112,11 @@ export default function ReviewForm() {
 
   const judgmentForm = (
     <div className="flexrow f-a-center" styleName="judgment-form">
-      <CommentForm onSubmit={createComment} onToggleExpand={setCommentFormVisible} />
+      <CommentForm
+        onSubmit={createComment}
+        onToggleExpand={setCommentFormVisible}
+        onTextAreaChange={handleTextAreaChange}
+      />
       {canPerformSubmitterActions && canReview && !editor && (
         <>
           <span className="comment-or-review">
@@ -124,7 +133,7 @@ export default function ReviewForm() {
           />
         </>
       )}
-      {!commentFormVisible && canJudge && (
+      {canJudge && (
         <div className="review-trigger flexrow">
           <span className="comment-or-review">
             <Translate>or</Translate>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -261,7 +261,7 @@ export default function ReviewForm() {
                       // XXX: For some reason the button does not properly update with the correct
                       // `dirty` state after setting the `comment` value programmatically, but by
                       // also subscribing to `touched` we avoid this bug.
-                      // If someone ever needs to change something there or test thie behavior, it
+                      // If someone ever needs to change something there or test this behavior, it
                       // happens when you write a comment, then switch to judgment mode, then close
                       // the judgment form again and then switch to judgment mode again.
                       extraSubscription={{touched: true}}

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -81,7 +81,6 @@ export default function ReviewForm() {
     avatarURL: Indico.User.avatarURL,
   };
 
-  const [commentFormVisible, setCommentFormVisible] = useState(false);
   const [judgmentType, setJudgmentType] = useState(null);
   const [loading, setLoading] = useState(false);
   const [textAreaValue, setTextAreaValue] = useState('');
@@ -108,11 +107,7 @@ export default function ReviewForm() {
 
   const judgmentForm = (
     <div className="flexrow f-a-center" styleName="judgment-form">
-      <CommentForm
-        onSubmit={createComment}
-        onToggleExpand={setCommentFormVisible}
-        onTextAreaChange={setTextAreaValue}
-      />
+      <CommentForm onSubmit={createComment} onTextAreaChange={setTextAreaValue} />
       {canPerformSubmitterActions && canReview && !editor && (
         <>
           <span className="comment-or-review">
@@ -129,7 +124,7 @@ export default function ReviewForm() {
           />
         </>
       )}
-      {commentFormVisible && canJudge && (
+      {canJudge && (
         <div className="review-trigger flexrow">
           <span className="comment-or-review">
             <Translate>or</Translate>

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -206,7 +206,7 @@ export default function ReviewForm() {
                     /* otherwise changing required doesn't work properly if the field has been touched */
                     key={judgmentType}
                   />
-                  <DirtyInitialValue field="comment" value={textAreaValue} />
+                  <DirtyInitialValue field="comment" value={textAreaValue} force={!judgmentType} />
                   {[EditingReviewAction.accept, EditingReviewAction.requestUpdate].includes(
                     judgmentType
                   ) && (

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -133,7 +133,7 @@ export default function ReviewForm() {
         </>
       )}
       {canJudge && (
-        <div className="flexcol allign-strech">
+        <div className="flexcol align-strech">
           <div className="review-trigger flexrow">
             <span className="comment-or-review">
               <Translate>or</Translate>

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -470,7 +470,14 @@ FinalInput.defaultProps = {
 /**
  * Like `FinalField` but with extra features for ``<textarea>`` fields.
  */
-export function FinalTextArea({name, label, nullIfEmpty, action, ...rest}) {
+export function FinalTextArea({name, label, nullIfEmpty, action, onTextAreaChange, ...rest}) {
+  const handleChange = event => {
+    const value = event.target.value;
+    if (onTextAreaChange) {
+      onTextAreaChange(value);
+    }
+  };
+
   return (
     <FinalField
       name={name}

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -650,6 +650,7 @@ export function FinalSubmitButton({
   fluid,
   style,
   children,
+  extraSubscription,
 }) {
   const {
     validating,
@@ -666,6 +667,7 @@ export function FinalSubmitButton({
       submitting: true,
       submitError: true,
       submitSucceeded: true,
+      ...extraSubscription,
     },
   });
   const disabled =
@@ -717,6 +719,7 @@ FinalSubmitButton.propTypes = {
   fluid: PropTypes.bool,
   size: PropTypes.string,
   style: PropTypes.object,
+  extraSubscription: PropTypes.object,
   children: PropTypes.func,
 };
 
@@ -734,6 +737,7 @@ FinalSubmitButton.defaultProps = {
   fluid: false,
   size: null,
   style: null,
+  extraSubscription: {},
   children: null,
 };
 

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -470,14 +470,7 @@ FinalInput.defaultProps = {
 /**
  * Like `FinalField` but with extra features for ``<textarea>`` fields.
  */
-export function FinalTextArea({name, label, nullIfEmpty, action, onTextAreaChange, ...rest}) {
-  const handleChange = event => {
-    const value = event.target.value;
-    if (onTextAreaChange) {
-      onTextAreaChange(value);
-    }
-  };
-
+export function FinalTextArea({name, label, nullIfEmpty, action, ...rest}) {
   return (
     <FinalField
       name={name}

--- a/indico/web/client/js/react/forms/final-form.jsx
+++ b/indico/web/client/js/react/forms/final-form.jsx
@@ -86,12 +86,12 @@ FieldCondition.defaultProps = {
  * to the `FinalSubmitButton` of the form to ensure it correctly gets enabled if the initial value
  * set using this component is all that's necessary for the submit button to be enabled.
  */
-export function DirtyInitialValue({field, value}) {
+export function DirtyInitialValue({field, value, force = false}) {
   const {
     input: {value: currentValue, onChange: setValue, onFocus, onBlur},
   } = useField(field);
   useEffect(() => {
-    if (currentValue) {
+    if (currentValue && !force) {
       // Do not set an initial value when there is already a value
       return;
     }
@@ -100,13 +100,14 @@ export function DirtyInitialValue({field, value}) {
       setValue(value);
       onBlur();
     });
-  }, [currentValue, setValue, onFocus, onBlur, value]);
+  }, [currentValue, setValue, onFocus, onBlur, value, force]);
   return null;
 }
 
 DirtyInitialValue.propTypes = {
   field: PropTypes.string.isRequired,
   value: PropTypes.any.isRequired,
+  force: PropTypes.bool,
 };
 
 /**

--- a/indico/web/client/js/react/forms/final-form.jsx
+++ b/indico/web/client/js/react/forms/final-form.jsx
@@ -8,8 +8,8 @@
 import {FORM_ERROR} from 'final-form';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
-import React from 'react';
-import {Field, Form as FinalForm} from 'react-final-form';
+import React, {useEffect} from 'react';
+import {Field, Form as FinalForm, useField} from 'react-final-form';
 import {Button, Form, Modal} from 'semantic-ui-react';
 
 import {FinalSubmitButton} from 'indico/react/forms';
@@ -75,6 +75,38 @@ FieldCondition.propTypes = {
 FieldCondition.defaultProps = {
   is: true,
   inverted: false,
+};
+
+/**
+ * A component that sets the value of a form field after the final-form has been initialized.
+ * This can be used when you want to set the initial value of a field in a way that marks the
+ * field as touched and dirty.
+ *
+ * Note that when using this, you most likely need to pass `extraSubscription={{touched: true}}`
+ * to the `FinalSubmitButton` of the form to ensure it correctly gets enabled if the initial value
+ * set using this component is all that's necessary for the submit button to be enabled.
+ */
+export function DirtyInitialValue({field, value}) {
+  const {
+    input: {value: currentValue, onChange: setValue, onFocus, onBlur},
+  } = useField(field);
+  useEffect(() => {
+    if (currentValue) {
+      // Do not set an initial value when there is already a value
+      return;
+    }
+    setTimeout(() => {
+      onFocus();
+      setValue(value);
+      onBlur();
+    });
+  }, [currentValue, setValue, onFocus, onBlur, value]);
+  return null;
+}
+
+DirtyInitialValue.propTypes = {
+  field: PropTypes.string.isRequired,
+  value: PropTypes.any.isRequired,
 };
 
 /**

--- a/indico/web/client/js/react/forms/final-form.jsx
+++ b/indico/web/client/js/react/forms/final-form.jsx
@@ -86,28 +86,25 @@ FieldCondition.defaultProps = {
  * to the `FinalSubmitButton` of the form to ensure it correctly gets enabled if the initial value
  * set using this component is all that's necessary for the submit button to be enabled.
  */
-export function DirtyInitialValue({field, value, force = false}) {
+export function DirtyInitialValue({field, value, onUpdate = () => {}}) {
   const {
-    input: {value: currentValue, onChange: setValue, onFocus, onBlur},
+    input: {onChange: setValue, onFocus, onBlur},
   } = useField(field);
   useEffect(() => {
-    if (currentValue && !force) {
-      // Do not set an initial value when there is already a value
-      return;
-    }
     setTimeout(() => {
       onFocus();
       setValue(value);
       onBlur();
+      onUpdate();
     });
-  }, [currentValue, setValue, onFocus, onBlur, value, force]);
+  }, [onUpdate, setValue, onFocus, onBlur, value]);
   return null;
 }
 
 DirtyInitialValue.propTypes = {
   field: PropTypes.string.isRequired,
   value: PropTypes.any.isRequired,
-  force: PropTypes.bool,
+  onUpdate: PropTypes.func,
 };
 
 /**

--- a/indico/web/client/styles/modules/_reviewing.scss
+++ b/indico/web/client/styles/modules/_reviewing.scss
@@ -193,6 +193,7 @@
   .review-trigger {
     white-space: nowrap;
     align-items: center;
+    flex-basis: 50%;
 
     .judgment-btn,
     .judgment-btn.active {
@@ -210,6 +211,10 @@
         vertical-align: bottom;
       }
     }
+  }
+
+  .align-strech {
+    align-self: stretch;
   }
 }
 


### PR DESCRIPTION
Problem
When clicking on the comment box in the editing timeline, the "Judge" button disappears, creating confusion with some editors, who don't realize they have to cancel the comment before they get back the judgment button.

Solution
The Judge drop-down button will remain visible when commenting and preserve any written text when changing to a judge action.

closes #6503