### PR TITLE
Fix registration list filters for single choice fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,6 +57,8 @@ Bugfixes
   :user:`foxbunny`)
 - Fix database error when importing protection settings in an unlisted event
   (:issue:`7550`, :pr:`7551`)
+- Use consistent sorting and hide deleted+unused single-choice options in
+  registration list filters (:pr:`7439`, thanks :user:`duartegalvao`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -21,7 +21,7 @@ from indico.modules.events.registration.fields.base import (FieldSetupSchemaBase
                                                             RegistrationFormBillableField,
                                                             RegistrationFormBillableItemsField)
 from indico.modules.events.registration.models.form_fields import RegistrationFormFieldData
-from indico.modules.events.registration.models.registrations import RegistrationData
+from indico.modules.events.registration.models.registrations import Registration, RegistrationData
 from indico.util.date_time import format_date
 from indico.util.i18n import _, ngettext
 from indico.util.marshmallow import UUIDString, not_empty
@@ -133,7 +133,22 @@ class ChoiceBaseField(RegistrationFormBillableItemsField):
     @property
     def filter_choices(self):
         captions = self.form_item.data['captions']
-        return dict(sorted(captions.items(), key=lambda item: natural_sort_key(item[1])))
+        current_choice_ids = {c['id'] for c in self.form_item.versioned_data['choices']}
+        deleted_ids = set(captions) - current_choice_ids
+        hidden_ids = {cid for cid in deleted_ids if not self._is_choice_used(cid)}
+        visible_choices = [(k, v) for k, v in captions.items() if k not in hidden_ids]
+        return dict(sorted(visible_choices, key=lambda item: natural_sort_key(item[1])))
+
+    def _is_choice_used(self, choice_id):
+        query = (RegistrationData.query
+                .join(RegistrationData.registration)
+                .filter(Registration.registration_form == self.form_item.registration_form,
+                        ~Registration.is_deleted,
+                        RegistrationData.field_data.has(field_id=self.form_item.id)))
+        has_key = RegistrationData.data.op('?')(choice_id)
+        is_legacy = db.and_(RegistrationData.data.op('?')('choice'),
+                            RegistrationData.data['choice'].astext == choice_id)
+        return query.filter(has_key | is_legacy).has_rows()
 
     @property
     def view_data(self):

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -25,7 +25,7 @@ from indico.modules.events.registration.models.registrations import Registration
 from indico.util.date_time import format_date
 from indico.util.i18n import _, ngettext
 from indico.util.marshmallow import UUIDString, not_empty
-from indico.util.string import camelize_keys, snakify_keys
+from indico.util.string import camelize_keys, natural_sort_key, snakify_keys
 
 
 def get_field_merged_options(field, registration_data):
@@ -132,7 +132,8 @@ class ChoiceBaseField(RegistrationFormBillableItemsField):
 
     @property
     def filter_choices(self):
-        return self.form_item.data['captions']
+        captions = self.form_item.data['captions']
+        return dict(sorted(captions.items(), key=lambda item: natural_sort_key(item[1])))
 
     @property
     def view_data(self):

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -135,20 +135,23 @@ class ChoiceBaseField(RegistrationFormBillableItemsField):
         captions = self.form_item.data['captions']
         current_choice_ids = {c['id'] for c in self.form_item.versioned_data['choices']}
         deleted_ids = set(captions) - current_choice_ids
-        hidden_ids = {cid for cid in deleted_ids if not self._is_choice_used(cid)}
+        hidden_ids = deleted_ids - self._get_used_choice_ids() if deleted_ids else set()
         visible_choices = [(k, v) for k, v in captions.items() if k not in hidden_ids]
         return dict(sorted(visible_choices, key=lambda item: natural_sort_key(item[1])))
 
-    def _is_choice_used(self, choice_id):
+    def _get_used_choice_ids(self):
         query = (RegistrationData.query
-                .join(RegistrationData.registration)
-                .filter(Registration.registration_form == self.form_item.registration_form,
-                        ~Registration.is_deleted,
-                        RegistrationData.field_data.has(field_id=self.form_item.id)))
-        has_key = RegistrationData.data.op('?')(choice_id)
-        is_legacy = db.and_(RegistrationData.data.op('?')('choice'),
-                            RegistrationData.data['choice'].astext == choice_id)
-        return query.filter(has_key | is_legacy).has_rows()
+                 .join(RegistrationData.registration)
+                 .filter(Registration.registration_form == self.form_item.registration_form,
+                          ~Registration.is_deleted,
+                          RegistrationData.field_data.has(field_id=self.form_item.id)))
+        choice_key = RegistrationData.data.op('?')('choice')
+        non_legacy_ids = (query.filter(~choice_key)
+                          .with_entities(db.func.jsonb_object_keys(RegistrationData.data).label('choice_id')))
+        legacy_ids = (query.filter(choice_key)
+                      .with_entities(RegistrationData.data['choice'].astext.label('choice_id')))
+        used_ids = non_legacy_ids.union_all(legacy_ids).distinct()
+        return {row.choice_id for row in used_ids}
 
     @property
     def view_data(self):

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -136,20 +136,23 @@ class ChoiceBaseField(RegistrationFormBillableItemsField):
         captions = self.form_item.data['captions']
         current_choice_ids = {c['id'] for c in self.form_item.versioned_data['choices']}
         deleted_ids = set(captions) - current_choice_ids
-        hidden_ids = {cid for cid in deleted_ids if not self._is_choice_used(cid)}
+        hidden_ids = deleted_ids - self._get_used_choice_ids() if deleted_ids else set()
         visible_choices = [(k, v) for k, v in captions.items() if k not in hidden_ids]
         return dict(sorted(visible_choices, key=lambda item: natural_sort_key(item[1])))
 
-    def _is_choice_used(self, choice_id):
+    def _get_used_choice_ids(self):
         query = (RegistrationData.query
-                .join(RegistrationData.registration)
-                .filter(Registration.registration_form == self.form_item.registration_form,
-                        ~Registration.is_deleted,
-                        RegistrationData.field_data.has(field_id=self.form_item.id)))
-        has_key = RegistrationData.data.op('?')(choice_id)
-        is_legacy = db.and_(RegistrationData.data.op('?')('choice'),
-                            RegistrationData.data['choice'].astext == choice_id)
-        return query.filter(has_key | is_legacy).has_rows()
+                 .join(RegistrationData.registration)
+                 .filter(Registration.registration_form == self.form_item.registration_form,
+                          ~Registration.is_deleted,
+                          RegistrationData.field_data.has(field_id=self.form_item.id)))
+        choice_key = RegistrationData.data.op('?')('choice')
+        non_legacy_ids = (query.filter(~choice_key)
+                          .with_entities(db.func.jsonb_object_keys(RegistrationData.data).label('choice_id')))
+        legacy_ids = (query.filter(choice_key)
+                      .with_entities(RegistrationData.data['choice'].astext.label('choice_id')))
+        used_ids = non_legacy_ids.union_all(legacy_ids).distinct()
+        return {row.choice_id for row in used_ids}
 
     @property
     def view_data(self):

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -26,7 +26,7 @@ from indico.modules.events.registration.models.registrations import Registration
 from indico.util.date_time import format_date
 from indico.util.i18n import _, ngettext
 from indico.util.marshmallow import UUIDString, not_empty
-from indico.util.string import camelize_keys, snakify_keys
+from indico.util.string import camelize_keys, natural_sort_key, snakify_keys
 
 
 def get_field_merged_options(field, registration_data):
@@ -133,7 +133,8 @@ class ChoiceBaseField(RegistrationFormBillableItemsField):
 
     @property
     def filter_choices(self):
-        return self.form_item.data['captions']
+        captions = self.form_item.data['captions']
+        return dict(sorted(captions.items(), key=lambda item: natural_sort_key(item[1])))
 
     @property
     def view_data(self):

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -144,8 +144,8 @@ class ChoiceBaseField(RegistrationFormBillableItemsField):
         query = (RegistrationData.query
                  .join(RegistrationData.registration)
                  .filter(Registration.registration_form == self.form_item.registration_form,
-                          ~Registration.is_deleted,
-                          RegistrationData.field_data.has(field_id=self.form_item.id)))
+                         ~Registration.is_deleted,
+                         RegistrationData.field_data.has(field_id=self.form_item.id)))
         choice_key = RegistrationData.data.op('?')('choice')
         non_legacy_ids = (query.filter(~choice_key)
                           .with_entities(db.func.jsonb_object_keys(RegistrationData.data).label('choice_id')))

--- a/indico/modules/events/registration/fields/choices.py
+++ b/indico/modules/events/registration/fields/choices.py
@@ -22,7 +22,7 @@ from indico.modules.events.registration.fields.base import (FieldSetupSchemaBase
                                                             RegistrationFormBillableField,
                                                             RegistrationFormBillableItemsField)
 from indico.modules.events.registration.models.form_fields import RegistrationFormFieldData
-from indico.modules.events.registration.models.registrations import RegistrationData
+from indico.modules.events.registration.models.registrations import Registration, RegistrationData
 from indico.util.date_time import format_date
 from indico.util.i18n import _, ngettext
 from indico.util.marshmallow import UUIDString, not_empty
@@ -134,7 +134,22 @@ class ChoiceBaseField(RegistrationFormBillableItemsField):
     @property
     def filter_choices(self):
         captions = self.form_item.data['captions']
-        return dict(sorted(captions.items(), key=lambda item: natural_sort_key(item[1])))
+        current_choice_ids = {c['id'] for c in self.form_item.versioned_data['choices']}
+        deleted_ids = set(captions) - current_choice_ids
+        hidden_ids = {cid for cid in deleted_ids if not self._is_choice_used(cid)}
+        visible_choices = [(k, v) for k, v in captions.items() if k not in hidden_ids]
+        return dict(sorted(visible_choices, key=lambda item: natural_sort_key(item[1])))
+
+    def _is_choice_used(self, choice_id):
+        query = (RegistrationData.query
+                .join(RegistrationData.registration)
+                .filter(Registration.registration_form == self.form_item.registration_form,
+                        ~Registration.is_deleted,
+                        RegistrationData.field_data.has(field_id=self.form_item.id)))
+        has_key = RegistrationData.data.op('?')(choice_id)
+        is_legacy = db.and_(RegistrationData.data.op('?')('choice'),
+                            RegistrationData.data['choice'].astext == choice_id)
+        return query.filter(has_key | is_legacy).has_rows()
 
     @property
     def view_data(self):

--- a/indico/modules/events/registration/fields/choices_test.py
+++ b/indico/modules/events/registration/fields/choices_test.py
@@ -13,6 +13,7 @@ from marshmallow import ValidationError
 
 from indico.modules.events.registration.fields.choices import MultiChoiceSetupSchema, _hashable_choice
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
+from indico.modules.events.registration.models.items import RegistrationFormSection
 from indico.modules.events.registration.models.registrations import RegistrationData
 
 
@@ -42,6 +43,38 @@ def multi_choice_field():
         },
         'max_choices': None
     }
+    return field
+
+
+@pytest.fixture
+def single_choice_field(db, dummy_regform):
+    section = RegistrationFormSection(
+        registration_form=dummy_regform,
+        title='Section'
+    )
+    db.session.add(section)
+    db.session.flush()
+    field = RegistrationFormField(
+        input_type='single_choice',
+        title='Field',
+        parent=section,
+        registration_form=dummy_regform
+    )
+    field.versioned_data = {
+        'choices': [
+            {'id': _id(1), 'places_limit': 0, 'price': 0},
+            {'id': _id(2), 'places_limit': 0, 'price': 0},
+        ]
+    }
+    field.data = {
+        'captions': {
+            _id(1): 'Alpha',
+            _id(2): 'Beta',
+            _id(3): 'Gamma',
+        }
+    }
+    db.session.add(field)
+    db.session.flush()
     return field
 
 
@@ -323,3 +356,31 @@ def test_accommodation_validators(dummy_accommodation_field, value, error):
         with pytest.raises(ValidationError) as exc_info:
             _validate(value)
         assert exc_info.value.messages == [error]
+
+
+def test_filter_choices_hide_unused_deleted_choice(single_choice_field):
+    choices = single_choice_field.field_impl.filter_choices
+    assert set(choices) == {_id(1), _id(2)}
+    assert _id(3) not in choices
+
+
+def test_filter_choices_show_used_deleted_choice(single_choice_field, create_registration, db, dummy_user,
+                                                 dummy_regform):
+    reg = create_registration(dummy_user, dummy_regform)
+    db.session.add(reg)
+    reg.data.append(RegistrationData(field_data=single_choice_field.current_data, data={_id(3): 1}))
+    db.session.flush()
+
+    choices = single_choice_field.field_impl.filter_choices
+    assert _id(3) in choices
+
+
+def test_filter_choices_show_used_deleted_choice_legacy(single_choice_field, create_registration, db, dummy_user,
+                                                        dummy_regform):
+    reg = create_registration(dummy_user, dummy_regform)
+    db.session.add(reg)
+    reg.data.append(RegistrationData(field_data=single_choice_field.current_data, data={'choice': _id(3)}))
+    db.session.flush()
+
+    choices = single_choice_field.field_impl.filter_choices
+    assert _id(3) in choices


### PR DESCRIPTION
This PR fixes two problems with the registration list filters for single choice fields:
- ordering of the filter options. Before it was random, but this PR enforces alphabetical order.
- options that were deleted were still visible even if unused. This PR hides those options, leaving only the ones which are actually present in (non-deleted) registrations.

Before:
<img width="370" height="193" alt="image" src="https://github.com/user-attachments/assets/e754432a-dfe3-4827-bb6a-2ddf49a74c21" />

After:
<img width="382" height="182" alt="image" src="https://github.com/user-attachments/assets/357a8e55-c5f1-4322-8317-9de57bce4af0" />