### PR TITLE
Stop calling videoconferences "rooms"

### DIFF
--- a/indico/modules/vc/client/js/index.js
+++ b/indico/modules/vc/client/js/index.js
@@ -81,7 +81,7 @@ import {$T} from 'indico/utils/i18n';
 
     $('.vc-room-entry.deleted').qtip({
       content: $T(
-        'This room has been deleted and cannot be used. You can detach it from the event, however.'
+        'This videoconference has been deleted and cannot be used. You can detach it from the event, however.'
       ),
       position: {
         my: 'top center',

--- a/indico/modules/vc/controllers.py
+++ b/indico/modules/vc/controllers.py
@@ -67,8 +67,8 @@ def process_vc_room_association(plugin: IndicoPlugin, event: Event, vc_room: VCR
         db.session.rollback()
         return None
     elif event_vc_room.link_type == VCRoomLinkType.event and vc_room in existing:
-        flash(_('This {plugin_name} room is already attached to the event.').format(plugin_name=plugin.friendly_name),
-              'error')
+        flash(_('This {plugin_name} videoconference is already attached to the event.')
+              .format(plugin_name=plugin.friendly_name), 'error')
         db.session.rollback()
         return None
     elif assoc_has_changed and not new_room:
@@ -137,7 +137,7 @@ class RHVCManageEventCreate(RHVCManageEventCreateBase):
 
     def _process(self):
         if not self.plugin.can_manage_vc_rooms(session.user, self.event):
-            flash(_('You are not allowed to create {plugin_name} rooms for this event.').format(
+            flash(_('You are not allowed to create {plugin_name} videoconferences for this event.').format(
                 plugin_name=self.plugin.friendly_name), 'error')
             raise Forbidden
 
@@ -170,7 +170,7 @@ class RHVCManageEventCreate(RHVCManageEventCreateBase):
             else:
                 db.session.add(vc_room)
 
-                flash(_("{plugin_name} room '{room.name}' created").format(
+                flash(_("{plugin_name} videoconference '{room.name}' created").format(
                     plugin_name=self.plugin.friendly_name, room=vc_room), 'success')
                 return jsonify_data(flash=False)
 
@@ -194,8 +194,8 @@ class RHVCManageEventModify(RHVCSystemEventBase):
 
     def _process(self):
         if not self.plugin.can_manage_vc_rooms(session.user, self.event):
-            flash(_('You are not allowed to modify {} rooms for this event.').format(self.plugin.friendly_name),
-                  'error')
+            flash(_('You are not allowed to modify {} videoconferences for this event.')
+                  .format(self.plugin.friendly_name), 'error')
             raise Forbidden
 
         form = self.plugin.create_form(self.event,
@@ -230,7 +230,7 @@ class RHVCManageEventModify(RHVCSystemEventBase):
                 # TODO
                 # notify_modified(self.vc_room, self.event, session.user)
 
-                flash(_("{plugin_name} room '{room.name}' updated").format(
+                flash(_("{plugin_name} videoconference '{room.name}' updated").format(
                     plugin_name=self.plugin.friendly_name, room=self.vc_room), 'success')
                 return jsonify_data(flash=False)
 
@@ -246,7 +246,7 @@ class RHVCManageEventRefresh(RHVCSystemEventBase):
 
     def _process(self):
         if not self.plugin.can_manage_vc_rooms(session.user, self.event):
-            flash(_('You are not allowed to refresh {plugin_name} rooms for this event.').format(
+            flash(_('You are not allowed to refresh {plugin_name} videoconferences for this event.').format(
                 plugin_name=self.plugin.friendly_name), 'error')
             raise Forbidden
 
@@ -260,7 +260,7 @@ class RHVCManageEventRefresh(RHVCSystemEventBase):
             flash(str(err), 'error')
             return redirect(url_for('.manage_vc_rooms', self.event))
 
-        flash(_("{plugin_name} room '{room.name}' refreshed").format(
+        flash(_("{plugin_name} videoconference '{room.name}' refreshed").format(
             plugin_name=self.plugin.friendly_name, room=self.vc_room), 'success')
         return redirect(url_for('.manage_vc_rooms', self.event))
 
@@ -271,8 +271,8 @@ class RHVCManageEventRemove(RHVCSystemEventBase):
     @use_kwargs({'delete_all': fields.Bool(load_default=False)}, location='query')
     def _process(self, delete_all):
         if not self.plugin.can_manage_vc_rooms(session.user, self.event):
-            flash(_('You are not allowed to remove {} rooms from this event.').format(self.plugin.friendly_name),
-                  'error')
+            flash(_('You are not allowed to remove {} videoconferences from this event.')
+                  .format(self.plugin.friendly_name), 'error')
             raise Forbidden
 
         if delete_all:
@@ -280,7 +280,7 @@ class RHVCManageEventRemove(RHVCSystemEventBase):
         else:
             self.event_vc_room.delete(session.user)
 
-        flash(_("{plugin_name} room '{room.name}' removed").format(
+        flash(_("{plugin_name} videoconference '{room.name}' removed").format(
             plugin_name=self.plugin.friendly_name, room=self.vc_room), 'success')
         return redirect(url_for('.manage_vc_rooms', self.event))
 
@@ -312,14 +312,14 @@ class RHVCManageAttach(RHVCManageEventCreateBase):
         if form.validate_on_submit():
             vc_room = form.data['room']
             if not self.plugin.can_manage_vc_rooms(session.user, self.event):
-                flash(_('You are not allowed to attach {plugin_name} rooms to this event.').format(
+                flash(_('You are not allowed to attach {plugin_name} videoconferences to this event.').format(
                     plugin_name=self.plugin.friendly_name), 'error')
             elif not self.plugin.can_manage_vc_room(session.user, vc_room):
-                flash(_("You are not authorized to attach the room '{0}'").format(vc_room.name), 'error')
+                flash(_("You are not authorized to attach the videoconference '{}'").format(vc_room.name), 'error')
             else:
                 event_vc_room = process_vc_room_association(self.plugin, self.event, vc_room, form)
                 if event_vc_room:
-                    flash(_('The room has been attached to the event.'), 'success')
+                    flash(_('The videoconference has been attached to the event.'), 'success')
                     db.session.add(event_vc_room)
             return jsonify_data(flash=False)
 

--- a/indico/modules/vc/forms.py
+++ b/indico/modules/vc/forms.py
@@ -76,9 +76,9 @@ class VCRoomLinkFormBase(IndicoForm):
                         [UsedIf(lambda form, field: form.linking.data == 'block'), DataRequired()],
                         coerce=lambda x: int(x) if x else None)
 
-    show = BooleanField(_('Show room'),
+    show = BooleanField(_('Show in event'),
                         widget=SwitchWidget(),
-                        description=_('Display this room on the event page'))
+                        description=_('Display this videoconference on the event page'))
 
     def __init__(self, *args, **kwargs):
         self.event = kwargs.pop('event')
@@ -102,9 +102,10 @@ class VCRoomLinkFormBase(IndicoForm):
 
 class VCRoomAttachFormBase(VCRoomLinkFormBase):
     room = VCRoomField(
-        _('Room to link'), [DataRequired()],
-        description=_('Please start writing the name of the room you would like to attach. '
-                      'Indico will suggest existing rooms. Only rooms created through Indico can be attached.'))
+        _('Videoconference to link'), [DataRequired()],
+        description=_('Please start writing the name of the videoconference you would like to attach. '
+                      'Indico will suggest existing videoconferences. Only those created through Indico can be '
+                      'attached.'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -115,14 +116,15 @@ class VCRoomFormBase(VCRoomLinkFormBase):
     advanced_fields = {'show'}
     skip_fields = advanced_fields | VCRoomLinkFormBase.conditional_fields
 
-    name = StringField(_('Name'), [DataRequired(), Length(min=3, max=60)], description=_('The name of the room.'))
+    name = StringField(_('Name'), [DataRequired(), Length(min=3, max=60)],
+                       description=_('The name of the videoconference.'))
 
     def validate_name(self, field):
         if field.data:
             room = VCRoom.query.filter(VCRoom.name == field.data, VCRoom.status != VCRoomStatus.deleted,
                                        VCRoom.type == self.service_name).first()
             if room and room != self.vc_room:
-                raise ValidationError(_('There is already a room with this name'))
+                raise ValidationError(_('There is already a videoconference with this name'))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/indico/modules/vc/templates/emails/created.html
+++ b/indico/modules/vc/templates/emails/created.html
@@ -7,7 +7,7 @@
 {% block header -%}
 <p>
     {% trans link='<a href="%s">'|format(event.external_url)|safe, endlink='</a>'|safe, title=event.title -%}
-        A videoconferencing room has just been created for the event "{{ link }}{{ title }}{{ endlink }}".
+        A videoconference has just been created for the event "{{ link }}{{ title }}{{ endlink }}".
     {%- endtrans %}
 </p>
 
@@ -20,7 +20,7 @@
 </p>
 <br>
 <p>
-    <strong>{% trans %}Room information{% endtrans %}</strong>
+    <strong>{% trans %}Videoconference information{% endtrans %}</strong>
     <br>
     <ul>
         <li><strong>{% trans %}Name:{% endtrans %}</strong> {{ vc_room.name }}</li>

--- a/indico/modules/vc/templates/emails/deleted.html
+++ b/indico/modules/vc/templates/emails/deleted.html
@@ -9,7 +9,7 @@
 {% block header -%}
 <p>
     {% trans room=vc_room.name, name=user.full_name -%}
-        The videoconferencing room "{{ room }}" has been deleted by {{ name }}.
+        The videoconference "{{ room }}" has been deleted by {{ name }}.
     {%- endtrans %}
 </p>
 {%- endblock %}

--- a/indico/modules/vc/templates/manage_event.html
+++ b/indico/modules/vc/templates/manage_event.html
@@ -46,7 +46,7 @@
                                                 <button class="ui button js-vcroom-edit hide-if-locked"
                                                         data-href="{{ url_for('.manage_vc_rooms_modify', event_vc_room) }}"
                                                         title="{% trans %}Edit{% endtrans %}"
-                                                        data-title="{% trans %}Edit room{% endtrans %}"
+                                                        data-title="{% trans %}Edit videoconference{% endtrans %}"
                                                         data-ajax-dialog
                                                         data-reload-after>
                                                     <i class="icon edit"></i>
@@ -86,11 +86,11 @@
                     <button class="ui icon button js-create-room"
                             data-vc-system="{{ plugins[0].service_name }}"
                             data-href="{{ url_for('.manage_vc_rooms_create', event, service=plugins[0].service_name) }}"
-                            data-title="{% trans plugin_name=plugins[0].friendly_name %}Create {{ plugin_name }} room{% endtrans %}"
+                            data-title="{% trans plugin_name=plugins[0].friendly_name %}Create {{ plugin_name }} videoconference{% endtrans %}"
                             data-ajax-dialog
                             data-reload-after>
                         <img src="{{ plugins[0].icon_url }}" alt="{{ plugins[0].service_name }}">
-                        {% trans plugin_name=plugins[0].friendly_name %}Create {{ plugin_name }} room{% endtrans %}
+                        {% trans plugin_name=plugins[0].friendly_name %}Create {{ plugin_name }} videoconference{% endtrans %}
                     </button>
                 {% elif plugins|length > 1 %}
                     <button class="ui button js-create-room"
@@ -99,7 +99,7 @@
                             data-ajax-dialog
                             data-reload-after>
                         <i class="icon plus"></i>
-                        {%- trans %}Create new room{% endtrans -%}
+                        {%- trans %}Create new videoconference{% endtrans -%}
                     </button>
                 {% endif %}
                 <span>
@@ -107,7 +107,7 @@
                        class="ui icon button"
                        {% if plugins|length == 1 %}
                            data-href="{{ url_for('.manage_vc_rooms_search_form', event, service=plugins[0].service_name) }}"
-                           data-title="{% trans plugin_name=plugins[0].friendly_name %}Attach {{ plugin_name }} room{% endtrans %}"
+                           data-title="{% trans plugin_name=plugins[0].friendly_name %}Attach {{ plugin_name }} videoconference{% endtrans %}"
                        {% else %}
                            data-href="{{ url_for('.manage_vc_rooms_select', event, vc_room_action='.manage_vc_rooms_search_form', attach=True)}}"
                            data-title="{% trans %}Attach videoconference{% endtrans %}"
@@ -115,7 +115,7 @@
                        data-ajax-dialog
                        data-reload-after>
                         <i class="icon plus"></i>
-                        {% trans %}Add existing room{% endtrans %}
+                        {% trans 'Videoconference' %}Add existing one{% endtrans %}
                     </a>
                 </span>
             </div>

--- a/indico/modules/vc/templates/manage_event_select.html
+++ b/indico/modules/vc/templates/manage_event_select.html
@@ -1,9 +1,13 @@
 {%- if plugins %}
     <p>
         {% if attach == '1' %}
-            {% trans %}The following video services are available. Click on one to attach a new room:{% endtrans %}
+            {% trans %}
+                The following video services are available. Click on one to attach an existing videoconference:
+            {% endtrans %}
         {% else %}
-            {% trans %}The following video services are available. Click on one to create a new room:{% endtrans %}
+            {% trans %}
+                The following video services are available. Click on one to create a new videoconference:
+            {% endtrans %}
         {% endif %}
     </p>
     <div class="i-badges-list-space-evenly">
@@ -11,7 +15,7 @@
             {% set action=_("Attach") if attach == '1' else _("Create") %}
             <a href="#" class="js-vc-plugin i-badge i-badge-gray"
                data-href="{{ url_for(vc_room_action, event, service=plugin.service_name) }}"
-               data-title="{% trans plugin_name=plugin.friendly_name %} {{ action }} {{ plugin_name }} room{% endtrans %}"
+               data-title="{% trans plugin_name=plugin.friendly_name %} {{ action }} {{ plugin_name }} videoconference{% endtrans %}"
                data-ajax-dialog
                data-reload-after>
                 <div class="i-badge-content">


### PR DESCRIPTION
This was a mistake we did when we had Vidyo where they used the "room" terminology, but with Zoom it's "meetings" and when you add "Zoom Rooms" on top it gets even more confusing. 

#4962 started cleaning this up, but missed some places...