### PR TITLE
Hide Jinja sidepanel on new timetable page

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.module.scss
+++ b/indico/modules/events/timetable/client/js/DayTimetable.module.scss
@@ -12,38 +12,55 @@
 $teal-shadow: rgba($dark-teal, 0.5);
 $toolbar-bg-color: $raincloud-gray;
 
-// Add vertical scroll to Indico sidebar, but only on the timetable management page
-body:has(:global(#timetable-container)) :global(.layout-side-menu) {
-  &:first-child {
-    > :global(.menu-column) {
-      display: flex;
-      position: relative;
+body:has(:global(#timetable-container)) :global(footer.footer) {
+  display: none;
+}
 
-      :global(.timetable-sidepanel-management-toggle) {
-        position: absolute;
-        top: 0;
-        right: -26px;
-        width: 26px;
-        height: 31px;
-        border-radius: 0 100vh 100vh 0;
-        font-size: 0.5rem;
-        bottom: 0;
-      }
+body:has(:global(#timetable-container)) :global(main.main) {
+  :global(.layout-side-menu) {
+    margin-right: 0;
+  }
 
-      > :global(.timetable-display-view-wrapper) {
-        position: relative;
-        width: 100%;
+  &:global(.side-panel-closed) {
+    :global(.timetable-sidepanel-management-toggle) {
+      margin-left: 0;
+    }
 
-        > :global(.group) {
-          margin-left: 0;
-        }
+    :global(.layout-side-menu) {
+      margin-left: 0;
+
+      > :global(.menu-column) {
+        width: 0;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
       }
     }
+  }
+}
+
+// Add vertical scroll to Indico sidebar, but only on the timetable management page
+body:has(:global(#timetable-container)) :global(.layout-side-menu) {
+  :global(.page-content) {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+
+  :global(.timetable-sidepanel-management-toggle) {
+    height: 100%;
+    width: 1.4rem;
+    padding: 0;
+    border: none;
+    font-size: 0.5rem;
+    margin: 0 0 0 5px;
   }
 
   &:nth-child(2) {
     > :global(.menu-column) {
       overflow-y: scroll;
+      position: relative;
+      margin-right: 2px;
     }
   }
 }

--- a/indico/modules/events/timetable/client/js/DayTimetable.module.scss
+++ b/indico/modules/events/timetable/client/js/DayTimetable.module.scss
@@ -13,8 +13,39 @@ $teal-shadow: rgba($dark-teal, 0.5);
 $toolbar-bg-color: $raincloud-gray;
 
 // Add vertical scroll to Indico sidebar, but only on the timetable management page
-body:has(:global(#timetable-container)) :global(.menu-column) {
-  overflow-y: scroll;
+body:has(:global(#timetable-container)) :global(.layout-side-menu) {
+  &:first-child {
+    > :global(.menu-column) {
+      display: flex;
+      position: relative;
+
+      :global(.timetable-sidepanel-management-toggle) {
+        position: absolute;
+        top: 0;
+        right: -26px;
+        width: 26px;
+        height: 31px;
+        border-radius: 0 100vh 100vh 0;
+        font-size: 0.5rem;
+        bottom: 0;
+      }
+
+      > :global(.timetable-display-view-wrapper) {
+        position: relative;
+        width: 100%;
+
+        > :global(.group) {
+          margin-left: 0;
+        }
+      }
+    }
+  }
+
+  &:nth-child(2) {
+    > :global(.menu-column) {
+      overflow-y: scroll;
+    }
+  }
 }
 
 .wrapper {

--- a/indico/modules/events/timetable/client/js/timetable.scss
+++ b/indico/modules/events/timetable/client/js/timetable.scss
@@ -59,12 +59,12 @@ main.main {
                   flex-direction: column;
                   overflow: hidden;
                   // Not exactly -60px because side button also has 5px margin
-                  margin-top: -55px;
+                  margin-top: -80px;
 
                   & > #timetable-container {
                     height: 100%;
                     overflow-y: auto;
-                    flex-grow: 0;
+                    flex-grow: 1;
 
                     & > div {
                       height: 100%;

--- a/indico/modules/events/timetable/templates/management_new.html
+++ b/indico/modules/events/timetable/templates/management_new.html
@@ -5,6 +5,18 @@
 {%- block banner -%}{%- endblock -%}
 {%- block title -%}{%- endblock -%}
 
+{% block display_view_button %}
+    <div class="group timetable-display-view-wrapper">
+        <button class="timetable-sidepanel-management-toggle icon-prev i-button" onclick="toggleSidePanel()" title="{{ _('Toggle side panel') }}">
+        </button>
+        {{ super() }}
+    </div>
+{% endblock %}
+
+{% block side_menu %}
+    {{ super() }}
+{% endblock %}
+
 {% block content %}
     <div id="timetable-container"
          data-timetable-data="{{ timetable_data | tojson | forceescape }}"
@@ -13,5 +25,38 @@
          data-search-token="{{ make_user_search_token() }}"></div>
     <script>
         setupTimetable();
+    </script>
+    <script>
+        let sidePanelIsOpen = true;
+        const sidePanelToggleButton = document.querySelector('.timetable-sidepanel-management-toggle');
+        const itemsToHide = document.querySelectorAll('.layout-side-menu:last-child > .menu-column, .timetable-display-view-wrapper > .group');
+        console.log(itemsToHide)
+
+        function toggleSidePanel() {
+            const hiddenInlineStyles = {
+                width: '0',
+                overflow: 'hidden',
+                margin: '0',
+                padding: '0'
+            }
+            itemsToHide.forEach(column => {
+                if (sidePanelIsOpen) {
+                    Object.assign(column.style, hiddenInlineStyles);
+                } else {
+                    column.removeAttribute('style');
+                }
+            });
+
+            sidePanelToggleButton.classList.toggle('icon-prev');
+            sidePanelToggleButton.classList.toggle('icon-next');
+
+            if (sidePanelIsOpen) {
+                sidePanelToggleButton.style.left = '-30px';
+            } else {
+                sidePanelToggleButton.style.removeProperty('left');
+            }
+
+            sidePanelIsOpen = !sidePanelIsOpen;
+        }
     </script>
 {% endblock %}

--- a/indico/modules/events/timetable/templates/management_new.html
+++ b/indico/modules/events/timetable/templates/management_new.html
@@ -5,19 +5,16 @@
 {%- block banner -%}{%- endblock -%}
 {%- block title -%}{%- endblock -%}
 
-{% block display_view_button %}
-    <div class="group timetable-display-view-wrapper">
-        <button class="timetable-sidepanel-management-toggle icon-prev i-button" onclick="toggleSidePanel()" title="{{ _('Toggle side panel') }}">
-        </button>
-        {{ super() }}
-    </div>
-{% endblock %}
-
 {% block side_menu %}
     {{ super() }}
 {% endblock %}
 
 {% block content %}
+    <button
+        class="timetable-sidepanel-management-toggle icon-prev i-button"
+        onclick="toggleSidePanel()"
+        title="{{ _('Toggle side panel') }}"
+        data-qtip-position="right"></button>
     <div id="timetable-container"
          data-timetable-data="{{ timetable_data | tojson | forceescape }}"
          data-event-info="{{ event_info | tojson | forceescape }}"
@@ -27,36 +24,12 @@
         setupTimetable();
     </script>
     <script>
-        let sidePanelIsOpen = true;
+        const main = document.querySelector('main.main');
         const sidePanelToggleButton = document.querySelector('.timetable-sidepanel-management-toggle');
-        const itemsToHide = document.querySelectorAll('.layout-side-menu:last-child > .menu-column, .timetable-display-view-wrapper > .group');
-        console.log(itemsToHide)
-
         function toggleSidePanel() {
-            const hiddenInlineStyles = {
-                width: '0',
-                overflow: 'hidden',
-                margin: '0',
-                padding: '0'
-            }
-            itemsToHide.forEach(column => {
-                if (sidePanelIsOpen) {
-                    Object.assign(column.style, hiddenInlineStyles);
-                } else {
-                    column.removeAttribute('style');
-                }
-            });
-
             sidePanelToggleButton.classList.toggle('icon-prev');
             sidePanelToggleButton.classList.toggle('icon-next');
-
-            if (sidePanelIsOpen) {
-                sidePanelToggleButton.style.left = '-30px';
-            } else {
-                sidePanelToggleButton.style.removeProperty('left');
-            }
-
-            sidePanelIsOpen = !sidePanelIsOpen;
+            main.classList.toggle('side-panel-closed');
         }
     </script>
 {% endblock %}


### PR DESCRIPTION
Before there was no possibility to hide the side panel. Now we have the functionality to collapse the jinja side panel without re-rendering.

If we decide to implement this feature on `master` we can find a general clean solution that will work on all pages. I believe this feature could be useful there as well.

For now it is important to have this for the user tests.

I made it in a way that should not affect the timetable itself, considering this is more related to the jinja part of things than our new timetable. If we rework things, we'd have to unnecessarily modify the timetable itself again. The CSS is stored there, which we could of course move if desired.

I also removed the footer and some unnecessary spacing around to allow for more timetable room.

**New**
[Screencast from 2026-07-07 17-16-14.webm](https://github.com/user-attachments/assets/2b26b88d-8e8f-44a8-b4f7-642d901705ea)

**First draft before Marina comment**
[Screencast from 2026-07-07 15-35-52.webm](https://github.com/user-attachments/assets/c0dda107-c543-4809-b84e-c23f2d3c6f99)
