### PR TITLE
Add action to bulk reset registration status

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ Improvements
 - Include abstract details in comment notification email subject (:issue:`6449`, :pr:`6782`,
   thanks :user:`amCap1712`)
 - Use markdown editor field in survey questionnaire setup (:pr:`6783`, thanks :user:`amCap1712`)
+- Allow resetting registrations back to pending in bulk (:issue:`5954`, :pr:`6784`, thanks
+  :user:`amCap1712`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/blueprint.py
+++ b/indico/modules/events/registration/blueprint.py
@@ -125,6 +125,8 @@ _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/approve',
                  reglists.RHRegistrationsApprove, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/reject', 'registrations_reject',
                  reglists.RHRegistrationsReject, methods=('POST',))
+_bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/reset', 'registrations_reset',
+                 reglists.RHRegistrationsReset, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/update-price', 'registrations_update_price',
                  reglists.RHRegistrationsBasePrice, methods=('POST',))
 _bp.add_url_rule('/manage/registration/<int:reg_form_id>/registrations/check-in', 'registrations_check_in',

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -836,6 +836,17 @@ class RHRegistrationsReject(RHRegistrationsActionBase):
         return jsonify_form(form, disabled_until_change=False, submit=_('Reject'), message=message)
 
 
+class RHRegistrationsReset(RHRegistrationsActionBase):
+    """Reset selected registration from registration list."""
+
+    def _process(self):
+        for registration in self.registrations:
+            registration.reset_state()
+        db.session.flush()
+        flash(_('The selected registrations were successfully reset.'), 'success')
+        return jsonify_data(**self.list_generator.render_list())
+
+
 class RHRegistrationsBasePrice(RHRegistrationsActionBase):
     """Edit the base price of the selected registrations."""
 

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -171,6 +171,14 @@
                                     {%- trans %}Reject registrations{% endtrans -%}
                                 </a>
                             </li>
+                            <li>
+                                <a href="#" class="icon-loop js-requires-selected-row disabled js-modify-status"
+                                   data-href="{{ url_for('.registrations_reset', regform) }}"
+                                   data-method="POST"
+                                   data-confirm="{% trans %}Do you really want to reset the selected registrations?{% endtrans %}">
+                                    {%- trans %}Reset registrations{% endtrans -%}
+                                </a>
+                            </li>
                         </ul>
                     {% endif %}
                     {% if not event.is_locked %}


### PR DESCRIPTION
Add a bulk 'Reset Registrations' action to the moderation menu on manage registrations page.

Fixes #5954.