### PR TITLE
Add missing translation markers to error messages

### DIFF
--- a/indico/modules/events/features/util.py
+++ b/indico/modules/events/features/util.py
@@ -27,7 +27,7 @@ def get_feature_definition(name):
     try:
         return get_feature_definitions()[name]
     except KeyError:
-        raise RuntimeError(_("Feature does not exist: {feature_name}.").format(feature_name=name))
+        raise RuntimeError(_('Feature does not exist: {feature_name}.').format(feature_name=name))
 
 
 def get_enabled_features(event, only_explicit=False):
@@ -110,7 +110,11 @@ def require_feature(event, name):
     """
     if not is_feature_enabled(event, name):
         feature = get_feature_definition(name)
-        raise NotFound(_("The '{feature_name}' feature is not enabled for this event.").format(feature_name=feature.friendly_name))
+        raise NotFound(
+            _("The '{feature_name}' feature is not enabled for this event.").format(
+                feature_name=feature.friendly_name
+            )
+        )
 
 
 def format_feature_names(names):

--- a/indico/modules/events/features/util.py
+++ b/indico/modules/events/features/util.py
@@ -27,7 +27,7 @@ def get_feature_definition(name):
     try:
         return get_feature_definitions()[name]
     except KeyError:
-        raise RuntimeError(f'Feature does not exist: {name}.')
+        raise RuntimeError(f'Feature does not exist: {name}')
 
 
 def get_enabled_features(event, only_explicit=False):
@@ -110,11 +110,8 @@ def require_feature(event, name):
     """
     if not is_feature_enabled(event, name):
         feature = get_feature_definition(name)
-        raise NotFound(
-            _("The '{feature_name}' feature is not enabled for this event.").format(
-                feature_name=feature.friendly_name
-            )
-        )
+        raise NotFound(_("The '{feature_name}' feature is not enabled for this event.")
+                       .format(feature_name=feature.friendly_name))
 
 
 def format_feature_names(names):

--- a/indico/modules/events/features/util.py
+++ b/indico/modules/events/features/util.py
@@ -13,8 +13,8 @@ from indico.core import signals
 from indico.core.db import db
 from indico.modules.events import Event
 from indico.modules.events.features import features_event_settings
-from indico.util.signals import named_objects_from_signal
 from indico.util.i18n import _
+from indico.util.signals import named_objects_from_signal
 
 
 def get_feature_definitions():
@@ -27,7 +27,7 @@ def get_feature_definition(name):
     try:
         return get_feature_definitions()[name]
     except KeyError:
-        raise RuntimeError(_('Feature does not exist: {feature_name}.').format(feature_name=name))
+        raise RuntimeError(f'Feature does not exist: {name}.')
 
 
 def get_enabled_features(event, only_explicit=False):

--- a/indico/modules/events/features/util.py
+++ b/indico/modules/events/features/util.py
@@ -14,6 +14,7 @@ from indico.core.db import db
 from indico.modules.events import Event
 from indico.modules.events.features import features_event_settings
 from indico.util.signals import named_objects_from_signal
+from indico.util.i18n import _
 
 
 def get_feature_definitions():
@@ -26,7 +27,7 @@ def get_feature_definition(name):
     try:
         return get_feature_definitions()[name]
     except KeyError:
-        raise RuntimeError(f'Feature does not exist: {name}')
+        raise RuntimeError(_("Feature does not exist: {feature_name}.").format(feature_name=name))
 
 
 def get_enabled_features(event, only_explicit=False):
@@ -109,7 +110,7 @@ def require_feature(event, name):
     """
     if not is_feature_enabled(event, name):
         feature = get_feature_definition(name)
-        raise NotFound(f"The '{feature.friendly_name}' feature is not enabled for this event.")
+        raise NotFound(_("The '{feature_name}' feature is not enabled for this event.").format(feature_name=feature.friendly_name))
 
 
 def format_feature_names(names):


### PR DESCRIPTION
An error message has mixed languages (looks weird to me):
![2025-04-14_10-27-47](https://github.com/user-attachments/assets/97032fae-9be9-4c7a-9bb4-3435992b7eaf)

Apart from the proposed fix, I didn't find where the "Not Found" string is defined in the code. Might be the default title in an error handler class. Not sure how to translate that right now.
