### PR TITLE
New timetable: Improvements to auto-scroll

### DIFF
--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -165,7 +165,6 @@ export default function Toolbar({
               key={n}
               content={d.format('ddd DD/MM')}
               onClick={() => onNavigate(d)}
-              onMouseEnter={e => e.buttons === 1 && onNavigate(d)}
               active={n + offset === currentDayIdx}
             />
           );

--- a/indico/modules/events/timetable/client/js/dnd/scroll.ts
+++ b/indico/modules/events/timetable/client/js/dnd/scroll.ts
@@ -73,12 +73,8 @@ export function useScrollIntent({
 
 function getScrollSpeed(mouse: MousePosition, scrollParent: HTMLElement) {
   const rect = scrollParent.getBoundingClientRect();
-  const mouseYPercent = (mouse.y - rect.top) / rect.height;
-  const mouseXPercent = (mouse.x - rect.left) / rect.width;
-
-  if (mouseYPercent < 0 || mouseYPercent > 1 || mouseXPercent < 0 || mouseXPercent > 1) {
-    return {x: 0, y: 0}; // Mouse is outside the scrollable area
-  }
+  const mouseYPercent = Math.min(1, Math.max(0, (mouse.y - rect.top) / rect.height));
+  const mouseXPercent = Math.min(1, Math.max(0, (mouse.x - rect.left) / rect.width));
 
   let speedX = 0;
   let speedY = 0;

--- a/indico/modules/events/timetable/client/js/dnd/scroll.ts
+++ b/indico/modules/events/timetable/client/js/dnd/scroll.ts
@@ -75,6 +75,11 @@ function getScrollSpeed(mouse: MousePosition, scrollParent: HTMLElement) {
   const rect = scrollParent.getBoundingClientRect();
   const mouseYPercent = (mouse.y - rect.top) / rect.height;
   const mouseXPercent = (mouse.x - rect.left) / rect.width;
+
+  if (mouseYPercent < 0 || mouseYPercent > 1 || mouseXPercent < 0 || mouseXPercent > 1) {
+    return {x: 0, y: 0}; // Mouse is outside the scrollable area
+  }
+
   let speedX = 0;
   let speedY = 0;
 


### PR DESCRIPTION
- When dragging, if the mouse pointer moves over one of the day buttons in the toolbar, it switches the day which is a bit confusing. This just disables it.
- Also fixes another bug when if during dragging the mouse leaves the bounds of the calendar (for example moves to the toolbar), the calendar would be abruptly scrolled down