### PR TITLE
Enable browser spellcheck in tinymce editor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,7 @@ Bugfixes
 - Fix participant visibility being set to "nobody" when a registration was modifified
   (:pr:`6863`)
 - Fix error when editing a room while no custom attributes have been defined (:pr:`6840`)
+- Allow the browser to perform spellchecking in the HTML/WYSIWYG minutes editor (:pr:`6890`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/tinymce.js
+++ b/indico/web/client/js/tinymce.js
@@ -225,6 +225,7 @@ export const getConfig = (
         .filter(x => x)
         .join(' '),
   entity_encoding: 'raw',
+  browser_spellcheck: true,
   convert_unsafe_embeds: true,
   sandbox_iframes: true,
   relative_urls: false, // kind of misleading: this just ensures domain-relative URLs


### PR DESCRIPTION
Not sure why it's off by default, probably so tinymce can more easily advertise their commercial spellchecking plugin? :D 