### PR TITLE
Disable resizing entries further than children

### DIFF
--- a/indico/modules/events/timetable/client/js/BlockEntry.module.scss
+++ b/indico/modules/events/timetable/client/js/BlockEntry.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/BlockEntry.tsx
+++ b/indico/modules/events/timetable/client/js/BlockEntry.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/ContributionEntry.module.scss
+++ b/indico/modules/events/timetable/client/js/ContributionEntry.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/ContributionEntry.tsx
+++ b/indico/modules/events/timetable/client/js/ContributionEntry.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/DayTimetable.module.scss
+++ b/indico/modules/events/timetable/client/js/DayTimetable.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/DayTimetable.module.scss
+++ b/indico/modules/events/timetable/client/js/DayTimetable.module.scss
@@ -83,6 +83,8 @@
   font-size: 15px;
   width: 100%;
   flex-grow: 1;
+  -webkit-user-select: none;
+  user-select: none;
 }
 
 .resize-handle {

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/Entry-old.jsx
+++ b/indico/modules/events/timetable/client/js/Entry-old.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/Entry.module.scss
+++ b/indico/modules/events/timetable/client/js/Entry.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/EntryDetails.module.scss
+++ b/indico/modules/events/timetable/client/js/EntryDetails.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/EntryDetails.tsx
+++ b/indico/modules/events/timetable/client/js/EntryDetails.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/ResizeHandle.tsx
+++ b/indico/modules/events/timetable/client/js/ResizeHandle.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/ResizeHandle.tsx
+++ b/indico/modules/events/timetable/client/js/ResizeHandle.tsx
@@ -51,10 +51,10 @@ export default function ResizeHandle({
         newDuration = Math.min(newDuration, maxDuration);
       }
 
-      if (newDuration >= 10) {
+      if (newDuration > minDuration) {
         setLocalDuration(newDuration);
       } else {
-        setLocalDuration(10);
+        setLocalDuration(minDuration);
       }
     }
 

--- a/indico/modules/events/timetable/client/js/Timetable.module.scss
+++ b/indico/modules/events/timetable/client/js/Timetable.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/Toolbar.module.scss
+++ b/indico/modules/events/timetable/client/js/Toolbar.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/UnscheduledContributions.module.scss
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributions.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/WeekTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/WeekTimetable.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/WeekViewToolbar.module.scss
+++ b/indico/modules/events/timetable/client/js/WeekViewToolbar.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/WeekViewToolbar.tsx
+++ b/indico/modules/events/timetable/client/js/WeekViewToolbar.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/colors.ts
+++ b/indico/modules/events/timetable/client/js/colors.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/components/AttachmentsDisplay.jsx
+++ b/indico/modules/events/timetable/client/js/components/AttachmentsDisplay.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/components/Changelog.jsx
+++ b/indico/modules/events/timetable/client/js/components/Changelog.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/components/Changelog.module.scss
+++ b/indico/modules/events/timetable/client/js/components/Changelog.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/components/DetailsSegment.jsx
+++ b/indico/modules/events/timetable/client/js/components/DetailsSegment.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/components/DetailsSegment.module.scss
+++ b/indico/modules/events/timetable/client/js/components/DetailsSegment.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/components/EntryColorPicker.jsx
+++ b/indico/modules/events/timetable/client/js/components/EntryColorPicker.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/components/EntryColorPicker.module.scss
+++ b/indico/modules/events/timetable/client/js/components/EntryColorPicker.module.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/components/NewEntryDropdown.jsx
+++ b/indico/modules/events/timetable/client/js/components/NewEntryDropdown.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/components/TimeDisplay.jsx
+++ b/indico/modules/events/timetable/client/js/components/TimeDisplay.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the
@@ -16,7 +16,7 @@ import {Accordion, Form, Icon} from 'semantic-ui-react';
 import {FinalCheckbox, FinalField, FinalSubmitButton} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
-import {entrySchema, getEndDt, handleUnimplemented} from '../util';
+import {entrySchema, handleUnimplemented} from '../util';
 
 function TimePickerField({value, onChange, uses24HourFormat}) {
   return (

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/dnd/index.ts
+++ b/indico/modules/events/timetable/client/js/dnd/index.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/dnd/modifiers.ts
+++ b/indico/modules/events/timetable/client/js/dnd/modifiers.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/dnd/scroll.ts
+++ b/indico/modules/events/timetable/client/js/dnd/scroll.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/dnd/types.ts
+++ b/indico/modules/events/timetable/client/js/dnd/types.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/dnd/utils.ts
+++ b/indico/modules/events/timetable/client/js/dnd/utils.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/entry_popups.jsx
+++ b/indico/modules/events/timetable/client/js/entry_popups.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/forms/ContributionEntryForm.jsx
+++ b/indico/modules/events/timetable/client/js/forms/ContributionEntryForm.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/i18n.ts
+++ b/indico/modules/events/timetable/client/js/i18n.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/index.jsx
+++ b/indico/modules/events/timetable/client/js/index.jsx
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/layout-old.js
+++ b/indico/modules/events/timetable/client/js/layout-old.js
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/layout.ts
+++ b/indico/modules/events/timetable/client/js/layout.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/operations.js
+++ b/indico/modules/events/timetable/client/js/operations.js
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/timetable.scss
+++ b/indico/modules/events/timetable/client/js/timetable.scss
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/util.js
+++ b/indico/modules/events/timetable/client/js/util.js
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -1,5 +1,5 @@
 // This file is part of Indico.
-// Copyright (C) 2002 - 2024 CERN
+// Copyright (C) 2002 - 2025 CERN
 //
 // Indico is free software; you can redistribute it and/or
 // modify it under the terms of the MIT License; see the


### PR DESCRIPTION
Disables the resizing of elements beyond the size of its children. Also fixes the selection issue when dragging elements.

Also unbeheaded all files in the `timetable/js/client` folder