### PR TITLE
Fix timing glitch between setup() and x-attrchange event

### DIFF
--- a/indico/web/client/js/custom_elements/_base.js
+++ b/indico/web/client/js/custom_elements/_base.js
@@ -22,6 +22,20 @@ export default class CustomElementBase extends HTMLElement {
     Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set.call(element, value);
   };
 
+  static define(tagName, subclass) {
+    console.assert(
+      Object.prototype.isPrototypeOf.call(CustomElementBase.prototype, subclass.prototype),
+      'Must extends CustomElementBase'
+    );
+    customElements.define(tagName, subclass);
+  }
+
+  static defineWhenDomReady(tagName, subclass) {
+    domReady.then(() => {
+      this.define(tagName, subclass);
+    });
+  }
+
   /**
    * Specification of attributes that will be used in the
    * custom element.
@@ -147,11 +161,9 @@ export default class CustomElementBase extends HTMLElement {
     // and disconnect, and the setup() method is expected to set up
     // listeners that will perform such operations.
 
-    domReady.then(() => {
-      this.setup?.();
-      this.setup = null;
-      this.dispatchEvent(new Event('x-connect'));
-    });
+    this.setup?.();
+    this.setup = null;
+    this.dispatchEvent(new Event('x-connect'));
   }
 
   setup() {

--- a/indico/web/client/js/custom_elements/ind_bypass_block_links.js
+++ b/indico/web/client/js/custom_elements/ind_bypass_block_links.js
@@ -5,24 +5,22 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import {domReady} from 'indico/utils/domstate';
+import CustomElementBase from 'indico/custom_elements/_base';
 import './ind_bypass_block_links.scss';
 
-customElements.define(
+CustomElementBase.defineWhenDomReady(
   'ind-bypass-block-links',
-  class extends HTMLElement {
-    connectedCallback() {
-      domReady.then(() => {
-        const bypassBlockTargets = document.querySelectorAll('[id][data-bypass-target]');
-        for (const target of bypassBlockTargets) {
-          this.append(
-            Object.assign(document.createElement('a'), {
-              href: `#${target.id}`,
-              textContent: target.dataset.bypassTarget,
-            })
-          );
-        }
-      });
+  class extends CustomElementBase {
+    setup() {
+      const bypassBlockTargets = document.querySelectorAll('[id][data-bypass-target]');
+      for (const target of bypassBlockTargets) {
+        this.append(
+          Object.assign(document.createElement('a'), {
+            href: `#${target.id}`,
+            textContent: target.dataset.bypassTarget,
+          })
+        );
+      }
     }
   }
 );

--- a/indico/web/client/js/custom_elements/ind_date_picker.js
+++ b/indico/web/client/js/custom_elements/ind_date_picker.js
@@ -37,7 +37,7 @@ const START_NEEDED = 0;
 const END_NEEDED = 1;
 const BOTH_POPULATED = 2;
 
-customElements.define(
+CustomElementBase.define(
   'ind-date-picker',
   class extends CustomElementBase {
     // Last value of the internal id used in the widgets
@@ -125,7 +125,7 @@ customElements.define(
   }
 );
 
-customElements.define(
+CustomElementBase.define(
   'ind-date-range-picker',
   class extends CustomElementBase {
     // Last value of the internal id used in the widgets
@@ -317,7 +317,7 @@ customElements.define(
   }
 );
 
-customElements.define(
+CustomElementBase.define(
   'ind-inline-date-picker',
   class extends CustomElementBase {
     static attributes = {
@@ -353,7 +353,7 @@ customElements.define(
   }
 );
 
-customElements.define(
+CustomElementBase.define(
   'ind-inline-date-range-picker',
   class extends CustomElementBase {
     static attributes = {
@@ -520,7 +520,7 @@ class InlineModeController {
   tearDownGlobalEvents() {}
 }
 
-customElements.define(
+CustomElementBase.define(
   'ind-calendar',
   class extends CustomElementBase {
     static attributes = {
@@ -815,7 +815,7 @@ customElements.define(
   }
 );
 
-customElements.define(
+CustomElementBase.define(
   'ind-date-grid',
   class extends CustomElementBase {
     static lastId = 0;

--- a/indico/web/client/js/custom_elements/ind_menu.js
+++ b/indico/web/client/js/custom_elements/ind_menu.js
@@ -6,51 +6,49 @@
 // LICENSE file for more details.
 
 import './ind_menu.scss';
-import {domReady} from 'indico/utils/domstate';
+import CustomElementBase from 'indico/custom_elements/_base';
 
 let lastId = 0; // Track the assigned IDs to give each element a unique ID
 
-customElements.define(
+CustomElementBase.defineWhenDomReady(
   'ind-menu',
-  class extends HTMLElement {
-    connectedCallback() {
-      domReady.then(() => {
-        const trigger = this.querySelector('button');
-        const list = this.querySelector('menu');
+  class extends CustomElementBase {
+    setup() {
+      const trigger = this.querySelector('button');
+      const list = this.querySelector('menu');
 
-        console.assert(
-          trigger.nextElementSibling === list,
-          'The <menu> element must come after <button>'
-        );
+      console.assert(
+        trigger.nextElementSibling === list,
+        'The <menu> element must come after <button>'
+      );
 
-        trigger.setAttribute('aria-expanded', false);
+      trigger.setAttribute('aria-expanded', false);
 
-        list.id = list.id || `dropdown-list-${lastId++}`;
-        trigger.setAttribute('aria-controls', list.id);
+      list.id = list.id || `dropdown-list-${lastId++}`;
+      trigger.setAttribute('aria-controls', list.id);
 
-        trigger.addEventListener('click', () => {
-          trigger.setAttribute('aria-expanded', trigger.getAttribute('aria-expanded') !== 'true');
-        });
+      trigger.addEventListener('click', () => {
+        trigger.setAttribute('aria-expanded', trigger.getAttribute('aria-expanded') !== 'true');
+      });
 
-        this.addEventListener('focusout', () => {
-          // Delay action as no element is focused immediately after focusout
-          requestAnimationFrame(() => {
-            if (this.contains(document.activeElement)) {
-              return;
-            }
-            trigger.removeAttribute('aria-expanded');
-          });
-        });
-
-        this.addEventListener('keydown', evt => {
-          if (!trigger.hasAttribute('aria-expanded')) {
+      this.addEventListener('focusout', () => {
+        // Delay action as no element is focused immediately after focusout
+        requestAnimationFrame(() => {
+          if (this.contains(document.activeElement)) {
             return;
           }
-          if (evt.code === 'Escape') {
-            trigger.removeAttribute('aria-expanded');
-            trigger.focus();
-          }
+          trigger.removeAttribute('aria-expanded');
         });
+      });
+
+      this.addEventListener('keydown', evt => {
+        if (!trigger.hasAttribute('aria-expanded')) {
+          return;
+        }
+        if (evt.code === 'Escape') {
+          trigger.removeAttribute('aria-expanded');
+          trigger.focus();
+        }
       });
     }
   }

--- a/indico/web/client/js/custom_elements/ind_select.js
+++ b/indico/web/client/js/custom_elements/ind_select.js
@@ -13,7 +13,7 @@ import * as positioning from 'indico/utils/positioning';
 
 import './ind_select.scss';
 
-customElements.define(
+CustomElementBase.define(
   'ind-select',
   class extends CustomElementBase {
     static formAssociated = true;

--- a/indico/web/client/js/custom_elements/ind_with_toggletip.js
+++ b/indico/web/client/js/custom_elements/ind_with_toggletip.js
@@ -5,11 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import CustomElementBase from 'indico/custom_elements/_base';
 import {TipBase} from 'indico/custom_elements/TipBase';
 
 const liveRegionUpdateDelay = 100;
 
-customElements.define(
+CustomElementBase.define(
   'ind-with-toggletip',
   class extends TipBase {
     show() {

--- a/indico/web/client/js/custom_elements/ind_with_tooltip.js
+++ b/indico/web/client/js/custom_elements/ind_with_tooltip.js
@@ -5,11 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import CustomElementBase from 'indico/custom_elements/_base';
 import {TipBase} from 'indico/custom_elements/TipBase';
 
 const tipDelay = 500; // ms
 
-customElements.define(
+CustomElementBase.defineWhenDomReady(
   'ind-with-tooltip',
   class extends TipBase {
     show() {


### PR DESCRIPTION
Moving setup() into domReady callback was a mistake. The whole custom element registration must be moved to domReady so that initial attribute setup is synchronized and setup() gets an opportunity to trap the x-attrchange events.

This also fixes the issue with RB calendar not working at all.
