### PR TITLE
Remove timetable group console log

### DIFF
--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -183,18 +183,6 @@ export function preprocessTimetableEntries(
     }
   }
 
-  // TODO: (Ajob) Temporary logs for debugging purposes. Remove later
-  console.group(
-    `%c Preprocessed Data `,
-    'font-size: 1.2em; background-color: lightgreen; color: green;'
-  );
-  Object.keys(dayEntries).forEach(k => {
-    console.group(`%c[${k}]`, 'color: orange;');
-    console.dir(dayEntries[k]);
-    console.groupEnd();
-  });
-  console.groupEnd();
-
   return {
     dayEntries,
     unscheduled: (eventInfo.contributions || [])


### PR DESCRIPTION
Removing the console log as it ends up being very annoying when dealing with large events. It is in the way of effective debugging.