### PR TITLE
template-hook added for summarize button

### DIFF
--- a/indico/modules/events/models/events.py
+++ b/indico/modules/events/models/events.py
@@ -765,6 +765,7 @@ class Event(SearchableTitleMixin, DescriptionMixin, LocationMixin, ProtectionMan
             yield 'notes_edit'
             if self.scheduled_notes:
                 yield 'notes_compile'
+        yield 'summarize'
         if self.can_manage_attachments(session.user):
             yield 'attachments_edit'
 

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -40,7 +40,6 @@
              {% endif %}
              data-modal-title="{{ title }}"
              data-title="{{ title }}"></div>
-    {{ template_hook('event-manage-dropdown-after-notes-compile', event=item) }}
     {%- elif opt == 'attachments_edit' -%}
         {% set attachment_item = item.session if item_type == 'SESSION_BLOCK' else item %}
         <a href="" class="js-material-editor"
@@ -104,6 +103,8 @@
            data-href="{{ url_for('contributions.manage_edit_subcontrib', item, standalone=true) }}">
             {%- trans -%}Edit subcontribution{%- endtrans -%}
         </a>
+    {%- elif opt == 'summarize' -%}
+    {{ template_hook('event-manage-dropdown-after-notes-compile', event=item) }}
     {%- else -%}
         ERROR: unknown option "{{ opt }}"
     {%- endif -%}

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -40,6 +40,7 @@
              {% endif %}
              data-modal-title="{{ title }}"
              data-title="{{ title }}"></div>
+    {{ template_hook('event-manage-dropdown-after-notes-compile', event=item) }}
     {%- elif opt == 'attachments_edit' -%}
         {% set attachment_item = item.session if item_type == 'SESSION_BLOCK' else item %}
         <a href="" class="js-material-editor"

--- a/indico/modules/events/templates/display/common/_manage_button.html
+++ b/indico/modules/events/templates/display/common/_manage_button.html
@@ -104,7 +104,7 @@
             {%- trans -%}Edit subcontribution{%- endtrans -%}
         </a>
     {%- elif opt == 'summarize' -%}
-    {{ template_hook('event-manage-dropdown-after-notes-compile', event=item) }}
+        {{ template_hook('event-manage-dropdown-after-notes-compile', event=item) }}
     {%- else -%}
         ERROR: unknown option "{{ opt }}"
     {%- endif -%}

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -27,8 +27,7 @@
                         {{- event.get_label_markup() -}}
                     </h1>
                 </div>
-                <div class="event-actions">
-                    
+                <div class="event-actions">                  
                     {{ template_hook('event-manage-button', event=event) }}
                     <div class="event-manage-button">
                         {{ render_manage_button(event, 'EVENT', toggle_notes=false) }}

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -28,7 +28,6 @@
                     </h1>
                 </div>
                 <div class="event-actions">                  
-                    {{ template_hook('event-manage-button', event=event) }}
                     <div class="event-manage-button">
                         {{ render_manage_button(event, 'EVENT', toggle_notes=false) }}
                     </div>

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -27,7 +27,7 @@
                         {{- event.get_label_markup() -}}
                     </h1>
                 </div>
-                <div class="event-actions">                  
+                <div class="event-actions">
                     <div class="event-manage-button">
                         {{ render_manage_button(event, 'EVENT', toggle_notes=false) }}
                     </div>

--- a/indico/modules/events/templates/display/indico/meeting.html
+++ b/indico/modules/events/templates/display/indico/meeting.html
@@ -28,6 +28,8 @@
                     </h1>
                 </div>
                 <div class="event-actions">
+                    
+                    {{ template_hook('event-manage-button', event=event) }}
                     <div class="event-manage-button">
                         {{ render_manage_button(event, 'EVENT', toggle_notes=false) }}
                     </div>


### PR DESCRIPTION
Some minor changes added in indico source code for the hfsummary plugin:

- Added a template hook for summarize  button in macro _render_dropdown_option ( _manage_button.html)
- Added yield 'summarize' in get_manage_button_options function (events.py)

See [PR#279](https://github.com/indico/indico-plugins/pull/279) as it needs to be merged first


