### PR TITLE
ci: Use node 22 and latest Python 3.12.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,8 @@ on:
 
 env:
   TZ: Europe/Zurich
+  PYTHON_VERSION: '3.12'
+  NODE_VERSION: '22.x'
 
 jobs:
   build:
@@ -41,11 +43,11 @@ jobs:
       - uses: actions/setup-python@v5
         name: Set up Python 🐍
         with:
-          python-version: '3.12'
+          python-version: ${{ env.PYTHON_VERSION }}
       - uses: actions/setup-node@v4
         name: Setup Node
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
       - name: Get uv cache dir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 env:
   TZ: Europe/Zurich
-  PYTHON_VERSION_312: '3.12.3'
+  PYTHON_VERSION_312: '3.12.7'
+  NODE_VERSION: '22.x'
 
 on:
   push:
@@ -45,7 +46,7 @@ jobs:
         uses: actions/setup-node@v4
         if: steps.cache-npm.outputs.cache-hit != 'true'
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install system dependencies
         run: sudo apt-get install libpq-dev
@@ -108,7 +109,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -250,7 +251,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -309,7 +310,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install uv
         run: curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -10,6 +10,11 @@ on:
       - '!v3.1.*'
       - '!*\+docs'
 
+env:
+  TZ: Europe/Zurich
+  PYTHON_VERSION: '3.12'
+  NODE_VERSION: '22.x'
+
 jobs:
   build:
     name: Build package 📦
@@ -19,7 +24,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Set up Python 🐍
         with:
-          python-version: '3.12'
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
           cache-dependency-path: |
             requirements.txt
@@ -35,7 +40,7 @@ jobs:
       - uses: actions/setup-node@v4
         name: Setup Node
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
       - name: Install Indico + Python deps 🔧
         run: pip install --user -e '.[dev]'
       - name: Install npm deps ☕

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   TZ: Europe/Zurich
+  PYTHON_VERSION: '3.12'
+  NODE_VERSION: '22.x'
 
 jobs:
   build:
@@ -19,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v5
         name: Set up Python 🐍
         with:
-          python-version: '3.12'
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
           cache-dependency-path: |
             requirements.txt
@@ -27,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v4
         name: Setup Node
         with:
-          node-version: 18.x
+          node-version: ${{ env.NODE_VERSION }}
       - name: Install build deps 🔧
         run: |
           sudo apt-get install libpq-dev


### PR DESCRIPTION
node 18 is already in security-only mode and goes EOL in a few months: https://endoflife.date/nodejs