### PR TITLE
Polish Registration.reset_state()

### DIFF
--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -25,7 +25,7 @@ from indico.core import signals
 from indico.core.cache import make_scoped_cache
 from indico.core.config import config
 from indico.core.db import db
-from indico.core.errors import NoReportError
+from indico.core.errors import IndicoError, NoReportError
 from indico.core.notifications import make_email, send_email
 from indico.legacy.pdfinterface.conference import RegistrantsListToBookPDF, RegistrantsListToPDF
 from indico.modules.categories.models.categories import Category
@@ -704,7 +704,12 @@ class RHRegistrationReset(RHManageRegistrationBase):
     """Reset a registration back to a non-approved status."""
 
     def _process(self):
-        self.registration.reset_state()
+        if self.registration.state == RegistrationState.pending:
+            raise BadRequest(_('The registration cannot be reset in its current state.'))
+        try:
+            self.registration.reset_state()
+        except IndicoError as err:
+            raise NoReportError(str(err))
         logger.info('Registration %r was reset by %r', self.registration, session.user)
         return jsonify_data(html=_render_registration_details(self.registration))
 

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -708,8 +708,8 @@ class RHRegistrationReset(RHManageRegistrationBase):
             raise BadRequest(_('The registration cannot be reset in its current state.'))
         try:
             self.registration.reset_state()
-        except IndicoError as err:
-            raise NoReportError(str(err))
+        except IndicoError as exc:
+            raise NoReportError.wrap_exc(exc)
         logger.info('Registration %r was reset by %r', self.registration, session.user)
         return jsonify_data(html=_render_registration_details(self.registration))
 

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -705,7 +705,7 @@ class RHRegistrationReset(RHManageRegistrationBase):
 
     def _process(self):
         if self.registration.state == RegistrationState.pending:
-            raise BadRequest(_('The registration cannot be reset in its current state.'))
+            raise NoReportError.wrap_exc(BadRequest(_('The registration cannot be reset in its current state.')))
         try:
             self.registration.reset_state()
         except IndicoError as exc:

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -19,14 +19,13 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.event import listens_for
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 from sqlalchemy.orm import column_property, mapper
-from werkzeug.exceptions import BadRequest
 
 from indico.core import signals
 from indico.core.config import config
 from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
 from indico.core.db.sqlalchemy.util.queries import increment_and_get
-from indico.core.errors import NoReportError
+from indico.core.errors import IndicoError
 from indico.core.storage import StoredFileMixin
 from indico.modules.events.payment.models.transactions import TransactionStatus
 from indico.modules.events.registration.models.items import PersonalDataType
@@ -755,14 +754,11 @@ class Registration(db.Model):
         if self.state != initial_state:
             signals.event.registration_state_updated.send(self, previous_state=initial_state)
 
-    def reset_state(self, *, silent=False):
+    def reset_state(self):
         """Reset the state of the registration back to pending."""
-        initial_state = self.state
         if self.has_conflict():
-            if silent:
-                return False
-            raise NoReportError(_('Cannot reset this registration since there is another valid registration for the '
-                                  'same user or email.'))
+            raise IndicoError(_('Cannot reset this registration since there is another valid registration for the '
+                                'same user or email.'))
         if self.state in (RegistrationState.complete, RegistrationState.unpaid):
             self.update_state(approved=False)
         elif self.state == RegistrationState.rejected:
@@ -770,13 +766,9 @@ class Registration(db.Model):
             self.update_state(rejected=False)
         elif self.state == RegistrationState.withdrawn:
             self.update_state(withdrawn=False)
-            signals.event.registration_state_updated.send(self, previous_state=initial_state)
-        elif silent:
-            return False
-        else:
-            raise BadRequest(_('The registration cannot be reset in its current state.'))
+        elif self.state != RegistrationState.pending:
+            raise ValueError(_('Cannot reset registration state {} back to Pending.').format(self.state.title))
         self.checked_in = False
-        return True
 
     def has_conflict(self):
         """Check if there are other valid registrations for the same user.

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -767,7 +767,7 @@ class Registration(db.Model):
         elif self.state == RegistrationState.withdrawn:
             self.update_state(withdrawn=False)
         elif self.state != RegistrationState.pending:
-            raise ValueError(_('Cannot reset registration state {} back to Pending.').format(self.state.title))
+            raise ValueError(f'Cannot reset registration state from {self.state.name}')
         self.checked_in = False
 
     def has_conflict(self):


### PR DESCRIPTION
This PR is about to fix and clean `Registration.reset_state()` method
* Calling `event.registration_state_updated` is removed: it lead to duplicate signal call (it is called from `update_state` anyway)
* Raising HTTPException moved back to `RHRegistrationReset`: Those should be raised only in request context, ideally in RH but definitely not from db model
* No return value, no `silent` parameter, and raising exception for no-op is removed (by making it similar to `update_state` and methods alike): The caller can decide how those cases should be handled