### PR TITLE
Add handle login signin signals

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,8 @@ Internal Changes
 
 - Remove the `marshmallow-enum` dependency (:issue:`6701`, :pr:`6703`, thanks
   :user:`federez-tba`)
+- Add new signals during signup email validation and login which can make the
+  process fail with a custom message (:pr:`6759`, thanks :user:`openprojects`)
 
 
 Version 3.3.5

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -120,9 +120,10 @@ class IndicoMultipass(Multipass):
         return super().handle_auth_error(exc, redirect_to_login=redirect_to_login)
 
     def handle_login_form(self, provider, data):
-        signal_response = values_from_signal(signals.users.handle_login.send(data.get('identifier', '')), as_list=True)
-        if signal_response and not signal_response[0][0]:
-            flash(signal_response[0][1], 'warning')
+        signal_responses = values_from_signal(signals.users.handle_login.send(data.get('identifier', '')))
+        signal_response = next((response for response in signal_responses if not response[0]), None)
+        if signal_response:
+            flash(signal_response[1], 'warning')
             return
         return super().handle_login_form(provider, data)
 

--- a/indico/core/signals/users.py
+++ b/indico/core/signals/users.py
@@ -100,7 +100,7 @@ Expected to return a ``(login_allowed, message)`` tuple.
 Called during the login process. The *sender* is the identity submitted.
 ''')
 
-handle_signin = _signals.signal('handle-signin', '''
-Expected to return a ``(signin_allowed, message)`` tuple.
+handle_signup = _signals.signal('handle-signup', '''
+Expected to return a ``(signup_allowed, message)`` tuple.
 Called during the signin process. The *sender* is the identity submitted.
 ''')

--- a/indico/core/signals/users.py
+++ b/indico/core/signals/users.py
@@ -95,9 +95,13 @@ Called when a new category is removed from a user's favorites. The *sender* is
 the user object and the category is passed in the `category` kwarg.
 ''')
 
-handle_login = _signals.signal('handle-login', '''
-Expected to return a ``(login_allowed, message)`` tuple.
-Called during the login process. The *sender* is the identity submitted.
+check_login_data = _signals.signal('check-login-data', '''
+Called when logging in using a form-based login provider.
+The *sender* is the flask-multipass auth provider class used for the login, and
+the data entered in the login form is passed in the `data` kwarg. The provider
+instance is passed in the `provider` kwarg.
+If this signal returns a string, the login will fail with the returned message;
+otherwise (``None`` return value) the signup can continue as normal.
 ''')
 
 check_signup_email = _signals.signal('check-signup-email', '''

--- a/indico/core/signals/users.py
+++ b/indico/core/signals/users.py
@@ -100,7 +100,9 @@ Expected to return a ``(login_allowed, message)`` tuple.
 Called during the login process. The *sender* is the identity submitted.
 ''')
 
-handle_signup = _signals.signal('handle-signup', '''
-Expected to return a ``(signup_allowed, message)`` tuple.
-Called during the signin process. The *sender* is the identity submitted.
+check_signup_email = _signals.signal('check-signup-email', '''
+Called during the email validation phase of the local account signup process.
+The *sender* is the email address the user is trying to use. If this signal returns
+a string, the signup will be refused with the returned message; otherwise (``None``
+return value) the signup can continue as normal.
 ''')

--- a/indico/core/signals/users.py
+++ b/indico/core/signals/users.py
@@ -94,3 +94,13 @@ favorite_category_removed = _signals.signal('favorite-category-removed', '''
 Called when a new category is removed from a user's favorites. The *sender* is
 the user object and the category is passed in the `category` kwarg.
 ''')
+
+handle_login = _signals.signal('handle-login', '''
+Expected to return a ``(login_allowed, message)`` tuple.
+Called during the login process. The *sender* is the identity submitted.
+''')
+
+handle_signin = _signals.signal('handle-signin', '''
+Expected to return a ``(signin_allowed, message)`` tuple.
+Called during the signin process. The *sender* is the identity submitted.
+''')

--- a/indico/modules/auth/forms.py
+++ b/indico/modules/auth/forms.py
@@ -54,8 +54,8 @@ def _check_not_email_address(form, field):
         raise ValidationError(_('Your username cannot be an email address.'))
 
 
-def _check_signin(form, field):
-    signal_responses = values_from_signal(signals.users.handle_signin.send(field.data))
+def _check_signup(form, field):
+    signal_responses = values_from_signal(signals.users.handle_signup.send(field.data))
     signal_response = next((response for response in signal_responses if not response[0]), None)
     if signal_response:
         raise ValidationError(signal_response[1])
@@ -130,7 +130,7 @@ class SelectEmailForm(IndicoForm):
 
 class RegistrationEmailForm(IndicoForm):
     email = EmailField(_('Email address'),
-                       [DataRequired(), Email(), _check_not_blacklisted, _check_existing_email, _check_signin],
+                       [DataRequired(), Email(), _check_not_blacklisted, _check_existing_email, _check_signup],
                        filters=[_tolower])
     captcha = WTFCaptchaField()
     is_email_verification = HiddenField()

--- a/indico/modules/auth/forms.py
+++ b/indico/modules/auth/forms.py
@@ -55,9 +55,10 @@ def _check_not_email_address(form, field):
 
 
 def _check_signin(form, field):
-    signal_response = values_from_signal(signals.users.handle_signin.send(field.data), as_list=True)
-    if signal_response and not signal_response[0][0]:
-        raise ValidationError(signal_response[0][1])
+    signal_responses = values_from_signal(signals.users.handle_signin.send(field.data))
+    signal_response = next((response for response in signal_responses if not response[0]), None)
+    if signal_response:
+        raise ValidationError(signal_response[1])
     return True
 
 

--- a/indico/modules/auth/forms.py
+++ b/indico/modules/auth/forms.py
@@ -55,11 +55,8 @@ def _check_not_email_address(form, field):
 
 
 def _check_signup(form, field):
-    signal_responses = values_from_signal(signals.users.handle_signup.send(field.data))
-    signal_response = next((response for response in signal_responses if not response[0]), None)
-    if signal_response:
-        raise ValidationError(signal_response[1])
-    return True
+    if errors := values_from_signal(signals.users.check_signup_email.send(field.data), as_list=True):
+        raise ValidationError(errors[0])
 
 
 class LocalLoginForm(IndicoForm):


### PR DESCRIPTION
As previously discussed with Alejandro:

we would like to introduce a signal in Indico core that allows refusing sign ups and logins and display a custom message that explains the reason.
This signal will return a tuple: True/False , String. --> The first value explain if the login/signin process can continue or not, the second value contains the eventual error message.
