### PR TITLE
Add external ID support on timetable

### DIFF
--- a/indico/modules/events/contributions/client/js/ContributionForm.tsx
+++ b/indico/modules/events/contributions/client/js/ContributionForm.tsx
@@ -19,7 +19,7 @@ import _ from 'lodash';
 import moment from 'moment';
 import React, {useEffect, useState} from 'react';
 import {Field} from 'react-final-form';
-import {Button, Dimmer, Form, Loader} from 'semantic-ui-react';
+import {Button, Dimmer, Form, Icon, Loader} from 'semantic-ui-react';
 
 import {
   UNSCHEDULED_CONTRIB_EDIT_MODAL,
@@ -74,6 +74,8 @@ interface ContributionFormFieldsProps {
   [key: string]: any; // Allow additional props
 }
 
+const referenceIsIncomplete = ref => !ref.type || !ref.value;
+
 export function ContributionFormFields({
   eventId,
   locationParent = {inheriting: false},
@@ -82,6 +84,7 @@ export function ContributionFormFields({
   customFields = [],
   extraOptions = {},
 }: ContributionFormFieldsProps) {
+  const [hasIncompleteReferences, setHasIncompleteReferences] = useState(false);
   const customFieldsSection = customFields.map(
     ({id, fieldType, title, description, isRequired, fieldData}) => {
       const key = `custom_field_${id}`;
@@ -186,7 +189,36 @@ export function ContributionFormFields({
       <CollapsibleContainer title={Translate.string('Advanced')} dividing>
         <FinalReferences
           name="references"
-          label={Translate.string('External IDs')}
+          label={
+            <>
+              <Translate>External IDs</Translate>
+              {hasIncompleteReferences && (
+                <span style={{display: 'block', color: '#ba8e23', marginTop: '0.5em'}}>
+                  <Icon name="warning sign" />
+                  <Translate>
+                    Some external IDs are incomplete, and therefore will not be saved on submission.
+                  </Translate>
+                </span>
+              )}
+            </>
+          }
+          onChange={refs => {
+            refs.map(ref => {
+              if (typeof ref.id === 'string') {
+                delete ref.id;
+              }
+              return ref;
+            });
+            const incompleteRefs = refs.some(
+              ref => ref.type + ref.value !== '' && referenceIsIncomplete(ref)
+            );
+
+            if (incompleteRefs !== hasIncompleteReferences) {
+              setHasIncompleteReferences(incompleteRefs);
+            }
+
+            return refs;
+          }}
           description={Translate.string('Manage external resources for this contribution')}
         />
         <Form.Group widths="equal">
@@ -238,6 +270,7 @@ export function ContributionForm({
       ...formData,
       custom_fields: customFieldsData,
       person_links: personLinks,
+      references: formData.references.filter(ref => !referenceIsIncomplete(ref)),
     };
     onSubmit(
       {

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -242,9 +242,15 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
       data.person_links = mapEntryToData({personLinks: data.person_links}, true).person_links;
     }
 
+    if (data.references) {
+      data.references = mapEntryToData({references: data.references}, true).references;
+    }
+
     try {
       if (isEditing) {
         const updatedEntry = {...entry, ...mapDataToEntry(data, true)};
+        // TODO: (Ajob) This was missed in a PR. The toast logic below should not be part of
+        //              the handleSubmit and instead have a separate function
         const oldDayKey = getDateKey(entry.startDt);
         const newDayKey = getDateKey(updatedEntry.startDt);
         dispatch(

--- a/indico/modules/events/timetable/client/js/mapperUtils.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.ts
@@ -49,6 +49,12 @@ const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
     toTransform: p => p.map(mapPersonLinkToData),
   },
   {
+    from: 'references',
+    to: 'references',
+    fromTransform: refs => refs.filter(ref => ref.type && ref.value),
+    toTransform: refs => refs.filter(ref => ref.type && ref.value),
+  },
+  {
     from: 'location_data',
     to: 'locationData',
     fromTransform: l => mapDataToLocationData(l),

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -116,6 +116,11 @@ export interface UnscheduledContribEntry extends Omit<BaseEntry, 'id' | 'type'> 
 export interface ContribEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMixin {
   id: ContribId;
   type: EntryType.Contribution;
+  references?: {
+    id: number;
+    type: string;
+    value: string;
+  };
   attachments?: Attachment[];
   sessionId?: number;
   boardNumber?: string;

--- a/indico/modules/events/timetable/controllers/manage.py
+++ b/indico/modules/events/timetable/controllers/manage.py
@@ -277,8 +277,7 @@ class RHTimetableContributionCreate(RHManageContributionsBase):
             reference_type = ReferenceType.get(entry['reference_type_id'])
             if not reference_type:
                 raise BadRequest('Invalid reference type')
-            references.append(ContributionReference(reference_type=reference_type, contribution=self.contrib,
-                                                    value=entry['value']))
+            references.append(ContributionReference(reference_type=reference_type, value=entry['value']))
         return references
 
     def _get_inherited_location(self, **kwargs):


### PR DESCRIPTION
Made it so that external IDs can be added and edited to contributions. Includes warning for better UX.

[Screencast from 2026-07-03 21-48-05.webm](https://github.com/user-attachments/assets/3c6441b1-dfb6-4c1e-8389-8fe17591a338)
