### PR TITLE
Make the minimum password length configurable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -39,6 +39,8 @@ Improvements
   use the email address (:pr:`6751`)
 - Tell search engines to not index events marked as "invisible" (:pr:`6762`, thanks
   :user:`openprojects`)
+- Make the minimum length of local account passwords configurable, and default to ``15``
+  instead of ``8`` for new installations (:issue:`6629`, :pr:`6740`, thanks :user:`amCap1712`)
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -63,6 +63,13 @@ Authentication
 
     Default: ``True``
 
+.. data:: LOCAL_PASSWORD_MIN_LENGTH
+
+    This setting controls the minimum number of characters required in
+    the new password for a local account.
+
+    Default: ``8``
+
 .. data:: LOCAL_MODERATION
 
     This setting controls whether a new registration needs to be approved

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -65,8 +65,16 @@ Authentication
 
 .. data:: LOCAL_PASSWORD_MIN_LENGTH
 
-    This setting controls the minimum number of characters required in
-    the new password for a local account.
+    This setting controls the minimum number of characters required for a
+    local account password.
+
+    Outside debug mode, this cannot be set to a value less than ``8``, which
+    is considered the bare minimum for a (somewhat) secure password.
+
+    The default value is ``8`` to avoid suddenly changing it for existing
+    installations which would require users to change their password at the
+    next login. Any new installation has a default of ``15``, which is the
+    recommendation from the NIST standard.
 
     Default: ``8``
 

--- a/indico/cli/setup.py
+++ b/indico/cli/setup.py
@@ -334,6 +334,7 @@ class SetupWizard:
         self.default_timezone = None
         self.rb_active = None
         self.system_notices = True
+        self.local_password_min_length = 15
 
     def run(self, dev):
         self._check_root()
@@ -630,6 +631,7 @@ class SetupWizard:
             'CACHE_DIR = {!r}'.format(os.path.join(self.data_root_path, 'cache')),
             'TEMP_DIR = {!r}'.format(os.path.join(self.data_root_path, 'tmp')),
             'LOG_DIR = {!r}'.format(os.path.join(self.data_root_path, 'log')),
+            f'LOCAL_PASSWORD_MIN_LENGTH = {self.local_password_min_length!r}',
             f'STORAGE_BACKENDS = {storage_backends!r}',
             "ATTACHMENT_STORAGE = 'default'",
             '',

--- a/indico/cli/setup.py
+++ b/indico/cli/setup.py
@@ -334,7 +334,6 @@ class SetupWizard:
         self.default_timezone = None
         self.rb_active = None
         self.system_notices = True
-        self.local_password_min_length = 15
 
     def run(self, dev):
         self._check_root()
@@ -631,7 +630,7 @@ class SetupWizard:
             'CACHE_DIR = {!r}'.format(os.path.join(self.data_root_path, 'cache')),
             'TEMP_DIR = {!r}'.format(os.path.join(self.data_root_path, 'tmp')),
             'LOG_DIR = {!r}'.format(os.path.join(self.data_root_path, 'log')),
-            f'LOCAL_PASSWORD_MIN_LENGTH = {self.local_password_min_length!r}',
+            'LOCAL_PASSWORD_MIN_LENGTH = 15',  # use NIST recommendation for new installations
             f'STORAGE_BACKENDS = {storage_backends!r}',
             "ATTACHMENT_STORAGE = 'default'",
             '',

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -307,7 +307,7 @@ class IndicoConfig:
         if self.SMTP_ALLOWED_SENDERS and not self.SMTP_SENDER_FALLBACK:
             raise ValueError('Cannot restrict SMTP senders without a fallback')
         if not self.DEBUG and self.LOCAL_PASSWORD_MIN_LENGTH < 8:
-            raise ValueError('Minimum password length cannot be less than 8')
+            raise ValueError('Minimum password length cannot be less than 8 characters long')
 
     def __getattr__(self, name):
         try:

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -62,6 +62,7 @@ DEFAULTS = {
     'LOCAL_IDENTITIES': True,
     'LOCAL_USERNAMES': True,
     'LOCAL_MODERATION': False,
+    'LOCAL_PASSWORD_MIN_LENGTH': 8,
     'LOCAL_REGISTRATION': True,
     'LOCAL_GROUPS': True,
     'LOGGING_CONFIG_FILE': 'logging.yaml',
@@ -305,6 +306,8 @@ class IndicoConfig:
             raise ValueError(f'Invalid default timezone: {self.DEFAULT_TIMEZONE}')
         if self.SMTP_ALLOWED_SENDERS and not self.SMTP_SENDER_FALLBACK:
             raise ValueError('Cannot restrict SMTP senders without a fallback')
+        if not self.DEBUG and self.LOCAL_PASSWORD_MIN_LENGTH < 8:
+            raise ValueError('Minimum password length cannot be less than 8')
 
     def __getattr__(self, name):
         try:

--- a/indico/util/passwords.py
+++ b/indico/util/passwords.py
@@ -156,7 +156,7 @@ def validate_secure_password(context, password, *, username='', emails=frozenset
 
     A password is considered secure if it:
 
-    - is at least LOCAL_PASSWORD_MIN_LENGTH characters long
+    - is at least :data:`LOCAL_PASSWORD_MIN_LENGTH` characters long
     - does not contain the username unless the username is <5 chars and the password is >16 chars long
     - does not contain the strings 'indico' (or common variations)
     - is not in the pwned password list

--- a/indico/util/passwords.py
+++ b/indico/util/passwords.py
@@ -12,6 +12,7 @@ import re
 import bcrypt
 import requests
 
+from indico.core.config import config
 from indico.util.i18n import _
 
 
@@ -155,7 +156,7 @@ def validate_secure_password(context, password, *, username='', emails=frozenset
 
     A password is considered secure if it:
 
-    - is at least 8 characters long
+    - is at least LOCAL_PASSWORD_MIN_LENGTH characters long
     - does not contain the username unless the username is <5 chars and the password is >16 chars long
     - does not contain the strings 'indico' (or common variations)
     - is not in the pwned password list
@@ -184,8 +185,8 @@ def validate_secure_password(context, password, *, username='', emails=frozenset
                                     as_list=True):
         return errors[0]
 
-    if len(password) < 8:
-        return _('Passwords must be at least 8 characters long.')
+    if len(password) < config.LOCAL_PASSWORD_MIN_LENGTH:
+        return _('Password must be at least %s characters long.') % config.LOCAL_PASSWORD_MIN_LENGTH
 
     if re.search(r'[i1|]nd[1i|]c[o0]', password.lower()):
         return _('Passwords may not contain the word "indico" or variations.')

--- a/indico/util/passwords.py
+++ b/indico/util/passwords.py
@@ -186,7 +186,7 @@ def validate_secure_password(context, password, *, username='', emails=frozenset
         return errors[0]
 
     if len(password) < config.LOCAL_PASSWORD_MIN_LENGTH:
-        return _('Password must be at least {} characters long.').format(config.LOCAL_PASSWORD_MIN_LENGTH)
+        return _('Passwords must be at least {} characters long.').format(config.LOCAL_PASSWORD_MIN_LENGTH)
 
     if re.search(r'[i1|]nd[1i|]c[o0]', password.lower()):
         return _('Passwords may not contain the word "indico" or variations.')

--- a/indico/util/passwords.py
+++ b/indico/util/passwords.py
@@ -186,7 +186,7 @@ def validate_secure_password(context, password, *, username='', emails=frozenset
         return errors[0]
 
     if len(password) < config.LOCAL_PASSWORD_MIN_LENGTH:
-        return _('Password must be at least %s characters long.') % config.LOCAL_PASSWORD_MIN_LENGTH
+        return _('Password must be at least {} characters long.').format(config.LOCAL_PASSWORD_MIN_LENGTH)
 
     if re.search(r'[i1|]nd[1i|]c[o0]', password.lower()):
         return _('Passwords may not contain the word "indico" or variations.')

--- a/indico/web/forms/jinja_helpers.py
+++ b/indico/web/forms/jinja_helpers.py
@@ -51,7 +51,7 @@ def _attrs_for_validators(field, validators):
             if validator.max >= 0:
                 attrs['maxlength'] = validator.max
         elif isinstance(validator, SecurePassword):
-            attrs['minlength'] = validator.MIN_LENGTH
+            attrs['minlength'] = validator.minlength
         elif isinstance(validator, IndicoRegexp) and validator.client_side:
             attrs['pattern'] = validator.regex.pattern
         elif isinstance(validator, NumberRange):

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -11,6 +11,7 @@ from urllib.parse import urlsplit
 
 from wtforms.validators import EqualTo, Length, Regexp, StopValidation, ValidationError
 
+from indico.core.config import config
 from indico.modules.events.settings import data_retention_settings
 from indico.modules.users.util import get_mastodon_server_name
 from indico.util.date_time import as_utc, format_date, format_datetime, format_human_timedelta, format_time, now_utc
@@ -395,10 +396,6 @@ class SoftLength(Length):
 class SecurePassword:
     """Validate that a string is a secure password."""
 
-    # This is only defined here so the `_attrs_for_validators` util does
-    # not need to hard-code it.
-    MIN_LENGTH = 8
-
     def __init__(self, context='wtforms-field', username_field=None, emails=None):
         self.context = context
         self.username_field = username_field
@@ -412,6 +409,12 @@ class SecurePassword:
         emails = self.get_emails(form) if self.get_emails else set()
         if error := validate_secure_password(self.context, password, username=username, emails=emails):
             raise ValidationError(error)
+
+    # This is only defined here so the `_attrs_for_validators` util does
+    # not need to hard-code it.
+    @property
+    def minlength(self):
+        return config.LOCAL_PASSWORD_MIN_LENGTH
 
 
 class NoRelativeURLs:


### PR DESCRIPTION
Fixes #6629.

Adds a new setting (LOCAL_PASSWORD_MIN_LENGTH) to configure the minimum required length of new passwords. The setup wizard is updated to create config files with 15 characters as the default minimum length as per the current NIST recommendations. For existing installations, the default is 8 characters.