### PR TITLE
Fix session block title display

### DIFF
--- a/indico/modules/events/timetable/client/js/ContributionEntry.tsx
+++ b/indico/modules/events/timetable/client/js/ContributionEntry.tsx
@@ -7,10 +7,9 @@
 
 import moment from 'moment';
 import React, {useEffect, useRef, useState, useMemo} from 'react';
-import {useDispatch, useSelector} from 'react-redux';
+import {useSelector} from 'react-redux';
 import {Icon, SemanticICONS} from 'semantic-ui-react';
 
-import * as actions from './actions';
 import {ENTRY_COLORS_BY_BACKGROUND} from './colors';
 import {useDroppable} from './dnd';
 import {DraggableEntry} from './Entry';
@@ -18,7 +17,7 @@ import {formatTimeRange} from './i18n';
 import {getWidthAndOffset} from './layout';
 import ResizeHandle from './ResizeHandle';
 import {ContribEntry, BreakEntry, EntryType, BlockEntry} from './types';
-import {minutesToPixels, pixelsToMinutes, snapPixels, snapMinutes} from './utils';
+import {minutesToPixels, pixelsToMinutes, snapPixels, snapMinutes, formatBlockTitle} from './utils';
 import './ContributionEntry.module.scss';
 import './DayTimetable.module.scss';
 
@@ -38,6 +37,7 @@ export default function ContributionEntry({
   title,
   blockRef,
   sessionId,
+  sessionTitle,
   textColor,
   backgroundColor,
   selected,
@@ -58,7 +58,6 @@ export default function ContributionEntry({
   renderChildren = true,
 }: DraggableEntryProps) {
   const {width, offset} = getWidthAndOffset(column, maxColumn);
-  const dispatch = useDispatch();
   const resizeStartRef = useRef<number | null>(null);
   const [isResizing, setIsResizing] = useState(false);
   const [duration, setDuration] = useState(_duration);
@@ -174,7 +173,12 @@ export default function ContributionEntry({
         {...listeners}
       >
         {/* TODO: (Ajob) Evaluate need for formatBlockTitle */}
-        <EntryTitle title={title} duration={duration} timeRange={timeRange} type={type} />
+        <EntryTitle
+          title={type === EntryType.SessionBlock ? formatBlockTitle(sessionTitle, title) : title}
+          duration={duration}
+          timeRange={timeRange}
+          type={type}
+        />
         {type === EntryType.SessionBlock && (
           <div
             ref={setDroppableNodeRef}

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -33,7 +33,7 @@ import * as actions from './actions';
 import {formatTimeRange} from './i18n';
 import * as selectors from './selectors';
 import {BreakEntry, ContribEntry, BlockEntry, EntryType, PersonLinkRole} from './types';
-import {getEntryColor, mapTTDataToEntry} from './utils';
+import {formatBlockTitle, getEntryColor, mapTTDataToEntry} from './utils';
 
 function ColoredDot({color}: {color: string}) {
   return (
@@ -60,15 +60,9 @@ function CardItem({icon, children}: {icon: SemanticICONS; children: React.ReactN
   );
 }
 
-function EntryPopupContent({
-  entry,
-  onClose,
-}: {
-  entry;
-  onClose: () => void;
-}) {
+function EntryPopupContent({entry, onClose}: {entry; onClose: () => void}) {
   const dispatch = useDispatch();
-  const {type, title} = entry;
+  const {type, title, sessionTitle} = entry;
   const sessions = useSelector(selectors.getSessions);
   const eventId = useSelector(selectors.getEventId);
   const {backgroundColor} = getEntryColor(entry, sessions);
@@ -76,13 +70,13 @@ function EntryPopupContent({
   const endTime = moment(entry.startDt).add(entry.duration, 'minutes');
 
   const _getFileCount = () => {
-    const {attachments = {}} = entry
+    const {attachments = {}} = entry;
     const {files = [], folders = []} = attachments;
     return files.length + folders.length;
   };
 
   const _getOrderedLocationArray = () => {
-    const {locationData = {}} = entry
+    const {locationData = {}} = entry;
     const {address, venueName, room} = locationData;
     return Object.values([address, venueName, room]).filter(Boolean);
   };
@@ -185,7 +179,9 @@ function EntryPopupContent({
         <Card.Header style={{marginTop: 20, marginLeft: 4, marginBottom: 20, fontSize: '1.6em'}}>
           <div style={{display: 'flex', gap: 10, alignItems: 'center'}}>
             <ColoredDot color={backgroundColor} />
-            <div>{title}</div>
+            <div>
+              {type === EntryType.SessionBlock ? formatBlockTitle(sessionTitle, title) : title}
+            </div>
           </div>
         </Card.Header>
         <CardItem icon="clock outline">{formatTimeRange('en', startTime, endTime)}</CardItem>
@@ -200,7 +196,7 @@ function EntryPopupContent({
             </List>
           </CardItem>
         ) : null}
-        {presenters?.length ? (
+        {presenters && presenters.length ? (
           <CardItem icon="microphone">
             {presenters.join(', ') || Translate.string('No presenters')}
           </CardItem>


### PR DESCRIPTION
Session blocks that didn't have a title set, the entry title title would show up as empty (not taking session title into account). Example:
<img width="326" height="140" alt="image" src="https://github.com/user-attachments/assets/30c362a8-c3f1-4e43-ac3a-0d5b4fcc02ff" />