### PR TITLE
Convert emails to lowercase during input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Bugfixes
   (:issue:`6700`, :pr:`6754`, thanks :user:`bhngupta`)
 - Fix date picker on category calendar view (:issue:`6849`, :pr:`6850`)
 - Fix scheduling existing contributions not working in rare cirucmstances (:pr:`6853`)
+- Convert author/speaker email addresses to lowercase during input and use the lowercase
+  version for deduplication (:pr:`6855`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -292,14 +292,14 @@ function PersonLinkField({
   };
 
   const onAdd = values => {
-    const existing = persons.filter(p => !!p.email).map(p => p.email);
+    const existing = persons.filter(p => !!p.email).map(p => p.email.toLowerCase());
     const hooks = getPluginObjects('onAddPersonLink');
     values.forEach(p => {
       p.name = formatName(p);
       p.roles = roles.filter(x => x.default).map(x => x.name);
       hooks.forEach(f => f(p));
     });
-    onChange([...persons, ...values.filter(v => !existing.includes(v.email))]);
+    onChange([...persons, ...values.filter(v => !existing.includes(v.email.toLowerCase()))]);
   };
 
   const onSubmit = value => {

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -425,7 +425,12 @@ export function FinalInput({name, label, type, nullIfEmpty, noAutoComplete, ...r
   } else if (type === 'text' || type === 'email' || type === 'tel') {
     extraProps.format = formatters.trim;
     extraProps.formatOnBlur = true;
-    extraProps.parse = nullIfEmpty ? parsers.nullIfEmpty : identity;
+    const parse = nullIfEmpty ? parsers.nullIfEmpty : identity;
+    if (type === 'email') {
+      extraProps.parse = v => parse(v.toLowerCase());
+    } else {
+      extraProps.parse = parse;
+    }
   }
 
   if (noAutoComplete) {


### PR DESCRIPTION
Also explicitly lowercase them when de-duplicating speakers, even though that should no longer be necessary now.