### PR TITLE
Boardnumber in timetables

### DIFF
--- a/indico/modules/events/timetable/templates/display/indico/_contribution.html
+++ b/indico/modules/events/timetable/templates/display/indico/_contribution.html
@@ -20,7 +20,7 @@
         <div class="timetable-item-body flexcol">
             <div class="timetable-item-header flexrow">
                 <span class="timetable-title {{ 'nested' if nested }}" data-anchor="{{ contrib.slug }}" data-anchor-strip-arg="note">
-                    {{- contrib.title -}}
+                    {%- if contrib.board_number -%}{{ contrib.board_number }}: {% endif -%}{{- contrib.title -}}
                 </span>
                 {% if contrib.duration and not theme_settings.hide_duration -%}
                     <span class="icon-time timetable-duration">

--- a/indico/modules/events/timetable/templates/pdf/_program.html
+++ b/indico/modules/events/timetable/templates/pdf/_program.html
@@ -215,7 +215,7 @@
     {% set sess = object.session %}
     {% set type = entry.type.name %}
 
-    <h3>{{ object.full_title or object.title }}</h3>
+    <h3>{{%- if object.board_number -%}{{ object.board_number }}: {% endif -%}{ object.full_title or object.title }}</h3>
     <div class="session-block-title-info">
         <p>
             <b>


### PR DESCRIPTION
Show board numbers in timetables: 
 - online
 -  pdf version

(This still a draft PR, as we maybe want to add config options to show/hide these as well)

CHANGES entry will be added before un-drafting this PR