### PR TITLE
Improve default styling to ul, ol, blockquote, th and hr within markdown comments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Version 3.3.7
 Improvements
 ^^^^^^^^^^^^
 
+- Improved styling on review comments that use markdown
 - Add a new :data:`ALLOWED_LANGUAGES` setting to ``indico.conf`` to restrict which
   languages can be used (:pr:`6818`, thanks :user:`openprojects`)
 - Set reasonable maximum lengths on signup form fields (:pr:`6724`)

--- a/indico/web/client/styles/modules/_reviewing.scss
+++ b/indico/web/client/styles/modules/_reviewing.scss
@@ -33,6 +33,23 @@
     p:last-child {
       margin-bottom: 0;
     }
+
+    ul, ol {
+      margin: 0.25em 0 0.5em 1em;
+      padding: 0;
+    }
+
+    blockquote {
+      margin: 0 1em 1em 1em;
+    }
+
+    th {
+      text-align: left;
+    }
+
+    hr {
+      border-bottom: 1px solid #dfdfdf;
+    }
   }
 
   textarea.grow {


### PR DESCRIPTION
I noticed some shortcomings in the markdown styles, particularly in the un-ordered lists when I started doing CatScan comments.

I produced a larger sample text with a bunch of markdown, observed which were poorly implemented, and adjusted accordingly.