### PR TITLE
Add registration tag metadata to Checkin API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,8 @@ Internal Changes
 - Expose cloning details such as object mappings in the ``event.cloned`` signal (:pr:`6858`)
 - Expose cloning details in the ``contribution.created`` and ``subcontribution.created``
   signals (:pr:`6858`)
+- Add the id and color of registration tags on the Checkin API endpoint for registation
+  data (:pr:`6874`, thanks :user:`duartegalvao`)
 
 
 Version 3.3.6

--- a/indico/modules/events/registration/controllers/api/test_snapshots/checkin_event_details.yml
+++ b/indico/modules/events/registration/controllers/api/test_snapshots/checkin_event_details.yml
@@ -1,5 +1,6 @@
 description: ''
 end_dt: <timestamp>
 id: <id>
+registration_tags: []
 start_dt: <timestamp>
 title: dummy#0

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -300,6 +300,7 @@ class Registration(db.Model):
         secondary=registrations_tags_table,
         passive_deletes=True,
         collection_class=set,
+        order_by='RegistrationTag.title',
         backref=db.backref(
             'registrations',
             lazy=False

--- a/indico/modules/events/registration/schemas.py
+++ b/indico/modules/events/registration/schemas.py
@@ -71,7 +71,7 @@ class CheckinRegistrationSchema(mm.SQLAlchemyAutoSchema):
     checkin_secret = fields.UUID(attribute='ticket_uuid')
     payment_date = fields.Method('_get_payment_date')
     formatted_price = fields.Function(lambda reg: reg.render_price())
-    tags = fields.Function(lambda reg: sorted(t.title for t in reg.tags))
+    tags = fields.List(fields.Nested(RegistrationTagSchema))
     registration_date = fields.DateTime(attribute='submitted_dt')
     registration_data = fields.Method('_get_registration_data')
 

--- a/indico/modules/events/registration/schemas.py
+++ b/indico/modules/events/registration/schemas.py
@@ -44,7 +44,9 @@ class RegistrationTagSchema(mm.SQLAlchemyAutoSchema):
 class CheckinEventSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Event
-        fields = ('id', 'title', 'description', 'start_dt', 'end_dt')
+        fields = ('id', 'title', 'description', 'start_dt', 'end_dt', 'registration_tags')
+
+    registration_tags = fields.Nested(RegistrationTagSchema, many=True)
 
 
 class CheckinRegFormSchema(mm.SQLAlchemyAutoSchema):
@@ -71,7 +73,7 @@ class CheckinRegistrationSchema(mm.SQLAlchemyAutoSchema):
     checkin_secret = fields.UUID(attribute='ticket_uuid')
     payment_date = fields.Method('_get_payment_date')
     formatted_price = fields.Function(lambda reg: reg.render_price())
-    tags = fields.List(fields.Nested(RegistrationTagSchema))
+    tags = fields.Nested(RegistrationTagSchema, many=True)
     registration_date = fields.DateTime(attribute='submitted_dt')
     registration_data = fields.Method('_get_registration_data')
 


### PR DESCRIPTION
Necessary to get the color of the tag. Shouldn't affect the Check-in app since it currently doesn't read the tags field anyway...