### PR TITLE
Fix saving room with no attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Bugfixes
 - Fix error when removing the title of an event person (:pr:`6859`)
 - Fix participant visibility being set to "nobody" when a registration was modifified
   (:pr:`6863`)
+- Fix error when editing a room while no custom attributes have been defined (:pr:`6840`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/edit/RoomEditModal.jsx
@@ -203,7 +203,7 @@ function RoomEditModal({roomId, locationId, onClose, afterCreation}) {
 
   const handleSubmit = async (data, form) => {
     const changedValues = getChangedValues(data, form);
-    const isAttributesDirty = form.getFieldState('attributes').dirty;
+    const isAttributesDirty = form.getFieldState('attributes')?.dirty;
     const {
       attributes,
       bookable_hours: bookableHours,


### PR DESCRIPTION
My colleague @tomako found this issue with the recent changes, when you have no room attribute configured in the rb then saving a room results in an error. 