### PR TITLE
Increase videoconference name length limit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,9 +30,6 @@ Improvements
   registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)
 - Automatically paste obvious email addresses into the email field when pasting in
   the user search dialog (:pr:`7538`)
-- Increase the videoconference name length limit to 255 characters, leaving
-  service-specific limits to each plugin (:pr:`7560`, thanks
-  :user:`moliholy, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^
@@ -69,6 +66,9 @@ Internal Changes
 
 - Modernize the PDF registrant list generation using weasyprint (:pr:`7077`, thanks
   :user:`abhinavohri`)
+- Relax the videoconference name length limit to 255 characters, delegating
+  service-specific limits to each plugin (:pr:`7560`, thanks
+  :user:`moliholy, unconventionaldotdev`)
 
 
 Version 3.3.12

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,9 @@ Improvements
   registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)
 - Automatically paste obvious email addresses into the email field when pasting in
   the user search dialog (:pr:`7538`)
+- Increase the videoconference name length limit to 255 characters, leaving
+  service-specific limits to each plugin (:pr:`7560`, thanks
+  :user:`moliholy, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/vc/forms.py
+++ b/indico/modules/vc/forms.py
@@ -116,7 +116,7 @@ class VCRoomFormBase(VCRoomLinkFormBase):
     advanced_fields = {'show'}
     skip_fields = advanced_fields | VCRoomLinkFormBase.conditional_fields
 
-    name = StringField(_('Name'), [DataRequired(), Length(min=3, max=60)],
+    name = StringField(_('Name'), [DataRequired(), Length(min=3, max=255)],
                        description=_('The name of the videoconference.'))
 
     def validate_name(self, field):


### PR DESCRIPTION
Videoconference names were capped at 60 characters, too short for many real meeting titles such as official working-group names. The underlying column is unbounded, so the cap was a purely cosmetic form restriction. This raises it to a generous 255 and leaves service-specific limits to each videoconference plugin, as suggested in indico/indico-plugins#320.

The Zoom plugin separately enforces its own 200-character limit in indico/indico-plugins#320.
