### PR TITLE
Fix UI regression when displaying unscheduled entries

### DIFF
--- a/indico/modules/events/timetable/client/js/Entry.module.scss
+++ b/indico/modules/events/timetable/client/js/Entry.module.scss
@@ -20,7 +20,7 @@ $title-row-line-height: 1.2rem;
   padding: 0;
   outline: none;
   font-size: 0.9rem;
-  container-type: size;
+  container-type: inline-size;
 
   .children-wrapper {
     flex-grow: 1;


### PR DESCRIPTION
Fix regression caused by #7587 where unscheduled entries in the side panel had their text centered instead of aligned to the left
