### PR TITLE
Fix drag&drop on an empty session block

### DIFF
--- a/indico/modules/events/timetable/client/js/ContributionEntry.tsx
+++ b/indico/modules/events/timetable/client/js/ContributionEntry.tsx
@@ -175,7 +175,7 @@ export default function ContributionEntry({
       >
         {/* TODO: (Ajob) Evaluate need for formatBlockTitle */}
         <EntryTitle title={title} duration={duration} timeRange={timeRange} type={type} />
-        {type === 'block' && (
+        {type === EntryType.SESSION_BLOCK && (
           <div
             ref={setDroppableNodeRef}
             style={{


### PR DESCRIPTION
The droppable area was not being rendered when there were no children. This prevented entries from being dropped on empty session blocks