### PR TITLE
Extract translator comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,7 @@ Internal Changes
   :user:`foxbunny`)
 - Add additional signals related to videoconferences and their event links (:pr:`6475`)
 - Videoconference plugins now need to implement a ``delete_room`` method (:pr:`6475`)
+- Support translator comments when extracting translatable strings (:pr:`6620`)
 
 
 Version 3.3.4

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -36,6 +36,8 @@ MESSAGES_POT = TRANSLATIONS_DIR / 'messages.pot'
 MESSAGES_JS_POT = TRANSLATIONS_DIR / 'messages-js.pot'
 MESSAGES_REACT_POT = TRANSLATIONS_DIR / 'messages-react.pot'
 
+TRANSLATOR_COMMENT_TAG = 'i18n:'
+
 DEFAULT_OPTIONS = {
     'InitCatalog': {
         'input_file': MESSAGES_POT,
@@ -49,6 +51,8 @@ DEFAULT_OPTIONS = {
         'mapping_file': 'babel.cfg',
         'input_paths': ['indico'],
         'add_location': 'file',
+        'add_comments': TRANSLATOR_COMMENT_TAG,  # Extract translator comments starting with 'i18n:'
+        'strip_comments': True,  # Strip the comment tag ('i18n:') from the extracted comments
         'project': 'Indico',
         'version': indico.__version__,
     },
@@ -76,6 +80,8 @@ DEFAULT_OPTIONS = {
         'no_default_keywords': True,
         'input_paths': ['indico'],
         'add_location': 'file',
+        'add_comments': TRANSLATOR_COMMENT_TAG,  # Extract translator comments starting with 'i18n:'
+        'strip_comments': True,  # Strip the comment tag ('i18n:') from the extracted comments
         'project': 'Indico',
         'version': indico.__version__,
     },

--- a/indico/translations/messages.pot
+++ b/indico/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Indico 3.3.5-dev\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-11-19 17:02+0100\n"
+"POT-Creation-Date: 2024-11-19 17:07+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18870,46 +18870,60 @@ msgstr ""
 msgid "tomorrow"
 msgstr ""
 
+#. keep the single quotes around the string
 #: indico/util/date_time.py
 msgid "'Yesterday'"
 msgstr ""
 
+#. keep the single quotes around the string
 #: indico/util/date_time.py
 msgid "'Today'"
 msgstr ""
 
+#. keep the single quotes around the string
 #: indico/util/date_time.py
 msgid "'Tomorrow'"
 msgstr ""
 
+#. keep the single quotes around the string, and only translate the "Last".
+#. EEEE is a babel-style placeholder for the long weekday (you should probably keep this as-is)
 #: indico/util/date_time.py
 msgid "'Last' EEEE"
 msgstr ""
 
+#. EEEE is a babel-style placeholder for the long weekday (you should probably keep this as-is)
 #: indico/util/date_time.py
 msgid "EEEE"
 msgstr ""
 
+#. keep the single quotes around the strings, and only translate the text inside
 #: indico/util/date_time.py
 msgid "'Yesterday' 'at' {time_fmt}"
 msgstr ""
 
+#. keep the single quotes around the strings, and only translate the text inside
 #: indico/util/date_time.py
 msgid "'Today' 'at' {time_fmt}"
 msgstr ""
 
+#. keep the single quotes around the strings, and only translate the text inside
 #: indico/util/date_time.py
 msgid "'Tomorrow' 'at' {time_fmt}"
 msgstr ""
 
+#. keep the single quotes around the strings, and only translate the text inside.
+#. EEEE is a babel-style placeholder for the long weekday (you should probably keep this as-is)
 #: indico/util/date_time.py
 msgid "'Last' EEEE 'at' {time_fmt}"
 msgstr ""
 
+#. keep the single quotes around the string, and only translate the text inside.
+#. EEEE is a babel-style placeholder for the long weekday (you should probably keep this as-is)
 #: indico/util/date_time.py
 msgid "EEEE 'at' {time_fmt}"
 msgstr ""
 
+#. keep the single quotes around the string, and only translate the text inside
 #: indico/util/date_time.py
 msgid "{date_fmt} 'at' {time_fmt}"
 msgstr ""

--- a/indico/util/date_time.py
+++ b/indico/util/date_time.py
@@ -310,10 +310,16 @@ def format_pretty_date(dt, locale=None, tzinfo=None):
     if not isinstance(dt, datetime):
         dt = datetime.combine(dt, dt_time())
     return _format_pretty_datetime(dt, locale, tzinfo, {
+        # i18n: keep the single quotes around the string
         'last_day': _("'Yesterday'"),
+        # i18n: keep the single quotes around the string
         'same_day': _("'Today'"),
+        # i18n: keep the single quotes around the string
         'next_day': _("'Tomorrow'"),
+        # i18n: keep the single quotes around the string, and only translate the "Last".
+        # i18n: EEEE is a babel-style placeholder for the long weekday (you should probably keep this as-is)
         'last_week': _("'Last' EEEE"),
+        # i18n: EEEE is a babel-style placeholder for the long weekday (you should probably keep this as-is)
         'next_week': _('EEEE'),
         'other': '{date_fmt}'
     })
@@ -329,11 +335,19 @@ def format_pretty_datetime(dt, locale=None, tzinfo=None):
     :param tzinfo: the timezone to use
     """
     return _format_pretty_datetime(dt, locale, tzinfo, {
+        # i18n: keep the single quotes around the strings, and only translate the text inside
         'last_day': _("'Yesterday' 'at' {time_fmt}"),
+        # i18n: keep the single quotes around the strings, and only translate the text inside
         'same_day': _("'Today' 'at' {time_fmt}"),
+        # i18n: keep the single quotes around the strings, and only translate the text inside
         'next_day': _("'Tomorrow' 'at' {time_fmt}"),
+        # i18n: keep the single quotes around the strings, and only translate the text inside.
+        # i18n: EEEE is a babel-style placeholder for the long weekday (you should probably keep this as-is)
         'last_week': _("'Last' EEEE 'at' {time_fmt}"),
+        # i18n: keep the single quotes around the string, and only translate the text inside.
+        # i18n: EEEE is a babel-style placeholder for the long weekday (you should probably keep this as-is)
         'next_week': _("EEEE 'at' {time_fmt}"),
+        # i18n: keep the single quotes around the string, and only translate the text inside
         'other': _("{date_fmt} 'at' {time_fmt}")
     })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "react-final-form": "^6.5.9",
         "react-final-form-arrays": "^3.1.3",
         "react-final-form-listeners": "^1.0.3",
-        "react-jsx-i18n": "^0.8.0",
+        "react-jsx-i18n": "^0.9.0",
         "react-leaflet": "^2.8.0",
         "react-leaflet-draw": "0.19.0",
         "react-leaflet-markercluster": "^2.0.0",
@@ -192,6 +192,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -233,6 +234,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.24.7.tgz",
       "integrity": "sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==",
+      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.24.7",
         "picocolors": "^1.0.0"
@@ -245,6 +247,7 @@
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
       "integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -253,6 +256,7 @@
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.24.0.tgz",
       "integrity": "sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==",
+      "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -282,6 +286,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -317,6 +322,7 @@
       "version": "7.24.10",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.24.10.tgz",
       "integrity": "sha512-o9HBZL1G2129luEUlG1hB4N/nlYNWHnpwlND9eOMclRqqu1YDy2sSYVCFUZwl8I1Gxh+QSRrP2vD7EpUmFVXxg==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.24.9",
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -355,6 +361,7 @@
       "version": "7.23.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
       "integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
+      "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.23.5",
         "@babel/helper-validator-option": "^7.23.5",
@@ -370,6 +377,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -452,6 +460,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.24.7.tgz",
       "integrity": "sha512-DoiN84+4Gnd0ncbBOM9AZENV4a5ZiL39HYMyZJGZ/AZEykHYdJw0wW3kdcsh9/Kn+BRXHLkkklZ51ecPKmI1CQ==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.24.7"
       },
@@ -463,6 +472,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.24.7.tgz",
       "integrity": "sha512-FyoJTsj/PEUWu1/TYRiXTIHc8lbw+TDYkZuoE43opPS5TrI7MyONBE1oNvfguEXAD9yhQRrVBnXdXzSLQl9XnA==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.24.7",
         "@babel/types": "^7.24.7"
@@ -475,6 +485,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.24.7.tgz",
       "integrity": "sha512-MJJwhkoGy5c4ehfoRyrJ/owKeMl19U54h27YYftT0o2teQ3FJ3nQUf/I3LlJsX4l3qlw7WRXUmiyajvHXoTubQ==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.24.7"
       },
@@ -499,6 +510,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.24.7.tgz",
       "integrity": "sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==",
+      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.24.7",
         "@babel/types": "^7.24.7"
@@ -511,6 +523,7 @@
       "version": "7.24.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.24.9.tgz",
       "integrity": "sha512-oYbh+rtFKj/HwBQkFlUzvcybzklmVdVV3UU+mN7n2t/q3yGHbuVdNxyFvSBO1tfvjyArpHNcWMAzsSPdyI46hw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.24.7",
         "@babel/helper-module-imports": "^7.24.7",
@@ -583,6 +596,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.24.7.tgz",
       "integrity": "sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==",
+      "dev": true,
       "dependencies": {
         "@babel/traverse": "^7.24.7",
         "@babel/types": "^7.24.7"
@@ -608,6 +622,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.7.tgz",
       "integrity": "sha512-oy5V7pD+UvfkEATUKvIjvIAH/xCzfsFVw7ygW2SI6NClZzquT+mwdTfgfdbUiceh6iQO0CHtCPsyze/MZ2YbAA==",
+      "dev": true,
       "dependencies": {
         "@babel/types": "^7.24.7"
       },
@@ -635,6 +650,7 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.24.8.tgz",
       "integrity": "sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -657,6 +673,7 @@
       "version": "7.24.0",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.24.0.tgz",
       "integrity": "sha512-ulDZdc0Aj5uLc5nETsa7EPx2L7rM0YJM8r7ck7U73AXi7qOV44IHHRAYZHY6iU1rr3C5N4NtTmMRUJP6kwCWeA==",
+      "dev": true,
       "dependencies": {
         "@babel/template": "^7.24.0",
         "@babel/traverse": "^7.24.0",
@@ -670,6 +687,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.24.7.tgz",
       "integrity": "sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.24.7",
         "chalk": "^2.4.2",
@@ -684,6 +702,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -695,6 +714,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -708,6 +728,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -716,6 +737,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -724,6 +746,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -735,6 +758,7 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.8.tgz",
       "integrity": "sha512-WzfbgXOkGzZiXXCqk43kKwZjzwx4oulxZi3nq2TYL9mOjQv6kYwul9mz6ID36njuL7Xkp6nJEfok848Zj10j/w==",
+      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -2174,6 +2198,7 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.24.7.tgz",
       "integrity": "sha512-jYqfPrU9JTF0PmPy1tLYHW4Mp4KlgxJD9l2nP9fD6yT/ICi554DmrWBAEYpIelzjHf1msDP3PxJIRt/nFNfBig==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
         "@babel/parser": "^7.24.7",
@@ -2187,6 +2212,7 @@
       "version": "7.24.8",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.24.8.tgz",
       "integrity": "sha512-t0P1xxAPzEDcEPmjprAQq19NWum4K0EQPjMwZQZbHt+GiZqvjCHjj755Weq1YRPVzBI+3zSfvScfpnuIecVFJQ==",
+      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
         "@babel/generator": "^7.24.8",
@@ -3285,6 +3311,7 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -3298,6 +3325,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3306,6 +3334,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -3323,12 +3352,14 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
@@ -5527,58 +5558,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/babel-plugin-extract-text": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-extract-text/-/babel-plugin-extract-text-2.0.0.tgz",
-      "integrity": "sha512-RpSjFSa6wLAhhpcxfLdi8IuONvlh/CkpzcA2uR/ePJEJgVwg6m6keJmfCdlz/g2LNIUgrLoe7rwY50relIzDjw==",
-      "dependencies": {
-        "@babel/core": "^7.0.0",
-        "@babel/plugin-syntax-jsx": "^7.0.0",
-        "gettext-parser": "^2.0.0"
-      }
-    },
-    "node_modules/babel-plugin-extract-text/node_modules/gettext-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-2.1.0.tgz",
-      "integrity": "sha512-YGmu8DSm7PBnwItT+aOiqejOogqctHFzn+wBKUzjDFQP00psAtn/W2paWQxqE5eA5Ijrqaf7xuTKqyCHpuxnrg==",
-      "dependencies": {
-        "encoding": "^0.1.12",
-        "readable-stream": "^2.0.0",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/babel-plugin-extract-text/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "node_modules/babel-plugin-extract-text/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/babel-plugin-extract-text/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "node_modules/babel-plugin-extract-text/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/babel-plugin-flask-urls": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-flask-urls/-/babel-plugin-flask-urls-0.1.0.tgz",
@@ -5883,6 +5862,7 @@
       "version": "4.23.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.2.tgz",
       "integrity": "sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6005,6 +5985,7 @@
       "version": "1.0.30001642",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001642.tgz",
       "integrity": "sha512-3XQ0DoRgLijXJErLSl+bLnJ+Et4KqV1PY6JJBGAFlsNsz31zeAIncyeZfLCabHK/jtSh+671RM9YMldxjUPZtA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6371,7 +6352,8 @@
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/copy-webpack-plugin": {
       "version": "12.0.2",
@@ -6431,11 +6413,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/cosmiconfig": {
       "version": "7.1.0",
@@ -7191,7 +7168,8 @@
     "node_modules/electron-to-chromium": {
       "version": "1.4.828",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.828.tgz",
-      "integrity": "sha512-QOIJiWpQJDHAVO4P58pwb133Cwee0nbvy/MV1CwzZVGpkH1RX33N3vsaWRCpR6bF63AAq366neZrRTu7Qlsbbw=="
+      "integrity": "sha512-QOIJiWpQJDHAVO4P58pwb133Cwee0nbvy/MV1CwzZVGpkH1RX33N3vsaWRCpR6bF63AAq366neZrRTu7Qlsbbw==",
+      "dev": true
     },
     "node_modules/element-internals-polyfill": {
       "version": "1.3.11",
@@ -7483,6 +7461,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
       "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -8794,6 +8773,7 @@
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -8970,6 +8950,7 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11719,6 +11700,7 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -11976,6 +11958,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -13147,7 +13130,8 @@
     "node_modules/node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
+      "dev": true
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -14115,11 +14099,6 @@
         "node": ">= 0.6.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -14653,11 +14632,11 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
     "node_modules/react-jsx-i18n": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/react-jsx-i18n/-/react-jsx-i18n-0.8.0.tgz",
-      "integrity": "sha512-KFu/0h+KwIE+XAQIjNHnj0yN7mxh/esWzdVCXRvAbYLJ6hiZeYgVD2SXc+Pkzz/pw/PrOk+VN2OjZxk6WGwU9Q==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/react-jsx-i18n/-/react-jsx-i18n-0.9.0.tgz",
+      "integrity": "sha512-xAmuWEOgSVLXwhPZeOruRkVg2XEpRze/4P5SEnZzG9NJe6NIJ3PGg/lFDSXh3Qx4fShyDSyqfxnHLx4WYXTYIg==",
+      "license": "MIT",
       "dependencies": {
-        "babel-plugin-extract-text": "^2.0.0",
         "chalk": "^2.4.2",
         "gettext-parser": "^4.0.3",
         "glob": "^7.1.6",
@@ -17762,6 +17741,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
       "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -18501,7 +18481,8 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-final-form": "^6.5.9",
     "react-final-form-arrays": "^3.1.3",
     "react-final-form-listeners": "^1.0.3",
-    "react-jsx-i18n": "^0.8.0",
+    "react-jsx-i18n": "^0.9.0",
     "react-leaflet": "^2.8.0",
     "react-leaflet-draw": "0.19.0",
     "react-leaflet-markercluster": "^2.0.0",


### PR DESCRIPTION
When you have a code like this:

```py
# i18n: some additional information which is not suitable as a msg context.
_('foo')
```

The comment, which must be prefixed with `i18n:` gets extracted together with the message.
These comments are useful because Transifex shows them nicely in the UI:

![image](https://github.com/user-attachments/assets/7621f220-df3d-4730-877b-1f325077aed8)

You can use the same style in js too:

```js
// i18n: comment
$T.gettext('foo')
```

JSX will also support this: https://github.com/indico/react-jsx-i18n/pull/28

