### PR TITLE
Use more verbose errors during rb moderation

### DIFF
--- a/indico/modules/rb/controllers/backend/bookings.py
+++ b/indico/modules/rb/controllers/backend/bookings.py
@@ -231,6 +231,15 @@ class RHBookingStateActions(RHBookingBase):
                  'reject': self.booking.can_reject,
                  'cancel': self.booking.can_cancel}
 
+        # The `can_*` methods contain both access and state checks, but it's nicer to show
+        # something more verbose in case e.g. someone accepted a conflicting booking which
+        # auto-rejected another one, and they then try to reject that from another tab.
+        match self.action:
+            case 'approve' if not self.booking.is_pending:
+                raise ExpectedError(_('This booking has already been approved or rejected.'))
+            case 'reject' | 'cancel' if self.booking.is_rejected or self.booking.is_cancelled:
+                raise ExpectedError(_('This booking has already been cancelled or rejected.'))
+
         if self.action not in funcs or not funcs[self.action](session.user):
             raise Forbidden
 


### PR DESCRIPTION
When people have multiple pending bookings they may open all of them in new tabs (from the email notifications) and then accept one which auto-rejects the other. If they then tried to reject the others, it failed with a generic (reportable) Forbidden error, instead of something nicer.