### PR TITLE
Fix exception in event logo upload and picture field 

### DIFF
--- a/indico/modules/events/layout/controllers/layout.py
+++ b/indico/modules/events/layout/controllers/layout.py
@@ -161,8 +161,8 @@ class RHLayoutLogoUpload(RHLayoutBase):
         f = request.files['logo']
         try:
             img = Image.open(f)
-        except OSError:
-            flash(_('You cannot upload this file as a logo.'), 'error')
+        except (OSError, Image.DecompressionBombError):
+            flash(_('You cannot upload this file as a logo, it may be corrupted or too big.'), 'error')
             return jsonify_data(content=None)
         if img.format.lower() not in {'jpeg', 'png', 'gif'}:
             flash(_('The file has an invalid format ({format})').format(format=img.format), 'error')

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -1026,7 +1026,7 @@ def process_registration_picture(source, *, thumbnail=False):
     size_x, size_y = picture.size
     if max(size_x, size_y) > max_size:
         ratio = max_size / max(size_x, size_y)
-        picture = picture.resize((int(ratio * size_x), int(ratio * size_y)), Image.Resampling.BICUBIC)
+        picture = picture.resize((max(1, int(ratio * size_x)), max(1, int(ratio * size_y))), Image.Resampling.BICUBIC)
     image_bytes = BytesIO()
     picture.save(image_bytes, 'JPEG')
     image_bytes.seek(0)

--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -260,7 +260,7 @@ const PictureManager = ({
       src={pictureState.imageSrc}
       onCrop={onImageCrop}
       backAction={cropBackAction}
-      minCropSize={minPictureSize || 0}
+      minCropSize={minPictureSize || 25}
     />
   );
 


### PR DESCRIPTION
Hello, this pr is to fix 2 exceptions we've noticed. 

The first is in the event logo upload: 
```
Traceback (most recent call last):
 File "/env/lib/python3.12/site-packages/flask/app.py", line 880, in full_dispatch_request
   rv = self.dispatch_request()
        ^^^^^^^^^^^^^^^^^^^^^^^
 File "env/lib/python3.12/site-packages/flask/app.py", line 865, in dispatch_request
   return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/main/src/indico/indico/web/flask/util.py", line 80, in wrapper
   return obj().process()
          ^^^^^^^^^^^^^^^
 File "/main/src/indico/indico/web/rh.py", line 307, in process
   res = self._do_process()
         ^^^^^^^^^^^^^^^^^^
 File "/main/src/un/web/rh.py", line 22, in _do_process
   return super()._do_process()
          ^^^^^^^^^^^^^^^^^^^^^
 File "/main/src/indico/indico/web/rh.py", line 275, in _do_process
   rv = self._process()
        ^^^^^^^^^^^^^^^
 File "/main/src/indico/indico/modules/events/layout/controllers/layout.py", line 153, in _process
   img = Image.open(f)
         ^^^^^^^^^^^^^
 File "/main/env/lib/python3.12/site-packages/PIL/Image.py", line 3318, in open
   im = _open_core(fp, filename, prefix, formats)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File "/main/env/lib/python3.12/site-packages/PIL/Image.py", line 3305, in _open_core
   _decompression_bomb_check(im.size)
 File "/main/env/lib/python3.12/site-packages/PIL/Image.py", line 3215, in _decompression_bomb_check
   raise DecompressionBombError(msg)
PIL.Image.DecompressionBombError: Image size (209255487 pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack.

```

The second is in the picture field, it was possible to crop into a straight line either horizontally or vertically:
```
Traceback (most recent call last):
  File "/Users/segilolamustapha/un/indico-un/.venv/lib/python3.12/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/.venv/lib/python3.12/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/indico/indico/web/flask/util.py", line 80, in wrapper
    return obj().process()
           ^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/indico/indico/web/rh.py", line 307, in process
    res = self._do_process()
          ^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/indico/indico/modules/events/controllers/base.py", line 106, in _do_process
    return RHEventBase._do_process(self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/indico/indico/web/rh.py", line 275, in _do_process
    rv = self._process()
         ^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/.venv/lib/python3.12/site-packages/webargs/core.py", line 649, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/indico/indico/modules/files/controllers.py", line 39, in _process
    return self._save_file(file, file.stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/indico/indico/modules/events/registration/controllers/__init__.py", line 130, in _save_file
    if not (resized_image_stream := process_registration_picture(stream)):
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/indico/indico/util/signals.py", line 111, in _wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/indico/indico/modules/events/registration/util.py", line 1028, in process_registration_picture
    picture = picture.resize((int(ratio * size_x), int(ratio * size_y)), Image.Resampling.BICUBIC)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/indico-un/.venv/lib/python3.12/site-packages/PIL/Image.py", line 2328, in resize
    return self._new(self.im.resize(size, resample, box))
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: height and width must be > 0
```
 