### PR TITLE
Add line to time indicator

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.module.scss
+++ b/indico/modules/events/timetable/client/js/DayTimetable.module.scss
@@ -113,20 +113,31 @@ $toolbar-bg-color: $raincloud-gray;
 }
 
 .hover-guide {
-  font-weight: bold;
   position: absolute;
+  left: 0;
+  right: 0;
+  height: 0;
+  border-top: 1px dashed $teal;
+  pointer-events: none;
+  z-index: 1;
+  transition: top 0.05s;
+}
+
+.hover-guide-label {
+  position: absolute;
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  width: max-content;
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
-  pointer-events: none;
-  z-index: 1;
-  background: $teal;
-  padding: 4px 6px;
   min-width: 60px;
+  padding: 4px 6px;
+  background: $teal;
+  color: #fff;
   font-size: 0.9rem;
+  font-weight: bold;
   line-height: 0.9rem;
   border-radius: 7px 0 0 7px;
-  transition: 0.05s;
-  transform: translate(-100%, -50%);
 }

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -659,7 +659,7 @@ export function DayTimetable({
               <Lines minHour={minHour} maxHour={maxHour} />
               {hoverGuideY !== null && (
                 <div styleName="hover-guide" style={{top: hoverGuideY}}>
-                  {getCalendarTimeFromY(hoverGuideY)}
+                  <span styleName="hover-guide-label">{getCalendarTimeFromY(hoverGuideY)}</span>
                 </div>
               )}
               <MemoizedTopLevelEntries dt={dt} entries={entries} />


### PR DESCRIPTION
Adds a dashed line to time indicator on the timetable to allow better accuracy and visibility when dragging existing entries, or dragging to create.