### PR TITLE
Fix double dialogue

### DIFF
--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -11,7 +11,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import * as actions from './actions';
 import ContributionEntry from './ContributionEntry';
 import {useDraggable} from './dnd';
-import {TimetablePopup} from './EntryPopup';
+import {EntryPopup} from './EntryPopup';
 import {ReduxState} from './reducers';
 import * as selectors from './selectors';
 
@@ -81,7 +81,7 @@ export function DraggableEntry({id, isChild = false, ...rest}: DraggableEntryPro
 
   if (popupsEnabled && isSelected && !isDragging) {
     return (
-      <TimetablePopup
+      <EntryPopup
         trigger={entry}
         onClose={() => {
           dispatch(actions.deselectEntry());

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -75,7 +75,7 @@ function EntryPopupContent({
   const eventId = useSelector(selectors.getEventId);
 
   const onEdit = async (e: MouseEvent) => {
-    if (!draftEntry.id) {
+    if (!draftEntry.objId) {
       return;
     }
 
@@ -83,9 +83,9 @@ function EntryPopupContent({
     e.stopPropagation();
     // TODO: (Ajob) Requires cleanup of old draftEntry strategy for editing as we now take data from the get request
     const editURL = {
-      [EntryType.Contribution]: contributionURL({event_id: eventId, contrib_id: entry.id}),
-      [EntryType.SessionBlock]: sessionBlockURL({event_id: eventId, session_block_id: entry.id}),
-      [EntryType.Break]: breakURL({event_id: eventId, break_id: entry.id}),
+      [EntryType.Contribution]: contributionURL({event_id: eventId, contrib_id: entry.objId}),
+      [EntryType.SessionBlock]: sessionBlockURL({event_id: eventId, session_block_id: entry.objId}),
+      [EntryType.Break]: breakURL({event_id: eventId, break_id: entry.objId}),
     }[type];
 
     const {data} = await indicoAxios.get(editURL);

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -57,7 +57,7 @@ function CardItem({icon, children}: {icon: SemanticICONS; children: React.ReactN
   );
 }
 
-function TimetablePopupContent({
+function EntryPopupContent({
   entry,
   onClose,
 }: {
@@ -151,7 +151,7 @@ function TimetablePopupContent({
   );
 }
 
-export function TimetablePopup({
+export function EntryPopup({
   trigger,
   onClose,
   entry,
@@ -170,7 +170,7 @@ export function TimetablePopup({
       basic
       hideOnScroll
     >
-      <TimetablePopupContent entry={entry} onClose={onClose} />
+      <EntryPopupContent entry={entry} onClose={onClose} />
     </Popup>
   );
 }

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -75,17 +75,18 @@ function EntryPopupContent({
   const eventId = useSelector(selectors.getEventId);
 
   const onEdit = async (e: MouseEvent) => {
-    if (!draftEntry.objId) {
+    const {objId} = draftEntry;
+    if (!objId) {
       return;
     }
 
-    onClose();
     e.stopPropagation();
-    // TODO: (Ajob) Requires cleanup of old draftEntry strategy for editing as we now take data from the get request
+    onClose();
+
     const editURL = {
-      [EntryType.Contribution]: contributionURL({event_id: eventId, contrib_id: entry.objId}),
-      [EntryType.SessionBlock]: sessionBlockURL({event_id: eventId, session_block_id: entry.objId}),
-      [EntryType.Break]: breakURL({event_id: eventId, break_id: entry.objId}),
+      [EntryType.Contribution]: contributionURL({event_id: eventId, contrib_id: objId}),
+      [EntryType.SessionBlock]: sessionBlockURL({event_id: eventId, session_block_id: objId}),
+      [EntryType.Break]: breakURL({event_id: eventId, break_id: objId}),
     }[type];
 
     const {data} = await indicoAxios.get(editURL);

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -77,8 +77,6 @@ interface DraftEntry {
   session_id?: number;
   code?: string;
   board_number?: string;
-  objId?: number;
-  id?: string;
 }
 
 // Prop interface
@@ -111,7 +109,6 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
   };
 
   const initialValues: DraftEntry = {
-    id,
     title: entry.title,
     description: entry.description,
     person_links: entry.personLinks || [],

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -77,7 +77,8 @@ interface DraftEntry {
   session_id?: number;
   code?: string;
   board_number?: string;
-  id?: number;
+  objId?: number;
+  id?: string;
 }
 
 // Prop interface
@@ -96,7 +97,10 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
   onSubmit = () => null,
 }) => {
   const dispatch = useDispatch();
-  const isEditing = !!entry.id;
+  // Within this timetable we only care about the database ID,
+  // not the unique ID generated for the timetable
+  const {objId} = entry;
+  const isEditing = !!objId;
   const personLinkFieldParams = {
     allowAuthors: true,
     canEnterManually: true,
@@ -107,7 +111,7 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
   };
 
   const initialValues: DraftEntry = {
-    id: entry.id,
+    id,
     title: entry.title,
     description: entry.description,
     person_links: entry.personLinks || [],
@@ -232,18 +236,15 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
   };
 
   const _handleEditContribution = async data => {
-    return indicoAxios.patch(contributionURL({event_id: eventId, contrib_id: entry.id}), data);
+    return indicoAxios.patch(contributionURL({event_id: eventId, contrib_id: objId}), data);
   };
 
   const _handleEditSessionBlock = async data => {
-    return indicoAxios.patch(
-      sessionBlockURL({event_id: eventId, session_block_id: entry.id}),
-      data
-    );
+    return indicoAxios.patch(sessionBlockURL({event_id: eventId, session_block_id: objId}), data);
   };
 
   const _handleEditBreak = async data => {
-    return indicoAxios.patch(breakURL({event_id: eventId, break_id: entry.id}), data);
+    return indicoAxios.patch(breakURL({event_id: eventId, break_id: objId}), data);
   };
 
   const handleSubmit = async data => {

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -80,10 +80,11 @@ export function preprocessTimetableEntries(
         location: venueName = '',
         presenters = [],
         conveners = [],
-        board_number: boardNumber = '',
+        boardNumber = '',
         code,
         title,
         id,
+        uniqueId,
       } = entry as any;
 
       // TODO: (Ajob) Currently not passing roles as they do not exist
@@ -103,6 +104,7 @@ export function preprocessTimetableEntries(
       dayEntries[day].push({
         type,
         id,
+        uniqueId,
         title,
         description,
         startDt: dateToMoment(entry.startDate),

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -63,7 +63,7 @@ const dateToMoment = (dt: SchemaDate) => moment.tz(`${dt.date} ${dt.time}`, dt.t
 export function preprocessTimetableEntries(
   data: Record<string, Record<string, SchemaBlock>>,
   eventInfo: {
-    contributions?: {uniqueId: number; title: string; duration: number; sessionId: number}[];
+    contributions?: {title: string; duration: number; sessionId: number}[];
   }
 ): {dayEntries: DayEntries; unscheduled: UnscheduledContrib[]} {
   const dayEntries = {};
@@ -84,7 +84,7 @@ export function preprocessTimetableEntries(
         code,
         title,
         id,
-        uniqueId,
+        objId,
       } = entry as any;
 
       // TODO: (Ajob) Currently not passing roles as they do not exist
@@ -104,7 +104,7 @@ export function preprocessTimetableEntries(
       dayEntries[day].push({
         type,
         id,
-        uniqueId,
+        objId,
         title,
         description,
         startDt: dateToMoment(entry.startDate),
@@ -167,7 +167,6 @@ export function preprocessTimetableEntries(
     dayEntries,
     unscheduled: (eventInfo.contributions || []).map(c => ({
       type: 'contrib',
-      id: c.uniqueId,
       sessionId: c.sessionId,
       title: c.title,
       duration: c.duration,

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -63,7 +63,14 @@ const dateToMoment = (dt: SchemaDate) => moment.tz(`${dt.date} ${dt.time}`, dt.t
 export function preprocessTimetableEntries(
   data: Record<string, Record<string, SchemaBlock>>,
   eventInfo: {
-    contributions?: {title: string; duration: number; sessionId: number}[];
+    contributions?: {
+      id: string;
+      objId: number;
+      title: string;
+      description: string;
+      duration: number;
+      sessionId: number;
+    }[];
   }
 ): {dayEntries: DayEntries; unscheduled: UnscheduledContrib[]} {
   const dayEntries = {};
@@ -165,11 +172,16 @@ export function preprocessTimetableEntries(
 
   return {
     dayEntries,
-    unscheduled: (eventInfo.contributions || []).map(c => ({
-      type: 'contrib',
-      sessionId: c.sessionId,
-      title: c.title,
-      duration: c.duration,
-    })),
+    unscheduled: (eventInfo.contributions || []).map(
+      ({id, objId, sessionId, title, description, duration}) => ({
+        type: EntryType.Contribution,
+        id,
+        objId,
+        sessionId,
+        title,
+        description,
+        duration,
+      })
+    ),
   };
 }

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -17,7 +17,8 @@ interface SchemaDate {
 }
 
 interface SchemaEntry {
-  id: number;
+  id: string;
+  objId: number;
   title: string;
   textColor?: string;
   color?: string;
@@ -142,29 +143,28 @@ export function preprocessTimetableEntries(
       } else if (type === EntryType.SessionBlock) {
         dayEntries[day].at(-1).sessionTitle = entry.sessionTitle;
 
-        const children = Object.entries(entry.entries).map(
-          ([childId, {id, title, startDate, duration}]: [string, SchemaBlock]) => {
-            const childEntry: ChildEntry = {
-              type: entryTypeMapping[childId[0]],
-              id,
-              title,
-              startDt: dateToMoment(startDate),
-              duration,
-              parentId: dayEntries[day].at(-1).id,
-              x: 0,
-              y: 0,
-              width: 0,
-              column: 0,
-              maxColumn: 0,
-            };
+        const children = Object.values(entry.entries).map((c: SchemaBlock) => {
+          const childEntry: ChildEntry = {
+            type: entryTypeMapping[c.id[0]],
+            objId: c.objId,
+            id: c.id,
+            title: c.title,
+            startDt: dateToMoment(c.startDate),
+            duration: c.duration,
+            parentId: dayEntries[day].at(-1).id,
+            x: 0,
+            y: 0,
+            width: 0,
+            column: 0,
+            maxColumn: 0,
+          };
 
-            if (entry.sessionId) {
-              childEntry.sessionId = entry.sessionId;
-            }
-
-            return childEntry;
+          if (entry.sessionId) {
+            childEntry.sessionId = entry.sessionId;
           }
-        );
+
+          return childEntry;
+        });
         dayEntries[day].at(-1).children = children;
       }
     }

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -23,7 +23,8 @@ export interface Session {
 
 export interface BaseEntry {
   type: EntryType;
-  id: number;
+  id: string;
+  objId: number;
   title: string;
   duration: number;
   description: string;

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -9,7 +9,7 @@ import moment, {Moment} from 'moment';
 
 import {camelizeKeys} from 'indico/utils/case';
 
-import {Entry, Session, TopLevelEntry} from './types';
+import {Entry, EntryType, Session, TopLevelEntry} from './types';
 
 export const GRID_SIZE_MINUTES = 5;
 export const GRID_SIZE = minutesToPixels(GRID_SIZE_MINUTES);
@@ -49,6 +49,17 @@ function gcd(a: number, b: number) {
   return a;
 }
 
+export const getEntryUniqueId = (entry): string => {
+  switch (entry.type) {
+    case EntryType.SessionBlock:
+      return `s${entry.id}`;
+    case EntryType.Contribution:
+      return `c${entry.id}`;
+    case EntryType.Break:
+      return `b${entry.id}`;
+  }
+};
+
 export const mapTTDataToEntry = (data): TopLevelEntry => {
   const {
     type,
@@ -68,7 +79,8 @@ export const mapTTDataToEntry = (data): TopLevelEntry => {
   } = camelizeKeys(data);
 
   const mappedObj = {
-    id,
+    id: getEntryUniqueId(data),
+    objId: id,
     type,
     title,
     description,

--- a/indico/modules/events/timetable/controllers/manage.py
+++ b/indico/modules/events/timetable/controllers/manage.py
@@ -31,7 +31,9 @@ from indico.modules.events.timetable.operations import (create_break_entry, crea
                                                         create_timetable_entry, delete_timetable_entry,
                                                         update_break_entry, update_timetable_entry)
 from indico.modules.events.timetable.schemas import BreakSchema, ContributionSchema, SessionBlockSchema
+# TODO: (Ajob) Remove 'new' indications once old timetable is fully replaced
 from indico.modules.events.timetable.serializer import TimetableSerializer as TimetableSerializerNew
+from indico.modules.events.timetable.serializer import serialize_event_info as serialize_event_info_new
 from indico.modules.events.timetable.util import render_entry_info_balloon
 from indico.modules.events.timetable.views import WPManageTimetable, WPManageTimetableOld
 from indico.modules.events.util import should_show_draft_warning, track_location_changes, track_time_changes
@@ -46,7 +48,7 @@ class RHManageTimetable(RHManageTimetableBase):
     session_management_level = SessionManagementLevel.coordinate
 
     def _process(self):
-        event_info = serialize_event_info(self.event)
+        event_info = serialize_event_info_new(self.event)
         # TODO: (Ajob) Rename TimetableSerializerNew to TimetableSerializer and remove the old one
         timetable_data = TimetableSerializerNew(self.event, management=True).serialize_timetable()
         return WPManageTimetable.render_template(


### PR DESCRIPTION
Prevents double dialogues from opening, or multiple entries being moved on drag. Needs to be tested properly by creating, reading, updating and dragging entries.

_Miscellaneous:_
- _Renamed entrypopup to be consistent_
- _Made board_number camelCase to be consistent_