### PR TITLE
Fix unhandled exception when registering account without password

### DIFF
--- a/indico/modules/auth/controllers.py
+++ b/indico/modules/auth/controllers.py
@@ -745,6 +745,8 @@ class LocalRegistrationHandler(RegistrationHandler):
 
             @validates_schema(skip_on_field_errors=False)
             def validate_password(self, data, **kwargs):
+                if 'password' not in data:
+                    return
                 if error := validate_secure_password('set-user-password', data['password'],
                                                      username=data.get('username', ''),
                                                      emails={session['register_verified_email']}):


### PR DESCRIPTION
Request change to fix unhandled exception in case "POST /register/  without password" is forced by scripts.