### PR TITLE
Shorten exported attachment paths in ZIP files for Windows compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,8 @@ Bugfixes
 - Honor room booking details restrictions in spreadsheet export (:pr:`7612`)
 - Show favorite events in the dashboard based on their end date instead of their
   start date (:pr:`7653`, thanks :user:`SegiNyn`)
+- Reduce max filename length in ZIP downloads to avoid issues on Windows (:pr:`7479`,
+  :user:`moliholy`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/util.py
+++ b/indico/modules/events/util.py
@@ -686,16 +686,19 @@ def get_event_from_url(url):
 class ZipGeneratorMixin:
     """Mixin for RHs that generate zip with files."""
 
+    _MAX_ARCHIVE_PATH_LENGTH = 200
+
     def _adjust_path_length(self, segments):
-        """Shorten the path length to < 260 chars.
+        """Shorten the archive path length to a Windows-safe limit.
 
         Windows' built-in ZIP tool doesn't like files whose
-        total path exceeds ~260 chars. Here we progressively
-        shorten the total until it matches that constraint.
+        extracted path exceeds ~260 chars. Since the extraction
+        target folder also contributes to that limit, we keep a
+        safety margin for the archive entry path itself.
         """
         result = []
         total_len = sum(len(seg) for seg in segments) + len(segments) - 1
-        excess = (total_len - 255) if total_len > 255 else 0
+        excess = (total_len - self._MAX_ARCHIVE_PATH_LENGTH) if total_len > self._MAX_ARCHIVE_PATH_LENGTH else 0
 
         for seg in reversed(segments):
             fname, ext = os.path.splitext(seg)

--- a/indico/modules/events/util_test.py
+++ b/indico/modules/events/util_test.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from indico.modules.events.util import get_event_from_url
+from indico.modules.events.util import ZipGeneratorMixin, get_event_from_url
 
 
 @pytest.mark.parametrize(('url', 'asserted_error_message'), (
@@ -23,3 +23,14 @@ def test_get_event_from_url_raises_value_error(url, asserted_error_message):
 def test_get_event_from_url_returns_event(dummy_event):
     event = get_event_from_url(f'http://localhost/event/{dummy_event.id}')
     assert event == dummy_event
+
+
+def test_adjust_path_length_keeps_safe_margin_for_windows_zip_extraction():
+    path = '/'.join(ZipGeneratorMixin()._adjust_path_length([
+        'registration_form_' + 'a' * 100,
+        'registrant_' + 'b' * 100,
+        'file_' + 'c' * 100 + '.docx',
+    ]))
+
+    assert len(path) <= 200
+    assert path.endswith('.docx')


### PR DESCRIPTION
This fixes an Indico core bug affecting exported registration attachments with very long names.

When generating the ZIP, some archive entry paths could become too long once extracted on Windows, causing files to fail to open properly. The fix shortens ZIP entry paths earlier and keeps a safe margin below Windows’ practical path-length limit, while preserving the file extension.

A regression test was added to verify that long exported paths are trimmed to a safe length and still keep the expected `.docx` suffix.