### PR TITLE
Fix escaping of LaTeX math blocks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Bugfixes
   (:issue:`7016`, :pr:`7017`, thanks :user:`behackl`)
 - Fix author contribution list not showing any other contributions (:issue:`7025`,
   :pr:`7049`, thanks :user:`diksharai9`)
+- Fix some LaTeX strings being rendered incorrectly and/or breaking the timetable
+  PDF generation (:pr:`7068`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/util/string_test.py
+++ b/indico/util/string_test.py
@@ -222,7 +222,9 @@ def test_html_to_plaintext(input, output):
     ('Name|Colour\n---|---\nLancelot|Blue',
      '<table>\n<thead>\n<tr>\n<th>Name</th>\n<th>Colour</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>Lancelot</td>\n'
      '<td>Blue</td>\n</tr>\n</tbody>\n</table>'),
-    ('**$2 * 2 * 2 > 7$**', '<p><strong>$2 * 2 * 2 > 7$</strong></p>'),
+    ('**$2 * 2 * 2 > 7$**', '<p><strong>$2 * 2 * 2 &gt; 7$</strong></p>'),
+    ('$a<b \\& b>c$', '<p>$a&lt;b \\&amp; b&gt;c$</p>'),
+    ('$<a_{b}>$', '<p>$&lt;a_{b}&gt;$</p>'),
     ('Escaping works just fine! $ *a* $', '<p>Escaping works just fine! $ *a* $</p>'),
     ('![Just a cat](http://myserver.example.com/cat.png)', '<p><img alt="Just a cat" '
      'src="http://myserver.example.com/cat.png"></p>'),


### PR DESCRIPTION
Some valid math formulas resulted in errors when generating a PDF timetable using weasyprint (see Kozea/cssselect2#34).