### PR TITLE
Hide receipts from deleted objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Bugfixes
   in the share event widget (:pr:`6649`)
 - Fix sending emails if site name contains an ``@`` character (:pr:`6687`)
 - Do not show country field description twice in registration forms (:pr:`6708`)
+- Do not show "other" receipt templates from deleted events/categories (:pr:`6711`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,7 +37,7 @@ Bugfixes
   in the share event widget (:pr:`6649`)
 - Fix sending emails if site name contains an ``@`` character (:pr:`6687`)
 - Do not show country field description twice in registration forms (:pr:`6708`)
-- Do not show "other" receipt templates from deleted events/categories (:pr:`6711`)
+- Do not show "other" document templates from deleted events/categories (:pr:`6711`)
 
 Accessibility
 ^^^^^^^^^^^^^
@@ -88,8 +88,8 @@ Improvements
   thanks :user:`omegak`)
 - Add email placeholder for the picture associated with a registration (:pr:`6580`, thanks
   :user:`vtran99`)
-- Allow setting placeholders for text fields in receipt templates (:pr:`6587`)
-- Add a new receipt template for Certificates of Attendance (:pr:`6587`)
+- Allow setting placeholders for text fields in document templates (:pr:`6587`)
+- Add a new document template for Certificates of Attendance (:pr:`6587`)
 - Show correct repetition details for bookings repeating every n weeks (:pr:`6592`)
 - Show context (event/contribution title etc.) in the title of the minutes editor (:issue:`6584`,
   :pr:`6591`)

--- a/indico/modules/receipts/client/js/templates/TemplateListPane.jsx
+++ b/indico/modules/receipts/client/js/templates/TemplateListPane.jsx
@@ -208,7 +208,7 @@ export default function TemplateListPane({
                   content: (
                     <table className="i-table-widget">
                       <tbody>
-                        {_.sortBy(otherTemplates, 'title').map(tpl => (
+                        {otherTemplates.map(tpl => (
                           <TemplateRow
                             key={tpl.id}
                             template={tpl}


### PR DESCRIPTION
Also improve sorting of the "other document templates" list (receipts from newer events first if the titles are the same)