### PR TITLE
Get next editable: UI improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,7 @@ Improvements
 - Show correct repetition details for bookings repeating every n weeks (:pr:`6592`)
 - Show context (event/contribution title etc.) in the title of the minutes editor (:issue:`6584`,
   :pr:`6591`)
+- Streamline "get next editable" UI and only show editables that still unassigned (:pr:`6583`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/TimelineHeader.jsx
@@ -150,6 +150,12 @@ export default function TimelineHeader({children, contribution, state, submitter
             )}
           </Message>
         )}
+        {editingEnabled && canAssignSelf && (
+          <Message warning>
+            <Icon name="warning sign" />
+            <Translate>This editable is not currently assigned to you.</Translate>
+          </Message>
+        )}
         {children && <div className="review-item-content">{children}</div>}
       </div>
     </>

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -13,7 +13,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import React, {useState, useMemo, useRef} from 'react';
 import {useHistory} from 'react-router-dom';
-import {Button, Loader, Modal, Table, Checkbox, Dimmer} from 'semantic-ui-react';
+import {Button, Loader, Modal, Table, Checkbox, Dimmer, Icon} from 'semantic-ui-react';
 
 import {ListFilter} from 'indico/react/components';
 import {useIndicoAxios} from 'indico/react/hooks';
@@ -257,10 +257,12 @@ function NextEditableTable({filteredEditables, selectedEditable, setSelectedEdit
   const codePresent = Object.values(filteredEditables).some(c => c.contributionCode);
 
   return filteredEditables.length ? (
-    <Table basic="very" striped>
+    <Table basic="very" striped selectable>
       <Table.Header>
         <Table.Row>
-          <Table.HeaderCell style={{width: '2%'}} />
+          <Table.HeaderCell style={{width: '2%'}}>
+            <Icon name="check" />
+          </Table.HeaderCell>
           <Table.HeaderCell style={{width: '6%'}}>ID</Table.HeaderCell>
           {codePresent && <Table.HeaderCell style={{width: '10%'}}>Code</Table.HeaderCell>}
           <Table.HeaderCell>Title</Table.HeaderCell>
@@ -269,7 +271,13 @@ function NextEditableTable({filteredEditables, selectedEditable, setSelectedEdit
       </Table.Header>
       <Table.Body>
         {filteredEditables.map(editable => (
-          <Table.Row key={editable.id} style={editable.canAssignSelf ? {} : {opacity: '50%'}}>
+          <Table.Row
+            key={editable.id}
+            style={editable.canAssignSelf ? {} : {opacity: '50%'}}
+            styleName="editable"
+            onClick={() => setSelectedEditable(editable)}
+            active={selectedEditable?.id === editable.id}
+          >
             <Table.Cell>
               <Checkbox
                 radio
@@ -279,17 +287,17 @@ function NextEditableTable({filteredEditables, selectedEditable, setSelectedEdit
                 onChange={() => setSelectedEditable(editable)}
               />
             </Table.Cell>
-            <Table.Cell>{editable.contributionFriendlyId}</Table.Cell>
+            <Table.Cell>
+              <a href={editable.timelineURL} target="_blank" rel="noopener noreferrer">
+                {editable.contributionFriendlyId}
+              </a>
+            </Table.Cell>
             {codePresent && (
               <Table.Cell>
                 {editable.contributionCode ? editable.contributionCode : Translate.string('n/a')}
               </Table.Cell>
             )}
-            <Table.Cell>
-              <a href={editable.timelineURL} target="_blank" rel="noopener noreferrer">
-                {editable.contributionTitle}
-              </a>
-            </Table.Cell>
+            <Table.Cell>{editable.contributionTitle}</Table.Cell>
             <Table.Cell>{editable.editor ? editable.editor.fullName : ''}</Table.Cell>
           </Table.Row>
         ))}

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.jsx
@@ -258,17 +258,6 @@ function NextEditableTable({filteredEditables, selectedEditable, setSelectedEdit
 
   return filteredEditables.length ? (
     <Table basic="very" striped selectable>
-      <Table.Header>
-        <Table.Row>
-          <Table.HeaderCell style={{width: '2%'}}>
-            <Icon name="check" />
-          </Table.HeaderCell>
-          <Table.HeaderCell style={{width: '6%'}}>ID</Table.HeaderCell>
-          {codePresent && <Table.HeaderCell style={{width: '10%'}}>Code</Table.HeaderCell>}
-          <Table.HeaderCell>Title</Table.HeaderCell>
-          <Table.HeaderCell style={{width: '18%'}}>Editor</Table.HeaderCell>
-        </Table.Row>
-      </Table.Header>
       <Table.Body>
         {filteredEditables.map(editable => (
           <Table.Row
@@ -278,7 +267,7 @@ function NextEditableTable({filteredEditables, selectedEditable, setSelectedEdit
             onClick={() => setSelectedEditable(editable)}
             active={selectedEditable?.id === editable.id}
           >
-            <Table.Cell>
+            <Table.Cell width={1}>
               <Checkbox
                 radio
                 disabled={!editable.canAssignSelf}
@@ -287,18 +276,18 @@ function NextEditableTable({filteredEditables, selectedEditable, setSelectedEdit
                 onChange={() => setSelectedEditable(editable)}
               />
             </Table.Cell>
-            <Table.Cell>
-              <a href={editable.timelineURL} target="_blank" rel="noopener noreferrer">
-                {editable.contributionFriendlyId}
-              </a>
-            </Table.Cell>
+            <Table.Cell width={1}>{editable.contributionFriendlyId}</Table.Cell>
             {codePresent && (
-              <Table.Cell>
+              <Table.Cell width={2}>
                 {editable.contributionCode ? editable.contributionCode : Translate.string('n/a')}
               </Table.Cell>
             )}
             <Table.Cell>{editable.contributionTitle}</Table.Cell>
-            <Table.Cell>{editable.editor ? editable.editor.fullName : ''}</Table.Cell>
+            <Table.Cell width={1}>
+              <a href={editable.timelineURL} target="_blank" rel="noopener noreferrer">
+                <Icon name="eye" />
+              </a>
+            </Table.Cell>
           </Table.Row>
         ))}
       </Table.Body>

--- a/indico/modules/events/editing/client/js/management/editable_type/NextEditable.module.scss
+++ b/indico/modules/events/editing/client/js/management/editable_type/NextEditable.module.scss
@@ -21,3 +21,7 @@
   text-align: center;
   color: $gray;
 }
+
+.editable {
+  cursor: pointer;
+}

--- a/indico/modules/events/editing/controllers/backend/editable_list.py
+++ b/indico/modules/events/editing/controllers/backend/editable_list.py
@@ -199,6 +199,7 @@ class RHFilterEditablesByFileTypes(RHEditableTypeEditorBase):
                         ),
                         Editable.type == self.editable_type,
                         Editable.state == EditableState.ready_for_review,
+                        Editable.editor_id.is_(None),
                         ~Editable.is_deleted,
                     )
                 )


### PR DESCRIPTION
- Now can click anywhere on the table row to select
- Option to see the editable is more discrete to avoid editors forgetting to assign it to themselves
- Removed unnecessary "editor" column
- Now showing only unassigned editables
- Future improvement: have a way to preview more info about the contribution (maybe description or keywords) so people don't need to open the editable before assignment to see what it's about

![image](https://github.com/user-attachments/assets/9874e55c-ff60-4c18-9847-2b26fcc8798a)
