### PR TITLE
Make it possible to skip terser during builds

### DIFF
--- a/webpack/base.mjs
+++ b/webpack/base.mjs
@@ -373,11 +373,13 @@ export function webpackDefaults(env, config, bundles, isPlugin = false) {
               },
             },
       },
-      minimizer: [
-        new TerserPlugin({
-          extractComments: false,
-        }),
-      ],
+      minimizer: process.env.NO_TERSER
+        ? []
+        : [
+            new TerserPlugin({
+              extractComments: false,
+            }),
+          ],
     },
   };
 }


### PR DESCRIPTION
Adds an environment variable, `NO_TERSER`, which, if set, causes webpack to skip TerserPlugin. The plugin consume quite a lot of RAM and prevents the build from finishing 1 out of 5 runs when done in a VM. This flag doesn't affect the build if not set, so should be a safe addition.