### PR TITLE
Fix color contrast on conference pages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -41,6 +41,7 @@ Accessibility
   thanks :user:`foxbunny`)
 - Fix the semantics for the empty materials text (:pr:`7096`, thanks :user:`foxbunny`)
 - Fix announcements accessibility (:pr:`7098`, thanks :user:`foxbuny`)
+- Fix conference description color contrast (thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/legacy/Conf_Basic.scss
+++ b/indico/web/client/styles/legacy/Conf_Basic.scss
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@use 'design_system';
+
 /*
         Default Styles and layout for Conf-pages
         Do not custom this CSS
@@ -288,7 +290,7 @@ li.over ul {
 /* ------Misc------ */
 
 .conferenceDetails .description {
-  color: #777;
+  color: var(--text-secondary-color);
   font-size: 1.2em;
   margin: 1em 0 2em 0;
 }


### PR DESCRIPTION
1.4.3 Contrast (Minimum) (Level AA)

# Before

<img width="1139" height="512" alt="2025-10-03 06_39_50-CHANGES rst - indico  WSL_ Ubuntu-Indico  - Visual Studio Code" src="https://github.com/user-attachments/assets/5b24d816-5da3-4540-ac87-b928af7f69be" />

# After

<img width="1139" height="512" alt="2025-10-03 06_40_21-CHANGES rst - indico  WSL_ Ubuntu-Indico  - Visual Studio Code" src="https://github.com/user-attachments/assets/23ef04fe-48c1-40ed-8a4d-b73997e9a6df" />