### PR TITLE
Use program codes to sort blocks in meeting view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Improvements
 - Improve conference participant list, especially when participants from multiple registration
   forms are shown separately (:issue:`6440`, :pr:`6489`)
 - Include information about attached files in JSON export of abstracts (:pr:`6556`)
+- Take session program codes into account when sorting parallel sessions with the same start time
+  in meeting timetable (:pr:`6575`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/timetable/views/__init__.py
+++ b/indico/modules/events/timetable/views/__init__.py
@@ -129,4 +129,6 @@ def inject_meeting_body(event, **kwargs):
 
 def _entry_title_key(entry):
     obj = entry.object
-    return obj.full_title if entry.type == TimetableEntryType.SESSION_BLOCK else obj.title
+    if entry.type == TimetableEntryType.SESSION_BLOCK:
+        return (obj.code, obj.full_title)
+    return obj.title

--- a/indico/modules/events/timetable/views/__init__.py
+++ b/indico/modules/events/timetable/views/__init__.py
@@ -130,5 +130,5 @@ def inject_meeting_body(event, **kwargs):
 def _entry_title_key(entry):
     obj = entry.object
     if entry.type == TimetableEntryType.SESSION_BLOCK:
-        return (obj.code, obj.full_title)
+        return (obj.session.code, obj.full_title)
     return (obj.title,)

--- a/indico/modules/events/timetable/views/__init__.py
+++ b/indico/modules/events/timetable/views/__init__.py
@@ -111,7 +111,7 @@ def inject_meeting_body(event, **kwargs):
         show_children_location[entry.id] = not all(child.object.inherit_location for child in entry.children)
 
     entries.sort(key=attrgetter('end_dt'), reverse=True)
-    entries.sort(key=lambda entry: (entry.start_dt, _entry_title_key(entry)))
+    entries.sort(key=lambda entry: (entry.start_dt, *_entry_title_key(entry)))
 
     days = [(day, list(e)) for day, e in groupby(entries, lambda e: e.start_dt.astimezone(event_tz).date())]
     theme = theme_settings.themes[get_theme(event, view)[0]]

--- a/indico/modules/events/timetable/views/__init__.py
+++ b/indico/modules/events/timetable/views/__init__.py
@@ -127,7 +127,7 @@ def inject_meeting_body(event, **kwargs):
                            show_children_location=show_children_location, multiple_days=multiple_days, **kwargs)
 
 
-def _entry_title_key(entry):
+def _entry_title_key(entry) -> tuple[str, str]:
     obj = entry.object
     if entry.type == TimetableEntryType.SESSION_BLOCK:
         return (obj.session.code, obj.full_title)

--- a/indico/modules/events/timetable/views/__init__.py
+++ b/indico/modules/events/timetable/views/__init__.py
@@ -131,4 +131,4 @@ def _entry_title_key(entry):
     obj = entry.object
     if entry.type == TimetableEntryType.SESSION_BLOCK:
         return (obj.code, obj.full_title)
-    return obj.title
+    return (obj.title,)

--- a/indico/modules/events/timetable/views/__init__.py
+++ b/indico/modules/events/timetable/views/__init__.py
@@ -131,4 +131,4 @@ def _entry_title_key(entry):
     obj = entry.object
     if entry.type == TimetableEntryType.SESSION_BLOCK:
         return (obj.session.code, obj.full_title)
-    return (obj.title,)
+    return ('', obj.title)


### PR DESCRIPTION
We already have this [trick](https://indico.docs.cern.ch/conferences/programme_codes/) in the standard conference timetable. This PR adds the same logic to the meeting-style timetable.