### PR TITLE
VC: fix position of room info box in meetings

### DIFF
--- a/indico/modules/events/templates/display/indico/_details.html
+++ b/indico/modules/events/templates/display/indico/_details.html
@@ -42,8 +42,6 @@
         </div>
     {% endif %}
 
-    {{ hook_event_header }}
-
     {% if event.contact_emails or event.contact_phones %}
         <div class="event-details-row">
             <div class="event-details-label">{{ event.contact_title }}</div>
@@ -63,4 +61,6 @@
             </div>
         </div>
     {% endif %}
+
+    {{ hook_event_header }}
 </div>

--- a/indico/modules/vc/__init__.py
+++ b/indico/modules/vc/__init__.py
@@ -36,7 +36,7 @@ def _inject_conference_home(event, **kwargs):
         return render_template('vc/conference_home.html', event=event, event_vc_rooms=event_vc_rooms)
 
 
-@template_hook('event-header')
+@template_hook('event-header', priority=100)
 def _inject_event_header(event, **kwargs):
     res = VCRoomEventAssociation.find_for_event(event, only_linked_to_event=True)
     event_vc_rooms = [event_vc_room for event_vc_room in res.all() if event_vc_room.vc_room.plugin is not None]


### PR DESCRIPTION
This makes sure it's always at the end of the meeting header. Also adds a priority to the `event-header` signal handler, so that we avoid future surprises.