### PR TITLE
Fix file upload for registration_edit managers

### DIFF
--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -711,6 +711,8 @@ class RHRegistrationTogglePayment(RHManageRegistrationBase):
 class RHRegistrationUploadFile(UploadRegistrationFileMixin, RHManageRegistrationFieldActionBase):
     """Upload a file from a registration form."""
 
+    PERMISSION = ('registration', 'registration_edit')
+
 
 class RHRegistrationUploadPicture(UploadRegistrationPictureMixin, RHRegistrationUploadFile):
     """Upload a picture from a registration form."""


### PR DESCRIPTION
This PR fixes a bug introduced in #7419 where `registration_edit` managers were not able to upload files to file & picture fields when creating registrations.