### PR TITLE
Allow managers to choose extra accommodation dates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Version 3.3.13
 Improvements
 ^^^^^^^^^^^^
 
+- Allow managers to override accommodation date range validation when editing
+  registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)
 - Include keywords in contribution CSV/Excel exports (:pr:`7421`)
 
 Bugfixes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Version 3.3.13
 Improvements
 ^^^^^^^^^^^^
 
+- Allow managers to override accommodation date range validation when editing
+  registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)
 - Include keywords in contribution CSV/Excel exports (:pr:`7421`)
 - Add new permission that grants only participant management (create, edit and
   delete registrations) without access to the registration form configuration

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,6 @@ Version 3.3.13
 Improvements
 ^^^^^^^^^^^^
 
-- Allow managers to override accommodation date range validation when editing
-  registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)
 - Include keywords in contribution CSV/Excel exports (:pr:`7421`)
 - Add new permission that grants only participant management (create, edit and
   delete registrations) without access to the registration form configuration
@@ -28,6 +26,8 @@ Improvements
 - Add placeholders for contribution link and board number for emailing contributions
   (:pr:`7525`, thanks :user:`duartegalvao`)
 - Add a weekday option to the contribution schedule email placeholder (:pr:`7526`)
+- Allow managers to override accommodation date range validation when editing
+  registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
@@ -140,6 +140,7 @@ function AccommodationInputComponent({
             rangeStartMax={arrival.endDate}
             rangeEndMin={departure.startDate}
             rangeEndMax={departure.endDate}
+            allowOutOfRange={management}
           />
           {!!selectedChoice.price && (
             <Label pointing="left" styleName="price-tag">
@@ -242,6 +243,7 @@ export default function AccommodationInput({
   placesUsed,
 }) {
   const existingValue = useSelector(state => getFieldValue(state, fieldId)) || {choice: null};
+  const management = useSelector(getManagement);
   return (
     <FinalField
       id={htmlId}
@@ -264,10 +266,10 @@ export default function AccommodationInput({
         if (!value.isNoAccommodation) {
           const rangeValidators = makeAccommodationRangeValidators({
             required: true,
-            rangeStartMin: arrival.startDate,
-            rangeStartMax: arrival.endDate,
-            rangeEndMin: departure.startDate,
-            rangeEndMax: departure.endDate,
+            rangeStartMin: management ? null : arrival.startDate,
+            rangeStartMax: management ? null : arrival.endDate,
+            rangeEndMin: management ? null : departure.startDate,
+            rangeEndMax: management ? null : departure.endDate,
           });
           return v.chain(...rangeValidators)(value);
         }

--- a/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/AccommodationInput.jsx
@@ -263,7 +263,11 @@ export default function AccommodationInput({
         } else if (!value.isNoAccommodation && (!value.arrivalDate || !value.departureDate)) {
           return Translate.string('You must select the arrival and departure date');
         }
-        if (!value.isNoAccommodation) {
+        if (
+          !value.isNoAccommodation &&
+          (existingValue?.arrivalDate !== value.arrivalDate ||
+            existingValue?.departureDate !== value.departureDate)
+        ) {
           const rangeValidators = makeAccommodationRangeValidators({
             required: true,
             rangeStartMin: management ? null : arrival.startDate,

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -165,7 +165,7 @@ class RegistrationFormFieldBase:
         :param registration: The previous registration if modifying an existing one, otherwise none
         :param management: Whether the field is being created in management context
         """
-        self._management = management
+        self.management = management
         validators = self.get_validators(registration) or []
         if not isinstance(validators, list):
             validators = [validators]
@@ -347,5 +347,5 @@ class InvalidRegistrationFormField(RegistrationFormFieldBase):
 
     is_invalid_field = True
 
-    def create_mm_field(self, registration=None, override_required=False):
+    def create_mm_field(self, registration=None, override_required=False, management=False):
         return None

--- a/indico/modules/events/registration/fields/base.py
+++ b/indico/modules/events/registration/fields/base.py
@@ -155,7 +155,7 @@ class RegistrationFormFieldBase:
         schema = self.setup_schema_base_cls.from_dict(self.setup_schema_fields, name=name)
         return schema(context=context)
 
-    def create_mm_field(self, registration=None, override_required=False):
+    def create_mm_field(self, registration=None, override_required=False, management=False):
         """
         Create a marshmallow field.
         When modifying an existing registration, the `registration` parameter is
@@ -163,7 +163,9 @@ class RegistrationFormFieldBase:
         some field validators need the old data.
 
         :param registration: The previous registration if modifying an existing one, otherwise none
+        :param management: Whether the field is being created in management context
         """
+        self._management = management
         validators = self.get_validators(registration) or []
         if not isinstance(validators, list):
             validators = [validators]

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -477,6 +477,7 @@ class AccommodationField(RegistrationFormBillableItemsField):
     mm_field_class = fields.Nested
     mm_field_args = (AccommodationSchema,)
     allow_condition = True
+    _management = False
 
     def _get_default_value(self, *, ui):
         versioned_data = self.form_item.versioned_data

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -573,14 +573,16 @@ class AccommodationField(RegistrationFormBillableItemsField):
                     raise ValidationError(_('Arrival/departure date is missing'))
                 if arrival_date > departure_date:
                     raise ValidationError(_("Arrival date can't be set after the departure date."))
-                arrival_date_from = date.fromisoformat(self.form_item.data['arrival_date_from'])
-                arrival_date_to = date.fromisoformat(self.form_item.data['arrival_date_to'])
-                departure_date_from = date.fromisoformat(self.form_item.data['departure_date_from'])
-                departure_date_to = date.fromisoformat(self.form_item.data['departure_date_to'])
-                if not (arrival_date_from <= arrival_date <= arrival_date_to):
-                    raise ValidationError(_('Arrival date is not within the required range.'))
-                if not (departure_date_from <= departure_date <= departure_date_to):
-                    raise ValidationError(_('Departure date is not within the required range.'))
+                # Managers can set dates outside the allowed range (e.g. for late arrivals or exceptions)
+                if not self._management:
+                    arrival_date_from = date.fromisoformat(self.form_item.data['arrival_date_from'])
+                    arrival_date_to = date.fromisoformat(self.form_item.data['arrival_date_to'])
+                    departure_date_from = date.fromisoformat(self.form_item.data['departure_date_from'])
+                    departure_date_to = date.fromisoformat(self.form_item.data['departure_date_to'])
+                    if not (arrival_date_from <= arrival_date <= arrival_date_to):
+                        raise ValidationError(_('Arrival date is not within the required range.'))
+                    if not (departure_date_from <= departure_date <= departure_date_to):
+                        raise ValidationError(_('Departure date is not within the required range.'))
 
         def _check_number_of_places(new_data):
             if not new_data:

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -477,7 +477,7 @@ class AccommodationField(RegistrationFormBillableItemsField):
     mm_field_class = fields.Nested
     mm_field_args = (AccommodationSchema,)
     allow_condition = True
-    _management = False
+    management = False
 
     def _get_default_value(self, *, ui):
         versioned_data = self.form_item.versioned_data
@@ -575,7 +575,7 @@ class AccommodationField(RegistrationFormBillableItemsField):
                 if arrival_date > departure_date:
                     raise ValidationError(_("Arrival date can't be set after the departure date."))
                 # Managers can set dates outside the allowed range (e.g. for late arrivals or exceptions)
-                if not self._management:
+                if not self.management:
                     arrival_date_from = date.fromisoformat(self.form_item.data['arrival_date_from'])
                     arrival_date_to = date.fromisoformat(self.form_item.data['arrival_date_to'])
                     departure_date_from = date.fromisoformat(self.form_item.data['departure_date_from'])

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -372,7 +372,8 @@ def make_registration_schema(
 
         if mm_field := form_item.field_impl.create_mm_field(
             registration=registration,
-            override_required=(management and override_required)
+            override_required=(management and override_required),
+            management=management
         ):
             schema[form_item.html_field_name] = mm_field
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -389,7 +389,8 @@ def make_registration_schema(
 
         if mm_field := form_item.field_impl.create_mm_field(
             registration=registration,
-            override_required=(management and override_required)
+            override_required=(management and override_required),
+            management=management
         ):
             schema[form_item.html_field_name] = mm_field
 

--- a/indico/web/client/js/custom_elements/ind_date_picker.js
+++ b/indico/web/client/js/custom_elements/ind_date_picker.js
@@ -152,6 +152,7 @@ CustomElementBase.define(
       rangeEndMin: Date, // Minimum allowed value for the end of the range (inclusive)
       rangeEndMax: Date, // Minimum allowed value for the end of the range (inclusive)
       format: String, // Date format
+      allowOutOfRange: Boolean, // Allow selecting dates outside the configured range
     };
 
     static observedAttributes = [
@@ -162,6 +163,7 @@ CustomElementBase.define(
       'range-end-min',
       'range-end-max',
       'format',
+      'allow-out-of-range',
     ];
 
     get value() {
@@ -253,6 +255,7 @@ CustomElementBase.define(
       this.addEventListener('x-attrchange.range-start-max', updateSelectionLimits);
       this.addEventListener('x-attrchange.range-end-min', updateSelectionLimits);
       this.addEventListener('x-attrchange.range-end-max', updateSelectionLimits);
+      this.addEventListener('x-attrchange.allow-out-of-range', updateSelectionLimits);
       rangeStartInput.addEventListener('input', () => {
         const date = parseDate(rangeStartInput.value);
         indCalendar.rangeStart = date;
@@ -312,9 +315,15 @@ CustomElementBase.define(
 
       function updateSelectionLimits() {
         if (selection.trigger === ds.LEFT) {
-          indCalendar.setAllowableSelectionRange(indDateRangePicker.startRange);
+          indCalendar.setAllowableSelectionRange(
+            indDateRangePicker.startRange,
+            indDateRangePicker.allowOutOfRange
+          );
         } else {
-          indCalendar.setAllowableSelectionRange(indDateRangePicker.endRange);
+          indCalendar.setAllowableSelectionRange(
+            indDateRangePicker.endRange,
+            indDateRangePicker.allowOutOfRange
+          );
         }
       }
 
@@ -574,8 +583,9 @@ CustomElementBase.define(
       );
     }
 
-    setAllowableSelectionRange(dateRange) {
+    setAllowableSelectionRange(dateRange, allowOutOfRange = false) {
       this.allowableSelectionRange = dateRange;
+      this.allowOutOfRange = allowOutOfRange;
       this.dispatchEvent(new Event('x-rangechange'));
     }
 
@@ -818,6 +828,7 @@ CustomElementBase.define(
           }
           grid.rangeStart = markedRange.start?.toString() || '';
           grid.rangeEnd = markedRange.end?.toString() || '';
+          grid.allowOutOfRange = indCalendar.allowOutOfRange;
           grid.setAllowableSelectionRange(indCalendar.allowableSelectionRange);
         });
       }
@@ -971,7 +982,8 @@ CustomElementBase.define(
                 locale: indDateGrid.locale,
                 weekInfo,
               });
-              const isSelectable = indDateGrid.allowableSelectionRange.includes(date) && isValid;
+              const inRange = indDateGrid.allowableSelectionRange.includes(date);
+              const isSelectable = (inRange || indDateGrid.allowOutOfRange) && isValid;
 
               calendarButton.textContent = date.getDate();
               calendarButton.setAttribute(
@@ -994,6 +1006,7 @@ CustomElementBase.define(
               } else {
                 calendarButton.setAttribute('aria-disabled', true);
               }
+              calendarButton.toggleAttribute('data-out-of-range', isValid && !inRange);
 
               if (selectedRange.includes(date)) {
                 calendarButton.setAttribute('aria-selected', true);

--- a/indico/web/client/js/custom_elements/ind_date_picker.js
+++ b/indico/web/client/js/custom_elements/ind_date_picker.js
@@ -152,6 +152,7 @@ CustomElementBase.define(
       rangeEndMin: Date, // Minimum allowed value for the end of the range (inclusive)
       rangeEndMax: Date, // Minimum allowed value for the end of the range (inclusive)
       format: String, // Date format
+      allowOutOfRange: Boolean, // Allow selecting dates outside the configured range
     };
 
     static observedAttributes = [
@@ -162,6 +163,7 @@ CustomElementBase.define(
       'range-end-min',
       'range-end-max',
       'format',
+      'allow-out-of-range',
     ];
 
     get value() {
@@ -253,6 +255,7 @@ CustomElementBase.define(
       this.addEventListener('x-attrchange.range-start-max', updateSelectionLimits);
       this.addEventListener('x-attrchange.range-end-min', updateSelectionLimits);
       this.addEventListener('x-attrchange.range-end-max', updateSelectionLimits);
+      this.addEventListener('x-attrchange.allow-out-of-range', updateSelectionLimits);
       rangeStartInput.addEventListener('input', () => {
         const date = parseDate(rangeStartInput.value);
         indCalendar.rangeStart = date;
@@ -312,9 +315,15 @@ CustomElementBase.define(
 
       function updateSelectionLimits() {
         if (selection.trigger === ds.LEFT) {
-          indCalendar.setAllowableSelectionRange(indDateRangePicker.startRange);
+          indCalendar.setAllowableSelectionRange(
+            indDateRangePicker.startRange,
+            indDateRangePicker.allowOutOfRange
+          );
         } else {
-          indCalendar.setAllowableSelectionRange(indDateRangePicker.endRange);
+          indCalendar.setAllowableSelectionRange(
+            indDateRangePicker.endRange,
+            indDateRangePicker.allowOutOfRange
+          );
         }
       }
 
@@ -574,8 +583,9 @@ CustomElementBase.define(
       );
     }
 
-    setAllowableSelectionRange(dateRange) {
+    setAllowableSelectionRange(dateRange, allowOutOfRange = false) {
       this.allowableSelectionRange = dateRange;
+      this.allowOutOfRange = allowOutOfRange;
       this.dispatchEvent(new Event('x-rangechange'));
     }
 
@@ -818,6 +828,7 @@ CustomElementBase.define(
           }
           grid.rangeStart = markedRange.start?.toDateString() || '';
           grid.rangeEnd = markedRange.end?.toDateString() || '';
+          grid.allowOutOfRange = indCalendar.allowOutOfRange;
           grid.setAllowableSelectionRange(indCalendar.allowableSelectionRange);
         });
       }
@@ -971,7 +982,8 @@ CustomElementBase.define(
                 locale: indDateGrid.locale,
                 weekInfo,
               });
-              const isSelectable = indDateGrid.allowableSelectionRange.includes(date) && isValid;
+              const inRange = indDateGrid.allowableSelectionRange.includes(date);
+              const isSelectable = (inRange || indDateGrid.allowOutOfRange) && isValid;
 
               calendarButton.textContent = date.getDate();
               calendarButton.setAttribute(
@@ -994,6 +1006,7 @@ CustomElementBase.define(
               } else {
                 calendarButton.setAttribute('aria-disabled', true);
               }
+              calendarButton.toggleAttribute('data-out-of-range', isValid && !inRange);
 
               if (selectedRange.includes(date)) {
                 calendarButton.setAttribute('aria-selected', true);

--- a/indico/web/client/js/custom_elements/ind_date_picker.scss
+++ b/indico/web/client/js/custom_elements/ind_date_picker.scss
@@ -351,6 +351,10 @@ ind-date-grid {
       opacity: 0.2;
     }
 
+    &[data-out-of-range]:not([aria-disabled]) {
+      opacity: 0.35;
+    }
+
     &:hover,
     &:focus-visible {
       background-color: var(--control-clickable-surface-focus-color);

--- a/indico/web/client/js/react/components/DateRangePicker.jsx
+++ b/indico/web/client/js/react/components/DateRangePicker.jsx
@@ -35,6 +35,7 @@ export default function DateRangePicker({
   startDisabled,
   endDisabled,
   required,
+  allowOutOfRange,
   onChange,
   onFocus,
   onBlur,
@@ -91,6 +92,7 @@ export default function DateRangePicker({
       range-start-max={rangeStartMax}
       range-end-min={rangeEndMin}
       range-end-max={rangeEndMax}
+      allow-out-of-range={allowOutOfRange || undefined}
       format={format}
       onChange={handleChange}
     >
@@ -183,6 +185,7 @@ DateRangePicker.propTypes = {
   rangeEndMax: PropTypes.string,
   min: PropTypes.string,
   max: PropTypes.string,
+  allowOutOfRange: PropTypes.bool,
   filter: PropTypes.func,
 };
 
@@ -203,6 +206,7 @@ DateRangePicker.defaultProps = {
   rangeEndMax: '',
   min: '',
   max: '',
+  allowOutOfRange: false,
   filter: undefined,
 };
 


### PR DESCRIPTION
Closes #7415.

This PR  skips arrival/departure date range validation for managers, allowing them to set  accommodation dates outside the configured range for exceptions like late arrivals. 

<img width="833" height="568" alt="Screenshot 2026-04-07 at 23 31 08" src="https://github.com/user-attachments/assets/b2a2ec7a-de88-433a-b1af-6b17ed84c787" />

<img width="907" height="815" alt="Screenshot 2026-04-07 at 22 58 45" src="https://github.com/user-attachments/assets/596bbd93-1af1-43bf-91ad-f26a72f45cd5" />
