### PR TITLE
Skip invalid search args quietly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Bugfixes
 ^^^^^^^^
 
 - Show event role dropdown when editing contribution/session ACLs (:pr:`7339`)
+- Fix error when loading category search results with extra query string params
+  from external search plugins (:pr:`7345`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/search/internal.py
+++ b/indico/modules/search/internal.py
@@ -7,7 +7,7 @@
 
 import itertools
 
-from marshmallow import fields
+from marshmallow import EXCLUDE, fields
 from sqlalchemy.orm import contains_eager, joinedload, load_only, raiseload, selectinload, subqueryload, undefer
 from werkzeug.exceptions import BadRequest
 
@@ -56,6 +56,9 @@ def _apply_acl_entry_strategy(rel, principal):
 class _InternalSearchArgs(mm.Schema):
     category_id = fields.Int()
     event_id = fields.Int()
+
+    class Meta:
+        unknown = EXCLUDE
 
 
 def _apply_event_access_strategy(rel):


### PR DESCRIPTION
When using an external search plugin, there can be other query string arguments (e.g. for sorting), but the category search is never forwarded to an external search provider.

The query string is the same for each result type though, so custom args were sent to the internal category search as well, and the schema there failed noisly instead of just silently discarding unexpected params.