### PR TITLE
PDF Timetable fixes

### DIFF
--- a/indico/modules/events/timetable/templates/pdf/_program.html
+++ b/indico/modules/events/timetable/templates/pdf/_program.html
@@ -151,11 +151,14 @@
     {% endif %}
 
     {% if show_location %}
-        <p>
-            <b>{% trans %}Location{% endtrans %}</b>
-            <br>
-            {{ _render_place(contrib) }}
-        </p>
+        {% set loc = _render_place(contrib)|trim %}
+        {% if loc != '' %}
+            <p>
+                <b>{% trans %}Location{% endtrans %}</b>
+                <br>
+                {{ loc }}
+            </p>
+        {% endif %}
     {% endif %}
     {% if config.show_abstract and (not contrib.session.is_poster or config.show_poster_abstract) and contrib.description %}
         <div class="description">
@@ -228,10 +231,13 @@
             </b>
         </p>
         {% if program_config.show_siblings_location %}
-            <p>
-                <b>{% trans %}Location{% endtrans %}:</b>
-                {{ _render_place(entry) }}
-            </p>
+            {% set loc = _render_place(entry)|trim %}
+            {% if loc != '' %}
+                <p>
+                    <b>{% trans %}Location{% endtrans %}:</b>
+                    {{ loc }}
+                </p>
+            {% endif %}
         {% endif %}
         {% set people = object.person_links if type == 'SESSION_BLOCK' else object.speakers %}
         {% if type != 'BREAK' and people %}
@@ -272,7 +278,7 @@
 {% macro _render_place(entry) %}
     {# Entry argument could be both an entry or a data object attached to an entry #}
     {% set entry = entry.object or entry %}
-    {{ [entry.venue_name, entry.room_name, entry.address] | select | join(', ') }}
+    {{ [entry.venue_name, entry.room_name, entry.address] | select | join(', ') | trim }}
 {% endmacro %}
 
 {% macro _render_names(people, show_title=false, show_affiliation=false) %}

--- a/indico/modules/events/timetable/templates/pdf/timetable.css
+++ b/indico/modules/events/timetable/templates/pdf/timetable.css
@@ -24,7 +24,7 @@ body {
 }
 
 .cover {
-  counter-reset: program-page 7;
+  /* counter-reset: program-page 7; */
 }
 
 .cover .logo {
@@ -92,7 +92,7 @@ body {
   margin-left: 3px;
   margin-right: 10px;
   text-align: center;
-  content: leader(' ') target-counter(attr(href), page, decimal);
+  content: leader(' ') target-counter(attr(href), program-page, decimal);
   margin-bottom: 5px;
   border-radius: 2px;
   font-weight: bold;
@@ -112,7 +112,7 @@ body {
   width: 2.4em;
   border-radius: 3px;
   margin-right: 15px;
-  content: target-counter(attr(href), page, decimal);
+  content: target-counter(attr(href), program-page, decimal);
   background-color: var(--primary-color);
   color: white;
 }
@@ -129,7 +129,7 @@ body {
 }
 
 #footer::after {
-  content: target-counter('#footer', page, decimal);
+  content: target-counter('#footer', program-page, decimal);
 }
 
 /* Main content */


### PR DESCRIPTION
Fixes #6824

Also includes a fix that prevents empty locations from rendering the 'Location:' label.