### PR TITLE
Introduce custom event reminder

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,9 @@ Improvements
 
 - Add a CAPTCHA and rate limiting to the material package endpoint, and an event
   setting to restrict who can generate one (defaults to managers only) (:pr:`6996`)
+- Add support for custom event reminders with freely chosen subject and body, and
+  allow rich-text for the custom message in standard reminders (:pr:`6989`, thanks
+  :user:`tomako, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/core/db/sqlalchemy/descriptions.py
+++ b/indico/core/db/sqlalchemy/descriptions.py
@@ -58,7 +58,9 @@ class RenderModeMixin:
                              if len(self.possible_render_modes) == 1 or self.render_mode is None
                              else self.render_mode)
             description_wrapper = RENDER_MODE_WRAPPER_MAP[selected_mode]
-            return description_wrapper(getattr(self, attr_name))
+            if (attr_value := getattr(self, attr_name)) is not None:
+                return description_wrapper(attr_value)
+            return description_wrapper()
         return _getter
 
     @classmethod

--- a/indico/core/emails.py
+++ b/indico/core/emails.py
@@ -26,7 +26,7 @@ from indico.util.date_time import now_utc
 from indico.util.i18n import _
 from indico.util.string import truncate
 from indico.vendor.django_mail import get_connection
-from indico.vendor.django_mail.message import EmailMessage
+from indico.vendor.django_mail.message import EmailMultiAlternatives
 
 
 logger = Logger.get('emails')
@@ -108,9 +108,10 @@ def do_send_email(email, log_entry=None, _from_task=False):
                        the celery task responsible for sending emails.
     """
     with get_connection() as conn:
-        msg = EmailMessage(subject=email['subject'], body=email['body'], from_email=email['from'],
-                           to=email['to'], cc=email['cc'], bcc=email['bcc'], reply_to=email['reply_to'],
-                           attachments=email['attachments'], connection=conn)
+        msg = EmailMultiAlternatives(subject=email['subject'], body=email['body'], from_email=email['from'],
+                                     to=email['to'], cc=email['cc'], bcc=email['bcc'], reply_to=email['reply_to'],
+                                     attachments=email['attachments'], alternatives=email.get('alternatives'),
+                                     connection=conn)
         if not msg.to:
             msg.extra_headers['To'] = 'Undisclosed-recipients:;'
         if email['html']:

--- a/indico/core/notifications.py
+++ b/indico/core/notifications.py
@@ -128,7 +128,7 @@ def flush_email_queue():
 
 @make_interceptable
 def make_email(to_list=None, cc_list=None, bcc_list=None, *, sender_address=None, reply_address=None, attachments=None,
-               subject=None, body=None, template=None, html=False):
+               subject=None, body=None, template=None, html=False, alternatives=None):
     """Create an email.
 
     The preferred way to specify the email content is using the
@@ -155,6 +155,7 @@ def make_email(to_list=None, cc_list=None, bcc_list=None, *, sender_address=None
     :param template: A template module containing ``get_subject`` and
                      ``get_body`` macros.
     :param html: ``True`` if the email body is HTML
+    :param alternatives: List of (content, mimetype) tuple of alternative representations of the message
     """
     from indico.core.emails import get_actual_sender_address
     if template is not None and (subject is not None or body is not None):
@@ -187,4 +188,5 @@ def make_email(to_list=None, cc_list=None, bcc_list=None, *, sender_address=None
         'subject': subject.strip(),
         'body': body.strip(),
         'html': html,
+        'alternatives': alternatives,
     }

--- a/indico/core/notifications.py
+++ b/indico/core/notifications.py
@@ -78,6 +78,7 @@ def _log_email(email, event, module, user, meta=None, summary=None):
         'body': email['body'].strip(),
         'state': 'pending',
         'sent_dt': None,
+        'alternatives': email['alternatives'],
         'attachments': sorted(
             a.get_filename('unnamed') if isinstance(a, MIMEBase) else a[0]
             for a in email['attachments']

--- a/indico/core/notifications.py
+++ b/indico/core/notifications.py
@@ -156,7 +156,8 @@ def make_email(to_list=None, cc_list=None, bcc_list=None, *, sender_address=None
     :param template: A template module containing ``get_subject`` and
                      ``get_body`` macros.
     :param html: ``True`` if the email body is HTML
-    :param alternatives: List of (content, mimetype) tuple of alternative representations of the message
+    :param alternatives: List of ``(content, mimetype)`` tuples of alternative
+                         representations of the message
     """
     from indico.core.emails import get_actual_sender_address
     if template is not None and (subject is not None or body is not None):

--- a/indico/migrations/versions/20250630_1129_6fac01c501b6_add_fields_for_custom_reminder_type.py
+++ b/indico/migrations/versions/20250630_1129_6fac01c501b6_add_fields_for_custom_reminder_type.py
@@ -33,16 +33,12 @@ class _RenderMode(int, Enum):
 
 def upgrade():
     op.alter_column('reminders', 'message', type_=sa.Text(), schema='events')
-    op.add_column('reminders',
-                  sa.Column('render_mode', PyIntEnum(_RenderMode), nullable=False, server_default='3'),
+    op.add_column('reminders', sa.Column('render_mode', PyIntEnum(_RenderMode), nullable=False, server_default='3'),
                   schema='events')
     op.alter_column('reminders', 'render_mode', server_default=None, schema='events')
-    op.add_column('reminders',
-                  sa.Column('subject', sa.String(), nullable=False, server_default=''),
-                  schema='events')
+    op.add_column('reminders', sa.Column('subject', sa.String(), nullable=False, server_default=''), schema='events')
     op.alter_column('reminders', 'subject', server_default=None, schema='events')
-    op.add_column('reminders',
-                  sa.Column('reminder_type', PyIntEnum(_ReminderType), nullable=False, server_default='1'),
+    op.add_column('reminders', sa.Column('reminder_type', PyIntEnum(_ReminderType), nullable=False, server_default='1'),
                   schema='events')
     op.alter_column('reminders', 'reminder_type', server_default=None, schema='events')
 

--- a/indico/migrations/versions/20250630_1129_6fac01c501b6_add_fields_for_custom_reminder_type.py
+++ b/indico/migrations/versions/20250630_1129_6fac01c501b6_add_fields_for_custom_reminder_type.py
@@ -1,0 +1,54 @@
+"""Add fields for custom reminder type
+
+Revision ID: 6fac01c501b6
+Revises: b4ee48f3052c
+Create Date: 2025-05-14 11:29:31.975949
+"""
+
+from enum import Enum
+
+import sqlalchemy as sa
+from alembic import op
+
+from indico.core.db.sqlalchemy import PyIntEnum
+
+
+# revision identifiers, used by Alembic.
+revision = '6fac01c501b6'
+down_revision = 'b4ee48f3052c'
+branch_labels = None
+depends_on = None
+
+
+class _ReminderType(int, Enum):
+    standard = 1
+    custom = 2
+
+
+class _RenderMode(int, Enum):
+    html = 1
+    markdown = 2
+    plain_text = 3
+
+
+def upgrade():
+    op.alter_column('reminders', 'message', type_=sa.Text(), schema='events')
+    op.add_column('reminders',
+                  sa.Column('render_mode', PyIntEnum(_RenderMode), nullable=False, server_default='3'),
+                  schema='events')
+    op.alter_column('reminders', 'render_mode', server_default=None, schema='events')
+    op.add_column('reminders',
+                  sa.Column('subject', sa.String(), nullable=False, server_default=''),
+                  schema='events')
+    op.alter_column('reminders', 'subject', server_default=None, schema='events')
+    op.add_column('reminders',
+                  sa.Column('reminder_type', PyIntEnum(_ReminderType), nullable=False, server_default='1'),
+                  schema='events')
+    op.alter_column('reminders', 'reminder_type', server_default=None, schema='events')
+
+
+def downgrade():
+    op.drop_column('reminders', 'reminder_type', schema='events')
+    op.drop_column('reminders', 'subject', schema='events')
+    op.drop_column('reminders', 'render_mode', schema='events')
+    op.alter_column('reminders', 'message', type_=sa.String(), schema='events')

--- a/indico/modules/events/reminders/controllers.py
+++ b/indico/modules/events/reminders/controllers.py
@@ -6,6 +6,7 @@
 # LICENSE file for more details.
 
 from flask import flash, jsonify, redirect, render_template, request, session
+from markupsafe import escape
 from marshmallow import fields
 
 from indico.core.db import db
@@ -18,7 +19,7 @@ from indico.modules.events.reminders.util import get_reminder_email_tpl
 from indico.modules.events.reminders.views import WPReminders
 from indico.util.date_time import format_datetime
 from indico.util.i18n import _
-from indico.util.string import PlainText, RichMarkup, strip_tags
+from indico.util.string import PlainText, RichMarkup
 from indico.web.args import use_kwargs
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults
@@ -153,7 +154,7 @@ class RHPreviewReminder(RHRemindersBase):
         with self.event.force_event_locale():
             html_email_tpl, text_email_tpl = get_reminder_email_tpl(self.event, reminder_type, render_mode,
                                                                     include_summary, include_description,
-                                                                    strip_tags(subject), message)
+                                                                    escape(subject), message)
         email_tpl = html_email_tpl or text_email_tpl
         html = render_template('events/reminders/preview.html', render_mode=render_mode.name,
                                subject=email_tpl.get_subject(), body=email_tpl.get_body())

--- a/indico/modules/events/reminders/controllers.py
+++ b/indico/modules/events/reminders/controllers.py
@@ -144,7 +144,7 @@ class RHPreviewReminder(RHRemindersBase):
         'include_description': fields.Boolean(required=True),
         'subject': fields.String(required=True),
         'message': fields.String(required=True),
-    }, location='form')
+    })
     def _process(self, reminder_type, render_mode, include_summary, include_description, subject, message):
         if render_mode == RenderMode.plain_text:  # Legacy reminder (text/plain email only)
             message = PlainText(message)

--- a/indico/modules/events/reminders/controllers.py
+++ b/indico/modules/events/reminders/controllers.py
@@ -6,16 +6,20 @@
 # LICENSE file for more details.
 
 from flask import flash, jsonify, redirect, render_template, request, session
+from marshmallow import fields
 
 from indico.core.db import db
+from indico.core.db.sqlalchemy.descriptions import RenderMode
 from indico.modules.events.management.controllers import RHManageEventBase
 from indico.modules.events.reminders import logger
 from indico.modules.events.reminders.forms import ReminderForm
-from indico.modules.events.reminders.models.reminders import EventReminder
-from indico.modules.events.reminders.util import make_reminder_email
+from indico.modules.events.reminders.models.reminders import EventReminder, ReminderType
+from indico.modules.events.reminders.util import get_reminder_email_tpl
 from indico.modules.events.reminders.views import WPReminders
 from indico.util.date_time import format_datetime
 from indico.util.i18n import _
+from indico.util.string import PlainText, RichMarkup, strip_tags
+from indico.web.args import use_kwargs
 from indico.web.flask.util import url_for
 from indico.web.forms.base import FormDefaults
 from indico.web.util import jsonify_data, jsonify_template
@@ -104,8 +108,15 @@ class RHEditReminder(RHSpecificReminderBase):
 class RHAddReminder(RHRemindersBase):
     """Add a new reminder."""
 
-    def _process(self):
-        form = ReminderForm(event=self.event, schedule_type='relative', attach_ical=True)
+    @use_kwargs({
+        'reminder_type': fields.Enum(ReminderType, required=True)
+    }, location='query')
+    def _process(self, reminder_type):
+        form = ReminderForm(event=self.event,
+                            schedule_type='relative',
+                            attach_ical=reminder_type == ReminderType.standard,
+                            reminder_type=reminder_type,
+                            render_mode=RenderMode.html)
         if form.validate_on_submit():
             reminder = EventReminder(creator=session.user, event=self.event)
             form.populate_obj(reminder, existing_only=True)
@@ -125,12 +136,24 @@ class RHAddReminder(RHRemindersBase):
 class RHPreviewReminder(RHRemindersBase):
     """Preview the email for a reminder."""
 
-    def _process(self):
-        include_summary = request.form.get('include_summary') == '1'
-        include_description = request.form.get('include_description') == '1'
+    @use_kwargs({
+        'reminder_type': fields.Enum(ReminderType, required=True),
+        'render_mode': fields.Enum(RenderMode, required=True),
+        'include_summary': fields.Boolean(required=True),
+        'include_description': fields.Boolean(required=True),
+        'subject': fields.String(required=True),
+        'message': fields.String(required=True),
+    }, location='form')
+    def _process(self, reminder_type, render_mode, include_summary, include_description, subject, message):
+        if render_mode == RenderMode.plain_text:  # Legacy reminder (text/plain email only)
+            message = PlainText(message)
+        else:
+            message = RichMarkup(message)
         with self.event.force_event_locale():
-            tpl = make_reminder_email(self.event, include_summary, include_description, request.form.get('message'))
-            subject = tpl.get_subject()
-            body = tpl.get_body()
-        html = render_template('events/reminders/preview.html', subject=subject, body=body)
+            html_email_tpl, text_email_tpl = get_reminder_email_tpl(self.event, reminder_type, render_mode,
+                                                                    include_summary, include_description,
+                                                                    strip_tags(subject), message)
+        email_tpl = html_email_tpl or text_email_tpl
+        html = render_template('events/reminders/preview.html', render_mode=render_mode.name,
+                               subject=email_tpl.get_subject(), body=email_tpl.get_body())
         return jsonify(html=html)

--- a/indico/modules/events/reminders/controllers.py
+++ b/indico/modules/events/reminders/controllers.py
@@ -87,7 +87,8 @@ class RHEditReminder(RHSpecificReminderBase):
 
     def _process(self):
         reminder = self.reminder
-        form = ReminderForm(obj=self._get_defaults(), event=self.event)
+        form = ReminderForm(obj=self._get_defaults(), event=self.event, render_mode=self.reminder.render_mode,
+                            reminder_type=self.reminder.reminder_type)
         if form.validate_on_submit():
             if reminder.is_sent:
                 flash(_('This reminder has already been sent and cannot be modified anymore.'), 'error')

--- a/indico/modules/events/reminders/forms.py
+++ b/indico/modules/events/reminders/forms.py
@@ -18,7 +18,7 @@ from indico.modules.events.registration.models.tags import RegistrationTag
 from indico.modules.events.reminders.models.reminders import ReminderType
 from indico.util.date_time import now_utc
 from indico.util.i18n import _
-from indico.util.string import natural_sort_key, strip_tags
+from indico.util.string import natural_sort_key
 from indico.web.forms.base import IndicoForm, generated_data
 from indico.web.forms.fields import (EmailListField, IndicoDateTimeField, IndicoQuerySelectMultipleCheckboxField,
                                      IndicoRadioField, TimeDeltaField)
@@ -67,7 +67,7 @@ class ReminderForm(IndicoForm):
     # Misc
     reply_to_address = SelectField(_('Sender'), [DataRequired()],
                                    description=_('The email address that will show up as the sender.'))
-    subject = StringField(_('Subject'), [DataRequired()], filters=[strip_tags])
+    subject = StringField(_('Subject'), [DataRequired()])
     message = TextAreaField(_('Note'), [NoRelativeURLs()],
                             widget=TinyMCEWidget(absolute_urls=True, height=300),
                             description=_('A custom message to include in the email.'))

--- a/indico/modules/events/reminders/models/reminders.py
+++ b/indico/modules/events/reminders/models/reminders.py
@@ -5,8 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from enum import Enum
-
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -27,12 +25,13 @@ from indico.modules.events.registration.models.registrations import Registration
 from indico.modules.events.reminders import logger
 from indico.modules.events.reminders.util import get_reminder_email_tpl
 from indico.util.date_time import now_utc
+from indico.util.enum import IndicoIntEnum
 from indico.util.signals import values_from_signal
 from indico.util.string import format_repr
 from indico.web.flask.templating import get_template_module
 
 
-class ReminderType(int, Enum):
+class ReminderType(IndicoIntEnum):
     standard = 1
     custom = 2
 
@@ -202,6 +201,7 @@ class EventReminder(RenderModeMixin, db.Model):
         PyIntEnum(ReminderType),
         nullable=False
     )
+
     #: The user who created the reminder
     creator = db.relationship(
         'User',

--- a/indico/modules/events/reminders/models/reminders.py
+++ b/indico/modules/events/reminders/models/reminders.py
@@ -28,7 +28,6 @@ from indico.util.date_time import now_utc
 from indico.util.enum import IndicoIntEnum
 from indico.util.signals import values_from_signal
 from indico.util.string import format_repr
-from indico.web.flask.templating import get_template_module
 
 
 class ReminderType(IndicoIntEnum):
@@ -339,15 +338,6 @@ class EventReminder(RenderModeMixin, db.Model):
         for param in values_from_signal(extra_params, as_list=True):
             email_params.update(param)
         return make_email(**email_params)
-
-    def _get_reminder_email_tpl(self):
-        with_agenda = self.include_summary
-        if self.event.type_ == EventType.lecture:
-            with_agenda = False
-        agenda = self.event.timetable_entries.filter_by(parent_id=None).all() if with_agenda else None
-        return get_template_module('events/reminders/emails/event_reminder.txt', event=self.event,
-                                   url=self.event.short_external_url, note=self.note, with_agenda=with_agenda,
-                                   with_description=self.with_description, agenda=agenda)
 
     def send(self):
         """Send the reminder to its recipients."""

--- a/indico/modules/events/reminders/models/reminders.py
+++ b/indico/modules/events/reminders/models/reminders.py
@@ -5,6 +5,8 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from enum import Enum
+
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -12,7 +14,8 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from indico.core import signals
 from indico.core.config import config
 from indico.core.db import db
-from indico.core.db.sqlalchemy import UTCDateTime
+from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
+from indico.core.db.sqlalchemy.descriptions import RenderMode, RenderModeMixin
 from indico.core.notifications import make_email, send_email
 from indico.modules.core.settings import core_settings
 from indico.modules.events.contributions.models.persons import ContributionPersonLink, SubContributionPersonLink
@@ -22,10 +25,16 @@ from indico.modules.events.models.events import EventType
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.registrations import Registration, registrations_tags_table
 from indico.modules.events.reminders import logger
-from indico.modules.events.reminders.util import make_reminder_email
+from indico.modules.events.reminders.util import get_reminder_email_tpl
 from indico.util.date_time import now_utc
 from indico.util.signals import values_from_signal
 from indico.util.string import format_repr
+from indico.web.flask.templating import get_template_module
+
+
+class ReminderType(int, Enum):
+    standard = 1
+    custom = 2
 
 
 reminders_forms_table = db.Table(
@@ -74,12 +83,14 @@ reminders_tags_table = db.Table(
 )
 
 
-class EventReminder(db.Model):
+class EventReminder(RenderModeMixin, db.Model):
     """Email reminders for events."""
 
     __tablename__ = 'reminders'
     __table_args__ = (db.Index(None, 'scheduled_dt', postgresql_where=db.text('not is_sent')),
                       {'schema': 'events'})
+    possible_render_modes = {RenderMode.html, RenderMode.plain_text}
+    default_render_mode = RenderMode.html
 
     #: The ID of the reminder
     id = db.Column(
@@ -171,13 +182,26 @@ class EventReminder(db.Model):
         db.String,
         nullable=False
     )
-    #: Custom message to include in the email
-    message = db.Column(
+    #: Subject of reminder email for customized reminder.
+    subject = db.Column(
         db.String,
         nullable=False,
         default=''
     )
-
+    #: Custom message to include in the email
+    #: It's the note for ReminderType.standard and the complete message for ReminderType.custom
+    _message = db.Column(
+        'message',
+        db.Text,
+        nullable=False,
+        default=''
+    )
+    message = RenderModeMixin.create_hybrid_property('_message')
+    #: It is a standard reminder or a customized one.
+    reminder_type = db.Column(
+        PyIntEnum(ReminderType),
+        nullable=False
+    )
     #: The user who created the reminder
     creator = db.relationship(
         'User',
@@ -302,17 +326,28 @@ class EventReminder(db.Model):
     def is_overdue(self):
         return not self.is_sent and self.scheduled_dt <= now_utc()
 
-    def _make_email(self, sender, recipient, template, attachments):
+    def _make_email(self, sender, recipient, template, attachments, html, alternatives):
         email_params = {
             'to_list': recipient,
             'sender_address': sender,
             'template': template,
             'attachments': attachments,
+            'html': html,
+            'alternatives': alternatives
         }
         extra_params = signals.event.reminder.before_reminder_make_email.send(self, **email_params)
         for param in values_from_signal(extra_params, as_list=True):
             email_params.update(param)
         return make_email(**email_params)
+
+    def _get_reminder_email_tpl(self):
+        with_agenda = self.include_summary
+        if self.event.type_ == EventType.lecture:
+            with_agenda = False
+        agenda = self.event.timetable_entries.filter_by(parent_id=None).all() if with_agenda else None
+        return get_template_module('events/reminders/emails/event_reminder.txt', event=self.event,
+                                   url=self.event.short_external_url, note=self.note, with_agenda=with_agenda,
+                                   with_description=self.with_description, agenda=agenda)
 
     def send(self):
         """Send the reminder to its recipients."""
@@ -322,7 +357,9 @@ class EventReminder(db.Model):
             logger.info('Notification %s has no recipients; not sending anything', self)
             return
         with self.event.force_event_locale():
-            email_tpl = make_reminder_email(self.event, self.include_summary, self.include_description, self.message)
+            html_email_tpl, text_email_tpl = get_reminder_email_tpl(self.event, self.reminder_type, self.render_mode,
+                                                                    self.include_summary, self.include_description,
+                                                                    self.subject, self.message)
         attachments = []
         if self.attach_ical:
             event_ical = event_to_ical(self.event, skip_access_check=True, method='REQUEST',
@@ -330,9 +367,11 @@ class EventReminder(db.Model):
             attachments.append(MIMECalendar('event.ics', event_ical))
 
         sender = self.event.get_verbose_email_sender(self.reply_to_address)
+        alternatives = [(text_email_tpl.get_body(), 'text/plain')] if html_email_tpl and text_email_tpl else None
         for recipient in recipients:
             with self.event.force_event_locale():
-                email = self._make_email(sender, recipient, email_tpl, attachments)
+                email = self._make_email(sender, recipient, html_email_tpl or text_email_tpl, attachments,
+                                         html=bool(html_email_tpl), alternatives=alternatives)
             send_email(email, self.event, 'Reminder', self.creator, log_metadata={'reminder_id': self.id})
 
     def __repr__(self):

--- a/indico/modules/events/reminders/notifications_test.py
+++ b/indico/modules/events/reminders/notifications_test.py
@@ -5,11 +5,15 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import textwrap
 from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+from indico.core.db.sqlalchemy.descriptions import RenderMode
+from indico.modules.events.reminders.models.reminders import ReminderType
+from indico.modules.events.reminders.util import get_reminder_email_tpl
 from indico.testing.util import assert_email_snapshot
 from indico.util.string import RichMarkup
 from indico.web.flask.templating import get_template_module
@@ -79,3 +83,23 @@ def test_event_reminder_email_html(snapshot, create_contribution, create_timetab
                                    note=RichMarkup('<p>Meow.</p><p>Nyah!</p>'), with_agenda=True, agenda=agenda)
     snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
     assert_email_snapshot(snapshot, template, snapshot_filename, html=True)
+
+
+def test_event_reminder_email_plaintext_from_html(snapshot, create_event):
+    event = create_event(start_dt=datetime(2025, 8, 8, 18, 18),
+                         end_dt=datetime(2025, 8, 8, 19, 19),
+                         title='Baking Cats',
+                         url_shortcut='nyan')
+    note = RichMarkup(textwrap.dedent('''
+        <p><a href="https://www.nyan.cat/">Nyan Nyan <strong>Nyan!</strong></a></p>
+
+        <table>
+            <tr><th>Animal</th><th>Cuteness</th></tr>
+            <tr><td>Kitten</td><td>OVER 9000</td></tr>
+            <tr><td>Molerat</td><td>WTF</td></tr>
+        </table>
+    ''').strip())
+    html_tpl, text_tpl = get_reminder_email_tpl(event, ReminderType.standard, RenderMode.html, False, False, None, note)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    assert_email_snapshot(snapshot, text_tpl, 'event_reminder_htmlconv.txt')
+    assert_email_snapshot(snapshot, html_tpl, 'event_reminder_htmlconv.html', html=True)

--- a/indico/modules/events/reminders/notifications_test.py
+++ b/indico/modules/events/reminders/notifications_test.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from indico.testing.util import assert_email_snapshot
+from indico.util.string import RichMarkup
 from indico.web.flask.templating import get_template_module
 
 
@@ -45,3 +46,36 @@ def test_event_reminder_email_plaintext(snapshot, create_contribution, create_ti
                                    note='Meow.\nNyah!', with_agenda=True, agenda=agenda)
     snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
     assert_email_snapshot(snapshot, template, snapshot_filename)
+
+
+@pytest.mark.parametrize(('with_label', 'venue', 'room', 'address', 'snapshot_filename'), (
+    (True, '', '', '', 'event_reminder_label.html'),
+    (False, '', '', '', 'event_reminder.html'),
+    (False, 'Home', '', '', 'event_reminder_v.html'),
+    (False, '', 'Bed', '', 'event_reminder_r.html'),
+    (False, '', '', 'Some\nWhere', 'event_reminder_a.html'),
+    (False, 'Home', 'Bed', '', 'event_reminder_vr.html'),
+    (False, '', 'Bed', 'Some\nWhere', 'event_reminder_ra.html'),
+    (False, 'Home', '', 'Some\nWhere', 'event_reminder_va.html'),
+    (False, 'Home', 'Bed', 'Some\nWhere', 'event_reminder_vra.html'),
+))
+def test_event_reminder_email_html(snapshot, create_contribution, create_timetable_entry, create_event,
+                                   create_label, with_label, venue, room, address, snapshot_filename):
+    event = create_event(start_dt=datetime(2022, 11, 11, 13, 37),
+                         end_dt=datetime(2022, 11, 11, 23, 37), title='Baking with Cats')
+    event.venue_name = venue
+    event.room_name = room
+    event.address = address
+    c1 = create_contribution(event, 'Kneading Dough', timedelta(minutes=23))
+    c2 = create_contribution(event, 'Pure Bread Cats', timedelta(minutes=40))
+    create_timetable_entry(event, c1, datetime(2022, 11, 11, 13, 37))
+    create_timetable_entry(event, c2, datetime(2022, 11, 11, 15, 50))
+    if with_label:
+        label = create_label('POSTPONED')
+        event.label = label
+    agenda = event.timetable_entries.filter_by(parent_id=None).all()
+    template = get_template_module('events/reminders/emails/event_reminder.html',
+                                   event=event, url='http://localhost/', with_description=True,
+                                   note=RichMarkup('<p>Meow.</p><p>Nyah!</p>'), with_agenda=True, agenda=agenda)
+    snapshot.snapshot_dir = Path(__file__).parent / 'templates/emails/tests'
+    assert_email_snapshot(snapshot, template, snapshot_filename, html=True)

--- a/indico/modules/events/reminders/templates/edit_reminder.html
+++ b/indico/modules/events/reminders/templates/edit_reminder.html
@@ -41,8 +41,8 @@
                     method: 'POST',
                     data: function() {
                         return {
-                            reminder_type: $('#reminder_type').val(),
-                            render_mode: $('#render_mode').val(),
+                            reminder_type: {{ form.reminder_type.data.name|tojson }},
+                            render_mode: {{ form.render_mode.data.name|tojson }},
                             include_summary: $('#include_summary').prop('checked') ? '1' : '0',
                             include_description: $('#include_description').prop('checked') ? '1' : '0',
                             attach_ical: $('#attach_ical').prop('checked') ? '1' : '0',

--- a/indico/modules/events/reminders/templates/edit_reminder.html
+++ b/indico/modules/events/reminders/templates/edit_reminder.html
@@ -49,7 +49,8 @@
                             subject: $('#subject').val() ?? '',
                             message: $('#message').val()
                         };
-                    }
+                    },
+                    dialogClasses: 'editor-output',
                 });
             })();
         </script>

--- a/indico/modules/events/reminders/templates/edit_reminder.html
+++ b/indico/modules/events/reminders/templates/edit_reminder.html
@@ -37,13 +37,16 @@
                 'use strict';
 
                 $('#preview-reminder').ajaxDialog({
-                    title: $T('Reminder Preview'),
+                    title: $T('Reminder preview'),
                     method: 'POST',
                     data: function() {
                         return {
+                            reminder_type: $('#reminder_type').val(),
+                            render_mode: $('#render_mode').val(),
                             include_summary: $('#include_summary').prop('checked') ? '1' : '0',
                             include_description: $('#include_description').prop('checked') ? '1' : '0',
                             attach_ical: $('#attach_ical').prop('checked') ? '1' : '0',
+                            subject: $('#subject').val() ?? '',
                             message: $('#message').val()
                         };
                     }

--- a/indico/modules/events/reminders/templates/emails/_agenda.html
+++ b/indico/modules/events/reminders/templates/emails/_agenda.html
@@ -1,0 +1,38 @@
+{%- macro render_agenda(event, agenda) -%}
+    <h3>{% trans title=event.title %}Agenda for {{ title }}{% endtrans %}</h3>
+    {% if not agenda -%}
+        <p>{% trans %}There are no events scheduled.{% endtrans %}</p>
+    {%- endif -%}
+        <ul>
+        {%- for item in agenda %}
+            {{ render_item(item) }}
+        {%- endfor -%}
+        </ul>
+{%- endmacro -%}
+
+{%- macro render_item(item) -%}
+    {%- if item.type.name == 'SESSION_BLOCK' -%}
+        {{ render_session_block(item) }}
+    {%- else -%}
+        {{ render_entry(item) }}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_session_block(entry) -%}
+    <li>
+        {{ render_times(entry) }} {{ entry.object.full_title }}
+        <ul>
+        {%- for item in entry.children %}
+            {{ render_entry(item) }}
+        {%- endfor -%}
+        </ul>
+    </li>
+{%- endmacro -%}
+
+{%- macro render_entry(entry) -%}
+    <li>{{ render_times(entry) }} {{ entry.object.title }}</li>
+{%- endmacro -%}
+
+{%- macro render_times(entry) -%}
+    [{{ entry.start_dt | format_time(timezone=entry.event.tzinfo) }} - {{ entry.end_dt | format_time(timezone=entry.event.tzinfo) }}]
+{%- endmacro -%}

--- a/indico/modules/events/reminders/templates/emails/_agenda.html
+++ b/indico/modules/events/reminders/templates/emails/_agenda.html
@@ -6,7 +6,7 @@
         <ul>
         {%- for item in agenda %}
             {{ render_item(item) }}
-        {%- endfor -%}
+        {%- endfor %}
         </ul>
 {%- endmacro -%}
 

--- a/indico/modules/events/reminders/templates/emails/_agenda.html
+++ b/indico/modules/events/reminders/templates/emails/_agenda.html
@@ -4,9 +4,9 @@
         <p>{% trans %}There are no events scheduled.{% endtrans %}</p>
     {%- endif -%}
         <ul>
-        {%- for item in agenda %}
-            {{ render_item(item) }}
-        {%- endfor %}
+            {%- for item in agenda %}
+                {{ render_item(item) }}
+            {%- endfor %}
         </ul>
 {%- endmacro -%}
 
@@ -22,9 +22,9 @@
     <li>
         {{ render_times(entry) }} {{ entry.object.full_title }}
         <ul>
-        {%- for item in entry.children %}
-            {{ render_entry(item) }}
-        {%- endfor -%}
+            {%- for item in entry.children %}
+                {{ render_entry(item) }}
+            {%- endfor -%}
         </ul>
     </li>
 {%- endmacro -%}

--- a/indico/modules/events/reminders/templates/emails/custom_event_reminder.html
+++ b/indico/modules/events/reminders/templates/emails/custom_event_reminder.html
@@ -1,0 +1,7 @@
+{% extends 'emails/base_i18n.html' %}
+
+{% block subject -%}{{ subject }}{%- endblock %}
+{% block header %}{% endblock %}
+{% block footer_url %}{{ url }}{% endblock %}
+
+{% block body -%}{{ message }}{% endblock %}

--- a/indico/modules/events/reminders/templates/emails/custom_event_reminder.html
+++ b/indico/modules/events/reminders/templates/emails/custom_event_reminder.html
@@ -1,7 +1,0 @@
-{% extends 'emails/base_i18n.html' %}
-
-{% block subject -%}{{ subject }}{%- endblock %}
-{% block header %}{% endblock %}
-{% block footer_url %}{{ url }}{% endblock %}
-
-{% block body -%}{{ message }}{% endblock %}

--- a/indico/modules/events/reminders/templates/emails/event_reminder.html
+++ b/indico/modules/events/reminders/templates/emails/event_reminder.html
@@ -16,9 +16,9 @@
 
 {% block body -%}
     <p>
-    {%- trans title=event.title, start=event.start_dt|format_datetime(timezone=event.tzinfo), tz=event.timezone -%}
-        Please note that the event <a href="{{ url }}">"{{ title }}"{{ label }}</a> will start on {{ start }} ({{ tz }}).
-    {%- endtrans -%}
+        {%- trans title=event.title, start=event.start_dt|format_datetime(timezone=event.tzinfo), tz=event.timezone -%}
+            Please note that the event <a href="{{ url }}">"{{ title }}"{{ label }}</a> will start on {{ start }} ({{ tz }}).
+        {%- endtrans -%}
     </p>
     {%- if location or room %}
         <p>{% trans loc=render_location() %}It will take place at {{ loc }}{% endtrans %}</p>

--- a/indico/modules/events/reminders/templates/emails/event_reminder.html
+++ b/indico/modules/events/reminders/templates/emails/event_reminder.html
@@ -1,0 +1,77 @@
+{% extends 'emails/base_i18n.html' %}
+{% from 'events/reminders/emails/_agenda.html' import render_agenda %}
+
+{% set address = event.address %}
+{% set location = event.venue_name %}
+{% set room = event.room_name %}
+{% set label = ' {%s}'|format(event.label.title) if event.label else '' %}
+
+
+{% block subject -%}
+    [{% trans %}Event reminder{% endtrans %}] {{ event.title }}{{ label }} ({{ event.start_dt | format_datetime('short', timezone=event.tzinfo) }} {{ event.timezone }})
+{%- endblock %}
+{% block header %}{% endblock %}
+{% block footer_url %}{{ url }}{% endblock %}
+
+
+{% block body -%}
+    <p>
+    {%- trans title=event.title, start=event.start_dt|format_datetime(timezone=event.tzinfo), tz=event.timezone -%}
+        Please note that the event <a href="{{ url }}">"{{ title }}"{{ label }}</a> will start on {{ start }} ({{ tz }}).
+    {%- endtrans %}
+    </p>
+    <p>
+    {%- if location or room -%}
+        {% trans loc=render_location() %}It will take place at {{ loc }}{% endtrans %}
+    {%- elif address %}
+        {% trans %}It will take place at the following address:{% endtrans %}
+        {{ address }}
+    {%- endif %}
+    </p>
+    {%- if with_description and event.description %}
+        <h3>{% trans %}Description{% endtrans %}</h3>
+        {{ event.description }}
+    {%- endif -%}
+
+    {%- if note %}
+        <h3>{% trans %}Note{% endtrans %}</h3>
+        {{ note }}
+    {%- endif -%}
+
+    {%- if with_agenda %}
+        {{ render_agenda(event, agenda) }}
+    {%- endif -%}
+{%- endblock %}
+
+{%- macro render_location() -%}
+    {%- if location -%}
+        {%- if room -%}
+            {{ location }} {{ render_room() }}.
+        {%- else -%}
+            {{ location }}.
+        {%- endif -%}
+        {{- render_address() }}
+    {%- elif room -%}
+        {{ render_room() }}.
+        {{- render_address() }}
+    {%- else -%}
+        {{ render_address() }}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_room() -%}
+    {%- if room -%}
+        {%- if location -%}
+            ({{ room }})
+        {%- else -%}
+            {% trans r=room|trim %}room {{ r }}{% endtrans %}
+        {%- endif -%}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_address() -%}
+    {%- if address %}
+        {% trans %}Address:{% endtrans %}
+        {{ address }}
+    {%- endif -%}
+{%- endmacro -%}

--- a/indico/modules/events/reminders/templates/emails/event_reminder.html
+++ b/indico/modules/events/reminders/templates/emails/event_reminder.html
@@ -1,7 +1,7 @@
 {% extends 'emails/base_i18n.html' %}
 {% from 'events/reminders/emails/_agenda.html' import render_agenda %}
 
-{% set address = event.address %}
+{% set address = event.address | markdown %}
 {% set location = event.venue_name %}
 {% set room = event.room_name %}
 {% set label = ' {%s}'|format(event.label.title) if event.label else '' %}
@@ -18,16 +18,15 @@
     <p>
     {%- trans title=event.title, start=event.start_dt|format_datetime(timezone=event.tzinfo), tz=event.timezone -%}
         Please note that the event <a href="{{ url }}">"{{ title }}"{{ label }}</a> will start on {{ start }} ({{ tz }}).
-    {%- endtrans %}
+    {%- endtrans -%}
     </p>
-    <p>
-    {%- if location or room -%}
-        {% trans loc=render_location() %}It will take place at {{ loc }}{% endtrans %}
+    {%- if location or room %}
+        <p>{% trans loc=render_location() %}It will take place at {{ loc }}{% endtrans %}</p>
+        {{ render_address() }}
     {%- elif address %}
-        {% trans %}It will take place at the following address:{% endtrans %}
+        <p>{% trans %}It will take place at the following address:{% endtrans %}</p>
         {{ address }}
-    {%- endif %}
-    </p>
+    {%- endif -%}
     {%- if with_description and event.description %}
         <h3>{% trans %}Description{% endtrans %}</h3>
         {{ event.description }}
@@ -50,12 +49,8 @@
         {%- else -%}
             {{ location }}.
         {%- endif -%}
-        {{- render_address() }}
     {%- elif room -%}
         {{ render_room() }}.
-        {{- render_address() }}
-    {%- else -%}
-        {{ render_address() }}
     {%- endif -%}
 {%- endmacro -%}
 
@@ -71,7 +66,7 @@
 
 {%- macro render_address() -%}
     {%- if address %}
-        {% trans %}Address:{% endtrans %}
+        <p>{% trans %}Address:{% endtrans %}</p>
         {{ address }}
     {%- endif -%}
 {%- endmacro -%}

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder.html
@@ -9,5 +9,8 @@
 </ul>
 <br><br>
 <hr>
-<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+<p>
+<a href="http://localhost/">Indico</a>
+:: Email Notifier
+</p>
 </body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder.html
@@ -1,0 +1,13 @@
+<body>
+<p>Please note that the event <a href="http://localhost/">"Baking with Cats"</a> will start on 11 Nov 2022, 13:37 (UTC).</p>
+<h3>Note</h3>
+<p>Meow.</p><p>Nyah!</p>
+<h3>Agenda for Baking with Cats</h3>
+<ul>
+<li>[13:37 - 14:00] Kneading Dough</li>
+<li>[15:50 - 16:30] Pure Bread Cats</li>
+</ul>
+<br><br>
+<hr>
+<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+</body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder.subject.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder.subject.html
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking with Cats (11/11/2022, 13:37 UTC)

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_a.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_a.html
@@ -12,5 +12,8 @@ Where</p>
 </ul>
 <br><br>
 <hr>
-<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+<p>
+<a href="http://localhost/">Indico</a>
+:: Email Notifier
+</p>
 </body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_a.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_a.html
@@ -1,0 +1,16 @@
+<body>
+<p>Please note that the event <a href="http://localhost/">"Baking with Cats"</a> will start on 11 Nov 2022, 13:37 (UTC).</p>
+<p>It will take place at the following address:</p>
+<p>Some<br>
+Where</p>
+<h3>Note</h3>
+<p>Meow.</p><p>Nyah!</p>
+<h3>Agenda for Baking with Cats</h3>
+<ul>
+<li>[13:37 - 14:00] Kneading Dough</li>
+<li>[15:50 - 16:30] Pure Bread Cats</li>
+</ul>
+<br><br>
+<hr>
+<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+</body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_a.subject.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_a.subject.html
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking with Cats (11/11/2022, 13:37 UTC)

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_htmlconv.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_htmlconv.html
@@ -1,0 +1,16 @@
+<body>
+<p>Please note that the event <a href="http://localhost/e/nyan">"Baking Cats"</a> will start on 8 Aug 2025, 18:18 (UTC).</p>
+<h3>Note</h3>
+<p><a href="https://www.nyan.cat/">Nyan Nyan <strong>Nyan!</strong></a></p>
+<table>
+<tbody><tr><th>Animal</th><th>Cuteness</th></tr>
+<tr><td>Kitten</td><td>OVER 9000</td></tr>
+<tr><td>Molerat</td><td>WTF</td></tr>
+</tbody></table>
+<br><br>
+<hr>
+<p>
+<a href="http://localhost/e/nyan">Indico</a>
+:: Email Notifier
+</p>
+</body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_htmlconv.subject.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_htmlconv.subject.html
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking Cats (08/08/2025, 18:18 UTC)

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_htmlconv.subject.txt
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_htmlconv.subject.txt
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking Cats (08/08/2025, 18:18 UTC)

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_htmlconv.txt
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_htmlconv.txt
@@ -1,0 +1,22 @@
+Please note that the event "Baking Cats" will start on 8 Aug 2025, 18:18 (UTC).
+
+You can access the full event here:
+http://localhost/e/nyan
+
+
+Note
+----
+[Nyan Nyan **Nyan!**][1]
+
+| Animal  | Cuteness  |
+|---------|-----------|
+| Kitten  | OVER 9000 |
+| Molerat | WTF       |
+
+
+
+   [1]: https://www.nyan.cat/
+
+--
+Indico :: Email Notifier
+http://localhost/e/nyan

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_label.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_label.html
@@ -9,5 +9,8 @@
 </ul>
 <br><br>
 <hr>
-<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+<p>
+<a href="http://localhost/">Indico</a>
+:: Email Notifier
+</p>
 </body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_label.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_label.html
@@ -1,0 +1,13 @@
+<body>
+<p>Please note that the event <a href="http://localhost/">"Baking with Cats" {POSTPONED}</a> will start on 11 Nov 2022, 13:37 (UTC).</p>
+<h3>Note</h3>
+<p>Meow.</p><p>Nyah!</p>
+<h3>Agenda for Baking with Cats</h3>
+<ul>
+<li>[13:37 - 14:00] Kneading Dough</li>
+<li>[15:50 - 16:30] Pure Bread Cats</li>
+</ul>
+<br><br>
+<hr>
+<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+</body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_label.subject.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_label.subject.html
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking with Cats {POSTPONED} (11/11/2022, 13:37 UTC)

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_r.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_r.html
@@ -1,0 +1,14 @@
+<body>
+<p>Please note that the event <a href="http://localhost/">"Baking with Cats"</a> will start on 11 Nov 2022, 13:37 (UTC).</p>
+<p>It will take place at room Bed.</p>
+<h3>Note</h3>
+<p>Meow.</p><p>Nyah!</p>
+<h3>Agenda for Baking with Cats</h3>
+<ul>
+<li>[13:37 - 14:00] Kneading Dough</li>
+<li>[15:50 - 16:30] Pure Bread Cats</li>
+</ul>
+<br><br>
+<hr>
+<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+</body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_r.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_r.html
@@ -10,5 +10,8 @@
 </ul>
 <br><br>
 <hr>
-<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+<p>
+<a href="http://localhost/">Indico</a>
+:: Email Notifier
+</p>
 </body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_r.subject.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_r.subject.html
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking with Cats (11/11/2022, 13:37 UTC)

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_ra.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_ra.html
@@ -13,5 +13,8 @@ Where</p>
 </ul>
 <br><br>
 <hr>
-<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+<p>
+<a href="http://localhost/">Indico</a>
+:: Email Notifier
+</p>
 </body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_ra.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_ra.html
@@ -1,0 +1,17 @@
+<body>
+<p>Please note that the event <a href="http://localhost/">"Baking with Cats"</a> will start on 11 Nov 2022, 13:37 (UTC).</p>
+<p>It will take place at room Bed.</p>
+<p>Address:</p>
+<p>Some<br>
+Where</p>
+<h3>Note</h3>
+<p>Meow.</p><p>Nyah!</p>
+<h3>Agenda for Baking with Cats</h3>
+<ul>
+<li>[13:37 - 14:00] Kneading Dough</li>
+<li>[15:50 - 16:30] Pure Bread Cats</li>
+</ul>
+<br><br>
+<hr>
+<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+</body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_ra.subject.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_ra.subject.html
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking with Cats (11/11/2022, 13:37 UTC)

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_v.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_v.html
@@ -10,5 +10,8 @@
 </ul>
 <br><br>
 <hr>
-<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+<p>
+<a href="http://localhost/">Indico</a>
+:: Email Notifier
+</p>
 </body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_v.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_v.html
@@ -1,0 +1,14 @@
+<body>
+<p>Please note that the event <a href="http://localhost/">"Baking with Cats"</a> will start on 11 Nov 2022, 13:37 (UTC).</p>
+<p>It will take place at Home.</p>
+<h3>Note</h3>
+<p>Meow.</p><p>Nyah!</p>
+<h3>Agenda for Baking with Cats</h3>
+<ul>
+<li>[13:37 - 14:00] Kneading Dough</li>
+<li>[15:50 - 16:30] Pure Bread Cats</li>
+</ul>
+<br><br>
+<hr>
+<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+</body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_v.subject.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_v.subject.html
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking with Cats (11/11/2022, 13:37 UTC)

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_va.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_va.html
@@ -13,5 +13,8 @@ Where</p>
 </ul>
 <br><br>
 <hr>
-<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+<p>
+<a href="http://localhost/">Indico</a>
+:: Email Notifier
+</p>
 </body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_va.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_va.html
@@ -1,0 +1,17 @@
+<body>
+<p>Please note that the event <a href="http://localhost/">"Baking with Cats"</a> will start on 11 Nov 2022, 13:37 (UTC).</p>
+<p>It will take place at Home.</p>
+<p>Address:</p>
+<p>Some<br>
+Where</p>
+<h3>Note</h3>
+<p>Meow.</p><p>Nyah!</p>
+<h3>Agenda for Baking with Cats</h3>
+<ul>
+<li>[13:37 - 14:00] Kneading Dough</li>
+<li>[15:50 - 16:30] Pure Bread Cats</li>
+</ul>
+<br><br>
+<hr>
+<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+</body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_va.subject.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_va.subject.html
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking with Cats (11/11/2022, 13:37 UTC)

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_vr.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_vr.html
@@ -1,0 +1,14 @@
+<body>
+<p>Please note that the event <a href="http://localhost/">"Baking with Cats"</a> will start on 11 Nov 2022, 13:37 (UTC).</p>
+<p>It will take place at Home (Bed).</p>
+<h3>Note</h3>
+<p>Meow.</p><p>Nyah!</p>
+<h3>Agenda for Baking with Cats</h3>
+<ul>
+<li>[13:37 - 14:00] Kneading Dough</li>
+<li>[15:50 - 16:30] Pure Bread Cats</li>
+</ul>
+<br><br>
+<hr>
+<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+</body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_vr.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_vr.html
@@ -10,5 +10,8 @@
 </ul>
 <br><br>
 <hr>
-<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+<p>
+<a href="http://localhost/">Indico</a>
+:: Email Notifier
+</p>
 </body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_vr.subject.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_vr.subject.html
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking with Cats (11/11/2022, 13:37 UTC)

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_vra.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_vra.html
@@ -13,5 +13,8 @@ Where</p>
 </ul>
 <br><br>
 <hr>
-<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+<p>
+<a href="http://localhost/">Indico</a>
+:: Email Notifier
+</p>
 </body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_vra.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_vra.html
@@ -1,0 +1,17 @@
+<body>
+<p>Please note that the event <a href="http://localhost/">"Baking with Cats"</a> will start on 11 Nov 2022, 13:37 (UTC).</p>
+<p>It will take place at Home (Bed).</p>
+<p>Address:</p>
+<p>Some<br>
+Where</p>
+<h3>Note</h3>
+<p>Meow.</p><p>Nyah!</p>
+<h3>Agenda for Baking with Cats</h3>
+<ul>
+<li>[13:37 - 14:00] Kneading Dough</li>
+<li>[15:50 - 16:30] Pure Bread Cats</li>
+</ul>
+<br><br>
+<hr>
+<p><a href="http://localhost/">Indico</a> :: Email Notifier</p>
+</body>

--- a/indico/modules/events/reminders/templates/emails/tests/event_reminder_vra.subject.html
+++ b/indico/modules/events/reminders/templates/emails/tests/event_reminder_vra.subject.html
@@ -1,0 +1,1 @@
+[Indico] [Event reminder] Baking with Cats (11/11/2022, 13:37 UTC)

--- a/indico/modules/events/reminders/templates/preview.html
+++ b/indico/modules/events/reminders/templates/preview.html
@@ -1,5 +1,12 @@
+{% if render_mode == 'plain_text' %}
 <strong>{% trans %}Subject{% endtrans %}</strong>
 <pre class="mono">{{ subject }}</pre>
 <br>
 <strong>{% trans %}Body{% endtrans %}</strong>
 <pre class="mono">{{ body }}</pre>
+{% else %}
+<h3>{% trans %}Subject{% endtrans %}</h3>
+{{ subject }}
+<h3>{% trans %}Body{% endtrans %}</h3>
+{{ body }}
+{% endif %}

--- a/indico/modules/events/reminders/templates/preview.html
+++ b/indico/modules/events/reminders/templates/preview.html
@@ -1,12 +1,12 @@
 {% if render_mode == 'plain_text' %}
-<strong>{% trans %}Subject{% endtrans %}</strong>
-<pre class="mono">{{ subject }}</pre>
-<br>
-<strong>{% trans %}Body{% endtrans %}</strong>
-<pre class="mono">{{ body }}</pre>
+    <strong>{% trans %}Subject{% endtrans %}</strong>
+    <pre class="mono">{{ subject }}</pre>
+    <br>
+    <strong>{% trans %}Body{% endtrans %}</strong>
+    <pre class="mono">{{ body }}</pre>
 {% else %}
-<h3>{% trans %}Subject{% endtrans %}</h3>
-{{ subject }}
-<h3>{% trans %}Body{% endtrans %}</h3>
-{{ body }}
+    <h3>{% trans %}Subject{% endtrans %}</h3>
+    {{ subject }}
+    <h3>{% trans %}Body{% endtrans %}</h3>
+    {{ body }}
 {% endif %}

--- a/indico/modules/events/reminders/templates/reminders.html
+++ b/indico/modules/events/reminders/templates/reminders.html
@@ -56,14 +56,24 @@
     <div class="i-box-group vert fixed-width reminders">
         <div class="i-box">
             <div class="i-box-header">
-                <div class="i-box-title">{%- trans %}Pending Reminders{% endtrans -%}</div>
-                <div class="i-box-buttons hide-if-locked">
-                    <button class="i-button icon-plus" data-href="{{ url_for('.add', event) }}"
-                        data-title="{%- trans %}Add Reminder{% endtrans -%}"
-                        data-ajax-dialog
-                        data-reload-after>
-                        {%- trans %}Add Reminder{% endtrans -%}
-                    </button>
+                <div class="i-box-title">{%- trans %}Pending reminders{% endtrans -%}</div>
+                <div class="i-box-buttons toolbar right hide-if-locked">
+                    <div class="group">
+                        <button class="i-button icon-plus" data-href="{{ url_for('.add', event, reminder_type='custom') }}"
+                            data-title="{%- trans %}Add custom reminder{% endtrans -%}"
+                            data-ajax-dialog
+                            data-reload-after>
+                            {%- trans %}Add custom reminder{% endtrans -%}
+                        </button>
+                    </div>
+                    <div class="group">
+                        <button class="i-button icon-plus" data-href="{{ url_for('.add', event, reminder_type='standard') }}"
+                            data-title="{%- trans %}Add standard reminder{% endtrans -%}"
+                            data-ajax-dialog
+                            data-reload-after>
+                            {%- trans %}Add standard reminder{% endtrans -%}
+                        </button>
+                    </div>
                 </div>
             </div>
             <div class="i-box-content">
@@ -77,7 +87,7 @@
         {% if sent_reminders %}
             <div class="i-box">
                 <div class="i-box-header">
-                    <div class="i-box-title">{%- trans %}Sent Reminders{% endtrans -%}</div>
+                    <div class="i-box-title">{%- trans %}Sent reminders{% endtrans -%}</div>
                 </div>
                 <div class="i-box-content">
                     {{ render_reminders(sent_reminders) }}

--- a/indico/modules/events/reminders/templates/reminders.html
+++ b/indico/modules/events/reminders/templates/reminders.html
@@ -59,18 +59,20 @@
                 <div class="i-box-title">{%- trans %}Pending reminders{% endtrans -%}</div>
                 <div class="i-box-buttons toolbar right hide-if-locked">
                     <div class="group">
-                        <button class="i-button icon-plus" data-href="{{ url_for('.add', event, reminder_type='custom') }}"
-                            data-title="{%- trans %}Add custom reminder{% endtrans -%}"
-                            data-ajax-dialog
-                            data-reload-after>
+                        <button class="i-button icon-plus"
+                                data-href="{{ url_for('.add', event, reminder_type='custom') }}"
+                                data-title="{%- trans %}Add custom reminder{% endtrans -%}"
+                                data-ajax-dialog
+                                data-reload-after>
                             {%- trans %}Add custom reminder{% endtrans -%}
                         </button>
                     </div>
                     <div class="group">
-                        <button class="i-button icon-plus" data-href="{{ url_for('.add', event, reminder_type='standard') }}"
-                            data-title="{%- trans %}Add standard reminder{% endtrans -%}"
-                            data-ajax-dialog
-                            data-reload-after>
+                        <button class="i-button icon-plus"
+                                data-href="{{ url_for('.add', event, reminder_type='standard') }}"
+                                data-title="{%- trans %}Add standard reminder{% endtrans -%}"
+                                data-ajax-dialog
+                                data-reload-after>
                             {%- trans %}Add standard reminder{% endtrans -%}
                         </button>
                     </div>

--- a/indico/modules/events/reminders/util.py
+++ b/indico/modules/events/reminders/util.py
@@ -35,7 +35,7 @@ def get_reminder_email_tpl(event, reminder_type, render_mode, with_agenda, with_
             with_agenda = False
         agenda = event.timetable_entries.filter_by(parent_id=None).all() if with_agenda else None
         note = str(message)  # Legacy reminder (text/plain email only)
-        if render_mode == RenderMode.html:
+        if note and render_mode == RenderMode.html:
             note = html_to_plaintext(note).strip()  # Standard reminder (text/html -> text/plain)
         text_tpl = get_template_module('events/reminders/emails/event_reminder.txt', event=event,
                                         url=event.short_external_url, note=note, with_agenda=with_agenda,

--- a/indico/modules/events/reminders/util.py
+++ b/indico/modules/events/reminders/util.py
@@ -29,23 +29,23 @@ def get_reminder_email_tpl(event, reminder_type, render_mode, with_agenda, with_
     """
     from indico.modules.events.reminders.models.reminders import ReminderType
 
-    html_tpl = text_tpl = None
-    if reminder_type == ReminderType.standard:
-        if event.type_ == EventType.lecture:
-            with_agenda = False
-        agenda = event.timetable_entries.filter_by(parent_id=None).all() if with_agenda else None
-        note = str(message)  # Legacy reminder (text/plain email only)
-        if note and render_mode == RenderMode.html:
-            note = html_to_plaintext(note).strip()  # Standard reminder (text/html -> text/plain)
-        text_tpl = get_template_module('events/reminders/emails/event_reminder.txt', event=event,
-                                        url=event.short_external_url, note=note, with_agenda=with_agenda,
-                                        with_description=with_description, agenda=agenda)
-        if render_mode == RenderMode.html:
-            html_tpl = get_template_module('events/reminders/emails/event_reminder.html', event=event,
-                                            url=event.short_external_url, note=message, with_agenda=with_agenda,
-                                            with_description=with_description, agenda=agenda)
-    else:
+    if reminder_type == ReminderType.custom:
         html_tpl = get_template_module('emails/custom.html',
                                        url=event.short_external_url, subject=subject, body=message)
+        return html_tpl, None
+
+    if event.type_ == EventType.lecture:
+        with_agenda = False
+    agenda = event.timetable_entries.filter_by(parent_id=None).all() if with_agenda else None
+    note = str(message)  # Legacy reminder (text/plain email only)
+    if note and render_mode == RenderMode.html:
+        note = html_to_plaintext(note).strip()  # Standard reminder (text/html -> text/plain)
+    text_tpl = get_template_module('events/reminders/emails/event_reminder.txt', event=event,
+                                    url=event.short_external_url, note=note, with_agenda=with_agenda,
+                                    with_description=with_description, agenda=agenda)
+    if render_mode == RenderMode.html:
+        html_tpl = get_template_module('events/reminders/emails/event_reminder.html', event=event,
+                                        url=event.short_external_url, note=message, with_agenda=with_agenda,
+                                        with_description=with_description, agenda=agenda)
 
     return html_tpl, text_tpl

--- a/indico/modules/events/reminders/util.py
+++ b/indico/modules/events/reminders/util.py
@@ -7,7 +7,7 @@
 
 from indico.core.db.sqlalchemy.descriptions import RenderMode
 from indico.modules.events.models.events import EventType
-from indico.util.string import html_to_plaintext
+from indico.util.string import html_to_markdown
 from indico.web.flask.templating import get_template_module
 
 
@@ -37,11 +37,12 @@ def get_reminder_email_tpl(event, reminder_type, render_mode, with_agenda, with_
     if event.type_ == EventType.lecture:
         with_agenda = False
     agenda = event.timetable_entries.filter_by(parent_id=None).all() if with_agenda else None
-    note = str(message)  # Legacy reminder (text/plain email only)
-    if note and render_mode == RenderMode.html:
-        note = html_to_plaintext(note).strip()  # Standard reminder (text/html -> text/plain)
+    text_message = str(message)  # Legacy reminder (text/plain email only)
+    if text_message and render_mode == RenderMode.html:
+        # Standard reminder (text/html -> text/plain)
+        text_message = html_to_markdown(text_message, inline_links=False).strip()
     text_tpl = get_template_module('events/reminders/emails/event_reminder.txt', event=event,
-                                    url=event.short_external_url, note=note, with_agenda=with_agenda,
+                                    url=event.short_external_url, note=text_message, with_agenda=with_agenda,
                                     with_description=with_description, agenda=agenda)
     if render_mode == RenderMode.html:
         html_tpl = get_template_module('events/reminders/emails/event_reminder.html', event=event,

--- a/indico/modules/events/reminders/util.py
+++ b/indico/modules/events/reminders/util.py
@@ -5,20 +5,47 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from indico.core.db.sqlalchemy.descriptions import RenderMode
 from indico.modules.events.models.events import EventType
+from indico.util.string import html_to_plaintext
 from indico.web.flask.templating import get_template_module
 
 
-def make_reminder_email(event, with_agenda, with_description, note):
-    """Return the template module for the reminder email.
+def get_reminder_email_tpl(event, reminder_type, render_mode, with_agenda, with_description, subject, message):
+    """Return template modules for reminder email in both text/html abd text/plain format if applicable.
+
+    Legacy reminder (text/plain message) -> text/plain email format only
+    Standard reminder (text/html message) -> both text/html and text/plain email format
+    Custom reminder (text/html message) -> text/html email format only
 
     :param event: The event
+    :param reminder_type: standard|custom
+    :param render_mode: plain_text|html
     :param with_agenda: If the event's agenda should be included
-    :param note: A custom message to include in the email
+    :param subject: Subject for the custom reminder
+    :param message: A custom message to include in the email (full email body for custom reminder)
+
+    :return: tuple of templates for text/html and text/plain representation
     """
-    if event.type_ == EventType.lecture:
-        with_agenda = False
-    agenda = event.timetable_entries.filter_by(parent_id=None).all() if with_agenda else None
-    return get_template_module('events/reminders/emails/event_reminder.txt', event=event,
-                               url=event.short_external_url, note=note, with_agenda=with_agenda,
-                               with_description=with_description, agenda=agenda)
+    from indico.modules.events.reminders.models.reminders import ReminderType
+
+    html_tpl = text_tpl = None
+    if reminder_type == ReminderType.standard:
+        if event.type_ == EventType.lecture:
+            with_agenda = False
+        agenda = event.timetable_entries.filter_by(parent_id=None).all() if with_agenda else None
+        note = str(message)  # Legacy reminder (text/plain email only)
+        if render_mode == RenderMode.html:
+            note = html_to_plaintext(note).strip()  # Standard reminder (text/html -> text/plain)
+        text_tpl = get_template_module('events/reminders/emails/event_reminder.txt', event=event,
+                                        url=event.short_external_url, note=note, with_agenda=with_agenda,
+                                        with_description=with_description, agenda=agenda)
+        if render_mode == RenderMode.html:
+            html_tpl = get_template_module('events/reminders/emails/event_reminder.html', event=event,
+                                            url=event.short_external_url, note=message, with_agenda=with_agenda,
+                                            with_description=with_description, agenda=agenda)
+    else:
+        html_tpl = get_template_module('events/reminders/emails/custom_event_reminder.html',
+                                       url=event.short_external_url, subject=subject, message=message)
+
+    return html_tpl, text_tpl

--- a/indico/modules/events/reminders/util.py
+++ b/indico/modules/events/reminders/util.py
@@ -45,7 +45,7 @@ def get_reminder_email_tpl(event, reminder_type, render_mode, with_agenda, with_
                                             url=event.short_external_url, note=message, with_agenda=with_agenda,
                                             with_description=with_description, agenda=agenda)
     else:
-        html_tpl = get_template_module('events/reminders/emails/custom_event_reminder.html',
-                                       url=event.short_external_url, subject=subject, message=message)
+        html_tpl = get_template_module('emails/custom.html',
+                                       url=event.short_external_url, subject=subject, body=message)
 
     return html_tpl, text_tpl

--- a/indico/modules/logs/client/style/logs.scss
+++ b/indico/modules/logs/client/style/logs.scss
@@ -200,6 +200,15 @@ table.log-modal-details {
     white-space: normal;
     // For custom HTML where wrapping doesn't work, we at least show a scrollbar.
     overflow-x: auto;
+
+    ul,
+    ol {
+      margin-left: 3em;
+    }
+
+    :is(ul, ol) :is(ul, ol) {
+      margin-left: 1.2em;
+    }
   }
 
   .diff {

--- a/indico/modules/logs/controllers.py
+++ b/indico/modules/logs/controllers.py
@@ -219,6 +219,7 @@ class RHResendEmail(RHManageEventBase):
             subject=self.entry.data['subject'],
             body=self.entry.data['body'],
             html=self.entry.data['content_type'] == 'text/html',
+            alternatives=self.entry.data.get('alternatives'),
         )
         send_email(email, event=self.event, module=self.entry.module, user=self.entry.user,
                    log_metadata=self.entry.meta, log_summary=f'Resent email: {self.entry.data['subject']}')

--- a/indico/testing/util.py
+++ b/indico/testing/util.py
@@ -15,8 +15,6 @@ from itertools import product
 
 import yaml
 
-from indico.util.string import strip_html_whitespace
-
 
 def bool_matrix(template, mask=None, expect=None):
     """Create a boolean matrix suitable for parametrized tests.
@@ -188,6 +186,11 @@ def extract_logs(caplog, required=True, count=None, one=False, regex=False, **kw
     return found
 
 
+def _strip_html_whitespace(content):
+    """Remove trailing/leading whitespace in each line of the input content."""
+    return '\n'.join(stripped for line in content.splitlines() if (stripped := line.strip()))
+
+
 def assert_email_snapshot(snapshot, template, snapshot_filename, *, html=False):
     """Assert that an email matches a snapshot.
 
@@ -201,7 +204,7 @@ def assert_email_snapshot(snapshot, template, snapshot_filename, *, html=False):
     body = template.get_body()
     if html:
         # we add a trailing linebreak so make manually editing the snapshot easier
-        body = strip_html_whitespace(body) + '\n'
+        body = _strip_html_whitespace(body) + '\n'
     subject = template.get_subject()
     name, ext = os.path.splitext(snapshot_filename)
     snapshot_filename_subject = f'{name}.subject{ext}'

--- a/indico/testing/util.py
+++ b/indico/testing/util.py
@@ -188,7 +188,7 @@ def extract_logs(caplog, required=True, count=None, one=False, regex=False, **kw
     return found
 
 
-def assert_email_snapshot(snapshot, template, snapshot_filename, html=False):
+def assert_email_snapshot(snapshot, template, snapshot_filename, *, html=False):
     """Assert that an email matches a snapshot.
 
     This verifies that both the subject and the body match the snapshots.
@@ -196,6 +196,7 @@ def assert_email_snapshot(snapshot, template, snapshot_filename, html=False):
     :param snapshot: The pytest snapshot fixture
     :param template: The email template module
     :param snapshot_filename: The filename for the snapshot
+    :param html: Whether the template is HTML
     """
     body = template.get_body()
     if html:

--- a/indico/testing/util.py
+++ b/indico/testing/util.py
@@ -15,6 +15,8 @@ from itertools import product
 
 import yaml
 
+from indico.util.string import strip_html_whitespace
+
 
 def bool_matrix(template, mask=None, expect=None):
     """Create a boolean matrix suitable for parametrized tests.
@@ -186,7 +188,7 @@ def extract_logs(caplog, required=True, count=None, one=False, regex=False, **kw
     return found
 
 
-def assert_email_snapshot(snapshot, template, snapshot_filename):
+def assert_email_snapshot(snapshot, template, snapshot_filename, html=False):
     """Assert that an email matches a snapshot.
 
     This verifies that both the subject and the body match the snapshots.
@@ -196,6 +198,9 @@ def assert_email_snapshot(snapshot, template, snapshot_filename):
     :param snapshot_filename: The filename for the snapshot
     """
     body = template.get_body()
+    if html:
+        # we add a trailing linebreak so make manually editing the snapshot easier
+        body = strip_html_whitespace(body) + '\n'
     subject = template.get_subject()
     name, ext = os.path.splitext(snapshot_filename)
     snapshot_filename_subject = f'{name}.subject{ext}'

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -407,6 +407,18 @@ def strip_whitespace(s):
     return s
 
 
+def strip_html_whitespace(content):
+    """Remove trailing/leading whitespace in each line of the input content.
+
+    This utility is useful when would like to compare template result.
+    """
+    lines = []
+    for line in content.splitlines():
+        if line := line.strip():
+            lines.append(line)  # noqa: PERF401
+    return '\n'.join(lines)
+
+
 def make_unique_token(is_unique):
     """Create a unique UUID4-based token.
 

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -410,13 +410,9 @@ def strip_whitespace(s):
 def strip_html_whitespace(content):
     """Remove trailing/leading whitespace in each line of the input content.
 
-    This utility is useful when would like to compare template result.
+    This utility is useful when comparing HTML template result.
     """
-    lines = []
-    for line in content.splitlines():
-        if line := line.strip():
-            lines.append(line)  # noqa: PERF401
-    return '\n'.join(lines)
+    return '\n'.join(stripped for line in content.splitlines() if (stripped := line.strip()))
 
 
 def make_unique_token(is_unique):

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -290,7 +290,7 @@ def render_markdown(text, escape_latex_math=True, md=None, extra_html=False, **k
         return result
 
 
-def html_to_markdown(html):
+def html_to_markdown(html, **config):
     """Convert basic HTML to Markdown.
 
     This util is meant for cases like comments where the text is generally written
@@ -299,6 +299,8 @@ def html_to_markdown(html):
     """
     ht = HTML2Text(bodywidth=0)
     ht.pad_tables = True
+    for key, value in config.items():
+        setattr(ht, key, value)
     return ht.handle(html)
 
 

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -407,14 +407,6 @@ def strip_whitespace(s):
     return s
 
 
-def strip_html_whitespace(content):
-    """Remove trailing/leading whitespace in each line of the input content.
-
-    This utility is useful when comparing HTML template result.
-    """
-    return '\n'.join(stripped for line in content.splitlines() if (stripped := line.strip()))
-
-
 def make_unique_token(is_unique):
     """Create a unique UUID4-based token.
 

--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -242,7 +242,7 @@ def truncate(text, max_size, ellipsis='...'):
 
 def strip_tags(text):
     """Strip HTML tags and replace adjacent whitespace by one space."""
-    return do_striptags(text)
+    return do_striptags(text or '')
 
 
 def render_markdown(text, escape_latex_math=True, md=None, extra_html=False, **kwargs):

--- a/indico/web/client/js/jquery/widgets/jinja/tinymce_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/tinymce_widget.js
@@ -13,6 +13,7 @@ import {getConfig} from 'indico/tinymce';
   global.setupTinyMCEWidget = async function setupTinyMCEWidget(options) {
     const {
       fieldId,
+      disabled = false,
       images = true,
       imageUploadURL = null,
       forceAbsoluteURLs = false,
@@ -28,6 +29,6 @@ import {getConfig} from 'indico/tinymce';
       // closed and then reopened) won't do anything
       tinymce.remove(old);
     }
-    tinymce.init(getConfig(field, {images, imageUploadURL, forceAbsoluteURLs, height, contentCSS}));
+    tinymce.init(getConfig(field, {disabled, images, imageUploadURL, forceAbsoluteURLs, height, contentCSS}));
   };
 })(window);

--- a/indico/web/client/js/tinymce.js
+++ b/indico/web/client/js/tinymce.js
@@ -55,6 +55,7 @@ body {
 export const getConfig = (
   field,
   {
+    disabled = false,
     images = true,
     imageUploadURL = null,
     fullScreen = true,
@@ -65,6 +66,7 @@ export const getConfig = (
   } = {},
   {onChange = null} = {}
 ) => ({
+  readonly: disabled,
   target: field,
   promotion: false,
   branding: false,

--- a/indico/web/client/styles/legacy/Default.css
+++ b/indico/web/client/styles/legacy/Default.css
@@ -231,9 +231,13 @@ span.errorTitle {
 div.exclusivePopup {
   background-color: white;
   display: block;
-  min-width: 250px;
+  min-width: 700px;
   padding: 15px;
   overflow: hidden;
+}
+
+div.exclusivePopup ul {
+  padding-left: 40px;
 }
 
 div.ui-dialog-titlebar {

--- a/indico/web/client/styles/legacy/Default.css
+++ b/indico/web/client/styles/legacy/Default.css
@@ -236,10 +236,6 @@ div.exclusivePopup {
   overflow: hidden;
 }
 
-div.exclusivePopup ul {
-  padding-left: 40px;
-}
-
 div.ui-dialog-titlebar {
   padding: 0.4em 15px !important;
   border-bottom-left-radius: 0;

--- a/indico/web/client/styles/legacy/Default.css
+++ b/indico/web/client/styles/legacy/Default.css
@@ -231,7 +231,7 @@ span.errorTitle {
 div.exclusivePopup {
   background-color: white;
   display: block;
-  min-width: 700px;
+  min-width: 250px;
   padding: 15px;
   overflow: hidden;
 }

--- a/indico/web/templates/emails/base_i18n.html
+++ b/indico/web/templates/emails/base_i18n.html
@@ -6,5 +6,8 @@
 
 {% block footer_content %}
     <hr>
-    <p><a href="{% block footer_url %}{{ url_for_index(_external=true) }}{% endblock %}">Indico</a> :: {% block footer_title %}{% trans %}Email Notifier{% endtrans %}{% endblock %}</p>
+    <p>
+        <a href="{% block footer_url %}{{ url_for_index(_external=true) }}{% endblock %}">Indico</a>
+        :: {% block footer_title %}{% trans %}Email Notifier{% endtrans %}{% endblock %}
+    </p>
 {% endblock %}

--- a/indico/web/templates/emails/base_i18n.html
+++ b/indico/web/templates/emails/base_i18n.html
@@ -6,6 +6,5 @@
 
 {% block footer_content %}
     <hr>
-    <a href="{% block footer_url %}{{ url_for_index(_external=true) }}{% endblock %}">Indico</a>
-    :: {% block footer_title %}{% trans %}Email Notifier{% endtrans %}{% endblock %}<br>
+    <p><a href="{% block footer_url %}{{ url_for_index(_external=true) }}{% endblock %}">Indico</a> :: {% block footer_title %}{% trans %}Email Notifier{% endtrans %}{% endblock %}</p>
 {% endblock %}

--- a/indico/web/templates/forms/tinymce_widget.html
+++ b/indico/web/templates/forms/tinymce_widget.html
@@ -10,6 +10,7 @@
     <script>
         setupTinyMCEWidget({
             fieldId: {{ field.id | tojson }},
+            disabled: {{ disabled|default(false) | tojson }},
             images: {{ images | tojson }},
             imageUploadURL: {{ field.get_form().editor_upload_url|default(none) | tojson }},
             forceAbsoluteURLs: {{ absolute_urls | tojson }},


### PR DESCRIPTION
This PR is about further improvements on event reminders
* Add WYSIWYG editor for reminder note (and transforms reminder emails to HTML while keeping the text-based one)
* Introduce custom reminder (with completely customizable subject and email body content)

Implementation details:
I followed your advise regarding using `RenderModeMixin` for the message field. Old reminders got the `RenderMode.plain_text` and new reminders gets `RenderMode.html`. The migration doesn't translate existing `text/plain` reminders to `text/html`. So at the end there are 3 types of reminder:
- Legacy reminder -> text/plain email format only
- Standard reminder -> both text/html and text/plain email format
- Custom reminder -> text/html email format only

In fact, the newly introduced `ReminderType` enum is only standard or customized. I didn't want to embed the legacy one.
