### PR TITLE
Log conference menu changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Improvements
 - Show moderated rooms as "mine" and enable "bookings in my rooms" etc. for room
   moderators (:pr:`6823`)
 - Use the new date picker in more places (:issue:`6662`, :pr:`6832`)
+- Log conference menu changes (:pr:`6851`, thanks :user:`openprojects`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/layout/controllers/menu.py
+++ b/indico/modules/events/layout/controllers/menu.py
@@ -118,7 +118,7 @@ class RHMenuEntryEdit(RHMenuEntryEditBase):
             if self.entry.is_link:
                 log_fields['link_url'] = 'URL'
 
-            form_data = {key: getattr(form, key).data for key in log_fields.keys()}
+            form_data = {key: getattr(form, key).data for key in log_fields}
             changes = self.entry.populate_from_dict(form_data, skip={'acl'})
 
             if self.entry.is_page:
@@ -172,8 +172,8 @@ class RHMenuEntryPosition(RHMenuEntryEditBase):
         else:
             self.entry.move(position)
 
-        log_msg = 'Separator Entry' if self.entry.is_separator else \
-            f'{self.entry.type.title} Entry "{self.entry.localized_title}"'
+        log_msg = ('Separator Entry' if self.entry.is_separator else
+                   f'{self.entry.type.title} Entry "{self.entry.localized_title}"')
         self.entry.log(EventLogRealm.management, LogKind.change, 'Menu Entry',
                        f"{log_msg} has been {'inserted' if parent_id != self.entry.parent_id else 'moved'} in "
                        f"position {self.entry.position}", session.user)

--- a/indico/modules/events/layout/controllers/menu.py
+++ b/indico/modules/events/layout/controllers/menu.py
@@ -173,7 +173,7 @@ class RHMenuEntryPosition(RHMenuEntryEditBase):
             self.entry.move(position)
 
         log_msg = ('Separator Entry' if self.entry.is_separator else
-                   f'{self.entry.type.title} Entry "{self.entry.localized_title}"')
+                   f'{self.entry.type.title} Entry "{self.entry.title}"')
         self.entry.log(EventLogRealm.management, LogKind.change, 'Menu Entry',
                        f"{log_msg} has been {'inserted' if parent_id != self.entry.parent_id else 'moved'} in "
                        f"position {self.entry.position}", session.user)
@@ -184,7 +184,7 @@ class RHMenuEntryToggleEnabled(RHMenuEntryEditBase):
     def _process(self):
         self.entry.is_enabled = not self.entry.is_enabled
         log_msg = 'Separator Entry' if self.entry.is_separator else \
-            f'{self.entry.type.title} Entry "{self.entry.localized_title}"'
+            f'{self.entry.type.title} Entry "{self.entry.title}"'
         self.entry.log(EventLogRealm.management, LogKind.positive if self.entry.is_enabled else LogKind.negative,
                        'Menu Entry', f"{log_msg} visibility has been "
                                      f"{'enabled' if self.entry.is_enabled else 'disabled'}", session.user)
@@ -283,7 +283,7 @@ class RHMenuDeleteEntry(RHMenuEntryEditBase):
         db.session.delete(self.entry)
         db.session.flush()
         log_msg = 'Separator Entry' if self.entry.is_separator else \
-            f'{self.entry.type.title} Entry "{self.entry.localized_title}"'
+            f'{self.entry.type.title} Entry "{self.entry.title}"'
         self.entry.log(EventLogRealm.management, LogKind.change, 'Menu Entry', f'{log_msg} has been deleted',
                        session.user)
 

--- a/indico/modules/events/layout/controllers/menu.py
+++ b/indico/modules/events/layout/controllers/menu.py
@@ -199,9 +199,13 @@ class RHMenuEntryToggleDefault(RHMenuEntryEditBase):
         if self.event.default_page == self.entry.page:
             is_default = False
             self.event.default_page = None
+            self.entry.log(EventLogRealm.management, LogKind.change, 'Menu',
+                            f'Event homepage unset: {self.entry.log_title}', session.user)
         else:
             is_default = True
             self.event.default_page = self.entry.page
+            self.entry.log(EventLogRealm.management, LogKind.change, 'Menu',
+                            f'Event homepage set: {self.entry.log_title}', session.user)
         return jsonify(is_default=is_default)
 
 

--- a/indico/modules/events/layout/models/menu.py
+++ b/indico/modules/events/layout/models/menu.py
@@ -414,6 +414,10 @@ class MenuEntry(MenuEntryMixin, ProtectionMixin, db.Model):
     def protection_parent(self):
         return self.parent or self.event_ref
 
+    def log(self, *args, **kwargs):
+        """Log with prefilled metadata for the entry."""
+        return self.event.log(*args, meta={'menu_entry_id': self.id}, **kwargs)
+
 
 class EventPage(db.Model):
     __tablename__ = 'pages'

--- a/indico/modules/events/layout/models/menu.py
+++ b/indico/modules/events/layout/models/menu.py
@@ -15,7 +15,7 @@ from indico.core.db.sqlalchemy import PyIntEnum
 from indico.core.db.sqlalchemy.protection import ProtectionMixin
 from indico.modules.events.layout.models.principals import MenuEntryPrincipal
 from indico.util.enum import RichIntEnum
-from indico.util.i18n import _
+from indico.util.i18n import _, orig_string
 from indico.util.locators import locator_property
 from indico.util.string import format_repr, slugify, text_to_repr
 from indico.web.flask.util import url_for
@@ -113,6 +113,19 @@ class MenuEntryMixin:
     @property
     def is_separator(self):
         return self.type == MenuEntryType.separator
+
+    @property
+    def log_title(self):
+        if self.is_separator:
+            return '<Spacer>'
+        elif self.title:
+            return self.title
+        elif defaults := self.default_data:
+            return orig_string(defaults.title)
+        # this is very unlikely to ever happen, since typically we hide orphaned entries (ie internal/plugin
+        # menu items which are no longer being defined via the signal) and thus managers cannot do loggable
+        # operations on them
+        return '<Orphaned>'
 
     @cached_property
     def default_data(self):


### PR DESCRIPTION
As discussed via Elements, we need to add log entries when the event menu is altered. The  idea is to log any change that can be made in that view:

Enable/disable custom menu
Renaming menu entry
Hiding/showing menu entry
Adding new menu entry
Reordering menu entry