### PR TITLE
Avoid shadowing user in legacy API

### DIFF
--- a/docs/source/http-api/exporters/user.rst
+++ b/docs/source/http-api/exporters/user.rst
@@ -7,6 +7,8 @@ General Information
 The user export is only available for authenticated users, i.e. when
 using an API key and a signature (if enabled).
 
+.. deprecated:: 3.3.8
+    Will be removed in Indico v3.4. Use ``/api/user/`` instead.
 
 URL Format
 ----------

--- a/indico/modules/users/api.py
+++ b/indico/modules/users/api.py
@@ -38,9 +38,9 @@ class UserInfoHook(HTTPAPIHook):
 
         if not user:
             raise HTTPAPIError('You need to be logged in', 403)
-        user = User.get(self._user_id, is_deleted=False)
-        if not user:
+        target_user = User.get(self._user_id, is_deleted=False)
+        if not target_user:
             raise HTTPAPIError('Requested user not found', 404)
-        if not user.can_be_modified(user):
+        if not target_user.can_be_modified(user):
             raise HTTPAPIError('You do not have access to that info', 403)
-        return [UserSchema().dump(user)]
+        return [UserSchema().dump(target_user)]


### PR DESCRIPTION
Also deprecated this legacy API, nobody's really using it anyway, and it's a good first step to reduce the amount of these legacy APIs we have.