### PR TITLE
Add missing `en` locale in weekday preselector

### DIFF
--- a/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingEditForm.jsx
@@ -131,6 +131,7 @@ class BookingEditForm extends React.Component {
     } = this.props;
 
     const today = moment()
+      .locale('en')
       .format('ddd')
       .toLowerCase();
 


### PR DESCRIPTION
This PR fixes a bug in RB, where editing a booking (whilst in a locale that isn't English/`en`) to a recurring by weekday booking would cause the `preselectWeekdayToday()` to select the current weekday in the users set locale, and not in English, thereby causing the backend to return a 422 error.