### PR TITLE
Add last update column to registration lists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Improvements
   :user:`tomako`)
 - Add a "Code" (short name) to predefined affiliations (:pr:`7400`, thanks
   :user:`duartegalvao, unconventionaldotdev`)
+- Track the last modified timestamp of registrations (:pr:`7478`, thanks :user:`jbtwist`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20260422_1200_5843fe23c03c_add_registration_modified_dt.py
+++ b/indico/migrations/versions/20260422_1200_5843fe23c03c_add_registration_modified_dt.py
@@ -1,6 +1,6 @@
 """Add modified_dt column to registrations
 
-Revision ID: add_registration_modified_dt
+Revision ID: 5843fe23c03c
 Revises: e5a08c20f2bc
 Create Date: 2026-04-22 12:00:00.000000
 """
@@ -12,7 +12,7 @@ from indico.core.db.sqlalchemy import UTCDateTime
 
 
 # revision identifiers, used by Alembic.
-revision = 'add_registration_modified_dt'
+revision = '5843fe23c03c'
 down_revision = 'e5a08c20f2bc'
 branch_labels = None
 depends_on = None

--- a/indico/migrations/versions/20260422_1200_add_registration_modified_dt.py
+++ b/indico/migrations/versions/20260422_1200_add_registration_modified_dt.py
@@ -1,0 +1,27 @@
+"""Add modified_dt column to registrations
+
+Revision ID: add_registration_modified_dt
+Revises: 577e564cf0ae
+Create Date: 2026-04-22 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from indico.core.db.sqlalchemy import UTCDateTime
+
+
+# revision identifiers, used by Alembic.
+revision = 'add_registration_modified_dt'
+down_revision = '577e564cf0ae'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('registrations', sa.Column('modified_dt', UTCDateTime(), nullable=True),
+                  schema='event_registration')
+
+
+def downgrade():
+    op.drop_column('registrations', 'modified_dt', schema='event_registration')

--- a/indico/migrations/versions/20260422_1200_add_registration_modified_dt.py
+++ b/indico/migrations/versions/20260422_1200_add_registration_modified_dt.py
@@ -1,7 +1,7 @@
 """Add modified_dt column to registrations
 
 Revision ID: add_registration_modified_dt
-Revises: 577e564cf0ae
+Revises: e5a08c20f2bc
 Create Date: 2026-04-22 12:00:00.000000
 """
 
@@ -13,14 +13,13 @@ from indico.core.db.sqlalchemy import UTCDateTime
 
 # revision identifiers, used by Alembic.
 revision = 'add_registration_modified_dt'
-down_revision = '577e564cf0ae'
+down_revision = 'e5a08c20f2bc'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column('registrations', sa.Column('modified_dt', UTCDateTime(), nullable=True),
-                  schema='event_registration')
+    op.add_column('registrations', sa.Column('modified_dt', UTCDateTime(), nullable=True), schema='event_registration')
 
 
 def downgrade():

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -60,6 +60,9 @@ class RegistrationListGenerator(ListGeneratorBase):
             'payment_date': {
                 'title': _('Payment date'),
             },
+            'modified_dt': {
+                'title': _('Last modified'),
+            },
             'visibility': {
                 'title': _('Visibility'),
             },

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -40,6 +40,9 @@ class RegistrationListGenerator(ListGeneratorBase):
             'reg_date': {
                 'title': _('Registration date'),
             },
+            'mod_date': {
+                'title': _('Modification date'),
+            },
             'price': {
                 'title': _('Price'),
             },
@@ -59,9 +62,6 @@ class RegistrationListGenerator(ListGeneratorBase):
             },
             'payment_date': {
                 'title': _('Payment date'),
-            },
-            'modified_dt': {
-                'title': _('Last modified'),
             },
             'visibility': {
                 'title': _('Visibility'),

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -38,7 +38,7 @@ class RegistrationListGenerator(ListGeneratorBase):
         registration_tag_choices = self._get_registration_tag_choices()
         self.static_items = {
             'reg_date': {
-                'title': _('Registration Date'),
+                'title': _('Registration date'),
             },
             'price': {
                 'title': _('Price'),

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -257,6 +257,11 @@ class Registration(db.Model):
         UTCDateTime,
         nullable=True
     )
+    #: The date/time when the registration was last modified
+    modified_dt = db.Column(
+        UTCDateTime,
+        nullable=True
+    )
 
     #: The Event containing this registration
     event = db.relationship(
@@ -814,6 +819,12 @@ class Registration(db.Model):
         awm = AppleWalletManager(self.event)
         if awm.is_configured:
             return awm.get_ticket(self)
+
+    def set_modified(self):
+        """Set the registration modified date at the current time. This function is only meant
+        to be called when the registration is modified by the user or an admin, not on automatic state changes.
+        """
+        self.modified_dt = now_utc()
 
 
 class RegistrationData(StoredFileMixin, db.Model):

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -821,8 +821,10 @@ class Registration(db.Model):
             return awm.get_ticket(self)
 
     def set_modified(self):
-        """Set the registration modified date at the current time. This function is only meant
-        to be called when the registration is modified by the user or an admin, not on automatic state changes.
+        """Update the modification date.
+
+        This function is only meant to be called when the registration is modified
+        by the user or an admin, not on automatic state changes.
         """
         self.modified_dt = now_utc()
 

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -61,6 +61,14 @@
                                         <td class="i-table" data-text="{{ registration.submitted_dt }}">
                                             {{- registration.submitted_dt | format_datetime(timezone=registration.event.tzinfo) -}}
                                         </td>
+                                    {% elif item.id == 'mod_date' %}
+                                        <td class="i-table" data-text="{{ registration.modified_dt }}">
+                                            {%- if registration.modified_dt %}
+                                                {{- registration.modified_dt | format_datetime(timezone=registration.event.tzinfo) -}}
+                                            {%- else %}
+                                                -
+                                            {%- endif %}
+                                        </td>
                                     {% elif item.id == 'state' %}
                                         <td class="i-table">{{ registration.state.title }}</td>
                                     {% elif item.id == 'price' %}
@@ -85,14 +93,6 @@
                                             {%- else %}
                                                 -
                                             {% endif %}
-                                        </td>
-                                    {% elif item.id == 'modified_dt' %}
-                                        <td class="i-table" data-text="{{ registration.modified_dt }}">
-                                            {%- if registration.modified_dt %}
-                                                {{- registration.modified_dt | format_datetime(timezone=registration.event.tzinfo) -}}
-                                            {%- else %}
-                                                -
-                                            {%- endif %}
                                         </td>
                                     {% elif item.id == 'tags_present' %}
                                         <td class="i-table" style="padding-top: 8px; padding-bottom: 8px;">

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -86,6 +86,14 @@
                                                 -
                                             {% endif %}
                                         </td>
+                                    {% elif item.id == 'modified_dt' %}
+                                        <td class="i-table" data-text="{{ registration.modified_dt }}">
+                                            {%- if registration.modified_dt %}
+                                                {{- registration.modified_dt | format_datetime(timezone=registration.event.tzinfo) -}}
+                                            {%- else %}
+                                                -
+                                            {%- endif %}
+                                        </td>
                                     {% elif item.id == 'tags_present' %}
                                         <td class="i-table" style="padding-top: 8px; padding-bottom: 8px;">
                                             {% for tag in registration.tags|sort(attribute='title', case_sensitive=false) %}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -536,6 +536,7 @@ def modify_registration(registration, data, management=False, notify_user=True):
             update_registration_consent_to_publish(registration, consent_to_publish)
 
     registration.sync_state()
+    registration.set_modified()
     db.session.flush()
     # sanity check
     if billable_items_locked and old_price != registration.price:

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -586,6 +586,7 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
     field_names = ['ID', 'Name']
     special_item_mapping = {
         'reg_date': ('Registration date', lambda x: x.submitted_dt),
+        'mod_date': ('Modification date', lambda x: x.modified_dt),
         'state': ('Registration state', lambda x: x.state.title),
         'price': ('Price', lambda x: x.render_price()),
         'checked_in': ('Checked in', lambda x: x.checked_in),


### PR DESCRIPTION
As discussed per Matrix, I would like to add this column to the Registration model to show in the managed registration list the last time a registration was updated.

I realised there's a small inconsistency between the general info columns regarding their capitalization. Registration Date is capitalised on every word, but the other columns aren't. I feel like it's a good opportunity to fix it here too.

<img width="278" height="255" alt="Screenshot 2026-04-22 at 17 32 55" src="https://github.com/user-attachments/assets/5c4edc5a-cdec-4c4d-a4e1-a602643bf9c9" />

<img width="1465" height="335" alt="Screenshot 2026-04-22 at 17 33 02" src="https://github.com/user-attachments/assets/610b3538-2a34-4752-abc2-3a4e52fc60c8" />
