### PR TITLE
Disable browser-native dragndrop in timetable

### DIFF
--- a/indico/modules/events/timetable/client/js/index.jsx
+++ b/indico/modules/events/timetable/client/js/index.jsx
@@ -24,6 +24,12 @@ import {getCurrentDateLocalStorage} from './utils';
   global.setupTimetable = function setupTimetable() {
     const root = document.querySelector('#timetable-container');
     if (root) {
+      // Avoid browser-native dragging of text, which can happen whenever something is selected
+      // within the timetable area, and which breaks the timetable drag&drop functionality.
+      root.addEventListener('dragstart', evt => {
+        evt.preventDefault();
+      });
+
       const searchToken = root.dataset.searchToken;
       const timetableData = JSON.parse(root.dataset.timetableData);
       const eventInfo = JSON.parse(root.dataset.eventInfo);


### PR DESCRIPTION
It avoids this annoying bug that happened randomly, but could also be reproduced easily by just using CTRL+A before starting to drag something in the timetable.

<img width="1054" height="356" alt="image" src="https://github.com/user-attachments/assets/92d7a057-9876-477b-8502-b0eb1e69c9bb" />
