### PR TITLE
Use rust-based markdown rendering

### DIFF
--- a/indico/modules/events/client/js/components/AutoLinkerTestDrive.jsx
+++ b/indico/modules/events/client/js/components/AutoLinkerTestDrive.jsx
@@ -7,10 +7,10 @@
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {Form, Grid, Icon, Segment} from 'semantic-ui-react';
+import {Form, Grid, Icon, Loader, Segment} from 'semantic-ui-react';
 
+import {useRustyMarkdown} from 'indico/react/hooks';
 import {Translate} from 'indico/react/i18n';
-import {AutoLinkerPlugin, Markdown} from 'indico/react/util';
 
 import {rulePropTypes} from './propTypes';
 
@@ -18,11 +18,16 @@ import {rulePropTypes} from './propTypes';
  * A "test drive" widget which just takes Markdown and renders it using the auto-linker rules which are provided
  */
 export default function AutoLinkerTestDrive({rules}) {
+  const md = useRustyMarkdown();
   const [source, setSource] = useState('');
 
   const onChange = value => {
     setSource(value);
   };
+
+  if (!md) {
+    return <Loader />;
+  }
 
   return (
     <Segment>
@@ -46,11 +51,11 @@ export default function AutoLinkerTestDrive({rules}) {
           </Grid.Column>
           <Grid.Column>
             {source ? (
-              <Segment>
-                <Markdown targetBlank remarkPlugins={[[AutoLinkerPlugin, {rules}]]}>
-                  {source}
-                </Markdown>
-              </Segment>
+              <Segment
+                dangerouslySetInnerHTML={{
+                  __html: md(source, {nl2br: true, autolinkRules: rules}),
+                }}
+              />
             ) : null}
           </Grid.Column>
         </Grid>

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -12,7 +12,7 @@ import {useSelector} from 'react-redux';
 import {Form, Icon, Popup} from 'semantic-ui-react';
 
 import {PluralTranslate, Translate} from 'indico/react/i18n';
-import {Markdown, toClasses} from 'indico/react/util';
+import {RustyMarkdown, toClasses} from 'indico/react/util';
 import {renderPluginComponents} from 'indico/utils/plugins';
 
 import {
@@ -236,11 +236,7 @@ export default function FormItem({
         ) : (
           `Unknown input type: ${inputType}`
         )}
-        {description && (
-          <div styleName="description">
-            <Markdown targetBlank>{description}</Markdown>
-          </div>
-        )}
+        {description && <RustyMarkdown styleName="description" source={description} />}
         {renderPluginComponents(`regform-${inputType}-field-item`, {htmlName, ...inputProps})}
       </div>
       <div styleName="actions">

--- a/indico/modules/events/registration/client/js/form/FormSection.jsx
+++ b/indico/modules/events/registration/client/js/form/FormSection.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 import {Form, Popup} from 'semantic-ui-react';
 
 import {Translate} from 'indico/react/i18n';
-import {Markdown} from 'indico/react/util';
+import {RustyMarkdown} from 'indico/react/util';
 
 import FormItem from './FormItem';
 
@@ -47,7 +47,7 @@ export default function FormSection({
             {title}
           </h4>
           <div className="i-box-description">
-            <Markdown targetBlank>{description}</Markdown>
+            <RustyMarkdown source={description} />
           </div>
         </div>
         {setupActions && (

--- a/indico/modules/rb/client/js/common/rooms/RoomDetailsModal.jsx
+++ b/indico/modules/rb/client/js/common/rooms/RoomDetailsModal.jsx
@@ -17,7 +17,7 @@ import {bindActionCreators} from 'redux';
 import {Button, Grid, Icon, Modal, Header, Message, List, Segment, Popup} from 'semantic-ui-react';
 
 import {Translate, Param} from 'indico/react/i18n';
-import {IndicoPropTypes, Markdown, Responsive, useResponsive} from 'indico/react/util';
+import {IndicoPropTypes, Responsive, RustyMarkdown, useResponsive} from 'indico/react/util';
 import {getWeekday, serializeDate} from 'indico/utils/date';
 
 import * as globalActions from '../../actions';
@@ -340,7 +340,7 @@ function RoomCommentsBox({room}) {
       <Message styleName="message-icon" icon info>
         <Icon name="info" />
         <Message.Content>
-          <Markdown targetBlank>{room.comments}</Markdown>
+          <RustyMarkdown source={room.comments} />
         </Message.Content>
       </Message>
     )

--- a/indico/modules/rb/client/js/components/Room.jsx
+++ b/indico/modules/rb/client/js/components/Room.jsx
@@ -15,7 +15,7 @@ import {Card, Icon, Label, Loader, Popup, Button} from 'semantic-ui-react';
 
 import {TooltipIfTruncated, ResponsivePopup} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
-import {Markdown, Slot} from 'indico/react/util';
+import {Slot, RustyMarkdown} from 'indico/react/util';
 
 import {actions as userActions, selectors as userSelectors} from '../common/user';
 
@@ -173,11 +173,7 @@ class Room extends React.Component {
           <Card.Description styleName="room-description">
             {room.comments && (
               <TooltipIfTruncated>
-                <div styleName="room-comments">
-                  <Markdown allowedElements={['br']} unwrapDisallowed>
-                    {room.comments}
-                  </Markdown>
-                </div>
+                <RustyMarkdown styleName="room-comments" source={room.comments} unstyled />
               </TooltipIfTruncated>
             )}
           </Card.Description>

--- a/indico/modules/rb/client/js/components/RoomKeyLocation.jsx
+++ b/indico/modules/rb/client/js/components/RoomKeyLocation.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Icon, Message} from 'semantic-ui-react';
 
-import {Markdown} from 'indico/react/util';
+import {RustyMarkdown} from 'indico/react/util';
 
 import './RoomKeyLocation.module.scss';
 
@@ -19,7 +19,7 @@ export default function RoomKeyLocation({room}) {
       <Message styleName="message-icon" icon>
         <Icon name="key" />
         <Message.Content>
-          <Markdown targetBlank>{room.keyLocation}</Markdown>
+          <RustyMarkdown source={room.keyLocation} />
         </Message.Content>
       </Message>
     )

--- a/indico/web/client/js/react/components/MarkdownEditor.jsx
+++ b/indico/web/client/js/react/components/MarkdownEditor.jsx
@@ -13,8 +13,7 @@ import MdEditor from 'react-markdown-editor-lite';
 import {Loader} from 'semantic-ui-react';
 
 import {formatters, FinalField} from 'indico/react/forms';
-import {useIndicoAxios} from 'indico/react/hooks';
-import {AutoLinkerPlugin, Markdown} from 'indico/react/util';
+import {useIndicoAxios, useRustyMarkdown} from 'indico/react/hooks';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 import './MarkdownEditor.module.scss';
@@ -43,6 +42,8 @@ export default function MarkdownEditor({height, imageUploadURL, ...rest}) {
     camelize: true,
   });
 
+  const md = useRustyMarkdown();
+
   const onImageUpload = async file => {
     const bodyFormData = new FormData();
     bodyFormData.append('upload', file);
@@ -62,17 +63,13 @@ export default function MarkdownEditor({height, imageUploadURL, ...rest}) {
     }
   };
 
-  return isLoadingRules ? (
+  return isLoadingRules || !md ? (
     <Loader />
   ) : (
     <div styleName="markdown-editor" onDragOver={handleDragOver}>
       <MdEditor
         htmlClass="editor-output"
-        renderHTML={text => (
-          <Markdown targetBlank remarkPlugins={[[AutoLinkerPlugin, {rules: data.rules}]]}>
-            {text.replace(/\n/gi, '  \n')}
-          </Markdown>
-        )}
+        renderHTML={text => md(text, {autolinkRules: data.rules, nl2br: true})}
         canView={{menu: true, md: true, html: false, fullScreen: false, hideMenu: false}}
         plugins={plugins.filter(p => imageUploadURL || p !== 'image')}
         style={{height}}

--- a/indico/web/client/js/react/hooks/hooks.js
+++ b/indico/web/client/js/react/hooks/hooks.js
@@ -9,6 +9,7 @@ import principalsURL from 'indico-url:core.principals';
 import favoriteUsersURL from 'indico-url:users.favorites_api';
 
 import {makeUseAxios} from 'axios-hooks';
+import initRustyMarkdown, {toHtml} from 'indico-md-wasm';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
@@ -365,4 +366,20 @@ export function useNativeEvent(ref, eventType, callback, options = {}) {
     node.addEventListener(eventType, callback, options);
     return () => node.removeEventListener(eventType, callback);
   }, [ref, eventType, callback, options]);
+}
+
+/**
+ * A hook that provides access to the Rust-based markdown renderer
+ */
+export function useRustyMarkdown() {
+  const [ready, setReady] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      await initRustyMarkdown();
+      setReady(true);
+    })();
+  }, []);
+
+  return ready ? toHtml : null;
 }

--- a/indico/web/client/js/react/util/Markdown.jsx
+++ b/indico/web/client/js/react/util/Markdown.jsx
@@ -6,8 +6,10 @@
 // LICENSE file for more details.
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {forwardRef} from 'react';
 import ReactMarkdown from 'react-markdown';
+
+import {useRustyMarkdown} from 'indico/react/hooks';
 
 // eslint-disable-next-line react/prop-types
 const ExternalLink = ({href, children}) => (
@@ -42,3 +44,21 @@ Markdown.defaultProps = {
 };
 
 export default Markdown;
+
+// eslint-disable-next-line prefer-arrow-callback
+export const RustyMarkdown = forwardRef(function RustyMarkdown(
+  {source, unstyled = false, ...rest},
+  ref
+) {
+  const md = useRustyMarkdown();
+  if (!md) {
+    return null;
+  }
+  const html = md(source, {unstyled});
+  return <div ref={ref} dangerouslySetInnerHTML={{__html: html}} {...rest} />;
+});
+
+RustyMarkdown.propTypes = {
+  source: PropTypes.string.isRequired,
+  unstyled: PropTypes.bool,
+};

--- a/indico/web/client/js/react/util/index.js
+++ b/indico/web/client/js/react/util/index.js
@@ -9,7 +9,7 @@ export {default as Preloader} from './Preloader';
 export {default as Slot} from './Slot';
 export {toClasses, injectModal} from './html';
 export {default as IndicoPropTypes} from './propTypes';
-export {default as Markdown} from './Markdown';
+export {default as Markdown, RustyMarkdown} from './Markdown';
 export {default as ConditionalRoute} from './ConditionalRoute';
 export {default as Responsive, useResponsive} from './Responsive';
 export {default as AutoLinkerPlugin} from './autolinker';

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "geodesy": "^2.4.0",
         "glob-to-regexp": "^0.4.1",
         "history": "^4.10.1",
+        "indico-md-wasm": "file:../../indico-md-rs/indico-md-wasm/pkg/indico-md-wasm-0.1.0.tgz",
         "indico-sui-theme": "^0.0.7",
         "jed": "^1.1.1",
         "jquery": "^3.6.0",
@@ -9986,6 +9987,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/indico-md-wasm": {
+      "version": "0.1.0",
+      "resolved": "file:../../indico-md-rs/indico-md-wasm/pkg/indico-md-wasm-0.1.0.tgz",
+      "integrity": "sha512-S3sws113yBLk/wN9ukHJZJVB7EI3PkTQUZBilHXnd4SSqb/eMI6WhWu1HaHXSqA8RxzwarJvMiD5hyaNQd3h0w=="
     },
     "node_modules/indico-sui-theme": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "geodesy": "^2.4.0",
     "glob-to-regexp": "^0.4.1",
     "history": "^4.10.1",
+    "indico-md-wasm": "file:../../indico-md-rs/indico-md-wasm/pkg/indico-md-wasm-0.1.0.tgz",
     "indico-sui-theme": "^0.0.7",
     "jed": "^1.1.1",
     "jquery": "^3.6.0",


### PR DESCRIPTION
This is heavily WIP (because [indico-md-rs](https://github.com/pferreir/indico-md-rs) is WIP as well), some TODOs (which are not necessarily TODOs on the Indico side, but can also be TODOs in indico-md-rs):

- [ ] Use in server-side rendering
- [ ] Remove old `Markdown` component (and update our plugins using it to use `RustyMarkdown` instead)
- [ ] Handle HTML sanitization for client-side rendering (`<img onerror="alert('hi')">` etc shouldn't be rendered - in the minutes editor this is currently *only* caught by the CSP!)
  - [ ] Consider using [`ammonia`](https://crates.io/crates/ammonia) in the wasm version to apply the same or similar sanitization as we have in Indico? (check for differences, especially when it comes to people writing math formulas containing `<` and `>`)
  - [ ] Disallow inline HTML altogether?
- [ ] Publish indico-md-rs packages on PyPI + NPM and install from there instead of locally