### PR TITLE
Add accessible names and tooltips to event header toolbar icons

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -149,6 +149,10 @@ Accessibility
   show a tooltip on hover and keyboard focus and have a reliable accessible name,
   instead of relying on the ``title`` attribute (:pr:`7718`, thanks
   :user:`foxbunny`)
+- Icon-only controls in the event header toolbar (home, event navigation, export,
+  download, theme, favourite and management) now have reliable accessible names
+  and tooltips that also appear on keyboard focus, instead of relying on the
+  ``title`` attribute (:issue:`7623`, :pr:`7689`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/client/js/header.jsx
+++ b/indico/modules/events/client/js/header.jsx
@@ -54,12 +54,21 @@ document.addEventListener('DOMContentLoaded', () => {
       endpoint="events.export_event_ical"
       params={{event_id: eventId}}
       renderButton={classes => (
-        <IButton
-          icon="calendar"
-          dropdown
-          classes={{'height-full': true, 'text-color': true, subtle: true, ...classes}}
-          title={Translate.string('Export')}
-        />
+        <ind-with-tooltip>
+          <IButton
+            icon="calendar"
+            dropdown
+            classes={{
+              'height-full': true,
+              'text-color': true,
+              subtle: true,
+              'icon-only': true,
+              ...classes,
+            }}
+          >
+            <span data-tip-content>{Translate.string('Export')}</span>
+          </IButton>
+        </ind-with-tooltip>
       )}
       dropdownPosition="top left"
       popupPosition="bottom right"

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -132,7 +132,7 @@
                     data-reload-after></button>
         {%- endif %}
         {{ template_hook('url-shortener', target=url_for('contributions.display_contribution', contribution),
-                         classes='i-button icon-link') }}
+                         classes='i-button icon-link icon-only') }}
         {% if indico_config.LATEX_ENABLED or contribution.timetable_entry %}
             <div class="group">
                 {% if indico_config.LATEX_ENABLED %}

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -83,17 +83,15 @@
 
 
 {%- macro _render_filters() -%}
-    {%- set filter_link_tooltip -%}
-        {%- if filters_active -%}
-            {%- trans %}Filtering is enabled{% endtrans -%}
-        {%- else -%}
-            {%- trans %}Add a filter{% endtrans -%}
-        {%- endif -%}
-    {%- endset -%}
-
     <ind-with-tooltip>
         <button class="i-button text-color subtle icon-only icon-filter filter-link {{ 'active' if filters_active }}">
-            <span data-tip-content>{{ filter_link_tooltip }}</span>
+            <span data-tip-content>
+                {%- if filters_active -%}
+                    {%- trans %}Filtering is enabled{% endtrans -%}
+                {%- else -%}
+                    {%- trans %}Add a filter{% endtrans -%}
+                {%- endif -%}
+            </span>
         </button>
     </ind-with-tooltip>
 

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -259,7 +259,7 @@
                 <span class="separator"></span>
             {% endif %}
 
-            {{ template_hook('url-shortener', event=event, classes='i-button text-color subtle icon-link') }}
+            {{ template_hook('url-shortener', event=event, classes='i-button text-color subtle icon-only icon-link') }}
 
             {% block management_button %}
                 {% if show_management_button %}

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -54,11 +54,13 @@
 
 
 {%- macro _render_theme_selector() -%}
-    <ind-with-tooltip>
-        <button class="i-button text-color subtle icon-only icon-layout arrow js-dropdown" data-toggle="dropdown">
-            <span data-tip-content>{% trans %}Change theme{% endtrans %}</span>
-        </button>
-        <ul class="i-dropdown">
+    <ind-menu>
+        <ind-with-tooltip>
+            <button class="i-button text-color subtle icon-only icon-layout">
+                <span data-tip-content>{% trans %}Change theme{% endtrans %}</span>
+            </button>
+        </ind-with-tooltip>
+        <menu>
             {% set endpoint = 'timetable.timetable' if event.type == 'conference' else 'events.display' %}
             {% for group in themes.items()|sort(attribute='1.name')|groupby('1.user_visible')|reverse
                if group.grouper or event.can_manage(session.user) %}
@@ -68,15 +70,15 @@
                 {% for id, data in group.list %}
                     <li>
                         {% if id == theme %}
-                            <a class="disabled"><strong>{{ data.name }}</strong></a>
+                            <a aria-current="true"><strong>{{ data.name }}</strong></a>
                         {% else %}
                             <a href="{{ url_for(endpoint, event, view=id) }}">{{ data.name }}</a>
                         {% endif %}
                     </li>
                 {% endfor %}
             {% endfor %}
-        </ul>
-    </ind-with-tooltip>
+        </menu>
+    </ind-menu>
 {%- endmacro -%}
 
 

--- a/indico/modules/events/templates/header.html
+++ b/indico/modules/events/templates/header.html
@@ -1,37 +1,50 @@
 {% from 'announcement/display.html' import render_announcements %}
 {% from 'core/impersonation.html' import render_impersonation %}
 
+{%- macro _toolbar_link(icon, href) -%}
+    <ind-with-tooltip>
+        <a class="i-button text-color subtle icon-only icon-{{ icon }}" href="{{ href }}">
+            <span data-tip-content>{{ caller() }}</span>
+        </a>
+    </ind-with-tooltip>
+{%- endmacro -%}
+
+
 {%- macro _render_nav_bar() -%}
     {% set rel = event.get_relative_event_ids() %}
 
-    <a class="i-button text-color subtle icon-home" href="{{ url_for_index() }}"
-       title="{% trans %}Go to the Indico Home Page{% endtrans %}"></a>
+    {% call _toolbar_link('home', url_for_index()) %}{% trans %}Go to the Indico Home Page{% endtrans %}{% endcall %}
 
     <span class="separator"></span>
 
     {% if rel.first is not none %}
-        <a class="i-button text-color subtle icon-first" href="{{ url_for('events.display', event_id=rel.first) }}"
-           title="{% trans %}Oldest event{% endtrans %}"></a>
+        {% call _toolbar_link('first', url_for('events.display', event_id=rel.first)) %}
+            {%- trans %}Oldest event{% endtrans -%}
+        {% endcall %}
     {% endif %}
 
     {% if rel.prev is not none %}
-        <a class="i-button text-color subtle icon-prev" href="{{ url_for('events.display', event_id=rel.prev) }}"
-           title="{% trans %}Older event{% endtrans %}"></a>
+        {% call _toolbar_link('prev', url_for('events.display', event_id=rel.prev)) %}
+            {%- trans %}Older event{% endtrans -%}
+        {% endcall %}
     {% endif %}
 
     {% if event.category %}
-        <a class="i-button text-color subtle icon-collapse" href="{{ event.category.url }}"
-           title="{% trans %}Up to category{% endtrans %}"></a>
+        {% call _toolbar_link('collapse', event.category.url) %}
+            {%- trans %}Up to category{% endtrans -%}
+        {% endcall %}
     {% endif %}
 
     {% if rel.next is not none %}
-        <a class="i-button text-color subtle icon-next" href="{{ url_for('events.display', event_id=rel.next) }}"
-           title="{% trans %}Newer event{% endtrans %}"></a>
+        {% call _toolbar_link('next', url_for('events.display', event_id=rel.next)) %}
+            {%- trans %}Newer event{% endtrans -%}
+        {% endcall %}
     {% endif %}
 
     {% if rel.last is not none %}
-        <a class="i-button text-color subtle icon-last" href="{{ url_for('events.display', event_id=rel.last) }}"
-           title="{% trans %}Newest event{% endtrans %}"></a>
+        {% call _toolbar_link('last', url_for('events.display', event_id=rel.last)) %}
+            {%- trans %}Newest event{% endtrans -%}
+        {% endcall %}
     {% endif %}
 
     {% if event.category or rel.first or rel.prev or rel.next or rel.last %}
@@ -41,26 +54,29 @@
 
 
 {%- macro _render_theme_selector() -%}
-    <button class="i-button text-color subtle icon-layout arrow js-dropdown" data-toggle="dropdown"
-       title="{% trans %}Change theme{% endtrans %}"></button>
-    <ul class="i-dropdown">
-        {% set endpoint = 'timetable.timetable' if event.type == 'conference' else 'events.display' %}
-        {% for group in themes.items()|sort(attribute='1.name')|groupby('1.user_visible')|reverse
-           if group.grouper or event.can_manage(session.user) %}
-            {% if not group.grouper %}
-                <li class="themes-separator"></li>
-            {% endif %}
-            {% for id, data in group.list %}
-                <li>
-                    {% if id == theme %}
-                        <a class="disabled"><strong>{{ data.name }}</strong></a>
-                    {% else %}
-                        <a href="{{ url_for(endpoint, event, view=id) }}">{{ data.name }}</a>
-                    {% endif %}
-                </li>
+    <ind-with-tooltip>
+        <button class="i-button text-color subtle icon-only icon-layout arrow js-dropdown" data-toggle="dropdown">
+            <span data-tip-content>{% trans %}Change theme{% endtrans %}</span>
+        </button>
+        <ul class="i-dropdown">
+            {% set endpoint = 'timetable.timetable' if event.type == 'conference' else 'events.display' %}
+            {% for group in themes.items()|sort(attribute='1.name')|groupby('1.user_visible')|reverse
+               if group.grouper or event.can_manage(session.user) %}
+                {% if not group.grouper %}
+                    <li class="themes-separator"></li>
+                {% endif %}
+                {% for id, data in group.list %}
+                    <li>
+                        {% if id == theme %}
+                            <a class="disabled"><strong>{{ data.name }}</strong></a>
+                        {% else %}
+                            <a href="{{ url_for(endpoint, event, view=id) }}">{{ data.name }}</a>
+                        {% endif %}
+                    </li>
+                {% endfor %}
             {% endfor %}
-        {% endfor %}
-    </ul>
+        </ul>
+    </ind-with-tooltip>
 {%- endmacro -%}
 
 
@@ -73,8 +89,11 @@
         {%- endif -%}
     {%- endset -%}
 
-    <button class="i-button text-color subtle icon-filter filter-link {{ 'active' if filters_active }}"
-       title="{{ filter_link_tooltip|forceescape }}"></button>
+    <ind-with-tooltip>
+        <button class="i-button text-color subtle icon-only icon-filter filter-link {{ 'active' if filters_active }}">
+            <span data-tip-content>{{ filter_link_tooltip }}</span>
+        </button>
+    </ind-with-tooltip>
 
     <div id="event-filters" class="event-filters">
         <form id="filterForm" style="margin: 0;">
@@ -197,8 +216,9 @@
 
             {% if event.can_access(session.user) %}
                 {% if print_url %}
-                    <a class="i-button text-color subtle icon-printer" href="{{ print_url }}"
-                       title="{% trans %}Printable version{% endtrans %}"></a>
+                    {% call _toolbar_link('printer', print_url) %}
+                        {%- trans %}Printable version{% endtrans -%}
+                    {% endcall %}
                 {% endif %}
 
                 {% if show_filter_button %}
@@ -211,14 +231,19 @@
                      {% if event.series %}data-event-in-series{% endif %}></div>
 
                 {% if event.type == 'meeting' %}
-                    <button class="i-button text-color subtle icon-file-pdf" title="{% trans %}Export to PDF{% endtrans %}"
-                       data-href="{{ url_for('timetable.export_pdf', event) }}"
-                       data-ajax-dialog></button>
+                    <ind-with-tooltip>
+                        <button class="i-button text-color subtle icon-only icon-file-pdf"
+                           data-href="{{ url_for('timetable.export_pdf', event) }}"
+                           data-ajax-dialog>
+                            <span data-tip-content>{% trans %}Export to PDF{% endtrans %}</span>
+                        </button>
+                    </ind-with-tooltip>
                 {% endif %}
 
                 {% if event.can_generate_attachment_package(session.user) %}
-                    <a class="i-button text-color subtle icon-package-download" href="{{ url_for('attachments.package', event) }}"
-                       title="{% trans %}Download material{% endtrans %}"></a>
+                    {% call _toolbar_link('package-download', url_for('attachments.package', event)) %}
+                        {%- trans %}Download material{% endtrans -%}
+                    {% endcall %}
                 {% endif %}
 
                 {{ _render_theme_selector() }}
@@ -236,9 +261,12 @@
 
             {% block management_button %}
                 {% if show_management_button %}
-                    <a class="i-button text-color subtle icon-edit"
-                       href="{% block management_button_url %}{{ url_for('event_management.settings', event) }}{% endblock %}"
-                       title="{% trans %}Switch to the management area of this event{% endtrans %}"></a>
+                    <ind-with-tooltip>
+                        <a class="i-button text-color subtle icon-only icon-edit"
+                           href="{% block management_button_url %}{{ url_for('event_management.settings', event) }}{% endblock %}">
+                            <span data-tip-content>{% trans %}Switch to the management area of this event{% endtrans %}</span>
+                        </a>
+                    </ind-with-tooltip>
                 {% endif %}
             {% endblock %}
 

--- a/indico/web/client/js/custom_elements/ind_menu.js
+++ b/indico/web/client/js/custom_elements/ind_menu.js
@@ -19,10 +19,8 @@ CustomElementBase.defineWhenDomReady(
       const trigger = this.querySelector('button');
       const list = this.querySelector('menu');
 
-      console.assert(
-        trigger.nextElementSibling === list,
-        'The <menu> element must come after <button>'
-      );
+      console.assert(trigger, 'Must contain a <button> element');
+      console.assert(list, 'Must contain a <menu> element');
 
       trigger.setAttribute('aria-expanded', false);
 

--- a/indico/web/client/js/custom_elements/ind_menu.scss
+++ b/indico/web/client/js/custom_elements/ind_menu.scss
@@ -35,17 +35,19 @@ ind-menu {
     pointer-events: none;
   }
 
-  > button::after {
+  > button::after,
+  > ind-with-tooltip > button::after {
     @extend %icon;
     @extend %icon-arrow-down;
     display: block; // XXX: Required for transform to work
   }
 
-  > button[aria-expanded='true']::after {
+  > button[aria-expanded='true']::after,
+  > ind-with-tooltip > button[aria-expanded='true']::after {
     transform: rotateX(-180deg);
   }
 
-  &[open] > button[aria-expanded='true'] + menu {
+  &[open] > menu {
     animation: menu-slide-down var(--time-menu-animation);
   }
 }

--- a/indico/web/client/js/custom_elements/ind_menu.scss
+++ b/indico/web/client/js/custom_elements/ind_menu.scss
@@ -22,7 +22,7 @@ ind-menu {
     z-index: 1;
   }
 
-  > menu :is(li, a) {
+  > menu :is(li, a, button) {
     width: 100%;
   }
 

--- a/indico/web/client/js/custom_elements/ind_with_tooltip.js
+++ b/indico/web/client/js/custom_elements/ind_with_tooltip.js
@@ -41,7 +41,6 @@ CustomElementBase.defineWhenDomReady(
       });
 
       this.addEventListener('focusin', () => {
-        this.removeEventListener('pointerleave', this.hide);
         this.show();
         this.addEventListener('focusout', this.hide);
       });

--- a/indico/web/client/js/custom_elements/tips.scss
+++ b/indico/web/client/js/custom_elements/tips.scss
@@ -32,7 +32,7 @@ ind-with-toggletip {
     @extend %popup-positioned-target;
     // The following are set by JavaScript in positioning.js
     display: block;
-    z-index: 1;
+    z-index: 10;
 
     width: max-content;
     max-width: min(calc(100dvw - 1em), 40ch);

--- a/indico/web/client/js/react/components/Favorite.jsx
+++ b/indico/web/client/js/react/components/Favorite.jsx
@@ -51,21 +51,33 @@ export default function Favorite({type, id, favorited, setFavText, deleteFavText
   };
 
   return fav ? (
-    <IButton
-      icon="star"
-      classes={type === 'event' ? {'height-full': true, 'text-color': true, subtle: true} : {}}
-      style={type === 'event' ? {color: Palette.indicoBlue} : {}}
-      highlight
-      title={deleteFavText}
-      onClick={() => deleteFavorite(id)}
-    />
+    <ind-with-tooltip>
+      <IButton
+        icon="star"
+        classes={{
+          'icon-only': true,
+          ...(type === 'event' ? {'height-full': true, 'text-color': true, subtle: true} : {}),
+        }}
+        style={type === 'event' ? {color: Palette.indicoBlue} : {}}
+        highlight
+        onClick={() => deleteFavorite(id)}
+      >
+        <span data-tip-content>{deleteFavText}</span>
+      </IButton>
+    </ind-with-tooltip>
   ) : (
-    <IButton
-      icon="star-empty"
-      classes={type === 'event' ? {'height-full': true, 'text-color': true, subtle: true} : {}}
-      title={setFavText}
-      onClick={() => putFavorite(id)}
-    />
+    <ind-with-tooltip>
+      <IButton
+        icon="star-empty"
+        classes={{
+          'icon-only': true,
+          ...(type === 'event' ? {'height-full': true, 'text-color': true, subtle: true} : {}),
+        }}
+        onClick={() => putFavorite(id)}
+      >
+        <span data-tip-content>{setFavText}</span>
+      </IButton>
+    </ind-with-tooltip>
   );
 }
 

--- a/indico/web/client/js/utils/positioning.js
+++ b/indico/web/client/js/utils/positioning.js
@@ -142,10 +142,22 @@ const verticalCenter = {
   },
 };
 
+// Keep a centered target this many pixels clear of the visible edges when
+// clamping, so it never sits flush against the viewport (matches the ~0.5rem
+// breathing room the tip's max-width already reserves).
+const viewportGutter = 8;
+
 const horizontalCenter = {
   calculateAlignment() {},
   setAlignment() {
-    this.setLeft(this.anchorLeft + (this.anchorWidth - this.targetWidth) / 2);
+    // Center over the anchor, but clamp to the visible viewport so a wide tip
+    // on an anchor near the left/right edge (e.g. the leftmost toolbar button)
+    // is shifted inward instead of being clipped. The arrow stays on the anchor
+    // because it is positioned against the wrapper, not the tip.
+    const centered = this.anchorLeft + (this.anchorWidth - this.targetWidth) / 2;
+    const min = this.visibleLeft + viewportGutter;
+    const max = this.visibleRight - this.targetWidth - viewportGutter;
+    this.setLeft(Math.max(min, Math.min(centered, max)));
   },
 };
 

--- a/indico/web/client/js/utils/positioning.test.js
+++ b/indico/web/client/js/utils/positioning.test.js
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import {dropdownPositionStrategy, position} from './positioning';
+import {dropdownPositionStrategy, position, verticalTooltipPositionStrategy} from './positioning';
 
 function mockRect(el, {top, left, width, height}) {
   el.getBoundingClientRect = () => ({
@@ -490,6 +490,67 @@ describe('positioning', () => {
 
       // anchorBottom = 130 (no offset added)
       expect(parsePx(target.style.getPropertyValue('--target-top'))).toBe(130);
+    });
+  });
+
+  describe('verticalTooltipPositionStrategy — horizontal clamping', () => {
+    it('centers the tip over the anchor when it fits', () => {
+      mockRect(anchor, {top: 100, left: 500, width: 36, height: 50});
+      mockRect(target, {top: 0, left: 0, width: 200, height: 30});
+
+      abort = position(target, anchor, verticalTooltipPositionStrategy, undefined, makeViewport());
+
+      // 500 + (36 - 200) / 2 = 418, within the viewport so unchanged
+      expect(parsePx(target.style.getPropertyValue('--target-left'))).toBe(418);
+    });
+
+    it('clamps a wide tip inward when the anchor is near the left edge', () => {
+      mockRect(anchor, {top: 100, left: 0, width: 36, height: 50});
+      mockRect(target, {top: 0, left: 0, width: 200, height: 30});
+
+      abort = position(target, anchor, verticalTooltipPositionStrategy, undefined, makeViewport());
+
+      // centered would be (36 - 200) / 2 = -82 (clipped); clamped to the 8px gutter
+      expect(parsePx(target.style.getPropertyValue('--target-left'))).toBe(8);
+    });
+
+    it('clamps a wide tip inward when the anchor is near the right edge', () => {
+      mockRect(anchor, {top: 100, left: 1000, width: 36, height: 50});
+      mockRect(target, {top: 0, left: 0, width: 200, height: 30});
+
+      abort = position(
+        target,
+        anchor,
+        verticalTooltipPositionStrategy,
+        undefined,
+        makeViewport({width: 1024})
+      );
+
+      // centered would be 918 (right edge at 1118, past 1024); clamped to
+      // 1024 - 200 - 8 = 816
+      expect(parsePx(target.style.getPropertyValue('--target-left'))).toBe(816);
+    });
+
+    it('clamps against the visible viewport, not the layout viewport', () => {
+      // Anchor near the left edge of a narrow visible viewport that is offset
+      // inside a wider layout viewport (pinch-zoomed / panned).
+      mockRect(anchor, {top: 100, left: 300, width: 36, height: 50});
+      mockRect(target, {top: 0, left: 0, width: 200, height: 30});
+
+      abort = position(
+        target,
+        anchor,
+        verticalTooltipPositionStrategy,
+        undefined,
+        makeViewport({
+          width: 1024,
+          visualViewport: makeVisualViewport({offsetLeft: 290, width: 375, height: 600}),
+        })
+      );
+
+      // centered would be 300 + (36 - 200) / 2 = 218, left of the visible area
+      // (offsetLeft 290); clamped to visibleLeft + gutter = 290 + 8 = 298
+      expect(parsePx(target.style.getPropertyValue('--target-left'))).toBe(298);
     });
   });
 });

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -94,8 +94,25 @@
       border-right: 1px dotted $light-black;
     }
 
+    ind-menu {
+      // Dark menu to fit the dark header bar — the same inverse override the
+      // global menu on the main page uses.
+      --menu-background-color: var(--surface-inverse-color);
+      --menu-text-color: var(--text-inverse-color);
+      --menu-text-hover-color: var(--text-inverse-color);
+      --menu-background-hover-color: var(--surface-highlight-inverse-color);
+      --menu-border: none;
+      --menu-shadow: none;
+    }
+
     ind-menu > menu {
       @extend %menu;
+
+      // With many themes (e.g. the themes_cern plugin) the menu can grow taller
+      // than the viewport; cap it and scroll internally so every theme stays
+      // reachable. --target-top is the menu's viewport offset set by positioning.
+      max-height: calc(100dvh - var(--target-top, 0px) - 1em);
+      overflow-y: auto;
     }
 
     .filter-link {

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -6,6 +6,7 @@
 // LICENSE file for more details.
 
 @use 'base' as *;
+@use 'design_system';
 @use 'partials/buttons' as *;
 @use 'partials/boxes' as *;
 
@@ -76,14 +77,6 @@
       align-self: stretch;
       align-items: stretch;
       height: 100%;
-
-      // The theme selector is a legacy js-dropdown: its absolutely-positioned
-      // .i-dropdown menu takes this relative wrapper as its containing block, so
-      // without an explicit width it shrink-wraps to the wrapper and the theme
-      // names wrap. max-content sizes it to its contents instead.
-      .i-dropdown {
-        width: max-content;
-      }
     }
 
     .i-button {
@@ -101,21 +94,8 @@
       border-right: 1px dotted $light-black;
     }
 
-    .i-dropdown {
-      @include border-all($color: $black);
-      @include single-box-shadow($color: $black);
-
-      background: $dark-black;
-
-      li {
-        a {
-          color: $dark-gray;
-        }
-
-        &:hover a:not(.disabled) {
-          color: $light-gray;
-        }
-      }
+    ind-menu > menu {
+      @extend %menu;
     }
 
     .filter-link {
@@ -127,9 +107,7 @@
     }
 
     .themes-separator {
-      @include border-bottom($black);
-      height: auto;
-      margin: 0 1em;
+      border-top: 1px solid var(--menu-border-color);
     }
   }
 

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -72,6 +72,12 @@
   .button-bar {
     align-self: stretch;
 
+    ind-with-tooltip {
+      align-self: stretch;
+      align-items: stretch;
+      height: 100%;
+    }
+
     .i-button {
       @include i-button-states($black, transparent, transparent, $gray, white, false);
       border-radius: 0;

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -108,6 +108,11 @@
     ind-menu > menu {
       @extend %menu;
 
+      // %menu paints the surface on each link, so an empty item (the group
+      // separator) would leave a see-through gap; give the panel its own
+      // background so the whole menu reads as one solid dark surface.
+      background: var(--menu-background-color);
+
       // With many themes (e.g. the themes_cern plugin) the menu can grow taller
       // than the viewport; cap it and scroll internally so every theme stays
       // reachable. --target-top is the menu's viewport offset set by positioning.

--- a/indico/web/client/styles/modules/event_display/_common.scss
+++ b/indico/web/client/styles/modules/event_display/_common.scss
@@ -76,6 +76,14 @@
       align-self: stretch;
       align-items: stretch;
       height: 100%;
+
+      // The theme selector is a legacy js-dropdown: its absolutely-positioned
+      // .i-dropdown menu takes this relative wrapper as its containing block, so
+      // without an explicit width it shrink-wraps to the wrapper and the theme
+      // names wrap. max-content sizes it to its contents instead.
+      .i-dropdown {
+        width: max-content;
+      }
     }
 
     .i-button {


### PR DESCRIPTION
The icon-only controls in the event header toolbar (home, event navigation,
printable version, filter, export to PDF, download material, change theme,
export/calendar, favourite, and switch-to-management) relied on the `title`
attribute for their name. `title` is exposed to screen readers only as a
secondary *description* (announced inconsistently), is skipped by browser
auto-translate, and its tooltip shows on mouse hover only.

Each control is now wrapped in `<ind-with-tooltip>` with a `<span
data-tip-content>`, following the existing project pattern: the span text is the
control's accessible **name** (from content) and doubles as a styled tooltip
shown on both hover and keyboard focus.

Notable points:
- The `Favorite` and `ICSCalendarLink` (export) React buttons get the same
  treatment. `Favorite` is shared, so the category favourite button improves too.
- The theme selector wraps its `<button>` together with its `<ul
  class="i-dropdown">`, so the dropdown JS (`elem.next('ul.i-dropdown')`) still
  resolves.
- Wrapped icon buttons carry the existing `icon-only` class so the icon-to-label
  margin (`.i-button:not(:empty)::before`) does not widen the toolbar; a scoped
  `.event-page-header .button-bar ind-with-tooltip` rule keeps them filling the
  toolbar height.

**User impact:** screen reader users now get a reliable name for every
event-header toolbar button, and the tooltips reach keyboard users, not just
mouse hover.