### PR TITLE
Preserve date when switching mode in RB DateNavigator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Improvements
 - Add a new :data:`ALLOWED_LANGUAGES` setting to ``indico.conf`` to restrict which
   languages can be used (:pr:`6818`, thanks :user:`openprojects`)
 - Set reasonable maximum lengths on signup form fields (:pr:`6724`)
+- Preserve the selected day when switching between room booking calendar view modes
+  (:pr:`6817`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/rb/client/js/common/timeline/DateNavigator.jsx
+++ b/indico/modules/rb/client/js/common/timeline/DateNavigator.jsx
@@ -90,14 +90,8 @@ export default class DateNavigator extends React.Component {
    */
   setDateWithMode(date, mode, force = false) {
     const {onDateChange, dateRange} = this.props;
-    let expectedDate;
-
-    if (mode === 'weeks') {
-      expectedDate = date.clone().startOf('week');
-    } else if (mode === 'months') {
-      expectedDate = date.clone().startOf('month');
-    } else {
-      expectedDate = date.clone();
+    let expectedDate = date.clone();
+    if (mode !== 'weeks' && mode !== 'month') {
       // check that we're not on a day that has no data
       if (this.dateBounds && dateRange.indexOf(serializeDate(date)) === -1) {
         expectedDate = toMoment(dateRange[0], 'YYYY-MM-DD');
@@ -123,13 +117,6 @@ export default class DateNavigator extends React.Component {
     const {mode, dateRange} = this.props;
     const freeRange = dateRange.length === 0;
     if (freeRange || isDateWithinRange(date, dateRange, toMoment)) {
-      if (mode === 'weeks') {
-        date = date.clone().startOf('week');
-      } else if (mode === 'months') {
-        date = date.clone().startOf('month');
-      } else {
-        date = date.clone();
-      }
       this.setDateWithMode(date, mode, true);
     }
     this.onClose();
@@ -239,7 +226,10 @@ export default class DateNavigator extends React.Component {
             {mode === 'months' && this.selectedDate.format('MMMM YYYY')}
             {mode === 'weeks' &&
               Translate.string('Week of {date}', {
-                date: this.selectedDate.format('MMM Do YYYY'),
+                date: this.selectedDate
+                  .clone()
+                  .startOf('week')
+                  .format('MMM Do YYYY'),
               })}
           </Button>
         }


### PR DESCRIPTION
More context in INC4379609

This is the component in question (e.g. on `/rooms/calendar`):
![image](https://github.com/user-attachments/assets/821e7136-8c52-42d5-b972-4ac9eb2f32f3)


Currently, when changing e.g. from the day mode to a week mode, the date changes as well. If the date is in the middle of the week and we select the 'week' mode, the date is changed to the start date of the week.

This means that for example selecting 'day' ->
'week' -> 'day' will not return to the same date which is surprising.

This PR makes it so that the date does not change when the view changes. This means that 'day' -> 'week' -> 'day' returns to the same date.
