### PR TITLE
Hide clone-abstract icon outside management

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,7 @@ Bugfixes
   module (:pr:`7475`)
 - Fix date picker showing January instead of the selected month when the user
   language is not English (:issue:`7471`, :pr:`7476`, thanks :user:`foxbunny`)
+- Do not show "Clone Abstract" icon outside management area (:pr:`7493`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/abstracts/templates/management/_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/_abstract_list.html
@@ -276,46 +276,48 @@
                                 <td class="i-table actions-column">
                                     <div class="group right">
                                         {% if abstract.state.name == 'accepted' and abstract.contribution %}
-                                        <a class="icon-arrow-right-sparse"
-                                           href="{{ url_for('contributions.display_contribution', abstract.contribution) }}"
-                                           title="{% trans %}Go to contribution{% endtrans %}"></a>
+                                            <a class="icon-arrow-right-sparse"
+                                               href="{{ url_for('contributions.display_contribution', abstract.contribution) }}"
+                                               title="{% trans %}Go to contribution{% endtrans %}"></a>
                                         {% endif %}
-                                        <div class="group hide-if-locked">
-                                            <a class="icon-copy hide-if-locked"
-                                               data-toggle="dropdown"
-                                               title="{% trans %}Clone{% endtrans %}"></a>
-                                            <ul class="i-dropdown">
-                                                <li>
-                                                    <a class="js-dialog-action"
-                                                       title="{% trans %}Add new abstract{% endtrans %}"
-                                                       data-title="{% trans %}Add new abstract{% endtrans %}"
-                                                       data-href="{{ url_for('.manage_create_abstract', abstract) }}"
-                                                       data-params-selector="#abstract-list input[name=abstract_id]:checked"
-                                                       data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
-                                                       data-confirm-close-unsaved
-                                                       data-ajax-dialog>
-                                                        {% trans %}Abstract{% endtrans %}
-                                                    </a>
-                                                </li>
-                                                <li>
-                                                    {%- if can_create_invited_abstracts -%}
-                                                        {%- set message = _("Add new invited abstract") %}
-                                                    {%- else -%}
-                                                        {%- set message = _("You first need to create a notification template for invited abstracts") %}
-                                                    {%- endif -%}
-                                                    <a class="js-dialog-action {{ 'disabled' if not can_create_invited_abstracts }}"
-                                                       title="{{ message }}"
-                                                       data-title="{% trans %}Add new invited abstract{% endtrans %}"
-                                                       data-href="{{ url_for('.manage_create_abstract', abstract, invited=true) }}"
-                                                       data-params-selector="#abstract-list input[name=abstract_id]:checked"
-                                                       data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
-                                                       data-confirm-close-unsaved
-                                                       data-ajax-dialog>
-                                                        {% trans %}Invited abstract{% endtrans %}
-                                                    </a>
-                                                </li>
-                                            </ul>
-                                        </div>
+                                        {% if g.rh.management %}
+                                            <div class="group hide-if-locked">
+                                                <a class="icon-copy hide-if-locked"
+                                                   data-toggle="dropdown"
+                                                   title="{% trans %}Clone{% endtrans %}"></a>
+                                                <ul class="i-dropdown">
+                                                    <li>
+                                                        <a class="js-dialog-action"
+                                                           title="{% trans %}Add new abstract{% endtrans %}"
+                                                           data-title="{% trans %}Add new abstract{% endtrans %}"
+                                                           data-href="{{ url_for('.manage_create_abstract', abstract) }}"
+                                                           data-params-selector="#abstract-list input[name=abstract_id]:checked"
+                                                           data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
+                                                           data-confirm-close-unsaved
+                                                           data-ajax-dialog>
+                                                            {% trans %}Abstract{% endtrans %}
+                                                        </a>
+                                                    </li>
+                                                    <li>
+                                                        {%- if can_create_invited_abstracts -%}
+                                                            {%- set message = _("Add new invited abstract") %}
+                                                        {%- else -%}
+                                                            {%- set message = _("You first need to create a notification template for invited abstracts") %}
+                                                        {%- endif -%}
+                                                        <a class="js-dialog-action {{ 'disabled' if not can_create_invited_abstracts }}"
+                                                           title="{{ message }}"
+                                                           data-title="{% trans %}Add new invited abstract{% endtrans %}"
+                                                           data-href="{{ url_for('.manage_create_abstract', abstract, invited=true) }}"
+                                                           data-params-selector="#abstract-list input[name=abstract_id]:checked"
+                                                           data-update='{"html": "#abstract-list", "filter_statistics": "#filter-statistics"}'
+                                                           data-confirm-close-unsaved
+                                                           data-ajax-dialog>
+                                                            {% trans %}Invited abstract{% endtrans %}
+                                                        </a>
+                                                    </li>
+                                                </ul>
+                                            </div>
+                                        {% endif %}
                                     </div>
                                 </td>
                             </tr>


### PR DESCRIPTION
Reviewers don't have the permission to clone abstracts, so the icon should not be shown there. It also makes no sense to have it in that view since cloning abstracts is not something that's part of reviewing an abstract.