### PR TITLE
Add block render_check_in in template registration details

### DIFF
--- a/indico/modules/events/registration/templates/management/_registration_details.html
+++ b/indico/modules/events/registration/templates/management/_registration_details.html
@@ -17,7 +17,7 @@
                     {{ _render_cancelled_actions(registration) }}
                 {% endif %}
             </div>
-            {% block render_check_in scoped %}
+            {% block checkin_state scoped %}
                 {% if registration.state.name in ('unpaid', 'complete') %}
                     {{ _render_check_in(registration) }}
                 {% endif %}


### PR DESCRIPTION
Request to add block "render_check_in" in template registrations_details.html to control the display of that information based on user's role.