### PR TITLE
Fix #7719

### DIFF
--- a/indico/web/http_api/handlers.py
+++ b/indico/web/http_api/handlers.py
@@ -69,7 +69,7 @@ def validateSignature(ak, signature, timestamp, path, query):
     elif timestamp and abs(timestamp - int(time.time())) > ttl:
         raise HTTPAPIError('Signature invalid (bad timestamp)', 403)
     digest = hmac.new(ak.secret.encode(), normalizeQuery(path, query).encode(), hashlib.sha1).hexdigest()
-    if signature != digest:
+    if not hmac.compare_digest(signature, digest):
         raise HTTPAPIError('Signature invalid', 403)
 
 


### PR DESCRIPTION
Replace non-constant-time comparison with `hmac.compare_digest` in `validateSignature()` in `indico/indico/web/http_api/handlers.py`.