### PR TITLE
Support custom render logic in regform fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,7 @@ Internal Changes
   data (:pr:`6874`, thanks :user:`duartegalvao`)
 - Allow disabling arbitrary dates in date picker / calendar controls (:pr:`6905`, thanks
   :user:`foxbunny`)
+- Support custom data rendering logic in custom registration form fields (:pr:`6967`)
 
 
 Version 3.3.6

--- a/indico/modules/events/registration/custom.py
+++ b/indico/modules/events/registration/custom.py
@@ -1,0 +1,20 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2025 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import dataclasses
+
+from markupsafe import Markup
+
+
+@dataclasses.dataclass(frozen=True)
+class RegistrationListColumn:
+    #: The content of the cell (``<td>`` element`)
+    content: str | Markup
+    #: The text value of the cell (``data-text``)
+    text_value: str
+    #: Additional HTML attributes of the cell
+    td_attrs: dict = dataclasses.field(default_factory=dict)

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -8,9 +8,11 @@
 from copy import deepcopy
 from decimal import Decimal
 
+from markupsafe import Markup
 from marshmallow import fields, validate
 
 from indico.core.marshmallow import mm
+from indico.modules.events.registration.custom import RegistrationListColumn
 from indico.modules.events.registration.models.registrations import RegistrationData
 from indico.util.i18n import _
 from indico.util.marshmallow import not_empty
@@ -252,6 +254,50 @@ class RegistrationFormFieldBase:
     def get_places_used(self):
         """Return the number of used places for the field."""
         return 0
+
+    def render_summary_data(self, data: RegistrationData) -> str | Markup:
+        """Render the field's data in the registration summary."""
+        return data.friendly_data
+
+    def render_invoice_data(self, data: RegistrationData) -> str | Markup:
+        """Render the field's data in the registration invoice."""
+        return data.friendly_data
+
+    def render_email_data(self, data: RegistrationData) -> str | Markup:
+        """Render the field's data in a registration notification email.
+
+        In case the field is being modified in an existing registration, this method
+        is not called.
+        """
+        return data.friendly_data
+
+    def render_email_diff_data(self, diff_data) -> str | Markup:
+        """Render the field's data in a registraiton notification email.
+
+        This method is called when an existing registration is being modified and
+        the field already contained data. `diff_data` contains the value as returned
+        by :meth:`get_snapshot_data`.
+        """
+        return diff_data
+
+    def get_snapshot_data(self, data: RegistrationData):
+        """Get the field's data for snapshotting.
+
+        The snapshot is used to generate the diff view in notification emails, so
+        this should usually use same format as :meth:`render_email_data.
+        """
+        return self.render_email_data(data)
+
+    def render_reglist_column(self, data: RegistrationData) -> RegistrationListColumn:
+        """Render the field's data in the management registration list table."""
+        return RegistrationListColumn(data.friendly_data, data.search_data)
+
+    def render_spreadsheet_data(self, data: RegistrationData):
+        """Render the field's data in a spreadsheet.
+
+        This may return any data type that's handled by Indico's spreadsheet utils.
+        """
+        return data.friendly_data
 
 
 class RegistrationFormBillableField(RegistrationFormFieldBase):

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -906,10 +906,6 @@ class RegistrationData(StoredFileMixin, db.Model):
         return self.field_data.field.calculate_price(self)
 
     @property
-    def summary_data(self):
-        return {'data': self.friendly_data, 'price': self.price}
-
-    @property
     def user_data(self):
         from indico.modules.events.registration.fields.simple import KEEP_EXISTING_FILE_UUID
         if self.field_data.field.field_impl.is_file_field:

--- a/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
+++ b/indico/modules/events/registration/templates/display/_registration_summary_blocks.html
@@ -106,8 +106,8 @@
         {% set picture_url = url_for('.manage_registration_file', data[field.id].locator.file) if from_management else
                              url_for('.registration_picture', data[field.id].locator.registrant_file) %}
         <img class="picture-preview" src="{{ picture_url }}" alt="{{ friendly_data }}">
-    {% elif friendly_data is not none %}
-        {{- friendly_data -}}
+    {% elif friendly_data is not none and friendly_data != '' %}
+        {{- field.field_impl.render_summary_data(data[field.id]) -}}
     {% endif %}
 {% endmacro %}
 
@@ -278,7 +278,7 @@
                                 {% elif item.field_data.field.input_type == 'multi_choice' %}
                                     {{ item.friendly_data | join(', ') }}
                                 {% else %}
-                                   {{ item.friendly_data }}
+                                   {{ item.field_data.field.field_impl.render_invoice_data(item) }}
                                 {% endif %}
                             </td>
                             <td class="text-right">{{ item.render_price() }}</td>

--- a/indico/modules/events/registration/templates/emails/base_registration_details.html
+++ b/indico/modules/events/registration/templates/emails/base_registration_details.html
@@ -67,8 +67,8 @@
         {%- set html_name = regdata.field_data.field.html_field_name -%}
         {%- set old = diff.old -%}
         {%- set new = diff.new -%}
-        {%- set old_friendly_data = render_friendly_data(old.friendly_data, type, regdata) -%}
-        {%- set new_friendly_data = render_friendly_data(new.friendly_data, type, regdata) -%}
+        {%- set old_friendly_data = render_friendly_data(old.friendly_data, type, regdata, true) -%}
+        {%- set new_friendly_data = render_friendly_data(new.friendly_data, type, regdata, true) -%}
         <span>
             {%- if old_friendly_data and type != 'picture' -%}
                 <s style="margin-right: 5px;">{{ old_friendly_data }}</s>
@@ -89,7 +89,7 @@
 {% endmacro %}
 
 
-{% macro render_friendly_data(friendly_data, type, raw_data) %}
+{% macro render_friendly_data(friendly_data, type, raw_data, from_diff=false) %}
     {%- if type == 'accommodation' and friendly_data -%}
         {{- render_accommodation(friendly_data) -}}
     {%- elif type == 'multi_choice' -%}
@@ -98,8 +98,10 @@
         {{- render_sessions(friendly_data) -}}
     {%- elif type == 'picture' and friendly_data -%}
         {{- render_picture(friendly_data, raw_data) -}}
+    {%- elif from_diff -%}
+        {{- raw_data.field_data.field.field_impl.render_email_diff_data(friendly_data) -}}
     {%- else -%}
-        {{- friendly_data -}}
+        {{- raw_data.field_data.field.field_impl.render_email_data(raw_data) -}}
     {%- endif -%}
 {% endmacro %}
 

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -161,11 +161,12 @@
                                                 {{- data[item.id].friendly_data | join('; ') }}
                                             {%- endif %}
                                         </td>
+                                    {% elif item.id not in data %}
+                                        <td class="i-table" data-text=""></td>
                                     {% else %}
-                                        <td class="i-table" data-text="{{ search_value }}">
-                                            {%- if item.id in data and data[item.id].friendly_data %}
-                                                {{- data[item.id].friendly_data }}
-                                            {%- endif %}
+                                        {% set spec = data[item.id].field_data.field.field_impl.render_reglist_column(data[item.id]) %}
+                                        <td class="i-table" data-text="{{ spec.text_value }}" {{ spec.td_attrs | html_params }}>
+                                            {{ spec.content }}
                                         </td>
                                     {% endif %}
                                 {% endfor %}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -605,8 +605,10 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
                     registration_dict[key] = dt
                 else:
                     registration_dict[key] = dt.date()
+            elif item.id in data:
+                registration_dict[key] = item.field_impl.render_spreadsheet_data(data[item.id])
             else:
-                registration_dict[key] = data[item.id].friendly_data if item.id in data else ''
+                registration_dict[key] = ''
         for name, (title, fn) in special_item_mapping.items():
             if name not in static_items:
                 continue
@@ -1010,7 +1012,7 @@ def snapshot_registration_data(registration):
             data[field.html_field_name] = {'price': regdata.price, 'data': regdata.data,
                                            'storage_file_id': regdata.storage_file_id,
                                            'is_file_field': field.field_impl.is_file_field,
-                                           'friendly_data': regdata.friendly_data}
+                                           'friendly_data': field.field_impl.get_snapshot_data(regdata)}
     return data
 
 


### PR DESCRIPTION
This is a nicer implementation of #6901 which does not rely on rather convoluted template hooks.

It could also be used later to move the field-specific render logic from the various templates into the field classes, and maybe use one template (module) per field for the more complex fields that need custom markup.