### PR TITLE
[codevoyager] fix: set Cache-Control: private on js-vars routes

### DIFF
--- a/indico/web/assets/blueprint.py
+++ b/indico/web/assets/blueprint.py
@@ -63,7 +63,9 @@ def js_vars_global():
         data = generate_global_file()
         cache_file.write_text(data)
 
-    return send_file('global.js', cache_file, mimetype='application/javascript', conditional=True)
+    resp = send_file('global.js', cache_file, mimetype='application/javascript', conditional=True)
+    resp.cache_control.private = True
+    return resp
 
 
 @assets_blueprint.route('/js-vars/user.js')
@@ -72,7 +74,9 @@ def js_vars_user():
 
     Useful for favorites, settings etc.
     """
-    return Response(generate_user_file(), mimetype='application/javascript')
+    resp = Response(generate_user_file(), mimetype='application/javascript')
+    resp.cache_control.private = True
+    return resp
 
 
 @assets_blueprint.route('/i18n/<locale_name>.js')

--- a/indico/web/assets/blueprint_test.py
+++ b/indico/web/assets/blueprint_test.py
@@ -1,0 +1,28 @@
+# This file is part of Indico.
+# Copyright (C) 2002 - 2026 CERN
+#
+# Indico is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see the
+# LICENSE file for more details.
+
+import pytest
+
+
+@pytest.fixture
+def mock_js_vars(mocker):
+    mocker.patch('indico.web.assets.blueprint.generate_global_file',
+                 return_value='var Indico = {};')
+    mocker.patch('indico.web.assets.blueprint.generate_user_file',
+                 return_value='Indico.User = {};')
+
+
+def test_js_vars_global_cache_control(test_client, mock_js_vars):
+    resp = test_client.get('/assets/js-vars/global.js')
+    assert resp.status_code == 200
+    assert resp.cache_control.private
+
+
+def test_js_vars_user_cache_control(test_client, mock_js_vars):
+    resp = test_client.get('/assets/js-vars/user.js')
+    assert resp.status_code == 200
+    assert resp.cache_control.private


### PR DESCRIPTION
Set `Cache-Control: private` on `/assets/js-vars/global.js` and `/assets/js-vars/user.js` to prevent reverse proxies (e.g. Cloudflare, Varnish, Squid) from caching user-specific content.

**Problem:** These endpoints did not set Cache-Control headers, so reverse proxies with default caching rules would cache the JS response for unauthenticated users. This caused features like the speaker search button to appear disabled for authenticated users.

**Solution:** Added `resp.cache_control.private = True` to both route handlers. This tells browsers they may cache the response, but intermediate proxies must not.

**How to test:**
1. Run the new tests: `pytest indico/web/assets/blueprint_test.py`
2. Verify `Cache-Control: private` appears in response headers for both endpoints

Closes #6891