### PR TITLE
Add plugin hook to prefill registration data

### DIFF
--- a/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/FileInput.jsx
@@ -14,7 +14,7 @@ import {useSelector} from 'react-redux';
 
 import {FinalSingleFileManager} from 'indico/react/components';
 
-import {getManagement, getUpdateMode} from '../../form_submission/selectors';
+import {getManagement} from '../../form_submission/selectors';
 import {getStaticData} from '../selectors';
 
 import '../../../styles/regform.module.scss';
@@ -22,14 +22,13 @@ import './FileInput.module.scss';
 
 export default function FileInput({fieldId, htmlId, htmlName, disabled, isRequired}) {
   const {eventId, regformId, registrationUuid, fileData} = useSelector(getStaticData);
-  const isUpdateMode = useSelector(getUpdateMode);
   const isManagement = useSelector(getManagement);
   const [invitationToken, formToken] = useMemo(() => {
     const params = new URLSearchParams(location.search);
     return [params.get('invitation'), params.get('form_token')];
   }, []);
 
-  const initialFileDetails = isUpdateMode ? fileData[htmlName] || null : null;
+  const initialFileDetails = fileData ? fileData[htmlName] || null : null;
 
   const urlParams = {
     event_id: eventId,

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -412,8 +412,8 @@ class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
 
     def _process_GET(self):
         user_data = get_user_data(self.regform, session.user, self.invitation)
-        initial_values = get_initial_form_values(self.regform) | user_data
         file_data = {}
+
         if session.user and user_data.get('picture'):
             metadata = session.user.picture_metadata or {}
             file_data['picture'] = {
@@ -422,6 +422,9 @@ class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
                 'uuid': PROFILE_PICTURE_SENTINEL,
                 'previewUrl': session.user.avatar_url,
             }
+
+        initial_values = get_initial_form_values(self.regform, file_data=file_data) | user_data
+
         if self._captcha_required:
             initial_values |= {'captcha': None}
         return self.view_class.render_template('display/regform_display.html', self.event,

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -200,7 +200,19 @@ def get_flat_section_submission_data(regform, *, management=False, registration=
     return {'sections': section_data, 'items': item_data}
 
 
-def get_initial_form_values(regform, *, management=False):
+@make_interceptable
+def get_initial_form_values(regform, *, management=False, **kwargs):
+    """Return the initial values for registration form fields.
+
+    This function can be intercepted by plugins, which may extend or modify
+    the returned values using the provided keyword arguments.
+
+    :param regform: The ``RegistrationForm`` whose fields are being initialized.
+    :param management: If ``True``, include manager-only sections.
+    :param kwargs: Additional context passed to plugin hooks.
+    :returns: A dict mapping each field's ``html_field_name`` to its default
+            value in camelCase format.
+    """
     initial_values = {}
     for item in regform.active_fields:
         can_modify = management or not item.parent.is_manager_only


### PR DESCRIPTION
As discussed at issue #7410, some people feel like it would be really useful to prefill the registration forms with the data from previous registrations. 

After exploring a little bit the codebase and analyzing how to do it, even though it has been said that it should belong to a plugin, I feel this could easily go in core, it's not complex functionality and there's already a similar behavior in it.

I have taken the commits from the PR #7276 because I feel they're important for this functionality and a good way to use the versatility it provides. 

RIght now it works with every field but:
- File Fields
- Picture Fields
- Sessions section Field

Also, if a previous caption is disabled in the new registration form, it will be selected for the radio buttons, but not for the checkboxes (this is a bug to be fixed)

I find that whilst this could be ok for File and Session section fields, it should find the Picture Field previous data, but I wanted to show it before making the decision on my own. 

Right now it searches for the past data introduced by field internal name (that way it doesn't matter if your past registration did not contain a field type, it will try to find a match with the current field name)

