### PR TITLE
Allow changing fee of pending registrations

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Improvements
   registrations (:issue:`7415`, :pr:`7433`, thanks :user:`moliholy, unconventionaldotdev`)
 - Automatically paste obvious email addresses into the email field when pasting in
   the user search dialog (:pr:`7538`)
+- Allow changing/removing the registration fee of pending registrations (:pr:`7572`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -980,7 +980,7 @@ class RHRegistrationsBasePrice(RHRegistrationsActionBase):
                 prev_state = reg.state
                 if form.apply_complete.data and reg.state == RegistrationState.complete and not reg.base_price:
                     reg.state = RegistrationState.unpaid
-                elif reg.state != RegistrationState.unpaid:
+                elif reg.state not in {RegistrationState.unpaid, RegistrationState.pending}:
                     num_skipped += 1
                     continue
                 new_price = {
@@ -994,7 +994,7 @@ class RHRegistrationsBasePrice(RHRegistrationsActionBase):
                                              format_currency(new_price, self.regform.currency, locale='en_GB'))
                     reg.base_price = new_price
                     reg.currency = self.regform.currency
-                if not reg.price:
+                if not reg.price and reg.state == RegistrationState.unpaid:
                     reg.state = RegistrationState.complete
                 if prev_state != reg.state:
                     changes['state'] = (prev_state, reg.state)


### PR DESCRIPTION
The price change only worked on unpaid registrations (and complete ones
when adding a price to a previously free registration). But in case of
a moderated registration form it makes sense to remove/change the price
before accepting (and thus triggering a "now awaiting payment"
notification email).