### PR TITLE
fix: show all event contributions for author on details page

### DIFF
--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -218,11 +218,12 @@ class RHContributionAuthor(RHContributionDisplayBase):
                        .one())
 
     def _process(self):
+        # Show all contributions for the same person in the event
         author_contribs = (Contribution.query.with_parent(self.event)
                            .join(ContributionPersonLink)
                            .options(joinedload('event'))
                            .options(load_only('id', 'title'))
-                           .filter(ContributionPersonLink.id == self.author.id,
+                           .filter(ContributionPersonLink.person_id == self.author.person_id,
                                    ContributionPersonLink.author_type != AuthorType.none)
                            .all())
         return WPContributions.render_template('display/contribution_author.html', self.event,


### PR DESCRIPTION
This PR fixes the author details page to correctly display all contributions by the same person within an event. Previously, only a single contribution was shown due to filtering by the unique contribution-person link. The query now uses the person's ID to list all relevant contributions for the event.

Fixes:

Author details page now lists all event contributions for the selected author.

