### PR TITLE
Replace translitcodec with unidecode

### DIFF
--- a/indico/util/string.py
+++ b/indico/util/string.py
@@ -26,7 +26,7 @@ import bleach
 import email_validator
 import html5lib
 import markdown
-import translitcodec
+from unidecode import unidecode
 from bleach.css_sanitizer import CSSSanitizer
 from flask import has_app_context
 from html2text import HTML2Text
@@ -190,7 +190,7 @@ def remove_non_alpha(text):
 
 
 def str_to_ascii(text):
-    return translitcodec.long_encode(text)[0].encode('ascii', 'ignore').decode().strip()
+    return unidecode(text).strip()
 
 
 def strict_str(value):
@@ -221,7 +221,7 @@ def slugify(*args, **kwargs):
     fallback = kwargs.get('fallback', '')
 
     value = '-'.join(str(val) for val in args)
-    value = translitcodec.long_encode(value)[0]
+    value = unidecode(value)
     value = re.sub(r'[^\w\s-]', '', value, flags=re.ASCII).strip()
 
     if lower:

--- a/requirements.in
+++ b/requirements.in
@@ -59,7 +59,7 @@ simplejson
 speaklater
 sqlalchemy<2  # major upgrade
 terminaltables
-translitcodec
+Unidecode
 ua-parser
 wallet-py3k
 weasyprint

--- a/requirements.txt
+++ b/requirements.txt
@@ -331,6 +331,8 @@ stack-data==0.6.3
     # via ipython
 terminaltables==3.1.10
     # via -r requirements.in
+Unidecode==1.3.8
+    # via -r requirements.in
 tinycss2==1.5.1
     # via
     #   bleach


### PR DESCRIPTION
Dear Indico team,

I just noted that there are some problems with translitcodec +Python 3.15^1 and trying to find solutions in Indico and translitcodec itself. 
Form what I see translitcodec was updated last time 5 years ago and probably can be safely replaced with unidecode.
Please note that this PR should be more or less considered a draft/suggestion/question.

Best regards,

Andrii

^1 E.g. the builds don't work so far in Fedora, as the tests fail.