### PR TITLE
Fix Typescript errors on *.s?css imports

### DIFF
--- a/indico/web/client/js/types/css.d.mts
+++ b/indico/web/client/js/types/css.d.mts
@@ -1,0 +1,2 @@
+declare module "*.css" {};
+declare module "*.scss" {};


### PR DESCRIPTION
When importing css or scss files within Typescript source files, the error `Cannot find module or type declarations for side-effect import of "./Somefile.module.scss"` would be shown. 

This change makes Typescript recognize css and scss files as valid module imports. 