### PR TITLE
Add option to manage contrib/session materials

### DIFF
--- a/indico/modules/attachments/client/js/legacy.js
+++ b/indico/modules/attachments/client/js/legacy.js
@@ -37,7 +37,8 @@ import {$T} from 'indico/utils/i18n';
       const locator = $(this).data('locator');
       const title = $(this).data('title');
       const reloadOnChange = $this.data('reload-on-change') !== undefined;
-      openAttachmentManager(locator, title, reloadOnChange, $this);
+      const details = $this.data('details');
+      openAttachmentManager(locator, title, reloadOnChange, details, $this);
     });
   });
 
@@ -220,7 +221,7 @@ import {$T} from 'indico/utils/i18n';
       });
   };
 
-  function openAttachmentManager(itemLocator, title, reloadOnChange, trigger) {
+  function openAttachmentManager(itemLocator, title, reloadOnChange, details, trigger) {
     reloadOnChange = reloadOnChange === undefined ? true : reloadOnChange;
     ajaxDialog({
       trigger,
@@ -232,7 +233,15 @@ import {$T} from 'indico/utils/i18n';
         if (customData && reloadOnChange) {
           location.reload();
         } else if (customData && trigger) {
-          trigger.trigger('attachments:updated');
+          // in case the triggering element is now disconnected from the DOM,
+          // we still want to be able to listen to these events
+          const triggerElement = trigger[0].isConnected ? trigger[0] : document;
+          $(triggerElement).trigger('attachments:updated');
+          triggerElement.dispatchEvent(
+            new CustomEvent('indico:attachmentsUpdate', {
+              detail: details,
+            })
+          );
         }
       },
     });

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -5,6 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import contributionURL from 'indico-url:timetable.tt_contrib_rest';
+import sessionBlockURL from 'indico-url:timetable.tt_session_block_rest';
+
 import moment, {Moment} from 'moment';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
@@ -12,6 +15,8 @@ import {ThunkDispatch} from 'redux-thunk';
 
 import {Translate, Param} from 'indico/react/i18n';
 import {localeUses24HourTime} from 'indico/utils/date';
+
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 import * as actions from './actions';
 import {Transform, Over, MousePosition} from './dnd';
@@ -41,6 +46,7 @@ import {
   isChildEntry,
   EntryType,
   Session,
+  AttachmentUpdatedEventDetail,
 } from './types';
 import {
   DAY_SIZE,
@@ -50,10 +56,10 @@ import {
   V_SPACE_BETWEEN_ENTRIES_PX,
   flattenEntries,
   getDateKey,
+  getEntryUniqueId,
   isWithinLimits,
   minutesToPixels,
   pixelsToMinutes,
-  getEntryUniqueId,
 } from './utils';
 
 import './DayTimetable.module.scss';
@@ -488,6 +494,28 @@ export function DayTimetable({
       document.removeEventListener('mousemove', onMouseMove);
     };
   }, []);
+
+  useEffect(() => {
+    async function handleMaterialsChanged(event: Event) {
+      const {type, id}: AttachmentUpdatedEventDetail = (event as CustomEvent).detail;
+      const url =
+        type === EntryType.SessionBlock
+          ? sessionBlockURL({event_id: eventId, session_block_id: id})
+          : contributionURL({event_id: eventId, contrib_id: id});
+      try {
+        const entry = await indicoAxios.get(url);
+        const attachmentCount = entry.data.attachment_count;
+        dispatch(actions.setEntryAttachments(type, getEntryUniqueId(type, id), attachmentCount));
+      } catch (e) {
+        handleAxiosError(e);
+      }
+    }
+
+    document.addEventListener('indico:attachmentsUpdate', handleMaterialsChanged);
+    return () => {
+      document.removeEventListener('indico:attachmentsUpdate', handleMaterialsChanged);
+    };
+  }, [dispatch, eventId]);
 
   useEffect(() => {
     let newEntryTimer: number | null = null;

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -504,8 +504,8 @@ export function DayTimetable({
           : contributionURL({event_id: eventId, contrib_id: id});
       try {
         const entry = await indicoAxios.get(url);
-        const attachmentCount = entry.data.attachment_count;
-        dispatch(actions.setEntryAttachments(type, getEntryUniqueId(type, id), attachmentCount));
+        const attachments = entry.data.attachments;
+        dispatch(actions.setEntryAttachments(type, getEntryUniqueId(type, id), attachments));
       } catch (e) {
         handleAxiosError(e);
       }

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -14,9 +14,8 @@ import {useDispatch, useSelector} from 'react-redux';
 import {ThunkDispatch} from 'redux-thunk';
 
 import {Translate, Param} from 'indico/react/i18n';
-import {localeUses24HourTime} from 'indico/utils/date';
-
 import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
+import {localeUses24HourTime} from 'indico/utils/date';
 
 import * as actions from './actions';
 import {Transform, Over, MousePosition} from './dnd';
@@ -501,13 +500,15 @@ export function DayTimetable({
         type === EntryType.SessionBlock
           ? sessionBlockURL({event_id: eventId, session_block_id: id})
           : contributionURL({event_id: eventId, contrib_id: id});
+      let entry;
       try {
-        const entry = await indicoAxios.get(url);
-        const attachments = entry.data.attachments;
-        dispatch(actions.setEntryAttachments(type, getEntryUniqueId(type, id), attachments));
+        entry = await indicoAxios.get(url);
       } catch (e) {
         handleAxiosError(e);
+        return;
       }
+      const attachments = entry.data.attachments;
+      dispatch(actions.setEntryAttachments(type, getEntryUniqueId(type, id), attachments));
     }
 
     document.addEventListener('indico:attachmentsUpdate', handleMaterialsChanged);

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -508,7 +508,7 @@ export function DayTimetable({
         return;
       }
       const attachments = entry.data.attachments;
-      dispatch(actions.setEntryAttachments(type, getEntryUniqueId(type, id), attachments));
+      dispatch(actions.setEntryAttachments(getEntryUniqueId(type, id), attachments));
     }
 
     document.addEventListener('indico:attachmentsUpdate', handleMaterialsChanged);

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -5,6 +5,9 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import contributionURL from 'indico-url:timetable.tt_contrib_rest';
+import sessionBlockURL from 'indico-url:timetable.tt_session_block_rest';
+
 import moment, {Moment} from 'moment';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
@@ -12,6 +15,8 @@ import {ThunkDispatch} from 'redux-thunk';
 
 import {Translate, Param} from 'indico/react/i18n';
 import {localeUses24HourTime} from 'indico/utils/date';
+
+import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 
 import * as actions from './actions';
 import {Transform, Over, MousePosition} from './dnd';
@@ -42,6 +47,7 @@ import {
   EntryType,
   Session,
   ContribEntry,
+  AttachmentUpdatedEventDetail,
 } from './types';
 import {
   DAY_SIZE,
@@ -51,10 +57,10 @@ import {
   V_SPACE_BETWEEN_ENTRIES_PX,
   flattenEntries,
   getDateKey,
+  getEntryUniqueId,
   isWithinLimits,
   minutesToPixels,
   pixelsToMinutes,
-  getEntryUniqueId,
 } from './utils';
 
 import './DayTimetable.module.scss';
@@ -487,6 +493,28 @@ export function DayTimetable({
       document.removeEventListener('mousemove', onMouseMove);
     };
   }, []);
+
+  useEffect(() => {
+    async function handleMaterialsChanged(event: Event) {
+      const {type, id}: AttachmentUpdatedEventDetail = (event as CustomEvent).detail;
+      const url =
+        type === EntryType.SessionBlock
+          ? sessionBlockURL({event_id: eventId, session_block_id: id})
+          : contributionURL({event_id: eventId, contrib_id: id});
+      try {
+        const entry = await indicoAxios.get(url);
+        const attachmentCount = entry.data.attachment_count;
+        dispatch(actions.setEntryAttachments(type, getEntryUniqueId(type, id), attachmentCount));
+      } catch (e) {
+        handleAxiosError(e);
+      }
+    }
+
+    document.addEventListener('indico:attachmentsUpdate', handleMaterialsChanged);
+    return () => {
+      document.removeEventListener('indico:attachmentsUpdate', handleMaterialsChanged);
+    };
+  }, [dispatch, eventId]);
 
   useEffect(() => {
     let newEntryTimer: number | null = null;

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -503,8 +503,8 @@ export function DayTimetable({
           : contributionURL({event_id: eventId, contrib_id: id});
       try {
         const entry = await indicoAxios.get(url);
-        const attachmentCount = entry.data.attachment_count;
-        dispatch(actions.setEntryAttachments(type, getEntryUniqueId(type, id), attachmentCount));
+        const attachments = entry.data.attachments;
+        dispatch(actions.setEntryAttachments(type, getEntryUniqueId(type, id), attachments));
       } catch (e) {
         handleAxiosError(e);
       }

--- a/indico/modules/events/timetable/client/js/Entry.module.scss
+++ b/indico/modules/events/timetable/client/js/Entry.module.scss
@@ -92,42 +92,54 @@ $title-row-line-height: 1.2rem;
 }
 
 .entry-actions {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 100%;
-    height: 100%;
-    justify-content: flex-end;
-    background: linear-gradient(
-      90deg,
-      color-mix(in srgb, var(--session-background) 0%, transparent) 32%,
-      color-mix(in srgb, var(--session-background) 100%, transparent) 66%,
-      color-mix(in srgb, var(--session-background) 100%, transparent) 100%
-    );
-    display: flex;
-    opacity: 0;
-    visibility: hidden;
-    transform: translateX(-10px);
-    transition: opacity 0.2s ease, transform 0.2s ease;
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+  justify-content: flex-end;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--session-background) 0%, transparent) 32%,
+    color-mix(in srgb, var(--session-background) 100%, transparent) 66%,
+    color-mix(in srgb, var(--session-background) 100%, transparent) 100%
+  );
+  display: flex;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateX(-10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
 
-    > :global(.ui.basic.button) {
-      color: var(--session-color);
-    }
+  > :global(.ui.basic.button) {
+    color: var(--session-color);
+  }
 
-    > :global(button.ui.small.basic.button):hover {
-      background: transparent !important;
-    }
+  > :global(button.ui.small.basic.button):hover {
+    background: transparent !important;
+  }
 
-    :global(.ui.basic.button),
-    :global(.ui.basic.buttons .button) {
-      // overrriding SemanticUI important color property
-      color: var(--session-color) !important;
+  :global(.ui.basic.button),
+  :global(.ui.basic.buttons .button) {
+    // overrriding SemanticUI important color property
+    color: var(--session-color) !important;
 
-      &:hover {
-        opacity: 0.8;
-      }
+    &:hover {
+      opacity: 0.8;
     }
   }
+}
+
+.attachment-label {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block !important;
+  max-width: 8rem;
+  overflow: hidden;
+}
+
+.extra-attachments {
+  border: none !important;
+}
 
 .title-wrapper {
   overflow: hidden;

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -65,20 +65,20 @@ export function DraggableEntry({id, setDuration, ...rest}: DraggableEntryProps) 
   const isClick = useRef<boolean>(true);
 
   function onClick(evt: React.MouseEvent<HTMLElement>) {
-    evt.stopPropagation();
     if (evt.target instanceof Node && !ref.current.contains(evt.target)) {
       return;
     }
+    evt.stopPropagation();
     if (isClick.current) {
       dispatch(actions.selectEntry(id));
     }
   }
 
   function onDoubleClick(evt: React.MouseEvent<HTMLElement>) {
-    evt.stopPropagation();
     if (evt.target instanceof Node && !ref.current.contains(evt.target)) {
       return;
     }
+    evt.stopPropagation();
     if (rest.type !== EntryType.SessionBlock || isPosterBlock) {
       return;
     }

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -9,7 +9,6 @@ import breakURL from 'indico-url:timetable.tt_break_rest';
 import contributionURL from 'indico-url:timetable.tt_contrib_rest';
 import sessionBlockURL from 'indico-url:timetable.tt_session_block_rest';
 
-import './EntryPopup.module.scss';
 import moment from 'moment';
 import React, {useEffect, useState} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
@@ -17,7 +16,6 @@ import {ThunkDispatch} from 'redux-thunk';
 import {Button, Card, Icon, List, Popup, Label, Header, PopupProps, Image} from 'semantic-ui-react';
 
 import {PluralTranslate, Translate} from 'indico/react/i18n';
-import './Entry.module.scss';
 import {indicoAxios} from 'indico/utils/axios';
 
 import * as actions from './actions';
@@ -37,6 +35,9 @@ import {
   AttachmentUpdatedEventDetail,
 } from './types';
 import {getIconByEntryType, getEntryColors} from './utils';
+
+import './EntryPopup.module.scss';
+import './Entry.module.scss';
 
 function ActionPopup({content, trigger, ...rest}: PopupProps) {
   return (
@@ -273,31 +274,46 @@ function EntryPopupContent({
             </List>
           </List.Item>
         )}
-        {(entry.type === EntryType.Contribution || entry.type === EntryType.SessionBlock) && (
-          <List.Item title={Translate.string('Attachments')}>
-            <Icon name="copy outline" />
-            <List styleName="inline">
-              <Button
-                as="a"
-                basic
-                size="mini"
-                icon="edit"
-                content={PluralTranslate.string(
-                  '{attachmentCount} material',
-                  '{attachmentCount} materials',
-                  entry.attachmentCount,
-                  {
-                    attachmentCount: entry.attachmentCount,
-                  }
+        {(entry.type === EntryType.Contribution || entry.type === EntryType.SessionBlock) &&
+          entry.attachments.length > 0 && (
+            <List.Item>
+              <Icon name="copy outline" title={Translate.string('Materials')} />
+              <List styleName="inline">
+                {entry.attachments.slice(0, 2).map(attachment => (
+                  <List.Item key={attachment.id}>
+                    <Label
+                      styleName="attachment-label"
+                      icon="file"
+                      content={attachment.title}
+                      title={attachment.title}
+                      basic
+                    />
+                  </List.Item>
+                ))}
+                {entry.attachments.length > 2 && (
+                  <List.Item>
+                    <ActionPopup
+                      content={PluralTranslate.string(
+                        'There is {extra} more material',
+                        'There are {extra} more materials',
+                        entry.attachments.length - 2,
+                        {extra: entry.attachments.length - 2}
+                      )}
+                      trigger={
+                        <Label
+                          styleName="attachment-label extra-attachments"
+                          content={Translate.string('...and {extra} more', {
+                            extra: entry.attachments.length - 2,
+                          })}
+                          basic
+                        />
+                      }
+                    />
+                  </List.Item>
                 )}
-                data-attachment-editor
-                data-details={JSON.stringify(entryDetails)}
-                data-locator={JSON.stringify(entryLocator)}
-                onClick={onClose}
-              />
-            </List>
-          </List.Item>
-        )}
+              </List>
+            </List.Item>
+          )}
       </Card.Content>
       <Card.Content styleName="actions" textAlign="right">
         {isPosterBlock && (
@@ -308,6 +324,21 @@ function EntryPopupContent({
                 <Icon name={getIconByEntryType(EntryType.Contribution)} />
                 {(entry as BlockEntry)?.children?.length}
               </Button>
+            }
+          />
+        )}
+        {(entry.type === EntryType.Contribution || entry.type === EntryType.SessionBlock) && (
+          <ActionPopup
+            content={<Translate>Manage materials</Translate>}
+            trigger={
+              <Button
+                basic
+                icon="copy outline"
+                data-attachment-editor
+                data-details={JSON.stringify(entryDetails)}
+                data-locator={JSON.stringify(entryLocator)}
+                onClick={onClose}
+              />
             }
           />
         )}

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -59,7 +59,7 @@ function EntryPopupContent({
   onClose: () => void;
 }) {
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
-  const {objId, type, title, attachmentCount, duration, startDt, sessionId} = entry;
+  const {objId, type, title, duration, startDt, sessionId} = entry;
   const eventId = useSelector(selectors.getEventId);
   const entries = useSelector(selectors.getCurrentDayEntries);
   const session = useSelector((state: ReduxState) => selectors.getSessionById(state, sessionId));
@@ -273,7 +273,7 @@ function EntryPopupContent({
             </List>
           </List.Item>
         )}
-        {attachmentCount !== undefined && (
+        {entry.type !== EntryType.Break && (
           <List.Item title={Translate.string('Attachments')}>
             <Icon name="copy outline" />
             <List styleName="inline">
@@ -285,9 +285,9 @@ function EntryPopupContent({
                 content={PluralTranslate.string(
                   '{attachmentCount} material',
                   '{attachmentCount} materials',
-                  attachmentCount,
+                  entry.attachmentCount,
                   {
-                    attachmentCount,
+                    attachmentCount: entry.attachmentCount,
                   }
                 )}
                 data-attachment-editor

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -16,7 +16,7 @@ import {useSelector, useDispatch} from 'react-redux';
 import {ThunkDispatch} from 'redux-thunk';
 import {Button, Card, Icon, List, Popup, Label, Header, PopupProps, Image} from 'semantic-ui-react';
 
-import {Translate} from 'indico/react/i18n';
+import {PluralTranslate, Translate} from 'indico/react/i18n';
 import './Entry.module.scss';
 import {indicoAxios} from 'indico/utils/axios';
 
@@ -34,6 +34,7 @@ import {
   PersonLinkRole,
   isChildEntry,
   SessionBlockId,
+  AttachmentUpdatedEventDetail,
 } from './types';
 import {getIconByEntryType, getEntryColors} from './utils';
 
@@ -58,7 +59,7 @@ function EntryPopupContent({
   onClose: () => void;
 }) {
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
-  const {objId, type, title, attachments, duration, startDt, sessionId} = entry;
+  const {objId, type, title, attachmentCount, duration, startDt, sessionId} = entry;
   const eventId = useSelector(selectors.getEventId);
   const entries = useSelector(selectors.getCurrentDayEntries);
   const session = useSelector((state: ReduxState) => selectors.getSessionById(state, sessionId));
@@ -78,7 +79,10 @@ function EntryPopupContent({
     event_id: eventId,
     [entryLocatorKey]: entryLocatorValue,
   };
-
+  const entryDetails: AttachmentUpdatedEventDetail = {
+    type,
+    id: objId,
+  };
   const _getOrderedLocationArray = () => {
     const {address, venueName, roomName} = entry.locationData;
     return Object.values([address, venueName, roomName]).filter(Boolean);
@@ -269,28 +273,28 @@ function EntryPopupContent({
             </List>
           </List.Item>
         )}
-        {attachments?.length > 0 && (
+        {attachmentCount !== undefined && (
           <List.Item title={Translate.string('Attachments')}>
             <Icon name="copy outline" />
             <List styleName="inline">
-              {attachments.map(a => {
-                const iconName = {
-                  attachment: 'file',
-                  folder: 'folder',
-                }[a.type];
-
-                return (
-                  <List.Item key={a.id}>
-                    <Label
-                      style={{fontWeight: 'normal'}}
-                      basic
-                      key={a.id}
-                      icon={iconName}
-                      content={a.title}
-                    />
-                  </List.Item>
-                );
-              })}
+              <Button
+                as="a"
+                basic
+                size="mini"
+                icon="edit"
+                content={PluralTranslate.string(
+                  '{attachmentCount} material',
+                  '{attachmentCount} materials',
+                  attachmentCount,
+                  {
+                    attachmentCount,
+                  }
+                )}
+                data-attachment-editor
+                data-details={JSON.stringify(entryDetails)}
+                data-locator={JSON.stringify(entryLocator)}
+                onClick={onClose}
+              />
             </List>
           </List.Item>
         )}
@@ -323,21 +327,6 @@ function EntryPopupContent({
           content={Translate.string('Edit')}
           trigger={<Button basic icon="edit" onClick={onEdit} />}
         />
-        {type !== EntryType.Break && (
-          <ActionPopup
-            content={Translate.string('Materials')}
-            trigger={
-              <Button
-                as="a"
-                basic
-                icon="attach"
-                data-attachment-editor
-                data-locator={JSON.stringify(entryLocator)}
-                onClick={onClose}
-              />
-            }
-          />
-        )}
         {type === EntryType.Contribution ? (
           <ActionPopup
             content={<Translate>Unschedule contribution</Translate>}

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -273,7 +273,7 @@ function EntryPopupContent({
             </List>
           </List.Item>
         )}
-        {entry.type !== EntryType.Break && (
+        {(entry.type === EntryType.Contribution || entry.type === EntryType.SessionBlock) && (
           <List.Item title={Translate.string('Attachments')}>
             <Icon name="copy outline" />
             <List styleName="inline">

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -72,6 +72,13 @@ function EntryPopupContent({
   const colors = getEntryColors(entry, session);
   const {openModal} = useModal();
 
+  const entryLocatorKey = entry.type === EntryType.SessionBlock ? 'session_id' : 'contrib_id';
+  const entryLocatorValue = entry.type === EntryType.SessionBlock ? sessionId : objId;
+  const entryLocator = {
+    event_id: eventId,
+    [entryLocatorKey]: entryLocatorValue,
+  };
+
   const _getOrderedLocationArray = () => {
     const {address, venueName, roomName} = entry.locationData;
     return Object.values([address, venueName, roomName]).filter(Boolean);
@@ -316,6 +323,21 @@ function EntryPopupContent({
           content={Translate.string('Edit')}
           trigger={<Button basic icon="edit" onClick={onEdit} />}
         />
+        {type !== EntryType.Break && (
+          <ActionPopup
+            content={Translate.string('Materials')}
+            trigger={
+              <Button
+                as="a"
+                basic
+                icon="attach"
+                data-attachment-editor
+                data-locator={JSON.stringify(entryLocator)}
+                onClick={onClose}
+              />
+            }
+          />
+        )}
         {type === EntryType.Contribution ? (
           <ActionPopup
             content={<Translate>Unschedule contribution</Translate>}

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -61,7 +61,7 @@ function EntryPopupContent({
   onClose: () => void;
 }) {
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
-  const {objId, type, title, attachmentCount, duration, startDt, sessionId} = entry;
+  const {objId, type, title, duration, startDt, sessionId} = entry;
   const eventId = useSelector(selectors.getEventId);
   const entries = useSelector(selectors.getCurrentDayEntries);
   const session = useSelector((state: ReduxState) => selectors.getSessionById(state, sessionId));
@@ -275,7 +275,7 @@ function EntryPopupContent({
             </List>
           </List.Item>
         )}
-        {attachmentCount !== undefined && (
+        {entry.type !== EntryType.Break && (
           <List.Item title={Translate.string('Attachments')}>
             <Icon name="copy outline" />
             <List styleName="inline">
@@ -287,9 +287,9 @@ function EntryPopupContent({
                 content={PluralTranslate.string(
                   '{attachmentCount} material',
                   '{attachmentCount} materials',
-                  attachmentCount,
+                  entry.attachmentCount,
                   {
-                    attachmentCount,
+                    attachmentCount: entry.attachmentCount,
                   }
                 )}
                 data-attachment-editor

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -11,7 +11,6 @@ import breakURL from 'indico-url:timetable.tt_break_rest';
 import contributionURL from 'indico-url:timetable.tt_contrib_rest';
 import sessionBlockURL from 'indico-url:timetable.tt_session_block_rest';
 
-import './EntryPopup.module.scss';
 import moment from 'moment';
 import React, {useEffect, useState} from 'react';
 import {useSelector, useDispatch} from 'react-redux';
@@ -19,7 +18,6 @@ import {ThunkDispatch} from 'redux-thunk';
 import {Button, Card, Icon, List, Popup, Label, Header, PopupProps, Image} from 'semantic-ui-react';
 
 import {PluralTranslate, Translate} from 'indico/react/i18n';
-import './Entry.module.scss';
 import {indicoAxios} from 'indico/utils/axios';
 
 import * as actions from './actions';
@@ -39,6 +37,9 @@ import {
   AttachmentUpdatedEventDetail,
 } from './types';
 import {getIconByEntryType, getEntryColors} from './utils';
+
+import './EntryPopup.module.scss';
+import './Entry.module.scss';
 
 function ActionPopup({content, trigger, ...rest}: PopupProps) {
   return (
@@ -275,31 +276,46 @@ function EntryPopupContent({
             </List>
           </List.Item>
         )}
-        {(entry.type === EntryType.Contribution || entry.type === EntryType.SessionBlock) && (
-          <List.Item title={Translate.string('Attachments')}>
-            <Icon name="copy outline" />
-            <List styleName="inline">
-              <Button
-                as="a"
-                basic
-                size="mini"
-                icon="edit"
-                content={PluralTranslate.string(
-                  '{attachmentCount} material',
-                  '{attachmentCount} materials',
-                  entry.attachmentCount,
-                  {
-                    attachmentCount: entry.attachmentCount,
-                  }
+        {(entry.type === EntryType.Contribution || entry.type === EntryType.SessionBlock) &&
+          entry.attachments.length > 0 && (
+            <List.Item>
+              <Icon name="copy outline" title={Translate.string('Materials')} />
+              <List styleName="inline">
+                {entry.attachments.slice(0, 2).map(attachment => (
+                  <List.Item key={attachment.id}>
+                    <Label
+                      styleName="attachment-label"
+                      icon="file"
+                      content={attachment.title}
+                      title={attachment.title}
+                      basic
+                    />
+                  </List.Item>
+                ))}
+                {entry.attachments.length > 2 && (
+                  <List.Item>
+                    <ActionPopup
+                      content={PluralTranslate.string(
+                        'There is {extra} more material',
+                        'There are {extra} more materials',
+                        entry.attachments.length - 2,
+                        {extra: entry.attachments.length - 2}
+                      )}
+                      trigger={
+                        <Label
+                          styleName="attachment-label extra-attachments"
+                          content={Translate.string('...and {extra} more', {
+                            extra: entry.attachments.length - 2,
+                          })}
+                          basic
+                        />
+                      }
+                    />
+                  </List.Item>
                 )}
-                data-attachment-editor
-                data-details={JSON.stringify(entryDetails)}
-                data-locator={JSON.stringify(entryLocator)}
-                onClick={onClose}
-              />
-            </List>
-          </List.Item>
-        )}
+              </List>
+            </List.Item>
+          )}
       </Card.Content>
       <Card.Content styleName="actions" textAlign="right">
         {isPosterBlock && (
@@ -310,6 +326,21 @@ function EntryPopupContent({
                 <Icon name={getIconByEntryType(EntryType.Contribution)} />
                 {(entry as BlockEntry)?.children?.length}
               </Button>
+            }
+          />
+        )}
+        {(entry.type === EntryType.Contribution || entry.type === EntryType.SessionBlock) && (
+          <ActionPopup
+            content={<Translate>Manage materials</Translate>}
+            trigger={
+              <Button
+                basic
+                icon="copy outline"
+                data-attachment-editor
+                data-details={JSON.stringify(entryDetails)}
+                data-locator={JSON.stringify(entryLocator)}
+                onClick={onClose}
+              />
             }
           />
         )}

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -18,7 +18,7 @@ import {useSelector, useDispatch} from 'react-redux';
 import {ThunkDispatch} from 'redux-thunk';
 import {Button, Card, Icon, List, Popup, Label, Header, PopupProps, Image} from 'semantic-ui-react';
 
-import {Translate} from 'indico/react/i18n';
+import {PluralTranslate, Translate} from 'indico/react/i18n';
 import './Entry.module.scss';
 import {indicoAxios} from 'indico/utils/axios';
 
@@ -36,6 +36,7 @@ import {
   PersonLinkRole,
   isChildEntry,
   SessionBlockId,
+  AttachmentUpdatedEventDetail,
 } from './types';
 import {getIconByEntryType, getEntryColors} from './utils';
 
@@ -60,7 +61,7 @@ function EntryPopupContent({
   onClose: () => void;
 }) {
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
-  const {objId, type, title, attachments, duration, startDt, sessionId} = entry;
+  const {objId, type, title, attachmentCount, duration, startDt, sessionId} = entry;
   const eventId = useSelector(selectors.getEventId);
   const entries = useSelector(selectors.getCurrentDayEntries);
   const session = useSelector((state: ReduxState) => selectors.getSessionById(state, sessionId));
@@ -80,7 +81,10 @@ function EntryPopupContent({
     event_id: eventId,
     [entryLocatorKey]: entryLocatorValue,
   };
-
+  const entryDetails: AttachmentUpdatedEventDetail = {
+    type,
+    id: objId,
+  };
   const _getOrderedLocationArray = () => {
     const {address, venueName, roomName} = entry.locationData;
     return Object.values([address, venueName, roomName]).filter(Boolean);
@@ -271,28 +275,28 @@ function EntryPopupContent({
             </List>
           </List.Item>
         )}
-        {attachments?.length > 0 && (
+        {attachmentCount !== undefined && (
           <List.Item title={Translate.string('Attachments')}>
             <Icon name="copy outline" />
             <List styleName="inline">
-              {attachments.map(a => {
-                const iconName = {
-                  attachment: 'file',
-                  folder: 'folder',
-                }[a.type];
-
-                return (
-                  <List.Item key={a.id}>
-                    <Label
-                      style={{fontWeight: 'normal'}}
-                      basic
-                      key={a.id}
-                      icon={iconName}
-                      content={a.title}
-                    />
-                  </List.Item>
-                );
-              })}
+              <Button
+                as="a"
+                basic
+                size="mini"
+                icon="edit"
+                content={PluralTranslate.string(
+                  '{attachmentCount} material',
+                  '{attachmentCount} materials',
+                  attachmentCount,
+                  {
+                    attachmentCount,
+                  }
+                )}
+                data-attachment-editor
+                data-details={JSON.stringify(entryDetails)}
+                data-locator={JSON.stringify(entryLocator)}
+                onClick={onClose}
+              />
             </List>
           </List.Item>
         )}
@@ -352,21 +356,6 @@ function EntryPopupContent({
           content={Translate.string('Edit')}
           trigger={<Button basic icon="edit" onClick={onEdit} />}
         />
-        {type !== EntryType.Break && (
-          <ActionPopup
-            content={Translate.string('Materials')}
-            trigger={
-              <Button
-                as="a"
-                basic
-                icon="attach"
-                data-attachment-editor
-                data-locator={JSON.stringify(entryLocator)}
-                onClick={onClose}
-              />
-            }
-          />
-        )}
         {type === EntryType.Contribution ? (
           <ActionPopup
             content={<Translate>Unschedule contribution</Translate>}

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -74,6 +74,13 @@ function EntryPopupContent({
   const colors = getEntryColors(entry, session);
   const {openModal} = useModal();
 
+  const entryLocatorKey = entry.type === EntryType.SessionBlock ? 'session_id' : 'contrib_id';
+  const entryLocatorValue = entry.type === EntryType.SessionBlock ? sessionId : objId;
+  const entryLocator = {
+    event_id: eventId,
+    [entryLocatorKey]: entryLocatorValue,
+  };
+
   const _getOrderedLocationArray = () => {
     const {address, venueName, roomName} = entry.locationData;
     return Object.values([address, venueName, roomName]).filter(Boolean);
@@ -345,6 +352,21 @@ function EntryPopupContent({
           content={Translate.string('Edit')}
           trigger={<Button basic icon="edit" onClick={onEdit} />}
         />
+        {type !== EntryType.Break && (
+          <ActionPopup
+            content={Translate.string('Materials')}
+            trigger={
+              <Button
+                as="a"
+                basic
+                icon="attach"
+                data-attachment-editor
+                data-locator={JSON.stringify(entryLocator)}
+                onClick={onClose}
+              />
+            }
+          />
+        )}
         {type === EntryType.Contribution ? (
           <ActionPopup
             content={<Translate>Unschedule contribution</Translate>}

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -275,7 +275,7 @@ function EntryPopupContent({
             </List>
           </List.Item>
         )}
-        {entry.type !== EntryType.Break && (
+        {(entry.type === EntryType.Contribution || entry.type === EntryType.SessionBlock) && (
           <List.Item title={Translate.string('Attachments')}>
             <Icon name="copy outline" />
             <List styleName="inline">

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -39,6 +39,7 @@ import {
   SidePanelView,
   ContribId,
   EntryUniqueID,
+  Attachment,
 } from './types';
 import {flattenEntries, getEntryUniqueId, getEntryURLByObjId} from './utils';
 
@@ -138,7 +139,7 @@ interface UpdateEntryAction {
 interface SetEntryAttachments {
   type: typeof SET_ENTRY_ATTACHMENTS;
   entryType: EntryType;
-  attachmentCount: number;
+  attachments: Attachment[];
   id: EntryUniqueID;
 }
 
@@ -531,10 +532,10 @@ export function updateEntry(
 
 export function setEntryAttachments(
   entryType: EntryType,
-  id: string,
-  attachmentCount: number
+  id: EntryUniqueID,
+  attachments: Attachment[]
 ): SetEntryAttachments {
-  return {type: SET_ENTRY_ATTACHMENTS, entryType, id, attachmentCount};
+  return {type: SET_ENTRY_ATTACHMENTS, entryType, id, attachments};
 }
 
 export function setCurrentDate(date: Moment, eventId: number): SetCurrentDateAction {

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -38,6 +38,7 @@ import {
   ReduxState,
   SidePanelView,
   ContribId,
+  EntryUniqueID,
 } from './types';
 import {flattenEntries, getEntryUniqueId, getEntryURLByObjId} from './utils';
 
@@ -136,9 +137,9 @@ interface UpdateEntryAction {
 
 interface SetEntryAttachments {
   type: typeof SET_ENTRY_ATTACHMENTS;
-  entryType: string;
+  entryType: EntryType;
   attachmentCount: number;
-  id: string;
+  id: EntryUniqueID;
 }
 
 interface DeleteBreakAction {

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -66,6 +66,7 @@ export const SET_EXPANDED_SESSION_BLOCK_ID = 'Set expanded session block ID';
 export const CREATE_ENTRY = 'Create entry';
 export const UPDATE_UNSCHEDULED_ENTRY = 'Update unscheduled entry';
 export const UPDATE_ENTRY = 'Update entry';
+export const SET_ENTRY_ATTACHMENTS = 'Set entry attachments';
 
 interface SetTimetableDataAction {
   type: typeof SET_TIMETABLE_DATA;
@@ -131,6 +132,13 @@ interface UpdateEntryAction {
   entry: TopLevelEntry;
   entryType: string;
   currentDay: string;
+}
+
+interface SetEntryAttachments {
+  type: typeof SET_ENTRY_ATTACHMENTS;
+  entryType: string;
+  attachmentCount: number;
+  id: string;
 }
 
 interface DeleteBreakAction {
@@ -208,6 +216,7 @@ export type Action =
   | UnscheduleEntryAction
   | CreateEntryAction
   | UpdateEntryAction
+  | SetEntryAttachments
   | DeleteBreakAction
   | DeleteUnscheduledContribAction
   | AddUnscheduledContribAction
@@ -517,6 +526,14 @@ export function updateEntry(
     );
     return dispatch(action);
   };
+}
+
+export function setEntryAttachments(
+  entryType: EntryType,
+  id: string,
+  attachmentCount: number
+): SetEntryAttachments {
+  return {type: SET_ENTRY_ATTACHMENTS, entryType, id, attachmentCount};
 }
 
 export function setCurrentDate(date: Moment, eventId: number): SetCurrentDateAction {

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -146,7 +146,6 @@ interface UpdateEntryAction {
 
 interface SetEntryAttachments {
   type: typeof SET_ENTRY_ATTACHMENTS;
-  entryType: EntryType;
   attachments: Attachment[];
   id: EntryUniqueID;
 }
@@ -544,11 +543,10 @@ export function updateEntry(
 }
 
 export function setEntryAttachments(
-  entryType: EntryType,
   id: EntryUniqueID,
   attachments: Attachment[]
 ): SetEntryAttachments {
-  return {type: SET_ENTRY_ATTACHMENTS, entryType, id, attachments};
+  return {type: SET_ENTRY_ATTACHMENTS, id, attachments};
 }
 
 export function setCurrentDate(date: Moment, eventId: number): SetCurrentDateAction {

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -43,6 +43,7 @@ import {
   ContribEntryWithoutLayout,
   SessionBlockId,
   EntryUniqueID,
+  Attachment,
 } from './types';
 import {getEntryUniqueId, getEntryURLByObjId} from './utils';
 
@@ -146,7 +147,7 @@ interface UpdateEntryAction {
 interface SetEntryAttachments {
   type: typeof SET_ENTRY_ATTACHMENTS;
   entryType: EntryType;
-  attachmentCount: number;
+  attachments: Attachment[];
   id: EntryUniqueID;
 }
 
@@ -544,10 +545,10 @@ export function updateEntry(
 
 export function setEntryAttachments(
   entryType: EntryType,
-  id: string,
-  attachmentCount: number
+  id: EntryUniqueID,
+  attachments: Attachment[]
 ): SetEntryAttachments {
-  return {type: SET_ENTRY_ATTACHMENTS, entryType, id, attachmentCount};
+  return {type: SET_ENTRY_ATTACHMENTS, entryType, id, attachments};
 }
 
 export function setCurrentDate(date: Moment, eventId: number): SetCurrentDateAction {

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -70,6 +70,7 @@ export const SET_EXPANDED_SESSION_BLOCK_ID = 'Set expanded session block ID';
 export const CREATE_ENTRY = 'Create entry';
 export const UPDATE_UNSCHEDULED_ENTRY = 'Update unscheduled entry';
 export const UPDATE_ENTRY = 'Update entry';
+export const SET_ENTRY_ATTACHMENTS = 'Set entry attachments';
 
 interface SetTimetableDataAction {
   type: typeof SET_TIMETABLE_DATA;
@@ -139,6 +140,13 @@ interface UpdateEntryAction {
   entryType: string;
   changes: Partial<Entry>;
   currentDay: string;
+}
+
+interface SetEntryAttachments {
+  type: typeof SET_ENTRY_ATTACHMENTS;
+  entryType: string;
+  attachmentCount: number;
+  id: string;
 }
 
 interface DeleteBreakAction {
@@ -216,6 +224,7 @@ export type Action =
   | UnscheduleEntryAction
   | CreateEntryAction
   | UpdateEntryAction
+  | SetEntryAttachments
   | DeleteBreakAction
   | DeleteUnscheduledContribAction
   | AddUnscheduledContribAction
@@ -530,6 +539,14 @@ export function updateEntry(
     );
     return dispatch(action);
   };
+}
+
+export function setEntryAttachments(
+  entryType: EntryType,
+  id: string,
+  attachmentCount: number
+): SetEntryAttachments {
+  return {type: SET_ENTRY_ATTACHMENTS, entryType, id, attachmentCount};
 }
 
 export function setCurrentDate(date: Moment, eventId: number): SetCurrentDateAction {

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -42,6 +42,7 @@ import {
   LayoutOverrides,
   ContribEntryWithoutLayout,
   SessionBlockId,
+  EntryUniqueID,
 } from './types';
 import {getEntryUniqueId, getEntryURLByObjId} from './utils';
 
@@ -144,9 +145,9 @@ interface UpdateEntryAction {
 
 interface SetEntryAttachments {
   type: typeof SET_ENTRY_ATTACHMENTS;
-  entryType: string;
+  entryType: EntryType;
   attachmentCount: number;
-  id: string;
+  id: EntryUniqueID;
 }
 
 interface DeleteBreakAction {

--- a/indico/modules/events/timetable/client/js/layout.spec.ts
+++ b/indico/modules/events/timetable/client/js/layout.spec.ts
@@ -87,7 +87,7 @@ function contrib({
     title,
     description: '',
     personLinks: [],
-    attachments: [],
+    attachmentCount: 0,
     type: EntryType.Contribution,
     duration,
     ...scheduleMixin({time, column, maxColumn}),
@@ -144,7 +144,7 @@ function block({
     title,
     description: '',
     personLinks: [],
-    attachments: [],
+    attachmentCount: 0,
     type: EntryType.SessionBlock,
     sessionId: 0,
     childLocationParent: {

--- a/indico/modules/events/timetable/client/js/layout.spec.ts
+++ b/indico/modules/events/timetable/client/js/layout.spec.ts
@@ -87,7 +87,7 @@ function contrib({
     title,
     description: '',
     personLinks: [],
-    attachmentCount: 0,
+    attachments: [],
     type: EntryType.Contribution,
     duration,
     ...scheduleMixin({time, column, maxColumn}),
@@ -144,7 +144,7 @@ function block({
     title,
     description: '',
     personLinks: [],
-    attachmentCount: 0,
+    attachments: [],
     type: EntryType.SessionBlock,
     sessionId: 0,
     childLocationParent: {

--- a/indico/modules/events/timetable/client/js/layout.ts
+++ b/indico/modules/events/timetable/client/js/layout.ts
@@ -314,7 +314,7 @@ export function layoutAfterUnscheduledDrop(
     colors: DEFAULT_CONTRIB_COLORS,
     column: null,
     maxColumn: null,
-    attachmentCount: 0,
+    attachments: [],
   };
   delete entry.sessionId;
 
@@ -384,7 +384,7 @@ export function layoutAfterUnscheduledDropOnBlock(
     sessionId: toBlock.sessionId,
     column: null,
     maxColumn: null,
-    attachmentCount: 0,
+    attachments: [],
   };
 
   if ('backgroundColor' in draftEntry) {

--- a/indico/modules/events/timetable/client/js/layout.ts
+++ b/indico/modules/events/timetable/client/js/layout.ts
@@ -314,6 +314,7 @@ export function layoutAfterUnscheduledDrop(
     colors: DEFAULT_CONTRIB_COLORS,
     column: null,
     maxColumn: null,
+    attachmentCount: 0,
   };
   delete entry.sessionId;
 
@@ -383,6 +384,7 @@ export function layoutAfterUnscheduledDropOnBlock(
     sessionId: toBlock.sessionId,
     column: null,
     maxColumn: null,
+    attachmentCount: 0,
   };
 
   if ('backgroundColor' in draftEntry) {

--- a/indico/modules/events/timetable/client/js/layout.ts
+++ b/indico/modules/events/timetable/client/js/layout.ts
@@ -317,7 +317,7 @@ export function layoutAfterUnscheduledDrop(
     colors: DEFAULT_CONTRIB_COLORS,
     column: null,
     maxColumn: null,
-    attachmentCount: 0,
+    attachments: [],
   };
   delete entry.sessionId;
 
@@ -385,7 +385,7 @@ export function layoutAfterUnscheduledDropOnBlock(
     sessionId: toBlock.sessionId,
     column: null,
     maxColumn: null,
-    attachmentCount: 0,
+    attachments: [],
   };
 
   if ('backgroundColor' in draftEntry) {

--- a/indico/modules/events/timetable/client/js/layout.ts
+++ b/indico/modules/events/timetable/client/js/layout.ts
@@ -317,6 +317,7 @@ export function layoutAfterUnscheduledDrop(
     colors: DEFAULT_CONTRIB_COLORS,
     column: null,
     maxColumn: null,
+    attachmentCount: 0,
   };
   delete entry.sessionId;
 
@@ -384,6 +385,7 @@ export function layoutAfterUnscheduledDropOnBlock(
     sessionId: toBlock.sessionId,
     column: null,
     maxColumn: null,
+    attachmentCount: 0,
   };
 
   if ('backgroundColor' in draftEntry) {

--- a/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
@@ -165,7 +165,7 @@ describe('mapperUtils', () => {
         y: 0,
         column: 0,
         maxColumn: 0,
-        attachmentCount: 0,
+        attachments: [],
       };
       const data = mapEntryToData(entry);
 
@@ -201,7 +201,7 @@ describe('mapperUtils', () => {
         y: 0,
         column: 0,
         maxColumn: 0,
-        attachmentCount: 0,
+        attachments: [],
       };
       const data = mapEntryToData(entry);
 

--- a/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
@@ -165,6 +165,7 @@ describe('mapperUtils', () => {
         y: 0,
         column: 0,
         maxColumn: 0,
+        attachmentCount: 0,
       };
       const data = mapEntryToData(entry);
 
@@ -200,6 +201,7 @@ describe('mapperUtils', () => {
         y: 0,
         column: 0,
         maxColumn: 0,
+        attachmentCount: 0,
       };
       const data = mapEntryToData(entry);
 

--- a/indico/modules/events/timetable/client/js/mapperUtils.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.ts
@@ -40,8 +40,8 @@ const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
     toTransform: (v: string) => +v.slice(1),
   },
   {
-    from: 'attachment_count',
-    to: 'attachmentCount',
+    from: 'attachments',
+    to: 'attachments',
   },
   {from: 'title', to: 'title'},
   {from: 'description', to: 'description'},

--- a/indico/modules/events/timetable/client/js/mapperUtils.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.ts
@@ -39,6 +39,10 @@ const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
     fromTransform: (v: number, data) => (v ? getEntryUniqueId(data.type as EntryType, v) : null),
     toTransform: (v: string) => +v.slice(1),
   },
+  {
+    from: 'attachment_count',
+    to: 'attachmentCount',
+  },
   {from: 'title', to: 'title'},
   {from: 'description', to: 'description'},
   {from: 'board_number', to: 'boardNumber'},

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -97,7 +97,7 @@ export default {
           .map(e => [e, ...(e.type === EntryType.SessionBlock ? e.children : [])])
           .flat();
         const entry = flatEntries.find(e => e.id === id);
-        if (!entry) {
+        if (!entry || entry.type === EntryType.Break) {
           return state;
         }
 
@@ -121,11 +121,21 @@ export default {
               ],
             },
           ];
-        } else {
+        } else if (entry.type === EntryType.Contribution) {
           newEntries[dateKey] = [
             ...dayEntries.filter(dayEntry => dayEntry.id !== id),
             {...entry, attachmentCount},
           ];
+        } else {
+          // attachments are linked to sessions, not session blocks, so we must update every
+          // session block that matches this sessionId
+          for (const key of Object.keys(newEntries)) {
+            newEntries[key] = newEntries[key].map(dayEntry =>
+              dayEntry.type === EntryType.SessionBlock && dayEntry.sessionId === entry.sessionId
+                ? {...dayEntry, attachmentCount}
+                : dayEntry
+            );
+          }
         }
 
         return {

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -91,7 +91,7 @@ export default {
       }
       case actions.SET_ENTRY_ATTACHMENTS: {
         const {id, attachments} = action;
-        const newEntries = {...state.changes[state.currentChangeIdx].entries};
+        const newEntries = {...state.entries};
         const flatEntries = Object.values(newEntries)
           .flat()
           .map(e => [e, ...(e.type === EntryType.SessionBlock ? e.children : [])])
@@ -140,15 +140,7 @@ export default {
 
         return {
           ...state,
-          currentChangeIdx: state.currentChangeIdx + 1,
-          changes: [
-            ...state.changes.slice(0, state.currentChangeIdx + 1),
-            {
-              entries: newEntries,
-              change: 'update',
-              unscheduled: state.changes[state.currentChangeIdx].unscheduled,
-            },
-          ],
+          entries: newEntries,
         };
       }
       case actions.UPDATE_ENTRY: {

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -90,7 +90,7 @@ export default {
         };
       }
       case actions.SET_ENTRY_ATTACHMENTS: {
-        const {id, attachmentCount} = action;
+        const {id, attachments} = action;
         const newEntries = {...state.changes[state.currentChangeIdx].entries};
         const flatEntries = Object.values(newEntries)
           .flat()
@@ -116,7 +116,7 @@ export default {
                 ...parentEntry.children.filter(childEntry => childEntry.id !== id),
                 {
                   ...entry,
-                  attachmentCount,
+                  attachments,
                 },
               ],
             },
@@ -124,7 +124,7 @@ export default {
         } else if (entry.type === EntryType.Contribution) {
           newEntries[dateKey] = [
             ...dayEntries.filter(dayEntry => dayEntry.id !== id),
-            {...entry, attachmentCount},
+            {...entry, attachments},
           ];
         } else {
           // attachments are linked to sessions, not session blocks, so we must update every
@@ -132,7 +132,7 @@ export default {
           for (const key of Object.keys(newEntries)) {
             newEntries[key] = newEntries[key].map(dayEntry =>
               dayEntry.type === EntryType.SessionBlock && dayEntry.sessionId === entry.sessionId
-                ? {...dayEntry, attachmentCount}
+                ? {...dayEntry, attachments}
                 : dayEntry
             );
           }

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -89,6 +89,58 @@ export default {
           unscheduled: updatedUnscheduled,
         };
       }
+      case actions.SET_ENTRY_ATTACHMENTS: {
+        const {id, attachmentCount} = action;
+        const newEntries = {...state.changes[state.currentChangeIdx].entries};
+        const flatEntries = Object.values(newEntries)
+          .flat()
+          .map(e => [e, ...(e.type === EntryType.SessionBlock ? e.children : [])])
+          .flat();
+        const entry = flatEntries.find(e => e.id === id);
+        if (!entry) {
+          return state;
+        }
+
+        const dateKey = getDateKey(entry.startDt);
+        const dayEntries = newEntries[dateKey];
+        if (isChildEntry(entry)) {
+          const parentEntry = dayEntries.find(dayEntry => dayEntry.id === entry.sessionBlockId);
+          if (parentEntry === undefined || parentEntry.type !== EntryType.SessionBlock) {
+            return state;
+          }
+          newEntries[dateKey] = [
+            ...dayEntries.filter(dayEntry => dayEntry.id !== parentEntry.id),
+            {
+              ...parentEntry,
+              children: [
+                ...parentEntry.children.filter(childEntry => childEntry.id !== id),
+                {
+                  ...entry,
+                  attachmentCount,
+                },
+              ],
+            },
+          ];
+        } else {
+          newEntries[dateKey] = [
+            ...dayEntries.filter(dayEntry => dayEntry.id !== id),
+            {...entry, attachmentCount},
+          ];
+        }
+
+        return {
+          ...state,
+          currentChangeIdx: state.currentChangeIdx + 1,
+          changes: [
+            ...state.changes.slice(0, state.currentChangeIdx + 1),
+            {
+              entries: newEntries,
+              change: 'update',
+              unscheduled: state.changes[state.currentChangeIdx].unscheduled,
+            },
+          ],
+        };
+      }
       case actions.UPDATE_ENTRY: {
         const {
           entry,

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -108,7 +108,7 @@ export default {
           .map(e => [e, ...(e.type === EntryType.SessionBlock ? e.children : [])])
           .flat();
         const entry = flatEntries.find(e => e.id === id);
-        if (!entry) {
+        if (!entry || entry.type === EntryType.Break) {
           return state;
         }
 
@@ -132,11 +132,21 @@ export default {
               ],
             },
           ];
-        } else {
+        } else if (entry.type === EntryType.Contribution) {
           newEntries[dateKey] = [
             ...dayEntries.filter(dayEntry => dayEntry.id !== id),
             {...entry, attachmentCount},
           ];
+        } else {
+          // attachments are linked to sessions, not session blocks, so we must update every
+          // session block that matches this sessionId
+          for (const key of Object.keys(newEntries)) {
+            newEntries[key] = newEntries[key].map(dayEntry =>
+              dayEntry.type === EntryType.SessionBlock && dayEntry.sessionId === entry.sessionId
+                ? {...dayEntry, attachmentCount}
+                : dayEntry
+            );
+          }
         }
 
         return {

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -103,7 +103,21 @@ export default {
       case actions.SET_ENTRY_ATTACHMENTS: {
         const {id, attachments} = action;
         const updatedEntry = {...state.entries[id], attachments};
-        return {...state, entries: {...state.entries, [id]: updatedEntry}};
+        let updatedEntries: Record<string, Entry>;
+        if (state.entries[id].type === EntryType.SessionBlock) {
+          updatedEntries = Object.fromEntries(
+            Object.entries(state.entries)
+              .filter(
+                ([, entry]) =>
+                  entry.type === EntryType.SessionBlock &&
+                  entry.sessionId === updatedEntry.sessionId
+              )
+              .map(([id_, entry]) => [id_, {...entry, attachments}])
+          );
+        } else {
+          updatedEntries = {[id]: updatedEntry};
+        }
+        return {...state, entries: {...state.entries, ...updatedEntries}};
       }
       case actions.UPDATE_ENTRY: {
         const {entry, changes} = action;

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -101,7 +101,7 @@ export default {
         };
       }
       case actions.SET_ENTRY_ATTACHMENTS: {
-        const {id, attachmentCount} = action;
+        const {id, attachments} = action;
         const newEntries = {...state.changes[state.currentChangeIdx].entries};
         const flatEntries = Object.values(newEntries)
           .flat()
@@ -127,7 +127,7 @@ export default {
                 ...parentEntry.children.filter(childEntry => childEntry.id !== id),
                 {
                   ...entry,
-                  attachmentCount,
+                  attachments,
                 },
               ],
             },
@@ -135,7 +135,7 @@ export default {
         } else if (entry.type === EntryType.Contribution) {
           newEntries[dateKey] = [
             ...dayEntries.filter(dayEntry => dayEntry.id !== id),
-            {...entry, attachmentCount},
+            {...entry, attachments},
           ];
         } else {
           // attachments are linked to sessions, not session blocks, so we must update every
@@ -143,7 +143,7 @@ export default {
           for (const key of Object.keys(newEntries)) {
             newEntries[key] = newEntries[key].map(dayEntry =>
               dayEntry.type === EntryType.SessionBlock && dayEntry.sessionId === entry.sessionId
-                ? {...dayEntry, attachmentCount}
+                ? {...dayEntry, attachments}
                 : dayEntry
             );
           }

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -102,57 +102,8 @@ export default {
       }
       case actions.SET_ENTRY_ATTACHMENTS: {
         const {id, attachments} = action;
-        const newEntries = {...state.entries};
-        const flatEntries = Object.values(newEntries)
-          .flat()
-          .map(e => [e, ...(e.type === EntryType.SessionBlock ? e.children : [])])
-          .flat();
-        const entry = flatEntries.find(e => e.id === id);
-        if (!entry || entry.type === EntryType.Break) {
-          return state;
-        }
-
-        const dateKey = getDateKey(entry.startDt);
-        const dayEntries = newEntries[dateKey];
-        if (isChildEntry(entry)) {
-          const parentEntry = dayEntries.find(dayEntry => dayEntry.id === entry.sessionBlockId);
-          if (parentEntry === undefined || parentEntry.type !== EntryType.SessionBlock) {
-            return state;
-          }
-          newEntries[dateKey] = [
-            ...dayEntries.filter(dayEntry => dayEntry.id !== parentEntry.id),
-            {
-              ...parentEntry,
-              children: [
-                ...parentEntry.children.filter(childEntry => childEntry.id !== id),
-                {
-                  ...entry,
-                  attachments,
-                },
-              ],
-            },
-          ];
-        } else if (entry.type === EntryType.Contribution) {
-          newEntries[dateKey] = [
-            ...dayEntries.filter(dayEntry => dayEntry.id !== id),
-            {...entry, attachments},
-          ];
-        } else {
-          // attachments are linked to sessions, not session blocks, so we must update every
-          // session block that matches this sessionId
-          for (const key of Object.keys(newEntries)) {
-            newEntries[key] = newEntries[key].map(dayEntry =>
-              dayEntry.type === EntryType.SessionBlock && dayEntry.sessionId === entry.sessionId
-                ? {...dayEntry, attachments}
-                : dayEntry
-            );
-          }
-        }
-
-        return {
-          ...state,
-          entries: newEntries,
-        };
+        const updatedEntry = {...state.entries[id], attachments};
+        return {...state, entries: {...state.entries, [id]: updatedEntry}};
       }
       case actions.UPDATE_ENTRY: {
         const {entry, changes} = action;

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -100,6 +100,58 @@ export default {
           unscheduled: newUnscheduled,
         };
       }
+      case actions.SET_ENTRY_ATTACHMENTS: {
+        const {id, attachmentCount} = action;
+        const newEntries = {...state.changes[state.currentChangeIdx].entries};
+        const flatEntries = Object.values(newEntries)
+          .flat()
+          .map(e => [e, ...(e.type === EntryType.SessionBlock ? e.children : [])])
+          .flat();
+        const entry = flatEntries.find(e => e.id === id);
+        if (!entry) {
+          return state;
+        }
+
+        const dateKey = getDateKey(entry.startDt);
+        const dayEntries = newEntries[dateKey];
+        if (isChildEntry(entry)) {
+          const parentEntry = dayEntries.find(dayEntry => dayEntry.id === entry.sessionBlockId);
+          if (parentEntry === undefined || parentEntry.type !== EntryType.SessionBlock) {
+            return state;
+          }
+          newEntries[dateKey] = [
+            ...dayEntries.filter(dayEntry => dayEntry.id !== parentEntry.id),
+            {
+              ...parentEntry,
+              children: [
+                ...parentEntry.children.filter(childEntry => childEntry.id !== id),
+                {
+                  ...entry,
+                  attachmentCount,
+                },
+              ],
+            },
+          ];
+        } else {
+          newEntries[dateKey] = [
+            ...dayEntries.filter(dayEntry => dayEntry.id !== id),
+            {...entry, attachmentCount},
+          ];
+        }
+
+        return {
+          ...state,
+          currentChangeIdx: state.currentChangeIdx + 1,
+          changes: [
+            ...state.changes.slice(0, state.currentChangeIdx + 1),
+            {
+              entries: newEntries,
+              change: 'update',
+              unscheduled: state.changes[state.currentChangeIdx].unscheduled,
+            },
+          ],
+        };
+      }
       case actions.UPDATE_ENTRY: {
         const {entry, changes} = action;
         const deltaStartDt = moment(entry.startDt).diff(state.entries[entry.id].startDt, 'minutes');

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -102,7 +102,7 @@ export default {
       }
       case actions.SET_ENTRY_ATTACHMENTS: {
         const {id, attachments} = action;
-        const newEntries = {...state.changes[state.currentChangeIdx].entries};
+        const newEntries = {...state.entries};
         const flatEntries = Object.values(newEntries)
           .flat()
           .map(e => [e, ...(e.type === EntryType.SessionBlock ? e.children : [])])
@@ -151,15 +151,7 @@ export default {
 
         return {
           ...state,
-          currentChangeIdx: state.currentChangeIdx + 1,
-          changes: [
-            ...state.changes.slice(0, state.currentChangeIdx + 1),
-            {
-              entries: newEntries,
-              change: 'update',
-              unscheduled: state.changes[state.currentChangeIdx].unscheduled,
-            },
-          ],
+          entries: newEntries,
         };
       }
       case actions.UPDATE_ENTRY: {

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -71,12 +71,6 @@ export interface LocationParent {
   type: string;
   title: string;
 }
-export interface Attachment {
-  type: 'attachment' | 'folder';
-  downloadURL: string;
-  id: number;
-  title: string;
-}
 
 export interface Session {
   id: number; // XXX probably we need an id-less variant during creation, but that should be a separate type
@@ -96,7 +90,6 @@ export interface BaseEntry {
   colors?: Colors;
   locationData?: LocationData;
   locationParent?: LocationParent;
-  attachments?: Attachment[];
 }
 
 export interface ScheduledMixin {
@@ -116,7 +109,7 @@ export interface UnscheduledContribEntry extends Omit<BaseEntry, 'id' | 'type'> 
 export interface ContribEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMixin {
   id: ContribId;
   type: EntryType.Contribution;
-  attachments?: Attachment[];
+  attachmentCount: number;
   sessionId?: number;
   boardNumber?: string;
   keywords?: string[];
@@ -136,7 +129,7 @@ export interface BlockEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMix
   children: ChildEntry[];
   personLinks: PersonLink[];
   childLocationParent: LocationParent;
-  attachments?: Attachment[];
+  attachmentCount: number;
   colors?: Colors;
   code?: string;
 }
@@ -199,4 +192,9 @@ export interface ReduxState {
   navigation: Navigation;
   staticData: StaticData;
   display: {activePanel: SidePanelView};
+}
+
+export interface AttachmentUpdatedEventDetail {
+  type: EntryType;
+  id: number;
 }

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -72,6 +72,13 @@ export interface LocationParent {
   title: string;
 }
 
+export interface Attachment {
+  id: number;
+  title: string;
+  type: 'attachment';
+  downloadUrl: string;
+}
+
 export interface Session {
   id: number; // XXX probably we need an id-less variant during creation, but that should be a separate type
   title: string;
@@ -109,7 +116,7 @@ export interface UnscheduledContribEntry extends Omit<BaseEntry, 'id' | 'type'> 
 export interface ContribEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMixin {
   id: ContribId;
   type: EntryType.Contribution;
-  attachmentCount: number;
+  attachments: Attachment[];
   sessionId?: number;
   boardNumber?: string;
   keywords?: string[];
@@ -129,7 +136,7 @@ export interface BlockEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMix
   children: ChildEntry[];
   personLinks: PersonLink[];
   childLocationParent: LocationParent;
-  attachmentCount: number;
+  attachments: Attachment[];
   colors?: Colors;
   code?: string;
 }

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -110,6 +110,7 @@ export interface ScheduledMixin {
 export interface UnscheduledContribEntry extends Omit<BaseEntry, 'id' | 'type'> {
   id: ContribId;
   type: EntryType.Contribution;
+  attachments: Attachment[];
   sessionId?: number;
 }
 

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -71,12 +71,6 @@ export interface LocationParent {
   type: string;
   title: string;
 }
-export interface Attachment {
-  type: 'attachment' | 'folder';
-  downloadURL: string;
-  id: number;
-  title: string;
-}
 
 export interface Session {
   id: number; // XXX probably we need an id-less variant during creation, but that should be a separate type
@@ -96,7 +90,6 @@ export interface BaseEntry {
   colors?: Colors;
   locationData?: LocationData;
   locationParent?: LocationParent;
-  attachments?: Attachment[];
 }
 
 export interface ScheduledMixin {
@@ -116,7 +109,7 @@ export interface UnscheduledContribEntry extends Omit<BaseEntry, 'id' | 'type'> 
 export interface ContribEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMixin {
   id: ContribId;
   type: EntryType.Contribution;
-  attachments?: Attachment[];
+  attachmentCount: number;
   sessionId?: number | null;
   boardNumber?: string;
   keywords?: string[];
@@ -136,7 +129,7 @@ export interface BlockEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMix
   children: ChildEntry[];
   personLinks: PersonLink[];
   childLocationParent: LocationParent;
-  attachments?: Attachment[];
+  attachmentCount: number;
   colors?: Colors;
   code?: string;
 }
@@ -214,4 +207,9 @@ export interface ReduxState {
   navigation: Navigation;
   staticData: StaticData;
   display: {activePanel: SidePanelView};
+}
+
+export interface AttachmentUpdatedEventDetail {
+  type: EntryType;
+  id: number;
 }

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -72,6 +72,13 @@ export interface LocationParent {
   title: string;
 }
 
+export interface Attachment {
+  id: number;
+  title: string;
+  type: 'attachment';
+  downloadUrl: string;
+}
+
 export interface Session {
   id: number; // XXX probably we need an id-less variant during creation, but that should be a separate type
   title: string;
@@ -109,7 +116,7 @@ export interface UnscheduledContribEntry extends Omit<BaseEntry, 'id' | 'type'> 
 export interface ContribEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMixin {
   id: ContribId;
   type: EntryType.Contribution;
-  attachmentCount: number;
+  attachments: Attachment[];
   sessionId?: number | null;
   boardNumber?: string;
   keywords?: string[];
@@ -129,7 +136,7 @@ export interface BlockEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMix
   children: ChildEntry[];
   personLinks: PersonLink[];
   childLocationParent: LocationParent;
-  attachmentCount: number;
+  attachments: Attachment[];
   colors?: Colors;
   code?: string;
 }

--- a/indico/modules/events/timetable/schemas.py
+++ b/indico/modules/events/timetable/schemas.py
@@ -16,6 +16,7 @@ from indico.modules.events.person_link_schemas import SessionBlockPersonLinkSche
 from indico.modules.events.sessions.models.blocks import SessionBlock
 from indico.modules.events.sessions.schemas import SessionColorSchema
 from indico.modules.events.timetable.models.breaks import Break
+from indico.modules.events.timetable.serializer import TimetableSerializer
 from indico.util.locations import LocationDataSchema, LocationParentSchema
 from indico.util.marshmallow import EventTimezoneDateTimeField, NonPartialNested
 
@@ -24,11 +25,8 @@ class SessionBlockSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = SessionBlock
         fields = ('id', 'title', 'start_dt', 'duration', 'code', 'person_links', 'location_data', 'location_parent',
-                  'child_location_parent', 'session_id', 'session_title', 'attachment_count')
+                  'child_location_parent', 'session_id', 'session_title', 'attachments')
         rh_context = ('event', {'object': 'session_block'})
-
-    def _get_attachment_count(self, session_block):
-        return len(session_block.session.attached_items.get('files', []))
 
     start_dt = EventTimezoneDateTimeField()
     location_data = fields.Nested(LocationDataSchema)
@@ -37,7 +35,7 @@ class SessionBlockSchema(mm.SQLAlchemyAutoSchema):
     person_links = NonPartialNested(_SessionBlockPersonLinkSchema(many=True, unknown=EXCLUDE))
     duration = fields.TimeDelta(required=True)
     session_title = fields.String(attribute='session.title', dump_only=True)
-    attachment_count = fields.Method('_get_attachment_count', dump_only=True)
+    attachments = fields.Function(lambda obj: TimetableSerializer.get_attachment_data(obj.session))
 
 
 def _get_break_session_id(entry):
@@ -69,10 +67,10 @@ class ContributionSchema(mm.SQLAlchemyAutoSchema):
         model = Contribution
         fields = ('id', 'title', 'description', 'code', 'board_number', 'keywords', 'location_data', 'location_parent',
                   'start_dt', 'duration', 'references', 'custom_fields', 'person_links', 'session_block',
-                  'session_block_id', 'session_id', 'parent_id', 'attachment_count')
+                  'session_block_id', 'session_id', 'parent_id', 'attachments')
         rh_context = ('event', {'object': 'contrib'})
 
-    def _get_attachment_count(self, contribution):
+    def _get_attachments(self, contribution):
         return len(contribution.attached_items.get('files', []))
 
     start_dt = EventTimezoneDateTimeField()
@@ -89,4 +87,4 @@ class ContributionSchema(mm.SQLAlchemyAutoSchema):
     duration = fields.TimeDelta(required=True)
     parent_id = fields.Integer(allow_none=True, load_only=True)
     session_block_id = fields.Integer(allow_none=True)
-    attachment_count = fields.Method('_get_attachment_count', dump_only=True)
+    attachments = fields.Function(TimetableSerializer.get_attachment_data)

--- a/indico/modules/events/timetable/schemas.py
+++ b/indico/modules/events/timetable/schemas.py
@@ -24,8 +24,11 @@ class SessionBlockSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = SessionBlock
         fields = ('id', 'title', 'start_dt', 'duration', 'code', 'person_links', 'location_data', 'location_parent',
-                  'child_location_parent', 'session_id', 'session_title')
+                  'child_location_parent', 'session_id', 'session_title', 'attachment_count')
         rh_context = ('event', {'object': 'session_block'})
+
+    def _get_attachment_count(self, session_block):
+        return len(session_block.session.attached_items.get('files', []))
 
     start_dt = EventTimezoneDateTimeField()
     location_data = fields.Nested(LocationDataSchema)
@@ -34,6 +37,7 @@ class SessionBlockSchema(mm.SQLAlchemyAutoSchema):
     person_links = NonPartialNested(_SessionBlockPersonLinkSchema(many=True, unknown=EXCLUDE))
     duration = fields.TimeDelta(required=True)
     session_title = fields.String(attribute='session.title', dump_only=True)
+    attachment_count = fields.Method('_get_attachment_count', dump_only=True)
 
 
 def _get_break_session_id(entry):
@@ -65,8 +69,11 @@ class ContributionSchema(mm.SQLAlchemyAutoSchema):
         model = Contribution
         fields = ('id', 'title', 'description', 'code', 'board_number', 'keywords', 'location_data', 'location_parent',
                   'start_dt', 'duration', 'references', 'custom_fields', 'person_links', 'session_block',
-                  'session_block_id', 'session_id', 'parent_id')
+                  'session_block_id', 'session_id', 'parent_id', 'attachment_count')
         rh_context = ('event', {'object': 'contrib'})
+
+    def _get_attachment_count(self, contribution):
+        return len(contribution.attached_items.get('files', []))
 
     start_dt = EventTimezoneDateTimeField()
     _description = fields.String(attribute='description')
@@ -82,3 +89,4 @@ class ContributionSchema(mm.SQLAlchemyAutoSchema):
     duration = fields.TimeDelta(required=True)
     parent_id = fields.Integer(allow_none=True, load_only=True)
     session_block_id = fields.Integer(allow_none=True)
+    attachment_count = fields.Method('_get_attachment_count', dump_only=True)

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -161,7 +161,7 @@ class TimetableSerializer:
                      'session_id': block.session_id,
                      'session_title': block.session.title,
                      'title': block.title,
-                     'attachments': self._get_attachment_data(block.session),
+                     'attachment_count': self._get_attachment_data(block.session),
                      'code': block.session.code,
                      'person_links': [self._get_person_data(x) for x in block.person_links],
                      'description': block.session.description,
@@ -183,7 +183,7 @@ class TimetableSerializer:
         data.update({'id': contribution.id,
                      'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
                      'start_dt': self._get_start_dt(entry),
-                     'attachments': self._get_attachment_data(contribution),
+                     'attachment_count': self._get_attachment_data(contribution),
                      'description': contribution.description,
                      'duration': contribution.duration_display.seconds,
                      'pdf': url_for('contributions.export_pdf', entry.contribution),
@@ -219,23 +219,7 @@ class TimetableSerializer:
         return data
 
     def _get_attachment_data(self, obj):
-        def serialize_attachment(attachment):
-            return {'id': attachment.id,
-                    'type': 'attachment',
-                    'title': attachment.title,
-                    'download_url': attachment.download_url}
-
-        def serialize_folder(folder):
-            return {'id': folder.id,
-                    'type': 'folder',
-                    'title': folder.title,
-                    'attachments': list(map(serialize_attachment, folder.attachments))}
-
-        items = obj.attached_items
-        files = list(map(serialize_attachment, items.get('files', [])))
-        folders = list(map(serialize_folder, items.get('folders', [])))
-
-        return files + folders
+        return len(obj.attached_items.get('files', []))
 
     def _get_start_dt(self, entry):
         tzinfo = entry.event.tzinfo
@@ -259,7 +243,7 @@ def serialize_unscheduled_contribution(contribution, *, can_manage_event=False):
     return {'id': contribution.id,
             'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
             'contribution_id': contribution.id,
-            'attachments': [],
+            'attachment_count': 0,
             'description': contribution.description,
             'duration': contribution.duration_display.seconds,
             'pdf': url_for('contributions.export_pdf', contribution),

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -161,7 +161,7 @@ class TimetableSerializer:
                      'session_id': block.session_id,
                      'session_title': block.session.title,
                      'title': block.title,
-                     'attachment_count': self._get_attachment_data(block.session),
+                     'attachments': self.get_attachment_data(block.session),
                      'code': block.session.code,
                      'person_links': [self._get_person_data(x) for x in block.person_links],
                      'description': block.session.description,
@@ -183,7 +183,7 @@ class TimetableSerializer:
         data.update({'id': contribution.id,
                      'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
                      'start_dt': self._get_start_dt(entry),
-                     'attachment_count': self._get_attachment_data(contribution),
+                     'attachments': self.get_attachment_data(contribution),
                      'description': contribution.description,
                      'duration': contribution.duration_display.seconds,
                      'pdf': url_for('contributions.export_pdf', entry.contribution),
@@ -218,8 +218,25 @@ class TimetableSerializer:
                      **get_color_data(break_)})
         return data
 
-    def _get_attachment_data(self, obj):
-        return len(obj.attached_items.get('files', []))
+    @staticmethod
+    def get_attachment_data(obj):
+        def serialize_attachment(attachment):
+            return {'id': attachment.id,
+                    'type': 'attachment',
+                    'title': attachment.title,
+                    'download_url': attachment.download_url}
+
+        def serialize_folder(folder):
+            return {'id': folder.id,
+                    'type': 'folder',
+                    'title': folder.title,
+                    'attachments': list(map(serialize_attachment, folder.attachments))}
+
+        items = obj.attached_items
+        files = list(map(serialize_attachment, items.get('files', [])))
+        folders = list(map(serialize_folder, items.get('folders', [])))
+
+        return files + folders
 
     def _get_start_dt(self, entry):
         tzinfo = entry.event.tzinfo
@@ -243,7 +260,7 @@ def serialize_unscheduled_contribution(contribution, *, can_manage_event=False):
     return {'id': contribution.id,
             'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
             'contribution_id': contribution.id,
-            'attachment_count': 0,
+            'attachments': [],
             'description': contribution.description,
             'duration': contribution.duration_display.seconds,
             'pdf': url_for('contributions.export_pdf', contribution),

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -128,7 +128,7 @@ class TimetableSerializer:
                      'session_id': block.session_id,
                      'session_title': block.session.title,
                      'title': block.title,
-                     'attachments': self._get_attachment_data(block.session),
+                     'attachment_count': self._get_attachment_data(block.session),
                      'code': block.session.code,
                      'person_links': [self._get_person_data(x) for x in block.person_links],
                      'description': block.session.description,
@@ -149,7 +149,7 @@ class TimetableSerializer:
         data.update({'id': contribution.id,
                      'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
                      'start_dt': self._get_start_dt(entry),
-                     'attachments': self._get_attachment_data(contribution),
+                     'attachment_count': self._get_attachment_data(contribution),
                      'description': contribution.description,
                      'duration': contribution.duration_display.seconds,
                      'pdf': url_for('contributions.export_pdf', entry.contribution),
@@ -185,23 +185,7 @@ class TimetableSerializer:
         return data
 
     def _get_attachment_data(self, obj):
-        def serialize_attachment(attachment):
-            return {'id': attachment.id,
-                    'type': 'attachment',
-                    'title': attachment.title,
-                    'download_url': attachment.download_url}
-
-        def serialize_folder(folder):
-            return {'id': folder.id,
-                    'type': 'folder',
-                    'title': folder.title,
-                    'attachments': list(map(serialize_attachment, folder.attachments))}
-
-        items = obj.attached_items
-        files = list(map(serialize_attachment, items.get('files', [])))
-        folders = list(map(serialize_folder, items.get('folders', [])))
-
-        return files + folders
+        return len(obj.attached_items.get('files', []))
 
     def _get_start_dt(self, entry):
         tzinfo = entry.event.tzinfo
@@ -225,7 +209,7 @@ def serialize_unscheduled_contribution(contribution, *, can_manage_event=False):
     return {'id': contribution.id,
             'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
             'contribution_id': contribution.id,
-            'attachments': [],
+            'attachment_count': 0,
             'description': contribution.description,
             'duration': contribution.duration_display.seconds,
             'pdf': url_for('contributions.export_pdf', contribution),

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -128,7 +128,7 @@ class TimetableSerializer:
                      'session_id': block.session_id,
                      'session_title': block.session.title,
                      'title': block.title,
-                     'attachment_count': self._get_attachment_data(block.session),
+                     'attachments': self.get_attachment_data(block.session),
                      'code': block.session.code,
                      'person_links': [self._get_person_data(x) for x in block.person_links],
                      'description': block.session.description,
@@ -149,7 +149,7 @@ class TimetableSerializer:
         data.update({'id': contribution.id,
                      'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
                      'start_dt': self._get_start_dt(entry),
-                     'attachment_count': self._get_attachment_data(contribution),
+                     'attachments': self.get_attachment_data(contribution),
                      'description': contribution.description,
                      'duration': contribution.duration_display.seconds,
                      'pdf': url_for('contributions.export_pdf', entry.contribution),
@@ -184,8 +184,25 @@ class TimetableSerializer:
                      **get_color_data(break_)})
         return data
 
-    def _get_attachment_data(self, obj):
-        return len(obj.attached_items.get('files', []))
+    @staticmethod
+    def get_attachment_data(obj):
+        def serialize_attachment(attachment):
+            return {'id': attachment.id,
+                    'type': 'attachment',
+                    'title': attachment.title,
+                    'download_url': attachment.download_url}
+
+        def serialize_folder(folder):
+            return {'id': folder.id,
+                    'type': 'folder',
+                    'title': folder.title,
+                    'attachments': list(map(serialize_attachment, folder.attachments))}
+
+        items = obj.attached_items
+        files = list(map(serialize_attachment, items.get('files', [])))
+        folders = list(map(serialize_folder, items.get('folders', [])))
+
+        return files + folders
 
     def _get_start_dt(self, entry):
         tzinfo = entry.event.tzinfo
@@ -209,7 +226,7 @@ def serialize_unscheduled_contribution(contribution, *, can_manage_event=False):
     return {'id': contribution.id,
             'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
             'contribution_id': contribution.id,
-            'attachment_count': 0,
+            'attachments': [],
             'description': contribution.description,
             'duration': contribution.duration_display.seconds,
             'pdf': url_for('contributions.export_pdf', contribution),

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -226,7 +226,7 @@ def serialize_unscheduled_contribution(contribution, *, can_manage_event=False):
     return {'id': contribution.id,
             'type': get_entry_type(TimetableEntryType.CONTRIBUTION),
             'contribution_id': contribution.id,
-            'attachments': [],
+            'attachments': TimetableSerializer.get_attachment_data(contribution),
             'description': contribution.description,
             'duration': contribution.duration_display.seconds,
             'pdf': url_for('contributions.export_pdf', contribution),


### PR DESCRIPTION
This ended up being quite a larger PR than I expected, mostly to be able to asynchronously update the timetable if changes are made in the material editor.