### PR TITLE
Fix markdown code block display in survey sections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Bugfixes
 - Fix breakage of the registration form dropdown field (and anything else using a custom
   element that uses ``ElementInternals``) in older versions of Safari (:pr:`6549`,
   :thanks:`foxbunny`)
+- Fix linebreak display in markdown code blocks in survey section descriptions (:pr:`6553`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/surveys/fields/base.py
+++ b/indico/modules/events/surveys/fields/base.py
@@ -16,7 +16,8 @@ from indico.web.forms.widgets import SwitchWidget
 
 class SurveyFieldConfigForm(IndicoForm):
     title = StringField(_('Title'), [DataRequired()], description=_('The title of the question'))
-    description = TextAreaField(_('Description'), description=_("The description (shown below the question's field.)"))
+    description = TextAreaField(_('Description'), description=_("The description (shown below the question's field). "
+                                                                'You may use Markdown for formatting.'))
     is_required = BooleanField(_('Required'), widget=SwitchWidget(),
                                description=_('If the user has to answer the question.'))
 

--- a/indico/modules/events/surveys/forms.py
+++ b/indico/modules/events/surveys/forms.py
@@ -94,7 +94,7 @@ class SectionForm(IndicoForm):
     title = StringField(_('Title'), [HiddenUnless('display_as_section', preserve_data=True), DataRequired()],
                         description=_('The title of the section.'))
     description = TextAreaField(_('Description'), [HiddenUnless('display_as_section', preserve_data=True)],
-                                description=_('The description text of the section.'))
+                                description=_('You may use Markdown for formatting.'))
 
 
 class TextForm(IndicoForm):

--- a/indico/modules/events/surveys/templates/display/survey_questionnaire.html
+++ b/indico/modules/events/surveys/templates/display/survey_questionnaire.html
@@ -20,8 +20,7 @@
 {% block content %}
     {{ form_header(form, id='survey-questionnaire', orientation='vertical') }}
     {% for section in survey.sections if section.children %}
-        {% call form_fieldset(section.title, section.description|replace('\n', '<br>'|safe),
-                              render_as_fieldset=section.display_as_section) %}
+        {% call form_fieldset(section.title, section.description, render_as_fieldset=section.display_as_section) %}
             {% for item in section.children %}
                 {% if item.type.name == 'question' %}
                     {{ form_row(form['question_{}'.format(item.id)]) }}


### PR DESCRIPTION
There was some very old code that replaced linebreaks with html linebreaks, but being a markdown string this was unnecessary and resulted in `<br>` being shown.

Also made it clearer that Markdown can be used there.