### PR TITLE
Fix weekday locales

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Bugfixes
 - Do not allow sending registration invitation reminders without the invitation
   link placeholder (:pr:`7093`)
 - Correctly log the user sending a registration invitation reminder (:pr:`7093`)
+- Fix error in weekday recurrence picker when using the Turkish locale (:pr:`7113`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/rb/client/js/__tests__/WeekdayRecurrencePicker.test.js
+++ b/indico/modules/rb/client/js/__tests__/WeekdayRecurrencePicker.test.js
@@ -1,0 +1,102 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2025 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import moment from 'moment';
+
+describe('can localize shorthand weekday names, but can keep the values in English', () => {
+  const cases = [
+    {
+      locale: 'de',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.', 'So.'],
+    },
+    {
+      locale: 'en-gb',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    },
+    {
+      locale: 'en-us',
+      expectedValues: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
+      expectedTexts: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    },
+    {
+      locale: 'fr',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.', 'dim.'],
+    },
+    {
+      locale: 'pt-br',
+      expectedValues: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
+      expectedTexts: ['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sáb'],
+    },
+    {
+      locale: 'es',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.', 'dom.'],
+    },
+    {
+      locale: 'it',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['lun', 'mar', 'mer', 'gio', 'ven', 'sab', 'dom'],
+    },
+    {
+      locale: 'tr',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt', 'Paz'],
+    },
+    {
+      locale: 'pl',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['pon', 'wt', 'śr', 'czw', 'pt', 'sob', 'ndz'],
+    },
+    {
+      locale: 'mn',
+      expectedValues: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
+      expectedTexts: ['Ням', 'Дав', 'Мяг', 'Лха', 'Пүр', 'Баа', 'Бям'],
+    },
+    {
+      locale: 'uk',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['пн', 'вт', 'ср', 'чт', 'пт', 'сб', 'нд'],
+    },
+    {
+      locale: 'hu',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['hét', 'kedd', 'sze', 'csüt', 'pén', 'szo', 'vas'],
+    },
+    {
+      locale: 'zh-cn',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['周一', '周二', '周三', '周四', '周五', '周六', '周日'],
+    },
+  ];
+
+  cases.forEach(({locale, expectedValues, expectedTexts}) => {
+    it(`should return correct mappings in ${locale}`, () => {
+      const oldLocale = moment.locale();
+      moment.locale(locale);
+
+      const weekdayNames = moment.weekdays(true);
+      const WEEKDAYS = weekdayNames.map((_, index) => {
+        const firstDayOfWeek = moment.localeData().firstDayOfWeek();
+        const dayNumber = (firstDayOfWeek + index) % 7;
+        return {
+          value: moment().day(dayNumber).locale('en').format('ddd').toLowerCase(),
+          text: moment().day(dayNumber).format('ddd'),
+        };
+      });
+
+      const texts = WEEKDAYS.map(wd => wd.text);
+      const values = WEEKDAYS.map(wd => wd.value);
+
+      expect(texts).toEqual(expectedTexts);
+      expect(values).toEqual(expectedValues);
+      moment.locale(oldLocale);
+    });
+  });
+});

--- a/indico/modules/rb/client/js/__tests__/WeekdayRecurrencePicker.test.js
+++ b/indico/modules/rb/client/js/__tests__/WeekdayRecurrencePicker.test.js
@@ -8,77 +8,35 @@
 import moment from 'moment';
 
 describe('can localize shorthand weekday names, but can keep the values in English', () => {
-  const cases = [
-    {
-      locale: 'de',
-      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-      expectedTexts: ['Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.', 'So.'],
-    },
-    {
-      locale: 'en-gb',
-      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-      expectedTexts: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
-    },
-    {
-      locale: 'en-us',
-      expectedValues: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
-      expectedTexts: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
-    },
-    {
-      locale: 'fr',
-      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-      expectedTexts: ['lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.', 'dim.'],
-    },
-    {
-      locale: 'pt-br',
-      expectedValues: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
-      expectedTexts: ['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sáb'],
-    },
-    {
-      locale: 'es',
-      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-      expectedTexts: ['lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.', 'dom.'],
-    },
-    {
-      locale: 'it',
-      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-      expectedTexts: ['lun', 'mar', 'mer', 'gio', 'ven', 'sab', 'dom'],
-    },
-    {
-      locale: 'tr',
-      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-      expectedTexts: ['Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt', 'Paz'],
-    },
-    {
-      locale: 'pl',
-      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-      expectedTexts: ['pon', 'wt', 'śr', 'czw', 'pt', 'sob', 'ndz'],
-    },
-    {
-      locale: 'mn',
-      expectedValues: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
-      expectedTexts: ['Ням', 'Дав', 'Мяг', 'Лха', 'Пүр', 'Баа', 'Бям'],
-    },
-    {
-      locale: 'uk',
-      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-      expectedTexts: ['пн', 'вт', 'ср', 'чт', 'пт', 'сб', 'нд'],
-    },
-    {
-      locale: 'hu',
-      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-      expectedTexts: ['hét', 'kedd', 'sze', 'csüt', 'pén', 'szo', 'vas'],
-    },
-    {
-      locale: 'zh-cn',
-      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
-      expectedTexts: ['周一', '周二', '周三', '周四', '周五', '周六', '周日'],
-    },
-  ];
+  let oldLocale = null;
 
-  cases.forEach(({locale, expectedValues, expectedTexts}) => {
-    it(`should return correct mappings in ${locale}`, () => {
-      const oldLocale = moment.locale();
+  beforeEach(() => {
+    oldLocale = moment.locale();
+  });
+
+  afterEach(() => {
+    moment.locale(oldLocale);
+  });
+
+  describe.each`
+    locale     | expectedValues                                       | expectedTexts
+    ${'de'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.', 'So.']}
+    ${'en-gb'} | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']}
+    ${'en-us'} | ${['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']} | ${['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']}
+    ${'fr'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.', 'dim.']}
+    ${'pt-br'} | ${['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']} | ${['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sáb']}
+    ${'es'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.', 'dom.']}
+    ${'it'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['lun', 'mar', 'mer', 'gio', 'ven', 'sab', 'dom']}
+    ${'tr'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt', 'Paz']}
+    ${'pl'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['pon', 'wt', 'śr', 'czw', 'pt', 'sob', 'ndz']}
+    ${'mn'}    | ${['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']} | ${['Ням', 'Дав', 'Мяг', 'Лха', 'Пүр', 'Баа', 'Бям']}
+    ${'uk'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['пн', 'вт', 'ср', 'чт', 'пт', 'сб', 'нд']}
+    ${'hu'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['hét', 'kedd', 'sze', 'csüt', 'pén', 'szo', 'vas']}
+    ${'zh-cn'} | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['周一', '周二', '周三', '周四', '周五', '周六', '周日']}
+  `('should return correct mappings in $locale', ({locale, expectedValues, expectedTexts}) => {
+    it(`Localized Text:      ${expectedTexts}
+        Weekday Values (en): ${expectedValues}
+    `, () => {
       moment.locale(locale);
 
       const weekdayNames = moment.weekdays(true);
@@ -96,7 +54,6 @@ describe('can localize shorthand weekday names, but can keep the values in Engli
 
       expect(texts).toEqual(expectedTexts);
       expect(values).toEqual(expectedValues);
-      moment.locale(oldLocale);
     });
   });
 });

--- a/indico/modules/rb/client/js/__tests__/WeekdayRecurrencePicker.test.js
+++ b/indico/modules/rb/client/js/__tests__/WeekdayRecurrencePicker.test.js
@@ -7,6 +7,8 @@
 
 import moment from 'moment';
 
+import {getWeekdaysMapping} from '../components/WeekdayRecurrencePicker';
+
 describe('can localize shorthand weekday names, but can keep the values in English', () => {
   let oldLocale = null;
 
@@ -89,20 +91,9 @@ describe('can localize shorthand weekday names, but can keep the values in Engli
         Weekday Values (en): ${expectedValues}
     `, () => {
       moment.locale(locale);
-
-      const weekdayNames = moment.weekdays(true);
-      const WEEKDAYS = weekdayNames.map((_, index) => {
-        const firstDayOfWeek = moment.localeData().firstDayOfWeek();
-        const dayNumber = (firstDayOfWeek + index) % 7;
-        return {
-          value: moment().day(dayNumber).locale('en').format('ddd').toLowerCase(),
-          text: moment().day(dayNumber).format('ddd'),
-        };
-      });
-
-      const texts = WEEKDAYS.map(wd => wd.text);
-      const values = WEEKDAYS.map(wd => wd.value);
-
+      const weekdays = getWeekdaysMapping();
+      const texts = weekdays.map(wd => wd.text);
+      const values = weekdays.map(wd => wd.value);
       expect(texts).toEqual(expectedTexts);
       expect(values).toEqual(expectedValues);
     });

--- a/indico/modules/rb/client/js/__tests__/WeekdayRecurrencePicker.test.js
+++ b/indico/modules/rb/client/js/__tests__/WeekdayRecurrencePicker.test.js
@@ -18,22 +18,73 @@ describe('can localize shorthand weekday names, but can keep the values in Engli
     moment.locale(oldLocale);
   });
 
-  describe.each`
-    locale     | expectedValues                                       | expectedTexts
-    ${'de'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.', 'So.']}
-    ${'en-gb'} | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']}
-    ${'en-us'} | ${['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']} | ${['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']}
-    ${'fr'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.', 'dim.']}
-    ${'pt-br'} | ${['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']} | ${['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sáb']}
-    ${'es'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.', 'dom.']}
-    ${'it'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['lun', 'mar', 'mer', 'gio', 'ven', 'sab', 'dom']}
-    ${'tr'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt', 'Paz']}
-    ${'pl'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['pon', 'wt', 'śr', 'czw', 'pt', 'sob', 'ndz']}
-    ${'mn'}    | ${['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat']} | ${['Ням', 'Дав', 'Мяг', 'Лха', 'Пүр', 'Баа', 'Бям']}
-    ${'uk'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['пн', 'вт', 'ср', 'чт', 'пт', 'сб', 'нд']}
-    ${'hu'}    | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['hét', 'kedd', 'sze', 'csüt', 'pén', 'szo', 'vas']}
-    ${'zh-cn'} | ${['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']} | ${['周一', '周二', '周三', '周四', '周五', '周六', '周日']}
-  `('should return correct mappings in $locale', ({locale, expectedValues, expectedTexts}) => {
+  describe.each([
+    {
+      locale: 'de',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['Mo.', 'Di.', 'Mi.', 'Do.', 'Fr.', 'Sa.', 'So.'],
+    },
+    {
+      locale: 'en-gb',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
+    },
+    {
+      locale: 'en-us',
+      expectedValues: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
+      expectedTexts: ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+    },
+    {
+      locale: 'fr',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['lun.', 'mar.', 'mer.', 'jeu.', 'ven.', 'sam.', 'dim.'],
+    },
+    {
+      locale: 'pt-br',
+      expectedValues: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
+      expectedTexts: ['dom', 'seg', 'ter', 'qua', 'qui', 'sex', 'sáb'],
+    },
+    {
+      locale: 'es',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['lun.', 'mar.', 'mié.', 'jue.', 'vie.', 'sáb.', 'dom.'],
+    },
+    {
+      locale: 'it',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['lun', 'mar', 'mer', 'gio', 'ven', 'sab', 'dom'],
+    },
+    {
+      locale: 'tr',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['Pzt', 'Sal', 'Çar', 'Per', 'Cum', 'Cmt', 'Paz'],
+    },
+    {
+      locale: 'pl',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['pon', 'wt', 'śr', 'czw', 'pt', 'sob', 'ndz'],
+    },
+    {
+      locale: 'mn',
+      expectedValues: ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'],
+      expectedTexts: ['Ням', 'Дав', 'Мяг', 'Лха', 'Пүр', 'Баа', 'Бям'],
+    },
+    {
+      locale: 'uk',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['пн', 'вт', 'ср', 'чт', 'пт', 'сб', 'нд'],
+    },
+    {
+      locale: 'hu',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['hét', 'kedd', 'sze', 'csüt', 'pén', 'szo', 'vas'],
+    },
+    {
+      locale: 'zh-cn',
+      expectedValues: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+      expectedTexts: ['周一', '周二', '周三', '周四', '周五', '周六', '周日'],
+    },
+  ])('should return correct mappings in $locale', ({locale, expectedValues, expectedTexts}) => {
     it(`Localized Text:      ${expectedTexts}
         Weekday Values (en): ${expectedValues}
     `, () => {

--- a/indico/modules/rb/client/js/__tests__/WeekdayRecurrencePicker.test.js
+++ b/indico/modules/rb/client/js/__tests__/WeekdayRecurrencePicker.test.js
@@ -7,7 +7,7 @@
 
 import moment from 'moment';
 
-import {getWeekdaysMapping} from '../components/WeekdayRecurrencePicker';
+import {getWeekdaysMapping} from '../util';
 
 describe('can localize shorthand weekday names, but can keep the values in English', () => {
   let oldLocale = null;

--- a/indico/modules/rb/client/js/components/WeekdayRecurrencePicker.jsx
+++ b/indico/modules/rb/client/js/components/WeekdayRecurrencePicker.jsx
@@ -13,10 +13,15 @@ import {Button} from 'semantic-ui-react';
 import {FinalField, unsortedArraysEqual} from 'indico/react/forms';
 
 export function WeekdayRecurrencePicker({onChange, value, disabled, requireOneSelected}) {
-  const WEEKDAYS = moment.weekdays(true).map(wd => ({
-    value: moment().day(wd).locale('en').format('ddd').toLowerCase(),
-    text: moment().isoWeekday(wd).format('ddd'),
-  }));
+  const weekdayNames = moment.weekdays(true);
+  const WEEKDAYS = weekdayNames.map((_, index) => {
+    const firstDayOfWeek = moment.localeData().firstDayOfWeek();
+    const dayNumber = (firstDayOfWeek + index) % 7;
+    return {
+      value: moment().day(dayNumber).locale('en').format('ddd').toLowerCase(),
+      text: moment().day(dayNumber).format('ddd'),
+    };
+  });
 
   const handleDayClick = day => {
     const selected = value.includes(day);

--- a/indico/modules/rb/client/js/components/WeekdayRecurrencePicker.jsx
+++ b/indico/modules/rb/client/js/components/WeekdayRecurrencePicker.jsx
@@ -5,29 +5,13 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
 import {Button} from 'semantic-ui-react';
 
 import {FinalField, unsortedArraysEqual} from 'indico/react/forms';
 
-/**
- * Returns an array of localized shorthand weekday names with their corresponding
- * English shorthand values.
- * @returns {Array<{text: string, value: string}>} Array of weekday value-text pairs
- */
-export function getWeekdaysMapping() {
-  const weekdayNames = moment.weekdays(true);
-  const firstDayOfWeek = moment.localeData().firstDayOfWeek();
-  return weekdayNames.map((_, index) => {
-    const dayNumber = (firstDayOfWeek + index) % 7;
-    return {
-      value: moment().day(dayNumber).locale('en').format('ddd').toLowerCase(),
-      text: moment().day(dayNumber).format('ddd'),
-    };
-  });
-}
+import {getWeekdaysMapping} from '../util';
 
 export function WeekdayRecurrencePicker({onChange, value, disabled, requireOneSelected}) {
   const handleDayClick = day => {

--- a/indico/modules/rb/client/js/components/WeekdayRecurrencePicker.jsx
+++ b/indico/modules/rb/client/js/components/WeekdayRecurrencePicker.jsx
@@ -12,17 +12,24 @@ import {Button} from 'semantic-ui-react';
 
 import {FinalField, unsortedArraysEqual} from 'indico/react/forms';
 
-export function WeekdayRecurrencePicker({onChange, value, disabled, requireOneSelected}) {
+/**
+ * Returns an array of localized shorthand weekday names with their corresponding
+ * English shorthand values.
+ * @returns {Array<{text: string, value: string}>} Array of weekday value-text pairs
+ */
+export function getWeekdaysMapping() {
   const weekdayNames = moment.weekdays(true);
-  const WEEKDAYS = weekdayNames.map((_, index) => {
-    const firstDayOfWeek = moment.localeData().firstDayOfWeek();
+  const firstDayOfWeek = moment.localeData().firstDayOfWeek();
+  return weekdayNames.map((_, index) => {
     const dayNumber = (firstDayOfWeek + index) % 7;
     return {
       value: moment().day(dayNumber).locale('en').format('ddd').toLowerCase(),
       text: moment().day(dayNumber).format('ddd'),
     };
   });
+}
 
+export function WeekdayRecurrencePicker({onChange, value, disabled, requireOneSelected}) {
   const handleDayClick = day => {
     const selected = value.includes(day);
     if (disabled || (requireOneSelected && selected && value.length === 1)) {
@@ -38,10 +45,12 @@ export function WeekdayRecurrencePicker({onChange, value, disabled, requireOneSe
     onChange(newValue);
   };
 
+  const weekdays = getWeekdaysMapping();
+
   return (
     <div>
       <Button.Group>
-        {WEEKDAYS.map(weekday => (
+        {weekdays.map(weekday => (
           <Button
             type="button"
             key={weekday.value}

--- a/indico/modules/rb/client/js/util.jsx
+++ b/indico/modules/rb/client/js/util.jsx
@@ -296,6 +296,23 @@ export function renderRecurrenceWeekdays({weekdays, repetition = null, weekdaysO
   return Translate.string('Every {weekdays}', {weekdays: formattedWeekdays});
 }
 
+/**
+ * Returns an array of localized shorthand weekday names with their corresponding
+ * English shorthand values.
+ * @returns {Array<{text: string, value: string}>} Array of weekday value-text pairs
+ */
+export function getWeekdaysMapping() {
+  const weekdayNames = moment.weekdays(true);
+  const firstDayOfWeek = moment.localeData().firstDayOfWeek();
+  return weekdayNames.map((__, index) => {
+    const dayNumber = (firstDayOfWeek + index) % 7;
+    return {
+      value: moment().day(dayNumber).locale('en').format('ddd').toLowerCase(),
+      text: moment().day(dayNumber).format('ddd'),
+    };
+  });
+}
+
 const _legendLabels = {
   candidates: {label: Translate.string('Available'), style: 'available'},
   bookings: {label: Translate.string('Booking'), style: 'booking'},


### PR DESCRIPTION
This fixes a bug in the RB `WeekdayRecurrencePicker` module where the Turkish locale would have repeated weekdays, due to how moment parses weekdays from its own locale mappings. 