### PR TITLE
Fix typo in delete editable dialog

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/DeleteEditable.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/DeleteEditable.jsx
@@ -66,7 +66,7 @@ export default function DeleteEditable() {
         open={isOpen}
         persistent
       >
-        <Translate>This operation is not reversible. Are you sure you want to procceed?</Translate>
+        <Translate>This operation is not reversible. Are you sure you want to proceed?</Translate>
       </RequestConfirmDelete>
     </>
   );


### PR DESCRIPTION
## Summary

- Fix the "procceed" typo in the delete editable confirmation dialog and sync the affected msgids across the POT/PO catalogues
- Record the change in CHANGES.rst

### Summary from GitHub Copilot

> This pull request fixes a typo in the delete confirmation message shown when deleting an editable item, ensuring the correct spelling of "proceed." The change updates the message in the UI, translation files, and documents the fix in the changelog.
> 
> Bugfix:
> 
> * Corrected the typo "procceed" to "proceed" in the delete confirmation message in `DeleteEditable.jsx`.
> 
> Localization:
> 
> * Updated the translation keys in `messages-all.pot` and `messages-react.pot` to reflect the corrected message [[1]](diffhunk://#diff-c418cb86f4d30971d1128c317c7db67b567f4093fb411a529f0befd00f3adc24L919-R919) [[2]](diffhunk://#diff-901fa05e051f58a2b9fc5535aaf1cd2b5dc0c2c84c2c72f85dfb52750fe8944dL788-R788).
> 
> Documentation:
> 
> * Added a note about the typo fix to the `CHANGES.rst` bugfixes section.

## Testing

- Not run (string-only change)
