### PR TITLE
Drop support for Postgres 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:13
+        image: postgres:14
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         ports:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,9 @@ Accessibility
 Internal Changes
 ^^^^^^^^^^^^^^^^
 
-- Nothing so far
+- Require at least Postgres 14 during new installations. This check can be forced on
+  older Postgres versions (even though they are end-of-life), but we make no guarantees
+  that nothing is broken (:pr:`7232`)
 
 
 Version 3.3.9

--- a/indico/core/db/sqlalchemy/migration.py
+++ b/indico/core/db/sqlalchemy/migration.py
@@ -80,7 +80,7 @@ def _require_encoding(encoding):
 
 def prepare_db(empty=False, root_path=None, verbose=True, force=False):
     """Initialize an empty database (create tables, set alembic rev to HEAD)."""
-    if not _require_pg_version(13, force=force):
+    if not _require_pg_version(14, force=force):
         return False
     if not _require_encoding('UTF8'):
         return False


### PR DESCRIPTION
- it's end of life since Nov 2025
- it should still work fine, but nobody should install a new indico instance on that version...