### PR TITLE
Load by default the user profile picture

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,6 @@ Version 3.3.13
 Improvements
 ^^^^^^^^^^^^
 
-- Pre-fill the picture field in registration forms with the user's profile
-  picture when available (:pr:`7447`, thanks :user:`moliholy, unconventionaldotdev`)
 - Include keywords in contribution CSV/Excel exports (:pr:`7421`)
 - Add new permission that grants only participant management (create, edit and
   delete registrations) without access to the registration form configuration
@@ -21,6 +19,8 @@ Improvements
 - Add a "Code" (short name) to predefined affiliations (:pr:`7400`, thanks
   :user:`duartegalvao, unconventionaldotdev`)
 - Track the last modified timestamp of registrations (:pr:`7478`, thanks :user:`jbtwist`)
+- Pre-fill the registration form picture field with the user's custom profile
+  picture when available (:pr:`7447`, thanks :user:`moliholy, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Version 3.3.13
 Improvements
 ^^^^^^^^^^^^
 
+- Pre-fill the picture field in registration forms with the user's profile
+  picture when available (:pr:`7447`, thanks :user:`moliholy, unconventionaldotdev`)
 - Include keywords in contribution CSV/Excel exports (:pr:`7421`)
 - Add new permission that grants only participant management (create, edit and
   delete registrations) without access to the registration form configuration

--- a/indico/modules/events/registration/client/js/form/fields/PictureInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/PictureInput.jsx
@@ -57,6 +57,8 @@ export default function PictureInput({
     uploadUrlParams.form_token = formToken;
   }
   const previewUrlParams = initialPictureDetails ? initialPictureDetails.locator : null;
+  const resolvedPreviewUrl =
+    initialPictureDetails?.previewUrl || (previewUrlParams ? previewURL(previewUrlParams) : '');
 
   return (
     <div styleName="file-field" id={htmlId}>
@@ -65,7 +67,7 @@ export default function PictureInput({
         disabled={disabled}
         required={isRequired}
         uploadURL={uploadURL(uploadUrlParams)}
-        previewURL={previewUrlParams ? previewURL(previewUrlParams) : ''}
+        previewURL={resolvedPreviewUrl}
         initialPictureDetails={initialPictureDetails}
         minPictureSize={minPictureSize}
       />

--- a/indico/modules/events/registration/constants.py
+++ b/indico/modules/events/registration/constants.py
@@ -10,3 +10,7 @@ REGISTRATION_PICTURE_SIZE = 1000
 
 #: Max size of the longest edge for registration pictures thumbnails (px)
 REGISTRATION_PICTURE_THUMBNAIL_SIZE = 120
+
+#: Sentinel UUID used to indicate that the user's profile picture should be used as the
+#: registration picture; the actual File is created at form submission time
+PROFILE_PICTURE_SENTINEL = '00000000-0000-0000-0000-000000000002'

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -417,7 +417,7 @@ class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
         if session.user and user_data.get('picture'):
             metadata = session.user.picture_metadata or {}
             file_data['picture'] = {
-                'filename': metadata.get('filename', 'profile_picture.jpg'),
+                'filename': metadata.get('filename', 'profile_picture.png'),
                 'size': metadata.get('size', 0),
                 'uuid': PROFILE_PICTURE_SENTINEL,
                 'previewUrl': session.user.avatar_url,

--- a/indico/modules/events/registration/controllers/display.py
+++ b/indico/modules/events/registration/controllers/display.py
@@ -18,6 +18,7 @@ from indico.modules.events.controllers.base import RegistrationRequired, RHDispl
 from indico.modules.events.models.events import EventType
 from indico.modules.events.payment import payment_event_settings
 from indico.modules.events.registration import registration_settings
+from indico.modules.events.registration.constants import PROFILE_PICTURE_SENTINEL
 from indico.modules.events.registration.controllers import (CheckEmailMixin, RegistrationEditMixin,
                                                             RegistrationFormMixin, UploadRegistrationFileMixin,
                                                             UploadRegistrationPictureMixin)
@@ -412,12 +413,22 @@ class RHRegistrationForm(InvitationMixin, RHRegistrationFormRegistrationBase):
     def _process_GET(self):
         user_data = get_user_data(self.regform, session.user, self.invitation)
         initial_values = get_initial_form_values(self.regform) | user_data
+        file_data = {}
+        if session.user and user_data.get('picture'):
+            metadata = session.user.picture_metadata or {}
+            file_data['picture'] = {
+                'filename': metadata.get('filename', 'profile_picture.jpg'),
+                'size': metadata.get('size', 0),
+                'uuid': PROFILE_PICTURE_SENTINEL,
+                'previewUrl': session.user.avatar_url,
+            }
         if self._captcha_required:
             initial_values |= {'captcha': None}
         return self.view_class.render_template('display/regform_display.html', self.event,
                                                regform=self.regform,
                                                form_data=get_flat_section_submission_data(self.regform),
                                                initial_values=initial_values,
+                                               file_data=file_data,
                                                payment_conditions=payment_event_settings.get(self.event, 'conditions'),
                                                payment_enabled=self.event.has_feature('payment'),
                                                invitation=self.invitation,

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -37,6 +37,7 @@ from indico.modules.events.registration import logger
 from indico.modules.events.registration.badges import (RegistrantsListToBadgesPDF,
                                                        RegistrantsListToBadgesPDFDoubleSided,
                                                        RegistrantsListToBadgesPDFFoldable)
+from indico.modules.events.registration.constants import PROFILE_PICTURE_SENTINEL
 from indico.modules.events.registration.controllers import (CheckEmailMixin, RegistrationEditMixin,
                                                             UploadRegistrationFileMixin, UploadRegistrationPictureMixin)
 from indico.modules.events.registration.controllers.management import (RHManageRegFormBase, RHManageRegFormsBase,
@@ -65,6 +66,7 @@ from indico.modules.events.util import ZipGeneratorMixin
 from indico.modules.logs import LogKind
 from indico.modules.logs.util import make_diff_log
 from indico.modules.receipts.models.files import ReceiptFile
+from indico.modules.users.models.users import ProfilePictureSource
 from indico.util.date_time import format_currency, now_utc, relativedelta
 from indico.util.fs import secure_filename
 from indico.util.i18n import _, ngettext
@@ -402,11 +404,6 @@ class RHRegistrationCreate(RHManageRegFormBase):
 
     PERMISSION = ('registration', 'registration_edit')
 
-    @use_kwargs({
-        'user': Principal(allow_external_users=True, load_default=None),
-    }, location='query')
-    def _get_user_data(self, user):
-        return get_user_data(self.regform, user)
 
     def _process_POST(self):
         if self.regform.is_purged:
@@ -419,14 +416,27 @@ class RHRegistrationCreate(RHManageRegFormBase):
         flash(_('The registration was created.'), 'success')
         return jsonify({'redirect': url_for('event_registration.manage_reglist', self.regform)})
 
-    def _process_GET(self):
-        user_data = self._get_user_data()
+    @use_kwargs({
+        'user': Principal(allow_external_users=True, load_default=None),
+    }, location='query')
+    def _process_GET(self, user):
+        user_data = get_user_data(self.regform, user)
         initial_values = get_initial_form_values(self.regform, management=True) | user_data
         form_data = get_flat_section_submission_data(self.regform, management=True)
+        file_data = {}
+        if user and user_data.get('picture'):
+            metadata = user.picture_metadata or {}
+            file_data['picture'] = {
+                'filename': metadata.get('filename', 'profile_picture.jpg'),
+                'size': metadata.get('size', 0),
+                'uuid': PROFILE_PICTURE_SENTINEL,
+                'previewUrl': user.avatar_url,
+            }
         return WPManageRegistration.render_template('display/regform_display.html', self.event,
                                                     regform=self.regform,
                                                     form_data=form_data,
                                                     initial_values=initial_values,
+                                                    file_data=file_data,
                                                     invitation=None,
                                                     registration=None,
                                                     management=True,
@@ -442,7 +452,11 @@ class RHRegistrationCreateMultiple(RHManageRegFormBase):
 
     def _register_user(self, user, notify):
         # Fill only the personal data fields, custom fields are left empty.
-        data = {pdt.name: getattr(user, pdt.name, None) for pdt in PersonalDataType}
+        # Picture is excluded from getattr loop: user.picture is raw bytes, not a file UUID.
+        data = {pdt.name: getattr(user, pdt.name, None) for pdt in PersonalDataType
+                if pdt != PersonalDataType.picture}
+        if user.picture_source == ProfilePictureSource.custom and user.has_picture:
+            data['picture'] = PROFILE_PICTURE_SENTINEL
         data['title'] = get_title_uuid(self.regform, data['title'])
         with db.session.no_autoflush:
             create_registration(self.regform, data, management=True, notify_user=notify)

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -404,7 +404,6 @@ class RHRegistrationCreate(RHManageRegFormBase):
 
     PERMISSION = ('registration', 'registration_edit')
 
-
     def _process_POST(self):
         if self.regform.is_purged:
             raise Forbidden(_('Registration is disabled due to an expired retention period'))

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -9,13 +9,18 @@ import re
 from calendar import monthrange
 from datetime import date, datetime
 from decimal import Decimal
+from io import BytesIO
 
+from flask import session
 from marshmallow import ValidationError, fields, pre_load, validate, validates_schema
 from PIL import Image
 
+from indico.core.db import db
+from indico.modules.events.registration.constants import PROFILE_PICTURE_SENTINEL
 from indico.modules.events.registration.fields.base import (BillableFieldDataSchema, FieldSetupSchemaBase,
                                                             LimitedPlacesBillableFieldDataSchema,
                                                             RegistrationFormBillableField, RegistrationFormFieldBase)
+from indico.modules.events.registration.util import process_registration_picture
 from indico.modules.files.models.files import File
 from indico.util.countries import get_countries, get_country
 from indico.util.date_time import strftime_all_years
@@ -476,7 +481,7 @@ class PictureField(FileField):
 
     def get_validators(self, existing_registration):
         def _picture_size_and_type(value):
-            if not value:
+            if not value or value == PROFILE_PICTURE_SENTINEL:
                 return
             file = File.query.filter(File.uuid == value, ~File.claimed).first()
             if not file:
@@ -494,7 +499,37 @@ class PictureField(FileField):
             if min_picture_size and min(pic.size) < min_picture_size:
                 raise ValidationError(_('The uploaded picture pixels is smaller than the minimum size of {}.')
                                       .format(min_picture_size))
-        return [_picture_size_and_type, *super().get_validators(existing_registration)]
+
+        def _skip_sentinel(validator):
+            def _wrapped(value):
+                if value != PROFILE_PICTURE_SENTINEL:
+                    validator(value)
+            return _wrapped
+
+        return [_picture_size_and_type, *(_skip_sentinel(v) for v in super().get_validators(existing_registration))]
+
+    def process_form_data(self, registration, value, old_data=None, billable_items_locked=False):
+        if value == PROFILE_PICTURE_SENTINEL:
+            value = self._create_file_from_profile_picture()
+        return super().process_form_data(registration, value, old_data, billable_items_locked)
+
+    def _create_file_from_profile_picture(self):
+        user = session.user
+        if not user or not user.has_picture or not user.picture:
+            return None
+        processed = process_registration_picture(BytesIO(user.picture))
+        if not processed:
+            return None
+        regform = self.form_item.registration_form
+        file = File(filename='profile_picture.jpg', content_type='image/jpeg')
+        file.save(('event', regform.event_id, 'regform', regform.id, 'registration'), processed)
+        if not file.size:
+            file.delete()
+            return None
+        file.meta = {'regform_field_id': self.form_item.id, 'registration_picture_checked': True}
+        db.session.add(file)
+        db.session.flush([file])
+        return str(file.uuid)
 
     @make_interceptable
     def _get_min_size(self):

--- a/indico/modules/events/registration/fields/simple.py
+++ b/indico/modules/events/registration/fields/simple.py
@@ -11,7 +11,6 @@ from datetime import date, datetime
 from decimal import Decimal
 from io import BytesIO
 
-from flask import session
 from marshmallow import ValidationError, fields, pre_load, validate, validates_schema
 from PIL import Image
 
@@ -510,18 +509,17 @@ class PictureField(FileField):
 
     def process_form_data(self, registration, value, old_data=None, billable_items_locked=False):
         if value == PROFILE_PICTURE_SENTINEL:
-            value = self._create_file_from_profile_picture()
+            value = self._create_file_from_profile_picture(registration.user)
         return super().process_form_data(registration, value, old_data, billable_items_locked)
 
-    def _create_file_from_profile_picture(self):
-        user = session.user
+    def _create_file_from_profile_picture(self, user):
         if not user or not user.has_picture or not user.picture:
             return None
-        processed = process_registration_picture(BytesIO(user.picture))
+        processed = process_registration_picture(BytesIO(user.picture), target_format='PNG')
         if not processed:
             return None
         regform = self.form_item.registration_form
-        file = File(filename='profile_picture.jpg', content_type='image/jpeg')
+        file = File(filename='profile_picture.png', content_type='image/png')
         file.save(('event', regform.event_id, 'regform', regform.id, 'registration'), processed)
         if not file.size:
             file.delete()

--- a/indico/modules/events/registration/templates/display/regform_display.html
+++ b/indico/modules/events/registration/templates/display/regform_display.html
@@ -131,6 +131,7 @@
                 data-currency="{{ regform.currency }}"
                 data-form-data="{{ form_data | tojson | forceescape }}"
                 data-initial-values="{{ initial_values | tojson | forceescape }}"
+                data-file-data="{{ file_data | tojson | forceescape }}"
                 data-management="{{ management | tojson | forceescape }}"
                 data-moderated="{{ moderated | tojson | forceescape }}"
                 data-lock-email="{{ (invitation.lock_email if invitation else false) | tojson | forceescape }}"

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -236,7 +236,7 @@ def get_user_data(regform, user, invitation=None):
     active_fields = {item.personal_data_type.name for item in regform.active_fields
                      if item.type == RegistrationFormItemType.field_pd}
 
-    if user and user.picture_source == ProfilePictureSource.custom and 'picture' in active_fields:
+    if user and user.picture_source == ProfilePictureSource.custom and user.has_picture and 'picture' in active_fields:
         user_data['picture'] = PROFILE_PICTURE_SENTINEL
 
     return {name: value for name, value in user_data.items() if name in active_fields}
@@ -1111,22 +1111,22 @@ def get_persons(registrations, include_accompanying_persons=False):
 
 
 @make_interceptable
-def process_registration_picture(source, *, thumbnail=False):
-    """Resize the picture to a maximum size and save it as JPEG."""
+def process_registration_picture(source, *, thumbnail=False, target_format='JPEG'):
+    """Resize the picture to a maximum size and save it in the target format."""
     max_size = REGISTRATION_PICTURE_THUMBNAIL_SIZE if thumbnail else REGISTRATION_PICTURE_SIZE
     try:
         picture = Image.open(source)
     except (OSError, Image.DecompressionBombError):
         return None
     picture = ImageOps.exif_transpose(picture)
-    if picture.mode != 'RGB':
+    if target_format == 'JPEG' and picture.mode != 'RGB':
         picture = picture.convert('RGB')
     size_x, size_y = picture.size
     if max(size_x, size_y) > max_size:
         ratio = max_size / max(size_x, size_y)
         picture = picture.resize((max(1, int(ratio * size_x)), max(1, int(ratio * size_y))), Image.Resampling.BICUBIC)
     image_bytes = BytesIO()
-    picture.save(image_bytes, 'JPEG')
+    picture.save(image_bytes, target_format)
     image_bytes.seek(0)
     return image_bytes
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -33,7 +33,8 @@ from indico.modules.events.models.events import Event
 from indico.modules.events.models.persons import EventPerson
 from indico.modules.events.payment.models.transactions import TransactionStatus
 from indico.modules.events.registration import logger
-from indico.modules.events.registration.constants import REGISTRATION_PICTURE_SIZE, REGISTRATION_PICTURE_THUMBNAIL_SIZE
+from indico.modules.events.registration.constants import (PROFILE_PICTURE_SENTINEL, REGISTRATION_PICTURE_SIZE,
+                                                          REGISTRATION_PICTURE_THUMBNAIL_SIZE)
 from indico.modules.events.registration.fields.accompanying import AccompanyingPersonsField
 from indico.modules.events.registration.fields.choices import (AccommodationField, ChoiceBaseField,
                                                                get_field_merged_options)
@@ -233,6 +234,9 @@ def get_user_data(regform, user, invitation=None):
 
     active_fields = {item.personal_data_type.name for item in regform.active_fields
                      if item.type == RegistrationFormItemType.field_pd}
+
+    if user and user.has_picture and 'picture' in active_fields:
+        user_data['picture'] = PROFILE_PICTURE_SENTINEL
 
     return {name: value for name, value in user_data.items() if name in active_fields}
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -50,6 +50,7 @@ from indico.modules.events.registration.notifications import (notify_invitation,
                                                               notify_registration_modification)
 from indico.modules.logs import LogKind
 from indico.modules.logs.util import make_diff_log
+from indico.modules.users.models.users import ProfilePictureSource
 from indico.modules.users.util import get_user_by_email
 from indico.util.countries import get_country_reverse
 from indico.util.date_time import now_utc
@@ -235,7 +236,7 @@ def get_user_data(regform, user, invitation=None):
     active_fields = {item.personal_data_type.name for item in regform.active_fields
                      if item.type == RegistrationFormItemType.field_pd}
 
-    if user and user.has_picture and 'picture' in active_fields:
+    if user and user.picture_source == ProfilePictureSource.custom and 'picture' in active_fields:
         user_data['picture'] = PROFILE_PICTURE_SENTINEL
 
     return {name: value for name, value in user_data.items() if name in active_fields}

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -11,13 +11,14 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
-from PIL import Image
 from flask import session
+from PIL import Image
 
 from indico.core.db import db
 from indico.core.errors import UserValueError
 from indico.modules.events.models.persons import EventPerson
 from indico.modules.events.registration.controllers.management.fields import _fill_form_field_with_data
+from indico.modules.events.registration.fields.simple import PROFILE_PICTURE_SENTINEL
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.invitations import RegistrationInvitation
 from indico.modules.events.registration.models.items import RegistrationFormItemType, RegistrationFormSection
@@ -27,7 +28,6 @@ from indico.modules.events.registration.util import (create_registration, get_ev
                                                      get_user_data, import_invitations_from_user_records,
                                                      import_registrations_from_csv, import_user_records_from_csv,
                                                      modify_registration)
-from indico.modules.events.registration.fields.simple import PROFILE_PICTURE_SENTINEL
 from indico.modules.users.models.users import ProfilePictureSource, UserTitle
 from indico.testing.util import assert_json_snapshot
 from indico.util.spreadsheets import CSVFieldDelimiter
@@ -772,11 +772,11 @@ def test_get_user_data_prefills_profile_picture(dummy_regform, dummy_user, db):
     assert user_data.get('picture') == PROFILE_PICTURE_SENTINEL
 
 
-@pytest.mark.parametrize('source', [
+@pytest.mark.parametrize('source', (
     pytest.param('standard', id='standard'),
     pytest.param('identicon', id='identicon'),
     pytest.param('gravatar', id='gravatar'),
-])
+))
 def test_get_user_data_skips_picture_for_non_custom_source(dummy_regform, dummy_user, db, source):
     img = Image.new('RGB', (100, 100), color=(200, 100, 50))
     img_bytes = BytesIO()

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -11,6 +11,7 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
+from PIL import Image
 from flask import session
 
 from indico.core.db import db
@@ -26,7 +27,8 @@ from indico.modules.events.registration.util import (create_registration, get_ev
                                                      get_user_data, import_invitations_from_user_records,
                                                      import_registrations_from_csv, import_user_records_from_csv,
                                                      modify_registration)
-from indico.modules.users.models.users import UserTitle
+from indico.modules.events.registration.fields.simple import PROFILE_PICTURE_SENTINEL
+from indico.modules.users.models.users import ProfilePictureSource, UserTitle
 from indico.testing.util import assert_json_snapshot
 from indico.util.spreadsheets import CSVFieldDelimiter
 
@@ -755,11 +757,6 @@ def test_get_user_data(monkeypatch, dummy_event, dummy_user, dummy_regform):
 
 
 def test_get_user_data_prefills_profile_picture(dummy_regform, dummy_user, db):
-    from io import BytesIO
-
-    from PIL import Image
-
-    from indico.modules.events.registration.fields.simple import PROFILE_PICTURE_SENTINEL
     img = Image.new('RGB', (100, 100), color=(200, 100, 50))
     img_bytes = BytesIO()
     img.save(img_bytes, 'JPEG')
@@ -767,11 +764,33 @@ def test_get_user_data_prefills_profile_picture(dummy_regform, dummy_user, db):
     dummy_user.picture_metadata = {'hash': 0, 'size': len(dummy_user.picture), 'filename': 'test.jpg',
                                    'content_type': 'image/jpeg',
                                    'lastmod': 'Thu, 01 Jan 2026 00:00:00 GMT'}
+    dummy_user.picture_source = ProfilePictureSource.custom
     db.session.flush()
 
     user_data = get_user_data(dummy_regform, dummy_user)
 
     assert user_data.get('picture') == PROFILE_PICTURE_SENTINEL
+
+
+@pytest.mark.parametrize('source', [
+    pytest.param('standard', id='standard'),
+    pytest.param('identicon', id='identicon'),
+    pytest.param('gravatar', id='gravatar'),
+])
+def test_get_user_data_skips_picture_for_non_custom_source(dummy_regform, dummy_user, db, source):
+    img = Image.new('RGB', (100, 100), color=(200, 100, 50))
+    img_bytes = BytesIO()
+    img.save(img_bytes, 'JPEG')
+    dummy_user.picture = img_bytes.getvalue()
+    dummy_user.picture_metadata = {'hash': 0, 'size': len(dummy_user.picture), 'filename': 'test.jpg',
+                                   'content_type': 'image/jpeg',
+                                   'lastmod': 'Thu, 01 Jan 2026 00:00:00 GMT'}
+    dummy_user.picture_source = ProfilePictureSource[source]
+    db.session.flush()
+
+    user_data = get_user_data(dummy_regform, dummy_user)
+
+    assert 'picture' not in user_data
 
 
 def test_get_user_data_skips_picture_when_no_profile_picture(dummy_regform, dummy_user):

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -27,7 +27,7 @@ from indico.modules.events.registration.util import (create_registration, get_ev
                                                      get_registered_event_persons, get_ticket_qr_code_data,
                                                      get_user_data, import_invitations_from_user_records,
                                                      import_registrations_from_csv, import_user_records_from_csv,
-                                                     modify_registration)
+                                                     modify_registration, process_registration_picture)
 from indico.modules.users.models.users import ProfilePictureSource, UserTitle
 from indico.testing.util import assert_json_snapshot
 from indico.util.spreadsheets import CSVFieldDelimiter
@@ -797,6 +797,17 @@ def test_get_user_data_skips_picture_when_no_profile_picture(dummy_regform, dumm
     assert dummy_user.picture_metadata is None
     user_data = get_user_data(dummy_regform, dummy_user)
     assert 'picture' not in user_data
+
+
+def test_process_registration_picture_png_format():
+    img = Image.new('RGBA', (100, 100), color=(200, 100, 50, 128))
+    img_bytes = BytesIO()
+    img.save(img_bytes, 'PNG')
+    img_bytes.seek(0)
+    result = process_registration_picture(img_bytes, target_format='PNG')
+    assert result is not None
+    result_img = Image.open(result)
+    assert result_img.format == 'PNG'
 
 
 @pytest.mark.parametrize(('url', 'ticket_uuid', 'person_id'), (

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -754,6 +754,32 @@ def test_get_user_data(monkeypatch, dummy_event, dummy_user, dummy_regform):
     assert get_user_data(dummy_regform, dummy_user, invitation) == {}
 
 
+def test_get_user_data_prefills_profile_picture(dummy_regform, dummy_user, db):
+    from io import BytesIO
+
+    from PIL import Image
+
+    from indico.modules.events.registration.fields.simple import PROFILE_PICTURE_SENTINEL
+    img = Image.new('RGB', (100, 100), color=(200, 100, 50))
+    img_bytes = BytesIO()
+    img.save(img_bytes, 'JPEG')
+    dummy_user.picture = img_bytes.getvalue()
+    dummy_user.picture_metadata = {'hash': 0, 'size': len(dummy_user.picture), 'filename': 'test.jpg',
+                                   'content_type': 'image/jpeg',
+                                   'lastmod': 'Thu, 01 Jan 2026 00:00:00 GMT'}
+    db.session.flush()
+
+    user_data = get_user_data(dummy_regform, dummy_user)
+
+    assert user_data.get('picture') == PROFILE_PICTURE_SENTINEL
+
+
+def test_get_user_data_skips_picture_when_no_profile_picture(dummy_regform, dummy_user):
+    assert dummy_user.picture_metadata is None
+    user_data = get_user_data(dummy_regform, dummy_user)
+    assert 'picture' not in user_data
+
+
 @pytest.mark.parametrize(('url', 'ticket_uuid', 'person_id'), (
     ('https://indico.cern.ch', '9982be4e-32cf-4656-a781-62ad45609d12', None),
     ('http://indico.cern.ch', '9982be4e-32cf-4656-a781-62ad45609d12', None),


### PR DESCRIPTION
  When a registration form includes a picture field and the user is logged in with a profile picture, the field is automatically pre-filled with their profile picture.

The pre-fill is deferred: on GET, only a sentinel UUID and a preview URL are passed to the frontend for display. The actual File object is created only on POST (form submit), avoiding any side effects on page load.