### PR TITLE
Fix linter errors

### DIFF
--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -199,7 +199,7 @@ function EntryPopupContent({
               size="tiny"
               style={{...session.colors}}
             >
-              <Translate>{session.title}</Translate>
+              {session.title}
             </Label>
           )}
           <Header as="h5" color={!title ? 'grey' : null}>

--- a/indico/web/client/js/react/forms/fields.d.ts
+++ b/indico/web/client/js/react/forms/fields.d.ts
@@ -15,6 +15,11 @@ interface SharedFieldProps {
   required?: boolean | 'no-validator';
   disabled?: boolean;
   initialValue?: any;
+  className?: string;
+  formatOnBlur?: boolean;
+  parse?: (value: any) => any;
+  format?: (value: any) => any;
+  validate?: (value: any) => string | undefined;
 }
 
 interface FinalFieldProps extends SharedFieldProps {
@@ -33,8 +38,10 @@ interface FinalInputProps extends SharedFieldProps {
 
 interface FinalTextAreaProps extends SharedFieldProps {
   label?: string | null;
+  placeholder?: string;
   nullIfEmpty?: boolean;
   action?: object;
+  rows?: number;
 }
 
 interface FinalCheckboxProps extends SharedFieldProps {
@@ -51,6 +58,8 @@ interface FinalDropdownProps extends SharedFieldProps {
   options: object[];
   placeholder?: string;
   label?: string | null;
+  fluid?: boolean;
+  loading?: boolean;
   multiple?: boolean;
   selection?: boolean;
   search?: boolean | ((options: DropdownItemProps[], value: string) => DropdownItemProps[]);
@@ -60,8 +69,6 @@ interface FinalDropdownProps extends SharedFieldProps {
     data: DropdownOnSearchChangeData
   ) => void;
   onKeyDown?: (event: React.KeyboardEvent<HTMLElement>) => void;
-  parse?: (value: any) => any;
-  format?: (value: any) => any;
 }
 
 interface FinalComboDropdownProps extends SharedFieldProps {

--- a/indico/web/client/js/react/forms/fields.d.ts
+++ b/indico/web/client/js/react/forms/fields.d.ts
@@ -8,6 +8,7 @@
 import {Moment} from 'moment/moment';
 import {ComponentType} from 'react';
 
+// TODO look into using FieldProps from react-final-form
 interface SharedFieldProps {
   name: string;
   description?: React.ReactNode;


### PR DESCRIPTION
I think it would be much nicer to use `import type {FieldProps} from 'react-final-form/typescript';` as a base for `SharedFieldProps` but it doesn't seem to pick up things like `format` and I don't want to spend time on this right now and just fix the linter errors that started after the last rebase to master.