### PR TITLE
Timtable add session title to session block schema

### DIFF
--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -268,8 +268,7 @@ export function createEntry(entryType, entry) {
   return (dispatch, getState) => {
     const sessions = getState().sessions;
     const color = getEntryColor(entry, sessions);
-    const sessionTitle = sessions[entry.sessionId]?.title || '';
-    const newEntry = {...entry, ...color, sessionTitle};
+    const newEntry = {...entry, ...color};
     dispatch(_createEntry(entryType, newEntry));
   };
 }

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -81,6 +81,7 @@ export const mapTTDataToEntry = (data): Entry => {
     keywords,
     sessionId,
     sessionBlockId,
+    sessionTitle,
   } = camelizeKeys(data);
 
   const mappedObj = {
@@ -111,6 +112,7 @@ export const mapTTDataToEntry = (data): Entry => {
     backgroundColor: colors ? colors.background : '',
     sessionId: sessionId || null,
     sessionBlockId: sessionBlockId || null,
+    sessionTitle: sessionTitle || '',
   };
 
   if (sessionBlockId) {

--- a/indico/modules/events/timetable/schemas.py
+++ b/indico/modules/events/timetable/schemas.py
@@ -22,7 +22,8 @@ from indico.util.marshmallow import EventTimezoneDateTimeField
 class SessionBlockSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = SessionBlock
-        fields = ('id', 'title', 'start_dt', 'duration', 'code', 'conveners', 'location_data', 'session_id')
+        fields = ('id', 'title', 'start_dt', 'duration', 'code', 'conveners', 'location_data', 'session_id',
+                  'session_title')
         rh_context = ('event',)
 
     start_dt = EventTimezoneDateTimeField()
@@ -31,6 +32,7 @@ class SessionBlockSchema(mm.SQLAlchemyAutoSchema):
         _SessionBlockPersonLinkSchema(unknown=EXCLUDE),
     ), attribute='person_links')
     duration = fields.TimeDelta(required=True)
+    session_title = fields.String(attribute='session.title', dump_only=True)
 
 
 def _get_break_session_id(entry):


### PR DESCRIPTION
This simplifies including the session title on redux state updates when creating/editing session blocks. This prevents showing `undefined` for session tittles on the session blocks