### PR TITLE
Fix creating label fields

### DIFF
--- a/indico/migrations/versions/20260728_1248_c412156094d6_disallow_internal_name_on_regform_labels.py
+++ b/indico/migrations/versions/20260728_1248_c412156094d6_disallow_internal_name_on_regform_labels.py
@@ -1,0 +1,34 @@
+"""Disallow internal name on regform labels
+
+Revision ID: c412156094d6
+Revises: d7e2a9c14f6b
+Create Date: 2026-07-28 12:48:27.294714
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'c412156094d6'
+down_revision = 'd7e2a9c14f6b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # There shouldn't be any text fields w/ an internal nane, but just in case...
+    op.execute('''
+        UPDATE event_registration.form_items
+        SET internal_name = NULL
+        WHERE type = 3 AND internal_name IS NOT NULL;
+    ''')
+    op.create_check_constraint(
+        'text_no_internal_name',
+        'form_items',
+        '(type != 3) OR (internal_name IS NULL)',
+        schema='event_registration'
+    )
+
+
+def downgrade():
+    op.drop_constraint('ck_form_items_text_no_internal_name', 'form_items', schema='event_registration')

--- a/indico/modules/events/registration/client/js/form/fields/registry.js
+++ b/indico/modules/events/registration/client/js/form/fields/registry.js
@@ -87,6 +87,7 @@ Available keys:
 - alwaysRequired: optional; always display the field as required
 - hasPrice: optional; show price field if the whole field can have a price attached
 - noRetentionPeriod: optional; hide the retention period setting
+- noInternalName: optional; hide the internal name advanced setting
 - renderAsFieldset: optional; whether the field should be rendered in a fieldset; applies
   to fields that use multiple controls, like radios, checkboxes, multi-button controls;
   can either be a Boolean or a function that takes field options and returns a Boolean
@@ -105,6 +106,7 @@ const fieldRegistry = {
     inputComponent: LabelInput,
     noRequired: true,
     noRetentionPeriod: true,
+    noInternalName: true,
     noLabel: true,
     icon: 'tag',
     customFormItem: true,

--- a/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
+++ b/indico/modules/events/registration/client/js/form_setup/ItemSettingsModal.jsx
@@ -215,54 +215,56 @@ export default function ItemSettingsModal({id, sectionId, defaultNewItemType, on
               </FormSpy>
             </Fieldset>
           )}
-          <Fieldset
-            legend={
-              <div
-                style={{cursor: 'pointer', userSelect: 'none'}}
-                onClick={() => setAdvancedSettingsOpen(open => !open)}
-              >
-                <Translate>Advanced settings</Translate>
-                <div className="group right">
-                  <span className={advancedSettingsOpen ? 'icon-expand' : 'icon-next'} />
+          {!meta.noInternalName && (
+            <Fieldset
+              legend={
+                <div
+                  style={{cursor: 'pointer', userSelect: 'none'}}
+                  onClick={() => setAdvancedSettingsOpen(open => !open)}
+                >
+                  <Translate>Advanced settings</Translate>
+                  <div className="group right">
+                    <span className={advancedSettingsOpen ? 'icon-expand' : 'icon-next'} />
+                  </div>
                 </div>
-              </div>
-            }
-            compact
-          >
-            <FinalInput
-              fieldProps={advancedSettingsOpen ? {} : {style: {display: 'none'}}}
-              name="internalName"
-              type="text"
-              label={Translate.string('Internal name')}
-              readOnly={itemData.fieldIsPersonalData}
-              nullIfEmpty
-              hideValidationError="never"
-              validate={val => {
-                if (val && !/^[a-z0-9-]+$/.test(val)) {
-                  return Translate.string(
-                    'Only lowercase alphanumeric characters and dashes are allowed.'
-                  );
-                }
-              }}
-              description={
-                <>
-                  <Translate>
-                    Used for identifying the same field across registration forms regardless of the
-                    title. This can also be used across events if you make sure to use the same
-                    internal name.
-                  </Translate>
-                  {itemData.fieldIsPersonalData && (
-                    <>
-                      {' '}
-                      <Translate>
-                        The internal name for a personal data field cannot be changed.
-                      </Translate>
-                    </>
-                  )}
-                </>
               }
-            />
-          </Fieldset>
+              compact
+            >
+              <FinalInput
+                fieldProps={advancedSettingsOpen ? {} : {style: {display: 'none'}}}
+                name="internalName"
+                type="text"
+                label={Translate.string('Internal name')}
+                readOnly={itemData.fieldIsPersonalData}
+                nullIfEmpty
+                hideValidationError="never"
+                validate={val => {
+                  if (val && !/^[a-z0-9-]+$/.test(val)) {
+                    return Translate.string(
+                      'Only lowercase alphanumeric characters and dashes are allowed.'
+                    );
+                  }
+                }}
+                description={
+                  <>
+                    <Translate>
+                      Used for identifying the same field across registration forms regardless of
+                      the title. This can also be used across events if you make sure to use the
+                      same internal name.
+                    </Translate>
+                    {itemData.fieldIsPersonalData && (
+                      <>
+                        {' '}
+                        <Translate>
+                          The internal name for a personal data field cannot be changed.
+                        </Translate>
+                      </>
+                    )}
+                  </>
+                }
+              />
+            </Fieldset>
+          )}
           {isUnsupportedField && (
             <Message visible warning>
               Unknown input type: {inputType}.<br />

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -115,9 +115,8 @@ class GeneralFieldDataSchema(mm.Schema):
     @no_autoflush
     def _check_internal_name(self, data, **kwargs):
         if isinstance(self, TextDataSchema):
-            input_type = 'label'
-        else:
-            input_type = data['input_type']
+            return
+        input_type = data['input_type']
         internal_name = data.get('internal_name')
         field = self.context['field']
         if field.type == RegistrationFormItemType.field_pd and internal_name != field.personal_data_type.internal_name:

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -258,7 +258,7 @@ class GeneralFieldDataSchema(mm.Schema):
 
 class TextDataSchema(GeneralFieldDataSchema):
     class Meta(GeneralFieldDataSchema.Meta):
-        exclude = ('is_required', 'retention_period', 'input_type')
+        exclude = ('is_required', 'retention_period', 'input_type', 'internal_name')
 
 
 def _fill_form_field_with_data(field, field_data, *, is_static_text=False):

--- a/indico/modules/events/registration/controllers/management/fields.py
+++ b/indico/modules/events/registration/controllers/management/fields.py
@@ -114,7 +114,10 @@ class GeneralFieldDataSchema(mm.Schema):
     @validates_schema(skip_on_field_errors=True)
     @no_autoflush
     def _check_internal_name(self, data, **kwargs):
-        input_type = data['input_type']
+        if isinstance(self, TextDataSchema):
+            input_type = 'label'
+        else:
+            input_type = data['input_type']
         internal_name = data.get('internal_name')
         field = self.context['field']
         if field.type == RegistrationFormItemType.field_pd and internal_name != field.personal_data_type.internal_name:

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -11,9 +11,11 @@ from werkzeug.exceptions import BadRequest
 
 from indico.modules.events.registration.controllers.management.fields import (GeneralFieldDataSchema,
                                                                               RHRegistrationFormToggleFieldState,
+                                                                              TextDataSchema,
                                                                               _fill_form_field_with_data)
 from indico.modules.events.registration.models.form_fields import RegistrationFormField
-from indico.modules.events.registration.models.items import PersonalDataType, RegistrationFormSection
+from indico.modules.events.registration.models.items import (PersonalDataType, RegistrationFormSection,
+                                                             RegistrationFormText)
 
 
 pytest_plugins = 'indico.modules.events.registration.testing.fixtures'
@@ -204,6 +206,33 @@ class TestGeneralFieldDataSchema:
                                             title='test', input_type='checkbox')
         schema = GeneralFieldDataSchema(context={'regform': other_form, 'field': other_field})
         schema.load({'input_type': 'checkbox', 'title': 'test', 'internal_name': 'test'})
+
+    def test_new_label_field_with_empty_internal_name(self, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        new_label_field = RegistrationFormText(parent=pd_section, registration_form=dummy_regform)
+        schema = TextDataSchema(context={'regform': dummy_regform, 'field': new_label_field})
+        assert schema.load({'input_type': 'label', 'title': 'New label field'})
+
+    def test_new_label_field_with_unique_internal_name(self, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        new_label_field = RegistrationFormText(parent=pd_section, registration_form=dummy_regform)
+        schema = TextDataSchema(context={'regform': dummy_regform, 'field': new_label_field})
+        assert schema.load({'input_type': 'label', 'title': 'New label field', 'internal_name': 'unique-internal-name'})
+
+    def test_multiple_label_fields_with_same_internal_name(self, db, dummy_regform):
+        pd_section = dummy_regform.sections[0]
+        label_field_1 = RegistrationFormText(parent=pd_section, registration_form=dummy_regform)
+        _fill_form_field_with_data(label_field_1, {'input_type': 'label', 'title': 'Label field 1',
+                                                   'internal_name': 'test-internal-name'},
+                                   is_static_text=True)
+        db.session.flush()
+        label_field_2 = RegistrationFormText(parent=pd_section, registration_form=dummy_regform)
+        schema = TextDataSchema(context={'regform': dummy_regform, 'field': label_field_2})
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({'input_type': 'label', 'title': 'Label field 2', 'internal_name': 'test-internal-name'})
+        assert exc_info.value.messages == {
+            'internal_name': ['The field "Label field 1" on this form has the same internal name.']
+        }
 
 
 class TestRegistrationFormToggleFieldState:

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -215,11 +215,13 @@ class TestTextDataSchema:
         schema = TextDataSchema(context={'regform': dummy_regform, 'field': new_label_field})
         assert schema.load({'input_type': 'label', 'title': 'New label field'})
 
-    def test_new_label_field_with_internal_name_not_saved(self, dummy_regform):
+    def test_new_label_field_with_internal_name_not_saved(self, db, dummy_regform):
         pd_section = dummy_regform.sections[0]
         new_label_field = RegistrationFormText(parent=pd_section, registration_form=dummy_regform)
-        schema = TextDataSchema(context={'regform': dummy_regform, 'field': new_label_field})
-        assert schema.load({'input_type': 'label', 'title': 'New label field', 'internal_name': 'unique-internal-name'})
+        _fill_form_field_with_data(new_label_field, {'input_type': 'label', 'title': 'New label field',
+                                                     'internal_name': 'unique-internal-name'},
+                                   is_static_text=True)
+        db.session.flush()
         assert new_label_field.internal_name is None
 
 

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -207,6 +207,9 @@ class TestGeneralFieldDataSchema:
         schema = GeneralFieldDataSchema(context={'regform': other_form, 'field': other_field})
         schema.load({'input_type': 'checkbox', 'title': 'test', 'internal_name': 'test'})
 
+
+class TestTextDataSchema:
+
     def test_new_label_field_with_empty_internal_name(self, dummy_regform):
         pd_section = dummy_regform.sections[0]
         new_label_field = RegistrationFormText(parent=pd_section, registration_form=dummy_regform)

--- a/indico/modules/events/registration/controllers/management/fields_test.py
+++ b/indico/modules/events/registration/controllers/management/fields_test.py
@@ -209,33 +209,18 @@ class TestGeneralFieldDataSchema:
 
 
 class TestTextDataSchema:
-
     def test_new_label_field_with_empty_internal_name(self, dummy_regform):
         pd_section = dummy_regform.sections[0]
         new_label_field = RegistrationFormText(parent=pd_section, registration_form=dummy_regform)
         schema = TextDataSchema(context={'regform': dummy_regform, 'field': new_label_field})
         assert schema.load({'input_type': 'label', 'title': 'New label field'})
 
-    def test_new_label_field_with_unique_internal_name(self, dummy_regform):
+    def test_new_label_field_with_internal_name_not_saved(self, dummy_regform):
         pd_section = dummy_regform.sections[0]
         new_label_field = RegistrationFormText(parent=pd_section, registration_form=dummy_regform)
         schema = TextDataSchema(context={'regform': dummy_regform, 'field': new_label_field})
         assert schema.load({'input_type': 'label', 'title': 'New label field', 'internal_name': 'unique-internal-name'})
-
-    def test_multiple_label_fields_with_same_internal_name(self, db, dummy_regform):
-        pd_section = dummy_regform.sections[0]
-        label_field_1 = RegistrationFormText(parent=pd_section, registration_form=dummy_regform)
-        _fill_form_field_with_data(label_field_1, {'input_type': 'label', 'title': 'Label field 1',
-                                                   'internal_name': 'test-internal-name'},
-                                   is_static_text=True)
-        db.session.flush()
-        label_field_2 = RegistrationFormText(parent=pd_section, registration_form=dummy_regform)
-        schema = TextDataSchema(context={'regform': dummy_regform, 'field': label_field_2})
-        with pytest.raises(ValidationError) as exc_info:
-            schema.load({'input_type': 'label', 'title': 'Label field 2', 'internal_name': 'test-internal-name'})
-        assert exc_info.value.messages == {
-            'internal_name': ['The field "Label field 1" on this form has the same internal name.']
-        }
+        assert new_label_field.internal_name is None
 
 
 class TestRegistrationFormToggleFieldState:

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -536,7 +536,6 @@ class RegistrationFormText(RegistrationFormItem):
             section_id=self.parent_id,
             is_enabled=self.is_enabled,
             input_type='label',
-            internal_name=self.internal_name,
             title=self.title,
             is_purged=self.is_purged,
             show_if_field_id=self.show_if_id,

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -536,6 +536,7 @@ class RegistrationFormText(RegistrationFormItem):
             section_id=self.parent_id,
             is_enabled=self.is_enabled,
             input_type='label',
+            internal_name=self.internal_name,
             title=self.title,
             is_purged=self.is_purged,
             show_if_field_id=self.show_if_id,

--- a/indico/modules/events/registration/models/items.py
+++ b/indico/modules/events/registration/models/items.py
@@ -203,6 +203,9 @@ class RegistrationFormItem(db.Model):
         db.CheckConstraint("internal_name != ''", name='internal_name_not_empty'),
         db.CheckConstraint('(internal_name IS NOT NULL) OR (personal_data_type IS NULL)',
                            name='pd_internal_name_required'),
+        db.CheckConstraint('(type != {t.text}) OR (internal_name IS NULL)'  # noqa: UP032
+                           .format(t=RegistrationFormItemType),
+                           name='text_no_internal_name'),
         db.Index('ix_uq_form_items_pd_section', 'registration_form_id', unique=True,
                  postgresql_where=db.text(f'type = {RegistrationFormItemType.section_pd}')),
         db.Index('ix_uq_form_items_pd_field', 'registration_form_id', 'personal_data_type', unique=True,


### PR DESCRIPTION
The Label fields have the internal_name advances settings, but data saved there was not being loaded 

And creating label fields was giving key error. I saw that the `input_type` was being dropped so another solution would be to not skip it instead of this if condition. 