### PR TITLE
Add abstract 'reviewer proposals' column

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Improvements
 - Log changes to event reminders in the event log (:pr:`7242`)
 - Allow sending account creation notifications to specific email addresses (:issue:`7166`,
   :pr:`7233`, thanks :user:`duartegalvao`)
+- Add a 'reviewer proposals' column to the abstract list (:pr:`7258`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/abstracts/lists.py
+++ b/indico/modules/events/abstracts/lists.py
@@ -50,6 +50,7 @@ class AbstractListGeneratorBase(ListGeneratorBase):
             'accepted_contrib_type': {'title': _('Accepted type'), 'filter_choices': type_empty | type_choices},
             'submitted_contrib_type': {'title': _('Submitted type'), 'filter_choices': type_empty | type_choices},
             'review_count': {'title': _('Number of reviews')},
+            'reviewer_proposals': {'title': _('Reviewer proposals')},
             'score': {'title': _('Score')},
             'score_std': {'title': _('Score standard deviation')},
             'submitted_dt': {'title': _('Submission date')},

--- a/indico/modules/events/abstracts/models/abstracts.py
+++ b/indico/modules/events/abstracts/models/abstracts.py
@@ -451,6 +451,27 @@ class Abstract(ProposalMixin, ProposalRevisionMixin, DescriptionMixin, CustomFie
             return AbstractReviewingState.mixed
 
     @property
+    def reviewer_proposals(self) -> str:
+        proposals = defaultdict(int)
+        for x in self.reviews:
+            match x.proposed_action:
+                case AbstractAction.accept:
+                    proposals['a'] += 1
+                case AbstractAction.reject:
+                    proposals['r'] += 1
+                case AbstractAction.change_tracks:
+                    proposals['c'] += 1
+                case AbstractAction.duplicate:
+                    proposals['d'] += 1
+                case AbstractAction.merge:
+                    proposals['m'] += 1
+                case _:
+                    raise ValueError(f'Unrecognized action: {x.proposed_action}')
+        proposals_order = ['a', 'r', 'c', 'd', 'm']
+        sorted_proposals = {k: proposals[k] for k in proposals_order if proposals[k] != 0}
+        return ', '.join([f'{k}: {v}' for k, v in sorted_proposals.items()])
+
+    @property
     def score(self):
         scores = [x.score for x in self.reviews if x.score is not None]
         if not scores:

--- a/indico/modules/events/abstracts/schemas.py
+++ b/indico/modules/events/abstracts/schemas.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from marshmallow.fields import Float, Nested
+from marshmallow.fields import Float, Nested, String
 
 from indico.core.marshmallow import mm
 from indico.modules.events.abstracts.models.abstracts import Abstract
@@ -95,6 +95,7 @@ class AbstractSchema(mm.SQLAlchemyAutoSchema):
     persons = Nested(AbstractPersonLinkSchema, attribute='person_links', many=True)
     custom_fields = Nested(ContributionFieldValueSchema, attribute='field_values', many=True)
     files = Nested(AbstractFileSchema, many=True)
+    reviewer_proposals = String()
     score = Float()
     score_std = Float()
     comments = Nested(AbstractCommentSchema, many=True)
@@ -111,7 +112,7 @@ class AbstractSchema(mm.SQLAlchemyAutoSchema):
                   'submitted_contrib_type', 'accepted_contrib_type',
                   'accepted_track', 'submitted_for_tracks', 'reviewed_for_tracks',
                   'duplicate_of', 'merged_into',
-                  'persons', 'custom_fields', 'files',
+                  'persons', 'custom_fields', 'files', 'reviewer_proposals',
                   'score', 'score_std', 'comments', 'reviews')
 
 

--- a/indico/modules/events/abstracts/templates/management/_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/_abstract_list.html
@@ -233,6 +233,10 @@
                                         <td class="i-table">
                                             {{- abstract.reviews | length -}}
                                         </td>
+                                    {% elif item.id == 'reviewer_proposals' %}
+                                        <td class="i-table">
+                                            {{- abstract.reviewer_proposals or '-' }}
+                                        </td>
                                     {% elif item.id == 'score' %}
                                         <td class="i-table">
                                             {{- abstract.score | round(1) if abstract.score is not none else '-' }}

--- a/indico/modules/events/abstracts/util.py
+++ b/indico/modules/events/abstracts/util.py
@@ -88,6 +88,7 @@ def generate_spreadsheet_from_abstracts(abstracts, static_item_ids, dynamic_item
         'submitted_contrib_type': ('Submitted type',
                                    lambda x: x.submitted_contrib_type.name if x.submitted_contrib_type else None),
         'review_count': ('Number of reviews', lambda x: len(x.reviews)),
+        'reviewer_proposals': ('Reviewer proposals', lambda x: x.reviewer_proposals),
         'score': ('Score', lambda x: round(x.score, 1) if x.score is not None else None),
         'score_std': ('Score standard deviation',
                       lambda x: round(x.score_std, 1) if x.score_std is not None else None),


### PR DESCRIPTION
This PR is based on heavily on #7173.

First-time contributor here!  I'm part of the organizing committee for [BSDCan](https://www.bsdcan.org/), the biggest North American conference for FreeBSD, NetBSD, OpenBSD, etc.  We have a set of local changes to indico, and I'm looking at upstreaming some of our changes.

This is one that was requested by our papers committee to aid in their judging of abstracts: a column that shows the reviewer's accept / reject / change track / etc.

<img width="781" height="384" alt="2026-01-13-151900_781x384_scrot" src="https://github.com/user-attachments/assets/59c235a4-a9a3-4327-8508-014fddd1c766" />
