### PR TITLE
Add indicator for time when hovering timetable

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.module.scss
+++ b/indico/modules/events/timetable/client/js/DayTimetable.module.scss
@@ -111,3 +111,18 @@ $toolbar-bg-color: $raincloud-gray;
 :global(body.timetable-entry-resizing *) {
   cursor: ns-resize;
 }
+
+.hover-guide {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  pointer-events: none;
+  z-index: 1;
+  background: #7dcfb6;
+  padding: 2px 10px;
+  font-size: 11px;
+  border-radius: 7px;
+  transform: translate(-100%, -50%);
+}

--- a/indico/modules/events/timetable/client/js/DayTimetable.module.scss
+++ b/indico/modules/events/timetable/client/js/DayTimetable.module.scss
@@ -113,6 +113,7 @@ $toolbar-bg-color: $raincloud-gray;
 }
 
 .hover-guide {
+  font-weight: bold;
   position: absolute;
   display: flex;
   align-items: center;
@@ -120,9 +121,12 @@ $toolbar-bg-color: $raincloud-gray;
   color: #fff;
   pointer-events: none;
   z-index: 1;
-  background: #7dcfb6;
-  padding: 2px 10px;
-  font-size: 11px;
-  border-radius: 7px;
+  background: $teal;
+  padding: 4px 6px;
+  min-width: 60px;
+  font-size: 0.9rem;
+  line-height: 0.9rem;
+  border-radius: 7px 0 0 7px;
+  transition: 0.05s;
   transform: translate(-100%, -50%);
 }

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -163,19 +163,21 @@ export function DayTimetable({
   }
 
   function handleCalendarMouseMove(event: React.MouseEvent<HTMLDivElement>) {
-    const clientY = event.clientY + wrapperRef.current.scrollTop;
-    const offsetY = clientY - wrapperRef.current.offsetTop;
-    const isWithinLimitsWithOffset = !isWithinLimits(limits, offsetY);
+    if (wrapperRef.current !== null) {
+      const clientY = event.clientY + wrapperRef.current.scrollTop;
+      const offsetY = clientY - wrapperRef.current.offsetTop;
+      const isWithinLimitsWithOffset = !isWithinLimits(limits, offsetY);
 
-    if (isDragging || selectedEntry || isWithinLimitsWithOffset) {
-      if (hoverGuideY !== null) {
-        setHoverGuideY(null);
+      if (isDragging || selectedEntry || isWithinLimitsWithOffset) {
+        if (hoverGuideY !== null) {
+          setHoverGuideY(null);
+        }
+        return;
       }
-      return;
-    }
 
-    const y = getPositionCalendarY(event.clientY);
-    setHoverGuideY(y);
+      const y = getPositionCalendarY(event.clientY);
+      setHoverGuideY(y);
+    }
   }
 
   function getCalendarTimeFromY(y: number) {

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -145,6 +145,7 @@ export function DayTimetable({
   const selectedEntry = useSelector(selectors.getSelectedEntry);
 
   const [draggingStartPos, setDraggingStartPos] = useState<number | null>(null);
+  const [hoverGuideY, setHoverGuideY] = useState<number | null>(null);
   const isDragging = draggingStartPos !== null;
 
   entries = useMemo(() => computeYoffset(entries, minHour), [entries, minHour]);
@@ -152,6 +153,37 @@ export function DayTimetable({
   const {openModal} = useModal();
 
   const sessions: Record<number, Session> = useSelector(selectors.getSessions);
+
+  function getPositionCalendarY(yAxis: number) {
+    const rect = calendarRef?.current?.getBoundingClientRect();
+
+    return minutesToPixels(
+      Math.round(pixelsToMinutes(yAxis - rect?.top) / GRID_SIZE_MINUTES) * GRID_SIZE_MINUTES
+    );
+  }
+
+  function handleCalendarMouseMove(event: React.MouseEvent<HTMLDivElement>) {
+    if (isDragging || selectedEntry?.id !== undefined) {
+      setHoverGuideY(null);
+      return;
+    }
+
+    const y = getPositionCalendarY(event.clientY);
+
+    if (isWithinLimits(limits, y)) {
+      setHoverGuideY(y);
+    } else {
+      setHoverGuideY(null);
+    }
+  }
+
+  function getCalendarTimeFromY(y: number) {
+    return moment(dt)
+      .startOf('day')
+      .add(minHour, 'hours')
+      .add(pixelsToMinutes(y), 'minutes')
+      .format('LT');
+  }
 
   function showToastIfContribSessionChanged(
     contribTitle?: string,
@@ -599,12 +631,27 @@ export function DayTimetable({
         <TimetableSidePanel dt={dt} />
       </div>
       {/* .timetable-popup-boundary is used by EntryPopup to be aware of its bounding box */}
-      <div ref={wrapperRef} className="wrapper timetable-popup-boundary">
-        <div ref={innerWrapperRef} styleName="wrapper" style={{background: limitsGradient}}>
+      <div
+        ref={wrapperRef}
+        className="wrapper timetable-popup-boundary"
+        onScroll={() => setHoverGuideY(null)}
+      >
+        <div
+          ref={innerWrapperRef}
+          styleName="wrapper"
+          style={{background: limitsGradient}}
+          onMouseMove={handleCalendarMouseMove}
+          onMouseLeave={() => setHoverGuideY(null)}
+        >
           <TimeGutter minHour={minHour} maxHour={maxHour} />
           <DnDCalendar>
             <div ref={calendarRef}>
               <Lines minHour={minHour} maxHour={maxHour} />
+              {hoverGuideY !== null && (
+                <div styleName="hover-guide" style={{top: hoverGuideY}}>
+                  {getCalendarTimeFromY(hoverGuideY)}
+                </div>
+              )}
               <MemoizedTopLevelEntries dt={dt} entries={entries} />
               <div
                 styleName="draft"

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -163,18 +163,19 @@ export function DayTimetable({
   }
 
   function handleCalendarMouseMove(event: React.MouseEvent<HTMLDivElement>) {
-    if (isDragging || selectedEntry?.id !== undefined) {
-      setHoverGuideY(null);
+    const clientY = event.clientY + wrapperRef.current.scrollTop;
+    const offsetY = clientY - wrapperRef.current.offsetTop;
+    const isWithinLimitsWithOffset = !isWithinLimits(limits, offsetY);
+
+    if (isDragging || selectedEntry || isWithinLimitsWithOffset) {
+      if (hoverGuideY !== null) {
+        setHoverGuideY(null);
+      }
       return;
     }
 
     const y = getPositionCalendarY(event.clientY);
-
-    if (isWithinLimits(limits, y)) {
-      setHoverGuideY(y);
-    } else {
-      setHoverGuideY(null);
-    }
+    setHoverGuideY(y);
   }
 
   function getCalendarTimeFromY(y: number) {


### PR DESCRIPTION
When hovering over timetable, an indicator in the time gutter will appear to specify what exact time the user is hovering over.

This is part of the user testing session feedback. This guide will allow more precise creation of entries by dragging, as well as prevent mistakes when user gets the starting time off by 5 or 10 minutes.

Indicator disappears when a user clicks on an entry, or to create an entry, as well as when the user scrolls. 

<img width="401" height="161" alt="Screenshot 2026-07-08 at 17 08 44" src="https://github.com/user-attachments/assets/270d705d-6fd3-4160-a5d8-837b1a284e76" />
