### PR TITLE
Improve form and toolbar accessibility

### DIFF
--- a/indico/modules/events/client/js/util/list_generator.js
+++ b/indico/modules/events/client/js/util/list_generator.js
@@ -35,6 +35,29 @@
     });
   }
 
+  function syncRequiresSelectedRowAccessibility() {
+    $('.js-requires-selected-row').each(function() {
+      const $this = $(this);
+      const disabled = $this.hasClass('disabled');
+
+      $this.attr('aria-disabled', disabled ? 'true' : 'false');
+      if (disabled) {
+        if ($this.attr('tabindex') !== '-1') {
+          $this.data('previous-tabindex', $this.attr('tabindex'));
+        }
+        $this.attr('tabindex', '-1');
+      } else {
+        const previousTabindex = $this.data('previous-tabindex');
+        if (previousTabindex === undefined) {
+          $this.removeAttr('tabindex');
+        } else {
+          $this.attr('tabindex', previousTabindex);
+        }
+        $this.removeData('previous-tabindex');
+      }
+    });
+  }
+
   global.handleRowSelection = function(trigger) {
     let lastClickedIndex;
     const $obj = $('table.i-table input.select-row');
@@ -57,10 +80,13 @@
         'disabled',
         !$('.list input:checkbox:checked').length
       );
+      syncRequiresSelectedRowAccessibility();
     });
 
     if (trigger) {
       $obj.trigger('change');
+    } else {
+      syncRequiresSelectedRowAccessibility();
     }
   };
 

--- a/indico/modules/events/client/js/util/list_generator.test.js
+++ b/indico/modules/events/client/js/util/list_generator.test.js
@@ -1,0 +1,44 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2026 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import $ from 'jquery';
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  window.$ = $;
+  window.jQuery = $;
+  global.$ = $;
+  global.jQuery = $;
+  jest.resetModules();
+});
+
+describe('handleRowSelection', () => {
+  it('removes disabled selected-row actions from the tab order and restores them after selection', () => {
+    document.body.innerHTML = `
+      <div class="list">
+        <table class="i-table"><tbody><tr><td><input class="select-row" type="checkbox"></td></tr></tbody></table>
+        <button class="js-requires-selected-row disabled">Remove</button>
+        <a href="#" class="js-requires-selected-row disabled" tabindex="2">Export</a>
+      </div>
+    `;
+
+    require('./list_generator');
+    window.handleRowSelection(true);
+
+    expect($('.js-requires-selected-row').eq(0).attr('aria-disabled')).toBe('true');
+    expect($('.js-requires-selected-row').eq(0).attr('tabindex')).toBe('-1');
+    expect($('.js-requires-selected-row').eq(1).attr('aria-disabled')).toBe('true');
+    expect($('.js-requires-selected-row').eq(1).attr('tabindex')).toBe('-1');
+
+    $('.select-row').prop('checked', true).trigger('change');
+
+    expect($('.js-requires-selected-row').eq(0).attr('aria-disabled')).toBe('false');
+    expect($('.js-requires-selected-row').eq(0).attr('tabindex')).toBeUndefined();
+    expect($('.js-requires-selected-row').eq(1).attr('aria-disabled')).toBe('false');
+    expect($('.js-requires-selected-row').eq(1).attr('tabindex')).toBe('2');
+  });
+});

--- a/indico/web/client/js/jquery/utils/errors.js
+++ b/indico/web/client/js/jquery/utils/errors.js
@@ -43,6 +43,34 @@ import {$T} from 'indico/utils/i18n';
     }
   };
 
+  function appendToken(value, token) {
+    return [...new Set(`${value || ''} ${token}`.trim().split(/\s+/))].join(' ');
+  }
+
+  function getFieldErrorId(field, input) {
+    const fieldId = input.attr('id') || field.closest('.form-group').attr('id') || field.index();
+    return `${fieldId}-error`;
+  }
+
+  function describeFormError(field, input) {
+    const errorId = getFieldErrorId(field, input);
+    let error = field.children(`#${$.escapeSelector(errorId)}`);
+
+    if (!error.length) {
+      error = $('<div>', {
+        id: errorId,
+        class: 'form-field-error-message',
+        role: 'alert',
+      }).appendTo(field);
+    }
+
+    error.html(field.data('error'));
+    input.attr({
+      'aria-invalid': 'true',
+      'aria-describedby': appendToken(input.attr('aria-describedby'), errorId),
+    });
+  }
+
   // Select the field of an i-form which has an error and display the tooltip.
   global.showFormErrors = function showFormErrors(context) {
     context = context || $('body');
@@ -59,10 +87,18 @@ import {$T} from 'indico/utils/i18n';
         }
 
         if (!input.length) {
+          // Try the first native or custom focusable field.
+          input = $this
+            .children('input, select, textarea, button, [tabindex], [contenteditable]')
+            .eq(0);
+        }
+
+        if (!input.length) {
           // Try the first element that's not a hidden input
           input = $this.children(':not(:input:hidden)').eq(0);
         }
         input.stickyTooltip('danger', () => $this.data('error'));
+        describeFormError($this, input);
       });
   };
 })(window);

--- a/indico/web/client/js/jquery/utils/errors.test.js
+++ b/indico/web/client/js/jquery/utils/errors.test.js
@@ -1,0 +1,51 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2026 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import $ from 'jquery';
+
+jest.mock('indico/react/errors', () => jest.fn());
+jest.mock('indico/utils/i18n', () => ({
+  $T: {
+    gettext: text => text,
+  },
+}));
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  window.$ = $;
+  window.jQuery = $;
+  global.$ = $;
+  global.jQuery = $;
+  $.fn.stickyTooltip = jest.fn();
+});
+
+describe('showFormErrors', () => {
+  it('links server-side error messages to the invalid field', () => {
+    document.body.innerHTML = `
+      <form class="i-form">
+        <div class="form-group has-error">
+          <div class="form-field" data-error="<ul><li>Enter a title</li></ul>">
+            <input id="title" aria-describedby="title-help">
+          </div>
+        </div>
+      </form>
+    `;
+
+    expect($('body').find('.i-form .has-error > .form-field')).toHaveLength(1);
+
+    require('./errors');
+    window.showFormErrors();
+
+    const input = $('#title');
+    const error = $('.form-field-error-message');
+    expect(error).toHaveLength(1);
+    expect(error.attr('role')).toBe('alert');
+    expect(error.html()).toBe('<ul><li>Enter a title</li></ul>');
+    expect(input.attr('aria-invalid')).toBe('true');
+    expect(input.attr('aria-describedby').split(/\s+/)).toEqual(['title-help', 'title-error']);
+  });
+});

--- a/indico/web/client/js/jquery/widgets/dropdown.js
+++ b/indico/web/client/js/jquery/widgets/dropdown.js
@@ -24,6 +24,7 @@
       const ul = elem.next('ul');
 
       elem.removeClass('open');
+      elem.attr('aria-expanded', 'false');
       elem.removeData('no-qtip');
 
       this._effect('off', ul, effect);
@@ -47,6 +48,7 @@
       const positionReference = this.options.relative_to || elem;
 
       elem.addClass('open');
+      elem.attr('aria-expanded', 'true');
       elem.data('no-qtip', true).trigger('indico:closeAutoTooltip');
 
       this._effect('on', sibl);
@@ -74,6 +76,21 @@
 
       elem.find(this.options.selector).each(function() {
         const $this = $(this);
+        const menu = $this.next('ul.i-dropdown');
+
+        if (menu.length) {
+          if (!menu.attr('id')) {
+            menu.attr('id', `dropdown-menu-${Math.random().toString(36).slice(2)}`);
+          }
+          $this.attr({
+            'aria-haspopup': 'menu',
+            'aria-expanded': 'false',
+            'aria-controls': menu.attr('id'),
+          });
+          menu.attr('role', 'menu');
+          menu.children('li').children('a').attr('role', 'menuitem');
+        }
+
         if (
           !$this.attr('href') ||
           $this.attr('href') === '#' ||

--- a/indico/web/client/js/jquery/widgets/dropdown.test.js
+++ b/indico/web/client/js/jquery/widgets/dropdown.test.js
@@ -1,0 +1,45 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2026 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import $ from 'jquery';
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  window.$ = $;
+  window.jQuery = $;
+  global.$ = $;
+  global.jQuery = $;
+});
+
+describe('dropdown widget accessibility', () => {
+  it('adds menu relationships and keeps aria-expanded in sync', () => {
+    document.body.innerHTML = `
+      <div class="toolbar">
+        <button class="i-button" data-toggle="dropdown">Export</button>
+        <ul class="i-dropdown"><li><a href="#">CSV</a></li></ul>
+      </div>
+    `;
+
+    require('jquery-ui/ui/widget');
+    require('./dropdown');
+    $('.toolbar').dropdown();
+
+    const trigger = $('[data-toggle="dropdown"]');
+    const menu = $('.i-dropdown');
+    expect(trigger.attr('aria-haspopup')).toBe('menu');
+    expect(trigger.attr('aria-expanded')).toBe('false');
+    expect(trigger.attr('aria-controls')).toBe(menu.attr('id'));
+    expect(menu.attr('role')).toBe('menu');
+    expect(menu.find('a').attr('role')).toBe('menuitem');
+
+    trigger.trigger('click');
+    expect(trigger.attr('aria-expanded')).toBe('true');
+
+    trigger.trigger('click');
+    expect(trigger.attr('aria-expanded')).toBe('false');
+  });
+});

--- a/indico/web/client/styles/partials/_forms.scss
+++ b/indico/web/client/styles/partials/_forms.scss
@@ -168,6 +168,18 @@ form {
       }
     }
   }
+
+  .form-field-error-message {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 }
 
 .i-form .form-group .form-label {


### PR DESCRIPTION
## Summary

This PR addresses two related accessibility issues in Indico's form and management-list UI:

- links server-side form errors back to the invalid control with `aria-invalid` and `aria-describedby`, while keeping the existing sticky tooltip behavior
- exposes dropdown triggers as menu buttons with `aria-haspopup`, `aria-expanded`, and `aria-controls`
- keeps row-selection dependent toolbar actions out of the tab order while they are disabled, and restores the previous tabindex when they become available

This is intentionally a shared-behavior change rather than a one-off template patch, so the improvement applies across the existing form and list-toolbar patterns.

Fixes #7624
Fixes #7625

## Validation

- `npm test -- indico/web/client/js/jquery/utils/errors.test.js indico/web/client/js/jquery/widgets/dropdown.test.js indico/modules/events/client/js/util/list_generator.test.js --runInBand`
- `npm run eslint -- indico/web/client/js/jquery/utils/errors.js indico/web/client/js/jquery/utils/errors.test.js indico/web/client/js/jquery/widgets/dropdown.js indico/web/client/js/jquery/widgets/dropdown.test.js indico/modules/events/client/js/util/list_generator.js indico/modules/events/client/js/util/list_generator.test.js`
- `npx stylelint indico/web/client/styles/partials/_forms.scss`
- `git diff --check`

Note: `npm run build` currently fails before compiling because the project script still invokes `webpack -p`, which this installed webpack-cli rejects as an unknown option. The targeted JS tests and lint/style checks above pass.