### PR TITLE
Fix positioning style

### DIFF
--- a/indico/web/client/js/utils/positioning.js
+++ b/indico/web/client/js/utils/positioning.js
@@ -80,14 +80,14 @@ const geometry = {
     const scrollOffset = window.pageYOffset - this.initialPageYOffset;
     this.target.style.setProperty(
       '--target-top',
-      `clamp(0px, ${top - scrollOffset}px, calc(100dvh - ${this.targetHeight}px))`
+      `clamp(0px, ${top - scrollOffset}px, calc(100% - ${this.targetHeight}px))`
     );
   },
   setLeft(left) {
     const scrollOffset = window.pageXOffset - this.initialPageXOffset;
     this.target.style.setProperty(
       '--target-left',
-      `clamp(0px, ${left - scrollOffset}px, calc(100dvw - ${this.targetWidth}px))`
+      `clamp(0px, ${left - scrollOffset}px, calc(100% - ${this.targetWidth}px))`
     );
   },
 };


### PR DESCRIPTION
For some unknown reason, dvw/dvh units didn't quite work... err... 100% in some cases. Using 100% instead appears to work well in the cases we have. It's difficult to tell if this is going to have any undesirable side-effects, but we can probably address that as it crops up. This issue was discovered in the time picker PR, but I've separated it here as I might need to adjust things in the other PRs after this lands.