### PR TITLE
Use accessible tooltips for the calendar export controls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,10 @@ Accessibility
 - Screen reader users can now access the full date range and timezone for events
   in the dashboard lists, which was previously shown only as a mouse-hover
   tooltip (:pr:`7608`, thanks :user:`foxbunny`)
+- The calendar export button on the dashboard, and the copy and download buttons
+  in the export popup, now have accessible names and show a tooltip on keyboard
+  focus instead of relying on the ``title`` attribute (:pr:`7609`, thanks
+  :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -201,6 +201,10 @@ Accessibility
   download, theme, favourite and management) now have reliable accessible names
   and tooltips that also appear on keyboard focus, instead of relying on the
   ``title`` attribute (:issue:`7623`, :pr:`7689`, thanks :user:`foxbunny`)
+- The calendar export button on the dashboard, and the copy and download buttons
+  in the export popup, now have accessible names and show a tooltip on keyboard
+  focus instead of relying on the ``title`` attribute (:pr:`7609`, thanks
+  :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/js/custom_elements/tips.scss
+++ b/indico/web/client/js/custom_elements/tips.scss
@@ -75,6 +75,14 @@ ind-with-toggletip {
     pointer-events: none;
   }
 
+  // When shown, lift the whole tooltip above sibling overlay chrome — e.g. a
+  // Semantic popup's own arrow (z-index 2), which would otherwise paint over a
+  // tooltip shown inside the popup. A stacking context on the host raises the
+  // box and arrow together, keeping the box-above-arrow order intact.
+  &[shown] {
+    z-index: 3;
+  }
+
   // Content background
   //
   // We use a transparent border to provide the necessary offset

--- a/indico/web/client/js/react/components/ICSCalendarLink.jsx
+++ b/indico/web/client/js/react/components/ICSCalendarLink.jsx
@@ -96,14 +96,18 @@ export default function ICSCalendarLink({
   const [exportEventSeries, setExportEventSeries] = useState(false);
 
   const copyButton = (
-    <Button
-      icon="copy"
-      title={Translate.string('Copy to clipboard')}
-      onClick={async () => {
-        await navigator.clipboard.writeText(popupState.url);
-        dispatch({type: 'COPIED'});
-      }}
-    />
+    <ind-with-tooltip>
+      <Button
+        icon
+        onClick={async () => {
+          await navigator.clipboard.writeText(popupState.url);
+          dispatch({type: 'COPIED'});
+        }}
+      >
+        <Icon name="copy" />
+        <span data-tip-content>{Translate.string('Copy to clipboard')}</span>
+      </Button>
+    </ind-with-tooltip>
   );
 
   const fetchURL = async (extraParams, controller) => {
@@ -157,10 +161,13 @@ export default function ICSCalendarLink({
         renderButton ? (
           renderButton({open: popupState.open})
         ) : (
-          <Button icon size="small" title={Translate.string('Export')}>
-            <Icon name="calendar alternate outline" />
-            <Icon name="caret down" />
-          </Button>
+          <ind-with-tooltip>
+            <Button icon size="small">
+              <Icon name="calendar alternate outline" />
+              <Icon name="caret down" />
+              <span data-tip-content>{Translate.string('Export')}</span>
+            </Button>
+          </ind-with-tooltip>
         )
       }
       position={popupPosition}
@@ -242,15 +249,19 @@ export default function ICSCalendarLink({
               Download an iCalendar file that you can use in calendaring applications.
             </Translate>
           </span>
-          <Button
-            styleName="download-button"
-            title={Translate.string('Download')}
-            as="a"
-            href={popupState.url}
-            icon="download"
-            loading={!popupState.url}
-            disabled={!popupState.url}
-          />
+          <ind-with-tooltip>
+            <Button
+              styleName="download-button"
+              as="a"
+              href={popupState.url}
+              icon
+              loading={!popupState.url}
+              disabled={!popupState.url}
+            >
+              <Icon name="download" />
+              <span data-tip-content>{Translate.string('Download')}</span>
+            </Button>
+          </ind-with-tooltip>
         </div>
       </Popup.Content>
     </Popup>

--- a/indico/web/client/js/react/components/ICSCalendarLink.module.scss
+++ b/indico/web/client/js/react/components/ICSCalendarLink.module.scss
@@ -78,3 +78,16 @@
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
+
+// The copy button is the action button of a Semantic input, which squares the
+// button's inner corners and stretches it to the input height using direct-child
+// selectors. Wrapping the button in ind-with-tooltip breaks those matches, so
+// restore the join here.
+.content :global(.ui.action.input) > ind-with-tooltip {
+  align-self: stretch;
+  align-items: stretch;
+}
+
+.content :global(.ui.action.input) > ind-with-tooltip > :global(.ui.button) {
+  border-radius: 0 0.28571429rem 0.28571429rem 0;
+}

--- a/indico/web/client/js/utils/positioning.js
+++ b/indico/web/client/js/utils/positioning.js
@@ -34,6 +34,40 @@
 //
 // Note that the calculations do not account for elastic scroll.
 
+// `position: fixed` resolves `top`/`left` against the layout viewport — UNLESS an
+// ancestor establishes a containing block for fixed descendants (a `transform`,
+// `filter`, `perspective`, a `will-change` naming one of those, or paint/layout
+// containment). When that happens — e.g. a tooltip rendered inside a Popper-
+// positioned popup, which is placed with a transform — the target's `top`/`left`
+// are measured from that ancestor's padding box instead of the viewport, so the
+// viewport coordinates the strategies compute land in the wrong place. We shift
+// them back by the ancestor's position. With no such ancestor (every normal
+// tooltip/dropdown) the offset is zero and behavior is unchanged.
+//
+// This compensates for the ancestor's translation, which covers the real cases
+// (popups, dropdowns, animated containers). A scaled or rotated container would
+// need full transform-matrix inversion, which we don't attempt here.
+function getFixedContainingBlockOffset(target) {
+  for (let node = target.parentElement; node; node = node.parentElement) {
+    const styles = getComputedStyle(node);
+    const establishesContainingBlock =
+      styles.transform !== 'none' ||
+      styles.perspective !== 'none' ||
+      (styles.filter !== undefined && styles.filter !== 'none') ||
+      styles.willChange
+        .split(',')
+        .some(p => ['transform', 'perspective', 'filter'].includes(p.trim())) ||
+      /\b(paint|layout|strict|content)\b/.test(styles.contain);
+    if (establishesContainingBlock) {
+      const rect = node.getBoundingClientRect();
+      // The containing block for fixed/absolute is the padding box, so step in
+      // past the border.
+      return {top: rect.top + node.clientTop, left: rect.left + node.clientLeft};
+    }
+  }
+  return {top: 0, left: 0};
+}
+
 const geometry = {
   setAnchorGeometry() {
     this.anchorRect ??= this.anchor.getBoundingClientRect();
@@ -65,6 +99,9 @@ const geometry = {
     // without forced reflow.
     this.initialScrollTop = this.getScrollTop();
     this.initialScrollLeft = this.getScrollLeft();
+    // Offset of the target's fixed containing block (zero unless a transformed
+    // ancestor is in play); see getFixedContainingBlockOffset.
+    this.containingBlockOffset ??= getFixedContainingBlockOffset(this.target);
   },
   resetGeometry(callback) {
     delete this.anchorRect;
@@ -79,6 +116,7 @@ const geometry = {
     delete this.targetHeight;
     delete this.initialScrollTop;
     delete this.initialScrollLeft;
+    delete this.containingBlockOffset;
 
     this.setAnchorGeometry();
     requestAnimationFrame(() => {
@@ -88,11 +126,17 @@ const geometry = {
   },
   setTop(top) {
     const scrollOffset = this.getScrollTop() - this.initialScrollTop;
-    this.target.style.setProperty('--target-top', `${top - scrollOffset}px`);
+    this.target.style.setProperty(
+      '--target-top',
+      `${top - scrollOffset - this.containingBlockOffset.top}px`
+    );
   },
   setLeft(left) {
     const scrollOffset = this.getScrollLeft() - this.initialScrollLeft;
-    this.target.style.setProperty('--target-left', `${left - scrollOffset}px`);
+    this.target.style.setProperty(
+      '--target-left',
+      `${left - scrollOffset - this.containingBlockOffset.left}px`
+    );
   },
 };
 


### PR DESCRIPTION
The icon-only iCal export button rendered by the shared `ICSCalendarLink`
component, and the Copy and Download buttons inside its export popup, used the
`title` attribute for their accessible names. `title` is unreliable for screen
reader users (VoiceOver and the mobile screen readers largely ignore it; NVDA and
JAWS read it inconsistently) and gives keyboard users no tooltip on focus.

This replaces `title` with the project's `ind-with-tooltip` + `<span
data-tip-content>` pattern, so the label is real button content: it is the
accessible name for every screen reader, and it shows as a styled tooltip on both
hover and keyboard focus. A small scoped style rule keeps the Copy button's joined
look inside the Semantic action input, which the tooltip wrapper would otherwise
break.

Scope: only the component's own default button (used on the user dashboard) and the
popup Copy/Download buttons. The event, category, session and contribution pages
pass their own button via `renderButton` and are unaffected; those legacy `IButton`
export triggers are tracked separately.

User impact: screen reader users now get a reliable name for the calendar export
controls, and keyboard users see a tooltip when the controls are focused.
