### PR TITLE
Ensure survey sections are cloned first

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,7 @@ Bugfixes
   :user:`amCap1712`)
 - Do not show default values for purged registration fields (:issue:`5898`, :pr:`6772`,
   thanks :user:`amCap1712`)
+- Do not create empty survey sections during event cloning (:pr:`6774`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/surveys/clone.py
+++ b/indico/modules/events/surveys/clone.py
@@ -40,14 +40,12 @@ class EventSurveyCloner(EventCloner):
             survey = Survey()
             survey.populate_from_attrs(old_survey, survey_attrs)
             item_map = {}
-            for old_item in old_survey.items:
+            # Clone sections first so they can be referenced later when items are cloned.
+            for old_item in sorted(old_survey.items, key=lambda x: (x.parent is not None, x.position)):
                 item = self._clone_item(survey, old_item)
                 if old_item.parent:
                     assert old_item.parent != old_item
-                    try:
-                        item.parent = item_map[old_item.parent]
-                    except KeyError:
-                        item.parent = item_map[old_item.parent] = self._clone_item(survey, old_item.parent)
+                    item.parent = item_map[old_item.parent]
                 item_map[old_item] = item
             new_event.surveys.append(survey)
 

--- a/indico/modules/events/surveys/clone.py
+++ b/indico/modules/events/surveys/clone.py
@@ -39,14 +39,9 @@ class EventSurveyCloner(EventCloner):
                 continue
             survey = Survey()
             survey.populate_from_attrs(old_survey, survey_attrs)
-            item_map = {}
-            # Clone sections first so they can be referenced later when items are cloned.
-            for old_item in sorted(old_survey.items, key=lambda x: (x.parent is not None, x.position)):
-                item = self._clone_item(survey, old_item)
-                if old_item.parent:
-                    assert old_item.parent != old_item
-                    item.parent = item_map[old_item.parent]
-                item_map[old_item] = item
+            for old_section in old_survey.sections:
+                section = self._clone_item(survey, old_section)
+                section.children = [self._clone_item(survey, item) for item in old_section.children]
             new_event.surveys.append(survey)
 
     def _clone_item(self, survey, old_item):

--- a/indico/modules/events/surveys/clone_test.py
+++ b/indico/modules/events/surveys/clone_test.py
@@ -31,6 +31,9 @@ def test_survey_clone(db, create_event, dummy_event):
 
     assert len(new_event.surveys) == 1
     assert len(new_event.surveys[0].items) == len(survey.items)
-    for i, item in enumerate(new_event.surveys[0].items):
+    for i, section in enumerate(new_event.surveys[0].sections):
         for attr in get_attrs_to_clone(SurveyItem):
-            assert getattr(item, attr) == getattr(survey.items[i], attr)
+            assert getattr(section, attr) == getattr(survey.sections[i], attr)
+        for j, child in enumerate(section.children):
+            for attr in get_attrs_to_clone(SurveyItem):
+                assert getattr(child, attr) == getattr(survey.sections[i].children[j], attr)


### PR DESCRIPTION
The `items` list of a survey is not ordered, so when question items got cloned before section items, this ended up creating a new section. Later, the original section got cloned nonetheless, remaining as an empty section.