### PR TITLE
Refactor weekendDisabled to disabledDays in date/datetime fields

### DIFF
--- a/indico/util/date_time.py
+++ b/indico/util/date_time.py
@@ -486,3 +486,8 @@ def get_display_tz(obj=None):
         # Avoid failing in a rather ugly way (unformatted error page) when a user has an invalid timezone
         Logger.get('date_time').warning('Invalid timezone: %s (obj=%r, session_tz=%s)', display_tz, obj, session_tz)
         return pytz.timezone(config.DEFAULT_TIMEZONE)
+
+
+def convert_py_weekdays_to_js(py_weekdays):
+    """Convert Python weekdays (0=Mon, 6=Sun) to JavaScript (0=Sun, 6=Sat)."""
+    return [(d + 1) % 7 for d in py_weekdays]

--- a/indico/util/date_time_test.py
+++ b/indico/util/date_time_test.py
@@ -10,8 +10,8 @@ from datetime import datetime, timedelta
 import pytest
 from pytz import timezone
 
-from indico.util.date_time import (_adjust_skeleton, as_utc, format_human_timedelta, format_skeleton, iterdays,
-                                   strftime_all_years)
+from indico.util.date_time import (_adjust_skeleton, as_utc, convert_py_weekdays_to_js, format_human_timedelta,
+                                   format_skeleton, iterdays, strftime_all_years)
 
 
 @pytest.mark.parametrize(('delta', 'granularity', 'expected'), (
@@ -101,3 +101,14 @@ def test__adjust_skeleton_skeleton(skeleton, format, expected):
 def test_format_skeleton(skeleton, expected):
     dt = as_utc(datetime(2021, 2, 8)).astimezone(timezone('Europe/Zurich'))
     assert format_skeleton(dt, skeleton, 'en_GB', 'Europe/Zurich') == expected
+
+
+@pytest.mark.parametrize(('py_weekdays', 'expected_js_weekdays'), (
+    ([0], [1]),
+    ([6], [0]),
+    ([0, 1, 2, 3, 4, 5, 6], [1, 2, 3, 4, 5, 6, 0]),
+    ([5, 6], [6, 0]),
+    ([], []),
+))
+def test_convert_py_weekdays_to_js(py_weekdays, expected_js_weekdays):
+    assert convert_py_weekdays_to_js(py_weekdays) == expected_js_weekdays

--- a/indico/web/client/js/jquery/widgets/jinja/date_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/date_widget.js
@@ -25,7 +25,7 @@ window.setupDateWidget = function setupDateWidget(options) {
         notBefore: false,
         notAfter: false,
       },
-      weekendDisabled: false,
+      disabledDays: null,
       disabledDates: null
     },
     options
@@ -45,7 +45,7 @@ window.setupDateWidget = function setupDateWidget(options) {
       earliest={options.earliest}
       latest={options.latest}
       linkedField={options.linkedField}
-      weekendDisabled={options.weekendDisabled}
+      disabledDays={options.disabledDays}
       disabledDates={options.disabledDates}
     />,
     document.getElementById(options.fieldId)

--- a/indico/web/client/js/jquery/widgets/jinja/datetime_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/datetime_widget.js
@@ -30,7 +30,7 @@ window.setupDateTimeWidget = function setupDateTimeWidget(options) {
         notBefore: false,
         notAfter: false,
       },
-      weekendDisabled: false,
+      disabledDays: null,
       disabledDates: null
     },
     options
@@ -55,7 +55,7 @@ window.setupDateTimeWidget = function setupDateTimeWidget(options) {
       latest={options.latest}
       defaultTime={options.defaultTime}
       linkedField={options.linkedField}
-      weekendDisabled={options.weekendDisabled}
+      disabledDays={options.disabledDays}
       disabledDates={options.disabledDates}
     />,
     document.getElementById(options.fieldId)

--- a/indico/web/client/js/react/components/WTFDateField.jsx
+++ b/indico/web/client/js/react/components/WTFDateField.jsx
@@ -28,7 +28,7 @@ export default function WTFDateField({
   earliest,
   latest,
   linkedField,
-  weekendDisabled,
+  disabledDays,
   disabledDates,
 }) {
   // The hidden field that holds the date (in isoformat) which is used during form submission.
@@ -48,12 +48,12 @@ export default function WTFDateField({
     dateField.value ? toMoment(dateField.value, moment.HTML5_FMT.DATE) : null
   );
   const clearRef = useRef(null);
-  const filter = (d, meta) => {
+  const filter = d => {
     const dateStr = formatDate(ISO_FORMAT, d);
     if (disabledDates?.includes(dateStr)) {
       return false;
     }
-    return !(weekendDisabled && meta.weekInfo.weekend.includes(d.getDay() || 7));
+    return !(disabledDays && disabledDays.includes(d.getDay()));
   };
 
   const updateDate = useCallback(
@@ -138,7 +138,7 @@ WTFDateField.propTypes = {
   earliest: PropTypes.string,
   latest: PropTypes.string,
   linkedField: PropTypes.object,
-  weekendDisabled: PropTypes.bool,
+  disabledDays: PropTypes.arrayOf(PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6])),
   disabledDates: PropTypes.arrayOf(PropTypes.string),
 };
 
@@ -149,6 +149,6 @@ WTFDateField.defaultProps = {
   earliest: null,
   latest: null,
   linkedField: null,
-  weekendDisabled: false,
+  disabledDays: null,
   disabledDates: null,
 };

--- a/indico/web/client/js/react/components/WTFDateTimeField.jsx
+++ b/indico/web/client/js/react/components/WTFDateTimeField.jsx
@@ -35,7 +35,7 @@ export default function WTFDateTimeField({
   latest,
   defaultTime,
   linkedField,
-  weekendDisabled,
+  disabledDays,
   disabledDates,
 }) {
   // The hidden field that holds the date (in isoformat) which is used during form submission.
@@ -73,12 +73,12 @@ export default function WTFDateTimeField({
     [timeField, timeId]
   );
 
-  const filter = (d, meta) => {
+  const filter = d => {
     const dateStr = formatDate(ISO_FORMAT, d);
     if (disabledDates?.includes(dateStr)) {
       return false;
     }
-    return !(weekendDisabled && meta.weekInfo.weekend.includes(d.getDay() || 7));
+    return !(disabledDays && disabledDays.includes(d.getDay()));
   };
 
   const updateDate = useCallback(
@@ -250,7 +250,7 @@ WTFDateTimeField.propTypes = {
   latest: PropTypes.string,
   defaultTime: PropTypes.string.isRequired,
   linkedField: PropTypes.object,
-  weekendDisabled: PropTypes.bool,
+  disabledDays: PropTypes.arrayOf(PropTypes.oneOf([0, 1, 2, 3, 4, 5, 6])),
   disabledDates: PropTypes.arrayOf(PropTypes.string),
 };
 
@@ -262,6 +262,6 @@ WTFDateTimeField.defaultProps = {
   earliest: null,
   latest: null,
   linkedField: null,
-  weekendDisabled: false,
+  disabledDays: null,
   disabledDates: null,
 };

--- a/indico/web/templates/forms/date_widget.html
+++ b/indico/web/templates/forms/date_widget.html
@@ -19,7 +19,7 @@
             allowClear: {{ (field.allow_clear if field.allow_clear else false) | tojson }},
             earliest: {{ (field.earliest_date.isoformat() if field.earliest_date else none) | tojson }},
             latest: {{ (field.latest_date.isoformat() if field.latest_date else none) | tojson }},
-            weekendDisabled: {{ field.weekend_disabled | default(false) | tojson }},
+            disabledDays: {{ field.disabled_days_js | tojson }},
             disabledDates: {{ field.disabled_dates | tojson }},
             {% if field.flags.linked_date %}
                 linkedField: {

--- a/indico/web/templates/forms/datetime_widget.html
+++ b/indico/web/templates/forms/datetime_widget.html
@@ -25,7 +25,7 @@
             required: {{ input_args.required | default(false) | tojson }},
             disabled: {{ input_args.disabled | default(false) | tojson }},
             allowClear: {{ (field.allow_clear if field.allow_clear else false) | tojson }},
-            weekendDisabled: {{ field.weekend_disabled | default(false) | tojson }},
+            disabledDays: {{ field.disabled_days_js | tojson }},
             disabledDates: {{ field.disabled_dates | tojson }},
             earliest: {{ (field.earliest_dt.astimezone(field.tzinfo).replace(tzinfo=none).isoformat() if field.earliest_dt else none) | tojson }},
             latest: {{ (field.latest_dt.astimezone(field.tzinfo).replace(tzinfo=none).isoformat() if field.latest_dt else none) | tojson }},


### PR DESCRIPTION
```py
--- a/indico/modules/events/forms.py
+++ b/indico/modules/events/forms.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from datetime import time, timedelta
+from datetime import date, time, timedelta
 
 from flask import session
 from wtforms.fields import BooleanField, StringField, TextAreaField, URLField
@@ -120,6 +120,11 @@ class EventCreationForm(EventCreationFormBase):
     end_dt = IndicoDateTimeField(_('End'), [InputRequired(), LinkedDateTime('start_dt', not_equal=True)],
                                  default_time=time(18), allow_clear=False)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.start_dt.disabled_days = [5, 6]
+        self.start_dt.disabled_dates = [date(2025, 7, 29), date(2025, 7, 31)]
+
 
```