### PR TITLE
Align event labels

### DIFF
--- a/indico/web/client/styles/legacy/Conf_Basic.scss
+++ b/indico/web/client/styles/legacy/Conf_Basic.scss
@@ -30,6 +30,7 @@
 .confheader .event-label {
   margin-left: 1em !important;
   text-transform: uppercase;
+  vertical-align: 50%;
 }
 
 .confLogoBox {

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -419,6 +419,7 @@ ul.category-resource-qtip {
 
     .ui.label {
       text-transform: uppercase;
+      vertical-align: 20%;
     }
   }
 }

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -233,6 +233,7 @@ div.event-header {
   .event-label {
     margin-left: 1em !important;
     text-transform: uppercase;
+    vertical-align: 50%;
   }
 }
 


### PR DESCRIPTION
This PR better aligns the event labels.

Before:
![image](https://github.com/user-attachments/assets/805e74cd-2a21-498d-8b0d-4c836b9af550)

After:
![image](https://github.com/user-attachments/assets/9f5a871a-1d28-4548-a915-f3a91d236150)
