### PR TITLE
Clone survey sections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,7 @@ Improvements
 - Allow changing/removing the registration fee of pending registrations (:pr:`7572`)
 - Add QR code generator to event share widget (:issue:`6796`, :pr:`7504`)
 - Add contribution link placeholder for emailing abstract roles (:issue:`3602`, :pr:`7569`)
+- Allow cloning survey sections (:issue:`7395`, :pr:`7536`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/surveys/controllers/management/questionnaire.py
+++ b/indico/modules/events/surveys/controllers/management/questionnaire.py
@@ -297,7 +297,8 @@ class RHAddSurveyQuestion(RHManageSurveySectionBase):
 
         if question_to_clone:
             form = question_to_clone.field.create_config_form(
-                    obj=FormDefaults(question_to_clone, **question_to_clone.field.copy_field_data()))
+                obj=FormDefaults(question_to_clone, **question_to_clone.field.copy_field_data())
+            )
 
         if form.validate_on_submit():
             question = add_survey_question(self.section, field_cls, form.data)

--- a/indico/modules/events/surveys/controllers/management/questionnaire.py
+++ b/indico/modules/events/surveys/controllers/management/questionnaire.py
@@ -181,36 +181,30 @@ class RHManageSurveyQuestionBase(RHManageSurveysBase):
 class RHAddSurveySection(RHManageSurveyBase):
     """Add a new section to a survey."""
 
+    def _clone_section_children(self, source_section, target_section):
+        for old_item in source_section.children:
+            item_cls = type(old_item)
+            new_item = item_cls(survey=target_section.survey, parent=target_section)
+            attrs = get_attrs_to_clone(item_cls, skip={'id', 'parent_id'})
+            new_item.populate_from_attrs(old_item, attrs)
+            db.session.add(new_item)
+        db.session.flush()
+
     def _process(self):
         form = SectionForm()
-        old_section = None
-        print('request args', request.args)
+        section_to_clone = None
         clone_id = request.args.get('clone', type=int)
-
-        # cloning titlle, description, display as session
         if clone_id:
-            old_section = SurveySection.query.with_parent(self.survey).filter_by(id=clone_id).one_or_none()
-            print('cloning old section metadata', old_section)
-            if old_section:
-                form = SectionForm(obj=FormDefaults(old_section))
-
+            try:
+                section_to_clone = SurveySection.query.with_parent(self.survey).filter_by(id=clone_id).one()
+                if section_to_clone:
+                    form = SectionForm(obj=FormDefaults(section_to_clone))
+            except NoResultFound:
+                pass
         if form.validate_on_submit():
             section = add_survey_section(self.survey, form.data)
-
-            if old_section:
-                # clone questions/texts in section such as in event survey cloner
-                print('cloning old section items')
-                for old_item in old_section.children:
-                    print('cloning item', old_item)
-                    item_cls = type(old_item)
-                    new_item = item_cls(survey=self.survey, parent=section)
-
-                    attrs = get_attrs_to_clone(item_cls, skip={'id', 'parent_id'})
-                    new_item.populate_from_attrs(old_item, attrs)
-                    db.session.add(new_item)
-
-                db.session.flush()
-
+            if section_to_clone:
+                self._clone_section_children(section_to_clone, section)
             if section.title:
                 message = _('Section "{title}" added').format(title=section.title)
             else:

--- a/indico/modules/events/surveys/controllers/management/questionnaire.py
+++ b/indico/modules/events/surveys/controllers/management/questionnaire.py
@@ -196,8 +196,11 @@ class RHAddSurveySection(RHManageSurveyBase):
     }, location='query', rh_context=('survey',))
     def _process(self, section_to_clone=None):
         form = SectionForm()
+        disabled_until_change = True
         if section_to_clone:
             form = SectionForm(obj=FormDefaults(section_to_clone))
+            if not section_to_clone.display_as_section:
+                disabled_until_change = False
         if form.validate_on_submit():
             section = add_survey_section(self.survey, form.data)
             if section_to_clone:
@@ -208,7 +211,8 @@ class RHAddSurveySection(RHManageSurveyBase):
                 message = _('Standalone section added')
             flash(message, 'success')
             return jsonify_data(questionnaire=_render_questionnaire_preview(self.survey))
-        return jsonify_template('forms/form_common_fields_first.html', form=form)
+        return jsonify_template('forms/form_common_fields_first.html', form=form,
+                                disabled_until_change=disabled_until_change)
 
 
 class RHEditSurveySection(RHManageSurveySectionBase):

--- a/indico/modules/events/surveys/controllers/management/questionnaire.py
+++ b/indico/modules/events/surveys/controllers/management/questionnaire.py
@@ -26,7 +26,7 @@ from indico.modules.events.surveys.util import make_survey_form
 from indico.modules.events.surveys.views import WPManageSurvey
 from indico.util.i18n import _
 from indico.util.marshmallow import ModelField
-from indico.web.args import use_rh_kwargs
+from indico.web.args import use_kwargs, use_rh_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.forms.base import FormDefaults
 from indico.web.util import jsonify_data, jsonify_form, jsonify_template
@@ -288,9 +288,9 @@ class RHAddSurveyQuestion(RHManageSurveySectionBase):
     @use_rh_kwargs({
         'question_to_clone': ModelField(SurveyQuestion, with_parent='survey', data_key='clone')
     }, rh_context=('survey',), location='query')
-    @use_rh_kwargs({
+    @use_kwargs({
         'field_type': fields.String(validate=validate.OneOf(get_field_types().keys()), data_key='type')
-    }, rh_context=('survey',), location='view_args')
+    }, location='view_args')
     def _process(self, field_type, question_to_clone=None):
         field_cls = get_field_types()[field_type]
         form = field_cls.create_config_form()

--- a/indico/modules/events/surveys/controllers/management/questionnaire.py
+++ b/indico/modules/events/surveys/controllers/management/questionnaire.py
@@ -8,10 +8,9 @@
 import json
 
 from flask import flash, jsonify, request, session
+from marshmallow import fields, validate
 from sqlalchemy.orm import contains_eager, joinedload
-from sqlalchemy.orm.exc import NoResultFound
 from werkzeug.datastructures import MultiDict
-from werkzeug.exceptions import NotFound
 
 from indico.core.db import db
 from indico.modules.events.cloning import get_attrs_to_clone
@@ -286,24 +285,19 @@ class RHDeleteSurveyText(RHManageSurveyTextBase):
 class RHAddSurveyQuestion(RHManageSurveySectionBase):
     """Add a new question to a survey."""
 
-    def _process(self):
-        try:
-            field_cls = get_field_types()[request.view_args['type']]
-        except KeyError:
-            raise NotFound
-
+    @use_rh_kwargs({
+        'question_to_clone': ModelField(SurveyQuestion, with_parent='survey', data_key='clone')
+    }, rh_context=('survey',), location='query')
+    @use_rh_kwargs({
+        'field_type': fields.String(validate=validate.OneOf(get_field_types().keys()), data_key='type')
+    }, rh_context=('survey',), location='view_args')
+    def _process(self, field_type, question_to_clone=None):
+        field_cls = get_field_types()[field_type]
         form = field_cls.create_config_form()
-        try:
-            clone_id = int(request.args['clone'])
-        except (KeyError, ValueError):
-            pass
-        else:
-            try:
-                question_to_clone = SurveyQuestion.query.with_parent(self.survey).filter_by(id=clone_id).one()
-                form = question_to_clone.field.create_config_form(
+
+        if question_to_clone:
+            form = question_to_clone.field.create_config_form(
                     obj=FormDefaults(question_to_clone, **question_to_clone.field.copy_field_data()))
-            except NoResultFound:
-                pass
 
         if form.validate_on_submit():
             question = add_survey_question(self.section, field_cls, form.data)

--- a/indico/modules/events/surveys/controllers/management/questionnaire.py
+++ b/indico/modules/events/surveys/controllers/management/questionnaire.py
@@ -26,6 +26,8 @@ from indico.modules.events.surveys.operations import add_survey_question, add_su
 from indico.modules.events.surveys.util import make_survey_form
 from indico.modules.events.surveys.views import WPManageSurvey
 from indico.util.i18n import _
+from indico.util.marshmallow import ModelField
+from indico.web.args import use_rh_kwargs
 from indico.web.flask.templating import get_template_module
 from indico.web.forms.base import FormDefaults
 from indico.web.util import jsonify_data, jsonify_form, jsonify_template
@@ -190,17 +192,13 @@ class RHAddSurveySection(RHManageSurveyBase):
             db.session.add(new_item)
         db.session.flush()
 
-    def _process(self):
+    @use_rh_kwargs({
+        'section_to_clone': ModelField(SurveySection, with_parent='survey', data_key='clone')
+    }, location='query', rh_context=('survey',))
+    def _process(self, section_to_clone=None):
         form = SectionForm()
-        section_to_clone = None
-        clone_id = request.args.get('clone', type=int)
-        if clone_id:
-            try:
-                section_to_clone = SurveySection.query.with_parent(self.survey).filter_by(id=clone_id).one()
-                if section_to_clone:
-                    form = SectionForm(obj=FormDefaults(section_to_clone))
-            except NoResultFound:
-                pass
+        if section_to_clone:
+            form = SectionForm(obj=FormDefaults(section_to_clone))
         if form.validate_on_submit():
             section = add_survey_section(self.survey, form.data)
             if section_to_clone:

--- a/indico/modules/events/surveys/controllers/management/questionnaire.py
+++ b/indico/modules/events/surveys/controllers/management/questionnaire.py
@@ -14,6 +14,7 @@ from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import NotFound
 
 from indico.core.db import db
+from indico.modules.events.cloning import get_attrs_to_clone
 from indico.modules.events.surveys import logger
 from indico.modules.events.surveys.controllers.management import RHManageSurveyBase, RHManageSurveysBase
 from indico.modules.events.surveys.fields import get_field_types
@@ -182,8 +183,34 @@ class RHAddSurveySection(RHManageSurveyBase):
 
     def _process(self):
         form = SectionForm()
+        old_section = None
+        print('request args', request.args)
+        clone_id = request.args.get('clone', type=int)
+
+        # cloning titlle, description, display as session
+        if clone_id:
+            old_section = SurveySection.query.with_parent(self.survey).filter_by(id=clone_id).one_or_none()
+            print('cloning old section metadata', old_section)
+            if old_section:
+                form = SectionForm(obj=FormDefaults(old_section))
+
         if form.validate_on_submit():
             section = add_survey_section(self.survey, form.data)
+
+            if old_section:
+                # clone questions/texts in section such as in event survey cloner
+                print('cloning old section items')
+                for old_item in old_section.children:
+                    print('cloning item', old_item)
+                    item_cls = type(old_item)
+                    new_item = item_cls(survey=self.survey, parent=section)
+
+                    attrs = get_attrs_to_clone(item_cls, skip={'id', 'parent_id'})
+                    new_item.populate_from_attrs(old_item, attrs)
+                    db.session.add(new_item)
+
+                db.session.flush()
+
             if section.title:
                 message = _('Section "{title}" added').format(title=section.title)
             else:

--- a/indico/modules/events/surveys/templates/management/_questionnaire_preview.html
+++ b/indico/modules/events/surveys/templates/management/_questionnaire_preview.html
@@ -19,9 +19,9 @@
                 <div class="i-box-buttons toolbar right hide-if-locked">
                     <div class="group">
                         <button data-href="{{ url_for('.add_section', section, clone=section.id) }}"
-                                title="{% trans %}Copy section{% endtrans %}"
+                                title="{% trans %}Clone section{% endtrans %}"
                                 class="i-button js-survey-item-dialog icon-copy"
-                                data-title="{% trans %}Copy section{% endtrans %}"></button>
+                                data-title="{% trans %}Clone section{% endtrans %}"></button>
                         <button data-href="{{ url_for('.edit_section', section) }}"
                                 title="{% trans %}Edit section{% endtrans %}"
                                 class="i-button js-survey-item-dialog icon-edit"

--- a/indico/modules/events/surveys/templates/management/_questionnaire_preview.html
+++ b/indico/modules/events/surveys/templates/management/_questionnaire_preview.html
@@ -18,6 +18,10 @@
                 </div>
                 <div class="i-box-buttons toolbar right hide-if-locked">
                     <div class="group">
+                        <button data-href="{{ url_for('.add_section', section, clone=section.id) }}"
+                                title="{% trans %}Copy section{% endtrans %}"
+                                class="i-button js-survey-item-dialog icon-copy"
+                                data-title="{% trans %}Copy section{% endtrans %}"></button>
                         <button data-href="{{ url_for('.edit_section', section) }}"
                                 title="{% trans %}Edit section{% endtrans %}"
                                 class="i-button js-survey-item-dialog icon-edit"

--- a/indico/web/templates/forms/form_common_fields_first.html
+++ b/indico/web/templates/forms/form_common_fields_first.html
@@ -6,7 +6,7 @@
 {{ form_rows(form, skip=common_fields) }}
 {% call form_footer(form) %}
     <input class="i-button big highlight" type="submit" value="{% trans %}Save{% endtrans %}"
-           data-disabled-until-change>
+           {% if disabled_until_change|default(true) %}data-disabled-until-change{% endif %}>
     <button type="button" class="i-button big" data-button-back>{% trans %}Cancel{% endtrans %}</button>
 {% endcall %}
 {% block javascript %}{% endblock %}


### PR DESCRIPTION
Closes #7395

Adds a cloning button that allows cloning a survey section while cloning all questions and texts within section as well.

<img width="400" alt="Screenshot from 2026-05-28 15-59-16" src="https://github.com/user-attachments/assets/3effd1e2-fc99-45c4-8e42-ecf9529f2967" />

<img width="400" alt="Screenshot from 2026-05-28 15-59-36" src="https://github.com/user-attachments/assets/2d492297-2d50-4487-8963-a6d156a550e2" />

