### PR TITLE
Add CSV delimiter to the remaining places

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ Improvements
   :data:`SMTP_SENDER_FALLBACK` config settings. Instead, the *From* address will be rewritten
   to the fallback whenever the requested address is not an allowed sender (:pr:`6231`, thanks
   :user:`SegiNyn`)
+- Allow alternative CSV delimiters everywhere when importing content from CSV files (:pr:`6607`,
+  thanks :user:`Moliholy, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -599,7 +599,9 @@ class RHContributionsImportCSV(RHManageContributionsBase):
         form = ImportContributionsForm()
 
         if form.validate_on_submit():
-            contributions, changes = import_contributions_from_csv(self.event, form.source_file.data)
+            delimiter = form.delimiter.data.delimiter
+            contributions, changes = import_contributions_from_csv(self.event, form.source_file.data,
+                                                                   delimiter=delimiter)
             flash(ngettext('{} contribution has been imported.',
                            '{} contributions have been imported.',
                            len(contributions)).format(len(contributions)), 'success')

--- a/indico/modules/events/contributions/util.py
+++ b/indico/modules/events/contributions/util.py
@@ -282,10 +282,10 @@ def serialize_contribution_for_ical(contrib):
     }
 
 
-def import_contributions_from_csv(event, f):
+def import_contributions_from_csv(event, f, delimiter=','):
     """Import timetable contributions from a CSV file into an event."""
     with csv_text_io_wrapper(f) as ftxt:
-        reader = csv.reader(ftxt.read().splitlines())
+        reader = csv.reader(ftxt.read().splitlines(), delimiter=delimiter)
 
     contrib_data = []
     for num_row, row in enumerate(reader, 1):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -494,7 +494,7 @@ class RHRegistrationsImport(RHRegistrationsActionBase):
             if self.regform.is_purged:
                 raise Forbidden(_('Registration is disabled due to an expired retention period'))
             skip_moderation = self.regform.moderation_enabled and form.skip_moderation.data
-            delimiter = form.delimiter.data
+            delimiter = form.delimiter.data.delimiter
             registrations = import_registrations_from_csv(self.regform, form.source_file.data,
                                                           skip_moderation=skip_moderation,
                                                           notify_users=form.notify_users.data,

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -494,9 +494,11 @@ class RHRegistrationsImport(RHRegistrationsActionBase):
             if self.regform.is_purged:
                 raise Forbidden(_('Registration is disabled due to an expired retention period'))
             skip_moderation = self.regform.moderation_enabled and form.skip_moderation.data
+            delimiter = form.delimiter.data
             registrations = import_registrations_from_csv(self.regform, form.source_file.data,
                                                           skip_moderation=skip_moderation,
-                                                          notify_users=form.notify_users.data)
+                                                          notify_users=form.notify_users.data,
+                                                          delimiter=delimiter)
             flash(ngettext('{} registration has been imported.',
                            '{} registrations have been imported.',
                            len(registrations)).format(len(registrations)), 'success')

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -582,6 +582,8 @@ class ImportRegistrationsForm(IndicoForm):
                                                    'event is access-restricted.'))
     notify_users = BooleanField(_('E-mail users'), widget=SwitchWidget(),
                                 description=_('Whether the imported users should receive an e-mail notification'))
+    delimiter = IndicoEnumSelectField(_('CSV field delimiter'), enum=CSVFieldDelimiter,
+                                      default=CSVFieldDelimiter.comma.name)
 
     def __init__(self, *args, **kwargs):
         self.regform = kwargs.pop('regform')

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -8,7 +8,6 @@
 import json
 from datetime import time, timedelta
 from decimal import Decimal
-from enum import auto
 from operator import itemgetter
 
 import jsonschema
@@ -32,9 +31,9 @@ from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import PublishRegistrationsMode, Registration
 from indico.modules.events.registration.models.tags import RegistrationTag
 from indico.modules.events.settings import data_retention_settings
-from indico.util.enum import RichStrEnum
 from indico.util.i18n import _, ngettext
 from indico.util.placeholders import get_missing_placeholders, render_placeholder_info
+from indico.util.spreadsheets import CSVFieldDelimiter
 from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm, generated_data
 from indico.web.forms.fields import EmailListField, FileField, IndicoDateTimeField, IndicoEnumSelectField, JSONField
@@ -317,30 +316,6 @@ class InvitationFormExisting(InvitationFormBase):
         if existing:
             raise ValidationError(_('There are already registrations with the following email addresses: {emails}')
                                   .format(emails=', '.join(sorted(existing))))
-
-
-class CSVFieldDelimiter(RichStrEnum):
-    __titles__ = {
-        'comma': _('Comma'),
-        'semicolon': _('Semicolon'),
-        'tab': _('Tab'),
-        'space': _('Space')
-    }
-    __delimiters__ = {
-        'comma': ',',
-        'semicolon': ';',
-        'tab': '\t',
-        'space': ' ',
-    }
-
-    comma = auto()
-    semicolon = auto()
-    tab = auto()
-    space = auto()
-
-    @property
-    def delimiter(self):
-        return self.__delimiters__[self.name]
 
 
 class ImportInvitationsForm(InvitationFormBase):

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -78,8 +78,9 @@ class ActionMenuEntry:
 def import_user_records_from_csv(fileobj, columns, delimiter=','):
     """Parse and do basic validation of user data from a CSV file.
 
-    :param fileobj: the CSV file to be read
+    :param fileobj: the CSV file to be read.
     :param columns: A list of column names, 'first_name', 'last_name', & 'email' are compulsory.
+    :param delimiter: the CSV separator.
     :return: A list dictionaries each representing one row,
              the keys of which are given by the column names.
     """

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -864,10 +864,10 @@ def create_invitation(regform, user, email_sender, email_subject, email_body, *,
     return invitation
 
 
-def import_registrations_from_csv(regform, fileobj, skip_moderation=True, notify_users=False):
+def import_registrations_from_csv(regform, fileobj, skip_moderation=True, notify_users=False, delimiter=','):
     """Import event registrants from a CSV file into a form."""
     columns = ['first_name', 'last_name', 'affiliation', 'position', 'phone', 'email']
-    user_records = import_user_records_from_csv(fileobj, columns=columns)
+    user_records = import_user_records_from_csv(fileobj, columns=columns, delimiter=delimiter)
 
     reg_data = (db.session.query(Registration.user_id, Registration.email)
                 .with_parent(regform)

--- a/indico/modules/events/roles/forms.py
+++ b/indico/modules/events/roles/forms.py
@@ -10,9 +10,10 @@ from wtforms.validators import DataRequired, Length, ValidationError
 
 from indico.modules.events.models.roles import EventRole
 from indico.util.i18n import _
+from indico.util.spreadsheets import CSVFieldDelimiter
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.colors import get_role_colors
-from indico.web.forms.fields import FileField, IndicoSinglePalettePickerField
+from indico.web.forms.fields import FileField, IndicoEnumSelectField, IndicoSinglePalettePickerField
 from indico.web.forms.widgets import SwitchWidget
 
 
@@ -42,3 +43,5 @@ class ImportMembersCSVForm(IndicoForm):
     source_file = FileField(_('Source File'), [DataRequired(_('You need to upload a CSV or TXT file.'))],
                             accepted_file_types='.csv,.txt')
     remove_existing = BooleanField(_('Remove existing members'), widget=SwitchWidget())
+    delimiter = IndicoEnumSelectField(_('CSV field delimiter'), enum=CSVFieldDelimiter,
+                                      default=CSVFieldDelimiter.comma.name)

--- a/indico/modules/events/timetable/forms.py
+++ b/indico/modules/events/timetable/forms.py
@@ -19,9 +19,10 @@ from indico.modules.events.sessions.forms import SessionBlockForm
 from indico.modules.events.timetable.models.entries import TimetableEntryType
 from indico.modules.events.timetable.util import find_next_start_dt
 from indico.util.i18n import _
+from indico.util.spreadsheets import CSVFieldDelimiter
 from indico.web.forms.base import FormDefaults, IndicoForm, generated_data
 from indico.web.forms.colors import get_colors
-from indico.web.forms.fields import (FileField, IndicoLocationField, IndicoPalettePickerField,
+from indico.web.forms.fields import (FileField, IndicoEnumSelectField, IndicoLocationField, IndicoPalettePickerField,
                                      IndicoSelectMultipleCheckboxBooleanField, IndicoTimeField)
 from indico.web.forms.fields.datetime import IndicoDurationField
 from indico.web.forms.util import get_form_field_names
@@ -203,3 +204,4 @@ class TimetablePDFExportForm(IndicoForm):
 class ImportContributionsForm(IndicoForm):
     source_file = FileField(_('Source File'), [DataRequired(_('You need to upload a CSV file.'))],
                             accepted_file_types='.csv')
+    delimiter = IndicoEnumSelectField(_('CSV field delimiter'), enum=CSVFieldDelimiter, default=CSVFieldDelimiter.comma)

--- a/indico/util/roles.py
+++ b/indico/util/roles.py
@@ -29,9 +29,9 @@ class ImportRoleMembersMixin:
     logger = None
     log_realm = None
 
-    def import_members_from_csv(self, f):
+    def import_members_from_csv(self, f, delimiter):
         with csv_text_io_wrapper(f) as ftxt:
-            reader = csv.reader(ftxt.read().splitlines())
+            reader = csv.reader(ftxt.read().splitlines(), delimiter=delimiter)
 
         emails = set()
         for num_row, row in enumerate(reader, 1):
@@ -55,7 +55,8 @@ class ImportRoleMembersMixin:
         form = ImportMembersCSVForm()
 
         if form.validate_on_submit():
-            new_members, users, unknown_emails = self.import_members_from_csv(form.source_file.data)
+            delimiter = form.delimiter.data.delimiter
+            new_members, users, unknown_emails = self.import_members_from_csv(form.source_file.data, delimiter)
             if form.remove_existing.data:
                 deleted_members = self.role.members - users
                 for member in deleted_members:

--- a/indico/util/spreadsheets.py
+++ b/indico/util/spreadsheets.py
@@ -9,6 +9,7 @@ import csv
 import re
 from contextlib import contextmanager
 from datetime import datetime
+from enum import auto
 from io import BytesIO, TextIOWrapper
 
 from markupsafe import Markup
@@ -17,8 +18,33 @@ from xlsxwriter import Workbook
 
 from indico.core.errors import UserValueError
 from indico.util.date_time import format_datetime
+from indico.util.enum import RichStrEnum
 from indico.util.i18n import _
 from indico.web.flask.util import send_file
+
+
+class CSVFieldDelimiter(RichStrEnum):
+    __titles__ = {
+        'comma': _('Comma'),
+        'semicolon': _('Semicolon'),
+        'tab': _('Tab'),
+        'space': _('Space')
+    }
+    __delimiters__ = {
+        'comma': ',',
+        'semicolon': ';',
+        'tab': '\t',
+        'space': ' ',
+    }
+
+    comma = auto()
+    semicolon = auto()
+    tab = auto()
+    space = auto()
+
+    @property
+    def delimiter(self):
+        return self.__delimiters__[self.name]
 
 
 def unique_col(name, id_):


### PR DESCRIPTION
This PR attempts to include CSV delimiters in the remaining cases through the whole project. It currently includes the following cases:

- Import registrations form
- Import invitations form
- Import event members form
- Import contributions form

<img width="855" alt="Screenshot 2024-11-08 at 16 42 34" src="https://github.com/user-attachments/assets/0e9ea0c9-0189-4693-b06c-3ad11a8181a4">


