### PR TITLE
Include abstract details in comment email subject

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,8 @@ Improvements
 - Log changes to event payment methods (:pr:`6739`)
 - Add button to select all rooms for exporting in the room list (:pr:`6773`, thanks
   :user:`Michi03`)
+- Include abstract details in comment notification email subject (:issue:`6449`, :pr:`6782`,
+  thanks :user:`amCap1712`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/templates/emails/comment.html
+++ b/indico/modules/events/abstracts/templates/emails/comment.html
@@ -1,6 +1,8 @@
 {% extends 'events/abstracts/emails/base.html' %}
 
-{% block subject_message %}{% trans %}New abstract comment{% endtrans %}{% endblock %}
+{% block subject_message %}
+    {%- trans title=abstract.verbose_title %}New comment on abstract {{ title }}{% endtrans -%}
+{% endblock %}
 
 {% block header_subtitle %}{% trans %}New abstract comment{% endtrans %}{% endblock %}
 


### PR DESCRIPTION
Added abstract id and title to the subject of abstract comment notifications to make them more informational.

Fixes #6449.