### PR TITLE
Fix not passing date format to DatePicker

### DIFF
--- a/indico/web/client/js/react/components/DatePicker.jsx
+++ b/indico/web/client/js/react/components/DatePicker.jsx
@@ -35,7 +35,7 @@ export default function DatePicker({
   const formattedValue = formatDate(format, fromISOLocalDate(value));
 
   return (
-    <ind-date-picker>
+    <ind-date-picker format={format}>
       <input
         type="text"
         onChange={handleDateChange}


### PR DESCRIPTION
This fixes a regression after an earlier refactor where I changed the format-passing to a proper attribute.
