### PR TITLE
Fail gracefully on invalid session timezone

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Bugfixes
 
 - Fix error when using the "Request approval" editing action on an editable that
   does not have publishable files (:pr:`6186`)
+- Do not fail if a user has an invalid timezone stored in the database (:pr:`6647`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -354,7 +354,7 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
     @property
     def display_tzinfo(self):
         """The tzinfo of the category or the one specified by the user."""
-        return get_display_tz(self, as_timezone=True)
+        return get_display_tz(self)
 
     def log(self, realm, kind, module, summary, user=None, type_='simple', data=None, meta=None):
         """Create a new log entry for the category.

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -640,7 +640,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     @property
     def display_tzinfo(self):
         """The tzinfo of the event as preferred by the current user."""
-        return get_display_tz(self, as_timezone=True)
+        return get_display_tz(self)
 
     @property
     def editable_types(self):

--- a/indico/util/date_time.py
+++ b/indico/util/date_time.py
@@ -451,7 +451,7 @@ def strftime_all_years(dt, fmt):
 
 
 @memoize_request
-def get_display_tz(obj=None, as_timezone=False):
+def get_display_tz(obj=None):
     display_tz = session_tz = session.timezone if has_request_context() else 'LOCAL'
     if display_tz == 'LOCAL':
         if obj is None:
@@ -461,8 +461,8 @@ def get_display_tz(obj=None, as_timezone=False):
     if not display_tz:
         display_tz = config.DEFAULT_TIMEZONE
     try:
-        return pytz.timezone(display_tz) if as_timezone else display_tz
+        return pytz.timezone(display_tz)
     except pytz.UnknownTimeZoneError:
         # Avoid failing in a rather ugly way (unformatted error page) when a user has an invalid timezone
         Logger.get('date_time').warning('Invalid timezone: %s (obj=%r, session_tz=%s)', display_tz, obj, session_tz)
-        return pytz.timezone(config.DEFAULT_TIMEZONE) if as_timezone else config.DEFAULT_TIMEZONE
+        return pytz.timezone(config.DEFAULT_TIMEZONE)

--- a/indico/util/date_time.py
+++ b/indico/util/date_time.py
@@ -24,6 +24,8 @@ from dateutil.rrule import DAILY, FR, MO, TH, TU, WE, rrule
 from flask import has_request_context, session
 
 from indico.core.config import config
+from indico.core.logger import Logger
+from indico.util.caching import memoize_request
 from indico.util.i18n import IndicoLocale, _, get_current_locale, ngettext, parse_locale
 
 
@@ -448,8 +450,9 @@ def strftime_all_years(dt, fmt):
         return dt.replace(year=1900).strftime(fmt.replace('%Y', '%%Y')).replace('%Y', str(dt.year))
 
 
+@memoize_request
 def get_display_tz(obj=None, as_timezone=False):
-    display_tz = session.timezone if has_request_context() else 'LOCAL'
+    display_tz = session_tz = session.timezone if has_request_context() else 'LOCAL'
     if display_tz == 'LOCAL':
         if obj is None:
             display_tz = config.DEFAULT_TIMEZONE
@@ -457,4 +460,9 @@ def get_display_tz(obj=None, as_timezone=False):
             display_tz = getattr(obj, 'timezone', 'UTC')
     if not display_tz:
         display_tz = config.DEFAULT_TIMEZONE
-    return pytz.timezone(display_tz) if as_timezone else display_tz
+    try:
+        return pytz.timezone(display_tz) if as_timezone else display_tz
+    except pytz.UnknownTimeZoneError:
+        # Avoid failing in a rather ugly way (unformatted error page) when a user has an invalid timezone
+        Logger.get('date_time').warning('Invalid timezone: %s (obj=%r, session_tz=%s)', display_tz, obj, session_tz)
+        return pytz.timezone(config.DEFAULT_TIMEZONE) if as_timezone else config.DEFAULT_TIMEZONE

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -131,7 +131,7 @@ class IndicoSession(BaseSession):
     def timezone(self, tz):
         self['_timezone'] = tz
 
-    @property
+    @cached_property
     def tzinfo(self):
         """The tzinfo of the user's current timezone.
 

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -138,7 +138,7 @@ class IndicoSession(BaseSession):
         This should only be used in places where no other timezone
         such as from an event or category is available.
         """
-        return get_display_tz(as_timezone=True)
+        return get_display_tz()
 
     @property
     def hard_expiry(self):


### PR DESCRIPTION
This can happen when a user has has bad timezone data in the DB, typically the case for very old users from times (no pun intended) where we did not properly validate changes to the user's preferred timezone.

(It would of course be nicer to automatically discard such garbage data, but making any changes in that util feels extremely wrong. I will just fix invalid timezones in out DB manually.)

Also memoize session timezone utils, since they get called A LOT when generating the timezone picker...