### PR TITLE
Give Registration Manager access to registration logs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ Improvements
 - Record who created a registration on behalf of someone else (:pr:`7629`, thanks
   :user:`moliholy, unconventionaldotdev`)
 - Support attaching files when emailing event persons (:pr:`7369`, thanks :user:`jbtwist`)
+- Let registration managers view logs for specific registrations (:pr:`7600`, thanks
+  :user:`vtran99`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/logs/client/js/components/EventLog.jsx
+++ b/indico/modules/logs/client/js/components/EventLog.jsx
@@ -66,10 +66,11 @@ LogsRefreshMessage.propTypes = {};
 export default function EventLog() {
   const metadataQuery = useSelector(state => state.logs.metadataQuery);
   const hasNewEntries = useSelector(state => state.logs.hasNewEntries);
+  const canRemoveFilter = useSelector(state => state.staticData.canRemoveFilter);
   return (
     <>
       {hasNewEntries && <LogsRefreshMessage />}
-      {Object.keys(metadataQuery).length !== 0 && <MetadataQueryMessage />}
+      {canRemoveFilter && Object.keys(metadataQuery).length !== 0 && <MetadataQueryMessage />}
       <Toolbar />
       <LogEntryList />
     </>

--- a/indico/modules/logs/client/js/index.jsx
+++ b/indico/modules/logs/client/js/index.jsx
@@ -24,6 +24,7 @@ window.addEventListener('load', () => {
       fetchLogsUrl: rootElement.dataset.fetchLogsUrl,
       realms: JSON.parse(rootElement.dataset.realms),
       pageSize: 15,
+      canRemoveFilter: rootElement.dataset.requireFilter === undefined,
     },
   };
   const store = createReduxStore(

--- a/indico/modules/logs/controllers.py
+++ b/indico/modules/logs/controllers.py
@@ -73,6 +73,8 @@ class RHCategoryLogs(RHManageCategoryBase):
 class RHEventLogs(RHManageEventBase):
     """Show the modification/action log for the event."""
 
+    PERMISSION = 'registration'
+
     def _process(self):
         metadata_query = _get_metadata_query()
         realms = {realm.name: realm.title for realm in EventLogRealm}
@@ -177,6 +179,15 @@ class RHCategoryLogsJSON(LogsAPIMixin, RHManageCategoryBase):
 class RHEventLogsJSON(LogsAPIMixin, RHManageEventBase):
     model = EventLogEntry
     realm_enum = EventLogRealm
+
+    PERMISSION = 'registration'
+
+    def _check_access(self):
+        RHManageEventBase._check_access(self)
+        if not request.args.get('meta.registration_id'):
+            # Logs not related to registration can be seen only by users with event management permission
+            if not self.event.can_manage(session.user):
+                raise Forbidden
 
     @property
     def object(self):

--- a/indico/modules/logs/controllers.py
+++ b/indico/modules/logs/controllers.py
@@ -78,8 +78,10 @@ class RHEventLogs(RHManageEventBase):
     def _process(self):
         metadata_query = _get_metadata_query()
         realms = {realm.name: realm.title for realm in EventLogRealm}
+        require_filter = not self.event.can_manage(session.user)
         return WPEventLogs.render_template('logs.html', self.event, realms=realms, metadata_query=metadata_query,
-                                           logs_api_url=url_for('.api_event_logs', self.event))
+                                           logs_api_url=url_for('.api_event_logs', self.event),
+                                           require_filter=require_filter)
 
 
 class RHUserLogsBase(RHUserBase):

--- a/indico/modules/logs/templates/logs.html
+++ b/indico/modules/logs/templates/logs.html
@@ -16,6 +16,7 @@
     <div class="event-log"
          data-fetch-logs-url="{{ logs_api_url }}"
          data-realms="{{ realms|tojson|forceescape }}"
-         data-metadata-query="{{ metadata_query|tojson|forceescape }}">
+         data-metadata-query="{{ metadata_query|tojson|forceescape }}"
+         {{ 'data-require-filter' if require_filter|default(false) }}>
     </div>
 {% endblock %}


### PR DESCRIPTION
Request to allow access to registration logs for Registration Manager:
currently the <View> logs button is available on the registration details page but the access is forbidden.
