### PR TITLE
Scope credential rate limits to user identifier

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,9 @@ Improvements
 - Allow adding/removing favorite users from search results (:pr:`6950`)
 - Make text overflow behavior in badge designer configurable (:pr:`6944`, thanks
   :user:`SegiNyn`)
+- Introduce new :data:`FAILED_LOGIN_RATE_LIMIT_USER` and :data:`SIGNUP_RATE_LIMIT_EMAIL`
+  settings to prevent locking out users during brute-force attacks (or more likely) poorly
+  behaving users behind a NAT or proxy (:pr:`6576`, thanks :user:`omegak`)
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -108,6 +108,15 @@ Authentication
 
     Default: ``'5 per 15 minutes; 10 per day'``
 
+.. data:: FAILED_LOGIN_RATE_LIMIT_USER
+
+    Applies a rate limit to failed login attempts by user identifier only after
+    the IP-based rate limiting :data:`FAILED_LOGIN_RATE_LIMIT` has been
+    exceeded.  This setting can be used to prevent well behaving users from being
+    locked out by a brute-force attack behind a NAT or proxy.
+
+    Default: ``None``
+
 .. data:: SIGNUP_RATE_LIMIT
 
     Applies a rate limit to sending verification emails in signup attempts.
@@ -121,6 +130,15 @@ Authentication
     the next 24 hours.  Setting the rate limit to ``None`` disables it.
 
     Default: ``'2 per hour; 5 per day'``
+
+.. data:: SIGNUP_RATE_LIMIT_EMAIL
+
+    Applies a rate limit to sending verification emails in signup attempts after
+    the IP-based rate limiting :data:`SIGNUP_RATE_LIMIT` has been
+    exceeded.  This setting can be used to prevent well behaving users from
+    being locked out by a brute-force attack behind a NAT or proxy.
+
+    Default: ``None``
 
 .. data:: EXTERNAL_REGISTRATION_URL
 

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -139,7 +139,8 @@ class IndicoMultipass(Multipass):
     def handle_login_form(self, provider, data):
         signal_res = signals.users.check_login_data.send(type(provider), provider=provider, data=data)
         if errors := values_from_signal(signal_res, as_list=True):
-            self.handle_auth_error(InvalidCredentials(errors[0], provider=provider, identifier=data['email']))
+            identifier = provider.get_identifier(data)
+            self.handle_auth_error(InvalidCredentials(errors[0], provider=provider, identifier=identifier))
             return
         return super().handle_login_form(provider, data)
 

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -19,8 +19,18 @@ from indico.util.signals import values_from_signal
 
 
 logger = Logger.get('auth')
-login_rate_limiter = LocalProxy(functools.cache(lambda: make_rate_limiter('login', config.FAILED_LOGIN_RATE_LIMIT)))
-signup_rate_limiter = LocalProxy(functools.cache(lambda: make_rate_limiter('signup', config.SIGNUP_RATE_LIMIT)))
+login_rate_limiter = LocalProxy(
+    functools.cache(lambda: make_rate_limiter('login', config.FAILED_LOGIN_RATE_LIMIT))
+)
+login_rate_limiter_user = LocalProxy(
+    functools.cache(lambda: make_rate_limiter('login-user', config.FAILED_LOGIN_RATE_LIMIT_USER))
+)
+signup_rate_limiter = LocalProxy(
+    functools.cache(lambda: make_rate_limiter('signup', config.SIGNUP_RATE_LIMIT))
+)
+signup_rate_limiter_email = LocalProxy(
+    functools.cache(lambda: make_rate_limiter('signup-email', config.SIGNUP_RATE_LIMIT_EMAIL))
+)
 
 
 class IndicoMultipass(Multipass):
@@ -106,11 +116,17 @@ class IndicoMultipass(Multipass):
                 raise ValueError('There is no default auth provider')
 
     def handle_auth_error(self, exc, redirect_to_login=False):
-        if isinstance(exc, (NoSuchUser, InvalidCredentials)):
+        if isinstance(exc, NoSuchUser):
             if not getattr(exc, '_indico_no_rate_limit', False):
                 login_rate_limiter.hit()
+                login_rate_limiter_user.hit(exc.identifier)
             logger.warning('Invalid credentials (ip=%s, provider=%s): %s',
                            request.remote_addr, exc.provider.name if exc.provider else None, exc)
+        elif isinstance(exc, InvalidCredentials):
+            login_rate_limiter.hit()
+            login_rate_limiter_user.hit(exc.identifier)
+            logger.warning('Invalid credentials (ip=%s, provider=%s, identifier=%s): %s',
+                           request.remote_addr, exc.provider.name if exc.provider else None, exc.identifier, exc)
         else:
             exc_str = str(exc)
             fn = logger.error
@@ -123,9 +139,33 @@ class IndicoMultipass(Multipass):
     def handle_login_form(self, provider, data):
         signal_res = signals.users.check_login_data.send(type(provider), provider=provider, data=data)
         if errors := values_from_signal(signal_res, as_list=True):
-            self.handle_auth_error(InvalidCredentials(errors[0], provider=provider))
+            self.handle_auth_error(InvalidCredentials(errors[0], provider=provider, identifier=data['email']))
             return
         return super().handle_login_form(provider, data)
+
+
+def get_exceeded_login_rate_limiter(identifier=None):
+    """Return the rate limiter that has been exceeded for login."""
+    if login_rate_limiter.test():
+        return None
+    elif not login_rate_limiter_user.limits or not identifier:
+        return login_rate_limiter
+    elif login_rate_limiter_user.test(identifier):
+        return None
+    else:
+        return login_rate_limiter_user
+
+
+def get_exceeded_signup_rate_limiter(email=None):
+    """Return the rate limiter that has been exceeded for signup."""
+    if signup_rate_limiter.test():
+        return None
+    elif not signup_rate_limiter_email.limits or not email:
+        return signup_rate_limiter
+    elif signup_rate_limiter_email.test(email):
+        return None
+    else:
+        return signup_rate_limiter_email
 
 
 multipass = IndicoMultipass()

--- a/indico/core/auth_test.py
+++ b/indico/core/auth_test.py
@@ -1,0 +1,59 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2025 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from limits import parse_many
+
+from indico.core.auth import (get_exceeded_login_rate_limiter, get_exceeded_signup_rate_limiter, login_rate_limiter,
+                              login_rate_limiter_user, signup_rate_limiter, signup_rate_limiter_email)
+
+
+def test_get_exceeded_login_rate_limiter_returns_global():
+    login_rate_limiter.limits = parse_many('1 per 1 minute')
+    login_rate_limiter_user.limits = []
+    # Test that the global limiter is not exceeded
+    assert get_exceeded_login_rate_limiter() is None
+    # Test that the global limiter is exceeded
+    login_rate_limiter.hit()
+    assert get_exceeded_login_rate_limiter() == login_rate_limiter
+
+
+def test_get_exceeded_login_rate_limiter_returns_scoped():
+    identifier = 'foo'
+    login_rate_limiter.limits = parse_many('1 per 1 minute')
+    login_rate_limiter_user.limits = parse_many('1 per 1 minute')
+    # Test that the global limiter is still active if not checking for a user
+    login_rate_limiter.hit()
+    assert get_exceeded_login_rate_limiter() == login_rate_limiter
+    # Test that limiter is not exceeded for this user
+    assert get_exceeded_login_rate_limiter(identifier) is None
+    # Test that limiter is exceeded for this user
+    login_rate_limiter_user.hit(identifier)
+    assert get_exceeded_login_rate_limiter(identifier) == login_rate_limiter_user
+
+
+def test_get_exceeded_signup_rate_limiter_global():
+    signup_rate_limiter.limits = parse_many('1 per 1 minute')
+    signup_rate_limiter_email.limits = []
+    # Test that the global limiter is not exceeded
+    assert get_exceeded_signup_rate_limiter() is None
+    # Test that the global limiter is exceeded
+    signup_rate_limiter.hit()
+    assert get_exceeded_signup_rate_limiter() == signup_rate_limiter
+
+
+def test_get_exceeded_signup_rate_limiter_scoped():
+    identifier = 'foo'
+    signup_rate_limiter.limits = parse_many('1 per 1 minute')
+    signup_rate_limiter_email.limits = parse_many('1 per 1 minute')
+    # Test that the global limiter is still active if not checking for a user
+    signup_rate_limiter.hit()
+    assert get_exceeded_signup_rate_limiter() == signup_rate_limiter
+    # Test that limiter is not exceeded for this user
+    assert get_exceeded_signup_rate_limiter(identifier) is None
+    # Test that limiter is exceeded for this user
+    signup_rate_limiter_email.hit(identifier)
+    assert get_exceeded_signup_rate_limiter(identifier) == signup_rate_limiter_email

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -57,6 +57,7 @@ DEFAULTS = {
     'EXTERNAL_REGISTRATION_URL': None,
     'HELP_URL': 'https://learn.getindico.io',
     'FAILED_LOGIN_RATE_LIMIT': '5 per 15 minutes; 10 per day',
+    'FAILED_LOGIN_RATE_LIMIT_USER': None,
     'FAVICON_URL': None,
     'IDENTITY_PROVIDERS': {},
     'LATEX_RATE_LIMIT': '2 per 3 seconds',
@@ -87,6 +88,7 @@ DEFAULTS = {
     'SESSION_LIFETIME': 86400 * 31,
     'SIGNUP_CAPTCHA': True,
     'SIGNUP_RATE_LIMIT': '2 per hour; 5 per day',
+    'SIGNUP_RATE_LIMIT_EMAIL': None,
     'SMTP_ALLOWED_SENDERS': set(),
     'SMTP_CERTFILE': None,
     'SMTP_KEYFILE': None,
@@ -298,10 +300,13 @@ class IndicoConfig:
         return urljoin(self.BASE_URL, self.WALLET_LOGO_URL) if self.WALLET_LOGO_URL else None
 
     def validate(self):
-        from indico.core.auth import login_rate_limiter, signup_rate_limiter
+        from indico.core.auth import (login_rate_limiter, login_rate_limiter_user, signup_rate_limiter,
+                                      signup_rate_limiter_email)
         from indico.legacy.pdfinterface.latex import latex_rate_limiter
         login_rate_limiter._get_current_object()  # fail in case FAILED_LOGIN_RATE_LIMIT is invalid
+        login_rate_limiter_user._get_current_object()  # fail in case FAILED_LOGIN_RATE_LIMIT is invalid
         signup_rate_limiter._get_current_object()  # fail in case SIGNUP_RATE_LIMIT is invalid
+        signup_rate_limiter_email._get_current_object()  # fail in case SIGNUP_RATE_LIMIT is invalid
         latex_rate_limiter._get_current_object()  # fail in case LATEX_RATE_LIMIT is invalid
         if self.DEFAULT_TIMEZONE not in pytz.all_timezones_set:
             raise ValueError(f'Invalid default timezone: {self.DEFAULT_TIMEZONE}')

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -110,14 +110,14 @@ class RHLogin(RH):
         if request.method == 'POST':
             active_provider = provider = _get_provider(request.form['_provider'], False)
             form = provider.login_form()
-            limiter = get_exceeded_login_rate_limiter()
-            if not limiter and form.validate_on_submit():
-                limiter = get_exceeded_login_rate_limiter(form.identifier.data)
+            if form.validate_on_submit():
+                identifier = provider.get_identifier(form.data)
+                limiter = get_exceeded_login_rate_limiter() or get_exceeded_login_rate_limiter(identifier)
                 if not limiter:
                     if response := multipass.handle_login_form(provider, form.data):
                         return response
                     # re-check since a failed login may have triggered the rate limit
-                    limiter = get_exceeded_login_rate_limiter(form.identifier.data)
+                    limiter = get_exceeded_login_rate_limiter(identifier)
         # Otherwise we show the form for the default provider
         else:
             active_provider = multipass.default_local_auth_provider

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -18,7 +18,8 @@ from webargs import fields
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from indico.core import signals
-from indico.core.auth import login_rate_limiter, multipass, signup_rate_limiter
+from indico.core.auth import (get_exceeded_login_rate_limiter, get_exceeded_signup_rate_limiter, multipass,
+                              signup_rate_limiter, signup_rate_limiter_email)
 from indico.core.config import config
 from indico.core.db import db
 from indico.core.marshmallow import mm
@@ -105,24 +106,25 @@ class RHLogin(RH):
             return provider.initiate_external_login()
 
         # If we have a POST request we submitted a login form for a local provider
-        rate_limit_exceeded = False
+        limiter = None
         if request.method == 'POST':
             active_provider = provider = _get_provider(request.form['_provider'], False)
             form = provider.login_form()
-            rate_limit_exceeded = not login_rate_limiter.test()
-            if not rate_limit_exceeded and form.validate_on_submit():
-                response = multipass.handle_login_form(provider, form.data)
-                if response:
-                    return response
-                # re-check since a failed login may have triggered the rate limit
-                rate_limit_exceeded = not login_rate_limiter.test()
+            limiter = get_exceeded_login_rate_limiter()
+            if not limiter and form.validate_on_submit():
+                limiter = get_exceeded_login_rate_limiter(form.identifier.data)
+                if not limiter:
+                    if response := multipass.handle_login_form(provider, form.data):
+                        return response
+                    # re-check since a failed login may have triggered the rate limit
+                    limiter = get_exceeded_login_rate_limiter(form.identifier.data)
         # Otherwise we show the form for the default provider
         else:
             active_provider = multipass.default_local_auth_provider
             form = active_provider.login_form() if active_provider else None
 
         providers = _sort_providers(multipass.auth_providers.values())
-        retry_in = login_rate_limiter.get_reset_delay() if rate_limit_exceeded else None
+        retry_in = limiter.get_reset_delay() if limiter else None
         return render_template('auth/login_page.html', form=form, providers=providers, active_provider=active_provider,
                                login_reason=login_reason, retry_in=retry_in, force=(force or None))
 
@@ -297,16 +299,16 @@ class RHRegister(RH):
     def _process_verify(self, handler):
         email_sent = session.pop('register_verification_email_sent', False)
         form = handler.create_verify_email_form()
-        rate_limit_exceeded = not signup_rate_limiter.test()
-        if not email_sent and rate_limit_exceeded:
-            # tell users that they exceeded the rate limit, but NOT if they just
-            # used their last attempt successfully
-            retry_in = login_rate_limiter.get_reset_delay()
-            delay = format_human_timedelta(retry_in, 'minutes')
-            flash(_('Too many signup attempts. Please wait {}').format(delay), 'error')
-        if not rate_limit_exceeded and form.validate_on_submit():
-            signup_rate_limiter.hit()
-            return self._send_confirmation(form.email.data)
+        if form.validate_on_submit():
+            limiter = get_exceeded_signup_rate_limiter()
+            if not limiter:
+                signup_rate_limiter.hit()
+                signup_rate_limiter_email.hit(form.email.data)
+                return self._send_confirmation(form.email.data)
+            else:
+                retry_in = limiter.get_reset_delay()
+                delay = format_human_timedelta(retry_in, 'minutes')
+                flash(_('Too many signup attempts. Please wait {}').format(delay), 'error')
         return WPSignup.render_template('register_verify.html', form=form, email_sent=email_sent)
 
     def _process_post(self, handler):

--- a/indico/modules/auth/providers.py
+++ b/indico/modules/auth/providers.py
@@ -59,10 +59,10 @@ class IndicoAuthProvider(AuthProvider):
         # XXX This is intentional, having an account on an Indico instance is generally not considered
         # secret information, and we want to give users the benefit of more verbose error messages.
         if not identities:
-            exc = NoSuchUser(provider=self)
+            identifier = self.get_identifier(data)
+            exc = NoSuchUser(provider=self, identifier=identifier)
             if not config.LOCAL_USERNAMES and '@' not in data['identifier']:
-                exc = NoSuchUser(_('Please use your email address to log in'),
-                                 provider=self, identifier=data['identifier'])
+                exc = NoSuchUser(_('Please use your email address to log in'), provider=self, identifier=identifier)
                 exc._indico_no_rate_limit = True
             raise exc
         # From all the matching identities (usually just one), get one where the password matches, or

--- a/indico/modules/auth/providers.py
+++ b/indico/modules/auth/providers.py
@@ -61,13 +61,14 @@ class IndicoAuthProvider(AuthProvider):
         if not identities:
             exc = NoSuchUser(provider=self)
             if not config.LOCAL_USERNAMES and '@' not in data['identifier']:
-                exc = NoSuchUser(_('Please use your email address to log in'), provider=self)
+                exc = NoSuchUser(_('Please use your email address to log in'),
+                                 provider=self, identifier=data['identifier'])
                 exc._indico_no_rate_limit = True
             raise exc
         # From all the matching identities (usually just one), get one where the password matches, or
         # fail with invalid-password if there is none.
         if not (identity := next((ide for ide in identities if self.check_password(ide, data['password'])), None)):
-            raise InvalidCredentials(provider=self)
+            raise InvalidCredentials(provider=self, identifier=data['identifier'])
         if data['identifier'] != identity.identifier and data['identifier'] in identity.user.secondary_emails:
             msg = _('You are logging in with a secondary email address. Please note that any email notifications '
                     'will always be sent to your primary email address ({email}). Go to '


### PR DESCRIPTION
Related PRs:
- [x] https://github.com/indico/flask-multipass/pull/93
- [x] https://github.com/indico/flask-multipass/pull/110
- [ ] https://github.com/indico/flask-multipass/pull/114

Requires:
- [x] `flask-multipass` bumped to `v0.9`.
- [ ] `flask-multipass` bumped to `v0.11`.