### PR TITLE
Do not require event access in fav contribution API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Bugfixes
 ^^^^^^^^
 
 - Fix "No value" filter for text-based abstract/contribution fields (:pr:`7725`)
+- Fix error when loading favorite contribution state when viewing a contribution in
+  a restricted event the user cannot access (:pr:`7740`)
 
 Accessibility
 ^^^^^^^^^^^^^

--- a/indico/modules/events/contributions/blueprint.py
+++ b/indico/modules/events/contributions/blueprint.py
@@ -157,10 +157,10 @@ _bp.add_url_rule('/contributions/<int:contrib_id>/subcontributions/<int:subcontr
                  display.RHSubcontributionDisplay)
 
 _bp.add_url_rule('/api/contributions/mine', 'my_contributions_api', api.RHAPIMyContributions)
-_bp.add_url_rule('/api/contributions/favorites', 'favorite_contributions_api',
-                 api.RHFavoriteContributionsAPI)
-_bp.add_url_rule('/api/contributions/favorites/<int:contrib_id>', 'favorite_contributions_api',
-                 api.RHFavoriteContributionsAPI, methods=('GET', 'PUT', 'DELETE'))
+_bp.add_url_rule('/api/contributions/favorites', 'favorite_contribution_list_api',
+                 api.RHFavoriteContributionListAPI)
+_bp.add_url_rule('/api/contributions/favorites/<int:contrib_id>', 'favorite_contribution_api',
+                 api.RHFavoriteContributionAPI, methods=('GET', 'PUT', 'DELETE'))
 
 # Legacy URLs
 _compat_bp = IndicoBlueprint('compat_contributions', __name__, url_prefix='/event/<int:event_id>')

--- a/indico/modules/events/contributions/client/js/MyTimetable.tsx
+++ b/indico/modules/events/contributions/client/js/MyTimetable.tsx
@@ -5,7 +5,8 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import contributionFavoriteURL from 'indico-url:contributions.favorite_contributions_api';
+import favoriteContributionURL from 'indico-url:contributions.favorite_contribution_api';
+import favoriteContributionListURL from 'indico-url:contributions.favorite_contribution_list_api';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -32,13 +33,13 @@ export function MyTimetable({eventId, timezone}: MyTimetableProps) {
     mutate,
     mutating,
   } = useIndicoAxiosWithMutation<Contribution[]>({
-    url: contributionFavoriteURL({event_id: eventId}),
+    url: favoriteContributionListURL({event_id: eventId}),
   });
 
   const removeScheduledContribution = async (id: number) => {
     try {
       await mutate(
-        indicoAxios.delete(contributionFavoriteURL({contrib_id: id, event_id: eventId})),
+        indicoAxios.delete(favoriteContributionURL({contrib_id: id, event_id: eventId})),
         oldData => oldData.filter(c => c.id !== id)
       );
     } catch (error) {

--- a/indico/modules/events/contributions/client/js/ScheduleContributionIcon.tsx
+++ b/indico/modules/events/contributions/client/js/ScheduleContributionIcon.tsx
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-import favoriteContributionURL from 'indico-url:contributions.favorite_contributions_api';
+import favoriteContributionURL from 'indico-url:contributions.favorite_contribution_api';
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/indico/modules/events/contributions/controllers/api.py
+++ b/indico/modules/events/contributions/controllers/api.py
@@ -13,16 +13,15 @@ from sqlalchemy.orm.exc import StaleDataError
 from werkzeug.exceptions import Forbidden
 
 from indico.core.db import db
-from indico.modules.events.contributions.controllers.display import RHDisplayProtectionBase
+from indico.modules.events.contributions.controllers.display import (RHAuthenticatedContributionDisplayBase,
+                                                                     RHDisplayProtectionBase)
 from indico.modules.events.contributions.models.contributions import Contribution
 from indico.modules.events.contributions.models.persons import AuthorType
 from indico.modules.events.contributions.schemas import UserContributionSchema
 from indico.modules.events.contributions.util import get_contributions_for_user
 from indico.modules.events.controllers.base import RHAuthenticatedEventBase
 from indico.modules.events.timetable.models.entries import TimetableEntry
-from indico.util.marshmallow import ModelField
 from indico.util.string import natural_sort_key
-from indico.web.args import use_rh_kwargs
 
 
 class RHAPIMyContributions(RHDisplayProtectionBase):
@@ -57,38 +56,38 @@ class RHAPIMyContributions(RHDisplayProtectionBase):
         })
 
 
-class RHFavoriteContributionsAPI(RHAuthenticatedEventBase):
-    @use_rh_kwargs({
-        'contribution': ModelField(Contribution, with_parent='event', data_key='contrib_id')
-    }, location='view_args', rh_context=('event',))
-    def _process(self, contribution=None):
-        self.contribution = contribution
-        return super()._process()
+class RHFavoriteContributionListAPI(RHAuthenticatedEventBase):
+    """RESTful API to get the user's list of favorite contributions in an event."""
 
     def _process_GET(self):
-        if self.contribution is None:
-            favorites = (
-                Contribution.query
-                .with_parent(session.user)
-                .with_parent(self.event)
-                .outerjoin(Contribution.timetable_entry)
-                .options(contains_eager(Contribution.timetable_entry).lazyload('*'))
-                .order_by(TimetableEntry.start_dt.is_(None), TimetableEntry.start_dt, Contribution.friendly_id)
-                .all()
-            )
-            return UserContributionSchema(exclude=('edit_url',), many=True).jsonify(favorites)
-        return jsonify(self.contribution in session.user.favorite_contributions)
+        favorites = (
+            Contribution.query
+            .with_parent(session.user)
+            .with_parent(self.event)
+            .outerjoin(Contribution.timetable_entry)
+            .options(contains_eager(Contribution.timetable_entry).lazyload('*'))
+            .order_by(TimetableEntry.start_dt.is_(None), TimetableEntry.start_dt, Contribution.friendly_id)
+            .all()
+        )
+        return UserContributionSchema(exclude=('edit_url',), many=True).jsonify(favorites)
+
+
+class RHFavoriteContributionAPI(RHAuthenticatedContributionDisplayBase):
+    """RESTful API to manage the favorite state of a contribution."""
+
+    def _process_GET(self):
+        return jsonify(self.contrib in session.user.favorite_contributions)
 
     def _process_PUT(self):
-        if self.contribution not in session.user.favorite_contributions:
-            if not self.contribution.can_access(session.user):
+        if self.contrib not in session.user.favorite_contributions:
+            if not self.contrib.can_access(session.user):
                 raise Forbidden
-            session.user.favorite_contributions.add(self.contribution)
+            session.user.favorite_contributions.add(self.contrib)
         return jsonify(success=True)
 
     def _process_DELETE(self):
-        if self.contribution in session.user.favorite_contributions:
-            session.user.favorite_contributions.discard(self.contribution)
+        if self.contrib in session.user.favorite_contributions:
+            session.user.favorite_contributions.discard(self.contrib)
             try:
                 db.session.flush()
             except StaleDataError:

--- a/indico/modules/events/contributions/controllers/display.py
+++ b/indico/modules/events/contributions/controllers/display.py
@@ -51,6 +51,12 @@ def _author_page_active(event):
 
 
 class RHContributionDisplayBase(RHDisplayEventBase):
+    """Base class for contribution-related endpoints.
+
+    This requires the user to have access to see the contribution, but not necessarily
+    to be logged in.
+    """
+
     normalize_url_spec = {
         'locators': {
             lambda self: self.contrib
@@ -73,6 +79,19 @@ class RHContributionDisplayBase(RHDisplayEventBase):
     def _process_args(self):
         RHDisplayEventBase._process_args(self)
         self.contrib = Contribution.get_or_404(request.view_args['contrib_id'], is_deleted=False)
+
+
+class RHAuthenticatedContributionDisplayBase(RHContributionDisplayBase):
+    """Base class for contribution-related endpoints that require the user to be logged in.
+
+    Like :class:`RHContributionDisplayBase this requires the user to have access to see
+    the contribution, but they also need to be authenticated.
+    """
+
+    def _check_access(self):
+        RHContributionDisplayBase._check_access(self)
+        if not session.user:
+            raise Forbidden
 
 
 class RHDisplayProtectionBase(RHDisplayEventBase):


### PR DESCRIPTION
In conferences it is possible to view a contribution to which you have access, even if you lack access to the event itself. In this case the user got an ugly error popup from trying to retrieve the favorite contribution status.