### PR TITLE
Add key to Finalfield to force a re render with updated choices

### DIFF
--- a/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/SingleChoiceInput.jsx
@@ -418,9 +418,11 @@ export default function SingleChoiceInput({
       return;
     }
   }
+  const fieldKey = choices.map(c => c.id).join(',');
 
   return (
     <FinalField
+      key={fieldKey}
       id={htmlId}
       name={htmlName}
       component={SingleChoiceInputComponent}


### PR DESCRIPTION
Fixes: https://github.com/indico/indico/issues/6911

Adding a new choice updated the UI properly but it was not updating the internal state of the form. As a result, the new option was visible but could not be selected. By adding a key, we make sure that the internal state is properly updated after every change.


PS: I was unable to run the pre commit hook locally because of the outdated husky version, will try to set it up before future PRs.

https://github.com/user-attachments/assets/a52af9c9-7bea-4054-8d30-a9662b010b95

