### PR TITLE
Fix category link aux info accessibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Accessibility
 ^^^^^^^^^^^^^
 
 - Fix category list link color contrast (:pr:`7070`, thanks :user:`foxbunny`)
+- Fix color contrast and semantics of the protection icon and event count in category link 
+  (:pr:`7071`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/categories/templates/display/category_list.html
+++ b/indico/modules/categories/templates/display/category_list.html
@@ -7,9 +7,20 @@
         <ul class="category-list" data-subcat-info-url="{{ url_for('.subcat_info', parent_category) }}">
             {% for category in parent_category.children %}
                 <li>
-                    <span class="protection {{ 'icon-shield' if category.is_self_protected }}"></span>
-                    <span class="number-events" id="category-event-count-{{ category.id }}"></span>
-                    <a href="{{ url_for('.display', category) }}" class="name">{{ category.title }}</a>
+                    <a href="{{ url_for('.display', category) }}" class="name"
+                       aria-describedby="category-description-{{ category.id }}">{{ category.title }}</a>
+                    <span class="category-description" id="category-description-{{ category.id }}">
+                        <span class="number-events" id="category-event-count-{{ category.id }}"></span>
+                        {% if category.is_self_protected %}
+                            <span class="protection">
+                                <span>{% trans %}Protected category{% endtrans %}</span>
+                            </span>
+                        {% else %}
+                            <span class="protection not-protected">
+                                <span>{% trans %}Public category{% endtrans %}</span>
+                            </span>
+                        {% endif %}
+                    </span>
                 </li>
             {% endfor %}
         </ul>

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -295,7 +295,8 @@ ul.category-list {
     user-select: none;
 
     background: #f2f2f2;
-    display: block;
+    display: flex;
+    align-items: center;
     line-height: 2.5em;
     color: #b3b3b3;
     cursor: pointer;
@@ -303,21 +304,10 @@ ul.category-list {
     border-top: 1px solid #fafafa;
     border-bottom: 1px solid #e6e6e6;
 
-    .number-events {
-      float: right;
-      margin-right: 1em;
-    }
-
-    .protection {
-      float: right;
-      color: #a36264;
-      height: 1em;
-      width: 1em;
-    }
-
     a {
       @include transition(color);
       @extend %link;
+      flex: 1;
       display: block;
       padding: 0 0 0 1em;
       position: relative;
@@ -330,22 +320,54 @@ ul.category-list {
       }
     }
 
-    &:hover {
-      color: $light-black;
+    .category-description {
+      display: flex;
+      align-items: center;
+      flex-shrink: 0;
+      gap: 0.5em;
 
-      &::before {
-        color: $light-black;
+      .number-events {
+        color: var(--text-secondary-color);
+        margin-right: 0.5em;
+      }
+
+      .protection {
+        display: flex;
+        height: 1em;
+        width: 1em;
+        color: #a36264;
+
+        &::before {
+          @extend %icon;
+          @extend %icon-shield;
+        }
+
+        > span {
+          @extend %visually-hidden;
+        }
+
+        &.not-protected {
+          opacity: 0;
+        }
       }
     }
 
-    &::before {
+    &:hover {
+      color: $light-black;
+
+      &::after {
+        color: var(--text-secondary-color);
+      }
+    }
+
+    &::after {
       @include transition(color);
       @extend %icon-arrow-right-sparse;
       color: #ccc;
-      float: right;
       font-family: 'icomoon-ultimate';
       margin-right: 1em;
       margin-left: 1em;
+      flex-shrink: 0;
     }
   }
 }


### PR DESCRIPTION
Fixes semantic structure, color contrast, and relationship of the information in the category link (event count, protection status).

# Before

<img width="646" height="619" alt="2025-09-12 10_20_36-_category scss - indico  WSL_ Ubuntu-Indico  - Visual Studio Code" src="https://github.com/user-attachments/assets/d4f7d5f7-2361-4d33-860c-8a4ca6e345b4" />

# After

<img width="630" height="597" alt="2025-09-12 10_22_10-image copy png - indico  WSL_ Ubuntu-Indico  - Visual Studio Code" src="https://github.com/user-attachments/assets/fda42e3a-5ab1-4fd2-b8fd-53b6a8a96df4" />
