### PR TITLE
Disable text selection of session titles in side panel

### DIFF
--- a/indico/modules/events/timetable/client/js/TimetableSidePanel.module.scss
+++ b/indico/modules/events/timetable/client/js/TimetableSidePanel.module.scss
@@ -342,9 +342,6 @@ $content-pane-bg-color: $white;
   overflow: hidden;
   word-break: break-word;
   padding: 0.5rem;
-  -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
 }
 

--- a/indico/modules/events/timetable/client/js/TimetableSidePanel.module.scss
+++ b/indico/modules/events/timetable/client/js/TimetableSidePanel.module.scss
@@ -342,6 +342,10 @@ $content-pane-bg-color: $white;
   overflow: hidden;
   word-break: break-word;
   padding: 0.5rem;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }
 
 .session-actions {


### PR DESCRIPTION
Disable text selection of session titles in side panel, tested and compatible on all browsers.