### PR TITLE
Fix duplicate React keys in registration FormErrorList for picture fields

### DIFF
--- a/indico/modules/events/registration/client/js/form/FormErrorList.jsx
+++ b/indico/modules/events/registration/client/js/form/FormErrorList.jsx
@@ -31,6 +31,7 @@ export default function FormErrorList() {
   const {errors} = useFormState({errors: true});
 
   const fieldsWithErrors = [];
+  const seenIds = new Set(); // Keep track of fields we've already added to the list so we don't duplicate them
   for (const fieldName in errors) {
     const field = fieldLabelLookup.get(fieldName) || SPECIAL_FIELDS[fieldName];
 
@@ -41,6 +42,11 @@ export default function FormErrorList() {
       );
       continue;
     }
+
+    if (seenIds.has(field.id)) {
+      continue;
+    }
+    seenIds.add(field.id);
 
     fieldsWithErrors.push({...field, message: errors[fieldName]});
   }


### PR DESCRIPTION
A picture field validates through two final-form fields:

- The value field itself (htmlName), which carries the required error
- A helper field _${htmlName}_invalidator (set by PictureManager via setValidationError) used to block submission while a picture is uploading / capturing / editing / failed.

FormErrorList then pushes two entries that resolve to the same id and renders two `<li key={field.id}>`, causing validation errors. 

This fix deduplicates those keys in FormErrorList, the React field.id duplication and fixing a frontend validator error:

<img width="1623" height="980" alt="Screenshot 2026-06-19 at 18 16 54" src="https://github.com/user-attachments/assets/a92c574b-0d64-4760-9cf8-03a206375b94" />
