### PR TITLE
Fix inaccurate timezone in PDF timetable dates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,7 @@ Bugfixes
 - Do not show default values for purged registration fields (:issue:`5898`, :pr:`6772`,
   thanks :user:`amCap1712`)
 - Do not create empty survey sections during event cloning (:pr:`6774`)
+- Fix inaccurate timezone in the dates of the timetable PDF (:pr:`6786`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/timetable/templates/pdf/_program.html
+++ b/indico/modules/events/timetable/templates/pdf/_program.html
@@ -2,7 +2,7 @@
     {% for day, entries in days.items() %}
         <div class="day pagebreak program-{{loop.index}} {{ 'pagebreak-children' if config.new_page_per_session else '' }}" id="day-{{ loop.index }}">
             <div class="day-title">
-                <h2>{{ day|format_skeleton('EEEEdMMMM', timezone=event.tzinfo) }}</h2>
+                <h2>{{ day|format_skeleton('EEEEdMMMM') }}</h2>
             </div>
             {% for entry in entries %}
                 {% set show_children_location = program_config.show_children_location[entry.id] %}
@@ -259,7 +259,7 @@
 {% macro _render_block_date(entry, day, print_date_close_to_sessions) %}
     {% if print_date_close_to_sessions %}
         <p class="session-block-date">
-            <b>{{ day|format_skeleton('EEEEdMMMM', timezone=entry.event.tzinfo) }}</b>
+            <b>{{ day|format_skeleton('EEEEdMMMM') }}</b>
             <span class="timebox">
                 {{ format_interval(entry.start_dt.astimezone(entry.event.tzinfo), entry.end_dt.astimezone(entry.event.tzinfo), format='HHmm') }}
             </span>

--- a/indico/modules/events/timetable/templates/pdf/timetable.html
+++ b/indico/modules/events/timetable/templates/pdf/timetable.html
@@ -34,7 +34,7 @@
             @top-right {
                 font-size: 0.8em;
                 color: grey;
-                content: '{{ day|format_skeleton('EEEEdMMMM', timezone=event.timezone) }}';
+                content: '{{ day|format_skeleton('EEEEdMMMM') }}';
             }
         }
 


### PR DESCRIPTION
Gets rid of redundant date formatting with timezone after it was already done before.