### PR TITLE
Support custom registration list columns+filters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -94,6 +94,7 @@ Internal Changes
 - Allow disabling arbitrary dates in date picker / calendar controls (:pr:`6905`, thanks
   :user:`foxbunny`)
 - Support custom data rendering logic in custom registration form fields (:pr:`6967`)
+- Support custom columns and filters in mangement registrant list (:pr:`6968`)
 
 
 Version 3.3.6

--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -133,6 +133,11 @@ at the top of the list of registrants/participants. The `sender` is the correspo
 registration form.
 ''')
 
+registrant_list_items = _signals.signal('registrant-list-item', '''
+Expected to return `CustomRegistrationListItem` subclasses. The `sender` is the
+`RegistrationForm` object for which to get the custom items.
+''')
+
 google_wallet_ticket_class_data = _signals.signal('google-wallet-ticket-class-data', '''
 Called when data for a Google Wallet ticket class has been generated. The `sender` is the
 `Event` object, the `data` kwarg contains the data that will be passed to the Google

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -194,6 +194,7 @@ class RHRegistrationsListCustomize(RHManageRegFormBase):
                                 RegistrationFormItemType=RegistrationFormItemType,
                                 visible_items=reg_list_config['items'],
                                 static_items=self.list_generator.static_items,
+                                custom_items=self.list_generator.extra_filters,  # XXX weird name, ListGen is a mess
                                 filters=reg_list_config['filters'])
 
     def _process_POST(self):
@@ -470,7 +471,7 @@ class RHRegistrationsExportPDFBook(RHRegistrationsExportBase):
     """Export registration list to a PDF in book style."""
 
     def _process(self):
-        static_item_ids, item_ids = self.list_generator.get_item_ids()
+        static_item_ids, item_ids, _extra_item_ids = self.list_generator.get_item_ids()
         pdf = RegistrantsListToBookPDF(self.event, self.regform, self.registrations, item_ids, static_item_ids)
         return send_file('RegistrantsBook.pdf', BytesIO(pdf.getPDFBin()), 'application/pdf')
 

--- a/indico/modules/events/registration/custom.py
+++ b/indico/modules/events/registration/custom.py
@@ -9,6 +9,8 @@ import dataclasses
 
 from markupsafe import Markup
 
+from indico.modules.events.registration.models.registrations import Registration
+
 
 @dataclasses.dataclass(frozen=True)
 class RegistrationListColumn:
@@ -18,3 +20,52 @@ class RegistrationListColumn:
     text_value: str
     #: Additional HTML attributes of the cell
     td_attrs: dict = dataclasses.field(default_factory=dict)
+
+
+class CustomRegistrationListItem:
+    #: The (globally unique) name of the custom item
+    name = None
+    #: The title of the custom item
+    title = None
+    #: Whether the item is only used for filtering and does not display a column
+    filter_only = False
+
+    def __init__(self, event, regform):
+        self.event = event
+        self.regform = regform
+        self.data: dict[Registration, RegistrationListColumn] = None  # assigned outside
+
+    @property
+    def filter_choices(self) -> dict:
+        """A dict of options to choose if the item can be used for filtering."""
+        return {}
+
+    def modify_query(self, query, values: list):
+        """Modify the query to retrieve the list of registrations.
+
+        This can be used to apply custom joins etc.
+        """
+        return query
+
+    def get_filter_criterion(self, values: list):
+        """Return an SQLAlchemy filter criterion for the registration list query.
+
+        This is a shorthand for applying a filter via `modify_query` and should be
+        preferred for simple cases.
+        """
+
+    def filter_list(self, registrations: list[Registration], values: list) -> list[Registration]:
+        """Filter the list of registrations after querying it.
+
+        This is intended for cases where an SQL filter is not suitable. Return the new
+        list of registrations with any items removed that do not match the filter.
+        """
+        return registrations
+
+    def load_data(self, registrations: list[Registration]) -> dict[Registration, RegistrationListColumn]:
+        """Load the data to show for the displayed registrations.
+
+        This data is then used while iterating over the registrations to display the
+        table cells. This method can be omitted in case this item is `filter_only`
+        """
+        raise NotImplementedError('Custom field is not filter-only but does not provide data')

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -1,6 +1,6 @@
 {% from 'message_box.html' import message_box %}
 
-{% macro render_registration_list(regform, registrations, dynamic_columns, static_columns, total_registrations) %}
+{% macro render_registration_list(regform, registrations, dynamic_columns, static_columns, extra_columns, total_registrations) %}
     {% if registrations %}
         <form method="POST">
             <input type="hidden" name="csrf_token" value="{{ session.csrf_token }}">
@@ -24,6 +24,9 @@
                             <th class="i-table">{% trans %}Full name{% endtrans %}</th>
                             {% for item in static_columns if not item.get('filter_only') %}
                                 <th class="i-table" data-sorter="text">{{ item.caption }}</th>
+                            {% endfor %}
+                            {% for item in extra_columns if not item.filter_only %}
+                                <th class="i-table" data-sorter="text">{{ item.title }}</th>
                             {% endfor %}
                             {% for item in dynamic_columns %}
                                 <th class="i-table" data-sorter="text">{{ item.title }}</th>
@@ -120,6 +123,16 @@
                                                 {{- data[item.id].friendly_data }}
                                             {%- endif %}
                                         </td>
+                                    {% endif %}
+                                {% endfor %}
+                                {% for item in extra_columns if not item.filter_only %}
+                                    {% set spec = item.data.get(registration) %}
+                                    {% if spec %}
+                                        <td class="i-table" data-text="{{ spec.text_value }}" {{ spec.td_attrs | html_params }}>
+                                            {{ spec.content }}
+                                        </td>
+                                    {% else %}
+                                        <td class="i-table" data-text=""></td>
                                     {% endif %}
                                 {% endfor %}
                                 {% for item in dynamic_columns %}

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -235,7 +235,7 @@
             </div>
         </div>
         <div class="list-content" id="registration-list">
-            {{ render_registration_list(regform, registrations, dynamic_columns, static_columns, total_registrations) }}
+            {{ render_registration_list(regform, registrations, dynamic_columns, static_columns, extra_columns, total_registrations) }}
         </div>
     </div>
 

--- a/indico/modules/events/registration/templates/management/reglist_filter.html
+++ b/indico/modules/events/registration/templates/management/reglist_filter.html
@@ -1,8 +1,8 @@
 {% from 'forms/_form.html' import form_header, form_footer, form_rows %}
 
-{% macro _render_column_selector(item_id, item, filter_choices, is_static_item=false, filter_only=false) %}
-    {% set filters = filters['items'] if is_static_item else filters['fields'] %}
-    {% set filter_title = item.get('filter_title', item.title) if is_static_item else item.title %}
+{% macro _render_column_selector(item_id, item, filter_choices, is_static_item=false, is_extra_item=false, filter_only=false) %}
+    {% set filters = filters['items'] if is_static_item else filters.get('extra', {}) if is_extra_item else filters['fields'] %}
+    {% set filter_title = item.filter_title|default(item.title) if is_static_item or is_extra_item else item.title %}
     <div class="label-group list-column">
         <div class="i-label title-wrapper" {% if filter_only %}data-only-filter{% endif %}
              data-id="{{ item.personal_data_type.name if item.personal_data_type else item_id }}">
@@ -89,6 +89,15 @@
                 {{ _render_column_selector(item_id, item, filter_choices, is_static_item=true, filter_only=filter_only) }}
             {% endfor %}
         </div>
+
+        {% if custom_items %}
+            <h3>{% trans %}Additional data{% endtrans %}</h3>
+            <div class="flexrow f-wrap">
+                {% for item_id, item in custom_items.items() %}
+                    {{ _render_column_selector(item_id, item, item.filter_choices, is_extra_item=true, filter_only=item.filter_only) }}
+                {% endfor %}
+            </div>
+        {% endif %}
 
         {% for section in regform.sections if section.is_visible and section.available_fields %}
             {{ _render_regform_item_col_selector(section) }}

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -311,8 +311,11 @@ class ListGeneratorBase:
 
     def _get_filters_from_request(self):
         """Get the new filters after the filter form is submitted."""
+        def _get(item, name):
+            return item.get(name) if isinstance(item, dict) else getattr(item, name, None)
+
         def get_selected_options(item_id, item):
-            if item.get('filter_choices') or item.get('type') == 'bool':
+            if _get(item, 'filter_choices') or _get('type', 'bool'):
                 return [x if x != 'None' else None for x in request.form.getlist(f'field_{item_id}')]
 
         filters = deepcopy(self.default_list_config['filters'])


### PR DESCRIPTION
Another case that came up related to #6967: Sometimes you just want to include other data in the registrant list for managers or provide filtering, or want to configure whether this extra data should be shown or not.

Using a dummy field for this is obviously a pretty bad idea, so we let plugins extend the registration list generator instead.

...and we should REALLY clean up all this stuff with the ListGenerator, it's really messy and most subclasses (the registration one included) interact w/ the base class in a weird way, instead of having all the standard functionality (static fields, dynamic fields, custom/plugin fields) in the base class and just extending what's needed in the subclass... Probably not something for now but rather when we look into reactifying all these ListGenerator abominations ;)