### PR TITLE
Update package_is_editable

### DIFF
--- a/indico/util/packaging.py
+++ b/indico/util/packaging.py
@@ -22,6 +22,8 @@ def package_is_editable(package):
             return True
         if (Path(path_item) / f'_{dist.name}.pth').is_file():  # hatchling
             return True
+        if (Path(path_item) / f'_editable_impl_{dist.name}.pth').is_file():  # editables
+            return True
     return False
 
 


### PR DESCRIPTION
This PR is about updating the function `package_is_editable` which identifies if the package is editable.

We started seeing this file name format last week in some of our environments. It still needs some investigation why in not all, but this file name is also valid (although there's no standard for this file name) and seems reasonable to update the code.
