### PR TITLE
Fix "or connect with" divider

### DIFF
--- a/indico/modules/auth/templates/login_page.html
+++ b/indico/modules/auth/templates/login_page.html
@@ -57,7 +57,7 @@
                 {% include 'flashed_messages.html' %}
             </div>
         {% endif %}
-        {% set external_providers = providers|selectattr('is_external') %}
+        {% set external_providers = providers|selectattr('is_external')|list %}
         {% if external_providers %}
             {% if active_provider %}
                 <div class="titled-rule">


### PR DESCRIPTION
Fixes the divider showing up even when there's no providers:
![image](https://github.com/user-attachments/assets/0ef67499-583a-4ae8-a132-d89ed0a30e16)
