### PR TITLE
Expose dashboard event role icons to screen readers via ind-with-tooltip

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,11 @@ Accessibility
   :user:`foxbunny`)
 - Screen readers now correctly recognise modal dialogs as modal, keeping
   navigation within the open dialog (:pr:`7570`, thanks :user:`foxbunny`)
+- Screen reader users can now reliably hear their relationship to each event in
+  the dashboard's "Your events at hand" list (management, reviewing, attendance
+  and favourite status), which was previously exposed only through role-icon
+  tooltips that assistive technology did not announce dependably (:pr:`7589`,
+  thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -130,6 +130,11 @@ Accessibility
   title as plain text with no heading (:pr:`7617`, thanks :user:`foxbunny`)
 - The abstract submission ID is now easier to read for users with low vision
   (:pr:`7463`, thanks :user:`foxbunny`)
+- Screen reader users can now reliably hear their relationship to each event in
+  the dashboard's "Your events at hand" list (management, reviewing, attendance
+  and favourite status), which was previously exposed only through role-icon
+  tooltips that assistive technology did not announce dependably (:pr:`7589`,
+  thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -130,17 +130,20 @@
                                     </a>
                                     {{ event.get_label_markup('mini') }}
                                 </span>
-                                {% set role_titles = {
-                                    'management': _('You have management rights') if roles.management else _('You do not have management rights'),
-                                    'reviewing': _('You are a reviewer') if roles.reviewing else _('You are not a reviewer'),
-                                    'attendance': _('You are an attendee') if roles.attendance else _('You are not an attendee'),
-                                    'favorited': _('You have favorited this event') if roles.favorited else _('You have not favorited this event')
-                                } %}
+                                {% set role_legend = [
+                                    ('management', 'icon-medal', _('You have management rights'), _('You do not have management rights')),
+                                    ('reviewing', 'icon-user-reading', _('You are a reviewer'), _('You are not a reviewer')),
+                                    ('attendance', 'icon-ticket', _('You are an attendee'), _('You are not an attendee')),
+                                    ('favorited', 'icon-star', _('You have favorited this event'), _('You have not favorited this event'))
+                                ] %}
                                 <span class="item-legend">
-                                    <span title="{{ role_titles.management }}" class="icon-medal {{ 'active' if roles.management }}"></span>
-                                    <span title="{{ role_titles.reviewing }}" class="icon-user-reading {{ 'active' if roles.reviewing }}"></span>
-                                    <span title="{{ role_titles.attendance }}" class="icon-ticket {{ 'active' if roles.attendance }}"></span>
-                                    <span title="{{ role_titles.favorited }}" class="icon-star {{ 'active' if roles.favorited }}"></span>
+                                    {% for key, icon, active_label, inactive_label in role_legend %}
+                                        <ind-with-tooltip>
+                                            <span class="{{ icon }} {{ 'active' if roles[key] }}">
+                                                <span data-tip-content>{{ active_label if roles[key] else inactive_label }}</span>
+                                            </span>
+                                        </ind-with-tooltip>
+                                    {% endfor %}
                                 </span>
                             </li>
                         {% else %}

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -135,17 +135,20 @@
                                     </a>
                                     {{ event.get_label_markup('mini') }}
                                 </span>
-                                {% set role_titles = {
-                                    'management': _('You have management rights') if roles.management else _('You do not have management rights'),
-                                    'reviewing': _('You are a reviewer') if roles.reviewing else _('You are not a reviewer'),
-                                    'attendance': _('You are an attendee') if roles.attendance else _('You are not an attendee'),
-                                    'favorited': _('You have favorited this event') if roles.favorited else _('You have not favorited this event')
-                                } %}
+                                {% set role_legend = [
+                                    ('management', 'icon-medal', _('You have management rights'), _('You do not have management rights')),
+                                    ('reviewing', 'icon-user-reading', _('You are a reviewer'), _('You are not a reviewer')),
+                                    ('attendance', 'icon-ticket', _('You are an attendee'), _('You are not an attendee')),
+                                    ('favorited', 'icon-star', _('You have favorited this event'), _('You have not favorited this event'))
+                                ] %}
                                 <span class="item-legend">
-                                    <span title="{{ role_titles.management }}" class="icon-medal {{ 'active' if roles.management }}"></span>
-                                    <span title="{{ role_titles.reviewing }}" class="icon-user-reading {{ 'active' if roles.reviewing }}"></span>
-                                    <span title="{{ role_titles.attendance }}" class="icon-ticket {{ 'active' if roles.attendance }}"></span>
-                                    <span title="{{ role_titles.favorited }}" class="icon-star {{ 'active' if roles.favorited }}"></span>
+                                    {% for key, icon, active_label, inactive_label in role_legend %}
+                                        <ind-with-tooltip>
+                                            <span class="{{ icon }} {{ 'active' if roles[key] }}">
+                                                <span data-tip-content>{{ active_label if roles[key] else inactive_label }}</span>
+                                            </span>
+                                        </ind-with-tooltip>
+                                    {% endfor %}
                                 </span>
                             </li>
                         {% else %}


### PR DESCRIPTION
The role icons in the dashboard's "Your events at hand" list (management, reviewing, attendance, favourite) previously carried their meaning in a `title` attribute on non-interactive `<span>`s — exposed to the accessibility tree only as a description on a nameless generic element, which assistive technology does not announce dependably, and otherwise only as a mouse-only hover tooltip.

Each icon is now wrapped in `<ind-with-tooltip>` with an inlined `<span data-tip-content>`, so the role text is always present in the accessibility tree (read reliably by screen readers) and shown as a styled tooltip on hover. Each role reads its active or inactive state in full ("You are a reviewer" / "You are not a reviewer").

Screen reader users can now hear their relationship to each event; the resting visual appearance is unchanged.