### PR TITLE
Fix typo in 'Send copy' field description

### DIFF
--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -337,7 +337,7 @@ class EmailRegistrantsForm(IndicoForm):
     body = TextAreaField(_('Email body'), [DataRequired(), NoRelativeURLs()], widget=TinyMCEWidget(absolute_urls=True))
     recipients = IndicoEmailRecipientsField(_('Recipients'))
     copy_for_sender = BooleanField(_('Send copy to me'), widget=SwitchWidget(),
-                                   description=_('Send copy of each email to my mailbox'))
+                                   description=_('Send a copy of each email to my mailbox'))
     attach_ticket = BooleanField(_('Attach ticket'), widget=SwitchWidget(),
                                  description=_('Attach tickets to emails'))
     registration_id = HiddenFieldList()


### PR DESCRIPTION
I thought it might make sense to use identical description text here (screenshot from Transifex):
![2024-12-13_14-02-56](https://github.com/user-attachments/assets/af314ddd-dd71-4beb-911a-e8335fc72935)

Currently one of them is missing an indefinite article *a* before "copy".