### PR TITLE
Use a level-1 heading for the management page banner title

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -79,6 +79,9 @@ Accessibility
 - Screen reader users can now access the full date range and timezone for events
   in the dashboard lists, which was previously shown only as a mouse-hover
   tooltip (:pr:`7608`, thanks :user:`foxbunny`)
+- Screen reader users can now navigate to the main page heading on the dashboard,
+  user profile, preferences and category pages, which previously showed the page
+  title as plain text with no heading (:pr:`7617`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -125,6 +125,9 @@ Accessibility
   abstracts / call for papers submission period instead of hearing the
   decorative opening-day / deadline timeline graphic (:pr:`7487`, thanks
   :user:`foxbunny`)
+- Screen reader users can now navigate to the main page heading on the dashboard,
+  user profile, preferences and category pages, which previously showed the page
+  title as plain text with no heading (:pr:`7617`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/base/_pages.scss
+++ b/indico/web/client/styles/base/_pages.scss
@@ -160,9 +160,12 @@
   }
 
   .title {
+    margin-top: 0;
     margin-bottom: $banner-title-margin;
     font-family: 'Roboto Light', sans-serif;
     font-size: 2em;
+    font-weight: normal;
+    line-height: inherit;
     color: $banner-title-color;
 
     a:not(:hover) {

--- a/indico/web/templates/layout/management_page.html
+++ b/indico/web/templates/layout/management_page.html
@@ -14,9 +14,11 @@
             {% block banner %}
                 <div class="content-column">
                     <div class="banner {% block banner_class %}{% endblock %}">
-                        <div class="title">
-                            {% block banner_title %}{% endblock %}
-                        </div>
+                        {% if self.banner_title()|trim %}
+                            <h1 class="title">
+                                {% block banner_title %}{% endblock %}
+                            </h1>
+                        {% endif %}
                         <div class="action-menu">
                             {% block banner_actions %}{% endblock %}
                         </div>


### PR DESCRIPTION
The shared management layout (`management_page.html`) rendered the banner
title — the most prominent text on the page, such as "Dashboard", a user's
name, or a category title — as a plain `<div class="title">`. As a result
these pages had no top-level heading, and screen-reader users could not jump
to the page's main heading.

This changes the banner title to an `<h1>`. It is only emitted when a title
is actually set, so the banner's action-only / view-button-only case does not
produce an empty heading. The `.banner .title` styles gain `margin-top: 0`,
`font-weight: normal` and `line-height: inherit` so the heading renders
identically to the old `<div>` (the last one overrides Semantic UI's default
heading line-height, which would otherwise make the title taller).

The change reaches the user area (dashboard, profile, preferences, …) and the
category display/management pages. Event-management pages, which override the
banner block with their own markup, and admin pages, which render no banner,
are unaffected. No page ends up with two `<h1>` headings.

Screen-reader users can now navigate to the main page heading on these pages.