### PR TITLE
Allow rejecting editables w/ missing required files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ Bugfixes
 - Fix date picker showing January instead of the selected month when the user
   language is not English (:issue:`7471`, :pr:`7476`, thanks :user:`foxbunny`)
 - Do not show "Clone Abstract" icon outside management area (:pr:`7493`)
+- Allow rejecting editables w/ missing required files (:pr:`7524`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/index.jsx
@@ -290,6 +290,7 @@ export default function FileManager({
   finalFieldName,
   pristine,
   mustChange,
+  allowMissingRequiredFiles,
   uploadableFiles,
 }) {
   const lastPristineRef = useRef(pristine);
@@ -326,7 +327,7 @@ export default function FileManager({
   }, [onChange, state, value]);
 
   const uploading = isUploading(state);
-  const validationError = getValidationError(state);
+  const validationError = getValidationError(state, allowMissingRequiredFiles);
   return (
     <div styleName="file-manager-wrapper">
       <div styleName="file-manager">
@@ -380,6 +381,7 @@ FileManager.propTypes = {
   finalFieldName: PropTypes.string,
   pristine: PropTypes.bool,
   mustChange: PropTypes.bool,
+  allowMissingRequiredFiles: PropTypes.bool,
   uploadableFiles: PropTypes.arrayOf(PropTypes.shape(uploadablePropTypes)),
 };
 
@@ -399,6 +401,7 @@ export function FinalFileManager({
   fileTypes,
   files = [],
   mustChange = false,
+  allowMissingRequiredFiles = false,
   uploadableFiles = [],
   ...rest
 }) {
@@ -418,6 +421,7 @@ export function FinalFileManager({
           pristine={pristine}
           mustChange={mustChange}
           uploadableFiles={uploadableFiles}
+          allowMissingRequiredFiles={allowMissingRequiredFiles}
         />
       )}
     </Field>
@@ -431,5 +435,6 @@ FinalFileManager.propTypes = {
   fileTypes: PropTypes.arrayOf(PropTypes.shape(fileTypePropTypes)).isRequired,
   files: PropTypes.arrayOf(PropTypes.shape(filePropTypes)),
   mustChange: PropTypes.bool,
+  allowMissingRequiredFiles: PropTypes.bool,
   uploadableFiles: PropTypes.arrayOf(PropTypes.shape(uploadablePropTypes)),
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/selectors.js
@@ -35,7 +35,8 @@ export const getUploadedFileUUIDs = state => {
 
 export const getValidationError = createSelector(
   state => state.fileTypes,
-  fileTypes => {
+  (__, allowMissingRequiredFiles) => allowMissingRequiredFiles,
+  (fileTypes, allowMissingRequiredFiles) => {
     const invalid = fileTypes
       .filter(ft => ft.invalidFiles.some(f => f.length > 0))
       .map(ft => ft.invalidFiles)
@@ -52,7 +53,7 @@ export const getValidationError = createSelector(
       .filter(ft => ft.required)
       .filter(ft => !ft.files.some(f => f.state !== 'deleted'))
       .map(ft => ft.name);
-    if (!missing.length) {
+    if (!missing.length || allowMissingRequiredFiles) {
       return null;
     }
     return PluralTranslate.string(

--- a/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/ReviewForm.jsx
@@ -250,6 +250,7 @@ export default function ReviewForm() {
                             uploadChanges)
                         }
                         mustChange={judgmentType === EditingReviewAction.update || uploadChanges}
+                        allowMissingRequiredFiles={judgmentType === EditingReviewAction.reject}
                         requirePublishable={[
                           EditingReviewAction.accept,
                           EditingReviewAction.update,

--- a/indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesBox.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/judgment/UpdateFilesBox.jsx
@@ -18,13 +18,18 @@ import {Translate, Param, Plural, PluralTranslate, Singular} from 'indico/react/
 import {FinalFileManager} from '../FileManager';
 import * as selectors from '../selectors';
 
-export default function UpdateFilesBox({visible, mustChange, requirePublishable}) {
+export default function UpdateFilesBox({
+  visible,
+  mustChange,
+  requirePublishable,
+  allowMissingRequiredFiles,
+}) {
   const lastRevisionWithFiles = useSelector(selectors.getLastRevisionWithFiles);
   const staticData = useSelector(selectors.getStaticData);
   const {eventId, contributionId, editableType} = staticData;
   const fileTypes = useSelector(selectors.getFileTypes);
   const publishableFileTypes = useSelector(selectors.getPublishableFileTypes);
-
+  const requiredFileTypes = useSelector(selectors.getRequiredFileTypes);
   return (
     <Form.Field style={{display: !visible ? 'none' : undefined}}>
       <FinalFileManager
@@ -37,6 +42,7 @@ export default function UpdateFilesBox({visible, mustChange, requirePublishable}
           type: editableType,
         })}
         mustChange={mustChange}
+        allowMissingRequiredFiles={allowMissingRequiredFiles}
       />
       <Field name="files" subscription={{value: true}}>
         {({input: {value: currentFiles}}) => {
@@ -79,6 +85,49 @@ export default function UpdateFilesBox({visible, mustChange, requirePublishable}
           );
         }}
       </Field>
+      <Field name="files" subscription={{value: true}}>
+        {({input: {value: currentFiles}}) => {
+          if (allowMissingRequiredFiles) {
+            return null;
+          }
+          const missingRequiredFileTypes = requiredFileTypes.filter(
+            fileType => !(fileType.id in currentFiles)
+          );
+          if (!missingRequiredFileTypes.length) {
+            return null;
+          }
+          return (
+            <>
+              <Message visible warning>
+                <PluralTranslate count={missingRequiredFileTypes.length}>
+                  <Singular>
+                    Required files are missing. Please upload a{' '}
+                    <Param
+                      name="types"
+                      wrapper={<strong />}
+                      value={missingRequiredFileTypes.map(ft => ft.name).join(', ')}
+                    />{' '}
+                    file.
+                  </Singular>
+                  <Plural>
+                    Required files are missing. Please upload files of the following types:{' '}
+                    <Param
+                      name="types"
+                      wrapper={<strong />}
+                      value={missingRequiredFileTypes.map(ft => ft.name).join(', ')}
+                    />
+                  </Plural>
+                </PluralTranslate>
+              </Message>
+              <Field
+                name="_norequired"
+                validate={() => Translate.string('Required file types are missing.')}
+                render={() => null}
+              />
+            </>
+          );
+        }}
+      </Field>
     </Form.Field>
   );
 }
@@ -87,4 +136,5 @@ UpdateFilesBox.propTypes = {
   visible: PropTypes.bool.isRequired,
   mustChange: PropTypes.bool.isRequired,
   requirePublishable: PropTypes.bool.isRequired,
+  allowMissingRequiredFiles: PropTypes.bool.isRequired,
 };

--- a/indico/modules/events/editing/client/js/editing/timeline/selectors.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/selectors.js
@@ -105,6 +105,11 @@ export const getPublishableFileTypes = createSelector(
   fileTypes => fileTypes.filter(ft => ft.publishable)
 );
 
+export const getRequiredFileTypes = createSelector(
+  getFileTypes,
+  fileTypes => fileTypes.filter(ft => ft.required)
+);
+
 export const hasPublishableFiles = createSelector(
   getPublishableFileTypes,
   getLastRevisionWithFiles,


### PR DESCRIPTION
Also show a nice warning in the file manager if required file types are missing, similar to what we do for missing publishable files.