### PR TITLE
Add option to run postgres tests in a container

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ Internal Changes
 - Remove broken support for custom multipass providers setting a maximum session
   lifetime; use :data:`SESSION_MAX_LIFETIME` instead (:pr:`7030`)
 - Use `Biome <https://biomejs.dev/>`__ to format JS/JSX, TS/TSX, JSON and CSS (:pr:`7042`)
+- Add the env var `INDICO_TEST_USE_DOCKER`, which allows for tests to be run on
+  a PostgreSQL server running in a container
 
 
 Version 3.3.7

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,7 +49,7 @@ Internal Changes
 - Remove broken support for custom multipass providers setting a maximum session
   lifetime; use :data:`SESSION_MAX_LIFETIME` instead (:pr:`7030`)
 - Use `Biome <https://biomejs.dev/>`__ to format JS/JSX, TS/TSX, JSON and CSS (:pr:`7042`)
-- Add the env var `INDICO_TEST_USE_DOCKER`, which allows for tests to be run on
+- Add the env var ``INDICO_TEST_USE_DOCKER``, which allows for tests to be run on
   a PostgreSQL server running in a container
 
 

--- a/docs/source/installation/development.rst
+++ b/docs/source/installation/development.rst
@@ -326,3 +326,75 @@ The Indico dev server should be run with the ``--proxy`` option::
     indico run -h 127.0.0.1 -p 8000 -q --enable-evalex --url https://acme.example.org --proxy
 
 You can then start nginx and access ``https://acme.example.org`` directly.
+
+
+Running the Unit Tests
+----------------------
+
+Indico comes with a comprehensive suite of unit tests. To run them, you will need to have PostgreSQL available. By default,
+the tests expect a local server, but you can also use the a Docker-backed setup for a more standalone and isolated environment.
+
+**Running tests with the default setup**
+
+To run all tests, simply execute:
+
+.. code-block:: shell
+
+    pytest
+
+You can also run a subset of tests by specifying the path or test name:
+
+.. code-block:: shell
+
+    pytest path/to/test_file.py
+    pytest -k test_some_function
+
+**Using the Docker-backed PostgreSQL for tests**
+
+Indico provides a Docker-based PostgreSQL fixture for running tests without requiring a local PostgreSQL installation. To enable this,
+set the ``INDICO_TEST_USE_DOCKER`` environment variable (to `yes`, `true` or `1`) before running the tests:
+
+.. code-block:: shell
+
+    INDICO_TEST_USE_DOCKER=1 pytest
+
+This will automatically start a temporary PostgreSQL server in a Docker container for the duration of the test run. The container and
+its data will be cleaned up automatically afterwards.
+
+If you want to use a custom Docker daemon (for example, if Docker is not running on the default socket), you can set
+``INDICO_TEST_USE_DOCKER`` to the Docker API URL, such as ``unix:///var/run/docker.sock`` or ``tcp://127.0.0.1:2375``.
+
+**Notes:**
+
+- Make sure Docker is installed and running on your system, and that your user has permission to access the Docker socket (you may need to be in the `docker` group);
+- The first time you run the tests with Docker, the required PostgreSQL image will be pulled, which may take a few minutes.
+
+
+**Using Podman instead of Docker**
+
+If you prefer to use Podman as a drop-in replacement for Docker, you can do so with Indico's Docker-backed PostgreSQL fixture. Podman is
+compatible with the Docker API, but you need to ensure that the Podman socket is available and that your user has permission to access it.
+
+To use Podman for running the tests, set the ``INDICO_TEST_USE_DOCKER`` environment variable to the Podman socket URL. For example:
+
+.. code-block:: shell
+
+    INDICO_TEST_USE_DOCKER=unix:///run/user/$(id -u)/podman/podman.sock pytest
+
+Make sure the Podman socket is running. You can start it with:
+
+.. code-block:: shell
+
+    systemctl --user start podman.socket
+
+Or, if you are not using systemd user services, you can run:
+
+.. code-block:: shell
+
+    podman system service --time=0 unix:///run/user/$(id -u)/podman/podman.sock
+
+**Notes:**
+
+- The first test run may take longer as Podman will pull the required PostgreSQL image;
+- Ensure your user has permission to access the Podman socket;
+- The rest of the test setup and cleanup works the same as with Docker.

--- a/indico/testing/fixtures/database_docker.py
+++ b/indico/testing/fixtures/database_docker.py
@@ -1,0 +1,207 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2025 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import os
+import shutil
+import tempfile
+import time
+import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
+from urllib.parse import urlparse
+
+import docker
+from docker.errors import NotFound
+from docker.models.containers import Container
+
+
+READY_TIMEOUT_SEC = 20
+CONTAINER_NAME_TPL = 'test-indico-pg-{pid}'
+POSTGRES_IMAGE = 'docker.io/postgres:16'
+DB_NAME = 'test'
+
+
+def create_container_low_level(
+    api_client: docker.APIClient, container_name: str, socket_dir: str, data_dir: str
+) -> str:
+    """
+    Create a PostgreSQL container using the low-level docker-py API.
+
+    :param api_client: The low-level Docker API client.
+    :param container_name: The name to assign to the new container.
+    :param socket_dir: Path to the host directory to mount as the PostgreSQL socket directory.
+    :param data_dir: Path to the host directory to mount as the PostgreSQL data directory.
+
+    :return: The ID of the created Docker container.
+    :raises docker.errors.APIError: If the container creation fails.
+    """
+    # TODO: once https://github.com/docker/docker-py/issues/3351 is solved, use the high level API
+
+    host_config = api_client.create_host_config(
+        binds={
+            socket_dir: {'bind': '/var/run/postgresql', 'mode': 'rw'},
+            data_dir: {'bind': '/var/lib/postgresql/data', 'mode': 'rw'},
+        }
+    )
+
+    # this is important so that the dirs above don't remain owned by some
+    # phony container-specific user
+    host_config['UsernsMode'] = 'keep-id'
+
+    container_config = api_client.create_container(
+        image=POSTGRES_IMAGE,
+        name=container_name,
+        # same here, we want everything in user space
+        user=f'{os.getuid()}:{os.getgid()}',
+        host_config=host_config,
+        labels={'indico-test': 'true'},
+        environment={'POSTGRES_USER': 'postgres', 'POSTGRES_PASSWORD': 'postgres', 'POSTGRES_DB': DB_NAME},
+    )
+
+    return container_config['Id']
+
+
+def exec_in_container(container: Container, cmd: list[str] | str):
+    """
+    Execute a command inside a Docker container.
+
+    :param container: The Docker container to run the command in.
+    :param cmd: The command (and its arguments) to execute inside the container.
+    :raises RuntimeError: If the command exits with a non-zero status code.
+    """
+    code, content = container.exec_run(cmd)
+    if code != 0:
+        raise RuntimeError(f'Command {cmd} failed: {content}')
+
+
+def find_zombie_containers(docker_client: docker.DockerClient) -> set[Container]:
+    """Find stopped test containers that can be safely removed.
+
+    This function scans all Docker containers and returns a set of containers
+    that have the 'exited' status and are labeled as Indico test containers
+    (i.e., have the label 'indico_test' set to 'true'). These containers are
+    considered "zombies" and can be cleaned up to free resources.
+
+    :param docker_client: A DockerClient instance to query containers.
+    :return: A set of Docker Container objects that are stopped Indico test containers.
+    """
+    zombies = set()
+
+    for container in docker_client.containers.list(all=True):
+        if (
+            container.status == 'exited'
+            and 'indico_test' in container.labels
+            and container.labels['indico_test'] == 'true'
+        ):
+            zombies.add(container)
+
+    return zombies
+
+
+def kill_containers(containers: set[Container], warn: bool = False):
+    """Kill and remove the specified Docker containers.
+
+    This function stops and removes each container in the provided set. If a container is already stopped or removed,
+    it will be skipped. Optionally, a warning can be emitted for each killed container.
+
+    :param containers: A set of Docker Container objects to be killed and removed.
+    :param warn: If True, emit a warning for each killed container.
+    """
+    for container in containers:
+        # stop the container first, if it's still running
+        if container.status in {'created', 'running', 'restarting', 'paused'}:
+            container.stop()
+
+        # It may happen that a container was created with --rm, in which case stopping it
+        # will result int it being removed as well. Not likely, but it doesn't hurt to check
+        try:
+            container.wait(condition='not-running')
+            container.remove()
+            container.wait(condition='removed')
+        except NotFound:
+            # Container already removed, let's move on with our lives
+            pass
+        if warn:
+            warnings.warn(f'Killed container {container.id}: {container.name}', stacklevel=0)
+
+
+@contextmanager
+def docker_postgresql() -> Iterator[str]:
+    """
+    Docker-based PostgreSQL server.
+
+    This fixture runs a PostgreSQL server in a Docker container for tests.
+
+    :yields: A PostgreSQL connection URL pointing to the UNIX socket in a temporary directory.
+    :raises ValueError: If ``INDICO_TEST_USE_DOCKER`` has an invalid scheme.
+    :raises RuntimeError: If the container or PostgreSQL does not become ready in time.
+    """
+    container_name = CONTAINER_NAME_TPL.format(pid=os.getpid())
+    use_docker = os.environ.get('INDICO_TEST_USE_DOCKER', None)
+    if use_docker in {'1', 'true', 'yes'}:
+        docker_client = docker.from_env()
+    else:
+        (scheme, _netloc, _path, _params, _query, _fragment) = urlparse(use_docker)
+        if scheme not in {'unix', 'tcp'}:
+            raise ValueError('Docker API URL should be unix:// or tcp://')
+
+        docker_client = docker.DockerClient(base_url=use_docker)
+
+    docker_client.images.pull(POSTGRES_IMAGE)
+
+    socket_dir = tempfile.mkdtemp(prefix='indicotestpg.socket.')
+    data_dir = tempfile.mkdtemp(prefix='indicotestpg.data.')
+
+    # kill any possible zombie containers to avoid issues
+    kill_containers(find_zombie_containers(docker_client), warn=True)
+
+    try:
+        container_id = create_container_low_level(docker_client.api, container_name, socket_dir, data_dir)
+        docker_client.api.start(container_id)
+
+        container = docker_client.containers.get(container_id)
+
+        for __ in range(READY_TIMEOUT_SEC):
+            container.reload()
+            if container.status == 'running':
+                break
+            time.sleep(1)
+        else:
+            # Dump container logs into stdout
+            print(container.logs().decode('utf8'))
+            raise RuntimeError('Container did not become ready in time')
+
+        for __ in range(READY_TIMEOUT_SEC):
+            (code, _output) = container.exec_run(
+                ['pg_isready', '-h', '/var/run/postgresql', '-U', 'postgres', '-d', DB_NAME]
+            )
+            if code == 0:
+                break
+            time.sleep(1)
+        else:
+            # Dump container logs into stdout
+            print(container.logs().decode('utf8'))
+            raise RuntimeError('PostgreSQL did not become ready in time')
+
+        # Run DB setup commands using the UNIX socket inside the container
+        exec_in_container(container, ['psql', DB_NAME, '-U', 'postgres', '-c', 'CREATE EXTENSION unaccent;'])
+        exec_in_container(container, ['psql', DB_NAME, '-U', 'postgres', '-c', 'CREATE EXTENSION pg_trgm;'])
+
+        yield f'postgresql://postgres:postgres@/{DB_NAME}?host={socket_dir}'
+    finally:
+        try:
+            kill_containers({docker_client.containers.get(container_name)})
+            zombies = find_zombie_containers(docker_client)
+            kill_containers(zombies, warn=True)
+
+        except NotFound:
+            # not found, container was already removed (or never created)
+            pass
+
+        # delete temporary dirs
+        shutil.rmtree(socket_dir)
+        shutil.rmtree(data_dir)

--- a/indico/testing/fixtures/database_docker.py
+++ b/indico/testing/fixtures/database_docker.py
@@ -28,8 +28,7 @@ DB_NAME = 'test'
 def create_container_low_level(
     api_client: docker.APIClient, container_name: str, socket_dir: str, data_dir: str
 ) -> str:
-    """
-    Create a PostgreSQL container using the low-level docker-py API.
+    """Create a PostgreSQL container using the low-level docker-py API.
 
     :param api_client: The low-level Docker API client.
     :param container_name: The name to assign to the new container.
@@ -66,8 +65,7 @@ def create_container_low_level(
 
 
 def exec_in_container(container: Container, cmd: list[str] | str):
-    """
-    Execute a command inside a Docker container.
+    """Execute a command inside a Docker container.
 
     :param container: The Docker container to run the command in.
     :param cmd: The command (and its arguments) to execute inside the container.
@@ -131,14 +129,12 @@ def kill_containers(containers: set[Container], warn: bool = False):
 
 @contextmanager
 def docker_postgresql() -> Iterator[str]:
-    """
-    Docker-based PostgreSQL server.
+    """Docker-based PostgreSQL server.
 
     This fixture runs a PostgreSQL server in a Docker container for tests.
 
-    :yields: A PostgreSQL connection URL pointing to the UNIX socket in a temporary directory.
     :raises ValueError: If ``INDICO_TEST_USE_DOCKER`` has an invalid scheme.
-    :raises RuntimeError: If the container or PostgreSQL does not become ready in time.
+    :raises RuntimeError: If the container or PostgreSQL do not become ready in time.
     """
     container_name = CONTAINER_NAME_TPL.format(pid=os.getpid())
     use_docker = os.environ.get('INDICO_TEST_USE_DOCKER', None)
@@ -197,7 +193,6 @@ def docker_postgresql() -> Iterator[str]:
             kill_containers({docker_client.containers.get(container_name)})
             zombies = find_zombie_containers(docker_client)
             kill_containers(zombies, warn=True)
-
         except NotFound:
             # not found, container was already removed (or never created)
             pass

--- a/indico/testing/fixtures/database_docker.py
+++ b/indico/testing/fixtures/database_docker.py
@@ -100,7 +100,7 @@ def find_zombie_containers(docker_client: docker.DockerClient) -> set[Container]
     return zombies
 
 
-def kill_containers(containers: set[Container], warn: bool = False):
+def kill_containers(containers: set[Container], *, warn: bool = False):
     """Kill and remove the specified Docker containers.
 
     This function stops and removes each container in the provided set. If a container is already stopped or removed,

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -1,5 +1,6 @@
 -c requirements.txt
 build
+docker
 flask-url-map-serializer
 freezegun
 hatchling

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -47,6 +47,8 @@ colorclass==2.2.2
     #   unbeheader
 coverage==7.6.9
     # via pytest-cov
+docker==7.1.0
+    # via -r requirements.dev.in
 docutils==0.21.2
     # via
     #   plantweb
@@ -164,6 +166,7 @@ redis==5.2.1
 requests==2.32.4
     # via
     #   -c requirements.txt
+    #   docker
     #   plantweb
     #   responses
     #   sphinx
@@ -242,6 +245,7 @@ unbeheader==1.4.0
 urllib3==2.5.0
     # via
     #   -c requirements.txt
+    #   docker
     #   requests
     #   responses
 uv==0.8.6


### PR DESCRIPTION
This should support both Docker and Podman out of the box. The easiest way to test is probably using podman, as Docker will require you to have user access to the docker socket, which is only possible if you're in the `docker` group.

```sh
$ systemctl --user start podman.socket
$ INDICO_TEST_USE_DOCKER=unix:///run/user/$(id -u)/podman/podman.sock pytest
```
