### PR TITLE
Fix internal name checking when re-enabling the field

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ Improvements
 - Add new permission that grants only participant management (create, edit and
   delete registrations) without access to the registration form configuration
   (:pr:`7419`, thanks :user:`moliholy, unconventionaldotdev`)
-- Add internal name for registration form fields (:pr:`7276`, thanks :user:`tomako`)
+- Add internal name for registration form fields (:pr:`7276`, :pr:`7485`, thanks
+  :user:`tomako`)
 - Add a "Code" (short name) to predefined affiliations (:pr:`7400`, thanks
   :user:`duartegalvao, unconventionaldotdev`)
 

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -288,10 +288,9 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                 BadRequest(_('There is already a field in this section with the same title.'))
             )
 
-    def _check_internal_name(self):
+    def _check_unique_internal_name_in_form(self):
         if not self.field.internal_name:
             return
-        # check unique internal name on form
         query = (RegistrationFormItem.query
                  .with_parent(self.field.registration_form)
                  .filter(RegistrationFormItem.internal_name == self.field.internal_name,
@@ -302,7 +301,10 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                 BadRequest(_('The field "{}" on this form has the same internal name.')
                            .format(same_field.title))
             )
-        # consistent type on forms of the same event
+
+    def _check_internal_name_type_consistency_in_event(self):
+        if not self.field.internal_name:
+            return
         query = (RegistrationFormItem.query
                  .join(RegistrationFormItem.registration_form)
                  .join(RegistrationForm.event)
@@ -328,7 +330,8 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
             raise NoReportError.wrap_exc(BadRequest(_('Fields used as conditional cannot be disabled')))
         if enabled:
             self._check_unique_title_in_section()
-            self._check_internal_name()
+            self._check_unique_internal_name_in_form()
+            self._check_internal_name_type_consistency_in_event()
 
         self.field.is_enabled = enabled
         update_regform_item_positions(self.regform)

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -277,8 +277,7 @@ class RHManageRegFormFieldBase(RHManageRegFormSectionBase):
 class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
     """Enable/Disable a field."""
 
-    def check_title_on_enable(self):
-        # check unique internal name in section
+    def _check_unique_title_in_section(self):
         query = (RegistrationFormItem.query
                  .filter(RegistrationFormItem.parent_id == self.field.parent.id,
                          db.func.lower(RegistrationFormItem.title) == self.field.title.lower(),
@@ -289,35 +288,36 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                 BadRequest(_('There is already a field in this section with the same title.'))
             )
 
-    def check_internal_name_on_enable(self):
-        if self.field.internal_name:
-            # check unique internal name on form
-            query = (RegistrationFormItem.query
-                     .with_parent(self.field.registration_form)
-                     .filter(RegistrationFormItem.internal_name == self.field.internal_name,
-                             RegistrationFormItem.is_enabled,
-                             ~RegistrationFormItem.is_deleted))
-            if same_field := query.first():
-                raise NoReportError.wrap_exc(
-                    BadRequest(_('The field "{}" on this form has the same internal name.')
-                               .format(same_field.title))
-                )
-            # consistent type on forms of the same event
-            query = (RegistrationFormItem.query
-                     .join(RegistrationFormItem.registration_form)
-                     .join(RegistrationForm.event)
-                     .filter(RegistrationFormItem.internal_name == self.field.internal_name,
-                             RegistrationFormItem.registration_form_id != self.field.registration_form.id,
-                             RegistrationFormItem.input_type != self.field.input_type,
-                             RegistrationFormItem.is_enabled,
-                             ~RegistrationFormItem.is_deleted,
-                             Event.id == self.field.registration_form.event_id))
-            if inconsistent_field := query.first():
-                raise NoReportError.wrap_exc(
-                    BadRequest(_('The field "{}" with the same internal name on form "{}" '
-                                 'uses a different input type which is not allowed.')
-                               .format(inconsistent_field.title, inconsistent_field.registration_form.title))
-                )
+    def _check_internal_name(self):
+        if not self.field.internal_name:
+            return
+        # check unique internal name on form
+        query = (RegistrationFormItem.query
+                 .with_parent(self.field.registration_form)
+                 .filter(RegistrationFormItem.internal_name == self.field.internal_name,
+                         RegistrationFormItem.is_enabled,
+                         ~RegistrationFormItem.is_deleted))
+        if same_field := query.first():
+            raise NoReportError.wrap_exc(
+                BadRequest(_('The field "{}" on this form has the same internal name.')
+                           .format(same_field.title))
+            )
+        # consistent type on forms of the same event
+        query = (RegistrationFormItem.query
+                 .join(RegistrationFormItem.registration_form)
+                 .join(RegistrationForm.event)
+                 .filter(RegistrationFormItem.internal_name == self.field.internal_name,
+                         RegistrationFormItem.registration_form_id != self.field.registration_form.id,
+                         RegistrationFormItem.input_type != self.field.input_type,
+                         RegistrationFormItem.is_enabled,
+                         ~RegistrationFormItem.is_deleted,
+                         Event.id == self.field.registration_form.event_id))
+        if inconsistent_field := query.first():
+            raise NoReportError.wrap_exc(
+                BadRequest(_('The field "{}" with the same internal name on form "{}" '
+                             'uses a different input type which is not allowed.')
+                           .format(inconsistent_field.title, inconsistent_field.registration_form.title))
+            )
 
     def _process(self):
         enabled = request.args.get('enable') == 'true'
@@ -327,8 +327,8 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
         if not enabled and self.field.condition_for:
             raise NoReportError.wrap_exc(BadRequest(_('Fields used as conditional cannot be disabled')))
         if enabled:
-            self.check_title_on_enable()
-            self.check_internal_name_on_enable()
+            self._check_unique_title_in_section()
+            self._check_internal_name()
 
         self.field.is_enabled = enabled
         update_regform_item_positions(self.regform)

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -113,7 +113,7 @@ class GeneralFieldDataSchema(mm.Schema):
         if internal_name is None:
             return
         if field.is_enabled is not False:  # None for new field
-            # unique on form
+            # check unique internal name on form
             query = (RegistrationFormItem.query
                      .with_parent(field.registration_form)
                      .filter(RegistrationFormItem.internal_name == internal_name,
@@ -295,32 +295,34 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                 raise NoReportError.wrap_exc(
                     BadRequest(_('There is already a field in this section with the same title.'))
                 )
-            # check unique internal name in form
-            query = (RegistrationFormItem.query
-                     .with_parent(self.field.registration_form)
-                     .filter(RegistrationFormItem.internal_name == self.field.internal_name,
-                             RegistrationFormItem.is_enabled,
-                             ~RegistrationFormItem.is_deleted))
-            if same_field := query.first():
-                raise NoReportError.wrap_exc(
-                    BadRequest(_('The field "{}" on this form has the same internal name.').format(same_field.title))
-                )
-            # consistent type on forms of the same event
-            query = (RegistrationFormItem.query
-                     .join(RegistrationFormItem.registration_form)
-                     .join(RegistrationForm.event)
-                     .filter(RegistrationFormItem.internal_name == self.field.internal_name,
-                             RegistrationFormItem.registration_form_id != self.field.registration_form.id,
-                             RegistrationFormItem.input_type != self.field.input_type,
-                             RegistrationFormItem.is_enabled,
-                             ~RegistrationFormItem.is_deleted,
-                             Event.id == self.field.registration_form.event_id))
-            if inconsistent_field := query.first():
-                raise NoReportError.wrap_exc(
-                    BadRequest(_('The field "{}" with the same internal name on form "{}" '
-                                 'uses a different input type which is not allowed.')
-                               .format(inconsistent_field.title, inconsistent_field.registration_form.title))
-                )
+            if self.field.internal_name:
+                # check unique internal name on form
+                query = (RegistrationFormItem.query
+                         .with_parent(self.field.registration_form)
+                         .filter(RegistrationFormItem.internal_name == self.field.internal_name,
+                                 RegistrationFormItem.is_enabled,
+                                 ~RegistrationFormItem.is_deleted))
+                if same_field := query.first():
+                    raise NoReportError.wrap_exc(
+                        BadRequest(_('The field "{}" on this form has the same internal name.')
+                                   .format(same_field.title))
+                    )
+                # consistent type on forms of the same event
+                query = (RegistrationFormItem.query
+                         .join(RegistrationFormItem.registration_form)
+                         .join(RegistrationForm.event)
+                         .filter(RegistrationFormItem.internal_name == self.field.internal_name,
+                                 RegistrationFormItem.registration_form_id != self.field.registration_form.id,
+                                 RegistrationFormItem.input_type != self.field.input_type,
+                                 RegistrationFormItem.is_enabled,
+                                 ~RegistrationFormItem.is_deleted,
+                                 Event.id == self.field.registration_form.event_id))
+                if inconsistent_field := query.first():
+                    raise NoReportError.wrap_exc(
+                        BadRequest(_('The field "{}" with the same internal name on form "{}" '
+                                     'uses a different input type which is not allowed.')
+                                   .format(inconsistent_field.title, inconsistent_field.registration_form.title))
+                    )
 
         self.field.is_enabled = enabled
         update_regform_item_positions(self.regform)

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -277,6 +277,48 @@ class RHManageRegFormFieldBase(RHManageRegFormSectionBase):
 class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
     """Enable/Disable a field."""
 
+    def check_title_on_enable(self):
+        # check unique internal name in section
+        query = (RegistrationFormItem.query
+                 .filter(RegistrationFormItem.parent_id == self.field.parent.id,
+                         db.func.lower(RegistrationFormItem.title) == self.field.title.lower(),
+                         RegistrationFormItem.is_enabled,
+                         ~RegistrationFormItem.is_deleted))
+        if query.has_rows():
+            raise NoReportError.wrap_exc(
+                BadRequest(_('There is already a field in this section with the same title.'))
+            )
+
+    def check_internal_name_on_enable(self):
+        if self.field.internal_name:
+            # check unique internal name on form
+            query = (RegistrationFormItem.query
+                     .with_parent(self.field.registration_form)
+                     .filter(RegistrationFormItem.internal_name == self.field.internal_name,
+                             RegistrationFormItem.is_enabled,
+                             ~RegistrationFormItem.is_deleted))
+            if same_field := query.first():
+                raise NoReportError.wrap_exc(
+                    BadRequest(_('The field "{}" on this form has the same internal name.')
+                               .format(same_field.title))
+                )
+            # consistent type on forms of the same event
+            query = (RegistrationFormItem.query
+                     .join(RegistrationFormItem.registration_form)
+                     .join(RegistrationForm.event)
+                     .filter(RegistrationFormItem.internal_name == self.field.internal_name,
+                             RegistrationFormItem.registration_form_id != self.field.registration_form.id,
+                             RegistrationFormItem.input_type != self.field.input_type,
+                             RegistrationFormItem.is_enabled,
+                             ~RegistrationFormItem.is_deleted,
+                             Event.id == self.field.registration_form.event_id))
+            if inconsistent_field := query.first():
+                raise NoReportError.wrap_exc(
+                    BadRequest(_('The field "{}" with the same internal name on form "{}" '
+                                 'uses a different input type which is not allowed.')
+                               .format(inconsistent_field.title, inconsistent_field.registration_form.title))
+                )
+
     def _process(self):
         enabled = request.args.get('enable') == 'true'
         if (not enabled and self.field.type == RegistrationFormItemType.field_pd and
@@ -285,44 +327,8 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
         if not enabled and self.field.condition_for:
             raise NoReportError.wrap_exc(BadRequest(_('Fields used as conditional cannot be disabled')))
         if enabled:
-            # check unique title in section
-            query = (RegistrationFormItem.query
-                     .filter(RegistrationFormItem.parent_id == self.field.parent.id,
-                             db.func.lower(RegistrationFormItem.title) == self.field.title.lower(),
-                             RegistrationFormItem.is_enabled,
-                             ~RegistrationFormItem.is_deleted))
-            if query.has_rows():
-                raise NoReportError.wrap_exc(
-                    BadRequest(_('There is already a field in this section with the same title.'))
-                )
-            if self.field.internal_name:
-                # check unique internal name on form
-                query = (RegistrationFormItem.query
-                         .with_parent(self.field.registration_form)
-                         .filter(RegistrationFormItem.internal_name == self.field.internal_name,
-                                 RegistrationFormItem.is_enabled,
-                                 ~RegistrationFormItem.is_deleted))
-                if same_field := query.first():
-                    raise NoReportError.wrap_exc(
-                        BadRequest(_('The field "{}" on this form has the same internal name.')
-                                   .format(same_field.title))
-                    )
-                # consistent type on forms of the same event
-                query = (RegistrationFormItem.query
-                         .join(RegistrationFormItem.registration_form)
-                         .join(RegistrationForm.event)
-                         .filter(RegistrationFormItem.internal_name == self.field.internal_name,
-                                 RegistrationFormItem.registration_form_id != self.field.registration_form.id,
-                                 RegistrationFormItem.input_type != self.field.input_type,
-                                 RegistrationFormItem.is_enabled,
-                                 ~RegistrationFormItem.is_deleted,
-                                 Event.id == self.field.registration_form.event_id))
-                if inconsistent_field := query.first():
-                    raise NoReportError.wrap_exc(
-                        BadRequest(_('The field "{}" with the same internal name on form "{}" '
-                                     'uses a different input type which is not allowed.')
-                                   .format(inconsistent_field.title, inconsistent_field.registration_form.title))
-                    )
+            self.check_title_on_enable()
+            self.check_internal_name_on_enable()
 
         self.field.is_enabled = enabled
         update_regform_item_positions(self.regform)

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -199,7 +199,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        assert rh.check_title_on_enable() is None
+        assert rh._check_unique_title_in_section() is None
 
     def test_same_title_on_enable(self, db, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -210,7 +210,7 @@ class TestRegistrationFormToggleFieldState:
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
         with pytest.raises(BadRequest, match='There is already a field in this section with the same title'):
-            rh.check_title_on_enable()
+            rh._check_unique_title_in_section()
 
     def test_same_title_in_other_section_on_enable(self, db, dummy_regform):
         other_section = RegistrationFormSection(registration_form=dummy_regform, title='Other Section',
@@ -221,7 +221,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        assert rh.check_title_on_enable() is None
+        assert rh._check_unique_title_in_section() is None
 
     # internal_name tests
 
@@ -232,7 +232,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        assert rh.check_internal_name_on_enable() is None
+        assert rh._check_internal_name() is None
 
     def test_multiple_fields_with_empty_internal_name_on_enable(self, db, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -243,7 +243,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        assert rh.check_internal_name_on_enable() is None
+        assert rh._check_internal_name() is None
 
     def test_unique_internal_name_on_enable(self, db, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -253,7 +253,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        assert rh.check_internal_name_on_enable() is None
+        assert rh._check_internal_name() is None
 
     def test_same_internal_name_on_enable(self, db, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -264,7 +264,7 @@ class TestRegistrationFormToggleFieldState:
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
         with pytest.raises(BadRequest, match='The field "Title" on this form has the same internal name'):
-            rh.check_internal_name_on_enable()
+            rh._check_internal_name()
 
     def test_same_internal_name_in_other_section_on_enable(self, db, dummy_regform):
         other_section = RegistrationFormSection(registration_form=dummy_regform, title='Other Section',
@@ -277,7 +277,7 @@ class TestRegistrationFormToggleFieldState:
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
         with pytest.raises(BadRequest, match='The field "Title" on this form has the same internal name'):
-            rh.check_internal_name_on_enable()
+            rh._check_internal_name()
 
     def test_consistent_type_on_enabled(self, db, dummy_regform, create_regform):
         other_regform = create_regform(dummy_regform.event, title='Other Form')
@@ -294,7 +294,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        assert rh.check_internal_name_on_enable() is None
+        assert rh._check_internal_name() is None
 
     def test_inconsistent_type_on_enabled(self, db, dummy_regform, create_regform):
         other_regform = create_regform(dummy_regform.event, title='Other Form')
@@ -313,4 +313,4 @@ class TestRegistrationFormToggleFieldState:
         rh.field = disabled_field
         with pytest.raises(BadRequest, match='The field "Field Title" with the same internal name on form "Other Form" '
                                              'uses a different input type which is not allowed'):
-            rh.check_internal_name_on_enable()
+            rh._check_internal_name()

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -232,7 +232,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        assert rh._check_internal_name() is None
+        assert rh._check_unique_internal_name_in_form() is None
 
     def test_multiple_fields_with_empty_internal_name_on_enable(self, db, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -243,7 +243,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        assert rh._check_internal_name() is None
+        assert rh._check_unique_internal_name_in_form() is None
 
     def test_unique_internal_name_on_enable(self, db, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -253,7 +253,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        assert rh._check_internal_name() is None
+        assert rh._check_unique_internal_name_in_form() is None
 
     def test_same_internal_name_on_enable(self, db, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -264,7 +264,7 @@ class TestRegistrationFormToggleFieldState:
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
         with pytest.raises(BadRequest, match='The field "Title" on this form has the same internal name'):
-            rh._check_internal_name()
+            rh._check_unique_internal_name_in_form()
 
     def test_same_internal_name_in_other_section_on_enable(self, db, dummy_regform):
         other_section = RegistrationFormSection(registration_form=dummy_regform, title='Other Section',
@@ -277,7 +277,7 @@ class TestRegistrationFormToggleFieldState:
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
         with pytest.raises(BadRequest, match='The field "Title" on this form has the same internal name'):
-            rh._check_internal_name()
+            rh._check_unique_internal_name_in_form()
 
     def test_consistent_type_on_enabled(self, db, dummy_regform, create_regform):
         other_regform = create_regform(dummy_regform.event, title='Other Form')
@@ -294,7 +294,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        assert rh._check_internal_name() is None
+        assert rh._check_internal_name_type_consistency_in_event() is None
 
     def test_inconsistent_type_on_enabled(self, db, dummy_regform, create_regform):
         other_regform = create_regform(dummy_regform.event, title='Other Form')
@@ -313,4 +313,4 @@ class TestRegistrationFormToggleFieldState:
         rh.field = disabled_field
         with pytest.raises(BadRequest, match='The field "Field Title" with the same internal name on form "Other Form" '
                                              'uses a different input type which is not allowed'):
-            rh._check_internal_name()
+            rh._check_internal_name_type_consistency_in_event()

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -7,8 +7,10 @@
 
 import pytest
 from marshmallow import ValidationError
+from werkzeug.exceptions import BadRequest
 
 from indico.modules.events.registration.controllers.management.fields import (GeneralFieldDataSchema,
+                                                                              RHRegistrationFormToggleFieldState,
                                                                               _fill_form_field_with_data)
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.items import PersonalDataType, RegistrationFormSection
@@ -185,3 +187,130 @@ class TestGeneralFieldDataSchema:
                                             title='test', input_type='checkbox')
         schema = GeneralFieldDataSchema(context={'regform': other_form, 'field': other_field})
         schema.load({'input_type': 'checkbox', 'title': 'test', 'internal_name': 'test'})
+
+
+class TestRegistrationFormToggleFieldState:
+    # title tests
+
+    def test_unique_title_on_enable(self, db, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False)
+        _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Unique Title'})
+        db.session.flush()
+        rh = RHRegistrationFormToggleFieldState()
+        rh.field = disabled_field
+        assert rh.check_title_on_enable() is None
+
+    def test_same_title_on_enable(self, db, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False,
+                                               id=1337)
+        _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Title'})
+        db.session.flush()
+        rh = RHRegistrationFormToggleFieldState()
+        rh.field = disabled_field
+        with pytest.raises(BadRequest, match='There is already a field in this section with the same title'):
+            rh.check_title_on_enable()
+
+    def test_same_title_in_other_section_on_enable(self, db, dummy_regform):
+        other_section = RegistrationFormSection(registration_form=dummy_regform, title='Other Section',
+                                                is_manager_only=False)
+        disabled_field = RegistrationFormField(parent=other_section, registration_form=dummy_regform, is_enabled=False,
+                                               id=1337)
+        _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Title'})
+        db.session.flush()
+        rh = RHRegistrationFormToggleFieldState()
+        rh.field = disabled_field
+        assert rh.check_title_on_enable() is None
+
+    # internal_name tests
+
+    def test_empty_internal_name_on_enable(self, db, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False)
+        _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Field Title'})
+        db.session.flush()
+        rh = RHRegistrationFormToggleFieldState()
+        rh.field = disabled_field
+        assert rh.check_internal_name_on_enable() is None
+
+    def test_multiple_fields_with_empty_internal_name_on_enable(self, db, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        enabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(enabled_field, {'input_type': 'text', 'title': 'Enabled Field Title'})
+        disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False)
+        _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Disabled Field Title'})
+        db.session.flush()
+        rh = RHRegistrationFormToggleFieldState()
+        rh.field = disabled_field
+        assert rh.check_internal_name_on_enable() is None
+
+    def test_unique_internal_name_on_enable(self, db, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False)
+        _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Field Title',
+                                                    'internal_name': 'unique-internal-name'})
+        db.session.flush()
+        rh = RHRegistrationFormToggleFieldState()
+        rh.field = disabled_field
+        assert rh.check_internal_name_on_enable() is None
+
+    def test_same_internal_name_on_enable(self, db, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False)
+        _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Field Title',
+                                                    'internal_name': 'title'})
+        db.session.flush()
+        rh = RHRegistrationFormToggleFieldState()
+        rh.field = disabled_field
+        with pytest.raises(BadRequest, match='The field "Title" on this form has the same internal name'):
+            rh.check_internal_name_on_enable()
+
+    def test_same_internal_name_in_other_section_on_enable(self, db, dummy_regform):
+        other_section = RegistrationFormSection(registration_form=dummy_regform, title='Other Section',
+                                                is_manager_only=False)
+        disabled_field = RegistrationFormField(parent=other_section, registration_form=dummy_regform, is_enabled=False,
+                                               id=1337)
+        _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Field Title',
+                                                    'internal_name': 'title'})
+        db.session.flush()
+        rh = RHRegistrationFormToggleFieldState()
+        rh.field = disabled_field
+        with pytest.raises(BadRequest, match='The field "Title" on this form has the same internal name'):
+            rh.check_internal_name_on_enable()
+
+    def test_consistent_type_on_enabled(self, db, dummy_regform, create_regform):
+        other_regform = create_regform(dummy_regform.event, title='Other Form')
+        other_pd_section = other_regform.sections[0]
+        other_field = RegistrationFormField(parent=other_pd_section, registration_form=other_regform)
+        _fill_form_field_with_data(other_field, {'input_type': 'text', 'title': 'Field Title',
+                                                 'internal_name': 'unique-internal-name'})
+        db.session.flush()
+
+        pd_section = dummy_regform.sections[0]
+        disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False)
+        _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Field Title',
+                                                    'internal_name': 'unique-internal-name'})
+        db.session.flush()
+        rh = RHRegistrationFormToggleFieldState()
+        rh.field = disabled_field
+        assert rh.check_internal_name_on_enable() is None
+
+    def test_inconsistent_type_on_enabled(self, db, dummy_regform, create_regform):
+        other_regform = create_regform(dummy_regform.event, title='Other Form')
+        other_pd_section = other_regform.sections[0]
+        other_field = RegistrationFormField(parent=other_pd_section, registration_form=other_regform)
+        _fill_form_field_with_data(other_field, {'input_type': 'text', 'title': 'Field Title',
+                                                 'internal_name': 'unique-internal-name'})
+        db.session.flush()
+
+        pd_section = dummy_regform.sections[0]
+        disabled_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform, is_enabled=False)
+        _fill_form_field_with_data(disabled_field, {'input_type': 'textarea', 'title': 'Field Title',
+                                                    'internal_name': 'unique-internal-name'})
+        db.session.flush()
+        rh = RHRegistrationFormToggleFieldState()
+        rh.field = disabled_field
+        with pytest.raises(BadRequest, match='The field "Field Title" with the same internal name on form "Other Form" '
+                                             'uses a different input type which is not allowed'):
+            rh.check_internal_name_on_enable()

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -8,7 +8,8 @@
 import pytest
 from marshmallow import ValidationError
 
-from indico.modules.events.registration.controllers.management.fields import GeneralFieldDataSchema
+from indico.modules.events.registration.controllers.management.fields import (GeneralFieldDataSchema,
+                                                                              _fill_form_field_with_data)
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.items import PersonalDataType, RegistrationFormSection
 
@@ -73,6 +74,27 @@ class TestGeneralFieldDataSchema:
         assert schema.load({'input_type': 'text', 'title': first_name_field.title})
 
     # internal_name tests
+
+    def test_new_field_with_empty_internal_name(self, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        assert schema.load({'input_type': 'text', 'title': 'New field'})
+
+    def test_multiple_fields_with_empty_internal_name(self, db, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        new_field_1 = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(new_field_1, {'input_type': 'text', 'title': 'New field 1'})
+        db.session.flush()
+        new_field_2 = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field_2})
+        assert schema.load({'input_type': 'text', 'title': 'New field 2'})
+
+    def test_new_field_with_unique_internal_name(self, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        new_field = RegistrationFormField(parent=pd_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        assert schema.load({'input_type': 'text', 'title': 'New field', 'internal_name': 'unique-internal-name'})
 
     def test_new_field_with_same_internal_name(self, dummy_regform):
         pd_section = dummy_regform.sections[0]


### PR DESCRIPTION
This PR fixes a bug which doesn't allow to re-enable a field with empty internal name. 

Beside that I refactored `RHRegistrationFormToggleFieldState` a bit to be able to test title and internal name when re-enabling the field.