### PR TITLE
Fix spacing issues in booking form

### DIFF
--- a/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
+++ b/indico/modules/rb/client/js/components/BookingBootstrapForm.jsx
@@ -415,7 +415,7 @@ class BookingBootstrapForm extends React.Component {
           </Form.Group>
         )}
         {type === 'every' && interval === 'week' && (
-          <Form.Group inline style={{marginLeft: '1em', marginRight: '1em'}}>
+          <Form.Group inline>
             <Translate as="label">Recurring every</Translate>
             <WeekdayRecurrencePicker onChange={this.updateRecurrenceWeekdays} value={weekdays} />
           </Form.Group>

--- a/indico/modules/rb/client/js/components/BookingBootstrapForm.module.scss
+++ b/indico/modules/rb/client/js/components/BookingBootstrapForm.module.scss
@@ -14,11 +14,8 @@
 
 :global(.ui.form) .recurrence-field:global(.inline.fields) {
   display: flex;
-  justify-content: space-around;
 
   > * {
-    flex: 1;
-
     :global(.ui.input input) {
       width: 100%;
       min-width: 60px;


### PR DESCRIPTION
This PR fixes spacing issues in the RB booking form:

Before:
![image](https://github.com/user-attachments/assets/b01e4ad6-3ba0-4a3f-99c2-9022258334e4)


After:
![image](https://github.com/user-attachments/assets/b3f6d9db-5151-4bef-a7b9-d8b7045b52e5)
