### PR TITLE
Introduce internal name for registration form fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Improvements
 - Add new permission that grants only participant management (create, edit and
   delete registrations) without access to the registration form configuration
   (:pr:`7419`, thanks :user:`moliholy, unconventionaldotdev`)
+- Add internal name for registration form fields (:pr:`7276`, thanks :user:`tomako`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20251216_0014_577e564cf0ae_add_internal_name_to_form_fields.py
+++ b/indico/migrations/versions/20251216_0014_577e564cf0ae_add_internal_name_to_form_fields.py
@@ -1,0 +1,48 @@
+"""Add internal name to form fields
+
+Revision ID: 577e564cf0ae
+Revises: 932389d22b1f
+Create Date: 2025-12-16 00:14:49.123118
+"""
+
+from enum import Enum
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '577e564cf0ae'
+down_revision = '932389d22b1f'
+branch_labels = None
+depends_on = None
+
+
+class _PersonalDataType(int, Enum):
+    email = 1
+    first_name = 2
+    last_name = 3
+    affiliation = 4
+    title = 5
+    address = 6
+    phone = 7
+    country = 8
+    position = 9
+    picture = 10
+
+
+def upgrade():
+    op.add_column('form_items', sa.Column('internal_name', sa.String(), nullable=True),
+                  schema='event_registration')
+    case_expr = ' '.join(f"WHEN {i} THEN '{_PersonalDataType(i).name}'" for i in range(1, 11))
+    op.execute(f'''
+    UPDATE event_registration.form_items
+    SET internal_name = CASE personal_data_type {case_expr} END
+    WHERE personal_data_type IS NOT NULL;
+    ''')  # noqa: S608
+    op.create_index(None, 'form_items', ['internal_name'], unique=False,
+                    schema='event_registration', postgresql_where=sa.text('is_enabled AND NOT is_deleted'))
+
+
+def downgrade():
+    op.drop_column('form_items', 'internal_name', schema='event_registration')

--- a/indico/migrations/versions/20251216_0014_577e564cf0ae_add_internal_name_to_form_fields.py
+++ b/indico/migrations/versions/20251216_0014_577e564cf0ae_add_internal_name_to_form_fields.py
@@ -1,7 +1,7 @@
 """Add internal name to form fields
 
 Revision ID: 577e564cf0ae
-Revises: 932389d22b1f
+Revises: af9d03d7073c
 Create Date: 2025-12-16 00:14:49.123118
 """
 
@@ -13,12 +13,12 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '577e564cf0ae'
-down_revision = '932389d22b1f'
+down_revision = 'af9d03d7073c'
 branch_labels = None
 depends_on = None
 
 
-class _PersonalDataType(int, Enum):
+class _PersonalDataType(Enum):
     email = 1
     first_name = 2
     last_name = 3
@@ -32,16 +32,20 @@ class _PersonalDataType(int, Enum):
 
 
 def upgrade():
-    op.add_column('form_items', sa.Column('internal_name', sa.String(), nullable=True),
+    op.add_column('form_items', sa.Column('internal_name', sa.String(), index=True, nullable=True),
                   schema='event_registration')
-    case_expr = ' '.join(f"WHEN {i} THEN '{_PersonalDataType(i).name}'" for i in range(1, 11))
+    op.create_check_constraint(
+        'internal_name_not_empty',
+        'form_items',
+        "internal_name != ''",
+        schema='event_registration'
+    )
+    case_expr = ' '.join(f"WHEN {e.value} THEN '{e.name}'" for e in _PersonalDataType)
     op.execute(f'''
     UPDATE event_registration.form_items
     SET internal_name = CASE personal_data_type {case_expr} END
     WHERE personal_data_type IS NOT NULL;
     ''')  # noqa: S608
-    op.create_index(None, 'form_items', ['internal_name'], unique=False,
-                    schema='event_registration', postgresql_where=sa.text('is_enabled AND NOT is_deleted'))
 
 
 def downgrade():

--- a/indico/migrations/versions/20251216_0014_577e564cf0ae_add_internal_name_to_form_fields.py
+++ b/indico/migrations/versions/20251216_0014_577e564cf0ae_add_internal_name_to_form_fields.py
@@ -42,10 +42,16 @@ def upgrade():
     )
     case_expr = ' '.join(f"WHEN {e.value} THEN '{e.name}'" for e in _PersonalDataType)
     op.execute(f'''
-    UPDATE event_registration.form_items
-    SET internal_name = CASE personal_data_type {case_expr} END
-    WHERE personal_data_type IS NOT NULL;
+        UPDATE event_registration.form_items
+        SET internal_name = CASE personal_data_type {case_expr} END
+        WHERE personal_data_type IS NOT NULL;
     ''')  # noqa: S608
+    op.create_check_constraint(
+        'pd_internal_name_required',
+        'form_items',
+        '(internal_name IS NOT NULL) OR (personal_data_type IS NULL)',
+        schema='event_registration'
+    )
 
 
 def downgrade():

--- a/indico/migrations/versions/20251216_0014_577e564cf0ae_add_internal_name_to_form_fields.py
+++ b/indico/migrations/versions/20251216_0014_577e564cf0ae_add_internal_name_to_form_fields.py
@@ -40,7 +40,7 @@ def upgrade():
         "internal_name != ''",
         schema='event_registration'
     )
-    case_expr = ' '.join(f"WHEN {e.value} THEN '{e.name}'" for e in _PersonalDataType)
+    case_expr = ' '.join(f"WHEN {e.value} THEN '{e.name.replace('_', '-')}'" for e in _PersonalDataType)
     op.execute(f'''
         UPDATE event_registration.form_items
         SET internal_name = CASE personal_data_type {case_expr} END

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -51,6 +51,7 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
   const isUnsupportedField = !(inputType in fieldRegistry);
   const meta = fieldRegistry[inputType] || {};
   const SettingsComponent = meta.settingsComponent;
+  const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
 
   const handleSubmit = async (formData, form) => {
     const data = getValuesForFields(formData, form);
@@ -212,6 +213,38 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
               </FormSpy>
             </Fieldset>
           )}
+          <Fieldset
+            legend={
+              <div
+                style={{cursor: 'pointer', userSelect: 'none'}}
+                onClick={() => setAdvancedSettingsOpen(open => !open)}
+              >
+                <Translate>Advanced settings</Translate>
+                <div className="group right">
+                  <span className={advancedSettingsOpen ? 'icon-expand' : 'icon-next'} />
+                </div>
+              </div>
+            }
+            compact
+          >
+            {advancedSettingsOpen && (
+              <FinalInput
+                name="internalName"
+                type="text"
+                label={Translate.string('Internal name')}
+                disabled={itemData.fieldIsPersonalData}
+                nullIfEmpty
+                validate={val => {
+                  if (val && val !== val.toLowerCase()) {
+                    return Translate.string('Only lowercase letters are allowed.');
+                  }
+                }}
+                description={Translate.string(
+                  'Use for identifying the same field across events regardless of the title.'
+                )}
+              />
+            )}
+          </Fieldset>
           {isUnsupportedField && (
             <Message visible warning>
               Unknown input type: {inputType}.<br />

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -235,13 +235,19 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
                 disabled={itemData.fieldIsPersonalData}
                 nullIfEmpty
                 validate={val => {
-                  if (val && val !== val.toLowerCase()) {
-                    return Translate.string('Only lowercase letters are allowed.');
+                  if (val && !/^[a-z0-9_]+$/.test(val)) {
+                    Translate.string(
+                      'Only lowercase alphanumeric characters and underscore ("_") are allowed.'
+                    );
                   }
                 }}
-                description={Translate.string(
-                  'Use for identifying the same field across events regardless of the title.'
-                )}
+                description={
+                  <Translate>
+                    Used for identifying the same field across registration forms regardless of the
+                    title. This can also be used across events if you make sure to use the same
+                    internal name.
+                  </Translate>
+                }
               />
             )}
           </Fieldset>

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -242,11 +242,21 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
                 }
               }}
               description={
-                <Translate>
-                  Used for identifying the same field across registration forms regardless of the
-                  title. This can also be used across events if you make sure to use the same
-                  internal name.
-                </Translate>
+                <>
+                  <Translate>
+                    Used for identifying the same field across registration forms regardless of the
+                    title. This can also be used across events if you make sure to use the same
+                    internal name.
+                  </Translate>
+                  {itemData.fieldIsPersonalData && (
+                    <>
+                      {' '}
+                      <Translate>
+                        The internal name for a personal data field cannot be changed.
+                      </Translate>
+                    </>
+                  )}
+                </>
               }
             />
           </Fieldset>

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -237,7 +237,7 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
                 validate={val => {
                   if (val && !/^[a-z0-9_]+$/.test(val)) {
                     Translate.string(
-                      'Only lowercase alphanumeric characters and underscore ("_") are allowed.'
+                      'Only lowercase alphanumeric characters and underscore are allowed.'
                     );
                   }
                 }}

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -235,9 +235,9 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
               readOnly={itemData.fieldIsPersonalData}
               nullIfEmpty
               validate={val => {
-                if (val && !/^[a-z0-9_]+$/.test(val)) {
+                if (val && !/^[a-z0-9-]+$/.test(val)) {
                   return Translate.string(
-                    'Only lowercase alphanumeric characters and underscore are allowed.'
+                    'Only lowercase alphanumeric characters and dashes are allowed.'
                   );
                 }
               }}

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -227,29 +227,28 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
             }
             compact
           >
-            {advancedSettingsOpen && (
-              <FinalInput
-                name="internalName"
-                type="text"
-                label={Translate.string('Internal name')}
-                readOnly={itemData.fieldIsPersonalData}
-                nullIfEmpty
-                validate={val => {
-                  if (val && !/^[a-z0-9_]+$/.test(val)) {
-                    return Translate.string(
-                      'Only lowercase alphanumeric characters and underscore are allowed.'
-                    );
-                  }
-                }}
-                description={
-                  <Translate>
-                    Used for identifying the same field across registration forms regardless of the
-                    title. This can also be used across events if you make sure to use the same
-                    internal name.
-                  </Translate>
+            <FinalInput
+              fieldProps={advancedSettingsOpen ? {} : {style: {display: 'none'}}}
+              name="internalName"
+              type="text"
+              label={Translate.string('Internal name')}
+              readOnly={itemData.fieldIsPersonalData}
+              nullIfEmpty
+              validate={val => {
+                if (val && !/^[a-z0-9_]+$/.test(val)) {
+                  return Translate.string(
+                    'Only lowercase alphanumeric characters and underscore are allowed.'
+                  );
                 }
-              />
-            )}
+              }}
+              description={
+                <Translate>
+                  Used for identifying the same field across registration forms regardless of the
+                  title. This can also be used across events if you make sure to use the same
+                  internal name.
+                </Translate>
+              }
+            />
           </Fieldset>
           {isUnsupportedField && (
             <Message visible warning>

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -232,7 +232,7 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
                 name="internalName"
                 type="text"
                 label={Translate.string('Internal name')}
-                disabled={itemData.fieldIsPersonalData}
+                readOnly={itemData.fieldIsPersonalData}
                 nullIfEmpty
                 validate={val => {
                   if (val && !/^[a-z0-9_]+$/.test(val)) {

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -236,7 +236,7 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
                 nullIfEmpty
                 validate={val => {
                   if (val && !/^[a-z0-9_]+$/.test(val)) {
-                    Translate.string(
+                    return Translate.string(
                       'Only lowercase alphanumeric characters and underscore are allowed.'
                     );
                   }

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -46,12 +46,12 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
     fieldIsRequired,
     ...itemData
   } = useSelector(state => (editing ? getItemById(state, id) : EMPTY_DATA));
+  const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
   const inputType = editing ? existingInputType : newItemType;
   const fieldRegistry = getFieldRegistry();
   const isUnsupportedField = !(inputType in fieldRegistry);
   const meta = fieldRegistry[inputType] || {};
   const SettingsComponent = meta.settingsComponent;
-  const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
 
   const handleSubmit = async (formData, form) => {
     const data = getValuesForFields(formData, form);

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -129,8 +129,9 @@ class GeneralFieldDataSchema(mm.Schema):
                              ~RegistrationFormItem.is_deleted))
             if field.id:
                 query = query.filter(RegistrationFormItem.id != field.id)
-            if query.has_rows():
-                raise ValidationError(_('There is already a field on this form with the same internal name.'))
+            if same_field := query.first():
+                raise ValidationError(_('The field "{}" on this form has the same internal name.')
+                                      .format(same_field.title))
 
     @validates('show_if_id')
     @no_autoflush
@@ -291,9 +292,9 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                              RegistrationFormItem.internal_name == self.field.internal_name,
                              RegistrationFormItem.is_enabled,
                              ~RegistrationFormItem.is_deleted))
-            if query.has_rows():
+            if same_field := query.first():
                 raise NoReportError.wrap_exc(
-                    BadRequest(_('There is already a field on this form with the same internal name.'))
+                    BadRequest(_('The field "{}" on this form has the same internal name.').format(same_field.title))
                 )
 
         self.field.is_enabled = enabled

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -8,7 +8,7 @@
 from datetime import timedelta
 
 from flask import jsonify, request, session
-from marshmallow import EXCLUDE, ValidationError, fields, post_load, validates, validates_schema
+from marshmallow import EXCLUDE, ValidationError, fields, post_load, pre_load, validates, validates_schema
 from werkzeug.exceptions import BadRequest
 
 from indico.core import signals
@@ -43,6 +43,15 @@ class GeneralFieldDataSchema(mm.Schema):
     input_type = fields.String(required=True, validate=not_empty)
     show_if_id = fields.Integer(required=False, load_default=None, data_key='show_if_field_id')
     show_if_values = fields.List(fields.Raw(), required=False, data_key='show_if_field_values')
+    internal_name = fields.String(allow_none=True)
+
+    @pre_load
+    def _avoid_resetting_advanced_settings(self, data, **kwargs):
+        # fields of collapsed (hidden) advanced settings are not in the payload
+        field = self.context['field']
+        if 'internal_name' not in data and field.internal_name:
+            data['internal_name'] = field.internal_name
+        return data
 
     @validates('title')
     @no_autoflush
@@ -100,6 +109,41 @@ class GeneralFieldDataSchema(mm.Schema):
             elif not max_retention_period and retention_period > timedelta(3650):
                 raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field empty '
                                         'for indefinite.'))
+
+    @validates('internal_name')
+    @no_autoflush
+    def _check_internal_name(self, internal_name, **kwargs):
+        field = self.context['field']
+        if field.type == RegistrationFormItemType.field_pd and internal_name != field.personal_data_type.name:
+            raise ValidationError(_('Changing internal name for personal data field is not allowed.'))
+        if internal_name is None:
+            return
+        if internal_name != internal_name.strip():
+            raise ValidationError(_('Leading and trailing whitespaces are not allowed.'))
+        if field.is_enabled is not False:  # None for new field
+            # unique on form
+            query = (RegistrationFormItem.query
+                     .filter(RegistrationFormItem.parent_id == field.parent.id,
+                             RegistrationFormItem.internal_name == internal_name,
+                             RegistrationFormItem.is_enabled,
+                             ~RegistrationFormItem.is_deleted))
+            if field.id:
+                query = query.filter(RegistrationFormItem.id != field.id)
+            if query.has_rows():
+                raise ValidationError(_('There is already a field on this form with the same internal name.'))
+            # same type accross events/forms
+            query = (RegistrationFormItem.query
+                     .filter(RegistrationFormItem.internal_name == internal_name,
+                             RegistrationFormItem.registration_form_id != field.registration_form.id,
+                             RegistrationFormItem.input_type != field.input_type,
+                             RegistrationFormItem.is_enabled,
+                             ~RegistrationFormItem.is_deleted))
+            if field.id:
+                query = query.filter(RegistrationFormItem.id != field.id)
+            query = query.signal_query('check-registration-form-field-internal-name', field=field)
+            if query.has_rows():
+                raise ValidationError(_('A field with the same internal name on another form uses '
+                                        'a different input type which is not allowed.'))
 
     @validates('show_if_id')
     @no_autoflush
@@ -244,6 +288,7 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
         if not enabled and self.field.condition_for:
             raise NoReportError.wrap_exc(BadRequest(_('Fields used as conditional cannot be disabled')))
         if enabled:
+            # check unique title in section
             query = (RegistrationFormItem.query
                      .filter(RegistrationFormItem.parent_id == self.field.parent.id,
                              db.func.lower(RegistrationFormItem.title) == self.field.title.lower(),
@@ -252,6 +297,29 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
             if query.has_rows():
                 raise NoReportError.wrap_exc(
                     BadRequest(_('There is already a field in this section with the same title.'))
+                )
+            # check unique internal name in from
+            query = (RegistrationFormItem.query
+                     .filter(RegistrationFormItem.parent_id == self.field.parent.id,
+                             RegistrationFormItem.internal_name == self.field.internal_name,
+                             RegistrationFormItem.is_enabled,
+                             ~RegistrationFormItem.is_deleted))
+            if query.has_rows():
+                raise NoReportError.wrap_exc(
+                    BadRequest(_('There is already a field on this form with the same internal name.'))
+                )
+            # same type accross events/forms
+            query = (RegistrationFormItem.query
+                     .filter(RegistrationFormItem.internal_name == self.field.internal_name,
+                             RegistrationFormItem.registration_form_id != self.field.registration_form.id,
+                             RegistrationFormItem.input_type != self.field.input_type,
+                             RegistrationFormItem.is_enabled,
+                             ~RegistrationFormItem.is_deleted)
+                     .signal_query('check-registration-form-field-internal-name', field=self.field))
+            if query.has_rows():
+                raise NoReportError.wrap_exc(
+                    BadRequest(_('A field with the same internal name on another form uses '
+                                 'a different input type which is not allowed.'))
                 )
 
         self.field.is_enabled = enabled

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -131,19 +131,6 @@ class GeneralFieldDataSchema(mm.Schema):
                 query = query.filter(RegistrationFormItem.id != field.id)
             if query.has_rows():
                 raise ValidationError(_('There is already a field on this form with the same internal name.'))
-            # same type accross events/forms
-            query = (RegistrationFormItem.query
-                     .filter(RegistrationFormItem.internal_name == internal_name,
-                             RegistrationFormItem.registration_form_id != field.registration_form.id,
-                             RegistrationFormItem.input_type != field.input_type,
-                             RegistrationFormItem.is_enabled,
-                             ~RegistrationFormItem.is_deleted))
-            if field.id:
-                query = query.filter(RegistrationFormItem.id != field.id)
-            query = query.signal_query('check-registration-form-field-internal-name', field=field)
-            if query.has_rows():
-                raise ValidationError(_('A field with the same internal name on another form uses '
-                                        'a different input type which is not allowed.'))
 
     @validates('show_if_id')
     @no_autoflush
@@ -307,19 +294,6 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
             if query.has_rows():
                 raise NoReportError.wrap_exc(
                     BadRequest(_('There is already a field on this form with the same internal name.'))
-                )
-            # same type accross events/forms
-            query = (RegistrationFormItem.query
-                     .filter(RegistrationFormItem.internal_name == self.field.internal_name,
-                             RegistrationFormItem.registration_form_id != self.field.registration_form.id,
-                             RegistrationFormItem.input_type != self.field.input_type,
-                             RegistrationFormItem.is_enabled,
-                             ~RegistrationFormItem.is_deleted)
-                     .signal_query('check-registration-form-field-internal-name', field=self.field))
-            if query.has_rows():
-                raise NoReportError.wrap_exc(
-                    BadRequest(_('A field with the same internal name on another form uses '
-                                 'a different input type which is not allowed.'))
                 )
 
         self.field.is_enabled = enabled

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -5,6 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+import re
 from datetime import timedelta
 
 from flask import jsonify, request, session
@@ -118,8 +119,8 @@ class GeneralFieldDataSchema(mm.Schema):
             raise ValidationError(_('Changing internal name for personal data field is not allowed.'))
         if internal_name is None:
             return
-        if internal_name != internal_name.strip():
-            raise ValidationError(_('Leading and trailing whitespaces are not allowed.'))
+        if not re.match(r'^[a-z0-9_]+$', internal_name):
+            raise ValidationError(_('Only lowercase alphanumeric characters and underscore ("_") are allowed.'))
         if field.is_enabled is not False:  # None for new field
             # unique on form
             query = (RegistrationFormItem.query
@@ -286,7 +287,7 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                 raise NoReportError.wrap_exc(
                     BadRequest(_('There is already a field in this section with the same title.'))
                 )
-            # check unique internal name in from
+            # check unique internal name in form
             query = (RegistrationFormItem.query
                      .filter(RegistrationFormItem.parent_id == self.field.parent.id,
                              RegistrationFormItem.internal_name == self.field.internal_name,

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -17,10 +17,12 @@ from indico.core.db import db
 from indico.core.db.sqlalchemy.util.session import no_autoflush
 from indico.core.errors import NoReportError
 from indico.core.marshmallow import mm
+from indico.modules.events.models.events import Event
 from indico.modules.events.registration import logger
 from indico.modules.events.registration.controllers.management.sections import RHManageRegFormSectionBase
 from indico.modules.events.registration.fields import get_field_types
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
+from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.items import (RegistrationFormItem, RegistrationFormItemType,
                                                              RegistrationFormText)
 from indico.modules.events.registration.util import get_flat_section_positions_setup_data, update_regform_item_positions
@@ -133,6 +135,21 @@ class GeneralFieldDataSchema(mm.Schema):
             if same_field := query.first():
                 raise ValidationError(_('The field "{}" on this form has the same internal name.')
                                       .format(same_field.title))
+            # consistent type on forms of the same event
+            query = (RegistrationFormItem.query
+                     .join(RegistrationForm, Event)
+                     .filter(RegistrationFormItem.internal_name == internal_name,
+                             RegistrationFormItem.registration_form_id != field.registration_form.id,
+                             RegistrationFormItem.input_type != field.input_type,
+                             RegistrationFormItem.is_enabled,
+                             ~RegistrationFormItem.is_deleted,
+                             Event.id == field.registration_form.event_id))
+            if field.id:
+                query = query.filter(RegistrationFormItem.id != field.id)
+            if inconsistent_field := query.first():
+                raise ValidationError(_('The field "{}" with the same internal name on form "{}" '
+                                        'uses a different input type which is not allowed.')
+                                      .format(inconsistent_field.title, inconsistent_field.registration_form.title))
 
     @validates('show_if_id')
     @no_autoflush
@@ -296,6 +313,21 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
             if same_field := query.first():
                 raise NoReportError.wrap_exc(
                     BadRequest(_('The field "{}" on this form has the same internal name.').format(same_field.title))
+                )
+            # consistent type on forms of the same event
+            query = (RegistrationFormItem.query
+                     .join(RegistrationForm, Event)
+                     .filter(RegistrationFormItem.internal_name == self.field.internal_name,
+                             RegistrationFormItem.registration_form_id != self.field.registration_form.id,
+                             RegistrationFormItem.input_type != self.field.input_type,
+                             RegistrationFormItem.is_enabled,
+                             ~RegistrationFormItem.is_deleted,
+                             Event.id == self.field.registration_form.event_id))
+            if inconsistent_field := query.first():
+                raise NoReportError.wrap_exc(
+                    BadRequest(_('The field "{}" with the same internal name on form "{}" '
+                                 'uses a different input type which is not allowed.')
+                               .format(inconsistent_field.title, inconsistent_field.registration_form.title))
                 )
 
         self.field.is_enabled = enabled

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -123,8 +123,8 @@ class GeneralFieldDataSchema(mm.Schema):
         if field.is_enabled is not False:  # None for new field
             # unique on form
             query = (RegistrationFormItem.query
-                     .filter(RegistrationFormItem.parent_id == field.parent.id,
-                             RegistrationFormItem.internal_name == internal_name,
+                     .with_parent(field.registration_form)
+                     .filter(RegistrationFormItem.internal_name == internal_name,
                              RegistrationFormItem.is_enabled,
                              ~RegistrationFormItem.is_deleted))
             if field.id:
@@ -304,8 +304,8 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                 )
             # check unique internal name in form
             query = (RegistrationFormItem.query
-                     .filter(RegistrationFormItem.parent_id == self.field.parent.id,
-                             RegistrationFormItem.internal_name == self.field.internal_name,
+                     .with_parent(self.field.registration_form)
+                     .filter(RegistrationFormItem.internal_name == self.field.internal_name,
                              RegistrationFormItem.is_enabled,
                              ~RegistrationFormItem.is_deleted))
             if same_field := query.first():

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -134,13 +134,14 @@ class GeneralFieldDataSchema(mm.Schema):
                                       .format(same_field.title))
             # consistent type on forms of the same event
             query = (RegistrationFormItem.query
-                     .join(RegistrationForm, Event)
+                     .join(RegistrationFormItem.registration_form)
+                     .join(RegistrationForm.event)
                      .filter(RegistrationFormItem.internal_name == internal_name,
                              RegistrationFormItem.registration_form_id != field.registration_form.id,
                              RegistrationFormItem.input_type != field.input_type,
                              RegistrationFormItem.is_enabled,
                              ~RegistrationFormItem.is_deleted,
-                             Event.id == field.registration_form.event_id))
+                             ~RegistrationForm.is_deleted))
             if field.id:
                 query = query.filter(RegistrationFormItem.id != field.id)
             if inconsistent_field := query.first():

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -45,7 +45,7 @@ class GeneralFieldDataSchema(mm.Schema):
     input_type = fields.String(required=True, validate=not_empty)
     show_if_id = fields.Integer(required=False, load_default=None, data_key='show_if_field_id')
     show_if_values = fields.List(fields.Raw(), required=False, data_key='show_if_field_values')
-    internal_name = fields.String(required=True, allow_none=True, validate=validate.Regexp(r'[a-z0-9-]+$'))
+    internal_name = fields.String(allow_none=True, validate=validate.Regexp(r'[a-z0-9-]+$'))
 
     @validates('title')
     @no_autoflush

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -380,6 +380,7 @@ class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
             'description': {'title': 'Description'},
             'is_required': {'title': 'Required'},
             'retention_period': {'title': 'Retention period'},
+            'internal_name': {'title': 'Internal name', 'type': 'string'},
         })
         self.field.log(
             EventLogRealm.management, LogKind.change, 'Registration',

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -307,7 +307,8 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                 )
             # consistent type on forms of the same event
             query = (RegistrationFormItem.query
-                     .join(RegistrationForm, Event)
+                     .join(RegistrationFormItem.registration_form)
+                     .join(RegistrationForm.event)
                      .filter(RegistrationFormItem.internal_name == self.field.internal_name,
                              RegistrationFormItem.registration_form_id != self.field.registration_form.id,
                              RegistrationFormItem.input_type != self.field.input_type,

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -133,7 +133,8 @@ class GeneralFieldDataSchema(mm.Schema):
                              RegistrationFormItem.input_type != field.input_type,
                              RegistrationFormItem.is_enabled,
                              ~RegistrationFormItem.is_deleted,
-                             ~RegistrationForm.is_deleted))
+                             ~RegistrationForm.is_deleted,
+                             Event.id == field.registration_form.event_id))
             if field.id:
                 query = query.filter(RegistrationFormItem.id != field.id)
             if inconsistent_field := query.first():

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -45,7 +45,7 @@ class GeneralFieldDataSchema(mm.Schema):
     input_type = fields.String(required=True, validate=not_empty)
     show_if_id = fields.Integer(required=False, load_default=None, data_key='show_if_field_id')
     show_if_values = fields.List(fields.Raw(), required=False, data_key='show_if_field_values')
-    internal_name = fields.String(allow_none=True, validate=validate.Regexp(r'[a-z0-9_]+$'))
+    internal_name = fields.String(allow_none=True, validate=validate.Regexp(r'[a-z0-9-]+$'))
 
     @pre_load
     def _avoid_resetting_advanced_settings(self, data, **kwargs):
@@ -116,7 +116,7 @@ class GeneralFieldDataSchema(mm.Schema):
     @no_autoflush
     def _check_internal_name(self, internal_name, **kwargs):
         field = self.context['field']
-        if field.type == RegistrationFormItemType.field_pd and internal_name != field.personal_data_type.name:
+        if field.type == RegistrationFormItemType.field_pd and internal_name != field.personal_data_type.internal_name:
             raise ValidationError(_('Changing internal name for personal data field is not allowed.'))
         if internal_name is None:
             return

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -5,11 +5,10 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-import re
 from datetime import timedelta
 
 from flask import jsonify, request, session
-from marshmallow import EXCLUDE, ValidationError, fields, post_load, pre_load, validates, validates_schema
+from marshmallow import EXCLUDE, ValidationError, fields, post_load, pre_load, validate, validates, validates_schema
 from werkzeug.exceptions import BadRequest
 
 from indico.core import signals
@@ -46,7 +45,7 @@ class GeneralFieldDataSchema(mm.Schema):
     input_type = fields.String(required=True, validate=not_empty)
     show_if_id = fields.Integer(required=False, load_default=None, data_key='show_if_field_id')
     show_if_values = fields.List(fields.Raw(), required=False, data_key='show_if_field_values')
-    internal_name = fields.String(allow_none=True)
+    internal_name = fields.String(allow_none=True, validate=validate.Regexp(r'[a-z0-9_]+$'))
 
     @pre_load
     def _avoid_resetting_advanced_settings(self, data, **kwargs):
@@ -121,8 +120,6 @@ class GeneralFieldDataSchema(mm.Schema):
             raise ValidationError(_('Changing internal name for personal data field is not allowed.'))
         if internal_name is None:
             return
-        if not re.match(r'^[a-z0-9_]+$', internal_name):
-            raise ValidationError(_('Only lowercase alphanumeric characters and underscore ("_") are allowed.'))
         if field.is_enabled is not False:  # None for new field
             # unique on form
             query = (RegistrationFormItem.query

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -8,7 +8,7 @@
 from datetime import timedelta
 
 from flask import jsonify, request, session
-from marshmallow import EXCLUDE, ValidationError, fields, post_load, pre_load, validate, validates, validates_schema
+from marshmallow import EXCLUDE, ValidationError, fields, post_load, validate, validates, validates_schema
 from werkzeug.exceptions import BadRequest
 
 from indico.core import signals
@@ -45,15 +45,7 @@ class GeneralFieldDataSchema(mm.Schema):
     input_type = fields.String(required=True, validate=not_empty)
     show_if_id = fields.Integer(required=False, load_default=None, data_key='show_if_field_id')
     show_if_values = fields.List(fields.Raw(), required=False, data_key='show_if_field_values')
-    internal_name = fields.String(allow_none=True, validate=validate.Regexp(r'[a-z0-9-]+$'))
-
-    @pre_load
-    def _avoid_resetting_advanced_settings(self, data, **kwargs):
-        # fields of collapsed (hidden) advanced settings are not in the payload
-        field = self.context['field']
-        if 'internal_name' not in data and field.internal_name:
-            data['internal_name'] = field.internal_name
-        return data
+    internal_name = fields.String(required=True, allow_none=True, validate=validate.Regexp(r'[a-z0-9-]+$'))
 
     @validates('title')
     @no_autoflush

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -81,8 +81,8 @@ class TestGeneralFieldDataSchema:
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
         with pytest.raises(ValidationError) as exc_info:
             schema.load({'input_type': 'text', 'title': 'New field', 'internal_name': position_field.internal_name})
-        assert exc_info.value.messages == {'internal_name': 'There is already a field on this form '
-                                                            'with the same internal name.'}
+        assert exc_info.value.messages == {'internal_name': [f'The field "{position_field.title}" on this form '
+                                                             f'has the same internal name.']}
 
     def test_update_internal_name_with_whitespaces(self, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -108,7 +108,7 @@ class TestGeneralFieldDataSchema:
                                if field.personal_data_type == PersonalDataType.position), None)
         disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': disabled_field})
-        assert schema.load({'input_type': 'text', 'title': position_field.title,
+        assert schema.load({'input_type': 'text', 'title': 'Disabled field',
                             'internal_name': position_field.internal_name})
 
     def test_new_field_with_same_internal_name_but_disabled(self, db, dummy_regform):
@@ -121,18 +121,3 @@ class TestGeneralFieldDataSchema:
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_position_field})
         assert schema.load({'input_type': 'text', 'title': position_field.title,
                             'internal_name': position_field.internal_name})
-
-    def test_internal_name_with_different_input_type_on_other_regform(self, db, create_regform, dummy_regform):
-        create_regform(dummy_regform.event, title='Other Form')
-        pd_section = dummy_regform.sections[0]
-        title_field = next((field for field in pd_section.fields
-                            if field.personal_data_type == PersonalDataType.title), None)
-        title_field.is_enabled = False
-        db.session.flush()
-        new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
-        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
-        with pytest.raises(ValidationError) as exc_info:
-            assert schema.load({'input_type': 'text', 'title': title_field.title,
-                                'internal_name': title_field.internal_name})
-        assert exc_info.value.messages == {'internal_name': 'A field with the same internal name on another form '
-                                                            'uses a different input type which is not allowed.'}

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -17,7 +17,6 @@ pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
 
 
 class TestGeneralFieldDataSchema:
-
     # title tests
 
     def test_new_field_with_same_title_in_same_section(self, dummy_regform):
@@ -84,13 +83,15 @@ class TestGeneralFieldDataSchema:
         assert exc_info.value.messages == {'internal_name': [f'The field "{position_field.title}" on this form '
                                                              f'has the same internal name.']}
 
-    def test_update_internal_name_with_whitespaces(self, dummy_regform):
+    @pytest.mark.parametrize('internal_name', ('internal name', 'InternalName', 'internal.name'))
+    def test_update_internal_name_with_not_allowed_chars(self, dummy_regform, internal_name):
         pd_section = dummy_regform.sections[0]
         new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
         with pytest.raises(ValidationError) as exc_info:
-            schema.load({'input_type': 'text', 'title': 'New field', 'internal_name': ' new_field '})
-        assert exc_info.value.messages == {'internal_name': 'Leading and trailing whitespaces are not allowed.'}
+            schema.load({'input_type': 'text', 'title': 'New field', 'internal_name': internal_name})
+        assert exc_info.value.messages == {'internal_name': 'Only lowercase alphanumeric characters '
+                                                            'and underscore ("_") are allowed.'}
 
     def test_update_internal_name_of_personal_data_field(self, dummy_regform):
         pd_section = dummy_regform.sections[0]

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -122,3 +122,21 @@ class TestGeneralFieldDataSchema:
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_position_field})
         assert schema.load({'input_type': 'text', 'title': position_field.title,
                             'internal_name': position_field.internal_name})
+
+    def test_internal_name_with_different_input_type_on_other_regform(self, db, create_regform, dummy_regform):
+        other_form = create_regform(dummy_regform.event, title='Other Form')
+        pd_section = dummy_regform.sections[0]
+        # Disable the title field on dummy_regform to be able to add another title field but with different type
+        title_field = next((field for field in pd_section.fields
+                            if field.personal_data_type == PersonalDataType.title), None)
+        title_field.is_enabled = False
+        db.session.flush()
+        new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            assert schema.load({'input_type': 'text', 'title': title_field.title,
+                                'internal_name': title_field.internal_name})
+        assert exc_info.value.messages == {
+            'internal_name': [f'The field "{title_field.title}" with the same internal name on form '
+                              f'"{other_form.title}" uses a different input type which is not allowed.']
+        }

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -17,7 +17,10 @@ pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
 
 
 class TestGeneralFieldDataSchema:
-    def test_add_new_field_with_same_title_in_same_section(self, dummy_regform):
+
+    # title tests
+
+    def test_new_field_with_same_title_in_same_section(self, dummy_regform):
         pd_section = dummy_regform.sections[0]
         first_name_field = next((field for field in pd_section.fields
                                  if field.personal_data_type == PersonalDataType.first_name), None)
@@ -27,7 +30,7 @@ class TestGeneralFieldDataSchema:
             schema.load({'input_type': 'text', 'title': first_name_field.title})
         assert exc_info.value.messages == {'title': 'There is already a field in this section with the same title.'}
 
-    def test_modify_field_with_same_title_in_same_section(self, dummy_regform):
+    def test_update_field_with_same_title_in_same_section(self, dummy_regform):
         pd_section = dummy_regform.sections[0]
         first_name_field = next((field for field in pd_section.fields
                                  if field.personal_data_type == PersonalDataType.first_name), None)
@@ -47,7 +50,7 @@ class TestGeneralFieldDataSchema:
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': disabled_field})
         assert schema.load({'input_type': 'text', 'title': position_field.title})
 
-    def test_add_new_field_with_same_title_but_disabled(self, db, dummy_regform):
+    def test_new_field_with_same_title_but_disabled(self, db, dummy_regform):
         pd_section = dummy_regform.sections[0]
         affiliation_field = next((field for field in pd_section.fields
                                     if field.personal_data_type == PersonalDataType.affiliation), None)
@@ -57,7 +60,7 @@ class TestGeneralFieldDataSchema:
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_affiliation_field})
         assert schema.load({'input_type': 'text', 'title': affiliation_field.title})
 
-    def test_add_new_field_with_same_title_in_other_section(self, dummy_regform):
+    def test_new_field_with_same_title_in_other_section(self, dummy_regform):
         pd_section = dummy_regform.sections[0]
         first_name_field = next((field for field in pd_section.fields
                                  if field.personal_data_type == PersonalDataType.first_name), None)
@@ -67,3 +70,69 @@ class TestGeneralFieldDataSchema:
         new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
         assert schema.load({'input_type': 'text', 'title': first_name_field.title})
+
+    # internal_name tests
+
+    def test_new_field_with_same_internal_name(self, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        position_field = next((field for field in pd_section.fields
+                               if field.personal_data_type == PersonalDataType.position), None)
+        new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field', 'internal_name': position_field.internal_name})
+        assert exc_info.value.messages == {'internal_name': 'There is already a field on this form '
+                                                            'with the same internal name.'}
+
+    def test_update_internal_name_with_whitespaces(self, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field', 'internal_name': ' new_field '})
+        assert exc_info.value.messages == {'internal_name': 'Leading and trailing whitespaces are not allowed.'}
+
+    def test_update_internal_name_of_personal_data_field(self, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        position_field = next((field for field in pd_section.fields
+                               if field.personal_data_type == PersonalDataType.position), None)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': position_field})
+        with pytest.raises(ValidationError) as exc_info:
+            assert schema.load({'input_type': 'text', 'title': position_field.title, 'internal_name': 'alt_position'})
+        assert exc_info.value.messages == {'internal_name': 'Changing internal name for personal data field '
+                                                            'is not allowed.'}
+
+    def test_update_internal_name_of_disabled_field(self, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        position_field = next((field for field in pd_section.fields
+                               if field.personal_data_type == PersonalDataType.position), None)
+        disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': disabled_field})
+        assert schema.load({'input_type': 'text', 'title': position_field.title,
+                            'internal_name': position_field.internal_name})
+
+    def test_new_field_with_same_internal_name_but_disabled(self, db, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        position_field = next((field for field in pd_section.fields
+                               if field.personal_data_type == PersonalDataType.position), None)
+        position_field.is_enabled = False
+        db.session.flush()
+        new_position_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_position_field})
+        assert schema.load({'input_type': 'text', 'title': position_field.title,
+                            'internal_name': position_field.internal_name})
+
+    def test_internal_name_with_different_input_type_on_other_regform(self, db, create_regform, dummy_regform):
+        create_regform(dummy_regform.event, title='Other Form')
+        pd_section = dummy_regform.sections[0]
+        title_field = next((field for field in pd_section.fields
+                            if field.personal_data_type == PersonalDataType.title), None)
+        title_field.is_enabled = False
+        db.session.flush()
+        new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            assert schema.load({'input_type': 'text', 'title': title_field.title,
+                                'internal_name': title_field.internal_name})
+        assert exc_info.value.messages == {'internal_name': 'A field with the same internal name on another form '
+                                                            'uses a different input type which is not allowed.'}

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -26,8 +26,7 @@ class TestGeneralFieldDataSchema:
         new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
         with pytest.raises(ValidationError) as exc_info:
-            schema.load({'input_type': 'text', 'title': first_name_field.title,
-                         'internal_name': None})
+            schema.load({'input_type': 'text', 'title': first_name_field.title})
         assert exc_info.value.messages == {'title': 'There is already a field in this section with the same title.'}
 
     def test_update_field_with_same_title_in_same_section(self, dummy_regform):
@@ -60,7 +59,7 @@ class TestGeneralFieldDataSchema:
         db.session.flush()
         new_affiliation_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_affiliation_field})
-        assert schema.load({'input_type': 'text', 'title': affiliation_field.title, 'internal_name': None})
+        assert schema.load({'input_type': 'text', 'title': affiliation_field.title})
 
     def test_new_field_with_same_title_in_other_section(self, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -71,7 +70,7 @@ class TestGeneralFieldDataSchema:
         )
         new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
-        assert schema.load({'input_type': 'text', 'title': first_name_field.title, 'internal_name': None})
+        assert schema.load({'input_type': 'text', 'title': first_name_field.title})
 
     # internal_name tests
 

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -26,7 +26,8 @@ class TestGeneralFieldDataSchema:
         new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
         with pytest.raises(ValidationError) as exc_info:
-            schema.load({'input_type': 'text', 'title': first_name_field.title})
+            schema.load({'input_type': 'text', 'title': first_name_field.title,
+                         'internal_name': None})
         assert exc_info.value.messages == {'title': 'There is already a field in this section with the same title.'}
 
     def test_update_field_with_same_title_in_same_section(self, dummy_regform):
@@ -37,7 +38,8 @@ class TestGeneralFieldDataSchema:
                                 if field.personal_data_type == PersonalDataType.last_name), None)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': last_name_field})
         with pytest.raises(ValidationError) as exc_info:
-            schema.load({'input_type': last_name_field.input_type, 'title': first_name_field.title})
+            schema.load({'input_type': last_name_field.input_type, 'title': first_name_field.title,
+                         'internal_name': last_name_field.internal_name})
         assert exc_info.value.messages == {'title': 'There is already a field in this section with the same title.'}
 
     def test_update_title_of_disabled_field(self, dummy_regform):
@@ -47,7 +49,8 @@ class TestGeneralFieldDataSchema:
         disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False,
                                                id=1337)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': disabled_field})
-        assert schema.load({'input_type': 'text', 'title': position_field.title})
+        assert schema.load({'input_type': 'text', 'title': position_field.title,
+                            'internal_name': position_field.internal_name})
 
     def test_new_field_with_same_title_but_disabled(self, db, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -57,7 +60,7 @@ class TestGeneralFieldDataSchema:
         db.session.flush()
         new_affiliation_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_affiliation_field})
-        assert schema.load({'input_type': 'text', 'title': affiliation_field.title})
+        assert schema.load({'input_type': 'text', 'title': affiliation_field.title, 'internal_name': None})
 
     def test_new_field_with_same_title_in_other_section(self, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -68,7 +71,7 @@ class TestGeneralFieldDataSchema:
         )
         new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
-        assert schema.load({'input_type': 'text', 'title': first_name_field.title})
+        assert schema.load({'input_type': 'text', 'title': first_name_field.title, 'internal_name': None})
 
     # internal_name tests
 

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -147,3 +147,19 @@ class TestGeneralFieldDataSchema:
         other_form.is_deleted = True
         db.session.flush()
         assert schema.load({'input_type': 'text', 'title': 'text', 'internal_name': 'title'})
+
+    def test_internal_name_with_different_input_type_on_other_event(self, db, create_event, dummy_regform,
+                                                                    create_regform):
+        # create field in dummy event
+        new_field = RegistrationFormField(parent=dummy_regform.sections[0], registration_form=dummy_regform,
+                                          title='test', input_type='text', internal_name='test')
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        schema.load({'input_type': 'text', 'title': 'test', 'internal_name': 'test'})
+        db.session.flush()
+        # create field in another event
+        other_event = create_event()
+        other_form = create_regform(other_event, title='Other Form')
+        other_field = RegistrationFormField(parent=other_form.sections[0], registration_form=other_form,
+                                            title='test', input_type='checkbox')
+        schema = GeneralFieldDataSchema(context={'regform': other_form, 'field': other_field})
+        schema.load({'input_type': 'checkbox', 'title': 'test', 'internal_name': 'test'})

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -131,12 +131,17 @@ class TestGeneralFieldDataSchema:
                             if field.personal_data_type == PersonalDataType.title), None)
         title_field.is_enabled = False
         db.session.flush()
-        new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        new_section = RegistrationFormSection(registration_form=dummy_regform, title='New Section',
+                                              is_manager_only=False)
+        new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform, title='test',
+                                          input_type='text')
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
         with pytest.raises(ValidationError) as exc_info:
-            assert schema.load({'input_type': 'text', 'title': title_field.title,
-                                'internal_name': title_field.internal_name})
+            schema.load({'input_type': 'text', 'title': 'test', 'internal_name': 'title'})
         assert exc_info.value.messages == {
-            'internal_name': [f'The field "{title_field.title}" with the same internal name on form '
+            'internal_name': [f'The field "Title" with the same internal name on form '
                               f'"{other_form.title}" uses a different input type which is not allowed.']
         }
+        other_form.is_deleted = True
+        db.session.flush()
+        assert schema.load({'input_type': 'text', 'title': 'text', 'internal_name': 'title'})

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -83,23 +83,23 @@ class TestGeneralFieldDataSchema:
         assert exc_info.value.messages == {'internal_name': [f'The field "{position_field.title}" on this form '
                                                              f'has the same internal name.']}
 
-    @pytest.mark.parametrize('internal_name', ('internal name', 'InternalName', 'internal.name'))
+    @pytest.mark.parametrize('internal_name', ('internal name', 'InternalName', 'internal.name', 'internal_name', ''))
     def test_update_internal_name_with_not_allowed_chars(self, dummy_regform, internal_name):
         pd_section = dummy_regform.sections[0]
         new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
         with pytest.raises(ValidationError) as exc_info:
             schema.load({'input_type': 'text', 'title': 'New field', 'internal_name': internal_name})
-        assert exc_info.value.messages == {'internal_name': 'Only lowercase alphanumeric characters '
-                                                            'and underscore ("_") are allowed.'}
+        assert exc_info.value.messages == {'internal_name': ['String does not match expected pattern.']}
 
-    def test_update_internal_name_of_personal_data_field(self, dummy_regform):
+    @pytest.mark.parametrize('internal_name', ('alt-position', None))
+    def test_update_internal_name_of_personal_data_field(self, dummy_regform, internal_name):
         pd_section = dummy_regform.sections[0]
         position_field = next((field for field in pd_section.fields
                                if field.personal_data_type == PersonalDataType.position), None)
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': position_field})
         with pytest.raises(ValidationError) as exc_info:
-            assert schema.load({'input_type': 'text', 'title': position_field.title, 'internal_name': 'alt_position'})
+            assert schema.load({'input_type': 'text', 'title': position_field.title, 'internal_name': internal_name})
         assert exc_info.value.messages == {'internal_name': 'Changing internal name for personal data field '
                                                             'is not allowed.'}
 

--- a/indico/modules/events/registration/models/form_fields.py
+++ b/indico/modules/events/registration/models/form_fields.py
@@ -97,6 +97,7 @@ class RegistrationFormField(RegistrationFormItem):
             show_if_field_values=self.show_if_values,
             show_if_condition_for=[f.id for f in self.condition_for],
             show_if_condition_for_transitive=[f.id for f in self.condition_for_transitive],
+            internal_name=self.internal_name,
             **super().view_data,
         )
         base_dict.update(self.field_impl.view_data)

--- a/indico/modules/events/registration/models/form_fields.py
+++ b/indico/modules/events/registration/models/form_fields.py
@@ -92,12 +92,12 @@ class RegistrationFormField(RegistrationFormItem):
             is_required=self.is_required,
             retention_period=(self.retention_period.days // 7 if self.retention_period else None),
             input_type=self.input_type,
+            internal_name=self.internal_name,
             html_name=self.html_field_name,
             show_if_field_id=self.show_if_id,
             show_if_field_values=self.show_if_values,
             show_if_condition_for=[f.id for f in self.condition_for],
             show_if_condition_for_transitive=[f.id for f in self.condition_for_transitive],
-            internal_name=self.internal_name,
             **super().view_data,
         )
         base_dict.update(self.field_impl.view_data)

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -196,6 +196,7 @@ class RegistrationFormItem(db.Model):
                  postgresql_where=db.text(f'type = {RegistrationFormItemType.section_pd}')),
         db.Index('ix_uq_form_items_pd_field', 'registration_form_id', 'personal_data_type', unique=True,
                  postgresql_where=db.text(f'type = {RegistrationFormItemType.field_pd}')),
+        db.Index(None, 'internal_name', postgresql_where=db.text('is_enabled AND NOT is_deleted')),
         {'schema': 'event_registration'}
     )
     __mapper_args__ = {
@@ -247,6 +248,11 @@ class RegistrationFormItem(db.Model):
     #: The values of the referenced form field for which to show this one
     show_if_values = db.Column(
         JSONB(none_as_null=True),
+        nullable=True,
+    )
+    #: The internal name of this field
+    internal_name = db.Column(
+        db.String,
         nullable=True,
     )
     #: The title of this field

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -192,11 +192,11 @@ class RegistrationFormItem(db.Model):
                            .format(t=RegistrationFormItemType,
                                    required_fields=','.join([str(f.value) for f in PersonalDataType if f.is_required])),
                            name='retention_period_allowed_fields'),
+        db.CheckConstraint("internal_name != ''", name='internal_name_not_empty'),
         db.Index('ix_uq_form_items_pd_section', 'registration_form_id', unique=True,
                  postgresql_where=db.text(f'type = {RegistrationFormItemType.section_pd}')),
         db.Index('ix_uq_form_items_pd_field', 'registration_form_id', 'personal_data_type', unique=True,
                  postgresql_where=db.text(f'type = {RegistrationFormItemType.field_pd}')),
-        db.Index(None, 'internal_name', postgresql_where=db.text('is_enabled AND NOT is_deleted')),
         {'schema': 'event_registration'}
     )
     __mapper_args__ = {
@@ -253,6 +253,7 @@ class RegistrationFormItem(db.Model):
     #: The internal name of this field
     internal_name = db.Column(
         db.String,
+        index=True,
         nullable=True,
     )
     #: The title of this field

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -193,6 +193,8 @@ class RegistrationFormItem(db.Model):
                                    required_fields=','.join([str(f.value) for f in PersonalDataType if f.is_required])),
                            name='retention_period_allowed_fields'),
         db.CheckConstraint("internal_name != ''", name='internal_name_not_empty'),
+        db.CheckConstraint('(internal_name IS NOT NULL) OR (personal_data_type IS NULL)',
+                           name='pd_internal_name_required'),
         db.Index('ix_uq_form_items_pd_section', 'registration_form_id', unique=True,
                  postgresql_where=db.text(f'type = {RegistrationFormItemType.section_pd}')),
         db.Index('ix_uq_form_items_pd_field', 'registration_form_id', 'personal_data_type', unique=True,

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -142,6 +142,10 @@ class PersonalDataType(IndicoIntEnum):
         return self in {PersonalDataType.email, PersonalDataType.first_name, PersonalDataType.last_name}
 
     @property
+    def internal_name(self):
+        return self.name.replace('_', '-')
+
+    @property
     def column(self):
         """
         The Registration column in which the value is stored in

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -392,7 +392,7 @@ def create_personal_data_fields(regform):
         if pd_type not in missing:
             continue
         field = RegistrationFormPersonalDataField(registration_form=regform, personal_data_type=pd_type,
-                                                  is_required=pd_type.is_required)
+                                                  is_required=pd_type.is_required, internal_name=pd_type.name)
         for key, value in data.items():
             setattr(field, key, value)
         field.data, versioned_data = field.field_impl.process_field_data(data.pop('data', {}))

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -392,7 +392,7 @@ def create_personal_data_fields(regform):
         if pd_type not in missing:
             continue
         field = RegistrationFormPersonalDataField(registration_form=regform, personal_data_type=pd_type,
-                                                  is_required=pd_type.is_required, internal_name=pd_type.name)
+                                                  is_required=pd_type.is_required, internal_name=pd_type.internal_name)
         for key, value in data.items():
             setattr(field, key, value)
         field.data, versioned_data = field.field_impl.process_field_data(data.pop('data', {}))

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -905,7 +905,7 @@ export function Fieldset({legend, children, active, compact}) {
 }
 
 Fieldset.propTypes = {
-  legend: PropTypes.string.isRequired,
+  legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   children: PropTypes.node.isRequired,
   active: PropTypes.bool,
   compact: PropTypes.bool,


### PR DESCRIPTION
This PR adds a new property to registration form fields: `internal_name`.
The purpose of this field is the need to be able to identify custom registration form fields on registration forms. The primary reason is statistics. Data should be collected from specific fields regardless of whether their title has ben renamed or translated. 

How it works:
* `internal_name` is populated automatically for personal data fields and they are not editable
* For custom fields there's no default value
* It can be edited on the field properties dialog in "Advanced settings"
* "Advanced settings" is collapsible and collapsed by default
* `internal_name` must be unique within the registration form