### PR TITLE
Use STATIC_SITE_STORAGE for material packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,8 @@ Improvements
 - Log conference menu changes (:pr:`6851`, thanks :user:`openprojects`)
 - Add duration and date/time placeholders when sending emails for contributions
   (:pr:`6860`)
+- Use :data:`STATIC_SITE_STORAGE` for the temporary file from a material package
+  (:pr:`6898`)
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -806,8 +806,10 @@ Storage
 .. data:: STATIC_SITE_STORAGE
 
     The name of the storage backend used to store "offline copies" of
-    events.  Files are written to this backend when generating an offline
-    copy and deleted after a certain amount of time.
+    events and material packages.  Files are written to this backend when generating
+    an offline copy and deleted after a certain amount of time.  When someone requests
+    a material package for an event, it is also written to this backend, and deleted
+    about a day later.
 
     If not set, the :data:`ATTACHMENT_STORAGE` backend is used.
 

--- a/indico/modules/attachments/tasks.py
+++ b/indico/modules/attachments/tasks.py
@@ -8,6 +8,7 @@
 import os
 
 from indico.core.celery import celery
+from indico.core.config import config
 from indico.core.db import db
 from indico.modules.attachments.models.attachments import Attachment
 from indico.modules.files.models.files import File
@@ -22,7 +23,7 @@ def generate_materials_package(attachment_ids, event):
     generated_zip = attachment_package_mixin._generate_zip_file(attachments, return_file=True)
     f = File(filename='material-package.zip', content_type='application/zip', meta={'event_id': event.id})
     context = ('event', event.id, 'attachment-package')
-    f.save(context, generated_zip)
+    f.save(context, generated_zip, backend=config.STATIC_SITE_STORAGE)
     db.session.add(f)
     db.session.commit()
     os.unlink(generated_zip.name)

--- a/indico/modules/files/models/files.py
+++ b/indico/modules/files/models/files.py
@@ -82,12 +82,15 @@ class File(StoredFileMixin, db.Model):
         self.assign_id()
         filename = '{}-{}'.format(self.id, secure_filename(self.filename, 'file'))
         path = posixpath.join(*path_segments, filename)
-        return config.ATTACHMENT_STORAGE, path
+        backend = self.__backend or config.ATTACHMENT_STORAGE
+        return backend, path
 
-    def save(self, context, data):
+    def save(self, context, data, *, backend=None):
         self.__context = context
+        self.__backend = backend
         super().save(data)
         del self.__context
+        del self.__backend
 
     @property
     def signed_download_url(self):


### PR DESCRIPTION
While not technically static site archives, these files are much closer to static site archives than to normal materials/attachments.

Using that storage (which for most people is the same one anyway) has the advantage that, just like for static site archives which are also temporary, these material packages can now go to a storage backend that is e.g. excluded from backups.