### PR TITLE
Hide default value data in purged regform fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,8 @@ Bugfixes
 - Fix display issues after reacting to a favorite category suggestion (:pr:`6771`)
 - Include event labels in dashboard ICS export (:issue:`5886, 6372`, :pr:`6769`, thanks
   :user:`amCap1712`)
+- Do not show default values for purged registration fields (:issue:`5898`, :pr:`6772`,
+  thanks :user:`amCap1712`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
+++ b/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
@@ -9,7 +9,9 @@
             <tr class="{{ 'deleted-field' if from_management and (field.is_deleted or section.is_deleted) }}">
                 <th class="regform-done-caption">{{ field.title }}</th>
                 <td class="regform-done-data">
-                    {{- render_data(registration, field, from_management) -}}
+                    {%- if not field.is_purged -%}
+                        {{- render_data(registration, field, from_management) -}}
+                    {%- endif -%}
                     {% if from_management and (field.is_deleted or section.is_deleted) -%}
                         <span class="icon-warning deleted-field-warning right"
                               data-qtip-style="warning"


### PR DESCRIPTION
The task to purge registration field data beyond retention period overwrites the field data with the field's default value. https://github.com/indico/indico/blob/e9e4daab682c1d93cde575d3446fed265427da72/indico/modules/events/registration/tasks.py#L63-L67.
Check if field is purged before trying to render its value in registration details to avoid displaying such data to the user.

Before:
![image](https://github.com/user-attachments/assets/c7fe37e4-28e6-4063-aa0f-f3307e242cbe)

After:
![image](https://github.com/user-attachments/assets/87c951a7-e8eb-4c37-b2e7-76bb58213c60)

Fixes #5898 