### PR TITLE
Add filter option search

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,7 @@ Improvements
   (:issue:`5486`, :pr:`7257`)
 - Allow admins to disable Gravatar/Identicon profile pictures via the :data:`DISABLE_GRAVATAR`
   config option (:issue:`7210`, :pr:`7251`, thanks :user:`duartegalvao, unconventionaldotdev`)
-- Add a UI for managing predefined affiliations (:pr:`7183`, thanks
+- Add a UI for managing predefined affiliations (:pr:`7183`, :pr:`7278`, thanks
   :user:`duartegalvao, unconventionaldotdev`)
 - Add support for configurable file types in Paper Peer Reviewing (:issue:`7162`, :pr:`7156`)
 

--- a/indico/web/client/js/react/components/ListFilter.module.scss
+++ b/indico/web/client/js/react/components/ListFilter.module.scss
@@ -12,6 +12,12 @@
 
 .filters-menu {
   max-width: 15em;
+
+  :global(.ui.dropdown.item > .menu.left) {
+    left: auto !important;
+    right: 100% !important;
+    margin-right: 0 !important;
+  }
 }
 
 .active-filters {
@@ -19,6 +25,14 @@
   flex-direction: column;
   margin: 0.4em;
   gap: 0.4em;
+}
+
+.options-search {
+  padding: 0.4em 0.6em 0.2em;
+
+  :global(.ui.input) {
+    width: 100%;
+  }
 }
 
 :global(.ui.label).filter {


### PR DESCRIPTION
Follow-up to #7183, as promised 😄 

This PR adds a search box on the `ListFilter`'s option submenus. It is currently hardcoded to only show up when there are more than 10 options (`OPTIONS_SEARCH_THRESHOLD` constant in the component file).

<img width="484" height="343" alt="image" src="https://github.com/user-attachments/assets/5747ccc3-cea5-40d4-89e2-86a2a15946bb" />

I also made the submenu open to the left since the input made the thing spill over the right limit of the page. The messy CSS in `.filters-menu` is yet another SUI patch...

Regarding the scrollbar being invisible in some systems: I'm not sure what to do about that, since `overflow-y: auto` SHOULD display a scrollbar. Adding `scrollbar-gutter: stable` to the `.menu` could be a fix, but I don't really have a way to test that, and I'm worried it could force a scrollbar even when it's not needed