### PR TITLE
Revert change to TT entry deletion

### DIFF
--- a/indico/modules/events/timetable/controllers/manage.py
+++ b/indico/modules/events/timetable/controllers/manage.py
@@ -32,8 +32,8 @@ from indico.modules.events.timetable.models.breaks import Break
 from indico.modules.events.timetable.models.entries import TimetableEntryType
 from indico.modules.events.timetable.operations import (create_break_entry, create_session_block_entry,
                                                         create_timetable_entry, delete_timetable_entry,
-                                                        schedule_contribution, unschedule_timetable_entry,
-                                                        update_break_entry, update_timetable_entry)
+                                                        schedule_contribution, update_break_entry,
+                                                        update_timetable_entry)
 from indico.modules.events.timetable.schemas import BreakSchema, ContributionSchema, SessionBlockSchema
 # TODO: (Ajob) Remove 'new' indications once old timetable is fully replaced
 from indico.modules.events.timetable.serializer import TimetableSerializer as TimetableSerializerNew
@@ -359,7 +359,7 @@ class RHTimetableContribution(RHManageContributionBase):
 
 class RHTimetableUnscheduleContribution(RHManageContributionBase):
     def _process_POST(self):
-        unschedule_timetable_entry(self.contrib.timetable_entry)
+        delete_timetable_entry(self.contrib.timetable_entry)
         return '', 204
 
 

--- a/indico/modules/events/timetable/operations.py
+++ b/indico/modules/events/timetable/operations.py
@@ -104,30 +104,15 @@ def update_timetable_entry(entry, data):
 
 
 def delete_timetable_entry(entry, log=True):
-    entry.object = None
-    entry.parent = None
-
-    db.session.flush()
-
-    if log:
-        logger.info('Timetable entry %s deleted by %s', entry, session.user)
-        entry.event.log(
-            EventLogRealm.management,
-            LogKind.negative,
-            'Timetable',
-            f'Contribution {entry.verbose_title} has been deleted', session.user)
-
-
-def unschedule_timetable_entry(entry, log=True):
     object_type, object_title = _get_object_info(entry)
     signals.event.timetable_entry_deleted.send(entry)
     entry.object = None
     entry.parent = None
     db.session.flush()
     if log:
-        logger.info('Timetable entry %s unscheduled by %s', entry, session.user)
+        logger.info('Timetable entry %s deleted by %s', entry, session.user)
         entry.event.log(EventLogRealm.management, LogKind.negative, 'Timetable',
-                        f"Entry for {object_type} '{object_title}' unscheduled", session.user,
+                        f"Entry for {object_type} '{object_title}' deleted", session.user,
                         data={'Time': format_datetime(entry.start_dt)})
 
 


### PR DESCRIPTION
This is a regression from #7500: There is no concept of unscheduled timetable entries on the backend, an entry is always deleted when it's removed from the timetable. The underlying object is left untouched during this operation, unless it's a break which cannot exist on its own (it is deleted via the SQLAlchemy `delete-orphan` cascade).