### PR TITLE
Allow disabling/deleting fields with condition

### DIFF
--- a/indico/modules/events/registration/client/js/form/ConditionalFieldsController.jsx
+++ b/indico/modules/events/registration/client/js/form/ConditionalFieldsController.jsx
@@ -26,7 +26,7 @@ export function DefaultConditionalFieldsController() {
   const fieldRegistry = getFieldRegistry();
 
   const hiddenItemIds = Object.values(fields)
-    .filter(field => field.showIfFieldId)
+    .filter(field => field.showIfFieldId && !field.isShowIfFieldDisabled)
     .map(field => {
       const conditionalField = fields[field.showIfFieldId];
       const conditionalValues = fieldRegistry[conditionalField.inputType].getDataForCondition(

--- a/indico/modules/events/registration/client/js/form/FormItem.jsx
+++ b/indico/modules/events/registration/client/js/form/FormItem.jsx
@@ -70,12 +70,16 @@ ItemLocked.propTypes = {
   reason: PropTypes.string.isRequired,
 };
 
-function ItemConditional({reason}) {
-  return <Popup trigger={<Icon name="code branch" styleName="conditional" />}>{reason}</Popup>;
+function ItemConditional({reason, icon = 'code branch', color = 'blue'}) {
+  return (
+    <Popup trigger={<Icon name={icon} styleName="conditional" color={color} />}>{reason}</Popup>
+  );
 }
 
 ItemConditional.propTypes = {
   reason: PropTypes.string.isRequired,
+  icon: PropTypes.string,
+  color: PropTypes.string,
 };
 
 function renderAsFieldset(fieldOptions, meta) {
@@ -100,6 +104,7 @@ export default function FormItem({
   setupMode,
   setupActions,
   showIfFieldId,
+  isShowIfFieldDisabled,
   htmlName,
   defaultValue,
   ...rest
@@ -137,6 +142,7 @@ export default function FormItem({
     setupMode,
     setupActions,
     showIfFieldId,
+    isShowIfFieldDisabled,
     ...rest,
     meta,
   };
@@ -246,9 +252,19 @@ export default function FormItem({
       <div styleName="actions">
         {setupActions}
         {lockedReason && <ItemLocked reason={lockedReason} />}
-        {!!showIfFieldId && setupMode && (
-          <ItemConditional reason={Translate.string('This field is conditionally shown')} />
-        )}
+        {!!showIfFieldId &&
+          setupMode &&
+          (isShowIfFieldDisabled ? (
+            <ItemConditional
+              reason={Translate.string(
+                'The conditional field set to display this field is currently disabled and not in effect'
+              )}
+              icon="warning sign"
+              color="orange"
+            />
+          ) : (
+            <ItemConditional reason={Translate.string('This field is conditionally shown')} />
+          ))}
         {!lockedReason && showPurged && <PurgedItemLocked isUpdateMode={isUpdateMode} />}
         {!lockedReason && !showPurged && paidItemLocked && (
           <PaidItemLocked management={isManagement} />
@@ -288,6 +304,8 @@ FormItem.propTypes = {
   setupActions: PropTypes.node,
   /** The ID of the field to use as condition for display */
   showIfFieldId: PropTypes.number,
+  /** Whether the field set as condition for display is currently disabled */
+  isShowIfFieldDisabled: PropTypes.bool,
   /** The default value for a given field **/
   defaultValue: PropTypes.any,
   // ... and various other field-specific keys (billing, limited-places, other config)
@@ -304,5 +322,6 @@ FormItem.defaultProps = {
   setupMode: false,
   setupActions: null,
   showIfFieldId: null,
+  isShowIfFieldDisabled: false,
   defaultValue: null,
 };

--- a/indico/modules/events/registration/client/js/form/fields/ShowIfInput.jsx
+++ b/indico/modules/events/registration/client/js/form/fields/ShowIfInput.jsx
@@ -9,20 +9,23 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Field, useForm} from 'react-final-form';
 import {useSelector} from 'react-redux';
+import {Icon, Popup} from 'semantic-ui-react';
 
 import {FinalDropdown} from 'indico/react/forms';
 import {Fieldset, unsortedArraysEqual} from 'indico/react/forms/fields';
 import {Translate} from 'indico/react/i18n';
 
-import {getItems, getNestedSections} from '../selectors';
+import {showIfFieldDisabled} from '../../form_setup/selectors';
+import {getAllNestedSections, getItems} from '../selectors';
 
 import {getFieldRegistry} from './registry';
 
 export function ShowIfInput({fieldId: thisFieldId}) {
   const fields = useSelector(getItems);
-  const sections = useSelector(getNestedSections);
+  const sections = useSelector(getAllNestedSections);
   const fieldRegistry = getFieldRegistry();
   const form = useForm();
+  const isShowIfFieldDisabled = useSelector(state => showIfFieldDisabled(state, thisFieldId));
 
   const choices = sections.flatMap(section =>
     section.items
@@ -30,12 +33,21 @@ export function ShowIfInput({fieldId: thisFieldId}) {
       .map(({title, id: fieldId, isEnabled}) => ({
         value: fieldId,
         text: `${section.title} » ${title}`,
-        disabled: !isEnabled,
+        disabled: !isEnabled || !section.enabled,
       }))
   );
 
   return (
     <Fieldset legend={Translate.string('Show if')}>
+      {isShowIfFieldDisabled && (
+        <Popup trigger={<Icon name="warning sign" color="orange" />}>
+          <Translate>
+            The conditional field set to display this field is currently disabled and not in effect.
+            You may either re-enable the previous field or select another field to use for the
+            condition below.
+          </Translate>
+        </Popup>
+      )}
       <FinalDropdown
         name="showIfFieldId"
         /* i18n: Form field */

--- a/indico/modules/events/registration/client/js/form/selectors.js
+++ b/indico/modules/events/registration/client/js/form/selectors.js
@@ -91,6 +91,17 @@ export const getNestedSections = createSelector(
     }))
 );
 
+/** Get the nested form structure of all sections and their items, including disabled ones. */
+export const getAllNestedSections = createSelector(
+  getFlatSections,
+  getSectionItemMapping,
+  (sections, sectionFields) =>
+    _.sortBy(Object.values(sections), ['position', 'id']).map(section => ({
+      ...section,
+      items: sectionFields.get(section.id),
+    }))
+);
+
 export const getFieldLabelLookup = createSelector(
   getItems,
   items => {

--- a/indico/modules/events/registration/client/js/form_setup/DisabledSectionsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/DisabledSectionsModal.jsx
@@ -14,13 +14,14 @@ import {RequestConfirmDelete} from 'indico/react/components';
 import {Translate, Param} from 'indico/react/i18n';
 
 import * as actions from './actions';
-import {getDisabledSections} from './selectors';
+import {getDisabledSections, sectionHasConditionalFields} from './selectors';
 
 import '../../styles/regform.module.scss';
 
 function DisabledSection({id, title}) {
   const dispatch = useDispatch();
   const [confirmDeleteActive, setConfirmDeleteActive] = useState(false);
+  const hasConditionalFields = useSelector(state => sectionHasConditionalFields(state, id));
 
   const handleEnableClick = () => {
     dispatch(actions.enableSection(id));
@@ -65,7 +66,6 @@ function DisabledSection({id, title}) {
         requestFunc={() => dispatch(actions.removeSection(id))}
         onClose={() => setConfirmDeleteActive(false)}
         open={confirmDeleteActive}
-        size="mini"
         persistent
       >
         <Translate>
@@ -73,6 +73,12 @@ function DisabledSection({id, title}) {
           <Param name="field" value={title} wrapper={<strong />} />
           "?
         </Translate>
+        {hasConditionalFields && (
+          <Translate as="p">
+            This section contains fields used as conditions for other fields. Deleting it will
+            permanently remove those conditional relationships. This action cannot be undone.
+          </Translate>
+        )}
       </RequestConfirmDelete>
     </Segment>
   );

--- a/indico/modules/events/registration/client/js/form_setup/FormItemSetupActions.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/FormItemSetupActions.jsx
@@ -9,7 +9,7 @@ import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
-import {RequestConfirmDelete} from 'indico/react/components';
+import {RequestConfirm, RequestConfirmDelete} from 'indico/react/components';
 import {Translate, Param} from 'indico/react/i18n';
 
 import * as actions from './actions';
@@ -26,6 +26,7 @@ export default function FormItemSetupActions({
   const dispatch = useDispatch();
   const [settingsModalActive, setSettingsModalActive] = useState(false);
   const [confirmDeleteActive, setConfirmDeleteActive] = useState(false);
+  const [confirmDisableActive, setConfirmDisableActive] = useState(false);
   const isCondition = useSelector(state => isFieldConditionFor(state, id));
 
   const handleEnableClick = () => {
@@ -33,7 +34,11 @@ export default function FormItemSetupActions({
   };
 
   const handleDisableClick = () => {
-    dispatch(actions.disableItem(id));
+    if (isCondition) {
+      setConfirmDisableActive(true);
+    } else {
+      dispatch(actions.disableItem(id));
+    }
   };
 
   const handleRemoveClick = () => {
@@ -48,12 +53,8 @@ export default function FormItemSetupActions({
     <>
       {!fieldIsPersonalData && (
         <a
-          className={`icon-remove hide-if-locked ${isCondition ? 'disabled' : ''}`}
-          title={
-            isCondition
-              ? Translate.string('Fields that are a condition for other fields cannot be deleted.')
-              : Translate.string('Delete field')
-          }
+          className="icon-remove hide-if-locked"
+          title={Translate.string('Delete field')}
           onClick={handleRemoveClick}
         />
       )}
@@ -66,12 +67,8 @@ export default function FormItemSetupActions({
       )}
       {!fieldIsRequired && isEnabled && (
         <a
-          className={`icon-disable hide-if-locked ${isCondition ? 'disabled' : ''}`}
-          title={
-            isCondition
-              ? Translate.string('Fields that are a condition for other fields cannot be disabled.')
-              : Translate.string('Disable field')
-          }
+          className="icon-disable hide-if-locked"
+          title={Translate.string('Disable field')}
           onClick={handleDisableClick}
         />
       )}
@@ -83,6 +80,23 @@ export default function FormItemSetupActions({
       {settingsModalActive && (
         <ItemSettingsModal id={id} onClose={() => setSettingsModalActive(false)} />
       )}
+      <RequestConfirm
+        header={Translate.string('Are you sure you want to disable this field?')}
+        confirmText={Translate.string('Disable field')}
+        requestFunc={() => dispatch(actions.disableItem(id))}
+        onClose={() => setConfirmDisableActive(false)}
+        open={confirmDisableActive}
+      >
+        <Translate>
+          Are you sure you want to disable the field "
+          <Param name="field" value={title} wrapper={<strong />} />
+          "?
+        </Translate>
+        <Translate as="p">
+          This field is used as a condition for other fields. Disabling it will render those
+          conditions ineffective and those fields will always be shown to the registrants.
+        </Translate>
+      </RequestConfirm>
       <RequestConfirmDelete
         requestFunc={() => dispatch(actions.removeItem(id))}
         onClose={() => setConfirmDeleteActive(false)}
@@ -94,6 +108,12 @@ export default function FormItemSetupActions({
           <Param name="field" value={title} wrapper={<strong />} />
           "?
         </Translate>
+        {isCondition && (
+          <Translate as="p">
+            This field is used as a condition for other fields. Deleting it will permanently remove
+            those conditional relationships. This action cannot be undone.
+          </Translate>
+        )}
       </RequestConfirmDelete>
     </>
   );

--- a/indico/modules/events/registration/client/js/form_setup/FormSectionSetupActions.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/FormSectionSetupActions.jsx
@@ -7,23 +7,31 @@
 
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
-import {useDispatch} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 
+import {RequestConfirm} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 
 import * as actions from './actions';
 import ItemSettingsModal from './ItemSettingsModal';
 import ItemTypeDropdown from './ItemTypeDropdown';
 import SectionSettingsModal from './SectionSettingsModal';
+import {sectionHasConditionalFields} from './selectors';
 
 export default function FormSectionSetupActions({id, isPersonalData}) {
   const [settingsModalActive, setSettingsModalActive] = useState(false);
   const [fieldModalActive, setFieldModalActive] = useState(false);
   const [newItemType, setNewItemType] = useState(null);
+  const [confirmDisableActive, setConfirmDisableActive] = useState(false);
   const dispatch = useDispatch();
+  const hasConditionalFields = useSelector(state => sectionHasConditionalFields(state, id));
 
   const handleDisableClick = () => {
-    dispatch(actions.disableSection(id));
+    if (hasConditionalFields) {
+      setConfirmDisableActive(true);
+    } else {
+      dispatch(actions.disableSection(id));
+    }
   };
 
   const handleConfigureClick = () => {
@@ -61,6 +69,19 @@ export default function FormSectionSetupActions({id, isPersonalData}) {
           onClose={() => setFieldModalActive(false)}
         />
       )}
+      <RequestConfirm
+        header={Translate.string('Are you sure you want to disable this section?')}
+        confirmText={Translate.string('Disable section')}
+        onClose={() => setConfirmDisableActive(false)}
+        requestFunc={() => dispatch(actions.disableSection(id))}
+        open={confirmDisableActive}
+      >
+        <Translate>
+          This section contains fields that are used as conditions for other fields. Those
+          conditions will be inactive while this section is disabled so the fields depending on them
+          are always shown to registrants. Re-enabling the section will restore the conditions.
+        </Translate>
+      </RequestConfirm>
     </>
   );
 }

--- a/indico/modules/events/registration/client/js/form_setup/actions.js
+++ b/indico/modules/events/registration/client/js/form_setup/actions.js
@@ -101,6 +101,12 @@ function _createItem(data) {
   return {type: CREATE_ITEM, data};
 }
 
+function updateViewDataForConditionFields(dispatch, data) {
+  for (const viewData of data) {
+    dispatch(_updateItem(viewData.id, viewData));
+  }
+}
+
 export function saveSectionPosition(sectionId, position, oldPosition) {
   return async (dispatch, getStore) => {
     const store = getStore();
@@ -125,6 +131,7 @@ export function enableSection(sectionId) {
     if (!resp.error) {
       dispatch(_toggleSection(sectionId, true));
       dispatch(updatePositions(resp.data.positions));
+      updateViewDataForConditionFields(dispatch, resp.data.updated_items_view_data || []);
     }
   };
 }
@@ -138,7 +145,9 @@ export function disableSection(sectionId) {
     if (!resp.error) {
       dispatch(_toggleSection(sectionId, false));
       dispatch(updatePositions(resp.data.positions));
+      updateViewDataForConditionFields(dispatch, resp.data.updated_items_view_data || []);
     }
+    return !!resp.error;
   };
 }
 
@@ -148,6 +157,7 @@ export function removeSection(sectionId) {
     const url = modifySectionURL(getURLParams(store)(sectionId));
     const resp = await lockingAjaxAction(() => indicoAxios.delete(url))(dispatch);
     if (!resp.error) {
+      updateViewDataForConditionFields(dispatch, resp.data.updated_items_view_data || []);
       dispatch(_removeSection(sectionId));
     }
     return !!resp.error;
@@ -208,6 +218,7 @@ export function enableItem(itemId) {
     if (!resp.error) {
       dispatch(_updateItem(itemId, resp.data.view_data));
       dispatch(updatePositions(resp.data.positions));
+      updateViewDataForConditionFields(dispatch, resp.data.updated_items_view_data || []);
     }
   };
 }
@@ -223,7 +234,9 @@ export function disableItem(itemId) {
     if (!resp.error) {
       dispatch(_updateItem(itemId, resp.data.view_data));
       dispatch(updatePositions(resp.data.positions));
+      updateViewDataForConditionFields(dispatch, resp.data.updated_items_view_data || []);
     }
+    return !!resp.error;
   };
 }
 
@@ -235,6 +248,7 @@ export function removeItem(itemId) {
     const url = urlFunc(getURLParams(store)(sectionId, itemId));
     const resp = await lockingAjaxAction(() => indicoAxios.delete(url))(dispatch);
     if (!resp.error) {
+      updateViewDataForConditionFields(dispatch, resp.data.updated_items_view_data || []);
       dispatch(_removeItem(itemId));
     }
     return !!resp.error;
@@ -251,6 +265,7 @@ export function updateItem(itemId, data) {
     const resp = await submitFormAction(() => indicoAxios.patch(url, payload))(dispatch);
     if (!resp.error) {
       dispatch(_updateItem(itemId, resp.data.view_data));
+      updateViewDataForConditionFields(dispatch, resp.data.updated_items_view_data || []);
     }
     return camelizeKeys(resp);
   };

--- a/indico/modules/events/registration/client/js/form_setup/selectors.js
+++ b/indico/modules/events/registration/client/js/form_setup/selectors.js
@@ -83,3 +83,24 @@ export const isFieldConditionFor = createSelector(
   getItemById,
   item => !!item.showIfConditionForTransitive.length
 );
+
+/** Get the IDs of the sections containing fields that are used as conditions for other fields */
+const getSectionIdsWithConditionalFields = createSelector(
+  getItems,
+  items =>
+    new Set(
+      Object.values(items)
+        .filter(item => item.showIfConditionForTransitive.length > 0)
+        .map(item => item.sectionId)
+    )
+);
+
+/** Return whether a section contains any fields that are used as conditions for other fields. */
+export const sectionHasConditionalFields = (state, sectionId) =>
+  getSectionIdsWithConditionalFields(state).has(sectionId);
+
+/** Return whether a field's show_if_field is disabled. */
+export const showIfFieldDisabled = createSelector(
+  getItemById,
+  item => !!item && item.isShowIfFieldDisabled
+);

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -24,7 +24,9 @@ from indico.modules.events.registration.models.form_fields import RegistrationFo
 from indico.modules.events.registration.models.forms import RegistrationForm
 from indico.modules.events.registration.models.items import (RegistrationFormItem, RegistrationFormItemType,
                                                              RegistrationFormText)
-from indico.modules.events.registration.util import get_flat_section_positions_setup_data, update_regform_item_positions
+from indico.modules.events.registration.util import (get_condition_items_view_data,
+                                                     get_flat_section_positions_setup_data,
+                                                     update_regform_item_positions)
 from indico.modules.events.settings import data_retention_settings
 from indico.modules.logs.models.entries import EventLogRealm, LogKind
 from indico.modules.logs.util import make_diff_log
@@ -172,22 +174,23 @@ class GeneralFieldDataSchema(mm.Schema):
         from indico.modules.events.registration.models.form_fields import RegistrationFormItem
         if field_id is None:
             return
-        field = self.context['field']
-        if self._check_manager_only(field):
+        current_field = self.context['field']
+        if self._check_manager_only(current_field):
             raise ValidationError('Manager-only fields cannot be conditionally shown')
         used_field_ids = set()
-        if field.id is not None:
-            if field.id == field_id:
+        if current_field.id is not None:
+            if current_field.id == field_id:
                 raise ValidationError('The field cannot conditionally depend on itself to be shown')
-            used_field_ids.add(field.id)
+            used_field_ids.add(current_field.id)
         regform = self.context['regform']
         if not (condition_field := RegistrationFormItem.query.with_parent(regform).filter_by(id=field_id).first()):
             raise ValidationError('The field to show does not belong to the same registration form.')
         if not condition_field.field_impl.allow_condition:
             raise ValidationError('This field cannot be used as a condition.')
-        if not condition_field.is_enabled:
+        # if the field is already used as a condition, then don't check again whether it is disabled or not
+        if current_field.show_if_field != condition_field and not condition_field.is_enabled:
             raise ValidationError('Disabled fields cannot be used as a condition.')
-        if not condition_field.parent.is_enabled:
+        if current_field.show_if_field != condition_field and not condition_field.parent.is_enabled:
             raise ValidationError('Fields in disabled sections cannot be used as a condition.')
         # Avoid cycles
         next_field_id = field_id
@@ -199,8 +202,6 @@ class GeneralFieldDataSchema(mm.Schema):
             next_field = RegistrationFormItem.query.filter_by(id=next_field_id).one()
             if self._check_manager_only(next_field):
                 raise ValidationError('Field conditions may not depend on fields in manager-only sections')
-            if not next_field.is_enabled:
-                raise ValidationError('Field conditions may not depend on disabled fields')
             next_field_id = next_field.show_if_id
 
     @validates_schema(skip_on_field_errors=True)
@@ -283,6 +284,17 @@ def _fill_form_field_with_data(field, field_data, *, is_static_text=False):
     return changes
 
 
+def _get_show_if_field_chain(field):
+    chain = []
+    seen = set()
+    current = field.show_if_field
+    while current is not None and current.id not in seen:
+        seen.add(current.id)
+        chain.append(current)
+        current = current.show_if_field
+    return chain
+
+
 class RHManageRegFormFieldBase(RHManageRegFormSectionBase):
     """Base class for a specific field within a registration form."""
 
@@ -356,8 +368,6 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
         if (not enabled and self.field.type == RegistrationFormItemType.field_pd and
                 self.field.personal_data_type.is_required):
             raise BadRequest
-        if not enabled and self.field.condition_for:
-            raise NoReportError.wrap_exc(BadRequest(_('Fields used as conditional cannot be disabled')))
         if enabled:
             self._check_unique_title_in_section()
             self._check_unique_internal_name_in_form()
@@ -378,17 +388,33 @@ class RHRegistrationFormToggleFieldState(RHManageRegFormFieldBase):
                 EventLogRealm.management, LogKind.negative, 'Registration',
                 f'Field "{self.field.title}" in "{self.regform.title}" disabled', session.user
             )
-        return jsonify(view_data=self.field.view_data, positions=get_flat_section_positions_setup_data(self.regform))
+        linked_fields = [field for field in self.field.condition_for if not field.is_deleted]
+        return jsonify(view_data=self.field.view_data, positions=get_flat_section_positions_setup_data(self.regform),
+                       updated_items_view_data=get_condition_items_view_data(linked_fields))
 
 
 class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
     """Remove/Modify a field."""
 
+    def _get_updated_condition_items_view_data(self, old_show_if_chain):
+        db.session.flush()
+        # the relationship is not refreshed automatically when the foreign key is modified directly
+        db.session.expire(self.field, ['show_if_field'])
+        new_show_if_chain = _get_show_if_field_chain(self.field)
+        if [f.id for f in old_show_if_chain] == [f.id for f in new_show_if_chain]:
+            return []
+        updated_items = {f.id: f for f in (*old_show_if_chain, *new_show_if_chain) if not f.is_deleted}
+        return get_condition_items_view_data(updated_items.values())
+
     def _process_DELETE(self):
         if self.field.type == RegistrationFormItemType.field_pd:
             raise BadRequest
-        if self.field.condition_for:
-            raise NoReportError.wrap_exc(BadRequest(_('Fields used as conditional cannot be deleted')))
+        linked_fields = []
+        for linked_field in self.field.condition_for:
+            linked_field.show_if_id = None
+            linked_field.show_if_values = None
+            if not linked_field.is_deleted:
+                linked_fields.append(linked_field)
         signals.event.registration_form_field_deleted.send(self.field)
         self.field.is_deleted = True
         self.field.show_if_id = None
@@ -400,7 +426,7 @@ class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
             f'Field "{self.field.title}" in "{self.regform.title}" deleted', session.user
         )
         logger.info('Field %s deleted by %s', self.field, session.user)
-        return jsonify()
+        return jsonify(updated_items_view_data=get_condition_items_view_data(linked_fields))
 
     def _process_PATCH(self):
         field_data = snakify_keys(request.json['fieldData'])
@@ -409,6 +435,7 @@ class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
         elif 'input_type' in field_data and self.field.input_type != field_data['input_type']:
             raise BadRequest
         field_data['input_type'] = self.field.input_type
+        old_show_if_chain = _get_show_if_field_chain(self.field)
         changes = _fill_form_field_with_data(self.field, field_data)
         signals.event.registration_form_field_changed.send(self.field)
         changes = make_diff_log(changes, {
@@ -418,12 +445,13 @@ class RHRegistrationFormModifyField(RHManageRegFormFieldBase):
             'retention_period': {'title': 'Retention period'},
             'internal_name': {'title': 'Internal name', 'type': 'string'},
         })
+        updated_items = self._get_updated_condition_items_view_data(old_show_if_chain)
         self.field.log(
             EventLogRealm.management, LogKind.change, 'Registration',
             f'Field "{self.field.title}" in "{self.regform.title}" modified', session.user,
             data={'Changes': changes}
         )
-        return jsonify(view_data=self.field.view_data)
+        return jsonify(view_data=self.field.view_data, updated_items_view_data=updated_items)
 
 
 class RHRegistrationFormMoveField(RHManageRegFormFieldBase):
@@ -484,17 +512,19 @@ class RHRegistrationFormModifyText(RHRegistrationFormModifyField):
     def _process_PATCH(self):
         field_data = snakify_keys(request.json['fieldData'])
         field_data.pop('input_type', None)
+        old_show_if_chain = _get_show_if_field_chain(self.field)
         changes = _fill_form_field_with_data(self.field, field_data, is_static_text=True)
         changes = make_diff_log(changes, {
             'title': {'title': 'Title', 'type': 'string'},
             'description': {'title': 'Description'},
         })
+        updated_items = self._get_updated_condition_items_view_data(old_show_if_chain)
         self.field.log(
             EventLogRealm.management, LogKind.change, 'Registration',
             f'Field "{self.field.title}" in "{self.regform.title}" modified', session.user,
             data={'Changes': changes}
         )
-        return jsonify(view_data=self.field.view_data)
+        return jsonify(view_data=self.field.view_data, updated_items_view_data=updated_items)
 
 
 class RHRegistrationFormMoveText(RHRegistrationFormMoveField):

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -10,6 +10,7 @@ from marshmallow import ValidationError
 from werkzeug.exceptions import BadRequest
 
 from indico.modules.events.registration.controllers.management.fields import (GeneralFieldDataSchema,
+                                                                              RHRegistrationFormModifyField,
                                                                               RHRegistrationFormToggleFieldState,
                                                                               TextDataSchema,
                                                                               _fill_form_field_with_data)
@@ -207,6 +208,150 @@ class TestGeneralFieldDataSchema:
         schema = GeneralFieldDataSchema(context={'regform': other_form, 'field': other_field})
         schema.load({'input_type': 'checkbox', 'title': 'test', 'internal_name': 'test'})
 
+    # show_if_field tests
+
+    def test_show_if_field_not_allowed_for_manager_only_section_field(self, db, dummy_regform):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section',
+                                                  is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        db.session.flush()
+        manager_section = RegistrationFormSection(registration_form=dummy_regform, title='Manager section',
+                                                  is_manager_only=True)
+        new_field = RegistrationFormField(parent=manager_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'Manager field',
+                         'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {'show_if_field_id': ['Manager-only fields cannot be conditionally shown']}
+
+    def test_show_if_field_self_reference(self, db, dummy_regform):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(field, {'input_type': 'checkbox', 'title': 'Field'})
+        db.session.flush()
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'checkbox', 'title': 'Field',
+                         'show_if_field_id': field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {
+            'show_if_field_id': ['The field cannot conditionally depend on itself to be shown']
+        }
+
+    def test_show_if_field_from_other_regform(self, db, dummy_regform, dummy_event, create_regform):
+        other_regform = create_regform(dummy_event, title='Other Form')
+        other_section = RegistrationFormSection(registration_form=other_regform, title='Other section',
+                                                is_manager_only=False)
+        other_condition_field = RegistrationFormField(parent=other_section, registration_form=other_regform)
+        _fill_form_field_with_data(other_condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        db.session.flush()
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        new_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field',
+                         'show_if_field_id': other_condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {
+            'show_if_field_id': ['The field to show does not belong to the same registration form.']
+        }
+
+    def test_show_if_field_unsupported_input_type(self, db, dummy_regform):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'text', 'title': 'Condition field'})
+        db.session.flush()
+        new_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field',
+                         'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {'show_if_field_id': ['This field cannot be used as a condition.']}
+
+    def test_show_if_field_cycle_detection(self, db, dummy_regform):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        field_a = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(field_a, {'input_type': 'checkbox', 'title': 'Field A'})
+        db.session.flush()
+        field_b = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(field_b, {'input_type': 'checkbox', 'title': 'Field B'})
+        field_b.show_if_id = field_a.id
+        field_b.show_if_values = ['yes']
+        db.session.flush()
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': field_a})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'checkbox', 'title': 'Field A',
+                         'show_if_field_id': field_b.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {
+            'show_if_field_id': ['Field conditions may not have cycles (a -> b -> c -> a)']
+        }
+
+    def test_show_if_field_condition_in_manager_only_section(self, db, dummy_regform):
+        manager_section = RegistrationFormSection(registration_form=dummy_regform, title='Manager section',
+                                                  is_manager_only=True)
+        condition_field = RegistrationFormField(parent=manager_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Manager condition'})
+        db.session.flush()
+        new_section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field',
+                         'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {
+            'show_if_field_id': ['Field conditions may not depend on fields in manager-only sections']
+        }
+
+    def test_show_if_field_does_not_allow_disabled_field(self, db, dummy_regform):
+        new_section = RegistrationFormSection(registration_form=dummy_regform, title='New section',
+                                              is_manager_only=False)
+        condition_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        condition_field.is_enabled = False
+        db.session.flush()
+        new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field',
+                         'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {'show_if_field_id': ['Disabled fields cannot be used as a condition.']}
+
+    def test_show_if_field_allows_existing_disabled_field(self, db, dummy_regform):
+        condition_section = RegistrationFormSection(registration_form=dummy_regform, title='Condition section',
+                                                    is_manager_only=False)
+        condition_field = RegistrationFormField(parent=condition_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        new_section = RegistrationFormSection(registration_form=dummy_regform, title='New section',
+                                                    is_manager_only=False)
+        new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(new_field, {'input_type': 'text', 'title': 'New field'})
+        db.session.flush()
+        new_field.show_if_id = condition_field.id
+        new_field.show_if_values = ['yes']
+        db.session.flush()
+        condition_field.is_enabled = False
+        db.session.flush()
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        assert schema.load({'input_type': 'text', 'title': 'New field',
+                            'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+
+    def test_show_if_field_does_not_allow_fields_in_disabled_section(self, db, dummy_regform):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Condition section',
+                                          is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        section.is_enabled = False
+        db.session.flush()
+        new_section = RegistrationFormSection(registration_form=dummy_regform, title='New section',
+                                                is_manager_only=False)
+        new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field',
+                         'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {
+            'show_if_field_id': ['Fields in disabled sections cannot be used as a condition.']
+        }
+
 
 class TestTextDataSchema:
     def test_new_label_field_with_empty_internal_name(self, dummy_regform):
@@ -350,3 +495,40 @@ class TestRegistrationFormToggleFieldState:
         with pytest.raises(BadRequest, match='The field "Field Title" with the same internal name on form "Other Form" '
                                              'uses a different input type which is not allowed'):
             rh._check_internal_name_type_consistency_in_event()
+
+
+class TestRegistrationFormModifyField:
+    def test_delete_condition_field_clears_show_if_field_and_values(self, db, dummy_regform, app_context):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        db.session.flush()
+        new_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(new_field, {'input_type': 'text', 'title': 'New field'})
+        new_field.show_if_id = condition_field.id
+        new_field.show_if_values = ['yes']
+        db.session.flush()
+        with app_context.test_request_context():
+            rh = RHRegistrationFormModifyField()
+            rh.field = condition_field
+            rh.regform = dummy_regform
+            rh._process_DELETE()
+        assert new_field.show_if_id is None
+        assert new_field.show_if_values is None
+
+    def test_delete_field_clears_condition_for_links(self, db, dummy_regform, app_context):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        db.session.flush()
+        new_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(new_field, {'input_type': 'text', 'title': 'New field'})
+        new_field.show_if_id = condition_field.id
+        new_field.show_if_values = ['yes']
+        db.session.flush()
+        with app_context.test_request_context():
+            rh = RHRegistrationFormModifyField()
+            rh.field = new_field
+            rh.regform = dummy_regform
+            rh._process_DELETE()
+        assert condition_field.condition_for == []

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -505,8 +505,7 @@ class TestRegistrationFormToggleFieldState:
     def test_same_title_in_other_section_on_enable(self, db, dummy_regform):
         other_section = RegistrationFormSection(registration_form=dummy_regform, title='Other Section',
                                                 is_manager_only=False)
-        disabled_field = RegistrationFormField(parent=other_section, registration_form=dummy_regform, is_enabled=False,
-                                               id=1337)
+        disabled_field = RegistrationFormField(parent=other_section, registration_form=dummy_regform, is_enabled=False)
         _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Title'})
         db.session.flush()
         rh = RHRegistrationFormToggleFieldState()
@@ -559,8 +558,7 @@ class TestRegistrationFormToggleFieldState:
     def test_same_internal_name_in_other_section_on_enable(self, db, dummy_regform):
         other_section = RegistrationFormSection(registration_form=dummy_regform, title='Other Section',
                                                 is_manager_only=False)
-        disabled_field = RegistrationFormField(parent=other_section, registration_form=dummy_regform, is_enabled=False,
-                                               id=1337)
+        disabled_field = RegistrationFormField(parent=other_section, registration_form=dummy_regform, is_enabled=False)
         _fill_form_field_with_data(disabled_field, {'input_type': 'text', 'title': 'Field Title',
                                                     'internal_name': 'title'})
         db.session.flush()

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -10,6 +10,7 @@ from marshmallow import ValidationError
 from werkzeug.exceptions import BadRequest
 
 from indico.modules.events.registration.controllers.management.fields import (GeneralFieldDataSchema,
+                                                                              RHRegistrationFormModifyField,
                                                                               RHRegistrationFormToggleFieldState,
                                                                               TextDataSchema,
                                                                               _fill_form_field_with_data)
@@ -316,6 +317,150 @@ class TestAccompanyingPersonsFieldSetupSchema:
         schema = GeneralFieldDataSchema(context={'regform': other_form, 'field': other_field})
         schema.load({'input_type': 'checkbox', 'title': 'test', 'internal_name': 'test'})
 
+    # show_if_field tests
+
+    def test_show_if_field_not_allowed_for_manager_only_section_field(self, db, dummy_regform):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section',
+                                                  is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        db.session.flush()
+        manager_section = RegistrationFormSection(registration_form=dummy_regform, title='Manager section',
+                                                  is_manager_only=True)
+        new_field = RegistrationFormField(parent=manager_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'Manager field',
+                         'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {'show_if_field_id': ['Manager-only fields cannot be conditionally shown']}
+
+    def test_show_if_field_self_reference(self, db, dummy_regform):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(field, {'input_type': 'checkbox', 'title': 'Field'})
+        db.session.flush()
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'checkbox', 'title': 'Field',
+                         'show_if_field_id': field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {
+            'show_if_field_id': ['The field cannot conditionally depend on itself to be shown']
+        }
+
+    def test_show_if_field_from_other_regform(self, db, dummy_regform, dummy_event, create_regform):
+        other_regform = create_regform(dummy_event, title='Other Form')
+        other_section = RegistrationFormSection(registration_form=other_regform, title='Other section',
+                                                is_manager_only=False)
+        other_condition_field = RegistrationFormField(parent=other_section, registration_form=other_regform)
+        _fill_form_field_with_data(other_condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        db.session.flush()
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        new_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field',
+                         'show_if_field_id': other_condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {
+            'show_if_field_id': ['The field to show does not belong to the same registration form.']
+        }
+
+    def test_show_if_field_unsupported_input_type(self, db, dummy_regform):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'text', 'title': 'Condition field'})
+        db.session.flush()
+        new_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field',
+                         'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {'show_if_field_id': ['This field cannot be used as a condition.']}
+
+    def test_show_if_field_cycle_detection(self, db, dummy_regform):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        field_a = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(field_a, {'input_type': 'checkbox', 'title': 'Field A'})
+        db.session.flush()
+        field_b = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(field_b, {'input_type': 'checkbox', 'title': 'Field B'})
+        field_b.show_if_id = field_a.id
+        field_b.show_if_values = ['yes']
+        db.session.flush()
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': field_a})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'checkbox', 'title': 'Field A',
+                         'show_if_field_id': field_b.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {
+            'show_if_field_id': ['Field conditions may not have cycles (a -> b -> c -> a)']
+        }
+
+    def test_show_if_field_condition_in_manager_only_section(self, db, dummy_regform):
+        manager_section = RegistrationFormSection(registration_form=dummy_regform, title='Manager section',
+                                                  is_manager_only=True)
+        condition_field = RegistrationFormField(parent=manager_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Manager condition'})
+        db.session.flush()
+        new_section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field',
+                         'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {
+            'show_if_field_id': ['Field conditions may not depend on fields in manager-only sections']
+        }
+
+    def test_show_if_field_does_not_allow_disabled_field(self, db, dummy_regform):
+        new_section = RegistrationFormSection(registration_form=dummy_regform, title='New section',
+                                              is_manager_only=False)
+        condition_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        condition_field.is_enabled = False
+        db.session.flush()
+        new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field',
+                         'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {'show_if_field_id': ['Disabled fields cannot be used as a condition.']}
+
+    def test_show_if_field_allows_existing_disabled_field(self, db, dummy_regform):
+        condition_section = RegistrationFormSection(registration_form=dummy_regform, title='Condition section',
+                                                    is_manager_only=False)
+        condition_field = RegistrationFormField(parent=condition_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        new_section = RegistrationFormSection(registration_form=dummy_regform, title='New section',
+                                                    is_manager_only=False)
+        new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(new_field, {'input_type': 'text', 'title': 'New field'})
+        db.session.flush()
+        new_field.show_if_id = condition_field.id
+        new_field.show_if_values = ['yes']
+        db.session.flush()
+        condition_field.is_enabled = False
+        db.session.flush()
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        assert schema.load({'input_type': 'text', 'title': 'New field',
+                            'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+
+    def test_show_if_field_does_not_allow_fields_in_disabled_section(self, db, dummy_regform):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Condition section',
+                                          is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        section.is_enabled = False
+        db.session.flush()
+        new_section = RegistrationFormSection(registration_form=dummy_regform, title='New section',
+                                                is_manager_only=False)
+        new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform)
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'text', 'title': 'New field',
+                         'show_if_field_id': condition_field.id, 'show_if_field_values': ['yes']})
+        assert exc_info.value.messages == {
+            'show_if_field_id': ['Fields in disabled sections cannot be used as a condition.']
+        }
+
 
 class TestTextDataSchema:
     def test_new_label_field_with_empty_internal_name(self, dummy_regform):
@@ -459,3 +604,40 @@ class TestRegistrationFormToggleFieldState:
         with pytest.raises(BadRequest, match='The field "Field Title" with the same internal name on form "Other Form" '
                                              'uses a different input type which is not allowed'):
             rh._check_internal_name_type_consistency_in_event()
+
+
+class TestRegistrationFormModifyField:
+    def test_delete_condition_field_clears_show_if_field_and_values(self, db, dummy_regform, app_context):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        db.session.flush()
+        new_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(new_field, {'input_type': 'text', 'title': 'New field'})
+        new_field.show_if_id = condition_field.id
+        new_field.show_if_values = ['yes']
+        db.session.flush()
+        with app_context.test_request_context():
+            rh = RHRegistrationFormModifyField()
+            rh.field = condition_field
+            rh.regform = dummy_regform
+            rh._process_DELETE()
+        assert new_field.show_if_id is None
+        assert new_field.show_if_values is None
+
+    def test_delete_field_clears_condition_for_links(self, db, dummy_regform, app_context):
+        section = RegistrationFormSection(registration_form=dummy_regform, title='Section', is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        db.session.flush()
+        new_field = RegistrationFormField(parent=section, registration_form=dummy_regform)
+        _fill_form_field_with_data(new_field, {'input_type': 'text', 'title': 'New field'})
+        new_field.show_if_id = condition_field.id
+        new_field.show_if_values = ['yes']
+        db.session.flush()
+        with app_context.test_request_context():
+            rh = RHRegistrationFormModifyField()
+            rh.field = new_field
+            rh.regform = dummy_regform
+            rh._process_DELETE()
+        assert condition_field.condition_for == []

--- a/indico/modules/events/registration/controllers/management/sections.py
+++ b/indico/modules/events/registration/controllers/management/sections.py
@@ -10,14 +10,14 @@ from marshmallow import ValidationError
 from werkzeug.exceptions import BadRequest
 
 from indico.core.db import db
-from indico.core.errors import NoReportError
 from indico.modules.events.registration import logger
 from indico.modules.events.registration.controllers.management import RHManageRegFormBase
 from indico.modules.events.registration.models.items import RegistrationFormItemType, RegistrationFormSection
-from indico.modules.events.registration.util import get_flat_section_positions_setup_data, update_regform_item_positions
+from indico.modules.events.registration.util import (get_condition_items_view_data,
+                                                     get_flat_section_positions_setup_data,
+                                                     update_regform_item_positions)
 from indico.modules.logs.models.entries import EventLogRealm, LogKind
 from indico.modules.logs.util import make_diff_log
-from indico.util.i18n import _
 from indico.web.util import jsonify_data
 
 
@@ -60,6 +60,15 @@ class RHRegistrationFormModifySection(RHManageRegFormSectionBase):
     def _process_DELETE(self):
         if self.section.type == RegistrationFormItemType.section_pd:
             raise BadRequest
+        linked_fields = []
+        for field in self.section.children:
+            field.show_if_id = None
+            field.show_if_values = None
+            for linked_field in field.condition_for:
+                linked_field.show_if_id = None
+                linked_field.show_if_values = None
+                if not linked_field.is_deleted:
+                    linked_fields.append(linked_field)
         self.section.is_deleted = True
         db.session.flush()
         self.section.log(
@@ -67,12 +76,13 @@ class RHRegistrationFormModifySection(RHManageRegFormSectionBase):
             f'Section "{self.section.title}" in "{self.regform.title}" deleted', session.user
         )
         logger.info('Section %s deleted by %s', self.section, session.user)
-        return jsonify(success=True)
+        return jsonify(success=True, updated_items_view_data=get_condition_items_view_data(linked_fields))
 
     def _check_field_condition_relations(self):
         # Check that no field in this section is conditionally shown
         if any(field.show_if_id is not None for field in self.section.children if not field.is_deleted):
-            raise ValidationError('Sections with conditional fields cannot be made manager-only')
+            raise ValidationError('This section cannot be made manager-only because it contains fields that are '
+                                  'conditionally shown. Remove those dependencies first.')
         # Check no conditional fields depend on this section if it is becoming manager-only now
         critical_fields_ids = {field.id for field in self.section.children if not field.is_deleted}
         for section in self.regform.sections:
@@ -81,7 +91,8 @@ class RHRegistrationFormModifySection(RHManageRegFormSectionBase):
             fields_ids = {field.show_if_id for field in section.children
                           if field.show_if_id is not None and not field.is_deleted}
             if critical_fields_ids & fields_ids:
-                raise ValidationError('Cannot make section manager-only due to conditional field relations')
+                raise ValidationError('This section cannot be made manager-only because other fields depend on '
+                                      'fields inside it. Remove those dependencies first.')
 
     def _process_PATCH(self):
         changes = request.json['changes']
@@ -112,13 +123,8 @@ class RHRegistrationFormToggleSection(RHManageRegFormSectionBase):
 
     def _process_POST(self):
         enabled = request.args.get('enable') == 'true'
-        if not enabled:
-            if self.section.type == RegistrationFormItemType.section_pd:
-                raise BadRequest
-            if any(f.condition_for for f in self.section.children):
-                raise NoReportError.wrap_exc(
-                    BadRequest(_('Sections with fields used as conditional cannot be disabled'))
-                )
+        if not enabled and self.section.type == RegistrationFormItemType.section_pd:
+            raise BadRequest
         self.section.is_enabled = enabled
         update_regform_item_positions(self.regform)
         db.session.flush()
@@ -134,8 +140,12 @@ class RHRegistrationFormToggleSection(RHManageRegFormSectionBase):
                 f'Section "{self.section.title}" in "{self.regform.title}" disabled', session.user
             )
             logger.info('Section %s disabled by %s', self.section, session.user)
+        linked_fields = [linked_field for field in self.section.children
+                         for linked_field in field.condition_for
+                         if not linked_field.is_deleted]
         return jsonify_data(view_data=self.section.view_data,
-                            positions=get_flat_section_positions_setup_data(self.regform))
+                            positions=get_flat_section_positions_setup_data(self.regform),
+                            updated_items_view_data=get_condition_items_view_data(linked_fields))
 
 
 class RHRegistrationFormMoveSection(RHManageRegFormSectionBase):

--- a/indico/modules/events/registration/controllers/management/sections_test.py
+++ b/indico/modules/events/registration/controllers/management/sections_test.py
@@ -1,0 +1,56 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2026 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from indico.modules.events.registration.controllers.management.fields import _fill_form_field_with_data
+from indico.modules.events.registration.controllers.management.sections import RHRegistrationFormModifySection
+from indico.modules.events.registration.models.form_fields import RegistrationFormField
+from indico.modules.events.registration.models.items import RegistrationFormSection
+
+
+pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
+
+
+class TestRHRegistrationFormModifySection:
+    def test_delete_section_clears_show_if_field_and_values(self, db, dummy_regform, app_context):
+        section_a = RegistrationFormSection(registration_form=dummy_regform, title='Section A',
+                                                 is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section_a, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        db.session.flush()
+        section_b = RegistrationFormSection(registration_form=dummy_regform, title='Section B', is_manager_only=False)
+        new_field = RegistrationFormField(parent=section_b, registration_form=dummy_regform)
+        _fill_form_field_with_data(new_field, {'input_type': 'text', 'title': 'New field'})
+        new_field.show_if_id = condition_field.id
+        new_field.show_if_values = ['yes']
+        db.session.flush()
+        with app_context.test_request_context():
+            rh = RHRegistrationFormModifySection()
+            rh.section = section_b
+            rh.regform = dummy_regform
+            rh._process_DELETE()
+        assert new_field.show_if_id is None
+        assert new_field.show_if_values is None
+        assert condition_field.condition_for == []
+
+    def test_delete_section_clears_condition_for_links_on_fields(self, db, dummy_regform, app_context):
+        section_a = RegistrationFormSection(registration_form=dummy_regform, title='Section A', is_manager_only=False)
+        condition_field = RegistrationFormField(parent=section_a, registration_form=dummy_regform)
+        _fill_form_field_with_data(condition_field, {'input_type': 'checkbox', 'title': 'Condition field'})
+        db.session.flush()
+        section_b = RegistrationFormSection(registration_form=dummy_regform, title='Section B', is_manager_only=False)
+        new_field = RegistrationFormField(parent=section_b, registration_form=dummy_regform)
+        _fill_form_field_with_data(new_field, {'input_type': 'text', 'title': 'New field'})
+        new_field.show_if_id = condition_field.id
+        new_field.show_if_values = ['yes']
+        db.session.flush()
+        with app_context.test_request_context():
+            rh = RHRegistrationFormModifySection()
+            rh.section = section_a
+            rh.regform = dummy_regform
+            rh._process_DELETE()
+        db.session.expire(condition_field, ['condition_for'])
+        assert condition_field.condition_for == []

--- a/indico/modules/events/registration/models/form_fields.py
+++ b/indico/modules/events/registration/models/form_fields.py
@@ -98,6 +98,7 @@ class RegistrationFormField(RegistrationFormItem):
             show_if_field_values=self.show_if_values,
             show_if_condition_for=[f.id for f in self.condition_for],
             show_if_condition_for_transitive=[f.id for f in self.condition_for_transitive],
+            is_show_if_field_disabled=self.is_show_if_field_disabled,
             **super().view_data,
         )
         base_dict.update(self.field_impl.view_data)

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -414,6 +414,12 @@ class RegistrationFormItem(db.Model):
     def is_active(self):
         return self.is_enabled and not self.is_deleted and self.parent.is_enabled and not self.parent.is_deleted
 
+    @property
+    def is_show_if_field_disabled(self):
+        if not self.show_if_field:
+            return False
+        return not self.show_if_field.is_active
+
     @hybrid_property
     def is_section(self):
         return self.type in {RegistrationFormItemType.section, RegistrationFormItemType.section_pd}
@@ -545,6 +551,7 @@ class RegistrationFormText(RegistrationFormItem):
             show_if_field_values=self.show_if_values,
             show_if_condition_for=[f.id for f in self.condition_for],
             show_if_condition_for_transitive=[f.id for f in self.condition_for_transitive],
+            is_show_if_field_disabled=self.is_show_if_field_disabled,
         )
         return camelize_keys(field_data)
 

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -175,6 +175,12 @@ def get_flat_section_positions_setup_data(regform):
     return {'sections': section_data, 'items': item_data}
 
 
+def get_condition_items_view_data(items):
+    for item in items:
+        db.session.expire(item, ['show_if_field', 'condition_for'])
+    return [item.view_data for item in items]
+
+
 @make_interceptable
 def get_flat_section_submission_data(regform, *, management=False, registration=None):
     section_data = {s.id: camelize_keys(s.own_data) for s in regform.active_sections
@@ -1255,6 +1261,9 @@ def process_registration_picture(source, *, thumbnail=False, target_format='JPEG
 def is_conditional_field_shown(field, data, *, is_db_data=False):
     # not conditional
     if not field.show_if_field:
+        return True
+    # condition field (or its section) is disabled, so the condition is not in effect
+    if field.is_show_if_field_disabled:
         return True
     # condition field has no data
     if (show_if_data := data.get(field.show_if_id)) is None:


### PR DESCRIPTION
This PR allows deleting/disabling fields used as conditionals. The reason for this PR is mainly to improve the user experience when using forms that contain multiple conditional fields and they need to unlink them before being allowed to disable/delete the fields/sections.