### PR TITLE
Reset approvals when registration is modified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -65,6 +65,8 @@ Improvements
   :user:`vtran99`)
 - Add pagination to public participant list and use tabs instead of an accordion in case
   of multiple registration forms (:issue:`6424`, :pr:`7472`)
+- Add new registration form setting to require approval again after a user modifies their
+  registration (:pr:`7434`, thanks :user:`moliholy`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20260722_1100_06a037da1ec6_add_reset_approval_on_modification.py
+++ b/indico/migrations/versions/20260722_1100_06a037da1ec6_add_reset_approval_on_modification.py
@@ -1,0 +1,30 @@
+"""Add reset_approval_on_modification column to registration forms
+
+Revision ID: 06a037da1ec6
+Revises: d7e2a9c14f6b
+Create Date: 2026-07-22 11:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '06a037da1ec6'
+down_revision = 'd7e2a9c14f6b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'forms',
+        sa.Column('reset_approval_on_modification', sa.Boolean(), nullable=False, server_default='false'),
+        schema='event_registration',
+    )
+    op.alter_column('forms', 'reset_approval_on_modification', server_default=None,
+                    schema='event_registration')
+
+
+def downgrade():
+    op.drop_column('forms', 'reset_approval_on_modification', schema='event_registration')

--- a/indico/migrations/versions/20260804_1845_06a037da1ec6_add_reset_approval_on_modification.py
+++ b/indico/migrations/versions/20260804_1845_06a037da1ec6_add_reset_approval_on_modification.py
@@ -1,7 +1,7 @@
 """Add reset_approval_on_modification column to registration forms
 
 Revision ID: 06a037da1ec6
-Revises: d7e2a9c14f6b
+Revises: c412156094d6
 Create Date: 2026-07-22 11:00:00.000000
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '06a037da1ec6'
-down_revision = 'd7e2a9c14f6b'
+down_revision = 'c412156094d6'
 branch_labels = None
 depends_on = None
 
@@ -22,8 +22,7 @@ def upgrade():
         sa.Column('reset_approval_on_modification', sa.Boolean(), nullable=False, server_default='false'),
         schema='event_registration',
     )
-    op.alter_column('forms', 'reset_approval_on_modification', server_default=None,
-                    schema='event_registration')
+    op.alter_column('forms', 'reset_approval_on_modification', server_default=None, schema='event_registration')
 
 
 def downgrade():

--- a/indico/modules/events/registration/forms.py
+++ b/indico/modules/events/registration/forms.py
@@ -83,6 +83,13 @@ class RegistrationFormEditForm(IndicoForm):
                                description=_('How registrants can get in touch with somebody for extra information'))
     moderation_enabled = BooleanField(_('Moderated'), widget=SwitchWidget(),
                                       description=_('If enabled, registrations require manager approval'))
+    reset_approval_on_modification = BooleanField(_('Reset approval on modification'),
+                                                  [HiddenUnless('moderation_enabled')],
+                                                  widget=SwitchWidget(),
+                                                  description=_('If enabled, modifying a registration resets its '
+                                                                'approval status back to pending. Only applies to '
+                                                                'modifications made by the registrant, not by a '
+                                                                'manager.'))
     private = BooleanField(_('Private'), widget=SwitchWidget(),
                            description=_('The registration form will not be publicly displayed on the event page. '
                                          'Only people with the secret link or an invitation will be able to register.'))

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -173,6 +173,12 @@ class RegistrationForm(db.Model):
         nullable=False,
         default=False
     )
+    #: Whether modifying a registration resets its approval status (requires moderation)
+    reset_approval_on_modification = db.Column(
+        db.Boolean,
+        nullable=False,
+        default=False
+    )
     #: Whether the registration form is only for selected users
     private = db.Column(
         db.Boolean,

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -695,7 +695,9 @@ class Registration(db.Model):
             if not self.price:
                 self.state = RegistrationState.complete
         elif self.state == RegistrationState.complete:
-            if payment_required:
+            if moderation_required:
+                self.state = RegistrationState.pending
+            elif payment_required:
                 self.state = RegistrationState.unpaid
         if self.state != initial_state:
             signals.event.registration_state_updated.send(self, previous_state=initial_state)

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -706,6 +706,7 @@ class Registration(db.Model):
         invitation = self.invitation
         moderation_required = (regform.moderation_enabled and not _skip_moderation and
                                (not invitation or not invitation.skip_moderation))
+        reset_on_modification = moderation_required and regform.reset_approval_on_modification
         with db.session.no_autoflush:
             payment_required = regform.event.has_feature('payment') and self.price and not self.is_paid
         if self.state is None:
@@ -716,10 +717,12 @@ class Registration(db.Model):
             else:
                 self.state = RegistrationState.complete
         elif self.state == RegistrationState.unpaid:
-            if not self.price:
+            if reset_on_modification:
+                self.state = RegistrationState.pending
+            elif not self.price:
                 self.state = RegistrationState.complete
         elif self.state == RegistrationState.complete:
-            if moderation_required:
+            if reset_on_modification:
                 self.state = RegistrationState.pending
             elif payment_required:
                 self.state = RegistrationState.unpaid

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -743,7 +743,8 @@ class Registration(db.Model):
         moderation_required = (regform.moderation_enabled and not _skip_moderation and
                                (not invitation or not invitation.skip_moderation))
         with db.session.no_autoflush:
-            payment_required = regform.event.has_feature('payment') and bool(self.price)
+            payment_required = (regform.event.has_feature('payment') and bool(self.price) and
+                                not self.is_paid)
         if self.state == RegistrationState.pending:
             if approved and payment_required:
                 self.state = RegistrationState.unpaid

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -719,7 +719,9 @@ class Registration(db.Model):
             if not self.price:
                 self.state = RegistrationState.complete
         elif self.state == RegistrationState.complete:
-            if payment_required:
+            if moderation_required:
+                self.state = RegistrationState.pending
+            elif payment_required:
                 self.state = RegistrationState.unpaid
         if self.state != initial_state:
             signals.event.registration_state_updated.send(self, previous_state=initial_state)

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -699,6 +699,15 @@ class Registration(db.Model):
     def render_price_adjustment(self):
         return self._render_price(self.price_adjustment)
 
+    @property
+    def modification_resets_approval(self):
+        regform = self.registration_form
+        invitation = self.invitation
+        moderation_required = (regform.moderation_enabled and
+                               (not invitation or not invitation.skip_moderation))
+        return (moderation_required and regform.reset_approval_on_modification and
+                self.state in (RegistrationState.unpaid, RegistrationState.complete))
+
     def sync_state(self, _skip_moderation=True):
         """Sync the state of the registration."""
         initial_state = self.state

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -703,10 +703,12 @@ class Registration(db.Model):
     def modification_resets_approval(self):
         regform = self.registration_form
         invitation = self.invitation
-        moderation_required = (regform.moderation_enabled and
-                               (not invitation or not invitation.skip_moderation))
-        return (moderation_required and regform.reset_approval_on_modification and
-                self.state in (RegistrationState.unpaid, RegistrationState.complete))
+        moderation_required = regform.moderation_enabled and (not invitation or not invitation.skip_moderation)
+        return (
+            moderation_required
+            and regform.reset_approval_on_modification
+            and self.state in (RegistrationState.unpaid, RegistrationState.complete)
+        )
 
     def sync_state(self, _skip_moderation=True):
         """Sync the state of the registration."""

--- a/indico/modules/events/registration/operations.py
+++ b/indico/modules/events/registration/operations.py
@@ -21,6 +21,7 @@ def _log_registration_form_update(regform, changes, extra_log_fields):
         'introduction': 'Introduction',
         'contact_info': {'title': 'Contact info', 'type': 'string'},
         'moderation_enabled': 'Moderated',
+        'reset_approval_on_modification': 'Reset approval on modification',
         'private': 'Private',
         'require_login': 'Only logged-in users',
         'require_user': 'Registrant must have account',

--- a/indico/modules/events/registration/templates/display/registration_modify.html
+++ b/indico/modules/events/registration/templates/display/registration_modify.html
@@ -16,6 +16,14 @@
 {% endblock %}
 
 {% block content %}
+    {% if registration.modification_resets_approval %}
+        {% call message_box('warning') %}
+            {%- trans -%}
+                Modifying your registration will reset its approval status. It will need to be approved again
+                before it is confirmed.
+            {%- endtrans -%}
+        {% endcall %}
+    {% endif %}
     <div id="registration-form-submission-container"
          data-event-id="{{ event.id }}"
          data-regform-id="{{ regform.id }}"

--- a/indico/modules/events/registration/templates/display/registration_modify.html
+++ b/indico/modules/events/registration/templates/display/registration_modify.html
@@ -19,8 +19,7 @@
     {% if registration.modification_resets_approval %}
         {% call message_box('warning') %}
             {%- trans -%}
-                Modifying your registration will reset its approval status. It will need to be approved again
-                before it is confirmed.
+                If you modify this registration, it needs to be approved again by the event organizer.
             {%- endtrans -%}
         {% endcall %}
     {% endif %}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -535,7 +535,7 @@ def modify_registration(registration, data, management=False, notify_user=True):
         if consent_to_publish is not None:
             update_registration_consent_to_publish(registration, consent_to_publish)
 
-    registration.sync_state()
+    registration.sync_state(_skip_moderation=management)
     db.session.flush()
     # sanity check
     if billable_items_locked and old_price != registration.price:

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -569,7 +569,7 @@ def modify_registration(registration, data, management=False, notify_user=True):
         if consent_to_publish is not None:
             update_registration_consent_to_publish(registration, consent_to_publish)
 
-    registration.sync_state()
+    registration.sync_state(_skip_moderation=management)
     registration.set_modified()
     db.session.flush()
     # sanity check

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -20,7 +20,7 @@ from indico.modules.events.registration.controllers.management.fields import _fi
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.invitations import RegistrationInvitation
 from indico.modules.events.registration.models.items import RegistrationFormItemType, RegistrationFormSection
-from indico.modules.events.registration.models.registrations import RegistrationVisibility
+from indico.modules.events.registration.models.registrations import RegistrationState, RegistrationVisibility
 from indico.modules.events.registration.util import (create_registration, get_event_regforms_registrations,
                                                      get_registered_event_persons, get_ticket_qr_code_data,
                                                      get_user_data, import_invitations_from_user_records,
@@ -941,3 +941,39 @@ def test_modify_registration_conditional(monkeypatch, dummy_user, dummy_regform)
     assert not reg.data_by_field[boolean_field.id].data
     assert boolean_field_2.id not in reg.data_by_field
     assert text_field.id not in reg.data_by_field
+
+
+@pytest.mark.usefixtures('request_context')
+def test_modify_registration_resets_to_pending_with_moderation(monkeypatch, dummy_user, dummy_regform):
+    monkeypatch.setattr('indico.modules.users.util.get_user_by_email', lambda *args, **kwargs: dummy_user)
+
+    section = RegistrationFormSection(registration_form=dummy_regform, title='dummy_section', is_manager_only=False)
+    boolean_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+    _fill_form_field_with_data(boolean_field, {
+        'input_type': 'bool', 'default_value': False, 'title': 'Yes/No'
+    })
+    db.session.flush()
+
+    # Create a registration as manager (bypasses moderation)
+    data = {
+        boolean_field.html_field_name: True,
+        'email': dummy_user.email, 'first_name': dummy_user.first_name, 'last_name': dummy_user.last_name
+    }
+    reg = create_registration(dummy_regform, data, management=True, notify_user=False)
+    assert reg.state == RegistrationState.complete
+
+    # Enable moderation
+    dummy_regform.moderation_enabled = True
+    db.session.flush()
+
+    # Registrant modifies their registration -> state should become pending
+    modify_registration(reg, {boolean_field.html_field_name: False}, management=False, notify_user=False)
+    assert reg.state == RegistrationState.pending
+
+    # Approve the registration again
+    reg.update_state(approved=True)
+    assert reg.state == RegistrationState.complete
+
+    # Manager modifies the registration -> state should stay complete
+    modify_registration(reg, {boolean_field.html_field_name: True}, management=True, notify_user=False)
+    assert reg.state == RegistrationState.complete

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -17,6 +17,7 @@ from speaklater import make_lazy_string
 
 from indico.core.db import db
 from indico.core.errors import UserValueError
+from indico.modules.events.features.util import set_feature_enabled
 from indico.modules.events.models.persons import EventPerson
 from indico.modules.events.registration.controllers.management.fields import _fill_form_field_with_data
 from indico.modules.events.registration.custom import RegistrationListColumn
@@ -40,7 +41,8 @@ from indico.testing.util import assert_json_snapshot
 from indico.util.spreadsheets import CSVFieldDelimiter
 
 
-pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
+pytest_plugins = ('indico.modules.events.registration.testing.fixtures',
+                  'indico.modules.events.payment.testing.fixtures')
 
 
 INVITATION_COLUMNS = ['first_name', 'last_name', 'affiliation', 'email']
@@ -1184,4 +1186,14 @@ def test_sync_state_does_not_reset_when_toggle_disabled(dummy_reg, dummy_regform
     dummy_regform.reset_approval_on_modification = False
     dummy_reg.state = RegistrationState.complete
     dummy_reg.sync_state(_skip_moderation=False)
+    assert dummy_reg.state == RegistrationState.complete
+
+
+@pytest.mark.usefixtures('request_context')
+def test_update_state_approves_paid_pending_back_to_complete(dummy_reg, dummy_event, dummy_transaction):
+    set_feature_enabled(dummy_event, 'payment', True)
+    dummy_reg.transaction = dummy_transaction
+    dummy_reg.base_price = 100
+    dummy_reg.state = RegistrationState.pending
+    dummy_reg.update_state(approved=True)
     assert dummy_reg.state == RegistrationState.complete

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -1130,3 +1130,39 @@ def test_generate_spreadsheet_no_extra_columns_backward_compat(dummy_reg):
     headers, rows = generate_spreadsheet_from_registrations([dummy_reg], [], set())
     assert 'ID' in headers
     assert len(rows) == 1
+
+
+@pytest.mark.usefixtures('request_context')
+def test_modify_registration_resets_to_pending_with_moderation(monkeypatch, dummy_user, dummy_regform):
+    monkeypatch.setattr('indico.modules.users.util.get_user_by_email', lambda *args, **kwargs: dummy_user)
+
+    section = RegistrationFormSection(registration_form=dummy_regform, title='dummy_section', is_manager_only=False)
+    boolean_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+    _fill_form_field_with_data(boolean_field, {
+        'input_type': 'bool', 'default_value': False, 'title': 'Yes/No'
+    })
+    db.session.flush()
+
+    # Create a registration as manager (bypasses moderation)
+    data = {
+        boolean_field.html_field_name: True,
+        'email': dummy_user.email, 'first_name': dummy_user.first_name, 'last_name': dummy_user.last_name
+    }
+    reg = create_registration(dummy_regform, data, management=True, notify_user=False)
+    assert reg.state == RegistrationState.complete
+
+    # Enable moderation
+    dummy_regform.moderation_enabled = True
+    db.session.flush()
+
+    # Registrant modifies their registration -> state should become pending
+    modify_registration(reg, {boolean_field.html_field_name: False}, management=False, notify_user=False)
+    assert reg.state == RegistrationState.pending
+
+    # Approve the registration again
+    reg.update_state(approved=True)
+    assert reg.state == RegistrationState.complete
+
+    # Manager modifies the registration -> state should stay complete
+    modify_registration(reg, {boolean_field.html_field_name: True}, management=True, notify_user=False)
+    assert reg.state == RegistrationState.complete

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -1151,8 +1151,9 @@ def test_modify_registration_resets_to_pending_with_moderation(monkeypatch, dumm
     reg = create_registration(dummy_regform, data, management=True, notify_user=False)
     assert reg.state == RegistrationState.complete
 
-    # Enable moderation
+    # Enable moderation and approval reset on modification
     dummy_regform.moderation_enabled = True
+    dummy_regform.reset_approval_on_modification = True
     db.session.flush()
 
     # Registrant modifies their registration -> state should become pending
@@ -1166,3 +1167,21 @@ def test_modify_registration_resets_to_pending_with_moderation(monkeypatch, dumm
     # Manager modifies the registration -> state should stay complete
     modify_registration(reg, {boolean_field.html_field_name: True}, management=True, notify_user=False)
     assert reg.state == RegistrationState.complete
+
+
+@pytest.mark.usefixtures('request_context')
+def test_sync_state_resets_unpaid_to_pending_with_moderation(dummy_reg, dummy_regform):
+    dummy_regform.moderation_enabled = True
+    dummy_regform.reset_approval_on_modification = True
+    dummy_reg.state = RegistrationState.unpaid
+    dummy_reg.sync_state(_skip_moderation=False)
+    assert dummy_reg.state == RegistrationState.pending
+
+
+@pytest.mark.usefixtures('request_context')
+def test_sync_state_does_not_reset_when_toggle_disabled(dummy_reg, dummy_regform):
+    dummy_regform.moderation_enabled = True
+    dummy_regform.reset_approval_on_modification = False
+    dummy_reg.state = RegistrationState.complete
+    dummy_reg.sync_state(_skip_moderation=False)
+    assert dummy_reg.state == RegistrationState.complete

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -24,6 +24,7 @@ from indico.modules.events.registration.custom import RegistrationListColumn
 from indico.modules.events.registration.fields.affiliation import AffiliationMode
 from indico.modules.events.registration.fields.simple import PROFILE_PICTURE_SENTINEL
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
+from indico.modules.events.registration.models.forms import ModificationMode
 from indico.modules.events.registration.models.invitations import RegistrationInvitation
 from indico.modules.events.registration.models.items import (PersonalDataType, RegistrationFormItemType,
                                                              RegistrationFormSection)
@@ -1197,3 +1198,21 @@ def test_update_state_approves_paid_pending_back_to_complete(dummy_reg, dummy_ev
     dummy_reg.state = RegistrationState.pending
     dummy_reg.update_state(approved=True)
     assert dummy_reg.state == RegistrationState.complete
+
+
+@pytest.mark.usefixtures('request_context')
+@pytest.mark.parametrize(('modification_mode', 'modifiable'), (
+    (ModificationMode.allowed_always, True),
+    (ModificationMode.allowed_until_payment, True),
+    (ModificationMode.allowed_until_approved, False),
+    (ModificationMode.not_allowed, False),
+))
+def test_reset_approval_requires_modifiable_complete_registration(dummy_reg, dummy_regform, modification_mode,
+                                                                  modifiable):
+    dummy_regform.moderation_enabled = True
+    dummy_regform.reset_approval_on_modification = True
+    dummy_regform.modification_mode = modification_mode
+    dummy_reg.state = RegistrationState.complete
+    assert dummy_reg.can_be_modified == modifiable
+    dummy_reg.sync_state(_skip_moderation=False)
+    assert dummy_reg.state == RegistrationState.pending


### PR DESCRIPTION
This PR resets the approval status whenever registration data is mutated only if:

- The edition is not performed by an admin.
- Moderation is enabled.

This ensures any relevant registration data is viewed by event owners and consequently approved or rejected.