### PR TITLE
Encode event name text in share widget

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Bugfixes
 - Fix error when using the "Request approval" editing action on an editable that
   does not have publishable files (:pr:`6186`)
 - Do not fail if a user has an invalid timezone stored in the database (:pr:`6647`)
+- Ensure the event name is correctly encoded to prevent issues with special characters
+  in the share event widget (:pr:`6649`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/custom_elements/ind_share_widget.js
+++ b/indico/web/client/js/custom_elements/ind_share_widget.js
@@ -321,7 +321,7 @@ function ShareWidget({
 }) {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isMastodonOpen, setMastodonOpen] = useState(false);
-  const shareText = `${eventName} (${eventStartDt}) · Indico (${eventUrl})`;
+  const shareText = encodeURIComponent(`${eventName} (${eventStartDt}) · Indico (${eventUrl})`);
   return (
     <Popup
       trigger={

--- a/indico/web/client/js/custom_elements/ind_share_widget.js
+++ b/indico/web/client/js/custom_elements/ind_share_widget.js
@@ -112,7 +112,7 @@ function TwitterButton({shareText}) {
     <GridColumn styleName="share-button-column">
       <Button
         as="a"
-        href={`https://twitter.com/intent/tweet?text=${shareText}`}
+        href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`}
         target="_blank"
         basic
         color="blue"
@@ -131,7 +131,7 @@ TwitterButton.propTypes = {
 
 function MastodonButton({shareText, setMastodonOpen}) {
   const href = Indico.User.mastodonServerURL
-    ? `${Indico.User.mastodonServerURL}/share?text=${shareText}`
+    ? `${Indico.User.mastodonServerURL}/share?text=${encodeURIComponent(shareText)}`
     : null;
   const isLoggedIn = !_.isEmpty(Indico.User);
   const hasMastodonServer = !_.isEmpty(Indico.User.mastodonServerName);
@@ -289,7 +289,7 @@ function SetupMastodonServer({setMastodonOpen, button, shareText}) {
             <Button
               as="a"
               target="_blank"
-              href={`${serverURL}/share?text=${shareText}`}
+              href={`${serverURL}/share?text=${encodeURIComponent(shareText)}`}
               icon="share square"
               content={Translate.string('Share on {mastodonServerName}', {
                 mastodonServerName,
@@ -321,7 +321,7 @@ function ShareWidget({
 }) {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isMastodonOpen, setMastodonOpen] = useState(false);
-  const shareText = encodeURIComponent(`${eventName} (${eventStartDt}) · Indico (${eventUrl})`);
+  const shareText = `${eventName} (${eventStartDt}) · Indico (${eventUrl})`;
   return (
     <Popup
       trigger={


### PR DESCRIPTION
This PR fixes a bug where event names with special characters (e.g. `&`, `#` etc.) would break the share url for Mastodon and Twitter.