### PR TITLE
Fix bugs in agreements module

### DIFF
--- a/indico/modules/events/agreements/controllers.py
+++ b/indico/modules/events/agreements/controllers.py
@@ -132,8 +132,9 @@ class RHAgreementManagerDetailsEmailBase(RHAgreementManagerDetails):
         raise NotImplementedError
 
     def _get_form(self):
-        template = self.definition.get_email_body_template(self.event)
-        form_defaults = FormDefaults(body=template.get_html_body())
+        with self.event.force_event_locale():
+            template = self.definition.get_email_body_template(self.event)
+            form_defaults = FormDefaults(body=template.get_html_body())
         return AgreementEmailForm(obj=form_defaults, definition=self.definition, event=self.event)
 
     def _process(self):

--- a/indico/modules/events/agreements/templates/agreement_type_details.html
+++ b/indico/modules/events/agreements/templates/agreement_type_details.html
@@ -28,7 +28,7 @@
     {% set pending = agreements | selectattr('pending') | list %}
     {% set signed = agreements | rejectattr('pending') | list %}
 
-    <div class="agreement-dashboard">
+    <div>
         <div class="action-box">
             <div class="section">
                 <div class="icon icon-bullhorn"></div>

--- a/indico/web/client/styles/modules/_agreements.scss
+++ b/indico/web/client/styles/modules/_agreements.scss
@@ -118,16 +118,6 @@
   }
 }
 
-.agreement-dashboard {
-  @extend .fixed-width;
-
-  .action-box {
-    .i-button {
-      width: 10em;
-    }
-  }
-}
-
 .agreement-list {
   .agreement-table {
     border-collapse: collapse;


### PR DESCRIPTION
- Use event locale for agreement email (to avoid having a default mail header/footer in the user's language with the untranslated default message for the rest of the email)
- Remove agreement dashboard button size: This was meant to make all buttons the same width, but it only worked well in English. In other languages such as French it looked awful because the text did not fit the buttons and overflowed. Spilled baguette all over the place! 🥖🥖🥖 