### PR TITLE
Log changes to event payment methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,7 @@ Improvements
   (:pr:`6758`)
 - Add setting to disallow entering custom affiliations when predefined affiliations are used
   (:pr:`6809`)
+- Log changes to event payment methods (:pr:`6739`)
 
 Bugfixes
 ^^^^^^^^


### PR DESCRIPTION
Currently this logs all changes, since a diff log would be hard since most options are provided by the payment plugin and not known to the core.

I might change it to at least skip the `enabled` flag and only log things that actually changed...