### PR TITLE
Allow plugins to declare config keys in `indico.conf`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -216,6 +216,11 @@ Internal Changes
   (:pr:`7694`)
 - Use the latest TeXLive container image (``TL2026-2026-08-09-full``) for LaTeX-based
   PDF builds (:pr:`7699`)
+- Allow plugins to declare file-backed config keys via the
+  ``plugin_config_defaults`` class attribute. Keys are auto-prefixed with the
+  plugin's entry-point name and exposed in ``indico.conf`` alongside core
+  settings, with parity for defaults, sanitization and ``INDICO_CONF_OVERRIDE``
+  (:pr:`7499`, thanks :user:`moliholy, unconventionaldotdev`)
 
 
 Version 3.3.12

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,11 @@ Accessibility
 Internal Changes
 ^^^^^^^^^^^^^^^^
 
-- Nothing so far
+- Allow plugins to declare file-backed config keys via the
+  ``plugin_config_defaults`` class attribute. Keys are exposed in ``indico.conf``
+  under the reserved ``PLUGIN_<NAME>_`` namespace, with parity for defaults,
+  sanitization and ``INDICO_CONF_OVERRIDE``
+  (:pr:`7499`, thanks :user:`moliholy, unconventionaldotdev`)
 
 
 Version 3.3.13
@@ -216,11 +220,6 @@ Internal Changes
   (:pr:`7694`)
 - Use the latest TeXLive container image (``TL2026-2026-08-09-full``) for LaTeX-based
   PDF builds (:pr:`7699`)
-- Allow plugins to declare file-backed config keys via the
-  ``plugin_config_defaults`` class attribute. Keys are auto-prefixed with the
-  plugin's entry-point name and exposed in ``indico.conf`` alongside core
-  settings, with parity for defaults, sanitization and ``INDICO_CONF_OVERRIDE``
-  (:pr:`7499`, thanks :user:`moliholy, unconventionaldotdev`)
 
 
 Version 3.3.12

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -1204,10 +1204,8 @@ applied when omitted, unknown ``PLUGIN_*`` keys produce an "Ignoring unknown
 config key" warning, and ``INDICO_CONF_OVERRIDE`` can override them. The
 ``PLUGIN_*`` namespace is reserved for plugins; core config keys never use it.
 
-If a plugin declares a key that collides with a core config key, the plugin
-default is ignored and a warning is emitted; the core default stays
-authoritative. If two plugins declare the same prefixed key, starting Indico
-raises a ``RuntimeError``.
+If two plugins declare the same prefixed key, starting Indico raises a
+``RuntimeError``.
 
 
 .. data:: CATEGORY_CLEANUP

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -1165,6 +1165,44 @@ System
 
     Default: ``set()``
 
+
+Plugin Configuration
+^^^^^^^^^^^^^^^^^^^^
+
+In addition to the regular database-backed plugin settings configured via the
+admin UI, plugins may declare file-backed config keys that live in
+``indico.conf`` alongside core settings. This is useful for values that should
+not be editable at runtime (e.g. credentials managed by infrastructure tooling).
+
+A plugin declares its file-backed config keys via the ``plugin_config_defaults``
+class attribute on its :class:`IndicoPlugin` subclass. Keys are written
+**unprefixed** in the plugin and exposed in ``indico.conf`` with the plugin's
+entry-point name uppercased as a prefix. For example, plugin ``zoom`` declaring
+``API_KEY`` becomes ``ZOOM_API_KEY``::
+
+    class ZoomPlugin(IndicoPlugin):
+        plugin_config_defaults = {
+            'API_KEY': None,
+            'API_SECRET': None,
+            'TIMEOUT': 30,
+        }
+
+In ``indico.conf``::
+
+    PLUGINS = {'zoom'}
+    ZOOM_API_KEY = 'xxxxxxxx'
+    ZOOM_API_SECRET = 'yyyyyyyy'
+
+Plugin code reads these via the ``plugin_config`` proxy on the plugin
+instance, which strips the prefix::
+
+    self.plugin_config.API_KEY  # reads ZOOM_API_KEY
+
+These keys participate in the same machinery as core settings: defaults are
+applied when omitted, unknown plugin-prefixed keys produce an "Ignoring unknown
+config key" warning, and ``INDICO_CONF_OVERRIDE`` can override them.
+
+
 .. data:: CATEGORY_CLEANUP
 
     This setting specifies categories where events are automatically

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -1202,6 +1202,11 @@ These keys participate in the same machinery as core settings: defaults are
 applied when omitted, unknown plugin-prefixed keys produce an "Ignoring unknown
 config key" warning, and ``INDICO_CONF_OVERRIDE`` can override them.
 
+If a plugin declares a key that collides with a core config key, the plugin
+default is ignored and a warning is emitted; the core default stays
+authoritative. If two plugins declare the same prefixed key, a warning is
+emitted and the latter declaration wins.
+
 
 .. data:: CATEGORY_CLEANUP
 

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -1206,8 +1206,8 @@ config key" warning, and ``INDICO_CONF_OVERRIDE`` can override them. The
 
 If a plugin declares a key that collides with a core config key, the plugin
 default is ignored and a warning is emitted; the core default stays
-authoritative. If two plugins declare the same prefixed key, loading raises a
-``RuntimeError``.
+authoritative. If two plugins declare the same prefixed key, starting Indico
+raises a ``RuntimeError``.
 
 
 .. data:: CATEGORY_CLEANUP

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -1176,9 +1176,10 @@ not be editable at runtime (e.g. credentials managed by infrastructure tooling).
 
 A plugin declares its file-backed config keys via the ``plugin_config_defaults``
 class attribute on its :class:`IndicoPlugin` subclass. Keys are written
-**unprefixed** in the plugin and exposed in ``indico.conf`` with the plugin's
-entry-point name uppercased as a prefix. For example, plugin ``zoom`` declaring
-``API_KEY`` becomes ``ZOOM_API_KEY``::
+**unprefixed** in the plugin and exposed in ``indico.conf`` with the
+``PLUGIN_<NAME>_`` prefix, where ``<NAME>`` is the plugin's entry-point name
+uppercased. For example, plugin ``zoom`` declaring ``API_KEY`` becomes
+``PLUGIN_ZOOM_API_KEY``::
 
     class ZoomPlugin(IndicoPlugin):
         plugin_config_defaults = {
@@ -1190,22 +1191,23 @@ entry-point name uppercased as a prefix. For example, plugin ``zoom`` declaring
 In ``indico.conf``::
 
     PLUGINS = {'zoom'}
-    ZOOM_API_KEY = 'xxxxxxxx'
-    ZOOM_API_SECRET = 'yyyyyyyy'
+    PLUGIN_ZOOM_API_KEY = 'xxxxxxxx'
+    PLUGIN_ZOOM_API_SECRET = 'yyyyyyyy'
 
 Plugin code reads these via the ``plugin_config`` proxy on the plugin
 instance, which strips the prefix::
 
-    self.plugin_config.API_KEY  # reads ZOOM_API_KEY
+    self.plugin_config.API_KEY  # reads PLUGIN_ZOOM_API_KEY
 
 These keys participate in the same machinery as core settings: defaults are
-applied when omitted, unknown plugin-prefixed keys produce an "Ignoring unknown
-config key" warning, and ``INDICO_CONF_OVERRIDE`` can override them.
+applied when omitted, unknown ``PLUGIN_*`` keys produce an "Ignoring unknown
+config key" warning, and ``INDICO_CONF_OVERRIDE`` can override them. The
+``PLUGIN_*`` namespace is reserved for plugins; core config keys never use it.
 
 If a plugin declares a key that collides with a core config key, the plugin
 default is ignored and a warning is emitted; the core default stays
-authoritative. If two plugins declare the same prefixed key, a warning is
-emitted and the latter declaration wins.
+authoritative. If two plugins declare the same prefixed key, loading raises a
+``RuntimeError``.
 
 
 .. data:: CATEGORY_CLEANUP

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -1165,48 +1165,45 @@ System
 
     Default: ``set()``
 
+    .. rubric:: Plugin Configuration
 
-Plugin Configuration
-^^^^^^^^^^^^^^^^^^^^
+    In addition to the regular database-backed plugin settings configured via the
+    admin UI, plugins may declare file-backed config keys that live in
+    ``indico.conf`` alongside core settings. This is useful for values that should
+    not be editable at runtime (e.g. credentials managed by infrastructure tooling).
 
-In addition to the regular database-backed plugin settings configured via the
-admin UI, plugins may declare file-backed config keys that live in
-``indico.conf`` alongside core settings. This is useful for values that should
-not be editable at runtime (e.g. credentials managed by infrastructure tooling).
+    A plugin declares its file-backed config keys via the ``plugin_config_defaults``
+    class attribute on its :class:`IndicoPlugin` subclass. Keys are written
+    **unprefixed** in the plugin and exposed in ``indico.conf`` with the
+    ``PLUGIN_<NAME>_`` prefix, where ``<NAME>`` is the plugin's entry-point name
+    uppercased. For example, plugin ``zoom`` declaring ``API_KEY`` becomes
+    ``PLUGIN_ZOOM_API_KEY``::
 
-A plugin declares its file-backed config keys via the ``plugin_config_defaults``
-class attribute on its :class:`IndicoPlugin` subclass. Keys are written
-**unprefixed** in the plugin and exposed in ``indico.conf`` with the
-``PLUGIN_<NAME>_`` prefix, where ``<NAME>`` is the plugin's entry-point name
-uppercased. For example, plugin ``zoom`` declaring ``API_KEY`` becomes
-``PLUGIN_ZOOM_API_KEY``::
+        class ZoomPlugin(IndicoPlugin):
+            plugin_config_defaults = {
+                'API_KEY': None,
+                'API_SECRET': None,
+                'TIMEOUT': 30,
+            }
 
-    class ZoomPlugin(IndicoPlugin):
-        plugin_config_defaults = {
-            'API_KEY': None,
-            'API_SECRET': None,
-            'TIMEOUT': 30,
-        }
+    In ``indico.conf``::
 
-In ``indico.conf``::
+        PLUGINS = {'zoom'}
+        PLUGIN_ZOOM_API_KEY = 'xxxxxxxx'
+        PLUGIN_ZOOM_API_SECRET = 'yyyyyyyy'
 
-    PLUGINS = {'zoom'}
-    PLUGIN_ZOOM_API_KEY = 'xxxxxxxx'
-    PLUGIN_ZOOM_API_SECRET = 'yyyyyyyy'
+    Plugin code reads these via the ``plugin_config`` proxy on the plugin
+    instance, which strips the prefix::
 
-Plugin code reads these via the ``plugin_config`` proxy on the plugin
-instance, which strips the prefix::
+        self.plugin_config.API_KEY  # reads PLUGIN_ZOOM_API_KEY
 
-    self.plugin_config.API_KEY  # reads PLUGIN_ZOOM_API_KEY
+    These keys participate in the same machinery as core settings: defaults are
+    applied when omitted, unknown ``PLUGIN_*`` keys produce an "Ignoring unknown
+    config key" warning, and ``INDICO_CONF_OVERRIDE`` can override them. The
+    ``PLUGIN_*`` namespace is reserved for plugins; core config keys never use it.
 
-These keys participate in the same machinery as core settings: defaults are
-applied when omitted, unknown ``PLUGIN_*`` keys produce an "Ignoring unknown
-config key" warning, and ``INDICO_CONF_OVERRIDE`` can override them. The
-``PLUGIN_*`` namespace is reserved for plugins; core config keys never use it.
-
-If two plugins declare the same prefixed key, starting Indico raises a
-``RuntimeError``.
-
+    If two plugins declare the same prefixed key, starting Indico raises a
+    ``RuntimeError``.
 
 .. data:: CATEGORY_CLEANUP
 

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -1173,9 +1173,9 @@ System
     not be editable at runtime (e.g. credentials managed by infrastructure tooling).
 
     A plugin declares its file-backed config keys via the ``plugin_config_defaults``
-    class attribute on its :class:`IndicoPlugin` subclass. Keys are written
-    **unprefixed** in the plugin and exposed in ``indico.conf`` with the
-    ``PLUGIN_<NAME>_`` prefix, where ``<NAME>`` is the plugin's entry-point name
+    class attribute on its :class:`~indico.core.plugins.IndicoPlugin` subclass.
+    Keys are written **unprefixed** in the plugin and exposed in ``indico.conf`` with
+    the ``PLUGIN_<NAME>_`` prefix, where ``<NAME>`` is the plugin's entry-point name
     uppercased. For example, plugin ``zoom`` declaring ``API_KEY`` becomes
     ``PLUGIN_ZOOM_API_KEY``::
 

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -1192,8 +1192,8 @@ System
         PLUGIN_FOO_API_KEY = 'xxxxxxxx'
         PLUGIN_FOO_API_SECRET = 'yyyyyyyy'
 
-    Plugin code reads these via the ``plugin_config`` proxy on the plugin
-    instance, which strips the prefix::
+    Plugin code reads these via the ``plugin_config`` proxy on the plugin class
+    which strips the prefix::
 
         FooPlugin.plugin_config.API_KEY  # reads PLUGIN_FOO_API_KEY
 

--- a/docs/source/config/settings.rst
+++ b/docs/source/config/settings.rst
@@ -1177,9 +1177,9 @@ System
     Keys are written **unprefixed** in the plugin and exposed in ``indico.conf`` with
     the ``PLUGIN_<NAME>_`` prefix, where ``<NAME>`` is the plugin's entry-point name
     uppercased. For example, plugin ``zoom`` declaring ``API_KEY`` becomes
-    ``PLUGIN_ZOOM_API_KEY``::
+    ``PLUGIN_FOO_API_KEY``::
 
-        class ZoomPlugin(IndicoPlugin):
+        class FooPlugin(IndicoPlugin):
             plugin_config_defaults = {
                 'API_KEY': None,
                 'API_SECRET': None,
@@ -1189,13 +1189,13 @@ System
     In ``indico.conf``::
 
         PLUGINS = {'zoom'}
-        PLUGIN_ZOOM_API_KEY = 'xxxxxxxx'
-        PLUGIN_ZOOM_API_SECRET = 'yyyyyyyy'
+        PLUGIN_FOO_API_KEY = 'xxxxxxxx'
+        PLUGIN_FOO_API_SECRET = 'yyyyyyyy'
 
     Plugin code reads these via the ``plugin_config`` proxy on the plugin
     instance, which strips the prefix::
 
-        self.plugin_config.API_KEY  # reads PLUGIN_ZOOM_API_KEY
+        FooPlugin.plugin_config.API_KEY  # reads PLUGIN_FOO_API_KEY
 
     These keys participate in the same machinery as core settings: defaults are
     applied when omitted, unknown ``PLUGIN_*`` keys produce an "Ignoring unknown
@@ -1203,7 +1203,7 @@ System
     ``PLUGIN_*`` namespace is reserved for plugins; core config keys never use it.
 
     If two plugins declare the same prefixed key, starting Indico raises a
-    ``RuntimeError``.
+    :exc:`RuntimeError`.
 
 .. data:: CATEGORY_CLEANUP
 

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -272,7 +272,11 @@ def load_config(only_defaults=False, override=None):
     if not only_defaults:
         path = get_config_path()
         raw_config = _parse_config(path)
-    plugins = set(raw_config.get('PLUGINS') or set()) | set((override or {}).get('PLUGINS') or set())
+    env_override = {}
+    if not only_defaults and (env_override_value := os.environ.get('INDICO_CONF_OVERRIDE')):
+        env_override = ast.literal_eval(env_override_value)
+    plugins = (set(raw_config.get('PLUGINS') or set()) | set(env_override.get('PLUGINS') or set()) |
+               set((override or {}).get('PLUGINS') or set()))
     plugin_cfg_defaults = _load_plugin_config_defaults(plugins)
     extra_keys = frozenset(plugin_cfg_defaults)
 
@@ -280,9 +284,8 @@ def load_config(only_defaults=False, override=None):
     if not only_defaults:
         config = _sanitize_data(raw_config, extra_keys=extra_keys)
         data.update(config)
-        env_override = os.environ.get('INDICO_CONF_OVERRIDE')
         if env_override:
-            data.update(_sanitize_data(ast.literal_eval(env_override), extra_keys=extra_keys))
+            data.update(_sanitize_data(env_override, extra_keys=extra_keys))
         resolved_path = resolve_link(path) if os.path.islink(path) else path
         resolved_path = None if resolved_path == os.devnull else resolved_path
         data['CONFIG_PATH'] = path

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -13,6 +13,7 @@ import socket
 import warnings
 from datetime import timedelta
 from functools import cache
+from importlib.metadata import entry_points
 from urllib.parse import urljoin, urlsplit
 
 import pytz
@@ -206,13 +207,47 @@ def _postprocess_config(data):
         data['DISABLE_CELERY_CHECK'] = data['DEBUG']
 
 
-def _sanitize_data(data, allow_internal=False):
-    allowed = set(DEFAULTS)
+def _sanitize_data(data, allow_internal=False, extra_keys=frozenset()):
+    allowed = set(DEFAULTS) | set(extra_keys)
     if allow_internal:
         allowed |= set(INTERNAL_DEFAULTS)
     for key in set(data) - allowed:
         warnings.warn(f'Ignoring unknown config key {key}', stacklevel=2)
     return {k: v for k, v in data.items() if k in allowed}
+
+
+def _load_plugin_config_defaults(plugin_names):
+    """Collect file-backed config defaults declared by the given plugins.
+
+    Returns a flat dict mapping prefixed keys (``<NAME>_<KEY>``) to default values.
+    Plugins whose entry-point is missing are silently skipped (the regular plugin
+    loader will surface the failure later). Collisions with core ``DEFAULTS`` or
+    between plugins are reported via ``warnings.warn`` and the latter wins.
+    """
+    if not plugin_names:
+        return {}
+    wanted = set(plugin_names)
+    result = {}
+    for ep in entry_points(group='indico.plugins'):
+        if ep.name not in wanted:
+            continue
+        try:
+            plugin_class = ep.load()
+        except Exception as exc:
+            warnings.warn(f'Could not load plugin entry-point {ep.name!r}: {exc}', stacklevel=2)
+            continue
+        defaults = getattr(plugin_class, 'plugin_config_defaults', None) or {}
+        prefix = ep.name.upper()
+        for key, value in defaults.items():
+            full = f'{prefix}_{key}'
+            if full in DEFAULTS:
+                warnings.warn(f'Plugin {ep.name!r} config key {full!r} collides with a core config key',
+                              stacklevel=2)
+            elif full in result:
+                warnings.warn(f'Plugin {ep.name!r} config key {full!r} collides with another plugin',
+                              stacklevel=2)
+            result[full] = value
+    return result
 
 
 def _validate_config(data):
@@ -231,14 +266,22 @@ def load_config(only_defaults=False, override=None):
                      the configuration.  Any values provided here
                      will override values from the config file.
     """
-    data = DEFAULTS | INTERNAL_DEFAULTS
+    raw_config = {}
+    path = None
     if not only_defaults:
         path = get_config_path()
-        config = _sanitize_data(_parse_config(path))
+        raw_config = _parse_config(path)
+    plugins = set(raw_config.get('PLUGINS') or set()) | set((override or {}).get('PLUGINS') or set())
+    plugin_cfg_defaults = _load_plugin_config_defaults(plugins)
+    extra_keys = frozenset(plugin_cfg_defaults)
+
+    data = DEFAULTS | INTERNAL_DEFAULTS | plugin_cfg_defaults
+    if not only_defaults:
+        config = _sanitize_data(raw_config, extra_keys=extra_keys)
         data.update(config)
         env_override = os.environ.get('INDICO_CONF_OVERRIDE')
         if env_override:
-            data.update(_sanitize_data(ast.literal_eval(env_override)))
+            data.update(_sanitize_data(ast.literal_eval(env_override), extra_keys=extra_keys))
         resolved_path = resolve_link(path) if os.path.islink(path) else path
         resolved_path = None if resolved_path == os.devnull else resolved_path
         data['CONFIG_PATH'] = path
@@ -247,7 +290,7 @@ def load_config(only_defaults=False, override=None):
             data['LOGGING_CONFIG_PATH'] = os.path.join(os.path.dirname(resolved_path), data['LOGGING_CONFIG_FILE'])
 
     if override:
-        data.update(_sanitize_data(override, allow_internal=True))
+        data.update(_sanitize_data(override, allow_internal=True, extra_keys=extra_keys))
     _postprocess_config(data)
     if not only_defaults:
         _validate_config(data)

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -236,14 +236,15 @@ def _load_plugin_config_defaults(plugin_names):
         except Exception as exc:
             warnings.warn(f'Could not load plugin entry-point {ep.name!r}: {exc}', stacklevel=2)
             continue
-        defaults = getattr(plugin_class, 'plugin_config_defaults', None) or {}
+        defaults = plugin_class.plugin_config_defaults
         prefix = ep.name.upper()
         for key, value in defaults.items():
             full = f'{prefix}_{key}'
             if full in DEFAULTS:
-                warnings.warn(f'Plugin {ep.name!r} config key {full!r} collides with a core config key',
-                              stacklevel=2)
-            elif full in result:
+                warnings.warn(f'Plugin {ep.name!r} config key {full!r} collides with a core config key; '
+                              f'plugin default ignored', stacklevel=2)
+                continue
+            if full in result:
                 warnings.warn(f'Plugin {ep.name!r} config key {full!r} collides with another plugin',
                               stacklevel=2)
             result[full] = value

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -219,10 +219,11 @@ def _sanitize_data(data, allow_internal=False, extra_keys=frozenset()):
 def _load_plugin_config_defaults(plugin_names):
     """Collect file-backed config defaults declared by the given plugins.
 
-    Returns a flat dict mapping prefixed keys (``<NAME>_<KEY>``) to default values.
-    Plugins whose entry-point is missing are silently skipped (the regular plugin
-    loader will surface the failure later). Collisions with core ``DEFAULTS`` or
-    between plugins are reported via ``warnings.warn`` and the latter wins.
+    Returns a flat dict mapping prefixed keys (``PLUGIN_<NAME>_<KEY>``) to default
+    values. Plugins whose entry-point is missing are silently skipped (the regular
+    plugin loader will surface the failure later). Collisions with core ``DEFAULTS``
+    are reported via ``warnings.warn`` and the plugin default is ignored. Collisions
+    between plugins raise ``RuntimeError``.
     """
     if not plugin_names:
         return {}
@@ -237,7 +238,7 @@ def _load_plugin_config_defaults(plugin_names):
             warnings.warn(f'Could not load plugin entry-point {ep.name!r}: {exc}', stacklevel=2)
             continue
         defaults = plugin_class.plugin_config_defaults
-        prefix = ep.name.upper()
+        prefix = f'PLUGIN_{ep.name.upper()}'
         for key, value in defaults.items():
             full = f'{prefix}_{key}'
             if full in DEFAULTS:
@@ -245,8 +246,7 @@ def _load_plugin_config_defaults(plugin_names):
                               f'plugin default ignored', stacklevel=2)
                 continue
             if full in result:
-                warnings.warn(f'Plugin {ep.name!r} config key {full!r} collides with another plugin',
-                              stacklevel=2)
+                raise RuntimeError(f'Plugin {ep.name!r} config key {full!r} collides with another plugin')
             result[full] = value
     return result
 

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -13,7 +13,6 @@ import socket
 import warnings
 from datetime import timedelta
 from functools import cache
-from importlib.metadata import entry_points
 from urllib.parse import urljoin, urlsplit
 
 import pytz
@@ -147,6 +146,11 @@ REQUIRED_KEYS = {'SQLALCHEMY_DATABASE_URI', 'SECRET_KEY', 'BASE_URL', 'CELERY_BR
                  'DEFAULT_TIMEZONE', 'DEFAULT_LOCALE', 'CACHE_DIR', 'TEMP_DIR', 'LOG_DIR', 'STORAGE_BACKENDS',
                  'ATTACHMENT_STORAGE', 'SUPPORT_EMAIL', 'NO_REPLY_EMAIL'}
 
+# Reserved namespace for file-backed plugin config keys (``PLUGIN_<NAME>_<KEY>``). These are
+# collected during config loading and resolved later, once each plugin is initialized, so that
+# loading the config never has to import any plugin.
+PLUGIN_CONFIG_PREFIX = 'PLUGIN_'
+
 
 def get_config_path():
     """Get the path of the indico config file.
@@ -207,48 +211,37 @@ def _postprocess_config(data):
         data['DISABLE_CELERY_CHECK'] = data['DEBUG']
 
 
-def _sanitize_data(data, allow_internal=False, extra_keys=frozenset()):
-    allowed = set(DEFAULTS) | set(extra_keys)
+def _sanitize_data(data, allow_internal=False):
+    """Split raw config into known core keys and pending plugin keys.
+
+    Returns a ``(clean, plugin)`` tuple: ``clean`` holds recognized core keys,
+    ``plugin`` holds keys under the reserved ``PLUGIN_`` namespace (left for the
+    owning plugin to claim later). Unknown keys outside that namespace are dropped
+    with a warning.
+    """
+    allowed = set(DEFAULTS)
     if allow_internal:
         allowed |= set(INTERNAL_DEFAULTS)
-    for key in set(data) - allowed:
-        warnings.warn(f'Ignoring unknown config key {key}', stacklevel=2)
-    return {k: v for k, v in data.items() if k in allowed}
+    clean = {}
+    plugin = {}
+    for key, value in data.items():
+        if key in allowed:
+            clean[key] = value
+        elif key.startswith(PLUGIN_CONFIG_PREFIX):
+            plugin[key] = value
+        else:
+            warnings.warn(f'Ignoring unknown config key {key}', stacklevel=2)
+    return clean, plugin
 
 
-def _load_plugin_config_defaults(plugin_names):
-    """Collect file-backed config defaults declared by the given plugins.
+def _warn_unclaimed_plugin_config(data):
+    """Warn about ``PLUGIN_*`` keys that no initialized plugin claimed.
 
-    Returns a flat dict mapping prefixed keys (``PLUGIN_<NAME>_<KEY>``) to default
-    values. Plugins whose entry-point is missing are silently skipped (the regular
-    plugin loader will surface the failure later). Collisions with core ``DEFAULTS``
-    are reported via ``warnings.warn`` and the plugin default is ignored. Collisions
-    between plugins raise ``RuntimeError``.
+    Runs after all plugins are loaded (via :meth:`IndicoConfig.validate`), so any key
+    still pending belongs to a plugin that is not enabled or does not declare it.
     """
-    if not plugin_names:
-        return {}
-    wanted = set(plugin_names)
-    result = {}
-    for ep in entry_points(group='indico.plugins'):
-        if ep.name not in wanted:
-            continue
-        try:
-            plugin_class = ep.load()
-        except Exception as exc:
-            warnings.warn(f'Could not load plugin entry-point {ep.name!r}: {exc}', stacklevel=2)
-            continue
-        defaults = plugin_class.plugin_config_defaults
-        prefix = f'PLUGIN_{ep.name.upper()}'
-        for key, value in defaults.items():
-            full = f'{prefix}_{key}'
-            if full in DEFAULTS:
-                warnings.warn(f'Plugin {ep.name!r} config key {full!r} collides with a core config key; '
-                              f'plugin default ignored', stacklevel=2)
-                continue
-            if full in result:
-                raise RuntimeError(f'Plugin {ep.name!r} config key {full!r} collides with another plugin')
-            result[full] = value
-    return result
+    for key in data['PLUGIN_CONFIG']['pending']:
+        warnings.warn(f'Ignoring unknown config key {key}', stacklevel=2)
 
 
 def _validate_config(data):
@@ -272,20 +265,18 @@ def load_config(only_defaults=False, override=None):
     if not only_defaults:
         path = get_config_path()
         raw_config = _parse_config(path)
-    env_override = {}
-    if not only_defaults and (env_override_value := os.environ.get('INDICO_CONF_OVERRIDE')):
-        env_override = ast.literal_eval(env_override_value)
-    plugins = (set(raw_config.get('PLUGINS') or set()) | set(env_override.get('PLUGINS') or set()) |
-               set((override or {}).get('PLUGINS') or set()))
-    plugin_cfg_defaults = _load_plugin_config_defaults(plugins)
-    extra_keys = frozenset(plugin_cfg_defaults)
 
-    data = DEFAULTS | INTERNAL_DEFAULTS | plugin_cfg_defaults
+    data = DEFAULTS | INTERNAL_DEFAULTS
+    # Plugin keys are held here until the owning plugin claims them during its init.
+    plugin_pending = {}
     if not only_defaults:
-        config = _sanitize_data(raw_config, extra_keys=extra_keys)
+        config, plugin = _sanitize_data(raw_config)
         data.update(config)
-        if env_override:
-            data.update(_sanitize_data(env_override, extra_keys=extra_keys))
+        plugin_pending.update(plugin)
+        if env_override := os.environ.get('INDICO_CONF_OVERRIDE'):
+            config, plugin = _sanitize_data(ast.literal_eval(env_override))
+            data.update(config)
+            plugin_pending.update(plugin)
         resolved_path = resolve_link(path) if os.path.islink(path) else path
         resolved_path = None if resolved_path == os.devnull else resolved_path
         data['CONFIG_PATH'] = path
@@ -294,7 +285,12 @@ def load_config(only_defaults=False, override=None):
             data['LOGGING_CONFIG_PATH'] = os.path.join(os.path.dirname(resolved_path), data['LOGGING_CONFIG_FILE'])
 
     if override:
-        data.update(_sanitize_data(override, allow_internal=True, extra_keys=extra_keys))
+        config, plugin = _sanitize_data(override, allow_internal=True)
+        data.update(config)
+        plugin_pending.update(plugin)
+    # ``pending`` and ``resolved`` are mutable on purpose: plugins move their keys from the former
+    # to the latter (via ``register_plugin_config``) after this immutable config is already built.
+    data['PLUGIN_CONFIG'] = {'pending': plugin_pending, 'resolved': {}}
     _postprocess_config(data)
     if not only_defaults:
         _validate_config(data)
@@ -394,12 +390,41 @@ class IndicoConfig:
             self.XELATEX_PODMAN_CONFIG  # noqa: B018
         except ValidationError as err:
             raise ValueError(f'Invalid value for XELATEX_PATH: {err}')
+        _warn_unclaimed_plugin_config(self.data)
+
+    def register_plugin_config(self, plugin):
+        """Resolve a plugin's file-backed config once the plugin is initialized.
+
+        Called from :meth:`~indico.core.plugins.IndicoPlugin.init`, when the plugin is
+        already imported. Declared defaults are applied for keys omitted from the config
+        file, and any values collected during :func:`load_config` are consumed here.
+        Collisions with a core key are warned about and the plugin default is ignored;
+        collisions between plugins raise ``RuntimeError``.
+        """
+        store = self.data['PLUGIN_CONFIG']
+        pending, resolved = store['pending'], store['resolved']
+        prefix = f'{PLUGIN_CONFIG_PREFIX}{plugin.name.upper()}'
+        for key, default in plugin.plugin_config_defaults.items():
+            full = f'{prefix}_{key}'
+            if full in DEFAULTS:
+                warnings.warn(f'Plugin {plugin.name!r} config key {full!r} collides with a core config key; '
+                              f'plugin default ignored', stacklevel=2)
+                continue
+            if full in resolved:
+                raise RuntimeError(f'Plugin {plugin.name!r} config key {full!r} collides with another plugin')
+            resolved[full] = pending.pop(full, default)
 
     def __getattr__(self, name):
         try:
             return self.data[name]
         except KeyError:
-            raise self._exc('no such setting: ' + name)
+            pass
+        if name.startswith(PLUGIN_CONFIG_PREFIX):
+            try:
+                return self.data['PLUGIN_CONFIG']['resolved'][name]
+            except KeyError:
+                pass
+        raise self._exc('no such setting: ' + name)
 
     def __setattr__(self, key, value):
         raise AttributeError('cannot change config at runtime')

--- a/indico/core/config.py
+++ b/indico/core/config.py
@@ -260,16 +260,13 @@ def load_config(only_defaults=False, override=None):
                      the configuration.  Any values provided here
                      will override values from the config file.
     """
-    raw_config = {}
-    path = None
-    if not only_defaults:
-        path = get_config_path()
-        raw_config = _parse_config(path)
-
     data = DEFAULTS | INTERNAL_DEFAULTS
     # Plugin keys are held here until the owning plugin claims them during its init.
     plugin_pending = {}
+
     if not only_defaults:
+        path = get_config_path()
+        raw_config = _parse_config(path)
         config, plugin = _sanitize_data(raw_config)
         data.update(config)
         plugin_pending.update(plugin)

--- a/indico/core/config_test.py
+++ b/indico/core/config_test.py
@@ -1,0 +1,133 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2026 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+
+from indico.core import config as config_module
+from indico.core.config import load_config
+
+
+class _FakeEntryPoint:
+    def __init__(self, name, plugin_class):
+        self.name = name
+        self._plugin_class = plugin_class
+
+    def load(self):
+        return self._plugin_class
+
+
+@pytest.fixture
+def fake_entry_points(monkeypatch):
+    eps = {}
+
+    def _entry_points(*, group):
+        if group != 'indico.plugins':
+            return []
+        return list(eps.values())
+
+    monkeypatch.setattr(config_module, 'entry_points', _entry_points, raising=False)
+    return eps
+
+
+@pytest.fixture
+def write_config(tmp_path, monkeypatch):
+    def _write(body):
+        path = tmp_path / 'indico.conf'
+        # Required keys to keep _postprocess_config / _validate_config happy.
+        baseline = "BASE_URL = 'https://example.test'\n"
+        path.write_text(baseline + body)
+        monkeypatch.setenv('INDICO_CONFIG', str(path))
+        return str(path)
+    return _write
+
+
+def _make_plugin(defaults):
+    class Plugin:
+        plugin_config_defaults = defaults
+    return Plugin
+
+
+def test_plugin_config_default_loaded(fake_entry_points, write_config):
+    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None, 'TIMEOUT': 30}))
+    write_config("PLUGINS = {'demo'}\n")
+    data = load_config()
+    assert data['DEMO_API_KEY'] is None
+    assert data['DEMO_TIMEOUT'] == 30
+
+
+def test_plugin_config_user_value_overrides_default(fake_entry_points, write_config):
+    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None, 'TIMEOUT': 30}))
+    write_config("PLUGINS = {'demo'}\nDEMO_API_KEY = 'secret'\nDEMO_TIMEOUT = 5\n")
+    data = load_config()
+    assert data['DEMO_API_KEY'] == 'secret'
+    assert data['DEMO_TIMEOUT'] == 5
+
+
+def test_plugin_config_unknown_key_warns(fake_entry_points, write_config):
+    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
+    write_config("PLUGINS = {'demo'}\nDEMO_BOGUS = 'x'\n")
+    with pytest.warns(UserWarning, match='DEMO_BOGUS'):
+        data = load_config()
+    assert 'DEMO_BOGUS' not in data
+
+
+def test_only_defaults_with_plugin_override_carries_keys(fake_entry_points):
+    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
+    data = load_config(only_defaults=True, override={
+        'BASE_URL': 'https://example.test',
+        'PLUGINS': {'demo'},
+        'DEMO_API_KEY': 'x',
+    })
+    assert data['DEMO_API_KEY'] == 'x'
+
+
+def test_plugin_config_collision_warns(fake_entry_points, write_config):
+    # Two plugins both contributing the same prefixed key (e.g. plugin name `un` and `un_extras`
+    # would resolve to UN_*; here we force collision via overlapping prefixes through duplicate names
+    # is not possible, so simulate a collision with a core key.
+    fake_entry_points['base'] = _FakeEntryPoint('base', _make_plugin({'URL': 'x'}))  # BASE_URL collides
+    write_config("PLUGINS = {'base'}\n")
+    with pytest.warns(UserWarning, match='BASE_URL'):
+        load_config()
+
+
+def test_indico_conf_override_env_passes_plugin_key(fake_entry_points, write_config, monkeypatch):
+    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
+    write_config("PLUGINS = {'demo'}\n")
+    monkeypatch.setenv('INDICO_CONF_OVERRIDE', "{'DEMO_API_KEY': 'fromenv'}")
+    data = load_config()
+    assert data['DEMO_API_KEY'] == 'fromenv'
+
+
+def test_missing_entry_point_graceful(fake_entry_points, write_config):
+    # 'ghost' has no registered entry-point; should not crash, key absent from result.
+    write_config("PLUGINS = {'ghost'}\n")
+    data = load_config()
+    assert 'GHOST_ANYTHING' not in data
+
+
+def test_plugin_config_proxy_reads_prefixed():
+    from indico.core.plugins import PluginConfigProxy
+
+    class FakeConfig:
+        UN_MFA_ENABLED = True
+        UN_TIMEOUT = 5
+
+    proxy = PluginConfigProxy(FakeConfig(), prefix='UN')
+    assert proxy.MFA_ENABLED is True
+    assert proxy.TIMEOUT == 5
+
+
+def test_plugin_config_proxy_missing_attr_raises():
+    from indico.core.plugins import PluginConfigProxy
+
+    class FakeConfig:
+        pass
+
+    proxy = PluginConfigProxy(FakeConfig(), prefix='UN')
+    with pytest.raises(AttributeError):
+        proxy.NOPE  # noqa: B018

--- a/indico/core/config_test.py
+++ b/indico/core/config_test.py
@@ -29,7 +29,7 @@ def fake_entry_points(monkeypatch):
             return []
         return list(eps.values())
 
-    monkeypatch.setattr(config_module, 'entry_points', _entry_points, raising=False)
+    monkeypatch.setattr(config_module, 'entry_points', _entry_points)
     return eps
 
 
@@ -85,14 +85,26 @@ def test_only_defaults_with_plugin_override_carries_keys(fake_entry_points):
     assert data['DEMO_API_KEY'] == 'x'
 
 
-def test_plugin_config_collision_warns(fake_entry_points, write_config):
-    # Two plugins both contributing the same prefixed key (e.g. plugin name `un` and `un_extras`
-    # would resolve to UN_*; here we force collision via overlapping prefixes through duplicate names
-    # is not possible, so simulate a collision with a core key.
-    fake_entry_points['base'] = _FakeEntryPoint('base', _make_plugin({'URL': 'x'}))  # BASE_URL collides
-    write_config("PLUGINS = {'base'}\n")
-    with pytest.warns(UserWarning, match='BASE_URL'):
-        load_config()
+def test_plugin_config_collision_with_core_key_warns_and_is_ignored(fake_entry_points, write_config):
+    # Plugin 'external' declaring 'REGISTRATION_URL' would shadow the core EXTERNAL_REGISTRATION_URL
+    # default. The user's indico.conf does not set this key, so the plugin default would otherwise win.
+    fake_entry_points['external'] = _FakeEntryPoint(
+        'external', _make_plugin({'REGISTRATION_URL': 'plugin-default'}))
+    write_config("PLUGINS = {'external'}\n")
+    with pytest.warns(UserWarning, match='EXTERNAL_REGISTRATION_URL'):
+        data = load_config()
+    # Core default wins; the plugin's value is dropped.
+    assert data['EXTERNAL_REGISTRATION_URL'] is None
+
+
+def test_plugin_config_collision_between_plugins_warns_and_latter_wins(fake_entry_points, write_config):
+    # Plugin 'a' declaring 'B_C' and plugin 'a_b' declaring 'C' both resolve to A_B_C.
+    fake_entry_points['a'] = _FakeEntryPoint('a', _make_plugin({'B_C': 'first'}))
+    fake_entry_points['a_b'] = _FakeEntryPoint('a_b', _make_plugin({'C': 'second'}))
+    write_config("PLUGINS = {'a', 'a_b'}\n")
+    with pytest.warns(UserWarning, match='A_B_C'):
+        data = load_config()
+    assert data['A_B_C'] == 'second'
 
 
 def test_indico_conf_override_env_passes_plugin_key(fake_entry_points, write_config, monkeypatch):

--- a/indico/core/config_test.py
+++ b/indico/core/config_test.py
@@ -55,24 +55,24 @@ def test_plugin_config_default_loaded(fake_entry_points, write_config):
     fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None, 'TIMEOUT': 30}))
     write_config("PLUGINS = {'demo'}\n")
     data = load_config()
-    assert data['DEMO_API_KEY'] is None
-    assert data['DEMO_TIMEOUT'] == 30
+    assert data['PLUGIN_DEMO_API_KEY'] is None
+    assert data['PLUGIN_DEMO_TIMEOUT'] == 30
 
 
 def test_plugin_config_user_value_overrides_default(fake_entry_points, write_config):
     fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None, 'TIMEOUT': 30}))
-    write_config("PLUGINS = {'demo'}\nDEMO_API_KEY = 'secret'\nDEMO_TIMEOUT = 5\n")
+    write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_API_KEY = 'secret'\nPLUGIN_DEMO_TIMEOUT = 5\n")
     data = load_config()
-    assert data['DEMO_API_KEY'] == 'secret'
-    assert data['DEMO_TIMEOUT'] == 5
+    assert data['PLUGIN_DEMO_API_KEY'] == 'secret'
+    assert data['PLUGIN_DEMO_TIMEOUT'] == 5
 
 
 def test_plugin_config_unknown_key_warns(fake_entry_points, write_config):
     fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
-    write_config("PLUGINS = {'demo'}\nDEMO_BOGUS = 'x'\n")
-    with pytest.warns(UserWarning, match='DEMO_BOGUS'):
+    write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_BOGUS = 'x'\n")
+    with pytest.warns(UserWarning, match='PLUGIN_DEMO_BOGUS'):
         data = load_config()
-    assert 'DEMO_BOGUS' not in data
+    assert 'PLUGIN_DEMO_BOGUS' not in data
 
 
 def test_only_defaults_with_plugin_override_carries_keys(fake_entry_points):
@@ -80,47 +80,45 @@ def test_only_defaults_with_plugin_override_carries_keys(fake_entry_points):
     data = load_config(only_defaults=True, override={
         'BASE_URL': 'https://example.test',
         'PLUGINS': {'demo'},
-        'DEMO_API_KEY': 'x',
+        'PLUGIN_DEMO_API_KEY': 'x',
     })
-    assert data['DEMO_API_KEY'] == 'x'
+    assert data['PLUGIN_DEMO_API_KEY'] == 'x'
 
 
-def test_plugin_config_collision_with_core_key_warns_and_is_ignored(fake_entry_points, write_config):
-    # Plugin 'external' declaring 'REGISTRATION_URL' would shadow the core EXTERNAL_REGISTRATION_URL
-    # default. The user's indico.conf does not set this key, so the plugin default would otherwise win.
-    fake_entry_points['external'] = _FakeEntryPoint(
-        'external', _make_plugin({'REGISTRATION_URL': 'plugin-default'}))
-    write_config("PLUGINS = {'external'}\n")
-    with pytest.warns(UserWarning, match='EXTERNAL_REGISTRATION_URL'):
+def test_plugin_config_collision_with_core_key_warns_and_is_ignored(fake_entry_points, write_config, monkeypatch):
+    # Inject a fake PLUGIN_* core default to exercise the safety branch (no real core key uses the
+    # PLUGIN_ prefix, but the check stays as defense-in-depth against future drift).
+    monkeypatch.setitem(config_module.DEFAULTS, 'PLUGIN_DEMO_API_KEY', 'core-default')
+    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': 'plugin-default'}))
+    write_config("PLUGINS = {'demo'}\n")
+    with pytest.warns(UserWarning, match='PLUGIN_DEMO_API_KEY'):
         data = load_config()
-    # Core default wins; the plugin's value is dropped.
-    assert data['EXTERNAL_REGISTRATION_URL'] is None
+    assert data['PLUGIN_DEMO_API_KEY'] == 'core-default'
 
 
-def test_plugin_config_collision_between_plugins_warns_and_latter_wins(fake_entry_points, write_config):
-    # Plugin 'a' declaring 'B_C' and plugin 'a_b' declaring 'C' both resolve to A_B_C.
+def test_plugin_config_collision_between_plugins_raises(fake_entry_points, write_config):
+    # Plugin 'a' declaring 'B_C' and plugin 'a_b' declaring 'C' both resolve to PLUGIN_A_B_C.
     fake_entry_points['a'] = _FakeEntryPoint('a', _make_plugin({'B_C': 'first'}))
     fake_entry_points['a_b'] = _FakeEntryPoint('a_b', _make_plugin({'C': 'second'}))
     write_config("PLUGINS = {'a', 'a_b'}\n")
-    with pytest.warns(UserWarning, match='A_B_C'):
-        data = load_config()
-    assert data['A_B_C'] == 'second'
+    with pytest.raises(RuntimeError, match='PLUGIN_A_B_C'):
+        load_config()
 
 
 def test_indico_conf_override_env_passes_plugin_key(fake_entry_points, write_config, monkeypatch):
     fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
     write_config("PLUGINS = {'demo'}\n")
-    monkeypatch.setenv('INDICO_CONF_OVERRIDE', "{'DEMO_API_KEY': 'fromenv'}")
+    monkeypatch.setenv('INDICO_CONF_OVERRIDE', "{'PLUGIN_DEMO_API_KEY': 'fromenv'}")
     data = load_config()
-    assert data['DEMO_API_KEY'] == 'fromenv'
+    assert data['PLUGIN_DEMO_API_KEY'] == 'fromenv'
 
 
 def test_indico_conf_override_env_can_enable_plugin_and_pass_plugin_key(fake_entry_points, write_config, monkeypatch):
     fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
     write_config('PLUGINS = set()\n')
-    monkeypatch.setenv('INDICO_CONF_OVERRIDE', "{'PLUGINS': {'demo'}, 'DEMO_API_KEY': 'fromenv'}")
+    monkeypatch.setenv('INDICO_CONF_OVERRIDE', "{'PLUGINS': {'demo'}, 'PLUGIN_DEMO_API_KEY': 'fromenv'}")
     data = load_config()
-    assert data['DEMO_API_KEY'] == 'fromenv'
+    assert data['PLUGIN_DEMO_API_KEY'] == 'fromenv'
 
 
 def test_missing_entry_point_graceful(fake_entry_points, write_config):

--- a/indico/core/config_test.py
+++ b/indico/core/config_test.py
@@ -115,6 +115,14 @@ def test_indico_conf_override_env_passes_plugin_key(fake_entry_points, write_con
     assert data['DEMO_API_KEY'] == 'fromenv'
 
 
+def test_indico_conf_override_env_can_enable_plugin_and_pass_plugin_key(fake_entry_points, write_config, monkeypatch):
+    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
+    write_config('PLUGINS = set()\n')
+    monkeypatch.setenv('INDICO_CONF_OVERRIDE', "{'PLUGINS': {'demo'}, 'DEMO_API_KEY': 'fromenv'}")
+    data = load_config()
+    assert data['DEMO_API_KEY'] == 'fromenv'
+
+
 def test_missing_entry_point_graceful(fake_entry_points, write_config):
     # 'ghost' has no registered entry-point; should not crash, key absent from result.
     write_config("PLUGINS = {'ghost'}\n")

--- a/indico/core/config_test.py
+++ b/indico/core/config_test.py
@@ -8,29 +8,13 @@
 import pytest
 
 from indico.core import config as config_module
-from indico.core.config import load_config
+from indico.core.config import IndicoConfig, load_config
 
 
-class _FakeEntryPoint:
-    def __init__(self, name, plugin_class):
+class _FakePlugin:
+    def __init__(self, name, defaults):
         self.name = name
-        self._plugin_class = plugin_class
-
-    def load(self):
-        return self._plugin_class
-
-
-@pytest.fixture
-def fake_entry_points(monkeypatch):
-    eps = {}
-
-    def _entry_points(*, group):
-        if group != 'indico.plugins':
-            return []
-        return list(eps.values())
-
-    monkeypatch.setattr(config_module, 'entry_points', _entry_points)
-    return eps
+        self.plugin_config_defaults = defaults
 
 
 @pytest.fixture
@@ -45,87 +29,112 @@ def write_config(tmp_path, monkeypatch):
     return _write
 
 
-def _make_plugin(defaults):
-    class Plugin:
-        plugin_config_defaults = defaults
-    return Plugin
+def _pending(data):
+    return data['PLUGIN_CONFIG']['pending']
 
 
-def test_plugin_config_default_loaded(fake_entry_points, write_config):
-    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None, 'TIMEOUT': 30}))
+def _resolved(data):
+    return data['PLUGIN_CONFIG']['resolved']
+
+
+def test_plugin_keys_are_deferred_not_top_level(write_config, recwarn):
+    write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_API_KEY = 'secret'\n")
+    data = load_config()
+    # Plugin keys are held aside without importing the plugin and without a warning.
+    assert 'PLUGIN_DEMO_API_KEY' not in data
+    assert _pending(data) == {'PLUGIN_DEMO_API_KEY': 'secret'}
+    assert _resolved(data) == {}
+    assert not any('PLUGIN_DEMO_API_KEY' in str(w.message) for w in recwarn.list)
+
+
+def test_register_plugin_config_resolves_value_and_default(write_config):
+    write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_API_KEY = 'secret'\n")
+    cfg = IndicoConfig(load_config())
+    cfg.register_plugin_config(_FakePlugin('demo', {'API_KEY': None, 'TIMEOUT': 30}))
+    assert _resolved(cfg.data) == {'PLUGIN_DEMO_API_KEY': 'secret', 'PLUGIN_DEMO_TIMEOUT': 30}
+    # Claimed keys are consumed from the pending set.
+    assert _pending(cfg.data) == {}
+
+
+def test_register_plugin_config_applies_default_when_absent(write_config):
     write_config("PLUGINS = {'demo'}\n")
+    cfg = IndicoConfig(load_config())
+    cfg.register_plugin_config(_FakePlugin('demo', {'TIMEOUT': 30}))
+    assert _resolved(cfg.data)['PLUGIN_DEMO_TIMEOUT'] == 30
+
+
+def test_plugin_key_precedence_override_wins(write_config):
+    write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_API_KEY = 'fromfile'\n")
+    data = load_config(override={'PLUGIN_DEMO_API_KEY': 'fromoverride'})
+    assert _pending(data)['PLUGIN_DEMO_API_KEY'] == 'fromoverride'
+
+
+def test_env_override_carries_plugin_key(write_config, monkeypatch):
+    write_config("PLUGINS = {'demo'}\n")
+    monkeypatch.setenv('INDICO_CONF_OVERRIDE', "{'PLUGIN_DEMO_API_KEY': 'fromenv'}")
     data = load_config()
-    assert data['PLUGIN_DEMO_API_KEY'] is None
-    assert data['PLUGIN_DEMO_TIMEOUT'] == 30
+    assert _pending(data)['PLUGIN_DEMO_API_KEY'] == 'fromenv'
 
 
-def test_plugin_config_user_value_overrides_default(fake_entry_points, write_config):
-    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None, 'TIMEOUT': 30}))
-    write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_API_KEY = 'secret'\nPLUGIN_DEMO_TIMEOUT = 5\n")
-    data = load_config()
-    assert data['PLUGIN_DEMO_API_KEY'] == 'secret'
-    assert data['PLUGIN_DEMO_TIMEOUT'] == 5
-
-
-def test_plugin_config_unknown_key_warns(fake_entry_points, write_config):
-    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
-    write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_BOGUS = 'x'\n")
-    with pytest.warns(UserWarning, match='PLUGIN_DEMO_BOGUS'):
-        data = load_config()
-    assert 'PLUGIN_DEMO_BOGUS' not in data
-
-
-def test_only_defaults_with_plugin_override_carries_keys(fake_entry_points):
-    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
+def test_only_defaults_override_carries_plugin_key():
     data = load_config(only_defaults=True, override={
         'BASE_URL': 'https://example.test',
         'PLUGINS': {'demo'},
         'PLUGIN_DEMO_API_KEY': 'x',
     })
-    assert data['PLUGIN_DEMO_API_KEY'] == 'x'
+    assert _pending(data) == {'PLUGIN_DEMO_API_KEY': 'x'}
+    assert _resolved(data) == {}
 
 
-def test_plugin_config_collision_with_core_key_warns_and_is_ignored(fake_entry_points, write_config, monkeypatch):
+def test_unknown_non_plugin_key_warns_at_load(write_config):
+    write_config('TOTALLY_BOGUS = 1\n')
+    with pytest.warns(UserWarning, match='TOTALLY_BOGUS'):
+        data = load_config()
+    assert 'TOTALLY_BOGUS' not in data
+
+
+def test_unclaimed_plugin_key_warns(write_config):
+    write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_BOGUS = 'x'\n")
+    data = load_config()
+    with pytest.warns(UserWarning, match='PLUGIN_DEMO_BOGUS'):
+        config_module._warn_unclaimed_plugin_config(data)
+
+
+def test_claimed_plugin_key_not_warned(write_config, recwarn):
+    write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_API_KEY = 'secret'\n")
+    cfg = IndicoConfig(load_config())
+    cfg.register_plugin_config(_FakePlugin('demo', {'API_KEY': None}))
+    config_module._warn_unclaimed_plugin_config(cfg.data)
+    assert not any('PLUGIN_DEMO_API_KEY' in str(w.message) for w in recwarn.list)
+
+
+def test_register_core_collision_warns_and_is_ignored(write_config, monkeypatch):
     # Inject a fake PLUGIN_* core default to exercise the safety branch (no real core key uses the
     # PLUGIN_ prefix, but the check stays as defense-in-depth against future drift).
     monkeypatch.setitem(config_module.DEFAULTS, 'PLUGIN_DEMO_API_KEY', 'core-default')
-    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': 'plugin-default'}))
     write_config("PLUGINS = {'demo'}\n")
+    cfg = IndicoConfig(load_config())
     with pytest.warns(UserWarning, match='PLUGIN_DEMO_API_KEY'):
-        data = load_config()
-    assert data['PLUGIN_DEMO_API_KEY'] == 'core-default'
+        cfg.register_plugin_config(_FakePlugin('demo', {'API_KEY': 'plugin-default'}))
+    assert 'PLUGIN_DEMO_API_KEY' not in _resolved(cfg.data)
 
 
-def test_plugin_config_collision_between_plugins_raises(fake_entry_points, write_config):
+def test_register_cross_plugin_collision_raises(write_config):
     # Plugin 'a' declaring 'B_C' and plugin 'a_b' declaring 'C' both resolve to PLUGIN_A_B_C.
-    fake_entry_points['a'] = _FakeEntryPoint('a', _make_plugin({'B_C': 'first'}))
-    fake_entry_points['a_b'] = _FakeEntryPoint('a_b', _make_plugin({'C': 'second'}))
     write_config("PLUGINS = {'a', 'a_b'}\n")
+    cfg = IndicoConfig(load_config())
+    cfg.register_plugin_config(_FakePlugin('a', {'B_C': 'first'}))
     with pytest.raises(RuntimeError, match='PLUGIN_A_B_C'):
-        load_config()
+        cfg.register_plugin_config(_FakePlugin('a_b', {'C': 'second'}))
 
 
-def test_indico_conf_override_env_passes_plugin_key(fake_entry_points, write_config, monkeypatch):
-    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
-    write_config("PLUGINS = {'demo'}\n")
-    monkeypatch.setenv('INDICO_CONF_OVERRIDE', "{'PLUGIN_DEMO_API_KEY': 'fromenv'}")
-    data = load_config()
-    assert data['PLUGIN_DEMO_API_KEY'] == 'fromenv'
-
-
-def test_indico_conf_override_env_can_enable_plugin_and_pass_plugin_key(fake_entry_points, write_config, monkeypatch):
-    fake_entry_points['demo'] = _FakeEntryPoint('demo', _make_plugin({'API_KEY': None}))
-    write_config('PLUGINS = set()\n')
-    monkeypatch.setenv('INDICO_CONF_OVERRIDE', "{'PLUGINS': {'demo'}, 'PLUGIN_DEMO_API_KEY': 'fromenv'}")
-    data = load_config()
-    assert data['PLUGIN_DEMO_API_KEY'] == 'fromenv'
-
-
-def test_missing_entry_point_graceful(fake_entry_points, write_config):
-    # 'ghost' has no registered entry-point; should not crash, key absent from result.
-    write_config("PLUGINS = {'ghost'}\n")
-    data = load_config()
-    assert 'GHOST_ANYTHING' not in data
+def test_plugin_config_proxy_reads_resolved(write_config):
+    from indico.core.plugins import PluginConfigProxy
+    write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_API_KEY = 'secret'\n")
+    cfg = IndicoConfig(load_config())
+    cfg.register_plugin_config(_FakePlugin('demo', {'API_KEY': None}))
+    proxy = PluginConfigProxy(cfg, 'PLUGIN_DEMO')
+    assert proxy.API_KEY == 'secret'
 
 
 def test_plugin_config_proxy_reads_prefixed():

--- a/indico/core/config_test.py
+++ b/indico/core/config_test.py
@@ -95,16 +95,16 @@ def test_unknown_non_plugin_key_warns_at_load(write_config):
 
 def test_unclaimed_plugin_key_warns(write_config):
     write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_BOGUS = 'x'\n")
-    data = load_config()
+    cfg = IndicoConfig(load_config())
     with pytest.warns(UserWarning, match='PLUGIN_DEMO_BOGUS'):
-        config_module._warn_unclaimed_plugin_config(data)
+        cfg.validate()
 
 
 def test_claimed_plugin_key_not_warned(write_config, recwarn):
     write_config("PLUGINS = {'demo'}\nPLUGIN_DEMO_API_KEY = 'secret'\n")
     cfg = IndicoConfig(load_config())
     cfg.register_plugin_config(_FakePlugin('demo', {'API_KEY': None}))
-    config_module._warn_unclaimed_plugin_config(cfg.data)
+    cfg.validate()
     assert not any('PLUGIN_DEMO_API_KEY' in str(w.message) for w in recwarn.list)
 
 

--- a/indico/core/config_test.py
+++ b/indico/core/config_test.py
@@ -141,10 +141,10 @@ def test_plugin_config_proxy_reads_prefixed():
     from indico.core.plugins import PluginConfigProxy
 
     class FakeConfig:
-        UN_MFA_ENABLED = True
-        UN_TIMEOUT = 5
+        FOO_MFA_ENABLED = True
+        FOO_TIMEOUT = 5
 
-    proxy = PluginConfigProxy(FakeConfig(), prefix='UN')
+    proxy = PluginConfigProxy(FakeConfig(), prefix='FOO')
     assert proxy.MFA_ENABLED is True
     assert proxy.TIMEOUT == 5
 
@@ -155,6 +155,6 @@ def test_plugin_config_proxy_missing_attr_raises():
     class FakeConfig:
         pass
 
-    proxy = PluginConfigProxy(FakeConfig(), prefix='UN')
+    proxy = PluginConfigProxy(FakeConfig(), prefix='FOO')
     with pytest.raises(AttributeError):
         proxy.NOPE  # noqa: B018

--- a/indico/core/plugins/__init__.py
+++ b/indico/core/plugins/__init__.py
@@ -68,6 +68,10 @@ class IndicoPlugin(Plugin):
     settings_form: IndicoForm | None = None
     #: A dictionary which can contain the kwargs for a specific field in the `settings_form`.
     settings_form_field_opts = {}
+    #: A dictionary of file-backed config defaults exposed via ``indico.conf``.
+    #: Keys are unprefixed (e.g. ``API_KEY``); the full key in the global config
+    #: is ``{PLUGIN_NAME_UPPER}_{KEY}`` (e.g. ``DEMO_API_KEY`` for plugin ``demo``).
+    plugin_config_defaults = {}
     #: A dictionary containing default values for settings
     default_settings = {}
     #: A dictionary containing default values for event-specific settings
@@ -142,6 +146,15 @@ class IndicoPlugin(Plugin):
     def get_vars_js(self):
         """Return a dictionary with variables to be added to vars.js file."""
         return None
+
+    @property
+    def plugin_config(self):
+        """Read-only proxy over file-backed config scoped to this plugin.
+
+        ``self.plugin_config.API_KEY`` reads ``config.<NAME>_API_KEY``.
+        """
+        from indico.core.config import config
+        return PluginConfigProxy(config, self.name.upper())
 
     @cached_property
     def translation_path(self):
@@ -280,6 +293,26 @@ def get_plugin_template_module(template_name, **context):
     """Like :func:`~indico.web.flask.templating.get_template_module`, but using plugin templates."""
     template_name = f'{current_plugin.name}:{template_name}'
     return get_template_module(template_name, **context)
+
+
+class PluginConfigProxy:
+    """Read-only view over the global config scoped to a plugin's prefix.
+
+    Allows ``plugin.plugin_config.API_KEY`` to read ``config.<PREFIX>_API_KEY``.
+    """
+
+    __slots__ = ('_config', '_prefix')
+
+    def __init__(self, config, prefix):
+        object.__setattr__(self, '_config', config)
+        object.__setattr__(self, '_prefix', prefix)
+
+    def __getattr__(self, name):
+        full = f'{self._prefix}_{name}'
+        try:
+            return getattr(self._config, full)
+        except AttributeError:
+            raise AttributeError(f'no such plugin config key: {name}')
 
 
 class IndicoPluginEngine(PluginEngine):

--- a/indico/core/plugins/__init__.py
+++ b/indico/core/plugins/__init__.py
@@ -70,7 +70,8 @@ class IndicoPlugin(Plugin):
     settings_form_field_opts = {}
     #: A dictionary of file-backed config defaults exposed via ``indico.conf``.
     #: Keys are unprefixed (e.g. ``API_KEY``); the full key in the global config
-    #: is ``{PLUGIN_NAME_UPPER}_{KEY}`` (e.g. ``DEMO_API_KEY`` for plugin ``demo``).
+    #: is ``PLUGIN_{PLUGIN_NAME_UPPER}_{KEY}`` (e.g. ``PLUGIN_DEMO_API_KEY`` for
+    #: plugin ``demo``).
     plugin_config_defaults = {}
     #: A dictionary containing default values for settings
     default_settings = {}
@@ -151,10 +152,10 @@ class IndicoPlugin(Plugin):
     def plugin_config(self):
         """Read-only proxy over file-backed config scoped to this plugin.
 
-        ``self.plugin_config.API_KEY`` reads ``config.<NAME>_API_KEY``.
+        ``self.plugin_config.API_KEY`` reads ``config.PLUGIN_<NAME>_API_KEY``.
         """
         from indico.core.config import config
-        return PluginConfigProxy(config, self.name.upper())
+        return PluginConfigProxy(config, f'PLUGIN_{self.name.upper()}')
 
     @cached_property
     def translation_path(self):
@@ -298,7 +299,7 @@ def get_plugin_template_module(template_name, **context):
 class PluginConfigProxy:
     """Read-only view over the global config scoped to a plugin's prefix.
 
-    Allows ``plugin.plugin_config.API_KEY`` to read ``config.<PREFIX>_API_KEY``.
+    Allows ``plugin.plugin_config.API_KEY`` to read ``config.PLUGIN_<NAME>_API_KEY``.
     """
 
     __slots__ = ('_config', '_prefix')

--- a/indico/core/plugins/__init__.py
+++ b/indico/core/plugins/__init__.py
@@ -156,8 +156,8 @@ class IndicoPlugin(Plugin):
 
         ``self.plugin_config.API_KEY`` reads ``config.PLUGIN_<NAME>_API_KEY``.
         """
-        from indico.core.config import config
-        return PluginConfigProxy(config, f'PLUGIN_{self.name.upper()}')
+        from indico.core.config import PLUGIN_CONFIG_PREFIX, config
+        return PluginConfigProxy(config, f'{PLUGIN_CONFIG_PREFIX}{self.name.upper()}')
 
     @cached_property
     def translation_path(self):

--- a/indico/core/plugins/__init__.py
+++ b/indico/core/plugins/__init__.py
@@ -109,6 +109,8 @@ class IndicoPlugin(Plugin):
         called anymore.
         """
         assert self.configurable or not self.settings_form, 'Non-configurable plugin cannot have a settings form'
+        from indico.core.config import config
+        config.register_plugin_config(self)
         self.alembic_versions_path = Path(self.root_path) / 'migrations'
         self.connect(signals.plugin.get_blueprints, lambda app: self.get_blueprints())
         self.template_hook('vars-js', self.inject_vars_js)

--- a/indico/core/plugins/__init__.py
+++ b/indico/core/plugins/__init__.py
@@ -150,14 +150,15 @@ class IndicoPlugin(Plugin):
         """Return a dictionary with variables to be added to vars.js file."""
         return None
 
-    @property
-    def plugin_config(self):
+    @cached_classproperty
+    @classmethod
+    def plugin_config(cls):
         """Read-only proxy over file-backed config scoped to this plugin.
 
-        ``self.plugin_config.API_KEY`` reads ``config.PLUGIN_<NAME>_API_KEY``.
+        ``cls.plugin_config.API_KEY`` reads ``config.PLUGIN_<NAME>_API_KEY``.
         """
         from indico.core.config import PLUGIN_CONFIG_PREFIX, config
-        return PluginConfigProxy(config, f'{PLUGIN_CONFIG_PREFIX}{self.name.upper()}')
+        return PluginConfigProxy(config, f'{PLUGIN_CONFIG_PREFIX}{cls.name.upper()}')
 
     @cached_property
     def translation_path(self):


### PR DESCRIPTION
This PR adds a way for plugins to declare file-backed config keys that live in `indico.conf` alongside core settings, complementing the existing DB-backed `wtform` plugin settings.

## Motivation

Some plugins need configuration values that don't fit the DB/admin-UI flow:

- credentials managed by infrastructure tooling (Kubernetes secrets, env vars, deploy-time injection),
- values that must never be editable at runtime,
- values that must be rotated programmatically without DB writes.

Today, plugins addressing this re-implement the same logic locally: parse a side-car config file, apply defaults, sanitize, optionally read env vars. This PR moves that mechanism to core so plugins stop reinventing it.

The DB-backed plugin settings model is untouched and remains the default. This change is strictly additive.

## Usage

A plugin declares its file-backed config keys via the `plugin_config_defaults` class attribute. Keys are unprefixed in the plugin and exposed in `indico.conf` with the plugin's entry-point name uppercased as a prefix:

```python
class MyPlugin(IndicoPlugin):
    plugin_config_defaults = {
        'API_KEY': None,
        'API_SECRET': None,
        'TIMEOUT': 30,
    }
```

In `indico.conf`:

```python
PLUGINS = {'myplugin'}
MYPLUGIN_API_KEY = 'xxxxxxxx'
MYPLUGIN_API_SECRET = 'yyyyyyyy'
```

Plugin code reads them via the `plugin_config` proxy on the plugin instance, which strips the prefix:

```python
self.plugin_config.API_KEY  # reads MYPLUGIN_API_KEY
```

## Behaviour

Plugin keys participate in the same machinery as core settings:

- Defaults declared in the plugin are applied if the key is omitted in `indico.conf`.
- Unknown plugin-prefixed keys emit the same "Ignoring unknown config key" warning as for core keys.
- `INDICO_CONF_OVERRIDE` and the `override` parameter of `load_config()` propagate plugin keys, including in the `only_defaults=True` path used by tests. Both can also add entries to `PLUGINS`; declared config keys for those plugins are discovered the same way.
- If a plugin declares a key that collides with a core config key, the plugin default is ignored and a warning is emitted; the core default stays authoritative.
- If two plugins declare the same prefixed key, a warning is emitted and the latter declaration wins.
- If a plugin listed in `PLUGINS` is missing as an entry-point, defaults loading skips it silently; the regular plugin loader continues to surface the underlying error.

## Migration

This PR does not change any existing plugin. However, plugins are expected to migrate, on a per-setting basis, any infra-grade values (credentials, secrets, fixed external endpoints) from `default_settings` to `plugin_config_defaults`. Settings that are per-event or per-user scoped, use ACLs, custom converters, or wtform validation should remain on the DB-backed path. Migration of existing plugins is intended as follow-up work and is not part of this PR.
