### PR TITLE
Promote dashboard section headings from <h3> to <h2>

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -63,6 +63,9 @@ Accessibility
   :user:`foxbunny`)
 - Screen reader users can now navigate to the footer link list as a named
   navigation landmark (:pr:`7559`, thanks :user:`foxbunny`)
+- Screen reader users can now navigate the dashboard sections as second-level
+  headings instead of a flat run of same-level headings (:pr:`7581`, thanks
+  :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -40,7 +40,7 @@
                         <img src="{{ user.avatar_url }}" alt="" class="ui large circular label">
                     </div>
                     <div class="your-details-wrapper">
-                        <h3>{{ user.full_name }}</h3>
+                        <h2>{{ user.full_name }}</h2>
                         <div class="your-labels">
                             {% if config.DEBUG %}
                                 <div class="ui small label">
@@ -92,7 +92,7 @@
                 </div>
                 {% if unlisted_events %}
                     <div class="dashboard-box">
-                        <h3>{% trans %}Your unlisted events{% endtrans %}</h3>
+                        <h2>{% trans %}Your unlisted events{% endtrans %}</h2>
                         <ul>
                             {% for event in unlisted_events %}
                                 <li class="flexrow">
@@ -115,9 +115,9 @@
                     </div>
                 {% endif %}
                 <div class="dashboard-box">
-                    <h3>
+                    <h2>
                         {% trans %}Your events at hand{% endtrans %}
-                    </h3>
+                    </h2>
                     <ul>
                         {% for event, roles in linked_events %}
                             <li id="event-{{ event.id }}" class="flexrow">
@@ -154,7 +154,7 @@
                 </div>
                 {% if suggested_categories %}
                     <div id="suggestedCategories" class="dashboard-box suggestions">
-                        <h3>{% trans %}You might be interested in the following categories...{% endtrans %}</h3>
+                        <h2>{% trans %}You might be interested in the following categories...{% endtrans %}</h2>
                         <ul>
                             {% for category in suggested_categories %}
                                 {{ suggested_category(category.categ, category.path) }}
@@ -165,7 +165,7 @@
             </div>
             <div class="dashboard-col">
                 <div id="yourCategories" class="dashboard-box">
-                    <h3>{% trans %}Your categories{% endtrans %}</h3>
+                    <h2>{% trans %}Your categories{% endtrans %}</h2>
                     <ul>
                         {% if not categories %}
                             <li class="no-event">
@@ -181,7 +181,7 @@
                     </ul>
                 </div>
                 <div class="dashboard-box">
-                    <h3>{% trans %}Happening in your categories{% endtrans %}</h3>
+                    <h2>{% trans %}Happening in your categories{% endtrans %}</h2>
                     <ul>
                         {% if not categories %}
                             <li class="no-event">

--- a/indico/web/client/styles/modules/_dashboard.scss
+++ b/indico/web/client/styles/modules/_dashboard.scss
@@ -64,7 +64,7 @@
   margin-bottom: 44px;
 }
 
-.dashboard-box h3 {
+.dashboard-box h2 {
   background: #f7f7f7;
   border-bottom: 1px solid #ddd;
   border-top-left-radius: 0.3em;
@@ -75,7 +75,7 @@
   padding: 10px;
 }
 
-.dashboard-box.suggestions h3 {
+.dashboard-box.suggestions h2 {
   background: #dcebf5;
 }
 
@@ -213,7 +213,10 @@
     max-width: 300px;
     margin-right: 5px;
 
-    h3 {
+    h2 {
+      // Pin the size the name had as an <h3>, so promoting the heading level
+      // does not change its appearance (the default <h2> size is larger).
+      font-size: 1.2em;
       margin-top: 0;
       margin-bottom: 10px;
     }


### PR DESCRIPTION
Promotes the user dashboard's section headings (user name, "Your events at hand", "Your categories", etc.) from `<h3>` to `<h2>`.

**Impact:** screen reader users get a proper second-level heading structure for the dashboard sections instead of a flat run of same-level `<h3>` headings with no heading above them. Visual appearance is unchanged (the user-name heading keeps its size via an explicit `font-size`).