### PR TITLE
Fix some events not showing as favourited in user profile

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,8 @@ Bugfixes
 - Use consistent sorting and hide deleted+unused single-choice options in
   registration list filters (:pr:`7439`, thanks :user:`duartegalvao`)
 - Honor room booking details restrictions in spreadsheet export (:pr:`7612`)
+- Show favorite events in the dashboard based on their end date instead of their
+  start date (:pr:`7653`, thanks :user:`SegiNyn`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/users/util.py
+++ b/indico/modules/users/util.py
@@ -157,7 +157,7 @@ def get_linked_events(user, dt=None, limit=None, load_also=(), extra_options=())
     for event_id, roles in get_events_with_paper_roles(user, dt).items():
         links.setdefault(event_id, set()).update(roles)
     for event in user.favorite_events:
-        if dt is None or event.start_dt >= dt:
+        if event.ends_after(dt):
             links.setdefault(event.id, set()).add('favorited')
 
     if not links:


### PR DESCRIPTION
This fixes favourited events appearing on the user profile as not favourited because they are being filtered out by their start date. This fixes so that events added in one of the previous loops will correctly show the favourited status.