### PR TITLE
Replace paragraph w/ link icon in meeting minute section direct links

### DIFF
--- a/indico/web/client/js/jquery/utils/declarative.js
+++ b/indico/web/client/js/jquery/utils/declarative.js
@@ -374,12 +374,10 @@ import {$T} from '../../utils/i18n';
       const url = window.location.pathname + (newQueryString ? `?${newQueryString}` : '');
 
       $('<a>', {
-        class: 'anchor-link',
+        class: 'anchor-link icon-link',
         href: permalink || `${url}#${fragment}`,
         title: $elem.data('anchor-text') || $T.gettext('Direct link to this item'),
-      })
-        .html('&para;')
-        .appendTo($elem);
+      }).appendTo($elem);
     });
   }
 


### PR DESCRIPTION
This should make things a bit more clear.

Before:
![image](https://github.com/user-attachments/assets/0c8b32ab-58c8-49a9-9433-6c66b3f2ae1d)

After:
![image](https://github.com/user-attachments/assets/70eb293d-e022-40a2-88fc-87567b523093)
