### PR TITLE
Make timetable toolbar more space-efficient

### DIFF
--- a/indico/modules/events/contributions/client/js/PublicationStateSwitch.tsx
+++ b/indico/modules/events/contributions/client/js/PublicationStateSwitch.tsx
@@ -19,12 +19,14 @@ import PublicationModal from './PublicationModal';
 interface PublicationStateSwitch {
   eventId: number;
   onSuccess?: () => void;
+  noText?: boolean;
   [key: string]: any;
 }
 
 export default function PublicationStateSwitch({
   eventId,
   onSuccess = () => undefined,
+  noText = false,
   ...rest
 }: PublicationStateSwitch) {
   const url = publicationURL({event_id: eventId});
@@ -62,7 +64,13 @@ export default function PublicationStateSwitch({
       {...rest}
     >
       <Icon name={published ? 'lock open' : 'lock'} />
-      {published ? <Translate>Published</Translate> : <Translate>Unpublished</Translate>}
+      {!noText ? (
+        published ? (
+          <Translate>Published</Translate>
+        ) : (
+          <Translate>Unpublished</Translate>
+        )
+      ) : null}
     </Button>
   );
 

--- a/indico/modules/events/timetable/client/js/TimetableTabRail.module.scss
+++ b/indico/modules/events/timetable/client/js/TimetableTabRail.module.scss
@@ -17,19 +17,29 @@ $toolbar-bg-color: $raincloud-gray;
 }
 
 :global(.ui.vertical.menu).tab-rail {
-    display: flex;
-    width: inherit;
-    gap: 10px;
-    height: calc(100% - 20px);
-    margin: 10px;
+  display: flex;
+  width: inherit;
+  gap: 10px;
+  height: calc(100% - 20px);
+  margin: 10px;
 
-     > :global(.item) {
+  > :global(.item) {
     margin: 0;
     padding: 10px;
 
     > :global(.icon) {
-       margin: 0;
-       font-size: 1.2rem;
+      margin: 0;
+      font-size: 1.2rem;
     }
+  }
+
+  &::after {
+    display: none;
+  }
+
+  .publication-switch {
+    margin-top: auto;
+    // SUI uses important so we need to override
+    box-shadow: none !important;
   }
 }

--- a/indico/modules/events/timetable/client/js/TimetableTabRail.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableTabRail.tsx
@@ -10,6 +10,7 @@ import {useDispatch, useSelector} from 'react-redux';
 import './TimetableTabRail.module.scss';
 import {Icon, Menu} from 'semantic-ui-react';
 
+import PublicationStateSwitch from 'indico/modules/events/contributions/PublicationStateSwitch';
 import {Translate} from 'indico/react/i18n';
 
 import * as actions from './actions';
@@ -21,6 +22,7 @@ export default function TimetableTabRail() {
   const showUnscheduled = useSelector(selectors.showUnscheduled);
   const showSessions = useSelector(selectors.showSessions);
   const activePanel = useSelector(selectors.getActivePanel);
+  const eventId = useSelector(selectors.getEventId);
 
   return (
     // TODO: (Marina) Rename to 'show draft entries' or something like that
@@ -57,6 +59,15 @@ export default function TimetableTabRail() {
         >
           <Icon name="file outline" size="large" />
         </Menu.Item>
+        <PublicationStateSwitch
+          as={Menu.Item}
+          styleName="publication-switch"
+          eventId={eventId}
+          onSuccess={() => dispatch(actions.toggleDraft())}
+          basic
+          noText
+          size="tiny"
+        />
       </Menu>
     </div>
   );

--- a/indico/modules/events/timetable/client/js/Toolbar.module.scss
+++ b/indico/modules/events/timetable/client/js/Toolbar.module.scss
@@ -13,27 +13,32 @@ $bg-color: $white;
 $toolbar-bg-color: $raincloud-gray;
 
 .toolbar {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
   position: sticky;
   top: 0;
   background-color: $bg-color;
   z-index: 100;
   border-bottom: 2px solid rgba($raincloud-gray, 0.8);
+  padding: 15px 10px 0 10px;
 
   > .actions-bar {
-    box-shadow: 0 10px 10px -10px rgba($raincloud-gray, 0.8);
-    padding: 0;
+    margin: 0 5px;
+    > .action {
+      &.right {
+        margin-left: auto;
+      }
+    }
   }
 
   .actions-bar,
-  :global(.ui.menu) {
-    height: 46px;
+  .timetable-bar {
     display: flex;
     align-items: center;
-    margin: 0;
-    border: 0;
 
     &.timetable-bar {
-      height: 4.2rem;
+      height: 3.8rem;
       overflow-y: hidden;
 
       &.block {
@@ -96,6 +101,7 @@ $toolbar-bg-color: $raincloud-gray;
           padding: 18px 0;
 
           .day {
+            cursor: pointer;
             display: flex;
             flex-direction: column;
             align-items: center;
@@ -112,14 +118,12 @@ $toolbar-bg-color: $raincloud-gray;
               margin-right: 15px;
             }
 
-            &:global(.active) {
+            &.active {
               .day-badge {
-                color: $bg-color;
-                background-color: $primary-color;
-                opacity: 1;
-
-                > .day-name {
-                  opacity: 0.8;
+                > .day-number {
+                  color: $bg-color;
+                  background-color: $primary-color;
+                  opacity: 1;
                 }
               }
 
@@ -128,23 +132,29 @@ $toolbar-bg-color: $raincloud-gray;
               }
             }
 
-            &:global(:not(.active)) {
+            &:not(.active) {
+              > .day-badge {
+                > .day-number {
+                  opacity: 0.7;
+                }
+              }
+
               &:hover {
                 > .day-badge {
-                  background-color: rgba($black, 0.1);
-                  transition: 0.1s;
+                  > .day-number {
+                    background-color: rgba($black, 0.1);
+                  }
                 }
               }
             }
 
             > .day-badge {
-              opacity: 0.7;
               font-weight: bold;
               // Needs to be px value for better calculations
-              width: 45px;
-              border-radius: 4px;
+              width: 60px;
               margin: 0.5rem 0;
               padding: 0.5rem 0;
+              border-radius: 4px;
               display: flex;
               flex-direction: column;
               justify-content: center;
@@ -152,9 +162,13 @@ $toolbar-bg-color: $raincloud-gray;
               gap: 0.3rem;
 
               > .day-number {
-                font-size: 0.85rem;
-                word-spacing: -0.1rem;
+                transition: 0.1s;
+                display: flex;
+                justify-content: center;
+                font-size: 0.9rem;
+                padding: 0.2rem 0.2rem;
                 margin-top: -0.2rem;
+                border-radius: 3px;
               }
 
               > .day-name {
@@ -167,21 +181,21 @@ $toolbar-bg-color: $raincloud-gray;
 
           .gradient {
             pointer-events: none;
-            width: 15px;
+            width: 30px;
             margin-top: 10px;
-            height: 60px;
+            top: 0;
             bottom: 0;
             flex-shrink: 0;
             position: sticky;
             z-index: 1;
 
             &:first-child {
-              background: linear-gradient(90deg, $bg-color, transparent);
+              background: linear-gradient(90deg, $bg-color 30%, transparent);
               left: 0;
             }
 
             &:last-child {
-              background: linear-gradient(-90deg, $bg-color, transparent);
+              background: linear-gradient(-90deg, $bg-color 30%, transparent);
               right: 0;
             }
           }
@@ -189,10 +203,9 @@ $toolbar-bg-color: $raincloud-gray;
       }
     }
 
-    .action {
-      padding-left: 0.7em;
-      padding-right: 0.7em;
+    .nav-button {
       background: none;
+      color: black;
 
       :global(.divider.text) {
         display: none;

--- a/indico/modules/events/timetable/client/js/Toolbar.module.scss
+++ b/indico/modules/events/timetable/client/js/Toolbar.module.scss
@@ -32,7 +32,7 @@ $toolbar-bg-color: $raincloud-gray;
     }
 
     &.timetable-bar {
-      height: 100px;
+      height: 4.2rem;
       overflow-y: hidden;
 
       &.block {
@@ -90,8 +90,6 @@ $toolbar-bg-color: $raincloud-gray;
           display: flex;
           overflow-x: auto;
           box-sizing: content-box;
-          // gap: 40px;
-
           // This padding in combination with fixed height
           // and overflow-y hidden above,it hides the scrollbar
           padding: 18px 0;
@@ -106,15 +104,22 @@ $toolbar-bg-color: $raincloud-gray;
             font-weight: normal;
             margin-bottom: 0;
             background: none;
+            padding: 0;
 
+            // Instead of gap we use this as the gradients also trigger a gap
             &:not(:last-of-type) {
-              margin-right: 20px;
+              margin-right: 15px;
             }
 
             &:global(.active) {
-              .day-number {
+              .day-badge {
                 color: $bg-color;
                 background-color: $primary-color;
+                opacity: 1;
+
+                > .day-name {
+                  opacity: 0.8;
+                }
               }
 
               > .day-month {
@@ -124,37 +129,38 @@ $toolbar-bg-color: $raincloud-gray;
 
             &:global(:not(.active)) {
               &:hover {
-                > .day-number {
+                > .day-badge {
                   background-color: rgba($black, 0.1);
                   transition: 0.1s;
                 }
               }
             }
 
-            > .day-month {
-              color: $bg-color;
+            > .day-badge {
+              opacity: 0.7;
               font-weight: bold;
-              font-size: 0.8em;
-              background-color: rgba($primary-color, 0.5);
-              border-radius: 3px;
-              padding: 2px 8px;
-              margin-bottom: 5px;
-              visibility: hidden;
-            }
-
-            > .day-name {
-              color: #555;
-            }
-
-            > .day-number {
-              font-size: 1.2em;
-              font-weight: bold;
-              width: 40px;
-              height: 40px;
+              // Needs to be px value for better calculations
+              width: 45px;
+              border-radius: 4px;
+              margin: 0.5rem 0;
+              padding: 0.5rem 0;
               display: flex;
+              flex-direction: column;
               justify-content: center;
               align-items: center;
-              border-radius: 100%;
+              gap: 0.3rem;
+
+              > .day-number {
+                font-size: 0.85rem;
+                word-spacing: -0.1rem;
+                margin-top: -0.2rem;
+              }
+
+              > .day-name {
+                font-size: 0.7rem;
+                text-transform: uppercase;
+                opacity: 0.6;
+              }
             }
           }
 
@@ -162,7 +168,7 @@ $toolbar-bg-color: $raincloud-gray;
             pointer-events: none;
             width: 15px;
             margin-top: 10px;
-            height: 88px;
+            height: 60px;
             bottom: 0;
             flex-shrink: 0;
             position: sticky;

--- a/indico/modules/events/timetable/client/js/Toolbar.module.scss
+++ b/indico/modules/events/timetable/client/js/Toolbar.module.scss
@@ -88,6 +88,12 @@ $toolbar-bg-color: $raincloud-gray;
           display: flex;
           overflow-x: auto;
           box-sizing: content-box;
+          scrollbar-width: none;
+
+          &::-webkit-scrollbar {
+            display: none;
+          }
+
           // This padding in combination with fixed height
           // and overflow-y hidden above,it hides the scrollbar
           padding: 18px 0;

--- a/indico/modules/events/timetable/client/js/Toolbar.module.scss
+++ b/indico/modules/events/timetable/client/js/Toolbar.module.scss
@@ -22,6 +22,8 @@ $toolbar-bg-color: $raincloud-gray;
   z-index: 100;
   border-bottom: 2px solid rgba($raincloud-gray, 0.8);
   padding: 15px 10px 0 10px;
+   // Makes sure there is spacing when there is no timetable bar (e.g. single day)
+  min-height: 64px;
 
   > .actions-bar {
     margin: 0 5px;
@@ -46,17 +48,25 @@ $toolbar-bg-color: $raincloud-gray;
         justify-content: flex-start;
         align-items: center;
         gap: 0.2rem;
+        padding: 0 10px;
 
         > :is(.header, .session) {
           margin: 0;
+          max-width: min(800px, 100%);
         }
 
         > .header {
+          overflow: hidden;
+          text-overflow: ellipsis;
           letter-spacing: 0.05rem;
           font-size: 1rem;
+          white-space: nowrap;
         }
 
         > .session {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
           font-size: 0.7rem;
           letter-spacing: 0.05rem;
           padding: 4px 8px;

--- a/indico/modules/events/timetable/client/js/Toolbar.module.scss
+++ b/indico/modules/events/timetable/client/js/Toolbar.module.scss
@@ -25,10 +25,9 @@ $toolbar-bg-color: $raincloud-gray;
 
   > .actions-bar {
     margin: 0 5px;
-    > .action {
-      &.right {
-        margin-left: auto;
-      }
+
+    > .right {
+      margin-left: auto;
     }
   }
 
@@ -44,41 +43,24 @@ $toolbar-bg-color: $raincloud-gray;
       &.block {
         display: flex;
         flex-direction: column;
-        justify-content: center;
+        justify-content: flex-start;
         align-items: center;
-        gap: 5px;
-        padding-top: 12px;
+        gap: 0.2rem;
 
         > :is(.header, .session) {
           margin: 0;
         }
 
         > .header {
-          display: flex;
-          align-items: center;
-          gap: 10px;
-          letter-spacing: 1px;
+          letter-spacing: 0.05rem;
+          font-size: 1rem;
         }
 
         > .session {
-          font-weight: normal;
-          padding: 2px 6px;
+          font-size: 0.7rem;
+          letter-spacing: 0.05rem;
+          padding: 4px 8px;
           border-radius: 100vh;
-        }
-
-        .close-btn {
-          box-shadow: none;
-          margin: 0;
-          padding: 2px;
-
-          kbd {
-            font-size: 0.75em;
-            padding: 1px 5px;
-            margin-left: 6px;
-            border: 1px solid #aaa;
-            border-radius: 3px;
-            background-color: #f9f9f9;
-          }
         }
       }
 

--- a/indico/modules/events/timetable/client/js/Toolbar.module.scss
+++ b/indico/modules/events/timetable/client/js/Toolbar.module.scss
@@ -19,17 +19,18 @@ $toolbar-bg-color: $raincloud-gray;
   z-index: 100;
   border-bottom: 2px solid rgba($raincloud-gray, 0.8);
 
+  > .actions-bar {
+    box-shadow: 0 10px 10px -10px rgba($raincloud-gray, 0.8);
+    padding: 0;
+  }
+
+  .actions-bar,
   :global(.ui.menu) {
     height: 46px;
     display: flex;
     align-items: center;
     margin: 0;
     border: 0;
-
-    &.actions-bar {
-      box-shadow: 0 10px 10px -10px rgba($raincloud-gray, 0.8);
-      padding: 0;
-    }
 
     &.timetable-bar {
       height: 4.2rem;
@@ -191,6 +192,7 @@ $toolbar-bg-color: $raincloud-gray;
     .action {
       padding-left: 0.7em;
       padding-right: 0.7em;
+      background: none;
 
       :global(.divider.text) {
         display: none;

--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -236,9 +236,10 @@ export default function Toolbar({onNavigate}: {onNavigate: (dt: Moment) => void}
                     styleName="day"
                     active={isActive}
                   >
-                    <span styleName="day-month">{d.format('MMM')}</span>
-                    <span styleName="day-number">{d.format('D')}</span>
-                    <span styleName="day-name">{d.format('ddd')}</span>
+                    <div styleName="day-badge">
+                      <div styleName="day-number">{d.format('DD / MM')}</div>
+                      <div styleName="day-name">{d.format('ddd')}</div>
+                    </div>
                   </Menu.Item>
                 );
               })}

--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -8,7 +8,7 @@
 import moment, {Moment} from 'moment';
 import React, {useCallback, useEffect, useRef} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
-import {Button, Header, Icon, Label, Menu} from 'semantic-ui-react';
+import {Button, Header, Icon, Label} from 'semantic-ui-react';
 
 import PublicationStateSwitch from 'indico/modules/events/contributions/PublicationStateSwitch';
 import {Translate} from 'indico/react/i18n';
@@ -50,31 +50,13 @@ function SessionBlockToolbar() {
     return null;
   }
 
-  const sessionColors = {
-    backgroundColor: `${colors.backgroundColor}55`,
-    color: colors.color,
-  };
-
   return (
-    <Menu tabular styleName="timetable-bar block">
-      <Label size="small" styleName="session" style={{...sessionColors}}>
+    <div styleName="timetable-bar block">
+      <Label size="small" styleName="session" style={{...colors}}>
         {session.title}
       </Label>
-      <Header as="h3" styleName="header">
-        <span>{title}</span>
-      </Header>
-      <Button
-        basic
-        size="mini"
-        onClick={closeExpandedBlock}
-        styleName="close-btn"
-        title={Translate.string('Close session block view')}
-      >
-        <Icon name="close" />
-        <Translate>Close session block view or press</Translate>
-        <kbd>Esc</kbd>
-      </Button>
-    </Menu>
+      {title && <Header styleName="header">{title}</Header>}
+    </div>
   );
 }
 
@@ -185,23 +167,28 @@ export default function Toolbar({onNavigate}: {onNavigate: (dt: Moment) => void}
           basic
           size="tiny"
         />
-        <Button
-          basic
-          onClick={addNewEntry}
-          title={Translate.string('Add new entry')}
-          size="tiny"
-        >
+        <Button basic onClick={addNewEntry} title={Translate.string('Add new entry')} size="tiny">
           <Icon name="plus" />
           <Translate>Add entry</Translate>
         </Button>
-        <Button
-          styleName="action right"
-          onClick={() => dispatch(actions.toggleExpand())}
-          title={isExpanded ? Translate.string('Exit Fullscreen') : Translate.string('Expand')}
-          icon={isExpanded ? 'compress' : 'expand'}
-          circular
-          size="tiny"
-        />
+        <div styleName="right">
+          {expandedSessionBlock && (
+            <Button
+              onClick={() => dispatch(actions.setExpandedSessionBlock(null))}
+              title={Translate.string('Exit session block view')}
+              icon="arrow left"
+              circular
+              size="tiny"
+            />
+          )}
+          <Button
+            onClick={() => dispatch(actions.toggleExpand())}
+            title={isExpanded ? Translate.string('Exit Fullscreen') : Translate.string('Expand')}
+            icon={isExpanded ? 'compress' : 'expand'}
+            circular
+            size="tiny"
+          />
+        </div>
         {/* TODO: (Ajob) The logic behind this component is broken.
                          Evaluate necessity then remove or fix */}
         {/* <ReviewChangesButton as={Menu.Item} styleName="action" /> */}

--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -10,7 +10,6 @@ import React, {useCallback, useEffect, useRef} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Button, Header, Icon, Label} from 'semantic-ui-react';
 
-import PublicationStateSwitch from 'indico/modules/events/contributions/PublicationStateSwitch';
 import {Translate} from 'indico/react/i18n';
 
 import * as actions from './actions';
@@ -161,12 +160,6 @@ export default function Toolbar({onNavigate}: {onNavigate: (dt: Moment) => void}
   return (
     <div styleName="toolbar" ref={ref}>
       <div styleName="actions-bar">
-        <PublicationStateSwitch
-          eventId={eventId}
-          onSuccess={() => dispatch(actions.toggleDraft())}
-          basic
-          size="tiny"
-        />
         <Button basic onClick={addNewEntry} title={Translate.string('Add new entry')} size="tiny">
           <Icon name="plus" />
           <Translate>Add entry</Translate>

--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -188,11 +188,15 @@ export default function Toolbar({onNavigate}: {onNavigate: (dt: Moment) => void}
           />
         </div>
         <Button
+          basic
           onClick={addNewEntry}
           title={Translate.string('Add new entry')}
-          icon="plus"
           styleName="action"
-        />
+          size="tiny"
+        >
+          <Icon name="plus" />
+          <Translate>Add entry</Translate>
+        </Button>
         <Button
           onClick={() => dispatch(actions.toggleExpand())}
           title={isExpanded ? Translate.string('Exit Fullscreen') : Translate.string('Expand')}

--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -98,8 +98,8 @@ export default function Toolbar({onNavigate}: {onNavigate: (dt: Moment) => void}
   const currentDayIdxRef = useRef<number>(currentDayIdx);
   const reachedLastDay = currentDayIdx >= numDays - 1;
 
-  const gradientWidth = 10;
-  const dayWidth = 60;
+  const gradientWidth = 30;
+  const dayWidth = 75;
 
   const getDateFromIdx = (idx: number): Moment => eventStart.clone().add(idx, 'days');
 
@@ -179,29 +179,28 @@ export default function Toolbar({onNavigate}: {onNavigate: (dt: Moment) => void}
   return (
     <div styleName="toolbar" ref={ref}>
       <div styleName="actions-bar">
-        <div className="right" styleName="action">
-          <PublicationStateSwitch
-            eventId={eventId}
-            onSuccess={() => dispatch(actions.toggleDraft())}
-            basic
-            size="tiny"
-          />
-        </div>
+        <PublicationStateSwitch
+          eventId={eventId}
+          onSuccess={() => dispatch(actions.toggleDraft())}
+          basic
+          size="tiny"
+        />
         <Button
           basic
           onClick={addNewEntry}
           title={Translate.string('Add new entry')}
-          styleName="action"
           size="tiny"
         >
           <Icon name="plus" />
           <Translate>Add entry</Translate>
         </Button>
         <Button
+          styleName="action right"
           onClick={() => dispatch(actions.toggleExpand())}
           title={isExpanded ? Translate.string('Exit Fullscreen') : Translate.string('Expand')}
           icon={isExpanded ? 'compress' : 'expand'}
-          styleName="action"
+          circular
+          size="tiny"
         />
         {/* TODO: (Ajob) The logic behind this component is broken.
                          Evaluate necessity then remove or fix */}
@@ -209,24 +208,24 @@ export default function Toolbar({onNavigate}: {onNavigate: (dt: Moment) => void}
       </div>
       {expandedSessionBlock && <SessionBlockToolbar />}
       {!expandedSessionBlock && numDays > 1 && (
-        <Menu tabular styleName="timetable-bar">
+        <div styleName="timetable-bar">
           {numDays > 2 && (
-            <Menu.Item
+            <Button
               onClick={() => scrollByPage(-1)}
               disabled={currentDayIdx === 0}
               title={Translate.string('Previous page')}
               icon="angle double left"
-              styleName="action"
+              styleName="nav-button"
             />
           )}
-          <Menu.Item
+          <Button
             onClick={() => scrollByDay(-1)}
             disabled={currentDayIdx === 0}
             title={Translate.string('Previous day')}
             icon="angle left"
-            styleName="action"
+            styleName="nav-button"
           />
-          <Menu.Item fitted styleName="days-wrapper">
+          <div styleName="days-wrapper">
             <div ref={daysBarRef} styleName="days">
               <div styleName="gradient" />
               {[...Array(numDays).keys()].map(n => {
@@ -234,41 +233,44 @@ export default function Toolbar({onNavigate}: {onNavigate: (dt: Moment) => void}
                 const isActive = n === currentDayIdx;
 
                 return (
-                  <Menu.Item
-                    fitted="horizontally"
+                  <Button
                     key={n}
                     onClick={() => navigateToDayNumber(n)}
-                    styleName="day"
-                    active={isActive}
+                    styleName={`day ${isActive ? 'active' : ''}`}
                   >
                     <div styleName="day-badge">
-                      <div styleName="day-number">{d.format('DD / MM')}</div>
+                      <div styleName="day-number">
+                        {new Intl.DateTimeFormat(moment.locale(), {
+                          month: 'short',
+                          day: 'numeric',
+                        }).format(d.toDate())}
+                      </div>
                       <div styleName="day-name">{d.format('ddd')}</div>
                     </div>
-                  </Menu.Item>
+                  </Button>
                 );
               })}
               <div styleName="gradient" />
             </div>
-          </Menu.Item>
-          <Menu.Item
+          </div>
+          <Button
             onClick={() => scrollByDay(1)}
             disabled={reachedLastDay}
             title={Translate.string('Next day')}
             icon="angle right"
             position="right"
-            styleName="action"
+            styleName="nav-button"
           />
           {numDays > 2 && (
-            <Menu.Item
+            <Button
               onClick={() => scrollByPage(1)}
               disabled={reachedLastDay}
               title={Translate.string('Next page')}
               icon="angle double right"
-              styleName="action"
+              styleName="nav-button"
             />
           )}
-        </Menu>
+        </div>
       )}
     </div>
   );

--- a/indico/modules/events/timetable/client/js/Toolbar.tsx
+++ b/indico/modules/events/timetable/client/js/Toolbar.tsx
@@ -178,21 +178,22 @@ export default function Toolbar({onNavigate}: {onNavigate: (dt: Moment) => void}
 
   return (
     <div styleName="toolbar" ref={ref}>
-      <Menu compact secondary styleName="actions-bar">
-        <Menu.Item className="right" styleName="action">
+      <div styleName="actions-bar">
+        <div className="right" styleName="action">
           <PublicationStateSwitch
             eventId={eventId}
             onSuccess={() => dispatch(actions.toggleDraft())}
             basic
+            size="tiny"
           />
-        </Menu.Item>
-        <Menu.Item
+        </div>
+        <Button
           onClick={addNewEntry}
           title={Translate.string('Add new entry')}
           icon="plus"
           styleName="action"
         />
-        <Menu.Item
+        <Button
           onClick={() => dispatch(actions.toggleExpand())}
           title={isExpanded ? Translate.string('Exit Fullscreen') : Translate.string('Expand')}
           icon={isExpanded ? 'compress' : 'expand'}
@@ -201,7 +202,7 @@ export default function Toolbar({onNavigate}: {onNavigate: (dt: Moment) => void}
         {/* TODO: (Ajob) The logic behind this component is broken.
                          Evaluate necessity then remove or fix */}
         {/* <ReviewChangesButton as={Menu.Item} styleName="action" /> */}
-      </Menu>
+      </div>
       {expandedSessionBlock && <SessionBlockToolbar />}
       {!expandedSessionBlock && numDays > 1 && (
         <Menu tabular styleName="timetable-bar">


### PR DESCRIPTION
**New**
Top bar 46px (same, just smaller publish button)
Days bar 56px (shrunk by 44%)
Different SB view (moved close button to top right, see 2nd picture top right)
Separated the actions and got rid of double line, combining both toolbars.

<img width="959" height="141" alt="image" src="https://github.com/user-attachments/assets/5a5a0e36-de1a-4da2-9290-cc06f9e0e2c7" />

<img width="959" height="141" alt="image" src="https://github.com/user-attachments/assets/dcc689ba-90dd-46f3-9039-5aeabc04325c" />


**Old**
Top bar 46px (same, just smaller publish button)
Days bar 100px
<img width="1030" height="158" alt="image" src="https://github.com/user-attachments/assets/cfcddb00-ac01-4368-8fc5-4fb9da31c29b" />

