### PR TITLE
Require a left-button click for all resize ops

### DIFF
--- a/indico/modules/events/timetable/client/js/ResizeHandle.tsx
+++ b/indico/modules/events/timetable/client/js/ResizeHandle.tsx
@@ -31,6 +31,10 @@ export default function ResizeHandle({
   setIsResizing: (b: boolean) => void;
 }) {
   function resizeHandler(e: SyntheticMouseEvent) {
+    if (e.button !== 0) {
+      return;
+    }
+
     e.stopPropagation();
     resizeStartRef.current = e.clientY;
     setIsResizing(true);

--- a/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributions.tsx
@@ -281,6 +281,9 @@ export default function UnscheduledContributions({dt}: {dt: Moment}) {
         <div
           styleName="pane-resize-handle"
           onMouseDown={e => {
+            if (e.button !== 0) {
+              return;
+            }
             resizing.current = true;
             initialPosition.current = e.pageX;
           }}


### PR DESCRIPTION
This was still missing when resizing timetable entries and the sidebar.