### PR TITLE
Fix domReady promise never resolving

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,6 +101,8 @@ Bugfixes
   :pr:`7668`)
 - Avoid serving incomplete webpack manifests during concurrent requests (:issue:`7530`,
   :pr:`7675`, thanks :user:`shuv-amp`)
+- Fix dropdown menus, tooltips and skip links being inert when their bundle is
+  evaluated after the document finished parsing (:issue:`7684`, :pr:`7685`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/web/client/js/utils/domstate.js
+++ b/indico/web/client/js/utils/domstate.js
@@ -6,10 +6,15 @@
 // LICENSE file for more details.
 
 export const domReady = new Promise(resolve => {
-  if (document.readyState === 'completed') {
+  // Note that this module may be evaluated after DOMContentLoaded has already
+  // fired (e.g. when it arrives in an async chunk), in which case adding a
+  // listener would leave the promise pending forever. Anything other than
+  // 'loading' means the document has been parsed already, so we resolve
+  // immediately in that case.
+  if (document.readyState !== 'loading') {
     resolve();
   } else {
-    window.addEventListener('DOMContentLoaded', resolve);
+    document.addEventListener('DOMContentLoaded', resolve, {once: true});
   }
 });
 


### PR DESCRIPTION
Closes #7684.

`indico/web/client/js/utils/domstate.js` checks `document.readyState === 'completed'`, but `'completed'` is not a valid `readyState` value — the only values are `loading`, `interactive` and `complete`. The "document is already parsed, resolve now" branch is therefore dead code, and `domReady` always falls through to waiting for `DOMContentLoaded`.

That is fine as long as the module is evaluated before the document finishes parsing. When it is evaluated afterwards (e.g. because it arrives via an async chunk), the event has already fired and will never fire again, so the promise stays pending forever — silently, with no console error.

Everything gated on `domReady` is then dead. Most visibly, every custom element registered through `CustomElementBase.defineWhenDomReady()` is never defined:

- `ind-menu` — all dropdown menus are inert, including the "Create event" button in the top nav and the category toolbar
- `ind-with-tooltip` — tooltips
- `ind-bypass-block` — accessibility skip links

(`ind-select`, `ind-combo-box` and `ind-date-picker` are unaffected because they call `customElements.define()` eagerly.)

On an affected page:

```js
document.readyState             // "complete"
customElements.get('ind-menu')  // undefined
// window.domReady never settles
```

## Fix

Check for `readyState !== 'loading'` instead, which resolves the promise immediately whenever the document has already been parsed, regardless of when the module runs.

The listener is also moved from `window` to `document`. `DOMContentLoaded` is dispatched on `document` and only reaches `window` by bubbling; `document` is what the rest of the codebase already listens on. `{once: true}` is added so the listener does not outlive the promise.

## Testing

Verified on a live affected instance by dispatching the missing event by hand (`window.dispatchEvent(new Event('DOMContentLoaded'))`): `ind-menu` and `ind-with-tooltip` registered immediately, the "Create event" dropdown opened, and picking "Lecture" loaded the creation dialog correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)