### PR TITLE
add date picker to calendar export for Events past 4 weeks

### DIFF
--- a/indico/web/client/js/react/components/ICSCalendarLink.module.scss
+++ b/indico/web/client/js/react/components/ICSCalendarLink.module.scss
@@ -72,9 +72,29 @@
 .popup .content {
   width: 0;
   min-width: 100%;
+  text-align: center;
 }
 
 .button-group :global(.ui.labeled.button) button:global(.ui.button):last-child {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
+}
+
+.date-range-container {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin: 0.5rem 0 1rem 0;
+  border: none;
+}
+
+.date-input {
+  flex: 1;
+
+  :global(.DateInput_input) {
+    cursor: pointer;
+    border: none !important;
+    padding: 6px 8px 4px !important;
+    font-size: 1rem !important;
+  }
 }


### PR DESCRIPTION
#5805 

- Added `SingleDatePicker` component to the calendar export popup
- Modified the backend to accept a `start_date` parameter and filter events accordingly

Events from start-date to all events in future are exported

![Screenshot 2025-03-10 at 3 32 15 AM](https://github.com/user-attachments/assets/6372f9a1-dec6-43cf-a730-52997b5ff573)
![Screenshot 2025-03-10 at 3 32 27 AM](https://github.com/user-attachments/assets/13698303-6851-45f7-a9d6-941517251376)


