### PR TITLE
Fix image sizing issue with picture field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,8 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- Nothing so far :)
+- Make picture field more resilient when uploading and resizing pictures close to
+  the max upload file size (:pr:`6530`, thanks :user:`SegiNyn`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -110,7 +110,7 @@ const PictureManager = ({
   }, [picturePreview, previewURL, isInitialPicture]);
 
   const deleteUploadedPicture = useCallback(() => {
-    if (uploadFinished || pictureState.picture !== null) {
+    if (uploadFinished || (pictureState.picture !== null && pictureState.picture.uuid !== null)) {
       deleteFile(pictureState.picture.uuid);
     }
   }, [uploadFinished, pictureState.picture]);
@@ -197,7 +197,9 @@ const PictureManager = ({
   const onImageCrop = () => {
     if (cropperRef.current.cropper !== undefined) {
       const settings = {minWidth: 25, minHeight: 25};
-      const imageSrc = cropperRef.current.cropper.getCroppedCanvas(settings).toDataURL();
+      const imageSrc = cropperRef.current.cropper
+        .getCroppedCanvas(settings)
+        .toDataURL('image/jpeg');
       setPicturePreview(imageSrc);
       fetch(imageSrc)
         .then(res => res.blob())


### PR DESCRIPTION
Unfortunately, there was an issue with the MAX_UPLOAD_FILE_SIZE check validation workflow for the picture field. 
Example scenario: if the MAX_UPLOAD_FILE_SIZE is set as 12MB, when an image less than 12MB but still large e.g 11MB is uploaded into the dropzone then it is accepted and then goes through the cropper which ends up returning an image that may be larger than the 12MB, especially if the original image was .png. When this image is checked again at `def validate_upload_file_size`, the validation then fails. 

This issue with the cropped image being bigger is mention in the cropper library with a workaround https://github.com/fengyuanchen/cropperjs?tab=readme-ov-file#known-issues