### PR TITLE
Fix LaTeX regexps

### DIFF
--- a/indico/util/mdx_latex.py
+++ b/indico/util/mdx_latex.py
@@ -164,6 +164,7 @@ def latex_escape(text, ignore_math=True, ignore_braces=False):
         '&': r'\&',
         '~': r'\~{}',
         '_': r'\_',
+        '^^5c': r'\textbackslash{}',
         '^': r'\^{}',
         '\\': r'\textbackslash{}',
         '\x0c': '',
@@ -188,7 +189,7 @@ def latex_escape(text, ignore_math=True, ignore_braces=False):
 
     if ignore_math:
         # Extract math-mode segments and replace with placeholder
-        text = re.sub(r'\$[^\$]+\$|\$\$(^\$)\$\$', math_replace, text)
+        text = re.sub(r'\$[^\$]+\$|\$\$[^\$]+\$\$', math_replace, text)
 
     pattern = re.compile('|'.join(re.escape(k) for k in chars))
     res = pattern.sub(substitute, text)
@@ -206,7 +207,7 @@ def sanitize_mathmode(text):
         command = m.group(1)
         return m.group(0) if command in safe_mathmode_commands else r'\\' + command
 
-    return re.sub(r'\\([a-zA-Z]+|\\)', _escape_unsafe_command, text)
+    return re.sub(r'(?:\\|\^\^5c)([a-zA-Z]+|(?:\\|\^\^5c))', _escape_unsafe_command, text)
 
 
 def escape_latex_entities(text):

--- a/indico/util/mdx_latex_test.py
+++ b/indico/util/mdx_latex_test.py
@@ -15,6 +15,7 @@ from indico.util.mdx_latex import LaTeXExtension, latex_escape
 
 def test_escape():
     assert latex_escape(r'\naughty') == r'\textbackslash{}naughty'
+    assert latex_escape(r'^^5cnaughty') == r'\textbackslash{}naughty'
     assert (latex_escape(r'this\\is\\harmless') ==
             r'this\textbackslash{}\textbackslash{}is\textbackslash{}\textbackslash{}harmless')
     assert latex_escape(r'\\\extranaughty') == r'\textbackslash{}\textbackslash{}\textbackslash{}extranaughty'
@@ -22,6 +23,7 @@ def test_escape():
 
 def test_escape_math():
     assert latex_escape(r'$\naughty$') == r'\protect $\\naughty$'
+    assert latex_escape(r'$^^5cnaughty$') == r'\protect $\\naughty$'
     assert latex_escape(r'$\\naughty$') == r'\protect $\\naughty$'
     assert latex_escape(r'$harm\\less$') == r'\protect $harm\\less$'
     assert latex_escape(r'$\\\extranaughty$') == r'\protect $\\\\extranaughty$'


### PR DESCRIPTION
- match weird escape syntax
- correctly match `$$...$$` when extracting math fragments