### PR TITLE
Improve display of invitation import errors

### DIFF
--- a/indico/modules/events/registration/client/js/components/ImportInvitationsField.tsx
+++ b/indico/modules/events/registration/client/js/components/ImportInvitationsField.tsx
@@ -110,6 +110,7 @@ export default function ImportInvitationsField({
     <>
       <FinalSingleFileDrop
         name={name}
+        label={Translate.string('CSV file')}
         onDropAccepted={onDropAccepted}
         onDropRejected={onDropRejected}
         dropzoneOptions={{accept: ['.csv']}}


### PR DESCRIPTION
The new invitation dialog introduced in #7168 omitted the "label" field on the CSV import dropzone. This meant that field errors were invisible unless hovering. This PR adds the label to improve the error display.

<img width="1000" height="916" alt="image" src="https://github.com/user-attachments/assets/21b9e8cb-d3da-4f6a-9dc1-b5f26d90dc2e" />
