### PR TITLE
Add length validation to sign-up form fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Improvements
 
 - Add a new :data:`ALLOWED_LANGUAGES` setting to ``indico.conf`` to restrict which
   languages can be used (:pr:`6818`, thanks :user:`openprojects`)
+- Set reasonable maximum lengths on signup form fields (:pr:`6724`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/auth/client/js/signup.jsx
+++ b/indico/modules/auth/client/js/signup.jsx
@@ -27,6 +27,7 @@ import {
   FinalSubmitButton,
   handleSubmitError,
   getValuesForFields,
+  validators as v,
 } from 'indico/react/forms';
 import {Fieldset, FinalTextArea, FinalCheckbox} from 'indico/react/forms/fields';
 import {Translate, Param} from 'indico/react/i18n';
@@ -197,6 +198,7 @@ function Signup({
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
                 lockedFieldMessage={lockedFieldMessage}
+                validate={v.maxLength(250)}
               />
               <SyncedFinalInput
                 name="last_name"
@@ -205,6 +207,7 @@ function Signup({
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
                 lockedFieldMessage={lockedFieldMessage}
+                validate={v.maxLength(250)}
               />
             </Form.Group>
             {hasPredefinedAffiliations ? (
@@ -226,6 +229,7 @@ function Signup({
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
                 lockedFieldMessage={lockedFieldMessage}
+                validate={value => value !== undefined && v.maxLength(250)(value)}
               />
             )}
             {'address' in syncedValues && (
@@ -235,6 +239,7 @@ function Signup({
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
                 lockedFieldMessage={lockedFieldMessage}
+                validate={v.maxLength(500)}
               />
             )}
             {'phone' in syncedValues && (
@@ -244,13 +249,19 @@ function Signup({
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
                 lockedFieldMessage={lockedFieldMessage}
+                validate={v.maxLength(100)}
               />
             )}
           </Fieldset>
           {showAccountForm && (
             <Fieldset legend={Translate.string('Login details')}>
               {showUsernameField && (
-                <FinalInput name="username" label={Translate.string('Username')} required />
+                <FinalInput
+                  name="username"
+                  label={Translate.string('Username')}
+                  required
+                  validate={v.maxLength(100)}
+                />
               )}
               <Form.Group widths="equal">
                 <FinalInput
@@ -259,6 +270,7 @@ function Signup({
                   label={Translate.string('Password')}
                   autoComplete="new-password"
                   required
+                  validate={v.maxLength(100)}
                 />
                 <FinalInput
                   name="password_confirm"
@@ -266,6 +278,7 @@ function Signup({
                   label={Translate.string('Confirm password')}
                   autoComplete="new-password"
                   required
+                  validate={v.maxLength(100)}
                 />
               </Form.Group>
               {renderPluginComponents('signup-form-after-password')}
@@ -287,6 +300,7 @@ function Signup({
                 description={Translate.string(
                   'You can provide additional information or a comment for the administrators who will review your registration.'
                 )}
+                validate={value => value !== undefined && v.maxLength(1000)(value)}
               />
             </Fieldset>
           )}

--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -491,14 +491,14 @@ class RegistrationHandler:
                 unknown = RAISE
 
             email = fields.String(required=True, validate=validate.OneOf(emails))
-            first_name = fields.String(required=True)
-            last_name = fields.String(required=True)
-            address = fields.String(load_default='')
+            first_name = fields.String(required=True, validate=[not_empty, validate.Length(max=250)])
+            last_name = fields.String(required=True, validate=[not_empty, validate.Length(max=250)])
+            address = fields.String(load_default='', validate=validate.Length(max=500))
             if self.moderate_registrations and 'affiliation' in mandatory_fields:
-                affiliation = fields.String(required=True, validate=not_empty)
+                affiliation = fields.String(required=True, validate=[not_empty, validate.Length(max=250)])
             else:
-                affiliation = fields.String(load_default='')
-            phone = fields.String(load_default='')
+                affiliation = fields.String(load_default='', validate=validate.Length(max=250))
+            phone = fields.String(load_default='', validate=validate.Length(max=100))
             affiliation_link = ModelField(Affiliation, data_key='affiliation_id', load_default=None)
 
             if legal_settings.get('terms_require_accept'):
@@ -729,11 +729,11 @@ class LocalRegistrationHandler(RegistrationHandler):
 
     def create_schema(self):
         class LocalSignupSchema(super().create_schema()):
-            first_name = fields.String(required=True, validate=not_empty)
-            last_name = fields.String(required=True, validate=not_empty)
+            first_name = fields.String(required=True, validate=[not_empty, validate.Length(max=250)])
+            last_name = fields.String(required=True, validate=[not_empty, validate.Length(max=250)])
             if config.LOCAL_USERNAMES:
-                username = LowercaseString(required=True, validate=not_empty)
-            password = fields.String(required=True, validate=not_empty)
+                username = LowercaseString(required=True, validate=[not_empty, validate.Length(max=100)])
+            password = fields.String(required=True, validate=[not_empty, validate.Length(max=100)])
 
             if config.LOCAL_USERNAMES:
                 @validates('username')

--- a/indico/modules/users/client/js/PersonalDataForm.jsx
+++ b/indico/modules/users/client/js/PersonalDataForm.jsx
@@ -26,6 +26,7 @@ import {
   getChangedValues,
   handleSubmitError,
   parsers as p,
+  validators as v,
 } from 'indico/react/forms';
 import {Translate, Param} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
@@ -93,6 +94,7 @@ function PersonalDataForm({
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
                 lockedFieldMessage={lockedFieldMessage}
+                validate={v.maxLength(250)}
               />
               <SyncedFinalInput
                 name="last_name"
@@ -101,6 +103,7 @@ function PersonalDataForm({
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
                 lockedFieldMessage={lockedFieldMessage}
+                validate={v.maxLength(250)}
               />
             </Form.Group>
             {hasPredefinedAffiliations ? (
@@ -120,6 +123,7 @@ function PersonalDataForm({
                 syncedValues={syncedValues}
                 lockedFields={lockedFields}
                 lockedFieldMessage={lockedFieldMessage}
+                validate={value => value !== undefined && v.maxLength(250)(value)}
               />
             )}
             <SyncedFinalTextArea
@@ -128,6 +132,7 @@ function PersonalDataForm({
               syncedValues={syncedValues}
               lockedFields={lockedFields}
               lockedFieldMessage={lockedFieldMessage}
+              validate={v.maxLength(500)}
             />
             <SyncedFinalInput
               name="phone"
@@ -135,6 +140,7 @@ function PersonalDataForm({
               syncedValues={syncedValues}
               lockedFields={lockedFields}
               lockedFieldMessage={lockedFieldMessage}
+              validate={v.maxLength(100)}
             />
             <SyncedFinalInput
               name="email"

--- a/indico/modules/users/schemas.py
+++ b/indico/modules/users/schemas.py
@@ -15,7 +15,7 @@ from indico.modules.users import User, user_management_settings
 from indico.modules.users.models.affiliations import Affiliation
 from indico.modules.users.models.users import UserTitle, syncable_fields
 from indico.util.countries import get_country
-from indico.util.marshmallow import ModelField, NoneValueEnumField
+from indico.util.marshmallow import ModelField, NoneValueEnumField, not_empty
 
 
 class AffiliationSchema(mm.SQLAlchemyAutoSchema):
@@ -65,8 +65,13 @@ class BasicUserSchema(UserSchema):
 
 class UserPersonalDataSchema(mm.SQLAlchemyAutoSchema):
     title = NoneValueEnumField(UserTitle, none_value=UserTitle.none, attribute='_title')
+    first_name = fields.String(required=True, validate=[not_empty, validate.Length(max=250)])
+    last_name = fields.String(required=True, validate=[not_empty, validate.Length(max=250)])
     email = String(dump_only=True)
+    address = fields.String(validate=validate.Length(max=500))
+    phone = fields.String(validate=validate.Length(max=100))
     synced_fields = List(String(validate=validate.OneOf(syncable_fields)))
+    affiliation = fields.String(validate=validate.Length(max=250))
     affiliation_link = ModelField(Affiliation, data_key='affiliation_id', load_default=None, load_only=True)
     affiliation_data = fields.Function(lambda u: {'id': u.affiliation_id, 'text': u.affiliation}, dump_only=True)
 

--- a/indico/web/client/js/react/forms/validators.js
+++ b/indico/web/client/js/react/forms/validators.js
@@ -48,6 +48,14 @@ function minLength(length) {
   };
 }
 
+function maxLength(length) {
+  return value => {
+    if (value.length > length) {
+      return Translate.string('Value must be at most {length} chars', {length});
+    }
+  };
+}
+
 function url(value) {
   if (!value.match(/https?:\/\/.+/)) {
     return Translate.string('Please provide a valid URL');
@@ -120,6 +128,7 @@ export default {
   max,
   range,
   minLength,
+  maxLength,
   url,
   required,
   optional,


### PR DESCRIPTION
This PR is about adding length validation to fields on registration and user profile forms to prevent abusing and sending garbage data to the application.
The following fields have got length validation:
* first name: 250
* last name: 250
* username: 100
* password: 100
* affiliation: 250
* address: 500
* phone: 100
* registration request comment: 500