### PR TITLE
Sort attendee list numbers numerically instead of alphabetically

### DIFF
--- a/indico/modules/events/registration/client/js/components/participant-list/ParticipantTable.tsx
+++ b/indico/modules/events/registration/client/js/components/participant-list/ParticipantTable.tsx
@@ -73,7 +73,13 @@ export default function ParticipantTable({table}: ParticipantTableProps) {
             } else if (comparedVals.every(el => typeof el === 'boolean')) {
               sortResult = comparedVals[0] > comparedVals[1] ? -1 : 1;
             } else {
-              sortResult = comparedVals[0].localeCompare(comparedVals[1]);
+              const aNum = Number(comparedVals[0]);
+              const bNum = Number(comparedVals[1]);
+              if (!isNaN(aNum) && !isNaN(bNum)) {
+                sortResult = aNum - bNum;
+              } else {
+                sortResult = comparedVals[0].localeCompare(comparedVals[1]);
+              }
             }
 
             return sortResult * (direction === 'ascending' ? 1 : -1);


### PR DESCRIPTION
Good day

The attendee list currently sorts numbers as strings, resulting in "1, 10, 2" instead of "1, 2, 10". This PR changes the sort key to use numeric comparison.

Thank you for your work on this project. I hope this small fix is helpful. Please let me know if there's anything to adjust.

Warmly, RoomWithRoof