### PR TITLE
Improve contribution url placeholder description

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Improvements
 - Allow users to mark contributions as favorites (:issue:`3524`, :pr:`7256`)
 - Allow choosing whether to clone registration tags (:pr:`7506`)
 - Add placeholders for contribution link and board number for emailing contributions
-  (:pr:`7525`, thanks :user:`duartegalvao`)
+  (:issue:`3602`, :pr:`7525`, thanks :user:`duartegalvao`)
 - Add a weekday option to the contribution schedule email placeholder (:pr:`7526`)
 - Allow managers to override accommodation date range validation when editing
   registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)

--- a/indico/modules/events/abstracts/placeholders.py
+++ b/indico/modules/events/abstracts/placeholders.py
@@ -172,7 +172,7 @@ class SubmitterTitlePlaceholder(Placeholder):
 class ContributionURLPlaceholder(Placeholder):
     advanced = True
     name = 'contribution_url'
-    description = _('Contribution URL')
+    description = _('The URL of the contribution')
 
     @classmethod
     def render(cls, abstract):


### PR DESCRIPTION
- Improve the description of the contribution url placeholder for abstract notifications.
- Add missing reference to issue #3602 in changelog. (Issue was already resolved)