### PR TITLE
Replace the SUI radio button in registration form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -82,7 +82,7 @@ Accessibility
 - Improve country input accessibility (:pr:`6551`, thanks :user:`foxbunny`)
 - Reimplement Checkbox to make it programmatically focusable (:pr:`6528`, thanks :user:`foxbunny`)
 - Implement a ``RadioButton`` component to replace the SUI radio button in order to improve
-  keyboard support (thanks :user:`foxbunny`)
+  keyboard support (:pr:`6621`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^
@@ -93,7 +93,7 @@ Internal Changes
 - Videoconference plugins now need to implement a ``delete_room`` method (:pr:`6475`)
 - Support translator comments when extracting translatable strings (:pr:`6620`)
 - ``renderAsFieldset`` option in the registration field registry can now be a function that
-  returns a boolean (thanks :user:`foxbunny`)
+  returns a boolean (:pr:`6621`, thanks :user:`foxbunny`)
 
 
 Version 3.3.4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -81,6 +81,8 @@ Accessibility
 
 - Improve country input accessibility (:pr:`6551`, thanks :user:`foxbunny`)
 - Reimplement Checkbox to make it programmatically focusable (:pr:`6528`, thanks :user:`foxbunny`)
+- Implement a ``RadioButton`` component to replace the SUI radio button in order to improve
+  keyboard support (thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^
@@ -90,6 +92,8 @@ Internal Changes
 - Add additional signals related to videoconferences and their event links (:pr:`6475`)
 - Videoconference plugins now need to implement a ``delete_room`` method (:pr:`6475`)
 - Support translator comments when extracting translatable strings (:pr:`6620`)
+- ``renderAsFieldset`` option in the registration field registry can now be a function that
+  returns a boolean (thanks :user:`foxbunny`)
 
 
 Version 3.3.4

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -63,6 +63,13 @@ ItemLocked.propTypes = {
   reason: PropTypes.string.isRequired,
 };
 
+function renderAsFieldset(fieldOptions, meta) {
+  if (typeof meta.renderAsFieldset === 'function') {
+    return meta.renderAsFieldset(fieldOptions);
+  }
+  return meta.renderAsFieldset;
+}
+
 export default function FormItem({
   id,
   title,
@@ -89,6 +96,23 @@ export default function FormItem({
   const inputProps = {title, description, isEnabled, fieldId: id, ...rest};
   const showPurged = !setupMode && isPurged;
   const disabled = !isEnabled || showPurged || !!lockedReason || (paidItemLocked && !isManagement);
+
+  const fieldOptions = {
+    id,
+    title,
+    description,
+    retentionPeriod,
+    inputType,
+    isEnabled,
+    isRequired,
+    isPurged,
+    lockedReason,
+    sortHandle,
+    setupMode,
+    setupActions,
+    ...rest,
+    meta,
+  };
 
   let retentionPeriodIcon = null;
   if (setupMode && retentionPeriod) {
@@ -149,8 +173,8 @@ export default function FormItem({
             />
           ) : (
             <Form.Field required={showAsRequired} styleName="field">
-              {meta.renderAsFieldset ? (
-                <fieldset>
+              {renderAsFieldset(fieldOptions, meta) ? (
+                <fieldset id={htmlId}>
                   <legend style={{opacity: disabled ? 0.8 : 1, display: 'inline-block'}}>
                     {title}
                   </legend>

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -174,10 +174,8 @@ export default function FormItem({
           ) : (
             <Form.Field required={showAsRequired} styleName="field">
               {renderAsFieldset(fieldOptions, meta) ? (
-                <fieldset id={htmlId}>
-                  <legend style={{opacity: disabled ? 0.8 : 1, display: 'inline-block'}}>
-                    {title}
-                  </legend>
+                <fieldset id={htmlId} disabled={disabled}>
+                  <legend>{title}</legend>
                   {fieldControls}
                 </fieldset>
               ) : (

--- a/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
@@ -10,9 +10,9 @@ import moment from 'moment';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {useSelector} from 'react-redux';
-import {Form, Label} from 'semantic-ui-react';
+import {Label} from 'semantic-ui-react';
 
-import {DatePeriodField, FinalDatePeriod} from 'indico/react/components';
+import {DatePeriodField, FinalDatePeriod, RadioButton} from 'indico/react/components';
 import {FinalField} from 'indico/react/forms';
 import {Param, Translate} from 'indico/react/i18n';
 import {serializeDate, toMoment} from 'indico/utils/date';
@@ -98,17 +98,11 @@ function AccommodationInputComponent({
               return (
                 <tr key={c.id} styleName="row">
                   <td>
-                    <Form.Radio
+                    <RadioButton
                       id={id ? `${id}-${index}` : ''}
-                      style={{pointerEvents: 'auto'}} // keep label tooltips working when disabled
-                      styleName="radio"
-                      label={{
-                        children: (
-                          <ChoiceLabel choice={c} management={management} paid={isPaidChoice(c)} />
-                        ),
-                      }}
                       key={c.id}
                       value={c.id}
+                      checked={!isPurged && c.id === value.choice}
                       disabled={
                         !c.isEnabled ||
                         disabled ||
@@ -117,7 +111,9 @@ function AccommodationInputComponent({
                           (placesUsed[c.id] || 0) >= c.placesLimit &&
                           c.id !== existingValue.choice)
                       }
-                      checked={!isPurged && c.id === value.choice}
+                      label={
+                        <ChoiceLabel choice={c} management={management} paid={isPaidChoice(c)} />
+                      }
                       onChange={makeHandleChange(c)}
                     />
                   </td>

--- a/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
@@ -100,6 +100,7 @@ function AccommodationInputComponent({
                   <td>
                     <RadioButton
                       id={id ? `${id}-${index}` : ''}
+                      name={id}
                       key={c.id}
                       value={c.id}
                       checked={!isPurged && c.id === value.choice}

--- a/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
@@ -13,7 +13,7 @@ import {Field} from 'react-final-form';
 import {useSelector} from 'react-redux';
 import {Form, Label, Dropdown} from 'semantic-ui-react';
 
-import {Select} from 'indico/react/components';
+import {RadioButton, Select} from 'indico/react/components';
 import {FinalCheckbox, FinalDropdown, FinalField, parsers as p} from 'indico/react/forms';
 import {Param, Translate} from 'indico/react/i18n';
 
@@ -216,15 +216,9 @@ function SingleChoiceRadioGroup({
           return (
             <tr key={c.id} styleName="row">
               <td>
-                <Form.Radio
+                <RadioButton
                   id={id ? `${id}-${index}` : ''}
-                  style={{pointerEvents: 'auto'}} // keep label tooltips working when disabled
-                  styleName="radio"
-                  label={{
-                    children: (
-                      <ChoiceLabel choice={c} management={management} paid={isPaidChoice(c)} />
-                    ),
-                  }}
+                  label={<ChoiceLabel choice={c} management={management} paid={isPaidChoice(c)} />}
                   key={c.id}
                   value={c.id}
                   disabled={

--- a/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
@@ -219,7 +219,7 @@ function SingleChoiceRadioGroup({
                 <RadioButton
                   id={id ? `${id}-${index}` : ''}
                   name={id}
-                  label={c.caption}
+                  label={<ChoiceLabel choice={c} management={management} paid={isPaidChoice(c)} />}
                   key={c.id}
                   value={c.id}
                   disabled={

--- a/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
@@ -218,7 +218,8 @@ function SingleChoiceRadioGroup({
               <td>
                 <RadioButton
                   id={id ? `${id}-${index}` : ''}
-                  label={<ChoiceLabel choice={c} management={management} paid={isPaidChoice(c)} />}
+                  name={id}
+                  label={c.caption}
                   key={c.id}
                   value={c.id}
                   disabled={

--- a/indico/modules/events/registration/client/js/form/fields/registry.js
+++ b/indico/modules/events/registration/client/js/form/fields/registry.js
@@ -69,7 +69,8 @@ Available keys:
 - hasPrice: optional; show price field if the whole field can have a price attached
 - noRetentionPeriod: optional; hide the retention period setting
 - renderAsFieldset: optional; whether the field should be rendered in a fieldset; applies
-  to fields that use multiple controls, like radios, checkboxes, multi-button controls
+  to fields that use multiple controls, like radios, checkboxes, multi-button controls;
+  can either be a Boolean or a function that takes field options and returns a Boolean
 */
 
 const fieldRegistry = {
@@ -158,6 +159,7 @@ const fieldRegistry = {
     settingsFormDecorators: [choiceFieldsSettingsFormDecorator, singleChoiceSettingsFormDecorator],
     settingsFormInitialData: singleChoiceSettingsInitialData,
     icon: 'dropmenu',
+    renderAsFieldset: options => options.itemType === 'radiogroup',
   },
   multi_choice: {
     title: Translate.string('Multiple Choice'),

--- a/indico/modules/events/registration/client/js/form/fields/table.module.scss
+++ b/indico/modules/events/registration/client/js/form/fields/table.module.scss
@@ -40,8 +40,7 @@ table.choice-table {
     border-bottom: 1px solid rgba(34, 36, 38, 0.15);
   }
 
-  .checkbox,
-  .radio {
+  .checkbox {
     max-width: 300px;
 
     label {

--- a/indico/modules/events/registration/client/styles/regform.module.scss
+++ b/indico/modules/events/registration/client/styles/regform.module.scss
@@ -94,7 +94,8 @@
     flex-grow: 1;
 
     :global(.field.disabled) {
-      opacity: 0.8;
+      opacity: 1;
+      pointer-events: auto;
     }
 
     // Prevent stacking opacity on SUI Buttons
@@ -321,6 +322,14 @@
       }
     }
 
+    .field legend {
+      display: inline-block;
+    }
+
+    .field fieldset:disabled legend {
+      opacity: 0.8;
+    }
+
     > .description {
       max-width: var(--max-form-item-width);
       padding-left: 2px;
@@ -477,4 +486,10 @@
 .dropdown-item:hover {
   background: rgba(0, 0, 0, 0.05);
   color: rgba(0, 0, 0, 0.95);
+}
+
+// FIXME: Semantic UI hack
+:global(.ui.form) :global(.field) fieldset:disabled {
+  pointer-events: auto;
+  opacity: 0.8;
 }

--- a/indico/web/client/js/react/components/RadioButton.jsx
+++ b/indico/web/client/js/react/components/RadioButton.jsx
@@ -1,0 +1,24 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import './RadioButton.module.scss';
+
+export default function RadioButton({label, ...inputProps}) {
+  return (
+    <label styleName="radio-label">
+      <input {...inputProps} type="radio" styleName="radio" />
+      <span>{label}</span>
+    </label>
+  );
+}
+
+RadioButton.propTypes = {
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
+};

--- a/indico/web/client/js/react/components/RadioButton.module.scss
+++ b/indico/web/client/js/react/components/RadioButton.module.scss
@@ -1,0 +1,55 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2024 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+@use 'design_system';
+
+.radio-label {
+  display: inline-flex;
+  gap: var(--content-gap-normal);
+  align-items: center;
+}
+
+.radio {
+  --radio-size: 1.2em;
+
+  appearance: none;
+
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: var(--radio-size);
+  height: var(--radio-size);
+  margin: 0;
+
+  // XXX: We cannot use sui_debt here because of `appearance:none`.
+  // Since we need this element to match the appearance of the SUI
+  // controls, we have to hard-code the styles here.
+  border: 1px solid rgba(34, 36, 38, 0.15);
+  border-radius: 50%;
+
+  &:disabled {
+    border-color: 1px solid rgba(34, 36, 38, 0.15);
+  }
+
+  &:focus {
+    border: 1px solid #85b7d9;
+  }
+
+  &::before {
+    content: '';
+
+    display: inline-block;
+    width: calc(0.5 * var(--radio-size));
+    aspect-ratio: 1;
+
+    border-radius: 50%;
+  }
+
+  &:checked::before {
+    background-color: currentcolor;
+  }
+}

--- a/indico/web/client/js/react/components/RadioButton.module.scss
+++ b/indico/web/client/js/react/components/RadioButton.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'design_system';
+@use 'partials/sui_debt';
 
 .radio-label {
   display: inline-flex;
@@ -16,23 +17,21 @@
 .radio {
   --radio-size: 1.2em;
 
-  appearance: none;
+  flex: none;
 
+  appearance: none;
   display: inline-flex;
   justify-content: center;
   align-items: center;
   width: var(--radio-size);
-  height: var(--radio-size);
+  aspect-ratio: 1;
   margin: 0;
 
-  // XXX: We cannot use sui_debt here because of `appearance:none`.
-  // Since we need this element to match the appearance of the SUI
-  // controls, we have to hard-code the styles here.
-  border: 1px solid rgba(34, 36, 38, 0.15);
+  @include sui_debt.input-border-default();
   border-radius: 50%;
 
   &:disabled {
-    border-color: 1px solid rgba(34, 36, 38, 0.15);
+    @include sui_debt.input-disabled-border();
   }
 
   &:focus {
@@ -51,5 +50,9 @@
 
   &:checked::before {
     background-color: currentcolor;
+  }
+
+  &:disabled:checked::before {
+    @include sui_debt.input-disabled-mark-background();
   }
 }

--- a/indico/web/client/js/react/components/index.js
+++ b/indico/web/client/js/react/components/index.js
@@ -40,6 +40,7 @@ export {default as FileSubmission} from './files/FileSubmission';
 export {default as FinalPictureManager} from './pictures/PictureManager';
 export {default as FinalSingleFileManager} from './files/SingleFileManager';
 export {default as ClipboardButton} from './ClipboardButton';
+export {default as RadioButton} from './RadioButton';
 export {default as RequestConfirm, RequestConfirmDelete} from './RequestConfirm';
 export {default as ReviewRating} from './ReviewRating';
 export {default as ManagementPageBackButton} from './ManagementPageBackButton';

--- a/indico/web/client/styles/base/_reset.scss
+++ b/indico/web/client/styles/base/_reset.scss
@@ -46,6 +46,11 @@ summary {
   cursor: pointer;
 }
 
+:disabled label,
+label:has(:disabled) {
+  cursor: default;
+}
+
 summary {
   list-style: none;
 }

--- a/indico/web/client/styles/partials/_sui_debt.scss
+++ b/indico/web/client/styles/partials/_sui_debt.scss
@@ -33,6 +33,18 @@
   border: 1px solid #85b7d9;
 }
 
+@mixin input-border-default {
+  border: 1px solid rgba(34, 36, 38, 0.15);
+}
+
+@mixin input-disabled-border {
+  border: 1px solid rgba(34, 36, 38, 0.15);
+}
+
+@mixin input-disabled-mark-background {
+  background-color: rgba(34, 36, 38, 0.15);
+}
+
 @mixin input-background {
   background: white;
 }


### PR DESCRIPTION
- Implement a RadioButton component to replace the SUI radio button
- Replace usages of SUI radio button within the reigstration form inputs
- Address the issue of SingleChoiceInput needing both fieldset and non-fieldset rendering depending on the settings by modifying the renderAsFieldset option to allow a function that returns the correct value based on the settings