### PR TITLE
Block form submission while a list widget row is unsaved

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,8 +10,8 @@ Version 3.3.14
 Improvements
 ^^^^^^^^^^^^
 
-- Save rows of list widgets that are still being edited when the form is submitted instead
-  of dropping them (:pr:`7702`, thanks :user:`moliholy, unconventionaldotdev`)
+- Block the submission of a form that has a list widget row still being edited, instead of
+  silently dropping the row (:pr:`7702`, thanks :user:`moliholy, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Version 3.3.14
 Improvements
 ^^^^^^^^^^^^
 
-- Nothing so far :(
+- Save rows of list widgets that are still being edited when the form is submitted instead
+  of dropping them (:pr:`7702`, thanks :user:`moliholy, unconventionaldotdev`)
 
 Bugfixes
 ^^^^^^^^

--- a/indico/modules/events/payment/forms.py
+++ b/indico/modules/events/payment/forms.py
@@ -22,8 +22,8 @@ CONDITIONS_DESC = _('The registrant must agree to these conditions before paying
 
 class AdminSettingsForm(IndicoForm):
     currencies = MultipleItemsField(_('Currencies'), [DataRequired()],
-                                    fields=[{'id': 'code', 'caption': _('Code')},
-                                            {'id': 'name', 'caption': _('Name')}],
+                                    fields=[{'id': 'code', 'caption': _('Code'), 'required': True},
+                                            {'id': 'name', 'caption': _('Name'), 'required': True}],
                                     unique_field='code',
                                     description=_('List of currencies that can be selected for an event. When deleting '
                                                   'a currency, existing events will keep using it. The currency code '

--- a/indico/web/client/js/jquery/utils/__tests__/forms.spec.js
+++ b/indico/web/client/js/jquery/utils/__tests__/forms.spec.js
@@ -1,0 +1,62 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2026 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+/* global initForms */
+
+import jQuery from 'jquery';
+
+global.$ = global.jQuery = window.$ = window.jQuery = jQuery;
+
+// the module runs on import, so it can only be loaded once jQuery is global
+require('../forms'); // eslint-disable-line import/no-commonjs
+
+function setupForm(widgetHtml = '') {
+  document.body.innerHTML = `
+    <form>
+      <input type="text" name="title" value="">
+      ${widgetHtml}
+      <input type="submit" value="Save" data-disabled-until-change>
+    </form>
+  `;
+  const form = $('form');
+  initForms(form);
+  return {form, submit: form.find(':submit')};
+}
+
+describe('initForms change tracking', () => {
+  // let the module's own document-ready run before any test builds a form
+  beforeAll(() => new Promise(resolve => setTimeout(resolve, 0)));
+
+  it('keeps the submit button disabled while the form is untouched', () => {
+    const {submit} = setupForm();
+
+    expect(submit.prop('disabled')).toBe(true);
+  });
+
+  it('enables the submit button once a field changes', () => {
+    const {form, submit} = setupForm();
+    form.find('[name="title"]').val('new').trigger('change');
+
+    expect(submit.prop('disabled')).toBe(false);
+  });
+
+  it('enables the submit button when a widget reports pending changes', () => {
+    const {form, submit} = setupForm('<div class="widget" data-pending-changes></div>');
+    form.trigger('change');
+
+    expect(submit.prop('disabled')).toBe(false);
+  });
+
+  it('disables the submit button again once the widget has no pending changes', () => {
+    const {form, submit} = setupForm('<div class="widget" data-pending-changes></div>');
+    form.trigger('change');
+    form.find('.widget').removeAttr('data-pending-changes');
+    form.trigger('change');
+
+    expect(submit.prop('disabled')).toBe(true);
+  });
+});

--- a/indico/web/client/js/jquery/utils/forms.js
+++ b/indico/web/client/js/jquery/utils/forms.js
@@ -113,6 +113,14 @@ import {$T} from 'indico/utils/i18n';
     });
   }
 
+  // widgets holding uncommitted state report it themselves since it is not part of the form data
+  function isUntouched($form) {
+    return (
+      !$form.find('[data-pending-changes]').length &&
+      $.param($form.serializeArray(), true) === $form.data('initialData')
+    );
+  }
+
   function isElementInView(elem) {
     const docViewTop = $(window).scrollTop();
     const docViewBottom = docViewTop + $(window).height();
@@ -208,7 +216,7 @@ import {$T} from 'indico/utils/i18n';
       })
       .on('change input', function() {
         const $this = $(this);
-        const untouched = $.param($this.serializeArray(), true) === $this.data('initialData');
+        const untouched = isUntouched($this);
         const $cornerMessage = $('.save-corner-message');
         $this.find('[data-disabled-until-change]').prop('disabled', untouched);
         $this.closest('form').data('fieldsChanged', !untouched);
@@ -234,7 +242,7 @@ import {$T} from 'indico/utils/i18n';
           const $form = forms.find('[data-save-reminder]').closest('form');
           if ($form.length) {
             const $cornerMessage = $('.save-corner-message');
-            const untouched = $.param($form.serializeArray(), true) === $form.data('initialData');
+            const untouched = isUntouched($form);
             if (isElementInView($form.find('[data-save-reminder]'))) {
               hideSaveCornerMessage($cornerMessage);
             } else if (!untouched && !$cornerMessage.length) {

--- a/indico/web/client/js/jquery/widgets/jinja/__tests__/multiple_items_widget.spec.js
+++ b/indico/web/client/js/jquery/widgets/jinja/__tests__/multiple_items_widget.spec.js
@@ -1,0 +1,226 @@
+// This file is part of Indico.
+// Copyright (C) 2002 - 2026 CERN
+//
+// Indico is free software; you can redistribute it and/or
+// modify it under the terms of the MIT License; see the
+// LICENSE file for more details.
+
+import jQuery from 'jquery';
+
+import 'indico/legacy/libs/presentation/Ui/Text';
+
+import '../multiple_items_widget';
+
+global.$ = global.jQuery = window.$ = window.jQuery = jQuery;
+jQuery.fn.qtip = function() {
+  return this;
+};
+global.repositionTooltips = () => {};
+
+const COLUMNS = [
+  {id: 'email', caption: 'Email', type: 'text', required: true},
+  {id: 'lang', caption: 'Language', type: 'select', required: true},
+];
+const CHOICES = {lang: {en: 'English', fr: 'French'}};
+
+function setupWidget(value = [], columns = COLUMNS) {
+  document.body.innerHTML = `
+    <form>
+      <div class="form-group">
+        <input type="hidden" id="items" name="items" value='${JSON.stringify(value)}'>
+        <div id="items-widget" class="multiple-items-widget">
+          <table class="i-table-widget"><tbody></tbody></table>
+          <button type="button" id="items-add-button" class="js-add-row"></button>
+        </div>
+      </div>
+    </form>
+  `;
+  window.setupMultipleItemsWidget({
+    fieldId: 'items',
+    uuidField: null,
+    columns,
+    sortable: false,
+    columnChoices: CHOICES,
+  });
+  return {form: $('form'), field: $('#items'), widget: $('#items-widget')};
+}
+
+function fillRow(widget, index, values) {
+  const inputs = widget.find('tbody > tr').eq(index).find('.js-table-input');
+  values.forEach((value, i) => inputs.eq(i).val(value));
+}
+
+function pressEnter(widget, index) {
+  const input = widget.find('tbody > tr').eq(index).find('input.js-table-input').first();
+  input.trigger($.Event('keypress', {keyCode: 13}));
+}
+
+// mirrors how jquery-form announces a serialization it can still be told to skip
+function submitAjax(form) {
+  const veto = {};
+  form.trigger('form-pre-serialize', [form, {}, veto]);
+  return !veto.veto;
+}
+
+describe('multiple items widget', () => {
+  it('commits a filled pending row before the form is serialized', () => {
+    const {form, field, widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', 'en']);
+
+    expect(submitAjax(form)).toBe(true);
+    expect(JSON.parse(field.val())).toEqual([{email: 'a@example.com', lang: 'en'}]);
+  });
+
+  it('commits a pending row that is being edited alongside committed ones', () => {
+    const {form, field, widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
+    widget.find('.js-add-row').trigger('click');
+    fillRow(widget, 1, ['b@example.com', 'fr']);
+
+    expect(submitAjax(form)).toBe(true);
+    expect(JSON.parse(field.val())).toEqual([
+      {email: 'a@example.com', lang: 'en'},
+      {email: 'b@example.com', lang: 'fr'},
+    ]);
+  });
+
+  it('commits a row that was reopened for editing', () => {
+    const {form, field, widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
+    widget.find('.js-edit-row').trigger('click');
+    fillRow(widget, 0, ['changed@example.com', 'fr']);
+
+    expect(submitAjax(form)).toBe(true);
+    expect(JSON.parse(field.val())).toEqual([{email: 'changed@example.com', lang: 'fr'}]);
+  });
+
+  it('drops the untouched empty row instead of blocking the submission', () => {
+    const {form, field, widget} = setupWidget();
+
+    expect(widget.find('tbody > tr')).toHaveLength(1);
+    expect(submitAjax(form)).toBe(true);
+    expect(JSON.parse(field.val())).toEqual([]);
+  });
+
+  it('keeps an editable row when another field blocks the submission', () => {
+    const {form, widget} = setupWidget();
+
+    submitAjax(form);
+    expect(widget.find('tbody > tr .js-table-input')).toHaveLength(2);
+  });
+
+  it('vetoes the serialization when a pending row is missing a required value', () => {
+    const {form, field, widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', '']);
+
+    expect(submitAjax(form)).toBe(false);
+    expect(JSON.parse(field.val())).toEqual([]);
+    expect(widget.find('tbody > tr .js-table-input')).toHaveLength(2);
+  });
+
+  it('ignores the widget when the field is disabled by a HiddenUnless toggle', () => {
+    const {form, field, widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', '']);
+    $('.form-group').find(':input').prop('disabled', true);
+
+    expect(submitAjax(form)).toBe(true);
+    expect(JSON.parse(field.val())).toEqual([]);
+  });
+
+  it('commits a filled pending row on a plain form submission', () => {
+    const {form, field, widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', 'en']);
+
+    form.trigger('submit');
+    expect(JSON.parse(field.val())).toEqual([{email: 'a@example.com', lang: 'en'}]);
+  });
+
+  it('commits the pending row before adding another one', () => {
+    const {field, widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', 'en']);
+    widget.find('.js-add-row').trigger('click');
+
+    expect(JSON.parse(field.val())).toEqual([{email: 'a@example.com', lang: 'en'}]);
+    expect(widget.find('tbody > tr')).toHaveLength(2);
+  });
+
+  it('refuses to add another row while the pending one is incomplete', () => {
+    const {widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', '']);
+    widget.find('.js-add-row').trigger('click');
+
+    expect(widget.find('tbody > tr')).toHaveLength(1);
+  });
+
+  it('never accumulates blank rows when adding repeatedly', () => {
+    const {widget} = setupWidget();
+    widget.find('.js-add-row').trigger('click');
+    widget.find('.js-add-row').trigger('click');
+
+    expect(widget.find('tbody > tr')).toHaveLength(1);
+  });
+
+  it('flags pending changes while a row is being filled', () => {
+    const {widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', '']);
+    widget.find('.js-table-input').eq(0).trigger('change');
+
+    expect(widget.is('[data-pending-changes]')).toBe(true);
+  });
+
+  it('flags pending changes while a committed row is reopened', () => {
+    const {widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
+    widget.find('.js-edit-row').trigger('click');
+
+    expect(widget.is('[data-pending-changes]')).toBe(true);
+  });
+
+  it('clears the pending flag once the row is committed', () => {
+    const {widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', 'en']);
+    widget.find('.js-table-input').eq(0).trigger('change');
+    pressEnter(widget, 0);
+
+    expect(widget.is('[data-pending-changes]')).toBe(false);
+  });
+
+  it('offers no per-row save button', () => {
+    const {widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
+    widget.find('.js-edit-row').trigger('click');
+
+    expect(widget.find('.js-save-row')).toHaveLength(0);
+    expect(widget.find('.js-cancel-edit')).toHaveLength(1);
+  });
+
+  it('commits a row when enter is pressed in it', () => {
+    const {field, widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', 'en']);
+    pressEnter(widget, 0);
+
+    expect(JSON.parse(field.val())).toEqual([{email: 'a@example.com', lang: 'en'}]);
+  });
+
+  it('clears the pending flag when the edit is cancelled', () => {
+    const {widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
+    widget.find('.js-edit-row').trigger('click');
+    widget.find('.js-cancel-edit').trigger('click');
+
+    expect(widget.is('[data-pending-changes]')).toBe(false);
+  });
+
+  it('does not flag pending changes for the untouched empty row', () => {
+    const {widget} = setupWidget();
+
+    expect(widget.is('[data-pending-changes]')).toBe(false);
+  });
+
+  it('keeps a row holding only a checked checkbox', () => {
+    const columns = [
+      {id: 'name', caption: 'Name', type: 'text'},
+      {id: 'enabled', caption: 'Enabled', type: 'checkbox'},
+    ];
+    const {form, field, widget} = setupWidget([], columns);
+    widget.find('tbody > tr .js-table-input').eq(1).prop('checked', true);
+
+    expect(submitAjax(form)).toBe(true);
+    expect(JSON.parse(field.val())).toEqual([{name: '', enabled: true}]);
+  });
+});

--- a/indico/web/client/js/jquery/widgets/jinja/__tests__/multiple_items_widget.spec.js
+++ b/indico/web/client/js/jquery/widgets/jinja/__tests__/multiple_items_widget.spec.js
@@ -47,180 +47,113 @@ function setupWidget(value = [], columns = COLUMNS) {
 
 function fillRow(widget, index, values) {
   const inputs = widget.find('tbody > tr').eq(index).find('.js-table-input');
-  values.forEach((value, i) => inputs.eq(i).val(value));
+  values.forEach((value, i) => inputs.eq(i).val(value).trigger('change'));
 }
 
-function pressEnter(widget, index) {
-  const input = widget.find('tbody > tr').eq(index).find('input.js-table-input').first();
-  input.trigger($.Event('keypress', {keyCode: 13}));
-}
-
-// mirrors how jquery-form announces a serialization it can still be told to skip
-function submitAjax(form) {
-  const veto = {};
-  form.trigger('form-pre-serialize', [form, {}, veto]);
-  return !veto.veto;
+function firstInput(widget, index = 0) {
+  return widget.find('tbody > tr').eq(index).find('.js-table-input')[0];
 }
 
 describe('multiple items widget', () => {
-  it('commits a filled pending row before the form is serialized', () => {
-    const {form, field, widget} = setupWidget();
-    fillRow(widget, 0, ['a@example.com', 'en']);
-
-    expect(submitAjax(form)).toBe(true);
-    expect(JSON.parse(field.val())).toEqual([{email: 'a@example.com', lang: 'en'}]);
-  });
-
-  it('commits a pending row that is being edited alongside committed ones', () => {
-    const {form, field, widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
-    widget.find('.js-add-row').trigger('click');
-    fillRow(widget, 1, ['b@example.com', 'fr']);
-
-    expect(submitAjax(form)).toBe(true);
-    expect(JSON.parse(field.val())).toEqual([
-      {email: 'a@example.com', lang: 'en'},
-      {email: 'b@example.com', lang: 'fr'},
-    ]);
-  });
-
-  it('commits a row that was reopened for editing', () => {
-    const {form, field, widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
-    widget.find('.js-edit-row').trigger('click');
-    fillRow(widget, 0, ['changed@example.com', 'fr']);
-
-    expect(submitAjax(form)).toBe(true);
-    expect(JSON.parse(field.val())).toEqual([{email: 'changed@example.com', lang: 'fr'}]);
-  });
-
-  it('drops the untouched empty row instead of blocking the submission', () => {
-    const {form, field, widget} = setupWidget();
-
-    expect(widget.find('tbody > tr')).toHaveLength(1);
-    expect(submitAjax(form)).toBe(true);
-    expect(JSON.parse(field.val())).toEqual([]);
-  });
-
-  it('keeps an editable row when another field blocks the submission', () => {
+  it('lets the form be submitted while the initial row is untouched', () => {
     const {form, widget} = setupWidget();
 
-    submitAjax(form);
-    expect(widget.find('tbody > tr .js-table-input')).toHaveLength(2);
+    expect(widget.find('tbody > tr')).toHaveLength(1);
+    expect(form[0].checkValidity()).toBe(true);
   });
 
-  it('vetoes the serialization when a pending row is missing a required value', () => {
-    const {form, field, widget} = setupWidget();
-    fillRow(widget, 0, ['a@example.com', '']);
-
-    expect(submitAjax(form)).toBe(false);
-    expect(JSON.parse(field.val())).toEqual([]);
-    expect(widget.find('tbody > tr .js-table-input')).toHaveLength(2);
-  });
-
-  it('ignores the widget when the field is disabled by a HiddenUnless toggle', () => {
-    const {form, field, widget} = setupWidget();
-    fillRow(widget, 0, ['a@example.com', '']);
-    $('.form-group').find(':input').prop('disabled', true);
-
-    expect(submitAjax(form)).toBe(true);
-    expect(JSON.parse(field.val())).toEqual([]);
-  });
-
-  it('commits a filled pending row on a plain form submission', () => {
-    const {form, field, widget} = setupWidget();
+  it('blocks the submission while a row is being filled', () => {
+    const {form, widget} = setupWidget();
     fillRow(widget, 0, ['a@example.com', 'en']);
 
-    form.trigger('submit');
-    expect(JSON.parse(field.val())).toEqual([{email: 'a@example.com', lang: 'en'}]);
+    expect(form[0].checkValidity()).toBe(false);
+    expect(firstInput(widget).validationMessage).not.toBe('');
   });
 
-  it('commits the pending row before adding another one', () => {
-    const {field, widget} = setupWidget();
-    fillRow(widget, 0, ['a@example.com', 'en']);
-    widget.find('.js-add-row').trigger('click');
-
-    expect(JSON.parse(field.val())).toEqual([{email: 'a@example.com', lang: 'en'}]);
-    expect(widget.find('tbody > tr')).toHaveLength(2);
-  });
-
-  it('refuses to add another row while the pending one is incomplete', () => {
-    const {widget} = setupWidget();
-    fillRow(widget, 0, ['a@example.com', '']);
-    widget.find('.js-add-row').trigger('click');
-
-    expect(widget.find('tbody > tr')).toHaveLength(1);
-  });
-
-  it('never accumulates blank rows when adding repeatedly', () => {
-    const {widget} = setupWidget();
-    widget.find('.js-add-row').trigger('click');
-    widget.find('.js-add-row').trigger('click');
-
-    expect(widget.find('tbody > tr')).toHaveLength(1);
-  });
-
-  it('flags pending changes while a row is being filled', () => {
-    const {widget} = setupWidget();
-    fillRow(widget, 0, ['a@example.com', '']);
-    widget.find('.js-table-input').eq(0).trigger('change');
-
-    expect(widget.is('[data-pending-changes]')).toBe(true);
-  });
-
-  it('flags pending changes while a committed row is reopened', () => {
-    const {widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
+  it('blocks the submission while a saved row is reopened for editing', () => {
+    const {form, widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
     widget.find('.js-edit-row').trigger('click');
 
-    expect(widget.is('[data-pending-changes]')).toBe(true);
+    expect(form[0].checkValidity()).toBe(false);
   });
 
-  it('clears the pending flag once the row is committed', () => {
-    const {widget} = setupWidget();
-    fillRow(widget, 0, ['a@example.com', 'en']);
-    widget.find('.js-table-input').eq(0).trigger('change');
-    pressEnter(widget, 0);
-
-    expect(widget.is('[data-pending-changes]')).toBe(false);
-  });
-
-  it('offers no per-row save button', () => {
-    const {widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
+  it('keeps blocking the submission when a reopened row is emptied', () => {
+    const {form, widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
     widget.find('.js-edit-row').trigger('click');
+    fillRow(widget, 0, ['', '']);
 
-    expect(widget.find('.js-save-row')).toHaveLength(0);
-    expect(widget.find('.js-cancel-edit')).toHaveLength(1);
+    expect(form[0].checkValidity()).toBe(false);
   });
 
-  it('commits a row when enter is pressed in it', () => {
-    const {field, widget} = setupWidget();
+  it('lets the form be submitted once the row is saved', () => {
+    const {form, field, widget} = setupWidget();
     fillRow(widget, 0, ['a@example.com', 'en']);
-    pressEnter(widget, 0);
+    widget.find('.js-save-row').trigger('click');
 
+    expect(form[0].checkValidity()).toBe(true);
     expect(JSON.parse(field.val())).toEqual([{email: 'a@example.com', lang: 'en'}]);
   });
 
-  it('clears the pending flag when the edit is cancelled', () => {
-    const {widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
+  it('lets the form be submitted once the edit is cancelled', () => {
+    const {form, widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
     widget.find('.js-edit-row').trigger('click');
     widget.find('.js-cancel-edit').trigger('click');
 
-    expect(widget.is('[data-pending-changes]')).toBe(false);
+    expect(form[0].checkValidity()).toBe(true);
   });
 
-  it('does not flag pending changes for the untouched empty row', () => {
-    const {widget} = setupWidget();
+  it('lets the form be submitted once the unsaved row is discarded', () => {
+    const {form, widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', 'en']);
+    widget.find('.js-cancel-edit').trigger('click');
 
-    expect(widget.is('[data-pending-changes]')).toBe(false);
+    expect(form[0].checkValidity()).toBe(true);
   });
 
-  it('keeps a row holding only a checked checkbox', () => {
+  it('blocks the submission while a row holding only a checked checkbox is unsaved', () => {
     const columns = [
       {id: 'name', caption: 'Name', type: 'text'},
       {id: 'enabled', caption: 'Enabled', type: 'checkbox'},
     ];
-    const {form, field, widget} = setupWidget([], columns);
-    widget.find('tbody > tr .js-table-input').eq(1).prop('checked', true);
+    const {form, widget} = setupWidget([], columns);
+    widget.find('.js-table-input').eq(1).prop('checked', true).trigger('change');
 
-    expect(submitAjax(form)).toBe(true);
-    expect(JSON.parse(field.val())).toEqual([{name: '', enabled: true}]);
+    expect(form[0].checkValidity()).toBe(false);
+  });
+
+  it('ignores a row whose inputs are disabled by a HiddenUnless toggle', () => {
+    const {form, widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', 'en']);
+    $('.form-group').find(':input').prop('disabled', true);
+
+    expect(form[0].checkValidity()).toBe(true);
+  });
+
+  it('flags pending changes while a row is being filled', () => {
+    const {widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', 'en']);
+
+    expect(widget.is('[data-pending-changes]')).toBe(true);
+  });
+
+  it('flags pending changes while a saved row is reopened', () => {
+    const {widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
+    widget.find('.js-edit-row').trigger('click');
+
+    expect(widget.is('[data-pending-changes]')).toBe(true);
+  });
+
+  it('clears the pending flag once the row is saved', () => {
+    const {widget} = setupWidget();
+    fillRow(widget, 0, ['a@example.com', 'en']);
+    widget.find('.js-save-row').trigger('click');
+
+    expect(widget.is('[data-pending-changes]')).toBe(false);
+  });
+
+  it('does not flag pending changes for the untouched initial row', () => {
+    const {widget} = setupWidget();
+
+    expect(widget.is('[data-pending-changes]')).toBe(false);
   });
 });

--- a/indico/web/client/js/jquery/widgets/jinja/__tests__/multiple_items_widget.spec.js
+++ b/indico/web/client/js/jquery/widgets/jinja/__tests__/multiple_items_widget.spec.js
@@ -23,7 +23,7 @@ const COLUMNS = [
 ];
 const CHOICES = {lang: {en: 'English', fr: 'French'}};
 
-function setupWidget(value = [], columns = COLUMNS) {
+function setupWidget(value = []) {
   document.body.innerHTML = `
     <form>
       <div class="form-group">
@@ -38,7 +38,7 @@ function setupWidget(value = [], columns = COLUMNS) {
   window.setupMultipleItemsWidget({
     fieldId: 'items',
     uuidField: null,
-    columns,
+    columns: COLUMNS,
     sortable: false,
     columnChoices: CHOICES,
   });
@@ -55,11 +55,12 @@ function firstInput(widget, index = 0) {
 }
 
 describe('multiple items widget', () => {
-  it('lets the form be submitted while the initial row is untouched', () => {
+  it('blocks the submission while an empty row is open', () => {
     const {form, widget} = setupWidget();
 
     expect(widget.find('tbody > tr')).toHaveLength(1);
-    expect(form[0].checkValidity()).toBe(true);
+    expect(form[0].checkValidity()).toBe(false);
+    expect(firstInput(widget).validationMessage).not.toBe('');
   });
 
   it('blocks the submission while a row is being filled', () => {
@@ -67,20 +68,11 @@ describe('multiple items widget', () => {
     fillRow(widget, 0, ['a@example.com', 'en']);
 
     expect(form[0].checkValidity()).toBe(false);
-    expect(firstInput(widget).validationMessage).not.toBe('');
   });
 
   it('blocks the submission while a saved row is reopened for editing', () => {
     const {form, widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
     widget.find('.js-edit-row').trigger('click');
-
-    expect(form[0].checkValidity()).toBe(false);
-  });
-
-  it('keeps blocking the submission when a reopened row is emptied', () => {
-    const {form, widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
-    widget.find('.js-edit-row').trigger('click');
-    fillRow(widget, 0, ['', '']);
 
     expect(form[0].checkValidity()).toBe(false);
   });
@@ -102,43 +94,22 @@ describe('multiple items widget', () => {
     expect(form[0].checkValidity()).toBe(true);
   });
 
-  it('lets the form be submitted once the unsaved row is discarded', () => {
+  it('lets the form be submitted once the empty row is discarded', () => {
     const {form, widget} = setupWidget();
-    fillRow(widget, 0, ['a@example.com', 'en']);
     widget.find('.js-cancel-edit').trigger('click');
 
     expect(form[0].checkValidity()).toBe(true);
   });
 
-  it('blocks the submission while a row holding only a checked checkbox is unsaved', () => {
-    const columns = [
-      {id: 'name', caption: 'Name', type: 'text'},
-      {id: 'enabled', caption: 'Enabled', type: 'checkbox'},
-    ];
-    const {form, widget} = setupWidget([], columns);
-    widget.find('.js-table-input').eq(1).prop('checked', true).trigger('change');
-
-    expect(form[0].checkValidity()).toBe(false);
-  });
-
   it('ignores a row whose inputs are disabled by a HiddenUnless toggle', () => {
-    const {form, widget} = setupWidget();
-    fillRow(widget, 0, ['a@example.com', 'en']);
+    const {form} = setupWidget();
     $('.form-group').find(':input').prop('disabled', true);
 
     expect(form[0].checkValidity()).toBe(true);
   });
 
-  it('flags pending changes while a row is being filled', () => {
+  it('flags pending changes while a row is open', () => {
     const {widget} = setupWidget();
-    fillRow(widget, 0, ['a@example.com', 'en']);
-
-    expect(widget.is('[data-pending-changes]')).toBe(true);
-  });
-
-  it('flags pending changes while a saved row is reopened', () => {
-    const {widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
-    widget.find('.js-edit-row').trigger('click');
 
     expect(widget.is('[data-pending-changes]')).toBe(true);
   });
@@ -151,8 +122,8 @@ describe('multiple items widget', () => {
     expect(widget.is('[data-pending-changes]')).toBe(false);
   });
 
-  it('does not flag pending changes for the untouched initial row', () => {
-    const {widget} = setupWidget();
+  it('does not flag pending changes when every row is saved', () => {
+    const {widget} = setupWidget([{email: 'a@example.com', lang: 'en'}]);
 
     expect(widget.is('[data-pending-changes]')).toBe(false);
   });

--- a/indico/web/client/js/jquery/widgets/jinja/multiple_items_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/multiple_items_widget.js
@@ -177,37 +177,7 @@ import {$T} from 'indico/utils/i18n';
           e.preventDefault();
           $(this).closest('tr').find('.js-cancel-edit').trigger('click');
         }
-      })
-      .on('change input', '.js-table-input', () => {
-        updatePendingRows();
       });
-
-    function editingRows() {
-      return widgetBody.children('tr').filter(function() {
-        return !!$(this).find('.js-table-input').length;
-      });
-    }
-
-    function isBlankRow(row) {
-      return !row.find('.js-table-input').filter(function() {
-        return this.type === 'checkbox' ? this.checked : !!$(this).val().trim();
-      }).length;
-    }
-
-    // a row being edited is not part of the form data, so the form has to be told about it
-    function updatePendingRows() {
-      let pending = false;
-      editingRows().each(function() {
-        const row = $(this);
-        const unsaved = !!row.data('hasItem') || !isBlankRow(row);
-        const input = row.find('.js-table-input')[0];
-        if ('setCustomValidity' in input) {
-          input.setCustomValidity(unsaved ? $T('Please save or cancel this row first.') : '');
-        }
-        pending = pending || unsaved;
-      });
-      widget.attr('data-pending-changes', pending ? '' : null);
-    }
 
     function fixWidths() {
       if (!options.sortable) {
@@ -231,8 +201,15 @@ import {$T} from 'indico/utils/i18n';
         widget.find('tbody.ui-sortable').sortable('refresh');
       }
       fixWidths();
-      updatePendingRows();
-      addButton.prop('disabled', !!widget.find('.js-table-input').length);
+      // a row being edited is not part of the form data, so the form has to be told about it
+      const editing = widget.find('.js-table-input');
+      editing.each(function() {
+        if ('setCustomValidity' in this) {
+          this.setCustomValidity($T('Please save or cancel this row first.'));
+        }
+      });
+      widget.attr('data-pending-changes', editing.length ? '' : null);
+      addButton.prop('disabled', !!editing.length);
       if (moveTooltips === undefined || moveTooltips) {
         repositionTooltips();
       }

--- a/indico/web/client/js/jquery/widgets/jinja/multiple_items_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/multiple_items_widget.js
@@ -32,16 +32,10 @@ import {$T} from 'indico/utils/i18n';
     const widgetBody = widget.children('table').children('tbody');
     const field = $(`#${options.fieldId}`);
     const data = JSON.parse(field.val());
-    const addButton = $(`#${options.fieldId}-add-button`);
     const deleteButton = $('<a>', {
       class: 'action-icon icon-remove js-remove-row',
       href: '#',
       title: $T('Delete'),
-    });
-    const saveButton = $('<a>', {
-      class: 'action-icon icon-floppy js-save-row',
-      href: '#',
-      title: $T('Save'),
     });
     const editButton = $('<a>', {
       class: 'action-icon icon-edit js-edit-row',
@@ -99,61 +93,14 @@ import {$T} from 'indico/utils/i18n';
         e.preventDefault();
         removeRow($(this).closest('tr'));
       })
-      .on('click', '.js-save-row', function(e) {
-        e.preventDefault();
-        const row = $(this).closest('tr');
-        const item = {};
-        let requiredFieldIsEmpty = false;
-        let invalidNumber = false;
-        if (options.uuidField && row.data('uuid')) {
-          item[options.uuidField] = row.data('uuid');
-        }
-        options.columns.forEach((col, i) => {
-          const inputField = row.find('.js-table-input').eq(i);
-          let value = inputField.val().trim();
-          if (!value && inputField.data('required')) {
-            requiredFieldIsEmpty = true;
-            inputField.addClass('hasError');
-          } else if (inputField.attr('type') === 'checkbox') {
-            item[col.id] = inputField.prop('checked');
-          } else {
-            item[col.id] = value;
-            inputField.removeClass('hasError');
-          }
-          if (inputField.attr('type') === 'number' && !requiredFieldIsEmpty) {
-            value = parseFloat(value);
-            if (
-              (inputField.attr('min') && value < parseFloat(inputField.attr('min'))) ||
-              (inputField.attr('max') && value > parseFloat(inputField.attr('max')))
-            ) {
-              invalidNumber = true;
-              inputField.addClass('hasError');
-              inputField.trigger('multipleItemsWidget:showNumberError');
-            } else {
-              inputField.removeClass('hasError');
-              inputField.trigger('multipleItemsWidget:hideNumberError');
-            }
-          }
-        });
-        if (requiredFieldIsEmpty) {
-          row.trigger('multipleItemsWidget:showRequiredError');
-        } else {
-          row.trigger('multipleItemsWidget:hideRequiredError');
-        }
-        if (!requiredFieldIsEmpty && !invalidNumber) {
-          if (row.data('hasItem')) {
-            data[row.index()] = item;
-          } else {
-            data.push(item);
-            row.data('hasItem', true);
-          }
-          updateField();
-          updateRow(row, false, false);
-        }
-      })
       .on('click', '.js-add-row', e => {
         e.preventDefault();
-        createRow();
+        const emptyRow = blankRows().first();
+        if (emptyRow.length) {
+          emptyRow.find('.js-table-input').first().trigger('focus');
+        } else if (commitPendingRows()) {
+          createRow();
+        }
       })
       .on('click', '.js-cancel-edit', function(e) {
         e.preventDefault();
@@ -169,15 +116,132 @@ import {$T} from 'indico/utils/i18n';
         const row = $(this).closest('tr');
         updateRow(row, true, false);
       })
+      .on('change input', '.js-table-input', () => {
+        updatePendingChanges();
+      })
       .on('keypress', 'input', function(e) {
         if (e.keyCode === 13) {
           e.preventDefault();
-          $(this).closest('tr').find('.js-save-row').trigger('click');
+          commitRow($(this).closest('tr'));
         } else if (e.keyCode === 27) {
           e.preventDefault();
           $(this).closest('tr').find('.js-cancel-edit').trigger('click');
         }
       });
+
+    const form = widget.closest('form');
+
+    // ajax forms read the field before 'ajaxForm:validateBeforeSubmit', so commit even earlier
+    form.on('form-pre-serialize', (e, $form, formOptions, veto) => {
+      if (!commitPendingRows()) {
+        veto.veto = true;
+      }
+    });
+
+    form.on('submit', e => {
+      if (!commitPendingRows()) {
+        e.preventDefault();
+        e.stopImmediatePropagation();
+      }
+    });
+
+    // rows being edited hold no form data of their own, so the form cannot see them as a change
+    function updatePendingChanges() {
+      const pending = editingRows().not(blankRows());
+      widget.attr('data-pending-changes', pending.length ? '' : null);
+    }
+
+    function editingRows() {
+      return widget.find('tbody > tr').filter(function() {
+        return !!$(this).find('.js-table-input').length;
+      });
+    }
+
+    function blankRows() {
+      return editingRows().filter(function() {
+        const row = $(this);
+        return !row.data('hasItem') && isBlankRow(row.find('.js-table-input'));
+      });
+    }
+
+    function isBlankRow(inputs) {
+      return !inputs.filter(function() {
+        return this.type === 'checkbox' ? this.checked : !!$(this).val().trim();
+      }).length;
+    }
+
+    function commitRow(row) {
+      const item = {};
+      let requiredFieldIsEmpty = false;
+      let invalidNumber = false;
+      if (options.uuidField && row.data('uuid')) {
+        item[options.uuidField] = row.data('uuid');
+      }
+      options.columns.forEach((col, i) => {
+        const inputField = row.find('.js-table-input').eq(i);
+        let value = inputField.val().trim();
+        if (!value && inputField.data('required')) {
+          requiredFieldIsEmpty = true;
+          inputField.addClass('hasError');
+        } else if (inputField.attr('type') === 'checkbox') {
+          item[col.id] = inputField.prop('checked');
+        } else {
+          item[col.id] = value;
+          inputField.removeClass('hasError');
+        }
+        if (inputField.attr('type') === 'number' && !requiredFieldIsEmpty) {
+          value = parseFloat(value);
+          if (
+            (inputField.attr('min') && value < parseFloat(inputField.attr('min'))) ||
+            (inputField.attr('max') && value > parseFloat(inputField.attr('max')))
+          ) {
+            invalidNumber = true;
+            inputField.addClass('hasError');
+            inputField.trigger('multipleItemsWidget:showNumberError');
+          } else {
+            inputField.removeClass('hasError');
+            inputField.trigger('multipleItemsWidget:hideNumberError');
+          }
+        }
+      });
+      if (requiredFieldIsEmpty) {
+        row.trigger('multipleItemsWidget:showRequiredError');
+      } else {
+        row.trigger('multipleItemsWidget:hideRequiredError');
+      }
+      if (requiredFieldIsEmpty || invalidNumber) {
+        return false;
+      }
+      if (row.data('hasItem')) {
+        data[row.index()] = item;
+      } else {
+        data.push(item);
+        row.data('hasItem', true);
+      }
+      updateField();
+      updateRow(row, false, false);
+      return true;
+    }
+
+    // the main save button is expected to persist rows that are still being edited
+    function commitPendingRows() {
+      if (field.prop('disabled')) {
+        return true;
+      }
+      let valid = true;
+      blankRows().each(function() {
+        removeRow($(this));
+      });
+      editingRows().each(function() {
+        if (!commitRow($(this))) {
+          valid = false;
+        }
+      });
+      if (!widget.find('tbody > tr').length) {
+        createRow();
+      }
+      return valid;
+    }
 
     function fixWidths() {
       if (!options.sortable) {
@@ -190,7 +254,7 @@ import {$T} from 'indico/utils/i18n';
           $(this).width('');
         })
         .each(function() {
-          // fix the iwdth to avoid ugly changes during sorting
+          // fix the width to avoid ugly changes during sorting
           const $this = $(this);
           $this.width($this.width());
         });
@@ -201,7 +265,7 @@ import {$T} from 'indico/utils/i18n';
         widget.find('tbody.ui-sortable').sortable('refresh');
       }
       fixWidths();
-      addButton.prop('disabled', !!widget.find('.js-table-input').length);
+      updatePendingChanges();
       if (moveTooltips === undefined || moveTooltips) {
         repositionTooltips();
       }
@@ -349,9 +413,7 @@ import {$T} from 'indico/utils/i18n';
         column.appendTo(row);
       });
       $('<td>', {
-        html: item
-          ? deleteButton.clone().add(editButton.clone())
-          : cancelButton.clone().add(saveButton.clone()),
+        html: item ? deleteButton.clone().add(editButton.clone()) : cancelButton.clone(),
         class: 'js-action-col',
       }).appendTo(row);
       widgetBody.append(row);
@@ -367,7 +429,7 @@ import {$T} from 'indico/utils/i18n';
         $(this).replaceWith(column);
       });
       if (editMode) {
-        row.children('.js-action-col').html(cancelButton.clone().add(saveButton.clone()));
+        row.children('.js-action-col').html(cancelButton.clone());
       } else {
         row.children('.js-action-col').html(deleteButton.clone().add(editButton.clone()));
       }

--- a/indico/web/client/js/jquery/widgets/jinja/multiple_items_widget.js
+++ b/indico/web/client/js/jquery/widgets/jinja/multiple_items_widget.js
@@ -32,10 +32,16 @@ import {$T} from 'indico/utils/i18n';
     const widgetBody = widget.children('table').children('tbody');
     const field = $(`#${options.fieldId}`);
     const data = JSON.parse(field.val());
+    const addButton = $(`#${options.fieldId}-add-button`);
     const deleteButton = $('<a>', {
       class: 'action-icon icon-remove js-remove-row',
       href: '#',
       title: $T('Delete'),
+    });
+    const saveButton = $('<a>', {
+      class: 'action-icon icon-floppy js-save-row',
+      href: '#',
+      title: $T('Save'),
     });
     const editButton = $('<a>', {
       class: 'action-icon icon-edit js-edit-row',
@@ -93,14 +99,61 @@ import {$T} from 'indico/utils/i18n';
         e.preventDefault();
         removeRow($(this).closest('tr'));
       })
+      .on('click', '.js-save-row', function(e) {
+        e.preventDefault();
+        const row = $(this).closest('tr');
+        const item = {};
+        let requiredFieldIsEmpty = false;
+        let invalidNumber = false;
+        if (options.uuidField && row.data('uuid')) {
+          item[options.uuidField] = row.data('uuid');
+        }
+        options.columns.forEach((col, i) => {
+          const inputField = row.find('.js-table-input').eq(i);
+          let value = inputField.val().trim();
+          if (!value && inputField.data('required')) {
+            requiredFieldIsEmpty = true;
+            inputField.addClass('hasError');
+          } else if (inputField.attr('type') === 'checkbox') {
+            item[col.id] = inputField.prop('checked');
+          } else {
+            item[col.id] = value;
+            inputField.removeClass('hasError');
+          }
+          if (inputField.attr('type') === 'number' && !requiredFieldIsEmpty) {
+            value = parseFloat(value);
+            if (
+              (inputField.attr('min') && value < parseFloat(inputField.attr('min'))) ||
+              (inputField.attr('max') && value > parseFloat(inputField.attr('max')))
+            ) {
+              invalidNumber = true;
+              inputField.addClass('hasError');
+              inputField.trigger('multipleItemsWidget:showNumberError');
+            } else {
+              inputField.removeClass('hasError');
+              inputField.trigger('multipleItemsWidget:hideNumberError');
+            }
+          }
+        });
+        if (requiredFieldIsEmpty) {
+          row.trigger('multipleItemsWidget:showRequiredError');
+        } else {
+          row.trigger('multipleItemsWidget:hideRequiredError');
+        }
+        if (!requiredFieldIsEmpty && !invalidNumber) {
+          if (row.data('hasItem')) {
+            data[row.index()] = item;
+          } else {
+            data.push(item);
+            row.data('hasItem', true);
+          }
+          updateField();
+          updateRow(row, false, false);
+        }
+      })
       .on('click', '.js-add-row', e => {
         e.preventDefault();
-        const emptyRow = blankRows().first();
-        if (emptyRow.length) {
-          emptyRow.find('.js-table-input').first().trigger('focus');
-        } else if (commitPendingRows()) {
-          createRow();
-        }
+        createRow();
       })
       .on('click', '.js-cancel-edit', function(e) {
         e.preventDefault();
@@ -116,131 +169,44 @@ import {$T} from 'indico/utils/i18n';
         const row = $(this).closest('tr');
         updateRow(row, true, false);
       })
-      .on('change input', '.js-table-input', () => {
-        updatePendingChanges();
-      })
       .on('keypress', 'input', function(e) {
         if (e.keyCode === 13) {
           e.preventDefault();
-          commitRow($(this).closest('tr'));
+          $(this).closest('tr').find('.js-save-row').trigger('click');
         } else if (e.keyCode === 27) {
           e.preventDefault();
           $(this).closest('tr').find('.js-cancel-edit').trigger('click');
         }
+      })
+      .on('change input', '.js-table-input', () => {
+        updatePendingRows();
       });
 
-    const form = widget.closest('form');
-
-    // ajax forms read the field before 'ajaxForm:validateBeforeSubmit', so commit even earlier
-    form.on('form-pre-serialize', (e, $form, formOptions, veto) => {
-      if (!commitPendingRows()) {
-        veto.veto = true;
-      }
-    });
-
-    form.on('submit', e => {
-      if (!commitPendingRows()) {
-        e.preventDefault();
-        e.stopImmediatePropagation();
-      }
-    });
-
-    // rows being edited hold no form data of their own, so the form cannot see them as a change
-    function updatePendingChanges() {
-      const pending = editingRows().not(blankRows());
-      widget.attr('data-pending-changes', pending.length ? '' : null);
-    }
-
     function editingRows() {
-      return widget.find('tbody > tr').filter(function() {
+      return widgetBody.children('tr').filter(function() {
         return !!$(this).find('.js-table-input').length;
       });
     }
 
-    function blankRows() {
-      return editingRows().filter(function() {
-        const row = $(this);
-        return !row.data('hasItem') && isBlankRow(row.find('.js-table-input'));
-      });
-    }
-
-    function isBlankRow(inputs) {
-      return !inputs.filter(function() {
+    function isBlankRow(row) {
+      return !row.find('.js-table-input').filter(function() {
         return this.type === 'checkbox' ? this.checked : !!$(this).val().trim();
       }).length;
     }
 
-    function commitRow(row) {
-      const item = {};
-      let requiredFieldIsEmpty = false;
-      let invalidNumber = false;
-      if (options.uuidField && row.data('uuid')) {
-        item[options.uuidField] = row.data('uuid');
-      }
-      options.columns.forEach((col, i) => {
-        const inputField = row.find('.js-table-input').eq(i);
-        let value = inputField.val().trim();
-        if (!value && inputField.data('required')) {
-          requiredFieldIsEmpty = true;
-          inputField.addClass('hasError');
-        } else if (inputField.attr('type') === 'checkbox') {
-          item[col.id] = inputField.prop('checked');
-        } else {
-          item[col.id] = value;
-          inputField.removeClass('hasError');
-        }
-        if (inputField.attr('type') === 'number' && !requiredFieldIsEmpty) {
-          value = parseFloat(value);
-          if (
-            (inputField.attr('min') && value < parseFloat(inputField.attr('min'))) ||
-            (inputField.attr('max') && value > parseFloat(inputField.attr('max')))
-          ) {
-            invalidNumber = true;
-            inputField.addClass('hasError');
-            inputField.trigger('multipleItemsWidget:showNumberError');
-          } else {
-            inputField.removeClass('hasError');
-            inputField.trigger('multipleItemsWidget:hideNumberError');
-          }
-        }
-      });
-      if (requiredFieldIsEmpty) {
-        row.trigger('multipleItemsWidget:showRequiredError');
-      } else {
-        row.trigger('multipleItemsWidget:hideRequiredError');
-      }
-      if (requiredFieldIsEmpty || invalidNumber) {
-        return false;
-      }
-      if (row.data('hasItem')) {
-        data[row.index()] = item;
-      } else {
-        data.push(item);
-        row.data('hasItem', true);
-      }
-      updateField();
-      updateRow(row, false, false);
-      return true;
-    }
-
-    // the main save button is expected to persist rows that are still being edited
-    function commitPendingRows() {
-      if (field.prop('disabled')) {
-        return true;
-      }
-      let valid = true;
-      blankRows().each(function() {
-        removeRow($(this));
-      });
+    // a row being edited is not part of the form data, so the form has to be told about it
+    function updatePendingRows() {
+      let pending = false;
       editingRows().each(function() {
-        if (!commitRow($(this))) {
-          valid = false;
+        const row = $(this);
+        const unsaved = !!row.data('hasItem') || !isBlankRow(row);
+        const input = row.find('.js-table-input')[0];
+        if ('setCustomValidity' in input) {
+          input.setCustomValidity(unsaved ? $T('Please save or cancel this row first.') : '');
         }
+        pending = pending || unsaved;
       });
-      if (!widget.find('tbody > tr').length) {
-        createRow();
-      }
-      return valid;
+      widget.attr('data-pending-changes', pending ? '' : null);
     }
 
     function fixWidths() {
@@ -254,7 +220,7 @@ import {$T} from 'indico/utils/i18n';
           $(this).width('');
         })
         .each(function() {
-          // fix the width to avoid ugly changes during sorting
+          // fix the iwdth to avoid ugly changes during sorting
           const $this = $(this);
           $this.width($this.width());
         });
@@ -265,7 +231,8 @@ import {$T} from 'indico/utils/i18n';
         widget.find('tbody.ui-sortable').sortable('refresh');
       }
       fixWidths();
-      updatePendingChanges();
+      updatePendingRows();
+      addButton.prop('disabled', !!widget.find('.js-table-input').length);
       if (moveTooltips === undefined || moveTooltips) {
         repositionTooltips();
       }
@@ -413,7 +380,9 @@ import {$T} from 'indico/utils/i18n';
         column.appendTo(row);
       });
       $('<td>', {
-        html: item ? deleteButton.clone().add(editButton.clone()) : cancelButton.clone(),
+        html: item
+          ? deleteButton.clone().add(editButton.clone())
+          : cancelButton.clone().add(saveButton.clone()),
         class: 'js-action-col',
       }).appendTo(row);
       widgetBody.append(row);
@@ -429,7 +398,7 @@ import {$T} from 'indico/utils/i18n';
         $(this).replaceWith(column);
       });
       if (editMode) {
-        row.children('.js-action-col').html(cancelButton.clone());
+        row.children('.js-action-col').html(cancelButton.clone().add(saveButton.clone()));
       } else {
         row.children('.js-action-col').html(deleteButton.clone().add(editButton.clone()));
       }


### PR DESCRIPTION
A row left in edit mode when a form is submitted is silently dropped: the form saves fine and the `MultipleItemsField` entry is gone. This PR blocks the submission while any row is open, so the row has to be saved or cancelled first.

Payment currencies were the only list with no required column, allowing a currency without a code. Both columns are required now.
