### PR TITLE
Add a skip-to-main-content bypass link to management pages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,9 @@ Bugfixes
 Accessibility
 ^^^^^^^^^^^^^
 
-- Nothing so far
+- Keyboard and screen reader users can now skip past the navigation to the main
+  content on management and user-area pages using the "Skip to main content"
+  bypass link (:issue:`7627`, :pr:`7741`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/templates/layout/management_page.html
+++ b/indico/web/templates/layout/management_page.html
@@ -15,7 +15,12 @@
                 <div class="content-column">
                     <div class="banner {% block banner_class %}{% endblock %}">
                         {% if self.banner_title()|trim %}
-                            <h1 class="title">
+                            {# When the page has no title block, base.html's
+                               <h2 id="main-content"> is not rendered via super(),
+                               so make this banner heading the bypass target. #}
+                            <h1 class="title"
+                                {%- if not self.title()|trim %} id="main-content"
+                                data-bypass-target="{% trans %}Skip to main content{% endtrans %}"{% endif %}>
                                 {% block banner_title %}{% endblock %}
                             </h1>
                         {% endif %}


### PR DESCRIPTION
Management pages had no "skip to main content" link (WCAG 2.4.1). layout/management_page.html overrides base.html's `{% block page %}`, so base.html's `<h2 id="main-content" data-bypass-target>` only appears when a page sets a `{% block title %}` (rendered via `super()`). Pages that rely on just the banner heading — the user area (dashboard, profile, preferences), user tokens, the category calendar, and category management landing pages — set `banner_title` but no `title`, so they had no anchor and no skip link.

Since #7617 made the banner title a real `<h1>`, this uses it as the bypass anchor: the `<h1>` gets `id="main-content"` and `data-bypass-target` only when the page has no title block, so on pages that do set one (which already get base.html's `<h2 id="main-content">` via `super()`) it does not create a second, duplicate anchor.

User impact: keyboard and screen reader users can now skip past the navigation straight to the main content on the management/user-area pages that previously lacked a skip link.

Verified with the visual + accessibility regression suite: the "Skip to main content" link is added to the banner-only pages, no pixels change, and pages that already had the link are unaffected (no duplicate).

Addresses #7627. (Event management and admin pages already expose the link via base.html's `<h2>`, so they were never gaps; only management pages with no heading at all — action-only banners — remain uncovered.)