### PR TITLE
Tweak alignment of block duration text

### DIFF
--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -69,7 +69,7 @@ body {
   font-size: 1em;
   float: right;
   max-width: 200px;
-  margin: 0.5rem 0.7em 0 0;
+  margin: 0.7rem 0.7em 0 0;
 
   &::before {
     color: $tt-secondary-color;
@@ -327,7 +327,7 @@ ul.day-list {
     }
 
     .timetable-duration {
-      margin: 0.5rem 0.7em 0 0;
+      margin: 0.7rem 0.7em 0 0;
       min-width: 4em;
       text-align: right;
       color: $dark-gray;

--- a/indico/web/client/styles/themes/indico.scss
+++ b/indico/web/client/styles/themes/indico.scss
@@ -367,7 +367,7 @@ ul.day-list {
     .timetable-title {
       font-weight: bold;
       font-size: 1.1em;
-      padding-top: 0.5rem;
+      padding-top: 0.7rem;
       @include font-family-title();
       flex: auto;
       line-height: 1rem;
@@ -485,6 +485,7 @@ ul.day-list {
   color: $tt-primary-color !important;
   flex-shrink: 0;
   line-height: 2rem;
+  margin-top: 0.2rem;
 
   &.top-level {
     .start-time {


### PR DESCRIPTION
This PR slightly tweaks the alignment of the session block duration text.

Before:
![image](https://github.com/user-attachments/assets/a558f232-02fa-4cb9-be13-22618251aaa7)

After:
![image](https://github.com/user-attachments/assets/9c220241-a6e3-4737-8b27-e82fc6ae23d9)
