### PR TITLE
Convert field/item prices to decimal

### DIFF
--- a/indico/modules/events/registration/fields/accompanying.py
+++ b/indico/modules/events/registration/fields/accompanying.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from decimal import Decimal
 from uuid import uuid4
 
 from marshmallow import ValidationError, fields, post_load, pre_load, validate
@@ -83,7 +84,7 @@ class AccompanyingPersonsField(RegistrationFormBillableField):
         return max(count, 0)
 
     def calculate_price(self, reg_data, versioned_data):
-        return versioned_data.get('price', 0) * len(reg_data)
+        return Decimal(str(versioned_data.get('price', 0))) * len(reg_data)
 
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):
         reg_data = registration_data.data

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -6,6 +6,7 @@
 # LICENSE file for more details.
 
 from copy import deepcopy
+from decimal import Decimal
 
 from marshmallow import fields, validate
 
@@ -202,7 +203,7 @@ class RegistrationFormBillableField(RegistrationFormFieldBase):
         return super().process_field_data(data, old_data, old_versioned_data)
 
     def calculate_price(self, reg_data, versioned_data):
-        return versioned_data.get('price', 0)
+        return Decimal(str(versioned_data.get('price', 0)))
 
     @classmethod
     def unprocess_field_data(cls, versioned_data, unversioned_data):

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -9,6 +9,7 @@ import sys
 from collections import Counter
 from copy import deepcopy
 from datetime import date, datetime
+from decimal import Decimal
 from uuid import uuid4
 
 from marshmallow import ValidationError, fields, post_load, pre_load, validate, validates_schema
@@ -204,9 +205,10 @@ class ChoiceBaseField(RegistrationFormBillableItemsField):
         billable_choices = [x for x in versioned_data['choices'] if x['id'] in reg_data and x['price']]
         price = 0
         for billable_field in billable_choices:
-            price += billable_field['price']
+            field_price = Decimal(str(billable_field['price']))
+            price += field_price
             if billable_field.get('extra_slots_pay'):
-                price += (reg_data[billable_field['id']] - 1) * billable_field['price']
+                price += (reg_data[billable_field['id']] - 1) * field_price
         return price
 
 
@@ -607,7 +609,7 @@ class AccommodationField(RegistrationFormBillableItemsField):
         if not item:
             return 0
         nights = (_to_date(reg_data['departure_date']) - _to_date(reg_data['arrival_date'])).days
-        return item['price'] * nights
+        return Decimal(str(item['price'])) * nights
 
     def process_form_data(self, registration, value, old_data=None, billable_items_locked=False, new_data_version=None):
         if billable_items_locked and old_data.price:

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -6,6 +6,7 @@
 # LICENSE file for more details.
 
 from datetime import datetime
+from decimal import Decimal
 
 from marshmallow import ValidationError, fields, pre_load, validate, validates_schema
 from PIL import Image
@@ -81,7 +82,7 @@ class NumberField(RegistrationFormBillableField):
                               max=self.form_item.data.get('max_value') or None)
 
     def calculate_price(self, reg_data, versioned_data):
-        return versioned_data.get('price', 0) * int(reg_data or 0)
+        return Decimal(str(versioned_data.get('price', 0) * int(reg_data or 0)))
 
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):
         if registration_data.data is None:
@@ -112,7 +113,7 @@ class CheckboxField(RegistrationFormBillableField):
     def calculate_price(self, reg_data, versioned_data):
         if not reg_data:
             return 0
-        return versioned_data.get('price', 0)
+        return Decimal(str(versioned_data.get('price', 0)))
 
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):
         return self.friendly_data_mapping[registration_data.data]
@@ -298,7 +299,7 @@ class BooleanField(RegistrationFormBillableField):
         return places_used
 
     def calculate_price(self, reg_data, versioned_data):
-        return versioned_data.get('price', 0) if reg_data else 0
+        return Decimal(str(versioned_data.get('price', 0))) if reg_data else 0
 
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):
         return self.friendly_data_mapping[registration_data.data]


### PR DESCRIPTION
An alternative fix could be to just convert to decimal and quantize to 2-3 decimal digits when summing the prices from the individual field data, but it feels cleaner to do it early on (before multiplying by number of nights, slots, whatever).

fixes #6671