### PR TITLE
Support restricting user search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,10 @@ Improvements
   tags when cloning registrations (:issue:`6820`, :pr:`6964`)
 - Allow restricting reminder recipients by registration form and tags (:pr:`6877`,
   thanks :user:`tomako, unconventionaldotdev`)
+- Searching existing Indico users can be restricted to managers by setting
+  :data:`ALLOW_PUBLIC_USER_SEARCH` to ``False``. This also limits the verbosity of email
+  status checks while registering for events and disallows registering on behalf
+  of another Indico user (:pr:`6960`)
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -745,6 +745,24 @@ Logging
 Security
 --------
 
+.. data:: ALLOW_PUBLIC_USER_SEARCH
+
+    If disabled, users without management permissions cannot search for
+    existing Indico users. This affects places such as abstract submission,
+    material ACLs and the verbosity of the email status check (whether the
+    registration will be linked to an Indico account) while registering for
+    an event.
+
+    It is recommended to disable this setting in case you run a public instance
+    with strong privacy requirements that weigh heavier than the convenience
+    of being able to search Indico users.
+
+    Note that this setting is only effective if event creation is properly
+    restricted since otherwise any user can just create an event where they
+    then have management permissions and thus the ability to search for users.
+
+    Default: ``True``
+
 .. data:: SECRET_KEY
 
     The secret key used to sign tokens in URLs.  It must be kept secret

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -760,6 +760,8 @@ Security
     Note that this setting is only effective if event creation is properly
     restricted since otherwise any user can just create an event where they
     then have management permissions and thus the ability to search for users.
+    This also means that unlisted events must be disabled or restricted to
+    trusted users.
 
     Default: ``True``
 

--- a/indico/cli/setup.py
+++ b/indico/cli/setup.py
@@ -334,6 +334,7 @@ class SetupWizard:
         self.default_timezone = None
         self.rb_active = None
         self.system_notices = True
+        self.public_user_search = None
 
     def run(self, dev):
         self._check_root()
@@ -604,6 +605,16 @@ class SetupWizard:
                                             'administrators. They are retrieved once a day without sending any data '
                                             'related to your Indico instance. It is strongly recommended to enable '
                                             'them.')
+        self.public_user_search = _confirm('Enable public user search?', default=True,
+                                            help='By default, authenticated users can search for other users by name, '
+                                                 'email address and affiliation, and see this data for users in their '
+                                                 'search results. This is usually expected in academic environments '
+                                                 'where the convenience of being able to find someone to add them as '
+                                                 'an abstract author is appreciated. In other environments, you may '
+                                                 'prefer the increased privacy of not revealing email addresses of '
+                                                 'users to other users, in which case you would need to disable this.\n'
+                                                 'Please see the documentation for details if you are unsure:\n'
+                                                 'https://docs.getindico.io/en/stable/config/settings/#ALLOW_PUBLIC_USER_SEARCH')
 
     def _setup(self, dev=False):
         storage_backends = {'default': 'fs:' + os.path.join(self.data_root_path, 'archive')}
@@ -658,6 +669,13 @@ class SetupWizard:
                 '',
                 '# Disable system notices',
                 'SYSTEM_NOTICES_URL = None'
+            ]
+
+        if not self.public_user_search:
+            config_data += [
+                '',
+                '# Disable public user search',
+                'ALLOW_PUBLIC_USER_SEARCH = False'
             ]
 
         config = '\n'.join(x for x in config_data if x is not None)

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -32,6 +32,7 @@ __all__ = ['config']
 # Note: Whenever you add/change something here, you MUST update the docs (settings.rst) as well
 DEFAULTS = {
     'ALLOW_ADMIN_USER_DELETION': False,
+    'ALLOW_PUBLIC_USER_SEARCH': True,
     'ALLOWED_LANGUAGES': None,
     'ATTACHMENT_STORAGE': 'default',
     'AUTH_PROVIDERS': {},

--- a/indico/modules/attachments/controllers/management/base.py
+++ b/indico/modules/attachments/controllers/management/base.py
@@ -115,7 +115,7 @@ class AddAttachmentFilesMixin:
                 filename = secure_client_filename(f.filename)
                 attachment = Attachment(folder=folder, user=session.user, title=f.filename,
                                         type=AttachmentType.file, protection_mode=form.protection_mode.data)
-                if attachment.is_self_protected:
+                if attachment.is_self_protected and form.acl:
                     attachment.acl = form.acl.data
                 content_type = mimetypes.guess_type(f.filename)[0] or f.mimetype or 'application/octet-stream'
                 attachment.file = AttachmentFile(user=session.user, filename=filename, content_type=content_type)
@@ -162,7 +162,7 @@ class EditAttachmentMixin(SpecificAttachmentMixin):
             logger.info('Attachment %s edited by %s', self.attachment, session.user)
             self.attachment.folder = folder
             form.populate_obj(self.attachment, skip={'acl', 'file', 'folder'})
-            if self.attachment.is_self_protected:
+            if self.attachment.is_self_protected and form.acl:
                 # can't use `=` because of https://bitbucket.org/zzzeek/sqlalchemy/issues/3583
                 self.attachment.acl |= form.acl.data
                 self.attachment.acl &= form.acl.data
@@ -194,7 +194,7 @@ class CreateFolderMixin:
         if form.validate_on_submit():
             folder = AttachmentFolder(object=self.object)
             form.populate_obj(folder, skip={'acl'})
-            if folder.is_self_protected:
+            if folder.is_self_protected and form.acl:
                 folder.acl = form.acl.data
             db.session.add(folder)
             logger.info('Folder %s created by %s', folder, session.user)
@@ -213,7 +213,7 @@ class EditFolderMixin(SpecificFolderMixin):
         form = AttachmentFolderForm(obj=defaults, linked_object=self.object)
         if form.validate_on_submit():
             form.populate_obj(self.folder, skip={'acl'})
-            if self.folder.is_self_protected:
+            if self.folder.is_self_protected and form.acl:
                 # can't use `=` because of https://bitbucket.org/zzzeek/sqlalchemy/issues/3583
                 self.folder.acl |= form.acl.data
                 self.folder.acl &= form.acl.data

--- a/indico/modules/attachments/forms.py
+++ b/indico/modules/attachments/forms.py
@@ -5,11 +5,13 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from flask import session
 from wtforms.fields import BooleanField, TextAreaField, URLField
 from wtforms.fields.simple import HiddenField, StringField
 from wtforms.validators import DataRequired, Optional, ValidationError
 from wtforms_sqlalchemy.fields import QuerySelectField
 
+from indico.core.config import config
 from indico.core.db import db
 from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.attachments.models.folders import AttachmentFolder
@@ -23,6 +25,13 @@ from indico.web.forms.validators import HiddenUnless, UsedIf
 from indico.web.forms.widgets import SwitchWidget, TypeaheadWidget
 
 
+def _is_user_search_allowed(obj):
+    # If public user search is disabled, we require full management access on the object
+    # so people who are just submitters (typically those are speakers not involved in
+    # organizing the event) do not get access to the user search.
+    return config.ALLOW_PUBLIC_USER_SEARCH or obj.can_manage(session.user)
+
+
 class AttachmentFormBase(IndicoForm):
     protected = BooleanField(_('Protected'), widget=SwitchWidget())
     folder = QuerySelectField(_('Folder'), allow_blank=True, blank_text=_('No folder selected'), get_label='title',
@@ -34,15 +43,19 @@ class AttachmentFormBase(IndicoForm):
                                  event=lambda form: form.event,
                                  description=_('The list of users and groups allowed to access the material'))
 
-    def __init__(self, *args, **kwargs):
-        linked_object = kwargs.pop('linked_object')
+    def __init__(self, *args, linked_object, **kwargs):
         self.event = getattr(linked_object, 'event', None)  # not present in categories
         super().__init__(*args, **kwargs)
+        # this also tells the ACL field to not provide a search token, even though
+        # the field should not be displayed anyway
+        self.allow_user_search = _is_user_search_allowed(linked_object)
         self.folder.query = (AttachmentFolder.query
                              .filter_by(object=linked_object, is_default=False, is_deleted=False)
                              .order_by(db.func.lower(AttachmentFolder.title)))
         if self.event and self.event.is_unlisted:
             self.acl.allow_category_roles = False
+        if not self.allow_user_search:
+            del self.acl
 
     @generated_data
     def protection_mode(self):
@@ -109,13 +122,18 @@ class AttachmentFolderForm(IndicoForm):
                                            'the event. You can use this for folders to store non-image files used '
                                            'e.g. in download links. The access permissions still apply.'))
 
-    def __init__(self, *args, **kwargs):
-        self.linked_object = kwargs.pop('linked_object')
+    def __init__(self, *args, linked_object, **kwargs):
+        self.linked_object = linked_object
         self.event = getattr(self.linked_object, 'event', None)  # not present in categories
         super().__init__(*args, **kwargs)
         self.title.choices = self._get_title_suggestions()
+        # this also tells the ACL field to not provide a search token, even though
+        # the field should not be displayed anyway
+        self.allow_user_search = _is_user_search_allowed(linked_object)
         if self.event and self.event.is_unlisted:
             self.acl.allow_category_roles = False
+        if not self.allow_user_search:
+            del self.acl
 
     def _get_title_suggestions(self):
         query = db.session.query(AttachmentFolder.title).filter_by(is_deleted=False, is_default=False,

--- a/indico/modules/attachments/operations.py
+++ b/indico/modules/attachments/operations.py
@@ -22,7 +22,7 @@ def add_attachment_link(data, linked_object):
     assert folder.object == linked_object
     link = Attachment(user=session.user, type=AttachmentType.link, folder=folder)
     link.populate_from_dict(data, skip={'acl', 'protected'})
-    if link.is_self_protected:
+    if link.is_self_protected and 'acl' in data:
         link.acl = data['acl']
     db.session.flush()
     logger.info('Attachment %s added by %s', link, session.user)

--- a/indico/modules/attachments/templates/add_link.html
+++ b/indico/modules/attachments/templates/add_link.html
@@ -26,7 +26,7 @@
             var form = $('#attachment-link-form');
             aclIfProtected(
                 $('#{{ form.protected.id }}'),
-                $('#{{ form.acl.id }}'),
+                {% if form.acl %}$('#{{ form.acl.id }}'){% else %}null{% endif %},
                 form.find('.protected-protection-message'),
                 form.find('.inheriting-protection-message'),
                 $('#{{ form.folder.id }}')

--- a/indico/modules/attachments/templates/create_folder.html
+++ b/indico/modules/attachments/templates/create_folder.html
@@ -17,7 +17,7 @@
             var form = $('#attachment-folder-form');
             aclIfProtected(
                 $('#{{ form.protected.id }}'),
-                $('#{{ form.acl.id }}'),
+                {% if form.acl %}$('#{{ form.acl.id }}'){% else %}null{% endif %},
                 form.find('.protected-protection-message'),
                 form.find('.inheriting-protection-message'),
                 null,

--- a/indico/modules/attachments/templates/upload.html
+++ b/indico/modules/attachments/templates/upload.html
@@ -33,7 +33,7 @@
             var form = $('#attachment-upload-form');
             aclIfProtected(
                 $('#{{ form.protected.id }}'),
-                $('#{{ form.acl.id }}'),
+                {% if form.acl %}$('#{{ form.acl.id }}'){% else %}null{% endif %},
                 form.find('.protected-protection-message'),
                 form.find('.inheriting-protection-message'),
                 $('#{{ form.folder.id }}')

--- a/indico/modules/categories/client/js/management.js
+++ b/indico/modules/categories/client/js/management.js
@@ -431,10 +431,11 @@ import {natSortCompare} from 'indico/utils/sort';
   }
 
   function setupRolesButtons() {
+    const searchToken = document.querySelector('#event-roles').dataset.searchToken;
     $('#event-roles').on('click', '.js-add-members', async evt => {
       evt.stopPropagation();
       const $this = $(evt.target);
-      const users = await showUserSearch({withExternalUsers: true});
+      const users = await showUserSearch({withExternalUsers: true, searchToken});
       if (users.length) {
         $.ajax({
           url: $this.data('href'),

--- a/indico/modules/categories/templates/management/roles.html
+++ b/indico/modules/categories/templates/management/roles.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans %}Roles Setup{% endtrans %}{% endblock %}
 
 {% block content %}
-    <table class="i-table-widget multi-tbody" id="event-roles">
+    <table class="i-table-widget multi-tbody" id="event-roles" data-search-token="{{ make_user_search_token() }}">
         {{ render_roles(roles, email_button=false) }}
     </table>
     <div class="toolbar f-j-end space-before">

--- a/indico/modules/core/client/js/impersonation.js
+++ b/indico/modules/core/client/js/impersonation.js
@@ -49,6 +49,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (loginAs) {
     ReactDOM.render(
       <LazyUserSearch
+        searchToken={loginAs.dataset.searchToken}
         existing={[]}
         onAddItems={e => impersonateUser(e.userId)}
         triggerFactory={searchTrigger}

--- a/indico/modules/events/abstracts/fields.py
+++ b/indico/modules/events/abstracts/fields.py
@@ -27,6 +27,7 @@ from indico.util.decorators import classproperty
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.fields import JSONField
+from indico.web.forms.fields.principals import SearchTokenMixin
 from indico.web.forms.widgets import DropdownWidget, JinjaWidget
 
 
@@ -195,7 +196,7 @@ class AbstractField(QuerySelectField):
         return {'excluded_abstract_id': list(self.excluded_abstract_ids)}
 
 
-class TrackRoleField(JSONField):
+class TrackRoleField(SearchTokenMixin, JSONField):
     """A field to assign track roles to principals."""
 
     CAN_POPULATE = True

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -502,16 +502,15 @@ class AbstractForm(IndicoForm):
     submission_comment = TextAreaField(_('Comments'))
     attachments = EditableFileField(_('Attachments'), multiple_files=True, lightweight=True)
 
-    def __init__(self, *args, **kwargs):
-        self.event = kwargs.pop('event')
-        self.abstract = kwargs.pop('abstract', None)
-        is_invited = kwargs.pop('invited', False)
-        management = kwargs.pop('management', False)
+    def __init__(self, *args, event, abstract=None, invited=False, management=False, **kwargs):
+        self.event = event
+        self.abstract = abstract
+        self.allow_user_search = management or config.ALLOW_PUBLIC_USER_SEARCH
         description_settings = abstracts_settings.get(self.event, 'description_settings')
-        description_validators = self._get_description_validators(description_settings, invited=is_invited)
+        description_validators = self._get_description_validators(description_settings, invited=invited)
         if description_validators:
             inject_validators(self, 'description', description_validators)
-        if not is_invited:
+        if not invited:
             inject_validators(self, 'person_links', [DataRequired()])
         if abstracts_settings.get(self.event, 'contrib_type_required'):
             inject_validators(self, 'submitted_contrib_type', [DataRequired()])
@@ -532,7 +531,7 @@ class AbstractForm(IndicoForm):
             del self.attachments
         if not description_settings['is_active']:
             del self.description
-        if not is_invited:
+        if not invited:
             self.person_links.allow_speakers = abstracts_settings.get(self.event, 'allow_speakers')
             self.person_links.require_speaker = abstracts_settings.get(self.event, 'speakers_required')
         else:

--- a/indico/modules/events/abstracts/templates/forms/track_role_widget.html
+++ b/indico/modules/events/abstracts/templates/forms/track_role_widget.html
@@ -45,6 +45,7 @@
             eventId: {{ field.event.id }},
             eventRoles: {{ field.event_roles|tojson }},
             categoryRoles: {{ field.category_roles|tojson }},
+            searchToken: {{ field.search_token | tojson }},
         });
     </script>
 {% endblock %}

--- a/indico/modules/events/client/js/roles.js
+++ b/indico/modules/events/client/js/roles.js
@@ -31,10 +31,11 @@ import {showUserSearch} from 'indico/react/components/principals/imperative';
   }
 
   function setupButtons() {
+    const searchToken = document.querySelector('#event-roles').dataset.searchToken;
     $('#event-roles').on('click', '.js-add-members', async evt => {
       evt.stopPropagation();
       const $this = $(evt.target);
-      const users = await showUserSearch({withExternalUsers: true});
+      const users = await showUserSearch({withExternalUsers: true, searchToken});
       if (users.length) {
         $.ajax({
           url: $this.data('href'),

--- a/indico/modules/events/controllers/admin.py
+++ b/indico/modules/events/controllers/admin.py
@@ -167,12 +167,16 @@ class RHUnlistedEvents(RHAdminBase):
     """Manage unlisted events in the server admin area."""
 
     def _process(self):
-        form = UnlistedEventsForm(obj=FormDefaults(**unlisted_events_settings.get_all()))
+        settings = unlisted_events_settings.get_all()
+        form = UnlistedEventsForm(obj=FormDefaults(**settings))
         if form.validate_on_submit():
             unlisted_events_settings.set_multi(form.data)
             flash(_('Settings have been saved'), 'success')
             return redirect(url_for('events.unlisted_events'))
-        return WPEventAdmin.render_template('admin/unlisted_events.html', 'unlisted_events', form=form)
+
+        unrestricted = settings['enabled'] and not settings['restricted']
+        return WPEventAdmin.render_template('admin/unlisted_events.html', 'unlisted_events', form=form,
+                                            unrestricted=unrestricted)
 
 
 class RHAutoLinker(RHAdminBase):

--- a/indico/modules/events/editing/client/js/management/index.jsx
+++ b/indico/modules/events/editing/client/js/management/index.jsx
@@ -8,6 +8,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import {UserSearchTokenContext} from 'indico/react/components/principals/Search';
+
 import EditingManagement from './EditingManagement';
 
 document.addEventListener('DOMContentLoaded', async () => {
@@ -15,5 +17,10 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (!editingManagementContainer) {
     return;
   }
-  ReactDOM.render(<EditingManagement />, editingManagementContainer);
+  ReactDOM.render(
+    <UserSearchTokenContext.Provider value={editingManagementContainer.dataset.searchToken}>
+      <EditingManagement />
+    </UserSearchTokenContext.Provider>,
+    editingManagementContainer
+  );
 });

--- a/indico/modules/events/editing/templates/management/editing.html
+++ b/indico/modules/events/editing/templates/management/editing.html
@@ -1,5 +1,5 @@
 {% extends 'events/editing/management/base.html' %}
 
 {% block content %}
-    <div id="editing-management"></div>
+    <div id="editing-management" data-search-token="{{ make_user_search_token() }}"></div>
 {% endblock %}

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -30,6 +30,7 @@ from indico.modules.users.models.users import UserTitle
 from indico.modules.users.util import get_user_by_email
 from indico.util.i18n import _
 from indico.util.signals import values_from_signal
+from indico.util.user import make_user_search_token
 from indico.web.flask.util import url_for
 from indico.web.forms.fields import MultipleItemsField
 from indico.web.forms.fields.principals import PrincipalListField
@@ -98,6 +99,13 @@ class PersonLinkListFieldBase(PrincipalListField):
     def event(self):
         # The event should be a property as it may only be available later, such as, in creation forms
         return getattr(self.get_form(), 'event', None)
+
+    @property
+    def search_token(self):
+        if not getattr(self.get_form(), 'allow_user_search', True):
+            # allow forms to disable user search, e.g. during abstract submission
+            return None
+        return make_user_search_token()
 
     @property
     def has_predefined_affiliations(self):
@@ -241,10 +249,10 @@ class EventPersonLinkListField(PersonLinkListFieldBase):
         return [{'name': 'submitter', 'label': _('Submitter'), 'icon': 'paperclip',
                  'default': self.default_is_submitter}]
 
-    def __init__(self, *args, **kwargs):
-        self.default_is_submitter = kwargs.pop('default_is_submitter', True)
+    def __init__(self, *args, default_is_submitter=True, event_type=None, search_token_source=None, **kwargs):
+        self.default_is_submitter = default_is_submitter
         self.empty_message = _('There are no chairpersons')
-        event_type = kwargs.pop('event_type', None)
+        self.search_token_source = search_token_source
         super().__init__(*args, **kwargs)
         if not event_type and self.object:
             event_type = self.object.event.type_

--- a/indico/modules/events/fields.py
+++ b/indico/modules/events/fields.py
@@ -145,7 +145,7 @@ class PersonLinkListFieldBase(PrincipalListField):
 
     @property
     def validate_email_url(self):
-        return url_for('events.check_email', self.object) if self.object else None
+        return url_for('events.check_email', self.object) if self.object and self.search_token else None
 
     @property
     def extra_params(self):

--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -11,6 +11,7 @@ from flask import session
 from wtforms.fields import BooleanField, StringField, TextAreaField, URLField
 from wtforms.validators import DataRequired, InputRequired, ValidationError
 
+from indico.core.config import config
 from indico.core.db import db
 from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.categories.fields import CategoryField
@@ -128,6 +129,12 @@ class LectureCreationForm(EventCreationFormBase):
     person_link_data = EventPersonLinkListField(_('Speakers'), event_type=EventType.lecture)
     description = TextAreaField(_('Description'), widget=TinyMCEWidget())
     theme = IndicoThemeSelectField(_('Theme'), event_type=EventType.lecture, allow_default=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not config.ALLOW_PUBLIC_USER_SEARCH:
+            # setting a token source disables providing a token unconditionally
+            self.person_link_data.search_token_source = 'event-creation-category'  # noqa: S105
 
 
 class UnlistedEventsForm(IndicoForm):

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -9,6 +9,7 @@ import itertools
 from collections import defaultdict
 
 from flask import flash, jsonify, redirect, request, session
+from itsdangerous import BadSignature
 from marshmallow import fields
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import contains_eager, joinedload
@@ -48,6 +49,7 @@ from indico.util.date_time import now_utc
 from indico.util.i18n import _, ngettext
 from indico.util.marshmallow import LowercaseString, no_relative_urls, not_empty, validate_with_message
 from indico.util.placeholders import get_sorted_placeholders, replace_placeholders
+from indico.util.signing import secure_serializer
 from indico.util.user import principal_from_identifier
 from indico.web.args import use_args, use_kwargs
 from indico.web.flask.templating import get_template_module
@@ -464,6 +466,20 @@ class RHSyncEventPerson(RHEventPersonActionBase):
 
 
 class RHEventPersonSearch(RHAuthenticatedEventBase):
+    @use_kwargs({
+        'token': fields.String(load_default=''),
+    }, location='query')
+    def _check_access(self, token):
+        RHAuthenticatedEventBase._check_access(self)
+        if not token:
+            raise Forbidden('No search token. This is a bug, please report it.')
+        try:
+            sig_uid = secure_serializer.loads(token, max_age=86400, salt='user-search-token')
+            if session.user.id != sig_uid:
+                raise BadSignature
+        except BadSignature:
+            raise Forbidden('Invalid search token')
+
     def _search_event_persons(self, exact=False, **criteria):
         criteria = {key: v for key, value in criteria.items() if (v := value.strip())}
 

--- a/indico/modules/events/persons/controllers.py
+++ b/indico/modules/events/persons/controllers.py
@@ -9,7 +9,6 @@ import itertools
 from collections import defaultdict
 
 from flask import flash, jsonify, redirect, request, session
-from itsdangerous import BadSignature
 from marshmallow import fields
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import contains_eager, joinedload
@@ -49,8 +48,7 @@ from indico.util.date_time import now_utc
 from indico.util.i18n import _, ngettext
 from indico.util.marshmallow import LowercaseString, no_relative_urls, not_empty, validate_with_message
 from indico.util.placeholders import get_sorted_placeholders, replace_placeholders
-from indico.util.signing import secure_serializer
-from indico.util.user import principal_from_identifier
+from indico.util.user import principal_from_identifier, validate_search_token
 from indico.web.args import use_args, use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import jsonify_data, url_for
@@ -471,14 +469,7 @@ class RHEventPersonSearch(RHAuthenticatedEventBase):
     }, location='query')
     def _check_access(self, token):
         RHAuthenticatedEventBase._check_access(self)
-        if not token:
-            raise Forbidden('No search token. This is a bug, please report it.')
-        try:
-            sig_uid = secure_serializer.loads(token, max_age=86400, salt='user-search-token')
-            if session.user.id != sig_uid:
-                raise BadSignature
-        except BadSignature:
-            raise Forbidden('Invalid search token')
+        validate_search_token(token, session.user)
 
     def _search_event_persons(self, exact=False, **criteria):
         criteria = {key: v for key, value in criteria.items() if (v := value.strip())}

--- a/indico/modules/events/registration/client/js/form/fields/EmailInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/EmailInput.jsx
@@ -76,6 +76,11 @@ export default function EmailInput({htmlId, htmlName, disabled, isRequired}) {
       msg = Translate.string('The user associated with this email address is already registered.');
     } else if (data.conflict === 'no-user') {
       msg = Translate.string('There is no Indico user associated with this email address.');
+    } else if (data.conflict === 'email-other-user-restricted') {
+      msg =
+        Indico.User.id !== undefined
+          ? Translate.string('You cannot use this email address to register.')
+          : Translate.string('Please log in using your Indico account to use this email address.');
     } else if (
       data.status === 'error' &&
       (data.conflict === 'email-other-user' || data.conflict === 'email-no-user')

--- a/indico/modules/events/registration/client/js/reglists.js
+++ b/indico/modules/events/registration/client/js/reglists.js
@@ -111,6 +111,7 @@ import {$T} from 'indico/utils/i18n';
         withExternalUsers: true,
         single: true,
         alwaysConfirm: true,
+        searchToken: document.querySelector('.js-add-user').dataset.searchToken,
       });
       if (user) {
         const url = $('.js-add-user').data('href');

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -62,7 +62,8 @@
                         <li>
                             <a href="#" class="js-add-user"
                                data-href="{{ url_for('.create_registration', regform) }}"
-                               data-title="{% trans %}Register a Indico user{% endtrans %}">
+                               data-title="{% trans %}Register a Indico user{% endtrans %}"
+                               data-search-token="{{ make_user_search_token() }}">
                                 {% trans %}Indico user{% endtrans %}
                             </a>
                         </li>

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -276,6 +276,8 @@ def check_registration_email(regform, email, registration=None, management=False
         as_list=True)
     if extra_checks:
         return min(extra_checks, key=lambda x: ['error', 'warning', 'ok'].index(x['status']))
+    if user and user != session.user and not management and not config.ALLOW_PUBLIC_USER_SEARCH:
+        return {'status': 'error', 'conflict': 'email-other-user-restricted'}
     if registration is not None:
         if email_registration and email_registration != registration:
             return {'status': 'error', 'conflict': 'email-already-registered'}

--- a/indico/modules/events/roles/templates/roles.html
+++ b/indico/modules/events/roles/templates/roles.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans %}Roles Setup{% endtrans %}{% endblock %}
 
 {% block content %}
-    <table class="i-table-widget multi-tbody" id="event-roles">
+    <table class="i-table-widget multi-tbody" id="event-roles" data-search-token="{{ make_user_search_token() }}">
         {{ render_roles(roles) }}
     </table>
     <div class="toolbar f-j-end space-before">

--- a/indico/modules/events/templates/admin/unlisted_events.html
+++ b/indico/modules/events/templates/admin/unlisted_events.html
@@ -6,7 +6,37 @@
 {% endblock %}
 
 {% block description %}
-    {% trans %}Unlisted events enable users to set up and customize events before publishing them into a category.{% endtrans %}
+    <p>
+        {% trans %}
+            Unlisted events enable users to set up and customize events before publishing them into a category.
+        {% endtrans %}
+    </p>
+
+    {% if not indico_config.ALLOW_PUBLIC_USER_SEARCH and unrestricted %}
+        <div class="ui icon orange message">
+            <i class="warning sign orange icon"></i>
+            <div class="content">
+                <div class="header">{% trans %}Potential misconfiguration{% endtrans %}</div>
+                <p>
+                    {%- set link -%}
+                        <a href="https://docs.getindico.io/en/stable/config/settings/#ALLOW_PUBLIC_USER_SEARCH">
+                    {%- endset -%}
+                    {%- set endlink %}</a>{% endset -%}
+                    {% trans -%}
+                        Your Indico system config {{ link }}disallows user search{{ endlink }} for regular users,
+                        but unlisted events are enabled without restricting who can create them.
+                    {%- endtrans %}
+                </p>
+                <p>
+                    {% trans -%}
+                        Unless Indico account creation is restricted/moderated, this means that the configured search
+                        restriction is not effective, as anyone can become an event manager by simply creating an
+                        unlisted event.
+                    {%- endtrans %}
+                </p>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}
 
 {% block content %}

--- a/indico/modules/events/templates/forms/event_creation_form.html
+++ b/indico/modules/events/templates/forms/event_creation_form.html
@@ -111,7 +111,7 @@ purely client-side and are worded for event creation instead of being generic.
 </script>
 
 <script type="text/html" id="event-creation-message">
-    <div class="action-box mid-form for-form danger hidden">
+    <div class="action-box mid-form for-form danger hidden" id="event-creation-message-container">
         <div class="section">
             <div class="icon icon-warning"></div>
             <div class="text">

--- a/indico/modules/rb/client/js/common/user/reducers.js
+++ b/indico/modules/rb/client/js/common/user/reducers.js
@@ -23,6 +23,7 @@ const initialUserInfoState = {
   hasOwnedRooms: false,
   hasModeratedRooms: false,
   isRBLocationManager: false,
+  searchToken: null,
 };
 
 export default combineReducers({
@@ -62,6 +63,7 @@ export default combineReducers({
           hasOwnedRooms: user.has_owned_rooms,
           hasModeratedRooms: user.has_moderated_rooms,
           isRBLocationManager: user.is_rb_location_manager && !user.is_rb_admin,
+          searchToken: user.search_token,
         };
       }
       case actions.TOGGLE_ADMIN_OVERRIDE:

--- a/indico/modules/rb/client/js/common/user/selectors.js
+++ b/indico/modules/rb/client/js/common/user/selectors.js
@@ -11,6 +11,7 @@ import {RequestState} from 'indico/utils/redux';
 
 export const hasLoadedUserInfo = ({user}) => user.requests.info.state === RequestState.SUCCESS;
 export const getUserInfo = ({user}) => user.info;
+export const getSearchToken = state => getUserInfo(state).searchToken;
 export const isUserRBAdmin = state => getUserInfo(state).isRBAdmin;
 export const isUserAdmin = state => getUserInfo(state).isAdmin;
 export const isUserRBLocationManager = state => getUserInfo(state).isRBLocationManager;

--- a/indico/modules/rb/client/js/setup.jsx
+++ b/indico/modules/rb/client/js/setup.jsx
@@ -6,11 +6,13 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
+import PropTypes from 'prop-types';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {OverridableContext} from 'react-overridable';
-import {Provider} from 'react-redux';
+import {Provider, useSelector} from 'react-redux';
 
+import {UserSearchTokenContext} from 'indico/react/components/principals/Search';
 import setupUserMenu from 'indico/react/containers/UserMenu';
 
 import {init} from './actions';
@@ -24,6 +26,19 @@ import createRBStore from './store';
 
 import 'indico-sui-theme/semantic.css';
 import '../styles/main.scss';
+
+function UserSearchTokenProvider({children}) {
+  const userSearchToken = useSelector(userSelectors.getSearchToken);
+  return (
+    <UserSearchTokenContext.Provider value={userSearchToken}>
+      {children}
+    </UserSearchTokenContext.Provider>
+  );
+}
+
+UserSearchTokenProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
 
 export default function setup(overrides = {}, postReducers = []) {
   window.addEventListener(
@@ -56,13 +71,16 @@ export default function setup(overrides = {}, postReducers = []) {
       document.getElementById('indico-user-menu-container'),
       store,
       userSelectors,
-      configSelectors
+      configSelectors,
+      UserSearchTokenProvider
     );
 
     ReactDOM.render(
       <OverridableContext.Provider value={overrides}>
         <Provider store={store}>
-          <App history={history} />
+          <UserSearchTokenProvider>
+            <App history={history} />
+          </UserSearchTokenProvider>
         </Provider>
       </OverridableContext.Provider>,
       appContainer

--- a/indico/modules/users/blueprint.py
+++ b/indico/modules/users/blueprint.py
@@ -20,7 +20,7 @@ from indico.modules.users.controllers import (RHAcceptRegistrationRequest, RHAdm
                                               RHUserPreferencesMarkdownAPI, RHUserPreferencesMastodonServer,
                                               RHUsersAdmin, RHUsersAdminCreate, RHUsersAdminMerge,
                                               RHUsersAdminMergeCheck, RHUsersAdminSettings, RHUserSearch,
-                                              RHUserSearchInfo, RHUserSuggestionsRemove)
+                                              RHUserSearchInfo, RHUserSearchToken, RHUserSuggestionsRemove)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
@@ -89,6 +89,7 @@ _bp.add_url_rule('/<int:user_id>/picture-<slug>/<signature>', 'user_profile_pict
 # User search
 _bp.add_url_rule('/search/info', 'user_search_info', RHUserSearchInfo)
 _bp.add_url_rule('/search/', 'user_search', RHUserSearch)
+_bp.add_url_rule('/search/token', 'user_search_token', RHUserSearchToken)
 
 # Users API
 _bp.add_url_rule('!/api/user/', 'authenticated_user', RHUserAPI)

--- a/indico/modules/users/client/js/Favorites.jsx
+++ b/indico/modules/users/client/js/Favorites.jsx
@@ -24,14 +24,18 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import './Favorites.module.scss';
 
 window.setupFavoriteSelection = function setupFavoriteSelection(userId) {
-  ReactDOM.render(<FavoriteManager userId={userId} />, document.getElementById('user-favorites'));
+  const container = document.getElementById('user-favorites');
+  ReactDOM.render(
+    <FavoriteManager userId={userId} searchToken={container.dataset.searchToken || null} />,
+    container
+  );
 };
 
-function FavoriteManager({userId}) {
+function FavoriteManager({userId, searchToken}) {
   return (
     <>
       <div className="row">
-        <FavoriteUserManager userId={userId} />
+        <FavoriteUserManager userId={userId} searchToken={searchToken} />
         <FavoriteCatManager userId={userId} />
       </div>
       <div className="row">
@@ -43,10 +47,12 @@ function FavoriteManager({userId}) {
 
 FavoriteManager.propTypes = {
   userId: PropTypes.number,
+  searchToken: PropTypes.string,
 };
 
 FavoriteManager.defaultProps = {
   userId: null,
+  searchToken: null,
 };
 
 function FavoriteCatManager({userId}) {
@@ -246,7 +252,7 @@ FavoriteEventManager.defaultProps = {
   userId: null,
 };
 
-function FavoriteUserManager({userId}) {
+function FavoriteUserManager({userId, searchToken}) {
   const [favoriteUsers, [addFavoriteUser, deleteFavoriteUser], loading] = useFavoriteUsers(userId);
 
   const searchTrigger = triggerProps => (
@@ -300,19 +306,24 @@ function FavoriteUserManager({userId}) {
           )}
         </div>
       </div>
-      <UserSearch
-        existing={Object.values(favoriteUsers).map(u => u.identifier)}
-        onAddItems={e => e.forEach(u => addFavoriteUser(u.identifier))}
-        triggerFactory={searchTrigger}
-      />
+      {searchToken && (
+        <UserSearch
+          existing={Object.values(favoriteUsers).map(u => u.identifier)}
+          onAddItems={e => e.forEach(u => addFavoriteUser(u.identifier))}
+          triggerFactory={searchTrigger}
+          searchToken={searchToken}
+        />
+      )}
     </div>
   );
 }
 
 FavoriteUserManager.propTypes = {
   userId: PropTypes.number,
+  searchToken: PropTypes.string,
 };
 
 FavoriteUserManager.defaultProps = {
   userId: null,
+  searchToken: null,
 };

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -38,6 +38,8 @@ from indico.modules.auth.util import register_user
 from indico.modules.categories import Category
 from indico.modules.core.settings import social_settings
 from indico.modules.events import Event
+from indico.modules.events.contributions.models.contributions import Contribution
+from indico.modules.events.sessions.models.sessions import Session
 from indico.modules.events.util import serialize_event_for_ical
 from indico.modules.logs.models.entries import LogKind, UserLogRealm
 from indico.modules.users import User, logger, user_management_settings
@@ -61,10 +63,11 @@ from indico.modules.users.views import (WPUser, WPUserDashboard, WPUserDataExpor
 from indico.util.date_time import now_utc
 from indico.util.i18n import _, force_locale
 from indico.util.images import square
-from indico.util.marshmallow import HumanizedDate, Principal, validate_with_message
+from indico.util.marshmallow import HumanizedDate, ModelField, Principal, validate_with_message
 from indico.util.signals import values_from_signal
-from indico.util.signing import static_secure_serializer
+from indico.util.signing import secure_serializer, static_secure_serializer
 from indico.util.string import make_unique_token, remove_accents
+from indico.util.user import make_user_search_token
 from indico.web.args import use_args, use_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import send_file, url_for
@@ -917,8 +920,58 @@ class UserSearchResultSchema(mm.SQLAlchemyAutoSchema):
 search_result_schema = UserSearchResultSchema()
 
 
+class RHUserSearchToken(RHProtected):
+    """Create a token that allows searching users."""
+
+    @use_kwargs({
+        'category': ModelField(Category, filter_deleted=True, load_default=None, data_key='category_id'),
+        'event': ModelField(Event, filter_deleted=True, load_default=None, data_key='event_id'),
+        'contribution': ModelField(Contribution, filter_deleted=True, load_default=None, data_key='contribution_id'),
+        'session': ModelField(Session, filter_deleted=True, load_default=None, data_key='session_id'),
+    }, location='query')
+    def _process_args(self, category, event, contribution, session):
+        self.category = category
+        self.event = event
+        self.contribution = contribution
+        self.session = session
+
+    def _check_access(self):
+        RHProtected._check_access(self)
+        # XXX for now we do not give admins a token "for free", since this would make spotting bugs
+        # where no context is passed much harder. of course any of the access checks below will still
+        # be short-circuited for an admin, so calling this endpoint with `category_id=0` would always
+        # work for an admin
+        if self.category and self.category.can_create_events(session.user):
+            return
+        elif self.event and self.event.can_manage(session.user):
+            return
+        elif self.contribution and self.contribution.can_manage(session.user):
+            return
+        elif self.session and self.session.can_manage(session.user):
+            return
+        else:
+            raise Forbidden('Not authorized to search users')
+
+    def _process(self):
+        return jsonify(token=make_user_search_token())
+
+
 class RHUserSearch(RHProtected):
     """Search for users based on given criteria."""
+
+    @use_kwargs({
+        'token': fields.String(load_default=''),
+    }, location='query')
+    def _check_access(self, token):
+        RHProtected._check_access(self)
+        if not token:
+            raise Forbidden('No search token. This is a bug, please report it.')
+        try:
+            sig_uid = secure_serializer.loads(token, max_age=86400, salt='user-search-token')
+            if session.user.id != sig_uid:
+                raise BadSignature
+        except BadSignature:
+            raise Forbidden('Invalid search token')
 
     def _serialize_pending_user(self, entry):
         first_name = entry.data.get('first_name') or ''

--- a/indico/modules/users/templates/favorites.html
+++ b/indico/modules/users/templates/favorites.html
@@ -2,7 +2,7 @@
 
 {% block user_content %}
     <div class="layout-wrapper">
-        <div id="user-favorites"></div>
+        <div id="user-favorites" data-search-token="{{ make_user_search_token(public=true) or '' }}"></div>
     </div>
     <script>
         setupFavoriteSelection({{ (user.id if user != session.user else none) | tojson }});

--- a/indico/util/user.py
+++ b/indico/util/user.py
@@ -5,9 +5,12 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from flask import session
+
 from indico.core.cache import make_scoped_cache
+from indico.core.config import config
 from indico.core.db.sqlalchemy.principals import EmailPrincipal
-from indico.util.signing import static_secure_serializer
+from indico.util.signing import secure_serializer, static_secure_serializer
 
 
 def iter_acl(acl):
@@ -195,3 +198,21 @@ def principal_from_identifier(identifier, *, allow_groups=False, allow_external_
         return netgroup
     else:
         raise ValueError('Invalid data')
+
+
+def make_user_search_token(*, public=False) -> str | None:
+    """Generate a token to access user search.
+
+    :param public: If true, a token is only returned if
+                   :data:`ALLOW_PUBLIC_USER_SEARCH` is True.
+                   This should be set when the token is used in
+                   a public place where any (authenticated) user
+                   would get access to it.
+    """
+    if not session.user:
+        # never allow unauthenticated users to search, the search endpoint requires
+        # login anyway, so the token would be useless
+        return None
+    if public and not config.ALLOW_PUBLIC_USER_SEARCH:
+        return None
+    return secure_serializer.dumps(session.user.id, 'user-search-token')

--- a/indico/web/client/js/jquery/utils/forms.js
+++ b/indico/web/client/js/jquery/utils/forms.js
@@ -286,7 +286,11 @@ import {Translate} from 'indico/react/i18n';
     folderProtection
   ) {
     protectionField.on('change', function() {
-      toggleAclField(aclField, !this.checked);
+      if (aclField) {
+        toggleAclField(aclField, !this.checked);
+      } else {
+        selfProtection.addClass('no-acl-field');
+      }
 
       if (selfProtection && inheritedProtection) {
         selfProtection.toggle(this.checked);

--- a/indico/web/client/js/jquery/widgets/jinja/category_picker_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/category_picker_widget.js
@@ -79,6 +79,9 @@
             .val(JSON.stringify(hiddenData))
             .trigger('change')
             .trigger(event, [category, dfd]);
+          // jquery events are not compatible with normal DOM events, so we also trigger a normal
+          // one so modern code can react to it
+          $field[0].dispatchEvent(new Event('change', {bubbles: true}));
           if (event.isDefaultPrevented()) {
             return dfd;
           }

--- a/indico/web/client/js/jquery/widgets/jinja/permissions_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/permissions_widget.js
@@ -25,6 +25,7 @@ import Palette from 'indico/utils/palette';
       permissionsInfo: null,
       hiddenPermissions: null,
       hiddenPermissionsInfo: null,
+      searchToken: null,
     },
 
     _update() {
@@ -502,6 +503,7 @@ import Palette from 'indico/utils/palette';
                   this._addItems(items, [READ_ACCESS_PERMISSIONS]);
                 }}
                 triggerFactory={userSearchTrigger}
+                searchToken={this.options.searchToken}
               />
               <GroupSearch
                 existing={existing.filter(e => e.startsWith('Group'))}

--- a/indico/web/client/js/jquery/widgets/jinja/person_link_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/person_link_widget.js
@@ -5,11 +5,84 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
+import userSearchTokenURL from 'indico-url:users.user_search_token';
+
+import React, {useEffect, useState} from 'react';
 import ReactDOM from 'react-dom';
 
 import {WTFPersonLinkField} from 'indico/react/components/PersonLinkField';
+import {handleAxiosError, indicoAxios} from 'indico/utils/axios';
 import {camelizeKeys} from 'indico/utils/case';
+
+// TODO Remove all this once event creation is reactified and we don't need all these awful hacks
+// anymore to make react and legacy jquery/wtforms components interact with each other...
+const searchTokenCache = new Map();
+// eslint-disable-next-line react/prop-types
+function EventCreationWTFPersonLinkField({searchTokenSource, ...rest}) {
+  const [userSearchDisabled, setUserSearchDisabled] = useState(true);
+  const [categoryId, setCategoryId] = useState(undefined);
+  useEffect(() => {
+    const abortController = new AbortController();
+
+    const listingField = document.querySelector('#event-creation-listing-checkbox');
+    const categoryField = document.querySelector('#event-creation-category');
+    const noCreationMessage = document.querySelector('#event-creation-message-container');
+
+    const onChange = () => {
+      // Get the selected category if available, or `undefined` if the event is being created
+      // as unlisted or no category is selected. This also handles the listingField not existing
+      // in case unlisted events are disabled.
+      // The categoryField has an empty default value of `{}`, but when switching to unlisted and
+      // back, we set its value to `null` instead of `{}` - don't ask me why! It seems to be related
+      // to the initialCategory in the event creation dialog but I really do not feel like debugging
+      // or changing this, since at some point that dialog gets rewritten in React anyway!
+      // XXX It is kind of stupid to even do this for unlisted events, because letting a user create
+      // unlisted events but restricting user search makes no sense whatsoever, as they will become
+      // event manager, and thus be able to use the user search anyway. So we could actually just
+      // provide a search token when the user is allowed to create unlisted events...
+      const catId =
+        listingField?.value === 'false' ? undefined : (JSON.parse(categoryField.value) ?? {}).id;
+      // We use this ugly hack to check if event creation is possible in the category, since we do
+      // not have access to the data from the event creation JS code... The only case where one can
+      // have a category selected where they cannot create events is by using the event creation
+      // button in such a category anyway, since it is not possible to select it via the category
+      // picker.
+      const eventCreationPossible = noCreationMessage.classList.contains('hidden');
+      setUserSearchDisabled(catId === undefined || !eventCreationPossible);
+      setCategoryId(catId);
+    };
+
+    listingField?.addEventListener('change', onChange, {signal: abortController.signal});
+    categoryField.addEventListener('change', onChange, {signal: abortController.signal});
+    onChange();
+
+    return () => abortController.abort();
+  }, []);
+
+  rest.searchToken = async () => {
+    let params, resp;
+    if (searchTokenSource === 'event-creation-category') {
+      params = {category_id: categoryId};
+    } else {
+      console.error(`Invalid search token source: ${searchTokenSource}`);
+      return null;
+    }
+    const key = JSON.stringify(params);
+    const cachedToken = searchTokenCache.get(key);
+    if (cachedToken) {
+      return cachedToken;
+    }
+    try {
+      resp = await indicoAxios.get(userSearchTokenURL(params));
+    } catch (error) {
+      return handleAxiosError(error);
+    }
+    searchTokenCache.set(key, resp.data.token);
+    return resp.data.token;
+  };
+
+  return <WTFPersonLinkField userSearchDisabled={userSearchDisabled} {...rest} />;
+}
 
 (function(global) {
   global.setupPersonLinkWidget = function setupPersonLinkWidget(options) {
@@ -25,6 +98,8 @@ import {camelizeKeys} from 'indico/utils/case';
       defaultSearchExternal,
       nameFormat,
       extraParams,
+      searchToken,
+      searchTokenSource,
       ...rest
     } = options;
     const field = document.getElementById(fieldId);
@@ -46,8 +121,13 @@ import {camelizeKeys} from 'indico/utils/case';
         type: sessionUser.type,
       };
 
+    const WTFPersonLinkFieldComponent =
+      searchTokenSource === 'event-creation-category'
+        ? EventCreationWTFPersonLinkField
+        : WTFPersonLinkField;
+
     ReactDOM.render(
-      <WTFPersonLinkField
+      <WTFPersonLinkFieldComponent
         fieldId={fieldId}
         eventId={eventId}
         defaultValue={camelizeKeys(persons)}
@@ -60,6 +140,8 @@ import {camelizeKeys} from 'indico/utils/case';
         defaultSearchExternal={defaultSearchExternal}
         nameFormat={nameFormat}
         extraParams={camelizeKeys(extraParams)}
+        searchToken={searchToken}
+        searchTokenSource={searchTokenSource}
         {...rest}
       />,
       document.getElementById(`person-link-field-${fieldId}`)

--- a/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_list_widget.js
@@ -20,6 +20,7 @@ window.setupPrincipalListWidget = function setupPrincipalListWidget({fieldId, ..
       withCategoryRoles: false,
       withRegistrants: false,
       withEmails: false,
+      searchToken: null,
     },
     ...options,
   };

--- a/indico/web/client/js/jquery/widgets/jinja/principal_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/principal_widget.js
@@ -7,6 +7,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import {WTFPrincipalField} from 'indico/react/components';
 
 window.setupPrincipalWidget = function setupPrincipalWidget({
@@ -14,6 +15,7 @@ window.setupPrincipalWidget = function setupPrincipalWidget({
   required,
   withExternalUsers,
   disabled,
+  searchToken,
 }) {
   const field = document.getElementById(fieldId);
 
@@ -24,6 +26,7 @@ window.setupPrincipalWidget = function setupPrincipalWidget({
       required={required}
       withExternalUsers={withExternalUsers}
       disabled={disabled}
+      searchToken={searchToken}
     />,
     document.getElementById(`principalField-${fieldId}`)
   );

--- a/indico/web/client/js/jquery/widgets/track_role_widget.js
+++ b/indico/web/client/js/jquery/widgets/track_role_widget.js
@@ -7,7 +7,9 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+
 import {TrackACLField} from 'indico/react/components';
+import {UserSearchTokenContext} from 'indico/react/components/principals/Search';
 
 (function($) {
   $.widget('indico.trackrolewidget', {
@@ -17,6 +19,7 @@ import {TrackACLField} from 'indico/react/components';
       eventId: null,
       eventRoles: null,
       categoryRoles: null,
+      searchToken: null,
     },
 
     _updateValue(newValue, trackId) {
@@ -28,15 +31,19 @@ import {TrackACLField} from 'indico/react/components';
     _renderACLField(trackId, value) {
       const onChange = newValue => this._updateValue(newValue, trackId);
       const element = document.querySelector(`#track-roles-${trackId}`);
-      const component = React.createElement(TrackACLField, {
-        value,
-        permissionInfo: this.options.permissionsInfo,
-        eventId: this.options.eventId,
-        eventRoles: this.options.eventRoles,
-        categoryRoles: this.options.categoryRoles,
-        scrollOnOpen: true,
-        onChange,
-      });
+      const component = (
+        <UserSearchTokenContext.Provider value={this.options.searchToken}>
+          <TrackACLField
+            value={value}
+            permissionInfo={this.options.permissionsInfo}
+            eventId={this.options.eventId}
+            eventRoles={this.options.eventRoles}
+            categoryRoles={this.options.categoryRoles}
+            scrollOnOpen
+            onChange={onChange}
+          />
+        </UserSearchTokenContext.Provider>
+      );
       ReactDOM.render(component, element);
     },
 

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import React, {useMemo, useState} from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
-import {Button, Segment, List, Label, Icon, Popup, Ref} from 'semantic-ui-react';
+import {Button, Icon, Label, List, Popup, Ref, Segment} from 'semantic-ui-react';
 
 import {UserSearch} from 'indico/react/components/principals/Search';
 import {PrincipalType} from 'indico/react/components/principals/util';
@@ -246,9 +246,11 @@ function PersonLinkField({
   customPersonsMode,
   requiredPersonFields,
   defaultSearchExternal,
+  userSearchDisabled,
   nameFormat,
   validateEmailUrl,
   extraParams,
+  searchToken,
 }) {
   const favoriteUsersController = useFavoriteUsers(null, !sessionUser);
   const [modalOpen, setModalOpen] = useState('');
@@ -393,7 +395,8 @@ function PersonLinkField({
             withEventPersons={eventId !== null}
             initialFormValues={{external: defaultSearchExternal}}
             eventId={eventId}
-            disabled={!sessionUser}
+            disabled={!sessionUser || !searchToken || userSearchDisabled}
+            searchToken={searchToken}
           />
           {customPersonsMode === 'always' && (
             <Button type="button" onClick={() => setModalOpen('details')}>
@@ -443,9 +446,11 @@ PersonLinkField.propTypes = {
   customPersonsMode: PropTypes.oneOf(['always', 'after_search', 'never']),
   requiredPersonFields: PropTypes.array,
   defaultSearchExternal: PropTypes.bool,
+  userSearchDisabled: PropTypes.bool,
   nameFormat: PropTypes.string,
   validateEmailUrl: PropTypes.string,
   extraParams: PropTypes.object,
+  searchToken: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 };
 
 PersonLinkField.defaultProps = {
@@ -460,9 +465,11 @@ PersonLinkField.defaultProps = {
   customPersonsMode: 'always',
   requiredPersonFields: [],
   defaultSearchExternal: false,
+  userSearchDisabled: false,
   nameFormat: '',
   validateEmailUrl: null,
   extraParams: {},
+  searchToken: null,
 };
 
 export function WTFPersonLinkField({
@@ -477,9 +484,11 @@ export function WTFPersonLinkField({
   customPersonsMode,
   requiredPersonFields,
   defaultSearchExternal,
+  userSearchDisabled,
   nameFormat,
   validateEmailUrl,
   extraParams,
+  searchToken,
 }) {
   const [persons, setPersons] = useState(
     defaultValue.sort((a, b) => a.displayOrder - b.displayOrder)
@@ -538,6 +547,8 @@ export function WTFPersonLinkField({
       nameFormat={nameFormat}
       validateEmailUrl={validateEmailUrl}
       extraParams={extraParams}
+      searchToken={searchToken}
+      userSearchDisabled={userSearchDisabled}
     />
   );
 }
@@ -555,8 +566,10 @@ WTFPersonLinkField.propTypes = {
   customPersonsMode: PropTypes.oneOf(['always', 'after_search', 'never']),
   requiredPersonFields: PropTypes.array,
   defaultSearchExternal: PropTypes.bool,
+  userSearchDisabled: PropTypes.bool,
   validateEmailUrl: PropTypes.string,
   extraParams: PropTypes.object,
+  searchToken: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 };
 
 WTFPersonLinkField.defaultProps = {
@@ -570,7 +583,9 @@ WTFPersonLinkField.defaultProps = {
   customPersonsMode: 'always',
   requiredPersonFields: [],
   defaultSearchExternal: false,
+  userSearchDisabled: false,
   nameFormat: '',
   validateEmailUrl: null,
   extraParams: {},
+  searchToken: null,
 };

--- a/indico/web/client/js/react/components/WTFPrincipalField.jsx
+++ b/indico/web/client/js/react/components/WTFPrincipalField.jsx
@@ -19,6 +19,7 @@ export default function WTFPrincipalField({
   required,
   disabled,
   withExternalUsers,
+  searchToken,
 }) {
   const favoriteUsersController = useFavoriteUsers();
   const inputField = useMemo(() => document.getElementById(fieldId), [fieldId]);
@@ -44,6 +45,7 @@ export default function WTFPrincipalField({
       onBlur={() => {}}
       value={value}
       styleName="fixed-width"
+      searchToken={searchToken}
     />
   );
 }
@@ -54,6 +56,7 @@ WTFPrincipalField.propTypes = {
   withExternalUsers: PropTypes.bool,
   required: PropTypes.bool,
   disabled: PropTypes.bool,
+  searchToken: PropTypes.string,
 };
 
 WTFPrincipalField.defaultProps = {
@@ -61,4 +64,5 @@ WTFPrincipalField.defaultProps = {
   withExternalUsers: false,
   required: false,
   disabled: false,
+  searchToken: null,
 };

--- a/indico/web/client/js/react/components/principals/PrincipalField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalField.jsx
@@ -35,6 +35,7 @@ const PrincipalField = props => {
     favoriteUsersController,
     withExternalUsers,
     className,
+    searchToken,
   } = props;
   const [favoriteUsers, [handleAddFavorite, handleDelFavorite]] = favoriteUsersController;
 
@@ -92,6 +93,7 @@ const PrincipalField = props => {
   );
   const userSearch = (
     <UserSearch
+      searchToken={searchToken}
       triggerFactory={searchTrigger}
       existing={value ? [value] : []}
       onAddItems={handleAddItem}
@@ -143,6 +145,7 @@ PrincipalField.propTypes = {
   favoriteUsersController: PropTypes.array.isRequired,
   withExternalUsers: PropTypes.bool,
   className: PropTypes.string,
+  searchToken: PropTypes.string,
 };
 
 PrincipalField.defaultProps = {
@@ -150,6 +153,7 @@ PrincipalField.defaultProps = {
   required: false,
   withExternalUsers: false,
   className: '',
+  searchToken: null,
 };
 
 export default React.memo(PrincipalField);

--- a/indico/web/client/js/react/components/principals/PrincipalListField.jsx
+++ b/indico/web/client/js/react/components/principals/PrincipalListField.jsx
@@ -45,6 +45,7 @@ const PrincipalListField = props => {
     eventId,
     favoriteUsersController,
     className,
+    searchToken,
   } = props;
   const [favoriteUsers, [handleAddFavorite, handleDelFavorite]] = favoriteUsersController;
 
@@ -131,6 +132,7 @@ const PrincipalListField = props => {
                 withExternalUsers={withExternalUsers}
                 onOpen={onFocus}
                 onClose={onBlur}
+                searchToken={searchToken}
               />
               {withGroups && (
                 <GroupSearch
@@ -195,6 +197,7 @@ PrincipalListField.propTypes = {
   withRegistrants: PropTypes.bool,
   eventId: PropTypes.number,
   className: PropTypes.string,
+  searchToken: PropTypes.string,
 };
 
 PrincipalListField.defaultProps = {
@@ -206,6 +209,7 @@ PrincipalListField.defaultProps = {
   eventId: null,
   readOnly: false,
   className: undefined,
+  searchToken: null,
 };
 
 export default React.memo(PrincipalListField);

--- a/indico/web/client/js/react/containers/UserMenu.jsx
+++ b/indico/web/client/js/react/containers/UserMenu.jsx
@@ -11,7 +11,7 @@ import {Provider, connect} from 'react-redux';
 
 import UserMenu from '../components/UserMenu';
 
-export default function setupUserMenu(element, store, userInfoSelectors, configSelectors) {
+export default function setupUserMenu(element, store, userInfoSelectors, configSelectors, Wrapper) {
   const Connector = connect(state => ({
     userData: userInfoSelectors.getUserInfo(state),
     languages: configSelectors.getLanguages(state),
@@ -21,7 +21,9 @@ export default function setupUserMenu(element, store, userInfoSelectors, configS
 
   ReactDOM.render(
     <Provider store={store}>
-      <Connector />
+      <Wrapper>
+        <Connector />
+      </Wrapper>
     </Provider>,
     element
   );

--- a/indico/web/client/styles/partials/_forms.scss
+++ b/indico/web/client/styles/partials/_forms.scss
@@ -370,3 +370,25 @@ form {
 .i-form .form-field-warning {
   margin-top: 2px;
 }
+
+.protection-message {
+  &.no-acl-field {
+    .has-acl {
+      display: none;
+    }
+
+    .no-acl {
+      display: block;
+    }
+  }
+
+  &:not(.no-acl-field) {
+    .has-acl {
+      display: block;
+    }
+
+    .no-acl {
+      display: none;
+    }
+  }
+}

--- a/indico/web/flask/app.py
+++ b/indico/web/flask/app.py
@@ -48,6 +48,7 @@ from indico.util.i18n import (_, babel, get_all_locales, get_current_locale, get
 from indico.util.mimetypes import icon_from_mimetype
 from indico.util.signals import values_from_signal
 from indico.util.string import RichMarkup, alpha_enum, crc32, html_to_plaintext, sanitize_html, slugify
+from indico.util.user import make_user_search_token
 from indico.web.flask.errors import errors_bp
 from indico.web.flask.stats import get_request_stats, setup_request_stats
 from indico.web.flask.templating import (call_template_hook, decodeprincipal, dedent, groupby, instanceof, markdown,
@@ -219,6 +220,7 @@ def setup_jinja(app):
     app.add_template_global(render_session_bar)
     app.add_template_global(get_request_stats)
     app.add_template_global(_get_indico_version(), 'indico_version')
+    app.add_template_global(make_user_search_token)
     # Global variables
     app.add_template_global(LocalProxy(get_current_locale), 'current_locale')
     app.add_template_global(LocalProxy(lambda: current_plugin.manifest if current_plugin else None), 'plugin_webpack')

--- a/indico/web/templates/_protection_messages.html
+++ b/indico/web/templates/_protection_messages.html
@@ -24,9 +24,14 @@
                 <div class="label">
                     {% trans %}Protected{% endtrans %}
                 </div>
-                <div>
+                <div class="has-acl">
                     {% trans -%}
                         This object is <strong>only</strong> accessible by the <strong>users specified</strong> above and the <strong>managers</strong> of <strong>parent resources</strong>.
+                    {%- endtrans %}
+                </div>
+                <div class="no-acl">
+                    {% trans -%}
+                        This object is <strong>only</strong> accessible by the <strong>managers</strong> of <strong>parent resources</strong>.
                     {%- endtrans %}
                 </div>
             </div>

--- a/indico/web/templates/_session_bar.html
+++ b/indico/web/templates/_session_bar.html
@@ -152,7 +152,7 @@
         </div>
         {% if session.user.is_admin %}
             <div class="settingsWidgetSection">
-                <div id="login-as"></div>
+                <div id="login-as" data-search-token="{{ make_user_search_token() }}"></div>
             </div>
         {% endif %}
         {% if 'login_as_orig_user' in session %}

--- a/indico/web/templates/forms/permissions_widget.html
+++ b/indico/web/templates/forms/permissions_widget.html
@@ -61,7 +61,8 @@
             isUnlisted: {{ field.is_unlisted | tojson }},
             permissionsInfo: {{ field.permissions_info | tojson }},
             hiddenPermissions: {{ field.hidden_permissions | default([]) | tojson }},
-            hiddenPermissionsInfo: {{ field.hidden_permissions_info | tojson }}
+            hiddenPermissionsInfo: {{ field.hidden_permissions_info | tojson }},
+            searchToken: {{ field.search_token | tojson }},
         });
 
         // make sure permission widget updates even if protection widget is not there to trigger an update

--- a/indico/web/templates/forms/person_link_widget.html
+++ b/indico/web/templates/forms/person_link_widget.html
@@ -36,6 +36,8 @@
             sessionUser: Indico.User,
             validateEmailUrl: {{ field.validate_email_url | tojson }},
             extraParams: {{ field.extra_params | tojson }},
+            searchToken: {{ (field.search_token if not field.search_token_source|default(none) else none) | tojson }},
+            searchTokenSource: {{ field.search_token_source|default(none) | tojson }},
         });
     </script>
 {% endblock %}

--- a/indico/web/templates/forms/principal_list_widget.html
+++ b/indico/web/templates/forms/principal_list_widget.html
@@ -25,6 +25,7 @@
             withRegistrants: {{ field.allow_registration_forms | tojson }},
             withEmails: {{ field.allow_emails | tojson }},
             protectedFieldId: {{ field.protected_field_id | default(none) | tojson }},
+            searchToken: {{ field.search_token | tojson }},
         });
     </script>
 {% endblock %}

--- a/indico/web/templates/forms/principal_widget.html
+++ b/indico/web/templates/forms/principal_widget.html
@@ -14,7 +14,8 @@
             fieldId: {{ field.id | tojson }},
             required: {{ input_args.required | default(false) | tojson }},
             withExternalUsers: {{ field.allow_external_users | tojson }},
-            disabled: {{ (field.render_kw.disabled if field.render_kw else false) | tojson }}
+            disabled: {{ (field.render_kw.disabled if field.render_kw else false) | tojson }},
+            searchToken: {{ field.search_token | tojson }},
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Some admins would prefer to lock down the user search more tightly. This gives them the ability to do so.

This is a re-implementation of #5024 in what I think is a cleaner and more maintainable way.

TODO:

- [x] Limit registration email check endpoint ~~(or remove from setting description)~~
- [x] Disable person link email check logic in CfA when search is restricted
- [x] Potentially ~~disallow~~ unlisted events w/o an ACL on who can create them when search is restricted. Added a warning instead.