### PR TITLE
Add spreadsheet export for paper assignments

### DIFF
--- a/indico/modules/events/papers/blueprint.py
+++ b/indico/modules/events/papers/blueprint.py
@@ -113,6 +113,10 @@ for prefix, is_management in (('/manage/papers/assignment-list', True), ('/paper
     if is_management:
         _bp.add_url_rule(prefix + '/export-json', 'export_json', paper.RHExportPapersJSON, methods=('GET', 'POST'),
                          defaults=defaults)
+        _bp.add_url_rule(prefix + '/export.csv', 'export_csv', paper.RHExportPapersCSV, methods=('GET', 'POST'),
+                         defaults=defaults)
+        _bp.add_url_rule(prefix + '/export.xlsx', 'export_excel', paper.RHExportPapersExcel, methods=('GET', 'POST'),
+                         defaults=defaults)
 
 
 @_bp.url_defaults

--- a/indico/modules/events/papers/controllers/paper.py
+++ b/indico/modules/events/papers/controllers/paper.py
@@ -24,10 +24,12 @@ from indico.modules.events.papers.models.revisions import PaperRevisionState
 from indico.modules.events.papers.operations import judge_paper, update_reviewing_roles
 from indico.modules.events.papers.schemas import CallForPapersSchema, PaperDumpSchema
 from indico.modules.events.papers.settings import PaperReviewingRole
+from indico.modules.events.papers.util import generate_spreadsheet_from_paper_assignments
 from indico.modules.events.papers.views import WPDisplayJudgingArea, WPManagePapers
 from indico.modules.events.util import ZipGeneratorMixin
 from indico.util.fs import secure_filename
 from indico.util.i18n import _, ngettext, pgettext
+from indico.util.spreadsheets import send_csv, send_xlsx
 from indico.web.args import use_kwargs
 from indico.web.flask.util import url_for
 from indico.web.util import jsonify_data, jsonify_form, jsonify_template
@@ -161,6 +163,38 @@ class RHExportPapersJSON(RHPapersActionBase):
         response = jsonify(version=1, papers=papers_dump, **cfp_dump)
         response.headers['Content-Disposition'] = 'attachment; filename="papers.json"'
         return response
+
+
+class RHExportPapersCSV(RHPapersActionBase):
+    """Export paper assignment list to CSV."""
+
+    ALLOW_LOCKED = True
+    _allow_get_all = True
+
+    def _check_access(self):
+        RHPapersActionBase._check_access(self)
+        if not self.management:
+            raise Forbidden
+
+    def _process(self):
+        headers, rows = generate_spreadsheet_from_paper_assignments(self.contributions, self.event)
+        return send_csv('papers.csv', headers, rows)
+
+
+class RHExportPapersExcel(RHPapersActionBase):
+    """Export paper assignment list to XLSX."""
+
+    ALLOW_LOCKED = True
+    _allow_get_all = True
+
+    def _check_access(self):
+        RHPapersActionBase._check_access(self)
+        if not self.management:
+            raise Forbidden
+
+    def _process(self):
+        headers, rows = generate_spreadsheet_from_paper_assignments(self.contributions, self.event)
+        return send_xlsx('papers.xlsx', headers, rows, tz=self.event.tzinfo)
 
 
 class RHJudgePapers(RHPapersActionBase):

--- a/indico/modules/events/papers/templates/_paper_list.html
+++ b/indico/modules/events/papers/templates/_paper_list.html
@@ -368,10 +368,29 @@
                     {%- trans %}Download papers{% endtrans -%}
                 </button>
                 {% if management %}
-                    <button class="i-button icon-attachment js-requires-selected-row disabled js-submit-list-form"
-                            data-href="{{ url_for('.export_json', event) }}">
-                        {%- trans %}Export as JSON{% endtrans -%}
-                    </button>
+                    <div class="group">
+                        <button class="i-button arrow button js-requires-selected-row disabled"
+                                data-toggle="dropdown">
+                            {%- trans %}Export{% endtrans -%}
+                        </button>
+                        <ul class="i-dropdown">
+                            <li>
+                                <a href="#"
+                                   class="icon-file-spreadsheet js-requires-selected-row disabled js-submit-list-form"
+                                   data-href="{{ url_for('.export_csv', event) }}">CSV</a>
+                            </li>
+                            <li>
+                                <a href="#"
+                                   class="icon-file-excel js-requires-selected-row disabled js-submit-list-form"
+                                   data-href="{{ url_for('.export_excel', event) }}">XLSX (Excel)</a>
+                            </li>
+                            <li>
+                                <a href="#"
+                                   class="icon-file-css js-requires-selected-row disabled js-submit-list-form"
+                                   data-href="{{ url_for('.export_json', event) }}">JSON</a>
+                            </li>
+                        </ul>
+                    </div>
                 {% endif %}
                 <div class="group">
                     <button class="i-button button change-columns-width" title="{% trans %}Adapt columns width{% endtrans %}"></button>

--- a/indico/modules/events/papers/util.py
+++ b/indico/modules/events/papers/util.py
@@ -76,6 +76,58 @@ def has_contributions_with_user_paper_submission_rights(event, user):
     return _query_contributions_with_user_paper_submission_rights(event, user).has_rows()
 
 
+def generate_spreadsheet_from_paper_assignments(contributions, event):
+    """Generate spreadsheet data for paper assignment exports."""
+    id_header = 'ID'
+    title_header = 'Title'
+    state_header = 'State'
+    track_header = 'Track'
+    session_header = 'Session'
+    type_header = 'Type'
+    revision_header = 'Revision'
+    judges_header = 'Judges'
+    content_reviewers_header = 'Content reviewers'
+    layout_reviewers_header = 'Layout reviewers'
+
+    headers = [
+        id_header,
+        title_header,
+        state_header,
+        track_header,
+        session_header,
+        type_header,
+        revision_header,
+        judges_header,
+    ]
+    if event.cfp.content_reviewing_enabled:
+        headers.append(content_reviewers_header)
+    if event.cfp.layout_reviewing_enabled:
+        headers.append(layout_reviewers_header)
+
+    def _user_names(users):
+        return [user.display_full_name for user in sorted(users, key=lambda user: user.display_full_name.lower())]
+
+    rows = []
+    for contrib in contributions:
+        paper = contrib.paper
+        row = {
+            id_header: contrib.friendly_id,
+            title_header: contrib.title,
+            state_header: paper.last_revision.state.title if paper else 'Not submitted',
+            track_header: contrib.track.title_with_group if contrib.track else 'No track',
+            session_header: contrib.session.title if contrib.session else 'No session',
+            type_header: contrib.type.name if contrib.type else '',
+            revision_header: paper.revision_count if paper else '',
+            judges_header: _user_names(contrib.paper_judges),
+        }
+        if event.cfp.content_reviewing_enabled:
+            row[content_reviewers_header] = _user_names(contrib.paper_content_reviewers)
+        if event.cfp.layout_reviewing_enabled:
+            row[layout_reviewers_header] = _user_names(contrib.paper_layout_reviewers)
+        rows.append(row)
+    return headers, rows
+
+
 def get_user_submittable_contributions(event, user):
     criteria = [Contribution._paper_last_revision == None,  # noqa: E711
                 Contribution._paper_last_revision.has(PaperRevision.state == PaperRevisionState.to_be_corrected)]


### PR DESCRIPTION
Closes #6904.

## Problem

On the **Peer Reviewing → Assign Papers** management page, managers could only export the selected papers as **JSON**. For reporting and offline workflows (spreadsheets, sharing with committees, etc.), a tabular export is more practical.

## Solution

Replace the standalone **Export as JSON** control with an **Export** dropdown offering three formats:

| Format | Endpoint | File |
|--------|----------|------|
| CSV | `export.csv` | `papers.csv` |
| XLSX | `export.xlsx` | `papers.xlsx` |
| JSON | `export-json` | `papers.json` (unchanged) |

CSV and XLSX reuse the same pattern as other Indico list exports (`send_csv` / `send_xlsx`, POST with selected row IDs via `RHPapersActionBase`).

### Spreadsheet columns

Exports include one row per selected contribution:

- **ID**, **Title**, **State**, **Track**, **Session**, **Type**, **Revision**
- **Judges**
- **Content reviewers** / **Layout reviewers** — only if the corresponding reviewing mode is enabled for the event

Reviewer/judge names are sorted alphabetically (by display name).

### JSON export

Behavior is unchanged: full paper dump via `PaperDumpSchema` plus CFP metadata, suitable for integrations and detailed analysis.

## Implementation notes

- New helper: `generate_spreadsheet_from_paper_assignments()` in `papers/util.py`
- New request handlers: `RHExportPapersCSV`, `RHExportPapersExcel` in `papers/controllers/paper.py`
- UI: dropdown in `_paper_list.html` (management toolbar only), same “requires selected row” semantics as before

## Out of scope (for this PR)

Issue #6904 also mentions **TeX** export. This PR does not add TeX; it can be a follow-up if maintainers want parity with other export menus.

## How to test

1. Enable peer reviewing on an event with several papers and assigned judges/reviewers.
2. Open **Peer Reviewing → Assign Papers** (management view).
3. Select one or more papers.
4. **Export → CSV** / **XLSX** — verify downloaded file opens correctly and columns match the list.
5. **Export → JSON** — verify output matches previous behavior.
6. Confirm export is blocked without selection (button disabled) and without management permissions.
7. With only content or only layout reviewing enabled, verify optional reviewer columns appear/disappear accordingly.