### PR TITLE
Handle pasted emails in user search dialog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,8 @@ Improvements
 - Add a weekday option to the contribution schedule email placeholder (:pr:`7526`)
 - Allow managers to override accommodation date range validation when editing
   registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)
+- Automatically paste obvious email addresses into the email field when pasting in
+  the user search dialog (:pr:`7538`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/web/client/js/react/components/principals/Search.jsx
+++ b/indico/web/client/js/react/components/principals/Search.jsx
@@ -45,6 +45,31 @@ const InitialFormValuesContext = React.createContext({});
 export const UserSearchTokenContext = (window._UserSearchTokenContext =
   window._UserSearchTokenContext || React.createContext(null));
 
+const PasteHandler = ({onPaste, formApi}) => {
+  useEffect(() => {
+    if (!onPaste) {
+      return;
+    }
+
+    const _handler = evt => {
+      const data = evt.clipboardData.getData('text');
+      if (!data) {
+        return;
+      }
+      onPaste(evt, data, formApi);
+    };
+
+    document.addEventListener('paste', _handler);
+    return () => document.removeEventListener('paste', _handler);
+  }, [formApi, onPaste]);
+  return null;
+};
+
+PasteHandler.propTypes = {
+  onPaste: PropTypes.func.isRequired,
+  formApi: PropTypes.object.isRequired,
+};
+
 const searchFactory = config => {
   const {
     componentName,
@@ -57,6 +82,7 @@ const searchFactory = config => {
     favoriteKey,
     noResultsText,
     runSearch,
+    onPaste,
     validateForm,
   } = config;
 
@@ -118,6 +144,7 @@ const searchFactory = config => {
       >
         {fprops => (
           <Form onSubmit={fprops.handleSubmit}>
+            {config.onPaste && <PasteHandler onPaste={onPaste} formApi={fprops.form} />}
             {searchFields}
             <div styleName="search-buttons">
               <Button
@@ -669,6 +696,23 @@ const InnerUserSearch = searchFactory({
   resultIcon: 'user',
   favoriteKey: 'identifier',
   searchFields: <UserSearchFields />,
+  onPaste: (evt, content, form) => {
+    if (evt.target.name === 'affiliation') {
+      // affiliations can be anything so one COULD look like a valid email
+      return;
+    }
+    // look for classic name+email patterns to extract the email `Foo <foo@example.com>`
+    let match = content.match(/<([^@\s]+@[^>\s]+\.[^>\s]+)>/);
+    if (!match) {
+      // look for just a standalone email address
+      match = content.match(/^\s*([^@\s]+@\S+\.\S+)\s*$/);
+    }
+    if (!match) {
+      return;
+    }
+    form.change('email', match[1]);
+    evt.preventDefault();
+  },
   validateForm: values => {
     if (!values.first_name && !values.last_name && !values.email && !values.affiliation) {
       // no i18n needed, we do not show this error


### PR DESCRIPTION
This is something I always wanted to add because it's very convenient to copy an
email sender address from the email client or an email address from a ticket and
paste it into the user search dialog w/o having to focus the field or manually
extract the email address from the standard `name <email>` pattern.

Basically it looks at anything pasted while the user search dialog is open, the
only special case is when the affiliation field is focused, because while
(very) unlikely, an affiliation could look like a valid email address. In any
case, this field is not the one focused by default so it's very unlikely to
break a "valid" case of this new functionality.