### PR TITLE
Add some contribution email placeholders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Improvements
   picture when available (:pr:`7447`, thanks :user:`moliholy, unconventionaldotdev`)
 - Allow users to mark contributions as favorites (:issue:`3524`, :pr:`7256`)
 - Allow choosing whether to clone registration tags (:pr:`7506`)
+- Add placeholders for contribution link and board number for emailing contributions
+  (:pr:`7525`, thanks :user:`duartegalvao`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/models/contributions.py
+++ b/indico/modules/events/contributions/models/contributions.py
@@ -572,6 +572,10 @@ class Contribution(SearchableTitleMixin, SearchableDescriptionMixin, ProtectionM
     def url(self):
         return url_for('contributions.display_contribution', self)
 
+    @property
+    def external_url(self):
+        return url_for('contributions.display_contribution', self, _external=True)
+
     def can_edit(self, user):
         # Submitters can edit their own contributions if configured
         from indico.modules.events.contributions import contribution_settings

--- a/indico/modules/events/persons/__init__.py
+++ b/indico/modules/events/persons/__init__.py
@@ -47,6 +47,8 @@ def _get_placeholders(sender, person, event, contribution=None, abstract=None, r
         yield person_placeholders.ContributionIDPlaceholder
         yield person_placeholders.ContributionTitlePlaceholder
         yield person_placeholders.ContributionCodePlaceholder
+        yield person_placeholders.ContributionBoardNumberPlaceholder
+        yield person_placeholders.ContributionLinkPlaceholder
         yield person_placeholders.ContributionDurationPlaceholder
         yield person_placeholders.ContributionSchedulePlaceholder
     else:

--- a/indico/modules/events/persons/placeholders.py
+++ b/indico/modules/events/persons/placeholders.py
@@ -109,6 +109,32 @@ class ContributionCodePlaceholder(Placeholder):
         return str(contribution.code)
 
 
+class ContributionBoardNumberPlaceholder(Placeholder):
+    advanced = True
+    name = 'contribution_board_number'
+    description = _('The board number of the contribution')
+
+    @classmethod
+    def render(cls, contribution, **kwargs):
+        return contribution.board_number
+
+
+class ContributionLinkPlaceholder(ParametrizedPlaceholder):
+    name = 'contribution_link'
+    param_friendly_name = 'link title'
+
+    @classmethod
+    def render(cls, param, contribution, **kwargs):
+        return Markup('<a href="{url}" title="{title}">{text}</a>').format(url=contribution.external_url,
+                                                                           title=contribution.title,
+                                                                           text=(param or contribution.external_url))
+
+    @classmethod
+    def iter_param_info(cls, **kwargs):
+        yield None, _('Link to the contribution')
+        yield 'custom-text', _('Custom link text instead of the full URL')
+
+
 class ContributionDurationPlaceholder(Placeholder):
     name = 'contribution_duration'
     description = _('The duration of the contribution (e.g. "20 minutes")')


### PR DESCRIPTION
This PR adds placeholders for contribution link and board number when emailing contributions:

<img width="1021" height="559" alt="image" src="https://github.com/user-attachments/assets/06227304-5cdb-408c-abae-31979c8e6024" />
