### PR TITLE
Webpack: Sort module aliases by specificity

### DIFF
--- a/plugin.webpack.config.mjs
+++ b/plugin.webpack.config.mjs
@@ -38,6 +38,17 @@ function generateModuleAliases() {
       alias: dirName,
       onlyModule: false,
     };
+  }).sort((a, b) => {
+    // Sort by specificity to ensure that child modules are matched first.
+    // For example, `indico/modules/events/registration` should come before `indico/modules/events`.
+    const aParts = a.name.split('/').length;
+    const bParts = b.name.split('/').length;
+
+    if (aParts !== bParts) {
+      // more parts == more specific => should come first
+      return bParts - aParts;
+    }
+    return a.name.localeCompare(b.name);
   });
 }
 


### PR DESCRIPTION
This prevents parent modules from shadowing child modules when importing js code inside plugins, for example `indico/modules/events` and `indico/modules/events/registration`

To test this, add e.g.
```js
import Foo from 'indico/modules/events/registration/form/fields/CountryInput';
```

to a plugin an try to compile it with webpack.
