### PR TITLE
Enable split PO and remove old TX resource files references

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,24 +1,6 @@
 [main]
 host = https://www.transifex.com
 
-[o:indico:p:indico:r:core-messages-react]
-file_filter = indico/translations/<lang>/LC_MESSAGES/messages-react.po
-source_file = indico/translations/messages-react.pot
-source_lang = en
-type        = PO
-
-[o:indico:p:indico:r:core-messages-js]
-file_filter = indico/translations/<lang>/LC_MESSAGES/messages-js.po
-source_file = indico/translations/messages-js.pot
-source_lang = en
-type        = PO
-
-[o:indico:p:indico:r:core-messages]
-file_filter = indico/translations/<lang>/LC_MESSAGES/messages.po
-source_file = indico/translations/messages.pot
-source_lang = en
-type        = PO
-
 [o:indico:p:indico:r:core-messages-all]
 file_filter = indico/translations/<lang>/LC_MESSAGES/messages-all.po
 source_file = indico/translations/messages-all.pot

--- a/indico/cli/i18n.py
+++ b/indico/cli/i18n.py
@@ -465,9 +465,8 @@ def _indico_command(babel_cmd, python, javascript, react, locale, no_check):
                         err=True)
             sys.exit(1)
     try:
-        # TODO: Re-enable once we actually moved to the merged translation file on transifex
-        # if babel_cmd == 'CompileCatalog':
-        #     split_all_po_files()
+        if babel_cmd == 'CompileCatalog':
+            split_all_po_files()
 
         if python:
             _run_command(babel_cmd, extra=extra)


### PR DESCRIPTION
Adds back splitting of `messages-all.po` file when running `indico i18n compile indico` and removes pull info from `.tx/config` for old resources.