### PR TITLE
Change base entry droppable and show overlay on hover

### DIFF
--- a/indico/modules/events/timetable/client/js/Entry.module.scss
+++ b/indico/modules/events/timetable/client/js/Entry.module.scss
@@ -20,6 +20,7 @@ $title-row-line-height: 1.2rem;
   padding: 0;
   outline: none;
   font-size: 0.9rem;
+  container-type: size;
 
   .children-wrapper {
     flex-grow: 1;
@@ -50,32 +51,27 @@ $title-row-line-height: 1.2rem;
 
   .children-droppable-container.hovered {
     opacity: 1;
-    background-color: rgba(0, 0, 0, 0.6);
     pointer-events: all;
   }
 
-  .children-droppable {
+  .children-droppable-outline {
     position: absolute;
     top: 0;
-    left: 20px;
+    left: 0;
     bottom: 0;
-    right: 20px;
+    right: 0;
     z-index: 10;
-    pointer-events: none;
-    border: 2px dashed gray;
     border-radius: 4px;
-    background-color: rgba(255, 255, 255, 0.6);
+    pointer-events: none;
     display: flex;
     align-items: center;
     justify-content: center;
-    overflow: hidden;
+    outline: 2px dashed gray;
+  }
 
-    p {
-      user-select: none;
-      text-align: center;
-      font-size: 1.25em;
-      font-weight: bold;
-    }
+  .children-droppable {
+    width: 100%;
+    height: 100%;
   }
 
   &:hover:not(:has(.entry:hover)) {

--- a/indico/modules/events/timetable/client/js/Entry.module.scss
+++ b/indico/modules/events/timetable/client/js/Entry.module.scss
@@ -62,7 +62,7 @@ $title-row-line-height: 1.2rem;
     right: 20px;
     z-index: 10;
     pointer-events: none;
-    border: 5px dashed gray;
+    border: 2px dashed gray;
     border-radius: 4px;
     background-color: rgba(255, 255, 255, 0.6);
     display: flex;
@@ -71,6 +71,7 @@ $title-row-line-height: 1.2rem;
     overflow: hidden;
 
     p {
+      user-select: none;
       text-align: center;
       font-size: 1.25em;
       font-weight: bold;

--- a/indico/modules/events/timetable/client/js/Entry.module.scss
+++ b/indico/modules/events/timetable/client/js/Entry.module.scss
@@ -37,6 +37,46 @@ $title-row-line-height: 1.2rem;
     }
   }
 
+  .children-droppable-container {
+    opacity: 0;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    pointer-events: none;
+    transition: opacity ease-out 0.2s;
+  }
+
+  .children-droppable-container.hovered {
+    opacity: 1;
+    background-color: rgba(0, 0, 0, 0.6);
+    pointer-events: all;
+  }
+
+  .children-droppable {
+    position: absolute;
+    top: 0;
+    left: 20px;
+    bottom: 0;
+    right: 20px;
+    z-index: 10;
+    pointer-events: none;
+    border: 5px dashed gray;
+    border-radius: 4px;
+    background-color: rgba(255, 255, 255, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+
+    p {
+      text-align: center;
+      font-size: 1.25em;
+      font-weight: bold;
+    }
+  }
+
   &:hover:not(:has(.entry:hover)) {
     > .mv-buttons-wrapper {
       visibility: visible;

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -10,7 +10,7 @@ import React, {useEffect, useRef, useState, useMemo} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Icon, SemanticICONS} from 'semantic-ui-react';
 
-import {PluralTranslate, Singular, Plural, Param} from 'indico/react/i18n';
+import {PluralTranslate, Singular, Plural, Param, Translate} from 'indico/react/i18n';
 
 import * as actions from './actions';
 import {useDraggable, useDroppable} from './dnd';
@@ -165,7 +165,9 @@ function DroppableArea({id, title}: {id: string; title: string}) {
         ref={setDroppableNodeRef}
       >
         <div>
-          <p>Move into "{title}"</p>
+          <Translate as="p">
+            Move into "<Param name="title" value={title} />"
+          </Translate>
         </div>
       </div>
     </div>

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -10,7 +10,7 @@ import React, {useEffect, useRef, useState, useMemo} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Icon, SemanticICONS} from 'semantic-ui-react';
 
-import {PluralTranslate, Singular, Plural, Param, Translate} from 'indico/react/i18n';
+import {PluralTranslate, Singular, Plural, Param} from 'indico/react/i18n';
 
 import * as actions from './actions';
 import {useDraggable, useDroppable} from './dnd';
@@ -156,19 +156,13 @@ interface _EntryProps {
 
 type EntryProps = _EntryProps & ScheduledMixin & BaseEntry;
 
-function DroppableArea({id, title}: {id: string; title: string}) {
+function DroppableArea({id, horizontalPadding}: {id: string; horizontalPadding?: string}) {
   const {setNodeRef: setDroppableNodeRef, hasDraggableOver} = useDroppable({id});
+
   return (
     <div styleName={`children-droppable-container ${hasDraggableOver ? 'hovered' : ''}`}>
-      <div
-        styleName={`children-droppable ${hasDraggableOver ? 'hovered' : ''}`}
-        ref={setDroppableNodeRef}
-      >
-        <div>
-          <Translate as="p">
-            Move into "<Param name="title" value={title} />"
-          </Translate>
-        </div>
+      <div styleName="children-droppable-outline" style={{padding: `0 ${horizontalPadding}`}}>
+        <div ref={setDroppableNodeRef} styleName="children-droppable" />
       </div>
     </div>
   );
@@ -207,9 +201,11 @@ export default function Entry({
   );
   const session = useSelector((state: ReduxState) => selectors.getSessionById(state, sessionId));
   const {width, offset} = getWidthAndOffset(column, maxColumn);
+  const entryRef = useRef<HTMLDivElement>(null);
   const resizeStartRef = useRef<number | null>(null);
   const [isResizing, setIsResizing] = useState(false);
   const [duration, setDuration] = useState(_duration);
+  const [droppableArea, setDroppableArea] = useState<'full' | 'partial'>('full');
   const colors = getEntryColors({type, sessionBlockId, colors: customColors}, session);
   const btnColors = {backgroundColor: colors.color, color: colors.backgroundColor};
   const draftEntry = useSelector(selectors.getDraftEntry);
@@ -278,6 +274,29 @@ export default function Entry({
     };
   }, [isDragging, isResizing, blockRef]);
 
+  useEffect(() => {
+    if (type !== EntryType.SessionBlock || !entryRef.current) {
+      return;
+    }
+    function updateDroppableArea(entryWidth: number) {
+      if (entryWidth - 5 > 250) {
+        setDroppableArea('partial');
+      } else {
+        setDroppableArea('full');
+      }
+    }
+
+    const observer = new ResizeObserver(entries => {
+      const entryWidth = entries[0].contentRect.width;
+      updateDroppableArea(entryWidth);
+    });
+    observer.observe(entryRef.current);
+
+    updateDroppableArea(entryRef.current.clientWidth);
+
+    return observer.disconnect;
+  }, [id, type]);
+
   const setChildDurations = useMemo(() => {
     const obj = {};
     for (const e of _children) {
@@ -290,6 +309,7 @@ export default function Entry({
     <div
       role="button"
       styleName="entry"
+      ref={entryRef}
       style={style}
       onMouseUp={() => {
         if (isResizing || isDragging) {
@@ -338,10 +358,15 @@ export default function Entry({
                 {...child}
               />
             ))}
+            {type === EntryType.SessionBlock && !isPosterBlock && droppableArea === 'partial' && (
+              <DroppableArea id={id} />
+            )}
           </div>
         )}
       </div>
-      {type === EntryType.SessionBlock && !isPosterBlock && <DroppableArea id={id} title={title} />}
+      {type === EntryType.SessionBlock && !isPosterBlock && droppableArea === 'full' && (
+        <DroppableArea id={id} horizontalPadding="15px" />
+      )}
       {!draftEntry && (
         <EntryMoveButtons
           id={id}

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -156,6 +156,22 @@ interface _EntryProps {
 
 type EntryProps = _EntryProps & ScheduledMixin & BaseEntry;
 
+function DroppableArea({id, title}: {id: string; title: string}) {
+  const {setNodeRef: setDroppableNodeRef, hasDraggableOver} = useDroppable({id});
+  return (
+    <div styleName={`children-droppable-container ${hasDraggableOver ? 'hovered' : ''}`}>
+      <div
+        styleName={`children-droppable ${hasDraggableOver ? 'hovered' : ''}`}
+        ref={setDroppableNodeRef}
+      >
+        <div>
+          <p>Move into "{title}"</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // TODO: (Ajob) Fix these type errors
 export default function Entry({
   type,
@@ -192,7 +208,6 @@ export default function Entry({
   const resizeStartRef = useRef<number | null>(null);
   const [isResizing, setIsResizing] = useState(false);
   const [duration, setDuration] = useState(_duration);
-  const {setNodeRef: setDroppableNodeRef} = useDroppable({id});
   const colors = getEntryColors({type, sessionBlockId, colors: customColors}, session);
   const btnColors = {backgroundColor: colors.color, color: colors.backgroundColor};
   const draftEntry = useSelector(selectors.getDraftEntry);
@@ -304,7 +319,6 @@ export default function Entry({
         {isPosterBlock && <PosterCount count={children.length} />}
         {type === EntryType.SessionBlock && !isPosterBlock && (
           <div
-            ref={setDroppableNodeRef}
             styleName="children-wrapper"
             style={{
               backgroundImage: `radial-gradient(${colors.color}11 1px, transparent 0)`,
@@ -325,6 +339,7 @@ export default function Entry({
           </div>
         )}
       </div>
+      {type === EntryType.SessionBlock && !isPosterBlock && <DroppableArea id={id} title={title} />}
       {!draftEntry && (
         <EntryMoveButtons
           id={id}

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -421,7 +421,12 @@ export function useDroppable({id}: {id: string}) {
   const unregisterDroppable = useContextSelector(DnDContext, ctx => ctx.unregisterDroppable);
   const hasDraggableOver = useContextSelector(DnDContext, ctx => {
     for (const [draggableId, draggable] of Object.entries(ctx.draggableData)) {
-      if (draggableId === id || !draggable.transform) {
+      // FIXME: !(draggableId.startsWith('c') || draggableId.startsWith('b')) is a huge hack
+      if (
+        draggableId === id ||
+        !(draggableId.startsWith('c') || draggableId.startsWith('b')) ||
+        !draggable.transform
+      ) {
         continue;
       }
       const overlapping = getOverlappingDroppables(ctx.droppables, draggable.mouse);

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -419,6 +419,18 @@ export function useDroppable({id}: {id: string}) {
   const ref = useRef<HTMLElement | null>(null);
   const registerDroppable = useContextSelector(DnDContext, ctx => ctx.registerDroppable);
   const unregisterDroppable = useContextSelector(DnDContext, ctx => ctx.unregisterDroppable);
+  const hasDraggableOver = useContextSelector(DnDContext, ctx => {
+    for (const [draggableId, draggable] of Object.entries(ctx.draggableData)) {
+      if (draggableId === id || !draggable.transform) {
+        continue;
+      }
+      const overlapping = getOverlappingDroppables(ctx.droppables, draggable.mouse);
+      if (overlapping.some(o => o.id === id)) {
+        return true;
+      }
+    }
+    return false;
+  });
 
   const setNodeRef = useCallback((node: HTMLElement | null) => {
     if (node) {
@@ -436,7 +448,7 @@ export function useDroppable({id}: {id: string}) {
     };
   }, [id, registerDroppable, unregisterDroppable]);
 
-  return {setNodeRef};
+  return useMemo(() => ({setNodeRef, hasDraggableOver}), [setNodeRef, hasDraggableOver]);
 }
 
 export function useDroppableData({id}: {id: string}) {


### PR DESCRIPTION
This both deals with the fact that:

1. when Session Block entries got too small, it was not possible to drag contributions into them;
2. there was no indicator to show where an entry would end up after dragging.

Marking this as a draft PR since I believe there is room for some input, such as:
* Should we also show an overlay when hovering over the calendar, to the side of another entry?
* The hover indicator itself could probably be aesthetically improved
* Do we want to keep the old background in the session block entry where contributions are placed? It seems to dragging, but is actually completely detached now.

<img width="2140" height="364" alt="image" src="https://github.com/user-attachments/assets/d4649315-51d6-455c-a39c-4e882aa48e7e" />

<img width="378" height="453" alt="image" src="https://github.com/user-attachments/assets/039f0b18-07ae-4788-8974-00cf3f6868fb" />
