### PR TITLE
Fix error with accommodation fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -104,6 +104,8 @@ Bugfixes
   thanks :user:`amCap1712`)
 - Do not create empty survey sections during event cloning (:pr:`6774`)
 - Fix inaccurate timezone in the dates of the timetable PDF (:pr:`6786`)
+- Fix error with accommodation fields that have the "no accommodation" option disabled
+  (:pr:`6812`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/controllers/management/regforms.py
+++ b/indico/modules/events/registration/controllers/management/regforms.py
@@ -285,6 +285,8 @@ class RHRegistrationFormNotificationPreview(RHManageRegFormBase):
                 value = getattr(mock_registration, form_item.personal_data_type.column)
             else:
                 value = form_item.field_impl.default_value
+            if value is NotImplemented:
+                continue
             data_entry = RegistrationData()
             mock_registration.data.append(data_entry)
             for attr, field_value in form_item.field_impl.process_form_data(mock_registration, value).items():

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -52,15 +52,38 @@ class RegistrationFormFieldBase:
 
     @property
     def default_value(self):
+        """A default value to store when the field does not have a real value.
+
+        This is used e.g. for manager-only fields when a user registers, when purging
+        a field's data, or when generating the preview for a notification email.
+
+        This may return `NotImplemented` to indicate that no default value exists. In
+        that case, it is mandatory to override `ui_default_value` and `empty_value`.
+        """
         return ''
 
     @property
+    def ui_default_value(self):
+        """A default value that is passed to the registration form UI.
+
+        For most fields this is the same as the `default_value`, but in some cases
+        it may not be possible to get a valid default value to be used in the backend
+        code or stored in the database; in that case the UI can use a more suitable
+        default while the backend uses something else (or no value at all).
+        """
+        default = self.default_value
+        assert default is not NotImplemented
+        return default
+
+    @property
     def empty_value(self):
-        # THis value is used when a manager edits an existing registration, and
+        # This value is used when a manager edits an existing registration, and
         # it should be something that, especially in case of choice fields, does
         # not preselect any of the available choices (such as "no accommodation"
         # or whatever default value is set for a field).
-        return self.default_value
+        default = self.default_value
+        assert default is not NotImplemented
+        return default
 
     def get_validators(self, existing_registration):
         """Return a list of marshmallow validators for this field.
@@ -172,7 +195,7 @@ class RegistrationFormFieldBase:
     @property
     def view_data(self):
         return (self.unprocess_field_data(self.form_item.versioned_data, self.form_item.data) |
-                {'default_value': self.default_value, 'is_purged': self.form_item.is_purged})
+                {'default_value': self.ui_default_value, 'is_purged': self.form_item.is_purged})
 
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):
         """Return the data contained in the field.

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -481,17 +481,26 @@ class AccommodationField(RegistrationFormBillableItemsField):
     mm_field_class = fields.Nested
     mm_field_args = (AccommodationSchema,)
 
-    @property
-    def default_value(self):
+    def _get_default_value(self, *, ui):
         versioned_data = self.form_item.versioned_data
         no_accommodation_option = next(
             (c for c in versioned_data['choices'] if c.get('is_no_accommodation') and c['is_enabled']), None)
+        if not ui and not no_accommodation_option:
+            return NotImplemented
         return {
             'choice': no_accommodation_option['id'] if no_accommodation_option else None,
             'isNoAccommodation': bool(no_accommodation_option),
             'arrivalDate': None,
             'departureDate': None,
         }
+
+    @property
+    def default_value(self):
+        return self._get_default_value(ui=False)
+
+    @property
+    def ui_default_value(self):
+        return self._get_default_value(ui=True)
 
     @property
     def empty_value(self):

--- a/indico/modules/events/registration/tasks.py
+++ b/indico/modules/events/registration/tasks.py
@@ -65,10 +65,14 @@ def delete_field_data():
             # expect structured data e.g. Accommodation & {Single,Multi}Choice.
             # This makes the React code relatively simple and we can always distinguish
             # purged fields since they have the 'is_purged' flag set to True
-            data.data = snakify_keys(data.field_data.field.field_impl.default_value)
+            default = data.field_data.field.field_impl.default_value
             if data.field_data.field.field_impl.is_file_field:
                 _delete_file(data)
             data.field_data.field.is_purged = True
+            if default is not NotImplemented:
+                data.data = snakify_keys(default)
+            else:
+                db.session.delete(data)
     db.session.commit()
 
 


### PR DESCRIPTION
When an accommodation field had "no accommodation" disabled, its default value was broken. This resulted in errors during registration in case of the field being in a manager-only section, and when previewing the registration email snippets.