### PR TITLE
Improve initial timetable scroll position

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -623,7 +623,7 @@ export function DayTimetable({
     };
   }, [limitTop, limitBottom]);
 
-  const limitsGradientColor = 'rgba(0, 0, 0, 0.15)';
+  const limitsGradientColor = 'rgba(0, 0, 0, 0.075)';
   const limitsGradientArg = [
     `${limitsGradientColor} 0`,
     `${limitsGradientColor} ${limits[0]}px`,

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -592,13 +592,19 @@ export function DayTimetable({
   }, [draftEntry, dt, dispatch, isDragging, minHour, limits, selectedEntry]);
 
   useEffect(() => {
-    if (wrapperRef.current) {
-      // We use a ref instead of scrollPosition directly to prevent jumping
-      // to the calculated position every single time DayTimetable renders,
-      // which mainly happens when changing days.
-      wrapperRef.current.scrollTop = scrollPositionRef.current;
+    // We use a ref instead of scrollPosition directly to prevent jumping
+    // to the calculated position every single time DayTimetable renders,
+    // which mainly happens when changing days.
+    const wrapper = wrapperRef.current;
+    if (!wrapper) {
+      return;
     }
-  }, [wrapperRef]);
+    const frame = requestAnimationFrame(() => {
+      wrapper.scrollTop = scrollPositionRef.current;
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, []);
 
   const restrictToCalendar = useMemo(() => {
     const limitsDelta: [number, number] = [
@@ -617,7 +623,7 @@ export function DayTimetable({
     };
   }, [limitTop, limitBottom]);
 
-  const limitsGradientColor = 'rgba(0, 0, 0, 0.05)';
+  const limitsGradientColor = 'rgba(0, 0, 0, 0.15)';
   const limitsGradientArg = [
     `${limitsGradientColor} 0`,
     `${limitsGradientColor} ${limits[0]}px`,

--- a/indico/modules/events/timetable/client/js/Timetable.tsx
+++ b/indico/modules/events/timetable/client/js/Timetable.tsx
@@ -32,16 +32,31 @@ export default function Timetable() {
   const maxHour = 23;
 
   const _getScrollMoment = () => {
-    const scrollMoment = !currentEntries.length
-      ? moment.max(currentDate.hours(minScrollHour), eventStartDt)
-      : moment.min(currentEntries.map(e => e.startDt));
+    let scrollMoment;
+    let shouldScrollBeforeTarget = true;
 
-    return moment(scrollMoment);
+    if (currentEntries.length) {
+      scrollMoment = moment.min(currentEntries.map(e => e.startDt));
+    } else if (currentDate.isSame(eventStartDt, 'day')) {
+      scrollMoment = eventStartDt;
+    } else {
+      scrollMoment = moment(currentDate).hours(minScrollHour).startOf('hour');
+      shouldScrollBeforeTarget = false;
+    }
+
+    return {
+      scrollMoment: moment(scrollMoment),
+      shouldScrollBeforeTarget,
+    };
   };
 
   const _getScrollOffset = () => {
-    const scrollMoment = _getScrollMoment();
-    const scrollMinutes = scrollMoment.diff(moment(scrollMoment).startOf('day'), 'minutes');
+    const {scrollMoment, shouldScrollBeforeTarget} = _getScrollMoment();
+    const scrollMinutes = Math.max(
+      0,
+      scrollMoment.diff(moment(scrollMoment).startOf('day'), 'minutes') -
+        (shouldScrollBeforeTarget ? 60 : 0)
+    );
     return minutesToPixels(scrollMinutes);
   };
 


### PR DESCRIPTION
This ensures that the initial scroll is set at the correct frame of page loading to fix its behavior on Chromium browsers. It also sets the initial scroll an hour before the event start date or the intended entry. Finally, it ensures that if the timetable is empty and the event starts before the minimum scroll hour, it will use the former rather than the latter.
