### PR TITLE
Email preview for contributions now respects selected roles

### DIFF
--- a/indico/modules/events/abstracts/controllers/abstract_list.py
+++ b/indico/modules/events/abstracts/controllers/abstract_list.py
@@ -28,7 +28,7 @@ from indico.modules.events.abstracts.views import WPManageAbstracts
 from indico.modules.events.cloning import get_attrs_to_clone
 from indico.modules.events.contributions.models.persons import AuthorType
 from indico.modules.events.management.controllers.emails import (EmailRolesMetadataMixin, EmailRolesPreviewMixin,
-                                                                 EmailRolesSendMixin)
+                                                                 EmailRolesSendMixin, get_roles_from_person_link)
 from indico.modules.events.persons.util import get_event_person_for_user
 from indico.modules.events.registration.util import get_registered_event_persons
 from indico.modules.events.util import get_field_values
@@ -322,5 +322,5 @@ class RHAbstractsAPIEmailAbstractRolesSend(EmailRolesSendMixin, RHManageAbstract
             for person_link in abstract.person_links:
                 if person_link.email in seen or person_link.person.user in seen or not person_link.email:
                     continue
-                if self.get_roles_from_person_link(person_link) & roles:
+                if get_roles_from_person_link(person_link) & roles:
                     yield person_link.email, {'abstract': abstract, 'person': person_link}, log_metadata

--- a/indico/modules/events/editing/controllers/backend/management.py
+++ b/indico/modules/events/editing/controllers/backend/management.py
@@ -26,7 +26,7 @@ from indico.modules.events.editing.schemas import (EditableFileTypeArgs, Editabl
 from indico.modules.events.editing.settings import editable_type_settings, editing_settings
 from indico.modules.events.editing.util import get_editors
 from indico.modules.events.management.controllers.emails import (EmailRolesMetadataMixin, EmailRolesPreviewMixin,
-                                                                 EmailRolesSendMixin)
+                                                                 EmailRolesSendMixin, get_roles_from_person_link)
 from indico.modules.events.models.persons import EventPerson
 from indico.modules.logs import EventLogRealm, LogKind
 from indico.util.i18n import _, orig_string
@@ -311,5 +311,5 @@ class RHEmailNotSubmittedEditablesSend(EmailRolesSendMixin, RHEditableTypeManage
         for contrib in contribs:
             log_metadata = {'contribution_id': contrib.id}
             for person_link in contrib.person_links:
-                if person_link.email and self.get_roles_from_person_link(person_link) & roles:
+                if person_link.email and get_roles_from_person_link(person_link) & roles:
                     yield person_link.email, {'contribution': contrib, 'person': person_link}, log_metadata

--- a/indico/modules/events/persons/client/js/EmailDialog.jsx
+++ b/indico/modules/events/persons/client/js/EmailDialog.jsx
@@ -93,12 +93,17 @@ export function EmailDialog({
 }) {
   const [preview, setPreview] = useState(null);
 
-  const togglePreview = async ({body, subject}) => {
+  const togglePreview = async ({body, subject, recipient_roles: recipientRoles}) => {
     if (preview) {
       setPreview(undefined);
       return;
     }
-    const {data} = await indicoAxios.post(previewURL, {body, subject, ...previewContext});
+    const {data} = await indicoAxios.post(previewURL, {
+      body,
+      subject,
+      recipient_roles: recipientRoles,
+      ...previewContext,
+    });
     setPreview(data);
   };
 


### PR DESCRIPTION
Problem
This PR fixes a bug where the email preview for contributions participants would ignore the selected roles and display random user's information.

Solution:
The EmailDialog component now shares the selected recipient roles with the backend and the preview endpoint's updated logic now shares the information of the user who actually matches with the selected roles.

Fixes: https://github.com/indico/indico/issues/6520