### PR TITLE
Add code to affiliations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Improvements
   delete registrations) without access to the registration form configuration
   (:pr:`7419`, thanks :user:`moliholy, unconventionaldotdev`)
 - Add internal name for registration form fields (:pr:`7276`, thanks :user:`tomako`)
-- Add a "Code" column to predefined affiliations (:pr:`7400`, thanks
+- Add a "Code" (short name) to predefined affiliations (:pr:`7400`, thanks
   :user:`duartegalvao, unconventionaldotdev`)
 
 Bugfixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Improvements
   delete registrations) without access to the registration form configuration
   (:pr:`7419`, thanks :user:`moliholy, unconventionaldotdev`)
 - Add internal name for registration form fields (:pr:`7276`, thanks :user:`tomako`)
+- Add a "Code" column to predefined affiliations (:pr:`7400`, thanks
+  :user:`duartegalvao, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20260323_1728_e5a08c20f2bc_add_code_to_affiliations.py
+++ b/indico/migrations/versions/20260323_1728_e5a08c20f2bc_add_code_to_affiliations.py
@@ -1,0 +1,25 @@
+"""Add code to affiliations
+
+Revision ID: e5a08c20f2bc
+Revises: af9d03d7073c
+Create Date: 2026-03-23 17:28:10.101572
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'e5a08c20f2bc'
+down_revision = 'af9d03d7073c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('affiliations', sa.Column('code', sa.String(), nullable=False, server_default=''), schema='indico')
+    op.alter_column('affiliations', 'code', server_default=None, schema='indico')
+
+
+def downgrade():
+    op.drop_column('affiliations', 'code', schema='indico')

--- a/indico/migrations/versions/20260323_1728_e5a08c20f2bc_add_code_to_affiliations.py
+++ b/indico/migrations/versions/20260323_1728_e5a08c20f2bc_add_code_to_affiliations.py
@@ -1,7 +1,7 @@
 """Add code to affiliations
 
 Revision ID: e5a08c20f2bc
-Revises: af9d03d7073c
+Revises: 577e564cf0ae
 Create Date: 2026-03-23 17:28:10.101572
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'e5a08c20f2bc'
-down_revision = 'af9d03d7073c'
+down_revision = '577e564cf0ae'
 branch_labels = None
 depends_on = None
 

--- a/indico/migrations/versions/20260323_1728_e5a08c20f2bc_add_code_to_affiliations.py
+++ b/indico/migrations/versions/20260323_1728_e5a08c20f2bc_add_code_to_affiliations.py
@@ -24,12 +24,12 @@ def upgrade():
     op.execute('''
         CREATE INDEX ix_affiliations_searchable_names_unaccent
         ON indico.affiliations
-        USING gin (indico.indico_unaccent(lower(indico.text_array_to_string(((ARRAY[''::text] || (alt_names)::text[]) || (ARRAY[name, code, ''::character varying])::text[]), '|||'::text))) gin_trgm_ops);
+        USING gin (indico.indico_unaccent(lower(indico.text_array_to_string(((ARRAY[''::text] || indico.text_array_append(indico.text_array_append((alt_names)::text[], (name)::text), (code)::text)) || ARRAY[''::text]), '|||'::text))) gin_trgm_ops);
     ''')
     op.execute('''
         CREATE INDEX ix_affiliations_searchable_names_fts
         ON indico.affiliations
-        USING gin (to_tsvector('simple'::regconfig, indico.text_array_to_string(((ARRAY[''::text] || (alt_names)::text[]) || (ARRAY[name, code, ''::character varying])::text[]), '|||'::text)));
+        USING gin (to_tsvector('simple'::regconfig, indico.text_array_to_string(((ARRAY[''::text] || indico.text_array_append(indico.text_array_append((alt_names)::text[], (name)::text), (code)::text)) || ARRAY[''::text]), '|||'::text)));
     ''')
 
 

--- a/indico/migrations/versions/20260323_1728_e5a08c20f2bc_add_code_to_affiliations.py
+++ b/indico/migrations/versions/20260323_1728_e5a08c20f2bc_add_code_to_affiliations.py
@@ -19,7 +19,31 @@ depends_on = None
 def upgrade():
     op.add_column('affiliations', sa.Column('code', sa.String(), nullable=False, server_default=''), schema='indico')
     op.alter_column('affiliations', 'code', server_default=None, schema='indico')
+    op.drop_index('ix_affiliations_searchable_names_unaccent', table_name='affiliations', schema='indico')
+    op.drop_index('ix_affiliations_searchable_names_fts', table_name='affiliations', schema='indico')
+    op.execute('''
+        CREATE INDEX ix_affiliations_searchable_names_unaccent
+        ON indico.affiliations
+        USING gin (indico.indico_unaccent(lower(indico.text_array_to_string(((ARRAY[''::text] || (alt_names)::text[]) || (ARRAY[name, code, ''::character varying])::text[]), '|||'::text))) gin_trgm_ops);
+    ''')
+    op.execute('''
+        CREATE INDEX ix_affiliations_searchable_names_fts
+        ON indico.affiliations
+        USING gin (to_tsvector('simple'::regconfig, indico.text_array_to_string(((ARRAY[''::text] || (alt_names)::text[]) || (ARRAY[name, code, ''::character varying])::text[]), '|||'::text)));
+    ''')
 
 
 def downgrade():
+    op.drop_index('ix_affiliations_searchable_names_unaccent', table_name='affiliations', schema='indico')
+    op.drop_index('ix_affiliations_searchable_names_fts', table_name='affiliations', schema='indico')
     op.drop_column('affiliations', 'code', schema='indico')
+    op.execute('''
+        CREATE INDEX ix_affiliations_searchable_names_unaccent
+        ON indico.affiliations
+        USING gin (indico.indico_unaccent(lower(indico.text_array_to_string(((ARRAY[''::text] || indico.text_array_append((alt_names)::text[], (name)::text)) || ARRAY[''::text]), '|||'::text))) gin_trgm_ops);
+    ''')
+    op.execute('''
+        CREATE INDEX ix_affiliations_searchable_names_fts
+        ON indico.affiliations
+        USING gin (to_tsvector('simple'::regconfig, indico.text_array_to_string(((ARRAY[''::text] || indico.text_array_append((alt_names)::text[], (name)::text)) || ARRAY[''::text]), '|||'::text)));
+    ''')

--- a/indico/modules/events/abstracts/templates/management/_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/_abstract_list.html
@@ -147,7 +147,7 @@
                                         <td class="i-table" data-searchable="{{ abstract.submitter.display_full_name }}">
                                             {{- abstract.submitter.display_full_name }}
                                             {% if abstract.submitter.affiliation %}
-                                                <span class="text-superfluous">({{ render_affiliation(abstract.submitter) }})</span>
+                                                <span class="text-superfluous">({{ render_affiliation(abstract.submitter, compact=true) }})</span>
                                             {% endif %}
                                         </td>
                                     {% elif item.id == 'speakers' %}
@@ -157,7 +157,7 @@
                                                 <div class="person-row icon-user">
                                                     {{- speaker.display_full_name }}
                                                     {% if speaker.affiliation %}
-                                                        <span class="text-superfluous">({{ render_affiliation(speaker) }})</span>
+                                                        <span class="text-superfluous">({{ render_affiliation(speaker, compact=true) }})</span>
                                                     {% endif %}
                                                 </div>
                                             {%- endfor %}
@@ -169,7 +169,7 @@
                                                 <div class="person-row icon-user">
                                                     {{- author.display_full_name }}
                                                     {% if author.affiliation %}
-                                                        <span class="text-superfluous">({{ render_affiliation(author) }})</span>
+                                                        <span class="text-superfluous">({{ render_affiliation(author, compact=true) }})</span>
                                                     {% endif %}
                                                 </div>
                                             {%- endfor %}
@@ -181,7 +181,7 @@
                                                 <div class="person-row icon-user">
                                                     {{- author.display_full_name }}
                                                     {% if author.affiliation %}
-                                                        <span class="text-superfluous">({{ render_affiliation(author) }})</span>
+                                                        <span class="text-superfluous">({{ render_affiliation(author, compact=true) }})</span>
                                                     {% endif %}
                                                 </div>
                                             {%- endfor %}

--- a/indico/modules/events/contributions/templates/management/_contribution_list.html
+++ b/indico/modules/events/contributions/templates/management/_contribution_list.html
@@ -135,7 +135,7 @@
                                                    title="{{ tooltip }}" data-qtip-position="bottom"></i>
                                                 {{ speaker.display_full_name }}
                                                 {% if speaker.affiliation %}
-                                                    <span class="text-superfluous">({{ render_affiliation(speaker) }})</span>
+                                                    <span class="text-superfluous">({{ render_affiliation(speaker, compact=true) }})</span>
                                                 {% endif %}
                                             </div>
                                         {%- endfor %}

--- a/indico/modules/events/persons/templates/management/_person_list_row.html
+++ b/indico/modules/events/persons/templates/management/_person_list_row.html
@@ -46,7 +46,7 @@
         {{ person.email }}
     </td>
     <td class="i-table affiliation-column">
-        {{ render_affiliation(person) }}
+        {{ render_affiliation(person, compact=true) }}
     </td>
     <td class="i-table roles-column">
         {% for role, role_data in person_data.roles.items() %}

--- a/indico/modules/events/templates/_affiliation.html
+++ b/indico/modules/events/templates/_affiliation.html
@@ -1,14 +1,21 @@
-{%- macro render_affiliation(person) -%}
+{%- macro render_affiliation(person, compact=false) -%}
     {% set affiliation = template_hook('custom-affiliation', person=person) %}
     {%- if affiliation -%}
         {{ affiliation }}
     {%- else -%}
         {% set details = person.affiliation_details %}
         {%- if details -%}
+            {%- if compact -%}
+                {%- set display_name = details.code or details.name -%}
+            {%- elif details.code -%}
+                {%- set display_name = details.name ~ ' - ' ~ details.code -%}
+            {%- else -%}
+                {%- set display_name = details.name -%}
+            {%- endif -%}
             {%- set uuid = uuid() -%}
             <span class="js-popup-container" id="affiliation-popup-container-{{ uuid }}">{#--#}
                 <span id="affiliation-popup-{{ uuid }}"></span>{#--#}
-                <span>{{ details.name }}</span>{#--#}
+                <span>{{ display_name }}</span>{#--#}
             </span>{#--#}
             <script>
                 setupAffiliationPopup({{ uuid|tojson }}, {{ details|tojson }});

--- a/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
+++ b/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
@@ -32,6 +32,7 @@ const isoToFlag = (country: string) =>
 
 const defaultValues: AffiliationFormValues = {
   name: '',
+  code: '',
   alt_names: [],
   street: '',
   postcode: '',
@@ -170,6 +171,11 @@ export default function AffiliationFormDialog({
       disabledUntilChange
     >
       <FinalInput name="name" label={Translate.string('Name')} required autoFocus />
+      <FinalInput
+        name="code"
+        label={Translate.string('Code')}
+        placeholder={Translate.string('Enter a short identifier for the affiliation')}
+      />
       <FinalStringListField
         name="alt_names"
         label={Translate.string('Alternative names')}

--- a/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
+++ b/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
@@ -171,16 +171,18 @@ export default function AffiliationFormDialog({
       disabledUntilChange
     >
       <FinalInput name="name" label={Translate.string('Name')} required autoFocus />
-      <FinalInput
-        name="code"
-        label={Translate.string('Code')}
-        placeholder={Translate.string('Enter a short identifier for the affiliation')}
-      />
-      <FinalStringListField
-        name="alt_names"
-        label={Translate.string('Alternative names')}
-        placeholder={Translate.string('Type a name and press Enter to add')}
-      />
+      <Form.Group widths="equal">
+        <FinalInput
+          name="code"
+          label={Translate.string('Short name')}
+          placeholder={Translate.string('Enter a short identifier for the affiliation')}
+        />
+        <FinalStringListField
+          name="alt_names"
+          label={Translate.string('Alternative names')}
+          placeholder={Translate.string('Type a name and press Enter to add')}
+        />
+      </Form.Group>
       <Accordion
         exclusive={false}
         panels={formSections}

--- a/indico/modules/users/client/js/affiliations/AffiliationListFilter.tsx
+++ b/indico/modules/users/client/js/affiliations/AffiliationListFilter.tsx
@@ -83,6 +83,7 @@ export default function AffiliationListFilter({
         });
         const searchableFields = [
           affiliation.name,
+          affiliation.code,
           ...affiliation.alt_names,
           affiliation.street,
           affiliation.postcode,

--- a/indico/modules/users/client/js/affiliations/types.ts
+++ b/indico/modules/users/client/js/affiliations/types.ts
@@ -7,6 +7,7 @@
 
 interface AffiliationBase {
   name: string;
+  code: string;
   alt_names: string[];
   street: string;
   postcode: string;

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -327,7 +327,7 @@ class RHSearchAffiliations(RH):
     @use_kwargs({'q': fields.String(load_default='')}, location='query')
     def _process(self, q):
         res = search_affiliations(q)
-        basic_fields = ('id', 'name', 'street', 'postcode', 'city', 'country_code', 'meta')
+        basic_fields = ('id', 'name', 'code', 'street', 'postcode', 'city', 'country_code', 'meta')
         return AffiliationSchema(many=True, only=basic_fields).jsonify(res)
 
 

--- a/indico/modules/users/models/affiliations.py
+++ b/indico/modules/users/models/affiliations.py
@@ -31,6 +31,11 @@ class Affiliation(db.Model):
         nullable=False,
         index=True
     )
+    code = db.Column(
+        db.String,
+        nullable=False,
+        default='',
+    )
     alt_names = db.Column(
         ARRAY(db.String),
         nullable=False,
@@ -72,9 +77,7 @@ class Affiliation(db.Model):
     #: against it lets you do a substring search, and searching for ``|||foo|||`` lets you do an
     #: exact match.
     searchable_names = column_property(
-        db.func.indico.text_array_to_string(array(['']) +
-                                            db.func.indico.text_array_append(alt_names, name) +
-                                            array(['']), '|||'),
+        db.func.indico.text_array_to_string(array(['']) + alt_names + array([name, code, '']), '|||'),
         deferred=True,
     )
 

--- a/indico/modules/users/models/affiliations.py
+++ b/indico/modules/users/models/affiliations.py
@@ -77,7 +77,12 @@ class Affiliation(db.Model):
     #: against it lets you do a substring search, and searching for ``|||foo|||`` lets you do an
     #: exact match.
     searchable_names = column_property(
-        db.func.indico.text_array_to_string(array(['']) + alt_names + array([name, code, '']), '|||'),
+        db.func.indico.text_array_to_string(
+            array(['']) +
+            db.func.indico.text_array_append(db.func.indico.text_array_append(alt_names, name), code) +
+            array(['']),
+            '|||'
+        ),
         deferred=True,
     )
 

--- a/indico/modules/users/schemas.py
+++ b/indico/modules/users/schemas.py
@@ -21,7 +21,7 @@ from indico.util.marshmallow import ModelField, NoneValueEnumField, not_empty
 class AffiliationSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Affiliation
-        fields = ('id', 'name', 'alt_names', 'street', 'postcode', 'city', 'country_code', 'meta')
+        fields = ('id', 'name', 'code', 'alt_names', 'street', 'postcode', 'city', 'country_code', 'meta')
 
     @post_dump
     def add_country_name(self, data, **kwargs):
@@ -36,14 +36,15 @@ class BasicAffiliationSchema(AffiliationSchema):
     """
 
     class Meta(AffiliationSchema.Meta):
-        fields = ('id', 'name', 'street', 'postcode', 'city', 'country_code')
+        fields = ('id', 'name', 'code', 'street', 'postcode', 'city', 'country_code')
 
 
 class AffiliationArgs(AffiliationSchema):
     class Meta(AffiliationSchema.Meta):
-        fields = ('name', 'alt_names', 'street', 'postcode', 'city', 'country_code', 'meta')
+        fields = ('name', 'code', 'alt_names', 'street', 'postcode', 'city', 'country_code', 'meta')
 
     name = fields.String(required=True, validate=[not_empty])
+    code = fields.String(load_default='')
     alt_names = fields.List(fields.String(validate=not_empty))
     meta = fields.Dict(keys=fields.Str())
 

--- a/indico/modules/users/tests/personal_data_export_schema.yml
+++ b/indico/modules/users/tests/personal_data_export_schema.yml
@@ -1,6 +1,7 @@
 affiliation: CERN
 affiliation_link:
   city: ''
+  code: ''
   country_code: ''
   country_name: ''
   id: <id>

--- a/indico/modules/users/tests/user_data_export_schema_with_files.yml
+++ b/indico/modules/users/tests/user_data_export_schema_with_files.yml
@@ -122,6 +122,7 @@ personal_data:
   affiliation: CERN
   affiliation_link:
     city: ''
+    code: ''
     country_code: ''
     country_name: ''
     id: <id>

--- a/indico/modules/users/tests/user_data_export_schema_without_files.yml
+++ b/indico/modules/users/tests/user_data_export_schema_without_files.yml
@@ -119,6 +119,7 @@ personal_data:
   affiliation: CERN
   affiliation_link:
     city: ''
+    code: ''
     country_code: ''
     country_name: ''
     id: <id>

--- a/indico/web/client/js/react/components/AffiliationPopup.jsx
+++ b/indico/web/client/js/react/components/AffiliationPopup.jsx
@@ -19,7 +19,9 @@ function AffiliationPopup({affiliation, context, container}) {
 
   return (
     <Popup context={context} open={open}>
-      <Popup.Header>{affiliation.name}</Popup.Header>
+      <Popup.Header>
+        {affiliation.code ? `${affiliation.name} (${affiliation.code})` : affiliation.name}
+      </Popup.Header>
       <Popup.Content>
         <div>{affiliation.street}</div>
         <div>
@@ -34,6 +36,7 @@ function AffiliationPopup({affiliation, context, container}) {
 AffiliationPopup.propTypes = {
   affiliation: PropTypes.shape({
     name: PropTypes.string.isRequired,
+    code: PropTypes.string,
     street: PropTypes.string,
     postcode: PropTypes.string,
     city: PropTypes.string,

--- a/indico/web/client/js/react/components/PersonDetailsModal.jsx
+++ b/indico/web/client/js/react/components/PersonDetailsModal.jsx
@@ -43,6 +43,8 @@ const FinalAffiliationField = ({hasPredefinedAffiliations, allowCustomAffiliatio
       ? [currentAffiliation, ..._affiliationResults]
       : _affiliationResults;
 
+  const formatAffiliationName = ({name, code}) => (code ? `${name} (${code})` : name);
+
   const getSubheader = ({city, countryName}) => {
     if (city && countryName) {
       return `${city}, ${countryName}`;
@@ -54,8 +56,15 @@ const FinalAffiliationField = ({hasPredefinedAffiliations, allowCustomAffiliatio
     key: res.id,
     value: res.id,
     meta: res,
-    text: `${res.name} `, // XXX: the space allows addition even if the entered text matches a result item
-    content: <Header style={{fontSize: 14}} content={res.name} subheader={getSubheader(res)} />,
+    // XXX: the space allows addition even if the entered text matches a result item
+    text: `${formatAffiliationName(res)} `,
+    content: (
+      <Header
+        style={{fontSize: 14}}
+        content={formatAffiliationName(res)}
+        subheader={getSubheader(res)}
+      />
+    ),
   }));
 
   const searchAffiliationChange = async (evt, {searchQuery}) => {

--- a/indico/web/client/js/react/components/syncedInputs.jsx
+++ b/indico/web/client/js/react/components/syncedInputs.jsx
@@ -146,11 +146,20 @@ export function SyncedFinalAffiliationDropdown({
     return city || countryName;
   };
 
+  const formatAffiliationName = ({name: name_, code}) => (code ? `${name_} (${code})` : name_);
+
   const affiliationOptions = affiliationResults.map(res => ({
     key: res.id,
     value: res.id,
-    text: `${res.name} `, // XXX: the space allows addition even if the entered text matches a result item
-    content: <Header style={{fontSize: 14}} content={res.name} subheader={getSubheader(res)} />,
+    // XXX: the space allows addition even if the entered text matches a result item
+    text: `${formatAffiliationName(res)} `,
+    content: (
+      <Header
+        style={{fontSize: 14}}
+        content={formatAffiliationName(res)}
+        subheader={getSubheader(res)}
+      />
+    ),
   }));
 
   const searchAffiliationChange = async (evt, {searchQuery}) => {

--- a/indico/web/client/js/react/components/syncedInputs.jsx
+++ b/indico/web/client/js/react/components/syncedInputs.jsx
@@ -123,6 +123,7 @@ export function SyncedFinalDropdown(props) {
 }
 
 // TODO: see if we can't converge with FinalAffiliationField to remove the duplicated code...
+const formatAffiliationName = ({name, code}) => (code ? `${name} (${code})` : name);
 export function SyncedFinalAffiliationDropdown({
   name,
   required,
@@ -145,8 +146,6 @@ export function SyncedFinalAffiliationDropdown({
     }
     return city || countryName;
   };
-
-  const formatAffiliationName = ({name: name_, code}) => (code ? `${name_} (${code})` : name_);
 
   const affiliationOptions = affiliationResults.map(res => ({
     key: res.id,


### PR DESCRIPTION
This PR adds a `code`  column to the `Affiliation` model, allowing admins to specify a short code for predefined affiliations.

<img width="852" height="578" alt="image" src="https://github.com/user-attachments/assets/9073136c-9c74-453f-90cf-1cf0ff768399" />

<img width="1086" height="281" alt="image" src="https://github.com/user-attachments/assets/25bd5a6b-edf7-4bed-aa86-146e74abbdb6" />
<img width="526" height="364" alt="image" src="https://github.com/user-attachments/assets/c4bd6ba5-ecfb-40a4-91a2-413c645706d1" />
