### PR TITLE
Set session cookies with SameSite=Lax

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ Improvements
 - Redact session cookie value in error emails (:pr:`6666`)
 - Allow creating a new local account during password reset if the user does not have
   one yet (:pr:`6688`)
+- Set session cookies with ``SameSite=Lax`` so they are not sent when Indico is embedded
+  in a third-party iframe (:pr:`6690`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/web/flask/app.py
+++ b/indico/web/flask/app.py
@@ -74,6 +74,7 @@ def configure_app(app):
     app.config['PROPAGATE_EXCEPTIONS'] = True
     app.config['TRAP_HTTP_EXCEPTIONS'] = False
     app.config['TRAP_BAD_REQUEST_ERRORS'] = config.DEBUG
+    app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
     app.config['SESSION_COOKIE_NAME'] = 'indico_session'
     app.config['PERMANENT_SESSION_LIFETIME'] = config.SESSION_LIFETIME
     app.config['RATELIMIT_STORAGE_URI'] = config.REDIS_CACHE_URL or 'memory://'

--- a/indico/web/flask/session.py
+++ b/indico/web/flask/session.py
@@ -231,6 +231,7 @@ class IndicoSessionInterface(SessionInterface):
     def save_session(self, app, session, response):
         domain = self.get_cookie_domain(app)
         secure = self.get_cookie_secure(app)
+        samesite = self.get_cookie_samesite(app)
         refresh_sid = self.should_refresh_sid(app, session)
         if not session and not session.new:
             # empty session, delete it from storage and cookie
@@ -268,5 +269,5 @@ class IndicoSessionInterface(SessionInterface):
         session['_secure'] = request.is_secure
         self.storage.set(session.sid, self.serializer.dumps(dict(session)), storage_ttl)
         response.set_cookie(app.session_cookie_name, session.sid, expires=cookie_lifetime, httponly=True,
-                            secure=secure)
+                            secure=secure, samesite=samesite)
         response.vary.add('Cookie')


### PR DESCRIPTION
There's no good reason to not use this, sometimes people embed event pages inside frames, but in that case there is no need to have session cookies.