### PR TITLE
Use accessible tooltips for dashboard event dates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -71,6 +71,9 @@ Accessibility
   :user:`foxbunny`)
 - Screen readers now correctly recognise modal dialogs as modal, keeping
   navigation within the open dialog (:pr:`7570`, thanks :user:`foxbunny`)
+- Screen reader users can now access the full date range and timezone for events
+  in the dashboard lists, which was previously shown only as a mouse-hover
+  tooltip (:pr:`7608`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/users/templates/dashboard.html
+++ b/indico/modules/users/templates/dashboard.html
@@ -96,10 +96,12 @@
                         <ul>
                             {% for event in unlisted_events %}
                                 <li class="flexrow">
-                                    <span class="event-date f-self-no-shrink"
-                                          title="{{ _format_event_times(event) }}">
-                                        {{ _format_event_time(event) }}
-                                    </span>
+                                    <time class="event-date f-self-no-shrink" datetime="{{ event.start_dt.isoformat() }}">
+                                        <ind-with-tooltip>
+                                            {{ _format_event_time(event) }}
+                                            <span data-tip-content>{{ _format_event_times(event) }}</span>
+                                        </ind-with-tooltip>
+                                    </time>
                                     <span class="event-title ellipsis f-self-stretch">
                                         <a href="{{ event.url }}">
                                             {{ event.get_verbose_title(show_series_pos=true) }}
@@ -121,9 +123,12 @@
                     <ul>
                         {% for event, roles in linked_events %}
                             <li id="event-{{ event.id }}" class="flexrow">
-                                <span class="event-date" title="{{ _format_event_times(event) }}">
-                                    {{ _format_event_time(event) }}
-                                </span>
+                                <time class="event-date" datetime="{{ event.start_dt.isoformat() }}">
+                                    <ind-with-tooltip>
+                                        {{ _format_event_time(event) }}
+                                        <span data-tip-content>{{ _format_event_times(event) }}</span>
+                                    </ind-with-tooltip>
+                                </time>
                                 <span class="event-title ellipsis f-self-stretch">
                                     <a href="{{ event.url }}">
                                         {{ event.get_verbose_title(show_series_pos=true) }}
@@ -198,10 +203,12 @@
                         {% else %}
                             {% for event in categories_events %}
                                 <li class="flexrow">
-                                    <span class="event-date f-self-no-shrink"
-                                          title="{{ _format_event_times(event) }}">
-                                        {{ _format_event_time(event) }}
-                                    </span>
+                                    <time class="event-date f-self-no-shrink" datetime="{{ event.start_dt.isoformat() }}">
+                                        <ind-with-tooltip>
+                                            {{ _format_event_time(event) }}
+                                            <span data-tip-content>{{ _format_event_times(event) }}</span>
+                                        </ind-with-tooltip>
+                                    </time>
                                     <div class="flexcol ellipsis">
                                         <span class="event-title ellipsis">
                                             <a href="{{ event.url }}">


### PR DESCRIPTION
The event rows on the user dashboard ("Your unlisted events", "Your events at
hand", and "Happening in your categories") showed each event's full date range
and timezone in a `title` attribute on a non-interactive `<span>`. That made the
information mouse-hover-only: keyboard users could not reach it, and screen
readers do not reliably expose `title` on non-interactive elements, so the
start/end times and timezone were effectively lost.

Each compact date is now a `<time datetime>` element wrapping an
`<ind-with-tooltip>` with a `data-tip-content` span. The full range and timezone
are always present in the accessibility tree (read by screen readers regardless
of hover), the styled tooltip still appears on mouse hover and keyboard focus,
and the `title` attribute is gone. The tooltip anchors to the date text rather
than the fixed-width column.

**User impact:** screen reader users can now access the full date range and
timezone for dashboard events, which was previously available only as a
mouse-hover tooltip.