### PR TITLE
Fix Re-send email modal when email is too long

### DIFF
--- a/indico/web/client/styles/partials/_forms.scss
+++ b/indico/web/client/styles/partials/_forms.scss
@@ -137,7 +137,9 @@ form {
       padding: 0.5em 0.5em 0 0;
       line-height: $i-form-line-height;
       color: $black;
-      width: 400px;
+      width: 100%;
+      max-height: 300px;
+      overflow-y: auto;
 
       .form-field-description {
         font-style: italic;


### PR DESCRIPTION
I found an issue with the "re-send email" modal. When the email address is too long, the modal overflows and the text goes off-screen.

To fix this, I made some basic changes so the text stays visible. However, I think the modal should probably have a max-height: 100% globally. I couldn't find exactly where the main modal component is defined, so I started with this "bare minimum" fix.

I would appreciate any guidance on how these modals work deeper in the project so I can improve the solution if needed!

<img width="965" height="1039" alt="Screenshot 2026-02-17 at 12 06 58" src="https://github.com/user-attachments/assets/13e663d7-48d3-4368-8d40-1ad6bbf789fa" />


<img width="837" height="893" alt="Screenshot 2026-02-17 at 12 05 54" src="https://github.com/user-attachments/assets/dcfd23a8-4d1a-450d-a676-2a31c232632d" />

