### PR TITLE
Fix error in event time reminder placeholders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Bugfixes
 - Fix error when adding a user to a material ACL in a subcontribution (:pr:`7209`)
 - Fix timezone selector behaving incorrectly when choosing a custom timezone (:pr:`7214`)
 - Fix error when using shibboleth for authentication (:issue:`7213`, :pr:`7215`)
+- Fix error when sending scheduled reminders using an event time placeholder (:pr:`7238`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/placeholders.py
+++ b/indico/modules/events/placeholders.py
@@ -27,7 +27,7 @@ class EventStartDatePlaceholder(Placeholder):
 
     @classmethod
     def render(cls, event, **kwargs):
-        return format_date(event.start_dt_local)
+        return format_date(event.start_dt, timezone=event.timezone)
 
 
 class EventStartTimePlaceholder(Placeholder):
@@ -36,7 +36,7 @@ class EventStartTimePlaceholder(Placeholder):
 
     @classmethod
     def render(cls, event, **kwargs):
-        return format_time(event.start_dt_local)
+        return format_time(event.start_dt, timezone=event.timezone)
 
 
 class EventLinkPlaceholder(ParametrizedPlaceholder):


### PR DESCRIPTION
Calling format_date without a timezone accesses the session which does not exist outside a request context...