### PR TITLE
Add accessible names and tooltips to calendar export triggers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,6 +106,9 @@ Bugfixes
 - Allow saving minutes after using the "Mark" formatting button in the editor (:pr:`7700`)
 - Fix room booking sprite image creation failing when there are many rooms (:pr:`7704`)
 - Use correct timezone information in log viewer (:pr:`7712`, thanks :user:`SegiNyn`)
+- Fix a small gap that could appear between a tooltip and its arrow when the
+  tooltip is attached to a control with a smaller font size (:pr:`7718`,
+  thanks :user:`foxbunny`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -142,6 +142,10 @@ Accessibility
 - Screen reader users now hear the affiliation, email and phone on their profile
   dashboard announced as labelled fields instead of bare values (:pr:`7593`,
   thanks :user:`foxbunny`)
+- The calendar export buttons on category, session and contribution pages now
+  show a tooltip on hover and keyboard focus and have a reliable accessible name,
+  instead of relying on the ``title`` attribute (:pr:`7718`, thanks
+  :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/categories/client/js/base.jsx
+++ b/indico/modules/categories/client/js/base.jsx
@@ -25,7 +25,11 @@ document.addEventListener('DOMContentLoaded', () => {
       endpoint="categories.export_ical"
       params={{category_id: categoryId}}
       renderButton={classes => (
-        <IButton icon="calendar" title={Translate.string('Export')} classes={classes} />
+        <ind-with-tooltip>
+          <IButton icon="calendar" classes={{'icon-only': true, ...classes}}>
+            <span data-tip-content>{Translate.string('Export')}</span>
+          </IButton>
+        </ind-with-tooltip>
       )}
       options={[{key: 'category', text: Translate.string('Category'), extraParams: {}}]}
     />,

--- a/indico/modules/events/contributions/client/js/index.jsx
+++ b/indico/modules/events/contributions/client/js/index.jsx
@@ -68,7 +68,11 @@ document.addEventListener('DOMContentLoaded', () => {
       endpoint="contributions.export_ics"
       params={{event_id: eventId, contrib_id: contributionId}}
       renderButton={classes => (
-        <IButton icon="calendar" classes={classes} title={Translate.string('Export')} />
+        <ind-with-tooltip>
+          <IButton icon="calendar" classes={{'icon-only': true, ...classes}}>
+            <span data-tip-content>{Translate.string('Export')}</span>
+          </IButton>
+        </ind-with-tooltip>
       )}
       options={[{key: 'contribution', text: Translate.string('Contribution'), extraParams: {}}]}
     />,

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -133,18 +133,23 @@
         {%- endif %}
         {{ template_hook('url-shortener', target=url_for('contributions.display_contribution', contribution),
                          classes='i-button icon-link') }}
-        {% if indico_config.LATEX_ENABLED %}
-            <a href="{{ url_for('contributions.export_pdf', contribution) }}" class="i-button icon-file-pdf" title="{% trans %}Export to PDF{% endtrans %}"></a>
+        {% if indico_config.LATEX_ENABLED or contribution.timetable_entry %}
+            <div class="group">
+                {% if indico_config.LATEX_ENABLED %}
+                    <a href="{{ url_for('contributions.export_pdf', contribution) }}" class="i-button icon-file-pdf"
+                       title="{% trans %}Export to PDF{% endtrans %}"></a>
+                {% endif %}
+                {% if contribution.timetable_entry -%}
+                    {% if g.static_site %}
+                        <a href="{{ url_for('contributions.export_ics', contribution) }}"
+                           class="i-button icon-calendar" title="{% trans %}Export{% endtrans %}"></a>
+                    {% else %}
+                        <div id="contribution-calendar-link" data-event-id="{{ contribution.event_id }}"
+                             data-contribution-id="{{ contribution.id }}"></div>
+                    {% endif %}
+                {%- endif %}
+            </div>
         {% endif %}
-        {% if contribution.timetable_entry -%}
-            {% if g.static_site %}
-                <a href="{{ url_for('contributions.export_ics', contribution) }}"
-                   class="i-button icon-calendar" title="{% trans %}Export{% endtrans %}"></a>
-            {% else %}
-                <div id="contribution-calendar-link" data-event-id="{{ contribution.event_id }}"
-                     data-contribution-id="{{ contribution.id }}"></div>
-            {% endif %}
-        {%- endif %}
     </div>
 {%- endblock %}
 

--- a/indico/modules/events/sessions/client/js/session_display.jsx
+++ b/indico/modules/events/sessions/client/js/session_display.jsx
@@ -33,7 +33,11 @@ document.addEventListener('DOMContentLoaded', () => {
       endpoint="sessions.export_ics"
       params={{event_id: eventId, session_id: sessionId}}
       renderButton={classes => (
-        <IButton icon="calendar" classes={classes} title={Translate.string('Export')} />
+        <ind-with-tooltip>
+          <IButton icon="calendar" classes={{'icon-only': true, ...classes}}>
+            <span data-tip-content>{Translate.string('Export')}</span>
+          </IButton>
+        </ind-with-tooltip>
       )}
       options={options}
     />,

--- a/indico/web/client/js/custom_elements/tips.scss
+++ b/indico/web/client/js/custom_elements/tips.scss
@@ -96,7 +96,7 @@ ind-with-toggletip {
 
   // Arrows
   &[shown]::after {
-    --arrow-size: 0.5em;
+    --arrow-size: 0.5rem;
 
     content: '';
     position: absolute;
@@ -111,8 +111,8 @@ ind-with-toggletip {
   }
 
   &[orientation='horizontal']::after {
-    left: calc(var(--arrow-left) - var(--arrow-size) + 0.1em);
-    right: calc(100% - var(--arrow-size) + 0.1em);
+    left: calc(var(--arrow-left) - var(--arrow-size) + 0.1rem);
+    right: calc(100% - var(--arrow-size) + 0.1rem);
     top: calc(50% - var(--arrow-size));
   }
 
@@ -120,8 +120,8 @@ ind-with-toggletip {
   // of testing that [orientation='vertical'] we test that
   // :not([orientation='horizontal'])
   &:not([orientation='horizontal'])::after {
-    top: calc(var(--arrow-top) - var(--arrow-size) + 0.1em);
-    bottom: calc(100% - var(--arrow-size) + 0.1em);
+    top: calc(var(--arrow-top) - var(--arrow-size) + 0.1rem);
+    bottom: calc(100% - var(--arrow-size) + 0.1rem);
     left: calc(50% - var(--arrow-size));
   }
 }


### PR DESCRIPTION
The calendar export (iCal) trigger buttons on the category, session and
contribution display pages were icon-only buttons whose only accessible name
came from the `title` attribute. `title` has unreliable screen-reader support,
isn't shown on keyboard focus, and is skipped by browser auto-translate.

Each of the three `renderButton` callbacks that pass a legacy `IButton` into the
shared `ICSCalendarLink` now wraps it in `<ind-with-tooltip>` with a
`<span data-tip-content>Export</span>`, following the existing accessible-tooltip
pattern already used for the event header toolbar. The span is genuine button
content — so it becomes the accessible name — and doubles as the styled tooltip
shown on hover and keyboard focus, replacing `title`. The shared `ICSCalendarLink`
component and `IButton` are untouched.

User impact: the calendar export buttons on category, session and contribution
pages now have a reliable accessible name and show a tooltip on hover and
keyboard focus, instead of relying on the `title` attribute.