### PR TITLE
Add form field setting content validation

### DIFF
--- a/indico/modules/events/registration/client/js/form/fields/TextAreaInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/TextAreaInput.jsx
@@ -9,7 +9,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Form} from 'semantic-ui-react';
 
-import {FinalInput, FinalTextArea, validators as v} from 'indico/react/forms';
+import {
+  FinalDropdown,
+  FinalInput,
+  FinalTextArea,
+  parsers as p,
+  validators as v,
+} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
 import '../../../styles/regform.module.scss';
@@ -49,19 +55,33 @@ TextAreaInput.defaultProps = {
 };
 
 export function TextAreaSettings() {
+  const contentValidationOptions = [
+    {key: 'nourl', value: 'no_url', text: Translate.string('Disallow URLs')},
+    {key: 'urlonly', value: 'url_only', text: Translate.string('Valid URL')},
+  ];
   return (
-    <Form.Group widths="equal">
-      <FinalInput
-        name="numberOfRows"
-        type="number"
-        label={Translate.string('Rows')}
-        placeholder={String(TextAreaInput.defaultProps.numberOfRows)}
-        step="1"
-        min="1"
-        max="20"
-        validate={v.optional(v.range(1, 20))}
-        fluid
+    <>
+      <FinalDropdown
+        name="contentValidation"
+        label={Translate.string('Content Validation')}
+        options={contentValidationOptions}
+        placeholder={Translate.string('None', 'Content Validation')}
+        parse={p.nullIfEmpty}
+        selection
       />
-    </Form.Group>
+      <Form.Group widths="equal">
+        <FinalInput
+          name="numberOfRows"
+          type="number"
+          label={Translate.string('Rows')}
+          placeholder={String(TextAreaInput.defaultProps.numberOfRows)}
+          step="1"
+          min="1"
+          max="20"
+          validate={v.optional(v.range(1, 20))}
+          fluid
+        />
+      </Form.Group>
+    </>
   );
 }

--- a/indico/modules/events/registration/client/js/form/fields/TextAreaInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/TextAreaInput.jsx
@@ -20,6 +20,7 @@ import {Translate} from 'indico/react/i18n';
 
 import '../../../styles/regform.module.scss';
 
+import {contentValidationOptions} from './TextInput';
 import {mapPropsToAttributes} from './util';
 
 const attributeMap = {
@@ -54,21 +55,10 @@ TextAreaInput.defaultProps = {
   numberOfRows: 2,
 };
 
-export function TextAreaSettings() {
-  const contentValidationOptions = [
-    {key: 'nourl', value: 'no_url', text: Translate.string('Disallow URLs')},
-    {key: 'urlonly', value: 'url_only', text: Translate.string('Valid URL')},
-  ];
+export function TextAreaSettings(...itemData) {
+  const settings = itemData[0];
   return (
     <>
-      <FinalDropdown
-        name="contentValidation"
-        label={Translate.string('Content Validation')}
-        options={contentValidationOptions}
-        placeholder={Translate.string('None', 'Content Validation')}
-        parse={p.nullIfEmpty}
-        selection
-      />
       <Form.Group widths="equal">
         <FinalInput
           name="numberOfRows"
@@ -82,6 +72,15 @@ export function TextAreaSettings() {
           fluid
         />
       </Form.Group>
+      <FinalDropdown
+        name="contentValidation"
+        label={Translate.string('Content validation')}
+        options={contentValidationOptions}
+        placeholder={Translate.string('None', 'Content validation')}
+        parse={p.nullIfEmpty}
+        selection
+        disabled={settings.fieldIsContentValidationProtected}
+      />
     </>
   );
 }

--- a/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Form} from 'semantic-ui-react';
 
-import {FinalInput, validators as v} from 'indico/react/forms';
+import {FinalDropdown, FinalInput, parsers as p, validators as v} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
 
 import {mapPropsToAttributes} from './util';
@@ -48,44 +48,60 @@ TextInput.defaultProps = {
   maxLength: 0,
 };
 
-export function TextSettings() {
+export function TextSettings(...itemData) {
+  const settings = itemData[0];
+  const contentValidationOptions = [
+    {key: 'nourl', value: 'no_url', text: Translate.string('Disallow URLs')},
+    {key: 'urlonly', value: 'url_only', text: Translate.string('Valid URL')},
+  ];
   return (
-    <Form.Group widths="equal">
-      <FinalInput
-        name="minLength"
-        type="number"
-        label={Translate.string('Min. length')}
-        placeholder={String(TextInput.defaultProps.minLength)}
-        step="1"
-        min="0"
-        validate={v.optional(
-          v.chain(val => {
-            if (val === 0) {
-              return v.STOP_VALIDATION;
-            } else if (val === 1) {
-              return Translate.string(
-                'If you want to make the field required, select the "Required field" checkbox. The minimum length only applies if the field is not empty.'
-              );
-            }
-          }, v.min(2))
-        )}
-        format={val => val || ''}
-        parse={val => +val || 0}
-        fluid
+    <>
+      <FinalDropdown
+        name="contentValidation"
+        label={Translate.string('Content Validation')}
+        options={contentValidationOptions}
+        placeholder={Translate.string('None', 'Content Validation')}
+        parse={p.nullIfEmpty}
+        selection
+        disabled={settings.fieldIsContentValidationProtected}
       />
-      <FinalInput
-        name="maxLength"
-        type="number"
-        label={Translate.string('Max. length')}
-        placeholder={Translate.string('No maximum')}
-        step="1"
-        min="0"
-        validate={v.optional(v.min(0))}
-        format={val => val || ''}
-        parse={val => +val || 0}
-        fluid
-      />
-    </Form.Group>
+      <Form.Group widths="equal">
+        <FinalInput
+          name="minLength"
+          type="number"
+          label={Translate.string('Min. length')}
+          placeholder={String(TextInput.defaultProps.minLength)}
+          step="1"
+          min="0"
+          validate={v.optional(
+            v.chain(val => {
+              if (val === 0) {
+                return v.STOP_VALIDATION;
+              } else if (val === 1) {
+                return Translate.string(
+                  'If you want to make the field required, select the "Required field" checkbox. The minimum length only applies if the field is not empty.'
+                );
+              }
+            }, v.min(2))
+          )}
+          format={val => val || ''}
+          parse={val => +val || 0}
+          fluid
+        />
+        <FinalInput
+          name="maxLength"
+          type="number"
+          label={Translate.string('Max. length')}
+          placeholder={Translate.string('No maximum')}
+          step="1"
+          min="0"
+          validate={v.optional(v.min(0))}
+          format={val => val || ''}
+          parse={val => +val || 0}
+          fluid
+        />
+      </Form.Group>
+    </>
   );
 }
 

--- a/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/TextInput.jsx
@@ -18,6 +18,11 @@ import '../../../styles/regform.module.scss';
 
 const attributeMap = {minLength: 'minLength', maxLength: 'maxLength'};
 
+export const contentValidationOptions = [
+  {key: 'nourl', value: 'no_url', text: Translate.string('Disallow URLs')},
+  {key: 'urlonly', value: 'url_only', text: Translate.string('Valid URL')},
+];
+
 export default function TextInput({htmlId, htmlName, disabled, title, isRequired, ...props}) {
   const inputProps = mapPropsToAttributes(props, attributeMap, TextInput.defaultProps);
   return (
@@ -50,21 +55,8 @@ TextInput.defaultProps = {
 
 export function TextSettings(...itemData) {
   const settings = itemData[0];
-  const contentValidationOptions = [
-    {key: 'nourl', value: 'no_url', text: Translate.string('Disallow URLs')},
-    {key: 'urlonly', value: 'url_only', text: Translate.string('Valid URL')},
-  ];
   return (
     <>
-      <FinalDropdown
-        name="contentValidation"
-        label={Translate.string('Content Validation')}
-        options={contentValidationOptions}
-        placeholder={Translate.string('None', 'Content Validation')}
-        parse={p.nullIfEmpty}
-        selection
-        disabled={settings.fieldIsContentValidationProtected}
-      />
       <Form.Group widths="equal">
         <FinalInput
           name="minLength"
@@ -101,6 +93,15 @@ export function TextSettings(...itemData) {
           fluid
         />
       </Form.Group>
+      <FinalDropdown
+        name="contentValidation"
+        label={Translate.string('Content validation')}
+        options={contentValidationOptions}
+        placeholder={Translate.string('None', 'Content validation')}
+        parse={p.nullIfEmpty}
+        selection
+        disabled={settings.fieldIsContentValidationProtected}
+      />
     </>
   );
 }

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -32,11 +32,13 @@ KEEP_EXISTING_FILE_UUID = '00000000-0000-0000-0000-000000000001'
 class TextFieldDataSchema(FieldSetupSchemaBase):
     min_length = fields.Integer(load_default=0, validate=validate.And(validate.Range(0), validate.NoneOf((1,))))
     max_length = fields.Integer(load_default=0, validate=validate.Range(0))
+    content_validation = fields.String(load_default=None)
 
     @validates_schema(skip_on_field_errors=True)
     def validate_min_max(self, data, **kwargs):
         if data['min_length'] and data['max_length'] and data['min_length'] > data['max_length']:
             raise ValidationError('Maximum value must be less than minimum value.', 'max_length')
+        # TODO: add validation on content_validation to prevent value change when registration exists
 
 
 class TextFieldLengthValidator(validate.Length):
@@ -98,6 +100,7 @@ class TextAreaField(RegistrationFormFieldBase):
     mm_field_class = fields.String
     setup_schema_fields = {
         'number_of_rows': fields.Integer(load_default=None, validate=validate.Range(1, 20)),
+        'content_validation': fields.String(load_default=None),
     }
 
 

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -32,7 +32,7 @@ KEEP_EXISTING_FILE_UUID = '00000000-0000-0000-0000-000000000001'
 class TextFieldDataSchema(FieldSetupSchemaBase):
     min_length = fields.Integer(load_default=0, validate=validate.And(validate.Range(0), validate.NoneOf((1,))))
     max_length = fields.Integer(load_default=0, validate=validate.Range(0))
-    content_validation = fields.String(load_default=None)
+    content_validation = fields.String(load_default=None, validate=validate.OneOf(['', 'no_url', 'url_only']))
 
     @validates_schema(skip_on_field_errors=True)
     def validate_min_max(self, data, **kwargs):
@@ -100,7 +100,7 @@ class TextAreaField(RegistrationFormFieldBase):
     mm_field_class = fields.String
     setup_schema_fields = {
         'number_of_rows': fields.Integer(load_default=None, validate=validate.Range(1, 20)),
-        'content_validation': fields.String(load_default=None),
+        'content_validation': fields.String(load_default=None, validate=validate.OneOf(['', 'no_url', 'url_only']))
     }
 
 

--- a/indico/modules/events/registration/models/form_fields.py
+++ b/indico/modules/events/registration/models/form_fields.py
@@ -125,6 +125,7 @@ class RegistrationFormPersonalDataField(RegistrationFormField):
     def view_data(self):
         data = dict(super().view_data,
                     field_is_required=self.personal_data_type.is_required,
+                    field_is_content_validation_protected=self.personal_data_type.is_content_validation_protected,
                     field_is_personal_data=True)
         return camelize_keys(data)
 

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -75,12 +75,18 @@ class PersonalDataType(IndicoIntEnum):
             (cls.first_name, {
                 'title': cls.first_name.get_title(),
                 'input_type': 'text',
-                'position': 1
+                'position': 1,
+                'data': {
+                    'content_validation': 'no_url'
+                }
             }),
             (cls.last_name, {
                 'title': cls.last_name.get_title(),
                 'input_type': 'text',
-                'position': 2
+                'position': 2,
+                'data': {
+                    'content_validation': 'no_url'
+                }
             }),
             (cls.email, {
                 'title': cls.email.get_title(),
@@ -139,6 +145,14 @@ class PersonalDataType(IndicoIntEnum):
 
     @property
     def is_required(self):
+        return self in {PersonalDataType.email, PersonalDataType.first_name, PersonalDataType.last_name}
+
+    @property
+    @make_interceptable
+    def is_content_validation_protected(self):
+        """
+        The setting for the content validation of the field can't be modified.
+        """
         return self in {PersonalDataType.email, PersonalDataType.first_name, PersonalDataType.last_name}
 
     @property

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -150,9 +150,7 @@ class PersonalDataType(IndicoIntEnum):
     @property
     @make_interceptable
     def is_content_validation_protected(self):
-        """
-        The setting for the content validation of the field can't be modified.
-        """
+        """The setting for the content validation of the field can't be modified."""
         return self in {PersonalDataType.email, PersonalDataType.first_name, PersonalDataType.last_name}
 
     @property


### PR DESCRIPTION
Request to add a new setting on Text form field to allow/not url contents.

Notes: 
There is still a missing code to prevent the change of the new setting when registration data already exists: see comment in TextFieldDataSchema,
I haven't found a solution yet as the context on event/registration_form is absent in schema validation.