### PR TITLE
Add RB setting to limit booking details access

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Improvements
 - Make the event export/import util much more flexible to support exporting whole
   category subtrees, add better support for dealing with files, and add various things
   that were not correctly exported before (:pr:`6446`)
+- Add a setting to limit the information room booking users can see for bookings not
+  linked to them or their rooms (:pr:`6704`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/rb/__init__.py
+++ b/indico/modules/rb/__init__.py
@@ -39,6 +39,7 @@ class BookingReasonRequiredOptions(RichIntEnum):
 
 rb_settings = SettingsProxy('roombooking', {
     'managers_edit_rooms': False,
+    'hide_booking_details': False,
     'hide_module_if_unauthorized': False,
     'excluded_categories': [],
     'notification_before_days': 2,

--- a/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
+++ b/indico/modules/rb/client/js/common/bookings/BookingDetails.jsx
@@ -917,7 +917,7 @@ class BookingDetails extends React.Component {
                   {bookingReason && this.renderReason(bookingReason)}
                   {room.canUserViewInternalNotes && this.renderNotes(internalNote)}
                   {isLinkedToObjects && <LazyBookingLinks id={id} />}
-                  {this.renderBookingHistory(editLogs, createdDt, createdByUser)}
+                  {editLogs && this.renderBookingHistory(editLogs, createdDt, createdByUser)}
                   {this.renderMessages(error, newBookingId)}
                 </>
               </Grid.Column>

--- a/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
+++ b/indico/modules/rb/client/js/modules/admin/SettingsPage.jsx
@@ -136,6 +136,16 @@ const SettingsPage = props => {
               }
             />
             <FinalCheckbox
+              name="hide_booking_details"
+              label={Translate.string('Hide booking details')}
+              description={
+                <Translate>
+                  If enabled, only room managers and people involved in a booking can see details
+                  such as who made the booking and its history.
+                </Translate>
+              }
+            />
+            <FinalCheckbox
               name="hide_module_if_unauthorized"
               label={Translate.string('Hide the Room Booking system from unauthorized users')}
               description={

--- a/indico/modules/rb/schemas.py
+++ b/indico/modules/rb/schemas.py
@@ -557,6 +557,7 @@ class SettingsSchema(mm.Schema):
     admin_principals = PrincipalList(allow_groups=True)
     authorized_principals = PrincipalList(allow_groups=True)
     managers_edit_rooms = fields.Bool()
+    hide_booking_details = fields.Bool()
     hide_module_if_unauthorized = fields.Bool()
     tileserver_url = fields.String(validate=validate.URL(schemes={'http', 'https'}), allow_none=True)
     booking_limit = fields.Int(validate=not_empty)

--- a/indico/modules/rb/schemas.py
+++ b/indico/modules/rb/schemas.py
@@ -663,6 +663,13 @@ class ReservationLegacyAPISchema(ReservationSchema):
                   'location_name', 'contact_email')
 
     @post_dump(pass_original=True)
+    def _hide_sensitive_data(self, data, booking, **kwargs):
+        if not booking.can_see_details(self.context.get('user')):
+            data['booked_for_name'] = None
+            data['contact_email'] = None
+        return data
+
+    @post_dump(pass_original=True)
     def _rename_keys(self, data, orig, **kwargs):
         data['startDT'] = _add_server_tz(orig.start_dt)
         data['endDT'] = _add_server_tz(orig.end_dt)


### PR DESCRIPTION
When enabled, this hides the booked by/for names names and (because it also contains names) the booking's history from people who aren't related to the booking or managing the room.