### PR TITLE
feat: show who created each registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,8 @@ Improvements
   thanks :user:`moliholy, unconventionaldotdev`)
 - Display embedded images in email log entries (:pr:`7338`, thanks
   :user:`duartegalvao, unconventionaldotdev`)
+- Record who created a registration on behalf of someone else (:pr:`7629`, thanks
+  :user:`moliholy, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/migrations/versions/20260629_1200_d7e2a9c14f6b_add_registration_created_by.py
+++ b/indico/migrations/versions/20260629_1200_d7e2a9c14f6b_add_registration_created_by.py
@@ -1,0 +1,28 @@
+"""Add created_by to registrations
+
+Revision ID: d7e2a9c14f6b
+Revises: e1e229910f7e
+Create Date: 2026-06-29 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'd7e2a9c14f6b'
+down_revision = 'e1e229910f7e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('registrations', sa.Column('created_by_id', sa.Integer(), nullable=True),
+                  schema='event_registration')
+    op.create_index(None, 'registrations', ['created_by_id'], schema='event_registration')
+    op.create_foreign_key(None, 'registrations', 'users', ['created_by_id'], ['id'],
+                          source_schema='event_registration', referent_schema='users')
+
+
+def downgrade():
+    op.drop_column('registrations', 'created_by_id', schema='event_registration')

--- a/indico/migrations/versions/20260721_1200_d7e2a9c14f6b_add_registration_created_by.py
+++ b/indico/migrations/versions/20260721_1200_d7e2a9c14f6b_add_registration_created_by.py
@@ -1,7 +1,7 @@
 """Add created_by to registrations
 
 Revision ID: d7e2a9c14f6b
-Revises: e1e229910f7e
+Revises: 461958bf2774
 Create Date: 2026-06-29 12:00:00.000000
 """
 
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'd7e2a9c14f6b'
-down_revision = 'e1e229910f7e'
+down_revision = '461958bf2774'
 branch_labels = None
 depends_on = None
 

--- a/indico/modules/events/registration/lists.py
+++ b/indico/modules/events/registration/lists.py
@@ -50,6 +50,9 @@ class RegistrationListGenerator(ListGeneratorBase):
                 'title': _('State'),
                 'filter_choices': {str(state.value): state.title for state in RegistrationState}
             },
+            'created_by': {
+                'title': _('Created by'),
+            },
             'checked_in': {
                 'title': _('Checked in'),
                 'filter_choices': {

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -294,7 +294,11 @@ class Registration(db.Model):
     created_by = db.relationship(
         'User',
         lazy=True,
-        foreign_keys=[created_by_id]
+        foreign_keys=[created_by_id],
+        backref=db.backref(
+            'created_registrations',
+            lazy='dynamic'
+        )
     )
     #: The latest payment transaction associated with this registration
     transaction = db.relationship(

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -359,6 +359,7 @@ class Registration(db.Model):
         for r in source.registrations.all():
             if r.registration_form not in target_regforms_used:
                 r.user = target
+        source.created_registrations.update({cls.created_by_id: target.id})
 
     @hybrid_method
     def is_publishable(self, is_participant):

--- a/indico/modules/events/registration/models/registrations.py
+++ b/indico/modules/events/registration/models/registrations.py
@@ -252,6 +252,13 @@ class Registration(db.Model):
         nullable=False,
         default=False
     )
+    #: The ID of the user who created the registration
+    created_by_id = db.Column(
+        db.Integer,
+        db.ForeignKey('users.users.id'),
+        index=True,
+        nullable=True
+    )
     #: The date/time until which the person can modify their registration
     modification_end_dt = db.Column(
         UTCDateTime,
@@ -276,11 +283,18 @@ class Registration(db.Model):
     user = db.relationship(
         'User',
         lazy=True,
+        foreign_keys=[user_id],
         backref=db.backref(
             'registrations',
             lazy='dynamic'
             # XXX: a delete-orphan cascade here would delete registrations when NULLing the user
         )
+    )
+    #: The user who created this registration
+    created_by = db.relationship(
+        'User',
+        lazy=True,
+        foreign_keys=[created_by_id]
     )
     #: The latest payment transaction associated with this registration
     transaction = db.relationship(

--- a/indico/modules/events/registration/templates/management/_reglist.html
+++ b/indico/modules/events/registration/templates/management/_reglist.html
@@ -71,6 +71,8 @@
                                         </td>
                                     {% elif item.id == 'state' %}
                                         <td class="i-table">{{ registration.state.title }}</td>
+                                    {% elif item.id == 'created_by' %}
+                                        <td class="i-table">{{ registration.created_by.full_name if registration.created_by else '' }}</td>
                                     {% elif item.id == 'price' %}
                                         <td class="i-table" data-text="{{ registration.price }}">{{ registration.render_price() }}</td>
                                     {% elif item.id == 'checked_in' %}

--- a/indico/modules/events/registration/util.py
+++ b/indico/modules/events/registration/util.py
@@ -437,7 +437,8 @@ def create_personal_data_fields(regform):
 def create_registration(regform, data, invitation=None, management=False, notify_user=True, skip_moderation=None):
     user = session.user if session else None
     registration = Registration(registration_form=regform, user=get_user_by_email(data['email']),
-                                base_price=regform.base_price, currency=regform.currency, created_by_manager=management)
+                                base_price=regform.base_price, currency=regform.currency,
+                                created_by_manager=management, created_by=user)
     if skip_moderation is None:
         skip_moderation = management
     all_data_by_id = {f.id: data.get(f.html_field_name) for f in regform.active_fields}
@@ -622,6 +623,7 @@ def generate_spreadsheet_from_registrations(registrations, regform_items, static
         'reg_date': ('Registration date', lambda x: x.submitted_dt),
         'mod_date': ('Modification date', lambda x: x.modified_dt),
         'state': ('Registration state', lambda x: x.state.title),
+        'created_by': ('Created by', lambda x: x.created_by.full_name if x.created_by else ''),
         'price': ('Price', lambda x: x.render_price()),
         'checked_in': ('Checked in', lambda x: x.checked_in),
         'checked_in_date': ('Check-in date', lambda x: x.checked_in_dt if x.checked_in else ''),
@@ -700,6 +702,10 @@ def generate_pdf_data_from_registrations(event, registrations, regform_items, st
         'state': (
             _('Registration state'),
             lambda x: x.state.title,
+        ),
+        'created_by': (
+            _('Created by'),
+            lambda x: x.created_by.full_name if x.created_by else empty_value,
         ),
         'price': (
             _('Price'),

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -26,7 +26,8 @@ from indico.modules.events.registration.models.form_fields import RegistrationFo
 from indico.modules.events.registration.models.invitations import RegistrationInvitation
 from indico.modules.events.registration.models.items import (PersonalDataType, RegistrationFormItemType,
                                                              RegistrationFormSection)
-from indico.modules.events.registration.models.registrations import RegistrationVisibility
+from indico.modules.events.registration.models.registrations import (Registration, RegistrationState,
+                                                                     RegistrationVisibility)
 from indico.modules.events.registration.util import (create_registration, generate_spreadsheet_from_registrations,
                                                      get_event_regforms_registrations, get_registered_event_persons,
                                                      get_ticket_qr_code_data, get_user_data,
@@ -583,6 +584,21 @@ def test_create_registration_records_creator(monkeypatch, dummy_user, dummy_regf
     session.set_session_user(None)
     reg = create_registration(dummy_regform, data, invitation=None, management=False, notify_user=False)
     assert reg.created_by is None
+
+
+def test_merge_users_reassigns_created_by(db, dummy_event, dummy_regform, create_user):
+    source = create_user(101)
+    target = create_user(102)
+    participant = create_user(103)
+    reg = Registration(registration_form=dummy_regform, first_name='Guinea', last_name='Pig',
+                       state=RegistrationState.complete, currency='USD', email=participant.email,
+                       user=participant, created_by=source)
+    dummy_event.registrations.append(reg)
+    db.session.flush()
+
+    Registration.merge_users(target, source)
+    db.session.expire(reg)
+    assert reg.created_by == target
 
 
 @pytest.mark.usefixtures('request_context')

--- a/indico/modules/events/registration/util_test.py
+++ b/indico/modules/events/registration/util_test.py
@@ -569,6 +569,23 @@ def test_create_registration(monkeypatch, dummy_user, dummy_regform):
 
 
 @pytest.mark.usefixtures('request_context')
+def test_create_registration_records_creator(monkeypatch, dummy_user, dummy_regform, create_user):
+    monkeypatch.setattr('indico.modules.users.util.get_user_by_email', lambda *args, **kwargs: dummy_user)
+    data = {'email': dummy_user.email, 'first_name': dummy_user.first_name, 'last_name': dummy_user.last_name}
+
+    creator = create_user(123)
+    session.set_session_user(creator)
+    reg = create_registration(dummy_regform, data, invitation=None, management=True, notify_user=False)
+    assert reg.created_by == creator
+    db.session.delete(reg)
+    db.session.flush()
+
+    session.set_session_user(None)
+    reg = create_registration(dummy_regform, data, invitation=None, management=False, notify_user=False)
+    assert reg.created_by is None
+
+
+@pytest.mark.usefixtures('request_context')
 def test_modify_registration(monkeypatch, dummy_user, dummy_regform):
     monkeypatch.setattr('indico.modules.users.util.get_user_by_email', lambda *args, **kwargs: dummy_user)
 

--- a/indico/modules/users/models/users.py
+++ b/indico/modules/users/models/users.py
@@ -467,6 +467,7 @@ class User(PersonMixin, db.Model):
     # - category_roles (CategoryRole.members)
     # - content_reviewer_for_contributions (Contribution.paper_content_reviewers)
     # - created_events (Event.creator)
+    # - created_registrations (Registration.created_by)
     # - data_export_request (DataExportRequest.user)
     # - editing_comments (EditingRevisionComment.user)
     # - editing_revisions (EditingRevision.user)


### PR DESCRIPTION
This PR records who created each registration and shows it as a "Created by" column in the management registration list. Useful to see who registered a participant (for example, which manager added them).

