### PR TITLE
Fix scheduling existing contrib sometimes not working

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Bugfixes
 - Do not trigger notifications for withdrawn service requests when deleting past events
   (:issue:`6700`, :pr:`6754`, thanks :user:`bhngupta`)
 - Fix date picker on category calendar view (:issue:`6849`, :pr:`6850`)
+- Fix scheduling existing contributions not working in rare cirucmstances (:pr:`6853`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/legacy/libs/timetable/Management.js
+++ b/indico/web/client/js/legacy/libs/timetable/Management.js
@@ -70,32 +70,25 @@ type(
     },
 
     _sortList: function(type, second_click) {
-      var self = this;
-      var selected = _(this.getSelectedList().getAll()).map(function(item) {
-        return item.get('id');
-      });
-      var initial = _(self.getAll());
+      const self = this;
+      const selected = Object.values(this.getSelectedList().getAll()).map(item => item.get('id'));
+      const initial = Object.values(self.getAll());
 
       $('#sortById').css('font-weight', type == 'friendly_id' ? 'bold' : '');
       $('#sortByTitle').css('font-weight', type == 'title' ? 'bold' : '');
 
-      var sorted = initial
-        .chain()
-        .map(function(value, key) {
-          return {
-            key: key,
-            value: value.get(type),
-          };
-        })
-        .sortBy(function(item) {
-          return item.value;
-        });
+      // XXX if someone ever needs to debug something here: it's basically random whether `_` in
+      // here is underscore or lodash...
+      const sorted = _.sortBy(
+        initial.map((value, key) => ({key, value: value.get(type)})),
+        'value'
+      );
 
       // reverse order only if second click, else reset order
       this.reverseState = second_click ? !this.reverseState : false;
 
       if (this.reverseState) {
-        sorted = sorted.reverse();
+        sorted.reverse();
       }
 
       // Clear selection and elements
@@ -103,10 +96,8 @@ type(
       self.clear();
 
       // Add sorted items
-      var counter = 0;
-      sorted.each(function(item) {
-        self.set(counter + '', initial.value()[item.key]);
-        counter++;
+      sorted.forEach((item, i) => {
+        self.set(String(i), initial[item.key]);
       });
 
       // Reselect items


### PR DESCRIPTION
This was a super obscure bug that only happened on the JACoW Indico instance (don't ask me why), and only in production.

The legacy timetable code uses some UnderscoreJS functionality that is not on par with lodash functionality, and for some reason (once again, don't ask me why) in dev this page was using underscore, and in prod this was using lodash.

Simply avoiding the chaining functionality and thus using only basic functionality that works the same in both libraries most likely fixes the issue.