### PR TITLE
Limit email subject length

### DIFF
--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -10,7 +10,7 @@ from itertools import groupby
 
 from flask import request, session
 from wtforms.fields import BooleanField, EmailField, HiddenField, IntegerField, SelectField, StringField, TextAreaField
-from wtforms.validators import DataRequired, InputRequired, NumberRange, Optional, ValidationError
+from wtforms.validators import DataRequired, InputRequired, Length, NumberRange, Optional, ValidationError
 from wtforms.widgets import Select
 from wtforms_sqlalchemy.fields import QuerySelectField
 
@@ -450,7 +450,7 @@ class EditEmailTemplateTextForm(IndicoForm):
     include_authors = BooleanField(_('Send to primary authors'), widget=SwitchWidget())
     include_coauthors = BooleanField(_('Send to co-authors'), widget=SwitchWidget())
     extra_cc_emails = EmailListField(_('CC'), description=_('Additional CC e-mail addresses (one per line)'))
-    subject = StringField(_('Subject'), [DataRequired()])
+    subject = StringField(_('Subject'), [DataRequired(), Length(max=200)])
     body = TextAreaField(_('Body'), [DataRequired()])
 
     def __init__(self, *args, event, **kwargs):

--- a/indico/modules/events/management/controllers/emails.py
+++ b/indico/modules/events/management/controllers/emails.py
@@ -51,7 +51,7 @@ class EmailRolesPreviewMixin:
 
     @use_kwargs({
         'body': fields.String(required=True),
-        'subject': fields.String(required=True),
+        'subject': fields.String(required=True, validate=validate.Length(max=200)),
     })
     def _process(self, body, subject):
         kwargs = self.get_placeholder_kwargs()
@@ -92,7 +92,7 @@ class EmailRolesSendMixin:
     @use_kwargs({
         'sender_address': fields.String(required=True, validate=not_empty),
         'body': fields.String(required=True, validate=[not_empty, no_relative_urls]),
-        'subject': fields.String(required=True, validate=not_empty),
+        'subject': fields.String(required=True, validate=[not_empty, validate.Length(max=200)]),
         'bcc_addresses': fields.List(LowercaseString(validate=validate.Email()), load_default=lambda: []),
         'copy_for_sender': fields.Bool(load_default=False),
         'recipient_roles': fields.List(

--- a/indico/modules/events/persons/client/js/EmailDialog.jsx
+++ b/indico/modules/events/persons/client/js/EmailDialog.jsx
@@ -154,7 +154,7 @@ export function EmailDialog({
           options={senders.map(([value, text]) => ({value, text}))}
           required
         />
-        <FinalInput name="subject" label={Translate.string('Subject')} required />
+        <FinalInput name="subject" label={Translate.string('Subject')} required maxLength={200} />
         <FinalTinyMCETextEditor
           name="body"
           label={Translate.string('Email body')}

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -300,7 +300,7 @@ class RHEmailEventPersonsPreview(RHEmailEventPersonsBase):
 
     @use_kwargs({
         'body': fields.String(required=True),
-        'subject': fields.String(required=True),
+        'subject': fields.String(required=True, validate=validate.Length(max=200)),
     })
     def _process(self, body, subject):
         person = next(iter(self.recipients)) if self.recipients else session.user
@@ -337,7 +337,7 @@ class RHAPIEmailEventPersonsSend(RHEmailEventPersonsBase):
     @use_kwargs({
         'sender_address': fields.String(required=True, validate=not_empty),
         'body': fields.String(required=True, validate=[not_empty, no_relative_urls]),
-        'subject': fields.String(required=True, validate=not_empty),
+        'subject': fields.String(required=True, validate=[not_empty, validate.Length(max=200)]),
         'bcc_addresses': fields.List(LowercaseString(validate=validate.Email())),
         'copy_for_sender': fields.Bool(load_default=False),
     })

--- a/indico/modules/events/registration/controllers/management/invitations.py
+++ b/indico/modules/events/registration/controllers/management/invitations.py
@@ -101,7 +101,7 @@ class RHRegistrationFormRemindersSend(RHManageRegFormBase):
     @use_kwargs({
         'sender_address': fields.String(required=True, validate=not_empty),
         'body': fields.String(required=True, validate=[not_empty, no_relative_urls]),
-        'subject': fields.String(required=True, validate=not_empty),
+        'subject': fields.String(required=True, validate=[not_empty, validate.Length(max=200)]),
         'bcc_addresses': fields.List(LowercaseString(validate=validate.Email())),
         'copy_for_sender': fields.Bool(load_default=False),
     })
@@ -149,7 +149,7 @@ class RHRegistrationFormRemindersPreview(RHManageRegFormBase):
 
     @use_kwargs({
         'body': fields.String(required=True),
-        'subject': fields.String(required=True),
+        'subject': fields.String(required=True, validate=validate.Length(max=200)),
     })
     def _process(self, body, subject):
         invitations = _query_pending_invitations(self.regform)

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -15,7 +15,7 @@ from babel.numbers import format_currency
 from flask import request, session
 from wtforms.fields import (BooleanField, DecimalField, EmailField, FloatField, HiddenField, IntegerField, SelectField,
                             StringField, TextAreaField)
-from wtforms.validators import DataRequired, Email, InputRequired, NumberRange, Optional, ValidationError
+from wtforms.validators import DataRequired, Email, InputRequired, Length, NumberRange, Optional, ValidationError
 from wtforms.widgets import NumberInput, html_params
 
 from indico.core import signals
@@ -333,7 +333,7 @@ class EmailRegistrantsForm(IndicoForm):
     cc_addresses = EmailListField(_('CC'),
                                   description=_('Beware, addresses in this field will receive one mail per '
                                                 'registrant.'))
-    subject = StringField(_('Subject'), [DataRequired()])
+    subject = StringField(_('Subject'), [DataRequired(), Length(max=200)])
     body = TextAreaField(_('Email body'), [DataRequired(), NoRelativeURLs()], widget=TinyMCEWidget(absolute_urls=True))
     recipients = IndicoEmailRecipientsField(_('Recipients'))
     copy_for_sender = BooleanField(_('Send copy to me'), widget=SwitchWidget(),

--- a/indico/modules/events/surveys/controllers/management/survey.py
+++ b/indico/modules/events/surveys/controllers/management/survey.py
@@ -165,7 +165,7 @@ class RHEmailEventSurveyPreview(RHManageSurveyBase):
 
     @use_kwargs({
         'body': fields.String(required=True),
-        'subject': fields.String(required=True),
+        'subject': fields.String(required=True, validate=validate.Length(max=200)),
     })
     def _process(self, body, subject):
         email_body = replace_placeholders('survey-link-email', body, event=self.event, survey=self.survey)
@@ -183,7 +183,7 @@ class RHAPIEmailEventSurveySend(RHManageSurveyBase):
             no_relative_urls,
             make_validate_indico_placeholders('survey-link-email'),
         ]),
-        'subject': fields.String(required=True, validate=not_empty),
+        'subject': fields.String(required=True, validate=[not_empty, validate.Length(max=200)]),
         'bcc_addresses': fields.List(LowercaseString(validate=validate.Email())),
         'copy_for_sender': fields.Bool(load_default=False),
         'email_all_participants': fields.Bool(load_default=False),


### PR DESCRIPTION
The vast majority of email subjects are <200 but I'm not dead set on this number. For context, outlook limits the length to 255. 