### PR TITLE
Add global action system and apply it to calendar popup in event page [PoC]

### DIFF
--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -205,10 +205,13 @@
                     {{ _render_filters() }}
                 {% endif %}
 
-                <div id="event-calendar-link" data-event-id="{{ event.id }}"
-                     data-event-contrib-count="{{ event.contributions_count }}"
-                     data-event-session-block-count="{{ event.session_block_count }}"
-                     {% if event.series %}data-event-in-series{% endif %}></div>
+                <button class="i-button text-color subtle icon-calendar arrow"
+                        data-action="event-export-calendar"
+                        data-event-id="{{ event.id }}"
+                        data-event-contrib-count="{{ event.contributions_count }}"
+                        data-event-session-block-count="{{ event.session_block_count }}"
+                        {% if event.series %}data-event-in-series{% endif %}
+                        title="{% trans %}Export{% endtrans %}"></button>
 
                 {% if event.type == 'meeting' %}
                     <button class="i-button text-color subtle icon-file-pdf" title="{% trans %}Export to PDF{% endtrans %}"

--- a/indico/web/client/js/index.js
+++ b/indico/web/client/js/index.js
@@ -15,6 +15,7 @@ import './legacy/timetable.js';
 import './custom_elements';
 import './widgets/tz_selector.js';
 import './widgets/dynamic-tips.js';
+import './utils/actions.js';
 
 import '../styles/screen.scss';
 import '../styles/editor-output.scss';

--- a/indico/web/client/js/utils/actions.js
+++ b/indico/web/client/js/utils/actions.js
@@ -1,0 +1,42 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2025 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import {domReady} from './domstate';
+
+function handleAction(evt) {
+  const actionElement = evt.target.closest('[data-action]:is(a, button)');
+  const action = actionElement?.dataset.action;
+
+  if (!action) {
+    return;
+  }
+
+  // Prevent default unless explicitly allowed
+  if (!actionElement.dataset.actionAllowDefault) {
+    evt.preventDefault();
+  }
+
+  // Dispatch action
+  const eventName = `indico:action:${action}`;
+  const detail = {
+    trigger: actionElement,
+    originalEvent: evt,
+    ...actionElement.dataset,
+  };
+
+  const customEvent = new CustomEvent(eventName, {
+    bubbles: true,
+    cancelable: true,
+    detail,
+  });
+
+  actionElement.dispatchEvent(customEvent);
+}
+
+domReady.then(() => {
+  document.addEventListener('click', handleAction);
+});


### PR DESCRIPTION
This is a proof of concept for the global action implementation as discussed with @ThiefMaster.

# Problem

The toolbar buttons are currently implemented via plain Jinja HTML and also as `IButton` in React. This makes it difficult to unify the implementation and make global changes (e.g., add a `<ind-with-tooltip>` wrapper around all of them or make style changes such as remove `.i-button` from the buttons to address issues with the `.i-button` implementation without affecting pretty much all of the app.

An alternative solution would be to continue to maintain two implementation and/or use high-specificity overrides in CSS. Both are costly and continue to pay interest on the existing tech debt.

# Solution

Move the button portion of the React-based implementation (e.g., calendar link) back into Jinja land, and implement a generic and non-intrusive way for these buttons to initialize and/or trigger React code.

# Rationale

This gives us an opportunity to unify the button markup and gives us levers to make sweeping changes to all toolbar controls. Longer term, this also potentially adds a partial template that plugin authors can use to implement buttons and links.

# Alternatives

One alternative I've considered is to implement the toolbar in React entirely. However, this likely breaks the existing plugins.