### PR TITLE
Use clearer error messages in form fields/sections config

### DIFF
--- a/indico/modules/events/registration/client/js/form_setup/FormItemSetupActions.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/FormItemSetupActions.jsx
@@ -51,7 +51,7 @@ export default function FormItemSetupActions({
           className={`icon-remove hide-if-locked ${isCondition ? 'disabled' : ''}`}
           title={
             isCondition
-              ? Translate.string('Fields that are a condition for other fields cannot be deleted.')
+              ? Translate.string('This field cannot be deleted because other fields depend on it.')
               : Translate.string('Delete field')
           }
           onClick={handleRemoveClick}
@@ -69,7 +69,7 @@ export default function FormItemSetupActions({
           className={`icon-disable hide-if-locked ${isCondition ? 'disabled' : ''}`}
           title={
             isCondition
-              ? Translate.string('Fields that are a condition for other fields cannot be disabled.')
+              ? Translate.string('This field cannot be disabled because other fields depend on it.')
               : Translate.string('Disable field')
           }
           onClick={handleDisableClick}

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -122,7 +122,7 @@ class GeneralFieldDataSchema(mm.Schema):
             if field.id:
                 query = query.filter(RegistrationFormItem.id != field.id)
             if same_field := query.first():
-                raise ValidationError(_('The field "{}" on this form has the same internal name.')
+                raise ValidationError(_('The field "{}" in this form has the same internal name.')
                                       .format(same_field.title))
             # consistent type on forms of the same event
             query = (RegistrationFormItem.query
@@ -138,7 +138,7 @@ class GeneralFieldDataSchema(mm.Schema):
             if field.id:
                 query = query.filter(RegistrationFormItem.id != field.id)
             if inconsistent_field := query.first():
-                raise ValidationError(_('The field "{}" with the same internal name on form "{}" '
+                raise ValidationError(_('The field "{}" with the same internal name in form "{}" '
                                         'uses a different input type which is not allowed.')
                                       .format(inconsistent_field.title, inconsistent_field.registration_form.title))
 
@@ -158,7 +158,7 @@ class GeneralFieldDataSchema(mm.Schema):
             used_field_ids.add(field.id)
         regform = self.context['regform']
         if not (condition_field := RegistrationFormItem.query.with_parent(regform).filter_by(id=field_id).first()):
-            raise ValidationError('The field to show does not belong to the same registration form.')
+            raise ValidationError('This field does not belong to the same registration form.')
         if not condition_field.field_impl.allow_condition:
             raise ValidationError('This field cannot be used as a condition.')
         if not condition_field.is_enabled:
@@ -298,7 +298,7 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                          ~RegistrationFormItem.is_deleted))
         if same_field := query.first():
             raise NoReportError.wrap_exc(
-                BadRequest(_('The field "{}" on this form has the same internal name.')
+                BadRequest(_('The field "{}" in this form has the same internal name.')
                            .format(same_field.title))
             )
 
@@ -316,7 +316,7 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                          Event.id == self.field.registration_form.event_id))
         if inconsistent_field := query.first():
             raise NoReportError.wrap_exc(
-                BadRequest(_('The field "{}" with the same internal name on form "{}" '
+                BadRequest(_('The field "{}" with the same internal name in form "{}" '
                              'uses a different input type which is not allowed.')
                            .format(inconsistent_field.title, inconsistent_field.registration_form.title))
             )
@@ -327,7 +327,8 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                 self.field.personal_data_type.is_required):
             raise BadRequest
         if not enabled and self.field.condition_for:
-            raise NoReportError.wrap_exc(BadRequest(_('Fields used as conditional cannot be disabled')))
+            raise NoReportError.wrap_exc(BadRequest(_('This field cannot be disabled because other fields depend on '
+                                                      'it. Remove those dependencies first.')))
         if enabled:
             self._check_unique_title_in_section()
             self._check_unique_internal_name_in_form()
@@ -358,7 +359,8 @@ class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
         if self.field.type == RegistrationFormItemType.field_pd:
             raise BadRequest
         if self.field.condition_for:
-            raise NoReportError.wrap_exc(BadRequest(_('Fields used as conditional cannot be deleted')))
+            raise NoReportError.wrap_exc(BadRequest(_('This field cannot be deleted because other fields depend on it. '
+                                                      'Remove those dependencies first.')))
         signals.event.registration_form_field_deleted.send(self.field)
         self.field.is_deleted = True
         self.field.show_if_id = None

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -106,7 +106,7 @@ class TestGeneralFieldDataSchema:
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
         with pytest.raises(ValidationError) as exc_info:
             schema.load({'input_type': 'text', 'title': 'New field', 'internal_name': position_field.internal_name})
-        assert exc_info.value.messages == {'internal_name': [f'The field "{position_field.title}" on this form '
+        assert exc_info.value.messages == {'internal_name': [f'The field "{position_field.title}" in this form '
                                                              f'has the same internal name.']}
 
     @pytest.mark.parametrize('internal_name', ('internal name', 'InternalName', 'internal.name', 'internal_name', ''))
@@ -165,7 +165,7 @@ class TestGeneralFieldDataSchema:
         with pytest.raises(ValidationError) as exc_info:
             schema.load({'input_type': 'text', 'title': 'test', 'internal_name': 'title'})
         assert exc_info.value.messages == {
-            'internal_name': [f'The field "Title" with the same internal name on form '
+            'internal_name': [f'The field "Title" with the same internal name in form '
                               f'"{other_form.title}" uses a different input type which is not allowed.']
         }
         other_form.is_deleted = True
@@ -263,7 +263,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        with pytest.raises(BadRequest, match='The field "Title" on this form has the same internal name'):
+        with pytest.raises(BadRequest, match='The field "Title" in this form has the same internal name'):
             rh._check_unique_internal_name_in_form()
 
     def test_same_internal_name_in_other_section_on_enable(self, db, dummy_regform):
@@ -276,7 +276,7 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        with pytest.raises(BadRequest, match='The field "Title" on this form has the same internal name'):
+        with pytest.raises(BadRequest, match='The field "Title" in this form has the same internal name'):
             rh._check_unique_internal_name_in_form()
 
     def test_consistent_type_on_enabled(self, db, dummy_regform, create_regform):
@@ -311,6 +311,6 @@ class TestRegistrationFormToggleFieldState:
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
         rh.field = disabled_field
-        with pytest.raises(BadRequest, match='The field "Field Title" with the same internal name on form "Other Form" '
+        with pytest.raises(BadRequest, match='The field "Field Title" with the same internal name in form "Other Form" '
                                              'uses a different input type which is not allowed'):
             rh._check_internal_name_type_consistency_in_event()

--- a/indico/modules/events/registration/controllers/management/sections.py
+++ b/indico/modules/events/registration/controllers/management/sections.py
@@ -79,7 +79,8 @@ class RHRegistrationFormModifySection(RHManageRegFormSectionBase):
         if changes.get('is_manager_only') == (False, True):
             # Check that no field in this section is conditionally shown
             if any(field.show_if_id is not None for field in self.section.children if not field.is_deleted):
-                raise ValidationError('Sections with conditional fields cannot be made manager-only')
+                raise ValidationError(_('This section cannot be made manager-only because it contains fields that are '
+                                        'conditionally shown. Remove those dependencies first.'))
             # Check no conditional fields depend on this section if it is becoming manager-only now
             critical_fields_ids = {field.id for field in self.section.children if not field.is_deleted}
             for section in self.regform.sections:
@@ -88,7 +89,8 @@ class RHRegistrationFormModifySection(RHManageRegFormSectionBase):
                 fields_ids = {field.show_if_id for field in section.children
                               if field.show_if_id is not None and not field.is_deleted}
                 if critical_fields_ids & fields_ids:
-                    raise ValidationError('Cannot make section manager-only due to conditional field relations')
+                    raise ValidationError(_('This section cannot be made manager-only because other fields depend on '
+                                            'fields inside it. Remove those dependencies first.'))
         db.session.flush()
         changes = make_diff_log(changes, {
             'title': {'title': 'Title', 'type': 'string'},
@@ -114,7 +116,8 @@ class RHRegistrationFormToggleSection(RHManageRegFormSectionBase):
                 raise BadRequest
             if any(f.condition_for for f in self.section.children):
                 raise NoReportError.wrap_exc(
-                    BadRequest(_('Sections with fields used as conditional cannot be disabled'))
+                    BadRequest(_('This section cannot be disabled because other fields depend on fields inside it. '
+                                 'Remove those dependencies first.'))
                 )
         self.section.is_enabled = enabled
         update_regform_item_positions(self.regform)


### PR DESCRIPTION
Proposal to improve the error messages in form section/field configuration because non-power users find it difficult to understand what action to take following the error. 