### PR TITLE
Fix unscheduled contrib bg color

### DIFF
--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -8,7 +8,7 @@
 import moment, {Moment} from 'moment';
 import {createSelector} from 'reselect';
 
-import {DEFAULT_CONTRIB_COLORS} from './colors';
+import {ENTRY_COLORS_BY_BACKGROUND} from './colors';
 import {ReduxState, Session} from './types';
 import {DAY_SIZE, getDiffInDays, getDateKey, minutesToPixels} from './utils';
 
@@ -130,7 +130,12 @@ export const getIsExpanded = createSelector(
 
 function appendSessionAttributes(entries: any[], sessions: Record<string, Session>) {
   return entries.map(e => {
-    const {isPoster = false, colors = DEFAULT_CONTRIB_COLORS} = sessions[e.sessionId] || {};
-    return e.sessionId ? {...e, isPoster, colors} : e;
+    if (!e.sessionId) {
+      return e;
+    }
+    const session = sessions[e.sessionId];
+    const isPoster = session.isPoster;
+    const colors = ENTRY_COLORS_BY_BACKGROUND[session.colors.backgroundColor];
+    return {...e, isPoster, colors};
   });
 }


### PR DESCRIPTION
fixes: https://github.com/orgs/indico/projects/7/views/1?pane=issue&itemId=145107643

Not sure if this is the best solution.. The problem is not just that the color is not updated after a drop, but also that color is the same as the session color. This means that during dragging it's hard to see where the entry if you're dragging over a session block with the same color.

For that reason, I went with using the same background color for unscheduled entries as we do for scheduled entries regardless of whether you're currently dragging or not.
