### PR TITLE
Hide entry move buttons when creating a draft entry

### DIFF
--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -325,14 +325,15 @@ export default function Entry({
           </div>
         )}
       </div>
-      <EntryMoveButtons
-        id={id}
-        sessionBlockId={sessionBlockId}
-        startDt={startDt}
-        duration={duration}
-        colors={btnColors}
-        hidden={!!draftEntry}
-      />
+      {!draftEntry && (
+        <EntryMoveButtons
+          id={id}
+          sessionBlockId={sessionBlockId}
+          startDt={startDt}
+          duration={duration}
+          colors={btnColors}
+        />
+      )}
       <ResizeHandle
         duration={duration}
         minDuration={Math.max(MIN_DURATION, latestChildEndDt.diff(startDt, 'minutes'))}

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -195,6 +195,7 @@ export default function Entry({
   const {setNodeRef: setDroppableNodeRef} = useDroppable({id});
   const colors = getEntryColors({type, sessionBlockId, colors: customColors}, session);
   const btnColors = {backgroundColor: colors.color, color: colors.backgroundColor};
+  const draftEntry = useSelector(selectors.getDraftEntry);
 
   let style: Record<string, string | number | undefined> = transform
     ? {
@@ -330,6 +331,7 @@ export default function Entry({
         startDt={startDt}
         duration={duration}
         colors={btnColors}
+        hidden={!!draftEntry}
       />
       <ResizeHandle
         duration={duration}

--- a/indico/modules/events/timetable/client/js/EntryMoveButtons.tsx
+++ b/indico/modules/events/timetable/client/js/EntryMoveButtons.tsx
@@ -28,11 +28,7 @@ interface EntryMoveButtonsProps {
 }
 
 export function EntryMoveButtons({hidden, ...props}: EntryMoveButtonsProps) {
-  if (hidden) {
-    return null;
-  }
-
-  return <VisibleEntryMoveButtons {...props} />;
+  return !hidden ? <VisibleEntryMoveButtons {...props} /> : null;
 }
 
 export function VisibleEntryMoveButtons({

--- a/indico/modules/events/timetable/client/js/EntryMoveButtons.tsx
+++ b/indico/modules/events/timetable/client/js/EntryMoveButtons.tsx
@@ -24,7 +24,6 @@ interface EntryMoveButtonsProps {
   duration: number;
   sessionBlockId?: string;
   colors?: Colors;
-  hidden?: boolean;
 }
 
 export function EntryMoveButtons({
@@ -33,7 +32,7 @@ export function EntryMoveButtons({
   duration,
   sessionBlockId,
   colors,
-}: Omit<EntryMoveButtonsProps, 'hidden'>) {
+}: EntryMoveButtonsProps) {
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
   const currentDate = useSelector(selectors.getCurrentDate);
   const dtKey = getDateKey(currentDate);

--- a/indico/modules/events/timetable/client/js/EntryMoveButtons.tsx
+++ b/indico/modules/events/timetable/client/js/EntryMoveButtons.tsx
@@ -27,11 +27,7 @@ interface EntryMoveButtonsProps {
   hidden?: boolean;
 }
 
-export function EntryMoveButtons({hidden, ...props}: EntryMoveButtonsProps) {
-  return !hidden ? <VisibleEntryMoveButtons {...props} /> : null;
-}
-
-export function VisibleEntryMoveButtons({
+export function EntryMoveButtons({
   id,
   startDt,
   duration,

--- a/indico/modules/events/timetable/client/js/EntryMoveButtons.tsx
+++ b/indico/modules/events/timetable/client/js/EntryMoveButtons.tsx
@@ -24,15 +24,24 @@ interface EntryMoveButtonsProps {
   duration: number;
   sessionBlockId?: string;
   colors?: Colors;
+  hidden?: boolean;
 }
 
-export function EntryMoveButtons({
+export function EntryMoveButtons({hidden, ...props}: EntryMoveButtonsProps) {
+  if (hidden) {
+    return null;
+  }
+
+  return <VisibleEntryMoveButtons {...props} />;
+}
+
+export function VisibleEntryMoveButtons({
   id,
   startDt,
   duration,
   sessionBlockId,
   colors,
-}: EntryMoveButtonsProps) {
+}: Omit<EntryMoveButtonsProps, 'hidden'>) {
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
   const currentDate = useSelector(selectors.getCurrentDate);
   const dtKey = getDateKey(currentDate);


### PR DESCRIPTION
We could simply move the draft entry in the z axis but I think this looks cleaner and avoids crowding with unusable buttons.

Before:
<img width="1703" height="648" alt="image" src="https://github.com/user-attachments/assets/9d71b2f7-657e-4a56-8a69-700ecd9b6a5c" />

After:
<img width="1424" height="305" alt="image" src="https://github.com/user-attachments/assets/29d80784-f11c-43af-864b-5038aabb5fd1" />
<img width="1424" height="305" alt="image" src="https://github.com/user-attachments/assets/2bd1b449-91b4-43fb-9724-e2717ef36010" />


Possible easier z-index fix:
<img width="1424" height="305" alt="image" src="https://github.com/user-attachments/assets/19635a54-3602-46d1-bddb-7eb9dfc0c5a1" />
<img width="1424" height="305" alt="image" src="https://github.com/user-attachments/assets/a476268c-0cb0-4fd2-864b-d4cc0cbb716f" />


