### PR TITLE
[Docs] Remove obsolete config option

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,6 @@ import re
 import sys
 import warnings
 
-import sphinx_rtd_theme
 from sqlalchemy.exc import SAWarning
 
 
@@ -136,10 +135,6 @@ html_theme = 'sphinx_rtd_theme'
 # further.  For a list of options available for each theme, see the
 # documentation.
 # html_theme_options = {}
-
-
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".


### PR DESCRIPTION
When building docs with `make html`, this message appears:
```sh
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v8.1.3
WARNING: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.
```

It seems that we can simply remove `html_theme_path` from our `conf.py`