### PR TITLE
Fix error in subcontrib material acl change

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Improvements
 Bugfixes
 ^^^^^^^^
 
-- Nothing so far :)
+- Fix error when adding a user to a material ACL in a subcontribution (:pr:`7209`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/core/db/sqlalchemy/protection.py
+++ b/indico/core/db/sqlalchemy/protection.py
@@ -690,7 +690,7 @@ def _get_hierarchical_log_data(obj):
         segments.append(_get_obj_name(obj))
         if isinstance(obj, db.m.Category) and 'Category path' not in data:
             data['Category path'] = sep.join(obj.chain_titles)
-        obj = obj.protection_parent
+        obj = obj.protection_parent if not isinstance(obj, db.m.SubContribution) else obj.contribution
         if obj is None or stop:
             break
         if isinstance(obj, stop_types):


### PR DESCRIPTION
Subcontributions have no `protection_parent` so when trying to get the hierarchical path to log a user being added to the ACL of a material inside a subcontribution, it failed