### PR TITLE
Fix AffiliationForm Address panel being stuck open

### DIFF
--- a/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
+++ b/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
@@ -105,7 +105,6 @@ export default function AffiliationFormDialog({
     {
       key: 'address',
       title: Translate.string('Address'),
-      active: true,
       content: {
         content: (
           <>
@@ -177,7 +176,13 @@ export default function AffiliationFormDialog({
         label={Translate.string('Alternative names')}
         placeholder={Translate.string('Type a name and press Enter to add')}
       />
-      <Accordion exclusive={false} panels={formSections} styled fluid />
+      <Accordion
+        exclusive={false}
+        panels={formSections}
+        defaultActiveIndex={[...Array(formSections.length - 1).keys()]}
+        styled
+        fluid
+      />
     </FinalModalForm>
   );
 }


### PR DESCRIPTION
This PR fixes a small UI bug introduced in #7183 which made the "Address" panel be stuck open, instead of being just open by default.

This PR makes it so all panels except the last one (advanced settings) are open by default.