### PR TITLE
Fix getting old price of acco field w/ no data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Bugfixes
 - Fix missing spacing between toolbar button groups (:pr:`6981`)
 - Fix error with certain registration form field types if the badge text overflow
   behavior was set to "resize" (:pr:`6993`)
+- Fix not being able to update a registration if an accommocation field was added
+  after registering and the user already paid for the registration (:pr:`7000`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/fields/accompanying.py
+++ b/indico/modules/events/registration/fields/accompanying.py
@@ -84,6 +84,10 @@ class AccompanyingPersonsField(RegistrationFormBillableField):
         return max(count, 0)
 
     def calculate_price(self, reg_data, versioned_data):
+        if not reg_data:
+            # this gets called when getting the old price during an update, but when the field was
+            # added after the registration was created, there is no reg data yet.
+            return 0
         return Decimal(str(versioned_data.get('price', 0))) * len(reg_data)
 
     def get_friendly_data(self, registration_data, for_humans=False, for_search=False):


### PR DESCRIPTION
When a user registered and paid, and an accommodation field got added to the form afterwards, updating the registration failed because calculating the previous price tried to call `len(None)`.

```py
  File "indico/modules/events/registration/util.py", line 516, in modify_registration
    _set_data(form_item, value)
  File "indico/modules/events/registration/util.py", line 463, in _set_data
    attrs = field.field_impl.process_form_data(registration, value, data_by_field[field.id],
  File "indico/modules/events/registration/fields/base.py", line 322, in process_form_data
    if billable_items_locked and old_data.price != self.calculate_price(value, new_data_version.versioned_data):
  File "indico/modules/events/registration/models/registrations.py", line 906, in price
    return self.field_data.field.calculate_price(self)
  File "indico/modules/events/registration/models/form_fields.py", line 113, in calculate_price
    return self.field_impl.calculate_price(registration_data.data, registration_data.field_data.versioned_data)
  File "indico/modules/events/registration/fields/accompanying.py", line 87, in calculate_price
    return Decimal(str(versioned_data.get('price', 0))) * len(reg_data)
```