### PR TITLE
Prototypes for opening badge printed PDF on a new tab

### DIFF
--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -592,7 +592,7 @@ class RHRegistrationsConfigBadges(RHRegistrationsActionBase):
     def _process(self):
         all_templates = set(self.event.designer_templates) | get_inherited_templates(self.event)
         badge_templates = {tpl.id: {
-            'data': tpl.data,
+            # 'data': tpl.data,
             'backside_tpl_id': tpl.backside_template_id,
             'orientation': 'landscape' if tpl.data['width'] > tpl.data['height'] else 'portrait',
             'format': get_badge_format(tpl)
@@ -623,10 +623,11 @@ class RHRegistrationsConfigBadges(RHRegistrationsActionBase):
             key = str(uuid.uuid4())
             badge_cache.set(key, data, timeout=1800)
             download_url = url_for('.registrations_print_badges', self.regform, template_id=template_id, uuid=key)
-            return jsonify_data(flash=False, redirect=download_url, redirect_no_loading=True)
+            return jsonify_data(flash=False, redirect=download_url, redirect_no_loading=True, target='_blank')
         return jsonify_template('events/registration/management/print_badges.html', event=self.event,
                                 regform=self.regform, settings_form=form, templates=badge_templates,
-                                registrations=registrations, all_registrations=all_registrations)
+                                registrations=registrations, all_registrations=all_registrations,
+                                form_action=url_for('.registrations_config_badges', self.regform))
 
 
 class RHRegistrationsConfigTickets(RHRegistrationsConfigBadges):

--- a/indico/modules/events/registration/templates/management/_print_badge_settings_form.html
+++ b/indico/modules/events/registration/templates/management/_print_badge_settings_form.html
@@ -1,7 +1,7 @@
 {% from 'forms/_form.html' import simple_form, form_fieldset, form_rows, form_row %}
 
-{% macro render_badge_print_settings_form(form, submit=_('Download PDF'), templates=none, registrations=()) %}
-    {% call simple_form(form, form_header_kwargs={'id': 'badge-settings-form'}, back=_('Cancel'),
+{% macro render_badge_print_settings_form(form, submit=_('Download PDF'), templates=none, registrations=(), form_action=none) %}
+    {% call simple_form(form, form_header_kwargs={'id': 'badge-settings-form', 'action': form_action}, back=_('Cancel'),
                         submit=submit, disabled_until_change=false, disable_if_locked=false) %}
         {% for legend, fieldset in form._fieldsets %}
             {% call form_fieldset(legend, render_as_fieldset=(legend is not none)) %}

--- a/indico/modules/events/registration/templates/management/print_badges.html
+++ b/indico/modules/events/registration/templates/management/print_badges.html
@@ -14,6 +14,6 @@
 
 {% if registrations %}
     {% block show_badge_printer_settings_form scoped %}
-        {{ render_badge_print_settings_form(settings_form, templates=templates, registrations=registrations) }}
+        {{ render_badge_print_settings_form(settings_form, templates=templates, registrations=registrations, form_action=form_action) }}
     {% endblock %}
 {% endif %}

--- a/indico/web/client/js/jquery/utils/ajaxdialog.js
+++ b/indico/web/client/js/jquery/utils/ajaxdialog.js
@@ -323,10 +323,18 @@
               savedFiles = {};
               closeDialog(data, true);
               if (data.redirect) {
-                if (!data.redirect_no_loading) {
-                  IndicoUI.Dialogs.Util.progress();
+                if (data.target) {
+                  const link = document.createElement("a");
+                  link.setAttribute('href', data.redirect);
+                  link.setAttribute('target', data.target);
+                  this.parentElement.appendChild(link);
+                  link.click();
+                } else {
+                  if (!data.redirect_no_loading) {
+                    IndicoUI.Dialogs.Util.progress();
+                  }
+                  location.href = data.redirect;
                 }
-                location.href = data.redirect;
               }
             } else if (data.html) {
               popup.contentContainer.html(data.html);

--- a/indico/web/templates/forms/_form.html
+++ b/indico/web/templates/forms/_form.html
@@ -166,9 +166,11 @@
         {{ form_rows(form, fields=fields, disable=disabled_fields, skip_labels=skip_labels) }}
     {% endif %}
     {% call form_footer(form, skip_label=skip_labels, align_right=footer_align_right) %}
-        <a id="form-submit-button" class="i-button big highlight {{ 'hide-if-locked' if disable_if_locked }}"
-            {%- if disabled_until_change %} data-disabled-until-change{% endif %}
-            {%- if save_reminder %} data-save-reminder{% endif %}>{{ submit }}+</a>
+        {% if form_header_kwargs.get('id') == 'badge-settings-form' %}
+            <a id="form-submit-button" class="i-button big highlight {{ 'hide-if-locked' if disable_if_locked }}"
+                {%- if disabled_until_change %} data-disabled-until-change{% endif %}
+                {%- if save_reminder %} data-save-reminder{% endif %}>{{ submit }}+</a>
+        {% endif %}
         <input class="i-button big highlight {{ 'hide-if-locked' if disable_if_locked }}" type="submit"
                value="{{ submit }}"
                {%- if disabled_until_change %} data-disabled-until-change{% endif %}
@@ -181,21 +183,18 @@
             {% endif %}
         {% endif %}
     {% endcall %}
-    <script>
-        document.getElementById('form-submit-button').addEventListener('click', event => {
-            const button = event.target;
-            if (!button.getAttribute('href')) {
-                event.preventDefault();
+    {% if form_header_kwargs.get('id') == 'badge-settings-form' %}
+        <script>
+            document.getElementById('form-submit-button').addEventListener('click', event => {
+                const button = event.target;
                 const formElement = document.getElementById('{{ form_header_kwargs['id'] }}');
-                fetch(formElement.getAttribute('action'), {
-                    method: formElement.getAttribute('method').toUpperCase(),
-                    body: new FormData(formElement)
-                }).then(response => response.json()).then(response => {
-                    button.setAttribute('href', response['redirect']);
-                    button.setAttribute('target', '_blank');
-                    button.click();
-                });
-            }
-        })
-    </script>
+                const request = new XMLHttpRequest();
+                request.open(formElement.getAttribute('method').toUpperCase(), formElement.getAttribute('action'), false);
+                request.send(new FormData(formElement));
+                const responseData = JSON.parse(request.responseText);
+                button.setAttribute('href', responseData['redirect']);
+                button.setAttribute('target', '_blank');
+            })
+        </script>
+    {% endif %}
 {% endmacro %}

--- a/indico/web/templates/forms/_form.html
+++ b/indico/web/templates/forms/_form.html
@@ -166,6 +166,9 @@
         {{ form_rows(form, fields=fields, disable=disabled_fields, skip_labels=skip_labels) }}
     {% endif %}
     {% call form_footer(form, skip_label=skip_labels, align_right=footer_align_right) %}
+        <a id="form-submit-button" class="i-button big highlight {{ 'hide-if-locked' if disable_if_locked }}"
+            {%- if disabled_until_change %} data-disabled-until-change{% endif %}
+            {%- if save_reminder %} data-save-reminder{% endif %}>{{ submit }}+</a>
         <input class="i-button big highlight {{ 'hide-if-locked' if disable_if_locked }}" type="submit"
                value="{{ submit }}"
                {%- if disabled_until_change %} data-disabled-until-change{% endif %}
@@ -178,4 +181,21 @@
             {% endif %}
         {% endif %}
     {% endcall %}
+    <script>
+        document.getElementById('form-submit-button').addEventListener('click', event => {
+            const button = event.target;
+            if (!button.getAttribute('href')) {
+                event.preventDefault();
+                const formElement = document.getElementById('{{ form_header_kwargs['id'] }}');
+                fetch(formElement.getAttribute('action'), {
+                    method: formElement.getAttribute('method').toUpperCase(),
+                    body: new FormData(formElement)
+                }).then(response => response.json()).then(response => {
+                    button.setAttribute('href', response['redirect']);
+                    button.setAttribute('target', '_blank');
+                    button.click();
+                });
+            }
+        })
+    </script>
 {% endmacro %}


### PR DESCRIPTION
This DRAFT PR has 2 prototypes to achieve the above goal. Both uses _anchor_ element to open the PDF on new tab, although they are following different approaches:

1. Using _anchor_ instead of _button_ on "Page configuration" form. This button is called "Download PDF+" (see the changes in indico/web/templates/forms/_form.html)
2. The original button still works but in a different way. `ajaxdialog.js` is modified to inject the required _anchor_ into the DOM and trigger a click on it.

The goal with this PR is to get some feedback whether any direction seems promising enough to improve it further.