### PR TITLE
Do not show future events after normal events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ Bugfixes
 - Fix date picker month/year navigation not working in Safari (:pr:`6505`, thanks :user:`foxbunny`)
 - Enforce a minimum size on the registration form picture cropper to avoid sending an empty
   image after repeated cropping (:pr:`6498`, thanks :user:`jbtwist`)
+- Fix future events being always displayed after current events in categories while not
+  logged in (:pr:`6509`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/categories/controllers/util.py
+++ b/indico/modules/categories/controllers/util.py
@@ -128,12 +128,13 @@ def get_category_view_params(category, now, is_flat=False):
     future_event_query = event_query.filter(Event.start_dt >= future_threshold)
     current_event_query = event_query.filter(Event.start_dt >= past_threshold,
                                              Event.start_dt < future_threshold)
-    json_ld_events = events = current_event_query.all()
+    events = current_event_query.all()
 
     future_event_count = future_event_query.count()
     past_event_count = past_event_query.count()
     has_hidden_events = bool(hidden_event_ids)
 
+    json_ld_events = events[:]
     if not session.user and future_event_count:
         json_ld_events += future_event_query.all()
 


### PR DESCRIPTION
This happened only while not logged in because the json-ld event list and event list were the same and both modified, instead of only adding the future events to the json-ld event list.