### PR TITLE
Prevent backend requests when nothing has changed

### DIFF
--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -112,18 +112,20 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
     minStartDt: useSelector(selectors.getEventStartDt),
     maxEndDt: useSelector(selectors.getEventEndDt),
   };
-  let initialStartDt = entry.startDt.format();
+  // Don't include timezone offset in string
+  let initialStartDt = entry.startDt.format('YYYY-MM-DDTHH:mm:ss');
 
   if (parent) {
     extraOptions.minStartDt = moment(parent.startDt);
     extraOptions.maxEndDt = moment(parent.startDt).add(parent.duration, 'minutes');
 
+    // Don't include timezone offset in string
     initialStartDt = moment
       .min(
         moment(initialStartDt),
         moment(extraOptions.maxEndDt).subtract(entry.duration, 'minutes')
       )
-      .format();
+      .format('YYYY-MM-DDTHH:mm:ss');
   }
 
   const initialValues: DraftEntry = {

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -36,7 +36,7 @@ import {
   Session,
   ReduxState,
 } from './types';
-import {getEntryURLByObjId} from './utils';
+import {flattenEntries, getEntryURLByObjId} from './utils';
 
 export const SET_DRAFT_ENTRY = 'Set draft entry';
 export const SET_TIMETABLE_DATA = 'Set timetable data';
@@ -291,7 +291,7 @@ export function changeEntryLayout(
   sessionBlockId?: number
 ) {
   return (dispatch: ThunkDispatch<ReduxState, unknown, Action>, getState: () => ReduxState) => {
-    const {staticData} = getState();
+    const {staticData, entries: stateEntries} = getState();
     const eventId = staticData.eventId;
 
     const entryURL = getEntryURLByObjId(eventId, entry.type, entry.objId);
@@ -300,6 +300,20 @@ export function changeEntryLayout(
       start_dt: entry.startDt.format(),
       session_block_id: sessionBlockId,
     };
+
+    const previousEntries = Object.values(
+      stateEntries.changes[stateEntries.currentChangeIdx].entries
+    ).flat();
+    const flattenedEntries = flattenEntries(previousEntries);
+    const entryBeforeChanges = flattenedEntries.find(e => e.id === entry.id);
+    if (
+      entryBeforeChanges &&
+      entryBeforeChanges.startDt.isSame(entry.startDt) &&
+      entryBeforeChanges.sessionId === entry.sessionId
+    ) {
+      // No changes were actually made, don't update state or backend
+      return;
+    }
 
     return dispatch(
       synchronizedAjaxAction(() => indicoAxios.patch(entryURL, entryData), {
@@ -332,6 +346,11 @@ export function resizeEntry(entry: Entry, duration: number, date: string) {
     const eventId = staticData.eventId;
     const entryURL = getEntryURLByObjId(eventId, entry.type, entry.objId);
     const entryData = {duration: duration * 60};
+
+    if (entry.duration === duration) {
+      // No changes were actually made, don't update state or backend
+      return;
+    }
 
     const action = synchronizedAjaxAction(() => indicoAxios.patch(entryURL, entryData), {
       type: RESIZE_ENTRY,


### PR DESCRIPTION
1. When resizing an entry, if the final duration is the same as the initial one, no backend requests are made; no action on the frontend is dispatched, which might matter if Undo/Redo is added), but I believe it would be more intuitive for an action that resulted in no changes to not be on the undo stack
2. When dragging an entry, if the final location is the same (both `sessionID` and `startDt` are the same), no requests to the backend are made; similarly to the previous one, no actions are dispatched either
3. Fixed an issue in the DateTimePicker that, due to including a timezone offset string (+XX:XX), prevented Final Form from figuring out that two dates were the same. This *might* conflict with https://github.com/indico/indico/pull/7468