### PR TITLE
Extend the registration check-in and check-out process

### DIFF
--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -21,9 +21,9 @@ Called when the state of a registration changes. The `sender` is the
 kwarg; the `silent` kwarg can be set to `True` to skip logging.
 ''')
 
-registration_checkin_updated = _signals.signal('registration-checkin-updated', '''
-Called when the checkin state of a registration changes. The `sender` is the
-`Registration` object.
+registration_check_added = _signals.signal('registration-check-added', '''
+Called when a check is performed on a registration. The `sender` is the
+`RegistrationCheck` object.
 ''')
 
 registration_created = _signals.signal('registration-created', '''

--- a/indico/legacy/pdfinterface/conference.py
+++ b/indico/legacy/pdfinterface/conference.py
@@ -227,6 +227,12 @@ class RegistrantToPDF(PDFBase):
             if 'checked_in_date' in self.static_items:
                 check_in_date = format_datetime(registration.checked_in_dt) if registration.checked_in else ''
                 _print_row(_('Check-in date'), check_in_date)
+            if 'checked_out' in self.static_items:
+                checked_out = 'Yes' if registration.checked_out else 'No'
+                _print_row(_('Checked out'), checked_out)
+            if 'checked_out_date' in self.static_items:
+                check_in_date = format_datetime(registration.checked_out_dt) if registration.checked_out else ''
+                _print_row(_('Check-out date'), check_in_date)
             if 'tags_present' in self.static_items and registration.tags:
                 tags = ', '.join(sorted(t.title for t in registration.tags))
                 _print_row(_('Tags'), tags)
@@ -394,6 +400,10 @@ class RegistrantsListToPDF(PDFBase):
             lp.append(Paragraph('<b>{}</b>'.format(_('Checked in')), text_format))
         if 'checked_in_date' in self.static_items:
             lp.append(Paragraph('<b>{}</b>'.format(_('Check-in date')), text_format))
+        if 'checked_out' in self.static_items:
+            lp.append(Paragraph('<b>{}</b>'.format(_('Checked out')), text_format))
+        if 'checked_out_date' in self.static_items:
+            lp.append(Paragraph('<b>{}</b>'.format(_('Check-out date')), text_format))
         if 'tags_present' in self.static_items:
             lp.append(Paragraph('<b>{}</b>'.format(_('Tags')), text_format))
         l.append(lp)
@@ -442,6 +452,12 @@ class RegistrantsListToPDF(PDFBase):
             if 'checked_in_date' in self.static_items:
                 check_in_date = format_datetime(registration.checked_in_dt) if registration.checked_in else ''
                 lp.append(Paragraph(check_in_date, text_format))
+            if 'checked_out' in self.static_items:
+                checked_out = 'Yes' if registration.checked_out else 'No'
+                lp.append(Paragraph(checked_out, text_format))
+            if 'checked_out_date' in self.static_items:
+                check_out_date = format_datetime(registration.checked_out_dt) if registration.checked_out else ''
+                lp.append(Paragraph(check_out_date, text_format))
             if 'tags_present' in self.static_items:
                 tags = ', '.join(sorted(t.title for t in registration.tags))
                 lp.append(Paragraph(escape(tags), text_format))

--- a/indico/migrations/versions/20251201_1139_1a5139970d93_add_event_registrations_checks_table.py
+++ b/indico/migrations/versions/20251201_1139_1a5139970d93_add_event_registrations_checks_table.py
@@ -1,0 +1,129 @@
+"""Add event_registrations.checks table.
+
+Revision ID: af9d03d7073c
+Revises: 932389d22b1f
+Create Date: 2025-01-30 11:39:30.511470
+"""
+
+from enum import Enum
+
+import sqlalchemy as sa
+from alembic import op
+
+from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = 'af9d03d7073c'
+down_revision = '932389d22b1f'
+branch_labels = None
+depends_on = None
+
+
+class _CheckRule(int, Enum):
+    once = 1
+    multiple = 2
+    once_daily = 3
+
+
+def upgrade():
+    op.create_table(
+        'check_types',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('rule', PyIntEnum(_CheckRule), nullable=False),
+        sa.Column('event_id', sa.Integer(), index=True),
+        sa.Column('is_system_defined', sa.Boolean(), nullable=False),
+        sa.Column('check_out_allowed', sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(['event_id'], ['events.events.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='event_registration'
+    )
+    op.create_index('ix_uq_check_types_title_lower', 'check_types',
+                    [sa.text('COALESCE(event_id, -1)'), sa.text('lower(title)')],
+                    unique=True, schema='event_registration')
+    op.create_check_constraint('valid_is_system_defined', 'check_types',
+                               '((is_system_defined = true AND event_id IS NULL) '
+                               'OR (is_system_defined = false AND event_id IS NOT NULL))',
+                               schema='event_registration')
+    conn = op.get_bind()
+    system_user_id = conn.execute('SELECT id FROM users.users WHERE is_system').scalar()
+    check_type_id = conn.execute('''
+        INSERT INTO event_registration.check_types (title, rule, is_system_defined, check_out_allowed)
+        VALUES (%s, %s, %s, %s)
+        RETURNING id
+    ''', ('Initial Attendance Check', _CheckRule.once.value, True, True)).scalar()
+
+    conn.execute('''
+        INSERT INTO indico.settings (module, name, value)
+        VALUES ('default_check_type', 'default_check_type', %s)
+    ''', (str(check_type_id)))
+
+    op.create_table(
+        'checks',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('registration_id', sa.Integer(), nullable=False, index=True),
+        sa.Column('timestamp', UTCDateTime, nullable=False, index=True),
+        sa.Column('check_type_id', sa.Integer(), nullable=False, index=True),
+        sa.Column('is_check_out', sa.Boolean(), nullable=False),
+        sa.Column('checked_by_user_id', sa.Integer(), index=True),
+        sa.ForeignKeyConstraint(['registration_id'], ['event_registration.registrations.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['check_type_id'], ['event_registration.check_types.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['checked_by_user_id'], ['users.users.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='event_registration'
+    )
+
+    conn.execute('''
+        INSERT INTO event_registration.checks (registration_id, check_type_id, timestamp, is_check_out, checked_by_user_id)
+        SELECT r.id, %s, r.checked_in_dt, %s, %s
+        FROM event_registration.registrations r
+        WHERE r.checked_in IS TRUE
+    ''', (check_type_id, False, system_user_id))
+
+    op.drop_column('registrations', 'checked_in', schema='event_registration')
+    op.drop_column('registrations', 'checked_in_dt', schema='event_registration')
+
+    op.add_column('events', sa.Column('default_check_type_id', sa.Integer(), nullable=False, index=True,
+                                      server_default=str(check_type_id)), schema='events')
+    op.alter_column('events', 'default_check_type_id', server_default=None, schema='events')
+    op.create_foreign_key(None, 'events', 'check_types', ['default_check_type_id'], ['id'], source_schema='events',
+                          referent_schema='event_registration')
+
+
+def downgrade():
+    op.drop_column('events', 'default_check_type_id', schema='events')
+    op.add_column('registrations', sa.Column('checked_in', sa.Boolean(), nullable=False, server_default='false'),
+                  schema='event_registration')
+    op.alter_column('registrations', 'checked_in', server_default=None, schema='event_registration')
+    op.add_column('registrations', sa.Column('checked_in_dt', UTCDateTime, nullable=True), schema='event_registration')
+
+    conn = op.get_bind()
+    check_type_id = conn.execute('''SELECT id FROM event_registration.check_types
+                                 WHERE title='Initial Attendance Check'
+                                 AND is_system_defined=True''').scalar()
+    conn.execute('''
+        UPDATE event_registration.registrations r
+        SET checked_in = TRUE,
+            checked_in_dt = last_check_in.timestamp
+        FROM (
+            SELECT c.registration_id, c.timestamp
+            FROM event_registration.checks c
+            WHERE c.timestamp = (
+                SELECT MAX(c2.timestamp)
+                FROM event_registration.checks c2
+                WHERE c2.registration_id = c.registration_id
+                AND c2.check_type_id = %s
+            )
+            AND c.is_check_out = False
+        ) AS last_check_in
+        WHERE r.id = last_check_in.registration_id
+    ''', (check_type_id))
+
+    conn.execute('''
+        DELETE FROM indico.settings
+        WHERE module = 'default_check_type' AND name = 'default_check_type'
+    ''')
+
+    op.drop_table('checks', schema='event_registration')
+    op.drop_table('check_types', schema='event_registration')

--- a/indico/migrations/versions/20260825_1139_1a5139970d93_add_event_registrations_checks_table.py
+++ b/indico/migrations/versions/20260825_1139_1a5139970d93_add_event_registrations_checks_table.py
@@ -1,0 +1,129 @@
+"""Add event_registrations.checks table.
+
+Revision ID: 1a5139970d93
+Revises: 06a037da1ec6
+Create Date: 2025-01-30 11:39:30.511470
+"""
+
+from enum import Enum
+
+import sqlalchemy as sa
+from alembic import op
+
+from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = '1a5139970d93'
+down_revision = '06a037da1ec6'
+branch_labels = None
+depends_on = None
+
+
+class _CheckRule(int, Enum):
+    once = 1
+    multiple = 2
+    once_daily = 3
+
+
+def upgrade():
+    op.create_table(
+        'check_types',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('title', sa.String(), nullable=False),
+        sa.Column('rule', PyIntEnum(_CheckRule), nullable=False),
+        sa.Column('event_id', sa.Integer(), index=True),
+        sa.Column('is_system_defined', sa.Boolean(), nullable=False),
+        sa.Column('check_out_allowed', sa.Boolean(), nullable=False),
+        sa.ForeignKeyConstraint(['event_id'], ['events.events.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='event_registration'
+    )
+    op.create_index('ix_uq_check_types_title_lower', 'check_types',
+                    [sa.text('COALESCE(event_id, -1)'), sa.text('lower(title)')],
+                    unique=True, schema='event_registration')
+    op.create_check_constraint('valid_is_system_defined', 'check_types',
+                               '((is_system_defined = true AND event_id IS NULL) '
+                               'OR (is_system_defined = false AND event_id IS NOT NULL))',
+                               schema='event_registration')
+    conn = op.get_bind()
+    system_user_id = conn.execute('SELECT id FROM users.users WHERE is_system').scalar()
+    check_type_id = conn.execute('''
+        INSERT INTO event_registration.check_types (title, rule, is_system_defined, check_out_allowed)
+        VALUES (%s, %s, %s, %s)
+        RETURNING id
+    ''', ('Initial Attendance Check', _CheckRule.once.value, True, True)).scalar()
+
+    conn.execute('''
+        INSERT INTO indico.settings (module, name, value)
+        VALUES ('default_check_type', 'default_check_type', %s)
+    ''', (str(check_type_id)))
+
+    op.create_table(
+        'checks',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('registration_id', sa.Integer(), nullable=False, index=True),
+        sa.Column('timestamp', UTCDateTime, nullable=False, index=True),
+        sa.Column('check_type_id', sa.Integer(), nullable=False, index=True),
+        sa.Column('is_check_out', sa.Boolean(), nullable=False),
+        sa.Column('checked_by_user_id', sa.Integer(), index=True),
+        sa.ForeignKeyConstraint(['registration_id'], ['event_registration.registrations.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['check_type_id'], ['event_registration.check_types.id'], ondelete='CASCADE'),
+        sa.ForeignKeyConstraint(['checked_by_user_id'], ['users.users.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='event_registration'
+    )
+
+    conn.execute('''
+        INSERT INTO event_registration.checks (registration_id, check_type_id, timestamp, is_check_out, checked_by_user_id)
+        SELECT r.id, %s, r.checked_in_dt, %s, %s
+        FROM event_registration.registrations r
+        WHERE r.checked_in IS TRUE
+    ''', (check_type_id, False, system_user_id))
+
+    op.drop_column('registrations', 'checked_in', schema='event_registration')
+    op.drop_column('registrations', 'checked_in_dt', schema='event_registration')
+
+    op.add_column('events', sa.Column('default_check_type_id', sa.Integer(), nullable=True, index=True,
+                                      server_default=str(check_type_id)), schema='events')
+    op.alter_column('events', 'default_check_type_id', server_default=None, schema='events')
+    op.create_foreign_key(None, 'events', 'check_types', ['default_check_type_id'], ['id'], source_schema='events',
+                          referent_schema='event_registration')
+
+
+def downgrade():
+    op.drop_column('events', 'default_check_type_id', schema='events')
+    op.add_column('registrations', sa.Column('checked_in', sa.Boolean(), nullable=False, server_default='false'),
+                  schema='event_registration')
+    op.alter_column('registrations', 'checked_in', server_default=None, schema='event_registration')
+    op.add_column('registrations', sa.Column('checked_in_dt', UTCDateTime, nullable=True), schema='event_registration')
+
+    conn = op.get_bind()
+    check_type_id = conn.execute('''SELECT id FROM event_registration.check_types
+                                 WHERE title='Initial Attendance Check'
+                                 AND is_system_defined=True''').scalar()
+    conn.execute('''
+        UPDATE event_registration.registrations r
+        SET checked_in = TRUE,
+            checked_in_dt = last_check_in.timestamp
+        FROM (
+            SELECT c.registration_id, c.timestamp
+            FROM event_registration.checks c
+            WHERE c.timestamp = (
+                SELECT MAX(c2.timestamp)
+                FROM event_registration.checks c2
+                WHERE c2.registration_id = c.registration_id
+                AND c2.check_type_id = %s
+            )
+            AND c.is_check_out = False
+        ) AS last_check_in
+        WHERE r.id = last_check_in.registration_id
+    ''', (check_type_id))
+
+    conn.execute('''
+        DELETE FROM indico.settings
+        WHERE module = 'default_check_type' AND name = 'default_check_type'
+    ''')
+
+    op.drop_table('checks', schema='event_registration')
+    op.drop_table('check_types', schema='event_registration')

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -154,6 +154,8 @@ def _sidemenu_items(sender, **kwargs):
                            section='customization')
         yield SideMenuItem('data_retention', _('Data Retention'), url_for('events.data_retention'),
                            section='customization')
+        yield SideMenuItem('check_types', _('Check Types'), url_for('events.check_types'),
+                           section='customization')
 
 
 @signals.menu.sections.connect_via('top-menu')

--- a/indico/modules/events/__init__.py
+++ b/indico/modules/events/__init__.py
@@ -155,6 +155,8 @@ def _sidemenu_items(sender, **kwargs):
                            section='customization')
         yield SideMenuItem('data_retention', _('Data Retention'), url_for('events.data_retention'),
                            section='customization')
+        yield SideMenuItem('check_types', _('Check Types'), url_for('events.check_types'),
+                           section='customization')
 
 
 @signals.menu.sections.connect_via('top-menu')

--- a/indico/modules/events/blueprint.py
+++ b/indico/modules/events/blueprint.py
@@ -5,11 +5,12 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from indico.modules.events.controllers.admin import (RHAutoLinker, RHAutoLinkerConfig, RHCreateEventLabel,
-                                                     RHCreateReferenceType, RHDataRetentionSettings, RHDeleteEventLabel,
-                                                     RHDeleteReferenceType, RHEditEventLabel, RHEditReferenceType,
-                                                     RHEventLabels, RHReferenceTypes, RHUnlistedEvents,
-                                                     RHUpdateAllowedKeywords)
+from indico.modules.events.controllers.admin import (RHAutoLinker, RHAutoLinkerConfig, RHCheckTypes, RHCreateCheckType,
+                                                     RHCreateEventLabel, RHCreateReferenceType, RHDataRetentionSettings,
+                                                     RHDeleteCheckType, RHDeleteEventLabel, RHDeleteReferenceType,
+                                                     RHEditCheckType, RHEditEventLabel, RHEditReferenceType,
+                                                     RHEventLabels, RHReferenceTypes, RHToggleDefaultCheckType,
+                                                     RHUnlistedEvents, RHUpdateAllowedKeywords)
 from indico.modules.events.controllers.api import RHEventCheckEmail, RHSingleEventAPI
 from indico.modules.events.controllers.creation import RHCreateEvent, RHPrepareEvent
 from indico.modules.events.controllers.display import (RHAutoLinkerRules, RHDisplayPrivacyPolicy, RHEventAccessKey,
@@ -33,6 +34,9 @@ _bp.add_url_rule('/admin/autolinker/', 'autolinker_admin', RHAutoLinker)
 _bp.add_url_rule('/admin/data-retention/', 'data_retention', RHDataRetentionSettings,
                  methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/autolinker/config', 'autolinker_config', RHAutoLinkerConfig, methods=('POST',))
+_bp.add_url_rule('/admin/check-types/', 'check_types', RHCheckTypes, methods=('GET', 'POST'))
+_bp.add_url_rule('/admin/check-types/create', 'create_check_type', RHCreateCheckType, methods=('GET', 'POST'))
+_bp.add_url_rule('/admin/check-types/toggle', 'toggle_default_check_type', RHToggleDefaultCheckType, methods=('POST',))
 
 # Single reference type
 _bp.add_url_rule('/admin/external-id-types/<int:reference_type_id>/edit', 'update_reference_type', RHEditReferenceType,
@@ -44,6 +48,12 @@ _bp.add_url_rule('/admin/external-id-types/<int:reference_type_id>', 'delete_ref
 _bp.add_url_rule('/admin/event-labels/<int:event_label_id>/edit', 'update_event_label', RHEditEventLabel,
                  methods=('GET', 'POST'))
 _bp.add_url_rule('/admin/event-labels/<int:event_label_id>', 'delete_event_label', RHDeleteEventLabel,
+                 methods=('DELETE',))
+
+# Single check type
+_bp.add_url_rule('/admin/check-types/<int:check_type_id>/edit', 'update_check_type', RHEditCheckType,
+                 methods=('GET', 'POST'))
+_bp.add_url_rule('/admin/check-types/<int:check_type_id>', 'delete_check_type', RHDeleteCheckType,
                  methods=('DELETE',))
 
 # Auto-linker rules

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -9,6 +9,7 @@ from flask import flash, redirect, request
 from webargs import fields
 
 from indico.core.db import db
+from indico.core.errors import NoReportError
 from indico.modules.admin import RHAdminBase
 from indico.modules.events.forms import (AllowedKeywordsForm, DataRetentionSettingsForm, EventLabelForm,
                                          ReferenceTypeForm, UnlistedEventsForm)
@@ -17,8 +18,13 @@ from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
 from indico.modules.events.operations import (create_event_label, create_reference_type, delete_event_label,
                                               delete_reference_type, update_event_label, update_reference_type)
+from indico.modules.events.registration.forms import RegistrationCheckTypeForm
+from indico.modules.events.registration.models.checks import RegistrationCheckType
+from indico.modules.events.registration.util import (create_registration_check_type, delete_registration_check_type,
+                                                     update_registration_check_type)
 from indico.modules.events.schemas import AutoLinkerRuleSchema
-from indico.modules.events.settings import autolinker_settings, data_retention_settings, unlisted_events_settings
+from indico.modules.events.settings import (autolinker_settings, data_retention_settings, default_check_type_settings,
+                                            unlisted_events_settings)
 from indico.modules.events.views import WPEventAdmin
 from indico.util.i18n import _
 from indico.util.string import natural_sort_key
@@ -206,3 +212,83 @@ class RHDataRetentionSettings(RHAdminBase):
             flash(_('Settings have been saved'), 'success')
             return redirect(url_for('events.data_retention'))
         return WPEventAdmin.render_template('admin/data_retention.html', 'data_retention', form=form)
+
+
+def _get_all_system_check_types():
+    return (RegistrationCheckType.query
+            .filter(RegistrationCheckType.is_system_defined)
+            .order_by(db.func.lower(RegistrationCheckType.title)).all())
+
+
+def _render_check_types():
+    tpl = get_template_module('events/admin/_system_check_type_list.html')
+    default_check_type = default_check_type_settings.get('default_check_type')
+    return tpl.render_check_types(_get_all_system_check_types(), default_check_type)
+
+
+class RHManageCheckTypeBase(RHAdminBase):
+    """Base class for a specific check type."""
+
+    def _process_args(self):
+        RHAdminBase._process_args(self)
+        self.check_type = RegistrationCheckType.get_or_404(request.view_args['check_type_id'])
+
+
+class RHCheckTypes(RHAdminBase):
+    """Manage check types in server admin area."""
+
+    def _process(self):
+        check_types = _get_all_system_check_types()
+        default_check_type = default_check_type_settings.get('default_check_type')
+        return WPEventAdmin.render_template('admin/system_check_types.html', 'check_types', check_types=check_types,
+                                            default_check_type=default_check_type)
+
+
+class RHCreateCheckType(RHAdminBase):
+    """Create a new check type."""
+
+    def _process(self):
+        form = RegistrationCheckTypeForm()
+        if form.validate_on_submit():
+            check_type = create_registration_check_type(form.data)
+            flash(_('Check type "{}" created successfully').format(check_type.title), 'success')
+            return jsonify_data(html=_render_check_types())
+        return jsonify_form(form)
+
+
+class RHEditCheckType(RHManageCheckTypeBase):
+    """Edit an existing check type."""
+
+    def _process(self):
+        form = RegistrationCheckTypeForm(obj=FormDefaults(self.check_type), check_type=self.check_type)
+        if form.validate_on_submit():
+            update_registration_check_type(self.check_type, form.data)
+            flash(_('Check type "{}" successfully updated').format(self.check_type.title), 'success')
+            return jsonify_data(html=_render_check_types())
+        return jsonify_form(form)
+
+
+class RHDeleteCheckType(RHManageCheckTypeBase):
+    """Delete an existing check type."""
+
+    def _process_DELETE(self):
+        default_check_type = default_check_type_settings.get('default_check_type')
+        if default_check_type == self.check_type:
+            raise NoReportError('Cannot delete check type currently set as default')
+        delete_registration_check_type(self.check_type)
+        flash(_('Check type "{}" successfully deleted').format(self.check_type.title), 'success')
+        return jsonify_data(html=_render_check_types())
+
+
+class RHToggleDefaultCheckType(RHAdminBase):
+    """Toggle the default check type for this instance."""
+
+    @use_kwargs({
+        'check_type_id': fields.Integer(),
+    }, location='query')
+    def _process(self, check_type_id):
+        check_type = RegistrationCheckType.get_or_404(check_type_id)
+        if not check_type.is_system_defined:
+            raise Exception('Invalid check type')
+        default_check_type_settings.set('default_check_type', check_type)
+        return jsonify_data(html=_render_check_types())

--- a/indico/modules/events/export.yaml
+++ b/indico/modules/events/export.yaml
@@ -119,6 +119,14 @@ export:
       category_id: category_id = SKIP if VALUE not in CATEGORIES else MAKE_ID_REF(Category.id, VALUE)
       url_shortcut: ~
       label_id: label_id = EventLabel.get(VALUE).title
+      default_check_type_id: |
+        _check_type = RegistrationCheckType.get(VALUE)
+        if _check_type is None:
+          default_check_type_id = SKIP
+        elif _check_type.is_system_defined:
+          default_check_type_id = _check_type.title
+        else:
+          default_check_type_id = MAKE_ID_REF(RegistrationCheckType.id, VALUE)
     fks:
       - EventPerson.event_id
       - EventPersonLink.event_id
@@ -146,6 +154,7 @@ export:
       - EventPrincipal.event_id
       - EventNote.event_id
       - RegistrationTag.event_id
+      - RegistrationCheckType.event_id
       - RegistrationForm.event_id
       - Survey.event_id
       - DesignerTemplate.event_id
@@ -501,6 +510,7 @@ export:
       - Registration.tags.prop.secondary.c.registration_id
       - PaymentTransaction.registration_id
       - ReceiptFile.registration_id
+      - RegistrationCheck.registration_id
 
   RegistrationFormItem:
     # top-level items first to satisfy top_level_sections check constraint
@@ -531,6 +541,19 @@ export:
   RegistrationInvitation:
     cols:
       uuid: uuid = VALUE if KEEP_UUIDS else SKIP
+  RegistrationCheckType:
+    skipif: ROW.is_system_defined
+    allow_duplicates: true
+
+  RegistrationCheck:
+    cols:
+      check_type_id: |
+        _check_type = RegistrationCheckType.get(VALUE)
+        if _check_type.is_system_defined:
+          check_type_id = _check_type.title
+        else:
+          check_type_id = MAKE_ID_REF(RegistrationCheckType.id, VALUE)
+
   RegistrationTag: {}
   event_registration.registration_tags: {}
 
@@ -627,6 +650,21 @@ import:
         label_id = None
         if _label := EventLabel.query.filter_by(title=VALUE).first():
           label_id = _label.id
+      default_check_type_id: |
+        if isinstance(VALUE, str):
+          _check_type = RegistrationCheckType.query.filter_by(title=VALUE, is_system_defined=True).first()
+          default_check_type_id = _check_type.id if _check_type else None
+        else:
+          default_check_type_id = RESOLVE_ID_REF(VALUE, None)
+
+    RegistrationCheck:
+      check_type_id: |
+        if isinstance(VALUE, str):
+          check_type_id = (RegistrationCheckType.query.filter_by(title=VALUE, is_system_defined=True).first() or
+                           RegistrationCheckType.query.filter_by(is_system_defined=True)
+                           .order_by(RegistrationCheckType.id).first()).id
+        else:
+          check_type_id = RESOLVE_ID_REF(VALUE)
 
     AbstractEmailTemplate:
       rules: |

--- a/indico/modules/events/export_test.py
+++ b/indico/modules/events/export_test.py
@@ -18,6 +18,7 @@ from indico.modules.attachments.util import get_attached_items
 from indico.modules.events.contributions import Contribution
 from indico.modules.events.export import export_event, import_event
 from indico.modules.events.sessions import Session
+from indico.modules.events.settings import default_check_type_settings
 from indico.testing.util import assert_yaml_snapshot
 from indico.util.date_time import as_utc
 
@@ -115,11 +116,11 @@ def test_event_attachment_export(db, dummy_event):
         assert file_['size'] == 11
         assert file_['md5'] == '5eb63bbbe01eeed093cb22bb8f5acdc3'
         # check that the file itself was included (and verify content)
-        assert tarf.getnames() == ['00000000-0000-4000-8000-000000000013', 'objects-1.yaml', 'data.yaml', 'ids.yaml']
-        assert tarf.extractfile('00000000-0000-4000-8000-000000000013').read() == b'hello world'
+        assert tarf.getnames() == ['00000000-0000-4000-8000-000000000014', 'objects-1.yaml', 'data.yaml', 'ids.yaml']
+        assert tarf.extractfile('00000000-0000-4000-8000-000000000014').read() == b'hello world'
 
 
-def test_event_import(db, dummy_user):
+def test_event_import(db, dummy_user, dummy_check_type):
     data_yaml_content = (Path(__file__).parent / 'tests' / 'export_test_2.yaml').read_text()
     objects_yaml_content = (Path(__file__).parent / 'tests' / 'export_test_2_objects.yaml').read_text()
     data_yaml = BytesIO(data_yaml_content.encode())
@@ -129,6 +130,8 @@ def test_event_import(db, dummy_user):
     # User should be matched by e-mail
     dummy_user.email = '1337@example.test'
     db.session.flush()
+
+    default_check_type_settings.set('default_check_type', dummy_check_type)
 
     # create a tar file artificially, using the provided YAML
     with tarfile.open(mode='w', fileobj=tar_buffer) as tarf:

--- a/indico/modules/events/export_test.py
+++ b/indico/modules/events/export_test.py
@@ -119,7 +119,7 @@ def test_event_attachment_export(db, dummy_event):
         assert tarf.extractfile('00000000-0000-4000-8000-000000000013').read() == b'hello world'
 
 
-def test_event_import(db, dummy_user):
+def test_event_import(db, dummy_user, dummy_check_type):
     data_yaml_content = (Path(__file__).parent / 'tests' / 'export_test_2.yaml').read_text()
     objects_yaml_content = (Path(__file__).parent / 'tests' / 'export_test_2_objects.yaml').read_text()
     data_yaml = BytesIO(data_yaml_content.encode())
@@ -146,6 +146,7 @@ def test_event_import(db, dummy_user):
     e = import_event(tar_buffer, create_users=False)[0]
     # Check that event metadata is fine
     assert e.title == 'dummy#0'
+    assert e.default_check_type == dummy_check_type
     assert e.creator == dummy_user
     assert e.created_dt == as_utc(datetime(2017, 8, 24, 15, 28, 42, 652626))
     assert e.start_dt == as_utc(datetime(2017, 8, 24, 10, 0, 0))

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -277,6 +277,13 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         nullable=False,
         default=True
     )
+    #: Default `RegistrationCheckType` for the event
+    default_check_type_id = db.Column(
+        db.Integer,
+        db.ForeignKey('event_registration.check_types.id'),
+        index=True,
+        nullable=False
+    )
 
     #: The last user-friendly registration ID
     _last_friendly_registration_id = db.deferred(db.Column(
@@ -387,6 +394,17 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
             lazy=True
         )
     )
+    #: The default check to be performed on registrations of this event
+    default_check_type = db.relationship(
+        'RegistrationCheckType',
+        foreign_keys=default_check_type_id,
+        post_update=True,
+        lazy=True,
+        backref=db.backref(
+            'default_check_type_of',
+            lazy=True
+        )
+    )
     #: The current pending move request
     pending_move_request = db.relationship(
         'EventMoveRequest',
@@ -409,6 +427,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     # - all_room_reservation_occurrence_links (ReservationOccurrenceLink.event)
     # - all_vc_room_associations (VCRoomEventAssociation.event)
     # - attachment_folders (AttachmentFolder.linked_event)
+    # - check_types (RegistrationCheckType.event)
     # - clones (Event.cloned_from)
     # - contribution_fields (ContributionField.event)
     # - contribution_types (ContributionType.event)

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -277,6 +277,13 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         nullable=False,
         default=True
     )
+    #: Default `RegistrationCheckType` for the event
+    default_check_type_id = db.Column(
+        db.Integer,
+        db.ForeignKey('event_registration.check_types.id'),
+        index=True,
+        nullable=True
+    )
 
     #: The last user-friendly registration ID
     _last_friendly_registration_id = db.deferred(db.Column(
@@ -387,6 +394,17 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
             lazy=True
         )
     )
+    #: The default check to be performed on registrations of this event
+    default_check_type = db.relationship(
+        'RegistrationCheckType',
+        foreign_keys=default_check_type_id,
+        post_update=True,
+        lazy=True,
+        backref=db.backref(
+            'default_check_type_of',
+            lazy=True
+        )
+    )
     #: The current pending move request
     pending_move_request = db.relationship(
         'EventMoveRequest',
@@ -409,6 +427,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
     # - all_room_reservation_occurrence_links (ReservationOccurrenceLink.event)
     # - all_vc_room_associations (VCRoomEventAssociation.event)
     # - attachment_folders (AttachmentFolder.linked_event)
+    # - check_types (RegistrationCheckType.event)
     # - clones (Event.cloned_from)
     # - contribution_fields (ContributionField.event)
     # - contribution_types (ContributionType.event)

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -22,6 +22,7 @@ from indico.modules.events.management.settings import privacy_settings
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
+from indico.modules.events.settings import default_check_type_settings
 from indico.modules.events.util import format_log_person, format_log_ref, split_log_location_changes
 from indico.modules.logs.models.entries import CategoryLogRealm, LogKind
 from indico.modules.logs.util import make_diff_log
@@ -94,7 +95,8 @@ def create_event(category, event_type, data, add_creator_as_manager=True, featur
     :param cloning: Whether the event is created via cloning or not
     """
     from indico.modules.rb.operations.bookings import create_booking_for_event
-    event = Event(category=category, type_=event_type)
+    check_type = default_check_type_settings.get('default_check_type')
+    event = Event(category=category, type_=event_type, default_check_type_id=check_type.id)
     data.setdefault('creator', session.user)
     theme = data.pop('theme', None)
     create_booking = data.pop('create_booking', False)

--- a/indico/modules/events/operations.py
+++ b/indico/modules/events/operations.py
@@ -22,6 +22,7 @@ from indico.modules.events.management.settings import privacy_settings
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.labels import EventLabel
 from indico.modules.events.models.references import ReferenceType
+from indico.modules.events.settings import default_check_type_settings
 from indico.modules.events.util import format_log_person, format_log_ref, split_log_location_changes
 from indico.modules.logs.models.entries import CategoryLogRealm, LogKind
 from indico.modules.logs.util import make_diff_log
@@ -94,7 +95,9 @@ def create_event(category, event_type, data, add_creator_as_manager=True, featur
     :param cloning: Whether the event is created via cloning or not
     """
     from indico.modules.rb.operations.bookings import create_booking_for_event
-    event = Event(category=category, type_=event_type)
+    check_type = default_check_type_settings.get('default_check_type')
+    event = Event(category=category, type_=event_type,
+                  default_check_type_id=(check_type.id if check_type else None))
     data.setdefault('creator', session.user)
     theme = data.pop('theme', None)
     create_booking = data.pop('create_booking', False)

--- a/indico/modules/events/operations_test.py
+++ b/indico/modules/events/operations_test.py
@@ -11,17 +11,18 @@ import pytest
 from flask import session
 
 from indico.modules.events.operations import clone_event
-from indico.modules.events.settings import event_language_settings
+from indico.modules.events.settings import default_check_type_settings, event_language_settings
 
 
 @pytest.mark.usefixtures('request_context')
-def test_language_settings_cloned(dummy_event, dummy_user):
+def test_language_settings_cloned(dummy_event, dummy_user, dummy_check_type):
     # Set up language settings
     event_language_settings.set(dummy_event, 'default_locale', 'fr_FR')
     event_language_settings.set(dummy_event, 'enforce_locale', True)
     event_language_settings.set(dummy_event, 'supported_locales', ['es_ES', 'en_GB'])
     session.set_session_user(dummy_user)
     # Clone the event
+    default_check_type_settings.set('default_check_type', dummy_check_type)
     new_event = clone_event(dummy_event, 1, datetime(2025, 6, 19, 13, 37), set())
     # Assert that the language settings are cloned correctly
     assert event_language_settings.get(new_event, 'default_locale') == 'fr_FR'

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -10,8 +10,8 @@ from indico.modules.events.registration.controllers.api import checkin as api_ch
 from indico.modules.events.registration.controllers.api import checkin_legacy as api_checkin_legacy
 from indico.modules.events.registration.controllers.api import misc as api_misc
 from indico.modules.events.registration.controllers.compat import compat_registration
-from indico.modules.events.registration.controllers.management import (fields, invitations, privacy, regforms, reglists,
-                                                                       sections, tags, tickets)
+from indico.modules.events.registration.controllers.management import (checks, fields, invitations, privacy, regforms,
+                                                                       reglists, sections, tags, tickets)
 from indico.web.flask.util import make_compat_redirect_func
 from indico.web.flask.wrappers import IndicoBlueprint
 
@@ -99,8 +99,6 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:regi
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/schedule-modification',
                  'registration_schedule_modification',
                  reglists.RHRegistrationScheduleModification, methods=('GET', 'POST'))
-_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/check-in',
-                 'registration_check_in', reglists.RHRegistrationCheckIn, methods=('PUT', 'DELETE'))
 _bp.add_url_rule(
     '/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/receipts/<int:file_id>/<filename>',
     'download_receipt', reglists.RHDownloadReceipt)
@@ -135,8 +133,6 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/reset', '
                  reglists.RHRegistrationsReset, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/update-price', 'registrations_update_price',
                  reglists.RHRegistrationsBasePrice, methods=('POST',))
-_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/check-in', 'registrations_check_in',
-                 reglists.RHRegistrationBulkCheckIn, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/attachments', 'registrations_attachments_export',
                  reglists.RHRegistrationsExportAttachments, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/receipts', 'registrations_receipts_export',
@@ -195,6 +191,28 @@ _bp.add_url_rule('/manage/registration/tags/<int:tag_id>/delete', 'manage_regist
                  tags.RHRegistrationTagDelete, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/tags/assign', 'manage_registration_tags_assign',
                  tags.RHRegistrationTagsAssign, methods=('POST',))
+
+# Registration checks management
+_bp.add_url_rule('/manage/registration/checks', 'manage_registration_check_types',
+                 checks.RHManageRegistrationCheckTypes, methods=('GET',))
+_bp.add_url_rule('/manage/registration/checks/add', 'manage_registration_check_types_add',
+                 checks.RHRegistrationCheckTypeAdd, methods=('GET', 'POST'))
+_bp.add_url_rule('/manage/registration/checks/<int:check_type_id>/delete', 'manage_registration_check_types_delete',
+                 checks.RHRegistrationCheckTypeDelete, methods=('POST',))
+_bp.add_url_rule('/manage/registration/checks/<int:check_type_id>/edit', 'manage_registration_check_types_edit',
+                 checks.RHRegistrationCheckTypeEdit, methods=('GET', 'POST'))
+_bp.add_url_rule('/manage/registration/checks/toggle', 'manage_registration_check_types_toggle',
+                 checks.RHRegistrationCheckTypeToggleDefault, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/check',
+                 'add_registration_check', checks.RHRegistrationChecksAdd, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/checks',
+                 'registration_checks', checks.RHRegistrationChecks)
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/reset-checks',
+                 'reset_registration_checks', checks.RHRegistrationChecksReset, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/delete-check/<int:check_id>',
+                 'delete_registration_check', checks.RHRegistrationChecksDelete, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/check', 'registrations_check',
+                 checks.RHRegistrationBulkCheck, methods=('POST',))
 
 # Regform edition: sections
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/form/sections', 'add_section',

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -10,8 +10,8 @@ from indico.modules.events.registration.controllers.api import checkin as api_ch
 from indico.modules.events.registration.controllers.api import checkin_legacy as api_checkin_legacy
 from indico.modules.events.registration.controllers.api import misc as api_misc
 from indico.modules.events.registration.controllers.compat import compat_registration
-from indico.modules.events.registration.controllers.management import (fields, invitations, privacy, regforms, reglists,
-                                                                       sections, tags, tickets)
+from indico.modules.events.registration.controllers.management import (checks, fields, invitations, privacy, regforms,
+                                                                       reglists, sections, tags, tickets)
 from indico.web.flask.util import make_compat_redirect_func
 from indico.web.flask.wrappers import IndicoBlueprint
 
@@ -101,8 +101,6 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:regi
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/schedule-modification',
                  'registration_schedule_modification',
                  reglists.RHRegistrationScheduleModification, methods=('GET', 'POST'))
-_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/check-in',
-                 'registration_check_in', reglists.RHRegistrationCheckIn, methods=('PUT', 'DELETE'))
 _bp.add_url_rule(
     '/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/receipts/<int:file_id>/<filename>',
     'download_receipt', reglists.RHDownloadReceipt)
@@ -137,8 +135,6 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/reset', '
                  reglists.RHRegistrationsReset, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/update-price', 'registrations_update_price',
                  reglists.RHRegistrationsBasePrice, methods=('POST',))
-_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/check-in', 'registrations_check_in',
-                 reglists.RHRegistrationBulkCheckIn, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/attachments', 'registrations_attachments_export',
                  reglists.RHRegistrationsExportAttachments, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/receipts', 'registrations_receipts_export',
@@ -197,6 +193,28 @@ _bp.add_url_rule('/manage/registration/tags/<int:tag_id>/delete', 'manage_regist
                  tags.RHRegistrationTagDelete, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/tags/assign', 'manage_registration_tags_assign',
                  tags.RHRegistrationTagsAssign, methods=('POST',))
+
+# Registration checks management
+_bp.add_url_rule('/manage/registration/checks', 'manage_registration_check_types',
+                 checks.RHManageRegistrationCheckTypes, methods=('GET',))
+_bp.add_url_rule('/manage/registration/checks/add', 'manage_registration_check_types_add',
+                 checks.RHRegistrationCheckTypeAdd, methods=('GET', 'POST'))
+_bp.add_url_rule('/manage/registration/checks/<int:check_type_id>/delete', 'manage_registration_check_types_delete',
+                 checks.RHRegistrationCheckTypeDelete, methods=('POST',))
+_bp.add_url_rule('/manage/registration/checks/<int:check_type_id>/edit', 'manage_registration_check_types_edit',
+                 checks.RHRegistrationCheckTypeEdit, methods=('GET', 'POST'))
+_bp.add_url_rule('/manage/registration/checks/toggle', 'manage_registration_check_types_toggle',
+                 checks.RHRegistrationCheckTypeToggleDefault, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/check',
+                 'add_registration_check', checks.RHRegistrationChecksAdd, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/checks',
+                 'registration_checks', checks.RHRegistrationChecks)
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/reset-checks',
+                 'reset_registration_checks', checks.RHRegistrationChecksReset, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/<int:registration_id>/delete-check/<int:check_id>',
+                 'delete_registration_check', checks.RHRegistrationChecksDelete, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/check', 'registrations_check',
+                 checks.RHRegistrationBulkCheck, methods=('POST',))
 
 # Regform edition: sections
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/form/sections', 'add_section',

--- a/indico/modules/events/registration/controllers/api/checkin.py
+++ b/indico/modules/events/registration/controllers/api/checkin.py
@@ -10,19 +10,20 @@ from io import BytesIO
 from flask import jsonify, request
 from sqlalchemy.orm import joinedload, selectinload, undefer
 from webargs import fields
-from werkzeug.exceptions import BadRequest, NotFound
+from werkzeug.exceptions import BadRequest, NotFound, UnprocessableEntity
 
-from indico.core import signals
 from indico.core.config import config
 from indico.modules.events.management.controllers.base import RHManageEventBase
 from indico.modules.events.payment.util import toggle_registration_payment
+from indico.modules.events.registration.models.checks import RegistrationCheckType
 from indico.modules.events.registration.models.form_fields import RegistrationFormFieldData
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import Registration, RegistrationData
 from indico.modules.events.registration.schemas import (CheckinEventSchema, CheckinRegFormSchema,
                                                         CheckinRegistrationSchema)
-from indico.modules.events.registration.util import _base64_encode_uuid, get_custom_ticket_qr_code_handlers
+from indico.modules.events.registration.util import (_base64_encode_uuid, create_registration_check,
+                                                     get_custom_ticket_qr_code_handlers)
 from indico.util.marshmallow import not_empty
 from indico.web.args import use_kwargs
 from indico.web.flask.util import send_file
@@ -48,20 +49,27 @@ class RHCheckinAPIEventDetails(RHCheckinAPIBase):
 class RHCheckinAPIRegForms(RHCheckinAPIBase):
     """Get details about the registrations forms in an event."""
 
-    def _process(self):
+    @use_kwargs({
+        'check_type_id': fields.Integer(),
+    }, location='query')
+    def _process(self, check_type_id=None):
         regforms = (RegistrationForm.query
                     .with_parent(self.event)
                     .filter(~RegistrationForm.is_deleted)
                     .options(undefer('existing_registrations_count'), undefer('checked_in_registrations_count'))
                     .all())
-        return CheckinRegFormSchema(many=True).jsonify(regforms)
+        return CheckinRegFormSchema(many=True, context={'check_type_id': check_type_id}).jsonify(regforms)
 
 
 class RHCheckinAPIRegFormBase(RHCheckinAPIBase):
     """Base class for Check-in API endpoints for a specific regform."""
 
-    def _process_args(self):
+    @use_kwargs({
+        'check_type_id': fields.Integer(),
+    }, location='query')
+    def _process_args(self, check_type_id=None):
         RHCheckinAPIBase._process_args(self)
+        self.check_type_id = check_type_id
         self.regform = (RegistrationForm.query
                         .with_parent(self.event)
                         .filter_by(id=request.view_args['reg_form_id'], is_deleted=False)
@@ -72,7 +80,7 @@ class RHCheckinAPIRegFormDetails(RHCheckinAPIRegFormBase):
     """Get details about a specific registration form."""
 
     def _process(self):
-        return CheckinRegFormSchema().jsonify(self.regform)
+        return CheckinRegFormSchema(context={'check_type_id': self.check_type_id}).jsonify(self.regform)
 
 
 class RHCheckinAPIRegistrations(RHCheckinAPIRegFormBase):
@@ -86,7 +94,8 @@ class RHCheckinAPIRegistrations(RHCheckinAPIRegFormBase):
                                   joinedload('transaction'),
                                   undefer('occupied_slots'))
                          .all())
-        return CheckinRegistrationSchema(many=True, exclude=('registration_data',)).jsonify(registrations)
+        return CheckinRegistrationSchema(many=True, exclude=('registration_data',),
+                                         context={'check_type_id': self.check_type_id}).jsonify(registrations)
 
 
 class RHCheckinAPIRegistration(RHCheckinAPIRegFormBase):
@@ -111,13 +120,29 @@ class RHCheckinAPIRegistration(RHCheckinAPIRegFormBase):
                              .first_or_404())
 
     def _process_GET(self):
-        return CheckinRegistrationSchema().jsonify(self.registration)
+        return CheckinRegistrationSchema(context={'check_type_id': self.check_type_id}).jsonify(self.registration)
 
-    @use_kwargs({'checked_in': fields.Bool(), 'paid': fields.Bool()})
-    def _process_PATCH(self, checked_in=None, paid=None):
-        if checked_in is not None:
-            self.registration.checked_in = checked_in
-            signals.event.registration_checkin_updated.send(self.registration)
+    @use_kwargs({
+        'checked_in': fields.Bool(),
+        'checked_out': fields.Bool(),
+        'check_type_id': fields.Integer(),
+        'paid': fields.Bool()
+    })
+    def _process_PATCH(self, checked_in=None, checked_out=None, check_type_id=None, paid=None):
+        if checked_in is not None or checked_out is not None:
+            if check_type_id is not None:
+                check_type = RegistrationCheckType.get_or_404(check_type_id)
+            else:
+                check_type = self.event.default_check_type
+            is_check_out = checked_out is not None
+            action = bool(checked_out) if is_check_out else bool(checked_in)
+            try:
+                if action:
+                    create_registration_check(self.registration, check_type=check_type, is_check_out=is_check_out)
+                else:
+                    self.registration.checks.remove(self.registration.get_last_check_for_type(check_type.id))
+            except ValueError as e:
+                raise UnprocessableEntity(str(e))
         if paid is not None and paid != self.registration.is_paid and self.registration.price:
             toggle_registration_payment(self.registration, paid=paid)
         return CheckinRegistrationSchema().jsonify(self.registration)
@@ -136,8 +161,11 @@ class RHCheckinAPIRegistrationUUID(RHCheckinAPIBase):
         if self.regform.is_deleted:
             raise NotFound
 
-    def _process_GET(self):
-        return CheckinRegistrationSchema().jsonify(self.registration)
+    @use_kwargs({
+        'check_type_id': fields.Integer(),
+    }, location='query')
+    def _process_GET(self, check_type_id=None):
+        return CheckinRegistrationSchema(context={'check_type_id': check_type_id}).jsonify(self.registration)
 
 
 class RHCheckinAPIRegistrationCustomQRCode(RHCheckinAPIBase):

--- a/indico/modules/events/registration/controllers/api/checkin_legacy.py
+++ b/indico/modules/events/registration/controllers/api/checkin_legacy.py
@@ -9,10 +9,10 @@ from flask import jsonify, request, session
 from sqlalchemy.orm import joinedload
 from werkzeug.exceptions import BadRequest, Forbidden
 
-from indico.core import signals
 from indico.modules.events import Event
 from indico.modules.events.registration.models.registrations import RegistrationState
-from indico.modules.events.registration.util import build_registration_api_data, build_registrations_api_data
+from indico.modules.events.registration.util import (build_registration_api_data, build_registrations_api_data,
+                                                     create_registration_check)
 from indico.web.rh import RH, oauth_scope
 
 
@@ -49,8 +49,11 @@ class RHAPIRegistrant(RH):
         if 'checked_in' in request.json:
             if self._registration.state not in (RegistrationState.complete, RegistrationState.unpaid):
                 raise BadRequest('This registration cannot be marked as checked-in')
-            self._registration.checked_in = bool(request.json['checked_in'])
-            signals.event.registration_checkin_updated.send(self._registration)
+            try:
+                create_registration_check(self.registration, is_check_out=not bool(request.json['checked_in']),
+                                          checked_by_user=session.user)
+            except ValueError:
+                pass
 
         return jsonify(build_registration_api_data(self._registration))
 

--- a/indico/modules/events/registration/controllers/api/test_snapshots/checkin_event_details.yml
+++ b/indico/modules/events/registration/controllers/api/test_snapshots/checkin_event_details.yml
@@ -1,3 +1,9 @@
+check_types:
+- id: <id>
+  title: Check type (Once)
+default_check_type:
+  id: <id>
+  title: Check type (Once)
 description: ''
 end_dt: <timestamp>
 id: <id>

--- a/indico/modules/events/registration/controllers/api/test_snapshots/checkin_registration_details.yml
+++ b/indico/modules/events/registration/controllers/api/test_snapshots/checkin_registration_details.yml
@@ -1,5 +1,7 @@
 checked_in: true
 checked_in_dt: <timestamp>
+checked_out: false
+checked_out_dt: <timestamp>
 checkin_secret: <uuid>
 currency: USD
 email: 1337@example.test

--- a/indico/modules/events/registration/controllers/api/test_snapshots/checkin_registrations.yml
+++ b/indico/modules/events/registration/controllers/api/test_snapshots/checkin_registrations.yml
@@ -1,5 +1,7 @@
 - checked_in: true
   checked_in_dt: <timestamp>
+  checked_out: false
+  checked_out_dt: <timestamp>
   checkin_secret: <uuid>
   currency: USD
   email: 1337@example.test

--- a/indico/modules/events/registration/controllers/management/checks.py
+++ b/indico/modules/events/registration/controllers/management/checks.py
@@ -1,0 +1,191 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2026 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from flask import flash, request, session
+from webargs import fields
+from werkzeug.exceptions import BadRequest
+
+from indico.core.db import db
+from indico.core.errors import NoReportError
+from indico.modules.events import EventLogRealm
+from indico.modules.events.registration import logger
+from indico.modules.events.registration.controllers.management import RHManageRegFormsBase, RHManageRegistrationBase
+from indico.modules.events.registration.controllers.management.reglists import (RHRegistrationsActionBase,
+                                                                                _render_registration_details)
+from indico.modules.events.registration.forms import RegistrationChecksAssignForm, RegistrationCheckTypeForm
+from indico.modules.events.registration.models.checks import RegistrationCheck, RegistrationCheckType
+from indico.modules.events.registration.models.registrations import RegistrationState
+from indico.modules.events.registration.util import (create_registration_check, create_registration_check_type,
+                                                     delete_registration_check_type, update_registration_check_type)
+from indico.modules.events.registration.views import WPManageRegistration
+from indico.modules.logs import LogKind
+from indico.util.i18n import _
+from indico.web.args import use_kwargs
+from indico.web.flask.templating import get_template_module
+from indico.web.util import jsonify_data, jsonify_form, jsonify_template
+
+
+def _render_registration_check_types(event):
+    tpl = get_template_module('events/registration/management/_registration_check_type_list.html')
+    return tpl.render_check_types(event.check_types, event)
+
+
+class RHManageRegistrationCheckTypeBase(RHManageRegFormsBase):
+    """Base class for a specific registration check type."""
+
+    def _process_args(self):
+        RHManageRegFormsBase._process_args(self)
+        self.check_type = RegistrationCheckType.query.with_parent(self.event, 'check_types').filter(
+            RegistrationCheckType.id == request.view_args['check_type_id']
+        ).first_or_404()
+
+
+class RHManageRegistrationCheckTypes(RHManageRegFormsBase):
+    """List all check types for an event."""
+
+    def _process(self):
+        system_check_types = (RegistrationCheckType.query
+                              .filter(RegistrationCheckType.is_system_defined)
+                              .order_by(db.func.lower(RegistrationCheckType.title))
+                              .all())
+        return WPManageRegistration.render_template('management/registration_check_types.html', self.event,
+                                                    system_check_types=system_check_types)
+
+
+class RHRegistrationCheckTypeAdd(RHManageRegFormsBase):
+    """Add a new registration check type."""
+
+    def _process(self):
+        form = RegistrationCheckTypeForm(event=self.event)
+        if form.validate_on_submit():
+            check_type = create_registration_check_type(form.data, self.event)
+            flash(_('A new check type "{}" has been created.').format(check_type.title), 'success')
+            return jsonify_data(html=_render_registration_check_types(self.event))
+        return jsonify_form(form)
+
+
+class RHRegistrationCheckTypeDelete(RHManageRegistrationCheckTypeBase):
+    """Delete a registration check type."""
+
+    def _process(self):
+        if self.check_type == self.event.default_check_type:
+            raise BadRequest(_('Cannot delete the current default check type of this event.'))
+        delete_registration_check_type(self.check_type)
+        flash(_('Check type "{}" has been deleted.').format(self.check_type.title), 'success')
+        return jsonify_data(html=_render_registration_check_types(self.event))
+
+
+class RHRegistrationCheckTypeEdit(RHManageRegistrationCheckTypeBase):
+    """Modify an existing registration check type."""
+
+    def _process(self):
+        form = RegistrationCheckTypeForm(obj=self.check_type, event=self.event, check_type=self.check_type)
+        if form.validate_on_submit():
+            update_registration_check_type(self.check_type, form.data)
+            flash(_('Check type "{}" has been modified.').format(self.check_type.title), 'success')
+            return jsonify_data(html=_render_registration_check_types(self.event))
+        return jsonify_form(form)
+
+
+class RHRegistrationCheckTypeToggleDefault(RHManageRegFormsBase):
+    """Toggle the default registration check type of the event."""
+
+    @use_kwargs({
+        'check_type_id': fields.Integer(),
+    }, location='query')
+    def _process(self, check_type_id):
+        check_type = RegistrationCheckType.get_or_404(check_type_id)
+        if not check_type.is_system_defined and check_type not in self.event.check_types:
+            raise Exception('Invalid check type')
+        if check_type != self.event.default_check_type:
+            self.event.default_check_type = check_type
+        return jsonify_data(flash=False)
+
+
+class RHRegistrationChecks(RHManageRegistrationBase):
+    def _process(self):
+        return jsonify_template('events/registration/management/registration_checks.html',
+                                registration=self.registration)
+
+
+class RHRegistrationChecksAdd(RHManageRegistrationBase):
+    """Set checked state of a registration."""
+
+    @use_kwargs({
+        'is_check_out': fields.Bool(load_default=False),
+    }, location='query')
+    def _process(self, is_check_out):
+        action = 'Checked-out' if is_check_out else 'Checked-in'
+        if self.registration.state not in (RegistrationState.complete, RegistrationState.unpaid):
+            raise BadRequest(_('This registration cannot be marked as checked-in/checked-out'))
+        try:
+            create_registration_check(self.registration, is_check_out=is_check_out, checked_by_user=session.user)
+        except ValueError as e:
+            raise NoReportError(e)
+        flash(_('Registration {} successfully.').format(action), 'success')
+        return jsonify_data(html=_render_registration_details(self.registration))
+
+
+class RHRegistrationChecksDelete(RHManageRegistrationBase):
+
+    normalize_url_spec = {
+        'locators': {
+            lambda self: self.check
+        }
+    }
+
+    def _process_args(self):
+        self.check = RegistrationCheck.query.filter_by(id=request.view_args['check_id']).one()
+        RHManageRegistrationBase._process_args(self)
+
+    def _process(self):
+        check_type = self.check.check_type
+        self.registration.checks.remove(self.check)
+        log_text = 'Previous registration check "{}" has been deleted for "{}"'
+        self.registration.log(EventLogRealm.participants, LogKind.change, 'Registration',
+                              log_text.format(check_type.title, self.registration.full_name), session.user)
+        flash(_('Registration check deleted successfully.'), 'success')
+        logger.info('Registration %s check "%s" deleted by %s', self.registration, check_type.title, session.user)
+        return '', 204
+
+
+class RHRegistrationChecksReset(RHManageRegistrationBase):
+
+    def _process(self):
+        self.registration.checks.clear()
+        log_text = 'All previous registration checks has been deleted for "{}"'
+        self.registration.log(EventLogRealm.participants, LogKind.change, 'Registration',
+                              log_text.format(self.registration.full_name), session.user)
+        flash(_('Registration checks reset successfully.'), 'success')
+        logger.info('Registration %s checks reset by %s', self.registration, session.user)
+        return '', 204
+
+
+class RHRegistrationBulkCheck(RHRegistrationsActionBase):
+    """Bulk apply check-in/check-out state to registrations."""
+
+    @use_kwargs({
+        'is_check_out': fields.Bool(load_default=False),
+    }, location='query')
+    def _process(self, is_check_out):
+        form = RegistrationChecksAssignForm(self.event, check_type_id=self.event.default_check_type_id,
+                                            registration_id=[r.id for r in self.registrations])
+        submit_text = _('Check-out') if is_check_out else _('Check-in')
+        if form.validate_on_submit():
+            action = 'Checked-out' if is_check_out else 'Checked-in'
+            check_type = RegistrationCheckType.query.get_or_404(form.check_type_id.data)
+            for registration in self.registrations:
+                if registration.state not in (RegistrationState.complete, RegistrationState.unpaid):
+                    continue
+                try:
+                    create_registration_check(registration, check_type=check_type, is_check_out=is_check_out,
+                                              checked_by_user=session.user)
+                except ValueError:
+                    pass
+            flash(_('Selected registrations marked as {} successfully.').format(action), 'success')
+            return jsonify_data(**self.list_generator.render_list())
+        return jsonify_form(form, disabled_until_change=False, submit=submit_text)

--- a/indico/modules/events/registration/controllers/management/checks.py
+++ b/indico/modules/events/registration/controllers/management/checks.py
@@ -1,0 +1,201 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2026 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from flask import flash, request, session
+from webargs import fields
+from werkzeug.exceptions import BadRequest
+
+from indico.core.db import db
+from indico.core.errors import NoReportError
+from indico.modules.events import EventLogRealm
+from indico.modules.events.registration import logger
+from indico.modules.events.registration.controllers.management import RHManageRegFormsBase, RHManageRegistrationBase
+from indico.modules.events.registration.controllers.management.reglists import (RHRegistrationsActionBase,
+                                                                                _render_registration_details)
+from indico.modules.events.registration.forms import RegistrationChecksAssignForm, RegistrationCheckTypeForm
+from indico.modules.events.registration.models.checks import RegistrationCheck, RegistrationCheckType
+from indico.modules.events.registration.models.registrations import RegistrationState
+from indico.modules.events.registration.util import (create_registration_check, create_registration_check_type,
+                                                     delete_registration_check_type, update_registration_check_type)
+from indico.modules.events.registration.views import WPManageRegistration
+from indico.modules.logs import LogKind
+from indico.util.i18n import _
+from indico.web.args import use_kwargs
+from indico.web.flask.templating import get_template_module
+from indico.web.util import jsonify_data, jsonify_form, jsonify_template
+
+
+def _render_registration_check_types(event):
+    tpl = get_template_module('events/registration/management/_registration_check_type_list.html')
+    return tpl.render_check_types(event.check_types, event)
+
+
+class RHManageRegistrationCheckTypeBase(RHManageRegFormsBase):
+    """Base class for a specific registration check type."""
+
+    def _process_args(self):
+        RHManageRegFormsBase._process_args(self)
+        self.check_type = RegistrationCheckType.query.with_parent(self.event, 'check_types').filter(
+            RegistrationCheckType.id == request.view_args['check_type_id']
+        ).first_or_404()
+
+
+class RHManageRegistrationCheckTypes(RHManageRegFormsBase):
+    """List all check types for an event."""
+
+    def _process(self):
+        system_check_types = (RegistrationCheckType.query
+                              .filter(RegistrationCheckType.is_system_defined)
+                              .order_by(db.func.lower(RegistrationCheckType.title))
+                              .all())
+        return WPManageRegistration.render_template('management/registration_check_types.html', self.event,
+                                                    system_check_types=system_check_types)
+
+
+class RHRegistrationCheckTypeAdd(RHManageRegFormsBase):
+    """Add a new registration check type."""
+
+    def _process(self):
+        form = RegistrationCheckTypeForm(event=self.event)
+        if form.validate_on_submit():
+            check_type = create_registration_check_type(form.data, self.event)
+            flash(_('A new check type "{}" has been created.').format(check_type.title), 'success')
+            return jsonify_data(html=_render_registration_check_types(self.event))
+        return jsonify_form(form)
+
+
+class RHRegistrationCheckTypeDelete(RHManageRegistrationCheckTypeBase):
+    """Delete a registration check type."""
+
+    def _process(self):
+        if self.check_type == self.event.default_check_type:
+            raise BadRequest(_('Cannot delete the current default check type of this event.'))
+        delete_registration_check_type(self.check_type)
+        flash(_('Check type "{}" has been deleted.').format(self.check_type.title), 'success')
+        return jsonify_data(html=_render_registration_check_types(self.event))
+
+
+class RHRegistrationCheckTypeEdit(RHManageRegistrationCheckTypeBase):
+    """Modify an existing registration check type."""
+
+    def _process(self):
+        form = RegistrationCheckTypeForm(obj=self.check_type, event=self.event, check_type=self.check_type)
+        if form.validate_on_submit():
+            update_registration_check_type(self.check_type, form.data)
+            flash(_('Check type "{}" has been modified.').format(self.check_type.title), 'success')
+            return jsonify_data(html=_render_registration_check_types(self.event))
+        return jsonify_form(form)
+
+
+class RHRegistrationCheckTypeToggleDefault(RHManageRegFormsBase):
+    """Toggle the default registration check type of the event."""
+
+    @use_kwargs({
+        'check_type_id': fields.Integer(),
+    }, location='query')
+    def _process(self, check_type_id):
+        check_type = RegistrationCheckType.get_or_404(check_type_id)
+        if not check_type.is_system_defined and check_type not in self.event.check_types:
+            raise Exception('Invalid check type')
+        if check_type != self.event.default_check_type:
+            self.event.default_check_type = check_type
+        return jsonify_data(flash=False)
+
+
+class RHRegistrationChecks(RHManageRegistrationBase):
+    PERMISSION = ('registration', 'registration_checkin')
+
+    def _process(self):
+        return jsonify_template('events/registration/management/registration_checks.html',
+                                registration=self.registration)
+
+
+class RHRegistrationChecksAdd(RHManageRegistrationBase):
+    """Set checked state of a registration."""
+
+    PERMISSION = ('registration', 'registration_checkin')
+
+    @use_kwargs({
+        'is_check_out': fields.Bool(load_default=False),
+    }, location='query')
+    def _process(self, is_check_out):
+        action = 'Checked-out' if is_check_out else 'Checked-in'
+        if self.registration.state not in (RegistrationState.complete, RegistrationState.unpaid):
+            raise BadRequest(_('This registration cannot be marked as checked-in/checked-out'))
+        try:
+            create_registration_check(self.registration, is_check_out=is_check_out, checked_by_user=session.user)
+        except ValueError as e:
+            raise NoReportError(e)
+        flash(_('Registration {} successfully.').format(action), 'success')
+        return jsonify_data(html=_render_registration_details(self.registration))
+
+
+class RHRegistrationChecksDelete(RHManageRegistrationBase):
+
+    PERMISSION = ('registration', 'registration_checkin')
+
+    normalize_url_spec = {
+        'locators': {
+            lambda self: self.check
+        }
+    }
+
+    def _process_args(self):
+        self.check = RegistrationCheck.query.filter_by(id=request.view_args['check_id']).one()
+        RHManageRegistrationBase._process_args(self)
+
+    def _process(self):
+        check_type = self.check.check_type
+        self.registration.checks.remove(self.check)
+        log_text = 'Previous registration check "{}" has been deleted for "{}"'
+        self.registration.log(EventLogRealm.participants, LogKind.change, 'Registration',
+                              log_text.format(check_type.title, self.registration.full_name), session.user)
+        flash(_('Registration check deleted successfully.'), 'success')
+        logger.info('Registration %s check "%s" deleted by %s', self.registration, check_type.title, session.user)
+        return '', 204
+
+
+class RHRegistrationChecksReset(RHManageRegistrationBase):
+
+    PERMISSION = ('registration', 'registration_checkin')
+
+    def _process(self):
+        self.registration.checks.clear()
+        log_text = 'All previous registration checks has been deleted for "{}"'
+        self.registration.log(EventLogRealm.participants, LogKind.change, 'Registration',
+                              log_text.format(self.registration.full_name), session.user)
+        flash(_('Registration checks reset successfully.'), 'success')
+        logger.info('Registration %s checks reset by %s', self.registration, session.user)
+        return '', 204
+
+
+class RHRegistrationBulkCheck(RHRegistrationsActionBase):
+    """Bulk apply check-in/check-out state to registrations."""
+
+    PERMISSION = ('registration', 'registration_checkin')
+
+    @use_kwargs({
+        'is_check_out': fields.Bool(load_default=False),
+    }, location='query')
+    def _process(self, is_check_out):
+        form = RegistrationChecksAssignForm(self.event, check_type_id=self.event.default_check_type_id,
+                                            registration_id=[r.id for r in self.registrations])
+        submit_text = _('Check-out') if is_check_out else _('Check-in')
+        if form.validate_on_submit():
+            action = 'Checked-out' if is_check_out else 'Checked-in'
+            check_type = RegistrationCheckType.query.get_or_404(form.check_type_id.data)
+            for registration in self.registrations:
+                if registration.state not in (RegistrationState.complete, RegistrationState.unpaid):
+                    continue
+                try:
+                    create_registration_check(registration, check_type=check_type, is_check_out=is_check_out,
+                                              checked_by_user=session.user)
+                except ValueError:
+                    pass
+            flash(_('Selected registrations marked as {} successfully.').format(action), 'success')
+            return jsonify_data(**self.list_generator.render_list())
+        return jsonify_form(form, disabled_until_change=False, submit=submit_text)

--- a/indico/modules/events/registration/controllers/management/permissions_test.py
+++ b/indico/modules/events/registration/controllers/management/permissions_test.py
@@ -10,7 +10,7 @@ import pytest
 from indico.modules.events.features.util import set_feature_enabled
 from indico.modules.events.registration import REGISTRATION_PERMISSIONS
 from indico.modules.events.registration.controllers import management
-from indico.modules.events.registration.controllers.management import regforms, reglists
+from indico.modules.events.registration.controllers.management import checks, regforms, reglists
 
 
 pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
@@ -67,7 +67,7 @@ def test_edit_permission_granted(rh):
     regforms.RHRegistrationFormSchedule,
     reglists.RHRegistrationsApprove,
     reglists.RHRegistrationsReject,
-    reglists.RHRegistrationCheckIn,
+    checks.RHRegistrationChecksAdd,
     reglists.RHRegistrationHide,
 ))
 def test_edit_permission_excluded(rh):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -795,38 +795,6 @@ class RHRegistrationRemoveModification(RHManageRegistrationBase):
         return jsonify_data(html=_render_registration_details(self.registration))
 
 
-class RHRegistrationCheckIn(RHManageRegistrationBase):
-    """Set checked in state of a registration."""
-
-    def _process_PUT(self):
-        if self.registration.state not in (RegistrationState.complete, RegistrationState.unpaid):
-            raise BadRequest(_('This registration cannot be marked as checked-in'))
-        self.registration.checked_in = True
-        signals.event.registration_checkin_updated.send(self.registration)
-        return jsonify_data(html=_render_registration_details(self.registration))
-
-    def _process_DELETE(self):
-        self.registration.checked_in = False
-        signals.event.registration_checkin_updated.send(self.registration)
-        return jsonify_data(html=_render_registration_details(self.registration))
-
-
-class RHRegistrationBulkCheckIn(RHRegistrationsActionBase):
-    """Bulk apply check-in/not checked-in state to registrations."""
-
-    def _process(self):
-        check_in = request.form['flag'] == '1'
-        msg = 'checked-in' if check_in else 'not checked-in'
-        for registration in self.registrations:
-            if registration.state not in (RegistrationState.complete, RegistrationState.unpaid):
-                continue
-            registration.checked_in = check_in
-            signals.event.registration_checkin_updated.send(registration)
-            logger.info('Registration %s marked as %s by %s', registration, msg, session.user)
-        flash(_('Selected registrations marked as {} successfully.').format(msg), 'success')
-        return jsonify_data(**self.list_generator.render_list())
-
-
 def _bulk_modify_registration_status(registrations, approve, rejection_reason='', attach_rejection_reason=False):
     num_modified = 0
     num_skipped = 0

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -869,42 +869,6 @@ class RHRegistrationRemoveModification(RHManageRegistrationBase):
         return jsonify_data(html=_render_registration_details(self.registration))
 
 
-class RHRegistrationCheckIn(RHManageRegistrationBase):
-    """Set checked in state of a registration."""
-
-    PERMISSION = ('registration', 'registration_checkin')
-
-    def _process_PUT(self):
-        if self.registration.state not in (RegistrationState.complete, RegistrationState.unpaid):
-            raise BadRequest(_('This registration cannot be marked as checked-in'))
-        self.registration.checked_in = True
-        signals.event.registration_checkin_updated.send(self.registration)
-        return jsonify_data(html=_render_registration_details(self.registration))
-
-    def _process_DELETE(self):
-        self.registration.checked_in = False
-        signals.event.registration_checkin_updated.send(self.registration)
-        return jsonify_data(html=_render_registration_details(self.registration))
-
-
-class RHRegistrationBulkCheckIn(RHRegistrationsActionBase):
-    """Bulk apply check-in/not checked-in state to registrations."""
-
-    PERMISSION = ('registration', 'registration_checkin')
-
-    def _process(self):
-        check_in = request.form['flag'] == '1'
-        msg = 'checked-in' if check_in else 'not checked-in'
-        for registration in self.registrations:
-            if registration.state not in (RegistrationState.complete, RegistrationState.unpaid):
-                continue
-            registration.checked_in = check_in
-            signals.event.registration_checkin_updated.send(registration)
-            logger.info('Registration %s marked as %s by %s', registration, msg, session.user)
-        flash(_('Selected registrations marked as {} successfully.').format(msg), 'success')
-        return jsonify_data(**self.list_generator.render_list())
-
-
 def _bulk_modify_registration_status(registrations, approve, rejection_reason='', attach_rejection_reason=False):
     num_modified = 0
     num_skipped = 0

--- a/indico/modules/events/registration/controllers/management/tags_test.py
+++ b/indico/modules/events/registration/controllers/management/tags_test.py
@@ -33,7 +33,7 @@ def test_assign_tags_logs_added(dummy_reg, create_tag):
 
     _assign_registration_tags([dummy_reg], add={tag_a, tag_b}, remove=set())
 
-    entry = dummy_reg.event.log_entries.one()
+    entry = dummy_reg.event.log_entries.filter_by(realm=EventLogRealm.management).one()
     assert entry.realm == EventLogRealm.management
     assert entry.kind == LogKind.positive
     assert entry.module == 'Registration'
@@ -50,7 +50,7 @@ def test_assign_tags_logs_removed(db, dummy_reg, create_tag):
 
     _assign_registration_tags([dummy_reg], add=set(), remove={tag_a})
 
-    entry = dummy_reg.event.log_entries.one()
+    entry = dummy_reg.event.log_entries.filter_by(realm=EventLogRealm.management).one()
     assert entry.realm == EventLogRealm.management
     assert entry.kind == LogKind.negative
     assert entry.module == 'Registration'
@@ -67,7 +67,7 @@ def test_assign_tags_logs_both(db, dummy_reg, create_tag):
 
     _assign_registration_tags([dummy_reg], add={tag_b}, remove={tag_a})
 
-    entries = dummy_reg.event.log_entries.all()
+    entries = dummy_reg.event.log_entries.filter_by(realm=EventLogRealm.management).all()
     assert len(entries) == 2
     kinds = {e.kind for e in entries}
     assert kinds == {LogKind.positive, LogKind.negative}
@@ -78,12 +78,12 @@ def test_assign_tags_no_log_when_nothing_changes(dummy_reg, create_tag):
     tag_b = create_tag('Beta')
     # empty changeset
     _assign_registration_tags([dummy_reg], add=set(), remove=set())
-    assert not dummy_reg.event.log_entries.has_rows()
+    assert not dummy_reg.event.log_entries.filter_by(realm=EventLogRealm.management).has_rows()
     # redundant changes
     dummy_reg.tags = {tag_a}
     _assign_registration_tags([dummy_reg], add={tag_a}, remove=set())
     _assign_registration_tags([dummy_reg], add=set(), remove={tag_b})
-    assert not dummy_reg.event.log_entries.has_rows()
+    assert not dummy_reg.event.log_entries.filter_by(realm=EventLogRealm.management).has_rows()
     # nonsense change
     _assign_registration_tags([dummy_reg], add={tag_b}, remove={tag_b})
-    assert not dummy_reg.event.log_entries.has_rows()
+    assert not dummy_reg.event.log_entries.filter_by(realm=EventLogRealm.management).has_rows()

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -24,6 +24,7 @@ from indico.modules.designer import PageLayout, PageOrientation, PageSize, Templ
 from indico.modules.designer.util import get_inherited_templates
 from indico.modules.events.features.util import is_feature_enabled
 from indico.modules.events.payment import payment_settings
+from indico.modules.events.registration.models.checks import RegistrationCheckRule, RegistrationCheckType
 from indico.modules.events.registration.models.forms import ModificationMode
 from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import PublishRegistrationsMode, Registration
@@ -678,3 +679,51 @@ class MultiFormsAnnouncementForm(IndicoForm):
     message = IndicoMarkdownField('Message', render_kw={'rows': 10},
                                   description=_('You can enter an announcement text that is displayed when there are '
                                                 'multiple registration forms for the user to choose from.'))
+
+
+class RegistrationCheckTypeForm(IndicoForm):
+    """Form to define a new registration check type."""
+
+    title = StringField(_('Title'), [DataRequired(), Length(min=3, max=200)])
+    rule = IndicoEnumSelectField(_('Rule'), enum=RegistrationCheckRule, sorted=True)
+    check_out_allowed = BooleanField(_('Can check out'), widget=SwitchWidget(),
+                                  description=_('If enabled, check-out actions can be performed on this check type.'))
+
+    def __init__(self, *args, **kwargs):
+        self.event = kwargs.pop('event', None)
+        self.check_type = kwargs.pop('check_type', None)
+        super().__init__(*args, **kwargs)
+
+    def validate_title(self, field):
+        if self.event:
+            query = (RegistrationCheckType.query.filter(
+                db.or_(db.and_(RegistrationCheckType.event_id == self.event.id,
+                               db.func.lower(RegistrationCheckType.title) == field.data.lower()),
+                       db.and_(RegistrationCheckType.is_system_defined,
+                               db.func.lower(RegistrationCheckType.title) == field.data.lower())))
+            )
+        else:
+            query = (RegistrationCheckType.query
+                     .filter(RegistrationCheckType.is_system_defined,
+                             db.func.lower(RegistrationCheckType.title) == field.data.lower()))
+        if self.check_type:
+            query = query.filter(RegistrationCheckType.id != self.check_type.id)
+        if query.has_rows():
+            raise ValidationError(_('This title is already in use.'))
+
+
+class RegistrationChecksAssignForm(IndicoForm):
+    """Form to perform bulk check on registrations."""
+
+    check_type_id = SelectField(_('Check'), [DataRequired()])
+    registration_id = HiddenFieldList()
+    submitted = HiddenField()
+
+    def __init__(self, event, **kwargs):
+        super().__init__(**kwargs)
+        check_types = (event.check_types +
+                       RegistrationCheckType.query.filter(RegistrationCheckType.is_system_defined).all())
+        self.check_type_id.choices = [(str(check_type.id), check_type.title) for check_type in check_types]
+
+    def is_submitted(self):
+        return super().is_submitted() and 'submitted' in request.form

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -24,6 +24,7 @@ from indico.modules.designer import PageLayout, PageOrientation, PageSize, Templ
 from indico.modules.designer.util import get_inherited_templates
 from indico.modules.events.features.util import is_feature_enabled
 from indico.modules.events.payment import payment_settings
+from indico.modules.events.registration.models.checks import RegistrationCheckRule, RegistrationCheckType
 from indico.modules.events.registration.models.forms import ModificationMode
 from indico.modules.events.registration.models.items import RegistrationFormItem
 from indico.modules.events.registration.models.registrations import PublishRegistrationsMode, Registration
@@ -700,3 +701,51 @@ class MultiFormsAnnouncementForm(IndicoForm):
     message = IndicoMarkdownField('Message', render_kw={'rows': 10},
                                   description=_('You can enter an announcement text that is displayed when there are '
                                                 'multiple registration forms for the user to choose from.'))
+
+
+class RegistrationCheckTypeForm(IndicoForm):
+    """Form to define a new registration check type."""
+
+    title = StringField(_('Title'), [DataRequired(), Length(min=3, max=200)])
+    rule = IndicoEnumSelectField(_('Rule'), enum=RegistrationCheckRule, sorted=True)
+    check_out_allowed = BooleanField(_('Can check out'), widget=SwitchWidget(),
+                                  description=_('If enabled, check-out actions can be performed on this check type.'))
+
+    def __init__(self, *args, **kwargs):
+        self.event = kwargs.pop('event', None)
+        self.check_type = kwargs.pop('check_type', None)
+        super().__init__(*args, **kwargs)
+
+    def validate_title(self, field):
+        if self.event:
+            query = (RegistrationCheckType.query.filter(
+                db.or_(db.and_(RegistrationCheckType.event_id == self.event.id,
+                               db.func.lower(RegistrationCheckType.title) == field.data.lower()),
+                       db.and_(RegistrationCheckType.is_system_defined,
+                               db.func.lower(RegistrationCheckType.title) == field.data.lower())))
+            )
+        else:
+            query = (RegistrationCheckType.query
+                     .filter(RegistrationCheckType.is_system_defined,
+                             db.func.lower(RegistrationCheckType.title) == field.data.lower()))
+        if self.check_type:
+            query = query.filter(RegistrationCheckType.id != self.check_type.id)
+        if query.has_rows():
+            raise ValidationError(_('This title is already in use.'))
+
+
+class RegistrationChecksAssignForm(IndicoForm):
+    """Form to perform bulk check on registrations."""
+
+    check_type_id = SelectField(_('Check'), [DataRequired()])
+    registration_id = HiddenFieldList()
+    submitted = HiddenField()
+
+    def __init__(self, event, **kwargs):
+        super().__init__(**kwargs)
+        check_types = (event.check_types +
+                       RegistrationCheckType.query.filter(RegistrationCheckType.is_system_defined).all())
+        self.check_type_id.choices = [(str(check_type.id), check_type.title) for check_type in check_types]
+
+    def is_submitted(self):
+        return super().is_submitted() and 'submitted' in request.form

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -57,6 +57,16 @@ class RegistrationListGenerator(ListGeneratorBase):
             'checked_in_date': {
                 'title': _('Check-in date'),
             },
+            'checked_out': {
+                'title': _('Checked out'),
+                'filter_choices': {
+                    '0': _('No'),
+                    '1': _('Yes')
+                }
+            },
+            'checked_out_date': {
+                'title': _('Check-out date'),
+            },
             'payment_date': {
                 'title': _('Payment date'),
             },
@@ -200,6 +210,12 @@ class RegistrationListGenerator(ListGeneratorBase):
             # If both values 'true' and 'false' are selected, there's no point in filtering
             if len(checked_in_values) == 1:
                 items_criteria.append(Registration.checked_in == bool(int(checked_in_values[0])))
+
+        if 'checked_out' in filters['items']:
+            checked_out_values = filters['items']['checked_out']
+            # If both values 'true' and 'false' are selected, there's no point in filtering
+            if len(checked_out_values) == 1:
+                items_criteria.append(Registration.checked_out == bool(int(checked_out_values[0])))
 
         if 'state' in filters['items']:
             states = [RegistrationState(int(state)) for state in filters['items']['state']]

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -63,6 +63,16 @@ class RegistrationListGenerator(ListGeneratorBase):
             'checked_in_date': {
                 'title': _('Check-in date'),
             },
+            'checked_out': {
+                'title': _('Checked out'),
+                'filter_choices': {
+                    '0': _('No'),
+                    '1': _('Yes')
+                }
+            },
+            'checked_out_date': {
+                'title': _('Check-out date'),
+            },
             'payment_date': {
                 'title': _('Payment date'),
             },
@@ -206,6 +216,12 @@ class RegistrationListGenerator(ListGeneratorBase):
             # If both values 'true' and 'false' are selected, there's no point in filtering
             if len(checked_in_values) == 1:
                 items_criteria.append(Registration.checked_in == bool(int(checked_in_values[0])))
+
+        if 'checked_out' in filters['items']:
+            checked_out_values = filters['items']['checked_out']
+            # If both values 'true' and 'false' are selected, there's no point in filtering
+            if len(checked_out_values) == 1:
+                items_criteria.append(Registration.checked_out == bool(int(checked_out_values[0])))
 
         if 'state' in filters['items']:
             states = [RegistrationState(int(state)) for state in filters['items']['state']]

--- a/indico/modules/events/registration/logging.py
+++ b/indico/modules/events/registration/logging.py
@@ -15,18 +15,21 @@ from indico.util.i18n import orig_string
 
 
 def connect_log_signals():
-    signals.event.registration_checkin_updated.connect(log_registration_check_in)
+    signals.event.registration_check_added.connect(log_registration_check)
     signals.event.registration_state_updated.connect(log_registration_updated)
 
 
-def log_registration_check_in(registration, **kwargs):
+def log_registration_check(registration_check, **kwargs):
     """Log a registration check-in action to the event log."""
-    if registration.checked_in:
-        log_text = f'"{registration.full_name}" has been checked in'
+    registration = registration_check.registration
+    check_type = registration_check.check_type
+    user = session.user if session else None
+    if registration_check.is_check_out:
+        log_text = '"{}" has been "checked-out" of "{}"'
     else:
-        log_text = '"{}" check-in has been reset'
+        log_text = '"{}" has been "checked-in" to "{}"'
     registration.log(EventLogRealm.participants, LogKind.change, 'Registration',
-                     log_text.format(registration.full_name), session.user)
+                     log_text.format(registration.full_name, check_type.title), user)
 
 
 def log_registration_updated(registration, previous_state, silent=False, **kwargs):

--- a/indico/modules/events/registration/models/checks.py
+++ b/indico/modules/events/registration/models/checks.py
@@ -1,0 +1,182 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2026 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from sqlalchemy.ext.declarative import declared_attr
+
+from indico.core.db import db
+from indico.core.db.sqlalchemy import UTCDateTime
+from indico.core.db.sqlalchemy.custom.int_enum import PyIntEnum
+from indico.util.date_time import now_utc
+from indico.util.enum import RichIntEnum
+from indico.util.i18n import L_
+from indico.util.locators import locator_property
+from indico.util.string import format_repr
+
+
+class RegistrationCheckRule(RichIntEnum):
+    __titles__ = [None, L_('Once'), L_('Multiple'), L_('Once daily')]
+
+    once = 1
+    multiple = 2
+    once_daily = 3
+
+
+class RegistrationCheckType(db.Model):
+    """Checks to be performed on registrations."""
+
+    __tablename__ = 'check_types'
+
+    @declared_attr
+    def __table_args__(cls):
+        return (db.Index('ix_uq_check_types_title_lower', cls.event_id, db.func.lower(cls.title), unique=True),
+                db.CheckConstraint('((is_system_defined = true AND event_id IS NULL) '
+                                   'OR (is_system_defined = false AND event_id IS NOT NULL))',
+                                   'valid_is_system_defined'),
+                {'schema': 'event_registration'})
+
+    #: The ID of the object
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+    #: The ID of the event where this check was created
+    event_id = db.Column(
+        db.Integer,
+        db.ForeignKey('events.events.id'),
+        index=True,
+    )
+    #: The name of the check
+    title = db.Column(
+        db.String,
+        nullable=False
+    )
+    #: The associated `RegistrationCheckRule`
+    rule = db.Column(
+        PyIntEnum(RegistrationCheckRule),
+        default=RegistrationCheckRule.once,
+        nullable=False
+    )
+    #: If this is a system defined check type
+    is_system_defined = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
+    #: If this check can be checked-out
+    check_out_allowed = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=True
+    )
+    #: The Event where this rule was created
+    event = db.relationship(
+        'Event',
+        lazy=True,
+        foreign_keys=event_id,
+        backref=db.backref(
+            'check_types',
+            lazy=True,
+            cascade='all, delete-orphan',
+        )
+    )
+
+    # relationship backrefs:
+    # - default_check_type_of (Event.default_check_type)
+    # - registration_checks (RegistrationCheck.check_type)
+
+    @property
+    def locator(self):
+        if self.event:
+            return dict(self.event.locator, check_type_id=self.id)
+        else:
+            return {'check_type_id': self.id}
+
+    def __repr__(self):
+        return format_repr(self, 'id', _text=self.title)
+
+
+class RegistrationCheck(db.Model):
+    """Stores the histroy of checks performed on registrations."""
+
+    __tablename__ = 'checks'
+    __table_args__ = {'schema': 'event_registration'}
+
+    #: The ID of the check
+    id = db.Column(
+        db.Integer,
+        primary_key=True
+    )
+    #: The ID of the registration
+    registration_id = db.Column(
+        db.Integer,
+        db.ForeignKey('event_registration.registrations.id'),
+        index=True,
+        nullable=False
+    )
+    #: Type of the check
+    check_type_id = db.Column(
+        db.Integer,
+        db.ForeignKey('event_registration.check_types.id'),
+        index=True,
+        nullable=False
+    )
+    #: The date/time of the check
+    timestamp = db.Column(
+        UTCDateTime,
+        nullable=False,
+        index=True,
+        default=now_utc
+    )
+    #: If this is a checkin/checkout
+    is_check_out = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
+    #: The ID of the user who performed the check
+    checked_by_user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.users.id'),
+        index=True
+    )
+    #: The associated registration
+    registration = db.relationship(
+        'Registration',
+        lazy=True,
+        backref=db.backref(
+            'checks',
+            cascade='all, delete-orphan',
+            lazy=True,
+        )
+    )
+    #: The associated RegistrationCheckType
+    check_type = db.relationship(
+        'RegistrationCheckType',
+        lazy=True,
+        backref=db.backref(
+            'registration_checks',
+            cascade='all, delete-orphan',
+            lazy=True,
+        )
+    )
+    #: The user who performed the check
+    checked_by_user = db.relationship(
+        'User',
+        lazy=True,
+        backref=db.backref(
+            'registration_checks_performed',
+            lazy=True,
+        )
+    )
+
+    @locator_property
+    def locator(self):
+        return dict(self.registration.locator, check_id=self.id)
+
+    def __repr__(self):
+        return format_repr(self, 'id', 'registration_id', 'timestamp',
+                           _text=f'{"Check-out" if self.is_check_out else "Check-in"} - {self.check_type.title}')

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -12,7 +12,7 @@ from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import UUID as pg_UUID  # noqa: N811
 from sqlalchemy.event import listens_for
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
-from sqlalchemy.orm import column_property, subqueryload
+from sqlalchemy.orm import aliased, column_property, subqueryload
 from werkzeug.exceptions import BadRequest
 
 from indico.core.config import config
@@ -20,6 +20,7 @@ from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
 from indico.core.db.sqlalchemy.principals import PrincipalType
 from indico.modules.designer.models.templates import DesignerTemplate
+from indico.modules.events.registration.models.checks import RegistrationCheck
 from indico.modules.events.registration.models.form_fields import RegistrationFormPersonalDataField
 from indico.modules.events.registration.models.registrations import (PublishRegistrationsMode, Registration,
                                                                      RegistrationState)
@@ -609,6 +610,27 @@ class RegistrationForm(db.Model):
     def log(self, *args, **kwargs):
         """Log with prefilled metadata for the regform."""
         return self.event.log(*args, meta={'registration_form_id': self.id}, **kwargs)
+
+    def get_checked_in_registrations_count(self, check_type_id):
+        registration_check = aliased(RegistrationCheck)
+        subquery = (db.session.query(
+                        registration_check.registration_id,
+                        registration_check.is_check_out
+                    )
+                    .filter(registration_check.check_type_id == check_type_id)
+                    .order_by(registration_check.registration_id, registration_check.timestamp.desc())
+                    .distinct(registration_check.registration_id)
+                    .subquery())
+
+        query = (db.session.query(db.func.coalesce(db.func.sum(Registration.occupied_slots), 0))
+                 .select_from(Registration)
+                 .join(subquery, subquery.c.registration_id == Registration.id)
+                 .filter(
+                     Registration.registration_form_id == self.id,
+                     ~Registration.is_deleted,
+                     subquery.c.is_check_out.is_(False)
+                 ))
+        return query.scalar()
 
 
 @listens_for(orm.mapper, 'after_configured', once=True)

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -12,7 +12,7 @@ from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.dialects.postgresql import UUID as pg_UUID  # noqa: N811
 from sqlalchemy.event import listens_for
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
-from sqlalchemy.orm import column_property, subqueryload
+from sqlalchemy.orm import aliased, column_property, subqueryload
 from werkzeug.exceptions import BadRequest
 
 from indico.core.config import config
@@ -20,6 +20,7 @@ from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
 from indico.core.db.sqlalchemy.principals import PrincipalType
 from indico.modules.designer.models.templates import DesignerTemplate
+from indico.modules.events.registration.models.checks import RegistrationCheck
 from indico.modules.events.registration.models.form_fields import RegistrationFormPersonalDataField
 from indico.modules.events.registration.models.registrations import (PublishRegistrationsMode, Registration,
                                                                      RegistrationState)
@@ -634,6 +635,27 @@ class RegistrationForm(db.Model):
     def log(self, *args, **kwargs):
         """Log with prefilled metadata for the regform."""
         return self.event.log(*args, meta={'registration_form_id': self.id}, **kwargs)
+
+    def get_checked_in_registrations_count(self, check_type_id):
+        registration_check = aliased(RegistrationCheck)
+        subquery = (db.session.query(
+                        registration_check.registration_id,
+                        registration_check.is_check_out
+                    )
+                    .filter(registration_check.check_type_id == check_type_id)
+                    .order_by(registration_check.registration_id, registration_check.timestamp.desc())
+                    .distinct(registration_check.registration_id)
+                    .subquery())
+
+        query = (db.session.query(db.func.coalesce(db.func.sum(Registration.occupied_slots), 0))
+                 .select_from(Registration)
+                 .join(subquery, subquery.c.registration_id == Registration.id)
+                 .filter(
+                     Registration.registration_form_id == self.id,
+                     ~Registration.is_deleted,
+                     subquery.c.is_check_out.is_(False)
+                 ))
+        return query.scalar()
 
 
 @listens_for(orm.mapper, 'after_configured', once=True)

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -17,7 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.event import listens_for
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
-from sqlalchemy.orm import column_property, mapper
+from sqlalchemy.orm import aliased, column_property, mapper
 
 from indico.core import signals
 from indico.core.config import config
@@ -26,7 +26,9 @@ from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
 from indico.core.db.sqlalchemy.util.queries import increment_and_get
 from indico.core.errors import IndicoError
 from indico.core.storage import StoredFileMixin
+from indico.modules.events.models.events import Event
 from indico.modules.events.payment.models.transactions import TransactionStatus
+from indico.modules.events.registration.models.checks import RegistrationCheck, RegistrationCheckRule
 from indico.modules.events.registration.models.items import PersonalDataType
 from indico.modules.events.registration.wallets.apple import AppleWalletManager
 from indico.modules.events.registration.wallets.google import GoogleWalletManager
@@ -216,18 +218,6 @@ class Registration(db.Model):
         nullable=False,
         default=lambda: str(uuid4())
     )
-    #: Whether the person has checked in. Setting this also sets or clears
-    #: `checked_in_dt`.
-    checked_in = db.Column(
-        db.Boolean,
-        nullable=False,
-        default=False
-    )
-    #: The date/time when the person has checked in
-    checked_in_dt = db.Column(
-        UTCDateTime,
-        nullable=True
-    )
     #: If given a reason for rejection
     rejection_reason = db.Column(
         db.String,
@@ -313,6 +303,7 @@ class Registration(db.Model):
         default='',
     )
     # relationship backrefs:
+    # - checks (RegistrationCheck.registration)
     # - invitation (RegistrationInvitation.registration)
     # - legacy_mapping (LegacyRegistrationMapping.registration)
     # - receipt_files (ReceiptFile.registration)
@@ -594,6 +585,92 @@ class Registration(db.Model):
     def published_receipts(self):
         return [receipt for receipt in self.receipt_files if receipt.is_published]
 
+    @property
+    def last_check(self):
+        return (RegistrationCheck.query
+                .with_parent(self)
+                .filter(RegistrationCheck.check_type_id == self.event.default_check_type_id)
+                .order_by(RegistrationCheck.timestamp.desc())
+                .limit(1).one_or_none())
+
+    @hybrid_property
+    def checked_in(self):
+        if last_check := self.last_check:
+            return not last_check.is_check_out
+        return False
+
+    @checked_in.expression
+    def checked_in(cls):
+        last_check = aliased(RegistrationCheck)
+        query = (
+            db.select(last_check.is_check_out)
+            .where(
+                last_check.registration_id == cls.id,
+                cls.event.has(Event.default_check_type_id == last_check.check_type_id)
+            )
+            .order_by(last_check.timestamp.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        return db.case(
+            (query.is_(False), True),
+            else_=False
+        )
+
+    @checked_in.setter
+    def checked_in(self, value):
+        from indico.modules.events.registration.util import create_registration_check
+
+        if value is True:
+            test_perform_check = self.can_perform_check()
+            if test_perform_check['can_check']:
+                create_registration_check(self)
+
+    @property
+    def checked_in_dt(self):
+        if self.checked_in:
+            return self.last_check.timestamp
+        return None
+
+    @hybrid_property
+    def checked_out(self):
+        if last_check := self.last_check:
+            return last_check.is_check_out
+        return False
+
+    @checked_out.expression
+    def checked_out(cls):
+        last_check = aliased(RegistrationCheck)
+        query = (
+            db.select(last_check.is_check_out)
+            .where(
+                last_check.registration_id == cls.id,
+                cls.event.has(Event.default_check_type_id == last_check.check_type_id)
+            )
+            .order_by(last_check.timestamp.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        return db.case(
+            (query.is_(True), True),
+            else_=False
+        )
+
+    @checked_out.setter
+    def checked_out(self, value):
+        from indico.modules.events.registration.util import create_registration_check
+
+        if value is True:
+            test_perform_check = self.can_perform_check(is_check_out=True)
+            if test_perform_check['can_check']:
+                create_registration_check(self, is_check_out=True)
+
+    @property
+    def checked_out_dt(self):
+        if self.checked_out:
+            return self.last_check.timestamp
+        return None
+
     @classproperty
     @classmethod
     def order_by_name(cls):
@@ -769,7 +846,6 @@ class Registration(db.Model):
             self.update_state(withdrawn=False)
         elif self.state != RegistrationState.pending:
             raise ValueError(f'Cannot reset registration state from {self.state.name}')
-        self.checked_in = False
 
     def has_conflict(self):
         """Check if there are other valid registrations for the same user.
@@ -814,6 +890,65 @@ class Registration(db.Model):
         awm = AppleWalletManager(self.event)
         if awm.is_configured:
             return awm.get_ticket(self)
+
+    def get_last_check_for_type(self, check_type_id):
+        return (RegistrationCheck.query
+                .with_parent(self)
+                .filter(RegistrationCheck.check_type_id == check_type_id)
+                .order_by(RegistrationCheck.timestamp.desc())
+                .limit(1).one_or_none())
+
+    def is_checked_in_for_type(self, check_type_id):
+        if check := self.get_last_check_for_type(check_type_id):
+            return not check.is_check_out
+        return False
+
+    def get_checked_in_dt_for_type(self, check_type_id):
+        if self.is_checked_in_for_type(check_type_id):
+            return self.get_last_check_for_type(check_type_id).timestamp
+        return None
+
+    def is_checked_out_for_type(self, check_type_id):
+        if check := self.get_last_check_for_type(check_type_id):
+            return check.is_check_out
+        return False
+
+    def get_checked_out_dt_for_type(self, check_type_id):
+        if self.is_checked_out_for_type(check_type_id):
+            return self.get_last_check_for_type(check_type_id).timestamp
+        return None
+
+    def can_perform_check(self, *, check_type=None, is_check_out=False):
+        can_check = True
+        reason = _('Check can be performed.')
+        event_tz = self.event.tzinfo if self.event else config.DEFAULT_TIMEZONE
+        if not check_type:
+            check_type = self.event.default_check_type if self.event else None
+        if not check_type:
+            can_check = False
+            reason = _('Check type not specified and no default check type has been defined for this event.')
+            return {'can_check': can_check, 'reason': reason}
+
+        previous_checks_for_type = [check for check in self.checks if check.check_type == check_type and
+                                    check.is_check_out == is_check_out]
+        inverse_checks_for_type = [check for check in self.checks if check.check_type == check_type and
+                                   check.is_check_out != is_check_out]
+
+        if is_check_out and not check_type.check_out_allowed:
+            can_check = False
+            reason = _('The selected check cannot be "checked-out".')
+        elif previous_checks_for_type and check_type.rule == RegistrationCheckRule.once:
+            can_check = False
+            reason = _('The selected check can only be performed once.')
+        elif is_check_out and len(previous_checks_for_type) >= len(inverse_checks_for_type):
+            can_check = False
+            reason = _('Attempting to check-out without a previous check-in.')
+        elif (check_type.rule == RegistrationCheckRule.once_daily and
+                any(check.timestamp.astimezone(event_tz).date() == now_utc().astimezone(event_tz).date()
+                    for check in previous_checks_for_type)):
+            can_check = False
+            reason = _('The selected check has already been performed once today.')
+        return {'can_check': can_check, 'reason': reason}
 
 
 class RegistrationData(StoredFileMixin, db.Model):
@@ -958,13 +1093,6 @@ def _mapper_configured():
     @listens_for(Registration.registration_form, 'set')
     def _set_event_id(target, value, *unused):
         target.event_id = value.event_id
-
-    @listens_for(Registration.checked_in, 'set')
-    def _set_checked_in_dt(target, value, *unused):
-        if not value:
-            target.checked_in_dt = None
-        elif target.checked_in != value:
-            target.checked_in_dt = now_utc()
 
     @listens_for(Registration.transaction, 'set')
     def _set_transaction_id(target, value, *unused):

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -17,7 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.event import listens_for
 from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
-from sqlalchemy.orm import column_property, mapper
+from sqlalchemy.orm import aliased, column_property, mapper
 
 from indico.core import signals
 from indico.core.config import config
@@ -26,7 +26,9 @@ from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
 from indico.core.db.sqlalchemy.util.queries import increment_and_get
 from indico.core.errors import IndicoError
 from indico.core.storage import StoredFileMixin
+from indico.modules.events.models.events import Event
 from indico.modules.events.payment.models.transactions import TransactionStatus
+from indico.modules.events.registration.models.checks import RegistrationCheck, RegistrationCheckRule
 from indico.modules.events.registration.models.items import PersonalDataType
 from indico.modules.events.registration.wallets.apple import AppleWalletManager
 from indico.modules.events.registration.wallets.google import GoogleWalletManager
@@ -216,18 +218,6 @@ class Registration(db.Model):
         nullable=False,
         default=lambda: str(uuid4())
     )
-    #: Whether the person has checked in. Setting this also sets or clears
-    #: `checked_in_dt`.
-    checked_in = db.Column(
-        db.Boolean,
-        nullable=False,
-        default=False
-    )
-    #: The date/time when the person has checked in
-    checked_in_dt = db.Column(
-        UTCDateTime,
-        nullable=True
-    )
     #: If given a reason for rejection
     rejection_reason = db.Column(
         db.String,
@@ -336,6 +326,7 @@ class Registration(db.Model):
         default='',
     )
     # relationship backrefs:
+    # - checks (RegistrationCheck.registration)
     # - invitation (RegistrationInvitation.registration)
     # - legacy_mapping (LegacyRegistrationMapping.registration)
     # - receipt_files (ReceiptFile.registration)
@@ -621,6 +612,92 @@ class Registration(db.Model):
     def published_receipts(self):
         return [receipt for receipt in self.receipt_files if receipt.is_published]
 
+    @property
+    def last_check(self):
+        return (RegistrationCheck.query
+                .with_parent(self)
+                .filter(RegistrationCheck.check_type_id == self.event.default_check_type_id)
+                .order_by(RegistrationCheck.timestamp.desc())
+                .limit(1).one_or_none())
+
+    @hybrid_property
+    def checked_in(self):
+        if last_check := self.last_check:
+            return not last_check.is_check_out
+        return False
+
+    @checked_in.expression
+    def checked_in(cls):
+        last_check = aliased(RegistrationCheck)
+        query = (
+            db.select(last_check.is_check_out)
+            .where(
+                last_check.registration_id == cls.id,
+                cls.event.has(Event.default_check_type_id == last_check.check_type_id)
+            )
+            .order_by(last_check.timestamp.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        return db.case(
+            (query.is_(False), True),
+            else_=False
+        )
+
+    @checked_in.setter
+    def checked_in(self, value):
+        from indico.modules.events.registration.util import create_registration_check
+
+        if value is True:
+            test_perform_check = self.can_perform_check()
+            if test_perform_check['can_check']:
+                create_registration_check(self)
+
+    @property
+    def checked_in_dt(self):
+        if self.checked_in:
+            return self.last_check.timestamp
+        return None
+
+    @hybrid_property
+    def checked_out(self):
+        if last_check := self.last_check:
+            return last_check.is_check_out
+        return False
+
+    @checked_out.expression
+    def checked_out(cls):
+        last_check = aliased(RegistrationCheck)
+        query = (
+            db.select(last_check.is_check_out)
+            .where(
+                last_check.registration_id == cls.id,
+                cls.event.has(Event.default_check_type_id == last_check.check_type_id)
+            )
+            .order_by(last_check.timestamp.desc())
+            .limit(1)
+            .scalar_subquery()
+        )
+        return db.case(
+            (query.is_(True), True),
+            else_=False
+        )
+
+    @checked_out.setter
+    def checked_out(self, value):
+        from indico.modules.events.registration.util import create_registration_check
+
+        if value is True:
+            test_perform_check = self.can_perform_check(is_check_out=True)
+            if test_perform_check['can_check']:
+                create_registration_check(self, is_check_out=True)
+
+    @property
+    def checked_out_dt(self):
+        if self.checked_out:
+            return self.last_check.timestamp
+        return None
+
     @classproperty
     @classmethod
     def order_by_name(cls):
@@ -813,7 +890,6 @@ class Registration(db.Model):
             self.update_state(withdrawn=False)
         elif self.state != RegistrationState.pending:
             raise ValueError(f'Cannot reset registration state from {self.state.name}')
-        self.checked_in = False
 
     def has_conflict(self):
         """Check if there are other valid registrations for the same user.
@@ -866,6 +942,65 @@ class Registration(db.Model):
         by the user or an admin, not on automatic state changes.
         """
         self.modified_dt = now_utc()
+
+    def get_last_check_for_type(self, check_type_id):
+        return (RegistrationCheck.query
+                .with_parent(self)
+                .filter(RegistrationCheck.check_type_id == check_type_id)
+                .order_by(RegistrationCheck.timestamp.desc())
+                .limit(1).one_or_none())
+
+    def is_checked_in_for_type(self, check_type_id):
+        if check := self.get_last_check_for_type(check_type_id):
+            return not check.is_check_out
+        return False
+
+    def get_checked_in_dt_for_type(self, check_type_id):
+        if self.is_checked_in_for_type(check_type_id):
+            return self.get_last_check_for_type(check_type_id).timestamp
+        return None
+
+    def is_checked_out_for_type(self, check_type_id):
+        if check := self.get_last_check_for_type(check_type_id):
+            return check.is_check_out
+        return False
+
+    def get_checked_out_dt_for_type(self, check_type_id):
+        if self.is_checked_out_for_type(check_type_id):
+            return self.get_last_check_for_type(check_type_id).timestamp
+        return None
+
+    def can_perform_check(self, *, check_type=None, is_check_out=False):
+        can_check = True
+        reason = _('Check can be performed.')
+        event_tz = self.event.tzinfo if self.event else config.DEFAULT_TIMEZONE
+        if not check_type:
+            check_type = self.event.default_check_type if self.event else None
+        if not check_type:
+            can_check = False
+            reason = _('Check type not specified and no default check type has been defined for this event.')
+            return {'can_check': can_check, 'reason': reason}
+
+        previous_checks_for_type = [check for check in self.checks if check.check_type == check_type and
+                                    check.is_check_out == is_check_out]
+        inverse_checks_for_type = [check for check in self.checks if check.check_type == check_type and
+                                   check.is_check_out != is_check_out]
+
+        if is_check_out and not check_type.check_out_allowed:
+            can_check = False
+            reason = _('The selected check cannot be "checked-out".')
+        elif previous_checks_for_type and check_type.rule == RegistrationCheckRule.once:
+            can_check = False
+            reason = _('The selected check can only be performed once.')
+        elif is_check_out and len(previous_checks_for_type) >= len(inverse_checks_for_type):
+            can_check = False
+            reason = _('Attempting to check-out without a previous check-in.')
+        elif (check_type.rule == RegistrationCheckRule.once_daily and
+                any(check.timestamp.astimezone(event_tz).date() == now_utc().astimezone(event_tz).date()
+                    for check in previous_checks_for_type)):
+            can_check = False
+            reason = _('The selected check has already been performed once today.')
+        return {'can_check': can_check, 'reason': reason}
 
 
 class RegistrationData(StoredFileMixin, db.Model):
@@ -1016,13 +1151,6 @@ def _mapper_configured():
     @listens_for(Registration.registration_form, 'set')
     def _set_event_id(target, value, *unused):
         target.event_id = value.event_id
-
-    @listens_for(Registration.checked_in, 'set')
-    def _set_checked_in_dt(target, value, *unused):
-        if not value:
-            target.checked_in_dt = None
-        elif target.checked_in != value:
-            target.checked_in_dt = now_utc()
 
     @listens_for(Registration.transaction, 'set')
     def _set_transaction_id(target, value, *unused):

--- a/indico/modules/events/registration/schemas.py
+++ b/indico/modules/events/registration/schemas.py
@@ -14,6 +14,7 @@ from webargs import fields
 
 from indico.core.marshmallow import mm
 from indico.modules.events import Event
+from indico.modules.events.registration.models.checks import RegistrationCheckType
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.invitations import RegistrationInvitation
 from indico.modules.events.registration.models.registrations import Registration, RegistrationState
@@ -124,9 +125,20 @@ class RegistrationInvitationSchema(mm.SQLAlchemyAutoSchema):
 class CheckinEventSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Event
-        fields = ('id', 'title', 'description', 'start_dt', 'end_dt', 'registration_tags')
+        fields = ('id', 'title', 'description', 'start_dt', 'end_dt', 'registration_tags', 'check_types',
+                  'default_check_type')
 
     registration_tags = fields.Nested(RegistrationTagSchema, many=True)
+
+    check_types = fields.Method('_get_check_types')
+    default_check_type = fields.Function(lambda event:
+        {'id': event.default_check_type.id,
+         'title': f'{event.default_check_type.title} ({event.default_check_type.rule.title})'})
+
+    def _get_check_types(self, event):
+        check_types = (event.check_types +
+                       RegistrationCheckType.query.filter(RegistrationCheckType.is_system_defined).all())
+        return [{'id': c.id, 'title': f'{c.title} ({c.rule.title})'} for c in check_types]
 
 
 class CheckinRegFormSchema(mm.SQLAlchemyAutoSchema):
@@ -137,7 +149,13 @@ class CheckinRegFormSchema(mm.SQLAlchemyAutoSchema):
 
     is_open = fields.Bool()
     registration_count = fields.Int(attribute='existing_registrations_count')
-    checked_in_count = fields.Int(attribute='checked_in_registrations_count')
+    checked_in_count = fields.Method('_checked_in_count')
+
+    def _checked_in_count(self, regform):
+        check_type_id = self.context.get('check_type_id')
+        if check_type_id is not None:
+            return regform.get_checked_in_registrations_count(check_type_id)
+        return regform.checked_in_registrations_count  # Uses the default_check_type of the event
 
 
 class CheckinRegistrationSchema(mm.SQLAlchemyAutoSchema):
@@ -145,18 +163,47 @@ class CheckinRegistrationSchema(mm.SQLAlchemyAutoSchema):
         model = Registration
         fields = ('id', 'regform_id', 'event_id', 'full_name', 'email', 'state', 'checked_in', 'checked_in_dt',
                   'checkin_secret', 'is_paid', 'price', 'payment_date', 'currency', 'formatted_price', 'tags',
-                  'occupied_slots', 'registration_date', 'registration_data', 'personal_data_picture')
+                  'occupied_slots', 'registration_date', 'registration_data', 'personal_data_picture',
+                  'checked_out', 'checked_out_dt')
 
     regform_id = fields.Int(attribute='registration_form_id')
     full_name = fields.Str(attribute='display_full_name')
     state = fields.Enum(RegistrationState)
     checkin_secret = fields.UUID(attribute='ticket_uuid')
+    checked_in = fields.Method('_get_checked_in')
+    checked_in_dt = fields.Method('_get_checked_in_dt')
+    checked_out = fields.Method('_get_checked_out')
+    checked_out_dt = fields.Method('_get_checked_out_dt')
     payment_date = fields.Method('_get_payment_date')
     formatted_price = fields.Function(lambda reg: reg.render_price())
     tags = fields.Nested(RegistrationTagSchema, many=True)
     registration_date = fields.DateTime(attribute='submitted_dt')
     registration_data = fields.Method('_get_registration_data')
     personal_data_picture = fields.Method('_get_personal_data_picture')
+
+    def _get_checked_in(self, registration):
+        check_type_id = self.context.get('check_type_id')
+        if check_type_id is not None:
+            return registration.is_checked_in_for_type(check_type_id)
+        return registration.checked_in
+
+    def _get_checked_in_dt(self, registration):
+        check_type_id = self.context.get('check_type_id')
+        if check_type_id is not None:
+            return str(registration.get_checked_in_dt_for_type(check_type_id))
+        return str(registration.checked_in_dt)
+
+    def _get_checked_out(self, registration):
+        check_type_id = self.context.get('check_type_id')
+        if check_type_id is not None:
+            return registration.is_checked_out_for_type(check_type_id)
+        return registration.checked_out
+
+    def _get_checked_out_dt(self, registration):
+        check_type_id = self.context.get('check_type_id')
+        if check_type_id is not None:
+            return str(registration.get_checked_out_dt_for_type(check_type_id))
+        return str(registration.checked_out_dt)
 
     def _get_payment_date(self, registration):
         if registration.is_paid and (transaction := registration.transaction):

--- a/indico/modules/events/registration/templates/management/_registration_check_type_list.html
+++ b/indico/modules/events/registration/templates/management/_registration_check_type_list.html
@@ -1,0 +1,61 @@
+{% macro render_check_types(check_types, event) %}
+    {% if check_types %}
+        <div class="i-box-content">
+        <table class="i-table-widget">
+            <tr>
+                <th>{% trans -%}Title{%- endtrans %}</th>
+                <th>{% trans -%}Rule{%- endtrans %}</th>
+                <th>{% trans -%}Can check out{%- endtrans %}</th>
+                <th></th>
+            </tr>
+            {% for check_type in check_types|sort(attribute='title', case_sensitive=false) %}
+                <tr>
+                    <td>
+                        {{ check_type.title }}
+                    </td>
+                    <td>
+                        {{ check_type.rule.title }}
+                    </td>
+                    <td>
+                        {{ check_type.check_out_allowed }}
+                    </td>
+                    <td>
+                        <span class="right hide-if-locked">
+                            <button class="icon-bookmark i-button text-color borderless" style="{{ 'opacity: 0.3;' if event.default_check_type_id != check_type.id }}"
+                                    data-href="{{ url_for('.manage_registration_check_types_toggle', event, check_type_id=check_type.id) }}"
+                                    {% if event.default_check_type_id == check_type.id %}
+                                        title="{% trans %}This is the default check type for this event{% endtrans %}"
+                                    {% else %}
+                                        title="{% trans %}Make default check type for this event{% endtrans %}"
+                                        data-confirm="{% trans %}Do you really want to make this the default check type of this event?
+                                                                 It will be used to calculate the checked-in state of the registration
+                                                                 on the registration list, participant list and other places in indico.
+                                                    {% endtrans %}"
+                                        data-method="POST"
+                                        data-reload-after
+                                    {% endif %}
+                                    ></button>
+                            {% if not check_type.is_system_defined %}
+                                <button class="icon-edit i-button text-color borderless" data-href="{{ url_for('.manage_registration_check_types_edit', check_type) }}"
+                                        data-title
+                                        title="{% trans %}Edit check type{% endtrans %}"
+                                        data-update="#check-types"
+                                        data-ajax-dialog></button>
+                                <button class="icon-remove i-button text-color borderless danger {{ 'disabled' if event.default_check_type_id == check_type.id }}"
+                                        data-href="{{ url_for('.manage_registration_check_types_delete', check_type) }}"
+                                        data-title
+                                        data-update="#check-types"
+                                        title="{% trans %}Delete check type{% endtrans %}"
+                                        data-confirm="{% trans %}Do you really want to delete this check type?
+                                                                This will delete all previously performed checks of this type on registrations
+                                                    {% endtrans %}"
+                                        data-method="POST">
+                                </button>
+                            {% endif %}
+                        </span>
+                    </td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% endif %}
+{% endmacro %}

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -19,7 +19,7 @@
             </div>
             {% block checkin_state scoped %}
                 {% if registration.state.name in ('unpaid', 'complete') %}
-                    {{ _render_check_in(registration) }}
+                    {{ _render_checks(registration) }}
                 {% endif %}
             {% endblock %}
             {{ template_hook('extra-registration-actions', registration=registration) }}
@@ -245,8 +245,7 @@
     {% endblock %}
 {% endmacro %}
 
-
-{% macro _render_check_in(registration) %}
+{% macro _render_checks(registration) %}
     <div class="section">
         {% if registration.checked_in %}
             <div class="icon icon-location registration-checked-in"></div>
@@ -257,24 +256,44 @@
                 {% trans checked_in_dt=registration.checked_in_dt|format_date(timezone=registration.event.tzinfo) -%}
                     Checked in: {{ checked_in_dt }}
                 {%- endtrans %}
-                <span class="hide-if-locked">
-                    (<a href="#"
-                       title="{% trans %}Mark as not checked in{% endtrans %}"
-                       data-update="#registration-details"
-                       data-method="DELETE"
-                       data-href="{{ url_for('.registration_check_in', registration) }}"
-                       data-confirm="{% trans %}Are you sure you want to reset the check-in info? The original check-in time will be lost.{% endtrans %}"
-                       data-title="{% trans %}Reset check-in info{% endtrans %}">
-                       {%- trans %}reset{% endtrans -%}
-                    </a>)
-                </span>
+                <a data-href="{{ url_for('.registration_checks', registration) }}"
+                    data-ajax-dialog
+                    data-title="{% trans %}Registration checks{% endtrans %}">
+                    {% trans %}View past checks{% endtrans %}
+                </a>
+            </div>
+            {% set can_check_out_result = registration.can_perform_check(is_check_out=True) %}
+            <div class="toolbar hide-if-locked">
+                <div class="group">
+                    <button class="i-button"
+                            data-href="{{ url_for('.add_registration_check', registration, is_check_out=True) }}"
+                            data-update="#registration-details"
+                            data-method="POST"
+                            {% if can_check_out_result['can_check'] %}
+                                data-title="{% trans %}Check-out{% endtrans %}"
+                            {% else %}
+                                disabled
+                                title="{{ can_check_out_result['reason'] }}"
+                            {% endif %}>
+                        {% trans %}Check-out{% endtrans %}
+                    </button>
+                </div>
             </div>
         {% else %}
             <div class="icon icon-location"></div>
             <div class="text">
-                <div class="label">
-                    {% trans %}Not checked in{% endtrans %}
-                </div>
+                {% if registration.checked_out %}
+                    <div class="label">
+                        {% trans %}Checked out{% endtrans %}
+                    </div>
+                    {% trans checked_out_dt=registration.checked_out_dt|format_date(timezone=registration.event.tzinfo) -%}
+                        Checked out: {{ checked_out_dt }}
+                    {%- endtrans %}
+                {% else %}
+                    <div class="label">
+                        {% trans %}Not checked in{% endtrans %}
+                    </div>
+                {% endif %}
                 {% if registration.registration_form.tickets_enabled %}
                     {% trans -%}
                         You can mark the registration as checked in manually here or with the Indico Check in app.
@@ -284,14 +303,30 @@
                         You can mark the registration as checked in manually.
                     {%- endtrans %}
                 {% endif %}
+                {% if registration.checks %}
+                    <a data-href="{{ url_for('.registration_checks', registration) }}"
+                       data-ajax-dialog
+                       data-title="{% trans %}Registration checks{% endtrans %}">
+                        {% trans %}View past checks{% endtrans %}
+                    </a>
+                {% endif %}
             </div>
+            {% set can_check_in_result = registration.can_perform_check() %}
             <div class="toolbar hide-if-locked">
-                <button class="i-button"
-                        data-update="#registration-details"
-                        data-method="PUT"
-                        data-href="{{ url_for('.registration_check_in', registration) }}">
-                    {% trans %}Check-in{% endtrans %}
-                </button>
+                <div class="group">
+                    <button class="i-button"
+                            data-href="{{ url_for('.add_registration_check', registration) }}"
+                            data-update="#registration-details"
+                            data-method="POST"
+                            {% if can_check_in_result['can_check'] %}
+                                data-title="{% trans %}Check-in{% endtrans %}"
+                            {% else %}
+                                disabled
+                                title="{{ can_check_in_result['reason'] }}"
+                            {% endif %}>
+                        {% trans %}Check-in{% endtrans %}
+                    </button>
+                </div>
             </div>
         {% endif %}
     </div>

--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -22,7 +22,7 @@
             </div>
             {% block checkin_state scoped %}
                 {% if registration.state.name in ('unpaid', 'complete') and (can_manage_registration or can_checkin) %}
-                    {{ _render_check_in(registration) }}
+                    {{ _render_checks(registration) }}
                 {% endif %}
             {% endblock %}
             {{ template_hook('extra-registration-actions', registration=registration) }}
@@ -268,8 +268,7 @@
     {% endblock %}
 {% endmacro %}
 
-
-{% macro _render_check_in(registration) %}
+{% macro _render_checks(registration) %}
     <div class="section">
         {% if registration.checked_in %}
             <div class="icon icon-location registration-checked-in"></div>
@@ -280,24 +279,44 @@
                 {% trans checked_in_dt=registration.checked_in_dt|format_datetime(timezone=registration.event.tzinfo) -%}
                     Checked in: {{ checked_in_dt }}
                 {%- endtrans %}
-                <span class="hide-if-locked">
-                    (<a href="#"
-                       title="{% trans %}Mark as not checked in{% endtrans %}"
-                       data-update="#registration-details"
-                       data-method="DELETE"
-                       data-href="{{ url_for('.registration_check_in', registration) }}"
-                       data-confirm="{% trans %}Are you sure you want to reset the check-in info? The original check-in time will be lost.{% endtrans %}"
-                       data-title="{% trans %}Reset check-in info{% endtrans %}">
-                       {%- trans %}reset{% endtrans -%}
-                    </a>)
-                </span>
+                <a data-href="{{ url_for('.registration_checks', registration) }}"
+                    data-ajax-dialog
+                    data-title="{% trans %}Registration checks{% endtrans %}">
+                    {% trans %}View past checks{% endtrans %}
+                </a>
+            </div>
+            {% set can_check_out_result = registration.can_perform_check(is_check_out=True) %}
+            <div class="toolbar hide-if-locked">
+                <div class="group">
+                    <button class="i-button"
+                            data-href="{{ url_for('.add_registration_check', registration, is_check_out=True) }}"
+                            data-update="#registration-details"
+                            data-method="POST"
+                            {% if can_check_out_result['can_check'] %}
+                                data-title="{% trans %}Check-out{% endtrans %}"
+                            {% else %}
+                                disabled
+                                title="{{ can_check_out_result['reason'] }}"
+                            {% endif %}>
+                        {% trans %}Check-out{% endtrans %}
+                    </button>
+                </div>
             </div>
         {% else %}
             <div class="icon icon-location"></div>
             <div class="text">
-                <div class="label">
-                    {% trans %}Not checked in{% endtrans %}
-                </div>
+                {% if registration.checked_out %}
+                    <div class="label">
+                        {% trans %}Checked out{% endtrans %}
+                    </div>
+                    {% trans checked_out_dt=registration.checked_out_dt|format_date(timezone=registration.event.tzinfo) -%}
+                        Checked out: {{ checked_out_dt }}
+                    {%- endtrans %}
+                {% else %}
+                    <div class="label">
+                        {% trans %}Not checked in{% endtrans %}
+                    </div>
+                {% endif %}
                 {% if registration.registration_form.tickets_enabled %}
                     {% trans -%}
                         You can mark the registration as checked in manually here or with the Indico Check in app.
@@ -307,14 +326,30 @@
                         You can mark the registration as checked in manually.
                     {%- endtrans %}
                 {% endif %}
+                {% if registration.checks %}
+                    <a data-href="{{ url_for('.registration_checks', registration) }}"
+                       data-ajax-dialog
+                       data-title="{% trans %}Registration checks{% endtrans %}">
+                        {% trans %}View past checks{% endtrans %}
+                    </a>
+                {% endif %}
             </div>
+            {% set can_check_in_result = registration.can_perform_check() %}
             <div class="toolbar hide-if-locked">
-                <button class="i-button"
-                        data-update="#registration-details"
-                        data-method="PUT"
-                        data-href="{{ url_for('.registration_check_in', registration) }}">
-                    {% trans %}Check-in{% endtrans %}
-                </button>
+                <div class="group">
+                    <button class="i-button"
+                            data-href="{{ url_for('.add_registration_check', registration) }}"
+                            data-update="#registration-details"
+                            data-method="POST"
+                            {% if can_check_in_result['can_check'] %}
+                                data-title="{% trans %}Check-in{% endtrans %}"
+                            {% else %}
+                                disabled
+                                title="{{ can_check_in_result['reason'] }}"
+                            {% endif %}>
+                        {% trans %}Check-in{% endtrans %}
+                    </button>
+                </div>
             </div>
         {% endif %}
     </div>

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -78,6 +78,19 @@
                                                 {{- registration.checked_in_dt | format_datetime(timezone=registration.event.tzinfo) -}}
                                             {%- endif %}
                                         </td>
+                                    {% elif item.id == 'checked_out' %}
+                                        <td class="i-table">
+                                            {% if registration.checked_out %}
+                                                {%- trans %}Yes{% endtrans -%}
+                                            {% else %}
+                                                {%- trans %}No{% endtrans -%}
+                                            {% endif %}
+                                    {% elif item.id == 'checked_out_date' %}
+                                        <td class="i-table" data-text="{{ registration.checked_out_dt }}">
+                                            {%- if registration.checked_out_dt %}
+                                                {{- registration.checked_out_dt | format_datetime(timezone=registration.event.tzinfo) -}}
+                                            {%- endif %}
+                                        </td>
                                     {% elif item.id == 'payment_date' %}
                                         <td class="i-table" data-text="{{ registration.payment_dt }}">
                                             {%- if registration.payment_dt %}

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -88,6 +88,20 @@
                                                 {{- registration.checked_in_dt | format_datetime(timezone=registration.event.tzinfo) -}}
                                             {%- endif %}
                                         </td>
+                                    {% elif item.id == 'checked_out' %}
+                                        <td class="i-table">
+                                            {% if registration.checked_out %}
+                                                {%- trans %}Yes{% endtrans -%}
+                                            {% else %}
+                                                {%- trans %}No{% endtrans -%}
+                                            {% endif %}
+                                        </td>
+                                    {% elif item.id == 'checked_out_date' %}
+                                        <td class="i-table" data-text="{{ registration.checked_out_dt }}">
+                                            {%- if registration.checked_out_dt %}
+                                                {{- registration.checked_out_dt | format_datetime(timezone=registration.event.tzinfo) -}}
+                                            {%- endif %}
+                                        </td>
                                     {% elif item.id == 'payment_date' %}
                                         <td class="i-table" data-text="{{ registration.payment_dt }}">
                                             {%- if registration.payment_dt %}

--- a/indico/modules/events/registration/templates/management/regform_list.html
+++ b/indico/modules/events/registration/templates/management/regform_list.html
@@ -118,6 +118,22 @@
                     </div>
                 {% endblock %}
             {% endif %}
+            {% block check_types_sectioon %}
+                <div class="section">
+                    <div class="icon icon-user-check"></div>
+                    <div class="text">
+                        <div class="label">{% trans %}Registration checks{% endtrans %}</div>
+                        {% trans %}Define registration verification checks and rules{% endtrans %}
+                    </div>
+                    <div class="toolbar">
+                        <div class="group">
+                            <a href="{{ url_for('.manage_registration_check_types', event) }}" class="i-button icon-settings">
+                                {%- trans %}Configure{% endtrans -%}
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            {% endblock %}
         </div>
     {% endblock %}
     {{ template_hook('extra-registration-settings', event=event) }}

--- a/indico/modules/events/registration/templates/management/regform_list.html
+++ b/indico/modules/events/registration/templates/management/regform_list.html
@@ -123,6 +123,22 @@
                     </div>
                 {% endblock %}
             {% endif %}
+            {% block check_types_section %}
+                <div class="section">
+                    <div class="icon icon-user-check"></div>
+                    <div class="text">
+                        <div class="label">{% trans %}Registration checks{% endtrans %}</div>
+                        {% trans %}Define registration verification checks and rules{% endtrans %}
+                    </div>
+                    <div class="toolbar">
+                        <div class="group">
+                            <a href="{{ url_for('.manage_registration_check_types', event) }}" class="i-button icon-settings">
+                                {%- trans %}Configure{% endtrans -%}
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            {% endblock %}
         </div>
     {% endblock %}
     {{ template_hook('extra-registration-settings', event=event) }}

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -188,21 +188,25 @@
                         </button>
                         <ul class="i-dropdown">
                             <li>
-                                <a href="#" class="icon-location js-requires-selected-row disabled js-modify-status"
+                                <a href="#" class="icon-location js-requires-selected-row disabled"
+                                   data-href="{{ url_for('.registrations_check', regform, is_check_out=False) }}"
+                                   data-params-selector="#registration-list tr input[type=checkbox]:checked"
                                    data-method="POST"
-                                   data-flag="1"
-                                   data-href="{{ url_for('.registrations_check_in', regform) }}">
+                                   data-title="{% trans %}Check-in registrations{% endtrans %}"
+                                   data-update="#registration-list"
+                                   data-ajax-dialog>
                                     {%- trans %}Check-in{% endtrans -%}
                                 </a>
                             </li>
                             <li>
-                                <a href="#" class="icon-close js-requires-selected-row disabled js-modify-status"
-                                   data-href="{{ url_for('.registrations_check_in', regform) }}"
+                                <a href="#" class="icon-undo js-requires-selected-row disabled"
+                                   data-href="{{ url_for('.registrations_check', regform, is_check_out=True) }}"
+                                   data-params-selector="#registration-list tr input[type=checkbox]:checked"
                                    data-method="POST"
-                                   data-flag="0"
-                                   data-confirm="{% trans %}Are you sure you want to reset the check-in info? The original check-in time will be lost.{% endtrans %}"
-                                   data-title="{% trans %}Reset check-in{% endtrans %}">
-                                    {%- trans %}Reset check-in{% endtrans -%}
+                                   data-title="{% trans %}Check-out registrations{% endtrans %}"
+                                   data-update="#registration-list"
+                                   data-ajax-dialog>
+                                    {%- trans %}Check-out{% endtrans -%}
                                 </a>
                             </li>
                         </ul>

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -202,21 +202,25 @@
                         </button>
                         <ul class="i-dropdown">
                             <li>
-                                <a href="#" class="icon-location js-requires-selected-row disabled js-modify-status"
+                                <a href="#" class="icon-location js-requires-selected-row disabled"
+                                   data-href="{{ url_for('.registrations_check', regform, is_check_out=False) }}"
+                                   data-params-selector="#registration-list tr input[type=checkbox]:checked"
                                    data-method="POST"
-                                   data-flag="1"
-                                   data-href="{{ url_for('.registrations_check_in', regform) }}">
+                                   data-title="{% trans %}Check-in registrations{% endtrans %}"
+                                   data-update="#registration-list"
+                                   data-ajax-dialog>
                                     {%- trans %}Check-in{% endtrans -%}
                                 </a>
                             </li>
                             <li>
-                                <a href="#" class="icon-close js-requires-selected-row disabled js-modify-status"
-                                   data-href="{{ url_for('.registrations_check_in', regform) }}"
+                                <a href="#" class="icon-undo js-requires-selected-row disabled"
+                                   data-href="{{ url_for('.registrations_check', regform, is_check_out=True) }}"
+                                   data-params-selector="#registration-list tr input[type=checkbox]:checked"
                                    data-method="POST"
-                                   data-flag="0"
-                                   data-confirm="{% trans %}Are you sure you want to reset the check-in info? The original check-in time will be lost.{% endtrans %}"
-                                   data-title="{% trans %}Reset check-in{% endtrans %}">
-                                    {%- trans %}Reset check-in{% endtrans -%}
+                                   data-title="{% trans %}Check-out registrations{% endtrans %}"
+                                   data-update="#registration-list"
+                                   data-ajax-dialog>
+                                    {%- trans %}Check-out{% endtrans -%}
                                 </a>
                             </li>
                         </ul>

--- a/indico/modules/events/registration/templates/management/registration_check_types.html
+++ b/indico/modules/events/registration/templates/management/registration_check_types.html
@@ -1,0 +1,57 @@
+{% extends 'events/management/base.html' %}
+{% from 'message_box.html' import message_box %}
+{% from 'events/registration/management/_registration_check_type_list.html' import render_check_types %}
+
+
+{% block title %}
+    {%- trans %}Registration checks{% endtrans -%}
+{% endblock %}
+
+{% block description %}
+    <p>
+        {% trans -%}
+            Define checks and rules to check-in/check-out registrations. Example:
+            "Entrance Check" or "Collect souvenir".
+        {%- endtrans %}
+    </p>
+    <p>
+        {% trans -%}
+            Also specify rules such as once, daily or multiple and whether it can be checked out.
+            Do not define 2 checks for inverse actions, e.g "Entered room" and "Exited room".
+            Instead define one check "Entered room" with "Check out" enabled.
+        {%- endtrans %}
+    </p>
+{% endblock %}
+
+{% block content %}
+    <div class="i-box-group vert fixed-width">
+        <div class="i-box">
+            <div class="i-box-header" style="margin-bottom: 10px;">
+                <div class="i-box-title">{%- trans %}Event Defined Check Types{% endtrans -%}</div>
+                <div class="i-box-buttons hide-if-locked">
+                    <button class="i-button icon-plus" data-href="{{ url_for('.manage_registration_check_types_add', event) }}"
+                       data-title="{%- trans %}Create a check type{% endtrans -%}"
+                       data-ajax-dialog
+                       data-update="#check-types">
+                        {%- trans %}Create a check type{% endtrans -%}
+                    </button>
+                </div>
+            </div>
+            <div id="check-types" class="i-box-content">
+                {% if event.check_types %}
+                    {{ render_check_types(event.check_types, event) }}
+                {% endif %}
+            </div>
+        </div>
+    </div>
+    <div class="i-box-group vert fixed-width">
+        <div class="i-box">
+            <div class="i-box-header" style="margin-bottom: 10px;">
+                <div class="i-box-title">{%- trans %}System Defined Check Types{% endtrans -%}</div>
+            </div>
+            <div id="system-check-types" class="i-box-content">
+                {{ render_check_types(system_check_types, event) }}
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/indico/modules/events/registration/templates/management/registration_checks.html
+++ b/indico/modules/events/registration/templates/management/registration_checks.html
@@ -1,0 +1,70 @@
+{% macro render_registration_checks(checks) %}
+    {% set time_zone = registration.event.tzinfo %}
+    <table class="i-table-widget">
+        <tr>
+            <th>{% trans -%}Check type{%- endtrans %}</th>
+            <th>{% trans -%}Check frequency{%- endtrans %}</th>
+            <th>{% trans -%}Action{%- endtrans %}</th>
+            <th>{% trans -%}Date{%- endtrans %}</th>
+            <th>{% trans -%}Performed by{%- endtrans %}</th>
+            <th></th>
+        </tr>
+        {% for check in checks %}
+            <tr>
+                <td>
+                    {{ check.check_type.title }}
+                </td>
+                <td>
+                    {{check.check_type.rule.title}}
+                </td>
+                <td>
+                    {{ 'Checked-out' if check.is_check_out else 'Checked-in' }}
+                </td>
+                <td>
+                    {% trans checked_dt=check.timestamp|format_datetime(timezone=time_zone) -%}
+                        {{ checked_dt }}
+                    {%- endtrans %}
+                </td>
+                <td>
+                    {{ check.checked_by_user.name if check.checked_by_user }}
+                </td>
+                <td>
+                    <button class="icon-remove i-button text-color borderless warning"
+                            data-method="POST"
+                            data-href="{{ url_for('.delete_registration_check', check) }}"
+                            data-reload-after
+                            title="{% trans %}Delete check{% endtrans %}"
+                            data-confirm="{% trans %}Do you really want to delete this check? Once deleted, this record cannot be recovered{% endtrans %}">
+                    </button>
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endmacro %}
+
+{% block content %}
+    <div class="i-box-group vert fixed-width">
+        <div class="i-box">
+            <div class="i-box-header">
+                <div class="i-box-title">
+                    {%- trans %}Registration Checks for{% endtrans %}
+                    {{ registration.full_name }}
+                </div>
+            </div>
+            <div class="i-box-content">
+                {{ render_registration_checks(registration.checks) }}
+            </div>
+            <div class="i-box-content" style="margin-top: 10px">
+                <span>{% trans %}You may additionally reset the registration checked state by deleting all past checks{%endtrans%}</span>
+                <button class="i-button danger"
+                        data-method="POST"
+                        data-href="{{ url_for('.reset_registration_checks', registration) }}"
+                        data-reload-after
+                        title="{% trans %}Delete all checks{% endtrans %}"
+                        data-confirm="{% trans %}Do you really want to delete all checks for this registration? Once reset, the checks cannot be recovered{% endtrans %}">
+                    {% trans %}Reset checks{% endtrans %}
+                </button>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/indico/modules/events/registration/testing/fixtures.py
+++ b/indico/modules/events/registration/testing/fixtures.py
@@ -44,13 +44,13 @@ def dummy_reg(db, dummy_event, dummy_regform, dummy_user):
         registration_form_id=dummy_regform.id,
         first_name='Guinea',
         last_name='Pig',
-        checked_in=True,
         state=RegistrationState.complete,
         currency='USD',
         email='1337@example.test',
         user=dummy_user
     )
     dummy_event.registrations.append(reg)
+    reg.checked_in = True
     db.session.flush()
     return reg
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -37,6 +37,7 @@ from indico.modules.events.registration.constants import REGISTRATION_PICTURE_SI
 from indico.modules.events.registration.fields.accompanying import AccompanyingPersonsField
 from indico.modules.events.registration.fields.choices import (AccommodationField, ChoiceBaseField,
                                                                get_field_merged_options)
+from indico.modules.events.registration.models.checks import RegistrationCheck, RegistrationCheckType
 from indico.modules.events.registration.models.form_fields import (RegistrationFormFieldData,
                                                                    RegistrationFormPersonalDataField)
 from indico.modules.events.registration.models.forms import RegistrationForm
@@ -589,6 +590,8 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
         'price': ('Price', lambda x: x.render_price()),
         'checked_in': ('Checked in', lambda x: x.checked_in),
         'checked_in_date': ('Check-in date', lambda x: x.checked_in_dt if x.checked_in else ''),
+        'checked_out': ('Checked out', lambda x: x.checked_out),
+        'checked_out_date': ('Check-out date', lambda x: x.checked_out_dt if x.checked_out else ''),
         'payment_date': ('Payment date', lambda x: (x.transaction.timestamp
                                                     if (x.transaction is not None and
                                                         x.transaction.status == TransactionStatus.successful)
@@ -1192,3 +1195,39 @@ class CustomTicketCode:
     def lookup_registration(cls, data: str) -> Registration | None:
         """Lookup a registration based on custom ticket code data."""
         raise NotImplementedError
+
+
+def create_registration_check_type(data, event=None):
+    check_type = RegistrationCheckType(event=event, is_system_defined=not event)
+    check_type.populate_from_dict(data)
+    db.session.add(check_type)
+    db.session.flush()
+    logger.info('Registration check type "%s" created by %s', check_type, session.user)
+    return check_type
+
+
+def update_registration_check_type(check_type, data):
+    check_type.populate_from_dict(data)
+    db.session.flush()
+    logger.info('Registration check type "%s" updated by %s', check_type, session.user)
+
+
+def delete_registration_check_type(check_type):
+    db.session.delete(check_type)
+    db.session.flush()
+    logger.info('Registration check type "%s" deleted by %s', check_type, session.user)
+
+
+def create_registration_check(registration, check_type=None, is_check_out=False, checked_by_user=None):
+    if not check_type:
+        check_type = registration.event.default_check_type
+    test_perform_check = registration.can_perform_check(check_type=check_type, is_check_out=is_check_out)
+    if not test_perform_check['can_check']:
+        raise ValueError(test_perform_check['reason'])
+    check = RegistrationCheck(registration=registration, check_type=check_type, is_check_out=is_check_out,
+                              checked_by_user=checked_by_user)
+    db.session.add(check)
+    db.session.flush()
+    signals.event.registration_check_added.send(check)
+    logger.info('Registration %s checked as "%s" by %s', registration, check_type.title, checked_by_user)
+    return check

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -39,6 +39,7 @@ from indico.modules.events.registration.fields.accompanying import AccompanyingP
 from indico.modules.events.registration.fields.affiliation import AffiliationMode
 from indico.modules.events.registration.fields.choices import (AccommodationField, ChoiceBaseField,
                                                                get_field_merged_options)
+from indico.modules.events.registration.models.checks import RegistrationCheck, RegistrationCheckType
 from indico.modules.events.registration.models.form_fields import (RegistrationFormFieldData,
                                                                    RegistrationFormPersonalDataField)
 from indico.modules.events.registration.models.forms import RegistrationForm
@@ -627,6 +628,8 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
         'price': ('Price', lambda x: x.render_price()),
         'checked_in': ('Checked in', lambda x: x.checked_in),
         'checked_in_date': ('Check-in date', lambda x: x.checked_in_dt if x.checked_in else ''),
+        'checked_out': ('Checked out', lambda x: x.checked_out),
+        'checked_out_date': ('Check-out date', lambda x: x.checked_out_dt if x.checked_out else ''),
         'payment_date': ('Payment date', lambda x: (x.transaction.timestamp
                                                     if (x.transaction is not None and
                                                         x.transaction.status == TransactionStatus.successful)
@@ -718,6 +721,14 @@ def generate_pdf_data_from_registrations(event, registrations, regform_items, st
         'checked_in_date': (
             _('Check-in date'),
             lambda x: format_datetime(x.checked_in_dt, timezone=event.tzinfo) if x.checked_in else '',
+        ),
+        'checked_out': (
+            _('Checked out'),
+            lambda x: x.checked_out,
+        ),
+        'checked_out_date': (
+            _('Check-out date'),
+            lambda x: format_datetime(x.checked_out_dt, timezone=event.tzinfo) if x.checked_out else '',
         ),
         'payment_date': (
             _('Payment date'),
@@ -1321,3 +1332,39 @@ class CustomTicketCode:
     def lookup_registration(cls, data: str) -> Registration | None:
         """Lookup a registration based on custom ticket code data."""
         raise NotImplementedError
+
+
+def create_registration_check_type(data, event=None):
+    check_type = RegistrationCheckType(event=event, is_system_defined=not event)
+    check_type.populate_from_dict(data)
+    db.session.add(check_type)
+    db.session.flush()
+    logger.info('Registration check type "%s" created by %s', check_type, session.user)
+    return check_type
+
+
+def update_registration_check_type(check_type, data):
+    check_type.populate_from_dict(data)
+    db.session.flush()
+    logger.info('Registration check type "%s" updated by %s', check_type, session.user)
+
+
+def delete_registration_check_type(check_type):
+    db.session.delete(check_type)
+    db.session.flush()
+    logger.info('Registration check type "%s" deleted by %s', check_type, session.user)
+
+
+def create_registration_check(registration, check_type=None, is_check_out=False, checked_by_user=None):
+    if not check_type:
+        check_type = registration.event.default_check_type
+    test_perform_check = registration.can_perform_check(check_type=check_type, is_check_out=is_check_out)
+    if not test_perform_check['can_check']:
+        raise ValueError(test_perform_check['reason'])
+    check = RegistrationCheck(registration=registration, check_type=check_type, is_check_out=is_check_out,
+                              checked_by_user=checked_by_user)
+    db.session.add(check)
+    db.session.flush()
+    signals.event.registration_check_added.send(check)
+    logger.info('Registration %s checked as "%s" by %s', registration, check_type.title, checked_by_user)
+    return check

--- a/indico/modules/events/settings.py
+++ b/indico/modules/events/settings.py
@@ -15,7 +15,7 @@ from flask.helpers import get_root_path
 
 from indico.core import signals
 from indico.core.settings import ACLProxyBase, SettingProperty, SettingsProxyBase
-from indico.core.settings.converters import DatetimeConverter, TimedeltaConverter
+from indico.core.settings.converters import DatetimeConverter, ModelConverter, TimedeltaConverter
 from indico.core.settings.proxy import SettingsProxy
 from indico.core.settings.util import get_all_settings, get_setting, get_setting_acl, preload_settings_bulk
 from indico.modules.events.models.settings import EventSetting, EventSettingPrincipal
@@ -284,4 +284,10 @@ data_retention_settings = SettingsProxy('data_retention', {
 }, converters={
     'minimum_data_retention': TimedeltaConverter,
     'maximum_data_retention': TimedeltaConverter
+})
+
+default_check_type_settings = SettingsProxy('default_check_type', {
+    'default_check_type': None,
+}, converters={
+    'default_check_type': ModelConverter('RegistrationCheckType'),
 })

--- a/indico/modules/events/templates/admin/_system_check_type_list.html
+++ b/indico/modules/events/templates/admin/_system_check_type_list.html
@@ -1,0 +1,53 @@
+{% macro render_check_types(check_types, default_check_type) %}
+    <table class="i-table-widget">
+        <tr>
+            <th>{% trans -%}Title{%- endtrans %}</th>
+            <th>{% trans -%}Rule{%- endtrans %}</th>
+            <th>{% trans -%}Can check out{%- endtrans %}</th>
+            <th></th>
+        </tr>
+        {% for check_type in check_types %}
+            <tr>
+                <td>
+                    {{ check_type.title }}
+                </td>
+                <td>
+                    {{ check_type.rule.title }}
+                </td>
+                <td>
+                    {{ check_type.check_out_allowed }}
+                </td>
+                <td>
+                    <span class="right hide-if-locked">
+                        <button class="icon-bookmark i-button text-color borderless" style="{{ 'opacity: 0.3;' if default_check_type != check_type }}"
+                                data-href="{{ url_for('.toggle_default_check_type', check_type_id=check_type.id) }}"
+                                {% if default_check_type == check_type %}
+                                    title="{% trans %}This is the default check type for this instance{% endtrans %}"
+                                {% else %}
+                                    title="{% trans %}Make default check type for this instance{% endtrans %}"
+                                    data-method="POST"
+                                    data-update="#check-types"
+                                {% endif %}
+                                ></button>
+                        <button class="icon-edit i-button text-color borderless"
+                                data-href="{{ url_for('.update_check_type', check_type) }}"
+                                data-title
+                                title="{% trans %}Edit check type{% endtrans %}"
+                                data-ajax-dialog
+                                data-update="#check-types"></button>
+                        <button class="icon-remove i-button text-color borderless danger {{ 'disabled' if default_check_type == check_type }}"
+                                    data-href="{{ url_for('.delete_check_type', check_type) }}"
+                                    data-title
+                                    data-update="#check-types"
+                                    title="{% trans %}Delete check type{% endtrans %}"
+                                    data-confirm="{% trans %}Do you really want to delete this check type?
+                                                            This will delete all previously performed checks of this type on registrations
+                                                  {% endtrans %}"
+                                    data-method="DELETE">
+                            </button>
+                    </span>
+                </td>
+            </tr>
+        {% endfor %}
+    </table>
+{% endmacro %}

--- a/indico/modules/events/templates/admin/system_check_types.html
+++ b/indico/modules/events/templates/admin/system_check_types.html
@@ -1,0 +1,22 @@
+{% extends 'layout/admin_page.html' %}
+{% from 'events/admin/_system_check_type_list.html' import render_check_types %}
+
+{%- block content %}
+    <div class="i-box">
+        <div class="i-box-header">
+            <div class="i-box-title">{%- trans %}System check types{% endtrans -%}</div>
+            <div class="i-box-buttons toolbar right">
+                <button class="i-button icon-plus"
+                        data-ajax-dialog
+                        data-href="{{ url_for('.create_check_type') }}"
+                        data-title="{% trans %}Create new check type{% endtrans %}"
+                        data-update="#check-types">
+                    {%- trans %}Create new check type{% endtrans -%}
+                </button>
+            </div>
+        </div>
+        <div id="check-types" class="i-box-table-widget">
+            {{ render_check_types(check_types, default_check_type) }}
+        </div>
+    </div>
+{%- endblock %}

--- a/indico/modules/events/tests/export_test_1_objects.yaml
+++ b/indico/modules/events/tests/export_test_1_objects.yaml
@@ -13,6 +13,9 @@
     - userref
     - 00000000-0000-4000-8000-000000000001
     custom_boa_id: null
+    default_check_type_id: !!python/tuple
+    - idref
+    - 00000000-0000-4000-8000-000000000002
     default_page_id: null
     description: ''
     end_dt: !!python/tuple
@@ -66,7 +69,7 @@
     friendly_id: 1
     id: !!python/tuple
     - idref_set
-    - 00000000-0000-4000-8000-000000000002
+    - 00000000-0000-4000-8000-000000000003
     inherit_location: true
     is_deleted: true
     protection_mode: !!python/object/apply:indico.core.db.sqlalchemy.protection.ProtectionMode
@@ -96,7 +99,7 @@
     friendly_id: 1
     id: !!python/tuple
     - idref_set
-    - 00000000-0000-4000-8000-000000000004
+    - 00000000-0000-4000-8000-000000000005
     inherit_location: true
     is_deleted: false
     keywords: []
@@ -132,7 +135,7 @@
     friendly_id: 2
     id: !!python/tuple
     - idref_set
-    - 00000000-0000-4000-8000-000000000006
+    - 00000000-0000-4000-8000-000000000007
     inherit_location: true
     is_deleted: true
     keywords: []
@@ -145,7 +148,7 @@
     session_block_id: null
     session_id: !!python/tuple
     - idref
-    - 00000000-0000-4000-8000-000000000002
+    - 00000000-0000-4000-8000-000000000003
     title: c2
     track_id: null
     type_id: null

--- a/indico/modules/events/tests/export_test_1_objects.yaml
+++ b/indico/modules/events/tests/export_test_1_objects.yaml
@@ -13,6 +13,7 @@
     - userref
     - 00000000-0000-4000-8000-000000000001
     custom_boa_id: null
+    default_check_type_id: Check type
     default_page_id: null
     description: ''
     end_dt: !!python/tuple

--- a/indico/modules/events/tests/export_test_2_objects.yaml
+++ b/indico/modules/events/tests/export_test_2_objects.yaml
@@ -12,6 +12,9 @@
     creator_id: !!python/tuple
     - userref
     - 00000000-0000-4000-8000-00000000000a
+    default_check_type_id: !!python/tuple
+    - idref
+    - 00000000-0000-4000-8000-000000000008
     default_page_id: null
     description: ''
     end_dt: !!python/tuple

--- a/indico/modules/events/tests/export_test_2_objects.yaml
+++ b/indico/modules/events/tests/export_test_2_objects.yaml
@@ -12,6 +12,7 @@
     creator_id: !!python/tuple
     - userref
     - 00000000-0000-4000-8000-00000000000a
+    default_check_type_id: Check type
     default_page_id: null
     description: ''
     end_dt: !!python/tuple

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -500,6 +500,7 @@ class User(PersonMixin, db.Model):
     # - paper_reviews (PaperReview.user)
     # - paper_revisions (PaperRevision.submitter)
     # - personal_tokens (PersonalToken.user)
+    # - registration_checks_performed (RegistrationCheck.checked_by_user)
     # - registrations (Registration.user)
     # - requests_created (Request.created_by_user)
     # - requests_processed (Request.processed_by_user)

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -510,6 +510,7 @@ class User(PersonMixin, db.Model):
     # - paper_reviews (PaperReview.user)
     # - paper_revisions (PaperRevision.submitter)
     # - personal_tokens (PersonalToken.user)
+    # - registration_checks_performed (RegistrationCheck.checked_by_user)
     # - registrations (Registration.user)
     # - requests_created (Request.created_by_user)
     # - requests_processed (Request.processed_by_user)

--- a/indico/testing/fixtures/event.py
+++ b/indico/testing/fixtures/event.py
@@ -12,6 +12,7 @@ import pytest
 from indico.modules.events import Event
 from indico.modules.events.models.events import EventType
 from indico.modules.events.models.labels import EventLabel
+from indico.modules.events.registration.models.checks import RegistrationCheckType
 from indico.util.date_time import now_utc
 from indico.util.string import crc32
 
@@ -22,7 +23,7 @@ DUMMY_BMP_IMAGE = (b'BM\x1e\x00\x00\x00\x00\x00\x00\x00\x1a\x00\x00\x00\x0c\x00'
 
 
 @pytest.fixture
-def create_event(dummy_user, dummy_category, db):
+def create_event(dummy_user, dummy_category, db, dummy_check_type):
     """Return a callable which lets you create dummy events."""
 
     def _create_event(id_=None, creator=None, creator_has_privileges=False, **kwargs):
@@ -36,6 +37,7 @@ def create_event(dummy_user, dummy_category, db):
         kwargs.setdefault('end_dt', now + timedelta(hours=1))
         kwargs.setdefault('timezone', 'UTC')
         kwargs.setdefault('category', dummy_category)
+        kwargs.setdefault('default_check_type_id', dummy_check_type.id)
         event = Event(id=id_, creator=creator, acl_entries=set(), **kwargs)
 
         if creator_has_privileges:
@@ -75,3 +77,22 @@ def dummy_event_logo(dummy_event):
         'filename': 'dummy-event-logo.bmp',
         'content_type': 'image/bmp'
     }
+
+
+@pytest.fixture
+def create_registration_check_type(db):
+    """Return a callable which lets you create dummy RegistrationCheckTypes."""
+
+    def _create_registration_check_type(title=None, is_system_defined=False):
+        check_type = RegistrationCheckType(title=title, is_system_defined=is_system_defined)
+        db.session.add(check_type)
+        db.session.flush()
+        return check_type
+
+    return _create_registration_check_type
+
+
+@pytest.fixture
+def dummy_check_type(create_registration_check_type):
+    """Create a mocked dummy RegistrationCheckType."""
+    return create_registration_check_type(title='Check type', is_system_defined=True)

--- a/indico/web/client/styles/partials/_icons.scss
+++ b/indico/web/client/styles/partials/_icons.scss
@@ -7,7 +7,7 @@
 
 /*
 Important: When adding new icons, read the guide below.
-Do not ediy any specific icons in here manually, the rules are generated
+Do not edit any specific icons in here manually, the rules are generated
 using the `bin/maintenance/generate_icons.py` script.
 */
 


### PR DESCRIPTION
TODO: 
- [ ] Make the check-in app compatible with the changes made https://github.com/indico/indico-checkin-pwa/pull/79
- [ ] The default check type of the event is used to calculate the check-in/out column in the registration list but perhaps it’ll be better to add a new column for each check type (in the registration list view) with check-in, check-out and their respective dates? 

Some details 

- Added configuring check types for Events (or in the admin area). The check types have a title, e.g a check "Collect souvenir" and can be performed based on the specified frequency. Available frequencies are "once", "once daily" and "multiple". 
<img width="1062" alt="Screenshot 2025-02-25 at 17 08 26" src="https://github.com/user-attachments/assets/2db24fbc-5742-4e17-9a69-535e67a94628" />
<img width="855" alt="Screenshot 2025-02-25 at 17 09 51" src="https://github.com/user-attachments/assets/05f5cf8d-bd47-4991-a422-01ce3a4fbd86" />



- Define if the check allows check-out or not. E.g "Entered room V" would allow check-out while "Collect Souvenir" would not
- Set a default check type for the event by enabling the star on each check type
<img width="834" alt="Screenshot 2025-02-25 at 17 32 47" src="https://github.com/user-attachments/assets/0bb1a05a-477d-4d9d-b329-dcad5a8c9021" />



- From the registration list you can check-in or check-out the registrations to a check type 
- The checked_in and checked_out state of the registrations are calculated using the default check type of the event
- From the registration details page, check-in or check-out will use the default check type of the event and you can see all the past checks as well as delete them 
<img width="757" alt="Screenshot 2025-02-25 at 17 42 24" src="https://github.com/user-attachments/assets/86d25930-7659-4050-bb28-c6748b3b7912" />



Opening this PR as draft since most of the things here are still up for discussion and all inputs are welcome. 

cc @OmeGak 