### PR TITLE
Correctly format email sender containing site name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Bugfixes
 - Do not fail if a user has an invalid timezone stored in the database (:pr:`6647`)
 - Ensure the event name is correctly encoded to prevent issues with special characters
   in the share event widget (:pr:`6649`)
+- Fix sending emails if site name contains an ``@`` character (:pr:`6687`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/core/emails.py
+++ b/indico/core/emails.py
@@ -70,7 +70,7 @@ def send_email_task(task, email, log_entry=None):
 def get_actual_sender_address(sender_address: str, reply_address: set[str]) -> tuple[str, set]:
     site_title = core_settings.get('site_title')
     if not sender_address:
-        return f'{site_title} <{config.NO_REPLY_EMAIL}>', reply_address
+        return formataddr((site_title, config.NO_REPLY_EMAIL)), reply_address
     if not config.SMTP_ALLOWED_SENDERS:
         # this may result in spoofing
         return sender_address, reply_address

--- a/indico/core/emails_test.py
+++ b/indico/core/emails_test.py
@@ -42,6 +42,12 @@ def test_get_actual_sender_address(mocker, sender_email, result):
     assert get_actual_sender_address(sender_email, {'reply@whatever.com'}) == (result[0], {'reply@whatever.com'})
 
 
+def test_get_actual_sender_address_weird_site_name(mocker):
+    mocker.patch('indico.core.emails.config', MockConfig())
+    core_settings.set('site_title', 'Indico @ Test')
+    assert get_actual_sender_address('', set())[0] == '"Indico @ Test" <noreply@example.com>'
+
+
 @pytest.mark.usefixtures('db')
 @pytest.mark.parametrize(('sender_email', 'result'), (
     ('Foo <foo@example.com>', ('Foo <foo@example.com>', set())),

--- a/indico/testing/fixtures/app.py
+++ b/indico/testing/fixtures/app.py
@@ -34,6 +34,7 @@ def app(request):
         'ENABLE_ROOMBOOKING': True,
         'SECRET_KEY': os.urandom(16),
         'SMTP_USE_CELERY': False,
+        'NO_REPLY_EMAIL': 'noreply@example.com',
     }
     return make_app(testing=True, config_override=config_override)
 


### PR DESCRIPTION
Certain characters such as `@` in the site name resulted in an invalid From address because the human-friendly part was not quoted.