### PR TITLE
Display event log datetime in the event timezone

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -105,6 +105,7 @@ Bugfixes
 - Reject invalid email addresses when entering person details (:issue:`7644`, :pr:`7698`)
 - Allow saving minutes after using the "Mark" formatting button in the editor (:pr:`7700`)
 - Fix room booking sprite image creation failing when there are many rooms (:pr:`7704`)
+- Use correct timezone information in log viewer (:pr:`7712`, thanks :user:`SegiNyn`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/logs/client/js/components/LogEntryList.jsx
+++ b/indico/modules/logs/client/js/components/LogEntryList.jsx
@@ -21,7 +21,7 @@ function LogEntryTime({time}) {
   return (
     <span
       className="logged-time"
-      title={`${moment.tz(time, timezone).format('DD/MM/YYYY HH:mm')} (${timezone})`}
+      title={`${moment.tz(time, timezone).format('L LTS')} (${timezone})`}
     >
       <time dateTime={time}>{moment.tz(time, timezone).fromNow()}</time>
     </span>

--- a/indico/modules/logs/client/js/components/LogEntryList.jsx
+++ b/indico/modules/logs/client/js/components/LogEntryList.jsx
@@ -84,8 +84,11 @@ class LogEntry extends React.PureComponent {
           </span>
         </TooltipIfTruncated>
         <span className="log-entry-details">
-          <span className="logged-time" title={moment(entry.time).format('DD/MM/YYYY HH:mm')}>
-            <time dateTime={entry.time}>{moment(entry.time).fromNow()}</time>
+          <span
+            className="logged-time"
+            title={`${moment.parseZone(entry.time).format('DD/MM/YYYY HH:mm')} (${entry.timezone})`}
+          >
+            <time dateTime={entry.time}>{moment.parseZone(entry.time).fromNow()}</time>
           </span>
           {entry.user.avatarURL ? (
             <Image

--- a/indico/modules/logs/client/js/components/LogEntryList.jsx
+++ b/indico/modules/logs/client/js/components/LogEntryList.jsx
@@ -8,12 +8,29 @@
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {useSelector} from 'react-redux';
 import {Image} from 'semantic-ui-react';
 
 import {Paginator, TooltipIfTruncated, MessageBox} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 
 import LogEntryModal from '../containers/LogEntryModal';
+
+function LogEntryTime({time}) {
+  const timezone = useSelector(state => state.staticData.timezone);
+  return (
+    <span
+      className="logged-time"
+      title={`${moment.tz(time, timezone).format('DD/MM/YYYY HH:mm')} (${timezone})`}
+    >
+      <time dateTime={time}>{moment.tz(time, timezone).fromNow()}</time>
+    </span>
+  );
+}
+
+LogEntryTime.propTypes = {
+  time: PropTypes.string.isRequired,
+};
 
 class LogEntry extends React.PureComponent {
   static propTypes = {
@@ -84,12 +101,7 @@ class LogEntry extends React.PureComponent {
           </span>
         </TooltipIfTruncated>
         <span className="log-entry-details">
-          <span
-            className="logged-time"
-            title={`${moment.parseZone(entry.time).format('DD/MM/YYYY HH:mm')} (${entry.timezone})`}
-          >
-            <time dateTime={entry.time}>{moment.parseZone(entry.time).fromNow()}</time>
-          </span>
+          <LogEntryTime time={entry.time} />
           {entry.user.avatarURL ? (
             <Image
               avatar

--- a/indico/modules/logs/client/js/components/LogEntryModal.jsx
+++ b/indico/modules/logs/client/js/components/LogEntryModal.jsx
@@ -18,7 +18,7 @@ function LogModalTime({time}) {
   const timezone = useSelector(state => state.staticData.timezone);
   return (
     <span className="log-modal-time">
-      {moment.tz(time, timezone).format('ddd, D/M/YYYY HH:mm')} ({timezone})
+      {moment.tz(time, timezone).format('L LTS')} ({timezone})
     </span>
   );
 }

--- a/indico/modules/logs/client/js/components/LogEntryModal.jsx
+++ b/indico/modules/logs/client/js/components/LogEntryModal.jsx
@@ -8,10 +8,24 @@
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import React from 'react';
+import {useSelector} from 'react-redux';
 
 import {IButton, Modal} from 'indico/react/components';
 import {Translate} from 'indico/react/i18n';
 import {Slot} from 'indico/react/util';
+
+function LogModalTime({time}) {
+  const timezone = useSelector(state => state.staticData.timezone);
+  return (
+    <span className="log-modal-time">
+      {moment.tz(time, timezone).format('ddd, D/M/YYYY HH:mm')} ({timezone})
+    </span>
+  );
+}
+
+LogModalTime.propTypes = {
+  time: PropTypes.string.isRequired,
+};
 
 export default class LogEntryModal extends React.Component {
   static propTypes = {
@@ -97,7 +111,6 @@ export default class LogEntryModal extends React.Component {
       html,
       user: {fullName},
       time,
-      timezone,
       detailsLink,
     } = entries[currentViewIndex];
 
@@ -116,10 +129,7 @@ export default class LogEntryModal extends React.Component {
           <div className="text-superfluous log-modal-author-info flexrow f-j-end">
             <span>
               {fullName && <span className="log-modal-user">{fullName} </span>}
-              on{' '}
-              <span className="log-modal-time">
-                {moment.parseZone(time).format('ddd, D/M/YYYY HH:mm')} ({timezone})
-              </span>
+              on <LogModalTime time={time} />
             </span>
           </div>
         </Slot>

--- a/indico/modules/logs/client/js/components/LogEntryModal.jsx
+++ b/indico/modules/logs/client/js/components/LogEntryModal.jsx
@@ -97,6 +97,7 @@ export default class LogEntryModal extends React.Component {
       html,
       user: {fullName},
       time,
+      timezone,
       detailsLink,
     } = entries[currentViewIndex];
 
@@ -115,8 +116,10 @@ export default class LogEntryModal extends React.Component {
           <div className="text-superfluous log-modal-author-info flexrow f-j-end">
             <span>
               {fullName && <span className="log-modal-user">{fullName} </span>}
-              on
-              <span className="log-modal-time"> {moment(time).format('ddd, D/M/YYYY HH:mm')}</span>
+              on{' '}
+              <span className="log-modal-time">
+                {moment.parseZone(time).format('ddd, D/M/YYYY HH:mm')} ({timezone})
+              </span>
             </span>
           </div>
         </Slot>

--- a/indico/modules/logs/client/js/index.jsx
+++ b/indico/modules/logs/client/js/index.jsx
@@ -25,6 +25,7 @@ window.addEventListener('load', () => {
       realms: JSON.parse(rootElement.dataset.realms),
       pageSize: 15,
       canRemoveFilter: rootElement.dataset.requireFilter === undefined,
+      timezone: rootElement.dataset.timezone,
     },
   };
   const store = createReduxStore(

--- a/indico/modules/logs/controllers.py
+++ b/indico/modules/logs/controllers.py
@@ -56,7 +56,7 @@ class RHAppLogs(RHAdminBase):
         realms = {realm.name: realm.title for realm in AppLogRealm}
         return WPAppLogs.render_template('logs.html', 'logs',
                                          realms=realms, metadata_query=metadata_query,
-                                         logs_api_url=url_for('.api_app_logs'), timezone=session.timezone)
+                                         logs_api_url=url_for('.api_app_logs'), timezone=session.tzinfo.zone)
 
 
 class RHCategoryLogs(RHManageCategoryBase):
@@ -99,8 +99,8 @@ class RHUserLogs(RHUserLogsBase):
         metadata_query = _get_metadata_query()
         realms = {realm.name: realm.title for realm in UserLogRealm}
         return WPUserLogs.render_template('logs.html', 'logs', user=self.user,
-                                          realms=realms, metadata_query=metadata_query,
-                                          logs_api_url=url_for('.api_user_logs', self.user), timezone=session.timezone)
+                                          realms=realms, metadata_query=metadata_query, timezone=session.tzinfo.zone,
+                                          logs_api_url=url_for('.api_user_logs', self.user))
 
 
 class LogsAPIMixin:

--- a/indico/modules/logs/controllers.py
+++ b/indico/modules/logs/controllers.py
@@ -56,7 +56,7 @@ class RHAppLogs(RHAdminBase):
         realms = {realm.name: realm.title for realm in AppLogRealm}
         return WPAppLogs.render_template('logs.html', 'logs',
                                          realms=realms, metadata_query=metadata_query,
-                                         logs_api_url=url_for('.api_app_logs'))
+                                         logs_api_url=url_for('.api_app_logs'), timezone=session.timezone)
 
 
 class RHCategoryLogs(RHManageCategoryBase):
@@ -67,6 +67,7 @@ class RHCategoryLogs(RHManageCategoryBase):
         realms = {realm.name: realm.title for realm in CategoryLogRealm}
         return WPCategoryLogs.render_template('logs.html', self.category, 'logs',
                                               realms=realms, metadata_query=metadata_query,
+                                              timezone=self.category.timezone,
                                               logs_api_url=url_for('.api_category_logs', self.category))
 
 
@@ -81,7 +82,7 @@ class RHEventLogs(RHManageEventBase):
         require_filter = not self.event.can_manage(session.user)
         return WPEventLogs.render_template('logs.html', self.event, realms=realms, metadata_query=metadata_query,
                                            logs_api_url=url_for('.api_event_logs', self.event),
-                                           require_filter=require_filter)
+                                           require_filter=require_filter, timezone=self.event.timezone)
 
 
 class RHUserLogsBase(RHUserBase):
@@ -99,7 +100,7 @@ class RHUserLogs(RHUserLogsBase):
         realms = {realm.name: realm.title for realm in UserLogRealm}
         return WPUserLogs.render_template('logs.html', 'logs', user=self.user,
                                           realms=realms, metadata_query=metadata_query,
-                                          logs_api_url=url_for('.api_user_logs', self.user))
+                                          logs_api_url=url_for('.api_user_logs', self.user), timezone=session.timezone)
 
 
 class LogsAPIMixin:

--- a/indico/modules/logs/templates/logs.html
+++ b/indico/modules/logs/templates/logs.html
@@ -17,6 +17,7 @@
          data-fetch-logs-url="{{ logs_api_url }}"
          data-realms="{{ realms|tojson|forceescape }}"
          data-metadata-query="{{ metadata_query|tojson|forceescape }}"
+         data-timezone="{{ timezone }}"
          {{ 'data-require-filter' if require_filter|default(false) }}>
     </div>
 {% endblock %}

--- a/indico/modules/logs/util.py
+++ b/indico/modules/logs/util.py
@@ -180,7 +180,6 @@ def serialize_log_entry(entry, tzinfo):
         'description': entry.summary,
         'meta': entry.meta,
         'time': entry.logged_dt.astimezone(tzinfo).isoformat(),
-        'timezone': str(tzinfo),
         'payload': entry.data,
         'user': {
             'fullName': entry.user.full_name if entry.user else None,

--- a/indico/modules/logs/util.py
+++ b/indico/modules/logs/util.py
@@ -180,6 +180,7 @@ def serialize_log_entry(entry, tzinfo):
         'description': entry.summary,
         'meta': entry.meta,
         'time': entry.logged_dt.astimezone(tzinfo).isoformat(),
+        'timezone': str(tzinfo),
         'payload': entry.data,
         'user': {
             'fullName': entry.user.full_name if entry.user else None,


### PR DESCRIPTION
In `RHEventLogsJSON` , the `object_tzinfo` is using `self.event.tzinfo`, but this event timezone isn't being kept for the date when finally displaying it to the user in the logs. 