### PR TITLE
Enable ruff 'W' (pycodestyle) checks

### DIFF
--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -1175,7 +1175,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         """Check if the event has any receipt document templates."""
         from indico.modules.receipts.util import has_any_templates
         return has_any_templates(self)
-    
+
     @property
     def ical_uid(self) -> str:
         """Return the event UID used by iCalendar."""

--- a/indico/util/i18n_test.py
+++ b/indico/util/i18n_test.py
@@ -259,7 +259,7 @@ def test_po_to_json(tmp_path):
         msgid "baz"
         msgid_plural "bazs"
         msgstr[0] "qux with context"
-        msgstr[1] "quxs with context"    
+        msgstr[1] "quxs with context"
     ''')
     po_file.write_text(po_content, encoding='utf-8')
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -7,7 +7,8 @@ preview = true
 dummy-variable-rgx = '^(_{2,}|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$' # a single `_` is already used for i18n
 
 select = [
-    'E',      # pycodestyle
+    'E',      # pycodestyle (errors)
+    'W',      # pycodestyle (warnings)
     'F',      # pyflakes
     'N',      # pep8-naming
     'Q',      # flake8-quotes


### PR DESCRIPTION
They seem quite useful: https://docs.astral.sh/ruff/rules/#warning-w