### PR TITLE
Consistently sort unscheduled contribs by (sessionId, title)

### DIFF
--- a/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
@@ -64,7 +64,15 @@ export default function UnscheduledContributions({dt}: {dt: Moment}) {
   const [selectedFilter, setSelectedFilter] = useState<FilterType>();
   const [selectedSessionId, setSelectedSessionId] = useState<number | 'draft'>();
 
-  const contribs = useSelector(selectors.getUnscheduled);
+  const contribs = useSelector(selectors.getUnscheduled).toSorted((c1, c2) => {
+    // sort by sessionId then by title
+    const c1SessionId = c1.sessionId ?? Number.MAX_SAFE_INTEGER;
+    const c2SessionId = c2.sessionId ?? Number.MAX_SAFE_INTEGER;
+    if (c1SessionId !== c2SessionId) {
+      return c1SessionId - c2SessionId;
+    }
+    return c1.title.localeCompare(c2.title);
+  });
   const sessions = useSelector(selectors.getSessions);
   const prevSessions = useRef(sessions);
   const showUnscheduled = useSelector(selectors.showUnscheduled);


### PR DESCRIPTION
fixes: https://github.com/orgs/indico/projects/7/views/1?pane=issue&itemId=145499727

Something I noticed just now but thought I'd fix it anyway. This fixes two things:
- unscheduled contributions appear in a semi-random order (we just take what the backend gives us and display it)
- the order also changes when you schedule and then unschedule a contribution: it goes to the end of the list which is confusing.

I'm proposing to simply sort the contributions by session and then by title so they are nicely grouped and in predictable order which stays consistent even after scheduling and unscheduling.