### PR TITLE
Add accessible names to person-link field icon controls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,6 +120,11 @@ Accessibility
 - Screen reader users can now access the full date range and timezone for events
   in the dashboard lists, which was previously shown only as a mouse-hover
   tooltip (:pr:`7608`, thanks :user:`foxbunny`)
+- The icon-only controls in the person fields used to manage event chairpersons,
+  speakers and authors (the role toggles, the sort toggle and the edit/delete
+  buttons) now have accessible names and tooltips instead of relying on the
+  ``title`` attribute, and the sort toggle is a proper checkbox (:pr:`7686`,
+  thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/js/react/components/PersonLinkField.jsx
+++ b/indico/web/client/js/react/components/PersonLinkField.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import React, {useMemo, useState} from 'react';
 import {DndProvider} from 'react-dnd';
 import {HTML5Backend} from 'react-dnd-html5-backend';
-import {Button, Icon, Label, List, Popup, Ref, Segment} from 'semantic-ui-react';
+import {Button, Icon, Label, List, Ref, Segment} from 'semantic-ui-react';
 
 import {UserSearch} from 'indico/react/components/principals/Search';
 import {PrincipalType} from 'indico/react/components/principals/util';
@@ -48,46 +48,53 @@ const PersonListItem = ({
     />
     <div styleName="roles">
       {roles &&
-        roles.map(({name, label, icon, active}, idx) => (
-          <Popup
-            key={name}
-            trigger={
-              <Label
-                as="a"
-                size="small"
-                color={active ? 'blue' : undefined}
-                onClick={() => onClickRole && onClickRole(idx, roles)}
-              >
-                {icon ? <Icon styleName="label-icon" name={icon} /> : label}
-              </Label>
-            }
-            disabled={!icon}
-            content={label}
-            size="tiny"
-          />
-        ))}
+        roles.map(({name, label, icon, active}, idx) => {
+          const roleLabel = (
+            <Label
+              as="a"
+              size="small"
+              color={active ? 'blue' : undefined}
+              onClick={() => onClickRole && onClickRole(idx, roles)}
+            >
+              {icon ? (
+                <>
+                  <Icon styleName="label-icon" name={icon} />
+                  <span data-tip-content>{label}</span>
+                </>
+              ) : (
+                label
+              )}
+            </Label>
+          );
+          return icon ? (
+            <ind-with-tooltip key={name}>{roleLabel}</ind-with-tooltip>
+          ) : (
+            <React.Fragment key={name}>{roleLabel}</React.Fragment>
+          );
+        })}
     </div>
     <div styleName="actions">
       {renderPluginComponents('personListItemActions', {person, onEdit, disabled, extraParams})}
       {canEdit && (
-        <Icon
-          styleName="button edit"
-          name="pencil alternate"
-          title={Translate.string('Edit person')}
-          size="large"
-          onClick={() => onEdit('details')}
-          disabled={disabled}
-        />
+        <ind-with-tooltip>
+          <button
+            type="button"
+            styleName="action-button"
+            onClick={() => onEdit('details')}
+            disabled={disabled}
+          >
+            <Icon styleName="button edit" name="pencil alternate" size="large" />
+            <span data-tip-content>{Translate.string('Edit person')}</span>
+          </button>
+        </ind-with-tooltip>
       )}
       {canDelete && (
-        <Icon
-          styleName="button delete"
-          name="remove"
-          title={Translate.string('Delete person')}
-          size="large"
-          onClick={onDelete}
-          disabled={disabled}
-        />
+        <ind-with-tooltip>
+          <button type="button" styleName="action-button" onClick={onDelete} disabled={disabled}>
+            <Icon styleName="button delete" name="remove" size="large" />
+            <span data-tip-content>{Translate.string('Delete person')}</span>
+          </button>
+        </ind-with-tooltip>
       )}
     </div>
   </PrincipalItem>
@@ -373,13 +380,18 @@ function PersonLinkField({
           {persons.length === 0 && (emptyMessage || <Translate>There are no persons</Translate>)}
         </Segment>
         <Button.Group size="small" attached="bottom">
-          <Button
-            toggle
-            icon="sort alphabet down"
-            type="button"
-            active={autoSort}
-            onClick={() => setAutoSort && setAutoSort(!autoSort)}
-          />
+          <ind-with-tooltip>
+            <label styleName="sort-toggle">
+              <input
+                type="checkbox"
+                styleName="sort-checkbox"
+                checked={autoSort}
+                onChange={() => setAutoSort && setAutoSort(!autoSort)}
+              />
+              <Icon name="sort alphabet down" />
+              <span data-tip-content>{Translate.string('Sort alphabetically')}</span>
+            </label>
+          </ind-with-tooltip>
           {sessionUser && (
             <Button
               type="button"

--- a/indico/web/client/js/react/components/PersonLinkField.module.scss
+++ b/indico/web/client/js/react/components/PersonLinkField.module.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base/palette' as *;
+@use 'design_system';
 
 .person-link-field {
   color: rgba(0, 0, 0, 0.87);
@@ -54,6 +55,65 @@
   }
 }
 
+.action-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+
+  &:disabled {
+    cursor: default;
+  }
+}
+
+.sort-checkbox {
+  @extend %visually-hidden;
+}
+
+.sort-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 0.85714286rem;
+  padding: 0.78571429em;
+  line-height: 1;
+  color: rgba(0, 0, 0, 0.6);
+  background: #e0e1e2;
+  border-radius: 0.28571429rem 0 0 0.28571429rem;
+  transition: background-color 0.1s ease, color 0.1s ease;
+
+  &:hover {
+    color: rgba(0, 0, 0, 0.8);
+    background: #cacbcd;
+  }
+
+  &:has(.sort-checkbox:checked) {
+    color: #fff;
+    background: #21ba45;
+
+    &:hover {
+      background: #16ab39;
+    }
+  }
+
+  &:has(.sort-checkbox:focus-visible) {
+    box-shadow: 0 0 0 2px rgb(0 0 0 / 40%);
+  }
+
+  :global(i.icon) {
+    margin: 0;
+  }
+}
+
+ind-with-tooltip:has(.sort-toggle) + :global(.ui.button) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
 .titled-rule {
   display: flex;
   align-items: center;
@@ -85,11 +145,13 @@
   margin: 0;
 }
 
+.roles ind-with-tooltip:not(:first-child) :global(.ui.label),
 .roles :global(.ui.label):not(:first-child) {
   border-bottom-left-radius: 0 !important;
   border-top-left-radius: 0 !important;
 }
 
+.roles ind-with-tooltip:not(:last-child) :global(.ui.label),
 .roles :global(.ui.label):not(:last-child) {
   border-bottom-right-radius: 0 !important;
   border-top-right-radius: 0 !important;


### PR DESCRIPTION
The icon-only controls in the person fields used to manage event chairpersons,
speakers and authors had no reliable accessible name — the role toggles and the
auto-sort toggle exposed nothing, and the edit/delete row actions relied on the
`title` attribute.

Each interactive control is now wrapped in `<ind-with-tooltip>` with a
`data-tip-content` span, which serves as both the styled tooltip and the
accessible name. The auto-sort toggle is now a real checkbox with an exposed
on/off state, and the edit/delete actions are real, keyboard-operable buttons.

Screen reader users can now identify each of these controls, and the tooltips
are available on keyboard focus as well as hover.
