### PR TITLE
Force type if type required and on single choice

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Improvements
 - Log conference menu changes (:pr:`6851`, thanks :user:`openprojects`)
 - Add duration and date/time placeholders when sending emails for contributions
   (:pr:`6860`)
+- Set the abstract type directly, if there is only 1 choice and type is required
+  (:pr:`6897`, thanks :user:`bpedersen2`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -528,6 +528,9 @@ class AbstractForm(IndicoForm):
                                                  .order_by(db.func.lower(ContributionType.name)))
         if not self.submitted_contrib_type.query.count():
             del self.submitted_contrib_type
+        if (abstracts_settings.get(self.event, 'contrib_type_required')
+            and self.submitted_contrib_type.query.count() == 1):
+            self.submitted_contrib_type.allow_blank = False
         if not self.event.cfa.allow_attachments:
             del self.attachments
         if not description_settings['is_active']:


### PR DESCRIPTION
If only one option is available for the type and the type is set to required, don't allow an empty choice, but instead use the single available option.



