### PR TITLE
Make the picture manager accessible

### DIFF
--- a/indico/web/client/js/react/components/pictures/Picture.module.scss
+++ b/indico/web/client/js/react/components/pictures/Picture.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'design_system';
 
 .dropzone-area {
   :global(.ui.segment) {
@@ -85,4 +86,17 @@
 
 .show {
   display: block;
+}
+
+.trigger {
+  @extend %button;
+  font-size: 120%;
+}
+
+.capture-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5em;
+  padding-bottom: 1em;
 }

--- a/indico/web/client/js/react/components/pictures/PictureCropper.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureCropper.jsx
@@ -61,6 +61,7 @@ export function PictureCropper({cropperRef, src, onCrop, backAction, minCropSize
             styleName="cropper-action-btn"
             icon="check"
             primary
+            // i18n: Crop an image
             content={Translate.string('Crop')}
             onClick={onCrop}
           />

--- a/indico/web/client/js/react/components/pictures/PictureCropper.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureCropper.jsx
@@ -61,7 +61,7 @@ export function PictureCropper({cropperRef, src, onCrop, backAction, minCropSize
             styleName="cropper-action-btn"
             icon="check"
             primary
-            content={Translate.string('Done')}
+            content={Translate.string('Crop')}
             onClick={onCrop}
           />
         </Button.Group>

--- a/indico/web/client/js/react/components/pictures/PictureWebcam.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureWebcam.jsx
@@ -50,6 +50,7 @@ export function PictureWebcam({
           />
           <div styleName="capture-controls">
             <button styleName="trigger" type="button" onClick={onCapture}>
+              {/* i18n: Capture an image with a webcam */}
               <Translate>Capture</Translate>
             </button>
             <Translate as="p">Or click anywhere on the image to take a picture</Translate>

--- a/indico/web/client/js/react/components/pictures/PictureWebcam.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureWebcam.jsx
@@ -52,9 +52,7 @@ export function PictureWebcam({
             <button styleName="trigger" type="button" onClick={onCapture}>
               <Translate>Capture</Translate>
             </button>
-            <p>
-              <Translate>Or click anywhere on the image to take a picture</Translate>
-            </p>
+            <Translate as="p">Or click anywhere on the image to take a picture</Translate>
           </div>
           <Icon
             styleName="back"

--- a/indico/web/client/js/react/components/pictures/PictureWebcam.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureWebcam.jsx
@@ -48,9 +48,14 @@ export function PictureWebcam({
             onUserMedia={() => setUserMediaActive(true)}
             mirrored
           />
-          <p>
-            <Translate>Click anywhere on the image to take a picture</Translate>
-          </p>
+          <div styleName="capture-controls">
+            <button styleName="trigger" type="button" onClick={onCapture}>
+              <Translate>Capture</Translate>
+            </button>
+            <p>
+              <Translate>Or click anywhere on the image to take a picture</Translate>
+            </p>
+          </div>
           <Icon
             styleName="back"
             name="arrow left"

--- a/indico/web/client/styles/design_system/_button.scss
+++ b/indico/web/client/styles/design_system/_button.scss
@@ -23,10 +23,11 @@
   gap: var(--control-internal-gap);
   padding: var(--control-padding);
 
-  border: var(--control-border-width) solid var(--button-border-color);
+  border: 0;
   color: var(--button-text-color);
   background: var(--button-surface-color);
   line-height: 1.1;
+  font-weight: bold;
 
   &:focus,
   &:hover {

--- a/indico/web/client/styles/design_system/variables.scss
+++ b/indico/web/client/styles/design_system/variables.scss
@@ -55,9 +55,9 @@ body {
   --control-disabled-indented-bg-color: var(--text-disabled-color);
   --control-disabled-inset-indented-color: var(--text-disabled-color);
   --control-border-width: 1px;
-  --control-border-radius: 0.15em;
+  --control-border-radius: 0.3em;
   --control-border: var(--control-border-width) solid var(--control-border-color);
-  --control-padding: 0.5em;
+  --control-padding: 0.5em 1em;
   --control-internal-gap: 0.2em;
   --control-raised-shadow: 0 0.2em 0.5em rgba(0, 0, 0, 0.3);
 


### PR DESCRIPTION
- Add an explicit Crop button to the webcam component
- Rename "Done" to "Crop" in the cropper so the user knows what the button does without navigating the page

Additionally, adjust some styles to make the experience less jarring:

- Match the SUI buttons more closely in the design system (this affects the other pages and components, like the session bar)
