### PR TITLE
Trigger change events in WMD editor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,8 @@ Bugfixes
   thanks :user:`jbtwist`)
 - Fix validation error when choosing exactly the maximum date in a regform date field
   (:pr:`7288`)
+- Fix submit buttons not being enabled when modifying a markdown field using only the
+  button bar or a keyboard shortcut (:pr:`7310`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/jquery/widgets/jinja/markdown_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/markdown_widget.js
@@ -85,6 +85,20 @@ import {$T} from 'indico/utils/i18n';
       const $field = $(`#${options.fieldId}`);
       $field.pagedown();
 
+      // The editor doesn't trigger any input/change events when applying changes via keyboard
+      // shortcuts or the button bar, so we need to manually take care of this to enable submit
+      // buttons etc.
+      const $container = $field.closest('[data-field-id]');
+      const textarea = $container.find('textarea.wmd-input')[0];
+      $container.find('.wmd-button-bar').on('click', () => {
+        textarea.dispatchEvent(new Event('change', {bubbles: true}));
+      });
+      textarea.addEventListener('keydown', evt => {
+        if (evt.ctrlKey) {
+          textarea.dispatchEvent(new Event('change', {bubbles: true}));
+        }
+      });
+
       if (options.maxLength || options.maxWords) {
         updateLimits($field, options);
         $field.on('change input', function() {


### PR DESCRIPTION
The joy of using 10-year-old legacy libraries... it doesn't trigger any `input` or `change` events, so the submit button e.g. in the contribution edit dialog remained disabled in some (edge) cases such as only making something bold using the `B` button in the toolbar or <kbd>CTRL</kbd>+<kbd>B</kbd>.