### PR TITLE
Move FinalCountryDropdown to a separated component

### DIFF
--- a/indico/modules/core/blueprint.py
+++ b/indico/modules/core/blueprint.py
@@ -8,7 +8,7 @@
 from flask import request
 
 from indico.modules.core.controllers import (RHAPIGenerateCaptcha, RHChangeLanguage, RHChangeTimezone, RHConfig,
-                                             RHContact, RHPrincipals, RHRenderMarkdown, RHReportErrorAPI,
+                                             RHContact, RHCountries, RHPrincipals, RHRenderMarkdown, RHReportErrorAPI,
                                              RHResetSignatureTokens, RHSessionExpiry, RHSessionRefresh, RHSettings,
                                              RHSignURL, RHVersionCheck)
 from indico.web.flask.util import redirect_view
@@ -34,6 +34,7 @@ with _bp.add_prefixed_rules('/user/<int:user_id>', '/user'):
     _bp.add_url_rule('/reset-signature-tokens', 'reset_signature_tokens', RHResetSignatureTokens, methods=('POST',))
 _bp.add_url_rule('/api/config', 'config', RHConfig)
 _bp.add_url_rule('/api/render-markdown', 'markdown', RHRenderMarkdown, methods=('POST',))
+_bp.add_url_rule('!/api/countries', 'api_countries', RHCountries)
 
 # Misc pages
 _bp.add_url_rule('/contact', 'contact', RHContact)

--- a/indico/modules/core/controllers.py
+++ b/indico/modules/core/controllers.py
@@ -36,10 +36,11 @@ from indico.modules.legal import legal_settings
 from indico.modules.logs.models.entries import LogKind, UserLogRealm
 from indico.modules.users.controllers import RHUserBase
 from indico.modules.users.schemas import AffiliationSchema
+from indico.util.countries import get_countries
 from indico.util.date_time import server_to_utc
 from indico.util.i18n import _, get_all_locales
 from indico.util.marshmallow import PrincipalDict, validate_with_message
-from indico.util.string import render_markdown, sanitize_html
+from indico.util.string import remove_accents, render_markdown, sanitize_html, str_to_ascii
 from indico.web.args import use_kwargs
 from indico.web.errors import load_error_data
 from indico.web.flask.templating import get_template_module
@@ -396,3 +397,10 @@ class RHSessionRefresh(RH):
 
     def _process(self):
         return '', 204
+
+
+class RHCountries(RH):
+    """Return the list of available countries."""
+
+    def _process(self):
+        return jsonify(sorted(get_countries().items(), key=lambda x: str_to_ascii(remove_accents(x[1]))))

--- a/indico/modules/users/blueprint.py
+++ b/indico/modules/users/blueprint.py
@@ -9,20 +9,19 @@ from flask import has_request_context, request
 
 from indico.modules.users.api import RHUserAPI
 from indico.modules.users.controllers import (RHAcceptRegistrationRequest, RHAdmins, RHAffiliationAPI,
-                                              RHAffiliationsAPI, RHAffiliationsDashboard, RHCountries,
-                                              RHExportDashboardICS, RHExportDashboardICSLegacy, RHPersonalData,
-                                              RHPersonalDataUpdate, RHProfilePictureDisplay, RHProfilePicturePage,
-                                              RHProfilePicturePreview, RHRegistrationRequestList,
-                                              RHRejectRegistrationRequest, RHSaveProfilePicture, RHSearchAffiliations,
-                                              RHUserBlock, RHUserDashboard, RHUserDataExport, RHUserDataExportAPI,
-                                              RHUserDataExportDownload, RHUserDelete, RHUserEmails, RHUserEmailsDelete,
-                                              RHUserEmailsSetPrimary, RHUserEmailsVerify, RHUserFavorites,
-                                              RHUserFavoritesAPI, RHUserFavoritesCategoryAPI, RHUserFavoritesEventAPI,
-                                              RHUserPreferences, RHUserPreferencesMarkdownAPI,
-                                              RHUserPreferencesMastodonServer, RHUsersAdmin, RHUsersAdminCreate,
-                                              RHUsersAdminMerge, RHUsersAdminMergeCheck, RHUsersAdminSettings,
-                                              RHUserSearch, RHUserSearchInfo, RHUserSearchToken,
-                                              RHUserSuggestionsRemove)
+                                              RHAffiliationsAPI, RHAffiliationsDashboard, RHExportDashboardICS,
+                                              RHExportDashboardICSLegacy, RHPersonalData, RHPersonalDataUpdate,
+                                              RHProfilePictureDisplay, RHProfilePicturePage, RHProfilePicturePreview,
+                                              RHRegistrationRequestList, RHRejectRegistrationRequest,
+                                              RHSaveProfilePicture, RHSearchAffiliations, RHUserBlock, RHUserDashboard,
+                                              RHUserDataExport, RHUserDataExportAPI, RHUserDataExportDownload,
+                                              RHUserDelete, RHUserEmails, RHUserEmailsDelete, RHUserEmailsSetPrimary,
+                                              RHUserEmailsVerify, RHUserFavorites, RHUserFavoritesAPI,
+                                              RHUserFavoritesCategoryAPI, RHUserFavoritesEventAPI, RHUserPreferences,
+                                              RHUserPreferencesMarkdownAPI, RHUserPreferencesMastodonServer,
+                                              RHUsersAdmin, RHUsersAdminCreate, RHUsersAdminMerge,
+                                              RHUsersAdminMergeCheck, RHUsersAdminSettings, RHUserSearch,
+                                              RHUserSearchInfo, RHUserSearchToken, RHUserSuggestionsRemove)
 from indico.web.flask.wrappers import IndicoBlueprint
 
 
@@ -98,7 +97,6 @@ _bp.add_url_rule('!/admin/affiliations', 'affiliations_dashboard', RHAffiliation
 _bp.add_url_rule('!/api/admin/affiliations', 'api_admin_affiliations', RHAffiliationsAPI, methods=('GET', 'POST'))
 _bp.add_url_rule('!/api/admin/affiliations/<int:affiliation_id>', 'api_admin_affiliation', RHAffiliationAPI,
                  methods=('GET', 'PATCH', 'DELETE'))
-_bp.add_url_rule('!/api/countries', 'api_countries', RHCountries)
 
 # Users API
 _bp.add_url_rule('!/api/user/', 'authenticated_user', RHUserAPI)

--- a/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
+++ b/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
@@ -5,30 +5,19 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import countriesURL from 'indico-url:users.api_countries';
-
 import type {FormApi} from 'final-form';
 import React, {useCallback} from 'react';
 import {Accordion, Form} from 'semantic-ui-react';
 
-import {
-  FinalDropdown,
-  FinalInput,
-  FinalTextArea,
-  getChangedValues,
-  handleSubmitError,
-} from 'indico/react/forms';
+import {FinalCountryDropdown} from 'indico/react/components';
+import {FinalInput, FinalTextArea, getChangedValues, handleSubmitError} from 'indico/react/forms';
 import {FinalModalForm} from 'indico/react/forms/final-form';
-import {useIndicoAxios} from 'indico/react/hooks';
 import {Translate} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
 import {getPluginObjects} from 'indico/utils/plugins';
 
 import FinalStringListField from './StringListField';
 import {AffiliationFormValues} from './types';
-
-const isoToFlag = (country: string) =>
-  String.fromCodePoint(...country.split('').map(char => char.charCodeAt(0) + 0x1f1a5));
 
 const defaultValues: AffiliationFormValues = {
   name: '',
@@ -83,8 +72,6 @@ export default function AffiliationFormDialog({
   onSuccess: () => void;
   edit?: boolean;
 }) {
-  const {data: countries} = useIndicoAxios(countriesURL({}), {manual: !open});
-
   const handleSubmit = useCallback(
     async (formData: AffiliationFormValues, form: FormApi<AffiliationFormValues>) => {
       const payload = edit ? getChangedValues(formData, form) : formData;
@@ -114,20 +101,7 @@ export default function AffiliationFormDialog({
             </Form.Group>
             <Form.Group widths="equal">
               <FinalInput name="city" label={Translate.string('City')} />
-              <FinalDropdown
-                name="country_code"
-                label={Translate.string('Country')}
-                fluid
-                selection
-                placeholder={Translate.string('Select a country')}
-                options={(countries ?? []).map(([name, title]) => ({
-                  key: name,
-                  value: name,
-                  text: `${isoToFlag(name)} ${title}`,
-                }))}
-                loading={!countries}
-                disabled={!countries}
-              />
+              <FinalCountryDropdown name="country_code" label={Translate.string('Country')} fluid />
             </Form.Group>
           </>
         ),

--- a/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
+++ b/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import countriesURL from 'indico-url:users.api_countries';
+
 import type {FormApi} from 'final-form';
 import React, {useCallback} from 'react';
 import {Accordion, Form} from 'semantic-ui-react';
@@ -101,7 +103,12 @@ export default function AffiliationFormDialog({
             </Form.Group>
             <Form.Group widths="equal">
               <FinalInput name="city" label={Translate.string('City')} />
-              <FinalCountryDropdown name="country_code" label={Translate.string('Country')} fluid />
+              <FinalCountryDropdown
+                name="country_code"
+                label={Translate.string('Country')}
+                fluid
+                countriesURL={countriesURL({})}
+              />
             </Form.Group>
           </>
         ),

--- a/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
+++ b/indico/modules/users/client/js/affiliations/AffiliationFormDialog.tsx
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import countriesURL from 'indico-url:users.api_countries';
+import countriesURL from 'indico-url:core.api_countries';
 
 import type {FormApi} from 'final-form';
 import React, {useCallback} from 'react';

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -396,15 +396,11 @@ class RHAffiliationAPI(RHAdminBase):
         return '', 204
 
 
-class CountriesListMixin:
-    """Mixin providing a country list endpoint."""
+class RHCountries(RHAdminBase):
+    """Return the available countries for affiliation forms."""
 
     def _process(self):
         return jsonify(list(get_countries().items()))
-
-
-class RHCountries(CountriesListMixin, RHAdminBase):
-    """Return the available countries."""
 
 
 class RHProfilePicturePage(RHUserBase):

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -396,11 +396,15 @@ class RHAffiliationAPI(RHAdminBase):
         return '', 204
 
 
-class RHCountries(RHAdminBase):
-    """Return the available countries for affiliation forms."""
+class CountriesListMixin:
+    """Mixin providing a country list endpoint."""
 
     def _process(self):
         return jsonify(list(get_countries().items()))
+
+
+class RHCountries(CountriesListMixin, RHAdminBase):
+    """Return the available countries."""
 
 
 class RHProfilePicturePage(RHUserBase):

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -62,7 +62,6 @@ from indico.modules.users.util import (GravatarError, SearchAffiliationsMixin, g
                                        search_affiliations, search_users, send_avatar, serialize_user, set_user_avatar)
 from indico.modules.users.views import (WPAffiliationsDashboard, WPUser, WPUserDashboard, WPUserDataExport,
                                         WPUserFavorites, WPUserPersonalData, WPUserProfilePic, WPUsersAdmin)
-from indico.util.countries import get_countries
 from indico.util.date_time import now_utc
 from indico.util.i18n import _, force_locale
 from indico.util.images import square
@@ -394,13 +393,6 @@ class RHAffiliationAPI(RHAdminBase):
                              f'Affiliation "{self.affiliation.name}" deleted', session.user)
         search_affiliations.bump_version()
         return '', 204
-
-
-class RHCountries(RHAdminBase):
-    """Return the available countries for affiliation forms."""
-
-    def _process(self):
-        return jsonify(list(get_countries().items()))
 
 
 class RHProfilePicturePage(RHUserBase):

--- a/indico/web/client/js/react/components/CountryDropdown.jsx
+++ b/indico/web/client/js/react/components/CountryDropdown.jsx
@@ -13,7 +13,7 @@ import {Dropdown} from 'semantic-ui-react';
 
 import {FinalField} from 'indico/react/forms';
 import {Translate} from 'indico/react/i18n';
-import {indicoAxios} from 'indico/utils/axios';
+import {handleAxiosError, indicoAxios} from 'indico/utils/axios';
 
 const isoToFlag = code =>
   String.fromCodePoint(...code.split('').map(c => c.charCodeAt(0) + 0x1f1a5));
@@ -24,7 +24,13 @@ function useCountries() {
   const [countries, setCountries] = React.useState(null);
   React.useEffect(() => {
     if (!countriesPromise) {
-      countriesPromise = indicoAxios.get(countriesURL({})).then(({data}) => data);
+      countriesPromise = indicoAxios
+        .get(countriesURL({}))
+        .then(({data}) => data)
+        .catch(error => {
+          countriesPromise = null;
+          handleAxiosError(error);
+        });
     }
     countriesPromise.then(setCountries);
   }, []);

--- a/indico/web/client/js/react/components/CountryDropdown.jsx
+++ b/indico/web/client/js/react/components/CountryDropdown.jsx
@@ -12,11 +12,24 @@ import React from 'react';
 import {Dropdown} from 'semantic-ui-react';
 
 import {FinalField} from 'indico/react/forms';
-import {useIndicoAxios} from 'indico/react/hooks';
 import {Translate} from 'indico/react/i18n';
+import {indicoAxios} from 'indico/utils/axios';
 
 const isoToFlag = code =>
   String.fromCodePoint(...code.split('').map(c => c.charCodeAt(0) + 0x1f1a5));
+
+let countriesPromise = null;
+
+function useCountries() {
+  const [countries, setCountries] = React.useState(null);
+  React.useEffect(() => {
+    if (!countriesPromise) {
+      countriesPromise = indicoAxios.get(countriesURL({})).then(({data}) => data);
+    }
+    countriesPromise.then(setCountries);
+  }, []);
+  return countries;
+}
 
 export function FinalCountryDropdown({name, ...rest}) {
   return <FinalField name={name} component={CountryDropdown} {...rest} />;
@@ -27,7 +40,7 @@ FinalCountryDropdown.propTypes = {
 };
 
 export default function CountryDropdown({value, onChange, fluid}) {
-  const {data: countries} = useIndicoAxios(countriesURL({}));
+  const countries = useCountries();
 
   return (
     <Dropdown

--- a/indico/web/client/js/react/components/CountryDropdown.jsx
+++ b/indico/web/client/js/react/components/CountryDropdown.jsx
@@ -8,7 +8,7 @@
 import countriesURL from 'indico-url:users.api_countries';
 
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {Dropdown} from 'semantic-ui-react';
 
 import {FinalField} from 'indico/react/forms';
@@ -21,8 +21,8 @@ const isoToFlag = code =>
 let countriesPromise = null;
 
 function useCountries() {
-  const [countries, setCountries] = React.useState(null);
-  React.useEffect(() => {
+  const [countries, setCountries] = useState(null);
+  useEffect(() => {
     if (!countriesPromise) {
       countriesPromise = indicoAxios
         .get(countriesURL({}))

--- a/indico/web/client/js/react/components/CountryDropdown.jsx
+++ b/indico/web/client/js/react/components/CountryDropdown.jsx
@@ -5,8 +5,6 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import countriesURL from 'indico-url:users.api_countries';
-
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 import {Dropdown} from 'semantic-ui-react';
@@ -18,35 +16,38 @@ import {handleAxiosError, indicoAxios} from 'indico/utils/axios';
 const isoToFlag = code =>
   String.fromCodePoint(...code.split('').map(c => c.charCodeAt(0) + 0x1f1a5));
 
-let countriesPromise = null;
+const countriesCache = {};
 
-function useCountries() {
+function useCountries(url) {
   const [countries, setCountries] = useState(null);
   useEffect(() => {
-    if (!countriesPromise) {
-      countriesPromise = indicoAxios
-        .get(countriesURL({}))
+    if (!countriesCache[url]) {
+      countriesCache[url] = indicoAxios
+        .get(url)
         .then(({data}) => data)
         .catch(error => {
-          countriesPromise = null;
+          delete countriesCache[url];
           handleAxiosError(error);
         });
     }
-    countriesPromise.then(setCountries);
-  }, []);
+    countriesCache[url].then(setCountries);
+  }, [url]);
   return countries;
 }
 
-export function FinalCountryDropdown({name, ...rest}) {
-  return <FinalField name={name} component={CountryDropdown} {...rest} />;
+export function FinalCountryDropdown({name, countriesURL, ...rest}) {
+  return (
+    <FinalField name={name} component={CountryDropdown} countriesURL={countriesURL} {...rest} />
+  );
 }
 
 FinalCountryDropdown.propTypes = {
   name: PropTypes.string.isRequired,
+  countriesURL: PropTypes.string.isRequired,
 };
 
-export default function CountryDropdown({value, onChange, fluid}) {
-  const countries = useCountries();
+export default function CountryDropdown({value, onChange, fluid, countriesURL}) {
+  const countries = useCountries(countriesURL);
 
   return (
     <Dropdown
@@ -72,6 +73,7 @@ CountryDropdown.propTypes = {
   value: PropTypes.string.isRequired,
   onChange: PropTypes.func.isRequired,
   fluid: PropTypes.bool,
+  countriesURL: PropTypes.string.isRequired,
 };
 
 CountryDropdown.defaultProps = {

--- a/indico/web/client/js/react/components/CountryDropdown.jsx
+++ b/indico/web/client/js/react/components/CountryDropdown.jsx
@@ -1,0 +1,60 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2026 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import countriesURL from 'indico-url:users.api_countries';
+
+import PropTypes from 'prop-types';
+import React from 'react';
+import {Dropdown} from 'semantic-ui-react';
+
+import {FinalField} from 'indico/react/forms';
+import {useIndicoAxios} from 'indico/react/hooks';
+import {Translate} from 'indico/react/i18n';
+
+const isoToFlag = code =>
+  String.fromCodePoint(...code.split('').map(c => c.charCodeAt(0) + 0x1f1a5));
+
+export function FinalCountryDropdown({name, ...rest}) {
+  return <FinalField name={name} component={CountryDropdown} {...rest} />;
+}
+
+FinalCountryDropdown.propTypes = {
+  name: PropTypes.string.isRequired,
+};
+
+export default function CountryDropdown({value, onChange, fluid}) {
+  const {data: countries} = useIndicoAxios(countriesURL({}));
+
+  return (
+    <Dropdown
+      fluid={fluid}
+      search
+      selection
+      clearable
+      value={value}
+      options={(countries ?? []).map(([code, name]) => ({
+        key: code,
+        value: code,
+        text: `${isoToFlag(code)} ${name}`,
+      }))}
+      onChange={(_, {value: v}) => onChange(v)}
+      placeholder={Translate.string('Select a country...')}
+      loading={!countries}
+      disabled={!countries}
+    />
+  );
+}
+
+CountryDropdown.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  fluid: PropTypes.bool,
+};
+
+CountryDropdown.defaultProps = {
+  fluid: false,
+};

--- a/indico/web/client/js/react/components/index.js
+++ b/indico/web/client/js/react/components/index.js
@@ -65,3 +65,4 @@ export {default as Favorite} from './Favorite';
 export {default as PersonDetailsModal} from './PersonDetailsModal';
 export {default as FinalAffiliationField, AffiliationField} from './AffiliationField';
 export {default as Captcha} from './Captcha';
+export {default as CountryDropdown, FinalCountryDropdown} from './CountryDropdown';


### PR DESCRIPTION
AffiliationFormDialog.tsx creates its own country dropdown component due the incompatibilities between itself and CountryInput.jsx.

However, I feel like this is incorrect, since we can follow the same pattern such as StringListField.tsx and separate the Dropdown logic from the FinalField logic, so other components (in my case a plugin component) could use just the Dropdown. Core functionalities are not changed, but they offer more flexibility for plugin developers