### PR TITLE
Fix translated extra columns for registration list

### DIFF
--- a/indico/modules/events/registration/lists_test.py
+++ b/indico/modules/events/registration/lists_test.py
@@ -7,6 +7,7 @@
 
 import pytest
 from flask import session
+from speaklater import make_lazy_string
 
 from indico.core import signals
 from indico.modules.events.registration.custom import CustomRegistrationListItem, RegistrationListColumn
@@ -18,7 +19,7 @@ pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
 
 class _TestColumn(CustomRegistrationListItem):
     name = 'test_col'
-    title = 'Test Column'
+    title = make_lazy_string(lambda: 'Test Column')
 
     def load_data(self, registrations):
         return {reg: RegistrationListColumn(content='val', text_value='val') for reg in registrations}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -622,7 +622,7 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
             field_names.append(unique_col('{} ({})'.format(item.title, 'Arrival'), item.id))
             field_names.append(unique_col('{} ({})'.format(item.title, 'Departure'), item.id))
     field_names.extend(title for name, (title, fn) in special_item_mapping.items() if name in static_items)
-    field_names.extend(col.title for col in extra_columns)
+    field_names.extend(str(col.title) for col in extra_columns)
     rows = []
     for registration in registrations:
         data = registration.data_by_field
@@ -657,7 +657,7 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
             registration_dict[title] = value
         for col in extra_columns:
             col_data = col.data.get(registration)
-            registration_dict[col.title] = col_data.text_value if col_data else ''
+            registration_dict[str(col.title)] = col_data.text_value if col_data else ''
         rows.append(registration_dict)
     return field_names, rows
 
@@ -713,7 +713,7 @@ def generate_pdf_data_from_registrations(event, registrations, regform_items, st
     }
     field_names.extend(unique_col(item.title, item.id) for item in regform_items)
     field_names.extend(title for name, (title, fn) in special_item_mapping.items() if name in static_items)
-    field_names.extend(col.title for col in extra_columns)
+    field_names.extend(str(col.title) for col in extra_columns)
     rows = []
     for registration in registrations:
         data = registration.data_by_field
@@ -739,7 +739,7 @@ def generate_pdf_data_from_registrations(event, registrations, regform_items, st
             row_data[title] = value
         for col in extra_columns:
             col_data = col.data.get(registration)
-            row_data[col.title] = col_data.text_value if col_data else empty_value
+            row_data[str(col.title)] = col_data.text_value if col_data else empty_value
         rows.append((registration, row_data))
     return field_names, rows
 

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import pytest
 from flask import session
 from PIL import Image
+from speaklater import make_lazy_string
 
 from indico.core.db import db
 from indico.core.errors import UserValueError
@@ -1005,7 +1006,7 @@ class _FakeExtraColumn:
     """Minimal stand-in for CustomRegistrationListItem for spreadsheet tests."""
 
     filter_only = False
-    title = 'Custom Column'
+    title = make_lazy_string(lambda: 'Custom Column')
 
     def __init__(self, data=None):
         self.data = data or {}


### PR DESCRIPTION
After fixing the bug to export extra columns for the registration list. I went back to my plugin to test the feature. I realised my injected column title was not being translated I did it. Afterwards, the feature broke up, due to the impossibility to evaluate the translated string for creating the dicts for the pdf, csv and excel. 

Since the export needs to know the translated string because it is going to write it just afterwards, I think the correct solution is to just force the value of the lazystring while generating the data dictionaries the feature needs. 

I've tried to avoid this, but after lots of thinking, I think there's no way to avoid it. I'm open to suggestions regarding how to tackle this bug.