### PR TITLE
Show color picker when editing top-level breaks

### DIFF
--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -186,7 +186,7 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
         locationParent={snakifyKeys(entry.locationParent)}
         initialValues={initialValues}
         extraOptions={extraOptions}
-        hasParent={'sessionBlockId' in entry}
+        hasParent={isCreatingChild}
       />
     ),
   };


### PR DESCRIPTION
Currently the "Edit Break" modal is not showing the color picker for top-level breaks, this fixes it.