### PR TITLE
Timetable scheduling bug fixes

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -36,6 +36,7 @@ import {
   DAY_SIZE,
   GRID_SIZE_MINUTES,
   MIN_DURATION,
+  V_SPACE_BETWEEN_ENTRIES_PX,
   getDateKey,
   isWithinLimits,
   minutesToPixels,
@@ -357,10 +358,7 @@ export function DayTimetable({
     function onMouseDown(event: MouseEvent) {
       const clientY = event.clientY + wrapperRef.current.scrollTop;
       const offsetY = clientY - wrapperRef.current.offsetTop;
-      const isWithinLimitsWithOffset = !isWithinLimits(limits, offsetY, [
-        0,
-        minutesToPixels(defaultContributionDuration),
-      ]);
+      const isWithinLimitsWithOffset = !isWithinLimits(limits, offsetY);
 
       const clickedOnCalendar =
         event.target === calendarRef.current || event.target === innerWrapperRef.current;
@@ -453,7 +451,11 @@ export function DayTimetable({
   }, [wrapperRef]);
 
   const restrictToCalendar = useMemo(() => {
-    const limitsDelta: [number, number] = [limitTop, DAY_SIZE - limitBottom];
+    const limitsDelta: [number, number] = [
+      limitTop,
+      DAY_SIZE - limitBottom + V_SPACE_BETWEEN_ENTRIES_PX,
+    ];
+
     return createRestrictToCalendar(calendarRef, limitsDelta);
   }, [limitTop, limitBottom]);
 

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -323,10 +323,11 @@ export function DayTimetable({
       .startOf('days')
       .add(minHour, 'hours')
       .add(pixelsToMinutes(draggingStartPos), 'minutes');
+    let y;
 
     if (minutesDelta <= -MIN_DURATION) {
       // Dragging up
-      const y = Math.max(
+      y = Math.max(
         minutesToPixels(
           Math.round(pixelsToMinutes(clientY - rect.top) / GRID_SIZE_MINUTES) * GRID_SIZE_MINUTES
         ),
@@ -334,13 +335,13 @@ export function DayTimetable({
       );
       duration = Math.min(duration, pixelsToMinutes(draggingStartPos - limitTop));
       startDt = moment(startDt).subtract(duration, 'minutes');
-
-      return {startDt, duration, y};
     } else {
       // Dragging down
       duration = Math.min(duration, pixelsToMinutes(limitBottom - draggingStartPos));
-      return {startDt, duration, y: draggingStartPos};
+      y = draggingStartPos;
     }
+
+    return {startDt, duration: Math.max(duration, MIN_DURATION), y};
   }
 
   useEffect(() => {

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -35,6 +35,7 @@ import UnscheduledContributions from './UnscheduledContributions';
 import {
   DAY_SIZE,
   GRID_SIZE_MINUTES,
+  MIN_DURATION,
   getDateKey,
   isWithinLimits,
   minutesToPixels,
@@ -311,19 +312,18 @@ export function DayTimetable({
     duration?: number;
     y?: number;
   } | null {
-    const minDraftDuration = 10;
     const rect = calendarRef.current.getBoundingClientRect();
     const minutesDelta =
       Math.round(pixelsToMinutes(clientY - rect.top - draggingStartPos) / GRID_SIZE_MINUTES) *
       GRID_SIZE_MINUTES;
 
-    let duration = Math.max(Math.abs(minutesDelta), minDraftDuration);
+    let duration = Math.max(Math.abs(minutesDelta), MIN_DURATION);
     let startDt = moment(dt)
       .startOf('days')
       .add(minHour, 'hours')
       .add(pixelsToMinutes(draggingStartPos), 'minutes');
 
-    if (minutesDelta <= -minDraftDuration) {
+    if (minutesDelta <= -MIN_DURATION) {
       // Dragging up
       const y = Math.max(
         minutesToPixels(

--- a/indico/modules/events/timetable/client/js/Entry.module.scss
+++ b/indico/modules/events/timetable/client/js/Entry.module.scss
@@ -95,6 +95,7 @@
   gap: 10px;
   border-left: 5px solid transparent;
   container-type: size;
+  border-radius: 4px;
 }
 
 .mv-buttons-wrapper {

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -34,6 +34,7 @@ import {
   formatBlockTitle,
   getIconByEntryType,
   getEntryColors,
+  MIN_DURATION,
 } from './utils';
 
 import './DayTimetable.module.scss';
@@ -322,7 +323,7 @@ export default function Entry({
       />
       <ResizeHandle
         duration={duration}
-        minDuration={latestChildEndDt.diff(startDt, 'minutes')}
+        minDuration={Math.max(MIN_DURATION, latestChildEndDt.diff(startDt, 'minutes'))}
         maxDuration={parentEndDt ? moment(parentEndDt).diff(startDt, 'minutes') : undefined}
         resizeStartRef={resizeStartRef}
         setLocalDuration={setDuration}

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -35,6 +35,7 @@ import {
   getIconByEntryType,
   getEntryColors,
   MIN_DURATION,
+  V_SPACE_BETWEEN_ENTRIES_PX,
 } from './utils';
 
 import './DayTimetable.module.scss';
@@ -195,7 +196,7 @@ export default function Entry({
     : {};
 
   const minHeight = minutesToPixels(5);
-  const height = minutesToPixels(Math.max(duration, minHeight)) - 1;
+  const height = minutesToPixels(Math.max(duration, minHeight)) - V_SPACE_BETWEEN_ENTRIES_PX;
 
   style = {
     ...style,

--- a/indico/modules/events/timetable/client/js/ResizeHandle.tsx
+++ b/indico/modules/events/timetable/client/js/ResizeHandle.tsx
@@ -7,7 +7,7 @@
 
 import React, {MouseEvent as SyntheticMouseEvent} from 'react';
 
-import {minutesToPixels, pixelsToMinutes} from './utils';
+import {MIN_DURATION, minutesToPixels, pixelsToMinutes} from './utils';
 
 import './DayTimetable.module.scss';
 
@@ -15,7 +15,7 @@ const gridSize = minutesToPixels(5);
 
 export default function ResizeHandle({
   duration,
-  minDuration = 10,
+  minDuration = MIN_DURATION,
   maxDuration,
   resizeStartRef,
   setLocalDuration,

--- a/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
@@ -14,7 +14,13 @@ import {pointerInside} from './dnd/utils';
 import {EntryTitle} from './Entry';
 import {formatTimeRange} from './i18n';
 import {Colors, EntryType} from './types';
-import {MIN_DURATION, minutesToPixels, pixelsToMinutes, snapMinutes} from './utils';
+import {
+  MIN_DURATION,
+  minutesToPixels,
+  pixelsToMinutes,
+  snapMinutes,
+  V_SPACE_BETWEEN_ENTRIES_PX,
+} from './utils';
 
 import './Entry.module.scss';
 
@@ -153,7 +159,9 @@ export function UnscheduledContributionEntry({
     ...colors,
     cursor: isDragging ? 'grabbing' : 'grab',
     userSelect: 'none' as const,
-    height: minutesToPixels(Math.max(duration, minutesToPixels(MIN_DURATION)) - 1),
+    height: minutesToPixels(
+      Math.max(duration, minutesToPixels(MIN_DURATION)) - V_SPACE_BETWEEN_ENTRIES_PX
+    ),
   };
 
   return (

--- a/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
@@ -14,7 +14,7 @@ import {pointerInside} from './dnd/utils';
 import {EntryTitle} from './Entry';
 import {formatTimeRange} from './i18n';
 import {Colors, EntryType} from './types';
-import {minutesToPixels, pixelsToMinutes, snapMinutes} from './utils';
+import {MIN_DURATION, minutesToPixels, pixelsToMinutes, snapMinutes} from './utils';
 
 import './Entry.module.scss';
 
@@ -153,7 +153,7 @@ export function UnscheduledContributionEntry({
     ...colors,
     cursor: isDragging ? 'grabbing' : 'grab',
     userSelect: 'none' as const,
-    height: minutesToPixels(Math.max(duration, minutesToPixels(10)) - 1),
+    height: minutesToPixels(Math.max(duration, minutesToPixels(MIN_DURATION)) - 1),
   };
 
   return (

--- a/indico/modules/events/timetable/client/js/dnd/modifiers.ts
+++ b/indico/modules/events/timetable/client/js/dnd/modifiers.ts
@@ -31,7 +31,9 @@ function restrictToBoundingRect(transform: Transform, rect: Rect, boundingRect: 
     value.x = boundingRect.left + boundingRect.width - rect.right;
   }
 
-  return value;
+  // (Ajob) Necessary to round as decimals cause issues in positioning
+  //        of elements in timetable
+  return {x: Math.round(value.x), y: Math.round(value.y)};
 }
 
 /**

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -18,6 +18,7 @@ import {
   sortEntriesByStartDt,
   computeOverlappingEntryIds,
   flattenEntries,
+  V_SPACE_BETWEEN_ENTRIES_PX,
 } from './utils';
 
 export const getStaticData = (state: ReduxState) => state.staticData;
@@ -151,6 +152,9 @@ export const getCurrentLimits = createSelector(
     if (endDt.isSame(currentDate, 'day')) {
       limits[1] = minutesToPixels(moment.duration(endDt.format('HH:mm')).asMinutes());
     }
+
+    // (Ajob) Accounts for entries hitting the bottom limit
+    limits[1] -= V_SPACE_BETWEEN_ENTRIES_PX;
 
     return limits;
   }

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -18,7 +18,6 @@ import {
   sortEntriesByStartDt,
   computeOverlappingEntryIds,
   flattenEntries,
-  V_SPACE_BETWEEN_ENTRIES_PX,
 } from './utils';
 
 export const getStaticData = (state: ReduxState) => state.staticData;
@@ -152,9 +151,6 @@ export const getCurrentLimits = createSelector(
     if (endDt.isSame(currentDate, 'day')) {
       limits[1] = minutesToPixels(moment.duration(endDt.format('HH:mm')).asMinutes());
     }
-
-    // (Ajob) Accounts for entries hitting the bottom limit
-    limits[1] -= V_SPACE_BETWEEN_ENTRIES_PX;
 
     return limits;
   }

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -26,6 +26,7 @@ export const GRID_SIZE_MINUTES = 5;
 export const GRID_SIZE = minutesToPixels(GRID_SIZE_MINUTES);
 export const HOUR_SIZE = minutesToPixels(60);
 export const DAY_SIZE = 24 * HOUR_SIZE;
+export const V_SPACE_BETWEEN_ENTRIES_PX = 1;
 
 export function snapPixels(x: number) {
   return Math.ceil(x / GRID_SIZE) * GRID_SIZE;

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -21,6 +21,7 @@ import {BlockEntry, Colors, Entry, EntryType, EntryUniqueID, Session} from './ty
 
 export const DATE_KEY_FORMAT = 'YYYYMMDD';
 export const LOCAL_STORAGE_KEY = 'manageTimetableData';
+export const MIN_DURATION = 10;
 export const GRID_SIZE_MINUTES = 5;
 export const GRID_SIZE = minutesToPixels(GRID_SIZE_MINUTES);
 export const HOUR_SIZE = minutesToPixels(60);


### PR DESCRIPTION
**Before**
- [Entry would get stuck with margin from top even though it starts at event start date](https://github.com/orgs/indico/projects/7?pane=issue&itemId=178140494)
- [Entry would be able to get dragged outside of event limits by 5 min, causing errors](https://github.com/orgs/indico/projects/7?pane=issue&itemId=178140494)
- [Could not create entries by clicking end of timetable](https://github.com/orgs/indico/projects/7?pane=issue&itemId=178140405)
- [Creation always has a minimum duration, but resizing is possible to 0, causing errors](https://github.com/orgs/indico/projects/7?pane=issue&itemId=162867540)
- [When clicking resize on start limit exactly and dragging up, duration of 0 was possible, causing errors](https://github.com/orgs/indico/projects/7?pane=issue&itemId=162130459)

[Screencast from 2026-04-20 17-50-59.webm](https://github.com/user-attachments/assets/400f5ac6-0046-4ab8-b68c-58564b1ee40c)

**After**
- Entry always has accurate start date/time
- Entry is actually within limits
- Clicking at the end of limits just starts the entry earlier (basically removed old logic)
- Resizing never allows an entry to be smaller than minimum duration
- Start date creation never allows entry to be smaller than minimum duration

[Screencast from 2026-04-20 17-52-36.webm](https://github.com/user-attachments/assets/713cc8ad-c7b7-4146-ac57-ebea8dfee218)
