### PR TITLE
Prevent unnecessary re-renders when selecting session blocks containing children

### DIFF
--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -461,6 +461,7 @@ export function useDroppableData({id}: {id: string}) {
 export function useDraggable({id, fixed = false}: {id: string; fixed?: boolean}) {
   const ref = useRef<HTMLElement | null>(null);
   const _onMouseDown = useContextSelector(DnDContext, ctx => ctx.onMouseDown);
+  // TODO: draggable couple potentially be undefined, but TS doesn't curently know that
   const draggable = useContextSelector(DnDContext, ctx => ctx.draggables[id]);
   const draggableData = useContextSelector(DnDContext, ctx => ctx.draggableData[id]);
   const registerDraggable = useContextSelector(DnDContext, ctx => ctx.registerDraggable);

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -497,11 +497,7 @@ export function useDraggable({id, fixed = false}: {id: string; fixed?: boolean})
     };
   }, [id, fixed, registerDraggable, unregisterDraggable]);
 
-  const transform = (draggableData || {}).transform;
-  const rect = (draggableData || {}).rect;
-  const initialScroll = (draggableData || {}).initialScroll;
-  const mouse = (draggableData || {}).mouse;
-  const offset = (draggableData || {}).initialOffset;
+  const {transform, rect, initialScroll, mouse, offset} = draggableData || {};
 
   return {
     setNodeRef,

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 import moment, {Moment} from 'moment';
+import {useEffect, useRef} from 'react';
 
 import {camelizeKeys} from 'indico/utils/case';
 
@@ -134,4 +135,24 @@ export function getEntryColor(
 
 export function formatBlockTitle(sessionTitle: string, blockTitle: string) {
   return blockTitle ? `${sessionTitle}: ${blockTitle}` : sessionTitle;
+}
+
+/*
+ * Custom hook to log changes to props.
+ * Useful for figuring out why a component is re-rendering.
+ */
+export function useTraceUpdate(props) {
+  const prev = useRef(props);
+  useEffect(() => {
+    const changedProps = Object.entries(props).reduce((ps, [k, v]) => {
+      if (prev.current[k] !== v) {
+        ps[k] = [prev.current[k], v];
+      }
+      return ps;
+    }, {});
+    if (Object.keys(changedProps).length > 0) {
+      console.log('Changed props:', changedProps);
+    }
+    prev.current = props;
+  });
 }


### PR DESCRIPTION
 __What this fixes__:
Currently, when you select a session block with children, the block including its children is re-rendered (this is expected, the `isSelected` is flipped which forces a re-render).
Since the children are re-rerendered, the associated draggable elements are removed (via `unregisterDraggable` inside `useDraggable`). This re-creates the `onMouseDown` callback inside `DnDProvider` which has the draggables as a dependency. This in turn forces all items `useDraggable` to re-render (i.e. every timetable entry).

The fix is to change `onMouseDown` to not depend on `draggables` anymore. We instead pass the draggable from inside the `useDraggable hook`.

__How to test__:
- Open up React devtools -> Profiler -> Settings -> Check `Highlight updates when components render.`
- Try selecting timetable entries (including some session blocks with children). Only the previous and the current entry should be re-rendering.


