### PR TITLE
Add back the htmlName in FormItem for plugins

### DIFF
--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -229,7 +229,7 @@ export default function FormItem({
             <Markdown targetBlank>{description}</Markdown>
           </div>
         )}
-        {renderPluginComponents(`regform-${inputType}-field-item`, inputProps)}
+        {renderPluginComponents(`regform-${inputType}-field-item`, {htmlName, ...inputProps})}
       </div>
       <div styleName="actions">
         {setupActions}


### PR DESCRIPTION
Hello, We'd like to add back this prop which used to be in the inputProps sent to the plugin component but was recently removed. 