### PR TITLE
Allow users to login using their email address

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Improvements
 - Support ``==text==`` to highlight text in markdown (:issue:`6731`, :pr:`6732`)
 - Add an event setting to allow enforcing search before entering a person manually to
   a persons list in abstracts and contributions (:pr:`6689`)
+- Allow users to login using their email address (:pr:`6522`, thanks :user:`SegiNyn`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/cli/user.py
+++ b/indico/cli/user.py
@@ -21,6 +21,7 @@ from indico.modules.users.operations import create_user
 from indico.modules.users.util import anonymize_user, search_users
 from indico.util.console import cformat, prompt_email, prompt_pass
 from indico.util.date_time import utc_to_server
+from indico.util.string import validate_email
 
 
 @cli_group()
@@ -130,6 +131,9 @@ def create(grant_admin):
     print()
     while True:
         username = click.prompt('Enter username').lower().strip()
+        if validate_email(username, check_dns=False):
+            click.secho('The username cannot be an email address.', fg='red')
+            continue
         if not Identity.query.filter_by(provider='indico', identifier=username).has_rows():
             break
         click.secho('Username already exists', fg='red')

--- a/indico/modules/auth/auth_test.py
+++ b/indico/modules/auth/auth_test.py
@@ -9,10 +9,11 @@ from datetime import UTC, datetime
 
 import pytest
 from flask import session
-from flask_multipass import IdentityInfo, Multipass
+from flask_multipass import IdentityInfo, InvalidCredentials, Multipass, NoSuchUser
 from flask_multipass.providers.static import StaticIdentityProvider
 
 from indico.modules.auth import process_identity
+from indico.modules.auth.providers import IndicoAuthProvider
 
 
 @pytest.mark.usefixtures('db')
@@ -45,3 +46,64 @@ def test_process_identity_raises_exc_for_non_dt_hard_expiry(app):
     with app.test_request_context('/ping', method='GET'):
         with pytest.raises(ValueError):
             process_identity(identity_info)
+
+
+@pytest.mark.parametrize(('user_id', 'email', 'secondary_email', 'identifier', 'password', 'login_data',
+                          'expected_exc'), (
+    ('1', 'user1@example.com', 'user11@example.com', 'user1', 'user1RealPassword',
+     {'identifier': 'user1', 'password': 'user1RealPassword'}, None),
+    ('2', 'user2@example.com', 'user22@example.com', 'user2', 'user2RealPassword',
+     {'identifier': 'user2@example.com', 'password': 'user2RealPassword'}, None),
+    ('3', 'user3@example.com', 'user33@example.com', 'user3', 'user3RealPassword',
+     {'identifier': 'user33@example.com', 'password': 'user3RealPassword'}, None),
+    ('4', 'user4@example.com', 'user44@example.com', 'user4', 'user4RealPassword',
+     {'identifier': 'user4NoUser', 'password': 'user4RealPassword'}, NoSuchUser),
+    ('5', 'user5@example.com', 'user55@example.com', 'user5', 'user5RealPassword',
+     {'identifier': 'user5', 'password': 'user5WrongPassword'}, InvalidCredentials),
+    ('6', 'user6@example.com', 'user66@example.com', 'user6', 'user6RealPassword',
+     {'identifier': 'user6@example.com', 'password': 'user6WrongPassword'}, InvalidCredentials),
+    ('7', 'user7@example.com', 'user77@example.com', 'user7', 'user7RealPassword',
+     {'identifier': 'user77@example.com', 'password': 'user7WrongPassword'}, InvalidCredentials),
+    ('8', 'user8@example.com', 'user88@example.com', 'user8', 'user8RealPassword',
+     {'identifier': 'user888@example.com', 'password': 'user8RealPassword'}, NoSuchUser),
+))
+def test_process_local_login(app, mocker, create_user, create_identity, user_id, email, secondary_email, identifier,
+                             password, login_data, expected_exc):
+    multipass = mocker.MagicMock()
+    settings = mocker.MagicMock()
+    auth_provider = IndicoAuthProvider(multipass, 'Test provider', settings)
+
+    user = create_user(user_id, email=email)
+    user.secondary_emails.add(secondary_email)
+    create_identity(user, 'Test provider', identifier, password=password)
+
+    with app.test_request_context():
+        if expected_exc:
+            with pytest.raises(expected_exc):
+                auth_provider.process_local_login(login_data)
+        else:
+            auth_provider.process_local_login(login_data)
+            auth_provider.multipass.handle_auth_success.assert_called_once()
+
+
+def test_process_local_login_with_same_identity_and_email(mocker, create_user, create_identity):
+    multipass = mocker.MagicMock()
+    settings = mocker.MagicMock()
+    auth_provider = IndicoAuthProvider(multipass, 'Test provider', settings)
+
+    user1 = create_user(21, email='dummy@example.com')
+    user2 = create_user(23, email='mumu@example.com')
+
+    create_identity(user1, 'Test provider', 'mumu@example.com', password='dummyUserPassword')
+    create_identity(user2, 'Test provider', 'mumu', password='mumuUserPassword')
+
+    auth_provider.process_local_login({'identifier': 'mumu@example.com', 'password': 'dummyUserPassword'})
+    auth_info = multipass.handle_auth_success.call_args[0][0]
+    assert auth_info.data['identity'].identifier == 'mumu@example.com'
+
+    auth_provider.process_local_login({'identifier': 'mumu@example.com', 'password': 'mumuUserPassword'})
+    auth_info = multipass.handle_auth_success.call_args[0][0]
+    assert auth_info.data['identity'].identifier == 'mumu'
+
+    with pytest.raises(InvalidCredentials):
+        auth_provider.process_local_login({'identifier': 'mumu@example.com', 'password': 'NonePassword'})

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -39,7 +39,7 @@ from indico.util.i18n import _, force_locale
 from indico.util.marshmallow import LowercaseString, ModelField, not_empty
 from indico.util.passwords import validate_secure_password
 from indico.util.signing import secure_serializer
-from indico.util.string import crc32
+from indico.util.string import crc32, validate_email
 from indico.web.args import parser, use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import url_for
@@ -718,6 +718,8 @@ class LocalRegistrationHandler(RegistrationHandler):
             def validate_username(self, username, **kwargs):
                 if Identity.query.filter_by(provider='indico', identifier=username).has_rows():
                     raise ValidationError(_('This username is already in use.'))
+                if validate_email(username, check_dns=False):
+                    raise ValidationError(_('Your username cannot be an email address.'))
 
             @validates_schema(skip_on_field_errors=False)
             def validate_password(self, data, **kwargs):

--- a/indico/modules/auth/providers.py
+++ b/indico/modules/auth/providers.py
@@ -5,20 +5,21 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from flask import session
-from flask_multipass.providers.sqlalchemy import SQLAlchemyAuthProviderBase, SQLAlchemyIdentityProviderBase
+from flask import flash, session
+from flask_multipass import AuthInfo, AuthProvider, InvalidCredentials, NoSuchUser
+from flask_multipass.providers.sqlalchemy import SQLAlchemyIdentityProviderBase
 
+from indico.core.db import db
 from indico.modules.auth import Identity, logger
 from indico.modules.auth.forms import LocalLoginForm
 from indico.modules.users import User
+from indico.modules.users.models.emails import UserEmail
+from indico.util.i18n import _
 from indico.util.passwords import validate_secure_password
 
 
-class IndicoAuthProvider(SQLAlchemyAuthProviderBase):
+class IndicoAuthProvider(AuthProvider):
     login_form = LocalLoginForm
-    identity_model = Identity
-    provider_column = Identity.provider
-    identifier_column = Identity.identifier
     multi_instance = False
 
     def check_password(self, identity, password):
@@ -29,6 +30,39 @@ class IndicoAuthProvider(SQLAlchemyAuthProviderBase):
             logger.warning('Account %s logged in with an insecure password: %s', identity.identifier, error)
             session['insecure_password_error'] = error
         return True
+
+    def process_local_login(self, data):
+        # Query identities either by (user-settable) username or by email address.
+        # In some very rare edge cases we can get more than one, e.g. when a user has an old identity
+        # with a username that happens to be the email address of another user (this is no longer possible,
+        # but existing accounts could have it).
+        identities = (
+            Identity.query
+            .join(User)
+            .join(UserEmail)
+            .filter(Identity.provider == self.name,
+                    db.or_(Identity.identifier == data['identifier'],
+                           UserEmail.email == data['identifier']),
+                    ~User.is_pending,
+                    ~UserEmail.is_user_deleted)
+            .order_by(Identity.id)
+            .all()
+        )
+        # If we have no matching identities we fail with invalid username
+        # XXX This is intentional, having an account on an Indico instance is generally not considered
+        # secret information, and we want to give users the benefit of more verbose error messages.
+        if not identities:
+            raise NoSuchUser(provider=self)
+        # From all the matching identities (usually just one), get one where the password matches, or
+        # fail with invalid-password if there is none.
+        if not (identity := next((ide for ide in identities if self.check_password(ide, data['password'])), None)):
+            raise InvalidCredentials(provider=self)
+        if data['identifier'] != identity.identifier and data['identifier'] in identity.user.secondary_emails:
+            flash(_('You are logging in with a secondary email address. Please note that account related '
+                    'notifications will always be sent to your primary email address. Go to "My profile" to '
+                    'manage your emails.'), 'warning')
+        auth_info = AuthInfo(self, identity=identity)
+        return self.multipass.handle_auth_success(auth_info)
 
 
 class IndicoIdentityProvider(SQLAlchemyIdentityProviderBase):


### PR DESCRIPTION
As discussed, this pr is to allow users to login with an email address linked to their account in place of their username, using the same credentials. So the email address will be checked and accepted for login if the password matches the one they already use to login with their username. 
It also prevents using an email address as username. This is to avoid using an email address linked to another account as your username.  