### PR TITLE
Open regform description links in a new tab

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Improvements
   unbookable on any other weekdays (:pr:`6439`)
 - Add global settings for min/max registration form data retention periods (:pr:`6445`,
   thanks :user:`SegiNyn`)
+- Always open links in registration form field/section descriptions in a new tab
+  (:pr:`6512`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -174,7 +174,7 @@ export default function FormItem({
         )}
         {description && (
           <div styleName="description">
-            <Markdown>{description}</Markdown>
+            <Markdown targetBlank>{description}</Markdown>
           </div>
         )}
         {renderPluginComponents(`regform-${inputType}-field-item`, inputProps)}

--- a/indico/modules/events/registration/client/js/form/FormSection.jsx
+++ b/indico/modules/events/registration/client/js/form/FormSection.jsx
@@ -47,7 +47,7 @@ export default function FormSection({
             {title}
           </div>
           <div className="i-box-description">
-            <Markdown>{description}</Markdown>
+            <Markdown targetBlank>{description}</Markdown>
           </div>
         </div>
         {setupActions && (


### PR DESCRIPTION
Clicking such a link would navigate you away from the form you are almost certainly filling out at that moment.