### PR TITLE
Make main section title a bypass block title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ Accessibility
   (:pr:`6324`, thanks :user:`foxbunny`)
 - Implement a new date range picker and use it in the Room Booking module
   (:pr:`6464`, thanks :user:`foxbunny`)
+- Make main section title in the base layout the default bypass blocks target
+  (:pr:`6726`, hanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/templates/display/conference.html
+++ b/indico/modules/events/templates/display/conference.html
@@ -3,7 +3,7 @@
 {% from 'attachments/_attachments.html' import render_attachments %}
 
 {% block content %}
-    <div class="conferenceDetails">
+    <div class="conferenceDetails" id="main-content" data-bypass-target="{% trans %}Skip to main content{% endtrans %}">
         <div itemprop="description" class="description js-mathjax editor-output">
             {{ event.description }}
         </div>

--- a/indico/modules/events/templates/display/indico/lecture.html
+++ b/indico/modules/events/templates/display/indico/lecture.html
@@ -11,7 +11,9 @@
                        or event.contact_emails or event.contact_phones
                        or (event.references and event.type == 'meeting') or hook_event_header %}
 
-<div class="event-wrapper {% block event_classes %}{% endblock %}">
+<div class="event-wrapper {% block event_classes %}{% endblock %}"
+     id="main-content"
+     data-bypass-target="{% trans %}Skip to main content{% endtrans %}">
     {% block header %}
         <div class="event-header event-header-lecture {%- if not has_subheader %} round-bottom-corners{% endif %}">
             <div class="event-title">

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -12,7 +12,9 @@
                        or event.contact_emails or event.contact_phones
                        or (event.references and event.type == 'meeting') or hook_event_header %}
 
-<div class="event-wrapper {% block event_classes %}{% endblock %}">
+<div class="event-wrapper {% block event_classes %}{% endblock %}"
+     id="main-content"
+     data-bypass-target="{% trans %}Skip to main content{% endtrans %}">
     {% block header %}
         <div class="event-header {%- if not has_subheader %} round-bottom-corners{% endif %}">
             <div class="event-title">

--- a/indico/web/templates/layout/base.html
+++ b/indico/web/templates/layout/base.html
@@ -14,7 +14,7 @@
                 <div class="title">
                     <div class="text">
                         <div class="title-with-actions">
-                            <h2>
+                            <h2 id="main-content" {% block bypass_target %}data-bypass-target="{% trans %}Skip to main content{% endtrans %}"{% endblock %}>
                                 {%- block title %}{% endblock -%}
                             </h2>
                             {%- if self.title_actions()|trim -%}


### PR DESCRIPTION
- Affects base layout and any page using it
- Reserves the `main-content` id for the H2 heading in the layout template
- Can be overridden by blanking out the bypass_target block

The original intent was to target event pages only, but unless this breaks other pages somewhere, it's an even better solution from the accessibility standpoint.