### PR TITLE
Make form required markers and validation errors accessible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,12 @@ Bugfixes
 Accessibility
 ^^^^^^^^^^^^^
 
-- Nothing so far
+- Screen readers now announce form validation errors and tie each error to the
+  field it belongs to, so the error is read out whenever that field is focused
+  (:pr:`7743`, thanks :user:`foxbunny`)
+- The red "required" asterisk next to form labels is no longer read out as a
+  stray symbol by screen readers; a field's required state is conveyed by the
+  field itself (:pr:`7743`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/web/client/js/jquery/extensions/global.js
+++ b/indico/web/client/js/jquery/extensions/global.js
@@ -6,7 +6,7 @@
 // LICENSE file for more details.
 
 // Global scripts that should be executed on all pages
-/* global showFormErrors, build_url, ajaxDialog */
+/* global build_url, ajaxDialog */
 
 import {$T} from 'indico/utils/i18n';
 
@@ -232,8 +232,6 @@ $(document).ready(() => {
   $('input.permalink').on('focus', function() {
     this.select();
   });
-
-  showFormErrors();
 
   // Show form creation dialog if hash is present in the URL
   const match = location.hash.match(

--- a/indico/web/client/js/jquery/utils/ajaxdialog.js
+++ b/indico/web/client/js/jquery/utils/ajaxdialog.js
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-/* global ExclusivePopup, showFormErrors, initForms, confirmPrompt, getDropzoneFiles,
+/* global ExclusivePopup, initForms, confirmPrompt, getDropzoneFiles,
    setDropzoneFiles, handleAjaxError, handleFlashes, ajaxDialog */
 
 import _ from 'lodash';
@@ -302,7 +302,6 @@ import {$T} from 'indico/utils/i18n';
         closeDialog();
       });
       const forms = popup.contentContainer.find('form');
-      showFormErrors(popup.resultContainer);
       initForms(forms);
       forms.filter(':not([data-no-ajax])').each(function() {
         const $this = $(this);

--- a/indico/web/client/js/jquery/utils/ajaxform.js
+++ b/indico/web/client/js/jquery/utils/ajaxform.js
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-/* global showFormErrors, initForms, confirmPrompt, updateHtml, getDropzoneFiles, setDropzoneFiles,
+/* global initForms, confirmPrompt, updateHtml, getDropzoneFiles, setDropzoneFiles,
           handleAjaxError, handleFlashes */
 
 import _ from 'lodash';
@@ -221,7 +221,6 @@ import {$T} from 'indico/utils/i18n';
     function ajaxifyForms(noInit) {
       const forms = formContainer.find('form');
       if (!noInit) {
-        showFormErrors(formContainer);
         initForms(forms);
       }
       forms.each(function() {

--- a/indico/web/client/js/jquery/utils/errors.js
+++ b/indico/web/client/js/jquery/utils/errors.js
@@ -42,27 +42,4 @@ import {$T} from 'indico/utils/i18n';
       return true;
     }
   };
-
-  // Select the field of an i-form which has an error and display the tooltip.
-  global.showFormErrors = function showFormErrors(context) {
-    context = context || $('body');
-    context
-      .find('.i-form .has-error > .form-field, .i-form .has-error > .form-subfield')
-      .each(function() {
-        const $this = $(this);
-        // Try a custom tooltip anchor
-        let input = $this.find('[data-tooltip-anchor]');
-
-        if (!input.length) {
-          // Try the first non-hidden input field
-          input = $this.children(':input:not(:hidden)').eq(0);
-        }
-
-        if (!input.length) {
-          // Try the first element that's not a hidden input
-          input = $this.children(':not(:input:hidden)').eq(0);
-        }
-        input.stickyTooltip('danger', () => $this.data('error'));
-      });
-  };
 })(window);

--- a/indico/web/client/js/jquery/utils/forms.js
+++ b/indico/web/client/js/jquery/utils/forms.js
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-/* global countWords, initForms, showFormErrors, toggleAclField, cornerMessage */
+/* global countWords, initForms, toggleAclField, cornerMessage */
 
 import _ from 'lodash';
 
@@ -254,7 +254,7 @@ import {$T} from 'indico/utils/i18n';
 
     forms.find('fieldset.collapsible.initially-collapsed').each(function() {
       const $this = $(this);
-      if ($this.find('div.form-field[data-error]').length) {
+      if ($this.find('div.form-field[data-has-error]').length) {
         $this.find('legend').trigger('click');
       }
     });
@@ -529,7 +529,6 @@ import {$T} from 'indico/utils/i18n';
       const $forms = $target.find('form');
       if ($forms.length) {
         initForms($forms);
-        showFormErrors($target);
       }
     });
   });

--- a/indico/web/client/js/jquery/widgets/ajaxqbubble.js
+++ b/indico/web/client/js/jquery/widgets/ajaxqbubble.js
@@ -5,7 +5,7 @@
 // modify it under the terms of the MIT License; see the
 // LICENSE file for more details.
 
-/* global showFormErrors, initForms, handleAjaxError */
+/* global initForms, handleAjaxError */
 
 import _ from 'lodash';
 
@@ -99,7 +99,6 @@ import {$T} from '../../utils/i18n';
                           api.hide(true);
                         } else {
                           updateContent(data);
-                          showFormErrors($(`#qtip-${api.id}-content`));
                         }
                       },
                     });

--- a/indico/web/client/styles/partials/_forms.scss
+++ b/indico/web/client/styles/partials/_forms.scss
@@ -170,6 +170,38 @@ form {
   }
 }
 
+.i-form .form-group .form-field > .form-field-error {
+  position: absolute;
+  left: 100%;
+  top: 1.25em;
+  z-index: 1;
+  margin-left: 0.6em;
+  width: max-content;
+  max-width: 30em;
+  padding: 0.4em 0.8em;
+  border-radius: 0.2em;
+  background-color: $red;
+  color: #fff;
+  white-space: nowrap;
+  transform: translateY(-50%);
+
+  &::before {
+    content: '';
+    position: absolute;
+    right: 100%;
+    top: 50%;
+    border: 0.4em solid transparent;
+    border-right-color: $red;
+    transform: translateY(-50%);
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+}
+
 .i-form .form-group .form-label {
   display: inline-block;
   line-height: $i-form-line-height;
@@ -213,6 +245,7 @@ form {
 .i-form .form-group .form-field {
   padding-left: 1em;
   margin-bottom: 0.7em;
+  position: relative;
 
   @include apply-to-text-inputs('.i-form-field-fluid');
   @include apply-to-inputs('.form-field-input');

--- a/indico/web/forms/jinja_helpers.py
+++ b/indico/web/forms/jinja_helpers.py
@@ -86,6 +86,9 @@ def render_field(field, widget_attrs, disabled=None):
     args['required'] = (bool(field.flags.required) and not field.flags.conditional and
                         not isinstance(field, (IndicoSelectMultipleCheckboxField,
                                                IndicoQuerySelectMultipleCheckboxField)))
+    if field.errors:
+        args['aria-invalid'] = 'true'
+        args['aria-describedby'] = f'error-{field.id}'
     args.update(widget_attrs)
     if disabled is not None:
         args['disabled'] = disabled

--- a/indico/web/templates/forms/_form.html
+++ b/indico/web/templates/forms/_form.html
@@ -43,8 +43,11 @@
 {%- endmacro %}
 
 {% macro form_field(field, field_classes, widget_attrs={}, disabled=none, hide_description=false) -%}
-    <div class="{{ field_classes }}"{% if field.errors %} data-error="{{ _render_errors(field.errors) }}"{% endif %}>
+    <div class="{{ field_classes }}"{% if field.errors %} data-has-error{% endif %}>
         {{ _render_field(field, widget_attrs, disabled) }}
+        {%- if field.errors %}
+            <div class="form-field-error" id="error-{{ field.id }}" role="alert">{{ _render_errors(field.errors) }}</div>
+        {%- endif %}
         {% if field.widget.input_type == 'checkbox' %}
             <div class="form-checkbox-label">{{ field.label() }}</div>
         {% endif %}
@@ -76,7 +79,7 @@
                     {%- if field.widget.input_type != 'checkbox' and (not field.widget.input_type or not placeholder) -%}
                         {{ field.label() }}
                     {%- endif -%}
-                    {%- if field.flags.required %}<i class="required" title="{% trans %}This field is required{% endtrans %}">*</i>{% endif -%}
+                    {%- if field.flags.required %}<i class="required" aria-hidden="true">*</i>{% endif -%}
                 </div>
             {% endif %}
             {% set widget_attrs = dict(widget_attrs, placeholder=(field.label.text if placeholder else widget_attrs.get('placeholder', ''))) %}

--- a/indico/web/templates/forms/email_recipients_widget.html
+++ b/indico/web/templates/forms/email_recipients_widget.html
@@ -1,7 +1,7 @@
 {% extends 'forms/base_widget.html' %}
 
 {% block html %}
-    <div class="recipients-box left" {% if field.errors %} data-error="{{ _render_errors(field.errors) }}"{% endif %}>
+    <div class="recipients-box left">
         <div class="text">
             {{- field.text_value|markdown -}}
         </div>


### PR DESCRIPTION
Two accessibility fixes for classic (server-rendered WTForms) forms.

**Required-field marker.** The red `*` next to required labels carried a
`title="This field is required"` and its `*` text was exposed to assistive
technology, so screen readers announced a meaningless "star". The asterisk is
now `aria-hidden`; the field's native `required` attribute already conveys the
required state.

**Validation errors.** Server-side validation errors were shown as a qtip
tooltip built in JavaScript from a `data-error` attribute, with no programmatic
link to the field. They are now rendered as a plain server-side element
(`<div class="form-field-error" role="alert">`), and the input carries
`aria-invalid="true"` + `aria-describedby` pointing at it — so the error is
announced on submit and read again whenever the field is focused. The bubble
looks and is positioned exactly as before (plain CSS), but no longer needs qtip
or any positioning JavaScript, so the now-unused `showFormErrors` plumbing is
removed. (`stickyTooltip` itself stays — two client-side widgets still use it.)

Scope: this covers the classic WTForms stack. The React `Form.Field` required
marker and the separate legacy client-side validation tooltip are left as
follow-ups.

User impact: screen reader users now hear which field failed validation and why,
and are no longer read a stray "star" on every required field.
