### PR TITLE
Do not import invalid protection mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -49,6 +49,8 @@ Bugfixes
   mobile when the page is pinch-zoomed, when the input is near a viewport
   edge, or when the virtual keyboard is open (:pr:`7529`, thanks
   :user:`foxbunny`)
+- Fix database error when importing protection settings in an unlisted event
+  (:issue:`7550`, :pr:`7551`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/clone.py
+++ b/indico/modules/events/clone.py
@@ -151,7 +151,8 @@ class EventProtectionCloner(EventCloner):
                                                 old_mode=None)
 
     def _clone_protection(self, new_event):
-        new_event.protection_mode = self.old_event.protection_mode
+        if not new_event.is_unlisted:
+            new_event.protection_mode = self.old_event.protection_mode
         new_event.access_key = self.old_event.access_key
         new_event.own_no_access_contact = self.old_event.own_no_access_contact
         new_event.public_regform_access = self.old_event.public_regform_access


### PR DESCRIPTION
Unlisted events are always inheriting, so importing a different protection mode fails.

closes #7550