### PR TITLE
Refactor i18n CLI

### DIFF
--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -48,6 +48,7 @@ DEFAULT_OPTIONS = {
         'output_file': MESSAGES_POT,
         'mapping_file': 'babel.cfg',
         'input_paths': ['indico'],
+        'add_location': 'file',
         'project': 'Indico',
         'version': indico.__version__,
     },
@@ -74,6 +75,7 @@ DEFAULT_OPTIONS = {
         'mapping_file': 'babel-js.cfg',
         'no_default_keywords': True,
         'input_paths': ['indico'],
+        'add_location': 'file',
         'project': 'Indico',
         'version': indico.__version__,
     },
@@ -302,10 +304,13 @@ def extract_messages_react(directory: Path = INDICO_DIR):
             return
         paths = [client_path]
     with _chdir(INDICO_DIR):
-        output = subprocess.check_output(
-            ['npx', 'react-jsx-i18n', 'extract', '--ext', 'js,jsx,ts,tsx', '--base', directory, *paths],
-            env=dict(os.environ, FORCE_COLOR='1')
-        )
+        output = subprocess.check_output([
+            'npx', 'react-jsx-i18n', 'extract',
+            '--ext', 'js,jsx,ts,tsx',
+            '--base', directory,
+            '--add-location', 'file',
+            *paths
+        ], env=dict(os.environ, FORCE_COLOR='1'))
     _get_messages_react_pot(directory).write_bytes(output)
 
 

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -298,14 +298,9 @@ def extract_messages_react(directory: Path = INDICO_DIR):
         packages = [x.parent.name for x in directory.glob('*/__init__.py')]
         assert len(packages) == 1
         client_path = directory / packages[0] / 'client'
-        module_path = directory / packages[0] / 'modules'
-        paths = []
-        if client_path.exists():
-            paths.append(client_path)
-        if module_path.exists():
-            paths.append(module_path)
-        if not paths:
+        if not client_path.exists():
             return
+        paths = [client_path]
     with _chdir(INDICO_DIR):
         output = subprocess.check_output(
             ['npx', 'react-jsx-i18n', 'extract', '--ext', 'js,jsx,ts,tsx', '--base', directory, *paths],

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "react-final-form": "^6.5.9",
         "react-final-form-arrays": "^3.1.3",
         "react-final-form-listeners": "^1.0.3",
-        "react-jsx-i18n": "^0.7.0",
+        "react-jsx-i18n": "^0.8.0",
         "react-leaflet": "^2.8.0",
         "react-leaflet-draw": "0.19.0",
         "react-leaflet-markercluster": "^2.0.0",
@@ -14667,9 +14667,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-jsx-i18n": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/react-jsx-i18n/-/react-jsx-i18n-0.7.0.tgz",
-      "integrity": "sha512-xrX+aNuqShcosJEQPVnZUU6HW916oR5181D0dvqL/kP13T45OErG171F3ZgMfTVAGQ6G+G3PR/lG+mAG1fIXVQ==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/react-jsx-i18n/-/react-jsx-i18n-0.8.0.tgz",
+      "integrity": "sha512-KFu/0h+KwIE+XAQIjNHnj0yN7mxh/esWzdVCXRvAbYLJ6hiZeYgVD2SXc+Pkzz/pw/PrOk+VN2OjZxk6WGwU9Q==",
       "dependencies": {
         "babel-plugin-extract-text": "^2.0.0",
         "chalk": "^2.4.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "react-final-form": "^6.5.9",
         "react-final-form-arrays": "^3.1.3",
         "react-final-form-listeners": "^1.0.3",
-        "react-jsx-i18n": "^0.6.0",
+        "react-jsx-i18n": "^0.7.0",
         "react-leaflet": "^2.8.0",
         "react-leaflet-draw": "0.19.0",
         "react-leaflet-markercluster": "^2.0.0",
@@ -14667,9 +14667,9 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-jsx-i18n": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/react-jsx-i18n/-/react-jsx-i18n-0.6.0.tgz",
-      "integrity": "sha512-Yy8BexC1GOZdQzx8AK5zu5p12LtBLx4/2t4MHwfcgiVL7/9l0rim/n2iAKKC/lkHGr5NAi4C0tmjPuHfn31xrw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/react-jsx-i18n/-/react-jsx-i18n-0.7.0.tgz",
+      "integrity": "sha512-xrX+aNuqShcosJEQPVnZUU6HW916oR5181D0dvqL/kP13T45OErG171F3ZgMfTVAGQ6G+G3PR/lG+mAG1fIXVQ==",
       "dependencies": {
         "babel-plugin-extract-text": "^2.0.0",
         "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-final-form": "^6.5.9",
     "react-final-form-arrays": "^3.1.3",
     "react-final-form-listeners": "^1.0.3",
-    "react-jsx-i18n": "^0.7.0",
+    "react-jsx-i18n": "^0.8.0",
     "react-leaflet": "^2.8.0",
     "react-leaflet-draw": "0.19.0",
     "react-leaflet-markercluster": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-final-form": "^6.5.9",
     "react-final-form-arrays": "^3.1.3",
     "react-final-form-listeners": "^1.0.3",
-    "react-jsx-i18n": "^0.6.0",
+    "react-jsx-i18n": "^0.7.0",
     "react-leaflet": "^2.8.0",
     "react-leaflet-draw": "0.19.0",
     "react-leaflet-markercluster": "^2.0.0",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[compile_catalog]
-directory = indico/translations
-
 [pep257]
 ignore = D100,D203,D105,D213
 


### PR DESCRIPTION
Since I ended up doing more refactoring on the i18n cli beyond what was needed for removing the setuptools dependency, I extracted this from #6552 into its own PR.

- Removed the legacy setuptools/distutils stuff from the CLI
- Switched to using pathlib consistently in the CLI
- Removed the very broken transifex pull/push commands for plugins
- Removed an unnecessary check for a directory that is never used in plugins
- Removed line numbers from pot files (ie only the file paths are kept), making updates to those files way less noisy