### PR TITLE
Make title in the SessionBlock edit form optional

### DIFF
--- a/indico/modules/events/sessions/client/js/SessionBlockForm.tsx
+++ b/indico/modules/events/sessions/client/js/SessionBlockForm.tsx
@@ -52,7 +52,6 @@ export function SessionBlockFormFields({
         label={Translate.string('Title')}
         description={Translate.string('Title of the session block')}
         autoFocus
-        required
       />
       <FinalDateTimePicker
         name="start_dt"

--- a/indico/util/marshmallow.py
+++ b/indico/util/marshmallow.py
@@ -451,7 +451,12 @@ class EventTimezoneDateTimeField(fields.DateTime):
         if value is None:
             return None
         dt = super()._deserialize(value, attr, data, **kwargs)
-        return self.context['event'].tzinfo.localize(dt).astimezone(pytz.utc)
+        event_tz = self.context['event'].tzinfo
+        if dt.tzinfo is None:
+            localized = event_tz.localize(dt)
+        else:
+            localized = dt.astimezone(event_tz)
+        return localized.astimezone(pytz.utc)
 
 
 class FilesField(ModelList):


### PR DESCRIPTION
The main changes include reformatting, improvements to timezone handling for datetime fields, and minor code style updates.

### Code style and readability improvements

* ~~Reformatted file `indico/util/marshmallow.py` using ruff (likely it was formatted in the past with other tool?)~~

### Functionality improvements

* Enhanced timezone handling in the event datetime field: now correctly localizes naive datetimes to the event's timezone, and converts aware datetimes before storing in UTC.
* Removed the `required` attribute from the session block title field in `SessionBlockFormFields`, making it optional in the form.