### PR TITLE
Fix RB prompt during event creation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,7 @@ Bugfixes
 - Fix date range picker not working in some languages (e.g. Japanese) (:issue:`6921`,
   :pr:`6922`)
 - Fix error when searching in user logs (:issue:`6933`, :pr:`6936`)
+- Fix room booking prompt during event creation not showing up (:pr:`6941`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/client/js/creation.js
+++ b/indico/modules/events/client/js/creation.js
@@ -167,8 +167,8 @@ import {camelizeKeys} from 'indico/utils/case';
       if (occurrences && occurrences.length === 1) {
         setLectureTimes(occurrences[0]);
       } else {
-        startDt = moment(`${startDate} ${startTime}`, 'DD/MM/YYYY HH:mm');
-        endDt = moment(`${endDate} ${endTime}`, 'DD/MM/YYYY HH:mm');
+        startDt = moment(`${startDate} ${startTime}`);
+        endDt = moment(`${endDate} ${endTime}`);
       }
     }
 
@@ -290,11 +290,11 @@ import {camelizeKeys} from 'indico/utils/case';
         const startTime = $('#event-creation-start_dt-timestorage').val();
         const endDate = $('#event-creation-end_dt-datestorage').val();
         const endTime = $('#event-creation-end_dt-timestorage').val();
-        startDt = moment(`${startDate} ${startTime}`, 'DD/MM/YYYY HH:mm');
-        endDt = moment(`${endDate} ${endTime}`, 'DD/MM/YYYY HH:mm');
+        startDt = moment(`${startDate} ${startTime}`);
+        endDt = moment(`${endDate} ${endTime}`);
         // workaround for automatic end date update if start date is after end date
         if (endDt.isBefore(startDt)) {
-          endDt = moment(`${startDate} ${endTime}`, 'DD/MM/YYYY HH:mm');
+          endDt = moment(`${startDate} ${endTime}`);
         }
         updateAvailability();
       });
@@ -302,21 +302,21 @@ import {camelizeKeys} from 'indico/utils/case';
       $('#event-creation-start_dt-timestorage').on('change', function() {
         const startDate = $('#event-creation-start_dt-datestorage').val();
         const startTime = $('#event-creation-start_dt-timestorage').val();
-        startDt = moment(`${startDate} ${startTime}`, 'DD/MM/YYYY HH:mm');
+        startDt = moment(`${startDate} ${startTime}`);
         updateAvailability();
       });
 
       $('#event-creation-end_dt-datestorage').on('change', function() {
         const endDate = $(this).val();
         const endTime = $('#event-creation-end_dt-timestorage').val();
-        endDt = moment(`${endDate} ${endTime}`, 'DD/MM/YYYY HH:mm');
+        endDt = moment(`${endDate} ${endTime}`);
         updateAvailability();
       });
 
       $('#event-creation-end_dt-timestorage').on('change', function() {
         const endDate = $('#event-creation-end_dt-datestorage').val();
         const endTime = $(this).val();
-        endDt = moment(`${endDate} ${endTime}`, 'DD/MM/YYYY HH:mm');
+        endDt = moment(`${endDate} ${endTime}`);
         updateAvailability();
       });
 


### PR DESCRIPTION
When switching to the new date picker, the date format changed to ISO, but the JS was still trying to parse the old format so the moment objects were always invalid.