### PR TITLE
Add placeholders to text fields in receipts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Improvements
   thanks :user:`omegak`)
 - Add email placeholder for the picture associated with a registration (:pr:`6580`, thanks
   :user:`vtran99`)
+- Allow setting placeholders for text fields in receipt templates (:pr:`6587`)
+- Add a new receipt template for Certificates of Attendance (:pr:`6587`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/receipts/client/js/printing/PrintReceiptsModal.jsx
+++ b/indico/modules/receipts/client/js/printing/PrintReceiptsModal.jsx
@@ -87,6 +87,7 @@ export default function PrintReceiptsModal({onClose, registrationIds, eventId}) 
   const {data: templateList, loading} = useIndicoAxios(allTemplatesURL({event_id: eventId}), {
     trigger: eventId,
     camelize: true,
+    skipCamelize: 'placeholders',
   });
   const ready = !loading && !!templateList;
 

--- a/indico/modules/receipts/client/js/printing/TemplateParameterEditor.jsx
+++ b/indico/modules/receipts/client/js/printing/TemplateParameterEditor.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Accordion, Checkbox, Dropdown, Form, Input, TextArea} from 'semantic-ui-react';
 
+import {PlaceholderInfo} from 'indico/react/components';
 import {useIndicoAxios} from 'indico/react/hooks';
 
 import EventImageSelectField from './EventImageSelectField';
@@ -38,6 +39,16 @@ function CustomField({
   loadingImages,
 }) {
   const id = `receipt-custom-${name}`;
+  const placeholderWidget = attributes.placeholders && (
+    <PlaceholderInfo
+      placeholders={Object.entries(attributes.placeholders).map(
+        ([placeholderName, description]) => ({
+          name: placeholderName,
+          description,
+        })
+      )}
+    />
+  );
   if (type === 'input') {
     return (
       <Form.Field required={validations.required}>
@@ -49,6 +60,7 @@ function CustomField({
           required={validations.required}
           onChange={(_, {value: v}) => onChange(v)}
         />
+        {placeholderWidget}
         {attributes.description && <p className="field-description">{attributes.description}</p>}
       </Form.Field>
     );
@@ -63,6 +75,7 @@ function CustomField({
           required={validations.required}
           onChange={(_, {value: v}) => onChange(v)}
         />
+        {placeholderWidget}
         {attributes.description && <p className="field-description">{attributes.description}</p>}
       </Form.Field>
     );
@@ -119,7 +132,14 @@ CustomField.propTypes = {
   name: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.number]),
   type: PropTypes.string.isRequired,
-  attributes: PropTypes.object.isRequired,
+  attributes: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+    options: PropTypes.arrayOf(PropTypes.string),
+    default: PropTypes.number,
+    placeholders: PropTypes.objectOf(PropTypes.string),
+  }).isRequired,
   validations: PropTypes.shape({
     required: PropTypes.bool,
   }).isRequired,

--- a/indico/modules/receipts/client/js/printing/TemplateParameterEditor.jsx
+++ b/indico/modules/receipts/client/js/printing/TemplateParameterEditor.jsx
@@ -60,8 +60,8 @@ function CustomField({
           required={validations.required}
           onChange={(_, {value: v}) => onChange(v)}
         />
-        {placeholderWidget}
         {attributes.description && <p className="field-description">{attributes.description}</p>}
+        {placeholderWidget}
       </Form.Field>
     );
   } else if (type === 'textarea') {
@@ -75,8 +75,8 @@ function CustomField({
           required={validations.required}
           onChange={(_, {value: v}) => onChange(v)}
         />
-        {placeholderWidget}
         {attributes.description && <p className="field-description">{attributes.description}</p>}
+        {placeholderWidget}
       </Form.Field>
     );
   } else if (type === 'dropdown') {

--- a/indico/modules/receipts/default_templates/attendance.yaml
+++ b/indico/modules/receipts/default_templates/attendance.yaml
@@ -1,0 +1,3 @@
+default_filename: certificate-of-attendance
+title: Certificate of Attendance
+version: 1

--- a/indico/modules/receipts/default_templates/attendance/metadata.yaml
+++ b/indico/modules/receipts/default_templates/attendance/metadata.yaml
@@ -1,0 +1,83 @@
+custom_fields:
+  - name: address_from
+    type: textarea
+    attributes:
+      label: Organizer Address
+
+  - name: venue
+    type: input
+    attributes:
+      label: Venue
+
+  - name: logo_url
+    type: image
+    attributes:
+      label: Logo
+
+  - name: add_url
+    type: checkbox
+    attributes:
+      label: Add event URL?
+
+  - name: text
+    type: textarea
+    attributes:
+      label: Certificate Text
+      value: >-
+        The Organizing Comitee certifies that {person} ({person_affiliation}) participated in the event {event}, which took place {date}, at {venue}.
+      placeholders:
+        person: Full name of the participant
+        person_affiliation: Participant's affiliation
+        event: Title of the event
+        date: Start date of the event
+        venue: Venue of the event
+
+  - name: place
+    type: input
+    attributes:
+      label: Place of Signature
+
+  - name: signature_name_0
+    type: input
+    attributes:
+      label: 1st Signature Name
+
+  - name: signature_position_0
+    type: input
+    attributes:
+      label: 1st Signature Position
+
+  - name: signature_url_0
+    type: image
+    attributes:
+      label: 1st Signature Image
+
+  - name: signature_name_1
+    type: input
+    attributes:
+      label: 2nd Signature Name
+
+  - name: signature_position_1
+    type: input
+    attributes:
+      label: 2nd Signature Position
+
+  - name: signature_url_1
+    type: image
+    attributes:
+      label: 2nd Signature Image
+
+  - name: signature_name_2
+    type: input
+    attributes:
+      label: 3rd Signature Name
+
+  - name: signature_position_2
+    type: input
+    attributes:
+      label: 3rd Signature Position
+
+  - name: signature_url_2
+    type: image
+    attributes:
+      label: 3rd Signature Image

--- a/indico/modules/receipts/default_templates/attendance/metadata.yaml
+++ b/indico/modules/receipts/default_templates/attendance/metadata.yaml
@@ -40,7 +40,7 @@ custom_fields:
     attributes:
       label: Certificate Text
       value: |
-        The Organizing Commitee certifies that {person} participated in the event {event}, which
+        The Organizing Committee certifies that {person} participated in the event {event}, which
         took place {date_range}, at {venue}.
       description: |
         The text to be shown on the certificate.

--- a/indico/modules/receipts/default_templates/attendance/metadata.yaml
+++ b/indico/modules/receipts/default_templates/attendance/metadata.yaml
@@ -1,36 +1,63 @@
 custom_fields:
+  - name: document_title
+    type: input
+    attributes:
+      label: Document Title
+      value: Certificate of Attendance
+      description: |
+        The title of the document, shown at the top of the page.
+
   - name: address_from
     type: textarea
     attributes:
       label: Organizer Address
+      description: |
+        The address of the entity who is issuing this receipt.
 
   - name: venue
     type: input
     attributes:
       label: Venue
+      description: |
+        A custom venue name instead of the event's venue.
 
-  - name: logo_url
+  - name: logo
     type: image
     attributes:
       label: Logo
+      description: |
+        A logo image to be shown on the receipt.
 
   - name: add_url
     type: checkbox
     attributes:
       label: Add event URL?
+      description: |
+        Whether to include the URL of the event on the receipt.
 
   - name: text
     type: textarea
     attributes:
       label: Certificate Text
-      value: >-
-        The Organizing Comitee certifies that {person} ({person_affiliation}) participated in the event {event}, which took place {date}, at {venue}.
+      value: |
+        The Organizing Commitee certifies that {person} participated in the event {event}, which
+        took place {date_range}, at {venue}.
+      description: |
+        The text to be shown on the certificate.
       placeholders:
         person: Full name of the participant
-        person_affiliation: Participant's affiliation
         event: Title of the event
-        date: Start date of the event
+        date_range: Date range of the event
+        start_date: Start date of the event
+        end_date: End date of the event
         venue: Venue of the event
+
+  - name: show_affiliation
+    type: checkbox
+    attributes:
+      label: Show participant affiliation
+      description: |
+        Whether to include the affiliation of the registrant next to their name.
 
   - name: place
     type: input

--- a/indico/modules/receipts/default_templates/attendance/template.html
+++ b/indico/modules/receipts/default_templates/attendance/template.html
@@ -1,7 +1,7 @@
 {% set personal_data = registration.personal_data %}
 {% set today = now_utc() %}
 
-<h1>Certificate of Attendance</h1>
+<h1>{{ custom_fields.document_title }}</h1>
 
 <aside id="title">
   <div class="title">
@@ -27,8 +27,8 @@
   </div>
 
   <!-- Logo -->
-  {% if custom_fields.logo_url %}
-    <img src="{{ custom_fields.logo_url }}">
+  {% if custom_fields.logo %}
+    <img src="{{ custom_fields.logo }}">
   {% endif %}
 </aside>
 
@@ -39,19 +39,27 @@
   </address>
 </aside>
 
+{% set start_date = event.start_dt | format_date('dd.MM.YYYY') %}
+{% set end_date = event.end_dt | format_date('dd.MM.YYYY') %}
 {%- if event.start_dt.date() != event.end_dt.date() %}
-  {% set date = 'between {} and {}'.format(event.start_dt | format_date('dd.MM.YYYY'), event.end_dt | format_date('dd.MM.YYYY')) %}
+  {% set date_range = 'between {} and {}'.format(start_date, end_date) %}
 {%- else %}
-  {% set date = 'on {}'.format(event.start_dt | format_date('dd.MM.YYYY')) %}
+  {% set date_range = 'on {}'.format(event.start_dt | format_date('dd.MM.YYYY')) %}
+{%- endif -%}
+    {%- if custom_fields.show_affiliation and personal_data.affiliation %}
+    {% set person = '<em>{} {}</em> (<em>{}</em>)'.format(personal_data.first_name | escape, personal_data.last_name | escape, personal_data.affiliation | escape) %}
+{%- else %}
+    {% set person = '<em>{} {}</em>'.format(personal_data.first_name | escape, personal_data.last_name | escape) %}
 {%- endif -%}
 
 <p>
   {% autoescape false %}
-    {{ custom_fields.text | format_html(
-      person='<em>{} {}</em>'.format(personal_data.first_name | escape, personal_data.last_name | escape),
-      person_affiliation='<em>{}</em>'.format(personal_data.affiliation | escape),
+    {{ custom_fields.text | format_placeholders(
+      person=person,
       event='<em>{}</em>'.format(event.title | escape),
-      date=date,
+      date_range=date_range,
+      start_date=start_date,
+      end_date=end_date,
       venue='<em>{}</em>'.format((custom_fields.venue or event.venue_name) | escape)
     ) }}
   {% endautoescape %}

--- a/indico/modules/receipts/default_templates/attendance/template.html
+++ b/indico/modules/receipts/default_templates/attendance/template.html
@@ -46,23 +46,21 @@
 {%- else %}
   {% set date_range = 'on {}'.format(event.start_dt | format_date('dd.MM.YYYY')) %}
 {%- endif -%}
-    {%- if custom_fields.show_affiliation and personal_data.affiliation %}
-    {% set person = '<em>{} {}</em> (<em>{}</em>)'.format(personal_data.first_name | escape, personal_data.last_name | escape, personal_data.affiliation | escape) %}
+{%- if custom_fields.show_affiliation and personal_data.affiliation %}
+  {% set person = '<em>{} {}</em> (<em>{}</em>)'.format(personal_data.first_name | escape, personal_data.last_name | escape, personal_data.affiliation | escape) %}
 {%- else %}
-    {% set person = '<em>{} {}</em>'.format(personal_data.first_name | escape, personal_data.last_name | escape) %}
+  {% set person = '<em>{} {}</em>'.format(personal_data.first_name | escape, personal_data.last_name | escape) %}
 {%- endif -%}
 
 <p>
-  {% autoescape false %}
-    {{ custom_fields.text | format_placeholders(
-      person=person,
-      event='<em>{}</em>'.format(event.title | escape),
-      date_range=date_range,
-      start_date=start_date,
-      end_date=end_date,
-      venue='<em>{}</em>'.format((custom_fields.venue or event.venue_name) | escape)
-    ) }}
-  {% endautoescape %}
+  {{ custom_fields.text | format_placeholders(
+    person=person,
+    event='<em>{}</em>'.format(event.title | escape),
+    date_range=date_range,
+    start_date=start_date,
+    end_date=end_date,
+    venue='<em>{}</em>'.format((custom_fields.venue or event.venue_name) | escape)
+  ) | safe }}
 </p>
 
 <p>

--- a/indico/modules/receipts/default_templates/attendance/template.html
+++ b/indico/modules/receipts/default_templates/attendance/template.html
@@ -1,0 +1,95 @@
+{% set personal_data = registration.personal_data %}
+{% set today = now_utc() %}
+
+<h1>Certificate of Attendance</h1>
+
+<aside id="title">
+  <div class="title">
+    <!-- Title -->
+    <h2>{{ event.title }}</h2>
+    <!-- Date(s) -->
+    {% if event.start_dt.date() != event.end_dt.date() %}
+      {{ format_interval(event.start_dt, event.end_dt, format='dMMMMy') }}
+    {% else %}
+      {{ event.start_dt | format_date('dd MMM YYYY') }}
+    {% endif %}
+
+    <!-- Venue -->
+    {% if custom_fields.venue %}
+      - {{ custom_fields.venue }}
+    {% elif event.venue_name %}
+      - {{ event.venue_name }}
+    {% endif %}
+
+    {% if custom_fields.add_url %}
+      <p>{{ event.url }}</p>
+    {% endif %}
+  </div>
+
+  <!-- Logo -->
+  {% if custom_fields.logo_url %}
+    <img src="{{ custom_fields.logo_url }}">
+  {% endif %}
+</aside>
+
+<aside id="addresses">
+  <!-- Address of organizer -->
+  <address id="from">
+    {{ custom_fields.address_from }}
+  </address>
+</aside>
+
+{%- if event.start_dt.date() != event.end_dt.date() %}
+  {% set date = 'between {} and {}'.format(event.start_dt | format_date('dd.MM.YYYY'), event.end_dt | format_date('dd.MM.YYYY')) %}
+{%- else %}
+  {% set date = 'on {}'.format(event.start_dt | format_date('dd.MM.YYYY')) %}
+{%- endif -%}
+
+<p>
+  {% autoescape false %}
+    {{ custom_fields.text | format_html(
+      person='<em>{} {}</em>'.format(personal_data.first_name | escape, personal_data.last_name | escape),
+      person_affiliation='<em>{}</em>'.format(personal_data.affiliation | escape),
+      event='<em>{}</em>'.format(event.title | escape),
+      date=date,
+      venue='<em>{}</em>'.format((custom_fields.venue or event.venue_name) | escape)
+    ) }}
+  {% endautoescape %}
+</p>
+
+<p>
+  {% if custom_fields.place %}
+    {{ custom_fields.place }}, {{ today | format_date('long') }}
+  {% else %}
+    {{ today | format_date('full') }}
+  {% endif %}
+</p>
+
+{% macro render_signature(i) %}
+  {% set name = custom_fields['signature_name_' ~ i] %}
+  {% set position = custom_fields['signature_position_' ~ i] %}
+  {% set url = custom_fields['signature_url_' ~ i] %}
+  {% if name or position or url %}
+    <div class="signature">
+      <div>
+        {% if url %}
+          <img src="{{ url }}" />
+        {% else %}
+          _____________
+        {% endif %}
+      </div>
+      <div class="name">
+        {{ name }}
+      </div>
+      <div class="position">
+        {{ position }}
+      </div>
+    </div>
+  {% endif %}
+{% endmacro %}
+
+<aside id="signatures">
+  {% for i in range(3) %}
+    {{ render_signature(i) }}
+  {% endfor %}
+</aside>

--- a/indico/modules/receipts/default_templates/attendance/theme.css
+++ b/indico/modules/receipts/default_templates/attendance/theme.css
@@ -1,0 +1,101 @@
+@page {
+  margin: 3cm;
+
+  @bottom-center {
+    color: #a9a;
+    content: 'Printed by Indico';
+    font-size: 9pt;
+  }
+}
+
+html {
+  color: #14213d;
+  font-family: sans-serif;
+  font-size: 11pt;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+}
+
+aside {
+  display: flex;
+  margin: 2em 0 4em;
+  width: 100%;
+}
+
+aside#title {
+  flex: 2;
+  align-items: center;
+}
+
+aside#title div.title {
+  flex: 2;
+}
+
+aside#addresses {
+  justify-content: space-between;
+}
+
+aside img {
+  max-width: 5cm;
+  max-height: 5cm;
+  margin-left: 0.5cm;
+}
+
+address {
+  display: block;
+  white-space: pre-line;
+}
+
+h1 {
+  color: #18597d;
+  font-size: 26pt;
+  margin: 0;
+}
+
+aside address#from {
+  color: #a9a;
+  flex: 1;
+}
+
+aside address#to {
+  text-align: right;
+  flex: 1;
+}
+
+p {
+  text-align: justify;
+  margin-bottom: 3em;
+}
+
+aside#signatures {
+  width: 100%;
+  justify-content: space-evenly;
+  align-items: flex-end;
+}
+
+aside .signature {
+  display: flex;
+  flex-direction: column;
+  min-width: 8em;
+  flex-basis: 100%;
+}
+
+aside .signature img {
+  width: 4cm;
+}
+
+aside .signature div {
+  text-align: center;
+  min-height: 1.8em;
+}
+
+aside .signature .name {
+  font-weight: bold;
+}
+
+aside .signature .position {
+  font-style: italic;
+}

--- a/indico/modules/receipts/schemas.py
+++ b/indico/modules/receipts/schemas.py
@@ -47,12 +47,17 @@ class _DropdownAttributesSchema(_AttributesSchemaBase):
             raise ValidationError('The provided value is out of range')
 
 
-class _InputAttributesSchema(_AttributesSchemaBase):
+class _TextAttributesSchemaBase(_AttributesSchemaBase):
     value = fields.String()
+    placeholders = fields.Dict(keys=fields.String(), values=fields.String())
 
 
-class _TextareaAttributesSchema(_AttributesSchemaBase):
-    value = fields.String()
+class _InputAttributesSchema(_TextAttributesSchemaBase):
+    pass
+
+
+class _TextareaAttributesSchema(_TextAttributesSchemaBase):
+    pass
 
 
 class _ImageAttributesSchema(_AttributesSchemaBase):

--- a/indico/modules/receipts/util.py
+++ b/indico/modules/receipts/util.py
@@ -139,6 +139,12 @@ def _format_currency(amount, currency, locale=None):
     return format_currency(amount, currency, locale=locale)
 
 
+def _format_html(value, **kwargs):
+    for k, v in kwargs.items():
+        value = value.replace(f'{{{k}}}', v)
+    return value
+
+
 def compile_jinja_code(code: str, template_context: dict, *, use_stack: bool = False) -> str:
     """Compile Jinja template of receipt in a sandboxed environment."""
     try:
@@ -149,6 +155,7 @@ def compile_jinja_code(code: str, template_context: dict, *, use_stack: bool = F
             'format_datetime': format_datetime,
             'format_time': format_time,
             'format_currency': _format_currency,
+            'format_html': _format_html,
         })
         env.globals.update({
             'format_interval': format_interval,

--- a/indico/modules/receipts/util.py
+++ b/indico/modules/receipts/util.py
@@ -139,7 +139,7 @@ def _format_currency(amount, currency, locale=None):
     return format_currency(amount, currency, locale=locale)
 
 
-def _format_html(value, **kwargs):
+def _format_placeholders(value, **kwargs):
     for k, v in kwargs.items():
         value = value.replace(f'{{{k}}}', v)
     return value
@@ -155,7 +155,7 @@ def compile_jinja_code(code: str, template_context: dict, *, use_stack: bool = F
             'format_datetime': format_datetime,
             'format_time': format_time,
             'format_currency': _format_currency,
-            'format_html': _format_html,
+            'format_placeholders': _format_placeholders,
         })
         env.globals.update({
             'format_interval': format_interval,

--- a/indico/web/client/js/react/hooks.js
+++ b/indico/web/client/js/react/hooks.js
@@ -143,7 +143,7 @@ FavoritesProvider.propTypes = {
  */
 export function useIndicoAxios(
   axiosConfig,
-  {camelize = false, unhandledErrors = [], ...hookConfig} = {}
+  {camelize = false, skipCamelize = null, unhandledErrors = [], ...hookConfig} = {}
 ) {
   const lastData = useRef(null);
   const lastError = useRef(null);
@@ -162,7 +162,7 @@ export function useIndicoAxios(
   if (response) {
     data = response.data;
     if (camelize) {
-      data = camelizeKeys(data);
+      data = camelizeKeys(data, skipCamelize);
     }
     lastData.current = data;
   } else if (

--- a/indico/web/client/js/utils/case.js
+++ b/indico/web/client/js/utils/case.js
@@ -11,20 +11,28 @@ function smartCamelCase(string) {
   return _.camelCase(string).replace(/Url/g, 'URL');
 }
 
-export function camelizeKeys(obj) {
+/**
+ * Camelizes keys of an object recursively.
+ *
+ * @param {Object} obj - Object to camelize
+ * @param {string|null} skip - Key of object to skip
+ */
+export function camelizeKeys(obj, skip = null) {
   if (!_.isPlainObject(obj) && !_.isArray(obj)) {
     return obj;
   }
 
   if (_.isArray(obj)) {
-    return obj.map(camelizeKeys);
+    return obj.map(x => camelizeKeys(x, skip));
   }
 
   return Object.entries(obj).reduce((accum, [key, value]) => {
-    if (key.match(/^[A-Za-z_]+$/)) {
-      return {...accum, [smartCamelCase(key)]: camelizeKeys(value)};
+    if (skip && skip === key) {
+      return {...accum, [smartCamelCase(key)]: value};
+    } else if (key.match(/^[A-Za-z_]+$/)) {
+      return {...accum, [smartCamelCase(key)]: camelizeKeys(value, skip)};
     } else {
-      return {...accum, [key]: camelizeKeys(value)};
+      return {...accum, [key]: camelizeKeys(value, skip)};
     }
   }, {});
 }


### PR DESCRIPTION
This PR adds the ability to add placeholders on text (input and textarea) fields, which are then displayed to the user. It also adds a template for Certificates of Attendance.

This is done by adding a placeholders dict in the attributes of the field, like so:
```yaml
  - name: text
    type: textarea
    attributes:
      label: Certificate Text
      value: >-
        The Organizing Comitee certifies that {person} ({person_affiliation}) participated in the event {event}, which took place {date}, at {venue}.
      placeholders:
        person: registration.personal_data.first_name
        person_affiliation: registration.personal_data.affiliation
        event: event.title
        date: event.start_dt
        venue: custom_fields.venue
```

And in the HTML, calling the `format_html` filter:
```html+jinja
{{ custom_fields.text | format_html(
      person='<em>{} {}</em>'.format(personal_data.first_name | escape, personal_data.last_name | escape),
      person_affiliation='<em>{}</em>'.format(personal_data.affiliation | escape),
      event='<em>{}</em>'.format(event.title | escape),
      date=date,
      venue='<em>{}</em>'.format((custom_fields.venue or event.venue_name) | escape)
    ) }}
```

Resulting in this view when generating receipts:
<img width="598" alt="image" src="https://github.com/user-attachments/assets/03a62324-1811-4808-81a1-ef5041714fb6">

The Certificate of Attendance looks like so:
<img width="592" alt="image" src="https://github.com/user-attachments/assets/9a82ee3d-5f46-4b97-8633-bdd729a5e70b">
