### PR TITLE
Fix+refactor custom fields handling

### DIFF
--- a/indico/modules/events/contributions/client/js/ContributionForm.tsx
+++ b/indico/modules/events/contributions/client/js/ContributionForm.tsx
@@ -22,10 +22,6 @@ import {Field} from 'react-final-form';
 import {Button, Dimmer, Form, Loader} from 'semantic-ui-react';
 
 import {
-  UNSCHEDULED_CONTRIB_EDIT_MODAL,
-  useModal,
-} from 'indico/modules/events/timetable/ModalContext';
-import {
   CollapsibleContainer,
   FinalLocationField,
   FinalReferences,
@@ -61,6 +57,7 @@ interface ContributionFormProps {
   initialValues: Record<string, any>;
   sessionBlock?: Record<string, any>;
   loading: boolean;
+  editing?: boolean;
   [key: string]: any; // Allow additional props
 }
 
@@ -85,7 +82,7 @@ export function ContributionFormFields({
   const customFieldsSection = customFields.map(
     ({id, fieldType, title, description, isRequired, fieldData}) => {
       const key = `custom_field_${id}`;
-      const name = `custom_fields.field_${id}`;
+      const name = `custom_fields.custom_${id}`;
       if (fieldType === 'text') {
         if (fieldData.multiline) {
           return (
@@ -124,6 +121,8 @@ export function ContributionFormFields({
             required={isRequired}
             options={options}
             selection
+            allowNull
+            nullIfEmpty
           />
         );
       } else {
@@ -182,8 +181,8 @@ export function ContributionFormFields({
         label={Translate.string('Keywords')}
         placeholder={Translate.string('Please enter a keyword')}
       />
-      {customFieldsSection}
       <CollapsibleContainer title={Translate.string('Advanced')} dividing>
+        {customFieldsSection}
         <FinalReferences
           name="references"
           label={Translate.string('External IDs')}
@@ -198,7 +197,7 @@ export function ContributionFormFields({
   );
 }
 
-export function ContributionForm({
+function ContributionForm({
   eventId,
   personLinkFieldParams = {},
   locationParent = {},
@@ -207,13 +206,10 @@ export function ContributionForm({
   initialValues = {},
   sessionBlock = null,
   loading,
+  editing = false,
   ...rest
 }: ContributionFormProps) {
-  const handleSubmit = (formData: any, form: FormApi) => {
-    const customFieldsData = Object.entries(formData.custom_fields).map(([key, data]) => ({
-      id: parseInt(key.replace('field_', ''), 10),
-      data,
-    }));
+  const handleSubmit = async (formData: any, form: FormApi) => {
     const personLinks = formData.person_links.map(
       ({
         affiliationMeta,
@@ -236,16 +232,11 @@ export function ContributionForm({
     );
     formData = {
       ...formData,
-      custom_fields: customFieldsData,
       person_links: personLinks,
+      references: formData.references.map(({id, ...refs}: any) => refs),
     };
-    onSubmit(
-      {
-        ...formData,
-        references: formData.references.map(({id, ...refs}: any) => refs),
-      },
-      form
-    );
+    const submitPayload = editing ? getChangedValues(formData, form) : formData;
+    return await onSubmit(submitPayload);
   };
 
   if (loading) {
@@ -297,11 +288,11 @@ export function ContributionEditForm({
   const contribURL = contributionURL(snakifyKeys({eventId, contribId}));
   const {data: contrib, loading: contribLoading} = useIndicoAxios(contribURL);
 
-  const handleSubmit = async (formData: any, form) => {
+  const handleSubmit = async (formData: any) => {
     try {
-      await indicoAxios.patch(contribURL, getChangedValues(formData, form));
+      await indicoAxios.patch(contribURL, formData);
     } catch (e) {
-      return handleSubmitError(e);
+      return handleSubmitError(e, {}, ['custom_fields']);
     }
 
     location.reload();
@@ -327,14 +318,12 @@ export function ContributionEditForm({
           ? {}
           : {
               ..._.omit(contrib, 'session_block'),
-              custom_fields: Object.fromEntries(
-                contrib.custom_fields.map((field: any) => [`field_${field.id}`, field.data])
-              ),
               person_links: camelizeKeys(contrib.person_links),
             }
       }
       sessionBlock={camelizeKeys(contrib?.session_block)}
       loading={loading}
+      editing
     />
   );
 }
@@ -343,14 +332,10 @@ export function ContributionCreateForm({
   eventId,
   onClose,
   onCreate,
-  customFields = {},
-  customInitialValues = {},
 }: {
   eventId: number;
   onClose: () => void;
   onCreate?: (contrib: any) => void;
-  customFields?: Record<string, any>;
-  customInitialValues?: Record<string, any>;
 }) {
   const {data: personLinkFieldParams, loading: personLinkFieldParamsLoading} = useIndicoAxios(
     personLinkFieldParamsURL({event_id: eventId}),
@@ -369,18 +354,17 @@ export function ContributionCreateForm({
 
   const handleSubmit = async (formData: any) => {
     try {
-      const response = await indicoAxios.post(contributionCreateURL({event_id: eventId}), {
-        ...formData,
-        event_id: eventId,
-      });
-
-      if (response.data) {
-        onCreate?.(response.data);
+      const response = await indicoAxios.post(contributionCreateURL({event_id: eventId}), formData);
+      if (onCreate) {
+        onCreate(response.data);
       } else {
         location.reload();
+        // never finish submitting to avoid fields being re-enabled
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        await new Promise(() => {});
       }
     } catch (e) {
-      return handleSubmitError(e);
+      return handleSubmitError(e, {}, ['custom_fields']);
     }
 
     onClose();
@@ -403,11 +387,9 @@ export function ContributionCreateForm({
         keywords: [],
         references: [],
         location_data: locationData,
-        custom_fields: {
-          ...Object.fromEntries(fields.map((field: any) => [`field_${field.id}`, ''])),
-          ...customFields,
-        },
-        ...customInitialValues,
+        custom_fields: Object.fromEntries(
+          fields.map((field: any) => [`custom_${field.id}`, field.fieldType === 'text' ? '' : null])
+        ),
       };
 
   return (
@@ -415,7 +397,7 @@ export function ContributionCreateForm({
       eventId={eventId}
       personLinkFieldParams={personLinkFieldParams}
       locationParent={locationParent}
-      customFields={(fields ?? []).concat(Object.values(customFields))}
+      customFields={fields ?? []}
       header={Translate.string('Add new contribution')}
       onSubmit={handleSubmit}
       onClose={onClose}
@@ -440,18 +422,10 @@ export function EditContributionButton({
   trigger?: React.ReactElement;
 }) {
   const [open, setOpen] = useState(false);
-  const modalContext = useModal();
 
   const openEditModal = React.useCallback(() => {
-    if (modalContext) {
-      modalContext.openModal(UNSCHEDULED_CONTRIB_EDIT_MODAL, {
-        eventId,
-        contribId,
-      });
-    } else {
-      setOpen(true);
-    }
-  }, [modalContext, eventId, contribId]);
+    setOpen(true);
+  }, []);
 
   useEffect(() => {
     if (!triggerSelector) {
@@ -465,8 +439,13 @@ export function EditContributionButton({
       return;
     }
 
-    element.addEventListener('click', openEditModal);
-    return () => element.removeEventListener('click', openEditModal);
+    const handleClick = (evt: any) => {
+      evt.preventDefault();
+      openEditModal();
+    };
+
+    element.addEventListener('click', handleClick);
+    return () => element.removeEventListener('click', handleClick);
   }, [triggerSelector, openEditModal]);
 
   return (
@@ -487,7 +466,7 @@ export function EditContributionButton({
           </Button>
         ))}
 
-      {!modalContext && open && (
+      {open && (
         <ContributionEditForm
           eventId={eventId}
           contribId={contribId}
@@ -530,14 +509,7 @@ export function CreateContributionButton({
           <Translate>Create contribution</Translate>
         </Button>
       )}
-      {open && (
-        <ContributionCreateForm
-          eventId={eventId}
-          onClose={() => setOpen(false)}
-          customFields={{}}
-          customInitialValues={{}}
-        />
-      )}
+      {open && <ContributionCreateForm eventId={eventId} onClose={() => setOpen(false)} />}
     </>
   );
 }

--- a/indico/modules/events/contributions/controllers/management.py
+++ b/indico/modules/events/contributions/controllers/management.py
@@ -41,7 +41,7 @@ from indico.modules.events.contributions.operations import (create_contribution,
                                                             delete_contribution, delete_subcontribution,
                                                             log_contribution_update, update_contribution,
                                                             update_subcontribution)
-from indico.modules.events.contributions.schemas import (ContributionFieldSchema, ContributionSchema,
+from indico.modules.events.contributions.schemas import (ContributionFieldSchema, ContributionRESTSchema,
                                                          FullContributionSchema)
 from indico.modules.events.contributions.util import (contribution_type_row, generate_spreadsheet_from_contributions,
                                                       get_boa_export_formats, get_contribution_person_link_field_params,
@@ -66,7 +66,7 @@ from indico.util.i18n import _, ngettext
 from indico.util.locations import LocationParentSchema
 from indico.util.spreadsheets import send_csv, send_xlsx
 from indico.util.string import handle_legacy_description
-from indico.web.args import use_args, use_args_schema_context, use_kwargs
+from indico.web.args import use_args, use_kwargs, use_rh_args
 from indico.web.flask.templating import get_template_module
 from indico.web.flask.util import send_file, url_for
 from indico.web.forms.base import FormDefaults
@@ -355,26 +355,19 @@ class RHContributionREST(RHManageContributionBase):
 
 class RHAPIContribution(RHManageContributionBase):
     def _process_GET(self):
-        return ContributionSchema(context={'event': self.event}).jsonify(self.contrib)
+        return ContributionRESTSchema(context={'event': self.event}).jsonify(self.contrib)
 
-    @use_args_schema_context(
-        ContributionSchema,
-        lambda self: {'event': self.event, 'object': self.contrib},
-        partial=True,
-    )
+    @use_rh_args(ContributionRESTSchema, partial=True)
     def _process_PATCH(self, data):
-        # from indico.web.args import parser
-        # data = parser.parse(ContributionSchema(context={'event': self.event, 'object': self.contrib}))
         if (references := data.get('references')) is not None:
             data['references'] = self._get_references(references)
 
         # TODO: quick hack to get the person_link data in the right format
         data['person_link_data'] = {v['person_link']: v['is_submitter'] for v in data.pop('person_links', [])}
         with (track_time_changes(), track_location_changes()):
-            # TODO: custom fields logs
-            update_contribution(self.contrib, data)
+            update_contribution(self.contrib, data, data.pop('custom_fields', None))
 
-        return ContributionSchema(context={'event': self.event}).jsonify(self.contrib)
+        return ContributionRESTSchema(context={'event': self.event}).jsonify(self.contrib)
 
     @no_autoflush
     def _get_references(self, data: list[dict]) -> list[ContributionReference]:
@@ -389,16 +382,14 @@ class RHAPIContribution(RHManageContributionBase):
 
 
 class RHAPIContributionCreate(RHManageContributionsBase):
-    # @use_args(ContributionSchema)
-    @use_args_schema_context(ContributionSchema, lambda self: {'event': self.event})
+    @use_rh_args(ContributionRESTSchema)
     def _process_POST(self, data):
         if (references := data.get('references')) is not None:
             data['references'] = self._get_references(references)
         # TODO: quick hack to get the person_link data in the right format
         data['person_link_data'] = {v['person_link']: v['is_submitter'] for v in data.pop('person_links', [])}
-
-        contrib = create_contribution(self.event, data)
-        return ContributionSchema(context={'event': self.event}).jsonify(contrib)
+        contrib = create_contribution(self.event, data, data.pop('custom_fields', None))
+        return ContributionRESTSchema(context={'event': self.event}).jsonify(contrib)
 
     @no_autoflush
     def _get_references(self, data: list[dict]) -> list[ContributionReference]:
@@ -437,6 +428,8 @@ class RHAPIContributionDefaultDuration(RHManageContributionsBase):
 
 class RHAPIContributionFields(RHManageContributionsBase):
     def _process(self):
+        # TODO: Skip restricted fields when using this outside management (e.g. editing a contribution as a speaker)
+        # TODO: Check if we really need all the fields on the client side.
         return ContributionFieldSchema(many=True).jsonify(self.event.contribution_fields.filter_by(is_active=True))
 
 

--- a/indico/modules/events/contributions/models/fields.py
+++ b/indico/modules/events/contributions/models/fields.py
@@ -175,7 +175,9 @@ class ContributionFieldValueBase(db.Model):
 
     @property
     def friendly_data(self):
-        return self.contribution_field.field.get_friendly_value(self.data)
+        if field_impl := self.contribution_field.field:
+            return field_impl.get_friendly_value(self.data)
+        return '<missing field impl>'
 
 
 class ContributionFieldValue(ContributionFieldValueBase):

--- a/indico/modules/events/contributions/schemas.py
+++ b/indico/modules/events/contributions/schemas.py
@@ -8,10 +8,9 @@
 import hashlib
 from operator import attrgetter
 
-from marshmallow import EXCLUDE, ValidationError, fields, post_dump, post_load, validates
+from marshmallow import EXCLUDE, fields, post_dump
 from marshmallow_sqlalchemy import column2field
 
-from indico.core.db.sqlalchemy.util.session import no_autoflush
 from indico.core.marshmallow import mm
 from indico.modules.events.abstracts.util import filter_field_values
 from indico.modules.events.contributions.models.contributions import Contribution
@@ -26,7 +25,7 @@ from indico.modules.events.sessions.schemas import BasicSessionBlockSchema, Basi
 from indico.modules.events.tracks.schemas import TrackSchema
 from indico.modules.users.schemas import AffiliationSchema
 from indico.util.locations import LocationDataSchema
-from indico.util.marshmallow import EventTimezoneDateTimeField, SortedList
+from indico.util.marshmallow import EventTimezoneDateTimeField, NonPartialNested, SortedList
 from indico.web.flask.util import url_for
 
 
@@ -143,31 +142,6 @@ contribution_type_schema = ContributionTypeSchema()
 contribution_type_schema_basic = ContributionTypeSchema(only=('id', 'name'))
 
 
-class ContribFieldSchema(mm.SQLAlchemyAutoSchema):
-    class Meta:
-        model = ContributionField
-        fields = ('title', 'description', 'is_required', 'field_data')
-
-
-class ContribFieldValueSchema(mm.SQLAlchemyAutoSchema):
-    class Meta:
-        model = ContributionFieldValue
-        fields = ('id', 'data')
-
-    id = fields.Integer(attribute='contribution_field_id', required=True)
-    data = fields.Raw(load_default=None)
-
-    @validates('id')
-    def _check_contribution_field(self, id, **kwargs):
-        if not ContributionField.get(id):
-            raise ValidationError('Invalid contribution field')
-
-    @post_load()
-    @no_autoflush
-    def make_instance(self, data, **kwargs):
-        return ContributionFieldValue(contribution_field_id=data['contribution_field_id'], data=data['data'])
-
-
 class TimezoneAwareSessionBlockSchema(mm.SQLAlchemyAutoSchema):
     class Meta:
         model = SessionBlock
@@ -177,22 +151,47 @@ class TimezoneAwareSessionBlockSchema(mm.SQLAlchemyAutoSchema):
     end_dt = EventTimezoneDateTimeField()
 
 
-# TODO: (Ajob) Evaluate this schema vs timetable one
-class ContributionSchema(mm.SQLAlchemyAutoSchema):
+class CustomFieldsMixin:
+    # TODO: filter inactive and restricted contrib fields
+    custom_fields = fields.Method('_dump_custom_fields', '_load_custom_fields')
+
+    def _make_custom_fields_schema(self):
+        schema = {}
+        for field in self.context['event'].contribution_fields:
+            # TODO handle is_active and restricted fields
+            # TODO generate proper field (type) from field definition, with validation where needed
+            schema[f'custom_{field.id}'] = fields.Raw()
+        return mm.Schema.from_dict(schema, name='CustomFieldsSchema')
+
+    def _load_custom_fields(self, value):
+        schema_cls = self._make_custom_fields_schema()
+        schema = schema_cls(partial=bool(self.partial))
+        return schema.load(value)
+
+    def _dump_custom_fields(self, contrib):
+        schema_cls = self._make_custom_fields_schema()
+        schema = schema_cls()
+        return schema.dump({f'custom_{k}': v.data for k, v in contrib.data_by_field.items()})
+
+
+class ContributionRESTSchema(CustomFieldsMixin, mm.SQLAlchemyAutoSchema):
+    """Schema for RESTful operations on contributions."""
+
     class Meta:
         model = Contribution
         fields = ('id', 'title', 'description', 'code', 'board_number', 'keywords', 'location_data',
-                  'start_dt', 'duration', 'event_id', 'references', 'custom_fields', 'person_links')
+                  'start_dt', 'duration', 'references', 'custom_fields', 'person_links')
+        rh_context = ('event', {'object': 'contrib'})
 
+    id = fields.Int(dump_only=True)
     start_dt = EventTimezoneDateTimeField()
-    # TODO: filter inactive and resitricted contrib fields
-    custom_fields = fields.List(fields.Nested(ContribFieldValueSchema), attribute='field_values')
+    # TODO use List+NonPartialNested
     person_links = fields.Nested(
         _ContributionPersonLinkSchema(many=True, partial=False),
         unknown=EXCLUDE
     )
-    references = fields.List(fields.Nested(ContributionReferenceSchema))
-    location_data = fields.Nested(LocationDataSchema)
-    session_block = fields.Nested(TimezoneAwareSessionBlockSchema)
+    references = fields.List(NonPartialNested(ContributionReferenceSchema))
+    location_data = NonPartialNested(LocationDataSchema)
+    session_block = NonPartialNested(TimezoneAwareSessionBlockSchema)
     duration = fields.TimeDelta(required=True)
     _description = fields.String(attribute='description')

--- a/indico/modules/events/contributions/schemas.py
+++ b/indico/modules/events/contributions/schemas.py
@@ -187,11 +187,7 @@ class ContributionRESTSchema(CustomFieldsMixin, mm.SQLAlchemyAutoSchema):
 
     id = fields.Int(dump_only=True)
     start_dt = EventTimezoneDateTimeField()
-    # TODO use List+NonPartialNested
-    person_links = fields.Nested(
-        _ContributionPersonLinkSchema(many=True, partial=False),
-        unknown=EXCLUDE
-    )
+    person_links = fields.List(NonPartialNested(_ContributionPersonLinkSchema, unknown=EXCLUDE))
     references = fields.List(NonPartialNested(ContributionReferenceSchema))
     location_data = NonPartialNested(LocationDataSchema)
     session_block = NonPartialNested(TimezoneAwareSessionBlockSchema)

--- a/indico/modules/events/contributions/schemas.py
+++ b/indico/modules/events/contributions/schemas.py
@@ -61,7 +61,9 @@ class ContributionFieldValueSchema(mm.Schema):
 
 
 def _get_principal_roles(principal):
-    roles = [principal.author_type.name]
+    roles = []
+    if principal.author_type:
+        roles.append(principal.author_type.name)
     if principal.is_speaker:
         roles.append('speaker')
     if principal.contribution and principal.is_submitter:

--- a/indico/modules/events/person_link_schemas.py
+++ b/indico/modules/events/person_link_schemas.py
@@ -233,16 +233,10 @@ class ContributionPersonLinkSchema(PersonLinkBaseSchema):
             data['roles'].append('submitter')
         return data
 
-    @post_load(pass_many=True, pass_original=True)
-    def add_submitter_info(self, data, orig, many, **kwargs):
-        if not many:
-            data = [data]
-            orig = [orig]
-        person_links = []
-        for person_link, original_data in zip(data, orig, strict=True):
-            roles = original_data['roles']
-            person_links.append({'person_link': person_link, 'is_submitter': is_submitter(roles)})
-        return person_links
+    @post_load(pass_original=True)
+    def add_submitter_info(self, data, orig, **kwargs):
+        roles = orig['roles']
+        return {'person_link': data, 'is_submitter': is_submitter(roles)}
 
 
 class SubContributionPersonLinkSchema(PersonLinkBaseSchema):

--- a/indico/modules/events/person_link_schemas.py
+++ b/indico/modules/events/person_link_schemas.py
@@ -224,7 +224,9 @@ class ContributionPersonLinkSchema(PersonLinkBaseSchema):
 
     @post_dump(pass_original=True)
     def add_roles(self, data, orig, **kwargs):
-        data['roles'] = [orig.author_type.name]
+        data['roles'] = []
+        if orig.author_type:
+            data['roles'].append(orig.author_type.name)
         if orig.is_speaker:
             data['roles'].append('speaker')
         if orig.is_submitter:

--- a/indico/modules/events/timetable/client/js/BreakForm.tsx
+++ b/indico/modules/events/timetable/client/js/BreakForm.tsx
@@ -177,15 +177,7 @@ export function BreakEditForm({
   );
 }
 
-export function BreakCreateForm({
-  eventId,
-  onClose,
-  customInitialValues = {},
-}: {
-  eventId: number;
-  onClose: () => void;
-  customInitialValues?: Record<string, any>;
-}) {
+export function BreakCreateForm({eventId, onClose}: {eventId: number; onClose: () => void}) {
   const {data: locationParent, loading: locationParentLoading} = useIndicoAxios(
     locationParentURL({event_id: eventId})
   );
@@ -212,7 +204,6 @@ export function BreakCreateForm({
     : {
         duration: '',
         location_data: locationData,
-        ...customInitialValues,
       };
 
   return (
@@ -289,13 +280,7 @@ export function CreateBreakButton({
           <Translate>Create break</Translate>
         </Button>
       )}
-      {open && (
-        <BreakCreateForm
-          eventId={eventId}
-          onClose={() => setOpen(false)}
-          customInitialValues={{}}
-        />
-      )}
+      {open && <BreakCreateForm eventId={eventId} onClose={() => setOpen(false)} />}
     </>
   );
 }

--- a/indico/modules/events/timetable/client/js/ModalContext.tsx
+++ b/indico/modules/events/timetable/client/js/ModalContext.tsx
@@ -43,7 +43,7 @@ type ModalState =
         eventId: number;
         contribId: number;
         onClose?: () => void;
-        onSubmit?: (formData: any, form: any) => void;
+        onSubmit?: (formData: any, form: any) => any | undefined;
       };
     };
 
@@ -104,8 +104,6 @@ function ModalRoot({modal, closeModal}: ModalRootInterface) {
             payload?.onClose?.();
           }}
           onCreate={payload?.onCreate}
-          customFields={{}}
-          customInitialValues={{}}
         />
       );
     case UNSCHEDULED_CONTRIB_EDIT_MODAL:
@@ -117,9 +115,12 @@ function ModalRoot({modal, closeModal}: ModalRootInterface) {
             closeModal();
             payload?.onClose?.();
           }}
-          onSubmit={(formData, form) => {
+          onSubmit={async (formData, form) => {
+            const err = await payload?.onSubmit?.(formData, form);
+            if (err) {
+              return err;
+            }
             closeModal();
-            payload?.onSubmit?.(formData, form);
           }}
         />
       );

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -74,6 +74,7 @@ interface DraftEntry {
   session_block_id?: number;
   code?: string;
   board_number?: string;
+  custom_fields?: any;
 }
 
 // Prop interface
@@ -152,6 +153,7 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
         background: entry.colors.backgroundColor,
       },
     }),
+    custom_fields: entry.customFields,
   };
 
   const typeLongNames = {
@@ -160,6 +162,7 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
     [EntryType.Break]: Translate.string('Break'),
   };
 
+  const customFields = useSelector(selectors.getCustomContribFields);
   const currentDay = useSelector(selectors.getCurrentDate).format(DATE_KEY_FORMAT);
   const sessionsObj = useSelector(selectors.getSessions);
   const sessions: Session[] = Object.values(sessionsObj);
@@ -174,6 +177,7 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
         extraOptions={extraOptions}
         locationParent={snakifyKeys(entry.locationParent)}
         sessionBlock={parent}
+        customFields={customFields}
       />
     ),
     ...(!isCreatingChild
@@ -247,9 +251,8 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
         const updatedEntry = {...entry, ...mapDataToEntry(data, true)};
         const oldDayKey = getDateKey(entry.startDt);
         const newDayKey = getDateKey(updatedEntry.startDt);
-        dispatch(
-          actions.updateEntry(activeType, updatedEntry, currentDay, getChangedValues(data, form))
-        );
+        const updatePayload = getChangedValues(data, form);
+        dispatch(actions.updateEntry(activeType, updatedEntry, currentDay, updatePayload));
         if (
           (activeType === EntryType.SessionBlock || activeType === EntryType.Contribution) &&
           oldDayKey !== newDayKey

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -252,7 +252,9 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
         const oldDayKey = getDateKey(entry.startDt);
         const newDayKey = getDateKey(updatedEntry.startDt);
         const updatePayload = getChangedValues(data, form);
-        dispatch(actions.updateEntry(activeType, updatedEntry, currentDay, updatePayload));
+        await dispatch(
+          actions.updateEntry(activeType, updatedEntry, currentDay, updatePayload, false)
+        );
         if (
           (activeType === EntryType.SessionBlock || activeType === EntryType.Contribution) &&
           oldDayKey !== newDayKey
@@ -276,10 +278,10 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
           });
         }
       } else {
-        dispatch(actions.createEntry(activeType, data));
+        await dispatch(actions.createEntry(activeType, data));
       }
     } catch (exc) {
-      return handleSubmitError(exc);
+      return handleSubmitError(exc, {}, ['custom_fields']);
     }
 
     onSubmit();

--- a/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableManageModal.tsx
@@ -222,6 +222,7 @@ const TimetableManageModal: React.FC<TimetableManageModalProps> = ({
   };
 
   const handleSubmit = async (data: any, form: any) => {
+    data = {...data};
     const sessionObj = data.session_object;
     delete data.session_object;
 

--- a/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
+++ b/indico/modules/events/timetable/client/js/UnscheduledContributionEntry.tsx
@@ -13,7 +13,7 @@ import {createPortal} from 'react-dom';
 import {useSelector, useDispatch} from 'react-redux';
 import {Button} from 'semantic-ui-react';
 
-import {getChangedValues, handleSubmitError} from 'indico/react/forms/final-form';
+import {handleSubmitError} from 'indico/react/forms/final-form';
 import {Translate} from 'indico/react/i18n';
 import {indicoAxios} from 'indico/utils/axios';
 
@@ -220,21 +220,20 @@ export function UnscheduledContributionEntry({
               openModal(UNSCHEDULED_CONTRIB_EDIT_MODAL, {
                 eventId,
                 contribId: objId,
-                onSubmit: async (formData, form) => {
+                onSubmit: async formData => {
                   // TODO: (Ajob) Instead, maybe create a separate timetable contrib form
                   //              that disregards scheduling info like startdt. Or modify
                   //              the existing timetable manage form to allow for this use case.
-                  const changedVals = getChangedValues(formData, form);
                   try {
                     await indicoAxios.patch(
                       contributionURL({event_id: eventId, contrib_id: objId}),
-                      changedVals
+                      formData
                     );
                   } catch (err) {
-                    return handleSubmitError(err);
+                    return handleSubmitError(err, {}, ['custom_fields']);
                   }
 
-                  const changedEntryData = mapDataToEntry(changedVals, true);
+                  const changedEntryData = mapDataToEntry(formData, true);
                   dispatch(
                     actions.updateUnscheduledEntry(
                       EntryType.Contribution,

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -523,9 +523,13 @@ export function updateEntry(
   entryType: EntryType,
   entry: Entry,
   currentDay: string,
-  customPayload: any
+  customPayload: any,
+  optimistic = true
 ) {
-  return (dispatch: ThunkDispatch<ReduxState, unknown, Action>, getState: () => ReduxState) => {
+  return async (
+    dispatch: ThunkDispatch<ReduxState, unknown, Action>,
+    getState: () => ReduxState
+  ) => {
     const {
       staticData: {eventId},
     } = getState();
@@ -535,11 +539,18 @@ export function updateEntry(
       [EntryType.Break]: breakURL({event_id: eventId, break_id: entry.objId}),
     }[entryType];
 
-    const action = synchronizedAjaxAction(
-      () => indicoAxios.patch(updateURL, customPayload),
-      _updateEntry(entryType, entry, currentDay, mapDataToEntry(customPayload))
-    );
-    return dispatch(action);
+    if (optimistic) {
+      const action = synchronizedAjaxAction(
+        () => indicoAxios.patch(updateURL, customPayload),
+        _updateEntry(entryType, entry, currentDay, mapDataToEntry(customPayload))
+      );
+      return dispatch(action);
+    } else {
+      // eslint-disable-next-line no-use-before-define
+      await requestQueue.ensureEmpty();
+      await indicoAxios.patch(updateURL, customPayload);
+      return dispatch(_updateEntry(entryType, entry, currentDay, mapDataToEntry(customPayload)));
+    }
   };
 }
 
@@ -576,6 +587,12 @@ class RequestQueue {
       this._processRequests().catch(error => {
         console.error('Error processing request queue:', error);
       });
+    }
+  }
+
+  async ensureEmpty() {
+    while (this.requests.length) {
+      await new Promise(r => setTimeout(r, 0));
     }
   }
 

--- a/indico/modules/events/timetable/client/js/index.jsx
+++ b/indico/modules/events/timetable/client/js/index.jsx
@@ -11,6 +11,7 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 
 import {UserSearchTokenContext} from 'indico/react/components/principals/Search';
+import {camelizeKeys} from 'indico/utils/case';
 import createReduxStore from 'indico/utils/redux';
 
 import {setSessionData, setTimetableData} from './actions';
@@ -44,6 +45,7 @@ import {getCurrentDateLocalStorage} from './utils';
           endDt: moment(eventInfo.end_dt_local),
           defaultContribDurationMinutes: eventInfo.default_contribution_duration / 60,
           eventLocationParent: eventInfo.location_parent,
+          customFields: camelizeKeys(eventInfo.customFields),
         },
         navigation: {
           isDraft: eventInfo.is_draft,

--- a/indico/modules/events/timetable/client/js/layout.spec.ts
+++ b/indico/modules/events/timetable/client/js/layout.spec.ts
@@ -88,6 +88,7 @@ function contrib({
     description: '',
     personLinks: [],
     attachments: [],
+    customFields: {},
     type: EntryType.Contribution,
     duration,
     ...scheduleMixin({time, column, maxColumn}),

--- a/indico/modules/events/timetable/client/js/layout.ts
+++ b/indico/modules/events/timetable/client/js/layout.ts
@@ -318,6 +318,7 @@ export function layoutAfterUnscheduledDrop(
     column: null,
     maxColumn: null,
     attachments: [],
+    customFields: {},
   };
   delete entry.sessionId;
 
@@ -386,6 +387,7 @@ export function layoutAfterUnscheduledDropOnBlock(
     column: null,
     maxColumn: null,
     attachments: [],
+    customFields: {},
   };
 
   if ('backgroundColor' in draftEntry) {

--- a/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.spec.ts
@@ -166,6 +166,7 @@ describe('mapperUtils', () => {
         column: 0,
         maxColumn: 0,
         attachments: [],
+        customFields: {},
       };
       const data = mapEntryToData(entry);
 
@@ -181,6 +182,7 @@ describe('mapperUtils', () => {
       expect(data.session_id).toBe(5);
       expect(data.duration).toBe(90);
       expect(data.start_dt).toBe('2024-01-01T09:00:00.000Z');
+      expect(data.custom_fields).toEqual({});
     });
 
     it('should map Session Block entry to API data', () => {

--- a/indico/modules/events/timetable/client/js/mapperUtils.ts
+++ b/indico/modules/events/timetable/client/js/mapperUtils.ts
@@ -98,6 +98,7 @@ const entryMapperConfig: MapperConfig<Record<string, unknown>, Entry> = [
     fromTransform: v => moment(v),
     toTransform: v => v.toISOString(),
   },
+  {from: 'custom_fields', to: 'customFields'},
 ];
 
 const sessionMapperConfig: MapperConfig<Record<string, unknown>, Session> = [

--- a/indico/modules/events/timetable/client/js/selectors.ts
+++ b/indico/modules/events/timetable/client/js/selectors.ts
@@ -132,6 +132,10 @@ export const getEventType = createSelector(
   getStaticData,
   staticData => staticData.eventType
 );
+export const getCustomContribFields = createSelector(
+  getStaticData,
+  staticData => staticData.customFields
+);
 export const getEventStartDt = createSelector(
   getStaticData,
   staticData => staticData.startDt

--- a/indico/modules/events/timetable/client/js/types.ts
+++ b/indico/modules/events/timetable/client/js/types.ts
@@ -121,6 +121,7 @@ export interface ContribEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledM
   sessionId?: number | null;
   boardNumber?: string;
   keywords?: string[];
+  customFields: any;
 }
 
 export interface BreakEntry extends Omit<BaseEntry, 'id' | 'type'>, ScheduledMixin {
@@ -194,6 +195,21 @@ export interface Entries {
   draggedIds: Set<number>;
 }
 
+// TODO: merge with the interface in the contribs module, and maybe remove unnecessary
+// stuff from both the interface and the schema used to serialize it
+interface CustomField {
+  id: number;
+  fieldType: 'text' | 'single_choice';
+  fieldData: object;
+  title: string;
+  description: string;
+  isActive: boolean;
+  isRequired: boolean;
+  isUserEditable: boolean;
+  position: number;
+  visibility: 'public' | 'managers_and_submitters' | 'managers_only';
+}
+
 interface StaticData {
   eventId: number;
   startDt: Moment;
@@ -201,6 +217,7 @@ interface StaticData {
   defaultContribDurationMinutes: number;
   eventLocationParent: LocationParent;
   eventType: EventType;
+  customFields: CustomField[];
 }
 
 export interface Navigation {

--- a/indico/modules/events/timetable/controllers/manage.py
+++ b/indico/modules/events/timetable/controllers/manage.py
@@ -267,7 +267,7 @@ class RHTimetableContributionCreate(RHManageContributionsBase):
             if data['location_data'].get('inheriting')
             else data['location_data']
         )
-        contrib = create_contribution(self.event, data, session_block=session_block)
+        contrib = create_contribution(self.event, data, data.pop('custom_fields', None), session_block=session_block)
         return ContributionSchema(context={'event': self.event}).jsonify(contrib)
 
     @no_autoflush
@@ -304,7 +304,7 @@ class RHTimetableContribution(RHManageContributionBase):
             self._change_parent(session_block_id)
 
         with (track_time_changes(), track_location_changes()):
-            update_contribution(self.contrib, data)
+            update_contribution(self.contrib, data, data.pop('custom_fields', None))
 
         return ContributionSchema(context={'event': self.event}).jsonify(self.contrib)
 

--- a/indico/modules/events/timetable/schemas.py
+++ b/indico/modules/events/timetable/schemas.py
@@ -8,9 +8,7 @@
 from marshmallow import EXCLUDE, fields
 
 from indico.core.marshmallow import mm
-from indico.modules.events.contributions.models.contributions import Contribution
-from indico.modules.events.contributions.schemas import (ContribFieldValueSchema, ContributionReferenceSchema,
-                                                         TimezoneAwareSessionBlockSchema)
+from indico.modules.events.contributions.schemas import ContributionRESTSchema, TimezoneAwareSessionBlockSchema
 from indico.modules.events.person_link_schemas import ContributionPersonLinkSchema as _ContributionPersonLinkSchema
 from indico.modules.events.person_link_schemas import SessionBlockPersonLinkSchema as _SessionBlockPersonLinkSchema
 from indico.modules.events.sessions.models.blocks import SessionBlock
@@ -62,29 +60,25 @@ class BreakSchema(mm.SQLAlchemyAutoSchema):
     session_id = fields.Function(_get_break_session_id, dump_only=True)
 
 
-class ContributionSchema(mm.SQLAlchemyAutoSchema):
-    class Meta:
-        model = Contribution
-        fields = ('id', 'title', 'description', 'code', 'board_number', 'keywords', 'location_data', 'location_parent',
-                  'start_dt', 'duration', 'references', 'custom_fields', 'person_links', 'session_block',
-                  'session_block_id', 'session_id', 'parent_id', 'attachments')
-        rh_context = ('event', {'object': 'contrib'})
+class ContributionSchema(ContributionRESTSchema):
+    class Meta(ContributionRESTSchema.Meta):
+        fields = (
+            *ContributionRESTSchema.Meta.fields,
+            'location_parent',
+            'session_block',
+            'session_block_id',
+            'session_id',
+            'event_id',
+            'parent_id',
+            'attachments',
+        )
 
-    def _get_attachments(self, contribution):
-        return len(contribution.attached_items.get('files', []))
-
-    start_dt = EventTimezoneDateTimeField()
-    _description = fields.String(attribute='description')
-    # TODO: filter inactive and restricted contrib fields
-    custom_fields = fields.List(NonPartialNested(ContribFieldValueSchema), attribute='field_values')
+    # TODO sync person_links code with parent schema and remove here
     person_links = NonPartialNested(_ContributionPersonLinkSchema(many=True, unknown=EXCLUDE))
-    references = fields.List(NonPartialNested(ContributionReferenceSchema))
-    location_data = NonPartialNested(LocationDataSchema)
     location_parent = NonPartialNested(LocationParentSchema, attribute='resolved_location_parent')
     session_block = NonPartialNested(TimezoneAwareSessionBlockSchema)
-    event_id = fields.Integer(dump_only=True)
-    session_id = fields.Integer(dump_only=True)
-    duration = fields.TimeDelta(required=True)
-    parent_id = fields.Integer(allow_none=True, load_only=True)
     session_block_id = fields.Integer(allow_none=True)
+    session_id = fields.Integer(dump_only=True)
+    event_id = fields.Integer(dump_only=True)  # XXX needed?
+    parent_id = fields.Integer(allow_none=True, load_only=True)
     attachments = fields.Function(TimetableSerializer.get_attachment_data)

--- a/indico/modules/events/timetable/schemas.py
+++ b/indico/modules/events/timetable/schemas.py
@@ -9,7 +9,6 @@ from marshmallow import EXCLUDE, fields
 
 from indico.core.marshmallow import mm
 from indico.modules.events.contributions.schemas import ContributionRESTSchema, TimezoneAwareSessionBlockSchema
-from indico.modules.events.person_link_schemas import ContributionPersonLinkSchema as _ContributionPersonLinkSchema
 from indico.modules.events.person_link_schemas import SessionBlockPersonLinkSchema as _SessionBlockPersonLinkSchema
 from indico.modules.events.sessions.models.blocks import SessionBlock
 from indico.modules.events.sessions.schemas import SessionColorSchema
@@ -73,8 +72,6 @@ class ContributionSchema(ContributionRESTSchema):
             'attachments',
         )
 
-    # TODO sync person_links code with parent schema and remove here
-    person_links = NonPartialNested(_ContributionPersonLinkSchema(many=True, unknown=EXCLUDE))
     location_parent = NonPartialNested(LocationParentSchema, attribute='resolved_location_parent')
     session_block = NonPartialNested(TimezoneAwareSessionBlockSchema)
     session_block_id = fields.Integer(allow_none=True)

--- a/indico/modules/events/timetable/serializer.py
+++ b/indico/modules/events/timetable/serializer.py
@@ -9,6 +9,7 @@ from flask import has_request_context, session
 from sqlalchemy.orm import defaultload
 
 from indico.modules.events.contributions.models.persons import AuthorType
+from indico.modules.events.contributions.schemas import ContributionFieldSchema
 from indico.modules.events.timetable.models.entries import TimetableEntry, TimetableEntryType
 from indico.modules.events.util import should_show_draft_warning
 from indico.util.locations import LocationDataSchema, LocationParentSchema
@@ -243,6 +244,7 @@ def serialize_unscheduled_contribution(contribution, *, can_manage_event=False):
 def serialize_event_info(event, *, user=None):
     from indico.modules.events.contributions import Contribution, contribution_settings
     can_manage_event = event.can_manage(user)
+    custom_fields = ContributionFieldSchema(many=True).dump(event.contribution_fields.filter_by(is_active=True))
 
     return {'id': str(event.id),
             'title': event.title,
@@ -254,7 +256,8 @@ def serialize_event_info(event, *, user=None):
             'default_contribution_duration': contribution_settings.get(event, 'default_duration').total_seconds(),
             'location_parent': LocationParentSchema().dump(event),
             'contributions': [serialize_unscheduled_contribution(c, can_manage_event=can_manage_event)
-                              for c in Contribution.query.with_parent(event).filter_by(is_scheduled=False)]}
+                              for c in Contribution.query.with_parent(event).filter_by(is_scheduled=False)],
+            'customFields': custom_fields}
 
 
 def serialize_session(sess):

--- a/indico/web/client/js/react/forms/errors.js
+++ b/indico/web/client/js/react/forms/errors.js
@@ -8,13 +8,27 @@
 import {FORM_ERROR} from 'final-form';
 import _ from 'lodash';
 
-function flatten(value) {
+function flatten(value, joinErrors, preserveNested) {
+  if (preserveNested) {
+    // When using a nested schema that's populated by individual final-form fields (ie field names
+    // whose name contains a dot, e.g. `custom_fields.custom_123`), we want to preserve this
+    // structure in order to show errors on the actual fields.
+    return Object.fromEntries(
+      Object.entries(value).map(([field, errors]) => {
+        if (_.isPlainObject(errors)) {
+          return [field, flatten(errors, joinErrors, true)];
+        }
+        return [field, joinErrors ? errors.join(' / ') : errors];
+      })
+    );
+  }
   // marshmallow's List returns an object with the index as the key
   if (_.isPlainObject(value)) {
     value = Object.values(value);
   }
   // Nested returns an object mapping the inner field name to its error(s)
-  return _.uniq(_.flattenDeep(value.map(x => (_.isPlainObject(x) ? Object.values(x) : x))));
+  const res = _.uniq(_.flattenDeep(value.map(x => (_.isPlainObject(x) ? Object.values(x) : x))));
+  return joinErrors ? res.join(' / ') : res;
 }
 
 /**
@@ -29,7 +43,8 @@ export function handleSubmissionError(
   error,
   defaultMessage = null,
   fieldErrorMap = {},
-  joinErrors = true
+  joinErrors = true,
+  preserveNested = []
 ) {
   const webargsErrors = _.get(error, 'response.data.webargs_errors');
   if (webargsErrors && error.response.status === 422) {
@@ -38,11 +53,11 @@ export function handleSubmissionError(
       return {[FORM_ERROR]: joinErrors ? webargsErrors.join(' / ') : webargsErrors};
     }
     // flatten errors in case there's more than one
-    return _.fromPairs(
+    return Object.fromEntries(
       Object.entries(webargsErrors).map(([field, errors]) => {
         return [
           fieldErrorMap[field] || field,
-          joinErrors ? flatten(errors).join(' / ') : flatten(errors),
+          flatten(errors, joinErrors, preserveNested.includes(field)),
         ];
       })
     );

--- a/indico/web/client/js/react/forms/fields.d.ts
+++ b/indico/web/client/js/react/forms/fields.d.ts
@@ -18,6 +18,7 @@ interface SharedFieldProps {
   initialValue?: any;
   className?: string;
   formatOnBlur?: boolean;
+  allowNull?: boolean;
   parse?: (value: any) => any;
   format?: (value: any) => any;
   validate?: (value: any) => string | undefined;

--- a/indico/web/client/js/react/forms/final-form.jsx
+++ b/indico/web/client/js/react/forms/final-form.jsx
@@ -21,12 +21,24 @@ import {handleSubmissionError} from './errors';
 import {FinalUnloadPrompt} from './unload';
 
 export function getChangedValues(data, form, always = []) {
-  const fields = form.getRegisteredFields().filter(x => !x.includes('['));
-  return _.fromPairs(
-    fields
+  const flatFields = form.getRegisteredFields().filter(x => !x.includes('[') && !x.includes('.'));
+  const nestedFields = form.getRegisteredFields().filter(x => !x.includes('[') && x.includes('.'));
+  const changedValues = Object.fromEntries(
+    flatFields
       .filter(name => form.getFieldState(name).dirty || always.includes(name))
       .map(name => [name, data[name]])
   );
+  // handle fields with names like `foo.something` which are nested objects in the data
+  // XXX this only supports one level of nesting, ie not `foo.bar.baz` etc
+  nestedFields.forEach(name => {
+    if (!form.getFieldState(name).dirty && !always.includes(name)) {
+      return;
+    }
+    const [key, subname] = name.split('.', 2);
+    changedValues[key] = changedValues[key] ?? {};
+    changedValues[key][subname] = data[key][subname];
+  });
+  return changedValues;
 }
 
 export function getValuesForFields(data, form) {
@@ -39,10 +51,10 @@ export function getValuesForFields(data, form) {
  * errors that can be handled by final-form instead of showing the usual
  * error dialog for them.
  */
-export function handleSubmitError(error, fieldErrorMap = {}) {
+export function handleSubmitError(error, fieldErrorMap = {}, preserveNested = []) {
   if (_.get(error, 'response.status') === 422) {
     // if it's 422 we assume it's from webargs validation
-    return handleSubmissionError(error, null, fieldErrorMap);
+    return handleSubmissionError(error, null, fieldErrorMap, true, preserveNested);
   } else if (_.get(error, 'response.status') === 418) {
     // this is an error that was expected, and will be handled by the app
     return {[FORM_ERROR]: error.response.data.message};


### PR DESCRIPTION
- Show custom fields in timetable contribution dialogs
- Correctly log changes to custom fields
- Avoid weird type mapping between data and final-form
- Adapt final-form utils to support nested structures that use separate fields in the form
- Deduplicate contribution schema between contributions/timetable modules

Open TODOs:

- [ ] Validate values based on field config (ie don't use `Raw` field but something matching the field type)
- [x] Test that person links didn't break, and maybe resolve the TODO on the schema about this