### PR TITLE
Add material package restrictions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Version 3.3.8
 Improvements
 ^^^^^^^^^^^^
 
-- Add a CAPTCHA to the material package endpoint (:pr:`6996`)
+- Add a CAPTCHA and rate limiting to the material package endpoint (:pr:`6996`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@ Version 3.3.8
 Improvements
 ^^^^^^^^^^^^
 
-- Nothing so far :(
+- Add a CAPTCHA to the material package endpoint (:pr:`6996`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Version 3.3.8
 Improvements
 ^^^^^^^^^^^^
 
-- Add a CAPTCHA and rate limiting to the material package endpoint (:pr:`6996`)
+- Add a CAPTCHA and rate limiting to the material package endpoint, and an event
+  setting to restrict who can generate one (defaults to managers only) (:pr:`6996`)
 
 Bugfixes
 ^^^^^^^^

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -846,6 +846,22 @@ Storage
 
     Default: ``10 * 1024``
 
+.. data:: MATERIAL_PACKAGE_RATE_LIMIT
+
+    Applies a rate limit to public endpoints that build material packages.
+
+    Rate limiting is applied by IP address.
+
+    The default allows 3 packages per 30 minutes, and an additional 3 once per day
+    in case someone builds separate packages e.g. for sessions. Setting the rate limit
+    to ``None`` disables it.
+
+    Depending on how limited your storage space is, especially in relation to the amount
+    of materials (slides etc.) in your events, you may want to go for an even stricter
+    rate limit.
+
+    Default: ``'3 per 30 minutes, 3 per day'``
+
 
 System
 ------

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -74,6 +74,7 @@ DEFAULTS = {
     'LOGIN_LOGO_URL': None,
     'LOGO_URL': None,
     'LOG_DIR': '/opt/indico/log',
+    'MATERIAL_PACKAGE_RATE_LIMIT': '3 per 30 minutes, 3 per day',
     'MAX_DATA_EXPORT_SIZE': 10 * 1024,  # 10GB
     'MAX_UPLOAD_FILES_TOTAL_SIZE': 0,
     'MAX_UPLOAD_FILE_SIZE': 0,

--- a/indico/modules/attachments/blueprint.py
+++ b/indico/modules/attachments/blueprint.py
@@ -28,9 +28,9 @@ from indico.modules.attachments.controllers.management.event import (RHAddEventA
                                                                      RHAttachmentManagementInfoColumn,
                                                                      RHCreateEventFolder, RHDeleteEventAttachment,
                                                                      RHDeleteEventFolder, RHEditEventAttachment,
-                                                                     RHEditEventFolder, RHManageEventAttachments,
-                                                                     RHPackageEventAttachmentsManagement,
-                                                                     RHSetUploadPermissions)
+                                                                     RHEditEventFolder, RHEventAttachmentPermissions,
+                                                                     RHManageEventAttachments,
+                                                                     RHPackageEventAttachmentsManagement)
 from indico.modules.events import event_management_object_url_prefixes, event_object_url_prefixes
 from indico.util.caching import memoize
 from indico.web.flask.util import make_compat_redirect_func, make_view_func
@@ -118,8 +118,8 @@ _bp.add_url_rule('/event/<int:event_id>/attachments/package/status/<task_id>', '
                  RHPackageEventAttachmentsStatus)
 
 # Event-level settings
-_bp.add_url_rule('/event/<int:event_id>/manage/attachments/upload-permissions', 'set_upload_permissions',
-                 RHSetUploadPermissions, methods=('GET', 'POST'))
+_bp.add_url_rule('/event/<int:event_id>/manage/attachments/permissions', 'event_permissions',
+                 RHEventAttachmentPermissions, methods=('GET', 'POST'))
 
 # Legacy redirects for the old URLs
 _compat_bp = IndicoBlueprint('compat_attachments', __name__, url_prefix='/event/<int:event_id>')

--- a/indico/modules/attachments/controllers/display/event.py
+++ b/indico/modules/attachments/controllers/display/event.py
@@ -55,6 +55,10 @@ class RHListEventAttachmentFolder(SpecificFolderMixin, RHDisplayEventBase):
 
 
 class RHPackageEventAttachmentsDisplay(AttachmentPackageMixin, RHDisplayEventBase):
+    def _check_access(self):
+        RHDisplayEventBase._check_access(self)
+        AttachmentPackageMixin._check_access(self)
+
     @property
     def wp(self):
         if self.event.type_ == EventType.conference:

--- a/indico/modules/attachments/controllers/event_package.py
+++ b/indico/modules/attachments/controllers/event_package.py
@@ -12,7 +12,7 @@ from celery.exceptions import TimeoutError
 from flask import flash, jsonify, request, session
 from markupsafe import escape
 from sqlalchemy import Date, cast
-from werkzeug.exceptions import TooManyRequests
+from werkzeug.exceptions import Forbidden, TooManyRequests
 from werkzeug.local import LocalProxy
 
 from indico.core.celery import AsyncResult
@@ -189,6 +189,10 @@ class AttachmentPackageGeneratorMixin(ZipGeneratorMixin):
 class AttachmentPackageMixin(AttachmentPackageGeneratorMixin):
     wp = None
     management = False
+
+    def _check_access(self):
+        if not self.event.can_generate_attachment_package(session.user):
+            raise Forbidden
 
     def _process(self):
         form = self._prepare_form()

--- a/indico/modules/attachments/controllers/event_package.py
+++ b/indico/modules/attachments/controllers/event_package.py
@@ -200,7 +200,10 @@ class AttachmentPackageMixin(AttachmentPackageGeneratorMixin):
             attachments = [attachment.id for attachment in self._filter_attachments(form.data)]
             if attachments:
                 if not self.management:
-                    if not material_package_rate_limiter.hit():
+                    # only increment the rate limit if the user is not a manager, so we don't annoy event managers
+                    # who use the button in the display view for some reason, instead of doing it via the management
+                    # area...
+                    if not self.event.can_manage(session.user) and not material_package_rate_limiter.hit():
                         delay = format_human_timedelta(material_package_rate_limiter.get_reset_delay())
                         raise TooManyRequests(f"You're doing this too fast, please try again in {delay}")
                     invalidate_captcha()

--- a/indico/modules/attachments/controllers/management/event.py
+++ b/indico/modules/attachments/controllers/management/event.py
@@ -14,7 +14,7 @@ from indico.modules.attachments.controllers.management.base import (AddAttachmen
                                                                     DeleteAttachmentMixin, DeleteFolderMixin,
                                                                     EditAttachmentMixin, EditFolderMixin,
                                                                     ManageAttachmentsMixin)
-from indico.modules.attachments.forms import SetUploadPermissionsForm
+from indico.modules.attachments.forms import EventAttachmentPermissionsForm
 from indico.modules.attachments.settings import attachments_settings
 from indico.modules.attachments.util import can_manage_attachments
 from indico.modules.attachments.views import WPEventAttachments, WPPackageEventAttachmentsManagement
@@ -101,11 +101,16 @@ class RHPackageEventAttachmentsManagement(AttachmentPackageMixin, RHManageEventB
     management = True
     ALLOW_LOCKED = True
 
+    def _check_access(self):
+        RHManageEventBase._check_access(self)
+        AttachmentPackageMixin._check_access(self)
 
-class RHSetUploadPermissions(EditEventSettingsMixin, RHManageEventBase):
+
+class RHEventAttachmentPermissions(EditEventSettingsMixin, RHManageEventBase):
     settings_proxy = attachments_settings
-    form_cls = SetUploadPermissionsForm
+    form_cls = EventAttachmentPermissionsForm
     success_message = _('Upload permissions changed successfully')
-    log_module = 'Attachments'
-    log_message = 'Upload settings updated'
-    log_fields = {'managers_only': 'Managers only'}
+    log_module = 'Materials'
+    log_message = 'Settings updated'
+    log_fields = {'managers_only': 'Managers only',
+                  'generate_package': 'Permissions'}

--- a/indico/modules/attachments/forms.py
+++ b/indico/modules/attachments/forms.py
@@ -16,6 +16,7 @@ from indico.core.db import db
 from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.attachments.models.folders import AttachmentFolder
 from indico.modules.attachments.util import get_default_folder_names
+from indico.modules.core.captcha import WTFCaptchaField
 from indico.util.i18n import _
 from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm, generated_data
@@ -176,6 +177,7 @@ class AttachmentPackageForm(IndicoForm):
                                                DataRequired()],
                                               description=_('Include materials from sessions/contributions scheduled '
                                                             'on the selected dates'))
+    captcha = WTFCaptchaField()
 
 
 class SetUploadPermissionsForm(IndicoForm):

--- a/indico/modules/attachments/forms.py
+++ b/indico/modules/attachments/forms.py
@@ -15,6 +15,7 @@ from indico.core.config import config
 from indico.core.db import db
 from indico.core.db.sqlalchemy.protection import ProtectionMode
 from indico.modules.attachments.models.folders import AttachmentFolder
+from indico.modules.attachments.settings import AttachmentPackageAccess
 from indico.modules.attachments.util import get_default_folder_names
 from indico.modules.core.captcha import WTFCaptchaField
 from indico.util.i18n import _
@@ -22,6 +23,7 @@ from indico.web.flask.util import url_for
 from indico.web.forms.base import IndicoForm, generated_data
 from indico.web.forms.fields import (AccessControlListField, EditableFileField, FileField, IndicoDateField,
                                      IndicoRadioField, IndicoSelectMultipleCheckboxField)
+from indico.web.forms.fields.enums import IndicoEnumSelectField
 from indico.web.forms.validators import HiddenUnless, UsedIf
 from indico.web.forms.widgets import SwitchWidget, TypeaheadWidget
 
@@ -180,7 +182,9 @@ class AttachmentPackageForm(IndicoForm):
     captcha = WTFCaptchaField()
 
 
-class SetUploadPermissionsForm(IndicoForm):
-    managers_only = BooleanField(_('Managers only'), widget=SwitchWidget(),
+class EventAttachmentPermissionsForm(IndicoForm):
+    managers_only = BooleanField(_('Upload: Managers only'), widget=SwitchWidget(),
                                  description=_('Only allow managers to upload materials to the event, '
                                                'contributions and sessions.'))
+    generate_package = IndicoEnumSelectField(_('Material packages'), enum=AttachmentPackageAccess,
+                                             description=_('Specify who can generate a material package.'))

--- a/indico/modules/attachments/settings.py
+++ b/indico/modules/attachments/settings.py
@@ -5,9 +5,30 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from enum import auto
+
+from indico.core.settings.converters import EnumConverter
 from indico.modules.events.settings import EventSettingsProxy
+from indico.util.enum import RichStrEnum
+from indico.util.i18n import _
+
+
+class AttachmentPackageAccess(RichStrEnum):
+    __titles__ = {
+        'everyone': _('Everyone'),
+        'logged_in': _('Logged-in users'),
+        'managers': _('Event managers'),
+    }
+    everyone = auto()
+    logged_in = auto()
+    managers = auto()
 
 
 attachments_settings = EventSettingsProxy('attachments', {
-    'managers_only': False,  # Only event managers can upload attachments
+    # Whether only managers can upload attachments
+    'managers_only': False,
+    # Who can generate attachment packages
+    'generate_package': AttachmentPackageAccess.managers,
+}, converters={
+    'generate_package': EnumConverter(AttachmentPackageAccess),
 })

--- a/indico/modules/attachments/templates/attachments.html
+++ b/indico/modules/attachments/templates/attachments.html
@@ -11,12 +11,12 @@
         <ul class="i-dropdown">
             <li>
                 <a href="#"
-                   title="{% trans %}Upload permissions{% endtrans %}"
+                   title="{% trans %}Material permissions{% endtrans %}"
                    data-ajax-dialog
-                   data-title="{% trans %}Set upload permissions{% endtrans %}"
-                   data-href="{{ url_for('.set_upload_permissions', event) }}"
+                   data-title="{% trans %}Material permissions{% endtrans %}"
+                   data-href="{{ url_for('.event_permissions', event) }}"
                    data-qtip-position="right">
-                    {% trans %}Upload permissions{% endtrans %}</a>
+                    {% trans %}Permissions{% endtrans %}</a>
             </li>
         </ul>
     {% endif %}

--- a/indico/modules/attachments/util.py
+++ b/indico/modules/attachments/util.py
@@ -83,6 +83,19 @@ def can_manage_attachments(obj, user, allow_admin=True):
     return False
 
 
+def can_generate_attachment_package(event, user):
+    """Check if the user can generate a material package."""
+    from indico.modules.attachments.settings import AttachmentPackageAccess, attachments_settings
+    mode = attachments_settings.get(event, 'generate_package')
+    match mode:
+        case AttachmentPackageAccess.everyone:
+            return True
+        case AttachmentPackageAccess.logged_in:
+            return user is not None
+        case AttachmentPackageAccess.managers:
+            return event.can_manage(user)
+
+
 def get_default_folder_names():
     return [
         'Agenda',

--- a/indico/modules/attachments/util_test.py
+++ b/indico/modules/attachments/util_test.py
@@ -1,0 +1,31 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2025 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from indico.modules.attachments.settings import AttachmentPackageAccess, attachments_settings
+from indico.modules.attachments.util import can_generate_attachment_package
+
+
+def test_can_generate_attachment_package(dummy_user, create_user, dummy_event):
+    manager = dummy_user
+    user = create_user(123)
+    dummy_event.update_principal(manager, full_access=True)
+
+    # default: only managers
+    assert attachments_settings.get(dummy_event, 'generate_package') == AttachmentPackageAccess.managers
+    assert can_generate_attachment_package(dummy_event, manager)
+    assert not can_generate_attachment_package(dummy_event, user)
+    assert not can_generate_attachment_package(dummy_event, None)
+    # logged-in users
+    attachments_settings.set(dummy_event, 'generate_package', AttachmentPackageAccess.logged_in)
+    assert can_generate_attachment_package(dummy_event, manager)
+    assert can_generate_attachment_package(dummy_event, user)
+    assert not can_generate_attachment_package(dummy_event, None)
+    # everyone
+    attachments_settings.set(dummy_event, 'generate_package', AttachmentPackageAccess.everyone)
+    assert can_generate_attachment_package(dummy_event, manager)
+    assert can_generate_attachment_package(dummy_event, user)
+    assert can_generate_attachment_package(dummy_event, None)

--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -748,6 +748,11 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
         """Check whether the user can display the event in the category."""
         return self.visibility != 0 or self.can_manage(user, allow_admin=allow_admin)
 
+    def can_generate_attachment_package(self, user):
+        """Check whether the user can generate an attachment package."""
+        from indico.modules.attachments.util import can_generate_attachment_package
+        return can_generate_attachment_package(self, user)
+
     @materialize_iterable()
     def get_manage_button_options(self, *, note_may_exist=False):
         if self.is_locked:

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -216,8 +216,10 @@
                        data-ajax-dialog></button>
                 {% endif %}
 
-                <a class="i-button text-color subtle icon-package-download" href="{{ url_for('attachments.package', event) }}"
-                   title="{% trans %}Download material{% endtrans %}"></a>
+                {% if event.can_generate_attachment_package(session.user) %}
+                    <a class="i-button text-color subtle icon-package-download" href="{{ url_for('attachments.package', event) }}"
+                       title="{% trans %}Download material{% endtrans %}"></a>
+                {% endif %}
 
                 {{ _render_theme_selector() }}
                 {% if session.user %}


### PR DESCRIPTION
- Add CAPTCHA to the user-facing material package form (only if not logged in)
- Add rate limit for material packages generated by regular users
- Add setting to restrict material packages (default to event managers)