### PR TITLE
Fix editing child breaks

### DIFF
--- a/indico/modules/events/timetable/controllers/manage.py
+++ b/indico/modules/events/timetable/controllers/manage.py
@@ -205,10 +205,10 @@ class RHTimetableBreak(RHManageEventBase):
 
     @use_rh_args(BreakSchema, partial=True)
     def _process_PATCH(self, data):
-        session_block_specified = 'session_block_id' in data
-        session_block_id = data.pop('session_block_id', None)
+        missing = object()
+        session_block_id = data.pop('session_block', {}).pop('id', missing)
 
-        if session_block_specified:
+        if session_block_id is not missing:
             self._change_parent(session_block_id)
 
         if not data.get('timetable_entry'):

--- a/indico/modules/events/timetable/schemas.py
+++ b/indico/modules/events/timetable/schemas.py
@@ -56,7 +56,7 @@ class BreakSchema(mm.SQLAlchemyAutoSchema):
     location_parent = fields.Nested(LocationParentSchema, attribute='resolved_location_parent')
     colors = fields.Nested(SessionColorSchema)
     parent_id = fields.Integer(allow_none=True, attribute='timetable_entry.parent_id')
-    session_block_id = fields.Integer(allow_none=True)
+    session_block_id = fields.Integer(allow_none=True, attribute='session_block.id')
     session_id = fields.Function(_get_break_session_id, dump_only=True)
 
 


### PR DESCRIPTION
When editing e.g. a child break title, the changes would only be visible when refreshing the page.

This is because the edit modal makes a new GET request, which was previously not returning the `session_block_id` of the break, leading to redux `updateEntry` action being "lost".
