### PR TITLE
Take data from unscheduled entry on schedule

### DIFF
--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -41,6 +41,7 @@ import {
   isChildEntry,
   LayoutOverrides,
   ContribEntryWithoutLayout,
+  SessionBlockId,
 } from './types';
 import {getEntryUniqueId, getEntryURLByObjId} from './utils';
 
@@ -107,7 +108,10 @@ interface DeselectEntryAction {
 
 interface ScheduleEntryAction {
   type: typeof SCHEDULE_ENTRY;
-  entry: ContribEntryWithoutLayout;
+  id: ContribId;
+  startDt: Moment;
+  sessionId: number | null;
+  sessionBlockId: SessionBlockId | null;
   layoutOverrides: LayoutOverrides;
 }
 
@@ -438,7 +442,10 @@ export function scheduleEntry(
       }),
     {
       type: SCHEDULE_ENTRY,
-      entry,
+      id: entry.id,
+      startDt: entry.startDt,
+      sessionBlockId: isChildEntry(entry) ? entry.sessionBlockId! : null,
+      sessionId: entry.sessionId!,
       layoutOverrides,
     }
   );

--- a/indico/modules/events/timetable/client/js/layout.spec.ts
+++ b/indico/modules/events/timetable/client/js/layout.spec.ts
@@ -104,7 +104,7 @@ function childContrib({
   maxColumn = 0,
 }: {
   id?: ContribId;
-  sessionBlockId: string;
+  sessionBlockId: SessionBlockId;
   title?: string;
   time: string;
   duration: number;

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -169,11 +169,19 @@ export default {
         };
       }
       case actions.SCHEDULE_ENTRY: {
-        const {entry, layoutOverrides} = action;
+        const {id, startDt, sessionId, sessionBlockId, layoutOverrides} = action;
+        const newEntry = {
+          ...state.unscheduled.find(u => u.id === id),
+          startDt,
+          sessionId,
+        };
+        if (sessionBlockId !== null) {
+          newEntry.sessionBlockId = sessionBlockId;
+        }
         return {
           ...state,
-          entries: {...state.entries, [entry.id]: entry},
-          unscheduled: state.unscheduled.filter(c => c.id !== entry.id),
+          entries: {...state.entries, [id]: newEntry},
+          unscheduled: state.unscheduled.filter(c => c.id !== id),
           layoutOverrides: {...state.layoutOverrides, ...layoutOverrides},
         };
       }

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -142,7 +142,7 @@ export interface BlockEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMix
 }
 
 export interface ChildBaseEntry {
-  sessionBlockId?: string;
+  sessionBlockId?: SessionBlockId;
 }
 
 interface LayoutOverride {

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -142,7 +142,7 @@ export interface BlockEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMix
 }
 
 export interface ChildBaseEntry {
-  sessionBlockId?: SessionBlockId;
+  sessionBlockId: SessionBlockId;
 }
 
 interface LayoutOverride {


### PR DESCRIPTION
Something I missed in my previous PR... the whole entry coming from the display/layout logic contains all kinds of weird stuff (such as layout data). Now we only take the relevant data (time, session and block) from there, and copy the rest from the original data of the unscheduled contribution.