### PR TITLE
Use a labelled description list for dashboard contact details

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,9 @@ Accessibility
   :user:`foxbunny`)
 - Screen readers now correctly recognise modal dialogs as modal, keeping
   navigation within the open dialog (:pr:`7570`, thanks :user:`foxbunny`)
+- Screen reader users now hear the affiliation, email and phone on their profile
+  dashboard announced as labelled fields instead of bare values (:pr:`7593`,
+  thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -135,6 +135,9 @@ Accessibility
   and favourite status), which was previously exposed only through role-icon
   tooltips that assistive technology did not announce dependably (:pr:`7589`,
   thanks :user:`foxbunny`)
+- Screen reader users now hear the affiliation, email and phone on their profile
+  dashboard announced as labelled fields instead of bare values (:pr:`7593`,
+  thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -69,19 +69,27 @@
                                 </div>
                             {% endif %}
                         </div>
-                        {% if user.affiliation %}
-                            <div>
-                                <i class="icon-users"></i><span>{{ user.affiliation }}</span>
-                            </div>
-                        {% endif %}
-                        <div>
-                            <i class="icon-mail"></i><span>{{ user.email }}</span>
-                        </div>
-                        {% if user.phone %}
-                            <div>
-                                <i class="icon-phone"></i><span>{{ user.phone }}</span>
-                            </div>
-                        {% endif %}
+                        <dl class="contact-details">
+                            {% if user.affiliation %}
+                                <dt>
+                                    <i class="icon-users" aria-hidden="true"></i>
+                                    <span class="contact-details-label">{% trans %}Affiliation{% endtrans %}</span>
+                                </dt>
+                                <dd>{{ user.affiliation }}</dd>
+                            {% endif %}
+                            <dt>
+                                <i class="icon-mail" aria-hidden="true"></i>
+                                <span class="contact-details-label">{% trans %}Email{% endtrans %}</span>
+                            </dt>
+                            <dd>{{ user.email }}</dd>
+                            {% if user.phone %}
+                                <dt>
+                                    <i class="icon-phone" aria-hidden="true"></i>
+                                    <span class="contact-details-label">{% trans %}Phone{% endtrans %}</span>
+                                </dt>
+                                <dd>{{ user.phone }}</dd>
+                            {% endif %}
+                        </dl>
                     </div>
                     <div class="actions">
                         <a class="ui icon button" href="{{ url_for('users.user_profile') }}">

--- a/indico/web/client/styles/modules/_dashboard.scss
+++ b/indico/web/client/styles/modules/_dashboard.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'design_system';
 @use 'rb:styles/responsive' as *;
 
 .banner.user-dashboard,
@@ -234,6 +235,22 @@
       .label {
         margin: 0 7px 7px 0;
       }
+    }
+
+    .contact-details {
+      display: grid;
+      grid-template-columns: max-content 1fr;
+      align-items: baseline;
+      margin: 0;
+
+      dt,
+      dd {
+        margin: 0;
+      }
+    }
+
+    .contact-details-label {
+      @extend %visually-hidden;
     }
   }
 


### PR DESCRIPTION
The user's contact details (affiliation, email, phone) on the dashboard were
rendered as a run of anonymous `<div>`s, each a decorative icon followed by the
bare value. Screen readers read each value with no indication of which field it
was — the affiliation, for instance, was announced as its text alone with no
"Affiliation" context.

This replaces the markup with a description list:

- `<dl>`/`<dt>`/`<dd>`, so each value is a proper term/description pair
- a visually-hidden field label (Affiliation/Email/Phone) per `<dt>`, following
  the existing `%visually-hidden` pattern (which, unlike `aria-label`, survives
  browser translation)
- decorative icons explicitly marked `aria-hidden="true"`

A CSS grid preserves the original two-column icon + value layout, so the change
is visually identical.

**User impact:** screen reader users now hear "Affiliation: …", "Email: …",
"Phone: …" instead of bare values.
