### PR TITLE
Only allow left click on unscheduled entries

### DIFF
--- a/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
@@ -34,11 +34,31 @@ export function DraggableUnscheduledContributionEntry({
   const droppableData = useDroppableData({id: 'calendar'});
 
   const draggableId = `unscheduled-${id}`;
-  const {listeners, setNodeRef, transform, isDragging, rect, initialScroll, mouse, offset, ref} =
-    useDraggable({
-      id: draggableId,
-      fixed: true,
-    });
+  const {
+    listeners: _listeners,
+    setNodeRef,
+    transform,
+    isDragging,
+    rect,
+    initialScroll,
+    mouse,
+    offset,
+    ref,
+  } = useDraggable({
+    id: draggableId,
+    fixed: true,
+  });
+
+  const listeners = {
+    ..._listeners,
+    onMouseDown: (event: React.MouseEvent<HTMLElement>) => {
+      if (event.button !== 0) {
+        return;
+      }
+
+      _listeners.onMouseDown(event);
+    },
+  };
 
   let timeRange = `${duration} minutes`;
   if (transform && droppableData && ref.current) {


### PR DESCRIPTION
Related to [DRAFT#164409594](https://github.com/orgs/indico/projects/7/views/1?pane=issue&itemId=164409594)

Disables any interaction that is not done with left-click on the unscheduled entries