### PR TITLE
Add missing translation marker

### DIFF
--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -12,6 +12,7 @@ from marshmallow import fields, validate
 from indico.core.marshmallow import mm
 from indico.modules.events.registration.models.registrations import RegistrationData
 from indico.util.marshmallow import not_empty
+from indico.util.i18n import _
 
 
 class BillableFieldDataSchema(mm.Schema):
@@ -182,7 +183,8 @@ class RegistrationFormFieldBase:
         return registration_data.data
 
     def iter_placeholder_info(self):
-        yield None, f'Value of "{self.form_item.title}" ({self.form_item.parent.title})'
+        yield None, _('Value of "{form_item}" ({parent_form_item})')
+                    .format(form_item=self.form_item.title, parent_form_item=self.form_item.parent.title)
 
     def render_placeholder(self, data, key=None):
         return self.get_friendly_data(data)


### PR DESCRIPTION
I looked through the code and didn't find any examples of using `_(...)` with f-strings, so replaced the f-string with `.format`