### PR TITLE
Fix caps in upcoming events string in sidebar

### DIFF
--- a/indico/modules/categories/templates/display/sidebar.html
+++ b/indico/modules/categories/templates/display/sidebar.html
@@ -74,11 +74,11 @@
                     <span class="timing">
                         {% if happening_now(event) %}
                             {% trans time=event.end_dt|format_pretty_date(tzinfo=tzinfo) -%}
-                                ongoing until {{ time }}
+                                Ongoing until {{ time }}
                             {%- endtrans %}
                         {% else %}
                             {% trans time=event.start_dt|format_pretty_date(tzinfo=tzinfo) -%}
-                                starts {{ time }}
+                                Starts {{ time }}
                             {%- endtrans %}
                         {% endif %}
                     </span>


### PR DESCRIPTION
This PR is to use caps for the upcoming events so it's aligned with the news section above, which uses "**P**osted"