### PR TITLE
Fix issues with custom elements that use ElementInternals on Safari

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Bugfixes
   schedule it on the first day of the event instead (:issue:`6540`, :pr:`6541`)
 - Fix error in unmerged participant list when the picture field is enabled and participant
   list columns have not been customized for that registration form (:pr:`6535`)
+- Fix breakage of combobox (and any custom element that uses `ElementInternals`) in
+  older versions of Safari (:pr:`6549`, :thanks:`foxbunny`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,8 +25,9 @@ Bugfixes
   schedule it on the first day of the event instead (:issue:`6540`, :pr:`6541`)
 - Fix error in unmerged participant list when the picture field is enabled and participant
   list columns have not been customized for that registration form (:pr:`6535`)
-- Fix breakage of combobox (and any custom element that uses `ElementInternals`) in
-  older versions of Safari (:pr:`6549`, :thanks:`foxbunny`)
+- Fix breakage of the registration form dropdown field (and anything else using a custom
+  element that uses ``ElementInternals``) in older versions of Safari (:pr:`6549`,
+  :thanks:`foxbunny`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/index.js
+++ b/indico/web/client/js/index.js
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 import 'core-js/es';
+import 'element-internals-polyfill';
 
 import './legacy/presentation.js';
 import './legacy/indico.js';

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "connected-react-router": "^6.9.2",
         "core-js": "^3.32.0",
         "dropzone": "^5.9.3",
+        "element-internals-polyfill": "^1.3.11",
         "file-selector": "^0.6.0",
         "final-form": "^4.20.7",
         "final-form-arrays": "^3.0.2",
@@ -7205,6 +7206,11 @@
       "version": "1.4.828",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.828.tgz",
       "integrity": "sha512-QOIJiWpQJDHAVO4P58pwb133Cwee0nbvy/MV1CwzZVGpkH1RX33N3vsaWRCpR6bF63AAq366neZrRTu7Qlsbbw=="
+    },
+    "node_modules/element-internals-polyfill": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/element-internals-polyfill/-/element-internals-polyfill-1.3.11.tgz",
+      "integrity": "sha512-SQLQNVY4wMdpnP/F/HtalJbpEenQd46Avtjm5hvUdeTs3QU0zHFNX5/AmtQIPPcfzePb0ipCkQGY4GwYJIhLJA=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "connected-react-router": "^6.9.2",
     "core-js": "^3.32.0",
     "dropzone": "^5.9.3",
+    "element-internals-polyfill": "^1.3.11",
     "file-selector": "^0.6.0",
     "final-form": "^4.20.7",
     "final-form-arrays": "^3.0.2",


### PR DESCRIPTION
- Adds a polyfill to add ElementInternals on older browsers
- Expected performance impact limited to browsers without native ElementInternals support
