### PR TITLE
Expose renderLabel prop on EmailListField

### DIFF
--- a/indico/web/client/js/react/components/EmailListField.jsx
+++ b/indico/web/client/js/react/components/EmailListField.jsx
@@ -19,7 +19,7 @@ const isValid = value => /^\S+@\S+\.\S+$/.test(value);
 /**
  * A field that lets the user enter email addresses
  */
-export function EmailListField({value, disabled, onChange, onFocus, onBlur}) {
+export function EmailListField({value, disabled, onChange, onFocus, onBlur, renderLabel}) {
   const [searchQuery, setSearchQuery] = useState('');
   const options = value.filter(isValid).map(x => ({text: x, value: x}));
 
@@ -72,6 +72,7 @@ export function EmailListField({value, disabled, onChange, onFocus, onBlur}) {
       onChange={handleChange}
       onSearchChange={handleSearchChange}
       onBlur={handleBlur}
+      renderLabel={renderLabel}
       selectedLabel={null}
       icon=""
     />
@@ -84,12 +85,14 @@ EmailListField.propTypes = {
   onChange: PropTypes.func.isRequired,
   onFocus: PropTypes.func,
   onBlur: PropTypes.func,
+  renderLabel: PropTypes.func,
 };
 
 EmailListField.defaultProps = {
   disabled: false,
   onFocus: () => {},
   onBlur: () => {},
+  renderLabel: undefined,
 };
 
 export default React.memo(EmailListField);


### PR DESCRIPTION
This PR exposes the `EmailListField`'s dropdown `renderLabel` prop, needed for a plugin.

We think this is the only prop we need, but if you prefer we can also instead just pass a `...rest` to the `Dropdown`. Up to you guys 😃 