### PR TITLE
Use flexbox for registration request action buttons

### DIFF
--- a/indico/modules/users/templates/registration_requests.html
+++ b/indico/modules/users/templates/registration_requests.html
@@ -25,16 +25,18 @@
                     <td>{{ req.user_data.affiliation }}</td>
                     <td>{{ req.comment }}</td>
                     <td>
-                        <button class="i-button danger right js-process-request"
-                                data-href="{{ url_for('.reject_registration_request', req) }}"
-                                data-method="POST">
-                            {% trans %}Reject{% endtrans %}
-                        </button>
-                        <button class="i-button accept right js-process-request"
-                                data-href="{{ url_for('.accept_registration_request', req) }}"
-                                data-method="POST">
-                            {% trans %}Accept{% endtrans %}
-                        </button>
+                        <div class="flexrow">
+                            <button class="i-button accept js-process-request"
+                                    data-href="{{ url_for('.accept_registration_request', req) }}"
+                                    data-method="POST">
+                                {% trans %}Accept{% endtrans %}
+                            </button>
+                            <button class="i-button danger js-process-request"
+                                    data-href="{{ url_for('.reject_registration_request', req) }}"
+                                    data-method="POST">
+                                {% trans %}Reject{% endtrans %}
+                            </button>
+                        </div>
                     </td>
                 </tr>
             {%- endfor %}


### PR DESCRIPTION
The action button layout is inconsistent depending on the content of the other table cells. When the content fits a single line, the buttons are also rendered on a single line which is fine. However, when the content is longer, they are rendered vertically and with the order swapped:

![image](https://github.com/user-attachments/assets/3b723aef-5878-4b10-94a1-d92dacb09f37)

![image](https://github.com/user-attachments/assets/7ea10365-5971-49a5-a96d-f1a46f48e589)

This PR keeps the horizontal layout regardless of the content length:

![obrazek](https://github.com/user-attachments/assets/b31a376c-072e-435b-8081-6218fbec79b0)
