### PR TITLE
Improvements on event reminder

### DIFF
--- a/indico/migrations/versions/20250412_2308_f2518f111aa7_add_tags_to_reminder.py
+++ b/indico/migrations/versions/20250412_2308_f2518f111aa7_add_tags_to_reminder.py
@@ -1,0 +1,42 @@
+"""Add tags to reminder
+
+Revision ID: f2518f111aa7
+Revises: 4615aff776e0
+Create Date: 2025-04-12 23:08:57.532639
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import ARRAY
+
+
+# revision identifiers, used by Alembic.
+revision = 'f2518f111aa7'
+down_revision = '4615aff776e0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('reminders_tags',
+        sa.Column('reminder_id', sa.Integer(), nullable=False, index=True),
+        sa.Column('reminder_tag_id', sa.Integer(), nullable=False, index=True),
+        sa.ForeignKeyConstraint(['reminder_id'], ['events.reminders.id']),
+        sa.ForeignKeyConstraint(['reminder_tag_id'], ['event_registration.tags.id']),
+        sa.PrimaryKeyConstraint('reminder_id', 'reminder_tag_id'),
+        schema='events'
+    )
+    op.add_column('reminders',
+                  sa.Column('all_tags_must_be_present', sa.Boolean(), nullable=False, server_default='false'),
+                  schema='events')
+    op.alter_column('reminders', 'all_tags_must_be_present', server_default=None, schema='events')
+    op.add_column('reminders',
+                  sa.Column('registration_form_ids', ARRAY(sa.Integer()), nullable=False, server_default='{}'),
+                  schema='events')
+    op.alter_column('reminders', 'registration_form_ids', server_default=None, schema='events')
+
+
+def downgrade():
+    op.drop_column('reminders', 'registration_form_ids', schema='events')
+    op.drop_column('reminders', 'all_tags_must_be_present', schema='events')
+    op.drop_table('reminders_tags', schema='events')

--- a/indico/modules/events/reminders/forms.py
+++ b/indico/modules/events/reminders/forms.py
@@ -11,13 +11,18 @@ from wtforms.validators import DataRequired, ValidationError
 from indico.modules.events.models.events import EventType
 from indico.util.date_time import now_utc
 from indico.util.i18n import _
+from indico.util.string import natural_sort_key
 from indico.web.forms.base import IndicoForm, generated_data
-from indico.web.forms.fields import EmailListField, IndicoDateTimeField, IndicoRadioField, TimeDeltaField
+from indico.web.forms.fields import (EmailListField, IndicoDateTimeField, IndicoRadioField,
+                                     IndicoSelectMultipleCheckboxField, TimeDeltaField)
+from indico.web.forms.fields.simple import IndicoMultipleTagSelectField
 from indico.web.forms.validators import DateTimeRange, HiddenUnless
+from indico.web.forms.widgets import TinyMCEWidget
 
 
 class ReminderForm(IndicoForm):
-    recipient_fields = ['recipients', 'send_to_participants', 'send_to_speakers']
+    recipient_fields = ['recipients', 'send_to_participants', 'registration_form_ids',
+                        'tags', 'all_tags_must_be_present', 'send_to_speakers']
     schedule_fields = ['schedule_type', 'absolute_dt', 'relative_delta']
     schedule_recipient_fields = recipient_fields + schedule_fields
 
@@ -33,14 +38,23 @@ class ReminderForm(IndicoForm):
     # Recipients
     recipients = EmailListField(_('Email addresses'), description=_('One email address per line.'))
     send_to_participants = BooleanField(_('Participants'),
-                                        description=_('Send the reminder to all participants/registrants '
-                                                      'of the event.'))
+                                        description=_('Send the reminder to participants/registrants of the event.'))
+    registration_form_ids = IndicoSelectMultipleCheckboxField(_('Filter by registration forms'),
+                                                              [HiddenUnless('send_to_participants')],
+                                                              description=_('Limit reminders to participants of '
+                                                                            'these registration forms.'))
+    tags = IndicoMultipleTagSelectField(_('Filter by tags'), [HiddenUnless('send_to_participants')],
+                                        description=_('Limit reminders to participants with these tags.'))
+    all_tags_must_be_present = BooleanField(_('All tags must be present'), [HiddenUnless('send_to_participants')],
+                                            description=_('Participants must have all of the selected tags. '
+                                                          'Otherwise at least one of them.'))
     send_to_speakers = BooleanField(_('Speakers'),
                                     description=_('Send the reminder to all speakers/chairpersons of the event.'))
     # Misc
     reply_to_address = SelectField(_('Sender'), [DataRequired()],
                                    description=_('The email address that will show up as the sender.'))
-    message = TextAreaField(_('Note'), description=_('A custom message to include in the email.'))
+    message = TextAreaField(_('Note'), widget=TinyMCEWidget(),
+                            description=_('A custom message to include in the email.'))
     include_summary = BooleanField(_('Include agenda'),
                                    description=_("Includes a simple text version of the event's agenda in the email."))
     include_description = BooleanField(_('Include description'),
@@ -57,6 +71,19 @@ class ReminderForm(IndicoForm):
         self.reply_to_address.choices = list(allowed_senders.items())
         if self.event.type_ == EventType.lecture:
             del self.include_summary
+        regforms = sorted([rf for rf in self.event.registration_forms if not rf.is_deleted], key=lambda rf: rf.title)
+        if len(regforms) > 1:
+            regform_choices = [(str(rf.id), rf.title) for rf in regforms]
+            self.registration_form_ids.choices = regform_choices
+        else:
+            del self.registration_form_ids
+        tags = sorted(self.event.registration_tags, key=lambda tag: natural_sort_key(tag.title))
+        if len(tags) > 0:
+            tag_choices = [(str(tag.id), (tag.title, tag.color)) for tag in tags]
+            self.tags.choices = tag_choices
+        else:
+            del self.tags
+            del self.all_tags_must_be_present
 
     def validate_recipients(self, field):
         if not field.data and not self.send_to_participants.data and not self.send_to_speakers.data:

--- a/indico/modules/events/reminders/models/reminders.py
+++ b/indico/modules/events/reminders/models/reminders.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.hybrid import hybrid_property
 
@@ -18,12 +19,36 @@ from indico.modules.events.contributions.models.persons import ContributionPerso
 from indico.modules.events.contributions.models.subcontributions import SubContribution
 from indico.modules.events.ical import MIMECalendar, event_to_ical
 from indico.modules.events.models.events import EventType
-from indico.modules.events.registration.models.registrations import Registration
+from indico.modules.events.registration.models.forms import RegistrationForm
+from indico.modules.events.registration.models.registrations import Registration, registrations_tags_table
 from indico.modules.events.reminders import logger
 from indico.modules.events.reminders.util import make_reminder_email
 from indico.util.date_time import now_utc
 from indico.util.signals import values_from_signal
 from indico.util.string import format_repr
+
+
+reminders_tags_table = db.Table(
+    'reminders_tags',
+    db.metadata,
+    db.Column(
+        'reminder_id',
+        db.Integer,
+        db.ForeignKey('events.reminders.id', ondelete='CASCADE'),
+        primary_key=True,
+        nullable=False,
+        index=True,
+    ),
+    db.Column(
+        'reminder_tag_id',
+        db.Integer,
+        db.ForeignKey('event_registration.tags.id', ondelete='CASCADE'),
+        primary_key=True,
+        nullable=False,
+        index=True,
+    ),
+    schema='events'
+)
 
 
 class EventReminder(db.Model):
@@ -88,6 +113,18 @@ class EventReminder(db.Model):
         nullable=False,
         default=False
     )
+    #: If participants should be filtered by registration forms
+    registration_form_ids = db.Column(
+        ARRAY(db.Integer),
+        nullable=False,
+        default=[]
+    )
+    #: If all the of the selected tags must be present for the participants (ie. AND relation)
+    all_tags_must_be_present = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
     #: If the notification should also be sent to all event speakers
     send_to_speakers = db.Column(
         db.Boolean,
@@ -143,6 +180,18 @@ class EventReminder(db.Model):
         )
     )
 
+    #: The registration tags assigned to this registration
+    tags = db.relationship(
+        'RegistrationTag',
+        secondary=reminders_tags_table,
+        passive_deletes=True,
+        collection_class=set,
+        backref=db.backref(
+            'reminders',
+            lazy=True
+        )
+    )
+
     @property
     def locator(self):
         return dict(self.event.locator, reminder_id=self.id)
@@ -156,7 +205,25 @@ class EventReminder(db.Model):
         """
         recipients = set(self.recipients)
         if self.send_to_participants:
-            recipients.update(reg.email for reg in Registration.get_all_for_event(self.event))
+            regs_query = (self.event.registrations
+                          .join(Registration.registration_form)
+                          .filter(Registration.is_active,
+                                  ~RegistrationForm.is_deleted))
+            if self.registration_form_ids:
+                regs_query = regs_query.filter(RegistrationForm.id.in_(self.registration_form_ids))
+            if self.tags:
+                tag_ids = [tag.id for tag in self.tags]
+                if self.all_tags_must_be_present:
+                    tags_query = (db.session.query(registrations_tags_table.c.registration_id)
+                                  .filter(registrations_tags_table.c.registration_tag_id.in_(tag_ids))
+                                  .group_by(registrations_tags_table.c.registration_id)
+                                  .having(func.count(registrations_tags_table.c.registration_id) == len(tag_ids)))
+                else:
+                    tags_query = (db.session.query(registrations_tags_table.c.registration_id.distinct())
+                                  .filter(registrations_tags_table.c.registration_tag_id.in_(tag_ids)))
+                regs_query = regs_query.filter(Registration.id.in_(tags_query))
+
+            recipients.update(reg.email for reg in regs_query)
 
         if self.send_to_speakers:
             recipients.update(person_link.email for person_link in self.event.person_links)

--- a/indico/modules/events/reminders/templates/preview.html
+++ b/indico/modules/events/reminders/templates/preview.html
@@ -2,4 +2,4 @@
 <pre class="mono">{{ subject }}</pre>
 <br>
 <strong>{% trans %}Body{% endtrans %}</strong>
-<pre class="mono">{{ body }}</pre>
+<pre class="mono">{{ body | safe }}</pre>

--- a/indico/web/client/js/jquery/widgets/jinja/multiple_tag_select_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/multiple_tag_select_widget.js
@@ -10,7 +10,7 @@ import ReactDOM from 'react-dom';
 
 import {WTFMultipleTagSelectField} from 'indico/react/components';
 
-window.setupMultipleTagSelectWidget = function setupMultipleTagSelectWidget({fieldId, choices}) {
+window.setupMultipleTagSelectWidget = function setupMultipleTagSelectWidget({fieldId, choices, inputArgs, initialSelection}) {
   const wrapperId = `${fieldId}-wrapper`;
   // The form dialog has a combination of overflow: hidden and auto.
   // Since WTFMultipleTagSelectField is much larger when expanded, most of its
@@ -21,7 +21,7 @@ window.setupMultipleTagSelectWidget = function setupMultipleTagSelectWidget({fie
   dialog.css('overflow', 'visible');
 
   ReactDOM.render(
-    <WTFMultipleTagSelectField fieldId={fieldId} wrapperId={wrapperId} choices={choices} />,
+    <WTFMultipleTagSelectField fieldId={fieldId} wrapperId={wrapperId} choices={choices} inputArgs={inputArgs} initialSelection={initialSelection} />,
     document.getElementById(wrapperId)
   );
 };

--- a/indico/web/client/js/react/components/WTFMultipleTagSelectField.jsx
+++ b/indico/web/client/js/react/components/WTFMultipleTagSelectField.jsx
@@ -11,9 +11,15 @@ import {Dropdown, Label} from 'semantic-ui-react';
 
 import {Translate} from '../i18n';
 
-export default function WTFMultipleTagSelectField({fieldId, wrapperId, choices}) {
+export default function WTFMultipleTagSelectField({
+  fieldId,
+  wrapperId,
+  choices,
+  inputArgs,
+  initialSelection,
+}) {
   const parentElement = useMemo(() => document.getElementById(wrapperId), [wrapperId]);
-  const [selectedOptions, setSelectedOptions] = useState([]);
+  const [selectedOptions, setSelectedOptions] = useState(initialSelection);
 
   // Trigger change only after the DOM has changed
   useEffect(() => {
@@ -52,6 +58,7 @@ export default function WTFMultipleTagSelectField({fieldId, wrapperId, choices})
         selection
         value={selectedOptions}
         renderLabel={renderLabel}
+        disabled={inputArgs.disabled ?? false}
       />
       {/* Since Dropdown does not render as a <select> element, we use a dummy <select>
        * with the correct name attribute and options selected which are used when the form is submitted.
@@ -63,6 +70,7 @@ export default function WTFMultipleTagSelectField({fieldId, wrapperId, choices})
         readOnly
         value={selectedOptions}
         style={{display: 'none'}}
+        {...inputArgs}
       >
         {options.map(({key, text, value}) => (
           <option key={key} value={value}>
@@ -78,4 +86,6 @@ WTFMultipleTagSelectField.propTypes = {
   fieldId: PropTypes.string.isRequired,
   wrapperId: PropTypes.string.isRequired,
   choices: PropTypes.array.isRequired,
+  inputArgs: PropTypes.object.isRequired,
+  initialSelection: PropTypes.array.isRequired,
 };

--- a/indico/web/templates/forms/multiple_tag_select_widget.html
+++ b/indico/web/templates/forms/multiple_tag_select_widget.html
@@ -9,6 +9,10 @@
         setupMultipleTagSelectWidget({
             fieldId: {{ field.id | tojson }},
             choices: {{ field.choices | tojson }},
+            inputArgs: {{ input_args | tojson }},
+            initialSelection: {{ field.data | default([]) | tojson }},
         });
+        {# Call `initForms()` again because `WTFMultipleTagSelectField` has been rendered only after its first call. #}
+        initForms($('form'));
     </script>
 {% endblock %}


### PR DESCRIPTION
This PR is about improving event reminders:
* Allow to limit registration forms participants belong to
* Allow to send reminders only to participants with specific tags

This is a **DRAFT PR** because before preparing the final one I would have a question.
The usual way of linking registration forms and tags to reminder would be using foreign keys. In this PR the reminders-tags relation is implemented in this way. However for registration forms I used a simple array on the reminder side because:
* In this specific case I can't see any benefit of having a strict connection between these objects
* I see these referred objects as filtering parameters and they could work on a simpler way 
* Implementation is much simpler and there's no need any extra logic to handle missing (deleted) IDs

So please let me know whether this loosely coupled approach would be accepted or not and I will update the code accordingly. 