### PR TITLE
Include submitter email in abstract PDF

### DIFF
--- a/indico/legacy/pdfinterface/latex_templates/inc/abstract.tex
+++ b/indico/legacy/pdfinterface/latex_templates/inc/abstract.tex
@@ -157,8 +157,9 @@
         \JINJA{endif}
     \JINJA{endif}
 
-    \VAR{(_('Submitted by {0} on {1}')|latex(true)).format(
+    \VAR{(_('Submitted by {0} <{1}> on {2}')|latex(true)).format(
         '\\textbf{%s}'|rawlatex|format(abstract.submitter.get_full_name(abbrev_first_name=false, show_title=true)),
+        abstract.submitter.email,
         '\\textbf{%s}'|rawlatex|format(abstract.submitted_dt|format_date('full'))
     )|rawlatex}
     \JINJA{if abstract.modified_dt}


### PR DESCRIPTION
Fix #3631 

Update the latex PDF template to include email in the generated abstract PDF in the following format: `Submitted by {AUTHOR NAME} <{PRIMARY EMAIL}> on {DATE}`
