### PR TITLE
Fix session/track dropdowns in contrib mgmt

### DIFF
--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -222,7 +222,7 @@ document.addEventListener('DOMContentLoaded', () => {
         onSelect(newSession, oldSession) {
           const $this = $(this);
           const styleObject = $this[0].style;
-          const postData = {session: {id: newSession ? newSession.id : null}};
+          const postData = {session_id: newSession ? newSession.id : null};
 
           return patchObject($this.data('href'), $this.data('method'), postData).then(data => {
             const label = newSession ? newSession.title : $T.gettext('No session');
@@ -304,7 +304,7 @@ document.addEventListener('DOMContentLoaded', () => {
         ],
         onSelect(newTrack) {
           const $this = $(this);
-          const postData = {track: {id: newTrack ? newTrack.id : null}};
+          const postData = {track_id: newTrack ? newTrack.id : null};
 
           return patchObject($this.data('href'), $this.data('method'), postData).then(() => {
             const label = newTrack ? newTrack.title : $T.gettext('No track');

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -42,7 +42,7 @@ from indico.modules.events.contributions.operations import (create_contribution,
                                                             log_contribution_update, update_contribution,
                                                             update_subcontribution)
 from indico.modules.events.contributions.schemas import (ContributionFieldSchema, ContributionSchema,
-                                                         ContributionUpdateSchema, FullContributionSchema)
+                                                         FullContributionSchema)
 from indico.modules.events.contributions.util import (contribution_type_row, generate_spreadsheet_from_contributions,
                                                       get_boa_export_formats, get_contribution_person_link_field_params,
                                                       import_contributions_from_csv, make_contribution_form)
@@ -305,9 +305,13 @@ class RHContributionREST(RHManageContributionBase):
         flash(_("Contribution '{}' successfully deleted").format(self.contrib.title), 'success')
         return jsonify_data(**self.list_generator.render_list())
 
-    @use_args(ContributionUpdateSchema, partial=True)
+    @use_args({
+        'session_id': fields.Integer(allow_none=True),
+        'track_id': fields.Integer(allow_none=True),
+    }, partial=True)
     def _process_PATCH(self, data):
-        updates = {k: v for k, v in data.items() if k in {'title', 'description', 'keywords', 'board_number', 'code'}}
+        # XXX this is ONLY used for the session/track dropdowns on the contribution management page
+        updates = {}
         if 'session_id' in data:
             if not self._can_update_scheduling():
                 raise Forbidden

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -42,7 +42,7 @@ from indico.modules.events.contributions.operations import (create_contribution,
                                                             log_contribution_update, update_contribution,
                                                             update_subcontribution)
 from indico.modules.events.contributions.schemas import (ContributionFieldSchema, ContributionSchema,
-                                                         FullContributionSchema)
+                                                         ContributionUpdateSchema, FullContributionSchema)
 from indico.modules.events.contributions.util import (contribution_type_row, generate_spreadsheet_from_contributions,
                                                       get_boa_export_formats, get_contribution_person_link_field_params,
                                                       import_contributions_from_csv, make_contribution_form)
@@ -305,17 +305,17 @@ class RHContributionREST(RHManageContributionBase):
         flash(_("Contribution '{}' successfully deleted").format(self.contrib.title), 'success')
         return jsonify_data(**self.list_generator.render_list())
 
-    @use_args(FullContributionSchema, partial=True)
+    @use_args(ContributionUpdateSchema, partial=True)
     def _process_PATCH(self, data):
         updates = {k: v for k, v in data.items() if k in {'title', 'description', 'keywords', 'board_number', 'code'}}
-        if session := data.get('session'):
+        if 'session_id' in data:
             if not self._can_update_scheduling():
                 raise Forbidden
-            updates.update(self._get_contribution_session_updates(session.get('id')))
-        if track := data.get('track'):
+            updates.update(self._get_contribution_session_updates(data['session_id']))
+        if 'track_id' in data:
             if not self._can_update_scheduling():
                 raise Forbidden
-            updates.update(self._get_contribution_track_updates(track.get('id')))
+            updates.update(self._get_contribution_track_updates(data['track_id']))
         rv = {}
         if updates:
             rv = update_contribution(self.contrib, updates)
@@ -622,7 +622,6 @@ class RHContributionsExportJSON(RHManageContributionsExportActionsBase):
     """Export list of contributions to JSON."""
 
     def _process(self):
-        from indico.modules.events.contributions.schemas import FullContributionSchema
         resp = FullContributionSchema(many=True).jsonify(sorted(self.contribs, key=attrgetter('friendly_id')))
         resp.headers['Content-Disposition'] = 'attachment; filename="contributions.json"'
         return resp

--- a/indico/modules/events/contributions/schemas.py
+++ b/indico/modules/events/contributions/schemas.py
@@ -112,6 +112,15 @@ class ContributionReferenceSchema(mm.SQLAlchemyAutoSchema):
     type = fields.Integer(attribute='reference_type_id')
 
 
+class ContributionUpdateSchema(mm.Schema):
+    class Meta:
+        model = Contribution
+        fields = ('title', 'description', 'keywords', 'board_number', 'code', 'session_id', 'track_id')
+
+    session_id = fields.Integer(allow_none=True)
+    track_id = fields.Integer(allow_none=True)
+
+
 class FullContributionSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Contribution

--- a/indico/modules/events/contributions/schemas.py
+++ b/indico/modules/events/contributions/schemas.py
@@ -112,15 +112,6 @@ class ContributionReferenceSchema(mm.SQLAlchemyAutoSchema):
     type = fields.Integer(attribute='reference_type_id')
 
 
-class ContributionUpdateSchema(mm.Schema):
-    class Meta:
-        model = Contribution
-        fields = ('title', 'description', 'keywords', 'board_number', 'code', 'session_id', 'track_id')
-
-    session_id = fields.Integer(allow_none=True)
-    track_id = fields.Integer(allow_none=True)
-
-
 class FullContributionSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = Contribution


### PR DESCRIPTION
Those broke when moving the PATCH endpoint to use a schema for processing args, since the frontend was sending a rather weird format not compatible with the schema.