### PR TITLE
Move user sessions to DB to invalidate sessions during password reset

### DIFF
--- a/indico/migrations/versions/20260223_1517_fb255305ea83_move_user_sessions_to_postgres.py
+++ b/indico/migrations/versions/20260223_1517_fb255305ea83_move_user_sessions_to_postgres.py
@@ -1,0 +1,34 @@
+"""move_user_sessions_to_postgres
+
+Revision ID: fb255305ea83
+Revises: af9d03d7073c
+Create Date: 2024-10-23 15:17:02.490888
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'fb255305ea83'
+down_revision = 'af9d03d7073c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'sessions',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('sid', sa.String(), nullable=False, unique=True),
+        sa.Column('data', sa.LargeBinary(), nullable=False),
+        sa.Column('ttl', sa.DateTime(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.users.id']),
+        schema='users'
+    )
+
+
+def downgrade():
+    op.drop_table('sessions', schema='users')

--- a/indico/modules/auth/forms.py
+++ b/indico/modules/auth/forms.py
@@ -8,7 +8,7 @@
 from fnmatch import fnmatch
 
 from flask import session
-from wtforms import HiddenField
+from wtforms import BooleanField, HiddenField
 from wtforms.fields import EmailField, PasswordField, SelectField, StringField
 from wtforms.validators import DataRequired, Email, Optional, ValidationError
 
@@ -21,7 +21,8 @@ from indico.util.i18n import _
 from indico.util.signals import values_from_signal
 from indico.util.string import validate_email
 from indico.web.forms.base import IndicoForm
-from indico.web.forms.validators import ConfirmPassword, SecurePassword
+from indico.web.forms.validators import ConfirmPassword, HiddenUnless, SecurePassword
+from indico.web.forms.widgets import SwitchWidget
 
 
 def _tolower(s):
@@ -96,6 +97,9 @@ class EditLocalIdentityForm(IndicoForm):
                                  render_kw={'autocomplete': 'new-password'})
     confirm_new_password = PasswordField(_('Confirm password'), [ConfirmPassword('new_password')],
                                          render_kw={'autocomplete': 'new-password'})
+    force_logout = BooleanField(_('Logout of other devices'), [HiddenUnless('new_password')], widget=SwitchWidget(),
+                                description=_('This will log you out of all other devices and sessions '
+                                              'where you are currently logged in.'))
 
     def __init__(self, *args, identity=None, **kwargs):
         self.identity = identity
@@ -193,6 +197,9 @@ class ResetPasswordForm(IndicoForm):
                              render_kw={'autocomplete': 'new-password'})
     confirm_password = PasswordField(_('Confirm password'), [DataRequired(), ConfirmPassword('password')],
                                      render_kw={'autocomplete': 'new-password'})
+    force_logout = BooleanField(_('Logout of other devices'), widget=SwitchWidget(),
+                                description=_('This will log you out of all other devices and sessions '
+                                              'where you are currently logged in.'))
 
     def __init__(self, *args, user_emails, **kwargs):
         self.user_emails = user_emails

--- a/indico/modules/users/models/sessions.py
+++ b/indico/modules/users/models/sessions.py
@@ -1,0 +1,49 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2026 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from indico.core.db import db
+from indico.util.string import format_repr
+
+
+class UserSession(db.Model):
+    __tablename__ = 'sessions'
+    __table_args__ = {'schema': 'users'}
+
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+    sid = db.Column(
+        db.String(),
+        unique=True,
+        nullable=False
+    )
+    data = db.Column(
+        db.LargeBinary,
+        nullable=False
+    )
+    ttl = db.Column(
+        db.DateTime,
+        nullable=False
+    )
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.users.id'),
+        nullable=False
+    )
+
+    user = db.relationship(
+        'User',
+        lazy=True,
+        backref=db.backref(
+            'sessions',
+            lazy='dynamic'
+        )
+    )
+
+    def __repr__(self):
+        return format_repr(self, 'sid', 'ttl')

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -506,6 +506,7 @@ class User(PersonMixin, db.Model):
     # - reservations (Reservation.created_by_user)
     # - reservations_booked_for (Reservation.booked_for_user)
     # - review_comments (PaperReviewComment.user)
+    # - sessions (UserSession.user)
     # - static_sites (StaticSite.creator)
     # - survey_submissions (SurveySubmission.user)
     # - user_log_entries (UserLogEntry.user)

--- a/indico/modules/users/tasks.py
+++ b/indico/modules/users/tasks.py
@@ -5,6 +5,8 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from datetime import datetime
+
 from celery.schedules import crontab
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -15,6 +17,7 @@ from indico.modules.users import logger
 from indico.modules.users.export import export_user_data as _export_user_data
 from indico.modules.users.export import get_old_requests
 from indico.modules.users.models.export import DataExportRequestState
+from indico.modules.users.models.sessions import UserSession
 from indico.modules.users.models.users import ProfilePictureSource, User
 from indico.modules.users.util import get_gravatar_for_user, set_user_avatar
 from indico.util.iterables import committing_iterator
@@ -73,4 +76,11 @@ def user_data_export_cleanup(days=30):
         request.state = DataExportRequestState.expired
         if request.file:
             request.file.claimed = False
+    db.session.commit()
+
+
+@celery.periodic_task(name='delete_user_sessions', run_every=crontab(minute='0'))
+def delete_user_sessions():
+    """Delete expired user sessions from postgres."""
+    UserSession.query.filter(UserSession.ttl < datetime.now()).delete()
     db.session.commit()


### PR DESCRIPTION
This PR moves flask sessions that are associated with a user from redis to postgres so that sessions can be queried by user and invalidated upon password reset. 
