### PR TITLE
Ensure proper ResizeObserver cleanup

### DIFF
--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -295,7 +295,7 @@ export default function Entry({
 
     updateDroppableArea(entryRef.current.clientWidth);
 
-    return observer.disconnect;
+    return () => observer.disconnect();
   }, [id, type]);
 
   const setChildDurations = useMemo(() => {


### PR DESCRIPTION
This ensures preserving the correct observer context when cleaning up the entry resize observer.