### PR TITLE
Add contact_info block to regform_info

### DIFF
--- a/indico/modules/events/registration/templates/display/_regform_info.html
+++ b/indico/modules/events/registration/templates/display/_regform_info.html
@@ -56,17 +56,19 @@
                 </div>
             </div>
         {%- endif %}
-        {% if regform.contact_info %}
-            <div class="infoline">
-                <i class="icon icon-phone"></i>
-                <div class="text">
-                    <div class="label">
-                        {% trans %}Contact info{% endtrans %}
+        {% block regform_contact_info scoped %}
+            {% if regform.contact_info %}
+                <div class="infoline">
+                    <i class="icon icon-phone"></i>
+                    <div class="text">
+                        <div class="label">
+                            {% trans %}Contact info{% endtrans %}
+                        </div>
+                        <div>{{ regform.contact_info }}</div>
                     </div>
-                    <div>{{ regform.contact_info }}</div>
                 </div>
-            </div>
-        {% endif %}
+            {% endif %}
+        {% endblock %}
     </div>
 
     {% if regform.introduction %}


### PR DESCRIPTION
Information, 
We are changing the registration form's contact info from generic contact info to a contact_email field. Therefore, we would like to change the display icon from icon-phone to icon-mail.
 More info here
  - https://github.com/UNOG-Indico/indico-un/pull/2376