### PR TITLE
Support multi-choice abstract/contrib fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,12 +10,12 @@ Version 3.3.14
 Improvements
 ^^^^^^^^^^^^
 
-- Nothing so far :(
+- Support multi-choice abstract/contribution fields (:pr:`7725`)
 
 Bugfixes
 ^^^^^^^^
 
-- Nothing so far :)
+- Fix "No value" filter for text-based abstract/contribution fields (:pr:`7725`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/legacy/pdfinterface/latex_templates/inc/contribution.tex
+++ b/indico/legacy/pdfinterface/latex_templates/inc/contribution.tex
@@ -1,6 +1,17 @@
 \JINJA{from 'inc/person_list.tex' import render_person_lists}
 
 
+\JINJA{macro render_field_value(field_value)}
+    \JINJA{set field = field_value.contribution_field}
+    \JINJA{if field.field_type == 'text'}
+        \VAR{field_value.friendly_data}
+    \JINJA{elif field.field_type == 'single_choice'}
+        \VAR{field_value.friendly_data}
+    \JINJA{elif field.field_type == 'multiselect'}
+        \VAR{field_value.friendly_data|join(', ')}
+    \JINJA{endif}
+\JINJA{endmacro}
+
 \JINJA{macro render_contribution(contrib, tz)}
     {
         \small
@@ -66,7 +77,7 @@
                 \sectionfont{\normalsize\rmfamily}
                 \subsectionfont{\small\rmfamily}
                 \small
-                \VAR{field_value.friendly_data | markdown}
+                \VAR{render_field_value(field_value)|markdown}
             }
             \vspace{1.5em}
         \end{addmargin}
@@ -194,7 +205,7 @@
             \sectionfont{\normalsize\rmfamily}
             \subsectionfont{\small\rmfamily}
             \small
-            \VAR{field_value.friendly_data | markdown}
+            \VAR{render_field_value(field_value)|markdown}
         }
         \vspace{1em}
         \newline

--- a/indico/modules/events/abstracts/lists.py
+++ b/indico/modules/events/abstracts/lists.py
@@ -88,7 +88,7 @@ class AbstractListGeneratorBase(ListGeneratorBase):
     def _get_filters_from_request(self):
         filters = super()._get_filters_from_request()
         for field in self.event.contribution_fields:
-            if field.field_type == 'single_choice':
+            if field.field_type in {'single_choice', 'multiselect'}:
                 options = [x if x != 'None' else None for x in request.form.getlist(f'field_{field.id}')]
                 if options:
                     filters['fields'][str(field.id)] = options
@@ -122,31 +122,33 @@ class AbstractListGeneratorBase(ListGeneratorBase):
             return query
 
         if field_filters:
+            fields_by_id: dict[int, ContributionField] = {f.id: f for f in self.event.contribution_fields}
             for field_id, field_values in field_filters.items():
-                field_values = set(field_values)
+                if not (field := fields_by_id.get(int(field_id))) or field.field_type not in (
+                    'multiselect',
+                    'single_choice',
+                ):
+                    continue
 
-                # Support filtering by 'No selection' in single-choice abstract fields.
-                field_criteria = []
+                field_values = set(field_values)
+                field_criteria = [
+                    Abstract.field_values.any(
+                        db.and_(
+                            AbstractFieldValue.contribution_field_id == field_id,
+                            field.field.create_sql_filter(AbstractFieldValue.data, field_values),
+                        )
+                    )
+                ]
                 if None in field_values:
                     # Handle the case when there is no value in
                     # 'Abstract.field_values' matching the 'field_id'.
                     # This can happen when custom fields are added after the
-                    # abstract had already been submitted or when submitting as a regular
-                    # user who cannot see a field that is only editable by managers.
-                    # In these cases, we still want to show the abstracts.
-                    field_values.discard(None)
-                    field_criteria += [
+                    # contribution had already been created or when the field is left
+                    # empty.
+                    # In these cases, we still want to show the contributions.
+                    field_criteria.append(
                         ~Abstract.field_values.any(AbstractFieldValue.contribution_field_id == field_id),
-                        Abstract.field_values.any(db.and_(
-                            AbstractFieldValue.contribution_field_id == field_id,
-                            AbstractFieldValue.data.op('#>>')('{}').is_(None)
-                        ))
-                    ]
-                if field_values:
-                    field_criteria.append(Abstract.field_values.any(db.and_(
-                        AbstractFieldValue.contribution_field_id == field_id,
-                        AbstractFieldValue.data.op('#>>')('{}').in_(field_values)
-                    )))
+                    )
 
                 criteria.append(db.or_(*field_criteria))
 

--- a/indico/modules/events/abstracts/lists.py
+++ b/indico/modules/events/abstracts/lists.py
@@ -88,10 +88,8 @@ class AbstractListGeneratorBase(ListGeneratorBase):
     def _get_filters_from_request(self):
         filters = super()._get_filters_from_request()
         for field in self.event.contribution_fields:
-            if field.field_type in {'single_choice', 'multiselect'}:
-                options = [x if x != 'None' else None for x in request.form.getlist(f'field_{field.id}')]
-                if options:
-                    filters['fields'][str(field.id)] = options
+            if options := [x if x != 'None' else None for x in request.form.getlist(f'field_{field.id}')]:
+                filters['fields'][str(field.id)] = options
         # Ensure enum filters remain as integers
         for idx, value in enumerate(filters['items'].get('state', [])):
             filters['items']['state'][idx] = int(value)
@@ -124,12 +122,7 @@ class AbstractListGeneratorBase(ListGeneratorBase):
         if field_filters:
             fields_by_id: dict[int, ContributionField] = {f.id: f for f in self.event.contribution_fields}
             for field_id, field_values in field_filters.items():
-                if not (field := fields_by_id.get(int(field_id))) or field.field_type not in (
-                    'multiselect',
-                    'single_choice',
-                ):
-                    continue
-
+                field = fields_by_id[int(field_id)]
                 field_values = set(field_values)
                 field_criteria = [
                     Abstract.field_values.any(

--- a/indico/modules/events/abstracts/templates/management/_abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/_abstract_list.html
@@ -258,6 +258,9 @@
                                 {% set data = abstract.data_by_field %}
                                 {% for item in dynamic_columns %}
                                     {% set friendly_data = data[item.id].friendly_data if item.id in data else '' %}
+                                    {% if friendly_data is sequence and friendly_data is not string %}
+                                        {% set friendly_data = friendly_data | join(', ') %}
+                                    {% endif %}
                                     <td class="i-table" data-text="{{ friendly_data }}"
                                         data-searchable="{{ friendly_data | lower }}">
                                         {{- friendly_data if friendly_data else '-' -}}

--- a/indico/modules/events/abstracts/templates/reviewing/public.html
+++ b/indico/modules/events/abstracts/templates/reviewing/public.html
@@ -541,14 +541,21 @@
 
 
 {% macro _render_field_value(value) %}
-        <div class="field-value {{ 'single-choice 'if value.contribution_field.field_type == 'single_choice' else ''}}">
-            <label>{{ value.contribution_field.title }}:</label>
-            {% if value.friendly_data %}
-                <span class="value">{{ value.friendly_data }}</span>
-            {% else %}
-                <span class="value empty">{% trans %}No answer{% endtrans %}</span>
-            {% endif %}
-        </div>
+    {% set field = value.contribution_field %}
+    <div class="field-value {{ 'single-choice' if value.contribution_field.field_type == 'single_choice' else ''}}">
+        <label>{{ value.contribution_field.title }}:</label>
+        {% if value.friendly_data %}
+            <span class="value">
+                {% if field.field_type == 'multiselect' %}
+                    {{ value.friendly_data|join(', ') }}
+                {% else %}
+                    {{ value.friendly_data }}
+                {% endif %}
+            </span>
+        {% else %}
+            <span class="value empty">{% trans %}No answer{% endtrans %}</span>
+        {% endif %}
+    </div>
 {% endmacro %}
 
 

--- a/indico/modules/events/contributions/__init__.py
+++ b/indico/modules/events/contributions/__init__.py
@@ -62,6 +62,7 @@ def _get_fields(sender, **kwargs):
     from . import contrib_fields
     yield contrib_fields.ContribTextField
     yield contrib_fields.ContribSingleChoiceField
+    yield contrib_fields.ContribMultiChoiceField
 
 
 @signals.core.app_created.connect

--- a/indico/modules/events/contributions/contrib_fields.py
+++ b/indico/modules/events/contributions/contrib_fields.py
@@ -11,7 +11,7 @@ from wtforms.validators import DataRequired, Optional
 from indico.modules.events.contributions.models.fields import ContributionField, ContributionFieldVisibility
 from indico.util.i18n import _
 from indico.web.fields import BaseField, get_field_definitions
-from indico.web.fields.choices import SingleChoiceField
+from indico.web.fields.choices import MultiSelectField, SingleChoiceField
 from indico.web.fields.simple import TextField
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.fields import IndicoEnumRadioField
@@ -59,3 +59,7 @@ class ContribTextField(TextField, ContribField):
 
 class ContribSingleChoiceField(SingleChoiceField, ContribField):
     pass
+
+
+class ContribMultiChoiceField(MultiSelectField, ContribField):
+    friendly_name = _('Multiple Choice')

--- a/indico/modules/events/contributions/lists.py
+++ b/indico/modules/events/contributions/lists.py
@@ -92,10 +92,8 @@ class ContributionListGenerator(ListGeneratorBase):
     def _get_filters_from_request(self):
         filters = super()._get_filters_from_request()
         for field in self.event.contribution_fields:
-            if field.field_type in {'single_choice', 'multiselect'}:
-                options = [x if x != 'None' else None for x in request.form.getlist(f'field_{field.id}')]
-                if options:
-                    filters['fields'][str(field.id)] = options
+            if options := [x if x != 'None' else None for x in request.form.getlist(f'field_{field.id}')]:
+                filters['fields'][str(field.id)] = options
         # Ensure enum filters remain as integers
         for idx, value in enumerate(filters['items'].get('state', [])):
             filters['items']['state'][idx] = int(value)
@@ -143,12 +141,7 @@ class ContributionListGenerator(ListGeneratorBase):
         if field_filters:
             fields_by_id: dict[int, ContributionField] = {f.id: f for f in self.event.contribution_fields}
             for field_id, field_values in field_filters.items():
-                if not (field := fields_by_id.get(int(field_id))) or field.field_type not in (
-                    'multiselect',
-                    'single_choice',
-                ):
-                    continue
-
+                field = fields_by_id[int(field_id)]
                 field_values = set(field_values)
                 field_criteria = [
                     Contribution.field_values.any(

--- a/indico/modules/events/contributions/lists.py
+++ b/indico/modules/events/contributions/lists.py
@@ -9,7 +9,6 @@ from datetime import timedelta
 from operator import attrgetter
 
 from flask import flash, request, session
-from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import joinedload, subqueryload
 
 from indico.core.db import db
@@ -144,33 +143,21 @@ class ContributionListGenerator(ListGeneratorBase):
         if field_filters:
             fields_by_id: dict[int, ContributionField] = {f.id: f for f in self.event.contribution_fields}
             for field_id, field_values in field_filters.items():
-                if not (field := fields_by_id.get(int(field_id))):
+                if not (field := fields_by_id.get(int(field_id))) or field.field_type not in (
+                    'multiselect',
+                    'single_choice',
+                ):
                     continue
 
                 field_values = set(field_values)
-
-                if field.field_type == 'multiselect':
-                    field_criteria = []
-                    if None in field_values:
-                        field_values.discard(None)
-                        field_criteria += [
-                            ~Contribution.field_values.any(ContributionFieldValue.contribution_field_id == field_id),
-                            Contribution.field_values.any(db.and_(
-                                ContributionFieldValue.contribution_field_id == field_id,
-                                ContributionFieldValue.data == [],
-                            ))
-                        ]
-
-                    if field_values:
-                        field_criteria.append(Contribution.field_values.any(db.and_(
+                field_criteria = [
+                    Contribution.field_values.any(
+                        db.and_(
                             ContributionFieldValue.contribution_field_id == field_id,
-                            ContributionFieldValue.data.has_any(db.func.cast(field_values, ARRAY(db.String))),
-                        )))
-
-                    criteria.append(db.or_(*field_criteria))
-                    continue
-
-                field_criteria = []
+                            field.field.create_sql_filter(ContributionFieldValue.data, field_values),
+                        )
+                    )
+                ]
                 if None in field_values:
                     # Handle the case when there is no value in
                     # 'Contribution.field_values' matching the 'field_id'.
@@ -178,20 +165,9 @@ class ContributionListGenerator(ListGeneratorBase):
                     # contribution had already been created or when the field is left
                     # empty.
                     # In these cases, we still want to show the contributions.
-                    field_values.discard(None)
-                    field_criteria += [
+                    field_criteria.append(
                         ~Contribution.field_values.any(ContributionFieldValue.contribution_field_id == field_id),
-                        Contribution.field_values.any(db.and_(
-                            ContributionFieldValue.contribution_field_id == field_id,
-                            ContributionFieldValue.data.op('#>>')('{}').is_(None)
-                        ))
-                    ]
-
-                if field_values:
-                    field_criteria.append(Contribution.field_values.any(db.and_(
-                        ContributionFieldValue.contribution_field_id == field_id,
-                        ContributionFieldValue.data.op('#>>')('{}').in_(field_values)
-                    )))
+                    )
 
                 criteria.append(db.or_(*field_criteria))
 

--- a/indico/modules/events/contributions/lists.py
+++ b/indico/modules/events/contributions/lists.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from operator import attrgetter
 
 from flask import flash, request, session
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.orm import joinedload, subqueryload
 
 from indico.core.db import db
@@ -92,7 +93,7 @@ class ContributionListGenerator(ListGeneratorBase):
     def _get_filters_from_request(self):
         filters = super()._get_filters_from_request()
         for field in self.event.contribution_fields:
-            if field.field_type == 'single_choice':
+            if field.field_type in {'single_choice', 'multiselect'}:
                 options = [x if x != 'None' else None for x in request.form.getlist(f'field_{field.id}')]
                 if options:
                     filters['fields'][str(field.id)] = options
@@ -141,8 +142,33 @@ class ContributionListGenerator(ListGeneratorBase):
             return query
 
         if field_filters:
+            fields_by_id: dict[int, ContributionField] = {f.id: f for f in self.event.contribution_fields}
             for field_id, field_values in field_filters.items():
+                if not (field := fields_by_id.get(int(field_id))):
+                    continue
+
                 field_values = set(field_values)
+
+                if field.field_type == 'multiselect':
+                    field_criteria = []
+                    if None in field_values:
+                        field_values.discard(None)
+                        field_criteria += [
+                            ~Contribution.field_values.any(ContributionFieldValue.contribution_field_id == field_id),
+                            Contribution.field_values.any(db.and_(
+                                ContributionFieldValue.contribution_field_id == field_id,
+                                ContributionFieldValue.data == [],
+                            ))
+                        ]
+
+                    if field_values:
+                        field_criteria.append(Contribution.field_values.any(db.and_(
+                            ContributionFieldValue.contribution_field_id == field_id,
+                            ContributionFieldValue.data.has_any(db.func.cast(field_values, ARRAY(db.String))),
+                        )))
+
+                    criteria.append(db.or_(*field_criteria))
+                    continue
 
                 field_criteria = []
                 if None in field_values:

--- a/indico/modules/events/contributions/templates/display/contribution_display.html
+++ b/indico/modules/events/contributions/templates/display/contribution_display.html
@@ -18,6 +18,8 @@
                 {{ field_value.data }}
             {% elif field.field_type == 'single_choice' %}
                 {{ field_value.friendly_data }}
+            {% elif field.field_type == 'multiselect' %}
+                {{ field_value.friendly_data|join(', ') }}
             {% endif %}
         </td>
     </tr>
@@ -193,7 +195,7 @@
     <table class="other-fields">
         {% for field_value in field_values|sort(attribute='contribution_field.position') %}
             {% set field = field_value.contribution_field %}
-            {% if (field.field_type == 'single_choice' or not field.field_data.multiline) and field_value.data and field.is_active %}
+            {% if (field.field_type in ('single_choice', 'multiselect') or not field.field_data.multiline) and field_value.data and field.is_active %}
                 {{ _render_field_value(field_value) }}
             {% endif %}
         {% endfor %}

--- a/indico/modules/events/contributions/templates/management/_contribution_list.html
+++ b/indico/modules/events/contributions/templates/management/_contribution_list.html
@@ -250,6 +250,9 @@
                                 {% set data = contrib.data_by_field %}
                                 {% for item in dynamic_columns %}
                                     {% set friendly_data = data[item.id].friendly_data if item.id in data else '' %}
+                                    {% if friendly_data is sequence and friendly_data is not string %}
+                                        {% set friendly_data = friendly_data | join(', ') %}
+                                    {% endif %}
                                     <td class="i-table" data-text="{{ friendly_data }}"
                                         data-searchable="{{ friendly_data | lower }}">
                                         {{- friendly_data if friendly_data else '-' -}}

--- a/indico/web/fields/base.py
+++ b/indico/web/fields/base.py
@@ -144,6 +144,7 @@ class BaseField:
         if None in data_list:
             data_list.discard(None)
             criteria.append(db_field.op('#>>')('{}').is_(None))
+            criteria.append(db_field.op('#>>')('{}') == '')  # noqa: PLC1901
         if data_list:
             criteria.append(db_field.op('#>>')('{}').in_(data_list))
         return db.or_(*criteria)

--- a/indico/web/fields/base.py
+++ b/indico/web/fields/base.py
@@ -10,6 +10,7 @@ from copy import deepcopy
 from wtforms.fields import BooleanField, StringField, TextAreaField
 from wtforms.validators import DataRequired, Optional
 
+from indico.core.db import db
 from indico.util.i18n import _
 from indico.web.forms.base import IndicoForm
 from indico.web.forms.widgets import SwitchWidget
@@ -130,3 +131,19 @@ class BaseField:
         elif self.not_required_validator:
             validators.append(self.not_required_validator())
         return field_cls(self.object.title, validators, description=self.object.description, **kwargs)
+
+    def create_sql_filter(self, db_field, data_list: set[str | None]):
+        """
+        Create an SQL criterion to check whether the field's value is
+        in `data_list`.  The function is expected to return an
+        operation on the provided `db_field` which must be a JSONB
+        column.
+        """
+        data_list = set(data_list)
+        criteria = []
+        if None in data_list:
+            data_list.discard(None)
+            criteria.append(db_field.op('#>>')('{}').is_(None))
+        if data_list:
+            criteria.append(db_field.op('#>>')('{}').in_(data_list))
+        return db.or_(*criteria)

--- a/indico/web/fields/choices.py
+++ b/indico/web/fields/choices.py
@@ -147,6 +147,8 @@ class MultiSelectField(_ChoiceFieldBase):
                 'coerce': lambda x: x}
 
     def get_friendly_value(self, value):
+        if not value:
+            return []
         option_map = {option_dict['id']: option_dict['option'] for option_dict in self.object.field_data['options']}
         return [option_map[id_] for id_ in value if id_ in option_map]
 

--- a/indico/web/fields/choices.py
+++ b/indico/web/fields/choices.py
@@ -5,9 +5,11 @@
 # modify it under the terms of the MIT License; see the
 # LICENSE file for more details.
 
+from sqlalchemy.dialects.postgresql import ARRAY
 from wtforms.fields import IntegerField, SelectField
 from wtforms.validators import DataRequired, Length, NumberRange, Optional, ValidationError
 
+from indico.core.db import db
 from indico.util.i18n import _, ngettext
 from indico.web.fields.base import BaseField
 from indico.web.forms.fields import IndicoRadioField, IndicoSelectMultipleCheckboxField, MultiStringField
@@ -147,3 +149,13 @@ class MultiSelectField(_ChoiceFieldBase):
     def get_friendly_value(self, value):
         option_map = {option_dict['id']: option_dict['option'] for option_dict in self.object.field_data['options']}
         return [option_map[id_] for id_ in value if id_ in option_map]
+
+    def create_sql_filter(self, db_field, data_list):
+        data_list = set(data_list)
+        criteria = []
+        if None in data_list:
+            data_list.discard(None)
+            criteria.append(db_field == [])
+        if data_list:
+            criteria.append(db_field.has_any(db.func.cast(data_list, ARRAY(db.String))))
+        return db.or_(*criteria)


### PR DESCRIPTION
We're using generic fields for this anyway, and the field implementation already existed (for surveys).

This also fixes bug where filtering for "No value" for text fields didn't do anything, and I refactored the SQL filtering logic there a bit (similar to how we do it in registration fields).

I did not bother cleaning up the quite ugly display logic for the values of these fields, but at some point this should done similar to what we do for registration fields as well (ie have the field class have the logic on how to render e.g. a table column or friendly data for the field).