### PR TITLE
Fix missing spacing between toolbar groups

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- Nothing so far :)
+- Fix missing spacing between toolbar button groups (:pr:`6981`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -86,7 +86,6 @@
 #category-toolbar {
   flex: 0 1 auto;
   display: flex;
-  gap: 0.5em;
   flex-wrap: wrap;
   justify-self: flex-end;
   width: fit-content;

--- a/indico/web/client/styles/partials/_toolbars.scss
+++ b/indico/web/client/styles/partials/_toolbars.scss
@@ -191,6 +191,7 @@ $toolbar-spacing: 10px;
   display: flex;
   flex-shrink: 0;
   align-items: center;
+  gap: 0.5em;
   min-height: $toolbar-height;
 
   &.fixed-height {


### PR DESCRIPTION
This fixes a regression from #6776 which resulted in consecutive toolbar groups losing the margin between them (except for the category one).

Before:
<img width="803" height="43" alt="image" src="https://github.com/user-attachments/assets/b9c44389-7db1-4f13-bfa7-583f97d974df" />
<img width="548" height="45" alt="image" src="https://github.com/user-attachments/assets/6fb11eb2-e18e-42ed-ba81-7b44c3f66426" />

After:
<img width="833" height="47" alt="image" src="https://github.com/user-attachments/assets/ee2a11b1-af51-493b-ae38-7887f7ea7085" />
<img width="546" height="44" alt="image" src="https://github.com/user-attachments/assets/c6133051-dfcf-4f2e-b59f-0a223feee946" />
