### PR TITLE
Improve logging of emails

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,8 @@ Improvements
   :user:`duartegalvao, unconventionaldotdev`)
 - Log registration tag changes in the event log (:pr:`7446`,
   thanks :user:`moliholy, unconventionaldotdev`)
+- Display embedded images in email log entries (:pr:`7338`, thanks
+  :user:`duartegalvao, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/core/emails.py
+++ b/indico/core/emails.py
@@ -58,7 +58,7 @@ def send_email_task(task, email, log_entry=None):
                            truncate(email['subject'], 100), attempt, MAX_TRIES, delay, exc)
             raise
     else:
-        event_id = log_entry.event_id if log_entry else None
+        event_id = getattr(log_entry, 'event_id', None) if log_entry else None
         if task.request.retries and event_id is not None:
             logger.info('Sent email "%s" for event %d (attempt %d/%d)', truncate(email['subject'], 100), event_id,
                         attempt, MAX_TRIES)

--- a/indico/core/notifications.py
+++ b/indico/core/notifications.py
@@ -127,12 +127,17 @@ def _log_email(email, obj, module, user, meta=None, summary=None):
                     logger.exception('Could not store email attachment')
                     continue
                 stored_attachments[name] = file_id
-            stored.append({
+            stored_item = {
                 'storage_backend': config.EMAIL_LOG_STORAGE,
                 'storage_file_id': file_id,
                 'filename': filename,
                 'content_type': ctype,
-            })
+            }
+            if isinstance(att, MIMEBase):
+                content_id = att.get('Content-ID')
+                if content_id:
+                    stored_item['content_id'] = content_id.strip('<>')
+            stored.append(stored_item)
         if stored:
             log_data['stored_attachments'] = stored
     log_realm = EventLogRealm.emails if isinstance(obj, Event) else AppLogRealm.emails

--- a/indico/core/notifications.py
+++ b/indico/core/notifications.py
@@ -51,7 +51,7 @@ def send_email(email, obj=None, module=None, user=None, log_metadata=None, log_s
 
     :param email: The email object returned by :func:`make_email`
     :param obj: If specified, the email will be saved in that object's log. The
-                object must have a `log()` method and an `id` attribute.
+                object must have a ``log`` method and an ``id`` attribute.
     :param module: The module name to show in the email log
     :param user: The user to show in the email log
     :param log_metadata: A metadata dictionary to be saved in the event's log

--- a/indico/migrations/versions/20260218_1346_461958bf2774_add_emails_realm_to_applogrealm.py
+++ b/indico/migrations/versions/20260218_1346_461958bf2774_add_emails_realm_to_applogrealm.py
@@ -1,0 +1,26 @@
+"""Add emails realm to AppLogRealm
+
+Revision ID: 461958bf2774
+Revises: af9d03d7073c
+Create Date: 2026-02-18 13:46:48.862976
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '461958bf2774'
+down_revision = 'af9d03d7073c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_constraint('ck_logs_valid_enum_realm', 'logs', schema='indico')
+    op.create_check_constraint('valid_enum_realm', 'logs', '(realm = ANY (ARRAY[1, 2, 3]))', schema='indico')
+
+
+def downgrade():
+    op.execute('UPDATE indico.logs SET realm = 2 WHERE realm = 3')
+    op.drop_constraint('ck_logs_valid_enum_realm', 'logs', schema='indico')
+    op.create_check_constraint('valid_enum_realm', 'logs', '(realm = ANY (ARRAY[1, 2]))', schema='indico')

--- a/indico/migrations/versions/20260710_1515_461958bf2774_add_emails_realm_to_applogrealm.py
+++ b/indico/migrations/versions/20260710_1515_461958bf2774_add_emails_realm_to_applogrealm.py
@@ -1,7 +1,7 @@
 """Add emails realm to AppLogRealm
 
 Revision ID: 461958bf2774
-Revises: af9d03d7073c
+Revises: e1e229910f7e
 Create Date: 2026-02-18 13:46:48.862976
 """
 
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '461958bf2774'
-down_revision = 'af9d03d7073c'
+down_revision = 'e1e229910f7e'
 branch_labels = None
 depends_on = None
 

--- a/indico/modules/events/papers/notifications.py
+++ b/indico/modules/events/papers/notifications.py
@@ -22,7 +22,7 @@ def notify_paper_revision_submission(revision):
                 template = get_template_module('events/papers/emails/revision_submission_to_judge.html', event=event,
                                                revision=revision, receiver=judge)
                 email = make_email(to_list=judge.email, template=template, html=True)
-            send_email(email, event=event, module='Papers', user=session.user)
+            send_email(email, obj=event, module='Papers', user=session.user)
     reviewers = set()
     if PaperReviewingRole.layout_reviewer in roles_to_notify:
         if revision.paper.cfp.layout_reviewing_enabled:
@@ -35,7 +35,7 @@ def notify_paper_revision_submission(revision):
             template = get_template_module('events/papers/emails/revision_submission_to_reviewer.html', event=event,
                                            revision=revision, receiver=reviewer)
             email = make_email(to_list=reviewer.email, template=template, html=True)
-        send_email(email, event=event, module='Papers', user=session.user)
+        send_email(email, obj=event, module='Papers', user=session.user)
 
 
 def notify_paper_review_submission(review):
@@ -48,7 +48,7 @@ def notify_paper_review_submission(review):
                                            review=review, contribution=review.revision.paper.contribution,
                                            receiver=judge)
             email = make_email(to_list=judge.email, template=template, html=True)
-        send_email(email, event=event, module='Papers', user=session.user)
+        send_email(email, obj=event, module='Papers', user=session.user)
 
 
 def notify_paper_judgment(paper, reset=False):
@@ -69,14 +69,14 @@ def notify_paper_judgment(paper, reset=False):
             template = get_template_module(template_file, event=event, paper=paper, contribution=paper.contribution,
                                            receiver=receiver)
             email = make_email(to_list=receiver.email, template=template, html=True)
-        send_email(email, event=event, module='Papers', user=session.user)
+        send_email(email, obj=event, module='Papers', user=session.user)
 
 
 def _notify_changes_in_reviewing_team(user, template, event, role):
     with user.force_user_locale():
         template = get_template_module(template, event=event, receiver=user, role=role)
         email = make_email(to_list=user.email, template=template, html=True)
-    send_email(email, event=event, module='Papers', user=session.user)
+    send_email(email, obj=event, module='Papers', user=session.user)
 
 
 def notify_added_to_reviewing_team(user, role, event):
@@ -94,7 +94,7 @@ def notify_paper_assignment(user, role, contributions, event, assign):
         template = get_template_module('events/papers/emails/paper_assignment.html', event=event,
                                        contribs=contributions, receiver=user, assign=assign, role=role)
         email = make_email(to_list=user.email, template=template, html=True)
-    send_email(email, event=event, module='Papers', user=session.user)
+    send_email(email, obj=event, module='Papers', user=session.user)
 
 
 def notify_comment(person, paper, comment, submitter):
@@ -104,4 +104,4 @@ def notify_comment(person, paper, comment, submitter):
         template = get_template_module('events/papers/emails/comment.html', event=event, receiver=receiver_name,
                                        contribution=paper.contribution, comment=comment, submitter=submitter)
         email = make_email(to_list=person.email, template=template, html=True)
-    send_email(email, event=event, module='Papers', user=session.user)
+    send_email(email, obj=event, module='Papers', user=session.user)

--- a/indico/modules/events/registration/notifications.py
+++ b/indico/modules/events/registration/notifications.py
@@ -69,7 +69,7 @@ def _notify_registration(registration, template_name, *, to_managers=False, atta
     signals.core.before_notification_send.send('notify-registration', email=mail, registration=registration,
                                                template_name=template_name, to_managers=to_managers,
                                                attach_rejection_reason=attach_rejection_reason)
-    send_email(mail, event=registration.registration_form.event, module='Registration', user=user,
+    send_email(mail, obj=registration.registration_form.event, module='Registration', user=user,
                log_metadata={'registration_id': registration.id})
 
 

--- a/indico/modules/events/surveys/models/surveys.py
+++ b/indico/modules/events/surveys/models/surveys.py
@@ -304,7 +304,7 @@ class Survey(db.Model):
         with self.event.force_event_locale():
             template_module = get_template_module('events/surveys/emails/start_notification_email.txt', survey=self)
             email = make_email(bcc_list=recipients, template=template_module)
-        send_email(email, event=self.event, module='Surveys')
+        send_email(email, obj=self.event, module='Surveys')
         logger.info('Sending start notification for survey %s', self)
         self.start_notification_sent = True
 
@@ -315,7 +315,7 @@ class Survey(db.Model):
             template_module = get_template_module('events/surveys/emails/new_submission_email.txt',
                                                   submission=submission)
             email = make_email(bcc_list=self.new_submission_emails, template=template_module)
-        send_email(email, event=self.event, module='Surveys')
+        send_email(email, obj=self.event, module='Surveys')
         logger.info('Sending submission notification for survey %s', self)
 
 

--- a/indico/modules/logs/blueprint.py
+++ b/indico/modules/logs/blueprint.py
@@ -7,8 +7,10 @@
 
 from flask import request
 
-from indico.modules.logs.controllers import (RHAppLogs, RHAppLogsJSON, RHCategoryLogs, RHCategoryLogsJSON, RHEventLogs,
-                                             RHEventLogsJSON, RHResendEmail, RHUserLogs, RHUserLogsJSON)
+from indico.modules.logs.controllers import (RHAppEmailAttachment, RHAppLogs, RHAppLogsJSON, RHCategoryEmailAttachment,
+                                             RHCategoryLogs, RHCategoryLogsJSON, RHEventEmailAttachment, RHEventLogs,
+                                             RHEventLogsJSON, RHResendEmail, RHUserEmailAttachment, RHUserLogs,
+                                             RHUserLogsJSON)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
@@ -17,19 +19,27 @@ _bp = IndicoBlueprint('logs', __name__, template_folder='templates', virtual_tem
 # App
 _bp.add_url_rule('/admin/logs/', 'app', RHAppLogs)
 _bp.add_url_rule('/admin/logs/api/logs', 'api_app_logs', RHAppLogsJSON)
+_bp.add_url_rule('/admin/logs/email-attachment/<int:log_entry_id>/<int:attachment_id>', 'app_email_attachment',
+                 RHAppEmailAttachment)
 
 # Categories
 _bp.add_url_rule('/category/<int:category_id>/manage/logs/', 'category', RHCategoryLogs)
 _bp.add_url_rule('/category/<int:category_id>/manage/logs/api/logs', 'api_category_logs', RHCategoryLogsJSON)
+_bp.add_url_rule('/category/<int:category_id>/manage/logs/email-attachment/<int:log_entry_id>/<int:attachment_id>',
+                 'category_email_attachment', RHCategoryEmailAttachment)
 
 # Events
 _bp.add_url_rule('/event/<int:event_id>/manage/logs/', 'event', RHEventLogs)
 _bp.add_url_rule('/event/<int:event_id>/manage/logs/api/logs', 'api_event_logs', RHEventLogsJSON)
+_bp.add_url_rule('/event/<int:event_id>/manage/logs/email-attachment/<int:log_entry_id>/<int:attachment_id>',
+                 'event_email_attachment', RHEventEmailAttachment)
 
 # Users
 with _bp.add_prefixed_rules('/user/<int:user_id>', '/user'):
     _bp.add_url_rule('/logs/', 'user', RHUserLogs)
     _bp.add_url_rule('/logs/api/logs', 'api_user_logs', RHUserLogsJSON)
+    _bp.add_url_rule('/logs/email-attachment/<int:log_entry_id>/<int:attachment_id>', 'user_email_attachment',
+                     RHUserEmailAttachment)
 
 # Actions
 _bp.add_url_rule('/event/<int:event_id>/manage/logs/api/resend-email/<int:log_entry_id>', 'resend_email',

--- a/indico/modules/logs/controllers.py
+++ b/indico/modules/logs/controllers.py
@@ -7,7 +7,8 @@
 
 from babel.dates import get_timezone
 from flask import flash, jsonify, request, session
-from werkzeug.exceptions import BadRequest, Forbidden
+from marshmallow import fields
+from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
 from indico.core.config import config
 from indico.core.db import db
@@ -25,6 +26,7 @@ from indico.modules.logs.views import WPAppLogs, WPCategoryLogs, WPEventLogs, WP
 from indico.modules.users.controllers import RHUserBase
 from indico.util.i18n import _
 from indico.util.string import html_to_markdown
+from indico.web.args import use_kwargs
 from indico.web.flask.util import url_for
 from indico.web.util import jsonify_data, jsonify_template
 
@@ -270,3 +272,68 @@ class RHResendEmail(RHManageEventBase):
             alternatives=alternatives,
             attachments=attachments,
         )
+
+
+class EmailLogAttachmentMixin:
+    model = None
+
+    @property
+    def object(self):
+        raise NotImplementedError
+
+    @use_kwargs({
+        'log_entry_id': fields.Int(required=True),
+        'attachment_id': fields.Int(required=True)
+    }, location='view_args')
+    def _process(self, log_entry_id, attachment_id):
+        query = self.object.log_entries if self.object else self.model.query
+        entry = query.filter_by(id=log_entry_id, type='email').first_or_404()
+
+        stored_attachments = entry.data.get('stored_attachments') or []
+        try:
+            attachment = stored_attachments[attachment_id]
+        except IndexError:
+            raise NotFound
+        storage = get_storage(attachment['storage_backend'])
+        content_type = attachment.get('content_type') or ''
+        if not content_type.startswith('image/'):
+            raise NotFound
+        filename = attachment.get('filename') or 'attachment'
+        return storage.send_file(attachment['storage_file_id'], content_type, filename, inline=True)
+
+
+class RHAppEmailAttachment(EmailLogAttachmentMixin, RHAdminBase):
+    model = AppLogEntry
+
+    @property
+    def object(self):
+        return None
+
+
+class RHCategoryEmailAttachment(EmailLogAttachmentMixin, RHManageCategoryBase):
+    model = CategoryLogEntry
+
+    @property
+    def object(self):
+        return self.category
+
+
+class RHEventEmailAttachment(EmailLogAttachmentMixin, RHManageEventBase):
+    model = EventLogEntry
+
+    @property
+    def object(self):
+        return self.event
+
+
+class RHUserEmailAttachment(EmailLogAttachmentMixin, RHUserBase):
+    model = UserLogEntry
+
+    def _check_access(self):
+        RHUserBase._check_access(self)
+        if not session.user.is_admin:
+            raise Forbidden
+
+    @property
+    def object(self):
+        return self.user

--- a/indico/modules/logs/controllers.py
+++ b/indico/modules/logs/controllers.py
@@ -5,8 +5,11 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from email.mime.image import MIMEImage
+
 from babel.dates import get_timezone
 from flask import flash, jsonify, request, session
+from markupsafe import Markup
 from marshmallow import fields
 from werkzeug.exceptions import BadRequest, Forbidden, NotFound
 
@@ -21,7 +24,7 @@ from indico.modules.events.management.controllers import RHManageEventBase
 from indico.modules.logs.forms import ResendEmailPrefaceForm
 from indico.modules.logs.models.entries import (AppLogEntry, AppLogRealm, CategoryLogEntry, CategoryLogRealm,
                                                 EventLogEntry, EventLogRealm, UserLogEntry, UserLogRealm)
-from indico.modules.logs.util import serialize_log_entry
+from indico.modules.logs.util import replace_cid_links, serialize_log_entry
 from indico.modules.logs.views import WPAppLogs, WPCategoryLogs, WPEventLogs, WPUserLogs
 from indico.modules.users.controllers import RHUserBase
 from indico.util.i18n import _
@@ -230,7 +233,13 @@ class RHResendEmail(RHManageEventBase):
                        log_metadata=self.entry.meta, log_summary=f'Resent email: {original_subject}')
             flash(_('The email has been re-sent.'), 'success')
             return jsonify_data()
-        return jsonify_template('logs/resend_email_dialog.html', form=form, entry=self.entry)
+
+        html_preview_body = None
+        if self.entry.data['content_type'] == 'text/html':
+            html_preview_body = replace_cid_links(self.entry)
+
+        return jsonify_template('logs/resend_email_dialog.html', form=form, entry=self.entry,
+                                html_preview_body=Markup(html_preview_body))
 
     def _build_email(self, form_data, is_html_email):
         email_data = self.entry.data
@@ -258,7 +267,13 @@ class RHResendEmail(RHManageEventBase):
             storage = get_storage(att['storage_backend'])
             with storage.open(att['storage_file_id']) as fd:
                 content = fd.read()
-            attachments.append((att['filename'], content, att['content_type']))
+            if (cid := att.get('content_id')) and att['content_type'].startswith('image/'):
+                subtype = att['content_type'].split('/')[1]
+                mime_att = MIMEImage(content, subtype)
+                mime_att.add_header('Content-ID', f'<{cid}>')
+                attachments.append(mime_att)
+            else:
+                attachments.append((att['filename'], content, att['content_type']))
 
         return make_email(
             to_list=email_data['to'],

--- a/indico/modules/logs/controllers.py
+++ b/indico/modules/logs/controllers.py
@@ -289,16 +289,16 @@ class EmailLogAttachmentMixin:
         query = self.object.log_entries if self.object else self.model.query
         entry = query.filter_by(id=log_entry_id, type='email').first_or_404()
 
-        stored_attachments = entry.data.get('stored_attachments') or []
+        stored_attachments = entry.data.get('stored_attachments', [])
         try:
             attachment = stored_attachments[attachment_id]
         except IndexError:
             raise NotFound
         storage = get_storage(attachment['storage_backend'])
-        content_type = attachment.get('content_type') or ''
+        content_type = attachment['content_type']
         if not content_type.startswith('image/'):
             raise NotFound
-        filename = attachment.get('filename') or 'attachment'
+        filename = attachment['filename']
         return storage.send_file(attachment['storage_file_id'], content_type, filename, inline=True)
 
 

--- a/indico/modules/logs/controllers.py
+++ b/indico/modules/logs/controllers.py
@@ -224,7 +224,7 @@ class RHResendEmail(RHManageEventBase):
         form = ResendEmailPrefaceForm(subject=original_subject, is_html_email=is_html_email)
         if form.validate_on_submit():
             email = self._build_email(form.data, is_html_email)
-            send_email(email, event=self.event, module=self.entry.module, user=self.entry.user,
+            send_email(email, obj=self.event, module=self.entry.module, user=self.entry.user,
                        log_metadata=self.entry.meta, log_summary=f'Resent email: {original_subject}')
             flash(_('The email has been re-sent.'), 'success')
             return jsonify_data()

--- a/indico/modules/logs/models/entries.py
+++ b/indico/modules/logs/models/entries.py
@@ -172,6 +172,10 @@ class LogEntryBase(db.Model):
         renderer = self.renderer
         return renderer.render_entry(self) if renderer else None
 
+    def get_email_attachment_url(self, attachment_id):
+        """Return the URL for a stored email attachment."""
+        raise NotImplementedError
+
     @property
     def object_details(self):
         details_mapping = {
@@ -234,6 +238,10 @@ class EventLogEntry(LogEntryBase):
         )
     )
 
+    def get_email_attachment_url(self, attachment_id):
+        return url_for('logs.event_email_attachment', event_id=self.event_id, log_entry_id=self.id,
+                       attachment_id=attachment_id)
+
     @locator_property
     def locator(self):
         return dict(self.event.locator, log_entry_id=self.id)
@@ -269,6 +277,10 @@ class CategoryLogEntry(LogEntryBase):
         )
     )
 
+    def get_email_attachment_url(self, attachment_id):
+        return url_for('logs.category_email_attachment', category_id=self.category_id, log_entry_id=self.id,
+                       attachment_id=attachment_id)
+
 
 class UserLogEntry(LogEntryBase):
     """Log entries for users."""
@@ -302,6 +314,10 @@ class UserLogEntry(LogEntryBase):
         foreign_keys=[target_user_id]
     )
 
+    def get_email_attachment_url(self, attachment_id):
+        return url_for('logs.user_email_attachment', user_id=self.target_user_id, log_entry_id=self.id,
+                       attachment_id=attachment_id)
+
 
 class AppLogEntry(LogEntryBase):
     """Log entries for the application."""
@@ -321,6 +337,9 @@ class AppLogEntry(LogEntryBase):
                             data=(data or {}), meta=(meta or {}))
         db.session.add(entry)
         return entry
+
+    def get_email_attachment_url(self, attachment_id):
+        return url_for('logs.app_email_attachment', log_entry_id=self.id, attachment_id=attachment_id)
 
     def __repr__(self):
         return format_repr(self, 'id', 'logged_dt', 'realm', 'module', _text=self.summary)

--- a/indico/modules/logs/models/entries.py
+++ b/indico/modules/logs/models/entries.py
@@ -59,9 +59,10 @@ class UserLogRealm(RichIntEnum):
 
 
 class AppLogRealm(RichIntEnum):
-    __titles__ = (None, _('System'), _('Admin'))
+    __titles__ = (None, _('System'), _('Admin'), _('Emails'))
     system = 1
     admin = 2
+    emails = 3
 
 
 class LogKind(IndicoIntEnum):

--- a/indico/modules/logs/models/entries.py
+++ b/indico/modules/logs/models/entries.py
@@ -238,13 +238,12 @@ class EventLogEntry(LogEntryBase):
         )
     )
 
-    def get_email_attachment_url(self, attachment_id):
-        return url_for('logs.event_email_attachment', event_id=self.event_id, log_entry_id=self.id,
-                       attachment_id=attachment_id)
-
     @locator_property
     def locator(self):
         return dict(self.event.locator, log_entry_id=self.id)
+
+    def get_email_attachment_url(self, attachment_id):
+        return url_for('logs.event_email_attachment', self, attachment_id=attachment_id)
 
 
 class CategoryLogEntry(LogEntryBase):
@@ -277,9 +276,12 @@ class CategoryLogEntry(LogEntryBase):
         )
     )
 
+    @locator_property
+    def locator(self):
+        return dict(self.category.locator, log_entry_id=self.id)
+
     def get_email_attachment_url(self, attachment_id):
-        return url_for('logs.category_email_attachment', category_id=self.category_id, log_entry_id=self.id,
-                       attachment_id=attachment_id)
+        return url_for('logs.category_email_attachment', self, attachment_id=attachment_id)
 
 
 class UserLogEntry(LogEntryBase):
@@ -314,9 +316,12 @@ class UserLogEntry(LogEntryBase):
         foreign_keys=[target_user_id]
     )
 
+    @locator_property
+    def locator(self):
+        return dict(self.user.locator, log_entry_id=self.id)
+
     def get_email_attachment_url(self, attachment_id):
-        return url_for('logs.user_email_attachment', user_id=self.target_user_id, log_entry_id=self.id,
-                       attachment_id=attachment_id)
+        return url_for('logs.user_email_attachment', self, attachment_id=attachment_id)
 
 
 class AppLogEntry(LogEntryBase):
@@ -338,8 +343,12 @@ class AppLogEntry(LogEntryBase):
         db.session.add(entry)
         return entry
 
+    @locator_property
+    def locator(self):
+        return {'log_entry_id': self.id}
+
     def get_email_attachment_url(self, attachment_id):
-        return url_for('logs.app_email_attachment', log_entry_id=self.id, attachment_id=attachment_id)
+        return url_for('logs.app_email_attachment', self, attachment_id=attachment_id)
 
     def __repr__(self):
         return format_repr(self, 'id', 'logged_dt', 'realm', 'module', _text=self.summary)

--- a/indico/modules/logs/renderers.py
+++ b/indico/modules/logs/renderers.py
@@ -7,7 +7,7 @@
 
 from flask import render_template
 
-from indico.modules.logs.util import render_changes
+from indico.modules.logs.util import render_changes, replace_cid_links
 
 
 class EventLogRendererBase:
@@ -63,22 +63,7 @@ class EmailRenderer(EventLogRendererBase):
     @classmethod
     def get_data(cls, entry):
         data = dict(entry.data)
-        stored_attachments = data.get('stored_attachments') or []
-        if data['content_type'] != 'text/html' or not stored_attachments:
+        if data['content_type'] != 'text/html' or not data.get('stored_attachments'):
             return data
-
-        replacements = {
-            content_id: entry.get_email_attachment_url(idx)
-            for idx, att in enumerate(stored_attachments)
-            if (content_id := att.get('content_id'))
-        }
-        if not replacements:
-            return data
-
-        body = data['body']
-        for content_id, url in replacements.items():
-            # this is a bit ugly, but cids are generally dynamic enough to avoid replacing
-            # unrelated content, and in any case it would not do any harm, but just look ugly
-            body = body.replace(f'cid:{content_id}', url)
-        data['body'] = body
+        data['body'] = replace_cid_links(entry)
         return data

--- a/indico/modules/logs/renderers.py
+++ b/indico/modules/logs/renderers.py
@@ -64,19 +64,21 @@ class EmailRenderer(EventLogRendererBase):
     def get_data(cls, entry):
         data = dict(entry.data)
         stored_attachments = data.get('stored_attachments') or []
-        if data.get('content_type') != 'text/html' or not stored_attachments:
+        if data['content_type'] != 'text/html' or not stored_attachments:
             return data
 
         replacements = {
-            att.get('content_id'): entry.get_email_attachment_url(idx)
+            content_id: entry.get_email_attachment_url(idx)
             for idx, att in enumerate(stored_attachments)
-            if att.get('content_id')
+            if (content_id := att.get('content_id'))
         }
         if not replacements:
             return data
 
-        body = data.get('body', '')
+        body = data['body']
         for content_id, url in replacements.items():
+            # this is a bit ugly, but cids are generally dynamic enough to avoid replacing
+            # unrelated content, and in any case it would not do any harm, but just look ugly
             body = body.replace(f'cid:{content_id}', url)
         data['body'] = body
         return data

--- a/indico/modules/logs/templates/resend_email_dialog.html
+++ b/indico/modules/logs/templates/resend_email_dialog.html
@@ -23,7 +23,7 @@
 {% call form_row_static(_('Original message')) %}
     {% if entry.data.content_type == 'text/html' %}
         <div class="html email-body-preview">
-            {{ entry.data.body | safe }}
+            {{ html_preview_body }}
         </div>
     {% else %}
         <pre class="mono">{{ entry.data.body }}</pre>

--- a/indico/modules/logs/util.py
+++ b/indico/modules/logs/util.py
@@ -187,3 +187,21 @@ def serialize_log_entry(entry, tzinfo):
         },
         'detailsLink': entry.object_details
     }
+
+
+def replace_cid_links(entry):
+    stored_attachments = entry.data.get('stored_attachments', [])
+    replacements = {
+        content_id: entry.get_email_attachment_url(idx)
+        for idx, att in enumerate(stored_attachments)
+        if (content_id := att.get('content_id'))
+    }
+    if not replacements:
+        return entry.data['body']
+
+    body = entry.data['body']
+    for content_id, url in replacements.items():
+        # this is a bit ugly, but cids are generally dynamic enough to avoid replacing
+        # unrelated content, and in any case it would not do any harm, but just look ugly
+        body = body.replace(f'cid:{content_id}', url)
+    return body

--- a/indico/modules/users/models/affiliations.py
+++ b/indico/modules/users/models/affiliations.py
@@ -110,9 +110,9 @@ class Affiliation(db.Model):
             return existing
         return cls(**affiliation_data)
 
-    def log(self, *args, **kwargs):
+    def log(self, *args, meta=None, **kwargs):
         """Log with prefilled metadata for the affiliation."""
-        return AppLogEntry.log(*args, meta={'affiliation_id': self.id}, **kwargs)
+        return AppLogEntry.log(*args, meta=dict(meta or {}, affiliation_id=self.id), **kwargs)
 
 
 define_unaccented_lowercase_index(Affiliation.searchable_names, Affiliation.__table__,


### PR DESCRIPTION
This PR adds two improvements to the email logging mechanism:
- Allows `send_email` to log emails that are not linked to events, by providing an object `obj` instead.
- Displays embedded image attachments if present.