### PR TITLE
Fix filename fallback in secure_path

### DIFF
--- a/indico/modules/users/export.py
+++ b/indico/modules/users/export.py
@@ -349,7 +349,7 @@ def build_filename(file):
 
 
 def secure_path(path):
-    parts = (secure_filename(p, uuid4()) for p in Path(path).parts)
+    parts = (secure_filename(p, str(uuid4())) for p in Path(path).parts)
     return Path(*parts)
 
 


### PR DESCRIPTION
Hello, we got this issue from user data export concerning the filename fallback 
```
In [25]: secure_filename('\u4e17.txt', uuid4())
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[25], line 1
----> 1 secure_filename('\u4e17.txt', uuid4())

File ~/un/indico/core/indico-un/indico/indico/util/fs.py:55, in secure_filename(filename, fallback)
     52 filename, ext = os.path.splitext(filename)
     53 if not (filename := _secure_filename(str_to_ascii(filename))):
     54     # fallback to the name part of the fallback (it may or may not contain an extension)
---> 55     filename = os.path.splitext(fallback)[0]
     56 if ext and not (ext := _secure_filename(str_to_ascii(ext.lstrip('.')))):
     57     ext = os.path.splitext(fallback)[1].lstrip('.')

File <frozen posixpath>:118, in splitext(p)

TypeError: expected str, bytes or os.PathLike object, not UUID
```

```
In [24]: secure_filename('\u4e17.txt', str(uuid4()))
Out[24]: '0850f31a-4321-41a6-8e46-a178ca5142ca.txt'
```