### PR TITLE
Timetable refactored mapper, serializer and preprocess

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -55,6 +55,7 @@ interface DayTimetableProps {
 function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) {
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
   // (Ajob) In session block view, children become top-level entries
+
   const parent = useSelector(selectors.getExpandedSessionBlock);
   const parentEndDt = parent
     ? moment(parent.startDt).add(parent.duration, 'minutes').format()

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -22,7 +22,7 @@ import {indicoAxios} from 'indico/utils/axios';
 
 import * as actions from './actions';
 import {formatTimeRange} from './i18n';
-import {mapDataToEntry, mapEntryToData} from './mapperUtils';
+import {mapDataToEntry} from './mapperUtils';
 import {DRAFT_ENTRY_MODAL, POSTER_BLOCK_CONTRIBUTIONS_MODAL, useModal} from './ModalContext';
 import * as selectors from './selectors';
 import {
@@ -57,8 +57,6 @@ function EntryPopupContent({
   entry: BreakEntry | ContribEntry | BlockEntry;
   onClose: () => void;
 }) {
-  console.log('popup entry', entry);
-  console.log('popup entry reverse', mapEntryToData(entry));
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
   const {objId, type, title, attachments, duration, startDt, sessionId} = entry;
   const eventId = useSelector(selectors.getEventId);

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -22,7 +22,7 @@ import {indicoAxios} from 'indico/utils/axios';
 
 import * as actions from './actions';
 import {formatTimeRange} from './i18n';
-import {mapDataToEntry} from './mapperUtils';
+import {mapDataToEntry, mapEntryToData} from './mapperUtils';
 import {DRAFT_ENTRY_MODAL, POSTER_BLOCK_CONTRIBUTIONS_MODAL, useModal} from './ModalContext';
 import * as selectors from './selectors';
 import {
@@ -57,6 +57,8 @@ function EntryPopupContent({
   entry: BreakEntry | ContribEntry | BlockEntry;
   onClose: () => void;
 }) {
+  console.log('popup entry', entry);
+  console.log('popup entry reverse', mapEntryToData(entry));
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
   const {objId, type, title, attachments, duration, startDt, sessionId} = entry;
   const eventId = useSelector(selectors.getEventId);

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -22,11 +22,11 @@ import {snakifyKeys} from 'indico/utils/case';
 
 import * as actions from './actions';
 import {BreakFormFields} from './BreakForm';
-import {mapDataToEntry, mapEntryToData} from './mapperUtils';
+import {mapDataToEntry, mapEntryToData, mapSessionToData} from './mapperUtils';
 import * as selectors from './selectors';
 import {FinalSessionSelect} from './SessionSelect';
 import {ReduxState, BlockEntry, EntryType, Session} from './types';
-import {DATE_KEY_FORMAT, mapSessionToTTData} from './utils';
+import {DATE_KEY_FORMAT} from './utils';
 
 // Generic models
 
@@ -205,7 +205,7 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
   const _createSession = async sessionObject => {
     try {
       // TODO: (Ajob) Replace once the back-end schemas allow us a more consistent mapping
-      const data = mapSessionToTTData(sessionObject);
+      const data = mapSessionToData(sessionObject);
       const {session: resSession} = await dispatch(actions.createSession(_.omit(data, 'id')));
       return resSession;
     } catch (error) {

--- a/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
@@ -8,17 +8,20 @@
 import moment, {Moment} from 'moment';
 import React from 'react';
 import {createPortal} from 'react-dom';
+import {useSelector} from 'react-redux';
 
 import {useDraggable, useDroppableData} from './dnd';
 import {pointerInside} from './dnd/utils';
 import {EntryTitle} from './Entry';
 import {formatTimeRange} from './i18n';
-import {Colors, EntryType} from './types';
+import * as selectors from './selectors';
+import {Colors, EntryType, ReduxState} from './types';
 import {
-  MIN_DURATION,
+  getEntryColors,
   minutesToPixels,
   pixelsToMinutes,
   snapMinutes,
+  MIN_DURATION,
   V_SPACE_BETWEEN_ENTRIES_PX,
 } from './utils';
 
@@ -30,12 +33,14 @@ export function DraggableUnscheduledContributionEntry({
   title,
   duration,
   colors,
+  sessionId,
 }: {
   id: string;
   dt: Moment;
   title: string;
   duration: number;
   colors?: Colors;
+  sessionId?: number;
 }) {
   const droppableData = useDroppableData({id: 'calendar'});
 
@@ -104,7 +109,7 @@ export function DraggableUnscheduledContributionEntry({
           title={title}
           timeRange={timeRange}
           duration={duration}
-          colors={colors}
+          sessionId={sessionId}
           isDragging={isDragging}
         />
       </div>,
@@ -134,7 +139,7 @@ export function DraggableUnscheduledContributionEntry({
         title={title}
         timeRange={`${duration} minutes`}
         duration={duration}
-        colors={colors}
+        sessionId={sessionId}
         isDragging={isDragging}
       />
     </div>
@@ -145,15 +150,17 @@ export function UnscheduledContributionEntry({
   title,
   timeRange,
   duration,
-  colors,
+  sessionId,
   isDragging,
 }: {
   title: string;
   timeRange: string;
   duration: number;
-  colors?: Colors;
+  sessionId?: number;
   isDragging?: boolean;
 }) {
+  const session = useSelector((state: ReduxState) => selectors.getSessionById(state, sessionId));
+  const colors = getEntryColors({type: EntryType.Contribution}, session);
   const style = {
     border: '2px solid transparent',
     ...colors,

--- a/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
@@ -48,6 +48,7 @@ function UnscheduledContributionList({
           title={contrib.title}
           duration={contrib.duration}
           colors={contrib.colors}
+          sessionId={contrib.sessionId}
         />
       ))}
     </div>

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -22,7 +22,7 @@ import {ThunkDispatch} from 'redux-thunk/es';
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 import {getRandomColors, parseColorsToSchema} from './colors';
-import {mapDataToEntry} from './mapperUtils';
+import {mapDataToEntry, mapDataToSession} from './mapperUtils';
 import {
   TopLevelEntry,
   BlockEntry,
@@ -36,7 +36,7 @@ import {
   Session,
   ReduxState,
 } from './types';
-import {getEntryURLByObjId, mapTTDataToSession} from './utils';
+import {getEntryURLByObjId} from './utils';
 
 export const SET_DRAFT_ENTRY = 'Set draft entry';
 export const SET_TIMETABLE_DATA = 'Set timetable data';
@@ -217,18 +217,18 @@ export function setSessionData(data: any): SetSessionDataAction {
   return {type: SET_SESSION_DATA, data};
 }
 
-export function editSession(sessionId: number, session: Partial<Session>) {
+export function editSession(sessionId: number, payload: Record<string, unknown>) {
   return (dispatch: ThunkDispatch<ReduxState, unknown, Action>, getState: () => ReduxState) => {
     const {
       staticData: {eventId},
       sessions,
     } = getState();
     const url = sessionURL({event_id: eventId, session_id: sessionId});
-    const newSessionObj = mapTTDataToSession(session);
-    const changedSession = {...sessions[sessionId], ...newSessionObj};
+    const partialSession = mapDataToSession(payload, true);
+    const changedSession = {...sessions[sessionId], ...partialSession};
 
     return dispatch(
-      synchronizedAjaxAction(() => indicoAxios.patch(url, session), {
+      synchronizedAjaxAction(() => indicoAxios.patch(url, payload), {
         type: EDIT_SESSION,
         session: changedSession,
       })
@@ -253,11 +253,10 @@ export function createSession(session) {
       }
 
       const {data: newSession} = await indicoAxios.post(url, session);
-      const mappedSession = mapTTDataToSession(newSession);
 
       return dispatch({
         type: CREATE_SESSION,
-        session: mappedSession,
+        session: mapDataToSession(newSession),
       });
     } catch (e) {
       handleAxiosError(e);

--- a/indico/modules/events/timetable/client/js/index.jsx
+++ b/indico/modules/events/timetable/client/js/index.jsx
@@ -27,26 +27,19 @@ import {getCurrentDateLocalStorage} from './utils';
       const timetableData = JSON.parse(root.dataset.timetableData);
       const eventInfo = JSON.parse(root.dataset.eventInfo);
       const eventId = parseInt(eventInfo.id, 10);
-      const eventType = eventInfo.type;
-      const startDt = moment.tz(
-        `${eventInfo.startDate.date} ${eventInfo.startDate.time}`,
-        eventInfo.startDate.tz
-      );
+      const startDt = moment(eventInfo.start_dt_local);
       const currentDate = getCurrentDateLocalStorage(eventId) || moment(startDt);
       const initialData = {
         staticData: {
           eventId,
-          eventType,
-          startDt,
-          endDt: moment.tz(
-            `${eventInfo.endDate.date} ${eventInfo.endDate.time}`,
-            eventInfo.endDate.tz
-          ),
-          defaultContribDurationMinutes: eventInfo.defaultContribDurationMinutes,
-          eventLocationParent: eventInfo.locationParent,
+          eventType: eventInfo.type,
+          startDt: moment(eventInfo.start_dt_local),
+          endDt: moment(eventInfo.end_dt_local),
+          defaultContribDurationMinutes: eventInfo.default_contribution_duration / 60,
+          eventLocationParent: eventInfo.location_parent,
         },
         navigation: {
-          isDraft: eventInfo.isDraft,
+          isDraft: eventInfo.is_draft,
           currentDate,
           // Refers to when a user clicks to view a session block as a timetable
           expandedSessionBlockId: null,

--- a/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
@@ -244,7 +244,7 @@ describe('mapperUtils', () => {
     });
   });
 
-    describe('mapDataToSession', () => {
+  describe('mapDataToSession', () => {
     it('should map API session data to Session object', () => {
       const data = {
         id: 11,

--- a/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
@@ -8,7 +8,7 @@
 import moment from 'moment';
 
 import {mapDataToEntry, mapEntryToData} from './mapperUtils';
-import {BlockEntry, BreakEntry, ContribEntry, EntryType} from './types';
+import {BlockEntry, BreakEntry, ContribEntry, EntryType, PersonLink} from './types';
 
 const dataLocationData = {
   address: 'Avenue du Jura',
@@ -32,7 +32,6 @@ const dataPersonLink = {
   address: '',
   affiliation: '',
   affiliation_id: null,
-  affiliation_meta: null,
   avatar_url: '/user/1/picture-default/xxx',
   display_order: 0,
   email: 'john.doe@cern.ch',
@@ -42,16 +41,14 @@ const dataPersonLink = {
   person_id: 1,
   phone: '+3131313131',
   title: null,
-  type: 'person_link',
   user_id: 1,
   user_identifier: 'User:1:xxx',
 };
 
-const entryPersonLink = {
+const entryPersonLink: PersonLink = {
   address: '',
   affiliation: '',
   affiliationId: null,
-  affiliationMeta: null,
   avatarURL: '/user/1/picture-default/xxx',
   displayOrder: 0,
   email: 'john.doe@cern.ch',
@@ -61,7 +58,6 @@ const entryPersonLink = {
   personId: 1,
   phone: '+3131313131',
   title: null,
-  type: 'person_link',
   userId: 1,
   userIdentifier: 'User:1:xxx',
 };

--- a/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
@@ -7,8 +7,8 @@
 
 import moment from 'moment';
 
-import {mapDataToEntry, mapEntryToData} from './mapperUtils';
-import {BlockEntry, BreakEntry, ContribEntry, EntryType, PersonLink} from './types';
+import {mapDataToEntry, mapDataToSession, mapEntryToData, mapSessionToData} from './mapperUtils';
+import {BlockEntry, BreakEntry, ContribEntry, EntryType, PersonLink, Session} from './types';
 
 const dataLocationData = {
   address: 'Avenue du Jura',
@@ -241,6 +241,46 @@ describe('mapperUtils', () => {
       expect(data.start_dt).toBe('2024-01-03T11:00:00.000Z');
       expect(data.location_data).toEqual(dataLocationData);
       expect(data.colors).toEqual({background: '#efefef', text: '#fefefe'});
+    });
+  });
+
+    describe('mapDataToSession', () => {
+    it('should map API session data to Session object', () => {
+      const data = {
+        id: 11,
+        title: 'Session Title',
+        is_poster: true,
+        colors: {background: '#112233', text: '#445566'},
+        default_contribution_duration: 1500,
+      };
+
+      const session = mapDataToSession(data) as Session;
+
+      expect(session.id).toBe(11);
+      expect(session.title).toBe('Session Title');
+      expect(session.isPoster).toBe(true);
+      expect(session.colors).toEqual({backgroundColor: '#112233', color: '#445566'});
+      expect(session.defaultContribDurationMinutes).toBe(25);
+    });
+  });
+
+  describe('mapSessionToData', () => {
+    it('should map Session object to API session data', () => {
+      const session: Session = {
+        id: 22,
+        title: 'Another Session',
+        isPoster: false,
+        colors: {backgroundColor: '#aabbcc', color: '#ddeeff'},
+        defaultContribDurationMinutes: 10,
+      };
+
+      const data = mapSessionToData(session);
+
+      expect(data.id).toBe(22);
+      expect(data.title).toBe('Another Session');
+      expect(data.is_poster).toBe(false);
+      expect(data.colors).toEqual({background: '#aabbcc', text: '#ddeeff'});
+      expect(data.default_contribution_duration).toBe(600);
     });
   });
 });

--- a/indico/modules/events/timetable/client/js/mapperUtils.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.ts
@@ -7,26 +7,33 @@
 
 import moment from 'moment';
 
-import {camelizeKeys, snakifyKeys} from 'indico/utils/case';
-
-import {Entry, EntryType} from './types';
+import {Entry, EntryType, Session} from './types';
 import {getEntryUniqueId} from './utils';
 
 // (Ajob) We have to use AllKeys instead of keyof Entry, because keyof Entry
 //        will be either keyof TopLevelEntry or keyof ChildEntry, instead of
 //        a recursive union of both types and deeper nested ones.
 type AllKeys<T> = T extends unknown ? keyof T : never;
-type EntryKey = AllKeys<Entry>;
 
-interface MapperEntry {
-  from: string;
-  to: EntryKey;
-  fromTransform?: (value: unknown) => unknown;
-  toTransform?: (value: unknown) => unknown;
+interface MapperEntry<From, To> {
+  from: AllKeys<From>;
+  to: AllKeys<To>;
+  fromTransform?: (value: any, data: From) => any;
+  toTransform?: (value: any, data: To) => any;
+  delete?: boolean;
 }
 
-const mapperConfig: MapperEntry[] = [
-  {from: 'id', to: 'objId'},
+type MapperConfig<From, To> = MapperEntry<From, To>[];
+
+// Mapper configurations for various timetable objects
+const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
+  {from: 'id', to: 'objId', toTransform: () => undefined},
+  {
+    from: 'id',
+    to: 'id',
+    fromTransform: (v: number, data) => (v ? getEntryUniqueId(data.type as EntryType, v) : null),
+    toTransform: (v: string) => +v.slice(1),
+  },
   {from: 'type', to: 'type'},
   {from: 'title', to: 'title'},
   {from: 'description', to: 'description'},
@@ -73,62 +80,90 @@ const mapperConfig: MapperEntry[] = [
     fromTransform: (v: unknown) => (typeof v === 'string' ? moment(v) : v),
     toTransform: (v: unknown) => (v as moment.Moment)?.toISOString?.() ?? v,
   },
+  {
+    from: 'children',
+    to: 'children',
+    // TODO: (Ajob) Find a clean way to fix this use-before-define error...
+    // eslint-disable-next-line no-use-before-define
+    fromTransform: (children: Record<string, unknown>[]) => children.map(c => mapDataToEntry(c)),
+    // eslint-disable-next-line no-use-before-define
+    toTransform: (children: Entry[]) => children.map(c => mapEntryToData(c)),
+  },
 ];
 
-export function mapDataToEntry(data: Record<string, unknown>, partial: true): Partial<Entry>;
-export function mapDataToEntry(data: Record<string, unknown>, partial?: false): Entry;
-export function mapDataToEntry(
-  data: Record<string, unknown>,
-  partial = false
-): Entry | Partial<Entry> {
-  const result: Partial<Entry> = {};
+const sessionMapperConfig: MapperConfig<Record<string, unknown>, Session> = [
+  {from: 'id', to: 'id'},
+  {from: 'title', to: 'title'},
+  {from: 'is_poster', to: 'isPoster'},
+  {
+    from: 'colors',
+    to: 'colors',
+    toTransform: (colors: {color: string; backgroundColor: string}) => ({
+      text: colors.color,
+      background: colors.backgroundColor,
+    }),
+    fromTransform: (colors: {text: string; background: string}) => ({
+      color: colors.text,
+      backgroundColor: colors.background,
+    }),
+  },
+  {
+    from: 'default_contribution_duration',
+    to: 'defaultContribDurationMinutes',
+    toTransform: (minutes: number) => minutes / 60,
+    fromTransform: (seconds: number) => seconds * 60,
+  },
+];
 
-  for (const {from, to, fromTransform} of mapperConfig) {
-    const rawValue = data[from];
-    if (rawValue === undefined) {
-      continue;
+// Generic mapper
+function createMapper<From, To>(config: MapperConfig<From, To>) {
+  function mapDataToObj(data: From, partial = false): To | Partial<To> {
+    const result: Partial<To> = {};
+    for (const {from, to, fromTransform} of config) {
+      // TODO: (Ajob) Resolve this any issue
+      if (partial && !(from in (data as any))) {
+        continue;
+      }
+      const rawValue = data[from];
+      if (rawValue === undefined) {
+        continue;
+      }
+      const value = fromTransform ? fromTransform(rawValue, data) : rawValue;
+      if (value !== undefined) {
+        result[to] = value;
+      }
     }
-    if (partial && !Object.prototype.hasOwnProperty.call(data, from)) {
-      continue;
-    }
-
-    const value = fromTransform ? fromTransform(rawValue) : camelizeKeys(rawValue);
-    if (value !== undefined) {
-      result[to] = value;
-    }
+    return partial ? result : (result as To);
   }
 
-  if (data.type && data.id) {
-    result.id = getEntryUniqueId(data.type as EntryType, data.id as number);
+  function mapObjToData(obj: Partial<To>, partial = false): Partial<From> | From {
+    const result: Partial<From> = {};
+    for (const {from, to, toTransform} of config) {
+      if (partial && !(to in obj)) {
+        continue;
+      }
+      const value = obj[to];
+      if (value === undefined) {
+        continue;
+      }
+      const rawValue = toTransform ? toTransform(value, obj as To) : value;
+      result[from] = rawValue;
+    }
+    return partial ? result : (result as From);
   }
 
-  if (!partial) {
-    Object.assign(result, {
-      x: 0,
-      y: 0,
-      column: 0,
-      maxColumn: 0,
-      children: [],
-    });
-  }
-
-  return result;
+  return {mapDataToObj, mapObjToData};
 }
 
-export function mapEntryToData(data: Partial<Entry>, partial = false): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
+// Custom mappers
+const {mapDataToObj: mapDataToEntry, mapObjToData: mapEntryToData} = createMapper<
+  Record<string, unknown>,
+  Entry
+>(entryMapperConfig);
+const {mapDataToObj: mapDataToSession, mapObjToData: mapSessionToData} = createMapper<
+  Record<string, unknown>,
+  Session
+>(sessionMapperConfig);
 
-  for (const {from, to, toTransform} of mapperConfig) {
-    const value = data[to];
-    if (value === undefined) {
-      continue;
-    }
-    if (partial && !Object.prototype.hasOwnProperty.call(data, to)) {
-      continue;
-    }
-    const rawValue = toTransform ? toTransform(value) : snakifyKeys(value);
-    result[from] = rawValue;
-  }
-
-  return result;
-}
+export {mapDataToEntry, mapEntryToData};
+export {mapDataToSession, mapSessionToData};

--- a/indico/modules/events/timetable/client/js/mapperUtils.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.ts
@@ -133,7 +133,6 @@ const personLinkMapperConfig: MapperConfig<Record<string, unknown>, PersonLink> 
   {from: 'address', to: 'address'},
   {from: 'affiliation', to: 'affiliation'},
   {from: 'affiliation_id', to: 'affiliationId'},
-  {from: 'affiliation_meta', to: 'affiliationMeta'},
   {from: 'avatar_url', to: 'avatarUrl'},
   {from: 'display_order', to: 'displayOrder'},
   {from: 'email', to: 'email'},
@@ -144,7 +143,6 @@ const personLinkMapperConfig: MapperConfig<Record<string, unknown>, PersonLink> 
   {from: 'phone', to: 'phone'},
   {from: 'roles', to: 'roles'},
   {from: 'title', to: 'title'},
-  {from: 'type', to: 'type'},
   {from: 'user_id', to: 'userId'},
   {from: 'user_identifier', to: 'userIdentifier'},
 ];

--- a/indico/modules/events/timetable/client/js/mapperUtils.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.ts
@@ -7,7 +7,7 @@
 
 import moment from 'moment';
 
-import {Entry, EntryType, PersonLink, Session} from './types';
+import {Entry, EntryType, LocationData, PersonLink, Session} from './types';
 import {getEntryUniqueId} from './utils';
 
 // (Ajob) We have to use AllKeys instead of keyof Entry, because keyof Entry
@@ -24,9 +24,9 @@ interface MapperEntry<From, To> {
 
 type MapperConfig<From, To> = MapperEntry<From, To>[];
 
-// (Ajob) We are assigning it at the bottom
+// (Ajob) We put the instantiation above so we can use them in other mappers
 // eslint-disable-next-line prefer-const
-let mapDataToPersonLink, mapPersonLinkToData;
+let mapDataToPersonLink, mapPersonLinkToData, mapDataToLocationData, mapLocationDataToData;
 
 // Mapper configurations for various timetable objects
 const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
@@ -58,8 +58,18 @@ const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
     fromTransform: p => p.map(mapDataToPersonLink),
     toTransform: p => p.map(mapPersonLinkToData),
   },
-  {from: 'location_data', to: 'locationData'},
-  {from: 'location_parent', to: 'locationParent'},
+  {
+    from: 'location_data',
+    to: 'locationData',
+    fromTransform: l => mapDataToLocationData(l),
+    toTransform: l => mapLocationDataToData(l),
+  },
+  {
+    from: 'location_parent',
+    to: 'locationParent',
+    fromTransform: l => mapDataToLocationData(l),
+    toTransform: l => mapLocationDataToData(l),
+  },
   {from: 'child_location_parent', to: 'childLocationParent'},
   {from: 'code', to: 'code'},
   {from: 'keywords', to: 'keywords'},
@@ -133,7 +143,7 @@ const personLinkMapperConfig: MapperConfig<Record<string, unknown>, PersonLink> 
   {from: 'address', to: 'address'},
   {from: 'affiliation', to: 'affiliation'},
   {from: 'affiliation_id', to: 'affiliationId'},
-  {from: 'avatar_url', to: 'avatarUrl'},
+  {from: 'avatar_url', to: 'avatarURL'},
   {from: 'display_order', to: 'displayOrder'},
   {from: 'email', to: 'email'},
   {from: 'first_name', to: 'firstName'},
@@ -145,6 +155,15 @@ const personLinkMapperConfig: MapperConfig<Record<string, unknown>, PersonLink> 
   {from: 'title', to: 'title'},
   {from: 'user_id', to: 'userId'},
   {from: 'user_identifier', to: 'userIdentifier'},
+];
+
+const locationDataMapperConfig: MapperConfig<Record<string, unknown>, LocationData> = [
+  {from: 'address', to: 'address'},
+  {from: 'inheriting', to: 'inheriting'},
+  {from: 'room_id', to: 'roomId'},
+  {from: 'room_name', to: 'roomName'},
+  {from: 'venue_id', to: 'venueId'},
+  {from: 'venue_name', to: 'venueName'},
 ];
 
 // Generic mapper
@@ -200,6 +219,10 @@ const {mapDataToObj: mapDataToSession, mapObjToData: mapSessionToData} = createM
   Record<string, unknown>,
   PersonLink
 >(personLinkMapperConfig));
+({mapDataToObj: mapDataToLocationData, mapObjToData: mapLocationDataToData} = createMapper<
+  Record<string, unknown>,
+  LocationData
+>(locationDataMapperConfig));
 // (Ajob) As we need to define some defaults, we need to re-apply some of the function types
 const {mapObjToData: mapEntryToData} = createMapper<Record<string, unknown>, Entry>(
   entryMapperConfig

--- a/indico/modules/events/timetable/client/js/mapperUtils.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.ts
@@ -101,8 +101,8 @@ const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
   {
     from: 'start_dt',
     to: 'startDt',
-    fromTransform: (v: unknown) => (typeof v === 'string' ? moment(v) : v),
-    toTransform: (v: unknown) => (v as moment.Moment)?.toISOString?.() ?? v,
+    fromTransform: v => moment(v),
+    toTransform: v => v.toISOString(),
   },
   {
     from: 'children',

--- a/indico/modules/events/timetable/client/js/mapperUtils.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.ts
@@ -7,7 +7,7 @@
 
 import moment from 'moment';
 
-import {Entry, EntryType, Session} from './types';
+import {Entry, EntryType, PersonLink, Session} from './types';
 import {getEntryUniqueId} from './utils';
 
 // (Ajob) We have to use AllKeys instead of keyof Entry, because keyof Entry
@@ -20,13 +20,18 @@ interface MapperEntry<From, To> {
   to: AllKeys<To>;
   fromTransform?: (value: any, data: From) => any;
   toTransform?: (value: any, data: To) => any;
-  delete?: boolean;
 }
 
 type MapperConfig<From, To> = MapperEntry<From, To>[];
 
+// (Ajob) We are assigning it at the bottom
+// eslint-disable-next-line prefer-const
+let mapDataToPersonLink, mapPersonLinkToData;
+
 // Mapper configurations for various timetable objects
 const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
+  // {from: 'type', to: 'type'},
+  {from: 'type', to: 'type'},
   {from: 'id', to: 'objId', toTransform: () => undefined},
   {
     from: 'id',
@@ -34,7 +39,6 @@ const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
     fromTransform: (v: number, data) => (v ? getEntryUniqueId(data.type as EntryType, v) : null),
     toTransform: (v: string) => +v.slice(1),
   },
-  {from: 'type', to: 'type'},
   {from: 'title', to: 'title'},
   {from: 'description', to: 'description'},
   {from: 'board_number', to: 'boardNumber'},
@@ -42,8 +46,18 @@ const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
   // 							back-end, and only personLinks in front-end. This is
   // 							causing inconsistency here. We should probably not
   // 							be using person_links for conveners on the front-end.
-  {from: 'person_links', to: 'personLinks'},
-  {from: 'conveners', to: 'personLinks'},
+  {
+    from: 'person_links',
+    to: 'personLinks',
+    fromTransform: p => p.map(mapDataToPersonLink),
+    toTransform: p => p.map(mapPersonLinkToData),
+  },
+  {
+    from: 'conveners',
+    to: 'personLinks',
+    fromTransform: p => p.map(mapDataToPersonLink),
+    toTransform: p => p.map(mapPersonLinkToData),
+  },
   {from: 'location_data', to: 'locationData'},
   {from: 'location_parent', to: 'locationParent'},
   {from: 'child_location_parent', to: 'childLocationParent'},
@@ -61,7 +75,7 @@ const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
       text: c.color,
     }),
   },
-  {from: 'session_id', to: 'sessionId', fromTransform: (v: unknown) => v ?? null},
+  {from: 'session_id', to: 'sessionId'},
   {
     from: 'session_block_id',
     to: 'sessionBlockId',
@@ -98,27 +112,49 @@ const sessionMapperConfig: MapperConfig<Record<string, unknown>, Session> = [
   {
     from: 'colors',
     to: 'colors',
-    toTransform: (colors: {color: string; backgroundColor: string}) => ({
-      text: colors.color,
-      background: colors.backgroundColor,
+    fromTransform: (c: {background: string; text: string}) => ({
+      backgroundColor: c.background,
+      color: c.text,
     }),
-    fromTransform: (colors: {text: string; background: string}) => ({
-      color: colors.text,
-      backgroundColor: colors.background,
+    toTransform: (c: {backgroundColor: string; color: string}) => ({
+      background: c.backgroundColor,
+      text: c.color,
     }),
   },
   {
     from: 'default_contribution_duration',
     to: 'defaultContribDurationMinutes',
-    toTransform: (minutes: number) => minutes / 60,
-    fromTransform: (seconds: number) => seconds * 60,
+    toTransform: (minutes: number) => minutes * 60,
+    fromTransform: (seconds: number) => seconds / 60,
   },
 ];
 
+const personLinkMapperConfig: MapperConfig<Record<string, unknown>, PersonLink> = [
+  {from: 'address', to: 'address'},
+  {from: 'affiliation', to: 'affiliation'},
+  {from: 'affiliation_id', to: 'affiliationId'},
+  {from: 'affiliation_meta', to: 'affiliationMeta'},
+  {from: 'avatar_url', to: 'avatarUrl'},
+  {from: 'display_order', to: 'displayOrder'},
+  {from: 'email', to: 'email'},
+  {from: 'first_name', to: 'firstName'},
+  {from: 'last_name', to: 'lastName'},
+  {from: 'name', to: 'name'},
+  {from: 'person_id', to: 'personId'},
+  {from: 'phone', to: 'phone'},
+  {from: 'roles', to: 'roles'},
+  {from: 'title', to: 'title'},
+  {from: 'type', to: 'type'},
+  {from: 'user_id', to: 'userId'},
+  {from: 'user_identifier', to: 'userIdentifier'},
+];
+
 // Generic mapper
-function createMapper<From, To>(config: MapperConfig<From, To>) {
+function createMapper<From, To>(config: MapperConfig<From, To>, defaults?: Partial<To>) {
+  function mapDataToObj(data: From, partial: true): Partial<To>;
+  function mapDataToObj(data: From, partial?: false): To;
   function mapDataToObj(data: From, partial = false): To | Partial<To> {
-    const result: Partial<To> = {};
+    const result: Partial<To> = defaults ? {...defaults} : {};
     for (const {from, to, fromTransform} of config) {
       // TODO: (Ajob) Resolve this any issue
       if (partial && !(from in (data as any))) {
@@ -136,6 +172,8 @@ function createMapper<From, To>(config: MapperConfig<From, To>) {
     return partial ? result : (result as To);
   }
 
+  function mapObjToData(obj: Partial<To>, partial: true): Partial<From>;
+  function mapObjToData(obj: Partial<To>, partial?: false): From;
   function mapObjToData(obj: Partial<To>, partial = false): Partial<From> | From {
     const result: Partial<From> = {};
     for (const {from, to, toTransform} of config) {
@@ -156,14 +194,30 @@ function createMapper<From, To>(config: MapperConfig<From, To>) {
 }
 
 // Custom mappers
-const {mapDataToObj: mapDataToEntry, mapObjToData: mapEntryToData} = createMapper<
-  Record<string, unknown>,
-  Entry
->(entryMapperConfig);
 const {mapDataToObj: mapDataToSession, mapObjToData: mapSessionToData} = createMapper<
   Record<string, unknown>,
   Session
 >(sessionMapperConfig);
+({mapDataToObj: mapDataToPersonLink, mapObjToData: mapPersonLinkToData} = createMapper<
+  Record<string, unknown>,
+  PersonLink
+>(personLinkMapperConfig));
+// (Ajob) As we need to define some defaults, we need to re-apply some of the function types
+const {mapObjToData: mapEntryToData} = createMapper<Record<string, unknown>, Entry>(
+  entryMapperConfig
+);
+function mapDataToEntry(data: Record<string, unknown>, partial: true): Partial<Entry>;
+function mapDataToEntry(data: Record<string, unknown>, partial?: false): Entry;
+function mapDataToEntry(data: Record<string, unknown>, partial = false): Entry | Partial<Entry> {
+  const entryDefaults: Partial<Record<EntryType, Partial<Entry>>> = {
+    [EntryType.SessionBlock]: {children: []},
+  };
+  const defaults = entryDefaults[data.type as EntryType] ?? {};
+  const {mapDataToObj} = createMapper<Record<string, unknown>, Entry>(entryMapperConfig, defaults);
+
+  // (Ajob) Had to do this otherwise type complains (boolean is not specific enough)
+  return partial ? mapDataToObj(data, true) : mapDataToObj(data, false);
+}
 
 export {mapDataToEntry, mapEntryToData};
 export {mapDataToSession, mapSessionToData};

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -5,87 +5,28 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import _ from 'lodash';
-
-import {mapDataToEntry} from './mapperUtils';
-import {
-  Attachment,
-  Colors,
-  DayEntries,
-  EntryUniqueID,
-  LocationData,
-  PersonLink,
-  Session,
-  UnscheduledContribEntry,
-} from './types';
-
-interface SchemaDate {
-  date: string;
-  time: string;
-  tz: string;
-}
-
-interface SchemaEntry {
-  startDt: SchemaDate;
-  id: EntryUniqueID;
-  objId: number;
-  title: string;
-  description?: string;
-  locationData: LocationData;
-  duration: number;
-  colors?: Colors;
-  slotTitle?: string;
-  personLinks?: PersonLink[];
-  // (Ajob) Attachments are not possible for breaks but we need to rework
-  //        the interfaces as a whole in general.
-  attachments?: Attachment[];
-}
-
-interface SchemaSession extends SchemaEntry {
-  isPoster: boolean;
-  defaultContribDurationMinutes: number;
-  colors: Colors;
-}
+import {mapDataToEntry, mapDataToSession} from './mapperUtils';
+import {DayEntries, Session, UnscheduledContribEntry} from './types';
 
 export function preprocessSessionData(
-  data: Record<string, SchemaSession>
+  data: Record<string, Record<string, unknown>>
 ): Record<string, Session> {
-  // @ts-expect-error number vs string mess with ids, to be fixed later...
-  return Object.fromEntries(
-    Object.entries(data).map(([, s]) => [
-      s.id,
-      {
-        // TODO: (Duarte) get other attrs
-        ..._.pick(s, ['id', 'title', 'colors', 'isPoster', 'defaultContribDurationMinutes']),
-      },
-    ])
-  );
+  return Object.fromEntries(Object.entries(data).map(([, s]) => [s.id, mapDataToSession(s)]));
 }
 
 export function preprocessTimetableEntries(
   data: Record<string, unknown>,
-  eventInfo: {
-    contributions?: {
-      id: string;
-      objId: number;
-      title: string;
-      description: string;
-      duration: number;
-      sessionId: number;
-    }[];
-  }
+  eventInfo: {contributions?: Record<string, unknown>[]}
 ): {dayEntries: DayEntries; unscheduled: UnscheduledContribEntry[]} {
   const dayEntries = Object.fromEntries(
     Object.entries(data).map(([day, entries]) => [
       day,
-      Object.values(entries).map((entryData: Record<string, unknown>) => mapDataToEntry(entryData)),
+      Object.values(entries).map(entryData => mapDataToEntry(entryData)),
     ])
   );
 
   return {
     dayEntries,
-    unscheduled: (eventInfo.contributions || []).map(
-      (c: Record<string, unknown>) => mapDataToEntry(c) as UnscheduledContribEntry
-    ),
+    unscheduled: eventInfo.contributions.map(c => mapDataToEntry(c) as UnscheduledContribEntry),
   };
 }

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -6,25 +6,18 @@
 // LICENSE file for more details.
 
 import _ from 'lodash';
-import moment from 'moment';
 
-import {camelizeKeys} from 'indico/utils/case';
-
+import {mapDataToEntry} from './mapperUtils';
 import {
   Attachment,
-  BreakId,
-  ChildEntry,
   Colors,
-  ContribId,
   DayEntries,
-  EntryType,
   EntryUniqueID,
   LocationData,
   PersonLink,
   Session,
   UnscheduledContribEntry,
 } from './types';
-import {getDefaultColorByType} from './utils';
 
 interface SchemaDate {
   date: string;
@@ -48,10 +41,6 @@ interface SchemaEntry {
   attachments?: Attachment[];
 }
 
-interface SchemaChild extends Omit<SchemaEntry, 'id'> {
-  id: ContribId | BreakId;
-}
-
 interface SchemaSession extends SchemaEntry {
   isPoster: boolean;
   defaultContribDurationMinutes: number;
@@ -64,12 +53,6 @@ interface SchemaBlock extends SchemaEntry {
   personLinks?: PersonLink[];
   attachments?: Attachment[];
 }
-
-const entryTypeMapping = {
-  s: EntryType.SessionBlock,
-  c: EntryType.Contribution,
-  b: EntryType.Break,
-};
 
 export function preprocessSessionData(
   data: Record<string, SchemaSession>
@@ -86,8 +69,6 @@ export function preprocessSessionData(
   );
 }
 
-const dateToMoment = (dt: SchemaDate) => moment.tz(`${dt.date} ${dt.time}`, dt.tz);
-
 export function preprocessTimetableEntries(
   data: Record<string, Record<string, SchemaBlock>>,
   eventInfo: {
@@ -103,124 +84,13 @@ export function preprocessTimetableEntries(
 ): {dayEntries: DayEntries; unscheduled: UnscheduledContribEntry[]} {
   const dayEntries = {};
   for (const day in data) {
-    dayEntries[day] = [];
-    for (const _id in data[day]) {
-      const type = entryTypeMapping[_id[0]];
-      // TODO: (Ajob) Instead of 'any', clean up interfaces and assign one for consistency
-      const entry: any = data[day][_id];
-
-      console.log('oldEntry', entry);
-      const {
-        duration,
-        description = '',
-        locationData,
-        childLocationParent,
-        personLinks,
-        boardNumber = '',
-        code,
-        title,
-        id,
-        objId,
-        attachments,
-        colors,
-      } = entry;
-
-      dayEntries[day].push({
-        type,
-        id,
-        objId,
-        title,
-        description,
-        startDt: dateToMoment(entry.startDt),
-        duration,
-        x: 0,
-        y: 0,
-        width: 0,
-        column: 0,
-        maxColumn: 0,
-        // TODO: (Ajob) Get other attributes such as person_links
-        personLinks,
-        boardNumber,
-        code,
-        locationData,
-        childLocationParent,
-        attachments,
-        ...(colors && {colors}),
-      });
-
-      if (entry.sessionId) {
-        dayEntries[day].at(-1).sessionId = entry.sessionId;
-      }
-
-      if (type === EntryType.SessionBlock) {
-        const children = Object.values(entry.entries).map((c: SchemaChild) => {
-          const childType = entryTypeMapping[c.id[0]];
-          const childEntry: ChildEntry = {
-            type: childType,
-            objId: c.objId,
-            id: c.id,
-            title: c.title,
-            description: c.description || '',
-            personLinks: c.personLinks || [],
-            startDt: dateToMoment(c.startDt),
-            duration: c.duration,
-            sessionBlockId: dayEntries[day].at(-1).id,
-            y: 0,
-            locationData: c.locationData,
-            column: 0,
-            maxColumn: 0,
-          };
-
-          if (childEntry.type === EntryType.Contribution) {
-            childEntry.attachments = c.attachments;
-            childEntry.personLinks = c.personLinks;
-          }
-
-          if (entry.sessionId) {
-            childEntry.sessionId = entry.sessionId;
-          }
-
-          return childEntry;
-        });
-        dayEntries[day].at(-1).children = children;
-      }
-      console.log('new entry', dayEntries[day].at(-1));
-    }
+    dayEntries[day] = Object.values(data[day]).map((entryData: any) => mapDataToEntry(entryData));
   }
 
   return {
     dayEntries,
-    unscheduled: (eventInfo.contributions || [])
-      .map(c => camelizeKeys(c))
-      .map(
-        ({
-          id,
-          objId,
-          sessionId,
-          title,
-          description,
-          duration,
-          personLinks,
-          boardNumber,
-          code,
-          locationData,
-          attachments,
-          colors = getDefaultColorByType(EntryType.Contribution),
-        }) => ({
-          id,
-          objId,
-          type: EntryType.Contribution,
-          sessionId,
-          title,
-          description,
-          duration,
-          personLinks,
-          boardNumber,
-          code,
-          locationData,
-          attachments,
-          colors,
-        })
-      ),
+    unscheduled: (eventInfo.contributions || []).map(
+      (c: any) => mapDataToEntry(c) as UnscheduledContribEntry
+    ),
   };
 }

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -33,7 +33,7 @@ interface SchemaDate {
 }
 
 interface SchemaEntry {
-  startDate: SchemaDate;
+  startDt: SchemaDate;
   id: EntryUniqueID;
   objId: number;
   title: string;
@@ -109,6 +109,7 @@ export function preprocessTimetableEntries(
       // TODO: (Ajob) Instead of 'any', clean up interfaces and assign one for consistency
       const entry: any = data[day][_id];
 
+      console.log('oldEntry', entry);
       const {
         duration,
         description = '',
@@ -130,7 +131,7 @@ export function preprocessTimetableEntries(
         objId,
         title,
         description,
-        startDt: dateToMoment(entry.startDate),
+        startDt: dateToMoment(entry.startDt),
         duration,
         x: 0,
         y: 0,
@@ -161,7 +162,7 @@ export function preprocessTimetableEntries(
             title: c.title,
             description: c.description || '',
             personLinks: c.personLinks || [],
-            startDt: dateToMoment(c.startDate),
+            startDt: dateToMoment(c.startDt),
             duration: c.duration,
             sessionBlockId: dayEntries[day].at(-1).id,
             y: 0,
@@ -183,6 +184,7 @@ export function preprocessTimetableEntries(
         });
         dayEntries[day].at(-1).children = children;
       }
+      console.log('new entry', dayEntries[day].at(-1));
     }
   }
 

--- a/indico/modules/events/timetable/client/js/preprocess.ts
+++ b/indico/modules/events/timetable/client/js/preprocess.ts
@@ -47,13 +47,6 @@ interface SchemaSession extends SchemaEntry {
   colors: Colors;
 }
 
-interface SchemaBlock extends SchemaEntry {
-  sessionId?: number;
-  entries?: Record<string, SchemaEntry>;
-  personLinks?: PersonLink[];
-  attachments?: Attachment[];
-}
-
 export function preprocessSessionData(
   data: Record<string, SchemaSession>
 ): Record<string, Session> {
@@ -70,7 +63,7 @@ export function preprocessSessionData(
 }
 
 export function preprocessTimetableEntries(
-  data: Record<string, Record<string, SchemaBlock>>,
+  data: Record<string, unknown>,
   eventInfo: {
     contributions?: {
       id: string;
@@ -82,15 +75,17 @@ export function preprocessTimetableEntries(
     }[];
   }
 ): {dayEntries: DayEntries; unscheduled: UnscheduledContribEntry[]} {
-  const dayEntries = {};
-  for (const day in data) {
-    dayEntries[day] = Object.values(data[day]).map((entryData: any) => mapDataToEntry(entryData));
-  }
+  const dayEntries = Object.fromEntries(
+    Object.entries(data).map(([day, entries]) => [
+      day,
+      Object.values(entries).map((entryData: Record<string, unknown>) => mapDataToEntry(entryData)),
+    ])
+  );
 
   return {
     dayEntries,
     unscheduled: (eventInfo.contributions || []).map(
-      (c: any) => mapDataToEntry(c) as UnscheduledContribEntry
+      (c: Record<string, unknown>) => mapDataToEntry(c) as UnscheduledContribEntry
     ),
   };
 }

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -439,8 +439,7 @@ export default {
       case actions.EDIT_SESSION:
         return {
           ...state,
-          // @ts-expect-error some TS mess with ids to fix later...
-          ...preprocessSessionData({[action.session.id]: {...action.session}}),
+          ...{[action.session.id]: {...action.session}},
         };
       case actions.DELETE_SESSION: {
         return _.omit(state, action.sessionId);
@@ -448,8 +447,7 @@ export default {
       case actions.CREATE_SESSION:
         return {
           ...state,
-          // @ts-expect-error some TS mess with ids to fix later...
-          ...preprocessSessionData({[action.session.id]: {...action.session, isPoster: false}}),
+          ...{[action.session.id]: {...action.session, isPoster: false}},
         };
       default:
         return state;

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -36,6 +36,15 @@ export interface PersonLink {
   lastName: string;
   firstName: string;
   name: string;
+  address?: string;
+  affiliationId?: number;
+  avatarUrl?: string;
+  displayOrder?: number;
+  personId?: number;
+  phone?: `+${number}`;
+  title?: string;
+  userId?: number;
+  userIdentifier?: `User:${string}`;
   roles?: PersonLinkRole[];
 }
 

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -31,14 +31,13 @@ export type EntryUniqueID = SessionBlockId | BreakId | ContribId;
 
 export interface PersonLink {
   affiliation: string;
-  avatarURL: string;
   email: string;
   lastName: string;
   firstName: string;
   name: string;
   address?: string;
   affiliationId?: number;
-  avatarUrl?: string;
+  avatarURL?: string;
   displayOrder?: number;
   personId?: number;
   phone?: `+${number}`;

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -13,11 +13,8 @@ import moment, {Moment} from 'moment';
 import {useEffect, useRef} from 'react';
 import {SemanticICONS} from 'semantic-ui-react';
 
-import {camelizeKeys} from 'indico/utils/case';
-
 import {DEFAULT_BREAK_COLORS, DEFAULT_CONTRIB_COLORS, ENTRY_COLORS_BY_BACKGROUND} from './colors';
-import {mapDataToEntry} from './mapperUtils';
-import {BlockEntry, Colors, Entry, EntryType, EntryUniqueID, Session} from './types';
+import {BlockEntry, Colors, Entry, EntryType, EntryUniqueID} from './types';
 
 export const DATE_KEY_FORMAT = 'YYYYMMDD';
 export const LOCAL_STORAGE_KEY = 'manageTimetableData';
@@ -86,19 +83,6 @@ export function getDefaultColorByType(type: Exclude<EntryType, 'block'>): Colors
   }[type];
 }
 
-export function mapTTEntryColor(dbEntry: any, session: Session): Colors {
-  const {type, colors} = dbEntry;
-
-  const fallbackColor = colors
-    ? mapDataToEntry({colors}, true).colors
-    : getDefaultColorByType(dbEntry.type);
-
-  if (type === EntryType.SessionBlock) {
-    return session?.colors ?? fallbackColor;
-  }
-  return fallbackColor;
-}
-
 export function getEntryColors(entry, session) {
   const {colors, type, sessionBlockId} = entry;
 
@@ -120,32 +104,6 @@ export const getEntryUniqueId = (type: EntryType, id: number): EntryUniqueID => 
     case EntryType.Break:
       return `b${id}`;
   }
-};
-
-export const mapTTDataToSession = (data: any): Session => {
-  data = camelizeKeys(data);
-
-  return {
-    ...data,
-    ...(data.colors && mapDataToEntry({colors: data.colors}, true)),
-    ...(data.defaultContributionDuration && {
-      defaultContribDurationMinutes: data.defaultContributionDuration / 60,
-    }),
-  };
-};
-
-export const mapSessionToTTData = (data): any => {
-  return {
-    id: data.id,
-    title: data.title,
-    is_poster: data.isPoster,
-    ...(data.colors && {
-      colors: {text: data.colors.color, background: data.colors.backgroundColor},
-    }),
-    ...(data.defaultContribDurationMinutes && {
-      default_contribution_duration: data.defaultContribDurationMinutes * 60,
-    }),
-  };
 };
 
 export function getIconByEntryType(type: EntryType) {

--- a/indico/modules/events/timetable/controllers/manage.py
+++ b/indico/modules/events/timetable/controllers/manage.py
@@ -55,7 +55,7 @@ class RHManageTimetable(RHManageTimetableBase):
     def _process(self):
         event_info = serialize_event_info_new(self.event, user=session.user)
         # TODO: (Ajob) Rename TimetableSerializerNew to TimetableSerializer and remove the old one
-        timetable_data = TimetableSerializerNew(self.event, management=True).serialize_timetable()
+        timetable_data = TimetableSerializerNew(self.event).serialize_timetable()
         return WPManageTimetable.render_template(
             'management_new.html',
             self.event,

--- a/indico/modules/events/timetable/controllers/manage.py
+++ b/indico/modules/events/timetable/controllers/manage.py
@@ -53,7 +53,7 @@ class RHManageTimetable(RHManageTimetableBase):
     session_management_level = SessionManagementLevel.coordinate
 
     def _process(self):
-        event_info = serialize_event_info_new(self.event, management=True, user=session.user)
+        event_info = serialize_event_info_new(self.event, user=session.user)
         # TODO: (Ajob) Rename TimetableSerializerNew to TimetableSerializer and remove the old one
         timetable_data = TimetableSerializerNew(self.event, management=True).serialize_timetable()
         return WPManageTimetable.render_template(

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -158,9 +158,9 @@ class TimetableSerializer:
             children = []
         else:
             children = [self.serialize_timetable_entry(x) for x in entry.children]
-        data.update(self._get_entry_data(entry))
         data.update({'id': block.id,
                      'type': get_entry_type(TimetableEntryType.SESSION_BLOCK),
+                     'start_dt': self._get_start_dt(entry),
                      'session_id': block.session_id,
                      'session_title': block.session.title,
                      'title': block.title,
@@ -183,9 +183,9 @@ class TimetableSerializer:
         block = entry.parent.session_block if entry.parent else None
         contribution = entry.contribution
         data = {}
-        data.update(self._get_entry_data(entry))
         data.update({'id': contribution.id,
                      'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
+                     'start_dt': self._get_start_dt(entry),
                      'attachments': self._get_attachment_data(contribution),
                      'description': contribution.description,
                      'duration': contribution.duration_display.seconds,
@@ -210,9 +210,9 @@ class TimetableSerializer:
         block = entry.parent.session_block if entry.parent else None
         break_ = entry.break_
         data = {}
-        data.update(self._get_entry_data(entry))
         data.update({'id': break_.id,
                      'type': get_entry_type(TimetableEntryType.BREAK),
+                     'start_dt': self._get_start_dt(entry),
                      'description': break_.description,
                      'duration': break_.duration.seconds,
                      'session_id': block.session_id if block else None,

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-
 from flask import has_request_context, session
 from sqlalchemy.orm import defaultload
 

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from collections import defaultdict
 from hashlib import md5
 
 from flask import has_request_context, session
@@ -120,10 +119,12 @@ class TimetableSerializer:
             key = get_unique_key(entry)
             if entry.parent:
                 parent_code = get_unique_key(entry.parent)
-                timetable[date_str][parent_code]['children'][key] = data
+                data['session_block_id'] = entry.parent.session_block.id
+                timetable[date_str][parent_code]['children'].append(data)
             else:
                 if (entry.type == TimetableEntryType.SESSION_BLOCK and
                         entry.start_dt.astimezone(tzinfo).date() != entry.end_dt.astimezone(tzinfo).date()):
+                    # (Ajob) TODO: Evaluate if comment below is actually something we want to do
                     # If a session block lasts into another day we need to add it to that day, too
                     timetable[entry.end_dt.astimezone(tzinfo).date().strftime('%Y%m%d')][key] = data
                 timetable[date_str][key] = data
@@ -155,9 +156,9 @@ class TimetableSerializer:
         block = entry.session_block
         data = {}
         if not load_children:
-            children = defaultdict(dict)
+            children = []
         else:
-            children = {get_unique_key(x): self.serialize_timetable_entry(x) for x in entry.children}
+            children = [self.serialize_timetable_entry(x) for x in entry.children]
         data.update(self._get_entry_data(entry))
         data.update({'id': block.id,
                      'type': get_entry_type(TimetableEntryType.SESSION_BLOCK),
@@ -175,8 +176,7 @@ class TimetableSerializer:
                      'pdf': url_for('sessions.export_session_timetable', block.session),
                      'url': url_for('sessions.display_session', block.session),
                      'location_data': LocationDataSchema().dump(block),
-                     'child_location_parent': LocationParentSchema().dump(block.child_location_parent),
-                     **get_color_data(block.session)})
+                     'child_location_parent': LocationParentSchema().dump(block.child_location_parent)})
         return data
 
     def serialize_contribution_entry(self, entry):

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from hashlib import md5
 
 from flask import has_request_context, session
 from sqlalchemy.orm import defaultload
@@ -64,15 +63,14 @@ def _get_person_link_roles(person_link):
 def _get_person_data(person_link, *, can_manage_event=False):
     person = person_link.person
 
-    data = {'firstName': person_link.first_name,
-            'familyName': person_link.last_name,
+    data = {'first_name': person_link.first_name,
+            'last_name': person_link.last_name,
             'affiliation': person_link.affiliation,
-            'emailHash': md5(person.email.encode()).hexdigest() if person.email else None,
             'name': person_link.get_full_name(last_name_first=False, last_name_upper=False,
                                               abbrev_first_name=False, show_title=person.event.show_titles),
-            'displayOrderKey': person_link.display_order_key}
+            'display_order_key': person_link.display_order_key}
     if person.user:
-        data['avatarURL'] = person.user.avatar_url
+        data['avatar_url'] = person.user.avatar_url
 
     if can_manage_event:
         data['email'] = person.email
@@ -167,7 +165,6 @@ class TimetableSerializer:
                      'title': block.title,
                      'attachments': self._get_attachment_data(block.session),
                      'code': block.session.code,
-                     'contrib_duration': block.session.default_contribution_duration.seconds,
                      'person_links': [self._get_person_data(x) for x in block.person_links],
                      'description': block.session.description,
                      'duration': block.duration.seconds,
@@ -208,7 +205,7 @@ class TimetableSerializer:
                                                              x.display_order_key))))
         return data
 
-    def serialize_break_entry(self, entry, management=False):
+    def serialize_break_entry(self, entry):
         block = entry.parent.session_block if entry.parent else None
         break_ = entry.break_
         data = {}
@@ -276,7 +273,7 @@ def serialize_contribution(contribution):
 
 # TODO: This is only temporary to get unscheduled contributions working
 # before we rewrite the timetable serializer
-def serialize_unscheduled_contribution(contribution, *, management=False, can_manage_event=False):
+def serialize_unscheduled_contribution(contribution, *, can_manage_event=False):
     data = {
         'id': f'c{contribution.id}',
     }
@@ -302,7 +299,7 @@ def serialize_unscheduled_contribution(contribution, *, management=False, can_ma
     return data
 
 
-def serialize_event_info(event, *, management=False, user=None):
+def serialize_event_info(event, *, user=None):
     from indico.modules.events.contributions import Contribution, contribution_settings
     can_manage_event = event.can_manage(user)
     return {'id': str(event.id),
@@ -314,8 +311,7 @@ def serialize_event_info(event, *, management=False, user=None):
             'sessions': {sess.id: serialize_session(sess) for sess in event.sessions},
             'defaultContribDurationMinutes': contribution_settings.get(event, 'default_duration').total_seconds() / 60,
             'locationParent': LocationParentSchema().dump(event),
-            'contributions': [serialize_unscheduled_contribution(c, management=management,
-                                                                 can_manage_event=can_manage_event)
+            'contributions': [serialize_unscheduled_contribution(c, can_manage_event=can_manage_event)
                               for c in Contribution.query.with_parent(event).filter_by(is_scheduled=False)]}
 
 
@@ -324,12 +320,9 @@ def serialize_session(sess):
     return {
         'description': sess.description,
         'id': sess.id,
-        'isPoster': sess.is_poster,
+        'is_poster': sess.is_poster,
         'title': sess.title,
         'url': url_for('sessions.display_session', sess),
-        'defaultContribDurationMinutes': sess.default_contribution_duration.total_seconds() / 60,
-        'colors': {
-            'backgroundColor': f'#{sess.background_color}',
-            'color': f'#{sess.text_color}',
-        }
+        'default_contribution_duration': sess.default_contribution_duration.total_seconds(),
+        **get_color_data(sess)
     }

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -84,19 +84,17 @@ def _get_person_data(person_link, *, can_manage_event=False):
 
 
 class TimetableSerializer:
-    def __init__(self, event, management=False, user=None, api=False):
-        self.management = management
+    def __init__(self, event, user=None, api=False):
         self.user = user if user is not None or not has_request_context() else session.user
         self.event = event
         self.can_manage_event = self.event.can_manage(self.user)
         self.api = api
 
-    def serialize_timetable(self, days=None, hide_weekends=False, strip_empty_days=False):
-        tzinfo = self.event.tzinfo if self.management else self.event.display_tzinfo
+    def serialize_timetable(self, strip_empty_days=False):
+        tzinfo = self.event.tzinfo
         self.event.preload_all_acl_entries()
         timetable = {}
-        for day in iterdays(self.event.start_dt.astimezone(tzinfo), self.event.end_dt.astimezone(tzinfo),
-                            skip_weekends=hide_weekends, day_whitelist=days):
+        for day in iterdays(self.event.start_dt.astimezone(tzinfo), self.event.end_dt.astimezone(tzinfo)):
             date_str = day.strftime('%Y%m%d')
             timetable[date_str] = {}
         contributions_strategy = defaultload('contribution')
@@ -241,21 +239,14 @@ class TimetableSerializer:
         return files + folders
 
     def _get_start_dt(self, entry):
-        if self.management:
-            tzinfo = entry.event.tzinfo
-        else:
-            tzinfo = entry.event.display_tzinfo
+        tzinfo = entry.event.tzinfo
+
         if entry.type == TimetableEntryType.CONTRIBUTION:
             start_dt = entry.contribution.start_dt_display
         else:
             start_dt = entry.start_dt
 
         return self._get_entry_date_dt(start_dt, tzinfo)
-
-    def _get_entry_data(self, entry):
-        data = {}
-        data['start_dt'] = self._get_start_dt(entry)
-        return data
 
     def _get_entry_date_dt(self, dt, tzinfo):
         return dt.astimezone(tzinfo).isoformat()
@@ -264,54 +255,40 @@ class TimetableSerializer:
         return _get_person_data(person_link, can_manage_event=self.can_manage_event)
 
 
-def serialize_contribution(contribution):
-    return {'id': contribution.id,
-            'friendly_id': contribution.friendly_id,
-            'title': contribution.title}
-
-
 # Event related functions:
-
-# TODO: This is only temporary to get unscheduled contributions working
-# before we rewrite the timetable serializer
 def serialize_unscheduled_contribution(contribution, *, can_manage_event=False):
-    data = {
-        'id': f'c{contribution.id}',
-    }
-    if contribution.session:
-        data.update(get_color_data(contribution.session))
-    data.update({'id': contribution.id,
-                 'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
-                 'contribution_id': contribution.id,
-                 'attachments': [],
-                 'description': contribution.description,
-                 'duration': contribution.duration_display.seconds,
-                 'pdf': url_for('contributions.export_pdf', contribution),
-                 'presenters': [],
-                 'person_links': [_get_person_data(x, can_manage_event=can_manage_event)
-                                 for x in contribution.person_links],
-                 'code': contribution.code,
-                 'session_id': contribution.session.id if contribution.session else None,
-                 'title': contribution.title,
-                 'url': url_for('contributions.display_contribution', contribution),
-                 'references': [],
-                 'location_data': LocationDataSchema().dump(contribution),
-                 'board_number': contribution.board_number})
-    return data
+    return {'id': contribution.id,
+            'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
+            'contribution_id': contribution.id,
+            'attachments': [],
+            'description': contribution.description,
+            'duration': contribution.duration_display.seconds,
+            'pdf': url_for('contributions.export_pdf', contribution),
+            'presenters': [],
+            'person_links': [_get_person_data(x, can_manage_event=can_manage_event)
+                            for x in contribution.person_links],
+            'code': contribution.code,
+            'session_id': contribution.session.id if contribution.session else None,
+            'title': contribution.title,
+            'url': url_for('contributions.display_contribution', contribution),
+            'references': [],
+            'location_data': LocationDataSchema().dump(contribution),
+            'board_number': contribution.board_number}
 
 
 def serialize_event_info(event, *, user=None):
     from indico.modules.events.contributions import Contribution, contribution_settings
     can_manage_event = event.can_manage(user)
+
     return {'id': str(event.id),
             'title': event.title,
-            'startDate': event.start_dt_local,
-            'endDate': event.end_dt_local,
+            'start_dt_local': event.start_dt_local.isoformat(),
+            'end_dt_local': event.end_dt_local.isoformat(),
             'type': event.type,
-            'isDraft': should_show_draft_warning(event),
+            'is_draft': should_show_draft_warning(event),
             'sessions': {sess.id: serialize_session(sess) for sess in event.sessions},
-            'defaultContribDurationMinutes': contribution_settings.get(event, 'default_duration').total_seconds() / 60,
-            'locationParent': LocationParentSchema().dump(event),
+            'default_contribution_duration': contribution_settings.get(event, 'default_duration').total_seconds(),
+            'location_parent': LocationParentSchema().dump(event),
             'contributions': [serialize_unscheduled_contribution(c, can_manage_event=can_manage_event)
                               for c in Contribution.query.with_parent(event).filter_by(is_scheduled=False)]}
 

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -16,17 +16,16 @@ from indico.modules.events.timetable.models.entries import TimetableEntry, Timet
 from indico.modules.events.util import should_show_draft_warning
 from indico.util.date_time import iterdays
 from indico.util.locations import LocationDataSchema, LocationParentSchema
-from indico.util.string import camelize_keys
 from indico.web.flask.util import url_for
 
 
-def get_obj_id(entry):
-    if entry.type == TimetableEntryType.SESSION_BLOCK:
-        return entry.session_block.id
-    elif entry.type == TimetableEntryType.CONTRIBUTION:
-        return entry.contribution.id
-    elif entry.type == TimetableEntryType.BREAK:
-        return entry.break_.id
+def get_entry_type(entry_type):
+    if entry_type == TimetableEntryType.SESSION_BLOCK:
+        return 'block'
+    elif entry_type == TimetableEntryType.CONTRIBUTION:
+        return 'contrib'
+    elif entry_type == TimetableEntryType.BREAK:
+        return 'break'
     else:
         raise ValueError
 
@@ -45,8 +44,8 @@ def get_unique_key(entry):
 def get_color_data(obj):
     return {
         'colors': {
-            'backgroundColor': f'#{obj.background_color}',
-            'color': f'#{obj.text_color}',
+            'background': f'#{obj.background_color}',
+            'text': f'#{obj.text_color}',
         }
     }
 
@@ -121,7 +120,7 @@ class TimetableSerializer:
             key = get_unique_key(entry)
             if entry.parent:
                 parent_code = get_unique_key(entry.parent)
-                timetable[date_str][parent_code]['entries'][key] = data
+                timetable[date_str][parent_code]['children'][key] = data
             else:
                 if (entry.type == TimetableEntryType.SESSION_BLOCK and
                         entry.start_dt.astimezone(tzinfo).date() != entry.end_dt.astimezone(tzinfo).date()):
@@ -156,25 +155,27 @@ class TimetableSerializer:
         block = entry.session_block
         data = {}
         if not load_children:
-            entries = defaultdict(dict)
+            children = defaultdict(dict)
         else:
-            entries = {get_unique_key(x): self.serialize_timetable_entry(x) for x in entry.children}
+            children = {get_unique_key(x): self.serialize_timetable_entry(x) for x in entry.children}
         data.update(self._get_entry_data(entry))
-        data.update({'sessionId': block.session_id,
-                     'sessionTitle': block.session.title,
+        data.update({'id': block.id,
+                     'type': get_entry_type(TimetableEntryType.SESSION_BLOCK),
+                     'session_id': block.session_id,
+                     'session_title': block.session.title,
                      'title': block.title,
                      'attachments': self._get_attachment_data(block.session),
                      'code': block.session.code,
-                     'contribDuration': block.session.default_contribution_duration.seconds / 60,
-                     'personLinks': [self._get_person_data(x) for x in block.person_links],
+                     'contrib_duration': block.session.default_contribution_duration.seconds,
+                     'person_links': [self._get_person_data(x) for x in block.person_links],
                      'description': block.session.description,
-                     'duration': block.duration.seconds / 60,
-                     'isPoster': block.session.is_poster,
-                     'entries': entries,
+                     'duration': block.duration.seconds,
+                     'is_poster': block.session.is_poster,
+                     'children': children,
                      'pdf': url_for('sessions.export_session_timetable', block.session),
                      'url': url_for('sessions.display_session', block.session),
-                     'locationData': camelize_keys(LocationDataSchema().dump(block)),
-                     'childLocationParent': LocationParentSchema().dump(block.child_location_parent),
+                     'location_data': LocationDataSchema().dump(block),
+                     'child_location_parent': LocationParentSchema().dump(block.child_location_parent),
                      **get_color_data(block.session)})
         return data
 
@@ -185,20 +186,20 @@ class TimetableSerializer:
         contribution = entry.contribution
         data = {}
         data.update(self._get_entry_data(entry))
-        data.update({'attachments': self._get_attachment_data(contribution),
+        data.update({'id': contribution.id,
+                     'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
+                     'attachments': self._get_attachment_data(contribution),
                      'description': contribution.description,
-                     'duration': contribution.duration_display.seconds / 60,
+                     'duration': contribution.duration_display.seconds,
                      'pdf': url_for('contributions.export_pdf', entry.contribution),
-                     'personLinks': [self._get_person_data(x) for x in contribution.person_links],
+                     'person_links': [self._get_person_data(x) for x in contribution.person_links],
                      'code': contribution.code,
-                     'sessionId': block.session_id if block else None,
-                     # 'sessionSlotId': block.id if block else None,
-                     # 'sessionSlotEntryId': entry.parent.id if entry.parent else None,
-                     'locationData': camelize_keys(LocationDataSchema().dump(contribution)),
+                     'session_id': block.session_id if block else None,
+                     'location_data': LocationDataSchema().dump(contribution),
                      'title': contribution.title,
                      'url': url_for('contributions.display_contribution', contribution),
                      'references': list(map(SerializerBase.serialize_reference, contribution.references)),
-                     'boardNumber': contribution.board_number})
+                     'board_number': contribution.board_number})
         if self.api:
             data['authors'] = list(map(self._get_person_data,
                                        sorted((p for p in contribution.person_links if not p.is_speaker),
@@ -212,11 +213,13 @@ class TimetableSerializer:
         break_ = entry.break_
         data = {}
         data.update(self._get_entry_data(entry))
-        data.update({'description': break_.description,
-                     'duration': break_.duration.seconds / 60,
-                     'sessionId': block.session_id if block else None,
+        data.update({'id': break_.id,
+                     'type': get_entry_type(TimetableEntryType.BREAK),
+                     'description': break_.description,
+                     'duration': break_.duration.seconds,
+                     'session_id': block.session_id if block else None,
                      'title': break_.title,
-                     'locationData': camelize_keys(LocationDataSchema().dump(break_)),
+                     'location_data': LocationDataSchema().dump(break_),
                      **get_color_data(break_)})
         return data
 
@@ -253,15 +256,11 @@ class TimetableSerializer:
 
     def _get_entry_data(self, entry):
         data = {}
-        data['startDt'] = self._get_start_dt(entry)
-        data['id'] = get_unique_key(entry)
-        data['objId'] = get_obj_id(entry)
+        data['start_dt'] = self._get_start_dt(entry)
         return data
 
     def _get_entry_date_dt(self, dt, tzinfo):
-        return {'date': dt.astimezone(tzinfo).strftime('%Y-%m-%d'),
-                'time': dt.astimezone(tzinfo).strftime('%H:%M:%S'),
-                'tz': str(tzinfo)}
+        return dt.astimezone(tzinfo).isoformat()
 
     def _get_person_data(self, person_link):
         return _get_person_data(person_link, can_manage_event=self.can_manage_event)
@@ -280,24 +279,25 @@ def serialize_contribution(contribution):
 def serialize_unscheduled_contribution(contribution, *, management=False, can_manage_event=False):
     data = {
         'id': f'c{contribution.id}',
-        'objId': contribution.id
     }
     if contribution.session:
         data.update(get_color_data(contribution.session))
-    data.update({'contributionId': contribution.id,
+    data.update({'id': contribution.id,
+                 'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
+                 'contribution_id': contribution.id,
                  'attachments': [],
                  'description': contribution.description,
-                 'duration': contribution.duration_display.seconds / 60,
+                 'duration': contribution.duration_display.seconds,
                  'pdf': url_for('contributions.export_pdf', contribution),
                  'presenters': [],
-                 'personLinks': [_get_person_data(x, can_manage_event=can_manage_event)
+                 'person_links': [_get_person_data(x, can_manage_event=can_manage_event)
                                  for x in contribution.person_links],
                  'code': contribution.code,
-                 'sessionId': contribution.session.id if contribution.session else None,
+                 'session_id': contribution.session.id if contribution.session else None,
                  'title': contribution.title,
                  'url': url_for('contributions.display_contribution', contribution),
                  'references': [],
-                 'locationData': camelize_keys(LocationDataSchema().dump(contribution)),
+                 'location_data': LocationDataSchema().dump(contribution),
                  'board_number': contribution.board_number})
     return data
 
@@ -328,5 +328,8 @@ def serialize_session(sess):
         'title': sess.title,
         'url': url_for('sessions.display_session', sess),
         'defaultContribDurationMinutes': sess.default_contribution_duration.total_seconds() / 60,
-        **get_color_data(sess),
+        'colors': {
+            'backgroundColor': f'#{sess.background_color}',
+            'color': f'#{sess.text_color}',
+        }
     }

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -63,7 +63,8 @@ def _get_person_link_roles(person_link):
 def _get_person_data(person_link, *, can_manage_event=False):
     person = person_link.person
 
-    data = {'first_name': person_link.first_name,
+    data = {'person_id': person.id,
+            'first_name': person_link.first_name,
             'last_name': person_link.last_name,
             'affiliation': person_link.affiliation,
             'name': person_link.get_full_name(last_name_first=False, last_name_upper=False,

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -160,9 +160,7 @@ class TimetableSerializer:
         else:
             entries = {get_unique_key(x): self.serialize_timetable_entry(x) for x in entry.children}
         data.update(self._get_entry_data(entry))
-        data.update({'entryType': 'Session',
-                     'sessionId': block.session_id,
-                     'sessionCode': block.session.code,
+        data.update({'sessionId': block.session_id,
                      'sessionTitle': block.session.title,
                      'title': block.title,
                      'attachments': self._get_attachment_data(block.session),
@@ -175,7 +173,6 @@ class TimetableSerializer:
                      'entries': entries,
                      'pdf': url_for('sessions.export_session_timetable', block.session),
                      'url': url_for('sessions.display_session', block.session),
-                     'friendlyId': block.session.friendly_id,
                      'locationData': camelize_keys(LocationDataSchema().dump(block)),
                      'childLocationParent': LocationParentSchema().dump(block.child_location_parent),
                      **get_color_data(block.session)})
@@ -188,23 +185,18 @@ class TimetableSerializer:
         contribution = entry.contribution
         data = {}
         data.update(self._get_entry_data(entry))
-        data.update({'entryType': 'Contribution',
-                     '_type': 'ContribSchEntry',
-                     '_fossil': 'contribSchEntryDisplay',
-                     'attachments': self._get_attachment_data(contribution),
+        data.update({'attachments': self._get_attachment_data(contribution),
                      'description': contribution.description,
                      'duration': contribution.duration_display.seconds / 60,
                      'pdf': url_for('contributions.export_pdf', entry.contribution),
                      'personLinks': [self._get_person_data(x) for x in contribution.person_links],
                      'code': contribution.code,
-                     'sessionCode': block.session.code if block else None,
                      'sessionId': block.session_id if block else None,
                      # 'sessionSlotId': block.id if block else None,
                      # 'sessionSlotEntryId': entry.parent.id if entry.parent else None,
                      'locationData': camelize_keys(LocationDataSchema().dump(contribution)),
                      'title': contribution.title,
                      'url': url_for('contributions.display_contribution', contribution),
-                     'friendlyId': contribution.friendly_id,
                      'references': list(map(SerializerBase.serialize_reference, contribution.references)),
                      'boardNumber': contribution.board_number})
         if self.api:
@@ -220,15 +212,9 @@ class TimetableSerializer:
         break_ = entry.break_
         data = {}
         data.update(self._get_entry_data(entry))
-        data.update({'entryType': 'Break',
-                     '_type': 'BreakTimeSchEntry',
-                     '_fossil': 'breakTimeSchEntry',
-                     'description': break_.description,
+        data.update({'description': break_.description,
                      'duration': break_.duration.seconds / 60,
                      'sessionId': block.session_id if block else None,
-                     'sessionCode': block.session.code if block else None,
-                    #  'sessionSlotId': block.id if block else None,
-                    #  'sessionSlotEntryId': entry.parent.id if entry.parent else None,
                      'title': break_.title,
                      'locationData': camelize_keys(LocationDataSchema().dump(break_)),
                      **get_color_data(break_)})
@@ -253,30 +239,23 @@ class TimetableSerializer:
 
         return files + folders
 
-    def _get_date_data(self, entry):
+    def _get_start_dt(self, entry):
         if self.management:
             tzinfo = entry.event.tzinfo
         else:
             tzinfo = entry.event.display_tzinfo
         if entry.type == TimetableEntryType.CONTRIBUTION:
             start_dt = entry.contribution.start_dt_display
-            end_dt = entry.contribution.end_dt_display
         else:
             start_dt = entry.start_dt
-            end_dt = entry.end_dt
-        return {'startDate': self._get_entry_date_dt(start_dt, tzinfo),
-                'endDate': self._get_entry_date_dt(end_dt, tzinfo)}
+
+        return self._get_entry_date_dt(start_dt, tzinfo)
 
     def _get_entry_data(self, entry):
         data = {}
-        data.update(self._get_date_data(entry))
+        data['startDt'] = self._get_start_dt(entry)
         data['id'] = get_unique_key(entry)
         data['objId'] = get_obj_id(entry)
-        data['conferenceId'] = entry.event_id
-        if self.management:
-            data['isParallel'] = entry.is_parallel()
-            data['isParallelInSession'] = entry.is_parallel(in_session=True)
-            data['scheduleEntryId'] = entry.id
         return data
 
     def _get_entry_date_dt(self, dt, tzinfo):
@@ -305,10 +284,7 @@ def serialize_unscheduled_contribution(contribution, *, management=False, can_ma
     }
     if contribution.session:
         data.update(get_color_data(contribution.session))
-    data.update({'entryType': 'Contribution',
-                 '_type': 'ContribSchEntry',
-                 '_fossil': 'contribSchEntryDisplay',
-                 'contributionId': contribution.id,
+    data.update({'contributionId': contribution.id,
                  'attachments': [],
                  'description': contribution.description,
                  'duration': contribution.duration_display.seconds / 60,
@@ -317,13 +293,9 @@ def serialize_unscheduled_contribution(contribution, *, management=False, can_ma
                  'personLinks': [_get_person_data(x, can_manage_event=can_manage_event)
                                  for x in contribution.person_links],
                  'code': contribution.code,
-                 'sessionCode': None,
                  'sessionId': contribution.session.id if contribution.session else None,
-                 'sessionSlotId': None,
-                 'sessionSlotEntryId': None,
                  'title': contribution.title,
                  'url': url_for('contributions.display_contribution', contribution),
-                 'friendlyId': contribution.friendly_id,
                  'references': [],
                  'locationData': camelize_keys(LocationDataSchema().dump(contribution)),
                  'board_number': contribution.board_number})
@@ -333,8 +305,7 @@ def serialize_unscheduled_contribution(contribution, *, management=False, can_ma
 def serialize_event_info(event, *, management=False, user=None):
     from indico.modules.events.contributions import Contribution, contribution_settings
     can_manage_event = event.can_manage(user)
-    return {'_type': 'Conference',
-            'id': str(event.id),
+    return {'id': str(event.id),
             'title': event.title,
             'startDate': event.start_dt_local,
             'endDate': event.end_dt_local,
@@ -351,7 +322,6 @@ def serialize_event_info(event, *, management=False, user=None):
 def serialize_session(sess):
     """Return data for a single session."""
     return {
-        '_type': 'Session',
         'description': sess.description,
         'id': sess.id,
         'isPoster': sess.is_poster,


### PR DESCRIPTION
This PR introduces a generic mapper, which allows for creating new mappers such as for `Session`, `LocationData` and `PersonLink`. It reflects the actual data format in the database, schemas and future schemas better. The serializer is also adjusted to represent real data formats coming from the back-end, allowing us to move to a RESTful approach instead of passing things through data attributes. The date format is now also a isoformat string instead of a non-standardizes object.

Introduced tests to cover the mappers which are essential.

Deleted a lot of old unused code and mappers. In serializer.py, code related to checking whether we are in management view or not is removed, as it is not relevant to our purpose and will be handled differently later anyway.