### PR TITLE
Fix contribution positioning when moving parent session block

### DIFF
--- a/indico/modules/events/timetable/client/js/EntryMoveButtons.tsx
+++ b/indico/modules/events/timetable/client/js/EntryMoveButtons.tsx
@@ -13,7 +13,7 @@ import {Icon} from 'semantic-ui-react';
 
 import * as actions from './actions';
 import * as selectors from './selectors';
-import {ReduxState, BlockEntry, Entry, EntryType, Colors, EntryUniqueID} from './types';
+import {ReduxState, BlockEntry, Entry, Colors, EntryUniqueID} from './types';
 import {getDateKey} from './utils';
 
 import './Entry.module.scss';
@@ -91,23 +91,10 @@ export function EntryMoveButtons({
   const [above, below] = isOverlapping ? [null, null] : _getAdjacentEntries();
   const canMove = above || below;
 
-  const _getMovedChildrenByDelta = (parentEntry: BlockEntry, delta: number) =>
-    parentEntry?.children.map(child => ({
-      ...child,
-      startDt: moment(child.startDt).add(delta, 'minutes'),
-    }));
-
   const _moveEntry = (e: Entry, newStartDt: Moment) => {
     const newEntry = {...e, startDt: newStartDt};
 
     if (newStartDt) {
-      if (newEntry.type === EntryType.SessionBlock && newEntry.children) {
-        newEntry.children = _getMovedChildrenByDelta(
-          newEntry as BlockEntry,
-          newStartDt.diff(e.startDt, 'minutes')
-        );
-      }
-
       dispatch(
         actions.updateEntry(e.type, newEntry, dtKey, {
           start_dt: newEntry.startDt,


### PR DESCRIPTION
When moving a session block with the buttons on the top-right, the child entries would be wrongly offset. More specifically, they would be moved by twice the required amount. 

<img width="1295" height="617" alt="image" src="https://github.com/user-attachments/assets/6eb939ec-efb4-4b13-b2af-0abf79819337" />


This happened because `shiftEntries()` was being called on the child entries after `actions.updateEntry()`, but also `_getMovedChildrenByDelta` was being called beforehand to do the exact same.

As far as I could test it, removing this fixes it and doesn't break anything else. I think removing this makes more sense than removing `shiftEntries` since otherwise duplicate code would be needed everywhere session blocks would be updated.

