### PR TITLE
Fix issue with select list auto-closing when scrollbar is used

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,7 +45,7 @@ Bugfixes
 - Fix price display of choice fields in registration form (:issue:`6728`, :pr:`6729`)
 - Fix error when creating a new room and setting attributes or equipment during creation
   (:pr:`6730`)
-- Fix the usage of select list scollbar causing it to close immediately (:issue:`6735`, 
+- Fix the usage of select list scrollbar causing it to close immediately (:issue:`6735`, 
   :pr:`6736`, thanks :user:`foxbunny`)
 
 Accessibility

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ Bugfixes
 - Fix price display of choice fields in registration form (:issue:`6728`, :pr:`6729`)
 - Fix error when creating a new room and setting attributes or equipment during creation
   (:pr:`6730`)
+- Fix the usage of select list scollbar causing it to close immediately (:issue:`6735`, 
+  :pr:`6736`, thanks :user:`foxbunny`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/custom_elements/ind_select.js
+++ b/indico/web/client/js/custom_elements/ind_select.js
@@ -167,6 +167,18 @@ customElements.define(
         if ($option) {
           selectOption($option);
           dispatchChange();
+        } else {
+          // If no option was selected, but the click happened
+          // within the listbox, it likely means the user was using
+          // the scrollbar. We will temporarily block the closing of
+          // the listbox.
+          indSelect._noImmediateClose = true;
+          setTimeout(() => {
+            // Refocus the filter because some of the behavior depends
+            // on its losing focus.
+            filter.focus();
+            delete indSelect._noImmediateClose;
+          });
         }
       });
 
@@ -189,7 +201,13 @@ customElements.define(
       // Internal functions
 
       function toggleListbox(shouldOpen = !indSelect.open) {
+        // Special case: request to close, but closing blocked
+        if (!shouldOpen && indSelect._noImmediateClose) {
+          return;
+        }
+
         indSelect.open = shouldOpen;
+
         if (shouldOpen) {
           dialog.show();
           positioning.position(listbox, indSelect, positioning.dropdownPositionStrategy, fit => {


### PR DESCRIPTION
- Detect scrollbar usage and flag the events to suppress closing
- Refocus the input after scrollbar usage

Fixes #6735
