### PR TITLE
Fix creating child breaks

### DIFF
--- a/indico/modules/events/timetable/controllers/manage.py
+++ b/indico/modules/events/timetable/controllers/manage.py
@@ -181,7 +181,7 @@ class RHTimetableREST(RHManageTimetableEntryBase):
 class RHTimetableBreakCreate(RHManageEventBase):
     @use_rh_args(BreakSchema)
     def _process_POST(self, data: Break):
-        session_block_id = data.pop('timetable_entry', {}).get('parent', {}).get('session_block_id')
+        session_block_id = data.pop('session_block_id', None)
         session_block = SessionBlock.get(session_block_id) if session_block_id else None
         data['location_data'] = (
             self._get_inherited_location(location_parent=session_block)


### PR DESCRIPTION
The structure of the POST request changed at some point and creating a child break returns a 500 now. This updates the backend logic.