### PR TITLE
Clip designer item top and left to 0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -66,6 +66,8 @@ Bugfixes
 - Do not allow mixing notification rules for invited abstracts with other rules (:issue:`6563`,
   :pr:`6567`)
 - Use locale-aware price formatting in registration form fields (:pr:`6586`)
+- Handle badge designer items exceeding the canvas boundaries more gracefully (:pr:`6603`,
+  thanks :user:`SegiNyn`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/designer/client/js/index.js
+++ b/indico/modules/designer/client/js/index.js
@@ -184,8 +184,8 @@ import {$T} from 'indico/utils/i18n';
       },
       stop: function(e, ui) {
         var itemId = $(this).data('id');
-        items[itemId].x = unzoom(ui.position.left);
-        items[itemId].y = unzoom(ui.position.top);
+        items[itemId].x = Math.max(0, unzoom(ui.position.left));
+        items[itemId].y = Math.max(0, unzoom(ui.position.top));
       },
     });
 
@@ -569,14 +569,20 @@ import {$T} from 'indico/utils/i18n';
         $fixedTextField.val(selectedItem.text);
       },
       width: function() {
-        selectedItem.width = Math.round($('.js-element-width').val() * pixelsPerCm);
+        selectedItem.width = Math.min(
+          templateDimensions.width,
+          Math.round($('.js-element-width').val() * pixelsPerCm)
+        );
         if (selectedItem.type === 'ticket_qr_code') {
           $('.js-element-height').val($('.js-element-width').val());
           selectedItem.height = selectedItem.width;
         }
       },
       height: function() {
-        selectedItem.height = Math.round($('.js-element-height').val() * pixelsPerCm);
+        selectedItem.height = Math.min(
+          templateDimensions.height,
+          Math.round($('.js-element-height').val() * pixelsPerCm)
+        );
         if (selectedItem.type === 'ticket_qr_code') {
           $('.js-element-width').val($('.js-element-height').val());
           selectedItem.width = selectedItem.height;


### PR DESCRIPTION
This is to fix getting error messages such as in the screenshot below when an element top or left is less than 0 in the badge designer
<img width="632" alt="Screenshot 2024-11-06 at 16 41 33" src="https://github.com/user-attachments/assets/0c37a7d1-a71f-4294-957c-1eee1b310dad">
