### PR TITLE
Rename "manager_notifications" to "registration_notifications"

### DIFF
--- a/indico/modules/events/registration/controllers/display_test.py
+++ b/indico/modules/events/registration/controllers/display_test.py
@@ -58,8 +58,8 @@ def test_RHRegistrationForm_can_register(db, dummy_regform, dummy_reg, dummy_use
 def test_withdraw_registration_rh(smtp, dummy_regform, dummy_reg, dummy_user):
     # Register the user and enable manager notifications
     dummy_regform.start_dt = now_utc(False)
-    dummy_regform.manager_notifications_enabled = True
-    dummy_regform.manager_notification_recipients = ['mgr@example.test']
+    dummy_regform.organizer_notifications_enabled = True
+    dummy_regform.organizer_notification_recipients = ['mgr@example.test']
     session.set_session_user(dummy_user)
 
     # Set up request

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -58,8 +58,8 @@ class RegistrationFormEditForm(IndicoForm):
     _price_fields = ('currency', 'base_price')
     _registrant_notification_fields = ('notification_sender_address', 'message_pending', 'message_unpaid',
                                        'message_complete', 'attach_ical')
-    _manager_notification_fields = ('manager_notifications_enabled', 'manager_notification_recipients')
-    _special_fields = _price_fields + _registrant_notification_fields + _manager_notification_fields
+    _organizer_notification_fields = ('organizer_notifications_enabled', 'organizer_notification_recipients')
+    _special_fields = _price_fields + _registrant_notification_fields + _organizer_notification_fields
 
     title = StringField(_('Title'), [DataRequired()], description=_('The title of the registration form'))
     introduction = TextAreaField(_('Introduction'),
@@ -113,12 +113,16 @@ class RegistrationFormEditForm(IndicoForm):
         widget=SwitchWidget(),
         description=_('Attach an iCalendar file to the mail sent once a registration is complete')
     )
-    manager_notifications_enabled = BooleanField(_('Enabled'), widget=SwitchWidget(),
-                                                 description=_('Enable notifications to managers about registrations'))
-    manager_notification_recipients = EmailListField(_('List of recipients'),
-                                                     [HiddenUnless('manager_notifications_enabled',
-                                                                   preserve_data=True), DataRequired()],
-                                                     description=_('Email addresses that will receive notifications'))
+    organizer_notifications_enabled = BooleanField(
+        _('Enabled'),
+        widget=SwitchWidget(),
+        description=_('Enable e-mail notifications about registrations to organizers'),
+    )
+    organizer_notification_recipients = EmailListField(
+        _('List of recipients'),
+        [HiddenUnless('organizer_notifications_enabled', preserve_data=True), DataRequired()],
+        description=_('Email addresses that will receive notifications'),
+    )
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -227,14 +227,16 @@ class RegistrationForm(db.Model):
         nullable=False,
         default=False
     )
-    #: Whether the manager notifications for this event are enabled
-    manager_notifications_enabled = db.Column(
+    #: Whether the organizer notifications for this event are enabled
+    organizer_notifications_enabled = db.Column(
+        'manager_notifications_enabled',
         db.Boolean,
         nullable=False,
         default=False
     )
-    #: List of emails that should receive management notifications
-    manager_notification_recipients = db.Column(
+    #: List of emails that should receive organizer notifications
+    organizer_notification_recipients = db.Column(
+        'manager_notification_recipients',
         ARRAY(db.String),
         nullable=False,
         default=[]

--- a/indico/modules/events/registration/notifications.py
+++ b/indico/modules/events/registration/notifications.py
@@ -51,7 +51,7 @@ def _notify_registration(registration, template_name, *, to_managers=False, atta
     if include_pictures:
         attachments += registration.get_picture_attachments()
     to_list = (
-        registration.email if not to_managers else registration.registration_form.manager_notification_recipients
+        registration.email if not to_managers else registration.registration_form.organizer_notification_recipients
     )
     from_address = registration.registration_form.notification_sender_address if not to_managers else None
     with registration.event.force_event_locale(registration.user if not to_managers else None,
@@ -72,7 +72,7 @@ def notify_registration_creation(registration, *, from_management=False, notify_
     if notify_user:
         _notify_registration(registration, 'registration_creation_to_registrant.html',
                              allow_session_locale=(not from_management), include_pictures=True)
-    if registration.registration_form.manager_notifications_enabled:
+    if registration.registration_form.organizer_notifications_enabled:
         _notify_registration(registration, 'registration_creation_to_managers.html', to_managers=True,
                              include_pictures=True)
 
@@ -83,7 +83,7 @@ def notify_registration_modification(registration, *, from_management=False, not
         _notify_registration(registration, 'registration_modification_to_registrant.html',
                              diff=diff, old_price=old_price, allow_session_locale=(not from_management),
                              include_pictures=True)
-    if registration.registration_form.manager_notifications_enabled:
+    if registration.registration_form.organizer_notifications_enabled:
         _notify_registration(registration, 'registration_modification_to_managers.html', to_managers=True,
                              diff=diff, old_price=old_price, include_pictures=True)
 
@@ -91,13 +91,13 @@ def notify_registration_modification(registration, *, from_management=False, not
 def notify_registration_state_update(registration, *, attach_rejection_reason=False, from_management=False):
     _notify_registration(registration, 'registration_state_update_to_registrant.html',
                          attach_rejection_reason=attach_rejection_reason, allow_session_locale=(not from_management))
-    if registration.registration_form.manager_notifications_enabled:
+    if registration.registration_form.organizer_notifications_enabled:
         _notify_registration(registration, 'registration_state_update_to_managers.html', to_managers=True)
 
 
 def notify_registration_receipt_created(registration, receipt, notify_user=True):
     if notify_user:
         _notify_registration(registration, 'registration_receipt_created_to_registrant.html', receipt=receipt)
-    if registration.registration_form.manager_notifications_enabled:
+    if registration.registration_form.organizer_notifications_enabled:
         _notify_registration(registration, 'registration_receipt_created_to_managers.html', to_managers=True,
                              receipt=receipt)

--- a/indico/modules/events/registration/operations.py
+++ b/indico/modules/events/registration/operations.py
@@ -34,8 +34,8 @@ def _log_registration_form_update(regform, changes, extra_log_fields):
         'message_unpaid': 'Message for unpaid',
         'message_complete': 'Message for complete',
         'attach_ical': 'Attach iCalendar file',
-        'manager_notifications_enabled': 'Notify managers',
-        'manager_notification_recipients': 'Notification recipients',
+        'organizer_notifications_enabled': 'Notify organizers',
+        'organizer_notification_recipients': 'Notification recipients',
         **(extra_log_fields or {})
     }
     regform.log(EventLogRealm.management, LogKind.change, 'Registration',

--- a/indico/modules/events/registration/templates/management/regform_edit.html
+++ b/indico/modules/events/registration/templates/management/regform_edit.html
@@ -19,8 +19,8 @@
     {% call form_fieldset(_('Notifications for registrants')) %}
         {{ form_rows(form, fields=form._registrant_notification_fields) }}
     {% endcall %}
-    {% call form_fieldset(_('Notifications for managers')) %}
-        {{ form_rows(form, fields=form._manager_notification_fields) }}
+    {% call form_fieldset(_('Notifications for organizers')) %}
+        {{ form_rows(form, fields=form._organizer_notification_fields) }}
     {% endcall %}
     {% call form_footer(form) %}
         <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}"


### PR DESCRIPTION
The "Notifications for managers" field set in the "general settings" of a Registation Form is a misnomer. These notifications are not sent to the managers necessarily, but to a list of e-mails which shows up below.
I propose renaming it "Notifications for organizers", and then the variables/columns from `manager_*` to `organizer_*`.

![image](https://github.com/user-attachments/assets/a4e57825-f635-47a2-b663-a9a9d323f994)
