### PR TITLE
Sort auth providers by `display_order` on the login page

### DIFF
--- a/docs/source/config/auth.rst
+++ b/docs/source/config/auth.rst
@@ -41,6 +41,9 @@ The following keys are available in the provider data:
   page so it should be the provider that most people use.
 - ``logo_url`` -- If set, the referenced image will be used as the
   background image of this provider's login button (on the login page).
+- ``display_order`` -- Controls the order of the provider login buttons
+  on the login page. Providers are sorted by this value in ascending
+  order.
 - Any provider-specific settings.
 
 

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -5,7 +5,10 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import math
+
 from flask import flash, jsonify, redirect, render_template, request, session
+from flask_multipass import AuthProvider
 from itsdangerous import BadData, BadSignature
 from markupsafe import Markup
 from marshmallow import RAISE, ValidationError, post_load, pre_load, validate, validates, validates_schema
@@ -52,6 +55,11 @@ def _get_provider(name, external):
     if provider.is_external != external:
         raise NotFound('Invalid provider')
     return provider
+
+
+def _sort_providers(providers: list[AuthProvider]) -> list[AuthProvider]:
+    """Sort providers by order and title."""
+    return sorted(providers, key=lambda p: (p.settings.get('order', math.inf), p.title))
 
 
 class RHLogin(RH):
@@ -110,7 +118,7 @@ class RHLogin(RH):
             active_provider = multipass.default_local_auth_provider
             form = active_provider.login_form() if active_provider else None
 
-        providers = list(multipass.auth_providers.values())
+        providers = _sort_providers(multipass.auth_providers.values())
         retry_in = login_rate_limiter.get_reset_delay() if rate_limit_exceeded else None
         return render_template('auth/login_page.html', form=form, providers=providers, active_provider=active_provider,
                                login_reason=login_reason, retry_in=retry_in, force=(force or None))

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -58,7 +58,7 @@ def _get_provider(name, external):
 
 
 def _sort_providers(providers: list[AuthProvider]) -> list[AuthProvider]:
-    """Sort providers by display order and title."""
+    """Sort providers by `display_order` and `title`."""
     return sorted(providers, key=lambda p: (p.settings.get('display_order', math.inf), p.title))
 
 

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -58,8 +58,8 @@ def _get_provider(name, external):
 
 
 def _sort_providers(providers: list[AuthProvider]) -> list[AuthProvider]:
-    """Sort providers by order and title."""
-    return sorted(providers, key=lambda p: (p.settings.get('order', math.inf), p.title))
+    """Sort providers by display order and title."""
+    return sorted(providers, key=lambda p: (p.settings.get('display_order', math.inf), p.title))
 
 
 class RHLogin(RH):

--- a/indico/modules/auth/templates/login_page.html
+++ b/indico/modules/auth/templates/login_page.html
@@ -56,7 +56,7 @@
                 {% include 'flashed_messages.html' %}
             </div>
         {% endif %}
-        {% set external_providers = providers|selectattr('is_external')|sort(attribute='title') %}
+        {% set external_providers = providers|selectattr('is_external') %}
         {% if external_providers %}
             {% if active_provider %}
                 <div class="titled-rule">


### PR DESCRIPTION
Allows defining a custom order for external auth providers on the login page.

![image](https://github.com/user-attachments/assets/420ae759-083c-4def-85cc-546ca00c0138)

The providers were previously always sorted by title. This lets you define a custom order by adding the `display_order` setting to your auth providers inside `indico.conf`:

```python
AUTH_PROVIDERS = {
    'foo': {
        'type': 'foo',
        'title': 'Foo',
        'display_order': 1,
    },
    'bar': {
        'type': 'bar',
        'title': 'Bar',
        'display_order': 2,
    },
}
```

The providers are sorted in ascending order. Providers which don't define the `display_order` key are placed at the bottom.