### PR TITLE
Fix internal name validation for new registration form fields

### DIFF
--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -118,9 +118,7 @@ class GeneralFieldDataSchema(mm.Schema):
         internal_name = data.get('internal_name')
         field = self.context['field']
         if field.type == RegistrationFormItemType.field_pd and internal_name != field.personal_data_type.internal_name:
-            raise ValidationError(
-                {'internal_name': [_('Changing internal name for personal data field is not allowed.')]}
-            )
+            raise ValidationError(_('Changing internal name for personal data field is not allowed.'), 'internal_name')
         if internal_name is None:
             return
         if field.is_enabled is not False:  # None for new field
@@ -134,8 +132,8 @@ class GeneralFieldDataSchema(mm.Schema):
                 query = query.filter(RegistrationFormItem.id != field.id)
             if same_field := query.first():
                 raise ValidationError(
-                    {'internal_name': [(_('The field "{}" on this form has the same internal name.')
-                                        .format(same_field.title))]}
+                    _('The field "{}" on this form has the same internal name.').format(same_field.title),
+                    'internal_name',
                 )
             # consistent type on forms of the same event
             query = (RegistrationFormItem.query
@@ -157,9 +155,10 @@ class GeneralFieldDataSchema(mm.Schema):
             )
             if inconsistent_field:
                 raise ValidationError(
-                    {'internal_name': [(_('The field "{}" with the same internal name on form "{}" '
-                                          'uses a different input type which is not allowed.')
-                                        .format(inconsistent_field.title, inconsistent_field.registration_form.title))]}
+                    _('The field "{field}" with the same internal name on form "{form}" uses a different input type '
+                      'which is not allowed.'
+                    ).format(field=inconsistent_field.title, form=inconsistent_field.registration_form.title),
+                    'internal_name',
                 )
 
     def _check_manager_only(self, field):

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -111,12 +111,16 @@ class GeneralFieldDataSchema(mm.Schema):
                 raise ValidationError(_('The retention period cannot be longer than 10 years. Leave the field empty '
                                         'for indefinite.'))
 
-    @validates('internal_name')
+    @validates_schema(skip_on_field_errors=True)
     @no_autoflush
-    def _check_internal_name(self, internal_name, **kwargs):
+    def _check_internal_name(self, data, **kwargs):
+        input_type = data['input_type']
+        internal_name = data.get('internal_name')
         field = self.context['field']
         if field.type == RegistrationFormItemType.field_pd and internal_name != field.personal_data_type.internal_name:
-            raise ValidationError(_('Changing internal name for personal data field is not allowed.'))
+            raise ValidationError(
+                {'internal_name': [_('Changing internal name for personal data field is not allowed.')]}
+            )
         if internal_name is None:
             return
         if field.is_enabled is not False:  # None for new field
@@ -129,15 +133,17 @@ class GeneralFieldDataSchema(mm.Schema):
             if field.id:
                 query = query.filter(RegistrationFormItem.id != field.id)
             if same_field := query.first():
-                raise ValidationError(_('The field "{}" on this form has the same internal name.')
-                                      .format(same_field.title))
+                raise ValidationError(
+                    {'internal_name': [(_('The field "{}" on this form has the same internal name.')
+                                        .format(same_field.title))]}
+                )
             # consistent type on forms of the same event
             query = (RegistrationFormItem.query
                      .join(RegistrationFormItem.registration_form)
                      .join(RegistrationForm.event)
                      .filter(RegistrationFormItem.internal_name == internal_name,
                              RegistrationFormItem.registration_form_id != field.registration_form.id,
-                             RegistrationFormItem.input_type != field.input_type,
+                             RegistrationFormItem.input_type != input_type,
                              RegistrationFormItem.is_enabled,
                              ~RegistrationFormItem.is_deleted,
                              ~RegistrationForm.is_deleted,
@@ -150,9 +156,11 @@ class GeneralFieldDataSchema(mm.Schema):
                 None
             )
             if inconsistent_field:
-                raise ValidationError(_('The field "{}" with the same internal name on form "{}" '
-                                        'uses a different input type which is not allowed.')
-                                      .format(inconsistent_field.title, inconsistent_field.registration_form.title))
+                raise ValidationError(
+                    {'internal_name': [(_('The field "{}" with the same internal name on form "{}" '
+                                          'uses a different input type which is not allowed.')
+                                        .format(inconsistent_field.title, inconsistent_field.registration_form.title))]}
+                )
 
     def _check_manager_only(self, field):
         return field.parent.is_manager_only

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -126,8 +126,9 @@ class TestGeneralFieldDataSchema:
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': position_field})
         with pytest.raises(ValidationError) as exc_info:
             assert schema.load({'input_type': 'text', 'title': position_field.title, 'internal_name': internal_name})
-        assert exc_info.value.messages == {'internal_name': ['Changing internal name for personal data field '
-                                                             'is not allowed.']}
+        assert exc_info.value.messages == {
+            'internal_name': 'Changing internal name for personal data field is not allowed.'
+        }
 
     def test_update_internal_name_of_disabled_field(self, dummy_regform):
         pd_section = dummy_regform.sections[0]

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -126,8 +126,8 @@ class TestGeneralFieldDataSchema:
         schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': position_field})
         with pytest.raises(ValidationError) as exc_info:
             assert schema.load({'input_type': 'text', 'title': position_field.title, 'internal_name': internal_name})
-        assert exc_info.value.messages == {'internal_name': 'Changing internal name for personal data field '
-                                                            'is not allowed.'}
+        assert exc_info.value.messages == {'internal_name': ['Changing internal name for personal data field '
+                                                             'is not allowed.']}
 
     def test_update_internal_name_of_disabled_field(self, dummy_regform):
         pd_section = dummy_regform.sections[0]
@@ -149,28 +149,33 @@ class TestGeneralFieldDataSchema:
         assert schema.load({'input_type': 'text', 'title': position_field.title,
                             'internal_name': position_field.internal_name})
 
-    def test_internal_name_with_different_input_type_on_other_regform(self, db, create_regform, dummy_regform):
-        other_form = create_regform(dummy_regform.event, title='Other Form')
-        pd_section = dummy_regform.sections[0]
-        # Disable the title field on dummy_regform to be able to add another title field but with different type
-        title_field = next((field for field in pd_section.fields
-                            if field.personal_data_type == PersonalDataType.title), None)
-        title_field.is_enabled = False
-        db.session.flush()
-        new_section = RegistrationFormSection(registration_form=dummy_regform, title='New Section',
-                                              is_manager_only=False)
-        new_field = RegistrationFormField(parent=new_section, registration_form=dummy_regform, title='test',
-                                          input_type='text')
-        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': new_field})
+    def test_add_new_field_with_same_internal_name_on_other_regform(self, db, create_regform, dummy_regform):
+        RegistrationFormField(parent=dummy_regform.sections[0], registration_form=dummy_regform,
+                              title='Test field', input_type='text', internal_name='test-internal-name')
+        other_regform = create_regform(dummy_regform.event, title='Other regform')
+        # No other properties are set on the new field.
+        # The missing input_type is the most important here because that comes from the form data.
+        new_field = RegistrationFormField(parent=other_regform.sections[0], registration_form=other_regform)
+        schema = GeneralFieldDataSchema(context={'regform': other_regform, 'field': new_field})
+        assert schema.load({'title': 'Test field', 'input_type': 'text', 'internal_name': 'test-internal-name'})
+
+    def test_update_field_to_same_internal_name_but_different_input_type_on_other_regform(self, db, create_regform,
+                                                                                          dummy_regform):
+        RegistrationFormField(parent=dummy_regform.sections[0], registration_form=dummy_regform,
+                              title='Test title', input_type='number', internal_name='test-internal-name')
+        other_regform = create_regform(dummy_regform.event, title='Other regform')
+        section = RegistrationFormSection(registration_form=other_regform, title='Other Section', is_manager_only=False)
+        field = RegistrationFormField(parent=section, registration_form=other_regform, title='test', input_type='text')
+        schema = GeneralFieldDataSchema(context={'regform': dummy_regform, 'field': field})
         with pytest.raises(ValidationError) as exc_info:
-            schema.load({'input_type': 'text', 'title': 'test', 'internal_name': 'title'})
+            schema.load({'input_type': 'text', 'title': 'test', 'internal_name': 'test-internal-name'})
         assert exc_info.value.messages == {
-            'internal_name': [f'The field "Title" with the same internal name on form '
-                              f'"{other_form.title}" uses a different input type which is not allowed.']
+            'internal_name': [f'The field "Test title" with the same internal name on form '
+                              f'"{dummy_regform.title}" uses a different input type which is not allowed.']
         }
-        other_form.is_deleted = True
+        dummy_regform.is_deleted = True
         db.session.flush()
-        assert schema.load({'input_type': 'text', 'title': 'text', 'internal_name': 'title'})
+        assert schema.load({'input_type': 'text', 'title': 'test', 'internal_name': 'test-internal-name'})
 
     def test_internal_name_allows_legacy_affiliation_type_on_other_regform(self, db, create_regform, dummy_regform):
         other_form = create_regform(dummy_regform.event, title='Other Form')


### PR DESCRIPTION
This PR is fixing the incorrect input type matching in internal name field validation of a registration form field in the following case:
* a new field is added with an internal name
* the same internal name already exists on another registration form of the same event
