### PR TITLE
Improve internal name field display

### DIFF
--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -46,7 +46,9 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
     fieldIsRequired,
     ...itemData
   } = useSelector(state => (editing ? getItemById(state, id) : EMPTY_DATA));
-  const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(false);
+  const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(
+    !!(editing && itemData.internalName)
+  );
   const inputType = editing ? existingInputType : newItemType;
   const fieldRegistry = getFieldRegistry();
   const isUnsupportedField = !(inputType in fieldRegistry);
@@ -234,6 +236,7 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
               label={Translate.string('Internal name')}
               readOnly={itemData.fieldIsPersonalData}
               nullIfEmpty
+              hideValidationError="never"
               validate={val => {
                 if (val && !/^[a-z0-9-]+$/.test(val)) {
                   return Translate.string(

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -47,7 +47,7 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
     ...itemData
   } = useSelector(state => (editing ? getItemById(state, id) : EMPTY_DATA));
   const [advancedSettingsOpen, setAdvancedSettingsOpen] = useState(
-    !!(editing && itemData.internalName)
+    editing && !!itemData.internalName && !itemData.fieldIsPersonalData
   );
   const inputType = editing ? existingInputType : newItemType;
   const fieldRegistry = getFieldRegistry();


### PR DESCRIPTION
I would open an issue, but this is such a quick fix I didn't think it was worth, the validator for the internal names is not displayed properly, so this change is fixing it:

<img width="777" height="310" alt="Screenshot 2026-04-30 at 13 56 22" src="https://github.com/user-attachments/assets/b6e88319-16a2-4ec0-91c3-e9bb580040f3" />

Into:

<img width="852" height="278" alt="Screenshot 2026-04-30 at 13 55 59" src="https://github.com/user-attachments/assets/b0fde6c4-e849-43a7-8ace-d3b7273669fd" />

