### PR TITLE
Sort items of the Timetable Sessions field in registration summary

### DIFF
--- a/indico/modules/events/registration/fields/sessions.py
+++ b/indico/modules/events/registration/fields/sessions.py
@@ -93,6 +93,8 @@ class SessionsField(RegistrationFormFieldBase):
         blocks = (SessionBlock.query
                   .filter(SessionBlock.id.in_(registration_data.data))
                   .options(joinedload(SessionBlock.timetable_entry).raiseload('*'))
+                  .join(Session)
+                  .order_by(SessionBlock.start_dt, Session.title, SessionBlock.title, SessionBlock.id)
                   .all())
         if for_humans or for_search:
             return '; '.join(b.full_title for b in blocks)


### PR DESCRIPTION
Sorts the selected session blocks by `start_dt`:

![image](https://github.com/user-attachments/assets/2d11018c-6648-4b3e-9b29-2e69e4af8f5c)
