### PR TITLE
Ensure event logo takes all page content width

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ Improvements
 - Take session program codes into account when sorting parallel sessions with the same start time
   in meeting timetable (:pr:`6575`)
 - Enforce browser-side caching of event logos and custom stylesheets (:issue:`6555`, :pr:`6559`)
+- Default to banner-style (full width) logos in newly created conference events (:pr:`6572`,
+  thanks :user:`omegak`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20241018_1501_34f27622213b_add_header_logo_as_banner_setting_for_events.py
+++ b/indico/migrations/versions/20241018_1501_34f27622213b_add_header_logo_as_banner_setting_for_events.py
@@ -1,0 +1,32 @@
+"""Add header_logo_as_banner setting for events
+
+Revision ID: 34f27622213b
+Revises: 75db3a4a4ed4
+Create Date: 2024-10-18 15:01:53.443953
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '34f27622213b'
+down_revision = '75db3a4a4ed4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Make existing conferences with logos use the old header style
+    op.execute('''
+        INSERT INTO events.settings (module, name, event_id, value)
+        SELECT 'layout', 'header_logo_as_banner', id, 'false'::jsonb
+        FROM events.events WHERE type = 3 and logo_metadata != 'null'
+        ON CONFLICT (module, name, event_id) DO NOTHING;
+    ''')
+
+
+def downgrade():
+    op.execute('''
+        DELETE FROM events.settings
+        WHERE module = 'layout' AND name = 'header_logo_as_banner';
+    ''')

--- a/indico/modules/events/layout/__init__.py
+++ b/indico/modules/events/layout/__init__.py
@@ -21,6 +21,8 @@ from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.menu import SideMenuItem
 
+EVENT_BANNER_WIDTH = 950
+EVENT_LOGO_WIDTH = 200
 
 logger = Logger.get('events.layout')
 layout_settings = EventSettingsProxy('layout', {
@@ -30,6 +32,7 @@ layout_settings = EventSettingsProxy('layout', {
     'name_format': None,
     'show_banner': False,
     'header_text_color': '',
+    'header_logo_as_banner': True,
     'header_background_color': '',
     'announcement': None,
     'show_announcement': False,

--- a/indico/modules/events/layout/__init__.py
+++ b/indico/modules/events/layout/__init__.py
@@ -21,6 +21,7 @@ from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.menu import SideMenuItem
 
+
 EVENT_BANNER_WIDTH = 950
 EVENT_LOGO_WIDTH = 200
 

--- a/indico/modules/events/layout/controllers/layout.py
+++ b/indico/modules/events/layout/controllers/layout.py
@@ -42,19 +42,11 @@ class RHLayoutBase(RHManageEventBase):
     def _check_and_flash_logo_warnings(self, logo):
         header_logo_as_banner = layout_settings.get(self.event, 'header_logo_as_banner')
         if header_logo_as_banner and logo.width < EVENT_BANNER_WIDTH * 0.8:
-            flash(self.event_banner_too_small_msg, 'warning')
+            flash(_('The event logo is too small. It is recommended to use a logo with a width of at least {}px.')
+                  .format(EVENT_BANNER_WIDTH), 'warning')
         if not header_logo_as_banner and logo.width > EVENT_LOGO_WIDTH * 1.2:
-            flash(self.event_logo_too_large_msg, 'warning')
-
-    @property
-    def event_banner_too_small_msg(self):
-        return (_('The event logo is too small. It is recommended to use a logo with a width of at least {}px.')
-                .format(EVENT_BANNER_WIDTH))
-
-    @property
-    def event_logo_too_large_msg(self):
-        return (_('The event logo is too large. It is recommended to use a logo with a width of at most {}px.')
-                .format(EVENT_LOGO_WIDTH))
+            flash(_('The event logo is too large. It is recommended to use a logo with a width of at most {}px.')
+                  .format(EVENT_LOGO_WIDTH), 'warning')
 
 
 def _make_theme_settings_form(event, theme):

--- a/indico/modules/events/layout/controllers/layout.py
+++ b/indico/modules/events/layout/controllers/layout.py
@@ -17,7 +17,7 @@ from wtforms.validators import DataRequired
 from indico.core.db import db
 from indico.modules.events import EventLogRealm
 from indico.modules.events.controllers.base import RegistrationRequired, RHDisplayEventBase
-from indico.modules.events.layout import layout_settings, logger, theme_settings
+from indico.modules.events.layout import EVENT_BANNER_WIDTH, EVENT_LOGO_WIDTH, layout_settings, logger, theme_settings
 from indico.modules.events.layout.forms import (ConferenceLayoutForm, CSSForm, CSSSelectionForm,
                                                 LectureMeetingLayoutForm, LogoForm)
 from indico.modules.events.layout.util import get_css_file_data, get_css_url, get_js_url, get_logo_data
@@ -39,7 +39,22 @@ from indico.web.util import _pop_injected_js, jsonify_data
 
 
 class RHLayoutBase(RHManageEventBase):
-    pass
+    def _check_and_flash_logo_warnings(self, logo):
+        header_logo_as_banner = layout_settings.get(self.event, 'header_logo_as_banner')
+        if header_logo_as_banner and logo.width < EVENT_BANNER_WIDTH * 0.8:
+            flash(self.event_banner_too_small_msg, 'warning')
+        if not header_logo_as_banner and logo.width > EVENT_LOGO_WIDTH * 1.2:
+            flash(self.event_logo_too_large_msg, 'warning')
+
+    @property
+    def event_banner_too_small_msg(self):
+        return (_('The event logo is too small. It is recommended to use a logo with a width of at least {}px.')
+                .format(EVENT_BANNER_WIDTH))
+
+    @property
+    def event_logo_too_large_msg(self):
+        return (_('The event logo is too large. It is recommended to use a logo with a width of at most {}px.')
+                .format(EVENT_LOGO_WIDTH))
 
 
 def _make_theme_settings_form(event, theme):
@@ -135,6 +150,9 @@ class RHLayoutEdit(RHLayoutBase):
             if form.theme.data == '_custom':
                 layout_settings.set(self.event, 'use_custom_css', True)
             flash(_('Settings saved'), 'success')
+            if self.event.has_logo:
+                img = Image.open(BytesIO(self.event.logo))
+                self._check_and_flash_logo_warnings(img)
             return redirect(url_for('.index', self.event))
         else:
             if self.event.logo_metadata:
@@ -173,6 +191,7 @@ class RHLayoutLogoUpload(RHLayoutBase):
             'content_type': 'image/png'
         }
         flash(_('New logo saved'), 'success')
+        self._check_and_flash_logo_warnings(img)
         logger.info("New logo '%s' uploaded by %s (%s)", f.filename, session.user, self.event)
         return jsonify_data(content=get_logo_data(self.event))
 

--- a/indico/modules/events/layout/forms.py
+++ b/indico/modules/events/layout/forms.py
@@ -127,10 +127,8 @@ class LectureMeetingLayoutForm(LoggedLayoutForm):
 
 
 class LogoForm(IndicoForm):
-    logo = EditableFileField(
-        accepted_file_types='image/jpeg,image/jpg,image/png,image/gif',
-        add_remove_links=False, handle_flashes=True, get_metadata=get_logo_data
-    )
+    logo = EditableFileField('Logo', accepted_file_types='image/jpeg,image/jpg,image/png,image/gif',
+                             add_remove_links=False, handle_flashes=True, get_metadata=get_logo_data)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/indico/modules/events/layout/forms.py
+++ b/indico/modules/events/layout/forms.py
@@ -11,7 +11,7 @@ from wtforms.validators import DataRequired, Optional, ValidationError
 
 from indico.core.config import config
 from indico.core.db.sqlalchemy.protection import ProtectionMode
-from indico.modules.events.layout import theme_settings
+from indico.modules.events.layout import EVENT_BANNER_WIDTH, EVENT_LOGO_WIDTH, theme_settings
 from indico.modules.events.layout.models.menu import MenuEntry
 from indico.modules.events.layout.util import get_css_file_data, get_logo_data, get_plugin_conference_themes
 from indico.modules.users import NameFormat
@@ -79,6 +79,8 @@ class ConferenceLayoutForm(LoggedLayoutForm):
     # Style
     header_text_color = StringField(_('Text color'), widget=ColorPickerWidget())
     header_background_color = StringField(_('Background color'), widget=ColorPickerWidget())
+    header_logo_as_banner = BooleanField(_('Use logo as banner'), widget=SwitchWidget(),
+                                         description=_('Use the event logo as a full-width banner.'))
 
     # Announcement
     announcement = StringField(_('Announcement'),
@@ -125,9 +127,17 @@ class LectureMeetingLayoutForm(LoggedLayoutForm):
 
 
 class LogoForm(IndicoForm):
-    logo = EditableFileField('Logo', accepted_file_types='image/jpeg,image/jpg,image/png,image/gif',
-                             add_remove_links=False, handle_flashes=True, get_metadata=get_logo_data,
-                             description=_("Logo to be displayed next to the event's title"))
+    logo = EditableFileField(
+        accepted_file_types='image/jpeg,image/jpg,image/png,image/gif',
+        add_remove_links=False, handle_flashes=True, get_metadata=get_logo_data
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.logo.description = (_('Logo to be displayed in the event page. When configured as banner, the logo will '
+                                   'be displayed above the event title and the optimal width is {}px. Otherwise, the '
+                                   'logo will be displayed to left of the event title and the optimal width is {}px.')
+                                 .format(EVENT_BANNER_WIDTH, EVENT_LOGO_WIDTH))
 
 
 class CSSForm(IndicoForm):

--- a/indico/modules/events/layout/templates/layout_conference.html
+++ b/indico/modules/events/layout/templates/layout_conference.html
@@ -13,7 +13,7 @@
                                        'name_format', 'show_vc_rooms')) }}
         {% endcall %}
         {% call form_fieldset(_('Header Style')) %}
-            {{ form_rows(form, fields=('header_text_color', 'header_background_color')) }}
+            {{ form_rows(form, fields=('header_text_color', 'header_background_color', 'header_logo_as_banner')) }}
         {% endcall %}
         {% call form_fieldset(_('Announcement')) %}
             {{ form_rows(form, fields=('announcement', 'show_announcement')) }}

--- a/indico/modules/events/templates/display/conference/base.html
+++ b/indico/modules/events/templates/display/conference/base.html
@@ -13,7 +13,7 @@
                         <a href="{{ event.url }}">
                             <span class="conference-title-link" style="{{ conf_layout_params.text_color_css }}">
                                 {% if event.has_logo %}
-                                    <div class="confLogoBox">
+                                    <div class="{{ 'confLogoBannerBox' if conf_layout_params.logo_as_banner else 'confLogoBox' }}">
                                        <img src="{{ event.logo_url }}" alt="{{ event.title }}" border="0" class="confLogo">
                                     </div>
                                 {% endif %}

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -265,6 +265,7 @@ class WPConferenceDisplayBase(WPJinjaMixin, MathjaxMixin, WPEventBase):
             'active_menu_item': self.sidemenu_option,
             'bg_color_css': f'background: #{bg_color}; border-color: #{bg_color};' if bg_color else '',
             'text_color_css': f'color: #{text_color};' if text_color else '',
+            'logo_as_banner': layout_settings.get(self.event, 'header_logo_as_banner'),
             'announcement': announcement,
         }
 

--- a/indico/web/client/styles/legacy/Conf_Basic.scss
+++ b/indico/web/client/styles/legacy/Conf_Basic.scss
@@ -40,6 +40,11 @@
   background: transparent none repeat scroll 0 0;
 }
 
+.confLogoBannerBox img {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
 .confTitleBox {
   color: white;
   min-height: 90px;

--- a/indico/web/static/css/confTemplates/standard.css
+++ b/indico/web/static/css/confTemplates/standard.css
@@ -44,6 +44,14 @@ on the left of the conference title.
 }
 
 /*
+The box containing the logo when configured in banner mode.
+*/
+.confLogoBannerBox img {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+/*
 The style for the title text.
 */
 .conference-title-link {


### PR DESCRIPTION
This PR makes sure that event logos take the entire width of the page content while preserving form factor. In particular, it solves issues when the event logo's width is lesser and greater than the content page's width.

|before|after|
|-|-|
|<img width="1792" alt="image" src="https://github.com/user-attachments/assets/b4864512-3550-42c5-900b-0452ed273a32">|<img width="1792" alt="image" src="https://github.com/user-attachments/assets/17ecb69c-e4e4-4f75-8155-dcfe66aa0849">|

|before|after|
|-|-|
|<img width="1792" alt="image" src="https://github.com/user-attachments/assets/4ebd534b-b4db-4b7e-8628-f040ae96f9f6">|<img width="1792" alt="image" src="https://github.com/user-attachments/assets/1896ea51-9194-4113-beae-2a86fedd8b44">|

|before|after|
|-|-|
|<img width="1792" alt="image" src="https://github.com/user-attachments/assets/b0e06185-a95d-41f8-9efc-f829e35b6e6e">|<img width="1792" alt="image" src="https://github.com/user-attachments/assets/4551da9f-ddff-4138-a994-0dab3988d3b6">|






