### PR TITLE
Fix display errors in category suggestions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -60,6 +60,7 @@ Bugfixes
 - Fix image uploading not working when editing an existing note without having permissions
   to manage materials on the event level (:pr:`6760`)
 - Do not redirect to the ToS acceptance page when impersonating a user (:pr:`6770`)
+- Fix display issues after reacting to a favorite category suggestion (:pr:`6771`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -240,8 +240,8 @@
                                     'class': 'category-action icon-star active',
                                     'title': $T('You have favorited this category')
                                 }));
-                            container.appendTo('#yourCategories ol');
-                            if(!$('#suggestedCategories ol > li').length) {
+                            container.appendTo('#yourCategories > ul');
+                            if (!$('#suggestedCategories > ul > li').length) {
                                 $('#suggestedCategories').remove();
                             }
                         }
@@ -259,7 +259,7 @@
                         error: handleAjaxError,
                         success: function() {
                             container.remove();
-                            if (!$('#suggestedCategories ol > li').length) {
+                            if (!$('#suggestedCategories > ul > li').length) {
                                 $('#suggestedCategories').remove();
                             }
                         }


### PR DESCRIPTION
- When dismissing one, the whole list got removed
- When accepting one, the same happened, and the favorite list got messed up because the new one was appended to every single item instead of just the actual list