### PR TITLE
Add text overflow option in badge designer

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,7 @@ Improvements
 - Allow re-sending emails from their log entries (:issue:`6805`, :pr:`6909`,
   thanks :user:`duartegalvao, unconventionaldotdev`)
 - Allow adding/removing favorite users from search results (:pr:`6950`)
+- Add a text overflow option to the badge designer (:pr:`6944`, thanks :user:`SegiNyn`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,8 @@ Improvements
 - Allow re-sending emails from their log entries (:issue:`6805`, :pr:`6909`,
   thanks :user:`duartegalvao, unconventionaldotdev`)
 - Allow adding/removing favorite users from search results (:pr:`6950`)
-- Add a text overflow option to the badge designer (:pr:`6944`, thanks :user:`SegiNyn`)
+- Make text overflow behavior in badge designer configurable (:pr:`6944`, thanks
+  :user:`SegiNyn`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/designer/client/js/index.js
+++ b/indico/modules/designer/client/js/index.js
@@ -107,13 +107,7 @@ import {$T} from 'indico/utils/i18n';
   }
 
   function getStyleForTextOverflow(overflowType) {
-    if (overflowType === 'ellipsis') {
-      return {
-        'white-space': 'nowrap',
-        'overflow': 'hidden',
-        'text-overflow': 'ellipsis',
-      };
-    } else if (overflowType === 'wrap') {
+    if (overflowType === 'wrap') {
       return {
         'white-space': 'normal',
         'overflow': 'visible',

--- a/indico/modules/designer/client/js/index.js
+++ b/indico/modules/designer/client/js/index.js
@@ -77,6 +77,56 @@ import {$T} from 'indico/utils/i18n';
     return itemIdCounter;
   }
 
+  function resizeFont(divContainer, item) {
+    // Adapted from https://stackoverflow.com/a/4166021
+    const $item = divContainer.find('.designer-item');
+    const pattern = /([0-9.]+)pt/g;
+    let fontSize = item.font_size;
+    fontSize = parseFloat(pattern.exec(fontSize)[1]);
+    const minFontSize = 4;
+
+    const resizer = $('<div>', {
+      id: 'font-resizer',
+      text: item.type === 'fixed' ? item.text : itemTitles[item.type],
+      css: {
+        visibility: 'hidden',
+        whiteSpace: 'nowrap',
+        overflow: 'visible',
+        fontSize: fontSize + 'pt',
+        fontFamily: $item.css('font-family'),
+        fontWeight: $item.css('font-weight'),
+        fontStyle: $item.css('font-style'),
+      },
+    }).appendTo(divContainer);
+
+    while (fontSize > minFontSize && resizer[0].scrollWidth > item.width) {
+      resizer.css('font-size', fontSize + 'pt');
+      $item.css('font-size', zoomFont(fontSize + 'pt'));
+      fontSize -= 0.5;
+    }
+    resizer.remove();
+  }
+
+  function getStyleForTextOverflow(overflowType) {
+    if (overflowType === 'ellipsis') {
+      return {
+        'white-space': 'nowrap',
+        'overflow': 'hidden',
+        'text-overflow': 'ellipsis',
+      };
+    } else if (overflowType === 'wrap') {
+      return {
+        'white-space': 'normal',
+        'overflow': 'visible',
+      };
+    } else if (overflowType === 'resize') {
+      return {
+        'white-space': 'nowrap',
+      };
+    }
+    return {};
+  }
+
   function createItem(type) {
     var item = {
       id: generateItemId(),
@@ -94,6 +144,7 @@ import {$T} from 'indico/utils/i18n';
       height: isImage(type) ? 150 : null,
       text: $T('Fixed text'),
       zIndex: itemIdCounter + 10,
+      text_overflow: 'wrap',
 
       // The following attributes have no meaning to the server
       selected: false,
@@ -115,6 +166,7 @@ import {$T} from 'indico/utils/i18n';
           color: this.color,
           backgroundColor: this.background_color,
           zIndex: this.zIndex,
+          ...getStyleForTextOverflow(this.text_overflow),
         })
         .attr('data-type', this.type)
         .text(
@@ -268,6 +320,7 @@ import {$T} from 'indico/utils/i18n';
     $('#alignment-selector').val(item.text_align);
     $('#font-selector').val(item.font_family);
     $('#size-selector').val(item.font_size);
+    $('#overflow-selector').val(item.text_overflow);
     $('#style-selector').val(itemStyles.length ? itemStyles.join('_') : 'normal');
     $('.js-element-width').val(item.width / pixelsPerCm);
     $('.js-element-height').val(item.height / pixelsPerCm);
@@ -311,6 +364,9 @@ import {$T} from 'indico/utils/i18n';
         var div = $item.parent('.ui-draggable');
         item.text = text;
         div.html(item.toHTML());
+        if (item.text_overflow === 'resize') {
+          resizeFont(div, item);
+        }
       }
     }
   }
@@ -380,6 +436,9 @@ import {$T} from 'indico/utils/i18n';
       }
       if (item.selected && !isBackside) {
         selectItem(newDiv.find('.designer-item'));
+      }
+      if (item.text_overflow === 'resize') {
+        resizeFont(newDiv, item);
       }
     });
   }
@@ -543,6 +602,9 @@ import {$T} from 'indico/utils/i18n';
       size: function() {
         selectedItem.font_size = $('#size-selector').val();
       },
+      overflow: function() {
+        selectedItem.text_overflow = $('#overflow-selector').val();
+      },
       style: function() {
         switch ($('#style-selector').val()) {
           case 'normal':
@@ -590,7 +652,11 @@ import {$T} from 'indico/utils/i18n';
       },
     }[attribute]());
 
+    const parentDiv = div.parent('.ui-draggable');
     div.replaceWith(selectedItem.toHTML());
+    if (selectedItem.text_overflow === 'resize') {
+      resizeFont(parentDiv, selectedItem);
+    }
     if (selectedItem.type === 'fixed_image') {
       $('.designer-item.selected').append(createFixedImageElement(selectedItem));
     }

--- a/indico/modules/designer/client/js/index.js
+++ b/indico/modules/designer/client/js/index.js
@@ -81,8 +81,7 @@ import {$T} from 'indico/utils/i18n';
     // Adapted from https://stackoverflow.com/a/4166021
     const $item = divContainer.find('.designer-item');
     const pattern = /([0-9.]+)pt/g;
-    let fontSize = item.font_size;
-    fontSize = parseFloat(pattern.exec(fontSize)[1]);
+    let fontSize = parseFloat(pattern.exec(item.font_size)[1]);
     const minFontSize = 4;
 
     const resizer = $('<div>', {

--- a/indico/modules/designer/client/js/index.js
+++ b/indico/modules/designer/client/js/index.js
@@ -82,7 +82,7 @@ import {$T} from 'indico/utils/i18n';
     const $item = divContainer.find('.designer-item');
     const pattern = /([0-9.]+)pt/g;
     let fontSize = parseFloat(pattern.exec(item.font_size)[1]);
-    const minFontSize = 4;
+    const minFontSize = 6;
 
     const resizer = $('<div>', {
       id: 'font-resizer',

--- a/indico/modules/designer/client/js/index.js
+++ b/indico/modules/designer/client/js/index.js
@@ -114,7 +114,7 @@ import {$T} from 'indico/utils/i18n';
       };
     } else if (overflowType === 'resize') {
       return {
-        'white-space': 'nowrap',
+        'white-space': 'pre',
       };
     }
     return {};

--- a/indico/modules/designer/controllers.py
+++ b/indico/modules/designer/controllers.py
@@ -76,6 +76,7 @@ TEMPLATE_DATA_JSON_SCHEMA = {
                     'text_align': {'type': 'string'},
                     'bold': {'type': 'boolean'},
                     'italic': {'type': 'boolean'},
+                    'text_overflow': {'type': 'string'},
                     'preserve_aspect_ratio': {'type': 'boolean'}
                 }
             },

--- a/indico/modules/designer/pdf.py
+++ b/indico/modules/designer/pdf.py
@@ -114,13 +114,6 @@ class DesignerPDFBase:
             resized_font -= 0.25
         return {'fontSize': resized_font, 'leading': resized_font}
 
-    def _get_truncated_text_with_ellipsis(self, content, font_size, font_name, width):
-        text = content
-        item_width = width / PIXELS_CM * cm
-        while len(text) > 4 and stringWidth(text, font_name, font_size) > item_width:
-            text = text[:-4] + '...'
-        return text
-
     def _draw_item(self, canvas, item, tpl_data, content, margin_x, margin_y):
         font_size = _extract_font_size(item['font_size'])
         styles = {
@@ -141,12 +134,8 @@ class DesignerPDFBase:
         else:
             styles['fontName'] = FONT_STYLES[item['font_family']][0]
 
-        if not isinstance(content, BytesIO):
-            overflow = item.get('text_overflow', 'wrap')
-            if overflow == 'resize':
-                styles.update(self._get_resized_font(content, font_size, styles['fontName'], item['width']))
-            elif overflow == 'ellipsis':
-                content = self._get_truncated_text_with_ellipsis(content, font_size, styles['fontName'], item['width'])
+        if not isinstance(content, BytesIO) and item.get('text_overflow', 'wrap') == 'resize':
+            styles.update(self._get_resized_font(content, font_size, styles['fontName'], item['width']))
 
         for update in values_from_signal(
             signals.event.designer.update_badge_style.send(self.template, item=item, styles=styles),

--- a/indico/modules/designer/pdf.py
+++ b/indico/modules/designer/pdf.py
@@ -107,7 +107,7 @@ class DesignerPDFBase:
         return color
 
     def _get_resized_font(self, content, font_size, font_name, width):
-        min_font_size = 4
+        min_font_size = 6
         resized_font = font_size
         item_width = width / PIXELS_CM * cm
         while resized_font > min_font_size and item_width < stringWidth(content, font_name, resized_font):

--- a/indico/modules/designer/pdf.py
+++ b/indico/modules/designer/pdf.py
@@ -16,6 +16,7 @@ from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY, TA_LEFT, TA_RIGHT
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.units import cm
 from reportlab.lib.utils import ImageReader
+from reportlab.pdfbase.pdfmetrics import stringWidth
 from reportlab.pdfgen.canvas import Canvas
 from reportlab.platypus import Paragraph
 
@@ -105,6 +106,21 @@ class DesignerPDFBase:
             color = f'#{color}'
         return color
 
+    def _get_resized_font(self, content, font_size, font_name, width):
+        min_font_size = 4
+        resized_font = font_size
+        item_width = width / PIXELS_CM * cm
+        while resized_font > min_font_size and item_width < stringWidth(content, font_name, resized_font):
+            resized_font -= 0.25
+        return {'fontSize': resized_font, 'leading': resized_font}
+
+    def _get_truncated_text_with_ellipsis(self, content, font_size, font_name, width):
+        text = content
+        item_width = width / PIXELS_CM * cm
+        while len(text) > 4 and stringWidth(text, font_name, font_size) > item_width:
+            text = text[:-4] + '...'
+        return text
+
     def _draw_item(self, canvas, item, tpl_data, content, margin_x, margin_y):
         font_size = _extract_font_size(item['font_size'])
         styles = {
@@ -124,6 +140,13 @@ class DesignerPDFBase:
             styles['fontName'] = FONT_STYLES[item['font_family']][1]
         else:
             styles['fontName'] = FONT_STYLES[item['font_family']][0]
+
+        if not isinstance(content, BytesIO):
+            overflow = item.get('text_overflow', 'wrap')
+            if overflow == 'resize':
+                styles.update(self._get_resized_font(content, font_size, styles['fontName'], item['width']))
+            elif overflow == 'ellipsis':
+                content = self._get_truncated_text_with_ellipsis(content, font_size, styles['fontName'], item['width'])
 
         for update in values_from_signal(
             signals.event.designer.update_badge_style.send(self.template, item=item, styles=styles),

--- a/indico/modules/designer/templates/template.html
+++ b/indico/modules/designer/templates/template.html
@@ -255,6 +255,13 @@
                             <option value="justified">{% trans %}Justified{% endtrans %}</option>
                         </select>
                     </div>
+                    <div class="subtool">
+                        <select id='overflow-selector' class="js-font-tool" data-attr="overflow">
+                            <option value="wrap">{% trans %}Wrap{% endtrans %}</option>
+                            <option value="ellipsis">{% trans %}Ellipsis{% endtrans %}</option>
+                            <option value="resize">{% trans %}Resize{% endtrans %}</option>
+                        </select>
+                    </div>
                 </div>
                 <div class="tool">
                     <i class="icon-rulers" title="{% trans %}Element dimensions{% endtrans %}"></i>

--- a/indico/modules/designer/templates/template.html
+++ b/indico/modules/designer/templates/template.html
@@ -245,6 +245,7 @@
                             <option value="10pt">10pt</option>
                             <option value="7.5pt">7.5pt</option>
                             <option value="7pt">7pt</option>
+                            <option value="6pt">6pt</option>
                         </select>
                     </div>
                     <div class="subtool">

--- a/indico/modules/designer/templates/template.html
+++ b/indico/modules/designer/templates/template.html
@@ -258,7 +258,6 @@
                     <div class="subtool">
                         <select id='overflow-selector' class="js-font-tool" data-attr="overflow">
                             <option value="wrap">{% trans %}Wrap{% endtrans %}</option>
-                            <option value="ellipsis">{% trans %}Ellipsis{% endtrans %}</option>
                             <option value="resize">{% trans %}Resize{% endtrans %}</option>
                         </select>
                     </div>


### PR DESCRIPTION
This PR adds an option in the badge designer for dealing with overflowing text: To either wrap (already the default), resize or add ellipsis to the text.

E.g Given this badge design: 
<img width="509" alt="Screenshot 2025-06-23 at 14 04 26" src="https://github.com/user-attachments/assets/c01e100e-1f08-459c-8d0c-a250edfd8154" />

Changing the text_overflow option for the "Event Title" and "Fixed text" as example, the resulting badge should look like:

**Wrap option:** 
<img width="384" alt="Screenshot 2025-06-23 at 14 03 14" src="https://github.com/user-attachments/assets/1992b9fa-37cb-4697-93a9-e27a15cf3da8" />


**Resize option:** 
<img width="383" alt="Screenshot 2025-06-23 at 14 04 04" src="https://github.com/user-attachments/assets/3b52ddf7-8a55-4741-bdf8-ee2528c4a333" />
