### PR TITLE
Fix removing last room attribute

### DIFF
--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
@@ -203,8 +203,9 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
 
   const handleSubmit = async (data, form) => {
     const changedValues = getChangedValues(data, form);
+    let {attributes} = changedValues;
+    const isAttributesDirty = form.getFieldState('attributes').dirty;
     const {
-      attributes,
       bookable_hours: bookableHours,
       nonbookable_periods: nonbookablePeriods,
       available_equipment: availableEquipment,
@@ -224,6 +225,9 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
         await indicoAxios.post(updateRoomEquipmentURL(roomIdArgs), {
           available_equipment: availableEquipment,
         });
+      }
+      if (!attributes && isAttributesDirty) {
+        attributes = [];
       }
       if (attributes) {
         await indicoAxios.post(updateRoomAttributesURL(roomIdArgs), {attributes});

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
@@ -203,9 +203,9 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
 
   const handleSubmit = async (data, form) => {
     const changedValues = getChangedValues(data, form);
-    let {attributes} = changedValues;
     const isAttributesDirty = form.getFieldState('attributes').dirty;
     const {
+      attributes,
       bookable_hours: bookableHours,
       nonbookable_periods: nonbookablePeriods,
       available_equipment: availableEquipment,
@@ -226,11 +226,8 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
           available_equipment: availableEquipment,
         });
       }
-      if (!attributes && isAttributesDirty) {
-        attributes = [];
-      }
-      if (attributes) {
-        await indicoAxios.post(updateRoomAttributesURL(roomIdArgs), {attributes});
+      if (isAttributesDirty) {
+        await indicoAxios.post(updateRoomAttributesURL(roomIdArgs), {attributes: attributes || []});
       }
       if (bookableHours || nonbookablePeriods) {
         const availability = {bookableHours, nonbookablePeriods};

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditOptions.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditOptions.jsx
@@ -48,10 +48,7 @@ export default function RoomEditOptions({active, showEquipment, globalAttributes
         {globalAttributes && globalAttributes.length > 0 && (
           <FieldArray name="attributes" isEqual={_.isEqual}>
             {({fields}) => {
-              if (!fields.value) {
-                return null;
-              }
-              const fieldsByName = new Set(fields.value.map(x => x.name));
+              const fieldsByName = new Set(fields.value?.map(x => x.name));
               const options = globalAttributes
                 .map(x => ({
                   key: x.name,
@@ -81,7 +78,7 @@ export default function RoomEditOptions({active, showEquipment, globalAttributes
                     <FinalInput
                       key={attribute}
                       name={`${attribute}.value`}
-                      label={attributeTitles[fields.value[index].name]}
+                      label={attributeTitles[(fields.value[index]?.name)]}
                       required
                       icon={{
                         name: 'remove',


### PR DESCRIPTION
There are 3 issues in updating room attributes when it's the last one. I have a proposed fix for the first 2. 
1. If there is only one attribute, the dropdown disappears whenever you click on the remove icon of the last item - because the attributes `fields.value` becomes undefined 
2. Clicking on save after removing the last item does not complete, the button just keeps rolling 
3. When you have multiple attributes selected and you remove the top one and try to save, it does not save. If you remove from the bottom to the top then it saves ok. 

