### PR TITLE
Use limits directly, w/o flask-limiter

### DIFF
--- a/indico/web/flask/app.py
+++ b/indico/web/flask/app.py
@@ -428,8 +428,6 @@ def make_app(testing=False, config_override=None):
         configure_db(app)
         mm.init_app(app)  # must be called after `configure_db`!
         limiter.init_app(app)
-        # unregister request-level limit check: https://github.com/alisaifee/flask-limiter/issues/489
-        app.before_request_funcs[None].remove(limiter._check_request_limit)
         extend_url_map(app)
         add_handlers(app)
         setup_request_stats(app)

--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,6 @@ feedgen
 flask-babel
 flask-caching
 flask-cors
-flask-limiter
 flask-marshmallow
 flask-migrate
 flask-multipass
@@ -32,6 +31,7 @@ ipython
 itsdangerous
 jinja2
 jsonschema
+limits
 lxml[html5]
 markdown
 markupsafe

--- a/requirements.txt
+++ b/requirements.txt
@@ -100,7 +100,6 @@ flask==3.1.2
     #   flask-babel
     #   flask-caching
     #   flask-cors
-    #   flask-limiter
     #   flask-marshmallow
     #   flask-migrate
     #   flask-multipass
@@ -114,8 +113,6 @@ flask-babel==4.0.0
 flask-caching==2.3.1
     # via -r requirements.in
 flask-cors==6.0.2
-    # via -r requirements.in
-flask-limiter==4.1.1
     # via -r requirements.in
 flask-marshmallow==1.3.0
     # via -r requirements.in
@@ -179,7 +176,7 @@ jsonschema-specifications==2025.9.1
 kombu==5.6.2
     # via celery
 limits==5.6.0
-    # via flask-limiter
+    # via -r requirements.in
 lxml==6.0.2
     # via
     #   -r requirements.in
@@ -215,8 +212,6 @@ matplotlib-inline==0.2.1
     # via ipython
 mypy-extensions==1.1.0
     # via typing-inspect
-ordered-set==4.1.0
-    # via flask-limiter
 packaging==25.0
     # via
     #   -r requirements.in
@@ -349,7 +344,6 @@ typeguard==4.4.4
 typing-extensions==4.15.0
     # via
     #   alembic
-    #   flask-limiter
     #   limits
     #   referencing
     #   typeguard


### PR DESCRIPTION
As the author of `limits` and `flask-limiter` pointed out in alisaifee/flask-limiter#489, we don't really make use of the extension's main functionality and just use it to access the underlying `Limiter` instance.

I also cleaned up some shadowing of the imported `limits` package in limiter.py