### PR TITLE
Tweak upcoming events sidebar title list to prevent overflows w/ long event names

### DIFF
--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -251,7 +251,7 @@
 
       font-size: 1em;
       display: block;
-      max-width: 100%;
+      max-width: 36em; // Adjusted to prevent long titles from overflowing
     }
 
     .timing {


### PR DESCRIPTION
This fixes an issue where long event names would cause the upcoming events sidebar to expand outwards and take up a lot of space.