### PR TITLE
Add toasts to timetable via context

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -10,6 +10,8 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {ThunkDispatch} from 'redux-thunk';
 
+import {Translate} from 'indico/react/i18n';
+
 import './DayTimetable.module.scss';
 import './Entry.module.scss';
 
@@ -30,13 +32,23 @@ import {
 } from './layout';
 import {DRAFT_ENTRY_MODAL, useModal} from './ModalContext';
 import * as selectors from './selectors';
-import {ReduxState, TopLevelEntry, BlockEntry, Entry, isChildEntry, EntryType} from './types';
+import {useToast} from './ToastContext';
+import {
+  ReduxState,
+  TopLevelEntry,
+  BlockEntry,
+  Entry,
+  isChildEntry,
+  EntryType,
+  Session,
+} from './types';
 import UnscheduledContributions from './UnscheduledContributions';
 import {
   DAY_SIZE,
   GRID_SIZE_MINUTES,
   MIN_DURATION,
   V_SPACE_BETWEEN_ENTRIES_PX,
+  flattenEntries,
   getDateKey,
   isWithinLimits,
   minutesToPixels,
@@ -108,6 +120,7 @@ export function DayTimetable({
   entries,
   scrollPosition = 0,
 }: DayTimetableProps) {
+  const toast = useToast();
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
   const eventStartDt = useSelector(selectors.getEventStartDt);
   const eventEndDt = useSelector(selectors.getEventEndDt);
@@ -132,6 +145,42 @@ export function DayTimetable({
   entries = useMemo(() => computeYoffset(entries, minHour), [entries, minHour]);
 
   const {openModal} = useModal();
+
+  const sessions: Record<number, Session> = useSelector(selectors.getSessions);
+
+  function showToastIfContribSessionChanged(
+    contribTitle: string | undefined,
+    oldSessionId: number | null | undefined,
+    newSessionId: number | null | undefined
+  ) {
+    const oldId = oldSessionId ?? null;
+    const newId = newSessionId ?? null;
+    if (oldId === newId) {
+      return;
+    }
+    const oldSessionTitle = oldId !== null ? sessions[oldId]?.title : null;
+    const newSessionTitle = newId !== null ? sessions[newId]?.title : null;
+    const title = contribTitle || Translate.string('the contribution');
+    let message: React.ReactNode;
+    if (oldSessionTitle && newSessionTitle) {
+      message = Translate.string(
+        '"{title}" was moved from session "{oldSession}" to session "{newSession}".',
+        {title, oldSession: oldSessionTitle, newSession: newSessionTitle}
+      );
+    } else if (newSessionTitle) {
+      message = Translate.string('"{title}" is now part of session "{newSession}".', {
+        title,
+        newSession: newSessionTitle,
+      });
+    } else {
+      return;
+    }
+    toast.addToast({type: 'info', message});
+  }
+
+  function findEntryById(id: string): Entry | undefined {
+    return flattenEntries(currentDayEntries).find(e => e.id === id);
+  }
 
   function handleOpenDraftModal() {
     openModal(DRAFT_ENTRY_MODAL, {
@@ -226,6 +275,8 @@ export function DayTimetable({
         ) || [];
       // TODO(tomas): use something better than 'unscheduled-' prefix
       const contribId = parseInt(who.slice('unscheduled-c'.length), 10);
+      const fromContrib = unscheduled.find(c => c.id === `c${contribId}`);
+      showToastIfContribSessionChanged(fromContrib?.title, fromContrib?.sessionId, null);
       dispatch(actions.scheduleEntry(eventId, contribId, startDt, newLayout, newUnscheduled));
     }
   }
@@ -259,12 +310,22 @@ export function DayTimetable({
     }
     // TODO(tomas): use something better than 'unscheduled-' prefix
     const contribId = parseInt(who.slice('unscheduled-c'.length), 10);
+    const fromContrib = unscheduled.find(c => c.id === `c${contribId}`);
+    const targetBlock = currentDayEntries.find(
+      e => e.type === EntryType.SessionBlock && e.objId === blockId
+    ) as BlockEntry | undefined;
+    showToastIfContribSessionChanged(
+      fromContrib?.title,
+      fromContrib?.sessionId,
+      targetBlock?.sessionId
+    );
     dispatch(
       actions.scheduleEntry(eventId, contribId, startDt, newLayout, newUnscheduled, blockId)
     );
   }
 
   function handleDropOnCalendar(who: string, over: Over, delta: Transform, mouse: MousePosition) {
+    const originalEntry = findEntryById(who);
     const sessionBlockId = expandedSessionBlock?.id;
     if (sessionBlockId) {
       const [newLayout, movedEntry] = layoutAfterDropOnBlock(
@@ -275,6 +336,13 @@ export function DayTimetable({
         mouse,
         over
       );
+      if (originalEntry?.type === EntryType.Contribution) {
+        showToastIfContribSessionChanged(
+          originalEntry.title,
+          originalEntry.sessionId,
+          expandedSessionBlock?.sessionId
+        );
+      }
       dispatch(
         actions.changeEntryLayout(
           movedEntry,
@@ -291,6 +359,9 @@ export function DayTimetable({
         delta,
         mouse
       );
+      if (originalEntry?.type === EntryType.Contribution) {
+        showToastIfContribSessionChanged(originalEntry.title, originalEntry.sessionId, null);
+      }
       dispatch(actions.changeEntryLayout(movedEntry, newLayout, getDateKey(dt), null));
     }
   }
@@ -302,10 +373,21 @@ export function DayTimetable({
     mouse: MousePosition,
     calendar: Over
   ) {
+    const originalEntry = findEntryById(who);
     const [newLayout, movedEntry, blockId] =
       layoutAfterDropOnBlock(entries, who, over, delta, mouse, calendar) || [];
     if (!newLayout) {
       return;
+    }
+    if (originalEntry?.type === EntryType.Contribution) {
+      const targetBlock = entries.find(
+        e => e.type === EntryType.SessionBlock && e.objId === blockId
+      ) as BlockEntry | undefined;
+      showToastIfContribSessionChanged(
+        originalEntry.title,
+        originalEntry.sessionId,
+        targetBlock?.sessionId
+      );
     }
     dispatch(actions.changeEntryLayout(movedEntry, newLayout, getDateKey(dt), blockId));
   }

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -151,15 +151,15 @@ export function DayTimetable({
 
   function showToastIfContribSessionChanged(
     contribTitle?: string,
-    fromSessionId?: number | null,
-    toSessionId?: number | null
+    fromSessionId?: number,
+    toSessionId?: number
   ) {
-    if ((fromSessionId ?? null) === (toSessionId ?? null)) {
+    if (fromSessionId === toSessionId) {
       return;
     }
 
-    const fromSession = fromSessionId ? sessions[fromSessionId] : null;
-    const toSession = toSessionId ? sessions[toSessionId] : null;
+    const fromSession = sessions[fromSessionId];
+    const toSession = sessions[toSessionId];
 
     const title = contribTitle || Translate.string('the contribution');
     let message: React.ReactNode;
@@ -168,14 +168,14 @@ export function DayTimetable({
         <Translate>
           <Param name="title" value={title} wrapper={<strong />} /> was moved from session{' '}
           <Param name="fromSession" value={fromSession.title} wrapper={<strong />} /> to session{' '}
-          <Param name="toSession" value={toSession.title} wrapper={<strong />} />.
+          <Param name="toSession" value={toSession.title} wrapper={<strong />} />
         </Translate>
       );
     } else if (toSession?.title) {
       message = (
         <Translate>
           <Param name="title" value={title} wrapper={<strong />} /> is now part of session{' '}
-          <Param name="toSession" value={toSession.title} wrapper={<strong />} />.
+          <Param name="toSession" value={toSession.title} wrapper={<strong />} />
         </Translate>
       );
     } else {

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -166,31 +166,16 @@ export function DayTimetable({
     if (fromSession?.title && toSession?.title) {
       message = (
         <Translate>
-          <Param name="title" wrapper={<strong />}>
-            {title}
-          </Param>{' '}
-          was moved from session{' '}
-          <Param name="fromSession" wrapper={<strong />}>
-            {fromSession.title}
-          </Param>{' '}
-          to session{' '}
-          <Param name="toSession" wrapper={<strong />}>
-            {toSession.title}
-          </Param>
-          .
+          <Param name="title" value={title} wrapper={<strong />} /> was moved from session{' '}
+          <Param name="fromSession" value={fromSession.title} wrapper={<strong />} /> to session{' '}
+          <Param name="toSession" value={toSession.title} wrapper={<strong />} />.
         </Translate>
       );
     } else if (toSession?.title) {
       message = (
         <Translate>
-          <Param name="title" wrapper={<strong />}>
-            {title}
-          </Param>{' '}
-          is now part of session{' '}
-          <Param name="toSession" wrapper={<strong />}>
-            {toSession.title}
-          </Param>
-          .
+          <Param name="title" value={title} wrapper={<strong />} /> is now part of session{' '}
+          <Param name="toSession" value={toSession.title} wrapper={<strong />} />.
         </Translate>
       );
     } else {

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -10,7 +10,7 @@ import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {ThunkDispatch} from 'redux-thunk';
 
-import {Translate} from 'indico/react/i18n';
+import {Translate, Param} from 'indico/react/i18n';
 
 import './DayTimetable.module.scss';
 import './Entry.module.scss';
@@ -53,6 +53,7 @@ import {
   isWithinLimits,
   minutesToPixels,
   pixelsToMinutes,
+  getEntryUniqueId,
 } from './utils';
 
 interface DayTimetableProps {
@@ -149,29 +150,49 @@ export function DayTimetable({
   const sessions: Record<number, Session> = useSelector(selectors.getSessions);
 
   function showToastIfContribSessionChanged(
-    contribTitle: string | undefined,
-    oldSessionId: number | null | undefined,
-    newSessionId: number | null | undefined
+    contribTitle?: string,
+    fromSessionId?: number | null,
+    toSessionId?: number | null
   ) {
-    const oldId = oldSessionId ?? null;
-    const newId = newSessionId ?? null;
-    if (oldId === newId) {
+    if ((fromSessionId ?? null) === (toSessionId ?? null)) {
       return;
     }
-    const oldSessionTitle = oldId !== null ? sessions[oldId]?.title : null;
-    const newSessionTitle = newId !== null ? sessions[newId]?.title : null;
+
+    const fromSession = fromSessionId ? sessions[fromSessionId] : null;
+    const toSession = toSessionId ? sessions[toSessionId] : null;
+
     const title = contribTitle || Translate.string('the contribution');
     let message: React.ReactNode;
-    if (oldSessionTitle && newSessionTitle) {
-      message = Translate.string(
-        '"{title}" was moved from session "{oldSession}" to session "{newSession}".',
-        {title, oldSession: oldSessionTitle, newSession: newSessionTitle}
+    if (fromSession?.title && toSession?.title) {
+      message = (
+        <Translate>
+          <Param name="title" wrapper={<strong />}>
+            {title}
+          </Param>{' '}
+          was moved from session{' '}
+          <Param name="fromSession" wrapper={<strong />}>
+            {fromSession.title}
+          </Param>{' '}
+          to session{' '}
+          <Param name="toSession" wrapper={<strong />}>
+            {toSession.title}
+          </Param>
+          .
+        </Translate>
       );
-    } else if (newSessionTitle) {
-      message = Translate.string('"{title}" is now part of session "{newSession}".', {
-        title,
-        newSession: newSessionTitle,
-      });
+    } else if (toSession?.title) {
+      message = (
+        <Translate>
+          <Param name="title" wrapper={<strong />}>
+            {title}
+          </Param>{' '}
+          is now part of session{' '}
+          <Param name="toSession" wrapper={<strong />}>
+            {toSession.title}
+          </Param>
+          .
+        </Translate>
+      );
     } else {
       return;
     }
@@ -275,7 +296,9 @@ export function DayTimetable({
         ) || [];
       // TODO(tomas): use something better than 'unscheduled-' prefix
       const contribId = parseInt(who.slice('unscheduled-c'.length), 10);
-      const fromContrib = unscheduled.find(c => c.id === `c${contribId}`);
+      const fromContrib = unscheduled.find(
+        c => c.id === getEntryUniqueId(EntryType.Contribution, contribId)
+      );
       showToastIfContribSessionChanged(fromContrib?.title, fromContrib?.sessionId, null);
       dispatch(actions.scheduleEntry(eventId, contribId, startDt, newLayout, newUnscheduled));
     }
@@ -310,7 +333,9 @@ export function DayTimetable({
     }
     // TODO(tomas): use something better than 'unscheduled-' prefix
     const contribId = parseInt(who.slice('unscheduled-c'.length), 10);
-    const fromContrib = unscheduled.find(c => c.id === `c${contribId}`);
+    const fromContrib = unscheduled.find(
+      c => c.id === getEntryUniqueId(EntryType.Contribution, contribId)
+    );
     const targetBlock = currentDayEntries.find(
       e => e.type === EntryType.SessionBlock && e.objId === blockId
     ) as BlockEntry | undefined;

--- a/indico/modules/events/timetable/client/js/SessionSelect.tsx
+++ b/indico/modules/events/timetable/client/js/SessionSelect.tsx
@@ -14,6 +14,7 @@ import {FormFieldAdapter} from 'indico/react/forms';
 import {FinalField} from 'indico/react/forms/fields';
 import {Translate} from 'indico/react/i18n';
 
+import {useToast} from './ToastContext';
 import {Colors, Session} from './types';
 
 import './SessionSelect.module.scss';
@@ -82,6 +83,7 @@ export function SessionSelect({value, sessions, onChange}: SessionSelectProps) {
   sessions = [...sessions]; // Avoid mutating the original array when adding draft session
   const [query, setQuery] = useState('');
   const [options, setOptions] = useState<SessionOption[]>(_mapSessionsToOptions(sessions || []));
+  const toast = useToast();
 
   const _onChangeValue = (id: number) => {
     const selectedSession = sessions.find(s => s.id === id);
@@ -110,6 +112,13 @@ export function SessionSelect({value, sessions, onChange}: SessionSelectProps) {
 
     setOptions([draftSessionOption, ...newOptions.toSorted(_sortOptionsFn)]);
     _onChangeValue(draftSession.id);
+    toast?.addToast({
+      type: 'warning',
+      message: Translate.string(
+        'The session "{title}" will only be created once you click Submit.',
+        {title: draftSession.title}
+      ),
+    });
   };
 
   return (

--- a/indico/modules/events/timetable/client/js/SessionSelect.tsx
+++ b/indico/modules/events/timetable/client/js/SessionSelect.tsx
@@ -14,7 +14,6 @@ import {FormFieldAdapter} from 'indico/react/forms';
 import {FinalField} from 'indico/react/forms/fields';
 import {Translate} from 'indico/react/i18n';
 
-import {useToast} from './ToastContext';
 import {Colors, Session} from './types';
 
 import './SessionSelect.module.scss';
@@ -83,7 +82,6 @@ export function SessionSelect({value, sessions, onChange}: SessionSelectProps) {
   sessions = [...sessions]; // Avoid mutating the original array when adding draft session
   const [query, setQuery] = useState('');
   const [options, setOptions] = useState<SessionOption[]>(_mapSessionsToOptions(sessions || []));
-  const toast = useToast();
 
   const _onChangeValue = (id: number) => {
     const selectedSession = sessions.find(s => s.id === id);
@@ -112,13 +110,6 @@ export function SessionSelect({value, sessions, onChange}: SessionSelectProps) {
 
     setOptions([draftSessionOption, ...newOptions.toSorted(_sortOptionsFn)]);
     _onChangeValue(draftSession.id);
-    toast?.addToast({
-      type: 'warning',
-      message: Translate.string(
-        'The session "{title}" will only be created once you click Submit.',
-        {title: draftSession.title}
-      ),
-    });
   };
 
   return (

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -91,8 +91,8 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
   onClose = () => null,
   onSubmit = () => null,
 }) => {
-  const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
   const toast = useToast();
+  const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
   const entries = useSelector(selectors.getCurrentEntries);
   const expandedSessionBlock = useSelector(selectors.getExpandedSessionBlock);
   // Within this timetable we only care about the database ID,
@@ -231,12 +231,6 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
       if (sessionId === -1) {
         const newSession = await _createSession(sessionObj);
         data.session_id = newSession.id;
-        toast?.addToast({
-          type: 'success',
-          message: Translate.string('Session "{title}" was created.', {
-            title: newSession.title,
-          }),
-        });
       } else {
         data.session_id = sessionId;
       }
@@ -251,9 +245,31 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
     try {
       if (isEditing) {
         const updatedEntry = {...entry, ...mapDataToEntry(data, true)};
+        const oldDayKey = moment(entry.startDt).format(DATE_KEY_FORMAT);
+        const newDayKey = moment(updatedEntry.startDt).format(DATE_KEY_FORMAT);
         dispatch(
           actions.updateEntry(activeType, updatedEntry, currentDay, getChangedValues(data, form))
         );
+        if (
+          (activeType === EntryType.SessionBlock || activeType === EntryType.Contribution) &&
+          oldDayKey !== newDayKey
+        ) {
+          const oldDayLabel = moment(entry.startDt).format('ll');
+          const newDayLabel = moment(updatedEntry.startDt).format('ll');
+          const fallbackTitle =
+            activeType === EntryType.SessionBlock
+              ? session?.title || Translate.string('Session block')
+              : Translate.string('Contribution');
+          const entryTitle = updatedEntry.title || entry.title || fallbackTitle;
+          toast.addToast({
+            type: 'info',
+            message: Translate.string('"{title}" was moved from {oldDay} to {newDay}.', {
+              title: entryTitle,
+              oldDay: oldDayLabel,
+              newDay: newDayLabel,
+            }),
+          });
+        }
       } else {
         dispatch(actions.createEntry(activeType, data));
       }

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -27,7 +27,7 @@ import * as selectors from './selectors';
 import {FinalSessionSelect} from './SessionSelect';
 import {useToast} from './ToastContext';
 import {ReduxState, BlockEntry, EntryType, Session} from './types';
-import {DATE_KEY_FORMAT} from './utils';
+import {DATE_KEY_FORMAT, getDateKey} from './utils';
 
 // Generic models
 
@@ -245,8 +245,8 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
     try {
       if (isEditing) {
         const updatedEntry = {...entry, ...mapDataToEntry(data, true)};
-        const oldDayKey = moment(entry.startDt).format(DATE_KEY_FORMAT);
-        const newDayKey = moment(updatedEntry.startDt).format(DATE_KEY_FORMAT);
+        const oldDayKey = getDateKey(entry.startDt);
+        const newDayKey = getDateKey(updatedEntry.startDt);
         dispatch(
           actions.updateEntry(activeType, updatedEntry, currentDay, getChangedValues(data, form))
         );

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -25,6 +25,7 @@ import {BreakFormFields} from './BreakForm';
 import {mapDataToEntry, mapEntryToData, mapSessionToData} from './mapperUtils';
 import * as selectors from './selectors';
 import {FinalSessionSelect} from './SessionSelect';
+import {useToast} from './ToastContext';
 import {ReduxState, BlockEntry, EntryType, Session} from './types';
 import {DATE_KEY_FORMAT} from './utils';
 
@@ -91,6 +92,7 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
   onSubmit = () => null,
 }) => {
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
+  const toast = useToast();
   const entries = useSelector(selectors.getCurrentEntries);
   const expandedSessionBlock = useSelector(selectors.getExpandedSessionBlock);
   // Within this timetable we only care about the database ID,
@@ -229,6 +231,12 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
       if (sessionId === -1) {
         const newSession = await _createSession(sessionObj);
         data.session_id = newSession.id;
+        toast?.addToast({
+          type: 'success',
+          message: Translate.string('Session "{title}" was created.', {
+            title: newSession.title,
+          }),
+        });
       } else {
         data.session_id = sessionId;
       }

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -265,18 +265,9 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
             type: 'info',
             message: (
               <Translate>
-                <Param name="title" wrapper={<strong />}>
-                  {entryTitle}
-                </Param>{' '}
-                was moved from{' '}
-                <Param name="oldDay" wrapper={<strong />}>
-                  {oldDayLabel}
-                </Param>{' '}
-                to{' '}
-                <Param name="newDay" wrapper={<strong />}>
-                  {newDayLabel}
-                </Param>
-                .
+                <Param name="title" value={entryTitle} wrapper={<strong />} /> was moved from{' '}
+                <Param name="oldDay" value={oldDayLabel} wrapper={<strong />} /> to{' '}
+                <Param name="newDay" value={newDayLabel} wrapper={<strong />} />.
               </Translate>
             ),
           });

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -16,7 +16,7 @@ import {ContributionFormFields} from 'indico/modules/events/contributions/Contri
 import {SessionBlockFormFields} from 'indico/modules/events/sessions/SessionBlockForm';
 import {FinalSubmitButton} from 'indico/react/forms';
 import {FinalModalForm, getChangedValues, handleSubmitError} from 'indico/react/forms/final-form';
-import {Translate} from 'indico/react/i18n';
+import {Translate, Param} from 'indico/react/i18n';
 import {handleAxiosError} from 'indico/utils/axios';
 import {snakifyKeys} from 'indico/utils/case';
 
@@ -263,11 +263,22 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
           const entryTitle = updatedEntry.title || entry.title || fallbackTitle;
           toast.addToast({
             type: 'info',
-            message: Translate.string('"{title}" was moved from {oldDay} to {newDay}.', {
-              title: entryTitle,
-              oldDay: oldDayLabel,
-              newDay: newDayLabel,
-            }),
+            message: (
+              <Translate>
+                <Param name="title" wrapper={<strong />}>
+                  {entryTitle}
+                </Param>{' '}
+                was moved from{' '}
+                <Param name="oldDay" wrapper={<strong />}>
+                  {oldDayLabel}
+                </Param>{' '}
+                to{' '}
+                <Param name="newDay" wrapper={<strong />}>
+                  {newDayLabel}
+                </Param>
+                .
+              </Translate>
+            ),
           });
         }
       } else {

--- a/indico/modules/events/timetable/client/js/TimetableSessionModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableSessionModal.tsx
@@ -22,7 +22,6 @@ import {Translate} from 'indico/react/i18n';
 
 import * as actions from './actions';
 import * as selectors from './selectors';
-import {useToast} from './ToastContext';
 
 interface TimetableSessionEditModalProps {
   sessionId: number;
@@ -86,7 +85,6 @@ export function TimetableSessionCreateModal({onClose}: TimetableSessionCreateMod
   const dispatch = useDispatch<any>();
   const eventId = useSelector(selectors.getEventId);
   const eventType = useSelector(selectors.getEventType);
-  const toast = useToast();
 
   const {data: sessionTypesData, loading: typesLoading} = useIndicoAxios(
     typesURL({event_id: eventId})
@@ -100,11 +98,6 @@ export function TimetableSessionCreateModal({onClose}: TimetableSessionCreateMod
 
   const handleSubmit = (formData: any) => {
     dispatch(actions.createSession(formData));
-    toast?.addToast({
-      type: 'success',
-      message: Translate.string('Session "{title}" was created.', {title: formData.title}),
-    });
-    onClose();
   };
 
   if (typesLoading || locationParentLoading || sessionColorLoading) {

--- a/indico/modules/events/timetable/client/js/TimetableSessionModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableSessionModal.tsx
@@ -22,6 +22,7 @@ import {Translate} from 'indico/react/i18n';
 
 import * as actions from './actions';
 import * as selectors from './selectors';
+import {useToast} from './ToastContext';
 
 interface TimetableSessionEditModalProps {
   sessionId: number;
@@ -85,6 +86,7 @@ export function TimetableSessionCreateModal({onClose}: TimetableSessionCreateMod
   const dispatch = useDispatch<any>();
   const eventId = useSelector(selectors.getEventId);
   const eventType = useSelector(selectors.getEventType);
+  const toast = useToast();
 
   const {data: sessionTypesData, loading: typesLoading} = useIndicoAxios(
     typesURL({event_id: eventId})
@@ -98,6 +100,10 @@ export function TimetableSessionCreateModal({onClose}: TimetableSessionCreateMod
 
   const handleSubmit = (formData: any) => {
     dispatch(actions.createSession(formData));
+    toast?.addToast({
+      type: 'success',
+      message: Translate.string('Session "{title}" was created.', {title: formData.title}),
+    });
     onClose();
   };
 

--- a/indico/modules/events/timetable/client/js/Toast.module.scss
+++ b/indico/modules/events/timetable/client/js/Toast.module.scss
@@ -80,6 +80,13 @@
         align-items: center;
         flex-direction: column-reverse;
     }
+
+    &[data-position='top-center'] {
+        top: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        align-items: center;
+    }
 }
 
 .toast-message {

--- a/indico/modules/events/timetable/client/js/Toast.module.scss
+++ b/indico/modules/events/timetable/client/js/Toast.module.scss
@@ -5,6 +5,50 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+@keyframes toastSlideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes toastCollapse {
+    from {
+        opacity: 1;
+        max-height: 200px;
+        margin-bottom: 0;
+        padding-top: 12px;
+        padding-bottom: 14px;
+        border-top-width: 1px;
+        border-bottom-width: 1px;
+    }
+
+    to {
+        opacity: 0;
+        max-height: 0;
+        margin-bottom: -10px;
+        padding-top: 0;
+        padding-bottom: 0;
+        border-top-width: 0;
+        border-bottom-width: 0;
+    }
+}
+
+@keyframes toastProgress {
+    from {
+        transform: scaleX(1);
+    }
+
+    to {
+        transform: scaleX(0);
+    }
+}
+
 .toast {
     position: relative;
     display: flex;

--- a/indico/modules/events/timetable/client/js/Toast.module.scss
+++ b/indico/modules/events/timetable/client/js/Toast.module.scss
@@ -1,0 +1,98 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2026 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+.toast {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    width: 100%;
+    box-sizing: border-box;
+    gap: 12px;
+    padding: 12px 14px 14px;
+    background: #fff;
+    border-radius: 6px;
+    border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.toast-container {
+    position: fixed;
+    z-index: 2000;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    pointer-events: none;
+    width: 380px;
+    max-width: calc(100vw - 40px);
+    max-height: calc(100vh - 40px);
+
+    &[data-position='bottom-center'] {
+        bottom: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        align-items: center;
+        flex-direction: column-reverse;
+    }
+}
+
+.toast-message {
+    flex: 1;
+    font-size: 0.9em;
+    line-height: 1.4;
+    color: #333;
+    word-break: break-word;
+}
+
+.toast-icon {
+    flex-shrink: 0;
+    margin: 0 !important;
+    font-size: 1.2em !important;
+
+    .toast[data-type='info'] & {
+        color: #2185d0;
+    }
+
+    .toast[data-type='success'] & {
+        color: #21ba45;
+    }
+
+    .toast[data-type='warning'] & {
+        color: #f2a33c;
+    }
+
+    .toast[data-type='error'] & {
+        color: #db2828;
+    }
+}
+
+.toast-progress {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    height: 3px;
+    width: 100%;
+    background: rgba(0, 0, 0, 0.25);
+    transform-origin: left center;
+    animation-name: toastProgress;
+    animation-timing-function: linear;
+    animation-fill-mode: forwards;
+
+    .toast[data-type='info'] & {
+        background: #2185d0;
+    }
+
+    .toast[data-type='success'] & {
+        background: #21ba45;
+    }
+
+    .toast[data-type='warning'] & {
+        background: #f2a33c;
+    }
+
+    .toast[data-type='error'] & {
+        background: #db2828;
+    }
+}

--- a/indico/modules/events/timetable/client/js/Toast.module.scss
+++ b/indico/modules/events/timetable/client/js/Toast.module.scss
@@ -60,6 +60,10 @@
     background: #fff;
     border-radius: 6px;
     border: 1px solid rgba(0, 0, 0, 0.12);
+
+    &.toast-leaving {
+        animation: toastCollapse 0.2s ease-in forwards;
+    }
 }
 
 .toast-container {
@@ -91,7 +95,7 @@
 
 .toast-message {
     flex: 1;
-    font-size: 0.9em;
+    font-size: 1em;
     line-height: 1.4;
     color: #333;
     word-break: break-word;

--- a/indico/modules/events/timetable/client/js/Toast.module.scss
+++ b/indico/modules/events/timetable/client/js/Toast.module.scss
@@ -46,6 +46,25 @@
     word-break: break-word;
 }
 
+.toast-close {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    color: #888;
+    line-height: 1;
+
+    &:hover {
+        color: #333;
+    }
+
+    :global(.icon) {
+        margin: 0 !important;
+    }
+}
+
 .toast-icon {
     flex-shrink: 0;
     margin: 0 !important;

--- a/indico/modules/events/timetable/client/js/Toast.module.scss
+++ b/indico/modules/events/timetable/client/js/Toast.module.scss
@@ -55,20 +55,21 @@ $color-error: #db2828;
 }
 
 .toast {
+  box-shadow: 0 5px 5px rgba(0, 0, 0, 0.1);
   position: relative;
   display: flex;
   align-items: flex-start;
   width: 100%;
   box-sizing: border-box;
   gap: 12px;
-  padding: 12px 14px 14px;
+  padding: 12px 14px 18px 12px;
   background: #fff;
   border-radius: 6px;
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid white;
   pointer-events: auto;
 
   &.toast-leaving {
-    animation: toastCollapse 0.2s ease-in forwards;
+    animation: toastCollapse 0.1s ease-in forwards;
   }
 }
 
@@ -103,15 +104,21 @@ $color-error: #db2828;
   flex: 1;
   font-size: 1em;
   line-height: 1.4;
+  margin-right: 40px;
   color: #333;
   word-break: break-word;
 }
 
 .toast-close {
+  position: absolute;
+  height: 100%;
+  top: 0;
+  right: 0;
+  width: 40px;
+  align-self: center;
   flex-shrink: 0;
   background: none;
   border: none;
-  padding: 0;
   margin: 0;
   cursor: pointer;
   color: #888;
@@ -123,6 +130,7 @@ $color-error: #db2828;
 
   :global(i.icon) {
     margin: 0;
+    transform: translateY(-2px);
   }
 }
 
@@ -153,10 +161,11 @@ $color-error: #db2828;
 
 .toast-progress {
   position: absolute;
-  bottom: 0;
-  left: 0;
-  height: 3px;
-  width: 100%;
+  bottom: 2px;
+  left: 4px;
+  right: 4px;
+  height: 4px;
+  border-radius: 2px;
   background: rgba(0, 0, 0, 0.25);
   transform-origin: left center;
   animation-name: toastProgress;

--- a/indico/modules/events/timetable/client/js/Toast.module.scss
+++ b/indico/modules/events/timetable/client/js/Toast.module.scss
@@ -5,168 +5,177 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-@keyframes toastSlideIn {
-    from {
-        opacity: 0;
-        transform: translateY(-10px);
-    }
+$color-info: #2185d0;
+$color-success: #21ba45;
+$color-warning: #f2a33c;
+$color-error: #db2828;
 
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+@keyframes toastSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes toastCollapse {
-    from {
-        opacity: 1;
-        max-height: 200px;
-        margin-bottom: 0;
-        padding-top: 12px;
-        padding-bottom: 14px;
-        border-top-width: 1px;
-        border-bottom-width: 1px;
-    }
+  from {
+    opacity: 1;
+    max-height: 200px;
+    margin-bottom: 0;
+    padding-top: 12px;
+    padding-bottom: 14px;
+    border-top-width: 1px;
+    border-bottom-width: 1px;
+  }
 
-    to {
-        opacity: 0;
-        max-height: 0;
-        margin-bottom: -10px;
-        padding-top: 0;
-        padding-bottom: 0;
-        border-top-width: 0;
-        border-bottom-width: 0;
-    }
+  to {
+    opacity: 0;
+    max-height: 0;
+    margin-bottom: -10px;
+    padding-top: 0;
+    padding-bottom: 0;
+    border-top-width: 0;
+    border-bottom-width: 0;
+  }
 }
 
 @keyframes toastProgress {
-    from {
-        transform: scaleX(1);
-    }
+  from {
+    transform: scaleX(1);
+  }
 
-    to {
-        transform: scaleX(0);
-    }
+  to {
+    transform: scaleX(0);
+  }
 }
 
 .toast {
-    position: relative;
-    display: flex;
-    align-items: flex-start;
-    width: 100%;
-    box-sizing: border-box;
-    gap: 12px;
-    padding: 12px 14px 14px;
-    background: #fff;
-    border-radius: 6px;
-    border: 1px solid rgba(0, 0, 0, 0.12);
+  position: relative;
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  box-sizing: border-box;
+  gap: 12px;
+  padding: 12px 14px 14px;
+  background: #fff;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  pointer-events: auto;
 
-    &.toast-leaving {
-        animation: toastCollapse 0.2s ease-in forwards;
-    }
+  &.toast-leaving {
+    animation: toastCollapse 0.2s ease-in forwards;
+  }
 }
 
 .toast-container {
-    position: fixed;
-    z-index: 2000;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    pointer-events: none;
-    width: 380px;
-    max-width: calc(100vw - 40px);
-    max-height: calc(100vh - 40px);
+  position: fixed;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  pointer-events: none;
+  width: 380px;
+  max-width: calc(100vw - 40px);
+  max-height: calc(100vh - 40px);
 
-    &[data-position='bottom-center'] {
-        bottom: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        align-items: center;
-        flex-direction: column-reverse;
-    }
+  &[data-position='bottom-center'] {
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    align-items: center;
+    flex-direction: column-reverse;
+  }
 
-    &[data-position='top-center'] {
-        top: 20px;
-        left: 50%;
-        transform: translateX(-50%);
-        align-items: center;
-    }
+  &[data-position='top-center'] {
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    align-items: center;
+  }
 }
 
 .toast-message {
-    flex: 1;
-    font-size: 1em;
-    line-height: 1.4;
-    color: #333;
-    word-break: break-word;
+  flex: 1;
+  font-size: 1em;
+  line-height: 1.4;
+  color: #333;
+  word-break: break-word;
 }
 
 .toast-close {
-    flex-shrink: 0;
-    background: none;
-    border: none;
-    padding: 0;
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: #888;
+  line-height: 1;
+
+  &:hover {
+    color: #333;
+  }
+
+  :global(i.icon) {
     margin: 0;
-    cursor: pointer;
-    color: #888;
-    line-height: 1;
-
-    &:hover {
-        color: #333;
-    }
-
-    :global(.icon) {
-        margin: 0 !important;
-    }
+  }
 }
 
 .toast-icon {
-    flex-shrink: 0;
-    margin: 0 !important;
-    font-size: 1.2em !important;
+  flex-shrink: 0;
 
-    .toast[data-type='info'] & {
-        color: #2185d0;
-    }
+  &:global(.icon) {
+    margin: 0;
+    font-size: 1.2em;
+  }
 
-    .toast[data-type='success'] & {
-        color: #21ba45;
-    }
+  .toast[data-type='info'] & {
+    color: $color-info;
+  }
 
-    .toast[data-type='warning'] & {
-        color: #f2a33c;
-    }
+  .toast[data-type='success'] & {
+    color: $color-success;
+  }
 
-    .toast[data-type='error'] & {
-        color: #db2828;
-    }
+  .toast[data-type='warning'] & {
+    color: $color-warning;
+  }
+
+  .toast[data-type='error'] & {
+    color: $color-error;
+  }
 }
 
 .toast-progress {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    height: 3px;
-    width: 100%;
-    background: rgba(0, 0, 0, 0.25);
-    transform-origin: left center;
-    animation-name: toastProgress;
-    animation-timing-function: linear;
-    animation-fill-mode: forwards;
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  height: 3px;
+  width: 100%;
+  background: rgba(0, 0, 0, 0.25);
+  transform-origin: left center;
+  animation-name: toastProgress;
+  animation-timing-function: linear;
+  animation-fill-mode: forwards;
 
-    .toast[data-type='info'] & {
-        background: #2185d0;
-    }
+  .toast[data-type='info'] & {
+    background: $color-info;
+  }
 
-    .toast[data-type='success'] & {
-        background: #21ba45;
-    }
+  .toast[data-type='success'] & {
+    background: $color-success;
+  }
 
-    .toast[data-type='warning'] & {
-        background: #f2a33c;
-    }
+  .toast[data-type='warning'] & {
+    background: $color-warning;
+  }
 
-    .toast[data-type='error'] & {
-        background: #db2828;
-    }
+  .toast[data-type='error'] & {
+    background: $color-error;
+  }
 }

--- a/indico/modules/events/timetable/client/js/Toast.tsx
+++ b/indico/modules/events/timetable/client/js/Toast.tsx
@@ -1,3 +1,10 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2026 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
 import React from 'react';
 import {Icon} from 'semantic-ui-react';
 

--- a/indico/modules/events/timetable/client/js/Toast.tsx
+++ b/indico/modules/events/timetable/client/js/Toast.tsx
@@ -6,14 +6,14 @@
 // LICENSE file for more details.
 
 import React, {useEffect} from 'react';
-import {Icon} from 'semantic-ui-react';
+import {Icon, SemanticICONS} from 'semantic-ui-react';
 
 import './Toast.module.scss';
 import {Translate} from 'indico/react/i18n';
 
 export type ToastType = 'info' | 'success' | 'warning' | 'error';
 
-const ICONS: Record<ToastType, string> = {
+const ICONS: Record<ToastType, SemanticICONS> = {
   info: 'info circle',
   success: 'check circle',
   warning: 'warning sign',

--- a/indico/modules/events/timetable/client/js/Toast.tsx
+++ b/indico/modules/events/timetable/client/js/Toast.tsx
@@ -25,17 +25,26 @@ interface ToastProps {
   type: ToastType;
   message: React.ReactNode;
   duration: number;
+  leaving?: boolean;
   onClose: (id: number) => void;
 }
 
-export function Toast({id, type, message, duration, onClose}: ToastProps) {
+export function Toast({id, type, message, duration, leaving, onClose}: ToastProps) {
   useEffect(() => {
+    if (leaving) {
+      return undefined;
+    }
     const timeoutId = window.setTimeout(() => onClose(id), duration);
     return () => window.clearTimeout(timeoutId);
-  }, [id, duration, onClose]);
+  }, [id, duration, leaving, onClose]);
 
   return (
-    <div styleName="toast" data-type={type} role="status" aria-live="polite">
+    <div
+      styleName={leaving ? 'toast toast-leaving' : 'toast'}
+      data-type={type}
+      role="status"
+      aria-live="polite"
+    >
       <Icon name={ICONS[type]} styleName="toast-icon" />
       <div styleName="toast-message">{message}</div>
       <button

--- a/indico/modules/events/timetable/client/js/Toast.tsx
+++ b/indico/modules/events/timetable/client/js/Toast.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import {Icon} from 'semantic-ui-react';
+
+export type ToastType = 'info' | 'success' | 'warning' | 'error';
+
+const ICONS: Record<ToastType, string> = {
+  info: 'info',
+  success: 'check',
+  warning: 'warning',
+  error: 'times',
+};
+
+interface ToastProps {
+  type: ToastType;
+  message: React.ReactNode;
+}
+
+export function Toast({type, message}: ToastProps) {
+  return (
+    <div data-type={type} role="status">
+      <Icon name={ICONS[type]} styleName="toast-icon" />
+      <div styleName="toast-message">{message}</div>
+      <div styleName="toast-progress" />
+    </div>
+  );
+}

--- a/indico/modules/events/timetable/client/js/Toast.tsx
+++ b/indico/modules/events/timetable/client/js/Toast.tsx
@@ -8,6 +8,9 @@
 import React from 'react';
 import {Icon} from 'semantic-ui-react';
 
+import './Toast.module.scss';
+import {Translate} from 'indico/react/i18n';
+
 export type ToastType = 'info' | 'success' | 'warning' | 'error';
 
 const ICONS: Record<ToastType, string> = {
@@ -18,16 +21,31 @@ const ICONS: Record<ToastType, string> = {
 };
 
 interface ToastProps {
+  id: number;
   type: ToastType;
   message: React.ReactNode;
+  duration: number;
+  onClose: (id: number) => void;
 }
 
-export function Toast({type, message}: ToastProps) {
+export function Toast({id, type, message, duration, onClose}: ToastProps) {
+  // useEffect(() => {
+  //   const timeoutId = window.setTimeout(() => onClose(id), duration);
+  //   return () => window.clearTimeout(timeoutId);
+  // }, [id, duration, onClose]);
+
   return (
-    <div data-type={type} role="status">
+    <div styleName="toast" data-type={type} role="status" aria-live="polite">
       <Icon name={ICONS[type]} styleName="toast-icon" />
       <div styleName="toast-message">{message}</div>
-      <div styleName="toast-progress" />
+      <button
+        type="button"
+        onClick={() => onClose(id)}
+        aria-label={Translate.string('Close notification')}
+      >
+        <Icon name="close" />
+      </button>
+      <div styleName="toast-progress" style={{animationDuration: `${duration}ms`}} />
     </div>
   );
 }

--- a/indico/modules/events/timetable/client/js/Toast.tsx
+++ b/indico/modules/events/timetable/client/js/Toast.tsx
@@ -14,10 +14,10 @@ import {Translate} from 'indico/react/i18n';
 export type ToastType = 'info' | 'success' | 'warning' | 'error';
 
 const ICONS: Record<ToastType, string> = {
-  info: 'info',
-  success: 'check',
-  warning: 'warning',
-  error: 'times',
+  info: 'info circle',
+  success: 'check circle',
+  warning: 'warning sign',
+  error: 'times circle',
 };
 
 interface ToastProps {

--- a/indico/modules/events/timetable/client/js/Toast.tsx
+++ b/indico/modules/events/timetable/client/js/Toast.tsx
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React from 'react';
+import React, {useEffect} from 'react';
 import {Icon} from 'semantic-ui-react';
 
 import './Toast.module.scss';
@@ -29,10 +29,10 @@ interface ToastProps {
 }
 
 export function Toast({id, type, message, duration, onClose}: ToastProps) {
-  // useEffect(() => {
-  //   const timeoutId = window.setTimeout(() => onClose(id), duration);
-  //   return () => window.clearTimeout(timeoutId);
-  // }, [id, duration, onClose]);
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => onClose(id), duration);
+    return () => window.clearTimeout(timeoutId);
+  }, [id, duration, onClose]);
 
   return (
     <div styleName="toast" data-type={type} role="status" aria-live="polite">
@@ -40,6 +40,7 @@ export function Toast({id, type, message, duration, onClose}: ToastProps) {
       <div styleName="toast-message">{message}</div>
       <button
         type="button"
+        styleName="toast-close"
         onClick={() => onClose(id)}
         aria-label={Translate.string('Close notification')}
       >

--- a/indico/modules/events/timetable/client/js/Toast.tsx
+++ b/indico/modules/events/timetable/client/js/Toast.tsx
@@ -8,8 +8,9 @@
 import React, {useEffect} from 'react';
 import {Icon, SemanticICONS} from 'semantic-ui-react';
 
-import './Toast.module.scss';
 import {Translate} from 'indico/react/i18n';
+
+import './Toast.module.scss';
 
 export type ToastType = 'info' | 'success' | 'warning' | 'error';
 
@@ -40,7 +41,7 @@ export function Toast({id, type, message, duration, leaving, onClose}: ToastProp
 
   return (
     <div
-      styleName={leaving ? 'toast toast-leaving' : 'toast'}
+      styleName={`toast ${leaving ? 'toast-leaving' : ''}`}
       data-type={type}
       role="status"
       aria-live="polite"

--- a/indico/modules/events/timetable/client/js/ToastContext.tsx
+++ b/indico/modules/events/timetable/client/js/ToastContext.tsx
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import React, {createContext, useContext, useState, ReactNode} from 'react';
+import React, {createContext, useCallback, useContext, useState, ReactNode} from 'react';
 import ReactDOM from 'react-dom';
 
 import './Toast.module.scss';
@@ -43,15 +43,15 @@ interface ToastProviderProps {
 export function ToastProvider({children, position = 'top-center'}: ToastProviderProps) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
 
-  const removeToast = (id: number) => {
+  const removeToast = useCallback((id: number) => {
     setToasts(current => current.map(t => (t.id === id ? {...t, leaving: true} : t)));
     window.setTimeout(
       () => setToasts(current => current.filter(t => t.id !== id)),
       TOAST_EXIT_DURATION
     );
-  };
+  }, []);
 
-  const addToast = (options: ToastOptions) => {
+  const addToast = useCallback((options: ToastOptions) => {
     const id = Date.now() + Math.random();
     const toast: ToastItem = {
       id,
@@ -61,7 +61,7 @@ export function ToastProvider({children, position = 'top-center'}: ToastProvider
     };
     setToasts(current => [...current, toast]);
     return id;
-  };
+  }, []);
 
   return (
     <ToastContext.Provider value={{addToast, removeToast}}>
@@ -89,5 +89,8 @@ export function ToastProvider({children, position = 'top-center'}: ToastProvider
 
 export function useToast() {
   const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
   return context;
 }

--- a/indico/modules/events/timetable/client/js/ToastContext.tsx
+++ b/indico/modules/events/timetable/client/js/ToastContext.tsx
@@ -1,0 +1,54 @@
+import React, {createContext, useContext, useState, ReactNode} from 'react';
+
+import {Toast, ToastType} from './Toast';
+
+export interface ToastOptions {
+  type?: ToastType;
+  message: ReactNode;
+}
+
+interface ToastContextValue {
+  addToast: (options: ToastOptions) => void;
+  removeToast: (id: number) => void;
+}
+
+interface ToastData extends ToastOptions {
+  id: number;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({children}: {children: ReactNode}) {
+  const [toasts, setToasts] = useState<ToastData[]>([]);
+
+  const removeToast = (id: number) => {
+    setToasts(currentToasts => currentToasts.filter(toast => toast.id !== id));
+  };
+
+  const addToast = (options: ToastOptions) => {
+    const id = Date.now(); // Simple unique ID
+    setToasts(currentToasts => [...currentToasts, {...options, id}]);
+
+    // Auto-remove the toast after a few seconds
+    // TODO: Customize the duration
+    setTimeout(() => {
+      removeToast(id);
+    }, 3000);
+  };
+
+  return (
+    <ToastContext.Provider value={{addToast, removeToast}}>
+      {children}
+      <>
+        {toasts.map(toast => (
+          <Toast key={toast.id} type={toast.type} message={toast.message} />
+        ))}
+      </>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  return context;
+}

--- a/indico/modules/events/timetable/client/js/ToastContext.tsx
+++ b/indico/modules/events/timetable/client/js/ToastContext.tsx
@@ -6,12 +6,26 @@
 // LICENSE file for more details.
 
 import React, {createContext, useContext, useState, ReactNode} from 'react';
+import ReactDOM from 'react-dom';
 
+import './Toast.module.scss';
 import {Toast, ToastType} from './Toast';
+
+export type ToastPosition = 'bottom-center';
+const TOAST_POSITIONS: ToastPosition[] = ['bottom-center'];
+const DEFAULT_TOAST_DURATION = 3000;
 
 export interface ToastOptions {
   type?: ToastType;
   message: ReactNode;
+  duration?: number;
+  position?: ToastPosition;
+}
+interface ToastItem extends ToastOptions {
+  id: number;
+  duration: number;
+  type: ToastType;
+  position: ToastPosition;
 }
 
 interface ToastContextValue {
@@ -19,38 +33,56 @@ interface ToastContextValue {
   removeToast: (id: number) => void;
 }
 
-interface ToastData extends ToastOptions {
-  id: number;
-}
-
 const ToastContext = createContext<ToastContextValue | null>(null);
 
 export function ToastProvider({children}: {children: ReactNode}) {
-  const [toasts, setToasts] = useState<ToastData[]>([]);
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
 
   const removeToast = (id: number) => {
     setToasts(currentToasts => currentToasts.filter(toast => toast.id !== id));
   };
 
   const addToast = (options: ToastOptions) => {
-    const id = Date.now(); // Simple unique ID
-    setToasts(currentToasts => [...currentToasts, {...options, id}]);
-
-    // Auto-remove the toast after a few seconds
-    // TODO: Customize the duration
-    setTimeout(() => {
-      removeToast(id);
-    }, 3000);
+    const id = Date.now() + Math.random();
+    const toast: ToastItem = {
+      id,
+      type: options.type ?? 'info',
+      message: options.message,
+      duration: options.duration ?? DEFAULT_TOAST_DURATION,
+      position: options.position ?? 'bottom-center',
+    };
+    setToasts(current => [...current, toast]);
+    return id;
   };
 
   return (
     <ToastContext.Provider value={{addToast, removeToast}}>
       {children}
-      <>
-        {toasts.map(toast => (
-          <Toast key={toast.id} type={toast.type} message={toast.message} />
-        ))}
-      </>
+      {ReactDOM.createPortal(
+        <>
+          {TOAST_POSITIONS.map(position => {
+            const positionToasts = toasts.filter(t => t.position === position);
+            if (positionToasts.length === 0) {
+              return null;
+            }
+            return (
+              <div key={position} styleName="toast-container" data-position={position}>
+                {positionToasts.map(toast => (
+                  <Toast
+                    key={toast.id}
+                    id={toast.id}
+                    type={toast.type}
+                    message={toast.message}
+                    duration={toast.duration}
+                    onClose={removeToast}
+                  />
+                ))}
+              </div>
+            );
+          })}
+        </>,
+        document.body
+      )}
     </ToastContext.Provider>
   );
 }

--- a/indico/modules/events/timetable/client/js/ToastContext.tsx
+++ b/indico/modules/events/timetable/client/js/ToastContext.tsx
@@ -14,7 +14,7 @@ import {Toast, ToastType} from './Toast';
 export type ToastPosition = 'bottom-center' | 'top-center';
 
 const TOAST_EXIT_DURATION = 200;
-const DEFAULT_TOAST_DURATION = 3000;
+const DEFAULT_TOAST_DURATION = 5000;
 
 export interface ToastOptions {
   type?: ToastType;

--- a/indico/modules/events/timetable/client/js/ToastContext.tsx
+++ b/indico/modules/events/timetable/client/js/ToastContext.tsx
@@ -1,3 +1,10 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2026 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
 import React, {createContext, useContext, useState, ReactNode} from 'react';
 
 import {Toast, ToastType} from './Toast';

--- a/indico/modules/events/timetable/client/js/ToastContext.tsx
+++ b/indico/modules/events/timetable/client/js/ToastContext.tsx
@@ -11,21 +11,18 @@ import ReactDOM from 'react-dom';
 import './Toast.module.scss';
 import {Toast, ToastType} from './Toast';
 
-export type ToastPosition = 'bottom-center';
-const TOAST_POSITIONS: ToastPosition[] = ['bottom-center'];
+export type ToastPosition = 'bottom-center' | 'top-center';
 const DEFAULT_TOAST_DURATION = 3000;
 
 export interface ToastOptions {
   type?: ToastType;
   message: ReactNode;
   duration?: number;
-  position?: ToastPosition;
 }
 interface ToastItem extends ToastOptions {
   id: number;
   duration: number;
   type: ToastType;
-  position: ToastPosition;
 }
 
 interface ToastContextValue {
@@ -35,7 +32,12 @@ interface ToastContextValue {
 
 const ToastContext = createContext<ToastContextValue | null>(null);
 
-export function ToastProvider({children}: {children: ReactNode}) {
+interface ToastProviderProps {
+  children: ReactNode;
+  position?: ToastPosition;
+}
+
+export function ToastProvider({children, position = 'bottom-center'}: ToastProviderProps) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
 
   const removeToast = (id: number) => {
@@ -49,7 +51,6 @@ export function ToastProvider({children}: {children: ReactNode}) {
       type: options.type ?? 'info',
       message: options.message,
       duration: options.duration ?? DEFAULT_TOAST_DURATION,
-      position: options.position ?? 'bottom-center',
     };
     setToasts(current => [...current, toast]);
     return id;
@@ -58,31 +59,22 @@ export function ToastProvider({children}: {children: ReactNode}) {
   return (
     <ToastContext.Provider value={{addToast, removeToast}}>
       {children}
-      {ReactDOM.createPortal(
-        <>
-          {TOAST_POSITIONS.map(position => {
-            const positionToasts = toasts.filter(t => t.position === position);
-            if (positionToasts.length === 0) {
-              return null;
-            }
-            return (
-              <div key={position} styleName="toast-container" data-position={position}>
-                {positionToasts.map(toast => (
-                  <Toast
-                    key={toast.id}
-                    id={toast.id}
-                    type={toast.type}
-                    message={toast.message}
-                    duration={toast.duration}
-                    onClose={removeToast}
-                  />
-                ))}
-              </div>
-            );
-          })}
-        </>,
-        document.body
-      )}
+      {toasts.length > 0 &&
+        ReactDOM.createPortal(
+          <div styleName="toast-container" data-position={position}>
+            {toasts.map(toast => (
+              <Toast
+                key={toast.id}
+                id={toast.id}
+                type={toast.type}
+                message={toast.message}
+                duration={toast.duration}
+                onClose={removeToast}
+              />
+            ))}
+          </div>,
+          document.body
+        )}
     </ToastContext.Provider>
   );
 }

--- a/indico/modules/events/timetable/client/js/ToastContext.tsx
+++ b/indico/modules/events/timetable/client/js/ToastContext.tsx
@@ -12,6 +12,8 @@ import './Toast.module.scss';
 import {Toast, ToastType} from './Toast';
 
 export type ToastPosition = 'bottom-center' | 'top-center';
+
+const TOAST_EXIT_DURATION = 200;
 const DEFAULT_TOAST_DURATION = 3000;
 
 export interface ToastOptions {
@@ -23,6 +25,7 @@ interface ToastItem extends ToastOptions {
   id: number;
   duration: number;
   type: ToastType;
+  leaving?: boolean;
 }
 
 interface ToastContextValue {
@@ -37,11 +40,15 @@ interface ToastProviderProps {
   position?: ToastPosition;
 }
 
-export function ToastProvider({children, position = 'bottom-center'}: ToastProviderProps) {
+export function ToastProvider({children, position = 'top-center'}: ToastProviderProps) {
   const [toasts, setToasts] = useState<ToastItem[]>([]);
 
   const removeToast = (id: number) => {
-    setToasts(currentToasts => currentToasts.filter(toast => toast.id !== id));
+    setToasts(current => current.map(t => (t.id === id ? {...t, leaving: true} : t)));
+    window.setTimeout(
+      () => setToasts(current => current.filter(t => t.id !== id)),
+      TOAST_EXIT_DURATION
+    );
   };
 
   const addToast = (options: ToastOptions) => {
@@ -69,6 +76,7 @@ export function ToastProvider({children, position = 'bottom-center'}: ToastProvi
                 type={toast.type}
                 message={toast.message}
                 duration={toast.duration}
+                leaving={toast.leaving}
                 onClose={removeToast}
               />
             ))}

--- a/indico/modules/events/timetable/client/js/index.jsx
+++ b/indico/modules/events/timetable/client/js/index.jsx
@@ -17,6 +17,7 @@ import {setSessionData, setTimetableData} from './actions';
 import {ModalProvider} from './ModalContext';
 import reducers from './reducers';
 import Timetable from './Timetable';
+import {ToastProvider} from './ToastContext';
 import {getCurrentDateLocalStorage} from './utils';
 
 (function(global) {
@@ -52,9 +53,11 @@ import {getCurrentDateLocalStorage} from './utils';
       ReactDOM.render(
         <Provider store={store}>
           <UserSearchTokenContext.Provider value={searchToken}>
-            <ModalProvider>
-              <Timetable />
-            </ModalProvider>
+            <ToastProvider>
+              <ModalProvider>
+                <Timetable />
+              </ModalProvider>
+            </ToastProvider>
           </UserSearchTokenContext.Provider>
         </Provider>,
         root


### PR DESCRIPTION
<img width="416" height="255" alt="Screenshot 2026-04-24 at 14 18 23" src="https://github.com/user-attachments/assets/c8c2222c-fe5e-44f5-bd83-3e9dc277b6e9" />

```ts
import {useToast} from './ToastContext';
const toast = useToast();

toast.addToast({
    type: 'info',
    message: 'Hello world',
});
```

- 3 types of toasts: info, warning, error and success.
- Duration can be configured (Default 5 seconds)

Toasts are displayed in the following situations:

- A contribution changes from one session to another 
- A contribution is moved to another day
- A contribution is moved to a session, becoming part of the session

Reference task: https://github.com/orgs/indico/projects/7/views/1?pane=issue&itemId=155552743
