### PR TITLE
Add contribution_link placeholder for abstract email context

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ Improvements
 - Add placeholders for contribution link and board number for emailing contributions
   (:issue:`3602`, :pr:`7525`, thanks :user:`duartegalvao`)
 - Add a weekday option to the contribution schedule email placeholder (:pr:`7526`)
+- Add contribution link placeholder for emailing abstract roles (:issue:`3602`, :pr:`7569`)
 - Allow managers to override accommodation date range validation when editing
   registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)
 - Automatically paste obvious email addresses into the email field when pasting in

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,13 +26,13 @@ Improvements
 - Add placeholders for contribution link and board number for emailing contributions
   (:issue:`3602`, :pr:`7525`, thanks :user:`duartegalvao`)
 - Add a weekday option to the contribution schedule email placeholder (:pr:`7526`)
-- Add contribution link placeholder for emailing abstract roles (:issue:`3602`, :pr:`7569`)
 - Allow managers to override accommodation date range validation when editing
   registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)
 - Automatically paste obvious email addresses into the email field when pasting in
   the user search dialog (:pr:`7538`)
 - Allow changing/removing the registration fee of pending registrations (:pr:`7572`)
 - Add QR code generator to event share widget (:issue:`6796`, :pr:`7504`)
+- Add contribution link placeholder for emailing abstract roles (:issue:`3602`, :pr:`7569`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Improvements
 - Allow users to mark contributions as favorites (:issue:`3524`, :pr:`7256`)
 - Allow choosing whether to clone registration tags (:pr:`7506`)
 - Add placeholders for contribution link and board number for emailing contributions
-  (:issue:`3602`, :pr:`7525`, thanks :user:`duartegalvao`)
+  (:pr:`7525`, thanks :user:`duartegalvao`)
 - Add a weekday option to the contribution schedule email placeholder (:pr:`7526`)
 - Allow managers to override accommodation date range validation when editing
   registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)

--- a/indico/modules/events/persons/__init__.py
+++ b/indico/modules/events/persons/__init__.py
@@ -43,6 +43,7 @@ def _get_placeholders(sender, person, event, contribution=None, abstract=None, r
     if object_context == 'abstracts':
         yield person_placeholders.AbstractIDPlaceholder
         yield person_placeholders.AbstractTitlePlaceholder
+        yield person_placeholders.AbstractContributionLinkPlaceholder
     elif object_context == 'contributions':
         yield person_placeholders.ContributionIDPlaceholder
         yield person_placeholders.ContributionTitlePlaceholder

--- a/indico/modules/events/persons/placeholders.py
+++ b/indico/modules/events/persons/placeholders.py
@@ -167,6 +167,22 @@ class ContributionSchedulePlaceholder(ParametrizedPlaceholder):
             return f'{weekday}, {scheduled}'
 
 
+class AbstractContributionLinkPlaceholder(ParametrizedPlaceholder):
+    name = 'contribution_link'
+    param_friendly_name = 'link title'
+
+    @classmethod
+    def render(cls, param, abstract, **kwargs):
+        if not abstract.contribution:
+            return ''
+        return ContributionLinkPlaceholder.render(param, contribution=abstract.contribution, **kwargs)
+
+    @classmethod
+    def iter_param_info(cls, **kwargs):
+        yield None, _('Link to the contribution created from the abstract (empty if not accepted)')
+        yield 'custom-text', _('Custom link text instead of the full URL')
+
+
 class AbstractIDPlaceholder(Placeholder):
     name = 'abstract_id'
     description = _('The ID of the abstract')


### PR DESCRIPTION
Adds `contribution_link` and `contribution_link:custom-text` placeholders to the abstract email context. As a result the list of abstracts view allows sending emails containing the contribution link to abstract roles.

In the case that the abstract is not accepted, the contribution placeholder renders an empty string.


<img width="1133" height="870" alt="image" src="https://github.com/user-attachments/assets/c25f12ab-6b8d-4f39-96d0-d4c9cbc5b086" />

Closes #3602 