### PR TITLE
Extract context in `po_to_json`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,7 @@ Bugfixes
 - Fix font rendering issue in event titles with some cyrillic characters (:issue:`6673`,
   :pr:`6881`, thanks :user:`Fedor204`)
 - Include registration tags in event export (:pr:`6896`)
+- Fix some messages not being translated due to a missing context (:pr:`6910`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/util/i18n.py
+++ b/indico/util/i18n.py
@@ -301,9 +301,5 @@ def _message_to_json(msg: Message) -> tuple[str, tuple[str, ...]]:
         singular = msg.id
         translation = (msg.string,)
 
-    if msg.context is None:
-        key = singular
-    else:
-        key = f'{msg.context}\x04{singular}'
-
-    return (key, translation)
+    key = singular if msg.context is None else f'{msg.context}\x04{singular}'
+    return key, translation

--- a/indico/util/i18n_test.py
+++ b/indico/util/i18n_test.py
@@ -7,6 +7,7 @@
 
 import os
 from datetime import datetime
+from textwrap import dedent
 
 import pytest
 from babel.messages import Catalog
@@ -19,7 +20,7 @@ from werkzeug.datastructures import LanguageAccept
 
 from indico.core.plugins import IndicoPlugin, plugin_engine
 from indico.util.date_time import format_datetime
-from indico.util.i18n import _, force_locale, gettext_context, make_bound_gettext, ngettext, pgettext
+from indico.util.i18n import _, force_locale, gettext_context, make_bound_gettext, ngettext, pgettext, po_to_json
 
 
 def _to_msgid(context, message):
@@ -232,3 +233,48 @@ def test_force_user_locale(dummy_user):
     assert _('I need a drink.') == "I be needin' a bottle of rhum!"
 
     assert session.lang == 'en_AU'
+
+
+def test_po_to_json(tmp_path):
+    po_file = tmp_path / 'messages.po'
+    po_content = dedent(r'''
+        msgid ""
+        msgstr ""
+        "Content-Type: text/plain; charset=UTF-8\n"
+        "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+        msgid "foo"
+        msgstr "bar"
+
+        msgctxt "context"
+        msgid "foo"
+        msgstr "bar with context"
+
+        msgid "baz"
+        msgid_plural "bazs"
+        msgstr[0] "qux"
+        msgstr[1] "quxs"
+
+        msgctxt "context"
+        msgid "baz"
+        msgid_plural "bazs"
+        msgstr[0] "qux with context"
+        msgstr[1] "quxs with context"    
+    ''')
+    po_file.write_text(po_content, encoding='utf-8')
+
+    expected_json = {
+        'messages': {
+            '': {
+                'domain': 'messages',
+                'lang': 'cs_CZ',
+                'plural_forms': 'nplurals=2; plural=(n != 1);'
+            },
+            'foo': ('bar',),
+            'context\x04foo': ('bar with context',),
+            'baz': ('qux', 'quxs'),
+            'context\x04baz': ('qux with context', 'quxs with context'),
+        },
+    }
+    result = po_to_json(po_file, domain='messages', locale='cs_CZ')
+    assert result == expected_json


### PR DESCRIPTION
The context is just stripped right now which either gives you a wrong translation or no translation at all.

This PR extracts the context so that pgettext works as expected.

Came up here: https://talk.getindico.io/t/translation-of-the-magic-add-new-button-on-the-timetable-page/4149