### PR TITLE
Clean up entry metadata on unschedule

### DIFF
--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -13,7 +13,13 @@ import {Action} from './actions';
 import {layout, layoutDays} from './layout';
 import {preprocessSessionData, preprocessTimetableEntries} from './preprocess';
 import {BlockEntry, Entries, EntryType, isChildEntry, SidePanelView} from './types';
-import {getDateKey, getEntryUniqueId, setCurrentDateLocalStorage, shiftEntries} from './utils';
+import {
+  getDateKey,
+  getEntryUniqueId,
+  setCurrentDateLocalStorage,
+  shiftEntries,
+  toUnscheduledContribEntry,
+} from './utils';
 
 export default {
   entries: (
@@ -306,10 +312,12 @@ export default {
               ])
             )
           );
+
+          const unscheduledEntry = toUnscheduledContribEntry(action.entry);
           return {
             ...state,
             entries: newEntries,
-            unscheduled: [...state.unscheduled, action.entry],
+            unscheduled: [...state.unscheduled, unscheduledEntry],
           };
         } else {
           const newEntries = layoutDays(

--- a/indico/modules/events/timetable/client/js/utils.ts
+++ b/indico/modules/events/timetable/client/js/utils.ts
@@ -14,7 +14,15 @@ import {useEffect, useRef} from 'react';
 import {SemanticICONS} from 'semantic-ui-react';
 
 import {DEFAULT_BREAK_COLORS, DEFAULT_CONTRIB_COLORS, ENTRY_COLORS_BY_BACKGROUND} from './colors';
-import {BlockEntry, Colors, Entry, EntryType, EntryUniqueID} from './types';
+import {
+  BlockEntry,
+  Colors,
+  ContribEntry,
+  Entry,
+  EntryType,
+  EntryUniqueID,
+  UnscheduledContribEntry,
+} from './types';
 
 export const DATE_KEY_FORMAT = 'YYYYMMDD';
 export const LOCAL_STORAGE_KEY = 'manageTimetableData';
@@ -233,3 +241,11 @@ export function computeOverlappingEntryIds(entries: Entry[]): Set<string> {
 export const flattenEntries = (entries: Entry[]): Entry[] => {
   return entries.map(e => [e, ...((e as BlockEntry)?.children ?? [])]).flat();
 };
+
+export function toUnscheduledContribEntry(
+  entry: ContribEntry & {sessionBlockId?: string}
+): UnscheduledContribEntry {
+  const {startDt, y, column, maxColumn, sessionBlockId, ...unscheduledEntry} = entry;
+
+  return unscheduledEntry;
+}


### PR DESCRIPTION
This fixes a bug were after unscheduling an entry from a block, scheduling it on top level and unscheduling again the entry persists on the timtable grid.