### PR TITLE
Add app logs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,8 @@ Improvements
 - Allow linking existing booking to an event even if there's no exact date/time overlap,
   and do not show a large number of unrelated bookings (:issue:`6568`, :issue:`6811`,
   :pr:`6846`, thanks :user:`Moliholy, unconventionaldotdev`)
+- Add a log for global admin actions, similar to that in events, categories and users
+  (:pr:`6868`, thanks :user:`tomako`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20250627_1627_b4ee48f3052c_add_app_logs.py
+++ b/indico/migrations/versions/20250627_1627_b4ee48f3052c_add_app_logs.py
@@ -1,0 +1,56 @@
+"""Add app logs
+
+Revision ID: b4ee48f3052c
+Revises: f2518f111aa7
+Create Date: 2025-04-24 16:27:44.822810
+"""
+
+from enum import Enum
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = 'b4ee48f3052c'
+down_revision = 'f2518f111aa7'
+branch_labels = None
+depends_on = None
+
+
+class _AppLogRealm(int, Enum):
+    system = 1
+    admin = 2
+
+
+class _LogKind(int, Enum):
+    other = 1
+    positive = 2
+    change = 3
+    negative = 4
+
+
+def upgrade():
+    op.create_table('logs',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('logged_dt', UTCDateTime, nullable=False),
+        sa.Column('kind', PyIntEnum(_LogKind), nullable=False),
+        sa.Column('module', sa.String(), nullable=False),
+        sa.Column('type', sa.String(), nullable=False),
+        sa.Column('summary', sa.String(), nullable=False),
+        sa.Column('data', postgresql.JSON(astext_type=sa.Text()), nullable=False),
+        sa.Column('meta', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column('realm', PyIntEnum(_AppLogRealm), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=True, index=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.users.id']),
+        sa.PrimaryKeyConstraint('id'),
+        schema='indico',
+    )
+    op.create_index(None, 'logs', ['meta'], unique=False, schema='indico', postgresql_using='gin')
+
+
+def downgrade():
+    op.drop_table('logs', schema='indico')

--- a/indico/modules/announcement/controllers.py
+++ b/indico/modules/announcement/controllers.py
@@ -5,21 +5,34 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from flask import flash, redirect
+from flask import flash, redirect, session
 
 from indico.modules.admin import RHAdminBase
 from indico.modules.announcement import announcement_settings
 from indico.modules.announcement.forms import AnnouncementForm
 from indico.modules.announcement.views import WPAnnouncement
+from indico.modules.logs import AppLogEntry, AppLogRealm, LogKind
+from indico.modules.logs.util import make_diff_log
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults
 
 
 class RHAnnouncement(RHAdminBase):
+    def _log_changes(self, changes):
+        log_fields = {
+            'enabled': 'Enabled',
+            'message': 'Message',
+        }
+        AppLogEntry.log(AppLogRealm.admin, LogKind.change, 'Announcement', 'Data updated', session.user,
+                        data={'Changes': make_diff_log(changes, log_fields)})
+
     def _process(self):
-        form = AnnouncementForm(obj=FormDefaults(**announcement_settings.get_all()))
+        current_settings = announcement_settings.get_all()
+        form = AnnouncementForm(obj=FormDefaults(**current_settings))
         if form.validate_on_submit():
+            changes = {k: (current_settings[k], v) for k, v in form.data.items() if current_settings[k] != v}
+            self._log_changes(changes)
             announcement_settings.set_multi(form.data)
             flash(_('Settings have been saved'), 'success')
             return redirect(url_for('announcement.manage'))

--- a/indico/modules/logs/__init__.py
+++ b/indico/modules/logs/__init__.py
@@ -8,7 +8,6 @@
 from flask import session
 
 from indico.core import signals
-from indico.core.db import db
 from indico.modules.logs.models.entries import AppLogEntry, CategoryLogEntry, EventLogEntry, EventLogRealm, LogKind
 from indico.modules.logs.renderers import EmailRenderer, SimpleRenderer
 from indico.modules.logs.util import get_log_renderers
@@ -54,14 +53,3 @@ def _check_log_renderers(app, **kwargs):
 def _extend_admin_menu(sender, **kwargs):
     if session.user.is_admin:
         return SideMenuItem('logs', _('Logs'), url_for('logs.app'), -100, icon='stack')
-
-
-@signals.core.app_created.connect
-def _set_app_logger(app, **kwargs):
-    def _log(realm, kind, module, summary, user=None, type_='simple', data=None, meta=None):
-        entry = AppLogEntry(user=user, realm=realm, kind=kind, module=module, type=type_, summary=summary,
-                            data=(data or {}), meta=(meta or {}))
-        db.session.add(entry)
-        return entry
-
-    app.log = _log

--- a/indico/modules/logs/__init__.py
+++ b/indico/modules/logs/__init__.py
@@ -8,7 +8,8 @@
 from flask import session
 
 from indico.core import signals
-from indico.modules.logs.models.entries import AppLogEntry, CategoryLogEntry, EventLogEntry, EventLogRealm, LogKind
+from indico.modules.logs.models.entries import (AppLogEntry, AppLogRealm, CategoryLogEntry, CategoryLogRealm,
+                                                EventLogEntry, EventLogRealm, LogKind)
 from indico.modules.logs.renderers import EmailRenderer, SimpleRenderer
 from indico.modules.logs.util import get_log_renderers
 from indico.util.i18n import _
@@ -16,7 +17,8 @@ from indico.web.flask.util import url_for
 from indico.web.menu import SideMenuItem
 
 
-__all__ = ('AppLogEntry', 'CategoryLogEntry', 'EventLogEntry', 'EventLogRealm', 'LogKind')
+__all__ = ('AppLogEntry', 'CategoryLogEntry', 'EventLogEntry', 'EventLogRealm', 'AppLogRealm', 'CategoryLogRealm',
+           'LogKind')
 
 
 @signals.menu.items.connect_via('event-management-sidemenu')

--- a/indico/modules/logs/blueprint.py
+++ b/indico/modules/logs/blueprint.py
@@ -7,20 +7,24 @@
 
 from flask import request
 
-from indico.modules.logs.controllers import (RHCategoryLogs, RHCategoryLogsJSON, RHEventLogs, RHEventLogsJSON,
-                                             RHResendEmail, RHUserLogs, RHUserLogsJSON)
+from indico.modules.logs.controllers import (RHAppLogs, RHAppLogsJSON, RHCategoryLogs, RHCategoryLogsJSON, RHEventLogs,
+                                             RHEventLogsJSON, RHResendEmail, RHUserLogs, RHUserLogsJSON)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
 _bp = IndicoBlueprint('logs', __name__, template_folder='templates', virtual_template_folder='logs')
 
-# Events
-_bp.add_url_rule('/event/<int:event_id>/manage/logs/', 'event', RHEventLogs)
-_bp.add_url_rule('/event/<int:event_id>/manage/logs/api/logs', 'api_event_logs', RHEventLogsJSON)
+# App
+_bp.add_url_rule('/admin/logs/', 'app', RHAppLogs)
+_bp.add_url_rule('/admin/logs/api/logs', 'api_app_logs', RHAppLogsJSON)
 
 # Categories
 _bp.add_url_rule('/category/<int:category_id>/manage/logs/', 'category', RHCategoryLogs)
 _bp.add_url_rule('/category/<int:category_id>/manage/logs/api/logs', 'api_category_logs', RHCategoryLogsJSON)
+
+# Events
+_bp.add_url_rule('/event/<int:event_id>/manage/logs/', 'event', RHEventLogs)
+_bp.add_url_rule('/event/<int:event_id>/manage/logs/api/logs', 'api_event_logs', RHEventLogsJSON)
 
 # Users
 with _bp.add_prefixed_rules('/user/<int:user_id>', '/user'):

--- a/indico/modules/logs/client/style/logs.scss
+++ b/indico/modules/logs/client/style/logs.scss
@@ -58,6 +58,10 @@
     pointer-events: none;
   }
 
+  li.log-realm-admin span.log-module span.log-icon i.log-realm {
+    @include icon-before('icon-settings');
+  }
+
   li.log-realm-emails span.log-module span.log-icon i.log-realm {
     @include icon-before('icon-mail');
   }
@@ -76,6 +80,10 @@
 
   li.log-realm-acl span.log-module span.log-icon i.log-realm {
     @include icon-before('icon-shield');
+  }
+
+  li.log-realm-system span.log-module span.log-icon i.log-realm {
+    @include icon-before('icon-wrench');
   }
 
   li.log-realm-user span.log-module span.log-icon i.log-realm {

--- a/indico/modules/logs/models/entries.py
+++ b/indico/modules/logs/models/entries.py
@@ -279,5 +279,12 @@ class AppLogEntry(LogEntryBase):
         nullable=False
     )
 
+    @staticmethod
+    def log(realm, kind, module, summary, user=None, type_='simple', data=None, meta=None):
+        entry = AppLogEntry(user=user, realm=realm, kind=kind, module=module, type=type_, summary=summary,
+                            data=(data or {}), meta=(meta or {}))
+        db.session.add(entry)
+        return entry
+
     def __repr__(self):
         return format_repr(self, 'id', 'logged_dt', 'realm', 'module', _text=self.summary)

--- a/indico/modules/logs/models/entries.py
+++ b/indico/modules/logs/models/entries.py
@@ -47,6 +47,12 @@ class UserLogRealm(RichIntEnum):
     acl = 3
 
 
+class AppLogRealm(RichIntEnum):
+    __titles__ = (None, _('System'), _('Admin'))
+    system = 1
+    admin = 2
+
+
 class LogKind(IndicoIntEnum):
     other = 1
     positive = 2
@@ -259,3 +265,19 @@ class UserLogEntry(LogEntryBase):
         ),
         foreign_keys=[target_user_id]
     )
+
+
+class AppLogEntry(LogEntryBase):
+    """Log entries for the application."""
+
+    __auto_table_args = {'schema': 'indico'}
+    user_backref_name = 'app_log_entries'
+
+    #: The general area of the user the entry comes from
+    realm = db.Column(
+        PyIntEnum(AppLogRealm),
+        nullable=False
+    )
+
+    def __repr__(self):
+        return format_repr(self, 'id', 'logged_dt', 'realm', 'module', _text=self.summary)

--- a/indico/modules/logs/models/entries.py
+++ b/indico/modules/logs/models/entries.py
@@ -273,7 +273,7 @@ class AppLogEntry(LogEntryBase):
     __auto_table_args = {'schema': 'indico'}
     user_backref_name = 'app_log_entries'
 
-    #: The general area of the user the entry comes from
+    #: The general area of the application the entry comes from
     realm = db.Column(
         PyIntEnum(AppLogRealm),
         nullable=False

--- a/indico/modules/logs/templates/logs.html
+++ b/indico/modules/logs/templates/logs.html
@@ -2,8 +2,10 @@
     {% extends 'categories/management/base.html' %}
 {% elif event|default(none) %}
     {% extends 'events/management/base.html' %}
-{% else %}
+{% elif user|default(none) %}
     {% extends 'users/base.html' %}
+{% else %}
+    {% extends 'layout/admin_page.html' %}
 {% endif %}
 
 {% block title %}

--- a/indico/modules/logs/util.py
+++ b/indico/modules/logs/util.py
@@ -6,7 +6,7 @@
 # LICENSE file for more details.
 
 import re
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from difflib import SequenceMatcher
 from enum import Enum
 
@@ -72,6 +72,9 @@ def make_diff_log(changes, fields):
         elif all(isinstance(x, datetime) for x in change):
             type_ = 'datetime'
             change = [x.isoformat() for x in change]
+        elif all(isinstance(x, date) for x in not_none_change):
+            type_ = 'date'
+            change = [x.isoformat() if x is not None else default for x in change]
         elif not_none_change and all(isinstance(x, timedelta) for x in not_none_change):
             type_ = 'timedelta'
             with force_locale(None, default=False):
@@ -90,7 +93,7 @@ def render_changes(a, b, type_):
     :param b: new value
     :param type_: the type determining how the values should be compared
     """
-    if type_ in ('number', 'enum', 'bool', 'datetime', 'timedelta'):
+    if type_ in ('number', 'enum', 'bool', 'datetime', 'date', 'timedelta'):
         if a in (None, ''):
             a = '\N{EMPTY SET}'
         if b in (None, ''):

--- a/indico/modules/logs/views.py
+++ b/indico/modules/logs/views.py
@@ -5,20 +5,26 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from indico.modules.admin.views import WPAdmin
 from indico.modules.categories.views import WPCategoryManagement
 from indico.modules.events.management.views import WPEventManagement
 from indico.modules.users.views import WPUser
+
+
+class WPAppLogs(WPAdmin):
+    bundles = ('module_logs.js', 'module_logs.css')
+    template_prefix = 'logs/'
+
+
+class WPCategoryLogs(WPCategoryManagement):
+    bundles = ('module_logs.js', 'module_logs.css')
+    template_prefix = 'logs/'
 
 
 class WPEventLogs(WPEventManagement):
     bundles = ('module_logs.js', 'module_logs.css')
     template_prefix = 'logs/'
     sidemenu_option = 'logs'
-
-
-class WPCategoryLogs(WPCategoryManagement):
-    bundles = ('module_logs.js', 'module_logs.css')
-    template_prefix = 'logs/'
 
 
 class WPUserLogs(WPUser):

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -12,7 +12,7 @@ from urllib.parse import urlsplit
 from uuid import uuid4
 
 from dateutil.relativedelta import relativedelta
-from flask import flash, jsonify, redirect, render_template, request, session
+from flask import current_app, flash, jsonify, redirect, render_template, request, session
 from itsdangerous import BadSignature
 from markupsafe import Markup, escape
 from marshmallow import fields
@@ -41,7 +41,7 @@ from indico.modules.events import Event
 from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.sessions.models.sessions import Session
 from indico.modules.events.util import serialize_event_for_ical
-from indico.modules.logs.models.entries import LogKind, UserLogRealm
+from indico.modules.logs.models.entries import AppLogRealm, LogKind, UserLogRealm
 from indico.modules.users import User, logger, user_management_settings
 from indico.modules.users.export_schemas import DataExportRequestSchema
 from indico.modules.users.forms import (AdminAccountRegistrationForm, AdminsForm, AdminUserSettingsForm, MergeForm,
@@ -695,12 +695,18 @@ class RHAdmins(RHAdminBase):
             removed = admins - form.admins.data
             for user in added:
                 user.is_admin = True
+                current_app.log(AppLogRealm.admin, LogKind.positive, 'Admins',
+                                f'Admin privileges granted to {user.full_name}',
+                                session.user, data={'IP': request.remote_addr, 'User ID': user.id})
                 user.log(UserLogRealm.management, LogKind.positive, 'Admins', 'Admin privileges granted', session.user,
                          data={'IP': request.remote_addr})
                 logger.warning('Admin rights granted to %r by %r [%s]', user, session.user, request.remote_addr)
                 flash(_('Admin added: {name} ({email})').format(name=user.name, email=user.email), 'success')
             for user in removed:
                 user.is_admin = False
+                current_app.log(AppLogRealm.admin, LogKind.negative, 'Admins',
+                                f'Admin privileges revoked from {user.full_name}',
+                                session.user, data={'IP': request.remote_addr, 'User ID': user.id})
                 user.log(UserLogRealm.management, LogKind.negative, 'Admins', 'Admin privileges revoked', session.user,
                          data={'IP': request.remote_addr})
                 logger.warning('Admin rights revoked from %r by %r [%s]', user, session.user, request.remote_addr)

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -12,7 +12,7 @@ from urllib.parse import urlsplit
 from uuid import uuid4
 
 from dateutil.relativedelta import relativedelta
-from flask import current_app, flash, jsonify, redirect, render_template, request, session
+from flask import flash, jsonify, redirect, render_template, request, session
 from itsdangerous import BadSignature
 from markupsafe import Markup, escape
 from marshmallow import fields
@@ -41,7 +41,7 @@ from indico.modules.events import Event
 from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.sessions.models.sessions import Session
 from indico.modules.events.util import serialize_event_for_ical
-from indico.modules.logs.models.entries import AppLogRealm, LogKind, UserLogRealm
+from indico.modules.logs.models.entries import AppLogEntry, AppLogRealm, LogKind, UserLogRealm
 from indico.modules.users import User, logger, user_management_settings
 from indico.modules.users.export_schemas import DataExportRequestSchema
 from indico.modules.users.forms import (AdminAccountRegistrationForm, AdminsForm, AdminUserSettingsForm, MergeForm,
@@ -695,7 +695,7 @@ class RHAdmins(RHAdminBase):
             removed = admins - form.admins.data
             for user in added:
                 user.is_admin = True
-                current_app.log(AppLogRealm.admin, LogKind.positive, 'Admins',
+                AppLogEntry.log(AppLogRealm.admin, LogKind.positive, 'Admins',
                                 f'Admin privileges granted to {user.full_name}',
                                 session.user, data={'IP': request.remote_addr, 'User ID': user.id})
                 user.log(UserLogRealm.management, LogKind.positive, 'Admins', 'Admin privileges granted', session.user,
@@ -704,7 +704,7 @@ class RHAdmins(RHAdminBase):
                 flash(_('Admin added: {name} ({email})').format(name=user.name, email=user.email), 'success')
             for user in removed:
                 user.is_admin = False
-                current_app.log(AppLogRealm.admin, LogKind.negative, 'Admins',
+                AppLogEntry.log(AppLogRealm.admin, LogKind.negative, 'Admins',
                                 f'Admin privileges revoked from {user.full_name}',
                                 session.user, data={'IP': request.remote_addr, 'User ID': user.id})
                 user.log(UserLogRealm.management, LogKind.negative, 'Admins', 'Admin privileges revoked', session.user,

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -440,6 +440,7 @@ class User(PersonMixin, db.Model):
     # - abstracts (Abstract.submitter)
     # - agreements (Agreement.user)
     # - anonymous_survey_submissions (AnonymousSurveySubmission.user)
+    # - app_log_entries (AppLogEntry.user)
     # - attachment_files (AttachmentFile.user)
     # - attachments (Attachment.user)
     # - blockings (Blocking.created_by_user)


### PR DESCRIPTION
This PR is about adding `AppLogEntry` for logging events related to system/admin features.

Highlights:

* Usage: ~~`current_app.log(...)`~~
   * I have to admit I don't really like how `log()` is attached to the `app` but I thought it's still better than a separate function.
   * changed to `AppLogEntry.log(...)`
* The Logs menu is placed in Administration side-menu
* In this PR only the admin user changes are logged
  * also logging changes to the legal settings and global announcements now