### PR TITLE
Move RHRegistrationReset logic to Registration model

### DIFF
--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -700,11 +700,8 @@ class RHRegistrationReset(RHManageRegistrationBase):
     """Reset a registration back to a non-approved status."""
 
     def _process(self):
-        try:
-            self.registration.reset_state(silent=False)
-            logger.info('Registration %r was reset by %r', self.registration, session.user)
-        except Exception as e:
-            flash(str(e), 'error')
+        self.registration.reset_state()
+        logger.info('Registration %r was reset by %r', self.registration, session.user)
         return jsonify_data(html=_render_registration_details(self.registration))
 
 


### PR DESCRIPTION
As per discussed via Matrix, I'm moving the RHRegistrationReset logic to Registration model, to create a method similar to update_state() to be used externally, for reset registrations in bulk in this case, but can be used for other purposes in the future