### PR TITLE
Disable 'add myself' button when you added yourself

### DIFF
--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -289,6 +289,7 @@ function PersonLinkField({
         'identifier',
         'type',
         'personId',
+        'userId',
         'avatarURL',
         ..._.flatten(getPluginObjects('personLinkCustomFields')),
       ])


### PR DESCRIPTION
Previously, the button was only disabled after closing and opening the dialog again. This was because there was no `userId` field in persons going through `cleanupPersons()`.