### PR TITLE
Skip disabled sections for field conditions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Bugfixes
   link placeholder (:pr:`7093`)
 - Correctly log the user sending a registration invitation reminder (:pr:`7093`)
 - Fix error in weekday recurrence picker when using the Turkish locale (:pr:`7113`)
+- Do not allow selecting fields in disabled sections as a condition (:pr:`7114`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/client/js/form/fields/ShowIfInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/ShowIfInput.jsx
@@ -14,15 +14,25 @@ import {FinalDropdown} from 'indico/react/forms';
 import {Fieldset, unsortedArraysEqual} from 'indico/react/forms/fields';
 import {Translate} from 'indico/react/i18n';
 
-import {getItems, getFlatSections} from '../selectors';
+import {getItems, getNestedSections} from '../selectors';
 
 import {getFieldRegistry} from './registry';
 
 export function ShowIfInput({fieldId: thisFieldId}) {
   const fields = useSelector(getItems);
-  const sections = useSelector(getFlatSections);
+  const sections = useSelector(getNestedSections);
   const fieldRegistry = getFieldRegistry();
   const form = useForm();
+
+  const choices = sections.flatMap(section =>
+    section.items
+      .filter(({id, inputType}) => id !== thisFieldId && !!fieldRegistry[inputType].showIfOptions)
+      .map(({title, id: fieldId, isEnabled}) => ({
+        value: fieldId,
+        text: `${section.title} » ${title}`,
+        disabled: !isEnabled,
+      }))
+  );
 
   return (
     <Fieldset legend={Translate.string('Show if')}>
@@ -31,15 +41,7 @@ export function ShowIfInput({fieldId: thisFieldId}) {
         /* i18n: Form field */
         label={Translate.string('Field')}
         placeholder={Translate.string('Select field...')}
-        options={Object.values(fields)
-          .filter(
-            ({id, inputType}) => id !== thisFieldId && !!fieldRegistry[inputType].showIfOptions
-          )
-          .map(({title, id: fieldId, sectionId, isEnabled}) => ({
-            value: fieldId,
-            text: `${sections[sectionId].title} » ${title}`,
-            disabled: !isEnabled,
-          }))}
+        options={choices}
         closeOnChange
         selection
         allowNull

--- a/indico/modules/events/registration/client/js/form/selectors.js
+++ b/indico/modules/events/registration/client/js/form/selectors.js
@@ -12,6 +12,7 @@ import {Translate} from 'indico/react/i18n';
 
 export const getStaticData = state => state.staticData;
 
+/** Get all sections, including disabled ones. */
 export const getFlatSections = state => state.sections;
 export const getItems = state => state.items;
 export const getHiddenItemsInitialized = state => state.hiddenItems.ready;

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -101,6 +101,10 @@ class GeneralFieldDataSchema(mm.Schema):
             raise ValidationError('The field to show does not belong to the same registration form.')
         if not condition_field.field_impl.allow_condition:
             raise ValidationError('This field cannot be used as a condition.')
+        if not condition_field.is_enabled:
+            raise ValidationError('Disabled fields cannot be used as a condition.')
+        if not condition_field.parent.is_enabled:
+            raise ValidationError('Fields in disabled sections cannot be used as a condition.')
         # Avoid cycles
         next_field_id = field_id
         while next_field_id is not None:


### PR DESCRIPTION
Such fields were displayed in the dropdown, and could be saved, which resulted in a broken registration form.