### PR TITLE
Fix editable review reset after accepted by submitter

### DIFF
--- a/indico/modules/events/editing/operations.py
+++ b/indico/modules/events/editing/operations.py
@@ -265,7 +265,7 @@ def reset_editable(revision):
     _ensure_revision_can_be_updated(revision)
     editable = revision.editable
     old_state = editable.state
-    if old_state != EditableState.accepted:
+    if old_state not in (EditableState.accepted, EditableState.accepted_submitter):
         return
     was_published = editable.published_revision is not None
     editable.published_revision = None


### PR DESCRIPTION
If the status of a review was 'Accepted by Submitter' just before a triggered reset of the editable status from a custom action the editor will reach a dead-end in the timeline. This allows the editing process to continue naturally after any of the "Accepted" states.