### PR TITLE
Add always_validate to DateRange validator

### DIFF
--- a/indico/web/forms/validators.py
+++ b/indico/web/forms/validators.py
@@ -131,9 +131,10 @@ class DateRange:
 
     field_flags = {'date_range': True}
 
-    def __init__(self, earliest='today', latest=None):
+    def __init__(self, *, earliest='today', latest=None, always_validate=False):
         self.earliest = earliest
         self.latest = latest
+        self.always_validate = always_validate
         # set to true in get_earliest/get_latest if applicable
         self.earliest_today = False
         self.latest_today = False
@@ -144,7 +145,7 @@ class DateRange:
         field_date = field.data
         earliest_date = self.get_earliest(form, field)
         latest_date = self.get_latest(form, field)
-        if field_date != field.object_data:
+        if self.always_validate or field_date != field.object_data:
             if earliest_date and field_date < earliest_date:
                 if self.earliest_today:
                     msg = _("'{}' can't be in the past").format(field.label)


### PR DESCRIPTION
Previously, unchanged date fields (field.data == field.object_data) were skipped during validation, allowing outdated records to bypass updated earliest/latest date constraints.
This update introduces an always_validate flag that forces revalidation even when the date hasn’t been modified.