### PR TITLE
Make no-such-user more verbose in email-only mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,7 +50,7 @@ Improvements
 - Do not "inline" the full participant list in conference events using a meeting-style
   timetable and link to the conference participant list instead (:pr:`6753`)
 - Add new setting :data:`LOCAL_USERNAMES` to disable usernames for logging in and only
-  use the email address (:pr:`6751`)
+  use the email address (:pr:`6751`, :pr:`6810`)
 - Tell search engines to not index events marked as "invisible" (:pr:`6762`, thanks
   :user:`openprojects`)
 - Make the minimum length of local account passwords configurable, and default to ``15``

--- a/indico/core/auth.py
+++ b/indico/core/auth.py
@@ -107,7 +107,8 @@ class IndicoMultipass(Multipass):
 
     def handle_auth_error(self, exc, redirect_to_login=False):
         if isinstance(exc, (NoSuchUser, InvalidCredentials)):
-            login_rate_limiter.hit()
+            if not getattr(exc, '_indico_no_rate_limit', False):
+                login_rate_limiter.hit()
             logger.warning('Invalid credentials (ip=%s, provider=%s): %s',
                            request.remote_addr, exc.provider.name if exc.provider else None, exc)
         else:

--- a/indico/modules/auth/providers.py
+++ b/indico/modules/auth/providers.py
@@ -59,7 +59,11 @@ class IndicoAuthProvider(AuthProvider):
         # XXX This is intentional, having an account on an Indico instance is generally not considered
         # secret information, and we want to give users the benefit of more verbose error messages.
         if not identities:
-            raise NoSuchUser(provider=self)
+            exc = NoSuchUser(provider=self)
+            if not config.LOCAL_USERNAMES and '@' not in data['identifier']:
+                exc = NoSuchUser(_('Please use your email address to log in'), provider=self)
+                exc._indico_no_rate_limit = True
+            raise exc
         # From all the matching identities (usually just one), get one where the password matches, or
         # fail with invalid-password if there is none.
         if not (identity := next((ide for ide in identities if self.check_password(ide, data['password'])), None)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ flask-marshmallow==1.2.1
     # via -r requirements.in
 flask-migrate==4.0.7
     # via -r requirements.in
-flask-multipass==0.9
+flask-multipass==0.10
     # via -r requirements.in
 flask-pluginengine==0.5
     # via -r requirements.in


### PR DESCRIPTION
When usernames are disabled, and the user's login does not look like an email address, show a message asking them to use their email address, and also do not count it against the failed-login rate limit.