### PR TITLE
Expose registration tag cloner to users

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Improvements
 - Pre-fill the registration form picture field with the user's custom profile
   picture when available (:pr:`7447`, thanks :user:`moliholy, unconventionaldotdev`)
 - Allow users to mark contributions as favorites (:issue:`3524`, :pr:`7256`)
+- Allow choosing whether to clone registration tags (:pr:`7506`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/clone.py
+++ b/indico/modules/events/registration/clone.py
@@ -22,14 +22,22 @@ from indico.util.i18n import _
 class RegistrationTagCloner(EventCloner):
     name = 'registration_tags'
     friendly_name = _('Registration tags')
-    is_internal = True
+    is_default = True
 
-    # We do not override `is_available` as we have cloners depending
-    # on this internal cloner even if it won't clone anything.
+    @property
+    def is_visible(self):
+        return is_feature_enabled(self.old_event, 'registration')
+
+    @property
+    def is_available(self):
+        return self._has_content(self.old_event)
 
     def get_conflicts(self, target_event):
-        if target_event.registration_tags:
+        if self._has_content(target_event):
             return [_('The target event already has registration tags')]
+
+    def _has_content(self, event):
+        return bool(event.registration_tags)
 
     def run(self, new_event, cloners, shared_data, event_exists=False):
         self._tag_map = {}
@@ -48,7 +56,7 @@ class RegistrationTagCloner(EventCloner):
 class RegistrationFormCloner(EventCloner):
     name = 'registration_forms'
     friendly_name = _('Registration forms')
-    requires = {'registration_tags'}
+    uses = {'registration_tags'}
 
     @property
     def is_visible(self):
@@ -149,8 +157,8 @@ class RegistrationFormCloner(EventCloner):
 class RegistrationCloner(EventCloner):
     name = 'registrations'
     friendly_name = _('Registrations')
-    requires = {'registration_forms', 'registration_tags'}
-    uses = {'sessions'}
+    requires = {'registration_forms'}
+    uses = {'sessions', 'registration_tags'}
 
     @property
     def is_visible(self):
@@ -174,7 +182,7 @@ class RegistrationCloner(EventCloner):
         form_map = shared_data['registration_forms']['form_map']
         field_data_map = shared_data['registration_forms']['field_data_map']
         block_map = shared_data['sessions']['session_block_map'] if 'sessions' in shared_data else None
-        tag_map = shared_data['registration_tags']['tag_map']
+        tag_map = shared_data['registration_tags']['tag_map'] if 'registration_tags' in shared_data else None
         for old_form, new_form in form_map.items():
             self._clone_registrations(old_form, new_form, field_data_map, block_map, tag_map)
         self._synchronize_registration_friendly_id(new_event)
@@ -197,7 +205,8 @@ class RegistrationCloner(EventCloner):
                 continue
             new_registration = Registration(user=old_registration.user, registration_form=new_form,
                                             **{attr: getattr(old_registration, attr) for attr in registration_attrs})
-            new_registration.tags = {tag_map[tag] for tag in old_registration.tags}
+            if tag_map is not None:
+                new_registration.tags = {tag_map[tag] for tag in old_registration.tags}
             reg_data_attrs = get_attrs_to_clone(RegistrationData, skip={'storage_file_id', 'storage_backend', 'size'})
             for old_registration_data in old_registration.data:
                 new_registration_data = RegistrationData(registration=new_registration,

--- a/indico/modules/events/registration/clone_test.py
+++ b/indico/modules/events/registration/clone_test.py
@@ -18,16 +18,18 @@ pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
 @pytest.mark.parametrize('has_tags', (False, True))
 def test_registration_clone(dummy_event, dummy_regform, dummy_reg, create_event, dummy_user, has_tags):
     set_feature_enabled(dummy_event, 'registration', True)
+    cloners = {'registrations', 'registration_forms'}
     if has_tags:
         tag = RegistrationTag(title='Foo', color='b33f69', event=dummy_event)
         dummy_reg.tags = {tag}
+        cloners.add('registration_tags')
 
     assert dummy_regform.event == dummy_event
     assert dummy_reg.user == dummy_user
     assert dummy_reg.checked_in
 
     copied_event = create_event()
-    EventCloner.run_cloners(dummy_event, copied_event, {'registrations', 'registration_forms'})
+    EventCloner.run_cloners(dummy_event, copied_event, cloners)
     copied_registration = copied_event.registrations.one()
 
     assert copied_registration.event == copied_event
@@ -47,7 +49,7 @@ def test_registration_tags_clone(dummy_event, create_event):
     dummy_event.registration_tags.append(tag)
 
     copied_event = create_event()
-    EventCloner.run_cloners(dummy_event, copied_event, {'registration_forms'})
+    EventCloner.run_cloners(dummy_event, copied_event, {'registration_tags'})
 
     assert len(copied_event.registration_tags) == 1
     copied_tag = copied_event.registration_tags[0]


### PR DESCRIPTION
The internal cloner was convenient but it meant that the event import did not work when the target event already had tags defined. With the user-visible cloner one can simply deselect it.

closes #7467 (which would have had some annoying side effects I didn't consider when suggesting it)