### PR TITLE
Allow overriding custom meeting themes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -96,6 +96,7 @@ Internal Changes
 - Support translator comments when extracting translatable strings (:pr:`6620`)
 - ``renderAsFieldset`` option in the registration field registry can now be a function that
   returns a boolean (:pr:`6621`, thanks :user:`foxbunny`)
+- Allow overriding global theme settings for custom meeting themes (:pr:`6622`)
 
 
 Version 3.3.4

--- a/indico/modules/events/layout/__init__.py
+++ b/indico/modules/events/layout/__init__.py
@@ -25,6 +25,14 @@ from indico.web.menu import SideMenuItem
 EVENT_BANNER_WIDTH = 950
 EVENT_LOGO_WIDTH = 200
 
+# Theme settings that can be overridden via theme user settings. This works bidirectionally,
+# ie if a theme's settings has all the keys set to True, then the user setting will default
+# to True as well.
+OVERRIDABLE_THEME_SETTINGS = {
+    'inline_minutes': {'show_notes'},
+    'numbered_contributions': {'hide_duration', 'hide_session_block_time', 'hide_end_time', 'number_contributions'}
+}
+
 logger = Logger.get('events.layout')
 layout_settings = EventSettingsProxy('layout', {
     'is_searchable': True,
@@ -67,13 +75,10 @@ def get_theme_global_settings(event, theme):
     # Override global settings with user settings, if present
     settings = settings.copy()
     event_settings = layout_settings.get(event, 'timetable_theme_settings')
-    if event_settings.get('inline_minutes'):
-        settings['show_notes'] = True
-    if event_settings.get('numbered_contributions'):
-        settings['hide_duration'] = True
-        settings['hide_session_block_time'] = True
-        settings['hide_end_time'] = True
-        settings['number_contributions'] = True
+    for event_key, theme_keys in OVERRIDABLE_THEME_SETTINGS.items():
+        if event_key not in event_settings:
+            continue
+        settings.update(dict.fromkeys(theme_keys, event_settings[event_key]))
     return settings
 
 

--- a/indico/modules/events/layout/__init__.py
+++ b/indico/modules/events/layout/__init__.py
@@ -74,11 +74,11 @@ def get_theme_global_settings(event, theme):
 
     # Override global settings with user settings, if present
     settings = settings.copy()
-    event_settings = layout_settings.get(event, 'timetable_theme_settings')
-    for event_key, theme_keys in OVERRIDABLE_THEME_SETTINGS.items():
-        if event_key not in event_settings:
+    event_user_settings = layout_settings.get(event, 'timetable_theme_settings')
+    for user_key, theme_keys in OVERRIDABLE_THEME_SETTINGS.items():
+        if user_key not in event_user_settings:
             continue
-        settings.update(dict.fromkeys(theme_keys, event_settings[event_key]))
+        settings.update(dict.fromkeys(theme_keys, event_user_settings[user_key]))
     return settings
 
 

--- a/indico/modules/events/layout/controllers/layout.py
+++ b/indico/modules/events/layout/controllers/layout.py
@@ -53,11 +53,11 @@ class RHLayoutBase(RHManageEventBase):
 def _make_theme_settings_form(event, theme):
     theme_global_settings = theme_settings.themes[theme].get('settings', {})
     try:
-        settings = theme_settings.themes[theme]['user_settings']
+        theme_user_settings = theme_settings.themes[theme]['user_settings']
     except KeyError:
         return None
     form_class = type('ThemeSettingsForm', (IndicoForm,), {})
-    for name, field_data in settings.items():
+    for name, field_data in theme_user_settings.items():
         field_type = field_data['type']
         field_class = getattr(indico_fields, field_type, None) or getattr(wtforms_fields, field_type, None)
         if not field_class:
@@ -68,11 +68,11 @@ def _make_theme_settings_form(event, theme):
         field = field_class(label, validators, description=description, **field_data.get('kwargs', {}))
         setattr(form_class, name, field)
 
-    defaults = {name: field_data.get('defaults') for name, field_data in settings.items()}
-    for event_key, theme_keys in OVERRIDABLE_THEME_SETTINGS.items():
-        if event_key not in settings:
+    defaults = {name: field_data.get('defaults') for name, field_data in theme_user_settings.items()}
+    for user_key, theme_keys in OVERRIDABLE_THEME_SETTINGS.items():
+        if user_key not in theme_user_settings:
             continue
-        defaults[event_key] = all(theme_global_settings.get(key) for key in theme_keys)
+        defaults[user_key] = all(theme_global_settings.get(key) for key in theme_keys)
     if theme == event.theme:
         defaults.update(layout_settings.get(event, 'timetable_theme_settings'))
 

--- a/indico/modules/events/themes.yaml
+++ b/indico/modules/events/themes.yaml
@@ -1,3 +1,15 @@
+_:
+  inline_minutes_setting: &user_setting_inline_minutes
+    inline_minutes:
+      caption: Inline minutes
+      description: Show minutes by default
+      type: BooleanField
+  numbered_contributions_setting: &user_setting_numbered_contributions
+    numbered_contributions:
+      caption: Numbered contributions
+      description: Show numbered contributions instead of times
+      type: BooleanField
+
 defaults:
     conference: ~
     lecture: lecture

--- a/indico/modules/events/views.py
+++ b/indico/modules/events/views.py
@@ -14,7 +14,7 @@ from werkzeug.utils import cached_property
 from indico.modules.admin.views import WPAdmin
 from indico.modules.core.settings import social_settings
 from indico.modules.events import Event
-from indico.modules.events.layout import layout_settings, theme_settings
+from indico.modules.events.layout import get_theme_global_settings, layout_settings, theme_settings
 from indico.modules.events.layout.util import (build_menu_entry_name, get_css_url, get_js_url, get_menu_entry_by_name,
                                                menu_entries_for_event)
 from indico.modules.events.management.settings import privacy_settings
@@ -234,7 +234,7 @@ class WPSimpleEventDisplay(WPSimpleEventDisplayBase):
                                event=self.event,
                                category=(self.event.category.title if self.event.category else None),
                                timezone=self.event.display_tzinfo,
-                               theme_settings=self.theme.get('settings', {}),
+                               theme_settings=get_theme_global_settings(self.event, self.theme_id),
                                theme_user_settings=layout_settings.get(self.event, 'timetable_theme_settings'),
                                files=files,
                                folders=folders,


### PR DESCRIPTION
Allows overriding the inline and numbered notes settings from `themes.yaml`.

These settings are available on the Layout page:

![image](https://github.com/user-attachments/assets/6f98c6b1-628b-43dd-aced-0266c787b86e)

For example if inline minutes is toggled, the meeting minutes will always render expanded even if the theme's default is different. 

The settings are only visible for themes that explicitly allow the settings to be overridden. This can be done by extending the `user_settings` with either `user_setting_inline_minutes`, `user_setting_numbered_contributions` or both:

```yaml
  oqi:
    <<: *standard_themes_cern
    stylesheet: oqi.scss
    title: Open Quantum Institute
    user_settings:
      <<: [*user_setting_inline_minutes, *user_setting_numbered_contributions]
```