### PR TITLE
Hide participant list in conference meeting timetable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ Improvements
 - Add an event setting to allow enforcing search before entering a person manually to
   a persons list in abstracts and contributions (:pr:`6689`)
 - Allow users to login using their email address (:pr:`6522`, thanks :user:`SegiNyn`)
+- Do not "inline" the full participant list in conference events using a meeting-style
+  timetable and link to the conference participant list instead (:pr:`6753`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/__init__.py
+++ b/indico/modules/events/registration/__init__.py
@@ -88,10 +88,11 @@ def _inject_event_header(event, **kwargs):
     if event.has_feature('registration'):
         displayed_regforms, user_registrations = get_event_regforms_registrations(event, session.user,
                                                                                   include_scheduled=False)
-        # A participant could appear more than once in the list in case he register to multiple registration form.
+        # A participant could appear more than once in the list in case they register to multiple registration form.
         # This is deemed very unlikely in the case of meetings and lectures and thus not worth the extra complexity.
         return render_template(
             'events/registration/display/event_header.html',
+            event=event,
             regforms=displayed_regforms,
             user_registrations=user_registrations,
             published_registrations=event.get_published_registrations(session.user),

--- a/indico/modules/events/registration/templates/display/event_header.html
+++ b/indico/modules/events/registration/templates/display/event_header.html
@@ -76,7 +76,19 @@
     </div>
 {% endif %}
 
-{% if published_registrations %}
+{% if event.type == 'conference' and (published_registrations or num_hidden_registrations) %}
+    <div class="event-details-row">
+        <div class="event-details-label">{% trans %}Participants{% endtrans %}</div>
+        <div class="event-details-content">
+            <span class="ui circular label">
+                {{ published_registrations|length + num_hidden_registrations }}
+            </span>
+            <a href="{{ url_for('event_registration.participant_list', event) }}">
+                {% trans %}View full list{% endtrans %}
+            </a>
+        </div>
+    </div>
+{% elif published_registrations %}
     <div class="event-details-row">
         <div class="event-details-label">{% trans %}Participants{% endtrans %}</div>
         <div class="event-details-content">


### PR DESCRIPTION
Instead, show the count and link to the participant list page.

Conference events are likely to have a large amount of participants (easily hundreds), and inlining those on the meeting page not only looks awful, but also results in hundreds of requests to show their avatar images from everyone just accessing the timetable.

![image](https://github.com/user-attachments/assets/69539cba-32fd-4d87-a406-323257c00b61)
