### PR TITLE
Prevent resizing an entry over the event end boundary

### DIFF
--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -209,6 +209,13 @@ export default function Entry({
   const colors = getEntryColors({type, sessionBlockId, colors: customColors}, session);
   const btnColors = {backgroundColor: colors.color, color: colors.backgroundColor};
   const draftEntry = useSelector(selectors.getDraftEntry);
+  const eventEndDt = useSelector(selectors.getEventEndDt);
+  const maxDuration = useMemo(() => {
+    if (parentEndDt) {
+      return moment(parentEndDt).diff(startDt, 'minutes');
+    }
+    return eventEndDt.diff(startDt, 'minutes');
+  }, [parentEndDt, eventEndDt, startDt]);
 
   let style: Record<string, string | number | undefined> = transform
     ? {
@@ -380,7 +387,7 @@ export default function Entry({
       <ResizeHandle
         duration={duration}
         minDuration={Math.max(MIN_DURATION, latestChildEndDt.diff(startDt, 'minutes'))}
-        maxDuration={parentEndDt ? moment(parentEndDt).diff(startDt, 'minutes') : undefined}
+        maxDuration={maxDuration}
         resizeStartRef={resizeStartRef}
         setLocalDuration={setDuration}
         setGlobalDuration={_setDuration}


### PR DESCRIPTION
When resizing an entry, it was possible to do so over the event end boundary, breaking the entry (https://github.com/orgs/indico/projects/7/views/1?pane=issue&itemId=198432548). This makes sure the entry duration is capped.