### PR TITLE
Accept filters in requests for any registration field implementing filter_choices instead of using a hard-coded list.

### DIFF
--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -337,6 +337,10 @@ class CountryField(RegistrationFormFieldBase):
             return ''
         return get_country(registration_data.data) if registration_data.data else ''
 
+    @property
+    def filter_choices(self):
+        return {x['countryKey']: x['caption'] for x in self.unprocess_field_data(None, None)['choices']}
+
 
 class FileField(RegistrationFormFieldBase):
     name = 'file'

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -145,7 +145,7 @@ class RegistrationListGenerator(ListGeneratorBase):
     def _get_filters_from_request(self):
         filters = super()._get_filters_from_request()
         for field in self.regform.form_items:
-            if field.is_field and hasattr(field, 'field_impl') and field.field_impl.filter_choices:
+            if field.is_field and field.field_impl.filter_choices:
                 options = request.form.getlist(f'field_{field.id}')
                 if options:
                     filters['fields'][str(field.id)] = options

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -145,8 +145,7 @@ class RegistrationListGenerator(ListGeneratorBase):
     def _get_filters_from_request(self):
         filters = super()._get_filters_from_request()
         for field in self.regform.form_items:
-            if field.is_field and field.input_type in {'single_choice', 'multi_choice', 'country', 'bool', 'checkbox',
-                                                       'sessions'}:
+            if field.is_field and hasattr(field, 'field_impl') and field.field_impl.filter_choices:
                 options = request.form.getlist(f'field_{field.id}')
                 if options:
                     filters['fields'][str(field.id)] = options


### PR DESCRIPTION
This replaces a check for specific fields to accept filters from a request to a generic check if a field has implemented "filter_choices". This in particular allows plugins that define custom registration fields, to offer filtering on these fields.

See discussion at https://talk.getindico.io/t/custom-field-filters/4173
