### PR TITLE
Hide BoA corresponding author emails by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,8 @@ Improvements
   :user:`tomako, unconventionaldotdev`)
 - Allow specifying a maximum session lifetime via :data:`SESSION_MAX_LIFETIME`
   beyond which it cannot be refreshed by activity (:pr:`7030`)
+- Make displaying corresponding author email addresses in the Book of Abstracts
+  opt-in (:pr:`7002`, thanks :user:`adamjenkins`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/forms.py
+++ b/indico/modules/events/abstracts/forms.py
@@ -94,7 +94,9 @@ class BOASettingsForm(IndicoForm):
     extra_text_end = IndicoMarkdownField(_('Additional text at end'), editor=True, mathjax=True)
     sort_by = IndicoEnumSelectField(_('Sort by'), [DataRequired()], enum=BOASortField, sorted=True)
     corresponding_author = IndicoEnumSelectField(_('Corresponding author'), [DataRequired()],
-                                                 enum=BOACorrespondingAuthorType, sorted=True)
+                                                 enum=BOACorrespondingAuthorType, sorted=True,
+                                                 description=_('Their email addresses will be published in the Book '
+                                                               'of Abstracts.'))
     show_abstract_ids = BooleanField(_('Show abstract IDs'), widget=SwitchWidget(),
                                      description=_('Show abstract IDs in the table of contents.'))
     min_lines_per_abstract = IntegerField(_('Minimum lines per abstract'),

--- a/indico/modules/events/abstracts/settings.py
+++ b/indico/modules/events/abstracts/settings.py
@@ -145,7 +145,7 @@ boa_settings = EventSettingsProxy('abstracts_book', {
     'extra_text': '',
     'extra_text_end': '',
     'sort_by': BOASortField.id,
-    'corresponding_author': BOACorrespondingAuthorType.submitter,
+    'corresponding_author': BOACorrespondingAuthorType.none,
     'show_abstract_ids': False,
     'cache_path': None,
     'cache_path_tex': None,


### PR DESCRIPTION
The Book of Abstracts will include the abstract submitter's email address as Corresponding Author in the generated PDF. This should perhaps be changed so that the default is "none" ensuring any information disclosure is intentional.

https://talk.getindico.io/t/submitted-pull-request-to-change-one-default/4296