### PR TITLE
Fix datetime handling in Excel exports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,8 @@ Bugfixes
   :pr:`6881`, thanks :user:`Fedor204`)
 - Include registration tags in event export (:pr:`6896`)
 - Fix some messages not being translated due to a missing context (:pr:`6910`)
+- Fix datetime handling in excel exports (:issue:`6806`, :pr:`6887`, thanks
+  :user:`duartegalvao, unconventionaldotdev`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -568,7 +568,7 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
                 departure_date = data[item.id].friendly_data.get('departure_date') if item.id in data else None
                 registration_dict[key] = departure_date or ''
             elif item.input_type == 'date':
-                if item.id not in data:
+                if item.id not in data or not data[item.id].data:  # missing or empty data for the field
                     registration_dict[key] = ''
                     continue
                 dt = datetime.fromisoformat(data[item.id].data).replace(tzinfo=tzinfo)

--- a/indico/util/spreadsheets.py
+++ b/indico/util/spreadsheets.py
@@ -17,6 +17,7 @@ from speaklater import is_lazy_string
 from xlsxwriter import Workbook
 
 from indico.core.errors import UserValueError
+from indico.util.date_time import format_datetime
 from indico.util.enum import RichStrEnum
 from indico.util.i18n import _
 from indico.web.flask.util import send_file
@@ -127,7 +128,7 @@ def _prepare_excel_data(data, tz=None):
     elif is_lazy_string(data) or isinstance(data, Markup):
         data = str(data)
     elif isinstance(data, datetime):
-        data = data.astimezone(tz=tz)
+        data = format_datetime(data, format='yyyy/MM/dd HH:mm', timezone=tz)
     return data
 
 
@@ -139,7 +140,7 @@ def generate_xlsx(headers, rows, tz=None):
     :return: an `io.BytesIO` containing the XLSX data
     """
     workbook_options = {'in_memory': True, 'strings_to_formulas': False, 'strings_to_numbers': False,
-                        'strings_to_urls': False, 'default_date_format': 'yyyy/mm/dd hh:mm:ss', 'remove_timezone': True}
+                        'strings_to_urls': False}
     buf = BytesIO()
     header_positions = {name: i for i, name in enumerate(headers)}
     # convert row dicts to lists

--- a/indico/util/spreadsheets.py
+++ b/indico/util/spreadsheets.py
@@ -17,7 +17,6 @@ from speaklater import is_lazy_string
 from xlsxwriter import Workbook
 
 from indico.core.errors import UserValueError
-from indico.util.date_time import format_date, format_datetime
 from indico.util.enum import RichStrEnum
 from indico.util.i18n import _
 from indico.web.flask.util import send_file
@@ -120,17 +119,13 @@ def generate_csv(headers, rows, *, include_header=True):
     return buf
 
 
-def _prepare_excel_data(data, tz=None):
+def _prepare_excel_data(data):
     if isinstance(data, (list, tuple)):
         data = '; '.join(data)
     elif isinstance(data, set):
         data = '; '.join(sorted(data, key=str.lower))
     elif is_lazy_string(data) or isinstance(data, Markup):
         data = str(data)
-    elif isinstance(data, datetime):
-        data = format_datetime(data, format='yyyy/MM/dd HH:mm', timezone=tz)
-    elif isinstance(data, date):
-        data = format_date(data, format='yyyy/MM/dd', timezone=tz)
     return data
 
 
@@ -150,11 +145,19 @@ def generate_xlsx(headers, rows, tz=None):
     assert all(len(row) == len(headers) for row in rows)
     with Workbook(buf, workbook_options) as workbook:
         bold = workbook.add_format({'bold': True})
+        date_format = workbook.add_format({'num_format': 'yyyy/mm/dd'})
+        datetime_format = workbook.add_format({'num_format': 'yyyy/mm/dd hh:mm'})
         sheet = workbook.add_worksheet()
         for col, name in enumerate(map(_prepare_header, headers)):
             sheet.write(0, col, name, bold)
         for row, values in enumerate(rows, 1):
-            sheet.write_row(row, 0, [_prepare_excel_data(data, tz) for data in values])
+            for col, data in enumerate(values):
+                if isinstance(data, datetime):
+                    sheet.write_datetime(row, col, data.astimezone(tz).replace(tzinfo=None), datetime_format)
+                elif isinstance(data, date):
+                    sheet.write_datetime(row, col, data, date_format)
+                else:
+                    sheet.write(row, col, _prepare_excel_data(data))
     buf.seek(0)
     return buf
 

--- a/indico/util/spreadsheets.py
+++ b/indico/util/spreadsheets.py
@@ -145,8 +145,8 @@ def generate_xlsx(headers, rows, tz=None):
     assert all(len(row) == len(headers) for row in rows)
     with Workbook(buf, workbook_options) as workbook:
         bold = workbook.add_format({'bold': True})
-        date_format = workbook.add_format({'num_format': 'yyyy/mm/dd'})
-        datetime_format = workbook.add_format({'num_format': 'yyyy/mm/dd hh:mm'})
+        date_format = workbook.add_format({'num_format': 'yyyy-mm-dd'})
+        datetime_format = workbook.add_format({'num_format': 'yyyy-mm-dd hh:mm'})
         sheet = workbook.add_worksheet()
         for col, name in enumerate(map(_prepare_header, headers)):
             sheet.write(0, col, name, bold)

--- a/indico/util/spreadsheets.py
+++ b/indico/util/spreadsheets.py
@@ -8,7 +8,7 @@
 import csv
 import re
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import date, datetime
 from enum import auto
 from io import BytesIO, TextIOWrapper
 
@@ -17,7 +17,7 @@ from speaklater import is_lazy_string
 from xlsxwriter import Workbook
 
 from indico.core.errors import UserValueError
-from indico.util.date_time import format_datetime
+from indico.util.date_time import format_date, format_datetime
 from indico.util.enum import RichStrEnum
 from indico.util.i18n import _
 from indico.web.flask.util import send_file
@@ -129,6 +129,8 @@ def _prepare_excel_data(data, tz=None):
         data = str(data)
     elif isinstance(data, datetime):
         data = format_datetime(data, format='yyyy/MM/dd HH:mm', timezone=tz)
+    elif isinstance(data, date):
+        data = format_date(data, format='yyyy/MM/dd', timezone=tz)
     return data
 
 

--- a/indico/util/spreadsheets.py
+++ b/indico/util/spreadsheets.py
@@ -17,7 +17,6 @@ from speaklater import is_lazy_string
 from xlsxwriter import Workbook
 
 from indico.core.errors import UserValueError
-from indico.util.date_time import format_datetime
 from indico.util.enum import RichStrEnum
 from indico.util.i18n import _
 from indico.web.flask.util import send_file
@@ -128,7 +127,7 @@ def _prepare_excel_data(data, tz=None):
     elif is_lazy_string(data) or isinstance(data, Markup):
         data = str(data)
     elif isinstance(data, datetime):
-        data = format_datetime(data, timezone=tz)
+        data = data.astimezone(tz=tz)
     return data
 
 
@@ -140,7 +139,7 @@ def generate_xlsx(headers, rows, tz=None):
     :return: an `io.BytesIO` containing the XLSX data
     """
     workbook_options = {'in_memory': True, 'strings_to_formulas': False, 'strings_to_numbers': False,
-                        'strings_to_urls': False}
+                        'strings_to_urls': False, 'default_date_format': 'yyyy/mm/dd hh:mm:ss', 'remove_timezone': True}
     buf = BytesIO()
     header_positions = {name: i for i, name in enumerate(headers)}
     # convert row dicts to lists


### PR DESCRIPTION
Closes #6806

This PR fixes the `datetime` object handling in Excel exports, following the recommendations in https://xlsxwriter.readthedocs.io/working_with_dates_and_time.html

The chosen format is `yyyy/mm/dd hh:mm:ss` which should be recognizable as a date in most locales.