### PR TITLE
Prevent clearing and incomplete values in timetable date/time pickers

### DIFF
--- a/indico/web/client/js/react/forms/__tests__/validators.spec.js
+++ b/indico/web/client/js/react/forms/__tests__/validators.spec.js
@@ -1,0 +1,30 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2026 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import v from '../validators';
+
+describe('datetime validator', () => {
+  const datetime = v.datetime();
+
+  it('accepts a full date and time', () => {
+    expect(datetime('2026-06-08T10:20:00')).toBeUndefined();
+  });
+
+  it('rejects a missing date (cleared date picker)', () => {
+    expect(datetime('T10:20:00')).not.toBeUndefined();
+  });
+
+  it('rejects a missing time', () => {
+    expect(datetime('2026-06-08T')).not.toBeUndefined();
+  });
+
+  it('rejects empty and malformed values', () => {
+    expect(datetime('')).not.toBeUndefined();
+    expect(datetime('T')).not.toBeUndefined();
+    expect(datetime('nonsense')).not.toBeUndefined();
+  });
+});

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -434,6 +434,7 @@ function DateTimePickerComponent({
   onFocus,
   minStartDt,
   maxEndDt,
+  required,
 }) {
   const [dateValue, timeValue] = value.split('T');
   const dt = moment(value);
@@ -454,6 +455,7 @@ function DateTimePickerComponent({
           onBlur={onBlur}
           onFocus={onFocus}
           disabled={disabled}
+          required={required}
           min={minStartDt.format('YYYY-MM-DD')}
           max={maxEndDt.format('YYYY-MM-DD')}
         />
@@ -481,11 +483,13 @@ DateTimePickerComponent.propTypes = {
   onFocus: PropTypes.func.isRequired,
   minStartDt: PropTypes.object,
   maxEndDt: PropTypes.object,
+  required: PropTypes.bool,
 };
 
 DateTimePickerComponent.defaultProps = {
   minStartDt: null,
   maxEndDt: null,
+  required: false,
 };
 
 /**

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -854,13 +854,17 @@ FinalDuration.defaultProps = {
   defaultValue: 1200, // 20 minutes
 };
 
-export function FinalDateTimePicker({name, label, defaultValue, ...rest}) {
+export function FinalDateTimePicker({name, label, defaultValue, validate, ...rest}) {
+  // Validate the whole datetime via `validators.datetime` rather than the built-in
+  // `required`, which can't reject half-empty values.
   return (
     <FinalField
       name={name}
       component={DateTimePickerComponent}
       label={label}
       defaultValue={defaultValue}
+      required="no-validator"
+      validate={validate}
       {...rest}
     />
   );
@@ -870,11 +874,13 @@ FinalDateTimePicker.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
   defaultValue: PropTypes.string,
+  validate: PropTypes.func,
 };
 
 FinalDateTimePicker.defaultProps = {
   label: null,
   defaultValue: moment().startOf('day').minutes(20).toISOString(),
+  validate: validators.datetime(),
 };
 
 /**

--- a/indico/web/client/js/react/forms/fields.jsx
+++ b/indico/web/client/js/react/forms/fields.jsx
@@ -854,7 +854,7 @@ FinalDuration.defaultProps = {
   defaultValue: 1200, // 20 minutes
 };
 
-export function FinalDateTimePicker({name, label, defaultValue, validate, ...rest}) {
+export function FinalDateTimePicker({name, label, defaultValue, validate, required, ...rest}) {
   // Validate the whole datetime via `validators.datetime` rather than the built-in
   // `required`, which can't reject half-empty values.
   return (
@@ -863,7 +863,7 @@ export function FinalDateTimePicker({name, label, defaultValue, validate, ...res
       component={DateTimePickerComponent}
       label={label}
       defaultValue={defaultValue}
-      required="no-validator"
+      required={required ? 'no-validator' : false}
       validate={validate}
       {...rest}
     />
@@ -875,12 +875,14 @@ FinalDateTimePicker.propTypes = {
   label: PropTypes.string,
   defaultValue: PropTypes.string,
   validate: PropTypes.func,
+  required: PropTypes.bool,
 };
 
 FinalDateTimePicker.defaultProps = {
   label: null,
   defaultValue: moment().startOf('day').minutes(20).toISOString(),
   validate: validators.datetime(),
+  required: false,
 };
 
 /**

--- a/indico/web/client/js/react/forms/validators.js
+++ b/indico/web/client/js/react/forms/validators.js
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import moment from 'moment';
+
 import {Translate} from 'indico/react/i18n';
 
 /** Special value indicating that chained validation should stop immediately. */
@@ -122,6 +124,17 @@ function dates() {
   };
 }
 
+function datetime() {
+  // the value of a datetime field is a combined `<date>T<time>` string, so a plain
+  // `required` check passes even when the date is cleared (e.g. `T10:20:00`). parse the
+  // whole thing instead so a missing date or time is correctly rejected.
+  return value => {
+    if (!moment(value, moment.ISO_8601, true).isValid()) {
+      return Translate.string('Please enter a valid date and time.');
+    }
+  };
+}
+
 export default {
   number,
   min,
@@ -135,5 +148,6 @@ export default {
   chain,
   or,
   dates,
+  datetime,
   STOP_VALIDATION,
 };


### PR DESCRIPTION
- Hide the clear button by marking the underlying date picker as required
- Add a datetime validator that rejects incomplete or malformed values, applied client-side in FinalDateTimePicker.
   > required only checks the combined <date>T<time> string is non-empty, so a half-filled value like T10:20:00 would still slip through, the validator parses the whole value instead.
- Add unit tests for the validator.

**Motivation for the use of a new validator:**
Before, the form could be submitted even if the date was invalid or empty and the user wouldn't be informed of the server-side failure. This way, at least there is some feedback.


Closes https://github.com/orgs/indico/projects/7/views/1?filterQuery=noahsalvi&pane=issue&itemId=164399584