### PR TITLE
refactor: replace if/elif with match/case

### DIFF
--- a/indico/core/db/sqlalchemy/principals.py
+++ b/indico/core/db/sqlalchemy/principals.py
@@ -648,26 +648,30 @@ class PrincipalComparator(Comparator):
         raise NotImplementedError
 
     def __eq__(self, other):
-        if other.principal_type == PrincipalType.email:
+       match other.principal_type:
+        case PrincipalType.email:
             criteria = [self.cls.email == other.email]
-        elif other.principal_type == PrincipalType.network:
+        case PrincipalType.network:
             criteria = [self.cls.ip_network_group_id == other.id]
-        elif other.principal_type == PrincipalType.event_role:
+        case PrincipalType.event_role:
             criteria = [self.cls.event_role_id == other.id]
-        elif other.principal_type == PrincipalType.category_role:
+        case PrincipalType.category_role:
             criteria = [self.cls.category_role_id == other.id]
-        elif other.principal_type == PrincipalType.registration_form:
+        case PrincipalType.registration_form:
             criteria = [self.cls.registration_form_id == other.id]
-        elif other.principal_type == PrincipalType.local_group:
+        case PrincipalType.local_group:
             criteria = [self.cls.local_group_id == other.id]
-        elif other.principal_type == PrincipalType.multipass_group:
-            criteria = [self.cls.multipass_group_provider == other.provider,
-                        self.cls.multipass_group_name == other.name]
-        elif other.principal_type == PrincipalType.user:
+        case PrincipalType.multipass_group:
+            criteria = [
+                self.cls.multipass_group_provider == other.provider,
+                self.cls.multipass_group_name == other.name
+            ]
+        case PrincipalType.user:
             criteria = [self.cls.user_id == other.id]
-        else:
-            raise ValueError(f'Unexpected object type {type(other)}: {other}')
-        return db.and_(self.cls.type == other.principal_type, *criteria)
+        case _:
+            raise ValueError(f"Unexpected object type {type(other)}: {other}")
+
+       return db.and_(self.cls.type == other.principal_type, *criteria)
 
 
 def clone_principals(cls, principals, event_role_map=None, regform_map=None):


### PR DESCRIPTION
:arrow_down::scissors: *Please delete the checklist before submitting your PR!* :scissors::arrow_down:

Thank you very much for submitting a **Pull Request** to Indico!  
We will be happy to review your contribution as soon as possible.  
Before sending it, please go through this quick checklist to ensure everything is complete and consistent.

---

### Summary

This pull request refactors the `__eq__` method to use Python’s structural pattern matching (`match/case`, PEP 634) instead of a long `if/elif` chain.  
The goal is to simplify the comparison logic between principal types, improve readability, and align the code with modern Python 3.10+ syntax.

### Motivation

The previous implementation relied on several conditional branches to handle different `PrincipalType` values (e.g., `email`, `network`, `event_role`, `category_role`, etc.).  
By replacing them with a `match/case` statement, each case becomes explicit and easier to maintain while preserving the original semantics.

### Changes
- Replaced `if/elif` chain with `match other.principal_type:`
- Kept identical logic for all supported types  
  (`email`, `network`, `event_role`, `category_role`, `registration_form`, `local_group`, `multipass_group`, `user`)
- Preserved the `ValueError` raised for unsupported object types
- No functional or behavioral changes introduced

### Example
```python
def __eq__(self, other):
    match other.principal_type:
        case PrincipalType.email:
            criteria = [self.cls.email == other.email]
        case PrincipalType.network:
            criteria = [self.cls.ip_network_group_id == other.id]
        case PrincipalType.event_role:
            criteria = [self.cls.event_role_id == other.id]
        case PrincipalType.category_role:
            criteria = [self.cls.category_role_id == other.id]
        case PrincipalType.registration_form:
            criteria = [self.cls.registration_form_id == other.id]
        case PrincipalType.local_group:
            criteria = [self.cls.local_group_id == other.id]
        case PrincipalType.multipass_group:
            criteria = [
                self.cls.multipass_group_provider == other.provider,
                self.cls.multipass_group_name == other.name
            ]
        case PrincipalType.user:
            criteria = [self.cls.user_id == other.id]
        case _:
            raise ValueError(f"Unexpected object type {type(other)}: {other}")

