### PR TITLE
Allow dragging contributions to the sidepanel to unschedule

### DIFF
--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -124,16 +124,24 @@ function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) 
 
 const MemoizedTopLevelEntries = React.memo(TopLevelEntries);
 
-function DragPlaceholderContainer({
-  findEntryById,
-}: {
-  findEntryById: (id: string) => Entry | undefined;
-}) {
+function DragPlaceholderContainer({entries}: {entries: TopLevelEntry[]}) {
   const dragged = useDraggedData();
-  const draggedEntry = useMemo(
-    () => (dragged ? findEntryById(dragged) : undefined),
-    [dragged, findEntryById]
-  );
+  const draggedEntry = useMemo(() => {
+    if (!dragged) {
+      return undefined;
+    }
+    for (const entry of entries) {
+      if (entry.id === dragged) {
+        return entry;
+      }
+      if (entry.id.startsWith('s')) {
+        const childEntry = (entry as BlockEntry).children.find(c => c.id === dragged);
+        if (childEntry) {
+          return childEntry;
+        }
+      }
+    }
+  }, [dragged, entries]);
 
   return (
     <DragPlaceholder>
@@ -146,6 +154,7 @@ function DragPlaceholderContainer({
           setDuration={() => null}
           setNodeRef={() => null}
           {...draggedEntry}
+          y={0}
           sessionId={draggedEntry.sessionId ?? undefined}
           column={0}
           maxColumn={1}
@@ -756,7 +765,7 @@ export function DayTimetable({
           </DnDCalendar>
         </div>
       </div>
-      <DragPlaceholderContainer findEntryById={findEntryById} />
+      <DragPlaceholderContainer entries={entries} />
     </DnDProvider>
   );
 }

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -18,7 +18,7 @@ import {indicoAxios, handleAxiosError} from 'indico/utils/axios';
 import {localeUses24HourTime} from 'indico/utils/date';
 
 import * as actions from './actions';
-import {Transform, Over, MousePosition} from './dnd';
+import {Transform, Over, MousePosition, Rect, Coords} from './dnd';
 import {useDroppable, DnDProvider, DragPlaceholder, useDraggedData} from './dnd/dnd';
 import {createRestrictToCalendar} from './dnd/modifiers';
 import EntryComponent, {DraggableEntry} from './Entry';
@@ -60,6 +60,7 @@ import {
   isWithinLimits,
   minutesToPixels,
   pixelsToMinutes,
+  snapMinutes,
 } from './utils';
 
 import './DayTimetable.module.scss';
@@ -286,12 +287,26 @@ export function DayTimetable({
     });
   }
 
+  function isValidEntryTime(
+    mouse: MousePosition,
+    calendarRect: Rect,
+    offset: Coords,
+    duration: number
+  ) {
+    const mousePositionY = mouse.y - calendarRect.top - window.scrollY;
+    const startDt = moment(dt)
+      .startOf('day')
+      .add(snapMinutes(pixelsToMinutes(mousePositionY - offset.y)), 'minutes');
+    const endDt = startDt.clone().add(duration, 'minutes');
+    return startDt.isSameOrAfter(eventStartDt) && endDt.isSameOrBefore(eventEndDt);
+  }
+
   function handleDragEnd(
     who: string,
     over: Over[],
     delta: Transform,
     mouse: MousePosition,
-    offset
+    offset: Coords
   ) {
     if (over.length === 0) {
       return;
@@ -331,7 +346,7 @@ export function DayTimetable({
     }
 
     if (over.length === 1) {
-      return handleDropOnCalendar(who, calendar, delta, mouse);
+      return handleDropOnCalendar(who, calendar, delta, mouse, offset);
     } else {
       const block = over.find(o => o.id !== 'calendar');
       if (block) {
@@ -345,7 +360,7 @@ export function DayTimetable({
     over: Over,
     delta: Transform,
     mouse: MousePosition,
-    offset
+    offset: Coords
   ) {
     const sessionBlockId = expandedSessionBlock?.id;
 
@@ -363,6 +378,19 @@ export function DayTimetable({
         sbEndDt
       );
     } else {
+      // TODO(tomas): use something better than 'unscheduled-' prefix
+      const contribId = parseInt(who.slice('unscheduled-c'.length), 10);
+      const fromContrib: ContribEntry | undefined = unscheduled.find(
+        c => c.id === getEntryUniqueId(EntryType.Contribution, contribId)
+      );
+
+      if (
+        fromContrib === undefined ||
+        !isValidEntryTime(mouse, over.rect, offset, fromContrib.duration)
+      ) {
+        return;
+      }
+
       const [entry, layoutOverrides] =
         layoutAfterUnscheduledDrop(
           dt,
@@ -376,12 +404,7 @@ export function DayTimetable({
           eventStartDt,
           eventEndDt
         ) || [];
-      // TODO(tomas): use something better than 'unscheduled-' prefix
-      const contribId = parseInt(who.slice('unscheduled-c'.length), 10);
-      const fromContrib = unscheduled.find(
-        c => c.id === getEntryUniqueId(EntryType.Contribution, contribId)
-      );
-      showToastIfContribSessionChanged(fromContrib?.title, fromContrib?.sessionId, null);
+      showToastIfContribSessionChanged(fromContrib.title, fromContrib.sessionId ?? undefined);
       dispatch(actions.scheduleEntry(eventId, entry as ContribEntry, layoutOverrides!));
     }
   }
@@ -391,7 +414,7 @@ export function DayTimetable({
     over: Over,
     delta: Transform,
     mouse: MousePosition,
-    offset,
+    offset: Coords,
     calendar: Over,
     minStartDt: Moment = eventStartDt,
     maxEndDt: Moment = eventEndDt
@@ -429,8 +452,21 @@ export function DayTimetable({
     dispatch(actions.scheduleEntry(eventId, entry, layoutOverrides));
   }
 
-  function handleDropOnCalendar(who: string, over: Over, delta: Transform, mouse: MousePosition) {
+  function handleDropOnCalendar(
+    who: string,
+    over: Over,
+    delta: Transform,
+    mouse: MousePosition,
+    offset: Coords
+  ) {
     const originalEntry = findEntryById(who);
+    if (
+      originalEntry === undefined ||
+      !isValidEntryTime(mouse, over.rect, offset, originalEntry.duration)
+    ) {
+      return;
+    }
+
     const sessionBlockId = expandedSessionBlock?.id;
     if (sessionBlockId) {
       const [newLayout, movedEntry] = layoutAfterDropOnBlock(

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -125,9 +125,9 @@ function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) 
 const MemoizedTopLevelEntries = React.memo(TopLevelEntries);
 
 function DragPlaceholderContainer({entries}: {entries: TopLevelEntry[]}) {
-  const dragged = useDraggedData();
+  const {dragged, transform} = useDraggedData();
   const draggedEntry = useMemo(() => {
-    if (!dragged) {
+    if (!dragged || dragged.startsWith('unscheduled')) {
       return undefined;
     }
     for (const entry of entries) {
@@ -153,6 +153,7 @@ function DragPlaceholderContainer({entries}: {entries: TopLevelEntry[]}) {
           selected={false}
           setDuration={() => null}
           setNodeRef={() => null}
+          transform={transform}
           {...draggedEntry}
           y={0}
           sessionId={draggedEntry.sessionId ?? undefined}

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -19,9 +19,9 @@ import {localeUses24HourTime} from 'indico/utils/date';
 
 import * as actions from './actions';
 import {Transform, Over, MousePosition} from './dnd';
-import {useDroppable, DnDProvider, DragPlaceholder} from './dnd/dnd';
+import {useDroppable, DnDProvider, DragPlaceholder, useDraggedData} from './dnd/dnd';
 import {createRestrictToCalendar} from './dnd/modifiers';
-import {DraggableEntry} from './Entry';
+import EntryComponent, {DraggableEntry} from './Entry';
 import {formatTimeRange} from './i18n';
 import {
   computeYoffset,
@@ -123,6 +123,37 @@ function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) 
 }
 
 const MemoizedTopLevelEntries = React.memo(TopLevelEntries);
+
+function DragPlaceholderContainer({
+  findEntryById,
+}: {
+  findEntryById: (id: string) => Entry | undefined;
+}) {
+  const dragged = useDraggedData();
+  const draggedEntry = useMemo(
+    () => (dragged ? findEntryById(dragged) : undefined),
+    [dragged, findEntryById]
+  );
+
+  return (
+    <DragPlaceholder>
+      {draggedEntry ? (
+        <EntryComponent
+          listeners={{}}
+          isDragging
+          isPlaceholder
+          selected={false}
+          setDuration={() => null}
+          setNodeRef={() => null}
+          {...draggedEntry}
+          sessionId={draggedEntry.sessionId ?? undefined}
+          column={0}
+          maxColumn={1}
+        />
+      ) : null}
+    </DragPlaceholder>
+  );
+}
 
 export function DayTimetable({
   dt,
@@ -725,7 +756,7 @@ export function DayTimetable({
           </DnDCalendar>
         </div>
       </div>
-      <DragPlaceholder />
+      <DragPlaceholderContainer findEntryById={findEntryById} />
     </DnDProvider>
   );
 }

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -19,7 +19,7 @@ import {localeUses24HourTime} from 'indico/utils/date';
 
 import * as actions from './actions';
 import {Transform, Over, MousePosition} from './dnd';
-import {useDroppable, DnDProvider} from './dnd/dnd';
+import {useDroppable, DnDProvider, DragPlaceholder} from './dnd/dnd';
 import {createRestrictToCalendar} from './dnd/modifiers';
 import {DraggableEntry} from './Entry';
 import {formatTimeRange} from './i18n';
@@ -272,6 +272,16 @@ export function DayTimetable({
           return handleUnscheduledDropOnBlock(who, block, delta, mouse, offset, calendar);
         }
       }
+    }
+
+    const sidepanel = over.find(o => o.id === 'sidepanel');
+    if (sidepanel && who.startsWith('c')) {
+      const entry = findEntryById(who);
+      if (entry === undefined) {
+        return;
+      }
+      dispatch(actions.unscheduleEntry(entry as ContribEntry, eventId));
+      return;
     }
 
     const calendar = over.find(o => o.id === 'calendar');
@@ -715,6 +725,7 @@ export function DayTimetable({
           </DnDCalendar>
         </div>
       </div>
+      <DragPlaceholder />
     </DnDProvider>
   );
 }

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -126,7 +126,7 @@ function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) 
 const MemoizedTopLevelEntries = React.memo(TopLevelEntries);
 
 function DragPlaceholderContainer({entries}: {entries: TopLevelEntry[]}) {
-  const {dragged, transform, ref} = useDraggedData();
+  const {dragged, transform, ref, overlappingDroppables} = useDraggedData();
   const draggedEntry = useMemo(() => {
     if (!dragged || dragged.startsWith('unscheduled')) {
       return undefined;
@@ -143,9 +143,20 @@ function DragPlaceholderContainer({entries}: {entries: TopLevelEntry[]}) {
       }
     }
   }, [dragged, entries]);
+  const overSidepanel = useMemo(
+    () => overlappingDroppables.find(over => over.id === 'sidepanel'),
+    [overlappingDroppables]
+  );
+  const width = useMemo(
+    () =>
+      overSidepanel && dragged && dragged.startsWith('c')
+        ? `${overSidepanel.rect.width}px`
+        : `${ref?.current?.clientWidth ?? 0}px`,
+    [ref, overSidepanel, dragged]
+  );
 
   return (
-    <DragPlaceholder width={`${ref?.current?.clientWidth ?? 0}px`}>
+    <DragPlaceholder width={width}>
       {draggedEntry ? (
         <EntryComponent
           listeners={{}}

--- a/indico/modules/events/timetable/client/js/DayTimetable.tsx
+++ b/indico/modules/events/timetable/client/js/DayTimetable.tsx
@@ -126,7 +126,7 @@ function TopLevelEntries({dt, entries}: {dt: Moment; entries: TopLevelEntry[]}) 
 const MemoizedTopLevelEntries = React.memo(TopLevelEntries);
 
 function DragPlaceholderContainer({entries}: {entries: TopLevelEntry[]}) {
-  const {dragged, transform} = useDraggedData();
+  const {dragged, transform, ref} = useDraggedData();
   const draggedEntry = useMemo(() => {
     if (!dragged || dragged.startsWith('unscheduled')) {
       return undefined;
@@ -145,7 +145,7 @@ function DragPlaceholderContainer({entries}: {entries: TopLevelEntry[]}) {
   }, [dragged, entries]);
 
   return (
-    <DragPlaceholder>
+    <DragPlaceholder width={`${ref?.current?.clientWidth ?? 0}px`}>
       {draggedEntry ? (
         <EntryComponent
           listeners={{}}
@@ -159,7 +159,7 @@ function DragPlaceholderContainer({entries}: {entries: TopLevelEntry[]}) {
           y={0}
           sessionId={draggedEntry.sessionId ?? undefined}
           column={0}
-          maxColumn={1}
+          maxColumn={0}
         />
       ) : null}
     </DragPlaceholder>

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -137,6 +137,7 @@ export function DraggableEntry({id, setDuration, ...rest}: DraggableEntryProps) 
 
 interface _EntryProps {
   id: EntryUniqueID;
+  transform: {x: number; y: number} | undefined;
   isDragging?: boolean;
   isPlaceholder?: boolean;
   listeners: Record<string, unknown>;
@@ -178,6 +179,7 @@ export default function Entry({
   y,
   listeners,
   setNodeRef,
+  transform,
   isDragging = false,
   isPlaceholder = false,
   column,
@@ -232,7 +234,7 @@ export default function Entry({
     ...colors,
   };
 
-  const deltaMinutes = snapMinutes(pixelsToMinutes(0));
+  const deltaMinutes = snapMinutes(pixelsToMinutes(transform ? transform.y : 0));
   const newStart = moment(startDt).add(deltaMinutes, 'minutes');
   const newEnd = moment(startDt).add(deltaMinutes + duration, 'minutes');
 
@@ -355,6 +357,7 @@ export default function Entry({
                   selected={false}
                   setDuration={() => null}
                   setNodeRef={() => null}
+                  transform={undefined}
                   {...child}
                   blockRef={blockRef}
                   parentEndDt={moment(startDt)

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -220,7 +220,7 @@ export default function Entry({
 
   const style = {
     opacity: isDragging && !isPlaceholder ? 0 : 1,
-    position: isPlaceholder ? 'relative' : 'absolute',
+    position: 'absolute',
     top: y,
     left: offset,
     width: `calc(${width} - 5px)`,
@@ -355,11 +355,11 @@ export default function Entry({
                   selected={false}
                   setDuration={() => null}
                   setNodeRef={() => null}
+                  {...child}
                   blockRef={blockRef}
                   parentEndDt={moment(startDt)
                     .add(deltaMinutes + duration, 'minutes')
                     .format()}
-                  {...child}
                   sessionId={child.sessionId ?? undefined}
                 />
               ) : (

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -31,7 +31,6 @@ import {
 import {
   minutesToPixels,
   pixelsToMinutes,
-  snapPixels,
   snapMinutes,
   formatBlockTitle,
   getIconByEntryType,
@@ -140,7 +139,8 @@ export function DraggableEntry({id, setDuration, ...rest}: DraggableEntryProps) 
 interface _EntryProps {
   id: EntryUniqueID;
   isDragging: boolean;
-  transform: {x: number; y: number} | undefined;
+  isPlaceholder: boolean;
+  // transform: {x: number; y: number} | undefined;
   listeners: Record<string, unknown>;
   setNodeRef: (element: HTMLElement | null) => void;
   blockRef?: React.RefObject<HTMLDivElement>;
@@ -180,8 +180,8 @@ export default function Entry({
   y,
   listeners,
   setNodeRef,
-  transform,
   isDragging,
+  isPlaceholder,
   column,
   maxColumn,
   setDuration: _setDuration,
@@ -217,31 +217,24 @@ export default function Entry({
     return eventEndDt.diff(startDt, 'minutes');
   }, [parentEndDt, eventEndDt, startDt]);
 
-  let style: Record<string, string | number | undefined> = transform
-    ? {
-        transform: `translate3d(${transform.x}px, ${snapPixels(transform.y)}px, 10px)`,
-        // zIndex: 70,
-      }
-    : {};
-
   const minHeight = minutesToPixels(5);
   const height = minutesToPixels(Math.max(duration, minHeight)) - V_SPACE_BETWEEN_ENTRIES_PX;
 
-  style = {
-    ...style,
-    position: 'absolute',
+  const style = {
+    opacity: isDragging && !isPlaceholder ? 0 : 1,
+    position: isPlaceholder ? 'relative' : 'absolute',
     top: y,
     left: offset,
     width: `calc(${width} - 5px)`,
     height,
     textAlign: 'left',
-    zIndex: isDragging || isResizing ? 1000 : selected ? 1 : style.zIndex,
+    zIndex: isDragging || isResizing ? 1000 : selected ? 1 : 0,
     cursor: isResizing ? undefined : isDragging ? 'grabbing' : 'grab',
     boxShadow: selected || isDragging ? `0 0 0 4px rgba(0,0,0,0.1)` : undefined,
     ...colors,
   };
 
-  const deltaMinutes = snapMinutes(pixelsToMinutes(transform ? transform.y : 0));
+  const deltaMinutes = snapMinutes(pixelsToMinutes(0));
   const newStart = moment(startDt).add(deltaMinutes, 'minutes');
   const newEnd = moment(startDt).add(deltaMinutes + duration, 'minutes');
 

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -52,7 +52,7 @@ interface DraggableEntryProps extends BaseEntry, ScheduledMixin {
 
 export function DraggableEntry({id, setDuration, ...rest}: DraggableEntryProps) {
   const dispatch = useDispatch();
-  const {listeners: _listeners, setNodeRef, transform, isDragging, ref} = useDraggable({id});
+  const {listeners: _listeners, setNodeRef, isDragging, ref} = useDraggable({id});
   const isSelected = useSelector((state: ReduxState) =>
     selectors.makeIsSelectedSelector()(state, id)
   );
@@ -116,7 +116,6 @@ export function DraggableEntry({id, setDuration, ...rest}: DraggableEntryProps) 
       {...rest}
       listeners={listeners}
       setNodeRef={setNodeRef}
-      transform={transform}
       isDragging={isDragging}
       selected={isSelected}
       setDuration={setDuration}
@@ -138,9 +137,8 @@ export function DraggableEntry({id, setDuration, ...rest}: DraggableEntryProps) 
 
 interface _EntryProps {
   id: EntryUniqueID;
-  isDragging: boolean;
-  isPlaceholder: boolean;
-  // transform: {x: number; y: number} | undefined;
+  isDragging?: boolean;
+  isPlaceholder?: boolean;
   listeners: Record<string, unknown>;
   setNodeRef: (element: HTMLElement | null) => void;
   blockRef?: React.RefObject<HTMLDivElement>;
@@ -180,8 +178,8 @@ export default function Entry({
   y,
   listeners,
   setNodeRef,
-  isDragging,
-  isPlaceholder,
+  isDragging = false,
+  isPlaceholder = false,
   column,
   maxColumn,
   setDuration: _setDuration,
@@ -348,26 +346,45 @@ export default function Entry({
               backgroundColor: `${colors.color}11`,
             }}
           >
-            {children.map(child => (
-              <DraggableEntry
-                key={child.id}
-                setDuration={_children ? setChildDurations[child.id] : null}
-                blockRef={blockRef}
-                parentEndDt={moment(startDt)
-                  .add(deltaMinutes + duration, 'minutes')
-                  .format()}
-                {...child}
-              />
-            ))}
-            {type === EntryType.SessionBlock && !isPosterBlock && droppableArea === 'partial' && (
-              <DroppableArea id={id} />
+            {children.map(child =>
+              isPlaceholder ? (
+                <Entry
+                  key={child.id}
+                  listeners={{}}
+                  isPlaceholder
+                  selected={false}
+                  setDuration={() => null}
+                  setNodeRef={() => null}
+                  blockRef={blockRef}
+                  parentEndDt={moment(startDt)
+                    .add(deltaMinutes + duration, 'minutes')
+                    .format()}
+                  {...child}
+                  sessionId={child.sessionId ?? undefined}
+                />
+              ) : (
+                <DraggableEntry
+                  key={child.id}
+                  setDuration={_children ? setChildDurations[child.id] : null}
+                  blockRef={blockRef}
+                  parentEndDt={moment(startDt)
+                    .add(deltaMinutes + duration, 'minutes')
+                    .format()}
+                  {...child}
+                />
+              )
             )}
+            {!isPlaceholder &&
+              type === EntryType.SessionBlock &&
+              !isPosterBlock &&
+              droppableArea === 'partial' && <DroppableArea id={id} />}
           </div>
         )}
       </div>
-      {type === EntryType.SessionBlock && !isPosterBlock && droppableArea === 'full' && (
-        <DroppableArea id={id} horizontalPadding="15px" />
-      )}
+      {!isPlaceholder &&
+        type === EntryType.SessionBlock &&
+        !isPosterBlock &&
+        droppableArea === 'full' && <DroppableArea id={id} horizontalPadding="15px" />}
       {!draftEntry && (
         <EntryMoveButtons
           id={id}

--- a/indico/modules/events/timetable/client/js/Entry.tsx
+++ b/indico/modules/events/timetable/client/js/Entry.tsx
@@ -20,14 +20,7 @@ import {formatTimeRange} from './i18n';
 import {getWidthAndOffset} from './layout';
 import ResizeHandle from './ResizeHandle';
 import * as selectors from './selectors';
-import {
-  ReduxState,
-  ContribEntry,
-  EntryType,
-  BaseEntry,
-  ScheduledMixin,
-  EntryUniqueID,
-} from './types';
+import {ReduxState, EntryType, BaseEntry, ScheduledMixin, EntryUniqueID, ChildEntry} from './types';
 import {
   minutesToPixels,
   pixelsToMinutes,
@@ -137,7 +130,7 @@ export function DraggableEntry({id, setDuration, ...rest}: DraggableEntryProps) 
 
 interface _EntryProps {
   id: EntryUniqueID;
-  transform: {x: number; y: number} | undefined;
+  transform?: {x: number; y: number};
   isDragging?: boolean;
   isPlaceholder?: boolean;
   listeners: Record<string, unknown>;
@@ -147,7 +140,7 @@ interface _EntryProps {
   setDuration: (duration: number) => void;
   onMouseUp?: () => void;
   setChildDuration?: (id: string) => (duration: number) => void;
-  children?: ContribEntry[];
+  children?: ChildEntry[];
   parentEndDt?: string;
   sessionId?: number;
   sessionBlockId?: string;
@@ -241,7 +234,7 @@ export default function Entry({
   const locale = moment.locale().replace('_', '-');
   const timeRange = formatTimeRange(locale, newStart, newEnd);
   // shift children startDt by deltaMinutes
-  const children: ContribEntry[] = _children.map(child => ({
+  const children = _children.map(child => ({
     ...child,
     startDt: moment(child.startDt).add(deltaMinutes, 'minutes'),
   }));
@@ -357,7 +350,6 @@ export default function Entry({
                   selected={false}
                   setDuration={() => null}
                   setNodeRef={() => null}
-                  transform={undefined}
                   {...child}
                   blockRef={blockRef}
                   parentEndDt={moment(startDt)

--- a/indico/modules/events/timetable/client/js/Timetable.module.scss
+++ b/indico/modules/events/timetable/client/js/Timetable.module.scss
@@ -23,6 +23,7 @@
 
   & > .content {
     display: flex;
+    overflow: hidden;
   }
 }
 

--- a/indico/modules/events/timetable/client/js/TimetableSidePanel.module.scss
+++ b/indico/modules/events/timetable/client/js/TimetableSidePanel.module.scss
@@ -13,7 +13,7 @@ $content-pane-bg-color: $white;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  min-height: 10em;
+  height: 100%;
 }
 
 .content {

--- a/indico/modules/events/timetable/client/js/TimetableSidePanel.module.scss
+++ b/indico/modules/events/timetable/client/js/TimetableSidePanel.module.scss
@@ -13,6 +13,7 @@ $content-pane-bg-color: $white;
   display: flex;
   flex-direction: column;
   gap: 10px;
+  min-height: 10em;
 }
 
 .content {

--- a/indico/modules/events/timetable/client/js/TimetableSidePanel.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableSidePanel.tsx
@@ -11,6 +11,7 @@ import React, {useEffect, useRef, useState} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 import {Button, Input, Dropdown, Icon, Popup} from 'semantic-ui-react';
 
+import {useDroppable} from 'indico/modules/events/timetable/dnd';
 import {SessionIcon} from 'indico/modules/events/timetable/SessionIcon';
 import PopoverDropdownMenu from 'indico/react/components/PopoverDropdownMenu';
 import {Translate} from 'indico/react/i18n';
@@ -25,9 +26,10 @@ import {
   useModal,
 } from './ModalContext';
 import * as selectors from './selectors';
-import './TimetableSidePanel.module.scss';
 import {EntryType, SidePanelView, UnscheduledContribEntry} from './types';
 import {DraggableUnscheduledContributionEntry} from './UnscheduledContributionEntry';
+
+import './TimetableSidePanel.module.scss';
 
 enum GenericFilterType {
   NO_SESSION = 'no-session',
@@ -43,19 +45,30 @@ function UnscheduledContributionList({
   contribs: UnscheduledContribEntry[];
 }) {
   const uniqueContribs = [...new Map(contribs.map(contrib => [contrib.id, contrib])).values()];
+  const {setNodeRef} = useDroppable({id: 'sidepanel'});
+
   return (
-    <div styleName="contributions-list">
-      {uniqueContribs.map(contrib => (
-        <DraggableUnscheduledContributionEntry
-          key={contrib.id}
-          dt={dt}
-          id={contrib.id}
-          objId={contrib.objId}
-          title={contrib.title}
-          duration={contrib.duration}
-          sessionId={contrib.sessionId}
-        />
-      ))}
+    <div ref={setNodeRef} styleName="contributions-list">
+      {contribs.length === 0 ? (
+        <div styleName="empty-state">
+          <Icon name="calendar times outline" />
+          <div styleName="empty-state-text">
+            <Translate>No contributions found</Translate>
+          </div>
+        </div>
+      ) : (
+        uniqueContribs.map(contrib => (
+          <DraggableUnscheduledContributionEntry
+            key={contrib.id}
+            dt={dt}
+            id={contrib.id}
+            objId={contrib.objId}
+            title={contrib.title}
+            duration={contrib.duration}
+            sessionId={contrib.sessionId}
+          />
+        ))
+      )}
     </div>
   );
 }
@@ -342,16 +355,7 @@ export default function TimetableSidePanel({dt}: {dt: Moment}) {
                   })
                 }
               />
-              {filteredContribs.length > 0 ? (
-                <UnscheduledContributionList dt={dt} contribs={filteredContribs} />
-              ) : (
-                <div styleName="empty-state">
-                  <Icon name="calendar times outline" />
-                  <div styleName="empty-state-text">
-                    <Translate>No contributions found</Translate>
-                  </div>
-                </div>
-              )}
+              <UnscheduledContributionList dt={dt} contribs={filteredContribs} />
               <div styleName="gradient" />
             </div>
           </>

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -7,7 +7,14 @@
 
 import _ from 'lodash';
 import React, {useCallback, useEffect, useRef, useState, useMemo} from 'react';
+import {useSelector} from 'react-redux/es';
 import {createContext, useContextSelector} from 'use-context-selector';
+
+import Entry from 'indico/modules/events/timetable/Entry';
+import {snapPixels} from 'indico/modules/events/timetable/utils';
+
+import * as selectors from '../selectors';
+import {EntryUniqueID} from '../types';
 
 import {getScrollParent, getTotalScroll} from './modifiers';
 import {ScrollBounds, useScrollIntent} from './scroll';
@@ -44,6 +51,7 @@ interface DnDContextType {
   droppables: Droppables;
   draggableData: DraggableData;
   onDrop: OnDrop;
+  dragged: EntryUniqueID | null;
   registerDroppable: (id: string, node: HTMLRef) => void;
   unregisterDroppable: (id: string) => void;
   registerDraggable: (id: string, fixed: boolean, node: HTMLRef) => void;
@@ -191,6 +199,74 @@ function getOverlappingDroppables(droppables: Droppables, mouse: MousePosition):
   return overlapping;
 }
 
+export function DragPlaceholder() {
+  const dragged = useContextSelector(DnDContext, ctx => ctx.dragged);
+  const dragState = useContextSelector(DnDContext, ctx =>
+    ctx.dragged ? ctx.draggableData[ctx.dragged] : undefined
+  );
+  const draggedDraggable = useContextSelector(DnDContext, ctx =>
+    ctx.dragged ? ctx.draggables[ctx.dragged] : null
+  );
+  const entries = useSelector(selectors.getEntries);
+
+  const [top, setTop] = useState(0);
+  const [left, setLeft] = useState(0);
+
+  const entry = useMemo(
+    () => Object.values(entries.entries).find(e => e.id === dragged),
+    [dragged, entries]
+  );
+
+  const transform = useMemo(
+    () =>
+      `translate3d(${dragState?.transform?.x ?? 0}px, ${snapPixels(dragState?.transform?.y ?? 0)}px, 10px)`,
+    [dragState]
+  );
+
+  useEffect(() => {
+    const draggedRef = draggedDraggable?.node?.current;
+    if (!draggedRef) {
+      return;
+    }
+
+    const rect = draggedRef.getBoundingClientRect();
+    setTop(rect.y);
+    setLeft(rect.x);
+  }, [draggedDraggable, transform]);
+
+  if (entry === undefined || dragState === undefined) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        width: '100%',
+        transform,
+        top,
+        left,
+        zIndex: 1000,
+        userSelect: 'none',
+        pointerEvents: 'none',
+      }}
+    >
+      <Entry
+        listeners={{}}
+        isDragging
+        isPlaceholder
+        selected={false}
+        setDuration={() => null}
+        setNodeRef={() => null}
+        {...entry}
+        sessionId={entry.sessionId ?? undefined}
+        column={0}
+        maxColumn={1}
+      />
+    </div>
+  );
+}
+
 export function DnDProvider({
   children,
   onDrop,
@@ -205,6 +281,7 @@ export function DnDProvider({
   const [droppables, setDroppables] = useState<Droppables>({});
   const [draggables, setDraggables] = useState<Draggables>({});
   const [draggableData, setDraggableData] = useState<DraggableData>({});
+  const [dragged, setDragged] = useState<EntryUniqueID | null>(null);
   const state = useRef<DnDState>({
     state: 'idle',
     initialMousePosition: {x: 0, y: 0},
@@ -247,6 +324,7 @@ export function DnDProvider({
         initialOffset: {x: 0, y: 0},
         activeDraggable: null,
       };
+      setDragged(null);
     }
     setDraggableData(d => _.omit(d, id));
     setDraggables(d => _.omit(d, id));
@@ -268,6 +346,7 @@ export function DnDProvider({
         initialOffset: {x: offsetX, y: offsetY},
         activeDraggable: id,
       };
+      setDragged(id as EntryUniqueID);
       setDraggableData(d =>
         setInitialOffset(setBoundingRectAndScroll(d, draggable.node, id), id, {
           x: offsetX,
@@ -334,6 +413,7 @@ export function DnDProvider({
       }
       setDraggableData(d => resetDraggableState(d, state.current.activeDraggable));
       state.current.activeDraggable = null;
+      setDragged(null);
     },
     [droppables, draggableData, onDrop, modifier]
   );
@@ -377,6 +457,7 @@ export function DnDProvider({
       state.current.state = 'idle';
       setDraggableData(d => resetDraggableState(d, state.current.activeDraggable));
       state.current.activeDraggable = null;
+      setDragged(null);
     }
   }, []);
 
@@ -405,6 +486,7 @@ export function DnDProvider({
       registerDraggable,
       unregisterDraggable,
       onMouseDown,
+      dragged,
     }),
     [
       draggables,
@@ -416,6 +498,7 @@ export function DnDProvider({
       unregisterDroppable,
       unregisterDraggable,
       onMouseDown,
+      dragged,
     ]
   );
 

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -7,13 +7,10 @@
 
 import _ from 'lodash';
 import React, {useCallback, useEffect, useRef, useState, useMemo} from 'react';
-import {useSelector} from 'react-redux/es';
 import {createContext, useContextSelector} from 'use-context-selector';
 
-import Entry from 'indico/modules/events/timetable/Entry';
 import {snapPixels} from 'indico/modules/events/timetable/utils';
 
-import * as selectors from '../selectors';
 import {EntryUniqueID} from '../types';
 
 import {getScrollParent, getTotalScroll} from './modifiers';
@@ -199,23 +196,16 @@ function getOverlappingDroppables(droppables: Droppables, mouse: MousePosition):
   return overlapping;
 }
 
-export function DragPlaceholder() {
-  const dragged = useContextSelector(DnDContext, ctx => ctx.dragged);
+export function DragPlaceholder({children}: {children: React.ReactNode}) {
   const dragState = useContextSelector(DnDContext, ctx =>
     ctx.dragged ? ctx.draggableData[ctx.dragged] : undefined
   );
   const draggedDraggable = useContextSelector(DnDContext, ctx =>
     ctx.dragged ? ctx.draggables[ctx.dragged] : null
   );
-  const entries = useSelector(selectors.getEntries);
 
   const [top, setTop] = useState(0);
   const [left, setLeft] = useState(0);
-
-  const entry = useMemo(
-    () => Object.values(entries.entries).find(e => e.id === dragged),
-    [dragged, entries]
-  );
 
   const transform = useMemo(
     () =>
@@ -234,7 +224,7 @@ export function DragPlaceholder() {
     setLeft(rect.x);
   }, [draggedDraggable, transform]);
 
-  if (entry === undefined || dragState === undefined) {
+  if (dragState === undefined) {
     return null;
   }
 
@@ -251,18 +241,7 @@ export function DragPlaceholder() {
         pointerEvents: 'none',
       }}
     >
-      <Entry
-        listeners={{}}
-        isDragging
-        isPlaceholder
-        selected={false}
-        setDuration={() => null}
-        setNodeRef={() => null}
-        {...entry}
-        sessionId={entry.sessionId ?? undefined}
-        column={0}
-        maxColumn={1}
-      />
+      {children}
     </div>
   );
 }
@@ -602,4 +581,9 @@ export function useDraggable({id, fixed = false}: {id: string; fixed?: boolean})
     offset,
     ref,
   };
+}
+
+export function useDraggedData() {
+  const dragged = useContextSelector(DnDContext, ctx => ctx.dragged);
+  return dragged;
 }

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -585,5 +585,21 @@ export function useDraggable({id, fixed = false}: {id: string; fixed?: boolean})
 
 export function useDraggedData() {
   const dragged = useContextSelector(DnDContext, ctx => ctx.dragged);
-  return dragged;
+  const transform = useContextSelector(DnDContext, ctx =>
+    ctx.dragged ? ctx.draggableData[ctx.dragged]?.transform : undefined
+  );
+
+  return useMemo(
+    () => ({
+      dragged,
+      transform:
+        transform?.x === undefined && transform?.y === undefined
+          ? undefined
+          : {
+              x: transform?.x,
+              y: transform?.y,
+            },
+    }),
+    [dragged, transform?.x, transform?.y]
+  );
 }

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -9,10 +9,6 @@ import _ from 'lodash';
 import React, {useCallback, useEffect, useRef, useState, useMemo} from 'react';
 import {createContext, useContextSelector} from 'use-context-selector';
 
-import {snapPixels} from 'indico/modules/events/timetable/utils';
-
-import {EntryUniqueID} from '../types';
-
 import {getScrollParent, getTotalScroll} from './modifiers';
 import {ScrollBounds, useScrollIntent} from './scroll';
 import {
@@ -48,7 +44,7 @@ interface DnDContextType {
   droppables: Droppables;
   draggableData: DraggableData;
   onDrop: OnDrop;
-  dragged: EntryUniqueID | null;
+  dragged: string | null;
   registerDroppable: (id: string, node: HTMLRef) => void;
   unregisterDroppable: (id: string) => void;
   registerDraggable: (id: string, fixed: boolean, node: HTMLRef) => void;
@@ -208,8 +204,7 @@ export function DragPlaceholder({children}: {children: React.ReactNode}) {
   const [left, setLeft] = useState(0);
 
   const transform = useMemo(
-    () =>
-      `translate3d(${dragState?.transform?.x ?? 0}px, ${snapPixels(dragState?.transform?.y ?? 0)}px, 10px)`,
+    () => `translate3d(${dragState?.transform?.x ?? 0}px, ${dragState?.transform?.y ?? 0}px, 10px)`,
     [dragState]
   );
 
@@ -260,7 +255,7 @@ export function DnDProvider({
   const [droppables, setDroppables] = useState<Droppables>({});
   const [draggables, setDraggables] = useState<Draggables>({});
   const [draggableData, setDraggableData] = useState<DraggableData>({});
-  const [dragged, setDragged] = useState<EntryUniqueID | null>(null);
+  const [dragged, setDragged] = useState<string | null>(null);
   const state = useRef<DnDState>({
     state: 'idle',
     initialMousePosition: {x: 0, y: 0},
@@ -339,7 +334,7 @@ export function DnDProvider({
       if (state.current.state === 'mousedown' || state.current.state === 'dragging') {
         if (state.current.state === 'mousedown') {
           state.current.state = 'dragging';
-          setDragged(state.current.activeDraggable as EntryUniqueID);
+          setDragged(state.current.activeDraggable);
         }
         const mousePosition = {
           x: e.pageX + state.current.scrollPosition.x,

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -325,7 +325,6 @@ export function DnDProvider({
         initialOffset: {x: offsetX, y: offsetY},
         activeDraggable: id,
       };
-      setDragged(id as EntryUniqueID);
       setDraggableData(d =>
         setInitialOffset(setBoundingRectAndScroll(d, draggable.node, id), id, {
           x: offsetX,
@@ -340,6 +339,7 @@ export function DnDProvider({
       if (state.current.state === 'mousedown' || state.current.state === 'dragging') {
         if (state.current.state === 'mousedown') {
           state.current.state = 'dragging';
+          setDragged(state.current.activeDraggable as EntryUniqueID);
         }
         const mousePosition = {
           x: e.pageX + state.current.scrollPosition.x,

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -587,11 +587,22 @@ export function useDraggedData() {
   const ref = useContextSelector(DnDContext, ctx =>
     ctx.dragged ? ctx.draggables[ctx.dragged]?.node : undefined
   );
+  const overlappingDroppables = useContextSelector(DnDContext, ctx => {
+    if (ctx.dragged === null) {
+      return [];
+    }
+    const mouse = ctx.draggableData[ctx.dragged].mouse;
+    if (mouse === undefined) {
+      return [];
+    }
+    return getOverlappingDroppables(ctx.droppables, mouse);
+  });
 
   return useMemo(
     () => ({
       dragged,
       ref,
+      overlappingDroppables,
       transform:
         transform?.x === undefined && transform?.y === undefined
           ? undefined
@@ -600,6 +611,6 @@ export function useDraggedData() {
               y: transform?.y,
             },
     }),
-    [dragged, transform?.x, transform?.y, ref]
+    [dragged, transform?.x, transform?.y, ref, overlappingDroppables]
   );
 }

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -226,7 +226,7 @@ export function DragPlaceholder({children, width}: {children: React.ReactNode; w
   return (
     <div
       style={{
-        position: 'absolute',
+        position: 'fixed',
         width: width ?? '100%',
         transform,
         top,

--- a/indico/modules/events/timetable/client/js/dnd/dnd.tsx
+++ b/indico/modules/events/timetable/client/js/dnd/dnd.tsx
@@ -192,7 +192,7 @@ function getOverlappingDroppables(droppables: Droppables, mouse: MousePosition):
   return overlapping;
 }
 
-export function DragPlaceholder({children}: {children: React.ReactNode}) {
+export function DragPlaceholder({children, width}: {children: React.ReactNode; width?: string}) {
   const dragState = useContextSelector(DnDContext, ctx =>
     ctx.dragged ? ctx.draggableData[ctx.dragged] : undefined
   );
@@ -227,13 +227,14 @@ export function DragPlaceholder({children}: {children: React.ReactNode}) {
     <div
       style={{
         position: 'absolute',
-        width: '100%',
+        width: width ?? '100%',
         transform,
         top,
         left,
         zIndex: 1000,
         userSelect: 'none',
         pointerEvents: 'none',
+        transition: 'width 0.25s ease-in-out',
       }}
     >
       {children}
@@ -583,10 +584,14 @@ export function useDraggedData() {
   const transform = useContextSelector(DnDContext, ctx =>
     ctx.dragged ? ctx.draggableData[ctx.dragged]?.transform : undefined
   );
+  const ref = useContextSelector(DnDContext, ctx =>
+    ctx.dragged ? ctx.draggables[ctx.dragged]?.node : undefined
+  );
 
   return useMemo(
     () => ({
       dragged,
+      ref,
       transform:
         transform?.x === undefined && transform?.y === undefined
           ? undefined
@@ -595,6 +600,6 @@ export function useDraggedData() {
               y: transform?.y,
             },
     }),
-    [dragged, transform?.x, transform?.y]
+    [dragged, transform?.x, transform?.y, ref]
   );
 }

--- a/indico/modules/events/timetable/client/js/dnd/index.ts
+++ b/indico/modules/events/timetable/client/js/dnd/index.ts
@@ -7,5 +7,5 @@
 
 export {createRestrictToElement} from './modifiers';
 // export type {Transform} from './types'; // prettier can't handle this
-export type {Transform, Over, MousePosition, Rect} from './types';
+export type {Transform, Over, MousePosition, Rect, Coords} from './types';
 export {DnDProvider, useDraggable, useDroppable, useDroppableData} from './dnd';

--- a/indico/modules/events/timetable/client/js/dnd/modifiers.ts
+++ b/indico/modules/events/timetable/client/js/dnd/modifiers.ts
@@ -114,6 +114,10 @@ export const createRestrictToCalendar =
       return transform;
     }
 
+    if (id.startsWith('c')) {
+      return transform;
+    }
+
     const boundingRect = containerRef.current.getBoundingClientRect();
     const scroll = getTotalScroll(containerRef.current);
     const rect = {

--- a/indico/modules/events/timetable/client/js/dnd/modifiers.ts
+++ b/indico/modules/events/timetable/client/js/dnd/modifiers.ts
@@ -5,6 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
+import {snapPixels} from 'indico/modules/events/timetable/utils';
+
 import {Rect, Transform, Modifier} from './types';
 
 /**
@@ -110,12 +112,19 @@ export function getTotalScroll(element: HTMLElement): {top: number; left: number
 export const createRestrictToCalendar =
   (containerRef, limits: [number, number] = [0, 0]): Modifier =>
   ({id, draggingNodeRect, transform}) => {
+    function snapTransform(t: Transform) {
+      return {
+        x: t.x,
+        y: snapPixels(t.y),
+      };
+    }
+
     if (id.startsWith('unscheduled')) {
-      return transform;
+      return snapTransform(transform);
     }
 
     if (id.startsWith('c')) {
-      return transform;
+      return snapTransform(transform);
     }
 
     const boundingRect = containerRef.current.getBoundingClientRect();
@@ -129,5 +138,5 @@ export const createRestrictToCalendar =
       height: boundingRect.height - limits[0] - limits[1],
     };
 
-    return restrictToBoundingRect(transform, draggingNodeRect, rect);
+    return snapTransform(restrictToBoundingRect(transform, draggingNodeRect, rect));
   };

--- a/indico/modules/events/timetable/client/js/dnd/types.ts
+++ b/indico/modules/events/timetable/client/js/dnd/types.ts
@@ -7,7 +7,7 @@
 
 import {MutableRefObject} from 'react';
 
-interface Coords {
+export interface Coords {
   x: number;
   y: number;
 }
@@ -66,7 +66,7 @@ export type OnDrop = (
   over: Over[],
   delta: Transform,
   mouse: MousePosition,
-  offset: MousePosition
+  offset: Coords
 ) => void;
 
 export type Modifier = ({

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -41,7 +41,7 @@ const getLayoutOverrides = (state: ReduxState) => state.entries.layoutOverrides;
 export const getSessions = (state: ReduxState) => state.sessions;
 export const getNavigation = (state: ReduxState) => state.navigation;
 
-const getEntries = createSelector(
+export const getEntries = createSelector(
   _getEntries,
   getSessions,
   (entries, sessions): Entries => {


### PR DESCRIPTION
Allows dragging contribution entries from the calendar to the unscheduled contributions section in the sidepanel. (https://github.com/orgs/indico/projects/7?pane=issue&itemId=220207288)
More generally, it renders a `<DragPlaceholder />` instead of transforming the original entry via CSS, bypassing any positioning, `z-index`, or `scroll` parameters.
It also fixes a bug where you could drag unscheduled contributions outside the event times and that would crash the page with no error message.

[Screencast from 2026-09-09 15-37-55.webm](https://github.com/user-attachments/assets/c06cb1a8-ccfa-4251-a354-a8dd4875770b)
