### PR TITLE
Improve contrast of status tag badges

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,7 @@ Accessibility
 - Screen reader users can now access the full date range and timezone for events
   in the dashboard lists, which was previously shown only as a mouse-hover
   tooltip (:pr:`7608`, thanks :user:`foxbunny`)
+- Status tag badges now meet WCAG AA color contrast requirements (:issue:`7621`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/styles/partials/_tags.scss
+++ b/indico/web/client/styles/partials/_tags.scss
@@ -7,19 +7,52 @@
 
 @use 'base' as *;
 
+$tag-default-color: $black;
+$tag-semantic-color-map: (
+  highlight: $dark-blue,
+  success: darken($green, 14%),
+  error: $dark-red,
+  warning: darken($yellow, 18%),
+  visited: $purple,
+  strong: $black,
+  editing-rejected: $midnight-black,
+  editing-make-changes: darken($bright-yellow, 25%),
+  editing-request-changes: $dark-red,
+  editing-accepted-submitter: darken($olive, 18%),
+);
+
+@mixin tag-background($color) {
+  @include border-all($color);
+  background: $color;
+  color: $white;
+}
+
+@mixin tag-outline($color) {
+  @include border-all($color);
+  color: $color;
+}
+
 .i-tag {
-  @include semantic-background();
+  @include tag-background($tag-default-color);
   @include default-border-radius();
   padding: 0.3em 0.6em;
   font-weight: bold;
   box-sizing: initial;
 
+  @each $style, $color in $tag-semantic-color-map {
+    &.#{$style} {
+      @include tag-background($color);
+    }
+  }
+
   &.outline {
-    @include semantic-outline();
+    @include tag-outline($tag-default-color);
     background: transparent;
 
-    @include semantic-versions() {
-      background: transparent;
+    @each $style, $color in $tag-semantic-color-map {
+      &.#{$style} {
+        @include tag-outline($color);
+      }
     }
 
     &.dashed {


### PR DESCRIPTION
## Summary

- Fixes the low-contrast `.i-tag` badge variants reported in #7621.
- Adds tag-specific foreground/background colors for filled and outline tags instead of changing the shared `semantic-background` mixin.
- Adds a changelog entry under Accessibility.

## Rationale

`.i-tag` uses normal-size bold text, so the WCAG 2.1 AA contrast threshold is 4.5:1. Several existing semantic tag variants were below that threshold with white text, including the default gray, highlight blue, success green, warning yellow, and editing tag colors.

This keeps the change scoped to tags because the shared semantic mixins are used by other UI components.

## Verification

- `git diff --check`
- Manually calculated contrast ratios for all filled and outline `.i-tag` variants changed here.

Minimum ratios after this change:

- filled tags: 4.69:1 or higher against white text
- outline tags: 4.69:1 or higher against a white/light background

I could not run local stylelint/build in this checkout because npm dependencies are not installed and the local environment cannot reach the npm registry. GitHub CI should provide the full style/build validation.
