### PR TITLE
Fix type annotation of `IndicoModel.get`

### DIFF
--- a/indico/core/db/sqlalchemy/util/models.py
+++ b/indico/core/db/sqlalchemy/util/models.py
@@ -6,9 +6,9 @@
 # LICENSE file for more details.
 
 import os
-import typing as t
 from copy import copy
 from importlib import import_module
+from typing import Self
 
 from flask import g
 from flask_sqlalchemy.model import Model
@@ -24,9 +24,6 @@ from sqlalchemy.orm.exc import NoResultFound
 from indico.core import signals
 from indico.util.packaging import get_package_root_path
 from indico.util.signals import values_from_signal
-
-
-_ModelT = t.TypeVar('_ModelT', bound='IndicoModel')
 
 
 class IndicoQueryPagination(QueryPagination):
@@ -97,7 +94,7 @@ class IndicoModel(Model):
     query_class = IndicoBaseQuery
 
     @classmethod
-    def get(cls: type[_ModelT], oid, is_deleted=None) -> _ModelT:
+    def get(cls, oid, is_deleted=None) -> Self | None:
         """Get an object based on its primary key.
 
         :param oid: The primary key of the object

--- a/indico/core/db/sqlalchemy/util/models.py
+++ b/indico/core/db/sqlalchemy/util/models.py
@@ -94,7 +94,7 @@ class IndicoModel(Model):
     query_class = IndicoBaseQuery
 
     @classmethod
-    def get(cls, oid, is_deleted=None) -> Self | None:
+    def get(cls, oid, is_deleted: bool | None = None) -> Self | None:
         """Get an object based on its primary key.
 
         :param oid: The primary key of the object


### PR DESCRIPTION
`IndicoModel.get` can return `None`. Also, since we're on 3.12, let's use `typing.Self` instead.

Before:

![image](https://github.com/user-attachments/assets/57f9b7dc-630b-4df1-8074-56ef56205968)

After:

![image](https://github.com/user-attachments/assets/a586eb6c-65f1-4941-94f2-2cdbdadd23f2)
