### PR TITLE
Fix category list link color contrast

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Bugfixes
 Accessibility
 ^^^^^^^^^^^^^
 
-- Nothing so far
+- Fix category list link color contrast (:pr:`7070`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/design_system/variables.scss
+++ b/indico/web/client/styles/design_system/variables.scss
@@ -24,7 +24,7 @@ body {
   --border-default-color: #5a5a5a;
   --border-disabled-color: #c4c4c4;
   --accent-color: #0075a3;
-  --accent-secondary-color: #b35905; // XXX: min font size 1.2rem or 1rem bold (or solid icon)
+  --accent-secondary-color: #aa5302; // XXX: min font size 1.2rem or 1rem bold (or solid icon)
   --accent-highlight-color: #035e81;
   --accent-border-color: #05425b;
   --active-color: #db1a1a;

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -316,9 +316,8 @@ ul.category-list {
     }
 
     a {
-      @include transition(color);
+      @extend %link;
       display: block;
-      color: lighten($dark-blue, 6%);
       padding: 0 0 0 1em;
       position: relative;
 
@@ -332,10 +331,6 @@ ul.category-list {
 
     &:hover {
       color: $light-black;
-
-      a {
-        color: darken($dark-blue, 6%);
-      }
 
       &::before {
         color: $light-black;
@@ -435,6 +430,7 @@ ul.category-resource-qtip {
     }
 
     .list-name a {
+      @extend %link;
       font-size: 17px;
     }
 

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -316,6 +316,7 @@ ul.category-list {
     }
 
     a {
+      @include transition(color);
       @extend %link;
       display: block;
       padding: 0 0 0 1em;


### PR DESCRIPTION
# Before

<img width="1164" height="792" alt="2025-09-12 09_09_27-CHANGES rst - indico  WSL_ Ubuntu-Indico  - Visual Studio Code" src="https://github.com/user-attachments/assets/98d2edea-2bce-4145-9e17-7e3674af6cfd" />

# After

<img width="1149" height="770" alt="2025-09-12 09_10_26-image copy 2 png - indico  WSL_ Ubuntu-Indico  - Visual Studio Code" src="https://github.com/user-attachments/assets/34f27e97-78f2-4389-87a7-69d36facc76b" />
