### PR TITLE
Display poster count on poster session blocks in timetable view

### DIFF
--- a/indico/modules/events/timetable/client/js/Entry.module.scss
+++ b/indico/modules/events/timetable/client/js/Entry.module.scss
@@ -96,6 +96,14 @@
   border-left: 5px solid transparent;
   container-type: size;
   border-radius: 4px;
+
+  .poster-count {
+    margin-left: auto;
+    flex-shrink: 0;
+    white-space: nowrap;
+    padding: 10px;
+    line-height: 1.2rem;
+  }
 }
 
 .mv-buttons-wrapper {
@@ -162,7 +170,8 @@
 }
 
 @container (height <= 50px) {
-  .title-wrapper {
+  .title-wrapper,
+  .poster-count {
     padding-block: 0;
     align-self: center;
   }

--- a/indico/modules/events/timetable/client/js/Entry.module.scss
+++ b/indico/modules/events/timetable/client/js/Entry.module.scss
@@ -7,6 +7,9 @@
 
 @use 'base/palette' as *;
 
+$title-row-padding: 10px;
+$title-row-line-height: 1.2rem;
+
 .entry {
   color: white;
   border-radius: 4px;
@@ -45,13 +48,13 @@
 
 .title-wrapper {
   overflow: hidden;
-  line-height: 1.2rem;
+  line-height: $title-row-line-height;
   font-size: 0.9rem;
   display: flex;
   align-items: center;
   flex-wrap: wrap;
   gap: 5px;
-  padding: 10px;
+  padding: $title-row-padding;
   max-height: 100%;
 
   .title-overflow-wrapper {
@@ -101,8 +104,8 @@
     margin-left: auto;
     flex-shrink: 0;
     white-space: nowrap;
-    padding: 10px;
-    line-height: 1.2rem;
+    padding: $title-row-padding;
+    line-height: $title-row-line-height;
   }
 }
 
@@ -179,6 +182,6 @@
 
 @container (height <= 34px) {
   .title-wrapper {
-    max-height: 1.2rem;
+    max-height: $title-row-line-height;
   }
 }

--- a/indico/modules/events/timetable/client/js/Entry.module.scss
+++ b/indico/modules/events/timetable/client/js/Entry.module.scss
@@ -161,7 +161,8 @@ $title-row-line-height: 1.2rem;
 }
 
 @container (width < 250px) {
-  .children-wrapper {
+  .children-wrapper,
+  .poster-count {
     display: none;
   }
 }

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -10,6 +10,8 @@ import React, {useEffect, useRef, useState, useMemo} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Icon, SemanticICONS} from 'semantic-ui-react';
 
+import {PluralTranslate, Singular, Plural, Param} from 'indico/react/i18n';
+
 import * as actions from './actions';
 import {useDraggable, useDroppable} from './dnd';
 import {EntryMoveButtons} from './EntryMoveButtons';
@@ -298,6 +300,7 @@ export default function Entry({
           type={type}
           {...(isPosterBlock ? {icon: 'flag outline'} : {})}
         />
+        {isPosterBlock && <PosterCount count={children.length} />}
         {type === EntryType.SessionBlock && !isPosterBlock && (
           <div
             ref={setDroppableNodeRef}
@@ -388,5 +391,20 @@ export function EntryTitle({
       </div>
       <span styleName="time">{timeRange}</span>
     </div>
+  );
+}
+
+function PosterCount({count}: {count: number}) {
+  return (
+    <span styleName="poster-count">
+      <PluralTranslate count={count}>
+        <Singular>
+          <Param name="count" value={count} /> poster
+        </Singular>
+        <Plural>
+          <Param name="count" value={count} /> posters
+        </Plural>
+      </PluralTranslate>
+    </span>
   );
 }


### PR DESCRIPTION
- Adds the number of posters contained in a poster session block in the timetable view.

<img width="1095" height="474" alt="image" src="https://github.com/user-attachments/assets/89574096-543b-4b87-9b5b-223f2cac30b8" />

<img width="621" height="487" alt="image" src="https://github.com/user-attachments/assets/70be3b23-aa0a-4b35-9a99-36a4a9a0795e" />

Closes  https://github.com/orgs/indico/projects/7/views/1?filterQuery=noahsalvi&pane=issue&itemId=164404695&pane=issue&itemId=164404695