### PR TITLE
Refactor usage of colors in timetable

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.module.scss
+++ b/indico/modules/events/timetable/client/js/DayTimetable.module.scss
@@ -61,7 +61,7 @@
 }
 
 .entry {
-  // background-color: #5b1aff;
+  background-color: rgba(0, 0, 0, 0.5);
   color: white;
   border-radius: 8px;
   position: relative;
@@ -71,14 +71,6 @@
   border: none;
   padding: 0;
   outline: none;
-
-  &.block {
-    // background-color: rgb(4, 115, 134);
-  }
-
-  &.break {
-    // background-color: #f09000;
-  }
 }
 
 .drag-handle {

--- a/indico/modules/events/timetable/client/js/DayTimetable.module.scss
+++ b/indico/modules/events/timetable/client/js/DayTimetable.module.scss
@@ -74,8 +74,9 @@
   outline: none;
 
   &.draft {
+    pointer-events: none;
     color: $white;
-    text-shadow: 0 0 5px rgba($dark-teal, 0.5);
+    text-shadow: 0 0 5px rgba($dark-teal, 0.25);
     background: rgba($teal, 0.8);
     backdrop-filter: blur(5px);
     -webkit-backdrop-filter: blur(5px);

--- a/indico/modules/events/timetable/client/js/DayTimetable.module.scss
+++ b/indico/modules/events/timetable/client/js/DayTimetable.module.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'base/palette' as *;
+
 .wrapper {
   position: relative;
   display: flex;
@@ -61,7 +63,6 @@
 }
 
 .entry {
-  background-color: rgba(0, 0, 0, 0.5);
   color: white;
   border-radius: 8px;
   position: relative;
@@ -71,6 +72,15 @@
   border: none;
   padding: 0;
   outline: none;
+
+  &.draft {
+    color: $white;
+    text-shadow: 0 0 5px rgba($dark-teal, 0.5);
+    background: rgba($teal, 0.8);
+    backdrop-filter: blur(5px);
+    -webkit-backdrop-filter: blur(5px);
+    border: 1px solid rgba($white, 0.2);
+  }
 }
 
 .drag-handle {

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -302,15 +302,13 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
               <Lines minHour={minHour} maxHour={maxHour} />
               <MemoizedTopLevelEntries dt={dt} entries={entries} />
               {draftEntry && (
-                <div style={{pointerEvents: 'none'}}>
-                  <DraggableEntry
-                    id="draft"
-                    width="100%"
-                    title="New entry"
-                    maxColumn={0}
-                    {...draftEntry}
-                  />
-                </div>
+                <DraggableEntry
+                  id="draft"
+                  width="100%"
+                  title="New entry"
+                  maxColumn={0}
+                  {...draftEntry}
+                />
               )}
               {!isDragging && draftEntry && (
                 <TimetableManageModal

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -302,7 +302,7 @@ export function DayTimetable({dt, eventId, minHour, maxHour, entries}: DayTimeta
               <Lines minHour={minHour} maxHour={maxHour} />
               <MemoizedTopLevelEntries dt={dt} entries={entries} />
               {draftEntry && (
-                <div style={{opacity: 0.5, pointerEvents: 'none'}}>
+                <div style={{pointerEvents: 'none'}}>
                   <DraggableEntry
                     id="draft"
                     width="100%"

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -11,7 +11,6 @@ import {useDispatch, useSelector} from 'react-redux';
 import {Icon, SemanticICONS} from 'semantic-ui-react';
 
 import * as actions from './actions';
-import {ENTRY_COLORS_BY_BACKGROUND} from './colors';
 import {useDraggable, useDroppable} from './dnd';
 import {EntryPopup} from './EntryPopup';
 import {formatTimeRange} from './i18n';

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -127,8 +127,7 @@ export default function ContributionEntry({
   blockRef,
   sessionId,
   sessionTitle,
-  textColor,
-  backgroundColor,
+  colors,
   selected,
   y,
   listeners,
@@ -176,15 +175,7 @@ export default function ContributionEntry({
     zIndex: isDragging || isResizing ? 1000 : selected ? 80 : style.zIndex,
     cursor: isResizing ? undefined : isDragging ? 'grabbing' : 'grab',
     filter: selected ? 'drop-shadow(0 0 2px #000)' : undefined,
-    // TODO: (Ajob) Very ugly triple ternary. Make prettier
-    backgroundColor: backgroundColor
-      ? backgroundColor
-      : sessionData
-        ? isChild
-          ? ENTRY_COLORS_BY_BACKGROUND[sessionData.backgroundColor].childColor
-          : sessionData.backgroundColor
-        : '#5b1aff',
-    color: textColor ? textColor : sessionData ? sessionData.textColor : undefined,
+    ...colors,
   };
 
   const deltaMinutes = snapMinutes(pixelsToMinutes(transform ? transform.y : 0));

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -122,7 +122,6 @@ export default function ContributionEntry({
   duration: _duration,
   title,
   blockRef,
-  sessionId,
   sessionTitle,
   colors,
   selected,

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -231,7 +231,7 @@ export default function ContributionEntry({
   return (
     <div
       role="button"
-      styleName={`entry ${type === 'break' ? 'break' : ''} ${renderChildren ? '' : 'simple'}`}
+      styleName={`entry ${id === 'draft' ? 'draft' : ''} ${renderChildren ? '' : 'simple'}`}
       style={style}
       onMouseUp={() => {
         if (isResizing || isDragging) {

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -26,11 +26,10 @@ import './ContributionEntry.module.scss';
 
 interface DraggableEntryProps {
   id: number;
-  isChild?: boolean;
   [key: string]: any;
 }
 
-export function DraggableEntry({id, isChild = false, ...rest}: DraggableEntryProps) {
+export function DraggableEntry({id, ...rest}: DraggableEntryProps) {
   const dispatch = useDispatch();
   const {
     listeners: _listeners,
@@ -81,7 +80,6 @@ export function DraggableEntry({id, isChild = false, ...rest}: DraggableEntryPro
   const entry = (
     <ContributionEntry
       id={id}
-      isChild={isChild}
       {...rest}
       listeners={listeners}
       setNodeRef={setNodeRef}
@@ -139,8 +137,6 @@ export default function ContributionEntry({
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   onMouseUp: _onMouseUp = () => {},
   parentEndDt,
-  // TODO: (Ajob) Taken from BlockEntry. Re-evaluate
-  isChild = false,
   children: _children = [],
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   setChildDuration = () => {},
@@ -150,7 +146,6 @@ export default function ContributionEntry({
   const resizeStartRef = useRef<number | null>(null);
   const [isResizing, setIsResizing] = useState(false);
   const [duration, setDuration] = useState(_duration);
-  const sessionData = useSelector(state => state.sessions[sessionId]);
   const {setNodeRef: setDroppableNodeRef} = useDroppable({
     id: `${id}`,
     // disabled: true,
@@ -277,7 +272,6 @@ export default function ContributionEntry({
                     parentEndDt={moment(startDt)
                       .add(deltaMinutes + duration, 'minutes')
                       .format()}
-                    isChild
                     {...child}
                   />
                 ))

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -106,7 +106,7 @@ function EntryPopupContent({entry, onClose}: {entry; onClose: () => void}) {
     const {data} = await indicoAxios.get(editURL);
     data['type'] = type;
 
-    const draftEntry = mapTTDataToEntry(data);
+    const draftEntry = mapTTDataToEntry(data, {[session.id]: session});
 
     if ('room' in draftEntry.locationData) {
       draftEntry.locationData.roomName = draftEntry.locationData.room;

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -34,7 +34,7 @@ import {formatTimeRange} from './i18n';
 import {ReduxState} from './reducers';
 import * as selectors from './selectors';
 import {BreakEntry, ContribEntry, BlockEntry, EntryType, PersonLinkRole} from './types';
-import {formatBlockTitle, getEntryColor, mapTTDataToEntry} from './utils';
+import {formatBlockTitle, mapTTDataToEntry} from './utils';
 
 function ColoredDot({color}: {color: string}) {
   return (
@@ -63,10 +63,8 @@ function CardItem({icon, children}: {icon: SemanticICONS; children: React.ReactN
 
 function EntryPopupContent({entry, onClose}: {entry; onClose: () => void}) {
   const dispatch = useDispatch();
-  const {type, title, sessionTitle} = entry;
-  const sessions = useSelector(selectors.getSessions);
+  const {type, title, sessionTitle, colors: {backgroundColor}} = entry;
   const eventId = useSelector(selectors.getEventId);
-  const {backgroundColor} = getEntryColor(entry, sessions);
   const startTime = moment(entry.startDt);
   const endTime = moment(entry.startDt).add(entry.duration, 'minutes');
 

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -63,7 +63,12 @@ function CardItem({icon, children}: {icon: SemanticICONS; children: React.ReactN
 
 function EntryPopupContent({entry, onClose}: {entry; onClose: () => void}) {
   const dispatch = useDispatch();
-  const {type, title, sessionTitle, colors: {backgroundColor}} = entry;
+  const {
+    type,
+    title,
+    sessionTitle,
+    colors: {backgroundColor},
+  } = entry;
   const eventId = useSelector(selectors.getEventId);
   const startTime = moment(entry.startDt);
   const endTime = moment(entry.startDt).add(entry.duration, 'minutes');

--- a/indico/modules/events/timetable/client/js/SessionSelect.tsx
+++ b/indico/modules/events/timetable/client/js/SessionSelect.tsx
@@ -28,11 +28,11 @@ interface SessionSelectProps {
 const processSessions = (sessions: Session[]) => {
   return sessions.length
     ? sessions.flatMap((session: Session): SessionOption[] => {
-        const {backgroundColor: background, textColor: text} = session;
+        const {colors} = session;
         return [
           {
             key: `session:${session.id}`,
-            text: <Label style={{background, color: text}}>{session.title}</Label>,
+            text: <Label style={colors}>{session.title}</Label>,
             value: session.id,
           },
         ];

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -289,7 +289,7 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
     const {data: resData} = await submitHandler(submitData);
     resData.type = activeType;
 
-    const resEntry = mapTTDataToEntry(resData);
+    const resEntry = mapTTDataToEntry(resData, sessions);
 
     if (isEditing) {
       if (resEntry.type === EntryType.SessionBlock) {

--- a/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
@@ -9,7 +9,6 @@ import moment, {Moment} from 'moment';
 import React from 'react';
 import {createPortal} from 'react-dom';
 
-import {ENTRY_COLORS_BY_BACKGROUND} from './colors';
 import {useDraggable, useDroppableData} from './dnd';
 import {pointerInside} from './dnd/utils';
 import {EntryTitle} from './Entry';
@@ -18,21 +17,20 @@ import {minutesToPixels, pixelsToMinutes, snapMinutes} from './utils';
 
 import './ContributionEntry.module.scss';
 import './UnscheduledContributionEntry.module.scss';
+import { Colors } from './types';
 
 export function DraggableUnscheduledContributionEntry({
   id,
   dt,
   title,
   duration,
-  color,
-  textColor,
+  colors,
 }: {
   id: number;
   dt: Moment;
   title: string;
   duration: number;
-  color?: string;
-  textColor?: string;
+  colors?: Colors;
 }) {
   const droppableData = useDroppableData({id: 'calendar'});
 
@@ -58,8 +56,7 @@ export function DraggableUnscheduledContributionEntry({
 
   let style = {
     fontSize: 15,
-    backgroundColor: color ? ENTRY_COLORS_BY_BACKGROUND[color].childColor : '#5b1aff',
-    color: textColor ? textColor : undefined,
+    ...colors,
   };
 
   if (transform) {
@@ -83,8 +80,7 @@ export function DraggableUnscheduledContributionEntry({
           title={title}
           timeRange={timeRange}
           duration={duration}
-          color={color}
-          textColor={textColor}
+          colors={colors}
           isDragging={isDragging}
         />
       </div>,
@@ -114,8 +110,7 @@ export function DraggableUnscheduledContributionEntry({
         title={title}
         timeRange={`${duration} minutes`}
         duration={duration}
-        color={color}
-        textColor={textColor}
+        colors={colors}
         isDragging={isDragging}
       />
     </div>
@@ -126,21 +121,17 @@ export function UnscheduledContributionEntry({
   title,
   timeRange,
   duration,
-  color,
-  textColor,
+  colors,
   isDragging,
 }: {
   title: string;
   timeRange: string;
   duration: number;
-  color?: string;
-  textColor?: string;
-  isDragging: boolean;
+  colors?: Colors;
 }) {
   const style = {
     border: '2px solid transparent',
-    backgroundColor: color ? ENTRY_COLORS_BY_BACKGROUND[color].childColor : '#5b1aff',
-    color: textColor ? textColor : undefined,
+    ...colors,
     fontSize: 15,
     borderRadius: 8,
     cursor: isDragging ? 'grabbing' : 'grab',

--- a/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
@@ -13,11 +13,11 @@ import {useDraggable, useDroppableData} from './dnd';
 import {pointerInside} from './dnd/utils';
 import {EntryTitle} from './Entry';
 import {formatTimeRange} from './i18n';
+import {Colors} from './types';
 import {minutesToPixels, pixelsToMinutes, snapMinutes} from './utils';
 
 import './ContributionEntry.module.scss';
 import './UnscheduledContributionEntry.module.scss';
-import { Colors } from './types';
 
 export function DraggableUnscheduledContributionEntry({
   id,
@@ -128,6 +128,7 @@ export function UnscheduledContributionEntry({
   timeRange: string;
   duration: number;
   colors?: Colors;
+  isDragging?: boolean;
 }) {
   const style = {
     border: '2px solid transparent',

--- a/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
@@ -122,7 +122,7 @@ export default function UnscheduledContributions({dt}: {dt: Moment}) {
                         borderRadius: '50%',
                         width: '1em',
                         height: '1em',
-                        ...session.colors
+                        ...session.colors,
                       }}
                     />
                   </span>

--- a/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
@@ -24,8 +24,7 @@ function UnscheduledContributionList({dt, contribs}: {dt: Moment; contribs: any[
           id={contrib.id}
           title={contrib.title}
           duration={contrib.duration}
-          color={contrib.backgroundColor}
-          textColor={contrib.textColor}
+          colors={contrib.colors}
         />
       ))}
     </div>
@@ -121,9 +120,9 @@ export default function UnscheduledContributions({dt}: {dt: Moment}) {
                     <span
                       style={{
                         borderRadius: '50%',
-                        backgroundColor: session.backgroundColor,
                         width: '1em',
                         height: '1em',
+                        ...session.colors
                       }}
                     />
                   </span>

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -24,7 +24,6 @@ import {
   UnscheduledContrib,
   EntryType,
 } from './types';
-import {getEntryColor} from './utils';
 
 export const SET_DRAFT_ENTRY = 'Set draft entry';
 export const SET_TIMETABLE_DATA = 'Set timetable data';
@@ -267,7 +266,7 @@ function _createEntry(entryType, entry) {
 export function createEntry(entryType, entry) {
   return (dispatch, getState) => {
     const sessions = getState().sessions;
-    const color = getEntryColor(entry, sessions);
+    const color = entry.colors;
     const sessionTitle = sessions[entry.sessionId]?.title || '';
     const newEntry = {...entry, ...color, sessionTitle};
     dispatch(_createEntry(entryType, newEntry));

--- a/indico/modules/events/timetable/client/js/colors.ts
+++ b/indico/modules/events/timetable/client/js/colors.ts
@@ -8,39 +8,42 @@
 export const DEFAULT_CONTRIB_COLORS = {
   color: '#ffffff',
   backgroundColor: '#5b1aff',
-}
+};
 
 export const DEFAULT_BREAK_COLORS = {
   color: '#000000de',
   backgroundColor: '#cce2ff',
-}
+};
 
 export const ENTRY_COLORS = [
   // childColor is baed on the backgroundColor of the parent
-  // If the parent textColor is dark, the childColor is lighter than the parent backgroundColor
-  // If the parent textColor is light, the childColor is darker than the parent backgroundColor
-  {textColor: '#1d041f', backgroundColor: '#eee0ef', childColor: '#c0a0c0'},
-  {textColor: '#253f08', backgroundColor: '#e3f2d3', childColor: '#a0c080'},
-  {textColor: '#1f1f02', backgroundColor: '#feffbf', childColor: '#c0c0a0'},
-  {textColor: '#202020', backgroundColor: '#dfe555', childColor: '#a0a020'},
-  {textColor: '#1f1d04', backgroundColor: '#ffec1f', childColor: '#c0b010'},
-  {textColor: '#0f264f', backgroundColor: '#dfebff', childColor: '#a0b0c0'},
-  {textColor: '#eff5ff', backgroundColor: '#0d316f', childColor: '#5070a0'},
-  {textColor: '#f1ffef', backgroundColor: '#1a3f14', childColor: '#609060'},
-  {textColor: '#ffffff', backgroundColor: '#5f171a', childColor: '#a06060'},
-  {textColor: '#272f09', backgroundColor: '#d9dfc3', childColor: '#a0a080'},
-  {textColor: '#ffefff', backgroundColor: '#4f144e', childColor: '#a060a0'},
-  {textColor: '#ffeddf', backgroundColor: '#6f390d', childColor: '#a07050'},
-  {textColor: '#021f03', backgroundColor: '#8ec473', childColor: '#608040'},
-  {textColor: '#03070f', backgroundColor: '#92b6db', childColor: '#506080'},
-  {textColor: '#151515', backgroundColor: '#dfdfdf', childColor: '#a0a0a0'},
-  {textColor: '#1f1100', backgroundColor: '#ecc495', childColor: '#c0a060'},
-  {textColor: '#0f0202', backgroundColor: '#b9cbca', childColor: '#80a0a0'},
-  {textColor: '#0d1e1f', backgroundColor: '#c2ecef', childColor: '#80a0a0'},
-  {textColor: '#000000', backgroundColor: '#d0c296', childColor: '#a0a080'},
-  {textColor: '#202020', backgroundColor: '#efebc2', childColor: '#c0c0a0'},
+  // If the parent text color (color) is dark, the childBackgroundColor is lighter than the parent backgroundColor
+  // If the parent text color (color) is light, the childBackgroundColor is darker than the parent backgroundColor
+  {color: '#1d041f', backgroundColor: '#eee0ef', childBackgroundColor: '#c0a0c0'},
+  {color: '#253f08', backgroundColor: '#e3f2d3', childBackgroundColor: '#a0c080'},
+  {color: '#1f1f02', backgroundColor: '#feffbf', childBackgroundColor: '#c0c0a0'},
+  {color: '#202020', backgroundColor: '#dfe555', childBackgroundColor: '#a0a020'},
+  {color: '#1f1d04', backgroundColor: '#ffec1f', childBackgroundColor: '#c0b010'},
+  {color: '#0f264f', backgroundColor: '#dfebff', childBackgroundColor: '#a0b0c0'},
+  {color: '#eff5ff', backgroundColor: '#0d316f', childBackgroundColor: '#5070a0'},
+  {color: '#f1ffef', backgroundColor: '#1a3f14', childBackgroundColor: '#609060'},
+  {color: '#ffffff', backgroundColor: '#5f171a', childBackgroundColor: '#a06060'},
+  {color: '#272f09', backgroundColor: '#d9dfc3', childBackgroundColor: '#a0a080'},
+  {color: '#ffefff', backgroundColor: '#4f144e', childBackgroundColor: '#a060a0'},
+  {color: '#ffeddf', backgroundColor: '#6f390d', childBackgroundColor: '#a07050'},
+  {color: '#021f03', backgroundColor: '#8ec473', childBackgroundColor: '#608040'},
+  {color: '#03070f', backgroundColor: '#92b6db', childBackgroundColor: '#506080'},
+  {color: '#151515', backgroundColor: '#dfdfdf', childBackgroundColor: '#a0a0a0'},
+  {color: '#1f1100', backgroundColor: '#ecc495', childBackgroundColor: '#c0a060'},
+  {color: '#0f0202', backgroundColor: '#b9cbca', childBackgroundColor: '#80a0a0'},
+  {color: '#0d1e1f', backgroundColor: '#c2ecef', childBackgroundColor: '#80a0a0'},
+  {color: '#000000', backgroundColor: '#d0c296', childBackgroundColor: '#a0a080'},
+  {color: '#202020', backgroundColor: '#efebc2', childBackgroundColor: '#c0c0a0'},
 ];
 
 export const ENTRY_COLORS_BY_BACKGROUND = Object.fromEntries(
-  ENTRY_COLORS.map(({backgroundColor, ...colors}) => [backgroundColor, colors])
+  ENTRY_COLORS.map(({backgroundColor, color, childBackgroundColor}) => [
+    backgroundColor,
+    {color, backgroundColor: childBackgroundColor},
+  ])
 );

--- a/indico/modules/events/timetable/client/js/colors.ts
+++ b/indico/modules/events/timetable/client/js/colors.ts
@@ -5,6 +5,16 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+export const DEFAULT_CONTRIB_COLORS = {
+  color: '#ffffff',
+  backgroundColor: '#5b1aff',
+}
+
+export const DEFAULT_BREAK_COLORS = {
+  color: '#000000de',
+  backgroundColor: '#cce2ff',
+}
+
 export const ENTRY_COLORS = [
   // childColor is baed on the backgroundColor of the parent
   // If the parent textColor is dark, the childColor is lighter than the parent backgroundColor

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -20,8 +20,8 @@ import {
   Session,
   UnscheduledContrib,
 } from './types';
-import {DEFAULT_BREAK_COLORS, DEFAULT_CONTRIB_COLORS, ENTRY_COLORS_BY_BACKGROUND} from './colors';
-import { getDefaultColorByType } from './utils';
+import {ENTRY_COLORS_BY_BACKGROUND} from './colors';
+import {getDefaultColorByType} from './utils';
 
 interface SchemaDate {
   date: string;
@@ -96,7 +96,6 @@ export function preprocessTimetableEntries(
       const type = entryTypeMapping[_id[0]];
       // TODO: (Ajob) Instead of 'any', clean up interfaces and assign one for consistency
       const entry: any = data[day][_id];
-      let defaultColors = getDefaultColorByType(type);
 
       const {
         duration,
@@ -111,7 +110,7 @@ export function preprocessTimetableEntries(
         id,
         objId,
         attachments,
-        colors = defaultColors,
+        colors = getDefaultColorByType(type),
       } = entry;
 
       dayEntries[day].push({

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -10,6 +10,7 @@ import moment from 'moment';
 
 import {camelizeKeys} from 'indico/utils/case';
 
+import {ENTRY_COLORS_BY_BACKGROUND} from './colors';
 import {
   Attachments,
   ChildEntry,
@@ -20,7 +21,6 @@ import {
   Session,
   UnscheduledContrib,
 } from './types';
-import {ENTRY_COLORS_BY_BACKGROUND} from './colors';
 import {getDefaultColorByType} from './utils';
 
 interface SchemaDate {

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -20,7 +20,7 @@ import {
   Session,
   UnscheduledContrib,
 } from './types';
-import { DEFAULT_BREAK_COLORS,  DEFAULT_CONTRIB_COLORS, ENTRY_COLORS_BY_BACKGROUND } from './colors';
+import {DEFAULT_BREAK_COLORS, DEFAULT_CONTRIB_COLORS, ENTRY_COLORS_BY_BACKGROUND} from './colors';
 
 interface SchemaDate {
   date: string;
@@ -97,7 +97,7 @@ export function preprocessTimetableEntries(
       const type = entryTypeMapping[_id[0]];
       // TODO: (Ajob) Instead of 'any', clean up interfaces and assign one for consistency
       const entry: any = data[day][_id];
-      let defaultColor = {
+      let defaultColors = {
         [EntryType.Contribution]: DEFAULT_CONTRIB_COLORS,
         [EntryType.Break]: DEFAULT_BREAK_COLORS,
       }[type];
@@ -115,7 +115,7 @@ export function preprocessTimetableEntries(
         id,
         objId,
         attachments,
-        colors = defaultColor,
+        colors = defaultColors,
       } = entry;
 
       dayEntries[day].push({
@@ -147,15 +147,11 @@ export function preprocessTimetableEntries(
         dayEntries[day].at(-1).sessionId = entry.sessionId;
       }
 
-      if (colors) {
-        dayEntries[day].at(-1).colors = colors;
-      }
-
       if (type === EntryType.SessionBlock) {
         dayEntries[day].at(-1).sessionTitle = entry.sessionTitle;
 
         const children = Object.values(entry.entries).map((c: SchemaBlock) => {
-          const childColors = ENTRY_COLORS_BY_BACKGROUND[c.colors.backgroundColor];
+          const childColors = ENTRY_COLORS_BY_BACKGROUND[entry.colors.backgroundColor];
           const childType = entryTypeMapping[c.id[0]];
           const childEntry: ChildEntry = {
             type: childType,
@@ -176,7 +172,7 @@ export function preprocessTimetableEntries(
             column: 0,
             maxColumn: 0,
             colors: {
-              textColor: childColors.textColor,
+              color: childColors.textColor,
               backgroundColor: childColors.childColor,
             },
             parent: {
@@ -202,8 +198,6 @@ export function preprocessTimetableEntries(
       }
 
       dayEntries[day].at(-1).colors = colors;
-      dayEntries[day].at(-1).textColor = colors.color;
-      dayEntries[day].at(-1).color = colors.backgroundColor;
     }
   }
 

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -32,7 +32,6 @@ interface SchemaEntry {
   id: string;
   objId: number;
   title: string;
-  textColor?: string;
   colors?: Colors;
   slotTitle?: string;
 }
@@ -67,9 +66,8 @@ export function preprocessSessionData(
     Object.entries(data).map(([, s]) => [
       s.id,
       {
-        ..._.pick(s, ['id', 'title', 'isPoster', 'defaultContribDurationMinutes']), // TODO: (Duarte) get other attrs
-        textColor: s.colors.color,
-        backgroundColor: s.colors.backgroundColor,
+        // TODO: (Duarte) get other attrs
+        ..._.pick(s, ['id', 'title', 'colors', 'isPoster', 'defaultContribDurationMinutes']),
       },
     ])
   );
@@ -151,7 +149,6 @@ export function preprocessTimetableEntries(
         dayEntries[day].at(-1).sessionTitle = entry.sessionTitle;
 
         const children = Object.values(entry.entries).map((c: SchemaBlock) => {
-          const childColors = ENTRY_COLORS_BY_BACKGROUND[entry.colors.backgroundColor];
           const childType = entryTypeMapping[c.id[0]];
           const childEntry: ChildEntry = {
             type: childType,
@@ -171,10 +168,7 @@ export function preprocessTimetableEntries(
             width: 0,
             column: 0,
             maxColumn: 0,
-            colors: {
-              color: childColors.textColor,
-              backgroundColor: childColors.childColor,
-            },
+            colors: ENTRY_COLORS_BY_BACKGROUND[entry.colors.backgroundColor],
             parent: {
               colors,
               id,

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -21,6 +21,7 @@ import {
   UnscheduledContrib,
 } from './types';
 import {DEFAULT_BREAK_COLORS, DEFAULT_CONTRIB_COLORS, ENTRY_COLORS_BY_BACKGROUND} from './colors';
+import { getDefaultColorByType } from './utils';
 
 interface SchemaDate {
   date: string;
@@ -95,10 +96,7 @@ export function preprocessTimetableEntries(
       const type = entryTypeMapping[_id[0]];
       // TODO: (Ajob) Instead of 'any', clean up interfaces and assign one for consistency
       const entry: any = data[day][_id];
-      let defaultColors = {
-        [EntryType.Contribution]: DEFAULT_CONTRIB_COLORS,
-        [EntryType.Break]: DEFAULT_BREAK_COLORS,
-      }[type];
+      let defaultColors = getDefaultColorByType(type);
 
       const {
         duration,

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -31,6 +31,11 @@ export interface PersonLink {
   roles: PersonLinkRole[];
 }
 
+export interface Colors {
+  color: string;
+  backgroundColor;
+}
+
 export interface LocationData {
   address: string;
   venueName: string;

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -53,7 +53,7 @@ export interface Session {
   id?: number;
   title: string;
   isPoster: boolean;
-  colors: Colors
+  colors: Colors;
   backgroundColor: string;
 }
 

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -53,7 +53,7 @@ export interface Session {
   id?: number;
   title: string;
   isPoster: boolean;
-  textColor: string;
+  colors: Colors
   backgroundColor: string;
 }
 
@@ -90,7 +90,7 @@ export interface ContribEntry extends UnscheduledContrib, ScheduledMixin {
 export interface BreakEntry extends BaseEntry, ScheduledMixin {
   type: EntryType.Break;
   sessionId?: number;
-  textColor: string;
+  colors: Colors;
   backgroundColor: string;
 }
 

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -64,6 +64,7 @@ export interface BaseEntry {
   title: string;
   duration: number;
   description: string;
+  colors?: Colors;
   locationData?: LocationData;
 }
 
@@ -90,7 +91,6 @@ export interface ContribEntry extends UnscheduledContrib, ScheduledMixin {
 export interface BreakEntry extends BaseEntry, ScheduledMixin {
   type: EntryType.Break;
   sessionId?: number;
-  colors: Colors;
   backgroundColor: string;
 }
 

--- a/indico/modules/events/timetable/client/js/util.js
+++ b/indico/modules/events/timetable/client/js/util.js
@@ -15,7 +15,6 @@ import _ from 'lodash';
  */
 export const appendSessionAttributes = (entries, sessions) => {
   return entries.map(e =>
-    e.sessionId
-      ? {...e, ..._.pick(sessions[e.sessionId], ['colors', 'isPoster'])}
-      : e
-  )};
+    e.sessionId ? {...e, ..._.pick(sessions[e.sessionId], ['colors', 'isPoster'])} : e
+  );
+};

--- a/indico/modules/events/timetable/client/js/util.js
+++ b/indico/modules/events/timetable/client/js/util.js
@@ -13,9 +13,9 @@ import _ from 'lodash';
  * @param {Map} sessions Sessions map
  * @returns {array} Entries array with color attribute
  */
-export const appendSessionAttributes = (entries, sessions) =>
-  entries.map(e =>
+export const appendSessionAttributes = (entries, sessions) => {
+  return entries.map(e =>
     e.sessionId
-      ? {...e, ..._.pick(sessions[e.sessionId], ['backgroundColor', 'textColor', 'isPoster'])}
+      ? {...e, ..._.pick(sessions[e.sessionId], ['colors', 'isPoster'])}
       : e
-  );
+  )};

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -57,8 +57,6 @@ export function getDefaultColorByType(type: EntryType) {
   return {
     [EntryType.Contribution]: DEFAULT_CONTRIB_COLORS,
     [EntryType.Break]: DEFAULT_BREAK_COLORS,
-    // TODO: (Ajob) Remove this one because it is temporary for debugging
-    [EntryType.SessionBlock]: {color: '#FF0000', backgroundColor: '#FFFFFF'},
   }[type]
 }
 

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -141,13 +141,13 @@ export function getEntryColor(
   console.assert(session, `Session ${entry.sessionId} not found for entry ${entry.id}`);
   if (entry.sessionId && entry.type !== EntryType.SessionBlock) {
     return {
-      textColor: session.textColor,
+      textColor: session.colors.color,
       backgroundColor: ENTRY_COLORS_BY_BACKGROUND[session.backgroundColor].childColor,
     };
   }
 
   return {
-    textColor: session.textColor,
+    textColor: session.colors.color,
     backgroundColor: session.backgroundColor,
   };
 }

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -62,10 +62,7 @@ export function getDefaultColorByType(type: EntryType) {
   }[type]
 }
 
-export function mapTTEntryColor(
-  dbEntry,
-  sessions: Record<number, Session> = {}
-): Colors {
+export function mapTTEntryColor(dbEntry, sessions: Record<number, Session> = {}): Colors {
   const {sessionId, type, colors} = dbEntry;
   const fallbackColor = colors
     ? {color: colors.text, backgroundColor: colors.background}

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -120,38 +120,6 @@ export const mapTTDataToEntry = (data): Entry => {
   return mappedObj;
 };
 
-const DEFAULT_CONTRIB_TEXT_COLOR = '#ffffff';
-const DEFAULT_CONTRIB_BACKGROUND_COLOR = '#5b1aff';
-
-export function getEntryColor(
-  entry: Entry,
-  sessions: Record<number, Session>
-): {textColor: string; backgroundColor: string} {
-  if (entry.type === EntryType.Break && !entry.sessionId) {
-    return {textColor: entry.textColor, backgroundColor: entry.backgroundColor};
-  }
-  if (entry.type === EntryType.Contribution && !entry.sessionId) {
-    return {
-      textColor: DEFAULT_CONTRIB_TEXT_COLOR,
-      backgroundColor: DEFAULT_CONTRIB_BACKGROUND_COLOR,
-    };
-  }
-
-  const session = sessions[entry.sessionId];
-  console.assert(session, `Session ${entry.sessionId} not found for entry ${entry.id}`);
-  if (entry.sessionId && entry.type !== EntryType.SessionBlock) {
-    return {
-      textColor: session.colors.color,
-      backgroundColor: ENTRY_COLORS_BY_BACKGROUND[session.backgroundColor].childColor,
-    };
-  }
-
-  return {
-    textColor: session.colors.color,
-    backgroundColor: session.backgroundColor,
-  };
-}
-
 export function formatBlockTitle(sessionTitle: string, blockTitle: string) {
   return blockTitle ? `${sessionTitle}: ${blockTitle}` : sessionTitle;
 }

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -57,7 +57,7 @@ export function getDefaultColorByType(type: EntryType) {
   return {
     [EntryType.Contribution]: DEFAULT_CONTRIB_COLORS,
     [EntryType.Break]: DEFAULT_BREAK_COLORS,
-  }[type]
+  }[type];
 }
 
 export function mapTTEntryColor(dbEntry, sessions: Record<number, Session> = {}): Colors {

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -10,8 +10,8 @@ import {useEffect, useRef} from 'react';
 
 import {camelizeKeys} from 'indico/utils/case';
 
-import {ENTRY_COLORS_BY_BACKGROUND} from './colors';
-import {Entry, EntryType, Session} from './types';
+import {DEFAULT_BREAK_COLORS, DEFAULT_CONTRIB_COLORS, ENTRY_COLORS_BY_BACKGROUND} from './colors';
+import {Colors, Entry, EntryType, Session} from './types';
 
 export const DATE_KEY_FORMAT = 'YYYYMMDD';
 export const LOCAL_STORAGE_KEY = 'manageTimetableData';
@@ -53,6 +53,37 @@ function gcd(a: number, b: number) {
   return a;
 }
 
+export function getDefaultColorByType(type: EntryType) {
+  return {
+    [EntryType.Contribution]: DEFAULT_CONTRIB_COLORS,
+    [EntryType.Break]: DEFAULT_BREAK_COLORS,
+    // TODO: (Ajob) Remove this one because it is temporary for debugging
+    [EntryType.SessionBlock]: {color: '#FF0000', backgroundColor: '#FFFFFF'},
+  }[type]
+}
+
+export function mapTTEntryColor(
+  dbEntry,
+  sessions: Record<number, Session> = {}
+): Colors {
+  const {sessionId, type, colors} = dbEntry;
+  const fallbackColor = colors
+    ? {color: colors.text, backgroundColor: colors.background}
+    : getDefaultColorByType(dbEntry.type);
+
+  if (type === EntryType.SessionBlock) {
+    return sessions[sessionId].colors ?? fallbackColor;
+  }
+
+  if (sessionId) {
+    const session = sessions[sessionId];
+    console.assert(session, `Session ${dbEntry.sessionId} not found for entry ${dbEntry.id}`);
+    return ENTRY_COLORS_BY_BACKGROUND[session.colors.backgroundColor];
+  }
+
+  return fallbackColor;
+}
+
 export const getEntryUniqueId = (entry): string => {
   switch (entry.type) {
     case EntryType.SessionBlock:
@@ -64,7 +95,8 @@ export const getEntryUniqueId = (entry): string => {
   }
 };
 
-export const mapTTDataToEntry = (data): Entry => {
+export const mapTTDataToEntry = (data, sessions): Entry => {
+  data = camelizeKeys(data);
   const {
     type,
     startDt,
@@ -74,14 +106,13 @@ export const mapTTDataToEntry = (data): Entry => {
     description,
     conveners,
     personLinks,
-    colors,
     boardNumber,
     locationData,
     code,
     keywords,
     sessionId,
     sessionBlockId,
-  } = camelizeKeys(data);
+  } = data;
 
   const mappedObj = {
     id: getEntryUniqueId(data),
@@ -106,12 +137,10 @@ export const mapTTDataToEntry = (data): Entry => {
     column: 0,
     maxColumn: 0,
     children: [],
-    colors,
-    textColor: colors ? colors.text : '',
-    backgroundColor: colors ? colors.background : '',
     sessionId: sessionId || null,
     sessionBlockId: sessionBlockId || null,
   };
+  mappedObj.colors = mapTTEntryColor(data, sessions);
 
   if (sessionBlockId) {
     mappedObj.sessionBlockId = `s${sessionBlockId}`;

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -139,8 +139,8 @@ export const mapTTDataToEntry = (data, sessions): Entry => {
     children: [],
     sessionId: sessionId || null,
     sessionBlockId: sessionBlockId || null,
+    colors: mapTTEntryColor(data, sessions),
   };
-  mappedObj.colors = mapTTEntryColor(data, sessions);
 
   if (sessionBlockId) {
     mappedObj.sessionBlockId = `s${sessionBlockId}`;

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -19,6 +19,37 @@ from indico.util.date_time import iterdays
 from indico.web.flask.util import url_for
 
 
+def get_obj_id(entry):
+    if entry.type == TimetableEntryType.SESSION_BLOCK:
+        return entry.session_block.id
+    elif entry.type == TimetableEntryType.CONTRIBUTION:
+        return entry.contribution.id
+    elif entry.type == TimetableEntryType.BREAK:
+        return entry.break_.id
+    else:
+        raise ValueError
+
+
+def get_unique_key(entry):
+    if entry.type == TimetableEntryType.SESSION_BLOCK:
+        return f's{entry.session_block.id}'
+    elif entry.type == TimetableEntryType.CONTRIBUTION:
+        return f'c{entry.contribution.id}'
+    elif entry.type == TimetableEntryType.BREAK:
+        return f'b{entry.break_.id}'
+    else:
+        raise ValueError
+
+
+def get_color_data(obj):
+    return {
+        'colors': {
+            'backgroundColor': '#' + obj.background_color,
+            'color': '#' + obj.text_color
+        }
+    }
+
+
 def _get_location_data(obj, *, management=False):
     data = {}
     data['location'] = obj.venue_name
@@ -141,8 +172,8 @@ class TimetableSerializer:
         else:
             entries = {get_unique_key(x): self.serialize_timetable_entry(x) for x in entry.children}
         data.update(self._get_entry_data(entry))
-        data.update(self._get_color_data(block.session))
         data.update(self._get_location_data(block))
+        data.update(get_color_data(block.session))
         data.update({'entryType': 'Session',
                      'sessionId': block.session_id,
                      'sessionCode': block.session.code,
@@ -169,7 +200,9 @@ class TimetableSerializer:
         data = {}
         data.update(self._get_entry_data(entry))
         if contribution.session:
-            data.update(self._get_color_data(contribution.session))
+            print('we goin here')
+            print(contribution.session)
+            data.update(get_color_data(contribution.session))
         data.update(self._get_location_data(contribution))
         data.update({'entryType': 'Contribution',
                      '_type': 'ContribSchEntry',
@@ -202,8 +235,8 @@ class TimetableSerializer:
         break_ = entry.break_
         data = {}
         data.update(self._get_entry_data(entry))
-        data.update(self._get_color_data(break_))
         data.update(self._get_location_data(break_))
+        data.update(get_color_data(break_))
         data.update({'entryType': 'Break',
                      '_type': 'BreakTimeSchEntry',
                      '_fossil': 'breakTimeSchEntry',
@@ -237,10 +270,6 @@ class TimetableSerializer:
         data['folders'] = list(map(serialize_folder, items.get('folders', [])))
 
         return data
-
-    def _get_color_data(self, obj):
-        return {'color': '#' + obj.background_color,
-                'textColor': '#' + obj.text_color}
 
     def _get_date_data(self, entry):
         if self.management:
@@ -286,28 +315,6 @@ def serialize_contribution(contribution):
             'title': contribution.title}
 
 
-def get_obj_id(entry):
-    if entry.type == TimetableEntryType.SESSION_BLOCK:
-        return entry.session_block.id
-    elif entry.type == TimetableEntryType.CONTRIBUTION:
-        return entry.contribution.id
-    elif entry.type == TimetableEntryType.BREAK:
-        return entry.break_.id
-    else:
-        raise ValueError
-
-
-def get_unique_key(entry):
-    if entry.type == TimetableEntryType.SESSION_BLOCK:
-        return f's{entry.session_block.id}'
-    elif entry.type == TimetableEntryType.CONTRIBUTION:
-        return f'c{entry.contribution.id}'
-    elif entry.type == TimetableEntryType.BREAK:
-        return f'b{entry.break_.id}'
-    else:
-        raise ValueError
-
-
 # Event related functions:
 
 # TODO: This is only temporary to get unscheduled contributions working
@@ -318,8 +325,7 @@ def serialize_unscheduled_contribution(contribution, *, management=False, can_ma
         'objId': contribution.id
     }
     if contribution.session:
-        data.update({'color': '#' + contribution.session.background_color,
-                     'textColor': '#' + contribution.session.text_color})
+        data.update(get_color_data(contribution.session))
     data.update({'entryType': 'Contribution',
                  '_type': 'ContribSchEntry',
                  '_fossil': 'contribSchEntryDisplay',
@@ -364,18 +370,19 @@ def serialize_event_info(event, *, management=False, user=None):
 
 def serialize_session(sess):
     """Return data for a single session."""
-    return {
+    data = {
         '_type': 'Session',
         'address': sess.address,
-        'color': '#' + sess.colors.background,
         'description': sess.description,
         'id': sess.id,
         'isPoster': sess.is_poster,
         'location': sess.venue_name,
         'room': sess.room_name,
         'roomFullname': sess.room_name,
-        'textColor': '#' + sess.colors.text,
         'title': sess.title,
         'url': url_for('sessions.display_session', sess),
         'defaultContribDurationMinutes': sess.default_contribution_duration.total_seconds() / 60
     }
+    data.update(get_color_data(sess))
+
+    return data

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -44,8 +44,8 @@ def get_unique_key(entry):
 def get_color_data(obj):
     return {
         'colors': {
-            'backgroundColor': '#' + obj.background_color,
-            'color': '#' + obj.text_color
+            'backgroundColor': f'#{obj.background_color}',
+            'color': f'#{obj.text_color}',
         }
     }
 
@@ -173,7 +173,6 @@ class TimetableSerializer:
             entries = {get_unique_key(x): self.serialize_timetable_entry(x) for x in entry.children}
         data.update(self._get_entry_data(entry))
         data.update(self._get_location_data(block))
-        data.update(get_color_data(block.session))
         data.update({'entryType': 'Session',
                      'sessionId': block.session_id,
                      'sessionCode': block.session.code,
@@ -189,7 +188,8 @@ class TimetableSerializer:
                      'entries': entries,
                      'pdf': url_for('sessions.export_session_timetable', block.session),
                      'url': url_for('sessions.display_session', block.session),
-                     'friendlyId': block.session.friendly_id})
+                     'friendlyId': block.session.friendly_id
+                     **get_color_data(block.session)})
         return data
 
     def serialize_contribution_entry(self, entry):
@@ -234,7 +234,6 @@ class TimetableSerializer:
         data = {}
         data.update(self._get_entry_data(entry))
         data.update(self._get_location_data(break_))
-        data.update(get_color_data(break_))
         data.update({'entryType': 'Break',
                      '_type': 'BreakTimeSchEntry',
                      '_fossil': 'breakTimeSchEntry',
@@ -244,7 +243,8 @@ class TimetableSerializer:
                      'sessionCode': block.session.code if block else None,
                     #  'sessionSlotId': block.id if block else None,
                     #  'sessionSlotEntryId': entry.parent.id if entry.parent else None,
-                     'title': break_.title})
+                     'title': break_.title
+                     **get_color_data(break_)})
         return data
 
     def _get_attachment_data(self, obj):
@@ -368,7 +368,7 @@ def serialize_event_info(event, *, management=False, user=None):
 
 def serialize_session(sess):
     """Return data for a single session."""
-    data = {
+    return {
         '_type': 'Session',
         'address': sess.address,
         'description': sess.description,
@@ -379,8 +379,6 @@ def serialize_session(sess):
         'roomFullname': sess.room_name,
         'title': sess.title,
         'url': url_for('sessions.display_session', sess),
-        'defaultContribDurationMinutes': sess.default_contribution_duration.total_seconds() / 60
+        'defaultContribDurationMinutes': sess.default_contribution_duration.total_seconds() / 60,
+        **get_color_data(sess),
     }
-    data.update(get_color_data(sess))
-
-    return data

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -200,8 +200,6 @@ class TimetableSerializer:
         data = {}
         data.update(self._get_entry_data(entry))
         if contribution.session:
-            print('we goin here')
-            print(contribution.session)
             data.update(get_color_data(contribution.session))
         data.update(self._get_location_data(contribution))
         data.update({'entryType': 'Contribution',

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -188,7 +188,7 @@ class TimetableSerializer:
                      'entries': entries,
                      'pdf': url_for('sessions.export_session_timetable', block.session),
                      'url': url_for('sessions.display_session', block.session),
-                     'friendlyId': block.session.friendly_id
+                     'friendlyId': block.session.friendly_id,
                      **get_color_data(block.session)})
         return data
 
@@ -243,7 +243,7 @@ class TimetableSerializer:
                      'sessionCode': block.session.code if block else None,
                     #  'sessionSlotId': block.id if block else None,
                     #  'sessionSlotEntryId': entry.parent.id if entry.parent else None,
-                     'title': break_.title
+                     'title': break_.title,
                      **get_color_data(break_)})
         return data
 


### PR DESCRIPTION
Replace separate `textColor` and `backgroundColor` properties with one that is consistent with its usage; CSS props. So now we have a property called `colors` which is pre-calculated which contains props `color` and `backgroundColor` which we can spread onto styling. Also got rid of all the child color logic and separate functions everywhere. Now it is in a concise place.