### PR TITLE
Fix Registrant List Export features for plugin-custom columns

### DIFF
--- a/indico/legacy/pdfinterface/conference.py
+++ b/indico/legacy/pdfinterface/conference.py
@@ -133,11 +133,12 @@ class ProgrammeToPDF(PDFBase):
 
 
 class RegistrantToPDF(PDFBase):
-    def __init__(self, event, reg, display, doc=None, story=None, static_items=None):
+    def __init__(self, event, reg, display, doc=None, story=None, static_items=None, extra_columns=None):
         self.event = event
         self._reg = reg
         self._display = display
         self.static_items = static_items
+        self.extra_columns = [col for col in (extra_columns or []) if not col.filter_only]
         if not story:
             story = [Spacer(inch, 5*cm)]
         PDFBase.__init__(self, doc, story)
@@ -255,17 +256,25 @@ class RegistrantToPDF(PDFBase):
                 value = data[item.id].friendly_data if item.id in data else ''
                 _print_row(item.title, value)
 
+        if self.extra_columns:
+            _print_section(_('Additional information'))
+            for col in self.extra_columns:
+                col_data = col.data.get(self._reg)
+                if col_data and col_data.text_value:
+                    _print_row(col.title, col_data.text_value)
+
         return story
 
 
 class RegistrantsListToBookPDF(PDFWithTOC):
-    def __init__(self, event, regform, reglist, item_ids, static_item_ids):
+    def __init__(self, event, regform, reglist, item_ids, static_item_ids, extra_columns=None):
         self.event = event
         self._regform = regform
         self._regList = reglist
         self._item_ids = set(item_ids)
         self._title = _('Registrants Book')
         self._static_item_ids = static_item_ids
+        self._extra_columns = [col for col in (extra_columns or []) if not col.filter_only]
         PDFWithTOC.__init__(self)
 
     def firstPage(self, c, doc):
@@ -307,13 +316,14 @@ class RegistrantsListToBookPDF(PDFWithTOC):
             items.append(section)
             items += fields
         for reg in self._regList:
-            temp = RegistrantToPDF(self.event, reg, items, static_items=self._static_item_ids)
+            temp = RegistrantToPDF(self.event, reg, items, static_items=self._static_item_ids,
+                                   extra_columns=self._extra_columns)
             temp.getBody(self._story, indexedFlowable=self._indexedFlowable, level=1)
             self._story.append(PageBreak())
 
 
 class RegistrantsListToPDF(PDFBase):
-    def __init__(self, event, doc=None, story=None, reglist=None, display=None, static_items=None):
+    def __init__(self, event, doc=None, story=None, reglist=None, display=None, static_items=None, extra_columns=None):
         if display is None:
             display = []
         if story is None:
@@ -326,6 +336,7 @@ class RegistrantsListToPDF(PDFBase):
         self._PAGE_HEIGHT = landscape(A4)[1]
         self._PAGE_WIDTH = landscape(A4)[0]
         self.static_items = static_items
+        self.extra_columns = [col for col in (extra_columns or []) if not col.filter_only]
 
     def firstPage(self, c, doc):
         c.saveState()
@@ -400,6 +411,8 @@ class RegistrantsListToPDF(PDFBase):
             lp.append(Paragraph('<b>{}</b>'.format(_('Check-in date')), text_format))
         if 'tags_present' in self.static_items:
             lp.append(Paragraph('<b>{}</b>'.format(_('Tags')), text_format))
+        # Add plugin-custom columns
+        lp.extend([Paragraph(f'<b>{escape(col.title)}</b>', text_format) for col in self.extra_columns])
         l.append(lp)
 
         for registration in self._regList:
@@ -454,8 +467,12 @@ class RegistrantsListToPDF(PDFBase):
             if 'tags_present' in self.static_items:
                 tags = ', '.join(sorted(t.title for t in registration.tags))
                 lp.append(Paragraph(escape(tags), text_format))
+            for col in self.extra_columns:
+                col_data = col.data.get(registration)
+                lp.append(Paragraph(escape(col_data.text_value if col_data else ''), text_format))
             l.append(lp)
-        noneList = (None,) * (len(self._display) + len(self.static_items) + (accommodation_col_counter * 2) + 2)
+        noneList = (None,) * (len(self._display) + len(self.static_items)
+                              + (accommodation_col_counter * 2) + len(self.extra_columns) + 2)
         t = Table(l, colWidths=noneList, style=tsRegs)
         self._story.append(t)
         return story

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -497,6 +497,8 @@ class RHRegistrationsExportBase(RHRegistrationsActionBase):
     def _process_args(self):
         RHRegistrationsActionBase._process_args(self)
         self.export_config = self.list_generator.get_list_export_config()
+        for col in self.export_config['extra_columns']:
+            col.data = col.load_data(self.registrations)
 
 
 class RHRegistrationsExportPDFTable(RHRegistrationsExportBase):
@@ -504,7 +506,8 @@ class RHRegistrationsExportPDFTable(RHRegistrationsExportBase):
 
     def _process(self):
         pdf = RegistrantsListToPDF(self.event, reglist=self.registrations, display=self.export_config['regform_items'],
-                                   static_items=self.export_config['static_item_ids'])
+                                   static_items=self.export_config['static_item_ids'],
+                                   extra_columns=self.export_config['extra_columns'])
         try:
             data = pdf.getPDFBin()
         except Exception:
@@ -520,7 +523,8 @@ class RHRegistrationsExportPDFBook(RHRegistrationsExportBase):
 
     def _process(self):
         static_item_ids, item_ids, _extra_item_ids = self.list_generator.get_item_ids()
-        pdf = RegistrantsListToBookPDF(self.event, self.regform, self.registrations, item_ids, static_item_ids)
+        pdf = RegistrantsListToBookPDF(self.event, self.regform, self.registrations, item_ids, static_item_ids,
+                                       extra_columns=self.export_config['extra_columns'])
         return send_file('RegistrantsBook.pdf', BytesIO(pdf.getPDFBin()), 'application/pdf')
 
 
@@ -529,7 +533,8 @@ class RHRegistrationsExportCSV(RHRegistrationsExportBase):
 
     def _process(self):
         headers, rows = generate_spreadsheet_from_registrations(self.registrations, self.export_config['regform_items'],
-                                                                self.export_config['static_item_ids'])
+                                                                self.export_config['static_item_ids'],
+                                                                extra_columns=self.export_config['extra_columns'])
         return send_csv('registrations.csv', headers, rows)
 
 
@@ -538,7 +543,8 @@ class RHRegistrationsExportExcel(RHRegistrationsExportBase):
 
     def _process(self):
         headers, rows = generate_spreadsheet_from_registrations(self.registrations, self.export_config['regform_items'],
-                                                                self.export_config['static_item_ids'])
+                                                                self.export_config['static_item_ids'],
+                                                                extra_columns=self.export_config['extra_columns'])
         column_formats = get_registration_spreadsheet_column_formats(self.export_config['regform_items'])
         return send_xlsx('registrations.xlsx', headers, rows, tz=self.event.tzinfo, column_formats=column_formats)
 

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -277,10 +277,11 @@ class RegistrationListGenerator(ListGeneratorBase):
         }
 
     def get_list_export_config(self):
-        static_item_ids, item_ids, _extra_item_ids = self.get_item_ids()
+        static_item_ids, item_ids, extra_item_ids = self.get_item_ids()
         return {
             'static_item_ids': static_item_ids,
-            'regform_items': self._get_sorted_regform_items(item_ids)
+            'regform_items': self._get_sorted_regform_items(item_ids),
+            'extra_columns': self._get_extra_columns(extra_item_ids),
         }
 
     def get_item_ids(self):

--- a/indico/modules/events/registration/lists_test.py
+++ b/indico/modules/events/registration/lists_test.py
@@ -1,0 +1,94 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2026 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+from flask import session
+
+from indico.core import signals
+from indico.modules.events.registration.custom import CustomRegistrationListItem, RegistrationListColumn
+from indico.modules.events.registration.lists import RegistrationListGenerator
+
+
+pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
+
+
+class _TestColumn(CustomRegistrationListItem):
+    name = 'test_col'
+    title = 'Test Column'
+
+    def load_data(self, registrations):
+        return {reg: RegistrationListColumn(content='val', text_value='val') for reg in registrations}
+
+
+@pytest.fixture
+def _connected_column():
+    """Connect _TestColumn to the registrant_list_items signal for the duration of the test."""
+    def _handler(sender, **kwargs):
+        yield _TestColumn
+
+    signals.event.registrant_list_items.connect(_handler)
+    yield
+    signals.event.registrant_list_items.disconnect(_handler)
+
+
+def test_get_list_export_config_always_has_extra_columns_key(dummy_regform, app_context):
+    """get_list_export_config must always return the extra_columns key, even when empty."""
+    with app_context.test_request_context():
+        gen = RegistrationListGenerator(regform=dummy_regform)
+        config = gen.get_list_export_config()
+
+    assert 'extra_columns' in config
+    assert isinstance(config['extra_columns'], list)
+
+
+@pytest.mark.usefixtures('_connected_column')
+def test_get_list_export_config_includes_selected_extra_column(dummy_regform, app_context):
+    """A custom column that the user has enabled appears in get_list_export_config.
+
+    This is the regression test for the bug where extra_item_ids were silently
+    discarded in get_list_export_config(), causing signal-added columns to be
+    missing from all export formats (CSV, Excel, PDF) even when selected.
+    """
+    with app_context.test_request_context():
+        # Simulate the user having enabled ext__test_col in the column chooser.
+        # The config must be set BEFORE constructing the generator because
+        # _get_config() is called in __init__.
+        session[f'registration_config_{dummy_regform.id}'] = {
+            'items': ['ext__test_col', 'state'],
+            'filters': {'fields': {}, 'items': {}, 'extra': {}},
+        }
+        gen = RegistrationListGenerator(regform=dummy_regform)
+        config = gen.get_list_export_config()
+
+    assert len(config['extra_columns']) == 1
+    assert config['extra_columns'][0].title == 'Test Column'
+
+
+@pytest.mark.usefixtures('_connected_column')
+def test_get_list_export_config_excludes_filter_only_column(dummy_regform, app_context):
+    """filter_only columns must not appear in extra_columns even when selected."""
+    class _FilterOnlyColumn(_TestColumn):
+        name = 'filter_col'
+        title = 'Filter Only'
+        filter_only = True
+
+    def _handler(sender, **kwargs):
+        yield _FilterOnlyColumn
+
+    signals.event.registrant_list_items.connect(_handler)
+    try:
+        with app_context.test_request_context():
+            session[f'registration_config_{dummy_regform.id}'] = {
+                'items': ['ext__filter_col'],
+                'filters': {'fields': {}, 'items': {}, 'extra': {}},
+            }
+            gen = RegistrationListGenerator(regform=dummy_regform)
+            config = gen.get_list_export_config()
+    finally:
+        signals.event.registrant_list_items.disconnect(_handler)
+
+    assert config['extra_columns'] == []

--- a/indico/modules/events/registration/lists_test.py
+++ b/indico/modules/events/registration/lists_test.py
@@ -25,14 +25,13 @@ class _TestColumn(CustomRegistrationListItem):
 
 
 @pytest.fixture
-def _connected_column():
+def connected_column():
     """Connect _TestColumn to the registrant_list_items signal for the duration of the test."""
     def _handler(sender, **kwargs):
         yield _TestColumn
 
-    signals.event.registrant_list_items.connect(_handler)
-    yield
-    signals.event.registrant_list_items.disconnect(_handler)
+    with signals.event.registrant_list_items.connected_to(_handler):
+        yield
 
 
 def test_get_list_export_config_always_has_extra_columns_key(dummy_regform, app_context):
@@ -45,7 +44,7 @@ def test_get_list_export_config_always_has_extra_columns_key(dummy_regform, app_
     assert isinstance(config['extra_columns'], list)
 
 
-@pytest.mark.usefixtures('_connected_column')
+@pytest.mark.usefixtures('connected_column')
 def test_get_list_export_config_includes_selected_extra_column(dummy_regform, app_context):
     """A custom column that the user has enabled appears in get_list_export_config.
 
@@ -68,7 +67,7 @@ def test_get_list_export_config_includes_selected_extra_column(dummy_regform, ap
     assert config['extra_columns'][0].title == 'Test Column'
 
 
-@pytest.mark.usefixtures('_connected_column')
+@pytest.mark.usefixtures('connected_column')
 def test_get_list_export_config_excludes_filter_only_column(dummy_regform, app_context):
     """filter_only columns must not appear in extra_columns even when selected."""
     class _FilterOnlyColumn(_TestColumn):
@@ -79,8 +78,7 @@ def test_get_list_export_config_excludes_filter_only_column(dummy_regform, app_c
     def _handler(sender, **kwargs):
         yield _FilterOnlyColumn
 
-    signals.event.registrant_list_items.connect(_handler)
-    try:
+    with signals.event.registrant_list_items.connected_to(_handler):
         with app_context.test_request_context():
             session[f'registration_config_{dummy_regform.id}'] = {
                 'items': ['ext__filter_col'],
@@ -88,7 +86,5 @@ def test_get_list_export_config_excludes_filter_only_column(dummy_regform, app_c
             }
             gen = RegistrationListGenerator(regform=dummy_regform)
             config = gen.get_list_export_config()
-    finally:
-        signals.event.registrant_list_items.disconnect(_handler)
 
     assert config['extra_columns'] == []

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -593,13 +593,13 @@ def get_registration_spreadsheet_column_formats(regform_items):
     }
 
 
-def generate_spreadsheet_from_registrations(registrations, regform_items, static_items, extra_columns=None):
+def generate_spreadsheet_from_registrations(registrations, regform_items, static_items, extra_columns):
     """Generate a spreadsheet data from a given registration list.
 
     :param registrations: The list of registrations to include in the file
     :param regform_items: The registration form items to be used as columns
     :param static_items: Registration form information as extra columns
-    :param extra_columns: Custom list items from the registrant_list_items signal
+    :param extra_columns: Custom list items from the `registrant_list_items` signal
     """
     field_names = ['ID', 'Name']
     special_item_mapping = {
@@ -621,8 +621,7 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
             field_names.append(unique_col('{} ({})'.format(item.title, 'Arrival'), item.id))
             field_names.append(unique_col('{} ({})'.format(item.title, 'Departure'), item.id))
     field_names.extend(title for name, (title, fn) in special_item_mapping.items() if name in static_items)
-    if extra_columns:
-        field_names.extend(col.title for col in extra_columns)
+    field_names.extend(col.title for col in extra_columns)
     rows = []
     for registration in registrations:
         data = registration.data_by_field
@@ -655,10 +654,9 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
                 continue
             value = fn(registration)
             registration_dict[title] = value
-        if extra_columns:
-            for col in extra_columns:
-                col_data = col.data.get(registration)
-                registration_dict[col.title] = col_data.text_value if col_data else ''
+        for col in extra_columns:
+            col_data = col.data.get(registration)
+            registration_dict[col.title] = col_data.text_value if col_data else ''
         rows.append(registration_dict)
     return field_names, rows
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -593,12 +593,13 @@ def get_registration_spreadsheet_column_formats(regform_items):
     }
 
 
-def generate_spreadsheet_from_registrations(registrations, regform_items, static_items):
+def generate_spreadsheet_from_registrations(registrations, regform_items, static_items, extra_columns=None):
     """Generate a spreadsheet data from a given registration list.
 
     :param registrations: The list of registrations to include in the file
     :param regform_items: The registration form items to be used as columns
     :param static_items: Registration form information as extra columns
+    :param extra_columns: Custom list items from the registrant_list_items signal
     """
     field_names = ['ID', 'Name']
     special_item_mapping = {
@@ -620,6 +621,8 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
             field_names.append(unique_col('{} ({})'.format(item.title, 'Arrival'), item.id))
             field_names.append(unique_col('{} ({})'.format(item.title, 'Departure'), item.id))
     field_names.extend(title for name, (title, fn) in special_item_mapping.items() if name in static_items)
+    if extra_columns:
+        field_names.extend(col.title for col in extra_columns)
     rows = []
     for registration in registrations:
         data = registration.data_by_field
@@ -652,6 +655,10 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
                 continue
             value = fn(registration)
             registration_dict[title] = value
+        if extra_columns:
+            for col in extra_columns:
+                col_data = col.data.get(registration)
+                registration_dict[col.title] = col_data.text_value if col_data else ''
         rows.append(registration_dict)
     return field_names, rows
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -593,7 +593,7 @@ def get_registration_spreadsheet_column_formats(regform_items):
     }
 
 
-def generate_spreadsheet_from_registrations(registrations, regform_items, static_items, extra_columns):
+def generate_spreadsheet_from_registrations(registrations, regform_items, static_items, extra_columns=()):
     """Generate a spreadsheet data from a given registration list.
 
     :param registrations: The list of registrations to include in the file

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -18,14 +18,16 @@ from indico.core.db import db
 from indico.core.errors import UserValueError
 from indico.modules.events.models.persons import EventPerson
 from indico.modules.events.registration.controllers.management.fields import _fill_form_field_with_data
+from indico.modules.events.registration.custom import RegistrationListColumn
 from indico.modules.events.registration.fields.simple import PROFILE_PICTURE_SENTINEL
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.invitations import RegistrationInvitation
 from indico.modules.events.registration.models.items import RegistrationFormItemType, RegistrationFormSection
 from indico.modules.events.registration.models.registrations import RegistrationVisibility
-from indico.modules.events.registration.util import (create_registration, get_event_regforms_registrations,
-                                                     get_registered_event_persons, get_ticket_qr_code_data,
-                                                     get_user_data, import_invitations_from_user_records,
+from indico.modules.events.registration.util import (create_registration, generate_spreadsheet_from_registrations,
+                                                     get_event_regforms_registrations, get_registered_event_persons,
+                                                     get_ticket_qr_code_data, get_user_data,
+                                                     import_invitations_from_user_records,
                                                      import_registrations_from_csv, import_user_records_from_csv,
                                                      modify_registration, process_registration_picture)
 from indico.modules.users.models.users import ProfilePictureSource, UserTitle
@@ -997,3 +999,35 @@ def test_modify_registration_conditional(monkeypatch, dummy_user, dummy_regform)
     assert not reg.data_by_field[boolean_field.id].data
     assert boolean_field_2.id not in reg.data_by_field
     assert text_field.id not in reg.data_by_field
+
+
+class _FakeExtraColumn:
+    """Minimal stand-in for CustomRegistrationListItem for spreadsheet tests."""
+
+    filter_only = False
+    title = 'Custom Column'
+
+    def __init__(self, data=None):
+        self.data = data or {}
+
+
+def test_generate_spreadsheet_extra_column_value(dummy_reg):
+    col = _FakeExtraColumn({dummy_reg: RegistrationListColumn(content='ACME', text_value='ACME')})
+    headers, rows = generate_spreadsheet_from_registrations([dummy_reg], [], set(), extra_columns=[col])
+    assert 'Custom Column' in headers
+    assert rows[0]['Custom Column'] == 'ACME'
+
+
+def test_generate_spreadsheet_extra_column_missing_data_is_empty(dummy_reg):
+    """Registration absent from col.data produces an empty string cell, not a KeyError."""
+    col = _FakeExtraColumn(data={})
+    headers, rows = generate_spreadsheet_from_registrations([dummy_reg], [], set(), extra_columns=[col])
+    assert 'Custom Column' in headers
+    assert rows[0]['Custom Column'] == ''
+
+
+def test_generate_spreadsheet_no_extra_columns_backward_compat(dummy_reg):
+    """Calling without extra_columns (default None) must not raise."""
+    headers, rows = generate_spreadsheet_from_registrations([dummy_reg], [], set())
+    assert 'ID' in headers
+    assert len(rows) == 1


### PR DESCRIPTION
Custom registration list columns added via signal are not being exported correctly.                                                                                                                                                  
The bug only surfaces when a custom column has been explicitly enabled in the column chooser UI.
                                     
Reproduction steps:
  1. Create a plugin/snippet with a CustomRegistrationListItem subclass connected to registrant_list_items                                                   
  2. Open a registration form list -> Open the column chooser -> Enable the custom column
  3. Export to CSV/Excel/PDF                                                                                                                                 
  4. Custom column missing from exported file despite being visible in the HTML list                                                                
                                                                                                                                                             