### PR TITLE
Allow assigning sessions to contributions in bulk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ Improvements
 - Automatically paste obvious email addresses into the email field when pasting in
   the user search dialog (:pr:`7538`)
 - Allow changing/removing the registration fee of pending registrations (:pr:`7572`)
+- Allow assigning multiple contributions to a session in bulk from the contribution
+  management list (:issue:`7571`, :pr:`7574`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/contributions/blueprint.py
+++ b/indico/modules/events/contributions/blueprint.py
@@ -25,6 +25,8 @@ _bp.add_url_rule('/manage/contributions/create', 'manage_create_contrib', manage
                  methods=('GET', 'POST'))
 _bp.add_url_rule('/manage/contributions/delete', 'manage_delete_contribs', management.RHDeleteContributions,
                  methods=('POST',))
+_bp.add_url_rule('/manage/contributions/assign-session', 'manage_contribs_assign_session',
+                 management.RHContributionsBulkAssignSession, methods=('POST',))
 _bp.add_url_rule('/manage/contributions/person-list', 'person_list', management.RHContributionPersonList,
                  methods=('POST',))
 _bp.add_url_rule('/manage/contributions/material-package', 'material_package',

--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -285,6 +285,20 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
+  function setupInlinePickerToggle() {
+    const $contributionList = $('#contribution-list');
+
+    function update() {
+      const selectedCount = $contributionList.find('input[name=contribution_id]:checked').length;
+      $contributionList
+        .find('.session-item-picker, .track-item-picker')
+        .prop('disabled', selectedCount > 1);
+    }
+
+    $contributionList.on('change', 'input[name=contribution_id]', update);
+    update();
+  }
+
   function setupStartDateQBubbles() {
     $('.js-contrib-start-date').each(function() {
       const $this = $(this);
@@ -337,6 +351,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setupTableSorter('#contribution-list .tablesorter');
     setupSessionPicker(options.createSessionURL, options.timetableRESTURL);
     setupTrackPicker(options.createTrackURL);
+    setupInlinePickerToggle();
     setupStartDateQBubbles();
     setupDurationQBubbles();
     enableIfChecked('#contribution-list', 'input[name=contribution_id]', '.js-enable-if-checked');

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -310,7 +310,7 @@ class RHContributionsBulkAssignSession(RHManageContributionsActionsBase):
                                '{count} contributions have been removed from their session.', assigned_count)
                       .format(count=assigned_count), 'success')
             if skipped_count:
-                flash(ngettext('1 contribution was skipped because it is currently scheduled.',
+                flash(ngettext('The contribution was skipped because it is currently scheduled.',
                                '{count} contributions were skipped because they are currently scheduled.',
                                skipped_count).format(count=skipped_count), 'warning')
             return jsonify_data(**self.list_generator.render_list())

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -28,8 +28,9 @@ from indico.modules.events.contributions.clone import ContributionCloner
 from indico.modules.events.contributions.controllers.common import ContributionListMixin
 from indico.modules.events.contributions.forms import (AllowSubmitterEditsForm, ContributionDefaultDurationForm,
                                                        ContributionDurationForm, ContributionExportTeXForm,
-                                                       ContributionProtectionForm, ContributionStartDateForm,
-                                                       ContributionTypeForm, SubContributionForm)
+                                                       ContributionProtectionForm, ContributionsBulkAssignSessionForm,
+                                                       ContributionStartDateForm, ContributionTypeForm,
+                                                       SubContributionForm)
 from indico.modules.events.contributions.lists import ContributionListGenerator
 from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.contributions.models.fields import ContributionField
@@ -275,6 +276,45 @@ class RHDeleteContributions(RHManageContributionsActionsBase):
                        '{count} contributions have been deleted.', deleted_count)
               .format(count=deleted_count), 'success')
         return jsonify_data(**self.list_generator.render_list())
+
+
+class RHContributionsBulkAssignSession(RHManageContributionsActionsBase):
+    """Assign multiple contributions to a session at once."""
+
+    _contrib_query_options = (joinedload('timetable_entry'),)
+
+    def _check_access(self):
+        RHManageContributionsActionsBase._check_access(self)
+
+        if not self.event.can_manage(session.user):
+            raise Forbidden
+
+    def _process(self):
+        form = ContributionsBulkAssignSessionForm(event=self.event,
+                                                  contribution_id=[c.id for c in self.contribs])
+        if form.validate_on_submit():
+            new_session = form.session.data
+            # Scheduled contributions may be unscheduled by this action
+            # To prevent this non-obvious side-effect, we filter them out.
+            to_assign = [c for c in self.contribs if c.timetable_entry is None]
+            skipped_count = len(self.contribs) - len(to_assign)
+            for contrib in to_assign:
+                update_contribution(contrib, {'session': new_session})
+            assigned_count = len(to_assign)
+            if assigned_count and new_session is not None:
+                flash(ngettext('The contribution has been assigned to the session "{session}".',
+                               '{count} contributions have been assigned to the session "{session}".', assigned_count)
+                      .format(count=assigned_count, session=new_session.title), 'success')
+            elif assigned_count:
+                flash(ngettext('The contribution has been removed from its session.',
+                               '{count} contributions have been removed from their session.', assigned_count)
+                      .format(count=assigned_count), 'success')
+            if skipped_count:
+                flash(ngettext('1 contribution was skipped because it is currently scheduled.',
+                               '{count} contributions were skipped because they are currently scheduled.',
+                               skipped_count).format(count=skipped_count), 'warning')
+            return jsonify_data(**self.list_generator.render_list())
+        return jsonify_form(form, submit=_('Assign'), disabled_until_change=False)
 
 
 class RHContributionACL(RHManageContributionBase):

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -281,13 +281,8 @@ class RHDeleteContributions(RHManageContributionsActionsBase):
 class RHContributionsBulkAssignSession(RHManageContributionsActionsBase):
     """Assign multiple contributions to a session at once."""
 
+    PERMISSION = None
     _contrib_query_options = (joinedload('timetable_entry'),)
-
-    def _check_access(self):
-        RHManageContributionsActionsBase._check_access(self)
-
-        if not self.event.can_manage(session.user):
-            raise Forbidden
 
     def _process(self):
         form = ContributionsBulkAssignSessionForm(event=self.event,

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -314,7 +314,7 @@ class RHContributionsBulkAssignSession(RHManageContributionsActionsBase):
             message = ngettext('One selected contribution is currently scheduled and will be skipped.',
                                '{count} selected contributions are currently scheduled and will be skipped.',
                                skipped_count).format(count=skipped_count)
-        return jsonify_form(form, submit=_('Assign'), disabled_until_change=False, message=message)
+        return jsonify_form(form, submit=_('Assign'), message=message)
 
 
 class RHContributionACL(RHManageContributionBase):

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -297,15 +297,15 @@ class RHContributionsBulkAssignSession(RHManageContributionsActionsBase):
                 update_contribution(contrib, {'session': new_session})
             assigned_count = len(to_assign)
             if assigned_count and new_session is not None:
-                flash(ngettext('The contribution has been assigned to the session "{session}".',
+                flash(ngettext('One contribution has been assigned to the session "{session}".',
                                '{count} contributions have been assigned to the session "{session}".', assigned_count)
                       .format(count=assigned_count, session=new_session.title), 'success')
             elif assigned_count:
-                flash(ngettext('The contribution has been removed from its session.',
+                flash(ngettext('One contribution has been removed from its session.',
                                '{count} contributions have been removed from their session.', assigned_count)
                       .format(count=assigned_count), 'success')
             if skipped_count:
-                flash(ngettext('The contribution was skipped because it is currently scheduled.',
+                flash(ngettext('One contribution was skipped because it is currently scheduled.',
                                '{count} contributions were skipped because they are currently scheduled.',
                                skipped_count).format(count=skipped_count), 'warning')
             return jsonify_data(**self.list_generator.render_list())

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -287,12 +287,12 @@ class RHContributionsBulkAssignSession(RHManageContributionsActionsBase):
     def _process(self):
         form = ContributionsBulkAssignSessionForm(event=self.event,
                                                   contribution_id=[c.id for c in self.contribs])
+        # Scheduled contributions may be unscheduled by this action.
+        # To prevent this non-obvious side-effect, we filter them out.
+        to_assign = [c for c in self.contribs if c.timetable_entry is None]
+        skipped_count = len(self.contribs) - len(to_assign)
         if form.validate_on_submit():
             new_session = form.session.data
-            # Scheduled contributions may be unscheduled by this action
-            # To prevent this non-obvious side-effect, we filter them out.
-            to_assign = [c for c in self.contribs if c.timetable_entry is None]
-            skipped_count = len(self.contribs) - len(to_assign)
             for contrib in to_assign:
                 update_contribution(contrib, {'session': new_session})
             assigned_count = len(to_assign)
@@ -309,7 +309,12 @@ class RHContributionsBulkAssignSession(RHManageContributionsActionsBase):
                                '{count} contributions were skipped because they are currently scheduled.',
                                skipped_count).format(count=skipped_count), 'warning')
             return jsonify_data(**self.list_generator.render_list())
-        return jsonify_form(form, submit=_('Assign'), disabled_until_change=False)
+        message = None
+        if skipped_count:
+            message = ngettext('One selected contribution is currently scheduled and will be skipped.',
+                               '{count} selected contributions are currently scheduled and will be skipped.',
+                               skipped_count).format(count=skipped_count)
+        return jsonify_form(form, submit=_('Assign'), disabled_until_change=False, message=message)
 
 
 class RHContributionACL(RHManageContributionBase):

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -205,11 +205,32 @@ class ContributionDurationForm(IndicoForm):
                 raise ValidationError(error_msg)
 
 
+class _BulkAssignSessionField(QuerySelectField):
+    """Session selector whose default leaves the current session untouched."""
+
+    _keep_value = '__keep'
+    _keep = object()
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault('default', self._keep)
+        super().__init__(*args, **kwargs)
+
+    def iter_choices(self):
+        yield (self._keep_value, _('Keep current session'), self.data is self._keep, {})
+        yield from super().iter_choices()
+
+    def process_formdata(self, valuelist):
+        if valuelist and valuelist[0] == self._keep_value:
+            self.data = self._keep
+        else:
+            super().process_formdata(valuelist)
+
+
 class ContributionsBulkAssignSessionForm(IndicoForm):
     contribution_id = HiddenFieldList()
     submitted = HiddenField()
-    session = QuerySelectField(_('Session'), get_label='title', allow_blank=True,
-                               blank_text=_('No session'))
+    session = _BulkAssignSessionField(_('Session'), get_label='title', allow_blank=True,
+                                      blank_text=_('No session'))
 
     def __init__(self, *args, event, **kwargs):
         self.event = event

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -211,8 +211,8 @@ class ContributionsBulkAssignSessionForm(IndicoForm):
     session = QuerySelectField(_('Session'), get_label='title', allow_blank=True,
                                blank_text=_('No session'))
 
-    def __init__(self, *args, **kwargs):
-        self.event = kwargs.pop('event')
+    def __init__(self, *args, event, **kwargs):
+        self.event = event
         super().__init__(*args, **kwargs)
         self.session.query = (Session.query
                               .with_parent(self.event)

--- a/indico/modules/events/contributions/forms.py
+++ b/indico/modules/events/contributions/forms.py
@@ -21,6 +21,7 @@ from indico.modules.events.contributions.fields import (ContributionPersonLinkLi
 from indico.modules.events.contributions.models.references import ContributionReference, SubContributionReference
 from indico.modules.events.contributions.models.types import ContributionType
 from indico.modules.events.fields import ReferencesField
+from indico.modules.events.sessions.models.sessions import Session
 from indico.modules.events.util import check_permissions
 from indico.util.date_time import get_day_end
 from indico.util.i18n import _
@@ -202,6 +203,23 @@ class ContributionDurationForm(IndicoForm):
                 error_msg = _('With this duration, the contribution would exceed the current day.')
             if self.contrib.start_dt + field.data > latest_dt:
                 raise ValidationError(error_msg)
+
+
+class ContributionsBulkAssignSessionForm(IndicoForm):
+    contribution_id = HiddenFieldList()
+    submitted = HiddenField()
+    session = QuerySelectField(_('Session'), get_label='title', allow_blank=True,
+                               blank_text=_('No session'))
+
+    def __init__(self, *args, **kwargs):
+        self.event = kwargs.pop('event')
+        super().__init__(*args, **kwargs)
+        self.session.query = (Session.query
+                              .with_parent(self.event)
+                              .order_by(db.func.lower(Session.title)))
+
+    def is_submitted(self):
+        return super().is_submitted() and 'submitted' in request.form
 
 
 class ContributionDefaultDurationForm(IndicoForm):

--- a/indico/modules/events/contributions/templates/management/contributions.html
+++ b/indico/modules/events/contributions/templates/management/contributions.html
@@ -178,6 +178,15 @@
                         data-reload-after>
                     {%- trans %}Assign program codes{% endtrans -%}
                 </button>
+                <button class="i-button js-enable-if-checked disabled hide-if-locked"
+                        data-title="{% trans %}Assign session{% endtrans %}"
+                        data-href="{{ url_for('.manage_contribs_assign_session', event) }}"
+                        data-params-selector="#contribution-list input[name=contribution_id]:checked"
+                        data-method="POST"
+                        data-ajax-dialog
+                        data-update='{"html": "#contribution-list", "filter_statistics": "#filter-statistics"}'>
+                    {%- trans %}Assign session{% endtrans -%}
+                </button>
                 <div class="group">
                     <button class="i-button button change-columns-width" title="{% trans %}Adapt columns width{% endtrans %}"></button>
                 </div>

--- a/indico/modules/events/contributions/templates/management/contributions.html
+++ b/indico/modules/events/contributions/templates/management/contributions.html
@@ -178,15 +178,17 @@
                         data-reload-after>
                     {%- trans %}Assign program codes{% endtrans -%}
                 </button>
-                <button class="i-button js-enable-if-checked disabled hide-if-locked"
-                        data-title="{% trans %}Assign session{% endtrans %}"
-                        data-href="{{ url_for('.manage_contribs_assign_session', event) }}"
-                        data-params-selector="#contribution-list input[name=contribution_id]:checked"
-                        data-method="POST"
-                        data-ajax-dialog
-                        data-update='{"html": "#contribution-list", "filter_statistics": "#filter-statistics"}'>
-                    {%- trans %}Assign session{% endtrans -%}
-                </button>
+                {% if event.can_manage(session.user) %}
+                    <button class="i-button js-enable-if-checked disabled hide-if-locked"
+                            data-title="{% trans %}Assign session{% endtrans %}"
+                            data-href="{{ url_for('.manage_contribs_assign_session', event) }}"
+                            data-params-selector="#contribution-list input[name=contribution_id]:checked"
+                            data-method="POST"
+                            data-ajax-dialog
+                            data-update='{"html": "#contribution-list", "filter_statistics": "#filter-statistics"}'>
+                        {%- trans %}Assign session{% endtrans -%}
+                    </button>
+                {% endif %}
                 <div class="group">
                     <button class="i-button button change-columns-width" title="{% trans %}Adapt columns width{% endtrans %}"></button>
                 </div>


### PR DESCRIPTION
Adds "Assign Session" button to management contribution view allowing the user to then assign one session to multiple contributions in one operation.

- Contributions that are scheduled are skipped during the reassignment and a warning is shown accordingly.
- Action is only allowed for full event managers and only visible accordingly.
- The existing inline pickers for Session and Track were modified to be disabled in the case where > 1 rows are selected.


<img width="1768" height="700" alt="image" src="https://github.com/user-attachments/assets/a074c684-7bde-4f42-aaf7-ab56543d0695" />

<img width="1770" height="682" alt="image" src="https://github.com/user-attachments/assets/530722e8-9667-4cea-9f9a-82d5b903db86" />

Closes #7571
