### PR TITLE
Fix clearing title of event persons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Bugfixes
 - Fix scheduling existing contributions not working in rare cirucmstances (:pr:`6853`)
 - Convert author/speaker email addresses to lowercase during input and use the lowercase
   version for deduplication (:pr:`6855`)
+- Fix error when removing the title of an event person (:pr:`6859`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/persons/schemas.py
+++ b/indico/modules/events/persons/schemas.py
@@ -115,7 +115,7 @@ class EventPersonUpdateSchema(EventPersonSchema):
     class Meta(EventPersonSchema.Meta):
         fields = ('title', 'first_name', 'last_name', 'address', 'phone', 'affiliation', 'affiliation_link')
 
-    title = fields.Enum(UserTitle)
+    title = NoneValueEnumField(UserTitle, none_value=UserTitle.none)
 
     @validates_schema(skip_on_field_errors=True)
     def check_restricted_affiliation(self, data, **kwargs):

--- a/indico/web/client/js/react/components/PersonDetailsModal.jsx
+++ b/indico/web/client/js/react/components/PersonDetailsModal.jsx
@@ -158,6 +158,7 @@ export default function PersonDetailsModal({
           options={titles}
           placeholder={Translate.string('None', 'Title (salutation)')}
           required={requiredPersonFields?.includes('title')}
+          nullIfEmpty
         />
         {!extraParams?.disableAffiliations && (
           <FinalAffiliationField

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -552,18 +552,19 @@ FinalRadio.propTypes = {
 /**
  * Like `FinalField` but for a dropdown.
  */
-export function FinalDropdown({name, label, multiple, ...rest}) {
+export function FinalDropdown({name, label, multiple, nullIfEmpty, ...rest}) {
   const extraProps = {};
   if (multiple) {
     extraProps.isEqual = unsortedArraysEqual;
   }
+  const parse = nullIfEmpty ? parsers.nullIfEmpty : identity;
   return (
     <FinalField
       name={name}
       adapter={DropdownAdapter}
       label={label}
       format={identity}
-      parse={identity}
+      parse={parse}
       search
       deburr
       // https://github.com/final-form/react-final-form/issues/544
@@ -578,11 +579,13 @@ FinalDropdown.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
   multiple: PropTypes.bool,
+  nullIfEmpty: PropTypes.bool,
 };
 
 FinalDropdown.defaultProps = {
   label: null,
   multiple: false,
+  nullIfEmpty: false,
 };
 
 /**


### PR DESCRIPTION
- Send `null` instead of `""` when there's no title - this also matches the initial data
- Use the correct field that translates between None and the no title enum value