### PR TITLE
Prevent `_adjust_skeleton` from replacing literals in format string

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -89,6 +89,8 @@ Bugfixes
   start date (:pr:`7653`, thanks :user:`SegiNyn`)
 - Reduce max filename length in ZIP downloads to avoid issues on Windows (:pr:`7479`,
   :user:`moliholy`)
+- Correctly format dates containing literal strings, such as "30 de junho" (:issue:`7590`,
+  :pr:`7668`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/util/date_time.py
+++ b/indico/util/date_time.py
@@ -5,7 +5,6 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
-import re
 from collections import Counter
 from datetime import datetime
 from datetime import time as dt_time
@@ -17,7 +16,7 @@ from babel.dates import format_datetime as _format_datetime
 from babel.dates import format_interval as _format_interval
 from babel.dates import format_time as _format_time
 from babel.dates import format_timedelta as _format_timedelta
-from babel.dates import get_timezone, match_skeleton
+from babel.dates import get_timezone, match_skeleton, tokenize_pattern, untokenize_pattern
 from babel.numbers import format_currency as _format_currency
 from babel.numbers import format_number as _format_number
 from dateutil.relativedelta import relativedelta as _relativedelta
@@ -171,20 +170,28 @@ def _adjust_skeleton(format, skeleton):
     See: https://cldr-smoke.unicode.org/spec/main/ldml/tr35-dates.html#Matching_Skeletons
     """
     skeleton_counter = Counter(skeleton)
-    format_counter = Counter(format)
+    tokenized_format = []
 
-    for char in skeleton_counter:
-        skeleton_count = skeleton_counter[char]
-        format_count = format_counter[char]
+    for type_, token in tokenize_pattern(format):
+        if type_ == 'chars':
+            # This is a literal string and should not be touched
+            tokenized_format.append((type_, token))
+            continue
+
+        pattern, format_count = token
+        skeleton_count = skeleton_counter[pattern]
 
         # Hours, minutes and seconds should not be expanded
-        if char in 'Hhms':
+        if pattern in 'Hhms':
+            tokenized_format.append((type_, token))
             continue
 
         if (format_count <= 2 and skeleton_count <= 2) or (format_count > 2 and skeleton_count > 2):
-            format = re.sub(fr'{re.escape(char)}+', char * skeleton_count, format)
+            tokenized_format.append((type_, (pattern, skeleton_count)))
+        else:
+            tokenized_format.append((type_, token))
 
-    return format
+    return untokenize_pattern(tokenized_format)
 
 
 def format_skeleton(dt, skeleton, locale=None, timezone=None):

--- a/indico/util/date_time_test.py
+++ b/indico/util/date_time_test.py
@@ -88,7 +88,10 @@ def test_iterdays(from_, to, skip_weekends, day_whitelist, day_blacklist, expect
     ('MMM', 'M', 'M'),  # Cannot expand numeric fields to alphabetic ones
     ('ss', 's', 's'),  # Hours, minutes and seconds should never be expanded
     ('MMdd', 'Md', 'MMdd'),  # Expand numeric fields
-    ('MMMMdddd', 'MMMddd', 'MMMMdddd')  # Expand alphabetic fields
+    ('MMMMdddd', 'MMMddd', 'MMMMdddd'),  # Expand alphabetic fields
+    ('ddMMM', "d 'de' MMM", "dd 'de 'MMM"),  # Cannot expand string literals
+    ('ddMMM', 'M月d日', 'M月dd日'),
+    ('EEEEdMMMM', "E, d 'de' MMM", "E, d 'de 'MMMM"),
 ))
 def test__adjust_skeleton_skeleton(skeleton, format, expected):
     assert _adjust_skeleton(format, skeleton) == expected


### PR DESCRIPTION
Fixes #7590

The function `_adjust_skeleton` was changing format strings such as `"MMMM 'de' y"` into `"MMMM 'dde' y"`. Now, it uses Babel's `tokenize_pattern` to split the string into patterns and string literals, and operates only on the patterns.