### PR TITLE
Add affiliation metadata to user search

### DIFF
--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -903,8 +903,8 @@ class RHRejectRegistrationRequest(RHRegistrationRequestBase):
 
 
 class UserSearchResultSchema(mm.SQLAlchemyAutoSchema):
-    affiliation_id = fields.Integer(attribute='_affiliation.affiliation_id')
-    affiliation_meta = fields.Nested(AffiliationSchema, attribute='_affiliation.affiliation_link')
+    affiliation_id = fields.Integer(attribute='affiliation_link.id')
+    affiliation_meta = fields.Nested(AffiliationSchema, attribute='affiliation_link')
     title = fields.Enum(UserTitle, attribute='_title')
 
     class Meta:


### PR DESCRIPTION
Fixes the bug for missing metadata of predetermined affiliations through user search results