### PR TITLE
Add timestamp to editing revision files

### DIFF
--- a/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/index.jsx
@@ -13,6 +13,7 @@ import {Button, Icon, Message, Popup} from 'semantic-ui-react';
 import {TooltipIfTruncated} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {toClasses} from 'indico/react/util';
+import {serializeDate} from 'indico/utils/date';
 
 import {fileTypePropTypes, filePropTypes, mapFileTypes} from '../FileManager/util';
 import * as selectors from '../selectors';
@@ -35,10 +36,15 @@ function FileListDisplay({files}) {
 
   return (
     <ul styleName="file-list-display">
-      {files.map(({filename, uuid, downloadURL, state}) => (
+      {files.map(({filename, uuid, downloadURL, state, uploadedDt}) => (
         <li key={uuid} styleName="file-row">
           <TooltipIfTruncated>
-            <span styleName="file-name">
+            <span
+              styleName="file-name"
+              title={Translate.string('Uploaded on {date}', {
+                date: serializeDate(uploadedDt, 'LLL'),
+              })}
+            >
               {state && (
                 <Popup
                   trigger={<Icon name={stateIcon[state].icon} color={stateIcon[state].color} />}

--- a/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/index.jsx
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileDisplay/index.jsx
@@ -10,7 +10,6 @@ import React from 'react';
 import {useSelector} from 'react-redux';
 import {Button, Icon, Message, Popup} from 'semantic-ui-react';
 
-import {TooltipIfTruncated} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {toClasses} from 'indico/react/util';
 import {serializeDate} from 'indico/utils/date';
@@ -38,24 +37,23 @@ function FileListDisplay({files}) {
     <ul styleName="file-list-display">
       {files.map(({filename, uuid, downloadURL, state, uploadedDt}) => (
         <li key={uuid} styleName="file-row">
-          <TooltipIfTruncated>
-            <span
-              styleName="file-name"
-              title={Translate.string('Uploaded on {date}', {
-                date: serializeDate(uploadedDt, 'LLL'),
-              })}
-            >
-              {state && (
-                <Popup
-                  trigger={<Icon name={stateIcon[state].icon} color={stateIcon[state].color} />}
-                  content={stateIcon[state].tooltip}
-                />
-              )}
-              <a href={downloadURL} target="_blank" rel="noopener noreferrer">
-                {filename}
-              </a>
-            </span>
-          </TooltipIfTruncated>
+          <span
+            styleName="file-name"
+            title={Translate.string('{filename} (uploaded on {date})', {
+              filename,
+              date: serializeDate(uploadedDt, 'LLL'),
+            })}
+          >
+            {state && (
+              <Popup
+                trigger={<Icon name={stateIcon[state].icon} color={stateIcon[state].color} />}
+                content={stateIcon[state].tooltip}
+              />
+            )}
+            <a href={downloadURL} target="_blank" rel="noopener noreferrer">
+              {filename}
+            </a>
+          </span>
         </li>
       ))}
       {!files.length && (

--- a/indico/modules/events/editing/client/js/editing/timeline/FileManager/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/FileManager/util.js
@@ -24,6 +24,7 @@ export const filePropTypes = {
   uuid: PropTypes.string.isRequired,
   claimed: PropTypes.bool,
   state: PropTypes.oneOf(['added', 'modified', 'deleted']),
+  uploadedDt: PropTypes.string,
 };
 
 export const uploadablePropTypes = {

--- a/indico/modules/events/editing/client/js/editing/timeline/util.js
+++ b/indico/modules/events/editing/client/js/editing/timeline/util.js
@@ -16,10 +16,16 @@ import {filePropTypes} from './FileManager/util';
 // This method defines each revision as a block
 // with a label referring to its previous state transition
 export function processRevisions(revisions) {
+  const fileUploadDates = new Map();
   return revisions.map((revision, i) => {
     const previousRevision = getPreviousRevisionWithFiles(revisions, i);
     // Set the state on the files that were added/modified in this revision
-    let files = revision.files;
+    let files = revision.files?.map(file => {
+      if (!fileUploadDates.has(file.uuid)) {
+        fileUploadDates.set(file.uuid, revision.createdDt);
+      }
+      return {...file, uploadedDt: fileUploadDates.get(file.uuid)};
+    });
     if (previousRevision && files?.length) {
       const previousFilesUUIDs = new Set(previousRevision.files.map(f => f.uuid));
       const previousFilenames = new Set(previousRevision.files.map(f => f.filename));


### PR DESCRIPTION
This PR adds a tooltip on Editing timeline revision files displaying the uploaded date and time.
<img width="459" height="183" alt="image" src="https://github.com/user-attachments/assets/aa7d867a-28fc-4d42-b087-6183d403b1f5" />
