### PR TITLE
Enforce browser caching in `send_file()` for event logos etc.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Improvements
 - Include information about attached files in JSON export of abstracts (:pr:`6556`)
 - Take session program codes into account when sorting parallel sessions with the same start time
   in meeting timetable (:pr:`6575`)
+- Enforce browser-side caching of event logos and custom stylesheets (:issue:`6555`, :pr:`6559`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -73,7 +73,7 @@ class RHCategoryIcon(RHDisplayCategoryBase):
             raise NotFound
         metadata = self.category.icon_metadata
         return send_file(metadata['filename'], BytesIO(self.category.icon), mimetype=metadata['content_type'],
-                         conditional=True)
+                         conditional=True, no_cache=False)
 
 
 class RHCategoryLogo(RHDisplayCategoryBase):
@@ -84,7 +84,7 @@ class RHCategoryLogo(RHDisplayCategoryBase):
             raise NotFound
         metadata = self.category.logo_metadata
         return send_file(metadata['filename'], BytesIO(self.category.logo), mimetype=metadata['content_type'],
-                         conditional=True)
+                         conditional=True, no_cache=False)
 
 
 class RHCategoryStatisticsJSON(RHDisplayCategoryBase):

--- a/indico/modules/events/layout/controllers/layout.py
+++ b/indico/modules/events/layout/controllers/layout.py
@@ -281,4 +281,5 @@ class RHLayoutCSSDisplay(RHDisplayEventBase):
         if not self.event.has_stylesheet:
             raise NotFound
         data = BytesIO(self.event.stylesheet.encode())
-        return send_file(self.event.stylesheet_metadata['filename'], data, mimetype='text/css', conditional=True)
+        return send_file(self.event.stylesheet_metadata['filename'], data, mimetype='text/css', conditional=True,
+                         no_cache=False)

--- a/indico/modules/events/layout/controllers/layout.py
+++ b/indico/modules/events/layout/controllers/layout.py
@@ -266,7 +266,7 @@ class RHLogoDisplay(RHDisplayEventBase):
             raise NotFound
         metadata = self.event.logo_metadata
         return send_file(metadata['filename'], BytesIO(self.event.logo), mimetype=metadata['content_type'],
-                         conditional=True)
+                         conditional=True, no_cache=False)
 
 
 class RHLayoutCSSDisplay(RHDisplayEventBase):

--- a/indico/web/flask/util.py
+++ b/indico/web/flask/util.py
@@ -276,6 +276,9 @@ def send_file(name, path_or_fd, mimetype, last_modified=None, no_cache=True, inl
         raise NotFound(f'File not found: {path_or_fd}')
     if safe:
         rv.headers.add('Content-Security-Policy', "script-src 'self'; object-src 'self'")
+    if not no_cache:
+        del rv.cache_control.no_cache
+        rv.cache_control.max_age = 86400  # cache content for 24 hours
     # if the request is conditional, then caching shouldn't be disabled
     if not conditional and no_cache:
         del rv.expires

--- a/indico/web/flask/util.py
+++ b/indico/web/flask/util.py
@@ -239,8 +239,8 @@ def _is_office_mimetype(mimetype):
     return False
 
 
-def send_file(name, path_or_fd, mimetype, last_modified=None, no_cache=True, inline=None, conditional=False, safe=True,
-              **kwargs):
+def send_file(name, path_or_fd, mimetype, *, last_modified=None, no_cache=True, inline=None,
+              max_age=86400, conditional=False, safe=True, **kwargs):
     """Send a file to the user.
 
     `name` is required and should be the filename visible to the user.
@@ -255,6 +255,8 @@ def send_file(name, path_or_fd, mimetype, last_modified=None, no_cache=True, inl
     the file only if it has been modified (based on mtime and size). Setting it will override `no_cache`.
     `safe` adds some basic security features such a adding a content-security-policy and forcing inline=False for
     text/html mimetypes
+    `max_age` sets the number of seconds to cache a file for in the browser - defaults to 86400 seconds (24 hours). This
+    can only be used in combination with `no_cache=False`.
     """
     name = re.sub(r'\s+', ' ', name).strip()  # get rid of crap like linebreaks
     assert '/' in mimetype
@@ -267,6 +269,8 @@ def send_file(name, path_or_fd, mimetype, last_modified=None, no_cache=True, inl
         inline = False
     if safe and mimetype in ('text/html', 'image/svg+xml'):
         inline = False
+    if not no_cache:
+        kwargs['max_age'] = max_age
     try:
         rv = _send_file(path_or_fd, mimetype=mimetype, as_attachment=(not inline), download_name=name,
                         conditional=conditional, last_modified=last_modified, **kwargs)
@@ -276,10 +280,6 @@ def send_file(name, path_or_fd, mimetype, last_modified=None, no_cache=True, inl
         raise NotFound(f'File not found: {path_or_fd}')
     if safe:
         rv.headers.add('Content-Security-Policy', "script-src 'self'; object-src 'self'")
-    if not no_cache:
-        del rv.cache_control.no_cache
-        rv.cache_control.max_age = 86400  # cache content for 24 hours
-    # if the request is conditional, then caching shouldn't be disabled
     if not conditional and no_cache:
         del rv.expires
         del rv.cache_control.max_age


### PR DESCRIPTION
This PR allows the `send_file()` method to send a `max_age` cache control header, so that content (e.g. images - such as large event logos etc.) is properly cached in the browser.

Closes: #6555