### PR TITLE
Custom pages: Use style from  event description

### DIFF
--- a/indico/web/client/styles/editor-output.scss
+++ b/indico/web/client/styles/editor-output.scss
@@ -20,6 +20,10 @@
   $image-spacing: 1.5em;
   display: flow-root;
 
+  // Use the same text color and size as for the event description page
+  color: var(--text-secondary-color);
+  font-size: 1.2em;
+
   img {
     max-width: 100%;
   }


### PR DESCRIPTION
Use the same styling as for the event description text on custom pages.

See also https://talk.getindico.io/t/how-to-make-menu-pages-inherit-global-styling/4391/6

