### PR TITLE
Timetable session undefined

### DIFF
--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -291,12 +291,11 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
 
     const resEntry = mapTTDataToEntry(resData);
 
-    if (resEntry.type === EntryType.SessionBlock) {
-      const deltaStartDt = moment(resEntry.startDt).diff(entry.startDt, 'minutes');
-      resEntry.children = shiftEntries(entry.children, deltaStartDt);
-    }
-
     if (isEditing) {
+      if (resEntry.type === EntryType.SessionBlock) {
+        const deltaStartDt = moment(resEntry.startDt).diff(entry.startDt, 'minutes');
+        resEntry.children = shiftEntries(entry.children, deltaStartDt);
+      }
       dispatch(actions.updateEntry(activeType, resEntry, currentDay));
     } else {
       dispatch(actions.createEntry(activeType, resEntry));

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -266,7 +266,7 @@ function _createEntry(entryType, entry) {
 
 export function createEntry(entryType, entry) {
   return (dispatch, getState) => {
-    const sessions = getState().sessions
+    const sessions = getState().sessions;
     const color = getEntryColor(entry, sessions);
     const sessionTitle = {sessionTitle: getSessionTitle(entry, sessions)};
     const newEntry = {...entry, ...color, ...sessionTitle};

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -24,7 +24,7 @@ import {
   UnscheduledContrib,
   EntryType,
 } from './types';
-import {getEntryColor} from './utils';
+import {getEntryColor, getSessionTitle} from './utils';
 
 export const SET_DRAFT_ENTRY = 'Set draft entry';
 export const SET_TIMETABLE_DATA = 'Set timetable data';
@@ -266,8 +266,10 @@ function _createEntry(entryType, entry) {
 
 export function createEntry(entryType, entry) {
   return (dispatch, getState) => {
-    const color = getEntryColor(entry, getState().sessions);
-    const newEntry = {...entry, ...color};
+    const sessions = getState().sessions
+    const color = getEntryColor(entry, sessions);
+    const sessionTitle = {sessionTitle: getSessionTitle(entry, sessions)};
+    const newEntry = {...entry, ...color, ...sessionTitle};
     dispatch(_createEntry(entryType, newEntry));
   };
 }

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -24,7 +24,7 @@ import {
   UnscheduledContrib,
   EntryType,
 } from './types';
-import {getEntryColor, getSessionTitle} from './utils';
+import {getEntryColor} from './utils';
 
 export const SET_DRAFT_ENTRY = 'Set draft entry';
 export const SET_TIMETABLE_DATA = 'Set timetable data';

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -268,8 +268,8 @@ export function createEntry(entryType, entry) {
   return (dispatch, getState) => {
     const sessions = getState().sessions;
     const color = getEntryColor(entry, sessions);
-    const sessionTitle = {sessionTitle: getSessionTitle(entry, sessions)};
-    const newEntry = {...entry, ...color, ...sessionTitle};
+    const sessionTitle = sessions[entry.sessionId]?.title || '';
+    const newEntry = {...entry, ...color, sessionTitle};
     dispatch(_createEntry(entryType, newEntry));
   };
 }

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -139,7 +139,7 @@ export function getEntryColor(
 
   const session = sessions[entry.sessionId];
   console.assert(session, `Session ${entry.sessionId} not found for entry ${entry.id}`);
-  if (entry.sessionId) {
+  if (entry.sessionId && entry.type !== 'block') {
     return {
       textColor: session.textColor,
       backgroundColor: ENTRY_COLORS_BY_BACKGROUND[session.backgroundColor].childColor,
@@ -201,4 +201,10 @@ export function shiftEntries<T extends Entry>(entries: T[], deltaMinutes: number
     ...child,
     startDt: moment(child.startDt).add(deltaMinutes, 'minutes'),
   }));
+}
+
+export function getSessionTitle(entry: Entry, sessions: Record<number, Session>): string {
+  const sessionId = entry.sessionId
+  const sessionTitle = sessionId ? sessions[sessionId].title : '';
+  return sessionTitle;
 }

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -204,7 +204,7 @@ export function shiftEntries<T extends Entry>(entries: T[], deltaMinutes: number
 }
 
 export function getSessionTitle(entry: Entry, sessions: Record<number, Session>): string {
-  const sessionId = entry.sessionId
+  const sessionId = entry.sessionId;
   const sessionTitle = sessionId ? sessions[sessionId].title : '';
   return sessionTitle;
 }

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -127,10 +127,10 @@ export function getEntryColor(
   entry: Entry,
   sessions: Record<number, Session>
 ): {textColor: string; backgroundColor: string} {
-  if (entry.type === 'break' && !entry.sessionId) {
+  if (entry.type === EntryType.Break && !entry.sessionId) {
     return {textColor: entry.textColor, backgroundColor: entry.backgroundColor};
   }
-  if (entry.type === 'contrib' && !entry.sessionId) {
+  if (entry.type === EntryType.Contribution && !entry.sessionId) {
     return {
       textColor: DEFAULT_CONTRIB_TEXT_COLOR,
       backgroundColor: DEFAULT_CONTRIB_BACKGROUND_COLOR,
@@ -139,7 +139,7 @@ export function getEntryColor(
 
   const session = sessions[entry.sessionId];
   console.assert(session, `Session ${entry.sessionId} not found for entry ${entry.id}`);
-  if (entry.sessionId && entry.type !== 'block') {
+  if (entry.sessionId && entry.type !== EntryType.SessionBlock) {
     return {
       textColor: session.textColor,
       backgroundColor: ENTRY_COLORS_BY_BACKGROUND[session.backgroundColor].childColor,
@@ -201,10 +201,4 @@ export function shiftEntries<T extends Entry>(entries: T[], deltaMinutes: number
     ...child,
     startDt: moment(child.startDt).add(deltaMinutes, 'minutes'),
   }));
-}
-
-export function getSessionTitle(entry: Entry, sessions: Record<number, Session>): string {
-  const sessionId = entry.sessionId;
-  const sessionTitle = sessionId ? sessions[sessionId].title : '';
-  return sessionTitle;
 }


### PR DESCRIPTION
This PR fixes the undefined title of a session and the wrong assigment of children colors when creating a session block. There is also a bug fix when creating a session block on the modal as it's trying to iterate through children like if it was an edit.