### PR TITLE
Fix display picture in non-merged participant list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Bugfixes
 - Fix the order of the event classifications in edit mode (:issue:`6531`, :pr:`6534`)
 - Fix an issue where scheduling a contribution on a day with an empty timetable would
   schedule it on the first day of the event instead (:issue:`6540`, :pr:`6541`)
+- Fix error in unmerged participant list when the picture field is enabled and participant
+  list columns have not been customized for that registration form (:pr:`6535`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -647,9 +647,9 @@ class RHParticipantListPictureDownload(RHParticipantList):
                 # only main picture from personal data is in merged form
                 raise Forbidden('Picture field is not the standard one')
         else:
-            participant_list_form_columns = registration_settings.get(self.event, 'participant_list_form_columns')
-            if (self.data.field_data.field_id not in
-                    participant_list_form_columns[str(request.view_args['reg_form_id'])]):
+            form = self.registration.registration_form
+            participant_list_form_columns = registration_settings.get_participant_list_columns(self.event, form)
+            if (self.data.field_data.field_id not in participant_list_form_columns):
                 raise Forbidden('Picture field is not exposed in participant list')
         is_participant = self.registration.event.is_user_registered(session.user)
         if not self.registration.is_publishable(is_participant):

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -649,7 +649,7 @@ class RHParticipantListPictureDownload(RHParticipantList):
         else:
             form = self.registration.registration_form
             participant_list_form_columns = registration_settings.get_participant_list_columns(self.event, form)
-            if (self.data.field_data.field_id not in participant_list_form_columns):
+            if self.data.field_data.field_id not in participant_list_form_columns:
                 raise Forbidden('Picture field is not exposed in participant list')
         is_participant = self.registration.event.is_user_registered(session.user)
         if not self.registration.is_publishable(is_participant):


### PR DESCRIPTION
Fix error display picture in non-merged participant list.
Cause:
direct reference to `registration_settings.get(self.event, 'participant_list_form_columns')` can't be used in check_access of RHParticipantListPictureDownload, as that setting isn't updated when forms contain default values.
