### PR TITLE
Don't strip avatarURL from form in PersonDetailsModal

### DIFF
--- a/indico/web/client/js/react/components/PersonDetailsModal.jsx
+++ b/indico/web/client/js/react/components/PersonDetailsModal.jsx
@@ -238,6 +238,7 @@ function EmailField({validateUrl, person, otherPersons, ...rest}) {
     email = email.trim();
 
     if (email === '' || email === person?.email) {
+      form.change('avatarURL', person?.avatarURL);
       setMessage({status: '', message: ''});
       return;
     }


### PR DESCRIPTION
As described in https://github.com/orgs/indico/projects/7?pane=issue&itemId=176673630 editing a user was stripping out the `avatarURL` from the form object. This change seemed to be enough, but there might be a situation where it is still stripped without need.