### PR TITLE
Change unique id type to string and remove parseInts

### DIFF
--- a/indico/modules/events/timetable/client/js/WeekTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/WeekTimetable.tsx
@@ -12,7 +12,7 @@ import {useDispatch} from 'react-redux';
 import './DayTimetable.module.scss';
 import * as actions from './actions';
 import {TimeGutter, Lines} from './DayTimetable';
-import {createRestrictToElement, Transform, Over, MousePosition, UniqueId} from './dnd';
+import {createRestrictToElement, Transform, Over, MousePosition} from './dnd';
 import {useDroppable, DnDProvider} from './dnd/dnd';
 import {DraggableBlockEntry, DraggableEntry} from './Entry';
 import {computeYoffset, getGroup, layout, layoutGroupAfterMove} from './layout';
@@ -83,7 +83,7 @@ export function WeekTimetable({
     handleDropOnDay(who, day, delta, mouse);
   }
 
-  function handleDropOnDay(who: UniqueId, over: Over, delta: Transform, mouse: MousePosition) {
+  function handleDropOnDay(who: string, over: Over, delta: Transform, mouse: MousePosition) {
     const [from, to] = layoutAfterDropOnDay(entries, who, over, delta, mouse) || [];
     if (!from) {
       return;
@@ -157,7 +157,7 @@ function DnDDay({dt, children}: {dt: string; children: React.ReactNode}) {
 
 function layoutAfterDropOnDay(
   entries: Record<string, TopLevelEntry[]>,
-  who: UniqueId,
+  who: string,
   over: Over,
   delta: Transform,
   mouse: MousePosition

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -60,9 +60,9 @@ interface SetDraftEntryAction {
 interface ResizeEntryAction {
   type: typeof RESIZE_ENTRY;
   date: string;
-  id: number;
+  id: string;
   duration: number;
-  parentId?: number;
+  parentId?: string;
 }
 
 interface MoveEntryAction {
@@ -73,7 +73,7 @@ interface MoveEntryAction {
 
 interface SelectEntryAction {
   type: typeof SELECT_ENTRY;
-  id: number;
+  id: string;
 }
 
 interface DeselectEntryAction {
@@ -152,14 +152,14 @@ export function moveEntry(date: string, entries: TopLevelEntry[]): MoveEntryActi
 
 export function resizeEntry(
   date: string,
-  id: number,
+  id: string,
   duration: number,
-  parentId?: number
+  parentId?: string
 ): ResizeEntryAction {
   return {type: RESIZE_ENTRY, date, id, duration, parentId};
 }
 
-export function selectEntry(id: number): SelectEntryAction {
+export function selectEntry(id: string): SelectEntryAction {
   return {type: SELECT_ENTRY, id};
 }
 

--- a/indico/modules/events/timetable/client/js/dnd/index.ts
+++ b/indico/modules/events/timetable/client/js/dnd/index.ts
@@ -7,6 +7,5 @@
 
 export {createRestrictToElement} from './modifiers';
 // export type {Transform} from './types'; // prettier can't handle this
-//export {UniqueId} from './types';
 export type {Transform, Over, MousePosition, Rect} from './types';
 export {DnDProvider, useDraggable, useDroppable, useDroppableData} from './dnd';

--- a/indico/modules/events/timetable/client/js/layout.ts
+++ b/indico/modules/events/timetable/client/js/layout.ts
@@ -159,15 +159,15 @@ export function layoutGroupAfterMove<T extends Entry>(
  * See getGroup for more details on what a 'group' is.
  */
 export function getGroups(entries: TopLevelEntry[]) {
-  const groups: Set<number>[] = [];
-  const seen = new Set<number>();
+  const groups: Set<string>[] = [];
+  const seen = new Set<string>();
 
   for (const entry of entries) {
     if (seen.has(entry.id)) {
       continue;
     }
 
-    const group = new Set<number>();
+    const group = new Set<string>();
     group.add(entry.id);
     seen.add(entry.id);
     dfs(entry, entries, group, seen);
@@ -185,14 +185,14 @@ export function getGroups(entries: TopLevelEntry[]) {
  * be {B, C}. because B is 'reachable' from A via C.
  */
 export function getGroup(entry: TopLevelEntry, entries: TopLevelEntry[]) {
-  const group = new Set<number>();
-  const seen = new Set<number>();
+  const group = new Set<string>();
+  const seen = new Set<string>();
   seen.add(entry.id);
   dfs(entry, entries, group, seen);
   return group;
 }
 
-function dfs(curr: Entry, entries: TopLevelEntry[], group: Set<number>, seen: Set<number>) {
+function dfs(curr: Entry, entries: TopLevelEntry[], group: Set<string>, seen: Set<string>) {
   for (const entry of entries) {
     if (seen.has(entry.id)) {
       continue;


### PR DESCRIPTION
Fixes issue with dragging caused by changing type of timetable entry ids.