### PR TITLE
Add reminder support to ical export

### DIFF
--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -355,9 +355,21 @@ class RHShowPastEventsInCategory(RHShowEventsInCategoryBase):
 @allow_signed_url
 class RHExportCategoryICAL(RHDisplayCategoryBase):
     def _process(self):
+        reminder = request.args.get('reminder')
+        reminder_minutes = None
+        if reminder:
+            try:
+                reminder_minutes = int(reminder)
+            except ValueError:
+                pass
+
         filename = f'{secure_filename(self.category.title, str(self.category.id))}-category.ics'
-        buf = serialize_categories_ical([self.category.id], session.user,
-                                        Event.end_dt >= (now_utc() - timedelta(weeks=4)))
+        buf = serialize_categories_ical(
+            [self.category.id],
+            session.user,
+            Event.end_dt >= (now_utc() - timedelta(weeks=4)),
+            reminder_minutes=reminder_minutes
+        )
         return send_file(filename, buf, 'text/calendar')
 
 

--- a/indico/modules/categories/controllers/display.py
+++ b/indico/modules/categories/controllers/display.py
@@ -354,21 +354,16 @@ class RHShowPastEventsInCategory(RHShowEventsInCategoryBase):
 
 @allow_signed_url
 class RHExportCategoryICAL(RHDisplayCategoryBase):
-    def _process(self):
-        reminder = request.args.get('reminder')
-        reminder_minutes = None
-        if reminder:
-            try:
-                reminder_minutes = int(reminder)
-            except ValueError:
-                pass
-
+    @use_kwargs({
+        'reminder': fields.Int(load_default=None, validate=validate.Range(0))
+    }, location='query')
+    def _process(self, reminder):
         filename = f'{secure_filename(self.category.title, str(self.category.id))}-category.ics'
         buf = serialize_categories_ical(
             [self.category.id],
             session.user,
             Event.end_dt >= (now_utc() - timedelta(weeks=4)),
-            reminder_minutes=reminder_minutes
+            reminder_minutes=reminder
         )
         return send_file(filename, buf, 'text/calendar')
 

--- a/indico/modules/categories/serialize.py
+++ b/indico/modules/categories/serialize.py
@@ -20,7 +20,7 @@ from indico.util.string import sanitize_html
 
 def serialize_categories_ical(
     category_ids, user, event_filter=True, event_filter_fn=None,
-    update_query=None, reminder_minutes=None
+    update_query=None, *, reminder_minutes=None
 ):
     """Export the events in a category to iCal.
 
@@ -32,7 +32,7 @@ def serialize_categories_ical(
     :param event_filter_fn: A callable that determines which events to include (after querying)
     :param update_query: A callable that can update the query used to retrieve the events.
                          Must return the updated query object.
-    :param reminder_minutes: If specified, add reminders to all events, handled in ical.py file
+    :param reminder_minutes: If specified, enable reminders in the ical events
     """
     own_room_strategy = joinedload('own_room')
     own_room_strategy.load_only('location_id', 'site', 'building', 'floor', 'number', 'verbose_name')

--- a/indico/modules/categories/serialize.py
+++ b/indico/modules/categories/serialize.py
@@ -18,7 +18,10 @@ from indico.modules.events.settings import event_contact_settings
 from indico.util.string import sanitize_html
 
 
-def serialize_categories_ical(category_ids, user, event_filter=True, event_filter_fn=None, update_query=None):
+def serialize_categories_ical(
+    category_ids, user, event_filter=True, event_filter_fn=None,
+    update_query=None, reminder_minutes=None
+):
     """Export the events in a category to iCal.
 
     :param category_ids: Category IDs to export
@@ -29,6 +32,7 @@ def serialize_categories_ical(category_ids, user, event_filter=True, event_filte
     :param event_filter_fn: A callable that determines which events to include (after querying)
     :param update_query: A callable that can update the query used to retrieve the events.
                          Must return the updated query object.
+    :param reminder_minutes: If specified, add reminders to all events, handled in ical.py file
     """
     own_room_strategy = joinedload('own_room')
     own_room_strategy.load_only('location_id', 'site', 'building', 'floor', 'number', 'verbose_name')
@@ -62,7 +66,7 @@ def serialize_categories_ical(category_ids, user, event_filter=True, event_filte
                                joinedload('acl_entries'))
                       .all())
 
-    return BytesIO(events_to_ical(events, user))
+    return BytesIO(events_to_ical(events, user, reminder_minutes=reminder_minutes))
 
 
 def serialize_category_atom(category, url, user, event_filter):

--- a/indico/modules/events/ical.py
+++ b/indico/modules/events/ical.py
@@ -24,6 +24,7 @@ from indico.modules.events.sessions.models.sessions import Session
 from indico.modules.users.models.users import User
 from indico.util.date_time import now_utc
 from indico.util.enum import IndicoEnum
+from indico.util.i18n import _
 from indico.util.signals import values_from_signal
 
 
@@ -244,7 +245,8 @@ def events_to_ical(
                 alarm = icalendar.Alarm()
                 alarm.add('action', 'DISPLAY')
                 alarm.add('trigger', timedelta(minutes=-reminder_minutes))
-                alarm.add('description', component.get('description', f"Reminder: {component['summary']}"))
+                reminder_text = _('Reminder: {summary}').format(summary=component['summary'])
+                alarm.add('description', component.get('description', reminder_text))
                 component.add_component(alarm)
 
         for component in components:

--- a/indico/web/client/js/react/components/ICSCalendarLink.jsx
+++ b/indico/web/client/js/react/components/ICSCalendarLink.jsx
@@ -223,15 +223,14 @@ export default function ICSCalendarLink({
           </>
         )}
         <strong styleName="export-option">
-          <Translate>Reminder Alerts</Translate>
+          <Translate>Reminders</Translate>
         </strong>
-        <Translate as="p">Add alerts to each event in your calendar.</Translate>
+        <Translate as="p">Add reminder to each event in your calendar.</Translate>
         <div styleName="reminder-options">
           <Dropdown
             selection
-            placeholder={Translate.string('Select alert time')}
             options={[
-              {key: 'None', text: Translate.string('None', 'alert'), value: 0},
+              {key: '0', text: Translate.string('No reminder', 'alert'), value: 0},
               {key: '5', text: Translate.string('5 minutes before'), value: 5},
               {key: '15', text: Translate.string('15 minutes before'), value: 15},
               {key: '30', text: Translate.string('30 minutes before'), value: 30},

--- a/indico/web/client/js/react/components/ICSCalendarLink.jsx
+++ b/indico/web/client/js/react/components/ICSCalendarLink.jsx
@@ -109,7 +109,7 @@ export default function ICSCalendarLink({
 
   const fetchURL = async (extraParams, controller) => {
     try {
-      const reminderParams = reminder !== null ? {reminder: reminder.toString()} : {};
+      const reminderParams = reminder !== null ? {reminder} : {};
 
       const {
         data: {url: signedURL},
@@ -228,7 +228,7 @@ export default function ICSCalendarLink({
           <Translate>Reminder Alerts</Translate>
         </strong>
         <p>
-          <Translate>Add alerts to each event in your calendar.</Translate>
+          <Translate as="p">Add alerts to each event in your calendar.</Translate>
         </p>
         <div styleName="reminder-options">
           <Dropdown

--- a/indico/web/client/js/react/components/ICSCalendarLink.jsx
+++ b/indico/web/client/js/react/components/ICSCalendarLink.jsx
@@ -227,9 +227,7 @@ export default function ICSCalendarLink({
         <strong styleName="export-option">
           <Translate>Reminder Alerts</Translate>
         </strong>
-        <p>
-          <Translate as="p">Add alerts to each event in your calendar.</Translate>
-        </p>
+        <Translate as="p">Add alerts to each event in your calendar.</Translate>
         <div styleName="reminder-options">
           <Dropdown
             selection

--- a/indico/web/client/js/react/components/ICSCalendarLink.jsx
+++ b/indico/web/client/js/react/components/ICSCalendarLink.jsx
@@ -233,12 +233,12 @@ export default function ICSCalendarLink({
             selection
             placeholder={Translate.string('Select alert time')}
             options={[
-              {key: 'None', text: Translate.string('None'), value: 0},
+              {key: 'None', text: Translate.string('None', 'alert'), value: 0},
               {key: '5', text: Translate.string('5 minutes before'), value: 5},
               {key: '15', text: Translate.string('15 minutes before'), value: 15},
               {key: '30', text: Translate.string('30 minutes before'), value: 30},
             ]}
-            value={reminder === null ? 0 : reminder}
+            value={reminder ?? 0}
             onChange={(_, {value}) => handleReminderChange(value === 0 ? null : value)}
           />
         </div>

--- a/indico/web/client/js/react/components/ICSCalendarLink.module.scss
+++ b/indico/web/client/js/react/components/ICSCalendarLink.module.scss
@@ -81,8 +81,6 @@
 }
 
 .reminder-options {
-  margin: 0 auto;
-  max-width: 50%;
   display: flex;
   justify-content: center;
 }

--- a/indico/web/client/js/react/components/ICSCalendarLink.module.scss
+++ b/indico/web/client/js/react/components/ICSCalendarLink.module.scss
@@ -72,9 +72,17 @@
 .popup .content {
   width: 0;
   min-width: 100%;
+  text-align: center;
 }
 
 .button-group :global(.ui.labeled.button) button:global(.ui.button):last-child {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
+}
+
+.reminder-options {
+  margin: 0 auto;
+  max-width: 50%;
+  display: flex;
+  justify-content: center;
 }


### PR DESCRIPTION
Fixes #4317 

Option to add reminder alerts (None/5/15/30 minutes before events) in exported calendars

![Screenshot 2025-03-12 at 5 33 23 AM](https://github.com/user-attachments/assets/05314b0a-0d80-4418-81ac-449d59253123)

![Screenshot 2025-03-12 at 5 33 29 AM](https://github.com/user-attachments/assets/e672dc32-8812-4264-a7a1-26c347d90fa2)


