### PR TITLE
Add more registration form field signals

### DIFF
--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -82,10 +82,9 @@ Called when a registration form field is changed. The `sender` is the
 `RegistrationFormField` object.
 ''')
 
-registration_form_field_moved = _signals.signal('registration-form-field-moved', '''
-Called when a registration form field is moved. The `sender` is the
+registration_form_field_toggled = _signals.signal('registration-form-field-toggled', '''
+Called when a registration form field is enabled or disabled. The `sender` is the
 `RegistrationFormField` object.
-The new ``position`` value is passed in the ``new_position`` kwarg.
 ''')
 
 is_ticketing_handled = _signals.signal('is-ticketing-handled', '''

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -225,9 +225,9 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
         if not enabled and self.field.condition_for:
             raise NoReportError.wrap_exc(BadRequest(_('Fields used as conditional cannot be disabled')))
         self.field.is_enabled = enabled
-        signals.event.registration_form_field_changed.send(self.field)
         update_regform_item_positions(self.regform)
         db.session.flush()
+        signals.event.registration_form_field_toggled.send(self.field)
         logger.info('Field %s modified by %s', self.field, session.user)
         if enabled:
             self.field.log(
@@ -270,8 +270,8 @@ class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
         elif 'input_type' in field_data and self.field.input_type != field_data['input_type']:
             raise BadRequest
         field_data['input_type'] = self.field.input_type
-        signals.event.registration_form_field_changed.send(self.field)
         changes = _fill_form_field_with_data(self.field, field_data)
+        signals.event.registration_form_field_changed.send(self.field)
         changes = make_diff_log(changes, {
             'title': {'title': 'Title', 'type': 'string'},
             'description': {'title': 'Description'},
@@ -291,7 +291,6 @@ class RHRegistrationFormMoveField(RHManageRegFormFieldBase):
 
     def _process(self):
         new_position = request.json['endPos'] + 1
-        signals.event.registration_form_field_moved.send(self.field, new_position=new_position)
         old_position = self.field.position
         if new_position == old_position:
             return jsonify()
@@ -320,9 +319,9 @@ class RHRegistrationFormAddField(RHManageRegFormSectionBase):
         field_data = snakify_keys(request.json['fieldData'])
         form_field = RegistrationFormField(parent=self.section, registration_form=self.regform)
         _fill_form_field_with_data(form_field, field_data)
-        signals.event.registration_form_field_added.send(form_field)
         db.session.add(form_field)
         db.session.flush()
+        signals.event.registration_form_field_added.send(form_field)
         form_field.log(
             EventLogRealm.management, LogKind.positive, 'Registration',
             f'Field "{form_field.title}" in "{self.regform.title}" added', session.user,
@@ -372,9 +371,9 @@ class RHRegistrationFormAddText(RHManageRegFormSectionBase):
         del field_data['input_type']
         form_field = RegistrationFormText(parent=self.section, registration_form=self.regform)
         _fill_form_field_with_data(form_field, field_data, is_static_text=True)
-        signals.event.registration_form_field_added.send(form_field)
         db.session.add(form_field)
         db.session.flush()
+        signals.event.registration_form_field_added.send(form_field)
         form_field.log(
             EventLogRealm.management, LogKind.positive, 'Registration',
             f'Field "{form_field.title}" in "{self.regform.title}" added', session.user,


### PR DESCRIPTION
New signals to have more complete signaling when form_field are changed 
 - registration_form_field_added
 - registration_form_field_changed
 - registration_form_field_moved

From discussion at: [Adding VAT information for all payment fields](https://talk.getindico.io/t/adding-vat-information-for-all-payment-fields/4369)