### PR TITLE
Allow editors to reject papers with missing files

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -239,24 +239,27 @@ export default function ReviewForm() {
                       showAsToggle
                     />
                   )}
-                  <Field name="upload_changes" subscription={{value: true}}>
-                    {({input: {value: uploadChanges}}) => (
-                      <UpdateFilesBox
-                        visible={
-                          judgmentType === EditingReviewAction.update ||
-                          ([EditingReviewAction.accept, EditingReviewAction.requestUpdate].includes(
-                            judgmentType
-                          ) &&
-                            uploadChanges)
-                        }
-                        mustChange={judgmentType === EditingReviewAction.update || uploadChanges}
-                        requirePublishable={[
-                          EditingReviewAction.accept,
-                          EditingReviewAction.update,
-                        ].includes(judgmentType)}
-                      />
-                    )}
-                  </Field>
+                  {judgmentType !== EditingReviewAction.reject && (
+                    <Field name="upload_changes" subscription={{value: true}}>
+                      {({input: {value: uploadChanges}}) => (
+                        <UpdateFilesBox
+                          visible={
+                            judgmentType === EditingReviewAction.update ||
+                            ([
+                              EditingReviewAction.accept,
+                              EditingReviewAction.requestUpdate,
+                            ].includes(judgmentType) &&
+                              uploadChanges)
+                          }
+                          mustChange={judgmentType === EditingReviewAction.update || uploadChanges}
+                          requirePublishable={[
+                            EditingReviewAction.accept,
+                            EditingReviewAction.update,
+                          ].includes(judgmentType)}
+                        />
+                      )}
+                    </Field>
+                  )}
                   <FinalTagInput name="tags" options={tagOptions} />
                   <div styleName="judgment-submit-button">
                     <Popup


### PR DESCRIPTION
When event managers change the required file types after an editable has already been submitted, existing editables may no longer satisfy the updated requirements. In such cases, editors are currently unable to submit a rejection due to form validation enforcing the new file type constraints.

However, rejecting an editable should always be possible, as it represents the end of the editing workflow and does not proceed to any further stages. Therefore, allowing rejection even when the current file requirements are not met should notcreate any problems.