### PR TITLE
Fix contrast of the category info text

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Accessibility
   (:pr:`7073`, thanks :user:`foxbunny`)
 - Fix color contrast and screen reader support of the hidden block buttons
   in the event list (:pr:`7079`, thanks :user:`foxbunny`)
+- Fix contrast of the category info text (:pr:`7078`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/modules/_category.scss
+++ b/indico/web/client/styles/modules/_category.scss
@@ -132,7 +132,7 @@
 .category-info {
   @include font-family-modern-body();
 
-  color: #888;
+  color: var(--text-secondary-color);
   font-size: 1.2em;
   min-height: 0.3em;
   margin: 0 0 2em 0;


### PR DESCRIPTION
# Before 

<img width="1542" height="131" alt="2025-09-16 06_04_24-_category scss - indico  WSL_ Ubuntu-Indico  - Visual Studio Code" src="https://github.com/user-attachments/assets/17e95bed-d4af-4a4f-9037-c7b5c0de4e35" />

# After

<img width="1542" height="131" alt="2025-09-16 06_04_49-_category scss - indico  WSL_ Ubuntu-Indico  - Visual Studio Code" src="https://github.com/user-attachments/assets/cab83f25-8883-4bc5-aae8-fc49cdb6618c" />
