### PR TITLE
Fix FormattedSubjectSMTPHandler.getSubject()

### DIFF
--- a/indico/core/logger.py
+++ b/indico/core/logger.py
@@ -44,7 +44,7 @@ class RequestInfoFormatter(logging.Formatter):
 
 class FormattedSubjectSMTPHandler(logging.handlers.SMTPHandler):
     def getSubject(self, record):  # noqa: N802
-        return self.subject % record.__dict__
+        return (self.subject % record.__dict__).splitlines()[0]
 
 
 class BlacklistFilter(logging.Filter):


### PR DESCRIPTION
This PR is about improving how the subject of the error logging email is generated.
In some cases the parameter for the subject is a string with newline characters. This is particularly true when DB error gets raised and the input is a complete SQL query. It is not allowed the subject line to have newline characters so that raises an error and error notification email is not sent out.
My solution is very simple because probably we don't want to fill the subject with a long string anyway. 
Please let me know if you would like to see a different approach.