### PR TITLE
Fix getting mime type from paper file

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Bugfixes
 - Use new MS Outlook URL in the share widget (:pr:`7424`, thanks :user:`hirishh`)
 - Fix editing contribution time from timetable bubbles when the CSP is enabled
   (:pr:`7432`)
+- Fix error when copying a paper file with an unguessable MIME type to the editing
+  module (:pr:`7475`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/editing/controllers/backend/timeline.py
+++ b/indico/modules/events/editing/controllers/backend/timeline.py
@@ -52,6 +52,12 @@ class RHEditingUploadFile(UploadFileMixin, RHContributionEditableBase):
         return 'event', self.event.id, 'editing', self.contrib.id, self.editable_type.name
 
 
+class _FileWrapper:
+    def __init__(self, file):
+        self.filename = file.filename
+        self.mimetype = file.content_type
+
+
 class RHEditingUploadContributionFile(RHEditingUploadFile):
     @use_kwargs({
         'id': fields.Int(load_default=None),
@@ -68,7 +74,7 @@ class RHEditingUploadContributionFile(RHEditingUploadFile):
             files = last_rev.files
         if found := next((f for f in files if f.id == (id or paper_id)), None):
             with found.open() as stream:
-                return self._save_file(found, stream)
+                return self._save_file(_FileWrapper(found), stream)
         raise UserValueError(_('No such file was found within the paper'))
 
 


### PR DESCRIPTION
The `_save_file` method usually expects a file wrapper coming from an uploaded file, but when copying files from peer reviewing to editing, this is actually a `File` which has a `content_type` instead of a `mimetype`.