### PR TITLE
Make 'source' arg required in RHSaveProfilePicture

### DIFF
--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -374,7 +374,7 @@ class RHSaveProfilePicture(RHUserBase):
     """Update the user's profile picture."""
 
     @use_kwargs({
-        'source': EnumField(ProfilePictureSource)
+        'source': EnumField(ProfilePictureSource, required=True)
     })
     def _process(self, source):
         self.user.picture_source = source


### PR DESCRIPTION
Hello, 

We have been getting tracebacks in RHSaveProfilePicture because of missing arg 'source'. 

It sometimes comes from what is obviously a fake user account trying out weird things but we've also gotten the traceback for some real accounts. 
But playing around with the profile picture, I'm not actually able to reproduce it from the UI. I can trigger the exception by removing this line https://github.com/UNOG-Indico/indico-core/blob/bf6ff9dc8325349b578c15fece3b62f727ae3106/indico/modules/users/client/js/ProfilePicture.jsx#L135 
So I think maybe just making it required would be enough since I cannot find how the source could not be present
```
2024-10-17 17:01:48,890  4ef9a2f1fe764580  93      indico.flask - ERROR errors.py:113 -- RHSaveProfilePicture._process() missing 1 required positional argument: 'source'

Traceback (most recent call last):
  File "/Users/segilolamustapha/un/v3.2/indico-un/.venv/lib/python3.12/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/v3.2/indico-un/.venv/lib/python3.12/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/v3.2/indico-un/indico/indico/web/flask/util.py", line 80, in wrapper
    return obj().process()
           ^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/v3.2/indico-un/indico/indico/web/rh.py", line 307, in process
    res = self._do_process()
          ^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/v3.2/indico-un/un/web/rh.py", line 22, in _do_process
    return super()._do_process()
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/v3.2/indico-un/indico/indico/web/rh.py", line 275, in _do_process
    rv = self._process()
         ^^^^^^^^^^^^^^^
  File "/Users/segilolamustapha/un/v3.2/indico-un/.venv/lib/python3.12/site-packages/webargs/core.py", line 649, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
TypeError: RHSaveProfilePicture._process() missing 1 required positional argument: 'source'
```
