### PR TITLE
Fix login logo sizing

### DIFF
--- a/indico/web/client/styles/modules/_auth.scss
+++ b/indico/web/client/styles/modules/_auth.scss
@@ -44,7 +44,8 @@
 
       .header-logo {
         margin-bottom: 20px;
-        height: 100px;
+        max-width: 100%;
+        max-height: 100px;
       }
 
       .footer {


### PR DESCRIPTION
Fixes the sizeing of the logo on login page for images with different aspect ratios, limiting its width to the container box.

Before:
![image](https://github.com/user-attachments/assets/ed0c465d-0926-4a3b-8b44-63146d603c00)

After:
![image](https://github.com/user-attachments/assets/4a8137f0-4b4c-41b7-9102-3157db048577)
