### PR TITLE
Join identical text messages about 'closed' status in Transifex

### DIFF
--- a/indico/modules/events/papers/templates/management/cfp_actions/ended.html
+++ b/indico/modules/events/papers/templates/management/cfp_actions/ended.html
@@ -7,7 +7,7 @@
 {% block text %}
     {% set tz = event.timezone %}
     {% trans date=cfp.end_dt|format_date(timezone=tz), time=cfp.end_dt|format_time(timezone=tz) -%}
-        Closed on <strong>{{ date }}</strong> at <strong>{{ time }}</strong> ({{ tz }}).
+        Closed on <strong>{{ date }}</strong> at <strong>{{ time }}</strong> ({{ tz }})
     {%- endtrans %}
 {% endblock %}
 


### PR DESCRIPTION
Currently there are two identical text strings in Transifex, see screenshot below. The only difference is that the latter has a dot at the end. I've checked and the first one (without the dot at the end) is found in 3 html files, while the second one (with the dot) is found only in one html file. 

I suggest to remove the dot, so that those strings get joined together.

![2024-12-07_23-31-18](https://github.com/user-attachments/assets/c62f2ec5-19db-4240-a783-76e5c55498fd)

According to Transifex, the first one is found in those files:
```
indico/modules/events/abstracts/templates/management/cfa_actions/ended.html
indico/modules/events/registration/templates/management/regform_actions/ended.html
indico/modules/events/surveys/templates/management/survey_actions/finished.html
```
The second one is found only in
```
indico/modules/events/papers/templates/management/cfp_actions/ended.html
```