### PR TITLE
Make management list toolbar disabled actions and selection button accessible

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,11 @@ Bugfixes
 Accessibility
 ^^^^^^^^^^^^^
 
-- Nothing so far
+- Management list toolbars (such as the list of abstracts, contributions or
+  registrations) now tell screen reader users when an action button is
+  unavailable because no rows are selected, and no longer let keyboard focus
+  land on those buttons; the row-selection button now has a name
+  (:pr:`7747`, thanks :user:`foxbunny`)
 
 Internal Changes
 ^^^^^^^^^^^^^^^^

--- a/indico/modules/events/abstracts/templates/display/abstracts.html
+++ b/indico/modules/events/abstracts/templates/display/abstracts.html
@@ -26,7 +26,9 @@
             <div class="toolbars space-after">
                 <div class="toolbar">
                     <button class="icon-checkbox-checked i-button arrow left icon-only"
-                            aria-hidden="true" data-toggle="dropdown"></button>
+                            data-toggle="dropdown">
+                        <span class="select-rows-label">{% trans %}Select rows{% endtrans %}</span>
+                    </button>
                     <ul class="i-dropdown">
                         <li><a href="#" id="select-all">{% trans 'Selection' %}All{% endtrans %}</a></li>
                         <li><a href="#" id="select-none">{% trans 'Selection' %}None{% endtrans %}</a></li>

--- a/indico/modules/events/abstracts/templates/management/abstract_list.html
+++ b/indico/modules/events/abstracts/templates/management/abstract_list.html
@@ -24,7 +24,9 @@
             <div class="toolbar">
                 <div class="group">
                     <button class="icon-checkbox-checked i-button arrow left icon-only"
-                            aria-hidden="true" data-toggle="dropdown"></button>
+                            data-toggle="dropdown">
+                        <span class="select-rows-label">{% trans %}Select rows{% endtrans %}</span>
+                    </button>
                     <ul class="i-dropdown">
                         <li><a href="#" id="select-all">{% trans 'Selection' %}All{% endtrans %}</a></li>
                         <li><a href="#" id="select-none">{% trans 'Selection' %}None{% endtrans %}</a></li>

--- a/indico/modules/events/client/js/util/list_generator.js
+++ b/indico/modules/events/client/js/util/list_generator.js
@@ -53,10 +53,11 @@
 
     $obj.on('change', function() {
       $(this).closest('tr').toggleClass('selected', this.checked);
-      $('.js-requires-selected-row').toggleClass(
-        'disabled',
-        !$('.list input:checkbox:checked').length
-      );
+      const disabled = !$('.list input:checkbox:checked').length;
+      $('.js-requires-selected-row')
+        .toggleClass('disabled', disabled)
+        .attr('aria-disabled', disabled ? 'true' : null)
+        .attr('tabindex', disabled ? '-1' : null);
     });
 
     if (trigger) {

--- a/indico/modules/events/contributions/templates/management/_subcontribution_list.html
+++ b/indico/modules/events/contributions/templates/management/_subcontribution_list.html
@@ -6,7 +6,9 @@
     <div id="subcontribution-list">
         <div class="hide-if-locked">
             <div class="toolbar form-group space-after">
-                <button class="icon-checkbox-checked i-button arrow js-dropdown" data-toggle="dropdown"></button>
+                <button class="icon-checkbox-checked i-button arrow js-dropdown" data-toggle="dropdown">
+                    <span class="select-rows-label">{% trans %}Select rows{% endtrans %}</span>
+                </button>
                 <ul class="i-dropdown">
                     <li>
                         <a href="#" data-select-all="#subcontribution-list input.select-row:visible">

--- a/indico/modules/events/management/templates/_base_person_list.html
+++ b/indico/modules/events/management/templates/_base_person_list.html
@@ -3,7 +3,9 @@
     <div>
         <div class="toolbar space-after">
             <button class="icon-checkbox-checked i-button arrow js-dropdown hide-if-locked"
-                    data-toggle="dropdown"></button>
+                    data-toggle="dropdown">
+                <span class="select-rows-label">{% trans %}Select rows{% endtrans %}</span>
+            </button>
             <ul class="i-dropdown hide-if-locked">
                 <li>
                     <a href="#" data-select-all="#person-list-table input.select-row:visible">

--- a/indico/modules/events/persons/client/js/AuthorsListButton.jsx
+++ b/indico/modules/events/persons/client/js/AuthorsListButton.jsx
@@ -22,6 +22,8 @@ export function AuthorsListButton({eventId, objectContext, paramsSelector}) {
       <button
         type="button"
         className="i-button icon-users js-requires-selected-row disabled"
+        aria-disabled="true"
+        tabIndex={-1}
         onClick={evt => {
           if (!evt.target.classList.contains('disabled')) {
             setOpen(true);

--- a/indico/modules/events/persons/client/js/EmailContribAbstractRolesButton.jsx
+++ b/indico/modules/events/persons/client/js/EmailContribAbstractRolesButton.jsx
@@ -24,12 +24,15 @@ export function EmailContribAbstractRolesButton({
   const [open, setOpen] = useState(false);
   const ids = idSelector && getIds(idSelector);
   const idType = {abstracts: 'abstract_id', contributions: 'contribution_id'}[objectContext];
+  const disabled = className.includes('disabled');
 
   return (
     <>
       <button
         type="button"
         className={`i-button icon-mail ${className}`}
+        aria-disabled={disabled ? 'true' : undefined}
+        tabIndex={disabled ? -1 : undefined}
         onClick={evt => {
           if (!evt.target.classList.contains('disabled')) {
             setOpen(true);

--- a/indico/modules/events/persons/templates/management/person_list.html
+++ b/indico/modules/events/persons/templates/management/person_list.html
@@ -38,7 +38,9 @@
         <div class="toolbars space-after">
             <div class="toolbar hide-if-locked">
                 <div class="group">
-                    <button class="icon-checkbox-checked i-button arrow js-dropdown" data-toggle="dropdown"></button>
+                    <button class="icon-checkbox-checked i-button arrow js-dropdown" data-toggle="dropdown">
+                        <span class="select-rows-label">{% trans %}Select rows{% endtrans %}</span>
+                    </button>
                     <ul class="i-dropdown">
                         <li>
                             <a href="#" data-select-all="#event-participants-list input.select-row:visible:not(:disabled)">

--- a/indico/modules/events/registration/templates/management/regform_reglist.html
+++ b/indico/modules/events/registration/templates/management/regform_reglist.html
@@ -40,7 +40,9 @@
             <div class="toolbar">
                 <div class="group">
                     <button class="icon-checkbox-checked i-button arrow left icon-only"
-                            aria-hidden="true" data-toggle="dropdown"></button>
+                            data-toggle="dropdown">
+                        <span class="select-rows-label">{% trans %}Select rows{% endtrans %}</span>
+                    </button>
                     <ul class="i-dropdown">
                         <li><a href="#" id="select-all">{% trans 'Selection' %}All{% endtrans %}</a></li>
                         <li><a href="#" id="select-none">{% trans 'Selection' %}None{% endtrans %}</a></li>

--- a/indico/modules/events/sessions/templates/management/session_list.html
+++ b/indico/modules/events/sessions/templates/management/session_list.html
@@ -39,7 +39,9 @@
         <div class="toolbars space-after">
             <div class="toolbar">
                 <div class="group">
-                    <button class="icon-checkbox-checked i-button arrow js-dropdown" data-toggle="dropdown"></button>
+                    <button class="icon-checkbox-checked i-button arrow js-dropdown" data-toggle="dropdown">
+                        <span class="select-rows-label">{% trans %}Select rows{% endtrans %}</span>
+                    </button>
                     <ul class="i-dropdown">
                         <li>
                             <a href="#" data-select-all="#sessions-wrapper input.select-row">

--- a/indico/web/client/styles/partials/_toolbars.scss
+++ b/indico/web/client/styles/partials/_toolbars.scss
@@ -8,6 +8,7 @@
 @use 'base/palette' as *;
 @use 'base/utilities' as *;
 @use 'base/defaults' as *;
+@use 'design_system';
 @use './buttons' as buttons;
 
 $toolbar-height: 2.2em;
@@ -214,6 +215,10 @@ $toolbar-spacing: 10px;
   align-items: center;
   gap: 0.5em;
   min-height: $toolbar-height;
+
+  .select-rows-label {
+    @extend %visually-hidden;
+  }
 
   &.fixed-height {
     max-height: 1.75rem;


### PR DESCRIPTION
Management list toolbars (abstracts, contributions, registrations, etc.) grey
out the row actions while nothing is selected, but that disabled state was CSS
only — the buttons kept a normal accessible name and stayed in the tab order.

Set `aria-disabled` on those controls and drop them from the tab order while
unavailable (centrally in `handleRowSelection`), clearing both when a row is
selected. Also name the row-selection split button and remove the
`aria-hidden` that was hiding it from assistive tech.

No visual change. Part of #7625; the menu-button ARIA and keyboard nav are left
for a separate `ind-menu` conversion.