### PR TITLE
Support reminders relative to event end date

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Improvements
 - Disallow sending registration emails or invitations containing hardcoded (and
   usually incorrect) token links (:pr:`7093`)
 - Add support for showing registration pictures in the check-in app (:pr:`7099`)
+- Support post-event reminders relative to the event end time (:pr:`7094`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20250923_1000_43d2bff509c1_add_event_end_delta_to_reminders.py
+++ b/indico/migrations/versions/20250923_1000_43d2bff509c1_add_event_end_delta_to_reminders.py
@@ -18,7 +18,14 @@ depends_on = None
 
 def upgrade():
     op.add_column('reminders', sa.Column('event_end_delta', sa.Interval(), nullable=True), schema='events')
+    op.create_check_constraint(
+        'event_start_delta_or_end_delta_is_null',
+        'reminders',
+        '(event_start_delta IS NULL) OR (event_end_delta IS NULL)',
+        schema='events'
+    )
 
 
 def downgrade():
+    op.drop_constraint('event_start_delta_or_end_delta_is_null', 'reminders', schema='events')
     op.drop_column('reminders', 'event_end_delta', schema='events')

--- a/indico/migrations/versions/20250923_1000_43d2bff509c1_add_event_end_delta_to_reminders.py
+++ b/indico/migrations/versions/20250923_1000_43d2bff509c1_add_event_end_delta_to_reminders.py
@@ -27,5 +27,5 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_constraint('event_start_delta_or_end_delta_is_null', 'reminders', schema='events')
+    op.drop_constraint('ck_reminders_event_start_delta_or_end_delta_is_null', 'reminders', schema='events')
     op.drop_column('reminders', 'event_end_delta', schema='events')

--- a/indico/migrations/versions/20250923_1000_43d2bff509c1_add_event_end_delta_to_reminders.py
+++ b/indico/migrations/versions/20250923_1000_43d2bff509c1_add_event_end_delta_to_reminders.py
@@ -1,0 +1,24 @@
+"""Add event_end_delta to event reminders
+
+Revision ID: 43d2bff509c1
+Revises: 869fb2760b41
+Create Date: 2025-09-23 10:00:03.291861
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '43d2bff509c1'
+down_revision = '869fb2760b41'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('reminders', sa.Column('event_end_delta', sa.Interval(), nullable=True), schema='events')
+
+
+def downgrade():
+    op.drop_column('reminders', 'event_end_delta', schema='events')

--- a/indico/modules/events/reminders/controllers.py
+++ b/indico/modules/events/reminders/controllers.py
@@ -78,9 +78,12 @@ class RHEditReminder(RHSpecificReminderBase):
 
     def _get_defaults(self):
         reminder = self.reminder
-        if reminder.is_relative:
-            defaults_kwargs = {'schedule_type': 'relative',
+        if reminder.is_start_time_relative:
+            defaults_kwargs = {'schedule_type': 'start_time_relative',
                                'relative_delta': reminder.event_start_delta}
+        elif reminder.is_end_time_relative:
+            defaults_kwargs = {'schedule_type': 'end_time_relative',
+                               'relative_delta': reminder.event_end_delta}
         else:
             defaults_kwargs = {'schedule_type': 'absolute',
                                'absolute_dt': reminder.scheduled_dt}
@@ -115,7 +118,7 @@ class RHAddReminder(RHRemindersBase):
     }, location='query')
     def _process(self, reminder_type):
         form = ReminderForm(event=self.event,
-                            schedule_type='relative',
+                            schedule_type='start_time_relative',
                             attach_ical=reminder_type == ReminderType.standard,
                             reminder_type=reminder_type,
                             render_mode=RenderMode.html)

--- a/indico/modules/events/reminders/forms.py
+++ b/indico/modules/events/reminders/forms.py
@@ -39,10 +39,13 @@ class ReminderForm(IndicoForm):
 
     # Schedule
     schedule_type = IndicoRadioField(_('Type'), [DataRequired()],
-                                     choices=[('relative', _('Relative to the event start time')),
+                                     choices=[('start_time_relative', _('Relative to the event start time')),
+                                              ('end_time_relative', _('Relative to the event end time')),
                                               ('absolute', _('Fixed date/time')),
                                               ('now', _('Send immediately'))])
-    relative_delta = TimeDeltaField(_('Offset'), [HiddenUnless('schedule_type', 'relative'), DataRequired()],
+    relative_delta = TimeDeltaField(_('Offset'), [HiddenUnless('schedule_type',
+                                                               {'start_time_relative', 'end_time_relative'}),
+                                                  DataRequired()],
                                     units=('weeks', 'days', 'hours'))
     absolute_dt = IndicoDateTimeField(_('Date'), [HiddenUnless('schedule_type', 'absolute'), DataRequired(),
                                                   DateTimeRange()])
@@ -141,16 +144,24 @@ class ReminderForm(IndicoForm):
             if self.absolute_dt.data is None:
                 return None
             return self.absolute_dt.data
-        elif self.schedule_type.data == 'relative':
+        elif self.schedule_type.data == 'start_time_relative':
             if self.relative_delta.data is None:
                 return None
             return self.event.start_dt - self.relative_delta.data
+        elif self.schedule_type.data == 'end_time_relative':
+            if self.relative_delta.data is None:
+                return None
+            return self.event.end_dt + self.relative_delta.data
         elif self.schedule_type.data == 'now':
             return now_utc()
 
     @generated_data
     def event_start_delta(self):
-        return self.relative_delta.data if self.schedule_type.data == 'relative' else None
+        return self.relative_delta.data if self.schedule_type.data == 'start_time_relative' else None
+
+    @generated_data
+    def event_end_delta(self):
+        return self.relative_delta.data if self.schedule_type.data == 'end_time_relative' else None
 
     @generated_data
     def reminder_type(self):

--- a/indico/modules/events/reminders/forms.py
+++ b/indico/modules/events/reminders/forms.py
@@ -39,8 +39,8 @@ class ReminderForm(IndicoForm):
 
     # Schedule
     schedule_type = IndicoRadioField(_('Type'), [DataRequired()],
-                                     choices=[('start_time_relative', _('Relative to the event start time')),
-                                              ('end_time_relative', _('Relative to the event end time')),
+                                     choices=[('start_time_relative', _('Before the event start time')),
+                                              ('end_time_relative', _('After the event end time')),
                                               ('absolute', _('Fixed date/time')),
                                               ('now', _('Send immediately'))])
     relative_delta = TimeDeltaField(_('Offset'), [HiddenUnless('schedule_type',

--- a/indico/modules/events/reminders/models/reminders.py
+++ b/indico/modules/events/reminders/models/reminders.py
@@ -86,6 +86,8 @@ class EventReminder(RenderModeMixin, db.Model):
 
     __tablename__ = 'reminders'
     __table_args__ = (db.Index(None, 'scheduled_dt', postgresql_where=db.text('not is_sent')),
+                      db.CheckConstraint('(event_start_delta IS NULL) OR (event_end_delta IS NULL)',
+                                         name='event_start_delta_or_end_delta_is_null'),
                       {'schema': 'events'})
     possible_render_modes = {RenderMode.html, RenderMode.plain_text}
     default_render_mode = RenderMode.html

--- a/indico/modules/events/reminders/templates/reminders.html
+++ b/indico/modules/events/reminders/templates/reminders.html
@@ -19,8 +19,10 @@
                        data-title="{{ _("Reminder details") if reminder.is_sent else _("Edit reminder")}}"
                        data-ajax-dialog
                        data-reload-after>
-                        {%- if reminder.is_relative -%}
+                        {%- if reminder.is_start_time_relative -%}
                             {{ reminder.event_start_delta|format_human_timedelta('hours') }} before the event
+                        {%- elif reminder.is_end_time_relative -%}
+                            {{ reminder.event_end_delta|format_human_timedelta('hours') }} after the event
                         {%- else -%}
                             {{ reminder.scheduled_dt|format_datetime(timezone=tzinfo) }} <small>({{ tzinfo }})</small>
                         {%- endif -%}


### PR DESCRIPTION
This should mostly work now. I'll see if there's a nice way to make it more obvious in the form that for start time, the schedule date will be before the event but for end time, the scheduled date is after.

<img width="350" height="150" alt="image" src="https://github.com/user-attachments/assets/2cec9186-3b71-4c5b-9b66-feec3e6e236c" />

<img width="676" height="165" alt="image" src="https://github.com/user-attachments/assets/9acb3216-4488-41bd-be29-769a28a0507e" />
