### PR TITLE
Disable interaction outside of event times and implement initial scroll position

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -220,9 +220,9 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
     ];
   }
 
-  function canInteractWithTimeline(y) {
+  function canInteractWithTimeline(y, offsets = [0, 0]) {
     const pixelLimits = limits.map(l => (calendarRef.current.clientHeight / 100) * l);
-    return y >= pixelLimits[0] && y <= pixelLimits[1];
+    return y > pixelLimits[0] + offsets[0] && y < pixelLimits[1] - offsets[1];
   }
 
   const draftEntry = useSelector(selectors.getDraftEntry);
@@ -243,7 +243,7 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
       if (
         event.button !== 0 ||
         event.target !== calendarRef.current ||
-        !canInteractWithTimeline(event.offsetY)
+        !canInteractWithTimeline(event.offsetY, [0, minutesToPixels(5)])
       ) {
         return;
       }

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -221,7 +221,7 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
   }
 
   function canInteractWithTimeline(y, offsets = [0, 0]) {
-    const pixelLimits = limits.map(l => (calendarRef.current.clientHeight / 100) * l);
+    const pixelLimits = limits.map(lim => (calendarRef.current.clientHeight / 100) * lim);
     return y > pixelLimits[0] + offsets[0] && y < pixelLimits[1] - offsets[1];
   }
 
@@ -324,7 +324,15 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
   }, [draftEntry, dt, dispatch, isDragging, minHour]);
 
   const restrictToCalendar = useMemo(() => createRestrictToCalendar(calendarRef), [calendarRef]);
-  const limitsGradient = `linear-gradient(180deg,rgba(0,0,0,0.05) 0%, rgba(0,0,0,0.05) ${limits[0]}%, transparent ${limits[0]}%, transparent ${limits[1]}%, rgba(0,0,0,0.05) ${limits[1]}%, rgba(0,0,0,0.05) 100%)`;
+  const limitsGradientArg = [
+    'rgba(0, 0, 0, 0.05) 0%',
+    `rgba(0, 0, 0, 0.05) ${limits[0]}%`,
+    `transparent ${limits[0]}%`,
+    `transparent ${limits[1]}%`,
+    `rgba(0, 0, 0, 0.05) ${limits[1]}%`,
+    'rgba(0, 0, 0, 0.05) 100%',
+  ].join(', ');
+  const limitsGradient = `linear-gradient(180deg, ${limitsGradientArg})`;
 
   return (
     <DnDProvider onDrop={handleDragEnd} modifier={restrictToCalendar}>

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -254,10 +254,17 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
           GRID_SIZE_MINUTES
       );
 
-      const startDt = moment(dt)
+      let startDt = moment(dt)
         .startOf('days')
         .add(minHour, 'hours')
         .add(pixelsToMinutes(y), 'minutes');
+
+      if (startDt < dt) {
+        startDt = dt;
+      }
+
+      // TODO: (Ajob) Make it so that duration can never go beyond max event time. Issue arises when using
+      //              end date that is not dividible by 5.
 
       setIsDragging(true);
       dispatch(

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -31,6 +31,7 @@ import TimetableManageModal from './TimetableManageModal';
 import {TopLevelEntry, BlockEntry, Entry, isChildEntry, EntryType} from './types';
 import UnscheduledContributions from './UnscheduledContributions';
 import {
+  DAY_SIZE,
   getDateKey,
   GRID_SIZE_MINUTES,
   isWithinLimits,
@@ -235,7 +236,7 @@ export function DayTimetable({
   }
 
   function getTimelinePixelLimitsDelta(): [number, number] {
-    return [pixelLimitsTotal[0], minutesToPixels((maxHour + 1 - endHourLimit) * 60)];
+    return [pixelLimitsTotal[0], DAY_SIZE - pixelLimitsTotal[1]];
   }
 
   const draftEntry = useSelector(selectors.getDraftEntry);

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -109,6 +109,7 @@ export function DayTimetable({
   const defaultContributionDuration = useSelector(selectors.getDefaultContribDurationMinutes);
   const pixelLimitsTotal = useSelector(selectors.getCurrentPixelLimits);
   const scrollPositionRef = useRef<number>(scrollPosition);
+  const draftEntry = useSelector(selectors.getDraftEntry);
 
   const [isDragging, setIsDragging] = useState(false);
 
@@ -233,8 +234,6 @@ export function DayTimetable({
   function getTimelinePixelLimitsDelta(): [number, number] {
     return [pixelLimitsTotal[0], DAY_SIZE - pixelLimitsTotal[1]];
   }
-
-  const draftEntry = useSelector(selectors.getDraftEntry);
 
   useEffect(() => {
     function onMouseMove(event: MouseEvent) {

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -31,8 +31,8 @@ import {TopLevelEntry, BlockEntry, Entry, isChildEntry, EntryType} from './types
 import UnscheduledContributions from './UnscheduledContributions';
 import {
   DAY_SIZE,
-  getDateKey,
   GRID_SIZE_MINUTES,
+  getDateKey,
   isWithinLimits,
   minutesToPixels,
   pixelsToMinutes,
@@ -44,7 +44,7 @@ interface DayTimetableProps {
   minHour: number;
   maxHour: number;
   entries: TopLevelEntry[];
-  scrollPosition?: number;
+  scrollPosition: number;
 }
 
 const TABLE_MARGIN_TOP = 10;
@@ -55,9 +55,8 @@ function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) 
   const setDurations = useMemo(() => {
     const obj = {};
     for (const e of entries) {
-      obj[e.id] = (duration: number) => {
+      obj[e.id] = (duration: number) =>
         dispatch(actions.resizeEntry(getDateKey(dt), e.id, duration));
-      };
     }
     return obj;
   }, [entries, dispatch, dt]);
@@ -111,7 +110,7 @@ export function DayTimetable({
   const scrollPositionRef = useRef<number>(scrollPosition);
   const draftEntry = useSelector(selectors.getDraftEntry);
   const [isDragging, setIsDragging] = useState(false);
-  const pixelLimitsDelta: [number, number] = getTimelinePixelLimitsDelta();
+  const pixelLimitsDelta: [number, number] = [pixelLimitsTotal[0], DAY_SIZE - pixelLimitsTotal[1]];
 
   entries = useMemo(() => computeYoffset(entries, minHour), [entries, minHour]);
 
@@ -227,10 +226,6 @@ export function DayTimetable({
       calendar
     );
     dispatch(actions.moveEntry(movedEntry, eventId, newLayout, getDateKey(dt)));
-  }
-
-  function getTimelinePixelLimitsDelta(): [number, number] {
-    return [pixelLimitsTotal[0], DAY_SIZE - pixelLimitsTotal[1]];
   }
 
   useEffect(() => {

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -10,6 +10,8 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import './DayTimetable.module.scss';
+import {select} from 'indico/custom_elements/date_selection';
+
 import * as actions from './actions';
 import {Transform, Over, MousePosition} from './dnd';
 import {useDroppable, DnDProvider} from './dnd/dnd';
@@ -268,19 +270,15 @@ export function DayTimetable({
           defaultContributionDuration
       );
 
-      let startDt = moment(dt)
+      const startDt = moment(dt)
         .startOf('days')
         .add(minHour, 'hours')
         .add(pixelsToMinutes(y), 'minutes');
 
-      if (startDt < dt) {
-        startDt = dt;
-      }
-
       setIsDragging(true);
       dispatch(
         actions.setDraftEntry({
-          startDt,
+          startDt: moment.min(startDt, dt),
           duration: defaultContributionDuration,
           y,
         })
@@ -461,8 +459,7 @@ function layoutAfterDropOnCalendar(
   mouse: MousePosition
 ) {
   const {y} = delta;
-  const deltaMinutes =
-    Math.ceil(pixelsToMinutes(y) / defaultContributionDuration) * defaultContributionDuration;
+  const deltaMinutes = Math.ceil(pixelsToMinutes(y) / GRID_SIZE_MINUTES) * GRID_SIZE_MINUTES;
   const mousePosition = (mouse.x - over.rect.left) / over.rect.width;
 
   let fromEntry: Entry | undefined = entries.find(e => e.id === who);

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -271,7 +271,7 @@ export function DayTimetable({
       setIsDragging(true);
       dispatch(
         actions.setDraftEntry({
-          startDt: moment.min(startDt, dt),
+          startDt: moment.max(startDt, dt),
           duration: defaultContributionDuration,
           y,
         })

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -297,7 +297,7 @@ export function DayTimetable({
     }
 
     function onMouseMove(event: MouseEvent) {
-      if (!isDragging || !draftEntry || !canInteractWithTimeline(event.offsetY)) {
+      if (!isDragging || !draftEntry) {
         return;
       }
       const rect = calendarRef.current.getBoundingClientRect();
@@ -346,11 +346,11 @@ export function DayTimetable({
     };
   }, [draftEntry, dt, dispatch, isDragging, minHour]);
 
-  // useEffect(() => {
-  //   if (wrapperRef.current && !wrapperRef.current.scrollTop) {
-  //     wrapperRef.current.scrollTop = scrollPosition;
-  //   }
-  // }, [scrollPosition, entries]);
+  useEffect(() => {
+    if (wrapperRef.current && !wrapperRef.current.scrollTop) {
+      wrapperRef.current.scrollTop = scrollPosition;
+    }
+  }, [scrollPosition]);
 
   const restrictToCalendar = useMemo(() => {
     const restrictLimits = pixelLimitsDelta;

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -28,7 +28,7 @@ import * as selectors from './selectors';
 import TimetableManageModal from './TimetableManageModal';
 import {TopLevelEntry, BlockEntry, Entry, isChildEntry, EntryType} from './types';
 import UnscheduledContributions from './UnscheduledContributions';
-import {GRID_SIZE_MINUTES, minutesToPixels, pixelsToMinutes} from './utils';
+import {getDateKey, GRID_SIZE_MINUTES, minutesToPixels, pixelsToMinutes} from './utils';
 
 interface DayTimetableProps {
   dt: Moment;
@@ -104,9 +104,13 @@ export function DayTimetable({
   entries = useMemo(() => computeYoffset(entries, minHour), [entries, minHour]);
 
   const startHourLimit =
-    eventStartDt.day() === dt.day() ? eventStartDt.hour() + eventStartDt.minutes() / 60 : minHour;
+    getDateKey(eventStartDt) === getDateKey(dt)
+      ? eventStartDt.hour() + eventStartDt.minutes() / 60
+      : minHour;
   const endHourLimit =
-    eventEndDt.day() === dt.day() ? eventEndDt.hour() + eventEndDt.minutes() / 60 : maxHour + 1;
+    getDateKey(eventEndDt) === getDateKey(dt)
+      ? eventEndDt.hour() + eventEndDt.minutes() / 60
+      : maxHour + 1;
   const limits: [number, number] = getTimelineLimits();
   const pixelLimitsTotal: [number, number] = getTimelinePixelLimits('total');
   const pixelLimitsDelta: [number, number] = getTimelinePixelLimits('delta');

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -102,20 +102,18 @@ export function DayTimetable({
 }: DayTimetableProps) {
   const dispatch = useDispatch();
   const mouseEventRef = useRef<MouseEvent | null>(null);
-  const unscheduled = useSelector(selectors.getUnscheduled);
   const calendarRef = useRef<HTMLDivElement | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const eventEndDt = useSelector(selectors.getEventEndDt);
+  const unscheduled = useSelector(selectors.getUnscheduled);
   const defaultContributionDuration = useSelector(selectors.getDefaultContribDurationMinutes);
   const pixelLimitsTotal = useSelector(selectors.getCurrentPixelLimits);
   const scrollPositionRef = useRef<number>(scrollPosition);
   const draftEntry = useSelector(selectors.getDraftEntry);
-
   const [isDragging, setIsDragging] = useState(false);
+  const pixelLimitsDelta: [number, number] = getTimelinePixelLimitsDelta();
 
   entries = useMemo(() => computeYoffset(entries, minHour), [entries, minHour]);
-
-  const pixelLimitsDelta: [number, number] = getTimelinePixelLimitsDelta();
 
   function handleDragEnd(
     who: string,

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -28,7 +28,13 @@ import * as selectors from './selectors';
 import TimetableManageModal from './TimetableManageModal';
 import {TopLevelEntry, BlockEntry, Entry, isChildEntry, EntryType} from './types';
 import UnscheduledContributions from './UnscheduledContributions';
-import {getDateKey, GRID_SIZE_MINUTES, isWithinLimits, minutesToPixels, pixelsToMinutes} from './utils';
+import {
+  getDateKey,
+  GRID_SIZE_MINUTES,
+  isWithinLimits,
+  minutesToPixels,
+  pixelsToMinutes,
+} from './utils';
 
 interface DayTimetableProps {
   dt: Moment;
@@ -98,28 +104,19 @@ export function DayTimetable({
   const unscheduled = useSelector(selectors.getUnscheduled);
   const calendarRef = useRef<HTMLDivElement | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
-  const eventStartDt = useSelector(selectors.getEventStartDt);
   const eventEndDt = useSelector(selectors.getEventEndDt);
   const defaultContributionDuration = useSelector(selectors.getDefaultContribDurationMinutes);
   const pixelLimitsTotal = useSelector(selectors.getCurrentPixelLimits);
-  const limits = useSelector(selectors.getCurrentLimits);
-
-  console.log('pixel limits', pixelLimitsTotal);
-  console.log('raw limits', limits);
+  const scrollPositionRef = useRef<number>(scrollPosition);
 
   const [isDragging, setIsDragging] = useState(false);
 
   entries = useMemo(() => computeYoffset(entries, minHour), [entries, minHour]);
 
-  const startHourLimit =
-    getDateKey(eventStartDt) === getDateKey(dt)
-      ? eventStartDt.hour() + eventStartDt.minutes() / 60
-      : minHour;
   const endHourLimit =
     getDateKey(eventEndDt) === getDateKey(dt)
       ? eventEndDt.hour() + eventEndDt.minutes() / 60
       : maxHour + 1;
-  console.log('limits', limits);
   const pixelLimitsDelta: [number, number] = getTimelinePixelLimitsDelta();
 
   function handleDragEnd(
@@ -237,10 +234,7 @@ export function DayTimetable({
   }
 
   function getTimelinePixelLimitsDelta(): [number, number] {
-    return [
-      minutesToPixels((startHourLimit - minHour) * 60),
-      minutesToPixels((maxHour + 1 - endHourLimit) * 60),
-    ];
+    return [pixelLimitsTotal[0], minutesToPixels((maxHour + 1 - endHourLimit) * 60)];
   }
 
   const draftEntry = useSelector(selectors.getDraftEntry);
@@ -345,10 +339,10 @@ export function DayTimetable({
   }, [draftEntry, dt, dispatch, isDragging, minHour]);
 
   useEffect(() => {
-    if (wrapperRef.current && !wrapperRef.current.scrollTop) {
-      wrapperRef.current.scrollTop = scrollPosition;
+    if (wrapperRef.current) {
+      wrapperRef.current.scrollTop = scrollPositionRef.current;
     }
-  }, [scrollPosition]);
+  }, [wrapperRef, scrollPositionRef]);
 
   const restrictToCalendar = useMemo(() => {
     const restrictLimits = pixelLimitsDelta;

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -394,7 +394,7 @@ export function TimeGutter({minHour, maxHour}: TimeGutterProps) {
     <div styleName="time-gutter">
       <div style={{height: 10}} />
       {Array.from({length: maxHour - minHour + 1}, (_, i) => (
-        <TimeSlot key={i} height={oneHour} time={`${minHour + i}:00`} />
+        <TimeSlot key={i} height={oneHour} time={`${(minHour + i) % 24}:00`} />
       ))}
     </div>
   );

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -107,6 +107,7 @@ export function DayTimetable({
   const unscheduled = useSelector(selectors.getUnscheduled);
   const defaultContributionDuration = useSelector(selectors.getDefaultContribDurationMinutes);
   const limits = useSelector(selectors.getCurrentLimits);
+  const [limitTop, limitBottom] = limits;
   const scrollPositionRef = useRef<number>(scrollPosition);
   const draftEntry = useSelector(selectors.getDraftEntry);
   const [isDragging, setIsDragging] = useState(false);
@@ -327,10 +328,10 @@ export function DayTimetable({
   }, [wrapperRef]);
 
   const restrictToCalendar = useMemo(() => {
-    const limitsDelta: [number, number] = [limits[0], DAY_SIZE - limits[1]];
+    const limitsDelta: [number, number] = [limitTop, DAY_SIZE - limitBottom];
     limitsDelta[1] += TABLE_MARGIN_TOP;
     return createRestrictToCalendar(calendarRef, limitsDelta);
-  }, [limits]);
+  }, [limitTop, limitBottom]);
 
   const limitsGradientArg = [
     'rgba(0, 0, 0, 0.05) 0',

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -257,8 +257,8 @@ export function DayTimetable({
 
       const rect = calendarRef.current.getBoundingClientRect();
       const y = minutesToPixels(
-        Math.round(pixelsToMinutes(event.clientY - rect.top) / defaultContributionDuration) *
-          defaultContributionDuration
+        Math.round(pixelsToMinutes(event.clientY - rect.top) / GRID_SIZE_MINUTES) *
+          GRID_SIZE_MINUTES
       );
 
       const startDt = moment(dt)
@@ -548,7 +548,7 @@ function layoutAfterDropOnBlock(
     .find(entry => !!entry.children.find(c => c.id === who));
 
   const {y} = delta;
-  const deltaMinutes = Math.ceil(pixelsToMinutes(y) / 5) * 5;
+  const deltaMinutes = Math.ceil(pixelsToMinutes(y) / GRID_SIZE_MINUTES) * GRID_SIZE_MINUTES;
   const mousePosition = (mouse.x - over.rect.left) / over.rect.width;
 
   let fromEntry: Entry | undefined;

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import moment, {Moment} from 'moment';
+import moment, {duration, Moment} from 'moment';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
@@ -263,14 +263,15 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
         startDt = dt;
       }
 
-      // TODO: (Ajob) Make it so that duration can never go beyond max event time. Issue arises when using
-      //              end date that is not dividible by 5.
+      const newEndDt = startDt.add(GRID_SIZE_MINUTES, 'minutes');
+      const draftDuration =
+        newEndDt > eventEndDt ? newEndDt.diff(eventEndDt, 'minutes') : GRID_SIZE_MINUTES;
 
       setIsDragging(true);
       dispatch(
         actions.setDraftEntry({
           startDt,
-          duration: GRID_SIZE_MINUTES, // TODO: (Ajob) Replace with default duration
+          duration: draftDuration, // TODO: (Ajob) Replace with default duration
           y,
         })
       );

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -14,7 +14,7 @@ import './DayTimetable.module.scss';
 import * as actions from './actions';
 import {Transform, Over, MousePosition} from './dnd';
 import {useDroppable, DnDProvider} from './dnd/dnd';
-import {createRestrictToCalendarWithLimits} from './dnd/modifiers';
+import {createRestrictToCalendar} from './dnd/modifiers';
 import {DraggableBlockEntry, DraggableEntry} from './Entry';
 import {
   computeYoffset,
@@ -344,7 +344,7 @@ export function DayTimetable({
   const restrictToCalendar = useMemo(() => {
     const restrictLimits = pixelLimitsDelta;
     restrictLimits[1] += TABLE_MARGIN_TOP;
-    return createRestrictToCalendarWithLimits(calendarRef, pixelLimitsDelta);
+    return createRestrictToCalendar(calendarRef, pixelLimitsDelta);
   }, [pixelLimitsDelta]);
 
   const limitsGradientArg = [

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -263,15 +263,11 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
         startDt = dt;
       }
 
-      const newEndDt = startDt.add(GRID_SIZE_MINUTES, 'minutes');
-      const draftDuration =
-        newEndDt > eventEndDt ? newEndDt.diff(eventEndDt, 'minutes') : GRID_SIZE_MINUTES;
-
       setIsDragging(true);
       dispatch(
         actions.setDraftEntry({
           startDt,
-          duration: draftDuration, // TODO: (Ajob) Replace with default duration
+          duration: GRID_SIZE_MINUTES, // TODO: (Ajob) Replace with default duration
           y,
         })
       );
@@ -282,17 +278,22 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
         return;
       }
       const rect = calendarRef.current.getBoundingClientRect();
-      const duration = Math.max(
+      let draftDuration = Math.max(
         Math.round(pixelsToMinutes(event.clientY - rect.top - draftEntry.y) / GRID_SIZE_MINUTES) *
           GRID_SIZE_MINUTES,
         GRID_SIZE_MINUTES // TODO: Replace with default duration
       );
 
-      if (draftEntry.duration === duration) {
+      const newEndDt = moment(draftEntry.startDt).add(draftDuration, 'minutes');
+      if (newEndDt > eventEndDt) {
+        draftDuration = eventEndDt.diff(draftEntry.startDt, 'minutes');
+      }
+
+      if (draftEntry.duration === draftDuration) {
         return;
       }
 
-      dispatch(actions.setDraftEntry({...draftEntry, duration}));
+      dispatch(actions.setDraftEntry({...draftEntry, duration: draftDuration}));
     }
 
     function onKeyDown(event: KeyboardEvent) {

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -277,6 +277,8 @@ export function DayTimetable({
     }
 
     function onMouseMove(event: MouseEvent) {
+      const minDurationMinutes = 10;
+
       if (!isDragging || !draftEntry) {
         return;
       }
@@ -284,7 +286,7 @@ export function DayTimetable({
       const currentDragDuration = Math.max(
         Math.round(pixelsToMinutes(event.clientY - rect.top - draftEntry.y) / GRID_SIZE_MINUTES) *
           GRID_SIZE_MINUTES,
-        defaultContributionDuration
+        minDurationMinutes
       );
       const maxAllowedDuration = eventEndDt.diff(draftEntry.startDt, 'minutes');
       const draftDuration = Math.min(currentDragDuration, maxAllowedDuration);

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -36,6 +36,7 @@ interface DayTimetableProps {
   minHour: number;
   maxHour: number;
   entries: TopLevelEntry[];
+  scrollPosition?: number;
 }
 
 function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) {
@@ -80,11 +81,19 @@ function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) 
 
 const MemoizedTopLevelEntries = React.memo(TopLevelEntries);
 
-export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimetableProps) {
+export function DayTimetable({
+  dt,
+  eventId,
+  minHour,
+  maxHour,
+  entries,
+  scrollPosition = 0,
+}: DayTimetableProps) {
   const dispatch = useDispatch();
   const mouseEventRef = useRef<MouseEvent | null>(null);
   const unscheduled = useSelector(selectors.getUnscheduled);
   const calendarRef = useRef<HTMLDivElement | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
   const eventStartDt = useSelector(selectors.getEventStartDt);
   const eventEndDt = useSelector(selectors.getEventEndDt);
 
@@ -323,6 +332,12 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
     };
   }, [draftEntry, dt, dispatch, isDragging, minHour]);
 
+  useEffect(() => {
+    if (wrapperRef.current) {
+      wrapperRef.current.scrollTop = scrollPosition;
+    }
+  }, [scrollPosition, entries]);
+
   const restrictToCalendar = useMemo(() => createRestrictToCalendar(calendarRef), [calendarRef]);
   const limitsGradientArg = [
     'rgba(0, 0, 0, 0.05) 0%',
@@ -337,7 +352,7 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
   return (
     <DnDProvider onDrop={handleDragEnd} modifier={restrictToCalendar}>
       <UnscheduledContributions dt={dt} />
-      <div className="wrapper">
+      <div ref={wrapperRef} className="wrapper">
         <div styleName="wrapper">
           <TimeGutter minHour={minHour} maxHour={maxHour} />
           <DnDCalendar>

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -10,7 +10,6 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import './DayTimetable.module.scss';
-import {select} from 'indico/custom_elements/date_selection';
 
 import * as actions from './actions';
 import {Transform, Over, MousePosition} from './dnd';

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -106,11 +106,11 @@ export function DayTimetable({
   const eventEndDt = useSelector(selectors.getEventEndDt);
   const unscheduled = useSelector(selectors.getUnscheduled);
   const defaultContributionDuration = useSelector(selectors.getDefaultContribDurationMinutes);
-  const pixelLimitsTotal = useSelector(selectors.getCurrentPixelLimits);
+  const limits = useSelector(selectors.getCurrentLimits);
   const scrollPositionRef = useRef<number>(scrollPosition);
   const draftEntry = useSelector(selectors.getDraftEntry);
   const [isDragging, setIsDragging] = useState(false);
-  const pixelLimitsDelta: [number, number] = [pixelLimitsTotal[0], DAY_SIZE - pixelLimitsTotal[1]];
+  const limitsDelta: [number, number] = [limits[0], DAY_SIZE - limits[1]];
 
   entries = useMemo(() => computeYoffset(entries, minHour), [entries, minHour]);
 
@@ -241,7 +241,7 @@ export function DayTimetable({
 
   useEffect(() => {
     function onMouseDown(event: MouseEvent) {
-      const isWithinLimitsWithOffset = !isWithinLimits(pixelLimitsTotal, event.offsetY, [
+      const isWithinLimitsWithOffset = !isWithinLimits(limits, event.offsetY, [
         0,
         minutesToPixels(defaultContributionDuration),
       ]);
@@ -325,17 +325,17 @@ export function DayTimetable({
   }, [wrapperRef, scrollPositionRef]);
 
   const restrictToCalendar = useMemo(() => {
-    const restrictLimits = pixelLimitsDelta;
+    const restrictLimits = limitsDelta;
     restrictLimits[1] += TABLE_MARGIN_TOP;
-    return createRestrictToCalendar(calendarRef, pixelLimitsDelta);
-  }, [pixelLimitsDelta]);
+    return createRestrictToCalendar(calendarRef, limitsDelta);
+  }, [limitsDelta]);
 
   const limitsGradientArg = [
     'rgba(0, 0, 0, 0.05) 0',
-    `rgba(0, 0, 0, 0.05) ${pixelLimitsTotal[0]}px`,
-    `transparent ${pixelLimitsTotal[0]}px`,
-    `transparent ${pixelLimitsTotal[1]}px`,
-    `rgba(0, 0, 0, 0.05) ${pixelLimitsTotal[1]}px`,
+    `rgba(0, 0, 0, 0.05) ${limits[0]}px`,
+    `transparent ${limits[0]}px`,
+    `transparent ${limits[1]}px`,
+    `rgba(0, 0, 0, 0.05) ${limits[1]}px`,
     'rgba(0, 0, 0, 0.05)',
   ].join(', ');
   const limitsGradient = `linear-gradient(180deg, ${limitsGradientArg})`;

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -110,7 +110,6 @@ export function DayTimetable({
   const scrollPositionRef = useRef<number>(scrollPosition);
   const draftEntry = useSelector(selectors.getDraftEntry);
   const [isDragging, setIsDragging] = useState(false);
-  const limitsDelta: [number, number] = [limits[0], DAY_SIZE - limits[1]];
 
   entries = useMemo(() => computeYoffset(entries, minHour), [entries, minHour]);
 
@@ -325,10 +324,10 @@ export function DayTimetable({
   }, [wrapperRef]);
 
   const restrictToCalendar = useMemo(() => {
-    const restrictLimits = limitsDelta;
-    restrictLimits[1] += TABLE_MARGIN_TOP;
+    const limitsDelta: [number, number] = [limits[0], DAY_SIZE - limits[1]];
+    limitsDelta[1] += TABLE_MARGIN_TOP;
     return createRestrictToCalendar(calendarRef, limitsDelta);
-  }, [limitsDelta]);
+  }, [limits]);
 
   const limitsGradientArg = [
     'rgba(0, 0, 0, 0.05) 0',

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -319,6 +319,9 @@ export function DayTimetable({
 
   useEffect(() => {
     if (wrapperRef.current) {
+      // We use a ref instead of scrollPosition directly to prevent jumping
+      // to the calculated position every single time DayTimetable renders,
+      // which mainly happens when changing days.
       wrapperRef.current.scrollTop = scrollPositionRef.current;
     }
   }, [wrapperRef]);

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -322,7 +322,7 @@ export function DayTimetable({
     if (wrapperRef.current) {
       wrapperRef.current.scrollTop = scrollPositionRef.current;
     }
-  }, [wrapperRef, scrollPositionRef]);
+  }, [wrapperRef]);
 
   const restrictToCalendar = useMemo(() => {
     const restrictLimits = limitsDelta;

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -54,8 +54,7 @@ function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) 
     const obj = {};
     for (const e of entries) {
       obj[e.id] = (duration: number) => {
-        console.log('too far', dt.add(duration, 'seconds'));
-        dispatch(actions.resizeEntry(dt.format('YYYYMMDD'), e.id, duration));
+        dispatch(actions.resizeEntry(getDateKey(dt), e.id, duration));
       };
     }
     return obj;
@@ -65,7 +64,7 @@ function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) 
     const obj = {};
     for (const e of entries) {
       obj[e.id] = (id: string) => (duration: number) =>
-        dispatch(actions.resizeEntry(dt.format('YYYYMMDD'), id, duration, e.id));
+        dispatch(actions.resizeEntry(getDateKey(dt), id, duration, e.id));
     }
     return obj;
   }, [entries, dispatch, dt]);
@@ -212,7 +211,7 @@ export function DayTimetable({
 
   function handleDropOnCalendar(who: string, over: Over, delta: Transform, mouse: MousePosition) {
     const [newLayout, movedEntry] = layoutAfterDropOnCalendar(entries, who, over, delta, mouse);
-    dispatch(actions.moveEntry(movedEntry, eventId, newLayout, dt.format('YYYYMMDD')));
+    dispatch(actions.moveEntry(movedEntry, eventId, newLayout, getDateKey(dt)));
   }
 
   function handleDropOnBlock(
@@ -230,7 +229,7 @@ export function DayTimetable({
       mouse,
       calendar
     );
-    dispatch(actions.moveEntry(movedEntry, eventId, newLayout, dt.format('YYYYMMDD')));
+    dispatch(actions.moveEntry(movedEntry, eventId, newLayout, getDateKey(dt)));
   }
 
   function getTimelinePixelLimitsDelta(): [number, number] {

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -307,24 +307,14 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
 
   const restrictToCalendar = useMemo(() => createRestrictToCalendar(calendarRef), [calendarRef]);
 
-  const startHourLimit =
-    eventStartDt.day() === dt.day() ? eventStartDt.hour() + eventStartDt.minutes() / 60 : minHour;
-  const endHourLimit =
-    eventEndDt.day() === dt.day() ? eventEndDt.hour() + eventEndDt.minutes() / 60 : maxHour + 1;
-
-  const limits = [
-    ((startHourLimit - minHour) / (maxHour + 1 - minHour)) * 100,
-    (1 - (maxHour + 1 - endHourLimit) / (maxHour + 1 - minHour)) * 100,
-  ];
-
   return (
     <DnDProvider onDrop={handleDragEnd} modifier={restrictToCalendar}>
       <UnscheduledContributions dt={dt} />
       <div className="wrapper">
-        <div styleName="wrapper" style={{background: getTimelineLimitGradient()}}>
+        <div styleName="wrapper">
           <TimeGutter minHour={minHour} maxHour={maxHour} />
           <DnDCalendar>
-            <div ref={calendarRef}>
+            <div ref={calendarRef} style={{background: getTimelineLimitGradient()}}>
               <Lines minHour={minHour} maxHour={maxHour} />
               <MemoizedTopLevelEntries dt={dt} entries={entries} />
               {draftEntry && (

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -114,10 +114,6 @@ export function DayTimetable({
 
   entries = useMemo(() => computeYoffset(entries, minHour), [entries, minHour]);
 
-  const endHourLimit =
-    getDateKey(eventEndDt) === getDateKey(dt)
-      ? eventEndDt.hour() + eventEndDt.minutes() / 60
-      : maxHour + 1;
   const pixelLimitsDelta: [number, number] = getTimelinePixelLimitsDelta();
 
   function handleDragEnd(

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -46,20 +46,21 @@ export default function Timetable() {
 
   const minScrollHour = !isSingleDayEvent ? minHourWithContent : 0;
   const minHour = !isSingleDayEvent ? 0 : minHourWithContent;
-  const maxHour = !isSingleDayEvent
-    ? 24
-    : Math.max(
-        eventEndDt.hour(),
-        ...(useWeekView
-          ? Object.values(entries)
-              .flat()
-              .map(e => e.startDt.add(e.duration, 'minutes').hour())
-          : currentDateEntries.map(e =>
-              moment(e.startDt)
-                .add(e.duration, 'minutes')
-                .hour()
-            ))
-      );
+  const maxHour =
+    !isSingleDayEvent
+      ? 24
+      : Math.max(
+          eventEndDt.hour(),
+          ...(useWeekView
+            ? Object.values(entries)
+                .flat()
+                .map(e => e.startDt.add(e.duration, 'minutes').hour())
+            : currentDateEntries.map(e =>
+                moment(e.startDt)
+                  .add(e.duration, 'minutes')
+                  .hour()
+              ))
+        );
 
   return (
     <div styleName={`timetable ${isExpanded ? 'expanded' : ''}`}>

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -13,7 +13,7 @@ import * as actions from './actions';
 import {DayTimetable} from './DayTimetable';
 import * as selectors from './selectors';
 import Toolbar from './Toolbar';
-import {getDateKey} from './utils';
+import {getDateKey, minutesToPixels} from './utils';
 import {WeekTimetable} from './WeekTimetable';
 
 import './timetable.scss';
@@ -32,19 +32,20 @@ export default function Timetable() {
 
   const useWeekView = false;
 
-  const minHour = !isSingleDayEvent
-    ? 0
-    : Math.max(
-        Math.min(
-          eventStartDt.hour(),
-          ...(useWeekView
-            ? Object.values(entries)
-                .flat()
-                .map(e => e.startDt.hour())
-            : currentDateEntries.map(e => e.startDt.hour()))
-        ) - 1,
-        0
-      );
+  const minHourWithContent = Math.max(
+    Math.min(
+      eventStartDt.hour(),
+      ...(useWeekView
+        ? Object.values(entries)
+            .flat()
+            .map(e => e.startDt.hour())
+        : currentDateEntries.map(e => e.startDt.hour()))
+    ) - 1,
+    0
+  );
+
+  const minScrollHour = !isSingleDayEvent ? minHourWithContent : 0;
+  const minHour = !isSingleDayEvent ? 0 : minHourWithContent;
   const maxHour = !isSingleDayEvent
     ? 24
     : Math.max(
@@ -80,6 +81,7 @@ export default function Timetable() {
             minHour={minHour}
             maxHour={maxHour}
             entries={currentDateEntries}
+            scrollPosition={minutesToPixels(minScrollHour * 60)}
           />
         )}
       </div>

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -13,7 +13,7 @@ import * as actions from './actions';
 import {DayTimetable} from './DayTimetable';
 import * as selectors from './selectors';
 import Toolbar from './Toolbar';
-import {getDateKey, minutesToPixels} from './utils';
+import {getDateKey, HOUR_SIZE, minutesToPixels} from './utils';
 import {WeekTimetable} from './WeekTimetable';
 
 import './timetable.scss';
@@ -32,6 +32,7 @@ export default function Timetable() {
   //              when we implement a weekview. This is unlikely to be the
   //              current WeekView component, which does not use day timetables.
   const useWeekView = false;
+  const minScrollHour = 8;
   const minHour = 0;
   const maxHour = 23;
 
@@ -44,7 +45,7 @@ export default function Timetable() {
   const getScrollOffset = () => {
     const scrollMoment = getScrollMoment();
     const scrollMinutes = scrollMoment.diff(moment(scrollMoment).startOf('day'), 'minutes');
-    return minutesToPixels(scrollMinutes);
+    return minutesToPixels(Math.max(scrollMinutes, minScrollHour * 60));
   };
 
   return (

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -32,34 +32,33 @@ export default function Timetable() {
 
   const useWeekView = false;
 
-  let minHour = 0;
-  let maxHour = 23;
-
-  if (isSingleDayEvent) {
-    minHour = Math.max(
-      Math.min(
-        eventStartDt.hour(),
+  const minHour = !isSingleDayEvent
+    ? 0
+    : Math.max(
+        Math.min(
+          eventStartDt.hour(),
+          ...(useWeekView
+            ? Object.values(entries)
+                .flat()
+                .map(e => e.startDt.hour())
+            : currentDateEntries.map(e => e.startDt.hour()))
+        ) - 1,
+        0
+      );
+  const maxHour = !isSingleDayEvent
+    ? 24
+    : Math.max(
+        eventEndDt.hour(),
         ...(useWeekView
           ? Object.values(entries)
               .flat()
-              .map(e => e.startDt.hour())
-          : currentDateEntries.map(e => e.startDt.hour()))
-      ) - 1,
-      0
-    );
-    maxHour = Math.max(
-      eventEndDt.hour(),
-      ...(useWeekView
-        ? Object.values(entries)
-            .flat()
-            .map(e => e.startDt.add(e.duration, 'minutes').hour())
-        : currentDateEntries.map(e =>
-            moment(e.startDt)
-              .add(e.duration, 'minutes')
-              .hour()
-          ))
-    );
-  }
+              .map(e => e.startDt.add(e.duration, 'minutes').hour())
+          : currentDateEntries.map(e =>
+              moment(e.startDt)
+                .add(e.duration, 'minutes')
+                .hour()
+            ))
+      );
 
   return (
     <div styleName={`timetable ${isExpanded ? 'expanded' : ''}`}>

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -37,15 +37,17 @@ export default function Timetable() {
   const maxHour = 23;
 
   const getScrollMoment = () => {
-    const minAllowedDate = moment.max(currentDate, eventStartDt);
-    const firstEntryDate = moment.min(currentDateEntries.map(e => e.startDt));
-    return moment(moment.max(minAllowedDate, firstEntryDate));
+    const scrollMoment = !currentDateEntries.length
+      ? moment.max(currentDate, eventStartDt)
+      : moment.min(currentDateEntries.map(e => e.startDt));
+
+    return moment(scrollMoment);
   };
 
   const getScrollOffset = () => {
     const scrollMoment = getScrollMoment();
     const scrollMinutes = scrollMoment.diff(moment(scrollMoment).startOf('day'), 'minutes');
-    return minutesToPixels(Math.max(scrollMinutes, minScrollHour * 60));
+    return minutesToPixels(scrollMinutes);
   };
 
   return (
@@ -68,7 +70,7 @@ export default function Timetable() {
             minHour={minHour}
             maxHour={maxHour}
             entries={currentDateEntries}
-            scrollPosition={getScrollOffset()}
+            scrollPosition={Math.max(getScrollOffset(), HOUR_SIZE * minScrollHour)}
           />
         )}
       </div>

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -13,7 +13,7 @@ import * as actions from './actions';
 import {DayTimetable} from './DayTimetable';
 import * as selectors from './selectors';
 import Toolbar from './Toolbar';
-import {getDateKey, HOUR_SIZE, minutesToPixels} from './utils';
+import {getDateKey, minutesToPixels} from './utils';
 import {WeekTimetable} from './WeekTimetable';
 
 import './timetable.scss';
@@ -36,21 +36,21 @@ export default function Timetable() {
   const minHour = 0;
   const maxHour = 23;
 
-  const getScrollMoment = () => {
+  const _getScrollMoment = () => {
     const scrollMoment = !currentDateEntries.length
-      ? moment.max(currentDate, eventStartDt)
+      ? moment.max(currentDate.hours(minScrollHour), eventStartDt)
       : moment.min(currentDateEntries.map(e => e.startDt));
 
     return moment(scrollMoment);
   };
 
-  const getScrollOffset = () => {
-    const scrollMoment = getScrollMoment();
+  const _getScrollOffset = () => {
+    const scrollMoment = _getScrollMoment();
     const scrollMinutes = scrollMoment.diff(moment(scrollMoment).startOf('day'), 'minutes');
     return minutesToPixels(scrollMinutes);
   };
 
-  const initialScrollPosition = Math.max(getScrollOffset(), HOUR_SIZE * minScrollHour);
+  const initialScrollPosition = _getScrollOffset();
 
   return (
     <div styleName={`timetable ${isExpanded ? 'expanded' : ''}`}>

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -50,6 +50,8 @@ export default function Timetable() {
     return minutesToPixels(scrollMinutes);
   };
 
+  const initialScrollPosition = Math.max(getScrollOffset(), HOUR_SIZE * minScrollHour);
+
   return (
     <div styleName={`timetable ${isExpanded ? 'expanded' : ''}`}>
       <GlobalEvents />
@@ -70,7 +72,7 @@ export default function Timetable() {
             minHour={minHour}
             maxHour={maxHour}
             entries={currentDateEntries}
-            scrollPosition={Math.max(getScrollOffset(), HOUR_SIZE * minScrollHour)}
+            scrollPosition={initialScrollPosition}
           />
         )}
       </div>

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -25,35 +25,41 @@ export default function Timetable() {
   const eventId = useSelector(selectors.getEventId);
   const eventStartDt = useSelector(selectors.getEventStartDt);
   const eventEndDt = useSelector(selectors.getEventEndDt);
-  // TODO: (Ajob) Get rid of this after disabled areas are merged
-  const showAllTimeslots = true;
   const isExpanded = useSelector(selectors.getIsExpanded);
   const currentDate = useSelector(selectors.getCurrentDate);
   const currentDateEntries = entries[getDateKey(currentDate)];
+  const isSingleDayEvent = eventStartDt.day() === eventEndDt.day();
+
   const useWeekView = false;
-  const minHour = showAllTimeslots
-    ? 0
-    : Math.max(
-        Math.min(
-          eventStartDt.hour(),
-          ...(useWeekView
-            ? Object.values(entries)
-                .flat()
-                .map(e => e.startDt.hour())
-            : currentDateEntries.map(e => e.startDt.hour()))
-        ) - 1,
-        0
-      );
-  const maxHour = showAllTimeslots
-    ? 24
-    : Math.max(
-        eventEndDt.hour(),
+
+  let minHour = 0;
+  let maxHour = 23;
+
+  if (isSingleDayEvent) {
+    minHour = Math.max(
+      Math.min(
+        eventStartDt.hour(),
         ...(useWeekView
           ? Object.values(entries)
               .flat()
-              .map(e => e.startDt.add(e.duration, 'minutes').hour())
-          : currentDateEntries.map(e => moment(e.startDt).add(e.duration, 'minutes').hour()))
-      );
+              .map(e => e.startDt.hour())
+          : currentDateEntries.map(e => e.startDt.hour()))
+      ) - 1,
+      0
+    );
+    maxHour = Math.max(
+      eventEndDt.hour(),
+      ...(useWeekView
+        ? Object.values(entries)
+            .flat()
+            .map(e => e.startDt.add(e.duration, 'minutes').hour())
+        : currentDateEntries.map(e =>
+            moment(e.startDt)
+              .add(e.duration, 'minutes')
+              .hour()
+          ))
+    );
+  }
 
   return (
     <div styleName={`timetable ${isExpanded ? 'expanded' : ''}`}>

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -47,7 +47,7 @@ export default function Timetable() {
   const minScrollHour = !isSingleDayEvent ? minHourWithContent : 0;
   const minHour = !isSingleDayEvent ? 0 : minHourWithContent;
   const maxHour = !isSingleDayEvent
-    ? 24
+    ? 23
     : Math.max(
         eventEndDt.hour(),
         ...(useWeekView

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -13,7 +13,7 @@ import * as actions from './actions';
 import {DayTimetable} from './DayTimetable';
 import * as selectors from './selectors';
 import Toolbar from './Toolbar';
-import {getDateKey, minutesToPixels, pixelsToMinutes} from './utils';
+import {getDateKey, minutesToPixels} from './utils';
 import {WeekTimetable} from './WeekTimetable';
 
 import './timetable.scss';

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -46,21 +46,20 @@ export default function Timetable() {
 
   const minScrollHour = !isSingleDayEvent ? minHourWithContent : 0;
   const minHour = !isSingleDayEvent ? 0 : minHourWithContent;
-  const maxHour =
-    !isSingleDayEvent
-      ? 24
-      : Math.max(
-          eventEndDt.hour(),
-          ...(useWeekView
-            ? Object.values(entries)
-                .flat()
-                .map(e => e.startDt.add(e.duration, 'minutes').hour())
-            : currentDateEntries.map(e =>
-                moment(e.startDt)
-                  .add(e.duration, 'minutes')
-                  .hour()
-              ))
-        );
+  const maxHour = !isSingleDayEvent
+    ? 24
+    : Math.max(
+        eventEndDt.hour(),
+        ...(useWeekView
+          ? Object.values(entries)
+              .flat()
+              .map(e => e.startDt.add(e.duration, 'minutes').hour())
+          : currentDateEntries.map(e =>
+              moment(e.startDt)
+                .add(e.duration, 'minutes')
+                .hour()
+            ))
+      );
 
   return (
     <div styleName={`timetable ${isExpanded ? 'expanded' : ''}`}>

--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -99,7 +99,7 @@ export default function Toolbar({
 
   useEffect(() => {
     scrollToDay(currentDayIdxRef.current);
-  }, [currentDayIdxRef, daysBarRef.current]);
+  }, [currentDayIdxRef]);
 
   return (
     <div styleName="toolbar" ref={ref}>

--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -98,10 +98,8 @@ export default function Toolbar({
   };
 
   useEffect(() => {
-    if (daysBarRef.current) {
-      scrollToDay(currentDayIdxRef.current);
-    }
-  }, [currentDayIdxRef]);
+    scrollToDay(currentDayIdxRef.current);
+  }, [currentDayIdxRef, daysBarRef.current]);
 
   return (
     <div styleName="toolbar" ref={ref}>

--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -98,7 +98,9 @@ export default function Toolbar({
   };
 
   useEffect(() => {
-    scrollToDay(currentDayIdxRef.current);
+    if (daysBarRef.current) {
+      scrollToDay(currentDayIdxRef.current);
+    }
   }, [currentDayIdxRef]);
 
   return (

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -207,12 +207,10 @@ export function DnDProvider({
   children,
   onDrop,
   modifier = ({transform}) => transform,
-  limits,
 }: {
   children: React.ReactNode;
   onDrop: OnDrop;
   modifier?: Modifier;
-  limits?: [number, number];
 }) {
   const [droppables, setDroppables] = useState<Droppables>({});
   const [draggables, setDraggables] = useState<Draggables>({});
@@ -231,8 +229,8 @@ export function DnDProvider({
     draggables,
     enabled:
       // TODO: does not really work atm
-      state.current.activeDraggable !== null,
-    limits,
+      state.current.activeDraggable === null ||
+      !state.current.activeDraggable.startsWith('unscheduled'),
   });
 
   const registerDroppable = useCallback((id, node) => {

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -207,7 +207,7 @@ export function DnDProvider({
   children,
   onDrop,
   modifier = ({transform}) => transform,
-  limits = [0, 0],
+  limits,
 }: {
   children: React.ReactNode;
   onDrop: OnDrop;
@@ -217,7 +217,6 @@ export function DnDProvider({
   const [droppables, setDroppables] = useState<Droppables>({});
   const [draggables, setDraggables] = useState<Draggables>({});
   const [draggableData, setDraggableData] = useState<DraggableData>({});
-  const [isWithinLimits, setIsWithinLimits] = useState<boolean>(true);
   const state = useRef<DnDState>({
     state: 'idle',
     initialMousePosition: {x: 0, y: 0},
@@ -232,7 +231,8 @@ export function DnDProvider({
     draggables,
     enabled:
       // TODO: does not really work atm
-      isWithinLimits && state.current.activeDraggable !== null,
+      state.current.activeDraggable !== null,
+    limits,
   });
 
   const registerDroppable = useCallback((id, node) => {
@@ -297,25 +297,19 @@ export function DnDProvider({
           x: e.pageX + state.current.scrollPosition.x,
           y: e.pageY + state.current.scrollPosition.y,
         };
-        // TODO: (Ajob) Doesn't work properly because e.pageY is more than just the timetable lines
-        const withinLimits = mousePosition.y >= limits[0] && mousePosition.y <= limits[1];
-        setIsWithinLimits(withinLimits);
-
-        if (withinLimits) {
-          setDraggableData(d =>
-            setMousePosition(
-              setTransform(
-                d,
-                state.current.activeDraggable,
-                state.current.initialMousePosition,
-                mousePosition,
-                modifier
-              ),
+        setDraggableData(d =>
+          setMousePosition(
+            setTransform(
+              d,
               state.current.activeDraggable,
-              {x: e.pageX, y: e.pageY}
-            )
-          );
-        }
+              state.current.initialMousePosition,
+              mousePosition,
+              modifier
+            ),
+            state.current.activeDraggable,
+            {x: e.pageX, y: e.pageY}
+          )
+        );
       }
     },
     [modifier]

--- a/indico/modules/events/timetable/client/js/dnd/modifiers.ts
+++ b/indico/modules/events/timetable/client/js/dnd/modifiers.ts
@@ -112,15 +112,15 @@ export const createRestrictToCalendar =
       return transform;
     }
 
-    let rect = containerRef.current.getBoundingClientRect();
+    const boundingRect = containerRef.current.getBoundingClientRect();
     const scroll = getTotalScroll(containerRef.current);
-    rect = {
-      top: rect.top + scroll.top + limits[0],
-      left: rect.left + scroll.left,
-      bottom: rect.bottom + scroll.top - limits[1],
-      right: rect.right + scroll.left,
-      width: rect.width,
-      height: rect.height - limits[0] - limits[1],
+    const rect = {
+      top: boundingRect.top + scroll.top + limits[0],
+      left: boundingRect.left + scroll.left,
+      bottom: boundingRect.bottom + scroll.top - limits[1],
+      right: boundingRect.right + scroll.left,
+      width: boundingRect.width,
+      height: boundingRect.height - limits[0] - limits[1],
     };
 
     return restrictToBoundingRect(transform, draggingNodeRect, rect);

--- a/indico/modules/events/timetable/client/js/dnd/modifiers.ts
+++ b/indico/modules/events/timetable/client/js/dnd/modifiers.ts
@@ -100,7 +100,7 @@ export function getTotalScroll(element: HTMLElement): {top: number; left: number
 /**
  * Restrict the dragged node to be contained within the calendar if it's
  * already scheduled. By default this takes into account the entire area of
- * the calendar, but can be limited to a specific region. 
+ * the calendar, but can be limited to a specific region.
  * @param containerRef React ref to the container element
  * @param limits Pixel limits on both sides of the y-axis
  * @returns A new Transform object

--- a/indico/modules/events/timetable/client/js/dnd/modifiers.ts
+++ b/indico/modules/events/timetable/client/js/dnd/modifiers.ts
@@ -46,9 +46,9 @@ export const createRestrictToElement =
       return transform;
     }
 
-    let rect = containerRef.current.getBoundingClientRect();
+    const boundingRect = containerRef.current.getBoundingClientRect();
     const scroll = getTotalScroll(containerRef.current);
-    rect = {
+    const rect = {
       // top: rect.top,
       // left: rect.left,
       // bottom: rect.bottom,
@@ -57,12 +57,12 @@ export const createRestrictToElement =
       // left: rect.left + scrollParent.scrollLeft,
       // bottom: rect.bottom + scrollParent.scrollTop,
       // right: rect.right + scrollParent.scrollLeft,
-      top: rect.top + scroll.top,
-      left: rect.left + scroll.left,
-      bottom: rect.bottom + scroll.top,
-      right: rect.right + scroll.left,
-      width: rect.width,
-      height: rect.height,
+      top: boundingRect.top + scroll.top,
+      left: boundingRect.left + scroll.left,
+      bottom: boundingRect.bottom + scroll.top,
+      right: boundingRect.right + scroll.left,
+      width: boundingRect.width,
+      height: boundingRect.height,
     };
     return restrictToBoundingRect(transform, draggingNodeRect, rect);
   };
@@ -99,7 +99,8 @@ export function getTotalScroll(element: HTMLElement): {top: number; left: number
 
 /**
  * Restrict the dragged node to be contained within the calendar if it's
- * already scheduled. Allows pixel limits to be set.
+ * already scheduled. By default this takes into account the entire area of
+ * the calendar, but can be limited to a specific region. 
  * @param containerRef React ref to the container element
  * @param limits Pixel limits on both sides of the y-axis
  * @returns A new Transform object

--- a/indico/modules/events/timetable/client/js/dnd/modifiers.ts
+++ b/indico/modules/events/timetable/client/js/dnd/modifiers.ts
@@ -99,34 +99,16 @@ export function getTotalScroll(element: HTMLElement): {top: number; left: number
 
 /**
  * Restrict the dragged node to be contained within the calendar if it's
- * already scheduled.
- * @param containerRef React ref to the container element
- * @returns A new Transform object
- */
-export const createRestrictToCalendar = (containerRef): Modifier => ({
-  draggingNodeRect,
-  transform,
-  id,
-}) => {
-  if (id.startsWith('unscheduled-')) {
-    // return createRestrictToElement(unscheduledRef)({draggingNodeRect, transform, id});
-    return transform;
-  }
-  return createRestrictToElement(containerRef)({draggingNodeRect, transform, id});
-};
-
-/**
- * Restrict the dragged node to be contained within the calendar if it's
  * already scheduled. Allows pixel limits to be set.
  * @param containerRef React ref to the container element
  * @param limits Pixel limits on both sides of the y-axis
  * @returns A new Transform object
  */
-export const createRestrictToCalendarWithLimits = (
+export const createRestrictToCalendar = (
   containerRef,
-  limits?: [number, number]
-): Modifier => ({draggingNodeRect, transform}) => {
-  if (!draggingNodeRect || !containerRef.current) {
+  limits: [number, number] = [0, 0]
+): Modifier => ({id, draggingNodeRect, transform}) => {
+  if (id.startsWith('unscheduled')) {
     return transform;
   }
 

--- a/indico/modules/events/timetable/client/js/dnd/modifiers.ts
+++ b/indico/modules/events/timetable/client/js/dnd/modifiers.ts
@@ -103,12 +103,43 @@ export function getTotalScroll(element: HTMLElement): {top: number; left: number
  * @param containerRef React ref to the container element
  * @returns A new Transform object
  */
-export const createRestrictToCalendar =
-  (containerRef): Modifier =>
-  ({draggingNodeRect, transform, id}) => {
-    if (id.startsWith('unscheduled-')) {
-      // return createRestrictToElement(unscheduledRef)({draggingNodeRect, transform, id});
-      return transform;
-    }
-    return createRestrictToElement(containerRef)({draggingNodeRect, transform, id});
+export const createRestrictToCalendar = (containerRef): Modifier => ({
+  draggingNodeRect,
+  transform,
+  id,
+}) => {
+  if (id.startsWith('unscheduled-')) {
+    // return createRestrictToElement(unscheduledRef)({draggingNodeRect, transform, id});
+    return transform;
+  }
+  return createRestrictToElement(containerRef)({draggingNodeRect, transform, id});
+};
+
+/**
+ * Restrict the dragged node to be contained within the calendar if it's
+ * already scheduled. Allows pixel limits to be set.
+ * @param containerRef React ref to the container element
+ * @param limits Pixel limits on both sides of the y-axis
+ * @returns A new Transform object
+ */
+export const createRestrictToCalendarWithLimits = (
+  containerRef,
+  limits?: [number, number]
+): Modifier => ({draggingNodeRect, transform}) => {
+  if (!draggingNodeRect || !containerRef.current) {
+    return transform;
+  }
+
+  let rect = containerRef.current.getBoundingClientRect();
+  const scroll = getTotalScroll(containerRef.current);
+  rect = {
+    top: rect.top + scroll.top + limits[0],
+    left: rect.left + scroll.left,
+    bottom: rect.bottom + scroll.top - limits[1],
+    right: rect.right + scroll.left,
+    width: rect.width,
+    height: rect.height - limits[0] - limits[1],
   };
+
+  return restrictToBoundingRect(transform, draggingNodeRect, rect);
+};

--- a/indico/modules/events/timetable/client/js/dnd/modifiers.ts
+++ b/indico/modules/events/timetable/client/js/dnd/modifiers.ts
@@ -104,24 +104,23 @@ export function getTotalScroll(element: HTMLElement): {top: number; left: number
  * @param limits Pixel limits on both sides of the y-axis
  * @returns A new Transform object
  */
-export const createRestrictToCalendar = (
-  containerRef,
-  limits: [number, number] = [0, 0]
-): Modifier => ({id, draggingNodeRect, transform}) => {
-  if (id.startsWith('unscheduled')) {
-    return transform;
-  }
+export const createRestrictToCalendar =
+  (containerRef, limits: [number, number] = [0, 0]): Modifier =>
+  ({id, draggingNodeRect, transform}) => {
+    if (id.startsWith('unscheduled')) {
+      return transform;
+    }
 
-  let rect = containerRef.current.getBoundingClientRect();
-  const scroll = getTotalScroll(containerRef.current);
-  rect = {
-    top: rect.top + scroll.top + limits[0],
-    left: rect.left + scroll.left,
-    bottom: rect.bottom + scroll.top - limits[1],
-    right: rect.right + scroll.left,
-    width: rect.width,
-    height: rect.height - limits[0] - limits[1],
+    let rect = containerRef.current.getBoundingClientRect();
+    const scroll = getTotalScroll(containerRef.current);
+    rect = {
+      top: rect.top + scroll.top + limits[0],
+      left: rect.left + scroll.left,
+      bottom: rect.bottom + scroll.top - limits[1],
+      right: rect.right + scroll.left,
+      width: rect.width,
+      height: rect.height - limits[0] - limits[1],
+    };
+
+    return restrictToBoundingRect(transform, draggingNodeRect, rect);
   };
-
-  return restrictToBoundingRect(transform, draggingNodeRect, rect);
-};

--- a/indico/modules/events/timetable/client/js/dnd/scroll.ts
+++ b/indico/modules/events/timetable/client/js/dnd/scroll.ts
@@ -11,7 +11,7 @@ import {getScrollParent} from './modifiers';
 import {Draggable, MousePosition} from './types';
 
 const SCROLL_MARGIN_PERCENT = 0.15;
-const SCROLL_MAX_OFFSET_PX = 100;
+const SCROLL_MAX_OFFSET_PX = 200;
 const SCROLL_INTERVAL_MS = 5;
 const BASE_SPEED = 3;
 
@@ -53,40 +53,22 @@ export function useScrollIntent({
       const draggable = draggables[state.current.activeDraggable];
       const scrollParent = getScrollParent(draggable.node.current);
 
-      // const rect = scrollParent.getBoundingClientRect();
       // const dragRect = draggable.node.current.getBoundingClientRect();
-
-      // const draggablePosTop = dragRect.top - rect.top + scrollParent.scrollTop;
-      // const draggablePosBottom = draggablePosTop + dragRect.height;
 
       scrollSpeed.current = getScrollSpeed({x: event.clientX, y: event.clientY}, scrollParent);
 
-      // console.log('top', draggablePosTop, 'rrr', Math.random());
-      // console.log(limits);
-      // if (
-      //   draggablePosTop <= limits[0] + BASE_SPEED ||
-      //   draggablePosBottom >= limits[1] - BASE_SPEED
-      // ) {
-      //   console.log('no speed here');
-      //   scrollSpeed.current.y = 0;
-      // }
+      const direction = Math.sign(scrollSpeed.current.y);
 
       if (scrollSpeed.current.x !== 0 || scrollSpeed.current.y !== 0) {
         if (intervalRef.current === null) {
           intervalRef.current = setInterval(() => {
-            const parentRect = scrollParent.getBoundingClientRect();
-            const dragRect = draggable.node.current.getBoundingClientRect();
-
-            const draggableTop = dragRect.top - parentRect.top + scrollParent.scrollTop;
-            const draggableBottom = draggableTop + dragRect.height;
-
-            // const newTop = draggableTop + scrollSpeed.current.y;
             const newTop = scrollSpeed.current.y + scrollParent.scrollTop;
-            const newBottom = draggableBottom + scrollSpeed.current.y;
+            const newBottom =
+              scrollSpeed.current.y + scrollParent.scrollTop + scrollParent.clientHeight;
 
-            if (newTop + SCROLL_MAX_OFFSET_PX <= limits[0]) {
+            if (direction === -1 && newTop + SCROLL_MAX_OFFSET_PX <= limits[0]) {
               scrollSpeed.current.y = 0;
-            } else if (newBottom - SCROLL_MAX_OFFSET_PX >= limits[1]) {
+            } else if (direction === 1 && newBottom - SCROLL_MAX_OFFSET_PX >= limits[1]) {
               scrollSpeed.current.y = 0;
             }
 
@@ -105,7 +87,7 @@ export function useScrollIntent({
       window.removeEventListener('mousemove', handleMouseMove);
       clearInterval(id);
     };
-  }, [state, draggables, enabled]);
+  }, [state, draggables, enabled, limits]);
 }
 
 function getScrollSpeed(mouse: MousePosition, scrollParent: HTMLElement) {

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -67,7 +67,7 @@ export const getCurrentLimits = createSelector(
   getEventStartDt,
   getEventEndDt,
   (currentDate: Moment, startDt: Moment, endDt: Moment): [number, number] => {
-    const limits: [number, number] = [0, DAY_SIZE]
+    const limits: [number, number] = [0, DAY_SIZE];
 
     if (startDt.isSame(currentDate, 'day')) {
       limits[0] = minutesToPixels(moment.duration(startDt.format('HH:mm')).asMinutes());

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -10,7 +10,7 @@ import {createSelector} from 'reselect';
 
 import {ReduxState} from './reducers';
 import {appendSessionAttributes} from './util';
-import {getDateKey, minutesToPixels} from './utils';
+import {DAY_SIZE, getDateKey, minutesToPixels} from './utils';
 
 export const getStaticData = state => state.staticData;
 export const getEntries = (state: ReduxState) => state.entries;
@@ -76,7 +76,7 @@ export const getCurrentPixelLimits = createSelector(
       limits[0] = 0;
     }
     if (getDateKey(currentDate) !== getDateKey(endDt)) {
-      limits[1] = minutesToPixels(24 * 60);
+      limits[1] = DAY_SIZE;
     }
 
     return limits;
@@ -84,10 +84,7 @@ export const getCurrentPixelLimits = createSelector(
 );
 export const getCurrentLimits = createSelector(
   getCurrentPixelLimits,
-  (limits): [number, number] => [
-    limits[0] / minutesToPixels(24 * 60),
-    limits[1] / minutesToPixels(24 * 60),
-  ]
+  (limits): [number, number] => [limits[0] / DAY_SIZE, limits[1] / DAY_SIZE]
 );
 export const getCurrentDayEntries = createSelector(
   getDayEntries,

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import moment, { Moment } from 'moment';
+import moment, {Moment} from 'moment';
 import {createSelector} from 'reselect';
 
 import {ReduxState} from './reducers';

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -67,16 +67,14 @@ export const getCurrentLimits = createSelector(
   getEventStartDt,
   getEventEndDt,
   (currentDate: Moment, startDt: Moment, endDt: Moment): [number, number] => {
-    const limits: [number, number] = [
-      minutesToPixels(moment.duration(startDt.format('HH:mm')).asMinutes()),
-      minutesToPixels(moment.duration(endDt.format('HH:mm')).asMinutes()),
-    ];
+    const limits: [number, number] = [0, DAY_SIZE]
 
     if (startDt.isSame(currentDate, 'day')) {
-      limits[0] = 0;
+      limits[0] = minutesToPixels(moment.duration(startDt.format('HH:mm')).asMinutes());
     }
+
     if (endDt.isSame(currentDate, 'day')) {
-      limits[1] = DAY_SIZE;
+      limits[1] = minutesToPixels(moment.duration(endDt.format('HH:mm')).asMinutes());
     }
 
     return limits;

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -5,13 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import moment, {Moment} from 'moment';
+import moment, { Moment } from 'moment';
 import {createSelector} from 'reselect';
 
 import {ReduxState} from './reducers';
 import {appendSessionAttributes} from './util';
 import {DAY_SIZE, getDateKey, minutesToPixels} from './utils';
-import { isSameDate } from 'indico/utils/date';
 
 export const getStaticData = state => state.staticData;
 export const getEntries = (state: ReduxState) => state.entries;
@@ -38,11 +37,20 @@ export const makeIsSelectedSelector = () =>
     (selectedId, id) => selectedId === id
   );
 
-export const getEventId = createSelector(getStaticData, staticData => {
-  return staticData.eventId;
-});
-export const getEventStartDt = createSelector(getStaticData, staticData => staticData.startDt);
-export const getEventEndDt = createSelector(getStaticData, staticData => staticData.endDt);
+export const getEventId = createSelector(
+  getStaticData,
+  staticData => {
+    return staticData.eventId;
+  }
+);
+export const getEventStartDt = createSelector(
+  getStaticData,
+  staticData => staticData.startDt
+);
+export const getEventEndDt = createSelector(
+  getStaticData,
+  staticData => staticData.endDt
+);
 export const getEventNumDays = createSelector(
   getEventStartDt,
   getEventEndDt,
@@ -74,30 +82,49 @@ export const getCurrentLimits = createSelector(
     return limits;
   }
 );
+
 export const getCurrentDayEntries = createSelector(
   getDayEntries,
   getCurrentDate,
   (entries, currentDate) => entries[getDateKey(currentDate)]
 );
 
-export const getUnscheduled = createSelector(getLatestChange, getSessions, (entries, sessions) =>
-  appendSessionAttributes(entries.unscheduled, sessions)
+export const getUnscheduled = createSelector(
+  getLatestChange,
+  getSessions,
+  (entries, sessions) => appendSessionAttributes(entries.unscheduled, sessions)
 );
 
-export const getSelectedEntry = createSelector(getDayEntries, getSelectedId, (entries, id) => {
-  entries = Object.values(entries).flatMap(x => x);
-  entries = entries.flatMap(e => (e.type === 'block' ? [e, ...e.children] : [e]));
-  return entries.find(e => e.id === id);
-});
-export const getDraftEntry = createSelector(getEntries, entries => entries.draftEntry);
-export const canUndo = createSelector(getEntries, entries => entries.currentChangeIdx > 0);
+export const getSelectedEntry = createSelector(
+  getDayEntries,
+  getSelectedId,
+  (entries, id) => {
+    entries = Object.values(entries).flatMap(x => x);
+    entries = entries.flatMap(e => (e.type === 'block' ? [e, ...e.children] : [e]));
+    return entries.find(e => e.id === id);
+  }
+);
+export const getDraftEntry = createSelector(
+  getEntries,
+  entries => entries.draftEntry
+);
+export const canUndo = createSelector(
+  getEntries,
+  entries => entries.currentChangeIdx > 0
+);
 export const canRedo = createSelector(
   getEntries,
   entries => entries.currentChangeIdx < entries.changes.length - 1
 );
-export const getError = createSelector(getEntries, entries => entries.error);
+export const getError = createSelector(
+  getEntries,
+  entries => entries.error
+);
 
-export const showUnscheduled = createSelector(getDisplay, display => display.showUnscheduled);
+export const showUnscheduled = createSelector(
+  getDisplay,
+  display => display.showUnscheduled
+);
 
 export const getDefaultContribDurationMinutes = createSelector(
   getStaticData,
@@ -105,5 +132,11 @@ export const getDefaultContribDurationMinutes = createSelector(
 );
 
 // Navigation state
-export const getIsExpanded = createSelector(getNavigation, navigation => navigation.isExpanded);
-export const getIsDraft = createSelector(getNavigation, navigation => navigation.isDraft);
+export const getIsExpanded = createSelector(
+  getNavigation,
+  navigation => navigation.isExpanded
+);
+export const getIsDraft = createSelector(
+  getNavigation,
+  navigation => navigation.isDraft
+);

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -5,11 +5,12 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import moment from 'moment';
 import {createSelector} from 'reselect';
 
 import {ReduxState} from './reducers';
 import {appendSessionAttributes} from './util';
-import {getDateKey} from './utils';
+import {getDateKey, minutesToPixels} from './utils';
 
 export const getStaticData = state => state.staticData;
 export const getEntries = (state: ReduxState) => state.entries;
@@ -61,6 +62,33 @@ export const getSessionById = createSelector(
   (sessions, id) => sessions[id]
 );
 
+export const getCurrentPixelLimits = createSelector(
+  getCurrentDate,
+  getEventStartDt,
+  getEventEndDt,
+  (currentDate, startDt, endDt): [number, number] => {
+    const limits: [number, number] = [
+      minutesToPixels(moment.duration(startDt.format('HH:mm')).asMinutes()),
+      minutesToPixels(moment.duration(endDt.format('HH:mm')).asMinutes()),
+    ];
+
+    if (getDateKey(currentDate) !== getDateKey(startDt)) {
+      limits[0] = 0;
+    }
+    if (getDateKey(currentDate) !== getDateKey(endDt)) {
+      limits[1] = minutesToPixels(24 * 60);
+    }
+
+    return limits;
+  }
+);
+export const getCurrentLimits = createSelector(
+  getCurrentPixelLimits,
+  (limits): [number, number] => [
+    limits[0] / minutesToPixels(24 * 60),
+    limits[1] / minutesToPixels(24 * 60),
+  ]
+);
 export const getCurrentDayEntries = createSelector(
   getDayEntries,
   getCurrentDate,

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -34,6 +34,10 @@ export function pixelsToMinutes(pixels: number) {
   return Math.round(pixels / 2);
 }
 
+export function isWithinLimits(limits: [number, number], y, offsets = [0, 0]) {
+  return y > limits[0] + offsets[0] && y < limits[1] - offsets[1];
+}
+
 export function minutesFromStartOfDay(dt: Moment) {
   return moment(dt).diff(moment(dt).startOf('day'), 'minutes');
 }

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -17,6 +17,8 @@ export const DATE_KEY_FORMAT = 'YYYYMMDD';
 export const LOCAL_STORAGE_KEY = 'manageTimetableData';
 export const GRID_SIZE_MINUTES = 5;
 export const GRID_SIZE = minutesToPixels(GRID_SIZE_MINUTES);
+export const HOUR_SIZE = minutesToPixels(60);
+export const DAY_SIZE = 24 * HOUR_SIZE;
 
 export function snapPixels(x: number) {
   return Math.ceil(x / GRID_SIZE) * GRID_SIZE;

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -36,7 +36,11 @@ export function pixelsToMinutes(pixels: number) {
   return Math.round(pixels / 2);
 }
 
-export function isWithinLimits(limits: [number, number], y, offsets = [0, 0]) {
+export function isWithinLimits(
+  limits: [number, number],
+  y: number,
+  offsets = [0, 0]
+) {
   return y > limits[0] + offsets[0] && y < limits[1] - offsets[1];
 }
 

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -106,6 +106,7 @@ export const mapTTDataToEntry = (data, sessions): Entry => {
     code,
     keywords,
     sessionId,
+    sessionTitle = '',
     sessionBlockId,
     sessionTitle,
   } = data;
@@ -137,6 +138,7 @@ export const mapTTDataToEntry = (data, sessions): Entry => {
     sessionBlockId: sessionBlockId || null,
     sessionTitle: sessionTitle || '',
     colors: mapTTEntryColor(data, sessions),
+    sessionTitle: sessionTitle,
   };
 
   if (sessionBlockId) {

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -112,9 +112,8 @@ export const mapTTDataToEntry = (data, sessions): Entry => {
     code,
     keywords,
     sessionId,
-    sessionTitle = '',
-    sessionBlockId,
     sessionTitle,
+    sessionBlockId,
   } = data;
 
   const mappedObj = {
@@ -144,7 +143,6 @@ export const mapTTDataToEntry = (data, sessions): Entry => {
     sessionBlockId: sessionBlockId || null,
     sessionTitle: sessionTitle || '',
     colors: mapTTEntryColor(data, sessions),
-    sessionTitle: sessionTitle,
   };
 
   if (sessionBlockId) {

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -36,11 +36,7 @@ export function pixelsToMinutes(pixels: number) {
   return Math.round(pixels / 2);
 }
 
-export function isWithinLimits(
-  limits: [number, number],
-  y: number,
-  offsets = [0, 0]
-) {
+export function isWithinLimits(limits: [number, number], y: number, offsets = [0, 0]) {
   return y > limits[0] + offsets[0] && y < limits[1] - offsets[1];
 }
 


### PR DESCRIPTION
This PR disables interaction on the timetable with slots that are outside of the event duration. It's visual and also includes limitations on creating and dragging entries. Also scrolls to relevant part of timetable.

_PS: The screenshots still use the old toolbar (other PR) and have single-day events clamped between hours (so no 24-hour view). I was a bit too lazy to update the screenshots_

**Single day example** _(Disabled both sides):_
![image](https://github.com/user-attachments/assets/ba9e6706-19ac-4a94-9b78-8d794ef7efa1)

**Multi-day example** _(Disabled one side on first and last days):_
_First day_
![image](https://github.com/user-attachments/assets/be843b3e-3852-42a9-ba91-a109d6a13bae)

_Last day_
![Screenshot from 2025-07-08 12-09-28](https://github.com/user-attachments/assets/cf30f72d-8918-40a3-830f-9fb05b4da36d)


