### PR TITLE
Add setting to disable usernames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,8 @@ Improvements
 - Allow users to login using their email address (:pr:`6522`, thanks :user:`SegiNyn`)
 - Do not "inline" the full participant list in conference events using a meeting-style
   timetable and link to the conference participant list instead (:pr:`6753`)
+- Add new setting :data:`LOCAL_USERNAMES` to disable usernames for logging in and only
+  use the email address (:pr:`6751`)
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -34,6 +34,14 @@ Authentication
 
     Default: ``True``
 
+.. data:: LOCAL_USERNAMES
+
+    This setting controls whether local Indico accounts have usernames
+    for logging in. If disabled, only the email address is used as the
+    "username", otherwise both can be used.
+
+    Default: ``True``
+
 .. data:: LOCAL_GROUPS
 
     This setting controls whether local Indico groups are available.

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -60,6 +60,7 @@ DEFAULTS = {
     'IDENTITY_PROVIDERS': {},
     'LATEX_RATE_LIMIT': '2 per 3 seconds',
     'LOCAL_IDENTITIES': True,
+    'LOCAL_USERNAMES': True,
     'LOCAL_MODERATION': False,
     'LOCAL_REGISTRATION': True,
     'LOCAL_GROUPS': True,

--- a/indico/modules/auth/client/js/signup.jsx
+++ b/indico/modules/auth/client/js/signup.jsx
@@ -45,6 +45,7 @@ function Signup({
   initialValues,
   hasPredefinedAffiliations,
   showAccountForm,
+  showUsernameField,
   syncedValues,
   emails,
   affiliationMeta,
@@ -246,7 +247,9 @@ function Signup({
           </Fieldset>
           {showAccountForm && (
             <Fieldset legend={Translate.string('Login details')}>
-              <FinalInput name="username" label={Translate.string('Username')} required />
+              {showUsernameField && (
+                <FinalInput name="username" label={Translate.string('Username')} required />
+              )}
               <Form.Group widths="equal">
                 <FinalInput
                   name="password"
@@ -345,6 +348,7 @@ Signup.propTypes = {
   initialValues: PropTypes.object.isRequired,
   hasPredefinedAffiliations: PropTypes.bool.isRequired,
   showAccountForm: PropTypes.bool.isRequired,
+  showUsernameField: PropTypes.bool,
   syncedValues: PropTypes.object.isRequired,
   emails: PropTypes.arrayOf(PropTypes.string).isRequired,
   affiliationMeta: PropTypes.object,
@@ -361,6 +365,7 @@ Signup.defaultProps = {
   privacyPolicyUrl: '',
   termsRequireAccept: false,
   termsEffectiveDate: null,
+  showUsernameField: false,
   affiliationMeta: null,
   hasPendingUser: false,
   lockedFields: [],

--- a/indico/modules/auth/forms.py
+++ b/indico/modules/auth/forms.py
@@ -53,18 +53,30 @@ def _check_not_email_address(form, field):
 
 
 class LocalLoginForm(IndicoForm):
-    identifier = StringField(_('Username'), [DataRequired()], filters=[_tolower])
+    identifier = StringField(_('Username or email'), [DataRequired()], filters=[_tolower])
     password = PasswordField(_('Password'), [DataRequired()])
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not config.LOCAL_USERNAMES:
+            self.identifier.label.text = _('Email')
 
 
 class AddLocalIdentityForm(IndicoForm):
     username = StringField(_('Username'), [DataRequired(), _check_existing_username, _check_not_email_address],
                            filters=[_tolower])
     password = PasswordField(_('Password'), [DataRequired(), SecurePassword('set-user-password',
-                                                                            username_field='username')],
+                                                                            username_field='username',
+                                                                            emails=lambda form: form.user_emails)],
                              render_kw={'autocomplete': 'new-password'})
     confirm_password = PasswordField(_('Confirm password'), [DataRequired(), ConfirmPassword('password')],
                                      render_kw={'autocomplete': 'new-password'})
+
+    def __init__(self, *args, user_emails, **kwargs):
+        self.user_emails = user_emails
+        super().__init__(*args, **kwargs)
+        if not config.LOCAL_USERNAMES:
+            del self.username
 
 
 class EditLocalIdentityForm(IndicoForm):
@@ -72,14 +84,18 @@ class EditLocalIdentityForm(IndicoForm):
     password = PasswordField(_('Current password'), [DataRequired()],
                              render_kw={'autocomplete': 'current-password'})
     new_password = PasswordField(_('New password'), [Optional(), SecurePassword('set-user-password',
-                                                                                username_field='username')],
+                                                                                username_field='username',
+                                                                                emails=lambda form: form.user_emails)],
                                  render_kw={'autocomplete': 'new-password'})
     confirm_new_password = PasswordField(_('Confirm password'), [ConfirmPassword('new_password')],
                                          render_kw={'autocomplete': 'new-password'})
 
-    def __init__(self, *args, **kwargs):
-        self.identity = kwargs.pop('identity', None)
+    def __init__(self, *args, identity=None, **kwargs):
+        self.identity = identity
+        self.user_emails = identity.user.all_emails
         super().__init__(*args, **kwargs)
+        if not config.LOCAL_USERNAMES:
+            del self.username
         if session.user.is_admin and session.user != self.identity.user:
             del self.password
 
@@ -123,10 +139,16 @@ class LocalRegistrationForm(IndicoForm):
     email = EmailField(_('Email address'), [Email(), _check_existing_email])
     username = StringField(_('Username'), [DataRequired(), _check_existing_username], filters=[_tolower])
     password = PasswordField(_('Password'), [DataRequired(), SecurePassword('set-user-password',
-                                                                            username_field='username')],
+                                                                            username_field='username',
+                                                                            emails=lambda form: {form.email.data})],
                              render_kw={'autocomplete': 'new-password'})
     confirm_password = PasswordField(_('Confirm password'), [DataRequired(), ConfirmPassword('password')],
                                      render_kw={'autocomplete': 'new-password'})
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not config.LOCAL_USERNAMES:
+            del self.username
 
     @property
     def data(self):
@@ -159,7 +181,14 @@ class ResetPasswordEmailForm(IndicoForm):
 class ResetPasswordForm(IndicoForm):
     username = StringField(_('Username'))
     password = PasswordField(_('New password'), [DataRequired(), SecurePassword('set-user-password',
-                                                                                username_field='username')],
+                                                                                username_field='username',
+                                                                                emails=lambda form: form.user_emails)],
                              render_kw={'autocomplete': 'new-password'})
     confirm_password = PasswordField(_('Confirm password'), [DataRequired(), ConfirmPassword('password')],
                                      render_kw={'autocomplete': 'new-password'})
+
+    def __init__(self, *args, user_emails, **kwargs):
+        self.user_emails = user_emails
+        super().__init__(*args, **kwargs)
+        if not config.LOCAL_USERNAMES:
+            del self.username

--- a/indico/modules/auth/notifications_test.py
+++ b/indico/modules/auth/notifications_test.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pytest
 from pytz import utc
 
+from indico.core.config import config
 from indico.testing.util import assert_email_snapshot
 from indico.web.flask.templating import get_template_module
 
@@ -21,8 +22,9 @@ def _assert_snapshot(snapshot, template_name, *, has_alternatives=False, **conte
     template = get_template_module(f'auth/emails/{template_name}', **context)
     name, ext = os.path.splitext(template_name)
     alternatives_suffix = '_alternatives' if has_alternatives else ''
+    usernames_suffix = '' if config.LOCAL_USERNAMES else '_nousernames'
     snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
-    assert_email_snapshot(snapshot, template, f'{name}{alternatives_suffix}{ext}')
+    assert_email_snapshot(snapshot, template, f'{name}{alternatives_suffix}{usernames_suffix}{ext}')
 
 
 @pytest.fixture
@@ -37,13 +39,17 @@ def alternatives(request):
 
 @pytest.mark.usefixtures('request_context')  # need to access session tzinfo for date format
 @pytest.mark.parametrize('alternatives', (False, True), indirect=True)
-def test_reset_password_email(snapshot, dummy_user, alternatives):
+@pytest.mark.parametrize('local_usernames', (False, True))
+def test_reset_password_email(patch_indico_config, snapshot, dummy_user, alternatives, local_usernames):
+    patch_indico_config('LOCAL_USERNAMES', local_usernames)
     _assert_snapshot(snapshot, 'reset_password.txt', has_alternatives=bool(alternatives),
                      user=dummy_user, username='foobar', alternatives=alternatives, url='<link>')
 
 
 @pytest.mark.usefixtures('request_context')  # need to access session tzinfo for date format
 @pytest.mark.parametrize('alternatives', (False, True), indirect=True)
-def test_create_local_identity_email(snapshot, dummy_user, alternatives):
+@pytest.mark.parametrize('local_usernames', (False, True))
+def test_create_local_identity_email(patch_indico_config, snapshot, dummy_user, alternatives, local_usernames):
+    patch_indico_config('LOCAL_USERNAMES', local_usernames)
     _assert_snapshot(snapshot, 'create_local_identity.txt', has_alternatives=bool(alternatives),
                      user=dummy_user, alternatives=alternatives, url='<link>')

--- a/indico/modules/auth/templates/create_local_identity.html
+++ b/indico/modules/auth/templates/create_local_identity.html
@@ -12,9 +12,15 @@
     {% include 'flashed_messages.html' %}
 
     {% call message_box('info') %}
-        {% trans email=user.email, name=user.full_name %}
-            You're setting username and password for your Indico account <strong>{{ name }}</strong> ({{ email }}).
-        {% endtrans %}
+        {% if indico_config.LOCAL_USERNAMES %}
+            {% trans email=user.email, name=user.full_name %}
+                You're setting username and password for your Indico account <strong>{{ name }}</strong> ({{ email }}).
+            {% endtrans %}
+        {% else %}
+            {% trans email=user.email, name=user.full_name %}
+                You're setting a password for your Indico account <strong>{{ name }}</strong> ({{ email }}).
+            {% endtrans %}
+        {% endif %}
     {% endcall %}
 
     {{ simple_form(form, back_button=false) }}

--- a/indico/modules/auth/templates/emails/create_local_identity.txt
+++ b/indico/modules/auth/templates/emails/create_local_identity.txt
@@ -1,7 +1,7 @@
 {% extends 'auth/emails/reset_password.txt' %}
 
 {% block subject -%}
-    {% trans %}Create local account{% endtrans %}
+    {% trans %}Set your password{% endtrans %}
 {%- endblock %}
 
 {% block local_identity_details -%}

--- a/indico/modules/auth/templates/emails/create_local_identity.txt
+++ b/indico/modules/auth/templates/emails/create_local_identity.txt
@@ -5,8 +5,14 @@
 {%- endblock %}
 
 {% block local_identity_details -%}
-    {%- trans %}
-        Currently there is no username/password set, but you can use the link below (within an hour)
-        to set one:
-    {% endtrans -%}
+    {%- if indico_config.LOCAL_USERNAMES -%}
+        {%- trans %}
+            Currently there is no username/password set, but you can use the link below (within an hour)
+            to set one:
+        {% endtrans -%}
+    {%- else -%}
+        {%- trans %}
+            Currently there is no password set, but you can use the link below (within an hour) to set one:
+        {% endtrans -%}
+    {%- endif -%}
 {%- endblock %}

--- a/indico/modules/auth/templates/emails/reset_password.txt
+++ b/indico/modules/auth/templates/emails/reset_password.txt
@@ -16,9 +16,11 @@
             {% endtrans %}
 
             {% block local_identity_details -%}
-                {%- trans %}
-                    Your username is: {{ username }}
-                {% endtrans %}
+                {%- if indico_config.LOCAL_USERNAMES -%}
+                    {%- trans %}
+                        Your username is: {{ username }}
+                    {% endtrans %}
+                {% endif -%}
                 {% trans %}
                     You can use the link below (within an hour) to set a new password:
                 {% endtrans -%}

--- a/indico/modules/auth/templates/emails/tests/create_local_identity.subject.txt
+++ b/indico/modules/auth/templates/emails/tests/create_local_identity.subject.txt
@@ -1,1 +1,1 @@
-[Indico] Create local account
+[Indico] Set your password

--- a/indico/modules/auth/templates/emails/tests/create_local_identity_alternatives.subject.txt
+++ b/indico/modules/auth/templates/emails/tests/create_local_identity_alternatives.subject.txt
@@ -1,1 +1,1 @@
-[Indico] Create local account
+[Indico] Set your password

--- a/indico/modules/auth/templates/emails/tests/create_local_identity_alternatives_nousernames.subject.txt
+++ b/indico/modules/auth/templates/emails/tests/create_local_identity_alternatives_nousernames.subject.txt
@@ -1,1 +1,1 @@
-[Indico] Create local account
+[Indico] Set your password

--- a/indico/modules/auth/templates/emails/tests/create_local_identity_alternatives_nousernames.subject.txt
+++ b/indico/modules/auth/templates/emails/tests/create_local_identity_alternatives_nousernames.subject.txt
@@ -1,0 +1,1 @@
+[Indico] Create local account

--- a/indico/modules/auth/templates/emails/tests/create_local_identity_alternatives_nousernames.txt
+++ b/indico/modules/auth/templates/emails/tests/create_local_identity_alternatives_nousernames.txt
@@ -1,0 +1,18 @@
+Dear Guinea,
+
+You requested a password reset for your Indico account.
+
+Currently there is no password set, but you can use the link below (within
+an hour) to set one:
+
+<link>
+
+You also have the following alternative login options configured on your account, which
+you can use instead:
+
+- SSO "foo.bar" (last used: 09/01/2025, 13:37)
+- Something "foo@bar" (last used: 24/12/2024, 12:00)
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/auth/templates/emails/tests/create_local_identity_nousernames.subject.txt
+++ b/indico/modules/auth/templates/emails/tests/create_local_identity_nousernames.subject.txt
@@ -1,1 +1,1 @@
-[Indico] Create local account
+[Indico] Set your password

--- a/indico/modules/auth/templates/emails/tests/create_local_identity_nousernames.subject.txt
+++ b/indico/modules/auth/templates/emails/tests/create_local_identity_nousernames.subject.txt
@@ -1,0 +1,1 @@
+[Indico] Create local account

--- a/indico/modules/auth/templates/emails/tests/create_local_identity_nousernames.txt
+++ b/indico/modules/auth/templates/emails/tests/create_local_identity_nousernames.txt
@@ -1,0 +1,12 @@
+Dear Guinea,
+
+You requested a password reset for your Indico account.
+
+Currently there is no password set, but you can use the link below (within
+an hour) to set one:
+
+<link>
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/auth/templates/emails/tests/reset_password_alternatives_nousernames.subject.txt
+++ b/indico/modules/auth/templates/emails/tests/reset_password_alternatives_nousernames.subject.txt
@@ -1,0 +1,1 @@
+[Indico] Reset your password

--- a/indico/modules/auth/templates/emails/tests/reset_password_alternatives_nousernames.txt
+++ b/indico/modules/auth/templates/emails/tests/reset_password_alternatives_nousernames.txt
@@ -1,0 +1,17 @@
+Dear Guinea,
+
+You requested a password reset for your Indico account.
+
+You can use the link below (within an hour) to set a new password:
+
+<link>
+
+You also have the following alternative login options configured on your account, which
+you can use instead:
+
+- SSO "foo.bar" (last used: 09/01/2025, 13:37)
+- Something "foo@bar" (last used: 24/12/2024, 12:00)
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/auth/templates/emails/tests/reset_password_nousernames.subject.txt
+++ b/indico/modules/auth/templates/emails/tests/reset_password_nousernames.subject.txt
@@ -1,0 +1,1 @@
+[Indico] Reset your password

--- a/indico/modules/auth/templates/emails/tests/reset_password_nousernames.txt
+++ b/indico/modules/auth/templates/emails/tests/reset_password_nousernames.txt
@@ -1,0 +1,11 @@
+Dear Guinea,
+
+You requested a password reset for your Indico account.
+
+You can use the link below (within an hour) to set a new password:
+
+<link>
+
+--
+Indico :: Email Notifier
+http://localhost/

--- a/indico/modules/bootstrap/controllers.py
+++ b/indico/modules/bootstrap/controllers.py
@@ -6,6 +6,7 @@
 # LICENSE file for more details.
 
 from platform import python_version
+from uuid import uuid4
 
 from flask import flash, redirect, render_template, request, session
 from markupsafe import Markup
@@ -56,7 +57,8 @@ class RHBootstrap(RH):
         user.email = setup_form.email.data
         user.is_admin = True
 
-        identity = Identity(provider='indico', identifier=setup_form.username.data, password=setup_form.password.data)
+        identifier = setup_form.username.data if config.LOCAL_USERNAMES else uuid4()
+        identity = Identity(provider='indico', identifier=identifier, password=setup_form.password.data)
         user.identities.add(identity)
 
         db.session.add(user)

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -9,6 +9,7 @@ from collections import namedtuple
 from io import BytesIO
 from operator import attrgetter
 from urllib.parse import urlsplit
+from uuid import uuid4
 
 from dateutil.relativedelta import relativedelta
 from flask import flash, jsonify, redirect, render_template, request, session
@@ -759,7 +760,8 @@ class RHUsersAdminCreate(RHAdminBase):
         if form.validate_on_submit():
             data = form.data
             if data.pop('create_identity', False):
-                identity = Identity(provider='indico', identifier=data.pop('username'), password=data.pop('password'))
+                identifier = data.pop('username') if config.LOCAL_USERNAMES else uuid4()
+                identity = Identity(provider='indico', identifier=identifier, password=data.pop('password'))
             else:
                 identity = None
                 data.pop('username', None)

--- a/indico/testing/fixtures/app.py
+++ b/indico/testing/fixtures/app.py
@@ -10,6 +10,7 @@ import os
 import pytest
 from flask_webpackext.ext import _FlaskWebpackExtState
 
+from indico.core.config import config
 from indico.web.flask.app import make_app
 from indico.web.flask.wrappers import IndicoFlask
 from indico.web.rh import RH
@@ -37,6 +38,14 @@ def app(request):
         'NO_REPLY_EMAIL': 'noreply@example.com',
     }
     return make_app(testing=True, config_override=config_override)
+
+
+@pytest.fixture
+def patch_indico_config(monkeypatch):
+    """Patch an Indico config setting."""
+    def _patcher(name, value):
+        monkeypatch.setattr(type(config), name, property(lambda self: value), raising=False)
+    return _patcher
 
 
 @pytest.fixture(autouse=True)

--- a/indico/util/passwords.py
+++ b/indico/util/passwords.py
@@ -150,7 +150,7 @@ def check_password_pwned(password, *, fast=False):
     return sha[5:] in hashes
 
 
-def validate_secure_password(context, password, *, username='', fast=False):
+def validate_secure_password(context, password, *, username='', emails=frozenset(), fast=False):
     """Check if a password is considered secure.
 
     A password is considered secure if it:
@@ -163,6 +163,7 @@ def validate_secure_password(context, password, *, username='', fast=False):
     :param context: A string indicating the context where the password is used
     :param password: The plaintext password
     :param username: The corresponding username (may be empty if not applicable)
+    :param emails: A set of email addresses (that may not be in the password)
     :param fast: Whether the check should finish quickly, even if that may
                  indicate not being able to check the password against the list
                  of pwned passwords. This should be used during interactive requests
@@ -191,6 +192,9 @@ def validate_secure_password(context, password, *, username='', fast=False):
 
     if len(username) >= 5 and len(password) <= 16 and username.lower() in password.lower():
         return _('Passwords may not contain your username.')
+
+    if any(x in password for x in emails):
+        return _('Passwords may not contain your email address.')
 
     if check_password_pwned(password, fast=fast):
         return _('This password has been seen in previous data breaches.')

--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -399,16 +399,18 @@ class SecurePassword:
     # not need to hard-code it.
     MIN_LENGTH = 8
 
-    def __init__(self, context='wtforms-field', username_field=None):
+    def __init__(self, context='wtforms-field', username_field=None, emails=None):
         self.context = context
         self.username_field = username_field
+        self.get_emails = emails
 
     def __call__(self, form, field):
         username = ''
-        if self.username_field:
+        if self.username_field and self.username_field in form:
             username = form[self.username_field].data or ''
         password = field.data or ''
-        if error := validate_secure_password(self.context, password, username=username):
+        emails = self.get_emails(form) if self.get_emails else set()
+        if error := validate_secure_password(self.context, password, username=username, emails=emails):
             raise ValidationError(error)
 
 


### PR DESCRIPTION
Now that it's possible to login with the email address, some instances may want to avoid the "hassle" of users having to set a username altogether, and just use the email address for this purpose.