### PR TITLE
Label the event toolbar navigation landmark

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -92,6 +92,8 @@ Accessibility
 - Screen reader users can now access the full date range and timezone for events
   in the dashboard lists, which was previously shown only as a mouse-hover
   tooltip (:pr:`7608`, thanks :user:`foxbunny`)
+- Screen reader users can now distinguish the event tools navigation landmark
+  from other navigation regions (:issue:`7626`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -190,7 +190,8 @@
 
 <header class="page-header page-header-dark event-page-header">
     <div class="main-action-bar flexrow f-j-space-between f-a-center">
-        <div class="button-bar flexrow f-j-start">
+        <nav class="button-bar flexrow f-j-start" aria-labelledby="event-toolbar-heading">
+            <h2 id="event-toolbar-heading" class="event-toolbar-heading">{% trans %}Event tools{% endtrans %}</h2>
             {% if event.type != 'conference' or show_nav_bar %}
                 {{ _render_nav_bar() }}
             {% endif %}
@@ -248,7 +249,7 @@
                     {%- trans %}Back to Conference View{% endtrans -%}
                 </a>
             {% endif %}
-        </div>
+        </nav>
 
         {{ render_session_bar(protected_object=event, local_tz=event.display_tzinfo.zone, force_locale=force_locale,
                               force_locale_alts=force_locale_alts) }}

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base' as *;
+@use 'design_system';
 @use 'partials/buttons' as *;
 @use 'partials/boxes' as *;
 
@@ -67,6 +68,10 @@
   .main-action-bar {
     height: 50px;
     min-height: 50px;
+  }
+
+  .event-toolbar-heading {
+    @extend %visually-hidden;
   }
 
   .button-bar {


### PR DESCRIPTION
## Summary

- Exposes the event tools toolbar as a named `<nav>` landmark.
- Adds a visually hidden `Event tools` heading using the existing `%visually-hidden` pattern.
- Adds an Accessibility changelog entry.

## Rationale

This addresses part of #7626. On current `master`, the shared breadcrumb template already has `aria-label="Breadcrumb"`, so this PR focuses on the remaining event toolbar landmark.

The event toolbar contains repeated navigation/actions such as home, adjacent-event links, category navigation, export/download/theme controls, and the management-area link. Naming it helps screen-reader users distinguish it from the breadcrumb, event menu, and footer navigation landmarks.

The visible layout is preserved by keeping the existing `button-bar flexrow f-j-start` classes on the `<nav>`.

## Verification

- `git diff --check`
- Checked the rendered-source structure in the changed template:
  - the toolbar is now a `<nav>`
  - the landmark is labelled with `aria-labelledby="event-toolbar-heading"`
  - the heading is visually hidden via the established SCSS placeholder

I could not run local stylelint/build in this checkout because npm dependencies are not installed, the local environment cannot reach the npm registry, and local disk space is low. GitHub CI should provide the full style/build validation.
