### PR TITLE
Show correct repetition details for bookings repeating every n weeks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,7 @@ Improvements
   :user:`vtran99`)
 - Allow setting placeholders for text fields in receipt templates (:pr:`6587`)
 - Add a new receipt template for Certificates of Attendance (:pr:`6587`)
+- Add repetition information for bookings that recur on specific weekdays (:pr:`6592`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,7 +40,7 @@ Improvements
   :user:`vtran99`)
 - Allow setting placeholders for text fields in receipt templates (:pr:`6587`)
 - Add a new receipt template for Certificates of Attendance (:pr:`6587`)
-- Add repetition information for bookings that recur on specific weekdays (:pr:`6592`)
+- Show correct repetition details for bookings repeating every n weeks (:pr:`6592`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/rb/client/js/__tests__/util.test.js
+++ b/indico/modules/rb/client/js/__tests__/util.test.js
@@ -117,21 +117,21 @@ describe('can render the recurrence weekdays whilst taking the locale into accou
 });
 
 describe('can render the recurrence weekdays with support for repetition', () => {
-  it('should handle a single weekday with an repetition', () => {
+  it('should handle a single weekday with a repetition', () => {
     const weekdays = ['mon'];
     const repetition = 2;
     const expected = 'Every 2 weeks on Monday';
     expect(renderRecurrenceWeekdays({weekdays, repetition})).toBe(expected);
   });
 
-  it('should handle multiple weekdays with an repetition', () => {
+  it('should handle multiple weekdays with a repetition', () => {
     const weekdays = ['mon', 'tue', 'wed'];
     const repetition = 3;
     const expected = 'Every 3 weeks on Monday, Tuesday, and Wednesday';
     expect(renderRecurrenceWeekdays({weekdays, repetition})).toBe(expected);
   });
 
-  it('should handle all weekdays with an repetition', () => {
+  it('should handle all weekdays with a repetition', () => {
     const weekdays = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
     const repetition = 4;
     const expected =
@@ -139,7 +139,7 @@ describe('can render the recurrence weekdays with support for repetition', () =>
     expect(renderRecurrenceWeekdays({weekdays, repetition})).toBe(expected);
   });
 
-  it('should handle all weekdays in non-sequential order with an repetition', () => {
+  it('should handle all weekdays in non-sequential order with a repetition', () => {
     const weekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
     const repetition = 5;
     const expected =

--- a/indico/modules/rb/client/js/__tests__/util.test.js
+++ b/indico/modules/rb/client/js/__tests__/util.test.js
@@ -9,7 +9,7 @@ import moment from 'moment';
 
 import {renderRecurrenceWeekdays} from '../util';
 
-describe('renderRecurrenceWeekdays', () => {
+describe('can render the recurrence weekdays', () => {
   it('should return null if weekdays array is empty', () => {
     const weekdays = [];
     expect(renderRecurrenceWeekdays(weekdays)).toBeNull();
@@ -32,38 +32,38 @@ describe('renderRecurrenceWeekdays', () => {
 
   it('correctly formats a single weekday', () => {
     const formatted = renderRecurrenceWeekdays(['mon']);
-    expect(formatted).toBe('Monday');
+    expect(formatted).toBe('Every Monday');
   });
 
   it('correctly formats two weekdays', () => {
     const formatted = renderRecurrenceWeekdays(['mon', 'tue']);
-    expect(formatted).toBe('Monday and Tuesday');
+    expect(formatted).toBe('Every Monday and Tuesday');
   });
 
   it('correctly formats multiple weekdays', () => {
     const formatted = renderRecurrenceWeekdays(['mon', 'tue', 'wed']);
-    expect(formatted).toBe('Monday, Tuesday, and Wednesday');
+    expect(formatted).toBe('Every Monday, Tuesday, and Wednesday');
   });
 
   it('correctly formats weekdays in non-sequential order', () => {
     const formatted = renderRecurrenceWeekdays(['wed', 'mon', 'fri']);
-    expect(formatted).toBe('Monday, Wednesday, and Friday');
+    expect(formatted).toBe('Every Monday, Wednesday, and Friday');
   });
 
   it('should handle all weekdays', () => {
     const weekdays = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
-    const expected = 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
+    const expected = 'Every Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
     expect(renderRecurrenceWeekdays(weekdays)).toBe(expected);
   });
 
   it('should handle all weekdays in non-sequential order', () => {
     const weekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
-    const expected = 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
+    const expected = 'Every Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
     expect(renderRecurrenceWeekdays(weekdays)).toBe(expected);
   });
 });
 
-describe('renderLocalizedRecurrenceWeekdays', () => {
+describe('can render the recurrence weekdays whilst taking the locale into account', () => {
   const unorderedWeekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
   const cases = [
     ['de', 'Montag, Dienstag, Mittwoch, Donnerstag, Freitag, Samstag und Sonntag'],
@@ -80,6 +80,7 @@ describe('renderLocalizedRecurrenceWeekdays', () => {
     ['pl', 'poniedziałek, wtorek, środa, czwartek, piątek, sobota i niedziela'],
     ['mn', 'Даваа, Мягмар, Лхагва, Пүрэв, Баасан, Бямба, Ням'],
     ['uk', 'понеділок, вівторок, середа, четвер, п’ятниця, субота і неділя'],
+    ['hu', 'hétfő, kedd, szerda, csütörtök, péntek, szombat és vasárnap'],
     ['zh-cn', '星期一、星期二、星期三、星期四、星期五、星期六和星期日'],
   ];
 
@@ -89,7 +90,73 @@ describe('renderLocalizedRecurrenceWeekdays', () => {
       const oldLocale = moment.locale();
       moment.locale(locale);
       const formatted = renderRecurrenceWeekdays(unorderedWeekdays);
-      expect(formatted).toBe(expected);
+      expect(formatted).toBe(`Every ${expected}`);
+      moment.locale(oldLocale);
+    }
+  );
+});
+
+describe('can render the recurrence weekdays with support for intervals', () => {
+  it('should handle a single weekday with an interval', () => {
+    const weekdays = ['mon'];
+    const interval = 2;
+    const expected = 'Every 2 weeks on Monday';
+    expect(renderRecurrenceWeekdays(weekdays, interval)).toBe(expected);
+  });
+
+  it('should handle multiple weekdays with an interval', () => {
+    const weekdays = ['mon', 'tue', 'wed'];
+    const interval = 3;
+    const expected = 'Every 3 weeks on Monday, Tuesday, and Wednesday';
+    expect(renderRecurrenceWeekdays(weekdays, interval)).toBe(expected);
+  });
+
+  it('should handle all weekdays with an interval', () => {
+    const weekdays = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+    const interval = 4;
+    const expected =
+      'Every 4 weeks on Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
+    expect(renderRecurrenceWeekdays(weekdays, interval)).toBe(expected);
+  });
+
+  it('should handle all weekdays in non-sequential order with an interval', () => {
+    const weekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
+    const interval = 5;
+    const expected =
+      'Every 5 weeks on Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
+    expect(renderRecurrenceWeekdays(weekdays, interval)).toBe(expected);
+  });
+});
+
+describe('can render the recurrence weekdays with support for intervals whilst taking the locale into account', () => {
+  const unorderedWeekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
+  const interval = 3;
+  const cases = [
+    ['de', 'Montag, Dienstag, Mittwoch, Donnerstag, Freitag, Samstag und Sonntag'],
+    ['en-gb', 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday and Sunday'],
+    ['en-us', 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday'],
+    ['fr', 'lundi, mardi, mercredi, jeudi, vendredi, samedi et dimanche'],
+    [
+      'pt-br',
+      'segunda-feira, terça-feira, quarta-feira, quinta-feira, sexta-feira, sábado e domingo',
+    ],
+    ['es', 'lunes, martes, miércoles, jueves, viernes, sábado y domingo'],
+    ['it', 'lunedì, martedì, mercoledì, giovedì, venerdì, sabato e domenica'],
+    ['tr', 'Pazartesi, Salı, Çarşamba, Perşembe, Cuma, Cumartesi ve Pazar'],
+    ['pl', 'poniedziałek, wtorek, środa, czwartek, piątek, sobota i niedziela'],
+    ['mn', 'Даваа, Мягмар, Лхагва, Пүрэв, Баасан, Бямба, Ням'],
+    ['uk', 'понеділок, вівторок, середа, четвер, п’ятниця, субота і неділя'],
+    ['hu', 'hétfő, kedd, szerda, csütörtök, péntek, szombat és vasárnap'],
+    ['zh-cn', '星期一、星期二、星期三、星期四、星期五、星期六和星期日'],
+  ];
+
+  test.each(cases)(
+    'should localize all weekdays in non-sequential order in %s with an interval',
+    (locale, expected) => {
+      const oldLocale = moment.locale();
+      moment.locale(locale);
+      const formatted = renderRecurrenceWeekdays(unorderedWeekdays, interval);
+      expect(formatted).toBe(`Every 3 weeks on ${expected}`);
       moment.locale(oldLocale);
     }
   );

--- a/indico/modules/rb/client/js/__tests__/util.test.js
+++ b/indico/modules/rb/client/js/__tests__/util.test.js
@@ -12,54 +12,74 @@ import {renderRecurrenceWeekdays} from '../util';
 describe('can render the recurrence weekdays', () => {
   it('should return null if weekdays array is empty', () => {
     const weekdays = [];
-    expect(renderRecurrenceWeekdays(weekdays)).toBeNull();
+    expect(renderRecurrenceWeekdays({weekdays})).toBeNull();
   });
 
   it('should return null if weekdays array is null', () => {
     const weekdays = null;
-    expect(renderRecurrenceWeekdays(weekdays)).toBeNull();
+    expect(renderRecurrenceWeekdays({weekdays})).toBeNull();
   });
 
   it('should handle a single unknown/bad weekday', () => {
     const weekdays = ['xyz'];
-    expect(renderRecurrenceWeekdays(weekdays)).toBeNull();
+    expect(renderRecurrenceWeekdays({weekdays})).toBeNull();
   });
 
   it('should handle multiple unknown/bad weekdays', () => {
     const weekdays = ['xyz', 'abc', 'def'];
-    expect(renderRecurrenceWeekdays(weekdays)).toBeNull();
+    expect(renderRecurrenceWeekdays({weekdays})).toBeNull();
   });
 
   it('correctly formats a single weekday', () => {
-    const formatted = renderRecurrenceWeekdays(['mon']);
+    const formatted = renderRecurrenceWeekdays({weekdays: ['mon']});
     expect(formatted).toBe('Every Monday');
   });
 
   it('correctly formats two weekdays', () => {
-    const formatted = renderRecurrenceWeekdays(['mon', 'tue']);
+    const formatted = renderRecurrenceWeekdays({weekdays: ['mon', 'tue']});
     expect(formatted).toBe('Every Monday and Tuesday');
   });
 
   it('correctly formats multiple weekdays', () => {
-    const formatted = renderRecurrenceWeekdays(['mon', 'tue', 'wed']);
+    const formatted = renderRecurrenceWeekdays({weekdays: ['mon', 'tue', 'wed']});
     expect(formatted).toBe('Every Monday, Tuesday, and Wednesday');
   });
 
   it('correctly formats weekdays in non-sequential order', () => {
-    const formatted = renderRecurrenceWeekdays(['wed', 'mon', 'fri']);
+    const formatted = renderRecurrenceWeekdays({weekdays: ['wed', 'mon', 'fri']});
     expect(formatted).toBe('Every Monday, Wednesday, and Friday');
   });
 
   it('should handle all weekdays', () => {
     const weekdays = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
     const expected = 'Every Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
-    expect(renderRecurrenceWeekdays(weekdays)).toBe(expected);
+    expect(renderRecurrenceWeekdays({weekdays})).toBe(expected);
   });
 
   it('should handle all weekdays in non-sequential order', () => {
     const weekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
     const expected = 'Every Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
-    expect(renderRecurrenceWeekdays(weekdays)).toBe(expected);
+    expect(renderRecurrenceWeekdays({weekdays})).toBe(expected);
+  });
+});
+
+describe('can render only the recurrence weekdays (short format)', () => {
+  it('should handle a single weekday', () => {
+    const weekdays = ['mon'];
+    expect(renderRecurrenceWeekdays({weekdays, weekdaysOnly: true})).toBe('Monday');
+  });
+
+  it('should handle multiple weekdays', () => {
+    const weekdays = ['mon', 'tue', 'wed'];
+    expect(renderRecurrenceWeekdays({weekdays, weekdaysOnly: true})).toBe(
+      'Monday, Tuesday, and Wednesday'
+    );
+  });
+
+  it('should handle all weekdays', () => {
+    const weekdays = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+    const expected = 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
+    expect(renderRecurrenceWeekdays({weekdays, weekdaysOnly: true})).toBe(expected);
   });
 });
 
@@ -89,48 +109,48 @@ describe('can render the recurrence weekdays whilst taking the locale into accou
     (locale, expected) => {
       const oldLocale = moment.locale();
       moment.locale(locale);
-      const formatted = renderRecurrenceWeekdays(unorderedWeekdays);
+      const formatted = renderRecurrenceWeekdays({weekdays: unorderedWeekdays});
       expect(formatted).toBe(`Every ${expected}`);
       moment.locale(oldLocale);
     }
   );
 });
 
-describe('can render the recurrence weekdays with support for intervals', () => {
-  it('should handle a single weekday with an interval', () => {
+describe('can render the recurrence weekdays with support for repetition', () => {
+  it('should handle a single weekday with an repetition', () => {
     const weekdays = ['mon'];
-    const interval = 2;
+    const repetition = 2;
     const expected = 'Every 2 weeks on Monday';
-    expect(renderRecurrenceWeekdays(weekdays, interval)).toBe(expected);
+    expect(renderRecurrenceWeekdays({weekdays, repetition})).toBe(expected);
   });
 
-  it('should handle multiple weekdays with an interval', () => {
+  it('should handle multiple weekdays with an repetition', () => {
     const weekdays = ['mon', 'tue', 'wed'];
-    const interval = 3;
+    const repetition = 3;
     const expected = 'Every 3 weeks on Monday, Tuesday, and Wednesday';
-    expect(renderRecurrenceWeekdays(weekdays, interval)).toBe(expected);
+    expect(renderRecurrenceWeekdays({weekdays, repetition})).toBe(expected);
   });
 
-  it('should handle all weekdays with an interval', () => {
+  it('should handle all weekdays with an repetition', () => {
     const weekdays = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
-    const interval = 4;
+    const repetition = 4;
     const expected =
       'Every 4 weeks on Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
-    expect(renderRecurrenceWeekdays(weekdays, interval)).toBe(expected);
+    expect(renderRecurrenceWeekdays({weekdays, repetition})).toBe(expected);
   });
 
-  it('should handle all weekdays in non-sequential order with an interval', () => {
+  it('should handle all weekdays in non-sequential order with an repetition', () => {
     const weekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
-    const interval = 5;
+    const repetition = 5;
     const expected =
       'Every 5 weeks on Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, and Sunday';
-    expect(renderRecurrenceWeekdays(weekdays, interval)).toBe(expected);
+    expect(renderRecurrenceWeekdays({weekdays, repetition})).toBe(expected);
   });
 });
 
-describe('can render the recurrence weekdays with support for intervals whilst taking the locale into account', () => {
+describe('can render the recurrence weekdays with support for repetitions whilst taking the locale into account', () => {
   const unorderedWeekdays = ['wed', 'mon', 'fri', 'tue', 'sun', 'thu', 'sat'];
-  const interval = 3;
+  const repetition = 3;
   const cases = [
     ['de', 'Montag, Dienstag, Mittwoch, Donnerstag, Freitag, Samstag und Sonntag'],
     ['en-gb', 'Monday, Tuesday, Wednesday, Thursday, Friday, Saturday and Sunday'],
@@ -151,11 +171,11 @@ describe('can render the recurrence weekdays with support for intervals whilst t
   ];
 
   test.each(cases)(
-    'should localize all weekdays in non-sequential order in %s with an interval',
+    'should localize all weekdays in non-sequential order in %s with an repetition',
     (locale, expected) => {
       const oldLocale = moment.locale();
       moment.locale(locale);
-      const formatted = renderRecurrenceWeekdays(unorderedWeekdays, interval);
+      const formatted = renderRecurrenceWeekdays({weekdays: unorderedWeekdays, repetition});
       expect(formatted).toBe(`Every 3 weeks on ${expected}`);
       moment.locale(oldLocale);
     }

--- a/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
+++ b/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
@@ -211,7 +211,16 @@ class TimelineItem extends React.Component {
             attached="bottom"
           >
             <Message.Content>
-              {renderRecurrenceWeekdays(reservation.recurrenceWeekdays)}
+              <Translate>
+                On{' '}
+                <Param
+                  name="weekdays"
+                  value={renderRecurrenceWeekdays({
+                    weekdays: reservation.recurrenceWeekdays,
+                    weekdaysOnly: true,
+                  })}
+                />
+              </Translate>
             </Message.Content>
           </Message>
         )}

--- a/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
+++ b/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
@@ -150,7 +150,12 @@ class TimelineItem extends React.Component {
           count: repeatInterval,
         });
       } else if (repeatFrequency === 'WEEK') {
-        return Translate.string('Recurs weekly');
+        return PluralTranslate.string(
+          'Recurs weekly',
+          'Recurs every {count} weeks',
+          repeatInterval,
+          {count: repeatInterval}
+        );
       } else if (repeatFrequency === 'MONTH') {
         return PluralTranslate.string(
           'Recurs monthly',
@@ -206,7 +211,7 @@ class TimelineItem extends React.Component {
             attached="bottom"
           >
             <Message.Content>
-              {renderRecurrenceWeekdays(reservation.recurrenceWeekdays, reservation.repeatInterval)}
+              {renderRecurrenceWeekdays(reservation.recurrenceWeekdays)}
             </Message.Content>
           </Message>
         )}

--- a/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
+++ b/indico/modules/rb/client/js/common/timeline/TimelineItem.jsx
@@ -206,13 +206,7 @@ class TimelineItem extends React.Component {
             attached="bottom"
           >
             <Message.Content>
-              <Translate>
-                Every{' '}
-                <Param
-                  name="weekdays"
-                  value={renderRecurrenceWeekdays(reservation.recurrenceWeekdays)}
-                />
-              </Translate>
+              {renderRecurrenceWeekdays(reservation.recurrenceWeekdays, reservation.repeatInterval)}
             </Message.Content>
           </Message>
         )}

--- a/indico/modules/rb/client/js/components/TimeInformation.jsx
+++ b/indico/modules/rb/client/js/components/TimeInformation.jsx
@@ -77,13 +77,10 @@ function TimeInformation({
         {recurrence.type === 'every' && recurrence.interval === 'week' && recurrenceWeekdays && (
           <Segment>
             <div>
-              <div>
+              <strong>
                 <Icon name="sync alternate" />
-                <Translate as="strong">
-                  Every{' '}
-                  <Param name="weekdays" value={renderRecurrenceWeekdays(recurrenceWeekdays)} />
-                </Translate>
-              </div>
+                {renderRecurrenceWeekdays(recurrenceWeekdays, recurrence.number)}
+              </strong>
             </div>
           </Segment>
         )}

--- a/indico/modules/rb/client/js/components/TimeInformation.jsx
+++ b/indico/modules/rb/client/js/components/TimeInformation.jsx
@@ -79,7 +79,10 @@ function TimeInformation({
             <div>
               <strong>
                 <Icon name="sync alternate" />
-                {renderRecurrenceWeekdays(recurrenceWeekdays, recurrence.number)}
+                {renderRecurrenceWeekdays({
+                  weekdays: recurrenceWeekdays,
+                  repetition: recurrence.number,
+                })}
               </strong>
             </div>
           </Segment>

--- a/indico/modules/rb/client/js/util.jsx
+++ b/indico/modules/rb/client/js/util.jsx
@@ -238,10 +238,10 @@ export function serializeRecurrenceInfo({type, number, interval}) {
 
 /**
  * Renders the array of recurrence weekdays into a nicely formatted string
- * @param {object} options Options object
- * @param {array} weekdays Array of weekdays
- * @param {number} repetition Recurrence repetition (e.g. every `2` weeks)
- * @param {boolean} [weekdaysOnly=false] Whether to return only the weekdays
+ * @param {object} opts Options
+ * @param {array} opts.weekdays Array of weekdays
+ * @param {number} opts.repetition Recurrence repetition (e.g. every `2` weeks)
+ * @param {boolean} opts.weekdaysOnly Whether to return only the weekdays
  * @returns {string} Formatted string of weekdays
  */
 export function renderRecurrenceWeekdays({weekdays, repetition = null, weekdaysOnly = false}) {

--- a/indico/modules/rb/client/js/util.jsx
+++ b/indico/modules/rb/client/js/util.jsx
@@ -239,9 +239,10 @@ export function serializeRecurrenceInfo({type, number, interval}) {
 /**
  * Renders the array of recurrence weekdays into a nicely formatted string
  * @param {array} weekdays Array of weekdays
+ * @param {number} repetition Recurrence repetition (e.g. every `2` weeks)
  * @returns {string} Formatted string of weekdays
  */
-export function renderRecurrenceWeekdays(weekdays) {
+export function renderRecurrenceWeekdays(weekdays, repetition = null) {
   const weekdaysMap = {
     mon: moment.weekdays(1),
     tue: moment.weekdays(2),
@@ -273,7 +274,20 @@ export function renderRecurrenceWeekdays(weekdays) {
     type: 'conjunction',
   }).format(sortedWeekdays.map(weekday => weekdaysMap[weekday]));
 
-  return formattedWeekdays;
+  // only show the repetition if it's greater than 1
+  if (repetition && repetition > 1) {
+    return PluralTranslate.string(
+      'Every {repetition} week on {weekdays}',
+      'Every {repetition} weeks on {weekdays}',
+      repetition,
+      {
+        repetition,
+        weekdays: formattedWeekdays,
+      }
+    );
+  }
+
+  return Translate.string('Every {weekdays}', {weekdays: formattedWeekdays});
 }
 
 const _legendLabels = {

--- a/indico/modules/rb/client/js/util.jsx
+++ b/indico/modules/rb/client/js/util.jsx
@@ -238,11 +238,13 @@ export function serializeRecurrenceInfo({type, number, interval}) {
 
 /**
  * Renders the array of recurrence weekdays into a nicely formatted string
+ * @param {object} options Options object
  * @param {array} weekdays Array of weekdays
  * @param {number} repetition Recurrence repetition (e.g. every `2` weeks)
+ * @param {boolean} [weekdaysOnly=false] Whether to return only the weekdays
  * @returns {string} Formatted string of weekdays
  */
-export function renderRecurrenceWeekdays(weekdays, repetition = null) {
+export function renderRecurrenceWeekdays({weekdays, repetition = null, weekdaysOnly = false}) {
   const weekdaysMap = {
     mon: moment.weekdays(1),
     tue: moment.weekdays(2),
@@ -285,6 +287,10 @@ export function renderRecurrenceWeekdays(weekdays, repetition = null) {
         weekdays: formattedWeekdays,
       }
     );
+  }
+
+  if (weekdaysOnly) {
+    return formattedWeekdays;
   }
 
   return Translate.string('Every {weekdays}', {weekdays: formattedWeekdays});

--- a/indico/modules/rb/client/js/util.jsx
+++ b/indico/modules/rb/client/js/util.jsx
@@ -279,7 +279,7 @@ export function renderRecurrenceWeekdays({weekdays, repetition = null, weekdaysO
   // only show the repetition if it's greater than 1
   if (repetition && repetition > 1) {
     return PluralTranslate.string(
-      'Every {repetition} week on {weekdays}',
+      'Every week on {weekdays}',
       'Every {repetition} weeks on {weekdays}',
       repetition,
       {


### PR DESCRIPTION
This PR adds repetition info the `renderRecurrenceWeekdays()` function, so that users can clearly distinguish between bookings that have recurring weekdays every week or every `n` weeks.

![image](https://github.com/user-attachments/assets/bf2e3948-b346-4e98-9e51-c930aabc402f)