### PR TITLE
Add UserLogEntry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,8 @@ Improvements
   :user:`amCap1712`)
 - Allow to configure a restrictive set of allowed contribution keywords (:pr:`6778`, thanks
   :user:`tomako, unconventionaldotdev`)
+- Add a log for user actions, similar to that in events and categories (:pr:`6779`, thanks
+  :user:`tomako`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20250320_1800_4615aff776e0_add_user_logs.py
+++ b/indico/migrations/versions/20250320_1800_4615aff776e0_add_user_logs.py
@@ -1,0 +1,58 @@
+"""Add user logs
+
+Revision ID: 4615aff776e0
+Revises: 3fbd5d4ffb11
+Create Date: 2025-02-24 18:32:20.784460
+"""
+
+from enum import Enum
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = '4615aff776e0'
+down_revision = '3fbd5d4ffb11'
+branch_labels = None
+depends_on = None
+
+
+class _UserLogRealm(int, Enum):
+    user = 1
+    management = 2
+
+
+class _LogKind(int, Enum):
+    other = 1
+    positive = 2
+    change = 3
+    negative = 4
+
+
+def upgrade():
+    op.create_table('logs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('logged_dt', UTCDateTime, nullable=False),
+        sa.Column('kind', PyIntEnum(_LogKind), nullable=False),
+        sa.Column('module', sa.String(), nullable=False),
+        sa.Column('type', sa.String(), nullable=False),
+        sa.Column('summary', sa.String(), nullable=False),
+        sa.Column('data', postgresql.JSON(astext_type=sa.Text()), nullable=False),
+        sa.Column('meta', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('target_user_id', sa.Integer(), nullable=False, index=True),
+        sa.Column('realm', PyIntEnum(_UserLogRealm), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=True, index=True),
+        sa.ForeignKeyConstraint(['target_user_id'], ['users.users.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['users.users.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='users'
+    )
+    op.create_index(None, 'logs', ['meta'], unique=False, schema='users', postgresql_using='gin')
+
+
+def downgrade():
+    op.drop_table('logs', schema='users')

--- a/indico/modules/categories/models/categories.py
+++ b/indico/modules/categories/models/categories.py
@@ -285,7 +285,7 @@ class Category(SearchableTitleMixin, DescriptionMixin, ProtectionManagersMixin, 
     # - events (Event.category)
     # - favorite_of (User.favorite_categories)
     # - legacy_mapping (LegacyCategoryMapping.category)
-    # - log_entries (CategoryLogEntry.event)
+    # - log_entries (CategoryLogEntry.category)
     # - parent (Category.children)
     # - receipt_templates (ReceiptTemplate.category)
     # - roles (CategoryRole.category)

--- a/indico/modules/logs/__init__.py
+++ b/indico/modules/logs/__init__.py
@@ -26,6 +26,13 @@ def _extend_event_management_menu(sender, event, **kwargs):
     return SideMenuItem('logs', _('Logs'), url_for('logs.event', event), section='reports')
 
 
+@signals.menu.items.connect_via('user-profile-sidemenu')
+def _extend_profile_sidemenu(sender, user, **kwargs):
+    if not session.user.is_admin:
+        return
+    return SideMenuItem('logs', _('Logs'), url_for('logs.user'), -100)
+
+
 @signals.users.merged.connect
 def _merge_users(target, source, **kwargs):
     EventLogEntry.query.filter_by(user_id=source.id).update({EventLogEntry.user_id: target.id})

--- a/indico/modules/logs/blueprint.py
+++ b/indico/modules/logs/blueprint.py
@@ -5,7 +5,10 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from indico.modules.logs.controllers import RHCategoryLogs, RHCategoryLogsJSON, RHEventLogs, RHEventLogsJSON
+from flask import request
+
+from indico.modules.logs.controllers import (RHCategoryLogs, RHCategoryLogsJSON, RHEventLogs, RHEventLogsJSON,
+                                             RHUserLogs, RHUserLogsJSON)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
@@ -18,3 +21,14 @@ _bp.add_url_rule('/event/<int:event_id>/manage/logs/api/logs', 'api_event_logs',
 # Categories
 _bp.add_url_rule('/category/<int:category_id>/manage/logs/', 'category', RHCategoryLogs)
 _bp.add_url_rule('/category/<int:category_id>/manage/logs/api/logs', 'api_category_logs', RHCategoryLogsJSON)
+
+# Users
+with _bp.add_prefixed_rules('/user/<int:user_id>', '/user'):
+    _bp.add_url_rule('/logs/', 'user', RHUserLogs)
+    _bp.add_url_rule('/logs/api/logs', 'api_user_logs', RHUserLogsJSON)
+
+
+@_bp.url_defaults
+def _add_user_id(endpoint, values):
+    if endpoint in {'logs.user', 'logs.api_user_logs'} and 'user_id' not in values:
+        values['user_id'] = request.view_args.get('user_id')

--- a/indico/modules/logs/client/style/logs.scss
+++ b/indico/modules/logs/client/style/logs.scss
@@ -74,6 +74,10 @@
     @include icon-before('icon-users');
   }
 
+  li.log-realm-user span.log-module span.log-icon i.log-realm {
+    @include icon-before('icon-user');
+  }
+
   li.log-realm-management span.log-module span.log-icon i.log-realm {
     @include icon-before('icon-medal');
   }

--- a/indico/modules/logs/models/entries.py
+++ b/indico/modules/logs/models/entries.py
@@ -33,6 +33,12 @@ class CategoryLogRealm(RichIntEnum):
     events = 2
 
 
+class UserLogRealm(RichIntEnum):
+    __titles__ = (None, _('User'), _('Management'))
+    user = 1
+    management = 2
+
+
 class LogKind(IndicoIntEnum):
     other = 1
     positive = 2
@@ -122,7 +128,8 @@ class LogEntryBase(db.Model):
             backref=db.backref(
                 cls.user_backref_name,
                 lazy='dynamic'
-            )
+            ),
+            foreign_keys=[cls.user_id]
         )
 
     @property
@@ -192,18 +199,50 @@ class CategoryLogEntry(LogEntryBase):
         index=True,
         nullable=False
     )
-    #: The general area of the event the entry comes from
+    #: The general area of the category the entry comes from
     realm = db.Column(
         PyIntEnum(CategoryLogRealm),
         nullable=False
     )
 
     #: The Category this log entry is associated with
-    event = db.relationship(
+    category = db.relationship(
         'Category',
         lazy=True,
         backref=db.backref(
             'log_entries',
             lazy='dynamic'
         )
+    )
+
+
+class UserLogEntry(LogEntryBase):
+    """Log entries for users."""
+
+    __auto_table_args = {'schema': 'users'}
+    user_backref_name = 'user_log_entries'
+    link_fk_name = 'user_id'
+
+    #: The ID of the user
+    target_user_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.users.id'),
+        index=True,
+        nullable=False
+    )
+    #: The general area of the user the entry comes from
+    realm = db.Column(
+        PyIntEnum(UserLogRealm),
+        nullable=False
+    )
+
+    #: The User this log entry is associated with
+    target_user = db.relationship(
+        'User',
+        lazy=True,
+        backref=db.backref(
+            'log_entries',
+            lazy='dynamic'
+        ),
+        foreign_keys=[target_user_id]
     )

--- a/indico/modules/logs/templates/logs.html
+++ b/indico/modules/logs/templates/logs.html
@@ -1,4 +1,10 @@
-{% extends 'categories/management/base.html' if category|default(none) else 'events/management/base.html' %}
+{% if category|default(none) %}
+    {% extends 'categories/management/base.html' %}
+{% elif event|default(none) %}
+    {% extends 'events/management/base.html' %}
+{% else %}
+    {% extends 'users/base.html' %}
+{% endif %}
 
 {% block title %}
     {%- trans %}Logs{% endtrans -%}

--- a/indico/modules/logs/util.py
+++ b/indico/modules/logs/util.py
@@ -167,7 +167,7 @@ def _diff_list(a, b):
     return Markup(', ').join(output)
 
 
-def serialize_log_entry(entry):
+def serialize_log_entry(entry, tzinfo):
     return {
         'id': entry.id,
         'type': entry.type,
@@ -176,7 +176,7 @@ def serialize_log_entry(entry):
         'module': entry.module,
         'description': entry.summary,
         'meta': entry.meta,
-        'time': entry.logged_dt.astimezone(entry.event.tzinfo).isoformat(),
+        'time': entry.logged_dt.astimezone(tzinfo).isoformat(),
         'payload': entry.data,
         'user': {
             'fullName': entry.user.full_name if entry.user else None,

--- a/indico/modules/logs/views.py
+++ b/indico/modules/logs/views.py
@@ -7,6 +7,7 @@
 
 from indico.modules.categories.views import WPCategoryManagement
 from indico.modules.events.management.views import WPEventManagement
+from indico.modules.users.views import WPUser
 
 
 class WPEventLogs(WPEventManagement):
@@ -16,5 +17,10 @@ class WPEventLogs(WPEventManagement):
 
 
 class WPCategoryLogs(WPCategoryManagement):
+    bundles = ('module_logs.js', 'module_logs.css')
+    template_prefix = 'logs/'
+
+
+class WPUserLogs(WPUser):
     bundles = ('module_logs.js', 'module_logs.css')
     template_prefix = 'logs/'

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -464,6 +464,7 @@ def anonymize_user(user):
 
     user.event_roles.clear()
     user.category_roles.clear()
+    user.log_entries.delete()
     user.suggested_categories.order_by(None).delete()
 
     # Unlink registrations + persons (those hold personal data and are linked by email which no longer matches)


### PR DESCRIPTION
This PR is about adding `UserLogEntry` for logging events related to user records.

Highlights:
* The Logs menu is placed in User Profile side-menu and visible only for admins
* In this PR only the user creation is logged
* The user log records are deleted during user anonymization