### PR TITLE
Let plugins extend InviteDialog

### DIFF
--- a/indico/modules/events/registration/client/js/components/InviteDialog.jsx
+++ b/indico/modules/events/registration/client/js/components/InviteDialog.jsx
@@ -23,6 +23,7 @@ import {FinalCheckbox, FinalInput, handleSubmitError} from 'indico/react/forms';
 import {useFavoriteUsers, useIndicoAxios} from 'indico/react/hooks';
 import {Translate, PluralTranslate, Singular, Plural, Param} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
+import {getPluginObjects} from 'indico/utils/plugins';
 
 import ImportInvitationsField from './ImportInvitationsField';
 
@@ -150,6 +151,7 @@ const getSkippedWarningMessage = skipped =>
     : null;
 
 export default function InviteDialog({eventId, regformId, onClose, onSuccess}) {
+  const pluginModes = useMemo(() => getPluginObjects('invite-dialog-extra-modes'), []);
   const [mode, setMode] = useState('existing');
   const [sentEmailsCount, setSentEmailsCount] = useState(0);
   const [sentEmailsWarning, setSentEmailsWarning] = useState(null);
@@ -161,10 +163,34 @@ export default function InviteDialog({eventId, regformId, onClose, onSuccess}) {
     {camelize: true}
   );
 
+  const allModes = useMemo(
+    () => ({
+      ...modeConfig,
+      ...Object.fromEntries(
+        pluginModes.map(pm => [
+          pm.key,
+          {
+            buttonLabel: pm.buttonLabel,
+            renderFields: props => <pm.Component {...props} />,
+            extraFields: pm.extraFields,
+            getCount: pm.getCount,
+            getPreviewPayload: () => ({context: {}, disabled: true}),
+            getSubmitURL: pm.getSubmitURL ?? null,
+          },
+        ])
+      ),
+    }),
+    [pluginModes]
+  );
+
   const initialFormValues = useMemo(() => {
     if (!metadata) {
       return {};
     }
+    const pluginInitialValues = pluginModes.reduce(
+      (acc, pm) => ({...acc, ...(pm.initialValues ?? {})}),
+      {}
+    );
     return {
       subject: metadata.defaultSubject,
       body: metadata.defaultBody,
@@ -180,8 +206,9 @@ export default function InviteDialog({eventId, regformId, onClose, onSuccess}) {
       email: '',
       affiliation: '',
       imported: [],
+      ...pluginInitialValues,
     };
-  }, [metadata]);
+  }, [metadata, pluginModes]);
 
   const requestConfirmation = useCallback(count => {
     return new Promise(resolve => {
@@ -201,9 +228,10 @@ export default function InviteDialog({eventId, regformId, onClose, onSuccess}) {
 
   const handleSubmit = useCallback(
     async values => {
-      const count = modeConfig[mode].getCount(values);
+      const activeMode = allModes[mode];
+      const count = activeMode.getCount(values);
       if (count === 0) {
-        return {[modeConfig[mode].extraFields[0]]: 'No recipients specified.'};
+        return {[activeMode.extraFields[0]]: 'No recipients specified.'};
       }
       const confirmed = await requestConfirmation(count);
       if (!confirmed) {
@@ -220,15 +248,17 @@ export default function InviteDialog({eventId, regformId, onClose, onSuccess}) {
         'skip_access_check',
         'lock_email',
         ...(metadata?.moderationEnabled ? ['skip_moderation'] : []),
-        ...modeConfig[mode].extraFields,
+        ...activeMode.extraFields,
       ]);
 
-      const submitURL = mode === 'import' ? inviteImportURL : inviteURL;
+      const submitURL =
+        mode === 'import'
+          ? inviteImportURL({event_id: eventId, reg_form_id: regformId})
+          : activeMode.getSubmitURL
+            ? activeMode.getSubmitURL({eventId, regformId})
+            : inviteURL({event_id: eventId, reg_form_id: regformId});
       try {
-        const {data} = await indicoAxios.post(
-          submitURL({event_id: eventId, reg_form_id: regformId}),
-          payload
-        );
+        const {data} = await indicoAxios.post(submitURL, payload);
         onSuccess(data);
         setSentEmailsCount(data.sent);
         setSentEmailsWarning(getSkippedWarningMessage(data.skipped));
@@ -238,6 +268,7 @@ export default function InviteDialog({eventId, regformId, onClose, onSuccess}) {
       setTimeout(() => onClose(), successTimeout);
     },
     [
+      allModes,
       eventId,
       metadata?.moderationEnabled,
       mode,
@@ -257,19 +288,19 @@ export default function InviteDialog({eventId, regformId, onClose, onSuccess}) {
     );
   }
 
-  const ModeFields = modeConfig[mode].renderFields;
+  const ModeFields = allModes[mode]?.renderFields;
 
   const recipientsField = (
     <>
       <Button.Group fluid attached="top">
-        {['existing', 'new', 'import'].map(key => (
+        {Object.entries(allModes).map(([key, config]) => (
           <Button type="button" key={key} primary={mode === key} onClick={() => setMode(key)}>
-            {modeConfig[key].buttonLabel}
+            {config.buttonLabel}
           </Button>
         ))}
       </Button.Group>
       <Segment attached="bottom">
-        <ModeFields eventId={eventId} regformId={regformId} />
+        {ModeFields && <ModeFields eventId={eventId} regformId={regformId} />}
       </Segment>
       {metadata.moderationEnabled && (
         <FinalCheckbox
@@ -305,7 +336,7 @@ export default function InviteDialog({eventId, regformId, onClose, onSuccess}) {
         senders={metadata.senders}
         placeholders={metadata.placeholders}
         previewURL={invitationPreviewURL({event_id: eventId, reg_form_id: regformId})}
-        getPreviewPayload={values => modeConfig[mode].getPreviewPayload(values)}
+        getPreviewPayload={values => allModes[mode].getPreviewPayload(values)}
         recipientsField={recipientsField}
         initialFormValues={initialFormValues}
         title={Translate.string('Invite people')}

--- a/indico/modules/events/registration/schemas.py
+++ b/indico/modules/events/registration/schemas.py
@@ -109,11 +109,16 @@ class RegistrationInvitationSchema(mm.SQLAlchemyAutoSchema):
 
     registration_details_url = fields.Function(
         lambda invitation: (
-            url_for('.registration_details', invitation.registration) if invitation.registration else None
+            url_for('event_registration.registration_details', invitation.registration)
+            if invitation.registration else None
         )
     )
-    decline_url = fields.Function(lambda invitation: url_for('.manager_decline_invitation', invitation))
-    delete_url = fields.Function(lambda invitation: url_for('.delete_invitation', invitation))
+    decline_url = fields.Function(
+        lambda invitation: url_for('event_registration.manager_decline_invitation', invitation)
+    )
+    delete_url = fields.Function(
+        lambda invitation: url_for('event_registration.delete_invitation', invitation)
+    )
 
 
 class CheckinEventSchema(mm.SQLAlchemyAutoSchema):


### PR DESCRIPTION
This PR extends the functionality for the Invitation Dialog to let the plugins add new tabs, data and endpoints to it. 

This means plugins might extend the invitations functionality to add other entities (like groups or affiliations)

It works by registering a plugin object (invite-dialog-extra-modes'). Those extra modes are the tabs to be added to the InviteDialog, and they must implement their own logic.

It also required a change in the schemas.py due to the way the url was being built, adding the core prefixes to the url instead of the plugin ones.

The core functionality remains intact after those changes for core, but allows to extend the dialog for plugins.

Example:
<img width="959" height="800" alt="Screenshot 2026-02-27 at 10 14 07" src="https://github.com/user-attachments/assets/19325ecf-bf6d-4b30-98a0-b7e00ddb72a1" />

