### PR TITLE
Prevent unscheduling contributions in meetings

### DIFF
--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -180,7 +180,7 @@ function EntryPopupContent({
         break;
       case EntryType.Contribution:
         if (eventType === 'meeting') {
-          dispatch(actions.deleteScheduledContrib(entry.objId, eventId));
+          dispatch(actions.deleteScheduledContrib(entry.objId));
         } else {
           dispatch(actions.unscheduleEntry(entry, eventId));
         }

--- a/indico/modules/events/timetable/client/js/EntryPopup.tsx
+++ b/indico/modules/events/timetable/client/js/EntryPopup.tsx
@@ -64,6 +64,7 @@ function EntryPopupContent({
   const dispatch: ThunkDispatch<ReduxState, unknown, actions.Action> = useDispatch();
   const {objId, type, title, duration, startDt, sessionId} = entry;
   const eventId = useSelector(selectors.getEventId);
+  const eventType = useSelector(selectors.getEventType);
   const entries = useSelector(selectors.getCurrentDayEntries);
   const session = useSelector((state: ReduxState) => selectors.getSessionById(state, sessionId));
   const isPosterBlock = useSelector((state: ReduxState) =>
@@ -178,7 +179,11 @@ function EntryPopupContent({
         dispatch(actions.deleteBlock(entry, eventId));
         break;
       case EntryType.Contribution:
-        dispatch(actions.unscheduleEntry(entry, eventId));
+        if (eventType === 'meeting') {
+          dispatch(actions.deleteScheduledContrib(entry.objId, eventId));
+        } else {
+          dispatch(actions.unscheduleEntry(entry, eventId));
+        }
         break;
     }
   };
@@ -389,8 +394,20 @@ function EntryPopupContent({
         />
         {type === EntryType.Contribution ? (
           <ActionPopup
-            content={<Translate>Unschedule contribution</Translate>}
-            trigger={<Button basic icon="calendar times" onClick={onDelete} />}
+            content={
+              eventType === 'meeting' ? (
+                <Translate>Delete contribution</Translate>
+              ) : (
+                <Translate>Unschedule contribution</Translate>
+              )
+            }
+            trigger={
+              <Button
+                basic
+                icon={eventType === 'meeting' ? 'trash' : 'calendar times'}
+                onClick={onDelete}
+              />
+            }
           />
         ) : (
           <ActionPopup

--- a/indico/modules/events/timetable/client/js/TimetableTabRail.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableTabRail.tsx
@@ -23,6 +23,7 @@ export default function TimetableTabRail() {
   const showSessions = useSelector(selectors.showSessions);
   const activePanel = useSelector(selectors.getActivePanel);
   const eventId = useSelector(selectors.getEventId);
+  const eventType = useSelector(selectors.getEventType);
 
   return (
     // TODO: (Marina) Rename to 'show draft entries' or something like that
@@ -43,22 +44,24 @@ export default function TimetableTabRail() {
         >
           <Icon name="bookmark outline" size="large" />
         </Menu.Item>
-        <Menu.Item
-          name="unscheduled"
-          active={showUnscheduled}
-          title={Translate.string('Unscheduled contributions')}
-          onClick={() =>
-            dispatch(
-              actions.setActivePanel(
-                activePanel === SidePanelView.Unscheduled
-                  ? SidePanelView.None
-                  : SidePanelView.Unscheduled
+        {eventType !== 'meeting' && (
+          <Menu.Item
+            name="unscheduled"
+            active={showUnscheduled}
+            title={Translate.string('Unscheduled contributions')}
+            onClick={() =>
+              dispatch(
+                actions.setActivePanel(
+                  activePanel === SidePanelView.Unscheduled
+                    ? SidePanelView.None
+                    : SidePanelView.Unscheduled
+                )
               )
-            )
-          }
-        >
-          <Icon name="file outline" size="large" />
-        </Menu.Item>
+            }
+          >
+            <Icon name="file outline" size="large" />
+          </Menu.Item>
+        )}
         <PublicationStateSwitch
           as={Menu.Item}
           styleName="publication-switch"

--- a/indico/modules/events/timetable/client/js/TimetableTabRail.tsx
+++ b/indico/modules/events/timetable/client/js/TimetableTabRail.tsx
@@ -24,6 +24,7 @@ export default function TimetableTabRail() {
   const activePanel = useSelector(selectors.getActivePanel);
   const eventId = useSelector(selectors.getEventId);
   const eventType = useSelector(selectors.getEventType);
+  const unscheduled = useSelector(selectors.getUnscheduled);
 
   return (
     // TODO: (Marina) Rename to 'show draft entries' or something like that
@@ -44,7 +45,7 @@ export default function TimetableTabRail() {
         >
           <Icon name="bookmark outline" size="large" />
         </Menu.Item>
-        {eventType !== 'meeting' && (
+        {(eventType !== 'meeting' || unscheduled.length > 0) && (
           <Menu.Item
             name="unscheduled"
             active={showUnscheduled}

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -429,13 +429,18 @@ export function deleteUnscheduledContrib(id: number, eventId: number) {
   });
 }
 
-export function deleteScheduledContrib(id: number, eventId: number) {
-  const contribURL = contributionURL({event_id: eventId, contrib_id: id});
-  return synchronizedAjaxAction(() => indicoAxios.delete(contribURL), {
-    type: DELETE_SCHEDULED_CONTRIB,
-    id: getEntryUniqueId(EntryType.Contribution, id) as ContribId,
-    eventId,
-  });
+export function deleteScheduledContrib(id: number) {
+  return (dispatch: ThunkDispatch<ReduxState, unknown, Action>, getState: () => ReduxState) => {
+    const {staticData} = getState();
+    const eventId = staticData.eventId;
+    const contribURL = contributionURL({event_id: eventId, contrib_id: id});
+    const action = synchronizedAjaxAction(() => indicoAxios.delete(contribURL), {
+      type: DELETE_SCHEDULED_CONTRIB,
+      id: getEntryUniqueId(EntryType.Contribution, id) as ContribId,
+      eventId,
+    });
+    return dispatch(action);
+  };
 }
 
 export function addUnscheduledContrib(entry: UnscheduledContribEntry) {

--- a/indico/modules/events/timetable/client/js/actions.ts
+++ b/indico/modules/events/timetable/client/js/actions.ts
@@ -61,6 +61,7 @@ export const SELECT_ENTRY = 'Select entry';
 export const DESELECT_ENTRY = 'Deselect entry';
 export const DELETE_BREAK = 'Delete break';
 export const DELETE_UNSCHEDULED_CONTRIB = 'Delete contrib';
+export const DELETE_SCHEDULED_CONTRIB = 'Delete scheduled contrib';
 export const ADD_UNSCHEDULED_CONTRIB = 'Add unscheduled contrib';
 export const DELETE_BLOCK = 'Delete block';
 export const SCHEDULE_ENTRY = 'Schedule entry';
@@ -159,10 +160,17 @@ interface DeleteBreakAction {
 interface DeleteBlockAction {
   type: typeof DELETE_BLOCK;
   entry: BlockEntry;
+  unscheduleChildContribs: boolean;
 }
 
 interface DeleteUnscheduledContribAction {
   type: typeof DELETE_UNSCHEDULED_CONTRIB;
+  id: ContribId;
+  eventId: number;
+}
+
+interface DeleteScheduledContribAction {
+  type: typeof DELETE_SCHEDULED_CONTRIB;
   id: ContribId;
   eventId: number;
 }
@@ -229,6 +237,7 @@ export type Action =
   | SetEntryAttachments
   | DeleteBreakAction
   | DeleteUnscheduledContribAction
+  | DeleteScheduledContribAction
   | AddUnscheduledContribAction
   | DeleteBlockAction
   | SetDraftEntryAction
@@ -420,6 +429,15 @@ export function deleteUnscheduledContrib(id: number, eventId: number) {
   });
 }
 
+export function deleteScheduledContrib(id: number, eventId: number) {
+  const contribURL = contributionURL({event_id: eventId, contrib_id: id});
+  return synchronizedAjaxAction(() => indicoAxios.delete(contribURL), {
+    type: DELETE_SCHEDULED_CONTRIB,
+    id: getEntryUniqueId(EntryType.Contribution, id) as ContribId,
+    eventId,
+  });
+}
+
 export function addUnscheduledContrib(entry: UnscheduledContribEntry) {
   return {
     type: ADD_UNSCHEDULED_CONTRIB,
@@ -428,11 +446,17 @@ export function addUnscheduledContrib(entry: UnscheduledContribEntry) {
 }
 
 export function deleteBlock(entry: BlockEntry, eventId: number) {
-  const entryURL = sessionBlockURL({event_id: eventId, session_block_id: entry.objId});
-  return synchronizedAjaxAction(() => indicoAxios.delete(entryURL), {
-    type: DELETE_BLOCK,
-    entry,
-  });
+  return (dispatch: ThunkDispatch<ReduxState, unknown, Action>, getState: () => ReduxState) => {
+    const {staticData} = getState();
+    const eventType = staticData.eventType;
+    const entryURL = sessionBlockURL({event_id: eventId, session_block_id: entry.objId});
+    const action = synchronizedAjaxAction(() => indicoAxios.delete(entryURL), {
+      type: DELETE_BLOCK,
+      unscheduleChildContribs: eventType !== 'meeting',
+      entry,
+    });
+    return dispatch(action);
+  };
 }
 
 export function scheduleEntry(

--- a/indico/modules/events/timetable/client/js/reducers.ts
+++ b/indico/modules/events/timetable/client/js/reducers.ts
@@ -148,6 +148,13 @@ export default {
           unscheduled: state.unscheduled.filter(e => e.id !== id),
         };
       }
+      case actions.DELETE_SCHEDULED_CONTRIB: {
+        const {id} = action;
+        return {
+          ...state,
+          entries: _.omit(state.entries, id),
+        };
+      }
       case actions.ADD_UNSCHEDULED_CONTRIB: {
         const {entry} = action;
         return {
@@ -164,8 +171,8 @@ export default {
         };
       }
       case actions.DELETE_BLOCK: {
-        const {entry} = action;
-        const newUnscheduled = Object.values(state.entries)
+        const {entry, unscheduleChildContribs} = action;
+        const removedEntries = Object.values(state.entries)
           .filter(
             x =>
               x.type === EntryType.Contribution && isChildEntry(x) && x.sessionBlockId === entry.id
@@ -173,8 +180,10 @@ export default {
           .map(x => _.omit(x, ['startDt', 'sessionBlockId']));
         return {
           ...state,
-          entries: _.omit(state.entries, [entry.id, ...newUnscheduled.map(c => c.id)]),
-          unscheduled: [...state.unscheduled, ...newUnscheduled],
+          entries: _.omit(state.entries, [entry.id, ...removedEntries.map(c => c.id)]),
+          ...(unscheduleChildContribs
+            ? {unscheduled: [...state.unscheduled, ...removedEntries]}
+            : undefined),
         };
       }
       case actions.SCHEDULE_ENTRY: {


### PR DESCRIPTION
This removes the sidepanel menu for unscheduled contributions, changes the "unschedule" button to "delete" and also makes it so when you delete a session block, the contributions are also deleted instead of unscheduled (does not seem to make a difference atm but added for correctness)