### PR TITLE
Add event label to title for dashboard ics export

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ Bugfixes
   to manage materials on the event level (:pr:`6760`)
 - Do not redirect to the ToS acceptance page when impersonating a user (:pr:`6770`)
 - Fix display issues after reacting to a favorite category suggestion (:pr:`6771`)
+- Include event labels in dashboard ICS export (:issue:`5886, 6372`, :pr:`6769`, thanks
+  :user:`amCap1712`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -552,10 +552,14 @@ def register_location_change(entry):
 
 
 def serialize_event_for_ical(event):
+    title = event.title
+    if label := getattr(event, 'label', None):
+        title += f' [{label.title}]'
+
     return {
         '_fossil': 'conferenceMetadata',
         'id': event.id,
-        'title': event.title,
+        'title': title,
         'description': event.description,
         'startDate': event.start_dt,
         'endDate': event.end_dt,

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -553,8 +553,8 @@ def register_location_change(entry):
 
 def serialize_event_for_ical(event):
     title = event.title
-    if label := getattr(event, 'label', None):
-        title += f' [{label.title}]'
+    if event.label:
+        title += f' [{event.label.title}]'
 
     return {
         '_fossil': 'conferenceMetadata',


### PR DESCRIPTION
Event labels are shown in Indico UI and present in .ics exports from the category page but absent from the .ics exported from dashboard page. Both pages use different logic to generate the ical file to export. Resolve the issue by adding the missing logic to check and add for event labels to the latter (serialize_event_for_ical).

Fixes #5886 and fixes #6372.