### PR TITLE
Fix action box color contrast

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,7 +64,7 @@ Bugfixes
 Accessibility
 ^^^^^^^^^^^^^
 
-- Nothing so far
+- Fix action box color contrast (:pr:`7125`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/design_system/variables.scss
+++ b/indico/web/client/styles/design_system/variables.scss
@@ -108,6 +108,26 @@ body {
   --text-size-abs-xl: 1.5rem;
   --text-size-abs-xxl: 2rem;
 
+  // Special messages components (action boxes, notices, etc.)
+  --msg-default-main-color: var(--text-color);
+  --msg-default-background-color: #f9f9f9;
+  --msg-default-text-color: var(--text-color);
+  --msg-highlight-main-color: var(--accent-color);
+  --msg-highlight-background-color: #edf4fd;
+  --msg-highlight-text-color: var(--text-color);
+  --msg-warning-main-color: #aa5302;
+  --msg-warning-background-color: #feefd5;
+  --msg-warning-text-color: var(--text-color);
+  --msg-danger-main-color: #d60000;
+  --msg-danger-background-color: #ffeded;
+  --msg-danger-text-color: var(--text-color);
+  --msg-accept-main-color: #1a8344;
+  --msg-accept-background-color: #ebfdeb;
+  --msg-accept-text-color: var(--text-color);
+  --msg-disabled-main-color: #9f9d9d;
+  --msg-disabled-background-color: #f9f9f9;
+  --msg-disabled-text-color: var(--text-secondary-color);
+
   // TODO: Compensates from base font size of 14px coming from SUI.
   // This should be set to 1 once SUI is removed.
   //

--- a/indico/web/client/styles/partials/_actionboxes.scss
+++ b/indico/web/client/styles/partials/_actionboxes.scss
@@ -115,54 +115,54 @@
 .action-box {
   @include action-box();
   @include action-box-colors(
-    $color: $dark-gray,
-    $emphasis-color: $light-black,
-    $background-color: $light-gray,
-    $border-color: $dark-gray
+    $color: var(--msg-default-text-color),
+    $emphasis-color: var(--msg-default-main-color),
+    $background-color: var(--msg-default-background-color),
+    $border-color: var(--msg-default-main-color)
   );
 
   &.highlight {
     @include action-box-colors(
-      $color: $light-black,
-      $emphasis-color: $blue,
-      $background-color: $light-blue,
-      $border-color: $blue
+      $color: var(--msg-highlight-text-color),
+      $emphasis-color: var(--msg-highlight-main-color),
+      $background-color: var(--msg-highlight-background-color),
+      $border-color: var(--msg-highlight-main-color)
     );
   }
 
   &.warning {
     @include action-box-colors(
-      $color: $dark-gray,
-      $emphasis-color: $yellow,
-      $background-color: $light-yellow,
-      $border-color: $yellow
+      $color: var(--msg-warning-text-color),
+      $emphasis-color: var(--msg-warning-main-color),
+      $background-color: var(--msg-warning-background-color),
+      $border-color: var(--msg-warning-main-color)
     );
   }
 
   &.danger {
     @include action-box-colors(
-      $color: $light-black,
-      $emphasis-color: $red,
-      $background-color: $light-red,
-      $border-color: $red
+      $color: var(--msg-danger-text-color),
+      $emphasis-color: var(--msg-danger-main-color),
+      $background-color: var(--msg-danger-background-color),
+      $border-color: var(--msg-danger-main-color)
     );
   }
 
   &.disabled {
     @include action-box-colors(
-      $color: $light-black,
-      $emphasis-color: $black,
-      $background-color: $pastel-gray,
-      $border-color: $black
+      $color: var(--msg-disabled-text-color),
+      $emphasis-color: var(--msg-disabled-main-color),
+      $background-color: var(--msg-disabled-background-color),
+      $border-color: var(--msg-disabled-main-color)
     );
   }
 
   &.accept {
     @include action-box-colors(
-      $color: $light-black,
-      $emphasis-color: $green,
-      $background-color: $light-green,
-      $border-color: $green
+      $color: var(--msg-accept-text-color),
+      $emphasis-color: var(--msg-accept-main-color),
+      $background-color: var(--msg-accept-background-color),
+      $border-color: var(--msg-accept-main-color)
     );
   }
 


### PR DESCRIPTION
# Before

<img width="1325" height="787" alt="2025-10-13 08_50_39-Greenshot" src="https://github.com/user-attachments/assets/d61f280d-3d2a-4cde-8cff-1d7f88791ce2" />

# After

<img width="1325" height="787" alt="2025-10-13 08_51_23-Greenshot" src="https://github.com/user-attachments/assets/1fedf861-8f68-4398-8ca4-6723abfe3399" />

# WCAG criteria

- 1.4.3 Contrast (Minimum) (Level AA)