### PR TITLE
Deduplicate session attachments

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -508,7 +508,8 @@ export function DayTimetable({
         return;
       }
       const attachments = entry.data.attachments;
-      dispatch(actions.setEntryAttachments(getEntryUniqueId(type, id), attachments));
+      const sessionId = type === EntryType.SessionBlock ? entry.data.session_id : null;
+      dispatch(actions.setEntryAttachments(getEntryUniqueId(type, id), sessionId, attachments));
     }
 
     document.addEventListener('indico:attachmentsUpdate', handleMaterialsChanged);

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -148,6 +148,7 @@ interface SetEntryAttachments {
   type: typeof SET_ENTRY_ATTACHMENTS;
   attachments: Attachment[];
   id: EntryUniqueID;
+  sessionId: number | null;
 }
 
 interface DeleteBreakAction {
@@ -544,9 +545,10 @@ export function updateEntry(
 
 export function setEntryAttachments(
   id: EntryUniqueID,
+  sessionId: number | null,
   attachments: Attachment[]
 ): SetEntryAttachments {
-  return {type: SET_ENTRY_ATTACHMENTS, id, attachments};
+  return {type: SET_ENTRY_ATTACHMENTS, id, sessionId, attachments};
 }
 
 export function setCurrentDate(date: Moment, eventId: number): SetCurrentDateAction {

--- a/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
@@ -274,6 +274,7 @@ describe('mapperUtils', () => {
         isPoster: false,
         colors: {backgroundColor: '#aabbcc', color: '#ddeeff'},
         defaultContribDurationMinutes: 10,
+        attachments: [],
       };
 
       const data = mapSessionToData(session);
@@ -283,6 +284,7 @@ describe('mapperUtils', () => {
       expect(data.is_poster).toBe(false);
       expect(data.colors).toEqual({background: '#aabbcc', text: '#ddeeff'});
       expect(data.default_contribution_duration).toBe(600);
+      expect(data.attachments).toEqual([]);
     });
   });
 });

--- a/indico/modules/events/timetable/client/js/mapperUtils.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.ts
@@ -103,6 +103,7 @@ const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
 const sessionMapperConfig: MapperConfig<Record<string, unknown>, Session> = [
   {from: 'id', to: 'id'},
   {from: 'title', to: 'title'},
+  {from: 'attachments', to: 'attachments'},
   {from: 'is_poster', to: 'isPoster'},
   {
     from: 'colors',

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -227,7 +227,7 @@ export default {
         // Remove the deleted session from all existing unscheduled contributions
         const oldUnscheduled = state.unscheduled.map(contrib => ({
           ...contrib,
-          sessionId: null,
+          sessionId: contrib.sessionId === action.sessionId ? null : contrib.sessionId,
         }));
         return {
           ...state,

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -15,7 +15,7 @@ import {
   preprocessTimetableEntries,
   preprocessUnscheduledContributions,
 } from './preprocess';
-import {Entries, EntryType, isChildEntry, SidePanelView, ChildEntry, Entry} from './types';
+import {Entries, EntryType, isChildEntry, SidePanelView, ChildEntry, Entry, Session} from './types';
 import {setCurrentDateLocalStorage} from './utils';
 
 export default {
@@ -101,23 +101,13 @@ export default {
         };
       }
       case actions.SET_ENTRY_ATTACHMENTS: {
-        const {id, attachments} = action;
-        const updatedEntry = {...state.entries[id], attachments};
-        let updatedEntries: Record<string, Entry>;
-        if (state.entries[id].type === EntryType.SessionBlock) {
-          updatedEntries = Object.fromEntries(
-            Object.entries(state.entries)
-              .filter(
-                ([, entry]) =>
-                  entry.type === EntryType.SessionBlock &&
-                  entry.sessionId === updatedEntry.sessionId
-              )
-              .map(([id_, entry]) => [id_, {...entry, attachments}])
-          );
-        } else {
-          updatedEntries = {[id]: updatedEntry};
+        const {id, sessionId, attachments} = action;
+        if (sessionId !== null) {
+          // Session attachments are stored in the sessions, so we do not need to touch any entries
+          return state;
         }
-        return {...state, entries: {...state.entries, ...updatedEntries}};
+        const updatedEntry = {...state.entries[id], attachments};
+        return {...state, entries: {...state.entries, [id]: updatedEntry}};
       }
       case actions.UPDATE_ENTRY: {
         const {entry, changes} = action;
@@ -249,7 +239,7 @@ export default {
         return state;
     }
   },
-  sessions: (state = [], action: Action) => {
+  sessions: (state: Record<string, Session> = {}, action: Action) => {
     switch (action.type) {
       case actions.SET_SESSION_DATA:
         return preprocessSessionData(action.data);
@@ -264,8 +254,18 @@ export default {
       case actions.CREATE_SESSION:
         return {
           ...state,
-          ...{[action.session.id]: {...action.session, isPoster: false}},
+          ...{[action.session.id]: {...action.session, attachments: [], isPoster: false}},
         };
+      case actions.SET_ENTRY_ATTACHMENTS: {
+        const {sessionId, attachments} = action;
+        if (sessionId === null) {
+          return state;
+        }
+        return {
+          ...state,
+          [sessionId]: {...state[sessionId], attachments},
+        };
+      }
       default:
         return state;
     }

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -23,6 +23,7 @@ import {
   DayEntries,
   Entry,
   isChildEntry,
+  Entries,
 } from './types';
 import {
   DAY_SIZE,
@@ -35,15 +36,32 @@ import {
 } from './utils';
 
 export const getStaticData = (state: ReduxState) => state.staticData;
-const getEntries = (state: ReduxState) => state.entries;
+const _getEntries = (state: ReduxState) => state.entries;
 const getLayoutOverrides = (state: ReduxState) => state.entries.layoutOverrides;
 export const getSessions = (state: ReduxState) => state.sessions;
 export const getNavigation = (state: ReduxState) => state.navigation;
 
+const getEntries = createSelector(
+  _getEntries,
+  getSessions,
+  (entries, sessions): Entries => {
+    return {
+      ...entries,
+      entries: Object.fromEntries(
+        Object.entries(entries.entries).map(([id, entry]) => {
+          if (entry.type !== EntryType.SessionBlock) {
+            return [id, entry];
+          }
+          return [id, {...entry, attachments: sessions[entry.sessionId].attachments}];
+        })
+      ),
+    };
+  }
+);
+
 const getNestedEntries = createSelector(
   getEntries,
   getLayoutOverrides,
-
   ({entries}, layoutOverrides) => {
     const topLevelEntries: Entry[] = [];
     const entriesById = new Map();
@@ -93,7 +111,7 @@ export const getSelectedId = (state: ReduxState) => state.entries.selectedId;
 
 export const getSelectedEntry = createSelector(
   [getEntries, getSelectedId],
-  (entries, selectedId) => (selectedId === null ? null : entries.entries[selectedId])
+  ({entries}, selectedId) => (selectedId === null ? null : entries[selectedId])
 );
 
 export const getCurrentDate = (state: ReduxState) => state.navigation.currentDate;

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -76,7 +76,6 @@ export interface Attachment {
   id: number;
   title: string;
   type: 'attachment';
-  downloadUrl: string;
 }
 
 export interface Session {
@@ -85,6 +84,7 @@ export interface Session {
   isPoster: boolean;
   defaultContribDurationMinutes: number;
   colors: Colors;
+  attachments: Attachment[];
 }
 
 export interface BaseEntry {

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -128,7 +128,6 @@ class TimetableSerializer:
                      'session_id': block.session_id,
                      'session_title': block.session.title,
                      'title': block.title,
-                     'attachments': self.get_attachment_data(block.session),
                      'code': block.session.code,
                      'person_links': [self._get_person_data(x) for x in block.person_links],
                      'description': block.session.description,
@@ -189,8 +188,7 @@ class TimetableSerializer:
         def serialize_attachment(attachment):
             return {'id': attachment.id,
                     'type': 'attachment',
-                    'title': attachment.title,
-                    'download_url': attachment.download_url}
+                    'title': attachment.title}
 
         def serialize_folder(folder):
             return {'id': folder.id,
@@ -268,5 +266,6 @@ def serialize_session(sess):
         'title': sess.title,
         'url': url_for('sessions.display_session', sess),
         'default_contribution_duration': sess.default_contribution_duration.total_seconds(),
+        'attachments': TimetableSerializer.get_attachment_data(sess),
         **get_color_data(sess)
     }


### PR DESCRIPTION
Also fixed a bug where all unscheduled contrib session details were cleared when deleting a session. This was just in the state so pretty harmless, but still a bug.