### PR TITLE
Redact session cookie value in error emails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Improvements
 - Highlight editables in the editable list that have been updated since the last time
   they were viewed (:pr:`6500`)
 - Refresh the looks of the PDF timetable (:issue:`6554`, :pr:`6558`)
+- Redact session cookie value in error emails (:pr:`6666`)
 
 Bugfixes
 ^^^^^^^^


### PR DESCRIPTION
Those emails are supposed to go to people who manage the Indico instance and thus have absolutely no benefit of taking over someone's session, but people tend to post those emails in the forums, without cleaning them up first...