### PR TITLE
Change ContributionForm's description to a markdown field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ Improvements
 - Include abstract details in comment notification email subject (:issue:`6449`, :pr:`6782`,
   thanks :user:`amCap1712`)
 - Use markdown editor field in survey questionnaire setup (:pr:`6783`, thanks :user:`amCap1712`)
+- Use markdown editor field for contribution description (:issue:`6723`, :pr:`6749`, thanks
+  :user:`amCap1712`)
 - Allow resetting registrations back to pending in bulk (:issue:`5954`, :pr:`6784`, thanks
   :user:`amCap1712`)
 

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -128,7 +128,7 @@ class ContributionProtectionForm(IndicoForm):
 class SubContributionForm(IndicoForm):
     _submitter_editable_fields = ('title', 'description', 'speakers')
     title = StringField(_('Title'), [DataRequired()])
-    description = TextAreaField(_('Description'))
+    description = IndicoMarkdownField(_('Description'), editor=True, mathjax=True)
     duration = IndicoDurationField(_('Duration'), [DataRequired(), MaxDuration(timedelta(hours=24))],
                                    default=timedelta(minutes=20))
     speakers = SubContributionPersonLinkListField(_('Speakers'), allow_submitters=False, allow_authors=False,

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -27,7 +27,7 @@ from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm, generated_data
 from indico.web.forms.fields import (HiddenFieldList, IndicoDateTimeField, IndicoEnumSelectField, IndicoLocationField,
-                                     IndicoProtectionField, IndicoTagListField)
+                                     IndicoMarkdownField, IndicoProtectionField, IndicoTagListField)
 from indico.web.forms.fields.datetime import IndicoDurationField
 from indico.web.forms.fields.principals import PermissionsField
 from indico.web.forms.validators import DateTimeRange, HiddenUnless, MaxDuration
@@ -37,7 +37,7 @@ from indico.web.forms.widgets import SwitchWidget
 class ContributionForm(IndicoForm):
     _submitter_editable_fields = ('title', 'description', 'person_link_data')
     title = StringField(_('Title'), [DataRequired()])
-    description = TextAreaField(_('Description'))
+    description = IndicoMarkdownField(_('Description'), editor=True, mathjax=True)
     start_dt = IndicoDateTimeField(_('Start date'),
                                    [DataRequired(),
                                     DateTimeRange(earliest=lambda form, field: form._get_earliest_start_dt(),


### PR DESCRIPTION
Fixes #6723.

The abstract submission form already supports markdown in the description field. An accepted abstract becomes a contribution with the content copied. It makes sense to support markdown in contribution editing form as well.