### PR TITLE
Show markdown editor in survey creator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,7 @@ Improvements
   :user:`Michi03`)
 - Include abstract details in comment notification email subject (:issue:`6449`, :pr:`6782`,
   thanks :user:`amCap1712`)
+- Use markdown editor field in survey questionnaire setup (:pr:`6783`, thanks :user:`amCap1712`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/surveys/fields/base.py
+++ b/indico/modules/events/surveys/fields/base.py
@@ -5,19 +5,20 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from wtforms.fields import BooleanField, StringField, TextAreaField
+from wtforms.fields import BooleanField, StringField
 from wtforms.validators import DataRequired
 
 from indico.util.i18n import _
 from indico.web.fields import BaseField
 from indico.web.forms.base import IndicoForm
+from indico.web.forms.fields import IndicoMarkdownField
 from indico.web.forms.widgets import SwitchWidget
 
 
 class SurveyFieldConfigForm(IndicoForm):
     title = StringField(_('Title'), [DataRequired()], description=_('The title of the question'))
-    description = TextAreaField(_('Description'), description=_("The description (shown below the question's field). "
-                                                                'You may use Markdown for formatting.'))
+    description = IndicoMarkdownField(_('Description'), editor=True,
+                                      description=_("The description (shown below the question's field)."))
     is_required = BooleanField(_('Required'), widget=SwitchWidget(),
                                description=_('If the user has to answer the question.'))
 

--- a/indico/modules/events/surveys/forms.py
+++ b/indico/modules/events/surveys/forms.py
@@ -15,7 +15,7 @@ from indico.core.db import db
 from indico.modules.events.surveys.models.surveys import Survey
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm
-from indico.web.forms.fields import EmailListField, FileField, IndicoDateTimeField
+from indico.web.forms.fields import EmailListField, FileField, IndicoDateTimeField, IndicoMarkdownField
 from indico.web.forms.validators import HiddenUnless, LinkedDateTime, UsedIf, ValidationError
 from indico.web.forms.widgets import SwitchWidget
 
@@ -93,13 +93,12 @@ class SectionForm(IndicoForm):
                                       description=_('Whether this is going to be displayed as a section or standalone'))
     title = StringField(_('Title'), [HiddenUnless('display_as_section', preserve_data=True), DataRequired()],
                         description=_('The title of the section.'))
-    description = TextAreaField(_('Description'), [HiddenUnless('display_as_section', preserve_data=True)],
-                                description=_('You may use Markdown for formatting.'))
+    description = IndicoMarkdownField(_('Description'), [HiddenUnless('display_as_section', preserve_data=True)],
+                                      editor=True)
 
 
 class TextForm(IndicoForm):
-    description = TextAreaField(_('Text'),
-                                description=_('The text that should be displayed.'))
+    description = IndicoMarkdownField(_('Text'), description=_('The text that should be displayed.'), editor=True)
 
 
 class ImportQuestionnaireForm(IndicoForm):

--- a/indico/modules/events/surveys/views.py
+++ b/indico/modules/events/surveys/views.py
@@ -7,13 +7,14 @@
 
 from indico.modules.events.management.views import WPEventManagement
 from indico.modules.events.views import WPConferenceDisplayBase, WPSimpleEventDisplayBase
+from indico.util.mathjax import MathjaxMixin
 from indico.web.views import WPJinjaMixin
 
 
-class WPManageSurvey(WPEventManagement):
+class WPManageSurvey(MathjaxMixin, WPEventManagement):
     template_prefix = 'events/surveys/'
     sidemenu_option = 'surveys'
-    bundles = ('module_events.surveys.js', 'module_events.surveys.css')
+    bundles = ('markdown.js', 'module_events.surveys.js', 'module_events.surveys.css')
 
 
 class WPSurveyResults(WPManageSurvey):


### PR DESCRIPTION
Several form fields on the survey creator page support markdown formatting:

1. description field in "Add/edit section"
2. description field in "Add/edit text item"
3. description field in "Add/edit question"

Show the markdown editor for these fields instead of a simple text area.