### PR TITLE
Normalize empty strings and None in affiliations

### DIFF
--- a/indico/modules/users/models/affiliations.py
+++ b/indico/modules/users/models/affiliations.py
@@ -71,8 +71,12 @@ class Affiliation(db.Model):
 
     @classmethod
     def get_or_create_from_data(cls, affiliation_data):
-        existing = cls.query.filter_by(name=affiliation_data['name'], city=affiliation_data['city'],
-                                       country_code=affiliation_data['country_code']).order_by(Affiliation.id).first()
+        existing = (cls.query
+                    .filter_by(name=affiliation_data['name'],
+                               city=(affiliation_data['city'] or ''),
+                               country_code=(affiliation_data['country_code'] or ''))
+                    .order_by(Affiliation.id)
+                    .first())
         if existing:
             return existing
         return cls(**affiliation_data)

--- a/indico/modules/users/models/affiliations_test.py
+++ b/indico/modules/users/models/affiliations_test.py
@@ -1,0 +1,34 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2025 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+
+from indico.modules.users.models.affiliations import Affiliation
+
+
+@pytest.mark.parametrize('none_field', ('street', 'postcode', 'city', 'country_code'))
+def test_get_or_create_from_data_none_empty_string(db, none_field):
+    data = {
+        'name': 'Atlantis Institute of Fake Science',
+        'street': 'Somewhere',
+        'postcode': '31337 Deep Below',
+        'city': 'nowhere',
+        'country_code': 'XX',
+    }
+    data[none_field] = None
+
+    # create initial one
+    assert not Affiliation.query.has_rows()
+    db.session.add(Affiliation.get_or_create_from_data(data))
+    assert Affiliation.query.count() == 1
+    # make sure we don't recreate it (DB has empty string, data has None)
+    db.session.add(Affiliation.get_or_create_from_data(data))
+    assert Affiliation.query.count() == 1
+    # make sure we also don't recreate it with data having an empty string
+    data[none_field] = ''
+    db.session.add(Affiliation.get_or_create_from_data(data))
+    assert Affiliation.query.count() == 1


### PR DESCRIPTION
Otherwise syncing affiliation data for a user may create duplicates, because passing None in the constructor seems to be using the default value, but then it gets stored as an empty string. So when querying it again to avoid duplicates (filter by None), no result is returned, and a new affiliation is inserted.