### PR TITLE
Fix minor issues found by SAST scan

### DIFF
--- a/indico/modules/attachments/client/js/legacy.js
+++ b/indico/modules/attachments/client/js/legacy.js
@@ -61,7 +61,7 @@ import {$T} from 'indico/utils/i18n';
             history.replaceState({}, document.title, pageURL);
             history.pushState({}, document.title, location.href + hash);
           }
-          const id = location.hash.split('#preview:')[1];
+          const id = parseInt(location.hash.split('#preview:')[1], 10);
           previewAttachment(id);
         }
       })

--- a/indico/util/mdx_latex.py
+++ b/indico/util/mdx_latex.py
@@ -261,7 +261,7 @@ def latex_render_image(src, alt, tmpdir, strict=False):
             raise ImageURLException(f'URL scheme not supported: {src}')
         else:
             try:
-                resp = requests.get(src, verify=False, timeout=5)  # noqa: S501
+                resp = requests.get(src, timeout=5)
             except InvalidURL:
                 raise ImageURLException(f"Cannot understand URL '{src}'")
             except (requests.Timeout, ConnectionError):


### PR DESCRIPTION
This PR is about small improvements infosec team requested after SAST report:
* To sanitize `id` taken from URL hash before using it
* To not ignore SSL check on external sites