### PR TITLE
Display newly uploaded picture even if there are errors.

### DIFF
--- a/indico/web/client/js/react/components/pictures/PictureManager.jsx
+++ b/indico/web/client/js/react/components/pictures/PictureManager.jsx
@@ -200,11 +200,10 @@ const PictureManager = ({
         onChange(data.uuid);
       } else {
         dispatch({type: 'FAILED', errors});
-        setPicturePreview(previewURL);
         onChange(null);
       }
     },
-    [deleteUploadedPicture, onChange, uploadURL, previewURL]
+    [deleteUploadedPicture, onChange, uploadURL]
   );
 
   const onImageCrop = () => {


### PR DESCRIPTION
As discussed via Elements, we want to allow the display of a newly uploaded picture even if there are errors returned.