### PR TITLE
Add translation marker for time-related strings with context

### DIFF
--- a/indico/web/forms/fields/datetime.py
+++ b/indico/web/forms/fields/datetime.py
@@ -20,7 +20,7 @@ from wtforms_dateutil import DateField, DateTimeField
 from indico.core.config import config
 from indico.core.logger import Logger
 from indico.util.date_time import localize_as_utc, relativedelta
-from indico.util.i18n import _, get_current_locale
+from indico.util.i18n import _, get_current_locale, pgettext
 from indico.web.forms.fields import JSONField
 from indico.web.forms.validators import DateRange, DateTimeRange, LinkedDate, LinkedDateTime
 from indico.web.forms.widgets import JinjaWidget
@@ -39,13 +39,12 @@ class TimeDeltaField(Field):
     """
 
     widget = JinjaWidget('forms/timedelta_widget.html', single_line=True, single_kwargs=True)
-    # XXX: do not translate, "Minutes" is ambiguous without context
     unit_names = {
-        'seconds': 'Seconds',
-        'minutes': 'Minutes',
-        'hours': 'Hours',
-        'days': 'Days',
-        'weeks': 'Weeks',
+        'seconds': _('Seconds'),
+        'minutes': pgettext('Time', 'Minutes'),
+        'hours': _('Hours'),
+        'days': _('Days'),
+        'weeks': _('Weeks'),
     }
     magnitudes = {
         'weeks': 7*86400,
@@ -120,15 +119,14 @@ class RelativeDeltaField(Field):
     """
 
     widget = JinjaWidget('forms/timedelta_widget.html', single_line=True, single_kwargs=True)
-    # XXX: do not translate, "Minutes" is ambiguous without context
     unit_names = {
-        'seconds': 'Seconds',
-        'minutes': 'Minutes',
-        'hours': 'Hours',
-        'days': 'Days',
-        'weeks': 'Weeks',
-        'months': 'Months',
-        'years': 'Years'
+        'seconds': _('Seconds'),
+        'minutes': pgettext('Time', 'Minutes'),
+        'hours': _('Hours'),
+        'days': _('Days'),
+        'weeks': _('Weeks'),
+        'months': _('Months'),
+        'years': _('Years')
     }
     magnitudes = {
         'years': relativedelta(years=1),

--- a/indico/web/forms/fields/datetime.py
+++ b/indico/web/forms/fields/datetime.py
@@ -41,7 +41,7 @@ class TimeDeltaField(Field):
     widget = JinjaWidget('forms/timedelta_widget.html', single_line=True, single_kwargs=True)
     unit_names = {
         'seconds': _('Seconds'),
-        'minutes': pgettext('Time', 'Minutes'),
+        'minutes': pgettext('Duration', 'Minutes'),
         'hours': _('Hours'),
         'days': _('Days'),
         'weeks': _('Weeks'),
@@ -121,7 +121,7 @@ class RelativeDeltaField(Field):
     widget = JinjaWidget('forms/timedelta_widget.html', single_line=True, single_kwargs=True)
     unit_names = {
         'seconds': _('Seconds'),
-        'minutes': pgettext('Time', 'Minutes'),
+        'minutes': pgettext('Duration', 'Minutes'),
         'hours': _('Hours'),
         'days': _('Days'),
         'weeks': _('Weeks'),


### PR DESCRIPTION
I apologise for disregard of the "do not translate" comment. I thought that it is not an issue to add some context. If I'm wrong, please feel free to close this PR