### PR TITLE
Replace unmaintained migra/schemainspect w/ results

### DIFF
--- a/bin/utils/db_diff.py
+++ b/bin/utils/db_diff.py
@@ -12,7 +12,7 @@ import sys
 
 import click
 from click._compat import should_strip_ansi
-from migra import Migration
+from results.dbdiff import Migration
 from sqlalchemy import create_engine, text
 
 

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -6,7 +6,6 @@ freezegun
 hatchling
 hatch-requirements-txt
 isort
-migra
 plantweb
 pygments
 pytest-cov
@@ -16,6 +15,7 @@ pytest-redis
 pytest-snapshot
 pytest
 responses
+results
 ruff
 sphinx-autobuild
 sphinx-issues

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -37,6 +37,7 @@ click==8.1.7
     #   -c requirements.txt
     #   flask
     #   flask-url-map-serializer
+    #   results
     #   unbeheader
     #   uvicorn
 colorama==0.4.6
@@ -62,10 +63,6 @@ flask-url-map-serializer==0.0.1
     # via -r requirements.dev.in
 freezegun==1.5.1
     # via -r requirements.dev.in
-greenlet==3.1.1
-    # via
-    #   -c requirements.txt
-    #   sqlalchemy
 h11==0.16.0
     # via uvicorn
 hatch-requirements-txt==0.4.1
@@ -100,8 +97,6 @@ markupsafe==3.0.3
     #   flask
     #   jinja2
     #   werkzeug
-migra==3.0.1663481299
-    # via -r requirements.dev.in
 mirakuru==2.5.3
     # via pytest-redis
 packaging==24.2
@@ -112,7 +107,6 @@ packaging==24.2
     #   hatchling
     #   pytest
     #   sphinx
-    #   sqlbag
 pathspec==0.12.1
     # via hatchling
 plantweb==1.3.0
@@ -125,6 +119,10 @@ port-for==0.7.4
     # via pytest-redis
 psutil==6.1.0
     # via mirakuru
+psycopg==3.3.2
+    # via results
+psycopg-pool==3.3.0
+    # via psycopg
 pygments==2.18.0
     # via
     #   -c requirements.txt
@@ -172,17 +170,15 @@ requests==2.32.4
     #   sphinx
 responses==0.25.3
     # via -r requirements.dev.in
+results==1.4.0
+    # via -r requirements.dev.in
 ruff==0.14.5
     # via -r requirements.dev.in
-schemainspect==3.1.1663587362
-    # via migra
 six==1.17.0
     # via
     #   -c requirements.txt
-    #   migra
     #   plantweb
     #   python-dateutil
-    #   sqlbag
 sniffio==1.3.1
     # via anyio
 snowballstemmer==2.2.0
@@ -220,13 +216,6 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-sqlalchemy==1.4.54
-    # via
-    #   -c requirements.txt
-    #   schemainspect
-    #   sqlbag
-sqlbag==0.1.1617247075
-    # via migra
 sqlparse==0.5.3
     # via -r requirements.dev.in
 starlette==0.49.1
@@ -239,6 +228,8 @@ typing-extensions==4.12.2
     # via
     #   -c requirements.txt
     #   anyio
+    #   psycopg
+    #   psycopg-pool
     #   starlette
 unbeheader==1.4.0
     # via -r requirements.dev.in


### PR DESCRIPTION
Same author, same API (seems like they just copypasted their original two libraries into the new one and did a few cleanups), but no annoying setuptools dependency and it's actually (somewhat?) maintained.