### PR TITLE
Add tempalte hooks to allow customization of data rendering for custom registration fields.

### DIFF
--- a/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
+++ b/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
@@ -106,7 +106,8 @@
                              url_for('.registration_picture', data[field.id].locator.registrant_file) %}
         <img class="picture-preview" src="{{ picture_url }}" alt="{{ friendly_data }}">
     {% elif friendly_data is not none %}
-        {{- friendly_data -}}
+        {{- template_hook('registration-summary-blocks-render-data', type=field.input_type, friendly_data=friendly_data)
+            or friendly_data -}}
     {% endif %}
 {% endmacro %}
 
@@ -277,7 +278,8 @@
                                 {% elif item.field_data.field.input_type == 'multi_choice' %}
                                     {{ item.friendly_data | join(', ') }}
                                 {% else %}
-                                   {{ item.friendly_data }}
+                                   {{- template_hook('registration-summary-invoice-render-data', type=item.field_data.field.input_type, friendly_data=item.friendly_data)
+                                       or item.friendly_data -}}
                                 {% endif %}
                             </td>
                             <td class="text-right">{{ item.render_price() }}</td>

--- a/indico/modules/events/registration/templates/emails/base_registration_details.html
+++ b/indico/modules/events/registration/templates/emails/base_registration_details.html
@@ -99,7 +99,8 @@
     {%- elif type == 'picture' and friendly_data -%}
         {{- render_picture(friendly_data, raw_data) -}}
     {%- else -%}
-        {{- friendly_data -}}
+        {{- template_hook('registration-email-render-data', type=type, friendly_data=friendly_data, raw_data=raw_data)
+            or friendly_data -}}
     {%- endif -%}
 {% endmacro %}
 

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -162,11 +162,20 @@
                                             {%- endif %}
                                         </td>
                                     {% else %}
-                                        <td class="i-table" data-text="{{ search_value }}">
-                                            {%- if item.id in data and data[item.id].friendly_data %}
-                                                {{- data[item.id].friendly_data }}
-                                            {%- endif %}
-                                        </td>
+                                        {% set custom_column = (
+                                            template_hook('registration-list-render-data', type=data[item.id].field_data.field.input_type, friendly_data=data[item.id].friendly_data)
+                                            if item.id in data
+                                            else none
+                                        ) %}
+                                        {% if custom_column %}
+                                            {{ custom_column }}
+                                        {% else %}
+                                            <td class="i-table" data-text="{{ search_value }}">
+                                                {%- if item.id in data and data[item.id].friendly_data %}
+                                                    {{- data[item.id].friendly_data }}
+                                                {%- endif %}
+                                            </td>
+                                        {% endif %}
                                     {% endif %}
                                 {% endfor %}
                             </tr>


### PR DESCRIPTION
This adds four template-hooks to allow customization of data rendering for registration fields that have been added through a plug in:

- `registration-summary-blocks-render-data`: Data in the registration summary shown to the user
- `registration-summary-invoice-render-data`: Data in a row of the invoice summary in case of fields with a price
- `registration-email-render-data`: Data presented in confirmation emails
- `registration-list-render-data`: Data in the columns of registration list in management area

See also https://talk.getindico.io/t/user-friendly-presentation-of-custom-registration-field-data/4125