### PR TITLE
Expose imageUploadURL in EmailDialog

### DIFF
--- a/indico/modules/events/persons/client/js/EmailDialog.jsx
+++ b/indico/modules/events/persons/client/js/EmailDialog.jsx
@@ -96,6 +96,7 @@ export function EmailDialog({
   validate,
   title,
   getPreviewPayload,
+  imageUploadURL,
 }) {
   const [preview, setPreview] = useState(null);
 
@@ -182,7 +183,7 @@ export function EmailDialog({
           name="body"
           label={Translate.string('Email body')}
           required
-          config={{images: false, forceAbsoluteURLs: true}}
+          config={{images: !!imageUploadURL, forceAbsoluteURLs: true, imageUploadURL}}
         />
         {placeholders.length > 0 && (
           <Form.Field>
@@ -272,6 +273,7 @@ EmailDialog.propTypes = {
   title: PropTypes.string,
   getPreviewPayload: PropTypes.func,
   sentEmailsWarning: PropTypes.node,
+  imageUploadURL: PropTypes.string,
 };
 
 EmailDialog.defaultProps = {
@@ -285,4 +287,5 @@ EmailDialog.defaultProps = {
   validate: undefined,
   title: null,
   getPreviewPayload: null,
+  imageUploadURL: null,
 };


### PR DESCRIPTION
This PR exposes TinyMCE's `imageUploadURL` in the `EmailDialog` component, allowing future (and plugin) support for attaching images to emails.

Alternatively we could expose a general `editorSettings` there but for my use case just the `imageUploadURL` is enough...