### PR TITLE
Disable crawler indexing for invisible events

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,8 @@ Improvements
   timetable and link to the conference participant list instead (:pr:`6753`)
 - Add new setting :data:`LOCAL_USERNAMES` to disable usernames for logging in and only
   use the email address (:pr:`6751`)
+- Tell search engines to not index events marked as "invisible" (:pr:`6762`, thanks
+  :user:`openprojects`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/controllers/base.py
+++ b/indico/modules/events/controllers/base.py
@@ -103,11 +103,11 @@ class RHDisplayEventBase(RHProtectedEventBase):
     def _do_process(self):
         with self.event_rh_contexts:
             try:
-                ret = RHEventBase._do_process(self)
+                rv = RHEventBase._do_process(self)
                 if self.event.visibility == 0:
                     # If the event is invisible, avoid web search engine indexing
                     self.noindex = True
-                return ret
+                return rv
             except AccessKeyRequired:
                 return self._show_access_key_form()
             except RegistrationRequired:

--- a/indico/modules/events/controllers/base.py
+++ b/indico/modules/events/controllers/base.py
@@ -103,7 +103,11 @@ class RHDisplayEventBase(RHProtectedEventBase):
     def _do_process(self):
         with self.event_rh_contexts:
             try:
-                return RHEventBase._do_process(self)
+                ret = RHEventBase._do_process(self)
+                if self.event.visibility == 0:
+                    # If the event is invisible, avoid web search engine indexing
+                    self.noindex = True
+                return ret
             except AccessKeyRequired:
                 return self._show_access_key_form()
             except RegistrationRequired:

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -331,6 +331,9 @@ class RH:
             res = ''
 
         response = current_app.make_response(res)
+        if hasattr(self, 'noindex'):
+            # If the event is invisible, avoid web search engine indexing
+            response.headers['X-Robots-Tag'] = 'noindex, nofollow, noarchive, nosnippet'
         if self.DENY_FRAMES:
             response.headers['X-Frame-Options'] = 'DENY'
         return response

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -85,6 +85,7 @@ class RH:
 
     def __init__(self):
         self.commit = True
+        self.noindex = False
 
     # Methods =============================================================
 
@@ -331,7 +332,7 @@ class RH:
             res = ''
 
         response = current_app.make_response(res)
-        if hasattr(self, 'noindex'):
+        if self.noindex:
             # If the event is invisible, avoid web search engine indexing
             response.headers['X-Robots-Tag'] = 'noindex, nofollow, noarchive, nosnippet'
         if self.DENY_FRAMES:

--- a/indico/web/rh.py
+++ b/indico/web/rh.py
@@ -333,7 +333,6 @@ class RH:
 
         response = current_app.make_response(res)
         if self.noindex:
-            # If the event is invisible, avoid web search engine indexing
             response.headers['X-Robots-Tag'] = 'noindex, nofollow, noarchive, nosnippet'
         if self.DENY_FRAMES:
             response.headers['X-Frame-Options'] = 'DENY'


### PR DESCRIPTION
As discussed, we have the need to "avoid" web search engines to index Events that are set in "invisible" state.
To achieve this we set the X-Robots-Tag header to noindex, nofollow, noarchive, nosnippet . 