### PR TITLE
Preserve filename in `ZipGeneratorMixin` if possible

### DIFF
--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -689,18 +689,34 @@ class ZipGeneratorMixin:
         Windows' built-in ZIP tool doesn't like files whose
         total path exceeds ~260 chars. Here we progressively
         shorten the total until it matches that constraint.
-        """
-        result = []
-        total_len = sum(len(seg) for seg in segments) + len(segments) - 1
-        excess = (total_len - 255) if total_len > 255 else 0
 
-        for seg in reversed(segments):
-            fname, ext = os.path.splitext(seg)
-            cut = min(excess, (len(fname) - 10) if len(fname) > 14 else 0)
-            if cut:
+        We try to preserve the filename if possible by first
+        truncating the directories (in reverse order). If this
+        is not enough, we truncate the filename as well.
+        """
+        filename = segments[-1]
+        directories = segments[:-1]
+
+        result = [filename]
+        total_path_separators = len(segments) - 1
+        total_segments_len = sum(len(seg) for seg in segments)
+        total_len = total_segments_len + total_path_separators
+        excess = max(0, total_len - 255)
+
+        for seg in reversed(directories):
+            cut = max(0, min(excess, len(seg) - 10))
+            if cut > 0:
                 excess -= cut
+                seg = seg[:-cut]
+            result.append(seg)
+
+        if excess:
+            # If there's still excess, we need to truncate the filename
+            fname, ext = os.path.splitext(filename)
+            cut = max(0, min(excess, len(fname) - 10))
+            if cut > 0:
                 fname = fname[:-cut]
-            result.append(fname + ext)
+                result[0] = fname + ext
 
         return reversed(result)
 

--- a/indico/modules/events/util_test.py
+++ b/indico/modules/events/util_test.py
@@ -5,9 +5,11 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from string import ascii_lowercase
+
 import pytest
 
-from indico.modules.events.util import get_event_from_url
+from indico.modules.events.util import ZipGeneratorMixin, get_event_from_url
 
 
 @pytest.mark.parametrize(('url', 'asserted_error_message'), (
@@ -23,3 +25,33 @@ def test_get_event_from_url_raises_value_error(url, asserted_error_message):
 def test_get_event_from_url_returns_event(dummy_event):
     event = get_event_from_url(f'http://localhost/event/{dummy_event.id}')
     assert event == dummy_event
+
+
+@pytest.mark.parametrize(('segments', 'expected'), (
+    # Total length is <=255, no change
+    # -> just the filename
+    (['a_long_filename.txt'],
+     ['a_long_filename.txt']),
+    # -> dir + filename
+    (['a' * 50, 'a_long_filename.txt'],
+     ['a' * 50, 'a_long_filename.txt']),
+    # -> dir + subdir + filename
+    (['a' * 50, 'b' * 50, 'a_long_filename.txt'],
+     ['a' * 50, 'b' * 50, 'a_long_filename.txt']),
+    # Total length is >255, only the last subdir before the filename is truncated
+    (['a' * 200, 'b' * 200, 'a_long_filename.txt'],
+     ['a' * 200, 'b' * 34,  'a_long_filename.txt']),
+    # Total length is >255, but truncating one subdir is not enough,
+    # so both are truncated while the filename is left unchanged
+    (['a' * 250, 'b' * 250, 'a_long_filename.txt'],
+     ['a' * 224, 'b' * 10,  'a_long_filename.txt']),
+    # Total length is >255, and all segments including the filename are truncated
+    ([*(letter * 50 for letter in ascii_lowercase), 'a_long_filename.txt'],
+     [*(letter * 10 for letter in ascii_lowercase), 'a_long_fil.txt']),
+    # A very long filename
+    (['a' * 300 + '.txt'],
+     ['a' * 251 + '.txt']),
+))
+def test_zip_generator_ajust_path_length(segments, expected):
+    generator = ZipGeneratorMixin()
+    assert list(generator._adjust_path_length(segments)) == expected


### PR DESCRIPTION
If the archive path must be truncated, try to preserve the filename by first truncating the directories (in reverse order). Only truncate the filename if necessary.
