### PR TITLE
Format regform prices correctly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,7 @@ Bugfixes
 - Only allow marking unpaid registrations as paid (:issue:`6330`, :pr:`6578`)
 - Do not allow mixing notification rules for invited abstracts with other rules (:issue:`6563`,
   :pr:`6567`)
+- Use locale-aware price formatting in registration form fields (:pr:`6586`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
@@ -14,10 +14,10 @@ import {Form, Label} from 'semantic-ui-react';
 
 import {DatePeriodField, FinalDatePeriod} from 'indico/react/components';
 import {FinalField} from 'indico/react/forms';
-import {Translate} from 'indico/react/i18n';
+import {Param, Translate} from 'indico/react/i18n';
 import {serializeDate, toMoment} from 'indico/utils/date';
 
-import {getFormatPrice} from '../../form/selectors';
+import {getPriceFormatter} from '../../form/selectors';
 import {getFieldValue, getManagement, getPaid} from '../../form_submission/selectors';
 
 import ChoiceLabel from './ChoiceLabel';
@@ -41,7 +41,7 @@ function AccommodationInputComponent({
 }) {
   const paid = useSelector(getPaid);
   const management = useSelector(getManagement);
-  const formatPrice = useSelector(getFormatPrice);
+  const formatPrice = useSelector(getPriceFormatter);
   const selectedChoice = choices.find(c => c.id === value.choice);
 
   const [focusedDateField, setFocusedDateField] = useState(null);
@@ -124,7 +124,9 @@ function AccommodationInputComponent({
                   <td>
                     {c.isEnabled && !!c.price && (
                       <Label pointing="left">
-                        {Translate.string('{price} per night', {price: formatPrice(c.price)})}
+                        <Translate>
+                          <Param name="price" value={formatPrice(c.price)} /> per night
+                        </Translate>
                       </Label>
                     )}
                   </td>
@@ -161,9 +163,9 @@ function AccommodationInputComponent({
           />
           {!!selectedChoice.price && (
             <Label pointing="left" styleName="price-tag">
-              {Translate.string('Total: {price}', {
-                price: formatPrice(nights * selectedChoice.price),
-              })}
+              <Translate>
+                Total: <Param name="price" value={formatPrice(nights * selectedChoice.price)} />
+              </Translate>
             </Label>
           )}
         </div>

--- a/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
@@ -17,7 +17,7 @@ import {FinalField} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 import {serializeDate, toMoment} from 'indico/utils/date';
 
-import {getCurrency} from '../../form/selectors';
+import {getFormatPrice} from '../../form/selectors';
 import {getFieldValue, getManagement, getPaid} from '../../form_submission/selectors';
 
 import ChoiceLabel from './ChoiceLabel';
@@ -41,7 +41,7 @@ function AccommodationInputComponent({
 }) {
   const paid = useSelector(getPaid);
   const management = useSelector(getManagement);
-  const currency = useSelector(getCurrency);
+  const formatPrice = useSelector(getFormatPrice);
   const selectedChoice = choices.find(c => c.id === value.choice);
 
   const [focusedDateField, setFocusedDateField] = useState(null);
@@ -124,10 +124,7 @@ function AccommodationInputComponent({
                   <td>
                     {c.isEnabled && !!c.price && (
                       <Label pointing="left">
-                        {Translate.string('{price} {currency} per night', {
-                          price: c.price.toFixed(2),
-                          currency,
-                        })}
+                        {Translate.string('{price} per night', {price: formatPrice(c.price)})}
                       </Label>
                     )}
                   </td>
@@ -164,9 +161,8 @@ function AccommodationInputComponent({
           />
           {!!selectedChoice.price && (
             <Label pointing="left" styleName="price-tag">
-              {Translate.string('Total: {total} {currency}', {
-                total: (nights * selectedChoice.price).toFixed(2),
-                currency,
+              {Translate.string('Total: {price}', {
+                price: formatPrice(nights * selectedChoice.price),
               })}
             </Label>
           )}

--- a/indico/modules/events/registration/client/js/form/fields/AccompanyingPersonsInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccompanyingPersonsInput.jsx
@@ -16,7 +16,7 @@ import {FinalCheckbox, FinalField, FinalInput, validators as v} from 'indico/rea
 import {FinalModalForm} from 'indico/react/forms/final-form';
 import {Translate} from 'indico/react/i18n';
 
-import {getCurrency, getItems} from '../selectors';
+import {getFormatPrice, getItems} from '../selectors';
 
 import {PlacesLeft} from './PlacesLeftLabel';
 
@@ -101,7 +101,7 @@ function AccompanyingPersonsComponent({
   maxPersons,
 }) {
   const [operation, setOperation] = useState({type: null, person: null});
-  const currency = useSelector(getCurrency);
+  const formatPrice = useSelector(getFormatPrice);
   const totalPrice = (value.length * price).toFixed(2);
   const items = useSelector(getItems);
   const formState = useFormState();
@@ -181,7 +181,7 @@ function AccompanyingPersonsComponent({
         </Button>
         {!!price && (
           <Label basic pointing="left" styleName="price-tag" size="small">
-            {price.toFixed(2)} {currency} (Total: {totalPrice} {currency})
+            {formatPrice(price)} (Total: {formatPrice(totalPrice)})
           </Label>
         )}
         {placesLimit !== Infinity && (

--- a/indico/modules/events/registration/client/js/form/fields/AccompanyingPersonsInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccompanyingPersonsInput.jsx
@@ -16,7 +16,7 @@ import {FinalCheckbox, FinalField, FinalInput, validators as v} from 'indico/rea
 import {FinalModalForm} from 'indico/react/forms/final-form';
 import {Translate} from 'indico/react/i18n';
 
-import {getFormatPrice, getItems} from '../selectors';
+import {getPriceFormatter, getItems} from '../selectors';
 
 import {PlacesLeft} from './PlacesLeftLabel';
 
@@ -101,7 +101,7 @@ function AccompanyingPersonsComponent({
   maxPersons,
 }) {
   const [operation, setOperation] = useState({type: null, person: null});
-  const formatPrice = useSelector(getFormatPrice);
+  const formatPrice = useSelector(getPriceFormatter);
   const totalPrice = (value.length * price).toFixed(2);
   const items = useSelector(getItems);
   const formState = useFormState();

--- a/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
@@ -13,7 +13,7 @@ import {Button, Label} from 'semantic-ui-react';
 import {FinalDropdown, FinalField, FinalInput, validators as v} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-import {getCurrency} from '../../form/selectors';
+import {getFormatPrice} from '../../form/selectors';
 import {getFieldValue} from '../../form_submission/selectors';
 
 import {PlacesLeft} from './PlacesLeftLabel';
@@ -31,7 +31,7 @@ function BooleanInputComponent({
   placesLimit,
   placesUsed,
 }) {
-  const currency = useSelector(getCurrency);
+  const formatPrice = useSelector(getFormatPrice);
   const existingValue = useSelector(state => getFieldValue(state, fieldId));
 
   const makeOnClick = newValue => () => {
@@ -64,7 +64,7 @@ function BooleanInputComponent({
       </Button.Group>
       {!!price && (
         <Label pointing="left" styleName={`price-tag ${value !== true ? 'greyed' : ''}`}>
-          {price.toFixed(2)} {currency}
+          {formatPrice(price)}
         </Label>
       )}
       {!!placesLimit && (

--- a/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/BooleanInput.jsx
@@ -13,7 +13,7 @@ import {Button, Label} from 'semantic-ui-react';
 import {FinalDropdown, FinalField, FinalInput, validators as v} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-import {getFormatPrice} from '../../form/selectors';
+import {getPriceFormatter} from '../../form/selectors';
 import {getFieldValue} from '../../form_submission/selectors';
 
 import {PlacesLeft} from './PlacesLeftLabel';
@@ -31,7 +31,7 @@ function BooleanInputComponent({
   placesLimit,
   placesUsed,
 }) {
-  const formatPrice = useSelector(getFormatPrice);
+  const formatPrice = useSelector(getPriceFormatter);
   const existingValue = useSelector(state => getFieldValue(state, fieldId));
 
   const makeOnClick = newValue => () => {

--- a/indico/modules/events/registration/client/js/form/fields/CheckboxInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/CheckboxInput.jsx
@@ -14,7 +14,7 @@ import {Label} from 'semantic-ui-react';
 import {FinalCheckbox, FinalInput, validators as v} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-import {getFormatPrice} from '../../form/selectors';
+import {getPriceFormatter} from '../../form/selectors';
 import {getFieldValue} from '../../form_submission/selectors';
 
 import {PlacesLeft} from './PlacesLeftLabel';
@@ -34,7 +34,7 @@ export default function CheckboxInput({
   placesUsed,
   retentionPeriodIcon,
 }) {
-  const formatPrice = useSelector(getFormatPrice);
+  const formatPrice = useSelector(getPriceFormatter);
   const existingValue = useSelector(state => getFieldValue(state, fieldId));
   const checkboxId = `${htmlId}-checkbox`;
 

--- a/indico/modules/events/registration/client/js/form/fields/CheckboxInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/CheckboxInput.jsx
@@ -14,7 +14,7 @@ import {Label} from 'semantic-ui-react';
 import {FinalCheckbox, FinalInput, validators as v} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-import {getCurrency} from '../../form/selectors';
+import {getFormatPrice} from '../../form/selectors';
 import {getFieldValue} from '../../form_submission/selectors';
 
 import {PlacesLeft} from './PlacesLeftLabel';
@@ -34,7 +34,7 @@ export default function CheckboxInput({
   placesUsed,
   retentionPeriodIcon,
 }) {
-  const currency = useSelector(getCurrency);
+  const formatPrice = useSelector(getFormatPrice);
   const existingValue = useSelector(state => getFieldValue(state, fieldId));
   const checkboxId = `${htmlId}-checkbox`;
 
@@ -52,7 +52,7 @@ export default function CheckboxInput({
         <Field name={htmlName} subscription={{value: true}}>
           {({input: {value: checked}}) => (
             <Label pointing="left" styleName={`price-tag ${!checked ? 'greyed' : ''}`}>
-              {price.toFixed(2)} {currency}
+              {formatPrice(price)}
             </Label>
           )}
         </Field>

--- a/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
@@ -13,9 +13,9 @@ import {useSelector} from 'react-redux';
 import {Checkbox, Dropdown, Label} from 'semantic-ui-react';
 
 import {FinalCheckbox, FinalField, FinalInput, validators as v} from 'indico/react/forms';
-import {Translate, PluralTranslate} from 'indico/react/i18n';
+import {Translate, PluralTranslate, Param} from 'indico/react/i18n';
 
-import {getFormatPrice} from '../../form/selectors';
+import {getPriceFormatter} from '../../form/selectors';
 import {getFieldValue, getManagement, getPaid} from '../../form_submission/selectors';
 
 import ChoiceLabel from './ChoiceLabel';
@@ -39,7 +39,7 @@ function MultiChoiceInputComponent({
 }) {
   const paid = useSelector(getPaid);
   const management = useSelector(getManagement);
-  const _formatPrice = useSelector(getFormatPrice);
+  const _formatPrice = useSelector(getPriceFormatter);
 
   const markTouched = () => {
     onFocus();
@@ -150,7 +150,9 @@ function MultiChoiceInputComponent({
                 <td>
                   {choice.isEnabled && !!choice.price && (
                     <Label pointing="left">
-                      {Translate.string('Total: {price}', {price: formatPrice(choice)})}
+                      <Translate>
+                        Total: <Param name="price" value={formatPrice(choice)} />
+                      </Translate>
                     </Label>
                   )}
                 </td>

--- a/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
@@ -15,7 +15,7 @@ import {Checkbox, Dropdown, Label} from 'semantic-ui-react';
 import {FinalCheckbox, FinalField, FinalInput, validators as v} from 'indico/react/forms';
 import {Translate, PluralTranslate} from 'indico/react/i18n';
 
-import {getCurrency} from '../../form/selectors';
+import {getFormatPrice} from '../../form/selectors';
 import {getFieldValue, getManagement, getPaid} from '../../form_submission/selectors';
 
 import ChoiceLabel from './ChoiceLabel';
@@ -39,7 +39,7 @@ function MultiChoiceInputComponent({
 }) {
   const paid = useSelector(getPaid);
   const management = useSelector(getManagement);
-  const currency = useSelector(getCurrency);
+  const _formatPrice = useSelector(getFormatPrice);
 
   const markTouched = () => {
     onFocus();
@@ -65,7 +65,7 @@ function MultiChoiceInputComponent({
 
   const formatPrice = choice => {
     const val = value[choice.id] || 0;
-    return ((val === 0 ? 0 : choice.extraSlotsPay ? val : 1) * choice.price).toFixed(2);
+    return _formatPrice((val === 0 ? 0 : choice.extraSlotsPay ? val : 1) * choice.price);
   };
 
   const isPaidChoice = choice => choice.price > 0 && paid;
@@ -106,9 +106,7 @@ function MultiChoiceInputComponent({
               </td>
               <td>
                 {choice.isEnabled && !!choice.price && (
-                  <Label pointing="left">
-                    {choice.price.toFixed(2)} {currency}
-                  </Label>
+                  <Label pointing="left">{formatPrice(choice.price)}</Label>
                 )}
               </td>
               <td>
@@ -152,10 +150,7 @@ function MultiChoiceInputComponent({
                 <td>
                   {choice.isEnabled && !!choice.price && (
                     <Label pointing="left">
-                      {Translate.string('Total: {total} {currency}', {
-                        total: formatPrice(choice),
-                        currency,
-                      })}
+                      {Translate.string('Total: {price}', {price: formatPrice(choice)})}
                     </Label>
                   )}
                 </td>

--- a/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/MultiChoiceInput.jsx
@@ -106,7 +106,7 @@ function MultiChoiceInputComponent({
               </td>
               <td>
                 {choice.isEnabled && !!choice.price && (
-                  <Label pointing="left">{formatPrice(choice.price)}</Label>
+                  <Label pointing="left">{formatPrice(choice)}</Label>
                 )}
               </td>
               <td>

--- a/indico/modules/events/registration/client/js/form/fields/NumberInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/NumberInput.jsx
@@ -13,12 +13,12 @@ import {Form, Label} from 'semantic-ui-react';
 import {FinalInput, FinalField, validators as v, parsers as p} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-import {getCurrency} from '../../form/selectors';
+import {getFormatPrice} from '../../form/selectors';
 
 import '../../../styles/regform.module.scss';
 
 function NumberInputComponent({id, value, onChange, disabled, price, minValue, maxValue}) {
-  const currency = useSelector(getCurrency);
+  const formatPrice = useSelector(getFormatPrice);
   const total = (value * price).toFixed(2);
 
   return (
@@ -34,7 +34,7 @@ function NumberInputComponent({id, value, onChange, disabled, price, minValue, m
       />
       {!!price && (
         <Label pointing="left" styleName="price-tag">
-          {price.toFixed(2)} {currency} (Total: {total} {currency})
+          {formatPrice(price)} (Total: {formatPrice(total)})
         </Label>
       )}
     </div>

--- a/indico/modules/events/registration/client/js/form/fields/NumberInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/NumberInput.jsx
@@ -13,12 +13,12 @@ import {Form, Label} from 'semantic-ui-react';
 import {FinalInput, FinalField, validators as v, parsers as p} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-import {getFormatPrice} from '../../form/selectors';
+import {getPriceFormatter} from '../../form/selectors';
 
 import '../../../styles/regform.module.scss';
 
 function NumberInputComponent({id, value, onChange, disabled, price, minValue, maxValue}) {
-  const formatPrice = useSelector(getFormatPrice);
+  const formatPrice = useSelector(getPriceFormatter);
   const total = (value * price).toFixed(2);
 
   return (

--- a/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
@@ -15,9 +15,9 @@ import {Form, Label, Dropdown} from 'semantic-ui-react';
 
 import {Select} from 'indico/react/components';
 import {FinalCheckbox, FinalDropdown, FinalField, parsers as p} from 'indico/react/forms';
-import {Translate} from 'indico/react/i18n';
+import {Param, Translate} from 'indico/react/i18n';
 
-import {getFormatPrice} from '../../form/selectors';
+import {getPriceFormatter} from '../../form/selectors';
 import {getFieldValue, getManagement, getPaid} from '../../form_submission/selectors';
 
 import ChoiceLabel from './ChoiceLabel';
@@ -43,7 +43,7 @@ function SingleChoiceDropdown({
 }) {
   const paid = useSelector(getPaid);
   const management = useSelector(getManagement);
-  const formatPrice = useSelector(getFormatPrice);
+  const formatPrice = useSelector(getPriceFormatter);
   const selectedChoice = choices.find(c => c.id in value) || {};
   const selectedSeats = value[selectedChoice.id] || 0;
 
@@ -144,11 +144,15 @@ function SingleChoiceDropdown({
         {extraSlotsDropdown}
         {shouldShowExtraSlotsLabel && (
           <Label pointing="left" id={extraSlotsLabelId}>
-            {Translate.string('Total: {price}', {
-              price: formatPrice(
-                (selectedChoice.extraSlotsPay ? selectedSeats : 1) * selectedChoice.price
-              ),
-            })}
+            <Translate>
+              Total:{' '}
+              <Param
+                name="price"
+                value={formatPrice(
+                  (selectedChoice.extraSlotsPay ? selectedSeats : 1) * selectedChoice.price
+                )}
+              />
+            </Translate>
           </Label>
         )}
       </div>
@@ -185,7 +189,7 @@ function SingleChoiceRadioGroup({
 }) {
   const paid = useSelector(getPaid);
   const management = useSelector(getManagement);
-  const formatPrice = useSelector(getFormatPrice);
+  const formatPrice = useSelector(getPriceFormatter);
   const selectedChoice = choices.find(c => c.id in value) || {id: ''};
   const radioChoices = [...choices];
   if (!isRequired) {
@@ -279,9 +283,13 @@ function SingleChoiceRadioGroup({
                   <td>
                     {c.isEnabled && !!c.price && (
                       <Label pointing="left">
-                        {Translate.string('Total: {price}', {
-                          price: formatPrice(value[selectedChoice.id] * c.price),
-                        })}
+                        <Translate>
+                          Total:{' '}
+                          <Param
+                            name="price"
+                            value={formatPrice(value[selectedChoice.id] * c.price)}
+                          />
+                        </Translate>
                       </Label>
                     )}
                   </td>

--- a/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
@@ -17,7 +17,7 @@ import {Select} from 'indico/react/components';
 import {FinalCheckbox, FinalDropdown, FinalField, parsers as p} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-import {getCurrency} from '../../form/selectors';
+import {getFormatPrice} from '../../form/selectors';
 import {getFieldValue, getManagement, getPaid} from '../../form_submission/selectors';
 
 import ChoiceLabel from './ChoiceLabel';
@@ -43,7 +43,7 @@ function SingleChoiceDropdown({
 }) {
   const paid = useSelector(getPaid);
   const management = useSelector(getManagement);
-  const currency = useSelector(getCurrency);
+  const formatPrice = useSelector(getFormatPrice);
   const selectedChoice = choices.find(c => c.id in value) || {};
   const selectedSeats = value[selectedChoice.id] || 0;
 
@@ -99,11 +99,7 @@ function SingleChoiceDropdown({
           <ChoiceLabel choice={choice} management={management} paid={isPaidChoice(choice)} />
         </div>
         <div styleName="labels">
-          {!!choice.price && (
-            <Label>
-              {choice.price} {currency}
-            </Label>
-          )}
+          {!!choice.price && <Label>{formatPrice(choice.price)}</Label>}
           {choice.placesLimit === 0 ? null : (
             <PlacesLeft
               placesLimit={choice.placesLimit}
@@ -148,11 +144,10 @@ function SingleChoiceDropdown({
         {extraSlotsDropdown}
         {shouldShowExtraSlotsLabel && (
           <Label pointing="left" id={extraSlotsLabelId}>
-            {Translate.string('Total: {total} {currency}', {
-              total: (
+            {Translate.string('Total: {price}', {
+              price: formatPrice(
                 (selectedChoice.extraSlotsPay ? selectedSeats : 1) * selectedChoice.price
-              ).toFixed(2),
-              currency,
+              ),
             })}
           </Label>
         )}
@@ -190,7 +185,7 @@ function SingleChoiceRadioGroup({
 }) {
   const paid = useSelector(getPaid);
   const management = useSelector(getManagement);
-  const currency = useSelector(getCurrency);
+  const formatPrice = useSelector(getFormatPrice);
   const selectedChoice = choices.find(c => c.id in value) || {id: ''};
   const radioChoices = [...choices];
   if (!isRequired) {
@@ -240,11 +235,7 @@ function SingleChoiceRadioGroup({
                 />
               </td>
               <td>
-                {c.isEnabled && !!c.price && (
-                  <Label pointing="left">
-                    {c.price.toFixed(2)} {currency}
-                  </Label>
-                )}
+                {c.isEnabled && !!c.price && <Label pointing="left">{formatPrice(c.price)}</Label>}
               </td>
               <td>
                 {c.id !== '' && c.placesLimit !== 0 && (
@@ -288,9 +279,8 @@ function SingleChoiceRadioGroup({
                   <td>
                     {c.isEnabled && !!c.price && (
                       <Label pointing="left">
-                        {Translate.string('Total: {total} {currency}', {
-                          total: (value[selectedChoice.id] * c.price).toFixed(2),
-                          currency,
+                        {Translate.string('Total: {price}', {
+                          price: formatPrice(value[selectedChoice.id] * c.price),
                         })}
                       </Label>
                     )}

--- a/indico/modules/events/registration/client/js/form/selectors.js
+++ b/indico/modules/events/registration/client/js/form/selectors.js
@@ -27,7 +27,7 @@ export const getCurrency = createSelector(
 );
 
 /** Get the price formatter function. */
-export const getFormatPrice = createSelector(
+export const getPriceFormatter = createSelector(
   getCurrency,
   currency => price =>
     new Intl.NumberFormat(document.documentElement.lang, {

--- a/indico/modules/events/registration/client/js/form/selectors.js
+++ b/indico/modules/events/registration/client/js/form/selectors.js
@@ -26,6 +26,18 @@ export const getCurrency = createSelector(
   staticData => staticData.currency
 );
 
+/** Get the price formatter function. */
+export const getFormatPrice = createSelector(
+  getCurrency,
+  currency => price =>
+    new Intl.NumberFormat(document.documentElement.lang, {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(price)
+);
+
 /** Get a sorted list of enabled top-level sections. */
 const getSections = createSelector(
   getFlatSections,


### PR DESCRIPTION
This PR fixes the price formatting in the registration fields, to switch from a concatenation of the price and the ISO code to the proper currency symbol, according to the user's locale.

Before:
![image](https://github.com/user-attachments/assets/ff32e232-25db-4360-860d-2c9ffe3c909c)

After:
![image](https://github.com/user-attachments/assets/8f3c35be-d525-41b3-9efd-53e51ef0a5de)
