### PR TITLE
Address issue with Safari/MacOS closing the date picker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,7 @@ Bugfixes
 - Allow deleting event persons which are linked to a deleted subcontribution (:pr:`6495`)
 - Fix validation error in registration form date fields when using Safari (:issue:`6474`,
   :pr:`6501`, thanks :user:`foxbunny`)
+- Fix date picker month/year navigation not working in Safari (:pr:`6505`, thanks :user:`foxbunny`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/custom_elements/ind_date_picker.js
+++ b/indico/web/client/js/custom_elements/ind_date_picker.js
@@ -183,16 +183,32 @@ customElements.define(
       });
       this.addEventListener('attrchange.value', updateCalendar);
 
+      dialog.addEventListener('pointerdown', () => {
+        // Because Safari does not focus buttons (and other elements) when they
+        // are clicked, we need to mark the dialog as having received such clicks
+        // and test for it in the close handler.
+        dialog.noImmediateClose = true;
+        setTimeout(() => {
+          // Unset with a delay to allow focusout handler to see this flag.
+          // It must still be unset so it doesn't linger on forever. The delay
+          // was chosen based on trial and error. In general, you don't want
+          // to make it shorter, but you may increase it if some browser/OS
+          // combination unsets the flag too quickly.
+          delete dialog.noImmediateClose;
+        }, 100);
+      });
+
       dialog.addEventListener('focusout', () => {
         // The focusout event is triggered on the dialog or somewhere in it.
         // We use requestAnimationFrame to allow the target element to get
         // focused so we know where the focus is going.
         requestAnimationFrame(() => {
-          // If the focus has moved to an element outside the dialog, we close
-          if (dialog.contains(document.activeElement)) {
-            return;
+          // When a button in the dialog is clicked, `noImmediateClose` is set on
+          // the dialog element. We test for the absence of this flag as well as
+          // focus escaping from the dialog as two cues to close it.
+          if (!dialog.noImmediateClose && !dialog.contains(document.activeElement)) {
+            this.open = false;
           }
-          this.open = false;
         });
       });
 


### PR DESCRIPTION
Safari closes the date picker as if thee user clicked away from it because clicking the button does not focus it. To work around this, we set a flag on all clicks happening within the dialog to signal that we don't want it closed.