### PR TITLE
Refactor multi tag field to be query-based

### DIFF
--- a/indico/modules/categories/fields.py
+++ b/indico/modules/categories/fields.py
@@ -63,7 +63,7 @@ class CategoryField(HiddenField):
 
 class EventRequestList(ModelList):
     def __init__(self, category, **kwargs):
-        def _get_query(m):
+        def _get_query(m, ctx):
             return m.query.filter(
                 EventMoveRequest.category == category,
                 EventMoveRequest.state == MoveRequestState.pending

--- a/indico/modules/events/editing/fields.py
+++ b/indico/modules/events/editing/fields.py
@@ -24,7 +24,7 @@ class EditingFilesField(Dict):
         self.contrib = contrib
         self.editing_file_types_query = EditingFileType.query.with_parent(event).filter_by(type=editable_type)
 
-        keys_field = ModelField(EditingFileType, get_query=lambda m: self.editing_file_types_query)
+        keys_field = ModelField(EditingFileType, get_query=lambda m, ctx: self.editing_file_types_query)
         values_field = FilesField(required=True, allow_claimed=allow_claimed_files)
         validators = [*kwargs.pop('validate', []), self.validate_files]
         super().__init__(keys=keys_field, values=values_field, validate=validators, **kwargs)
@@ -77,7 +77,7 @@ class EditingFilesField(Dict):
 
 class EditingTagsField(ModelList):
     def __init__(self, event, allow_system_tags=False, **kwargs):
-        def _get_query(m):
+        def _get_query(m, ctx):
             query = m.query.with_parent(event)
             if not allow_system_tags:
                 query = query.filter_by(system=False)
@@ -88,7 +88,7 @@ class EditingTagsField(ModelList):
 
 class EditableList(ModelList):
     def __init__(self, event, editable_type, **kwargs):
-        def _get_query(m):
+        def _get_query(m, ctx):
             return (m.query
                     .join(Contribution)
                     .filter(~Contribution.is_deleted, Contribution.event_id == event.id, m.type == editable_type))

--- a/indico/modules/events/registration/controllers/management/tags.py
+++ b/indico/modules/events/registration/controllers/management/tags.py
@@ -6,7 +6,6 @@
 # LICENSE file for more details.
 
 from flask import flash, redirect, request, session
-from webargs import fields
 
 from indico.core.db import db
 from indico.modules.events.registration import logger
@@ -16,8 +15,8 @@ from indico.modules.events.registration.forms import RegistrationTagForm, Regist
 from indico.modules.events.registration.models.tags import RegistrationTag
 from indico.modules.events.registration.views import WPManageRegistration
 from indico.util.i18n import _
-from indico.util.string import natural_sort_key
-from indico.web.args import use_kwargs
+from indico.util.marshmallow import ModelList
+from indico.web.args import use_rh_kwargs
 from indico.web.flask.util import url_for
 from indico.web.util import jsonify_data, jsonify_form
 
@@ -79,30 +78,20 @@ class RHRegistrationTagEdit(RHManageRegistrationTagBase):
         return jsonify_form(form)
 
 
-def _assign_registration_tags(event, registrations, add, remove):
-    add_ids = [int(id) for id in add]
-    remove_ids = [int(id) for id in remove]
-    add_tags = set(RegistrationTag.query.with_parent(event).filter(RegistrationTag.id.in_(add_ids)).all())
-    remove_tags = set(RegistrationTag.query.with_parent(event).filter(RegistrationTag.id.in_(remove_ids)).all())
-
+def _assign_registration_tags(registrations, add, remove):
     for reg in registrations:
-        reg.tags |= add_tags
-        reg.tags -= remove_tags
+        reg.tags |= add
+        reg.tags -= remove
 
 
 class RHRegistrationTagsAssign(RHRegistrationsActionBase):
     """Assign and remove registration tags."""
 
     def _process(self):
-        tags = sorted(self.event.registration_tags, key=lambda tag: natural_sort_key(tag.title))
-        choices = [(str(tag.id), (tag.title, tag.color)) for tag in tags]
-
-        form = RegistrationTagsAssignForm(regform=self.regform, registration_id=[reg.id for reg in self.registrations])
-        form.add.choices = choices
-        form.remove.choices = choices
+        form = RegistrationTagsAssignForm(event=self.event, registration_id=[reg.id for reg in self.registrations])
 
         if form.validate_on_submit():
-            _assign_registration_tags(self.event, self.registrations, form.add.data, form.remove.data)
+            _assign_registration_tags(self.registrations, form.add.data, form.remove.data)
             return jsonify_data()
 
         return jsonify_form(form, form_header_kwargs={'classes': 'registration-tags-assign-form'})
@@ -111,10 +100,16 @@ class RHRegistrationTagsAssign(RHRegistrationsActionBase):
 class RHAPIRegistrationTagsAssign(RHRegistrationsActionBase):
     """Internal API to assign and remove registration tags."""
 
-    @use_kwargs({
-        'add': fields.List(fields.Integer(), load_default=lambda: []),
-        'remove': fields.List(fields.Integer(), load_default=lambda: [])
-    })
+    @use_rh_kwargs({
+        'add': ModelList(RegistrationTag,
+                         get_query=lambda m, ctx: m.query.with_parent(ctx['event']),
+                         collection_class=set,
+                         load_default=lambda: set()),
+        'remove': ModelList(RegistrationTag,
+                            get_query=lambda m, ctx: m.query.with_parent(ctx['event']),
+                            collection_class=set,
+                            load_default=lambda: set())
+    }, rh_context=('event',))
     def _process_POST(self, add, remove):
-        _assign_registration_tags(self.event, self.registrations, add, remove)
+        _assign_registration_tags(self.registrations, add, remove)
         return '', 204

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -40,8 +40,8 @@ from indico.web.forms.fields import EmailListField, FileField, IndicoDateTimeFie
 from indico.web.forms.fields.colors import SUIColorPickerField
 from indico.web.forms.fields.datetime import TimeDeltaField
 from indico.web.forms.fields.principals import PrincipalListField
-from indico.web.forms.fields.simple import (HiddenFieldList, IndicoEmailRecipientsField, IndicoMultipleTagSelectField,
-                                            IndicoParticipantVisibilityField)
+from indico.web.forms.fields.simple import HiddenFieldList, IndicoEmailRecipientsField, IndicoParticipantVisibilityField
+from indico.web.forms.fields.sqlalchemy import IndicoQuerySelectMultipleTagField
 from indico.web.forms.util import inject_validators
 from indico.web.forms.validators import (DataRetentionPeriodValidator, HiddenUnless, IndicoEmail, LinkedDateTime,
                                          NoRelativeURLs)
@@ -601,10 +601,14 @@ class RegistrationTagForm(IndicoForm):
 class RegistrationTagsAssignForm(IndicoForm):
     """Form to assign registration tags to registrations."""
 
-    add = IndicoMultipleTagSelectField(_('Add'), description=_('Select tags to assign'))
-    remove = IndicoMultipleTagSelectField(_('Remove'), description=_('Select tags to remove'))
+    add = IndicoQuerySelectMultipleTagField(_('Add'), description=_('Select tags to assign'))
+    remove = IndicoQuerySelectMultipleTagField(_('Remove'), description=_('Select tags to remove'))
     registration_id = HiddenFieldList()
     submitted = HiddenField()
+
+    def __init__(self, *args, event, **kwargs):
+        self.event = event  # used by IndicoQuerySelectMultipleTagField
+        super().__init__(*args, **kwargs)
 
     def validate_remove(self, field):
         if set(self.remove.data) & set(self.add.data):

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -303,7 +303,7 @@ class Registration(db.Model):
         order_by='RegistrationTag.title',
         backref=db.backref(
             'registrations',
-            lazy=False
+            lazy=True
         )
     )
     #: The serial number assigned to the Apple Wallet pass

--- a/indico/util/marshmallow.py
+++ b/indico/util/marshmallow.py
@@ -212,7 +212,7 @@ class ModelField(I18nAwareField):
         'type': 'Invalid input type.'
     }
 
-    def __init__(self, model, column=None, column_type=None, get_query=lambda m: m.query, filter_deleted=False,
+    def __init__(self, model, *, column=None, column_type=None, get_query=lambda m, ctx: m.query, filter_deleted=False,
                  none_if_missing=False, **kwargs):
         self.model = model
         self.get_query = get_query
@@ -240,7 +240,7 @@ class ModelField(I18nAwareField):
             value = self.column_type(value)
         except (TypeError, ValueError):
             self.fail('type')
-        query = self.get_query(self.model).filter(self.column == value)
+        query = self.get_query(self.model, self.context).filter(self.column == value)
         if self.filter_deleted:
             query = query.filter(~self.model.is_deleted)
         obj = query.one_or_none()
@@ -264,7 +264,7 @@ class ModelList(fields.Field):
         'type': 'Invalid input type.'
     }
 
-    def __init__(self, model, column=None, column_type=None, get_query=lambda m: m.query, collection_class=list,
+    def __init__(self, model, *, column=None, column_type=None, get_query=lambda m, ctx: m.query, collection_class=list,
                  filter_deleted=False, **kwargs):
         self.model = model
         self.get_query = get_query
@@ -293,7 +293,7 @@ class ModelList(fields.Field):
         except (TypeError, ValueError):
             self.fail('type')
         requested = set(value)
-        query = self.get_query(self.model).filter(self.column.in_(value))
+        query = self.get_query(self.model, self.context).filter(self.column.in_(value))
         if self.filter_deleted:
             query = query.filter(~self.model.is_deleted)
         objs = query.all()

--- a/indico/web/client/js/jquery/widgets/jinja/multiple_tag_select_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/multiple_tag_select_widget.js
@@ -10,7 +10,12 @@ import ReactDOM from 'react-dom';
 
 import {WTFMultipleTagSelectField} from 'indico/react/components';
 
-window.setupMultipleTagSelectWidget = function setupMultipleTagSelectWidget({fieldId, choices}) {
+window.setupMultipleTagSelectWidget = function setupMultipleTagSelectWidget({
+  fieldId,
+  choices,
+  inputArgs,
+  initialSelection,
+}) {
   const wrapperId = `${fieldId}-wrapper`;
   // The form dialog has a combination of overflow: hidden and auto.
   // Since WTFMultipleTagSelectField is much larger when expanded, most of its
@@ -21,7 +26,12 @@ window.setupMultipleTagSelectWidget = function setupMultipleTagSelectWidget({fie
   dialog.css('overflow', 'visible');
 
   ReactDOM.render(
-    <WTFMultipleTagSelectField fieldId={fieldId} wrapperId={wrapperId} choices={choices} />,
+    <WTFMultipleTagSelectField
+      fieldId={fieldId}
+      choices={choices}
+      inputArgs={inputArgs}
+      initialSelection={initialSelection}
+    />,
     document.getElementById(wrapperId)
   );
 };

--- a/indico/web/client/js/react/components/WTFMultipleTagSelectField.jsx
+++ b/indico/web/client/js/react/components/WTFMultipleTagSelectField.jsx
@@ -6,22 +6,21 @@
 // LICENSE file for more details.
 
 import PropTypes from 'prop-types';
-import React, {useMemo, useState, useEffect} from 'react';
+import React, {useMemo, useState} from 'react';
 import {Dropdown, Label} from 'semantic-ui-react';
 
 import {Translate} from '../i18n';
 
-export default function WTFMultipleTagSelectField({fieldId, wrapperId, choices}) {
-  const parentElement = useMemo(() => document.getElementById(wrapperId), [wrapperId]);
-  const [selectedOptions, setSelectedOptions] = useState([]);
-
-  // Trigger change only after the DOM has changed
-  useEffect(() => {
-    parentElement.dispatchEvent(new Event('change', {bubbles: true}));
-  }, [selectedOptions, parentElement]);
+export default function WTFMultipleTagSelectField({fieldId, choices, inputArgs, initialSelection}) {
+  const selectField = useMemo(() => document.getElementById(fieldId), [fieldId]);
+  const [selectedOptions, setSelectedOptions] = useState(initialSelection);
 
   const handleChange = (e, {value}) => {
     setSelectedOptions(value);
+    [...selectField.querySelectorAll('option')].forEach(opt => {
+      opt.selected = value.includes(opt.value);
+    });
+    selectField.dispatchEvent(new Event('change', {bubbles: true}));
   };
 
   const renderLabel = label => ({
@@ -42,40 +41,23 @@ export default function WTFMultipleTagSelectField({fieldId, wrapperId, choices})
   }));
 
   return (
-    <div>
-      <Dropdown
-        fluid
-        multiple
-        onChange={handleChange}
-        options={options}
-        placeholder={Translate.string('Choose an option')}
-        selection
-        value={selectedOptions}
-        renderLabel={renderLabel}
-      />
-      {/* Since Dropdown does not render as a <select> element, we use a dummy <select>
-       * with the correct name attribute and options selected which are used when the form is submitted.
-       */}
-      <select
-        id={fieldId}
-        name={fieldId}
-        multiple
-        readOnly
-        value={selectedOptions}
-        style={{display: 'none'}}
-      >
-        {options.map(({key, text, value}) => (
-          <option key={key} value={value}>
-            {text}
-          </option>
-        ))}
-      </select>
-    </div>
+    <Dropdown
+      fluid
+      multiple
+      onChange={handleChange}
+      options={options}
+      placeholder={Translate.string('Choose an option')}
+      selection
+      value={selectedOptions}
+      renderLabel={renderLabel}
+      disabled={inputArgs.disabled ?? false}
+    />
   );
 }
 
 WTFMultipleTagSelectField.propTypes = {
   fieldId: PropTypes.string.isRequired,
-  wrapperId: PropTypes.string.isRequired,
   choices: PropTypes.array.isRequired,
+  inputArgs: PropTypes.object.isRequired,
+  initialSelection: PropTypes.array.isRequired,
 };

--- a/indico/web/forms/fields/simple.py
+++ b/indico/web/forms/fields/simple.py
@@ -215,10 +215,6 @@ def validate_keywords_field(obj_type: t.Literal['event', 'contribution'], field)
             raise ValidationError(_('Invalid keyword found'))
 
 
-class IndicoMultipleTagSelectField(SelectMultipleField):
-    widget = JinjaWidget('forms/multiple_tag_select_widget.html', single_kwargs=True, single_line=True)
-
-
 class IndicoLinkListField(JSONField):
     widget = JinjaWidget('forms/link_list_widget.html', single_kwargs=True, single_line=True)
 

--- a/indico/web/forms/fields/sqlalchemy.py
+++ b/indico/web/forms/fields/sqlalchemy.py
@@ -5,9 +5,12 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from operator import attrgetter
+
 from wtforms.widgets import CheckboxInput
 from wtforms_sqlalchemy.fields import QuerySelectMultipleField
 
+from indico.util.string import natural_sort_key
 from indico.web.forms.widgets import JinjaWidget
 
 
@@ -17,9 +20,9 @@ class IndicoQuerySelectMultipleField(QuerySelectMultipleField):
     The callback can return a new list or yield items, and you can use it e.g. to sort the list.
     """
 
-    def __init__(self, *args, **kwargs):
-        self.modify_object_list = kwargs.pop('modify_object_list', None)
-        self.collection_class = kwargs.pop('collection_class', list)
+    def __init__(self, *args, modify_object_list=None, collection_class=list, **kwargs):
+        self.modify_object_list = modify_object_list
+        self.collection_class = collection_class
         super().__init__(*args, **kwargs)
 
     def _get_object_list(self):
@@ -38,3 +41,29 @@ class IndicoQuerySelectMultipleField(QuerySelectMultipleField):
 class IndicoQuerySelectMultipleCheckboxField(IndicoQuerySelectMultipleField):
     option_widget = CheckboxInput()
     widget = JinjaWidget('forms/checkbox_group_widget.html', single_kwargs=True)
+
+
+class IndicoQuerySelectMultipleTagField(IndicoQuerySelectMultipleField):
+    widget = JinjaWidget('forms/multiple_tag_select_widget.html', single_kwargs=True, single_line=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            collection_class=set,
+            modify_object_list=lambda objs: sorted(objs, key=lambda x: natural_sort_key(x[1].title)),
+            get_label=attrgetter('title', 'color'),
+            query_factory=self._get_query,
+            **kwargs,
+        )
+
+    def _get_query(self):
+        from indico.modules.events.registration.models.tags import RegistrationTag
+        return RegistrationTag.query.with_parent(self.get_form().event)
+
+    @property
+    def initial_selection(self):
+        return [val for val, __, selected, *__ in self.iter_choices() if selected]
+
+    @property
+    def choices(self):
+        return [[val, [title, color]] for val, [title, color], *__ in self.iter_choices()]

--- a/indico/web/templates/forms/multiple_tag_select_widget.html
+++ b/indico/web/templates/forms/multiple_tag_select_widget.html
@@ -2,6 +2,16 @@
 
 {% block html %}
     <div id="{{ field.id }}-wrapper"></div>
+    <select id="{{ field.id }}"
+            name="{{ field.name }}"
+            style="display: none;"
+            multiple
+            readonly
+            {{ input_args | html_params }}>
+        {% for value, label, selected, render_kw in field.iter_choices() %}
+            <option value="{{ value }}" {% if selected %}selected{% endif %}>{{ label[0] }}</option>
+        {% endfor %}
+    </select>
 {% endblock %}
 
 {% block javascript %}
@@ -9,6 +19,8 @@
         setupMultipleTagSelectWidget({
             fieldId: {{ field.id | tojson }},
             choices: {{ field.choices | tojson }},
+            inputArgs: {{ input_args | tojson }},
+            initialSelection: {{ field.initial_selection | tojson }},
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
Also add support for filtering ModelField and ModelList based on schema context, which makes it much more flexible to be used when e.g. only objects linked to the current event should be selectable via the field.

These are changed I initially added on top of #6877 to clean things up, but IMHO they are significant enough to deserve their own PR.