### PR TITLE
Prevent events inside entry popups from triggering in their parents

### DIFF
--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -51,7 +51,7 @@ interface DraggableEntryProps extends BaseEntry, ScheduledMixin {
 
 export function DraggableEntry({id, setDuration, ...rest}: DraggableEntryProps) {
   const dispatch = useDispatch();
-  const {listeners: _listeners, setNodeRef, transform, isDragging} = useDraggable({id});
+  const {listeners: _listeners, setNodeRef, transform, isDragging, ref} = useDraggable({id});
   const isSelected = useSelector((state: ReduxState) =>
     selectors.makeIsSelectedSelector()(state, id)
   );
@@ -64,6 +64,9 @@ export function DraggableEntry({id, setDuration, ...rest}: DraggableEntryProps) 
 
   function onClick(evt: React.MouseEvent<HTMLElement>) {
     evt.stopPropagation();
+    if (evt.target instanceof Node && !ref.current.contains(evt.target)) {
+      return;
+    }
     if (isClick.current) {
       dispatch(actions.selectEntry(id));
     }
@@ -71,6 +74,9 @@ export function DraggableEntry({id, setDuration, ...rest}: DraggableEntryProps) 
 
   function onDoubleClick(evt: React.MouseEvent<HTMLElement>) {
     evt.stopPropagation();
+    if (evt.target instanceof Node && !ref.current.contains(evt.target)) {
+      return;
+    }
     if (rest.type !== EntryType.SessionBlock || isPosterBlock) {
       return;
     }

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -462,6 +462,9 @@ export function useDraggable({id, fixed = false}: {id: string; fixed?: boolean})
   const onMouseDown = useCallback(
     (e: React.MouseEvent<HTMLElement>) => {
       e.stopPropagation();
+      if (e.target instanceof Node && !ref.current.contains(e.target)) {
+        return;
+      }
       const rect = e.currentTarget.getBoundingClientRect();
       const offsetX = e.clientX - rect.left;
       const offsetY = e.clientY - rect.top;


### PR DESCRIPTION
When interacting with an entry's popup window (`EntryPopup`), events also trigger in the parent Session Block, if it exists. This caused issues such as https://github.com/orgs/indico/projects/7/views/1?pane=issue&itemId=145116964 because a drag event would be fired before any click events (since drag events fire on drag or after some small time has elapsed since mousedown, not mouse up).

This seems to fix the issue, although a better solution would be to make the popup events not bubble up at all.