### PR TITLE
Add support for lazy `pgettext`

### DIFF
--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -63,6 +63,12 @@ def lazy_gettext(string, plugin_name=None):
     return make_lazy_string(_indico_gettext, string, plugin_name=plugin_name)
 
 
+def lazy_pgettext(context, string, plugin_name=None):
+    if is_lazy_string(string):
+        return string
+    return make_lazy_string(_indico_gettext, context, string, func_name='pgettext', plugin_name=plugin_name)
+
+
 def orig_string(lazy_string):
     """Get the original string from a lazy string."""
     return lazy_string._args[0] if is_lazy_string(lazy_string) else lazy_string
@@ -74,12 +80,14 @@ def smart_func(func_name, plugin_name=None):
         Return either a translated string or a lazy-translatable object,
         depending on whether there is a session language or not (respectively).
         """
-        if has_request_context() or func_name != 'gettext':
+        if has_request_context() or func_name not in {'gettext', 'pgettext'}:
             # straight translation
             return _indico_gettext(*args, func_name=func_name, plugin_name=plugin_name, **kwargs)
-        else:
             # otherwise, defer translation to eval time
+        elif func_name == 'gettext':
             return lazy_gettext(*args, plugin_name=plugin_name)
+        else:
+            return lazy_pgettext(*args, plugin_name=plugin_name)
 
     if plugin_name is _use_context:
         _wrap.__name__ = f'<smart {func_name}>'

--- a/indico/util/i18n_test.py
+++ b/indico/util/i18n_test.py
@@ -34,6 +34,8 @@ DICTIONARIES = {
     'fr_CH': {  # monty python french (some of it), but babel doesn't like fr_MP :(
         'Fetch the cow': 'Fetchez la vache',
         'The wheels': 'Les wheels',
+        _to_msgid('Monty Python', 'Fetch the cow'): 'Fetchez la vache',
+        _to_msgid('Monty Python', 'The wheels'): 'Les wheels',
         ('{} cow', 0): '{} vache',
         ('{} cow', 1): '{} vaches',
         'I need a drink.': 'Booze, svp.',
@@ -93,15 +95,23 @@ def test_lazy_translation(monkeypatch):
     monkeypatch.setattr('indico.util.i18n.has_request_context', lambda: False)
     a = _('Fetch the cow')
     b = _('The wheels')
+    a_with_context = pgettext('Monty Python', 'Fetch the cow')
+    b_with_context = pgettext('Monty Python', 'The wheels')
     monkeypatch.setattr('indico.util.i18n.has_request_context', lambda: True)
 
     assert isinstance(a, _LazyString)
     assert isinstance(b, _LazyString)
+    assert isinstance(a_with_context, _LazyString)
+    assert isinstance(b_with_context, _LazyString)
+    assert a_with_context._args == ('Monty Python', 'Fetch the cow')
+    assert b_with_context._args == ('Monty Python', 'The wheels')
 
     session.lang = 'fr_CH'
 
     assert str(a) == 'Fetchez la vache'
     assert str(b) == 'Les wheels'
+    assert str(a_with_context) == 'Fetchez la vache'
+    assert str(b_with_context) == 'Les wheels'
 
 
 @pytest.mark.usefixtures('mock_translations')


### PR DESCRIPTION
I realized we don't have this yet while working on https://github.com/indico/indico/pull/6610.
I need lazy pgettext for a few strings, for example:
https://github.com/indico/indico/pull/6610/files#diff-3c0e69aa32f6e05a867aab6f654c16ea1ee398b5b36cc94df2ef66185491eefeR35
