### PR TITLE
Improve webargs support in editing fields

### DIFF
--- a/indico/web/args.py
+++ b/indico/web/args.py
@@ -149,3 +149,14 @@ def use_rh_kwargs(schema_cls, **kwargs):
     """Like ``use_rh_args``, but using kwargs when calling the decorated function."""
     kwargs['as_kwargs'] = True
     return use_rh_args(schema_cls, **kwargs)
+
+
+def parse_single_arg(name, field):
+    """Parse a single arg using webargs.
+
+    This is simply convenience to avoid having to use the parser directly
+    and extracting the element from a single-element dict.
+
+    Note that the field must have a `load_default` or be `required`.
+    """
+    return parser.parse({name: field}, unknown=EXCLUDE)[name]


### PR DESCRIPTION
- allow using these fields via the decorator (and taking RH context data)
- use the decorator notation where possible (unfortunately in some cases we have to provide additional dynamic data which still excludes the decorator syntax)
- added a new `parse_single_arg` to have nice code when we just need to get one arg w/o the decorator