### PR TITLE
Do not show default values for purged fields in list of registrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -95,7 +95,7 @@ Bugfixes
 - Include event labels in dashboard ICS export (:issue:`5886, 6372`, :pr:`6769`, thanks
   :user:`amCap1712`)
 - Do not show default values for purged registration fields (:issue:`5898`, :pr:`6772`,
-  thanks :user:`amCap1712`)
+  :pr:6781, thanks :user:`amCap1712`)
 - Do not create empty survey sections during event cloning (:pr:`6774`)
 - Fix inaccurate timezone in the dates of the timetable PDF (:pr:`6786`)
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -99,7 +99,6 @@ Bugfixes
 - Do not create empty survey sections during event cloning (:pr:`6774`)
 - Fix inaccurate timezone in the dates of the timetable PDF (:pr:`6786`)
 
-
 Accessibility
 ^^^^^^^^^^^^^
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,10 +94,11 @@ Bugfixes
 - Fix display issues after reacting to a favorite category suggestion (:pr:`6771`)
 - Include event labels in dashboard ICS export (:issue:`5886, 6372`, :pr:`6769`, thanks
   :user:`amCap1712`)
-- Do not show default values for purged registration fields (:issue:`5898`, :pr:`6772`,
-  :pr:6781, thanks :user:`amCap1712`)
+- Do not show default values for purged registration fields (:issue:`5898`, :pr:`6772, 6781`,
+  thanks :user:`amCap1712`)
 - Do not create empty survey sections during event cloning (:pr:`6774`)
 - Fix inaccurate timezone in the dates of the timetable PDF (:pr:`6786`)
+
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -125,7 +125,7 @@
                                 {% for item in dynamic_columns %}
                                     {% set search_value = data[item.id].search_data if item.id in data else '' %}
                                     {% if item.id in data and data[item.id].field_data.field.is_purged %}
-                                        <td class="i-table center">
+                                        <td class="i-table">
                                             <span class="icon-warning purged-field-warning"
                                                   data-qtip-style="warning"
                                                   title="{% trans %}The field data has been purged due to an expired retention period{% endtrans %}">

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -129,7 +129,8 @@
                                             <span class="icon-warning purged-field-warning"
                                                   data-qtip-style="warning"
                                                   title="{% trans %}The field data has been purged due to an expired retention period{% endtrans %}">
-                                            </span></td>
+                                            </span>
+                                        </td>
                                     {% elif item.id in data and data[item.id].field_data.field.input_type == 'checkbox' %}
                                         <td class="i-table{%- if data[item.id].data %} icon-checkmark{% endif %}"
                                             data-text="{{ search_value }}"></td>

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -124,7 +124,13 @@
                                 {% endfor %}
                                 {% for item in dynamic_columns %}
                                     {% set search_value = data[item.id].search_data if item.id in data else '' %}
-                                    {% if item.id in data and data[item.id].field_data.field.input_type == 'checkbox' %}
+                                    {% if item.id in data and data[item.id].field_data.field.is_purged %}
+                                        <td class="i-table center">
+                                            <span class="icon-warning purged-field-warning"
+                                                  data-qtip-style="warning"
+                                                  title="{% trans %}The field data has been purged due to an expired retention period{% endtrans %}">
+                                            </span></td>
+                                    {% elif item.id in data and data[item.id].field_data.field.input_type == 'checkbox' %}
                                         <td class="i-table{%- if data[item.id].data %} icon-checkmark{% endif %}"
                                             data-text="{{ search_value }}"></td>
                                     {% elif item.id in data and data[item.id].field_data.field.input_type == 'accommodation' %}


### PR DESCRIPTION
Implemented the same changes as #6772 but for registrations list table on manage registrations page.

The table looks like this now:

![image](https://github.com/user-attachments/assets/fa87a259-1d8e-4498-927e-518dd34a86a8)

In the other page, the warning icon was right aligned but that looked a bit off to me in this case so I center aligned but can change that if you prefer something else.