### PR TITLE
Fix recurrence in RB ical export

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Bugfixes
 - Fix changing tracks for invited abstracts (:issue:`7061`, :pr:`7240`)
 - Disallow local account passwords longer than 72 characters instead of truncating them
   (:pr:`7254`)
+- Fix recurrence information not being correctly included in room booking ical export
+  (:pr:`7255`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/rb/api.py
+++ b/indico/modules/rb/api.py
@@ -25,7 +25,6 @@ from indico.modules.rb.util import rb_check_user_access
 from indico.modules.users import User
 from indico.util.date_time import utc_to_server
 from indico.web.http_api import HTTPAPIHook
-from indico.web.http_api.metadata import ical
 from indico.web.http_api.responses import HTTPAPIError
 from indico.web.http_api.util import get_query_parameter
 
@@ -308,14 +307,15 @@ def _ical_serialize_repeatability(data):
     start_dt_utc = data['startDT'].astimezone(pytz.utc)
     end_dt_utc = data['endDT'].astimezone(pytz.utc)
     week_days = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']
-    recur = ical.vRecur()
+    recur = icalendar.vRecur()
     recur['until'] = end_dt_utc
-    if data['repeat_frequency'] == RepeatFrequency.DAY:
+    assert isinstance(data['repeat_frequency'], str)
+    if data['repeat_frequency'] == 'DAY':
         recur['freq'] = 'daily'
-    elif data['repeat_frequency'] == RepeatFrequency.WEEK:
+    elif data['repeat_frequency'] == 'WEEK':
         recur['freq'] = 'weekly'
         recur['interval'] = data['repeat_interval']
-    elif data['repeat_frequency'] == RepeatFrequency.MONTH:
+    elif data['repeat_frequency'] == 'MONTH':
         recur['freq'] = 'monthly'
         recur['byday'] = f'{start_dt_utc.day // 7}{week_days[start_dt_utc.weekday()]}'
     return recur

--- a/indico/web/http_api/metadata/ical.py
+++ b/indico/web/http_api/metadata/ical.py
@@ -19,27 +19,6 @@ from indico.util.date_time import now_utc
 from indico.web.http_api.metadata.serializer import Serializer
 
 
-class vRecur(ical.vRecur):  # noqa: N801
-    """Fix vRecur so the frequency comes first."""
-
-    def ical(self):
-        # SequenceTypes
-        freq = self.types['FREQ'](self['FREQ']).ical()
-        result = [f'FREQ={freq}']
-        for key, vals in self.items():
-            if key == 'FREQ':
-                continue
-            typ = self.types[key]
-            if type(vals) not in ical.prop.SequenceTypes:
-                vals = [vals]
-            vals = ','.join(typ(val).ical() for val in vals)
-            result.append(f'{key}={vals}')
-        return ';'.join(result)
-
-
-ical.cal.types_factory['recur'] = vRecur
-
-
 def _deserialize_date(date_dict):
     if isinstance(date_dict, datetime):
         return date_dict


### PR DESCRIPTION
Also remove obsolete `vRecur` fix that's been in upstream for a long time

closes #7141