### PR TITLE
Add extension points for plugins to scope registration management

### DIFF
--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -26,6 +26,15 @@ Called when the checkin state of a registration changes. The `sender` is the
 `Registration` object.
 ''')
 
+registration_pre_create = _signals.signal('registration-pre-create', '''
+Called before a new registration is created, before any database work is done. The `sender` is
+the `RegistrationForm` object. The `user` kwarg is the user performing the action (or ``None``).
+The `data` kwarg contains the submitted form data, keyed by each field's HTML field name. The
+`management` kwarg is set to `True` if the registration is being created from the event management
+area. A handler may raise to veto the creation; raising cleanly aborts before the registration is
+built.
+''')
+
 registration_created = _signals.signal('registration-created', '''
 Called when a new registration has been created. The `sender` is the `Registration` object.
 The `data` kwarg contains the form data used to populate the registration fields.
@@ -151,6 +160,16 @@ registration form.
 registrant_list_items = _signals.signal('registrant-list-item', '''
 Expected to return `CustomRegistrationListItem` subclasses. The `sender` is the
 `RegistrationForm` object for which to get the custom items.
+''')
+
+filter_registration_list = _signals.signal('filter-registration-list', '''
+Called to scope which registrations a user may manage. The `sender` is the `RegistrationForm`;
+the `user` kwarg identifies the user. Return a SQLAlchemy filter criterion selecting the
+registrations `user` may manage (an empty result set is acceptable), or ``None`` for "no
+opinion". This only scopes access on top of the regular ACL; it never grants it. Criteria from
+multiple handlers are AND-combined and applied to the management list, the managed-registration
+count and the per-registration `Registration.can_manage` check, so a plugin that grants a user
+event-wide registration management (e.g. via `acl.can_manage`) can bound it to a subset here.
 ''')
 
 google_wallet_ticket_class_data = _signals.signal('google-wallet-ticket-class-data', '''

--- a/indico/core/signals/event/registration.py
+++ b/indico/core/signals/event/registration.py
@@ -172,6 +172,15 @@ count and the per-registration `Registration.can_manage` check, so a plugin that
 event-wide registration management (e.g. via `acl.can_manage`) can bound it to a subset here.
 ''')
 
+is_registration_download_blocked = _signals.signal('is-registration-download-blocked', '''
+Called to decide whether a manager may download or export registration data in bulk for a form,
+such as the participant list exports (CSV, Excel, PDF), badges, or similar downloads. The `sender`
+is the `RegistrationForm`; the `user` kwarg identifies the user. Return ``True`` to block the
+download. This only restricts access on top of the regular ACL; it never grants it. Intended for
+plugins that grant scoped registration management (e.g. via `acl.can_manage`) yet must withhold
+bulk data downloads from those scoped managers.
+''')
+
 google_wallet_ticket_class_data = _signals.signal('google-wallet-ticket-class-data', '''
 Called when data for a Google Wallet ticket class has been generated. The `sender` is the
 `Event` object, the `data` kwarg contains the data that will be passed to the Google

--- a/indico/core/signals/users.py
+++ b/indico/core/signals/users.py
@@ -110,3 +110,22 @@ The *sender* is the email address the user is trying to use. If this signal retu
 a string, the signup will be refused with the returned message; otherwise (``None``
 return value) the signup can continue as normal.
 ''')
+
+filter_user_search_results = _signals.signal('filter-user-search-results', '''
+Called to let a plugin restrict the results of a user search. The *sender* is the
+``RHUserSearch`` request handler. The user performing the search is passed in the ``user``
+kwarg and the serialized result entries (each a dict with keys such as ``id``, ``identifier``,
+``email``, ``affiliation``, ``affiliation_id`` and ``full_name``) in the ``results`` kwarg. A
+handler should return a filtered list of those entries, or ``None`` for "no opinion". Each
+non-``None`` returned list is applied in turn, so a handler only ever sees the entries left by
+the previous ones.
+''')
+
+extra_linked_events = _signals.signal('extra-linked-events', '''
+Called to let a plugin add events to the set a user is linked to (the events shown on the
+user's dashboard and exported to their personal calendar feed). The *sender* is the ``User``;
+when the ``dt`` kwarg is set, handlers should only include events taking place on/after that
+date. A handler should return a dict mapping event IDs to a set of role tokens (the same tokens
+the dashboard uses to flag an event as managed, reviewing, attendance or favorited), or ``None``
+for "no opinion". The returned events are merged with the ones Indico finds itself.
+''')

--- a/indico/modules/events/management/controllers/base.py
+++ b/indico/modules/events/management/controllers/base.py
@@ -29,13 +29,14 @@ class ManageEventMixin:
 
     def _check_access(self):
         self._require_user()
-        if isinstance(self.PERMISSION, (tuple, set, list)):
-            allowed = any(self.event.can_manage(session.user, permission=p) for p in self.PERMISSION)
-        else:
-            allowed = self.event.can_manage(session.user, permission=self.PERMISSION)
-        if not allowed:
+        if not self._check_management_permission():
             raise Forbidden(_('You are not authorized to manage this event.'))
         check_event_locked(self, self.event)
+
+    def _check_management_permission(self):
+        if isinstance(self.PERMISSION, (tuple, set, list)):
+            return any(self.event.can_manage(session.user, permission=p) for p in self.PERMISSION)
+        return self.event.can_manage(session.user, permission=self.PERMISSION)
 
 
 class RHManageEventBase(RHEventBase, ManageEventMixin):

--- a/indico/modules/events/registration/controllers/management/__init__.py
+++ b/indico/modules/events/registration/controllers/management/__init__.py
@@ -55,7 +55,6 @@ class RHManageRegistrationBase(RHManageRegFormBase):
                              .one())
 
     def _check_management_permission(self):
-        # re-checked per registration so a plugin can bound management to a subset of registrations
         permissions = self.PERMISSION if isinstance(self.PERMISSION, (tuple, set, list)) else (self.PERMISSION,)
         return any(self.registration.can_manage(session.user, p) for p in permissions)
 

--- a/indico/modules/events/registration/controllers/management/__init__.py
+++ b/indico/modules/events/registration/controllers/management/__init__.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from flask import request
+from flask import request, session
 from sqlalchemy.orm import contains_eager, defaultload
 
 from indico.modules.events.management.controllers import RHManageEventBase
@@ -53,6 +53,11 @@ class RHManageRegistrationBase(RHManageRegFormBase):
                              .options(defaultload(Registration.data)
                                       .joinedload('field_data'))
                              .one())
+
+    def _check_management_permission(self):
+        # re-checked per registration so a plugin can bound management to a subset of registrations
+        permissions = self.PERMISSION if isinstance(self.PERMISSION, (tuple, set, list)) else (self.PERMISSION,)
+        return any(self.registration.can_manage(session.user, p) for p in permissions)
 
 
 class RHManageRegistrationModerationBase(RHManageRegistrationBase):

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -251,6 +251,11 @@ class RHRegistrationDownloadAttachment(RHManageRegFormsBase):
                            .options(joinedload('registration').joinedload('registration_form'))
                            .one())
 
+    def _check_management_permission(self):
+        # re-checked per registration so a plugin can bound management to a subset of registrations
+        permissions = self.PERMISSION if isinstance(self.PERMISSION, (tuple, set, list)) else (self.PERMISSION,)
+        return any(self.field_data.registration.can_manage(session.user, p) for p in permissions)
+
     def _process(self):
         return self.field_data.send()
 
@@ -297,6 +302,12 @@ class RHRegistrationsActionBase(RHManageRegFormBase):
             # the user wants everything (e.g. API-like usage via personal token)
             query = query.filter(Registration.id.in_(registration_ids))
         self.registrations = query.all()
+
+    @property
+    def manageable_registrations(self):
+        # the selected registrations the user may manage, honouring per-registration scoping
+        permissions = self.PERMISSION if isinstance(self.PERMISSION, (tuple, set, list)) else (self.PERMISSION,)
+        return [r for r in self.registrations if any(r.can_manage(session.user, p) for p in permissions)]
 
 
 class RHRegistrationsActionModerationBase(RHRegistrationsActionBase):
@@ -393,14 +404,15 @@ class RHRegistrationDelete(RHRegistrationsActionBase):
     PERMISSION = ('registration', 'registration_edit')
 
     def _process(self):
-        for registration in self.registrations:
+        registrations = self.manageable_registrations
+        for registration in registrations:
             registration.is_deleted = True
             signals.event.registration_deleted.send(registration, permanent=False)
             logger.info('Registration %s deleted by %s', registration, session.user)
             registration.log(EventLogRealm.management, LogKind.negative, 'Registration',
                              f'Registration deleted: {registration.full_name}',
                              session.user, data={'Email': registration.email})
-        num_reg_deleted = len(self.registrations)
+        num_reg_deleted = len(registrations)
         flash(ngettext('Registration was deleted.',
                        '{num} registrations were deleted.', num_reg_deleted).format(num=num_reg_deleted), 'success')
         return jsonify_data()

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -252,7 +252,6 @@ class RHRegistrationDownloadAttachment(RHManageRegFormsBase):
                            .one())
 
     def _check_management_permission(self):
-        # re-checked per registration so a plugin can bound management to a subset of registrations
         permissions = self.PERMISSION if isinstance(self.PERMISSION, (tuple, set, list)) else (self.PERMISSION,)
         return any(self.field_data.registration.can_manage(session.user, p) for p in permissions)
 
@@ -305,7 +304,6 @@ class RHRegistrationsActionBase(RHManageRegFormBase):
 
     @property
     def manageable_registrations(self):
-        # the selected registrations the user may manage, honouring per-registration scoping
         permissions = self.PERMISSION if isinstance(self.PERMISSION, (tuple, set, list)) else (self.PERMISSION,)
         return [r for r in self.registrations if any(r.can_manage(session.user, p) for p in permissions)]
 

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -943,7 +943,7 @@ class RHRegistrationsApprove(RHRegistrationsActionModerationBase):
     """Accept selected registrations from registration list."""
 
     def _process(self):
-        num_approved, num_skipped = _bulk_modify_registration_status(self.registrations, approve=True)
+        num_approved, num_skipped = _bulk_modify_registration_status(self.manageable_registrations, approve=True)
         if num_approved:
             flash(ngettext('{num} registration was successfully approved.',
                            '{num} registrations were successfully approved.',
@@ -961,11 +961,12 @@ class RHRegistrationsReject(RHRegistrationsActionModerationBase):
     """Reject selected registrations from registration list."""
 
     def _process(self):
-        form = RejectRegistrantsForm(registration_id=[r.id for r in self.registrations])
+        registrations = self.manageable_registrations
+        form = RejectRegistrantsForm(registration_id=[r.id for r in registrations])
         message = _('Rejecting these registrations will trigger a notification email for each registrant.')
         if form.validate_on_submit():
             num_rejected, num_skipped = _bulk_modify_registration_status(
-                self.registrations,
+                registrations,
                 approve=False,
                 rejection_reason=form.rejection_reason.data,
                 attach_rejection_reason=form.attach_rejection_reason.data
@@ -988,7 +989,7 @@ class RHRegistrationsReset(RHRegistrationsActionModerationBase):
     """Reset selected registration from registration list."""
 
     def _process(self):
-        for registration in self.registrations:
+        for registration in self.manageable_registrations:
             registration.reset_state()
         db.session.flush()
         flash(_('The selected registrations were successfully reset.'), 'success')

--- a/indico/modules/events/registration/controllers/management/reglists.py
+++ b/indico/modules/events/registration/controllers/management/reglists.py
@@ -307,6 +307,10 @@ class RHRegistrationsActionBase(RHManageRegFormBase):
         permissions = self.PERMISSION if isinstance(self.PERMISSION, (tuple, set, list)) else (self.PERMISSION,)
         return [r for r in self.registrations if any(r.can_manage(session.user, p) for p in permissions)]
 
+    def _check_download_blocked(self):
+        if self.regform.is_download_blocked(session.user):
+            raise Forbidden
+
 
 class RHRegistrationsActionModerationBase(RHRegistrationsActionBase):
     """Base class for moderating multiple registrations."""
@@ -513,6 +517,10 @@ class RHRegistrationsExportBase(RHRegistrationsActionBase):
     _allow_get_all = True
     registration_query_options = (subqueryload('data'),)
 
+    def _check_access(self):
+        RHRegistrationsActionBase._check_access(self)
+        self._check_download_blocked()
+
     def _process_args(self):
         RHRegistrationsActionBase._process_args(self)
         self.export_config = self.list_generator.get_list_export_config()
@@ -627,6 +635,7 @@ class RHRegistrationsPrintBadges(RHRegistrationsActionBase):
 
     def _check_access(self):
         RHRegistrationsActionBase._check_access(self)
+        self._check_download_blocked()
 
         # Check that template belongs to this event or a category that is a parent
         if self.template.owner == self.event:
@@ -665,6 +674,10 @@ class RHRegistrationsConfigBadges(RHRegistrationsActionBase):
 
     ALLOW_LOCKED = True
     TICKET_BADGES = False
+
+    def _check_access(self):
+        RHRegistrationsActionBase._check_access(self)
+        self._check_download_blocked()
 
     def _process_args(self):
         RHManageRegFormBase._process_args(self)
@@ -1117,6 +1130,10 @@ class RHRegistrationsExportReceipts(ZipGeneratorMixin, RHRegistrationsActionBase
     """Export registration receipts in a zip file."""
 
     ALLOW_LOCKED = True
+
+    def _check_access(self):
+        RHRegistrationsActionBase._check_access(self)
+        self._check_download_blocked()
 
     def _prepare_folder_structure(self, data):
         if isinstance(data, _FileWrapper):

--- a/indico/modules/events/registration/controllers/management/reglists_test.py
+++ b/indico/modules/events/registration/controllers/management/reglists_test.py
@@ -8,13 +8,15 @@
 from decimal import Decimal
 
 import pytest
-from flask import request
-from werkzeug.exceptions import UnprocessableEntity
+from flask import request, session
+from werkzeug.exceptions import Forbidden, UnprocessableEntity
 
+from indico.core import signals
 from indico.modules.events.registration.controllers.management.fields import _fill_form_field_with_data
 from indico.modules.events.registration.controllers.management.reglists import (RHRegistrationCreate,
                                                                                 RHRegistrationEdit,
-                                                                                RHRegistrationsBasePrice)
+                                                                                RHRegistrationsBasePrice,
+                                                                                RHRegistrationsExportCSV)
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.items import RegistrationFormSection
 from indico.modules.events.registration.models.registrations import RegistrationState
@@ -159,3 +161,29 @@ def test_registration_update_base_price(dummy_regform, dummy_user, app_context, 
 
     assert reg.base_price == Decimal(expected_price)
     assert reg.state == expected_state
+
+
+def test_export_download_blocked(db, dummy_regform, dummy_user, app_context):
+    dummy_regform.event.update_principal(dummy_user, full_access=True)
+    db.session.flush()
+
+    with app_context.test_request_context(method='POST'):
+        request.view_args = {
+            'reg_form_id': dummy_regform.id,
+            'event_id': dummy_regform.event_id,
+        }
+        session.set_session_user(dummy_user)
+
+        rh = RHRegistrationsExportCSV()
+        rh.event = dummy_regform.event
+        rh.regform = dummy_regform
+
+        # No handler vetoes the download.
+        rh._check_access()
+
+        def _block(sender, user, **kwargs):
+            return True
+
+        with signals.event.is_registration_download_blocked.connected_to(_block):
+            with pytest.raises(Forbidden):
+                rh._check_access()

--- a/indico/modules/events/registration/controllers/management/reglists_test.py
+++ b/indico/modules/events/registration/controllers/management/reglists_test.py
@@ -15,11 +15,12 @@ from indico.core import signals
 from indico.modules.events.registration.controllers.management.fields import _fill_form_field_with_data
 from indico.modules.events.registration.controllers.management.reglists import (RHRegistrationCreate,
                                                                                 RHRegistrationEdit,
+                                                                                RHRegistrationsApprove,
                                                                                 RHRegistrationsBasePrice,
                                                                                 RHRegistrationsExportCSV)
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
 from indico.modules.events.registration.models.items import RegistrationFormSection
-from indico.modules.events.registration.models.registrations import RegistrationState
+from indico.modules.events.registration.models.registrations import Registration, RegistrationState
 from indico.modules.events.registration.util import create_registration
 
 
@@ -187,3 +188,30 @@ def test_export_download_blocked(db, dummy_regform, dummy_user, app_context):
         with signals.event.is_registration_download_blocked.connected_to(_block):
             with pytest.raises(Forbidden):
                 rh._check_access()
+
+
+@pytest.mark.usefixtures('smtp')
+def test_bulk_approve_skips_unmanageable_registrations(db, dummy_regform, dummy_user, app_context):
+    dummy_regform.moderation_enabled = True
+    dummy_regform.event.update_principal(dummy_user, full_access=True)
+    mine, theirs = (create_registration(dummy_regform, {'email': email, 'first_name': 'A', 'last_name': last_name},
+                                        invitation=None, management=True, notify_user=False)
+                    for email, last_name in (('mine@example.test', 'Mine'), ('theirs@example.test', 'Theirs')))
+    mine.state = theirs.state = RegistrationState.pending
+    db.session.flush()
+
+    def _only_mine(sender, user, **kwargs):
+        return Registration.id == mine.id
+
+    form_data = {'registration_id': [mine.id, theirs.id], 'csrf_token': '00000000-0000-0000-0000-000000000000'}
+    with app_context.test_request_context(method='POST', data=form_data):
+        request.view_args = {'reg_form_id': dummy_regform.id, 'event_id': dummy_regform.event_id}
+        session.set_session_user(dummy_user)
+
+        rh = RHRegistrationsApprove()
+        rh._process_args()
+        with signals.event.filter_registration_list.connected_to(_only_mine):
+            rh._process()
+
+    assert mine.state == RegistrationState.complete
+    assert theirs.state == RegistrationState.pending

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -5,7 +5,7 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-from flask import request
+from flask import request, session
 from sqlalchemy.orm import joinedload, undefer
 
 from indico.core import signals
@@ -17,7 +17,7 @@ from indico.modules.events.registration.models.registrations import (Registratio
 from indico.modules.events.registration.models.tags import RegistrationTag
 from indico.modules.events.util import ListGeneratorBase
 from indico.util.i18n import _
-from indico.util.signals import named_objects_from_signal
+from indico.util.signals import named_objects_from_signal, values_from_signal
 from indico.util.string import natural_sort_key
 from indico.web.flask.templating import get_template_module
 
@@ -168,9 +168,15 @@ class RegistrationListGenerator(ListGeneratorBase):
         return filters
 
     def _build_query(self):
+        # Plugins may scope the list to the registrations the current user may manage; each returns
+        # a SQL criterion AND-combined into the query. No receivers (or a full manager) means no
+        # extra criteria, so the list is unscoped.
+        extra_criteria = [c for c in values_from_signal(
+            signals.event.filter_registration_list.send(self.regform, user=session.user), as_list=True
+        ) if c is not None]
         return (Registration.query
                 .with_parent(self.regform)
-                .filter(~Registration.is_deleted)
+                .filter(~Registration.is_deleted, *extra_criteria)
                 .options(joinedload('data').joinedload('field_data').joinedload('field'),
                          joinedload('tags'),
                          undefer('num_receipt_files'))

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -168,9 +168,6 @@ class RegistrationListGenerator(ListGeneratorBase):
         return filters
 
     def _build_query(self):
-        # Plugins may scope the list to the registrations the current user may manage; each returns
-        # a SQL criterion AND-combined into the query. No receivers (or a full manager) means no
-        # extra criteria, so the list is unscoped.
         extra_criteria = [c for c in values_from_signal(
             signals.event.filter_registration_list.send(self.regform, user=session.user), as_list=True
         ) if c is not None]

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -570,12 +570,7 @@ class RegistrationForm(db.Model):
         return self.is_active and (not self.require_login or user)
 
     def get_managed_registration_count(self, user):
-        """Number of active registrations ``user`` may manage on this form.
-
-        For a full manager this is the total active count; for a user a plugin scopes to a subset it
-        counts only the registrations matching their scope, so the displayed number matches the list
-        they actually see.
-        """
+        """Number of active registrations ``user`` may manage on this form."""
         from indico.modules.events.registration.models.registrations import Registration
         criteria = [c for c in values_from_signal(
             signals.event.filter_registration_list.send(self, user=user), as_list=True

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 from sqlalchemy.orm import column_property, subqueryload
 from werkzeug.exceptions import BadRequest
 
+from indico.core import signals
 from indico.core.config import config
 from indico.core.db import db
 from indico.core.db.sqlalchemy import PyIntEnum, UTCDateTime
@@ -28,6 +29,7 @@ from indico.util.date_time import format_currency, now_utc
 from indico.util.enum import RichIntEnum
 from indico.util.i18n import L_
 from indico.util.locators import locator_property
+from indico.util.signals import values_from_signal
 from indico.util.string import format_repr
 
 
@@ -566,6 +568,23 @@ class RegistrationForm(db.Model):
 
     def can_submit(self, user):
         return self.is_active and (not self.require_login or user)
+
+    def get_managed_registration_count(self, user):
+        """Number of active registrations ``user`` may manage on this form.
+
+        For a full manager this is the total active count; for a user a plugin scopes to a subset it
+        counts only the registrations matching their scope, so the displayed number matches the list
+        they actually see.
+        """
+        from indico.modules.events.registration.models.registrations import Registration
+        criteria = [c for c in values_from_signal(
+            signals.event.filter_registration_list.send(self, user=user), as_list=True
+        ) if c is not None]
+        if not criteria:
+            return self.active_registration_count
+        return (db.session.query(db.func.coalesce(db.func.sum(Registration.occupied_slots), 0))
+                .filter(Registration.registration_form_id == self.id, Registration.is_active, *criteria)
+                .scalar())
 
     @memoize_request
     def get_registration(self, user=None, uuid=None, email=None):

--- a/indico/modules/events/registration/models/forms.py
+++ b/indico/modules/events/registration/models/forms.py
@@ -581,6 +581,17 @@ class RegistrationForm(db.Model):
                 .filter(Registration.registration_form_id == self.id, Registration.is_active, *criteria)
                 .scalar())
 
+    def is_download_blocked(self, user):
+        """Whether a plugin bars ``user`` from bulk-downloading this form's registration data.
+
+        A plugin that grants scoped registration management (e.g. via `acl.can_manage`) can withhold
+        the participant-list exports, badges and similar bulk downloads from those scoped managers
+        through the `is_registration_download_blocked` signal.
+        """
+        return any(values_from_signal(
+            signals.event.is_registration_download_blocked.send(self, user=user), as_list=True
+        ))
+
     @memoize_request
     def get_registration(self, user=None, uuid=None, email=None):
         """Retrieve registrations for this registration form by user or uuid."""

--- a/indico/modules/events/registration/models/forms_test.py
+++ b/indico/modules/events/registration/models/forms_test.py
@@ -1,0 +1,39 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2026 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from indico.core import signals
+from indico.modules.events.registration.models.registrations import Registration, RegistrationState
+
+
+pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
+
+
+def _add_registration(db, regform, email):
+    reg = Registration(first_name='Test', last_name='User', email=email, currency='USD',
+                       state=RegistrationState.complete, registration_form=regform)
+    regform.event.registrations.append(reg)
+    db.session.flush()
+    return reg
+
+
+def test_get_managed_registration_count_unscoped(db, dummy_regform, dummy_user):
+    # With no scoping handler the full active count is returned.
+    _add_registration(db, dummy_regform, 'a@example.test')
+    _add_registration(db, dummy_regform, 'b@example.test')
+    assert dummy_regform.get_managed_registration_count(dummy_user) == 2
+
+
+def test_get_managed_registration_count_scoped(db, dummy_regform, dummy_user):
+    # A handler returning a criterion scopes the count to the matching registrations.
+    mine = _add_registration(db, dummy_regform, 'a@example.test')
+    _add_registration(db, dummy_regform, 'b@example.test')
+
+    def _scope(sender, user, **kwargs):
+        return Registration.id == mine.id
+
+    with signals.event.filter_registration_list.connected_to(_scope):
+        assert dummy_regform.get_managed_registration_count(dummy_user) == 1

--- a/indico/modules/events/registration/models/forms_test.py
+++ b/indico/modules/events/registration/models/forms_test.py
@@ -21,14 +21,12 @@ def _add_registration(db, regform, email):
 
 
 def test_get_managed_registration_count_unscoped(db, dummy_regform, dummy_user):
-    # With no scoping handler the full active count is returned.
     _add_registration(db, dummy_regform, 'a@example.test')
     _add_registration(db, dummy_regform, 'b@example.test')
     assert dummy_regform.get_managed_registration_count(dummy_user) == 2
 
 
 def test_get_managed_registration_count_scoped(db, dummy_regform, dummy_user):
-    # A handler returning a criterion scopes the count to the matching registrations.
     mine = _add_registration(db, dummy_regform, 'a@example.test')
     _add_registration(db, dummy_regform, 'b@example.test')
 

--- a/indico/modules/events/registration/models/forms_test.py
+++ b/indico/modules/events/registration/models/forms_test.py
@@ -35,3 +35,13 @@ def test_get_managed_registration_count_scoped(db, dummy_regform, dummy_user):
 
     with signals.event.filter_registration_list.connected_to(_scope):
         assert dummy_regform.get_managed_registration_count(dummy_user) == 1
+
+
+def test_is_download_blocked(db, dummy_regform, dummy_user):
+    assert dummy_regform.is_download_blocked(dummy_user) is False
+
+    def _block(sender, user, **kwargs):
+        return True
+
+    with signals.event.is_registration_download_blocked.connected_to(_block):
+        assert dummy_regform.is_download_blocked(dummy_user) is True

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -466,9 +466,6 @@ class Registration(db.Model):
     def can_manage(self, user, permission, allow_admin=True):
         if not self.event.can_manage(user, permission=permission, allow_admin=allow_admin):
             return False
-        # A plugin may grant a user event-wide registration management but scope it to a subset of
-        # registrations, expressed as a SQL criterion through the `filter_registration_list`
-        # signal. A user scoped that way may only manage the registrations matching their scope.
         criteria = [c for c in values_from_signal(
             signals.event.filter_registration_list.send(self.registration_form, user=user), as_list=True
         ) if c is not None]

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -463,6 +463,19 @@ class Registration(db.Model):
     def can_be_modified(self):
         return self.registration_form.is_modification_allowed(self)
 
+    def can_manage(self, user, permission, allow_admin=True):
+        if not self.event.can_manage(user, permission=permission, allow_admin=allow_admin):
+            return False
+        # A plugin may grant a user event-wide registration management but scope it to a subset of
+        # registrations, expressed as a SQL criterion through the `filter_registration_list`
+        # signal. A user scoped that way may only manage the registrations matching their scope.
+        criteria = [c for c in values_from_signal(
+            signals.event.filter_registration_list.send(self.registration_form, user=user), as_list=True
+        ) if c is not None]
+        if not criteria:
+            return True
+        return Registration.query.filter(Registration.id == self.id, *criteria).has_rows()
+
     @property
     def can_be_withdrawn(self):
         from indico.modules.events.registration.models.forms import ModificationMode

--- a/indico/modules/events/registration/models/registrations_test.py
+++ b/indico/modules/events/registration/models/registrations_test.py
@@ -1,0 +1,50 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2026 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+from indico.core import signals
+from indico.modules.events.registration.models.registrations import Registration, RegistrationState
+
+
+pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
+
+
+def _add_registration(db, regform, email):
+    reg = Registration(first_name='Test', last_name='User', email=email, currency='USD',
+                       state=RegistrationState.complete, registration_form=regform)
+    regform.event.registrations.append(reg)
+    db.session.flush()
+    return reg
+
+
+def test_can_manage_full_manager(db, dummy_regform, create_user):
+    manager = create_user(2)
+    dummy_regform.event.update_principal(manager, full_access=True)
+    db.session.flush()
+    reg = _add_registration(db, dummy_regform, 'a@example.test')
+    assert reg.can_manage(manager, 'registration_edit')
+
+
+def test_can_manage_scoped_grant_is_bounded(db, dummy_regform, create_user):
+    # A user holding the event-wide registration_edit permission is bounded to the registrations
+    # matching a scope criterion: they manage the in-range one and are vetoed on the out-of-range one.
+    manager = create_user(2)
+    dummy_regform.event.update_principal(manager, permissions={'registration_edit'})
+    db.session.flush()
+    in_range = _add_registration(db, dummy_regform, 'in@example.test')
+    out_range = _add_registration(db, dummy_regform, 'out@example.test')
+
+    def _scope(sender, user, **kwargs):
+        return Registration.id == in_range.id
+
+    with signals.event.filter_registration_list.connected_to(_scope):
+        assert in_range.can_manage(manager, 'registration_edit')
+        assert not out_range.can_manage(manager, 'registration_edit')
+
+
+def test_can_manage_denied_without_access(db, dummy_regform, create_user):
+    reg = _add_registration(db, dummy_regform, 'a@example.test')
+    assert not reg.can_manage(create_user(3), 'registration_edit')

--- a/indico/modules/events/registration/models/registrations_test.py
+++ b/indico/modules/events/registration/models/registrations_test.py
@@ -29,8 +29,6 @@ def test_can_manage_full_manager(db, dummy_regform, create_user):
 
 
 def test_can_manage_scoped_grant_is_bounded(db, dummy_regform, create_user):
-    # A user holding the event-wide registration_edit permission is bounded to the registrations
-    # matching a scope criterion: they manage the in-range one and are vetoed on the out-of-range one.
     manager = create_user(2)
     dummy_regform.event.update_principal(manager, permissions={'registration_edit'})
     db.session.flush()

--- a/indico/modules/events/registration/templates/management/regform_list.html
+++ b/indico/modules/events/registration/templates/management/regform_list.html
@@ -153,7 +153,7 @@
                                 {%- trans %}Registrations{% endtrans -%}
                                 {% block existing_count scoped %}
                                     <span class="badge">
-                                        {{- regform.active_registration_count -}}
+                                        {{- regform.get_managed_registration_count(session.user) -}}
                                         {% if regform.registration_limit %}
                                             / {{ regform.registration_limit }}
                                         {%- endif -%}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -436,6 +436,7 @@ def create_personal_data_fields(regform):
 @no_autoflush
 def create_registration(regform, data, invitation=None, management=False, notify_user=True, skip_moderation=None):
     user = session.user if session else None
+    signals.event.registration_pre_create.send(regform, user=user, data=data, management=management)
     registration = Registration(registration_form=regform, user=get_user_by_email(data['email']),
                                 base_price=regform.base_price, currency=regform.currency,
                                 created_by_manager=management, created_by=user)

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -1116,8 +1116,6 @@ class RHUserSearch(RHProtected):
             return *exact_match_keys, *unaccent_exact_match_keys, entry['full_name'], entry['email']
 
         results = sorted((self._serialize_entry(entry) for entry in matches), key=_sort_key)
-        # Let plugins restrict the results. Each handler that returns a list replaces the current
-        # results, so later handlers only see what earlier ones left. With no receivers this is a no-op.
         for filtered in values_from_signal(
             signals.users.filter_user_search_results.send(self, user=session.user, results=results),
             as_list=True

--- a/indico/modules/users/controllers.py
+++ b/indico/modules/users/controllers.py
@@ -1116,6 +1116,14 @@ class RHUserSearch(RHProtected):
             return *exact_match_keys, *unaccent_exact_match_keys, entry['full_name'], entry['email']
 
         results = sorted((self._serialize_entry(entry) for entry in matches), key=_sort_key)
+        # Let plugins restrict the results. Each handler that returns a list replaces the current
+        # results, so later handlers only see what earlier ones left. With no receivers this is a no-op.
+        for filtered in values_from_signal(
+            signals.users.filter_user_search_results.send(self, user=session.user, results=results),
+            as_list=True
+        ):
+            if filtered is not None:
+                results = filtered
         if favorites_first:
             favorites = {u.id for u in session.user.favorite_users}
             results.sort(key=lambda x: x['id'] not in favorites)

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -160,6 +160,10 @@ def get_linked_events(user, dt=None, limit=None, load_also=(), extra_options=())
         if event.ends_after(dt):
             links.setdefault(event.id, set()).add('favorited')
 
+    for extra in values_from_signal(signals.users.extra_linked_events.send(user, dt=dt), as_list=True):
+        for event_id, roles in extra.items():
+            links.setdefault(event_id, set()).update(roles)
+
     if not links:
         return {}
 


### PR DESCRIPTION
## Summary

Generic extension points that let a plugin scope registration management to a subset of registrations. No behaviour change without a plugin.

- `filter_registration_list`: return a SQL criterion bounding which registrations a user may manage; criteria are AND-combined and applied to the management list, the managed-registration count and `Registration.can_manage`. It only scopes access on top of the regular ACL, never grants it.
- `registration_pre_create`: guard/veto registration creation before any DB work.
- `filter_user_search_results`: restrict user-search results.
- `extra_linked_events`: contribute events to a user&#39;s dashboard and personal calendar feed.

The bulk moderation actions (approve, reject, reset) now act on `manageable_registrations`, like the other bulk actions already did. They took every registration id posted to the endpoint, so a user whose reach is scoped to a subset could moderate any registration of the form.

Motivated by affiliation focal-point work in `indico-plugins-contrib`: https://github.com/duartegalvao/indico-plugins-contrib/pull/4
