### PR TITLE
Notify event creation for cloned events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,7 @@ Bugfixes
   (:pr:`6730`)
 - Fix the usage of select list scrollbar causing it to close immediately (:issue:`6735`,
   :pr:`6736`, thanks :user:`foxbunny`)
+- Trigger event creation notification emails when cloning events (:pr:`6744`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/management/controllers/cloning.py
+++ b/indico/modules/events/management/controllers/cloning.py
@@ -17,6 +17,7 @@ from indico.modules.events.management.forms import (CLONE_REPEAT_CHOICES, CloneC
                                                     CloneRepeatabilityForm, CloneRepeatIntervalForm,
                                                     CloneRepeatOnceForm, CloneRepeatPatternForm, ImportContentsForm,
                                                     ImportSourceEventForm)
+from indico.modules.events.notifications import notify_event_creation
 from indico.modules.events.operations import clone_event, clone_into_event
 from indico.modules.events.util import get_event_from_url
 from indico.util.i18n import _
@@ -178,6 +179,7 @@ class RHCloneEvent(RHManageEventBase):
                         self.event, 0, form.start_dt.data, set(form.selected_items.data), form.category.data,
                         form.refresh_users.data
                     )
+                    notify_event_creation(clone)
                     flash(_('Welcome to your cloned event!'), 'success')
                     return jsonify_data(redirect=url_for('event_management.settings', clone), flash=False)
                 else:
@@ -185,8 +187,9 @@ class RHCloneEvent(RHManageEventBase):
                     clone_calculator = get_clone_calculator(form.repeatability.data, self.event)
                     dates = clone_calculator.calculate(request.form)[0]
                     for n, start_dt in enumerate(dates, 1):
-                        clone_event(self.event, n, start_dt, set(form.selected_items.data), form.category.data,
-                                    form.refresh_users.data)
+                        clone = clone_event(self.event, n, start_dt, set(form.selected_items.data), form.category.data,
+                                            form.refresh_users.data)
+                        notify_event_creation(clone)
                     flash(_('{} new events created.').format(len(dates)), 'success')
                     return jsonify_data(redirect=form.category.data.url, flash=False)
             else:

--- a/indico/modules/events/management/controllers/cloning.py
+++ b/indico/modules/events/management/controllers/cloning.py
@@ -186,11 +186,14 @@ class RHCloneEvent(RHManageEventBase):
                     # recurring event
                     clone_calculator = get_clone_calculator(form.repeatability.data, self.event)
                     dates = clone_calculator.calculate(request.form)[0]
-                    for n, start_dt in enumerate(dates, 1):
-                        clone = clone_event(self.event, n, start_dt, set(form.selected_items.data), form.category.data,
-                                            form.refresh_users.data)
-                        notify_event_creation(clone)
-                    flash(_('{} new events created.').format(len(dates)), 'success')
+                    clones = [
+                        clone_event(self.event, n, start_dt, set(form.selected_items.data), form.category.data,
+                                    form.refresh_users.data)
+                        for n, start_dt in enumerate(dates, 1)
+                    ]
+                    if clones:
+                        notify_event_creation(clones[0], clones)
+                        flash(_('{} new events created.').format(len(clones)), 'success')
                     return jsonify_data(redirect=form.category.data.url, flash=False)
             else:
                 # back to step 4, since there's been an error

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -184,7 +184,7 @@ def clone_event(event, n_occurrence, start_dt, cloners, category=None, refresh_u
         'end_dt': end_dt,
         'timezone': event.timezone,
         'title': event.title,
-        'description': event.description,
+        'description': event._description,
         'own_map_url': event.own_map_url
     }
     new_event = create_event(category or event.category, event.type_, data,


### PR DESCRIPTION
There is still the issue of an empty description section being present in the notification email of the cloned event due to the added wrapper `RichMarkup('<div class="preformatted"></div>')` 

